### PR TITLE
refactor(stm): decouple surfacing via remote-only MCP

### DIFF
--- a/packages/memtomem-stm/README.md
+++ b/packages/memtomem-stm/README.md
@@ -457,19 +457,26 @@ Fine-tune surfacing behavior per tool:
 
 Template variables: `{tool_name}`, `{server}`, `{arg.ARGUMENT_NAME}`
 
-### LTM Connection Modes
+### LTM Connection
 
-| Mode | Config | Description |
-|------|--------|-------------|
-| **in_process** (default) | `ltm_mode: "in_process"` | Imports memtomem directly (faster, requires `memtomem` installed) |
-| **mcp_client** | `ltm_mode: "mcp_client"` | Connects to remote memtomem server via MCP (isolated, works without local memtomem) |
-
-For MCP client mode:
+STM connects to the LTM exclusively over the MCP protocol. The surfacing
+engine spawns (or attaches to) a memtomem MCP server using these settings:
 
 ```bash
-export MEMTOMEM_STM_SURFACING__LTM_MODE=mcp_client
+# Default — spawns `memtomem-server` as a child process
 export MEMTOMEM_STM_SURFACING__LTM_MCP_COMMAND=memtomem-server
+
+# Pass extra arguments if needed (e.g. point at a custom config)
+export MEMTOMEM_STM_SURFACING__LTM_MCP_ARGS='["--config","/etc/memtomem.json"]'
 ```
+
+This makes memtomem just another MCP upstream as far as STM is concerned —
+the same compression / cache / surfacing pipeline applies, and a memtomem
+crash never takes down STM's other upstream connections.
+
+> **Note**: prior versions supported an in-process mode that imported
+> memtomem directly. That path was removed so STM has a single LTM
+> retrieval path and so core internals can evolve without breaking STM.
 
 ### Feedback & Auto-Tuning
 

--- a/packages/memtomem-stm/src/memtomem_stm/proxy/extraction.py
+++ b/packages/memtomem-stm/src/memtomem_stm/proxy/extraction.py
@@ -61,33 +61,14 @@ def _parse_facts_json(raw: str, *, max_facts: int) -> list[ExtractedFact]:
 
 
 def _extract_heuristic(text: str, *, max_facts: int) -> list[ExtractedFact]:
-    """Heuristic fallback using regex entity extraction from core."""
-    try:
-        from memtomem.tools.entity_extraction import extract_entities
+    """Heuristic fallback for fact extraction.
 
-        entities = extract_entities(text)
-    except ImportError:
-        logger.debug("memtomem core not available for heuristic extraction")
-        return []
-
-    facts: list[ExtractedFact] = []
-    seen: set[str] = set()
-    for e in entities:
-        key = f"{e.entity_type}:{e.entity_value}"
-        if key in seen:
-            continue
-        seen.add(key)
-        facts.append(
-            ExtractedFact(
-                content=f"{e.entity_type}: {e.entity_value}",
-                category=e.entity_type,
-                confidence=e.confidence,
-                tags=[e.entity_type],
-            )
-        )
-        if len(facts) >= max_facts:
-            break
-    return facts
+    STM no longer imports memtomem core directly; the LLM extractor is the
+    primary path. This stub returns an empty list, so when LLM extraction
+    fails (circuit open, transport error) extraction silently yields no facts.
+    A native STM heuristic can be added later if demand emerges.
+    """
+    return []
 
 
 class FactExtractor:

--- a/packages/memtomem-stm/src/memtomem_stm/server.py
+++ b/packages/memtomem-stm/src/memtomem_stm/server.py
@@ -59,69 +59,38 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[STMContext]:
 
     tracker = TokenTracker(metrics_store=metrics_store)
 
-    # Initialize surfacing engine (in-process mode with optional memtomem LTM)
+    # Initialize surfacing engine — LTM access is always remote-only via the
+    # MCP client adapter. The adapter spawns (or connects to) a memtomem
+    # MCP server using config.surfacing.ltm_mcp_command / ltm_mcp_args.
     surfacing_engine: SurfacingEngine | None = None
+    mcp_adapter = None
+    feedback_tracker: FeedbackTracker | None = None
     if config.surfacing.enabled:
-        search_pipeline = None
-        storage = None
-        webhook_manager = None
+        try:
+            from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
 
-        mcp_adapter = None
+            mcp_adapter = McpClientSearchAdapter(config.surfacing)
+            await mcp_adapter.start()
+            logger.info(
+                "Surfacing engine connected via MCP client to %s",
+                config.surfacing.ltm_mcp_command,
+            )
+        except Exception:
+            logger.warning(
+                "MCP client surfacing initialization failed — surfacing disabled",
+                exc_info=True,
+            )
+            mcp_adapter = None
 
-        if config.surfacing.ltm_mode == "mcp_client":
-            # MCP Client mode: connect to a remote memtomem server
-            try:
-                from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
-
-                mcp_adapter = McpClientSearchAdapter(config.surfacing)
-                await mcp_adapter.start()
-                logger.info(
-                    "Surfacing engine connected via MCP client to %s",
-                    config.surfacing.ltm_mcp_command,
-                )
-            except Exception:
-                logger.warning("MCP client surfacing initialization failed", exc_info=True)
-        else:
-            # In-process mode: import memtomem directly
-            try:
-                from memtomem.server.component_factory import create_components
-                from memtomem.config import Mem2MemConfig
-
-                ltm_config = Mem2MemConfig()
-                comp = await create_components(ltm_config)
-                search_pipeline = comp.search_pipeline
-                storage = comp.storage
-                logger.info("Surfacing engine connected to in-process LTM")
-            except ImportError:
-                logger.info("memtomem not installed — trying MCP client mode")
-                # Fall back to MCP client
-                try:
-                    from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
-
-                    mcp_adapter = McpClientSearchAdapter(config.surfacing)
-                    await mcp_adapter.start()
-                    logger.info("Surfacing engine connected via MCP client fallback")
-                except Exception:
-                    logger.warning("MCP client fallback failed — surfacing disabled", exc_info=True)
-            except Exception:
-                logger.warning("Failed to initialize LTM for surfacing", exc_info=True)
-
-        # Initialize feedback tracker before engine so it can be injected
-        feedback_tracker: FeedbackTracker | None = None
         if config.surfacing.feedback_enabled:
             feedback_tracker = FeedbackTracker(config.surfacing)
 
-        if search_pipeline is not None or mcp_adapter is not None:
+        if mcp_adapter is not None:
             surfacing_engine = SurfacingEngine(
                 config.surfacing,
-                search_pipeline=search_pipeline,
-                storage=storage,
-                webhook_manager=webhook_manager,
                 mcp_adapter=mcp_adapter,
                 feedback_tracker=feedback_tracker,
             )
-    else:
-        feedback_tracker = None
 
     # Initialize proxy cache
     from memtomem_stm.proxy.cache import ProxyCache

--- a/packages/memtomem-stm/src/memtomem_stm/surfacing/config.py
+++ b/packages/memtomem-stm/src/memtomem_stm/surfacing/config.py
@@ -18,10 +18,14 @@ class ToolSurfacingConfig(BaseModel):
 
 
 class SurfacingConfig(BaseModel):
-    """Proactive memory surfacing configuration."""
+    """Proactive memory surfacing configuration.
+
+    LTM access is always remote-only via the MCP protocol. The surfacing
+    engine spawns (or connects to) a memtomem MCP server using the
+    ltm_mcp_command / ltm_mcp_args settings below.
+    """
 
     enabled: bool = True
-    ltm_mode: str = "in_process"  # "in_process" | "mcp_client"
     ltm_mcp_command: str = "memtomem-server"
     ltm_mcp_args: list[str] = []
     min_score: float = 0.02

--- a/packages/memtomem-stm/src/memtomem_stm/surfacing/engine.py
+++ b/packages/memtomem-stm/src/memtomem_stm/surfacing/engine.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from typing import TYPE_CHECKING, Any
-from uuid import UUID
+from typing import Any
 
 from memtomem_stm.surfacing.cache import SurfacingCache
 from memtomem_stm.surfacing.config import SurfacingConfig
@@ -15,33 +14,31 @@ from memtomem_stm.surfacing.formatter import SurfacingFormatter
 from memtomem_stm.surfacing.relevance import RelevanceGate
 from memtomem_stm.utils.circuit_breaker import CircuitBreaker
 
-if TYPE_CHECKING:
-    from memtomem.search.pipeline import SearchPipeline
-    from memtomem.storage.sqlite_backend import SqliteBackend
-
 logger = logging.getLogger(__name__)
 
 
 class SurfacingEngine:
     """Core proactive memory surfacing engine.
 
-    On each proxied tool call, extracts context, searches LTM,
-    and injects relevant memories into the response.
+    On each proxied tool call, extracts context, searches LTM via the
+    MCP client adapter, and injects relevant memories into the response.
+
+    LTM access is always remote-only via the MCP protocol (no in-process
+    SearchPipeline coupling). The adapter is responsible for talking to a
+    memtomem MCP server, whether spawned as a child process or addressed
+    over an existing transport.
     """
 
     def __init__(
         self,
         config: SurfacingConfig,
-        search_pipeline: SearchPipeline | None = None,
-        storage: SqliteBackend | None = None,
+        *,
+        mcp_adapter: Any,
         webhook_manager: Any | None = None,
-        mcp_adapter: Any | None = None,
         feedback_tracker: Any | None = None,
     ) -> None:
         self._config = config
-        self._search_pipeline = search_pipeline
         self._mcp_adapter = mcp_adapter
-        self._storage = storage
         self._webhook_manager = webhook_manager
         self._feedback_tracker = feedback_tracker
         self._auto_tuner = None
@@ -69,8 +66,6 @@ class SurfacingEngine:
                     )
             except Exception:
                 logger.debug("Failed to load cross-session seen IDs", exc_info=True)
-        # Track surfacing IDs already boosted to prevent double-counting
-        self._boosted_surfacings: set[str] = set()
 
     async def surface(
         self,
@@ -83,14 +78,11 @@ class SurfacingEngine:
 
         Returns the original response_text unmodified if:
         - surfacing is disabled
-        - no search pipeline available
         - circuit breaker is open
         - relevance gate rejects the call
         - timeout exceeded
         """
-        if not self._config.enabled or (
-            self._search_pipeline is None and self._mcp_adapter is None
-        ):
+        if not self._config.enabled:
             return response_text
 
         if len(response_text) < self._config.min_response_chars:
@@ -136,44 +128,19 @@ class SurfacingEngine:
         rating: str,
         memory_id: str | None = None,
     ) -> str:
-        """Record feedback and boost access count for helpful memories.
+        """Record feedback for a surfaced memory.
 
-        When rating is 'helpful', increments access_count on the surfaced
-        memory chunks in the core storage. This feeds into the search
-        pipeline's access-frequency boost, making helpful memories rank
-        higher in future searches.
+        Note: the previous in-process implementation also incremented
+        access_count on the surfaced chunks via direct SqliteBackend access
+        when the rating was "helpful". After the move to remote-only LTM
+        access this boost is temporarily disabled — it will be restored once
+        the core exposes an MCP action for incrementing access counts (see
+        follow-up task: mem_increment_access action).
         """
         if self._feedback_tracker is None:
             return "Feedback tracking is not enabled."
 
-        result = self._feedback_tracker.record_feedback(surfacing_id, rating, memory_id)
-
-        # Boost access count for helpful memories (once per surfacing event)
-        if (
-            rating == "helpful"
-            and self._storage is not None
-            and surfacing_id not in self._boosted_surfacings
-        ):
-            try:
-                if memory_id:
-                    ids = [UUID(memory_id)]
-                else:
-                    id_strs = self._feedback_tracker.store.get_memory_ids_for_surfacing(
-                        surfacing_id
-                    )
-                    ids = [UUID(mid) for mid in id_strs]
-                if ids:
-                    await self._storage.increment_access(ids)
-                    self._boosted_surfacings.add(surfacing_id)
-                    logger.debug(
-                        "Boosted access count for %d memories (surfacing %s)",
-                        len(ids),
-                        surfacing_id,
-                    )
-            except Exception:
-                logger.debug("Failed to boost access for feedback", exc_info=True)
-
-        return result
+        return self._feedback_tracker.record_feedback(surfacing_id, rating, memory_id)
 
     async def _do_surface(
         self,
@@ -219,10 +186,9 @@ class SurfacingEngine:
             else self._config.default_namespace
         )
 
-        # Search LTM (in-process or MCP client)
-        searcher = self._search_pipeline or self._mcp_adapter
+        # Search LTM via remote MCP client
         ctx_win = self._config.context_window_size or None
-        results, _stats = await searcher.search(
+        results, _stats = await self._mcp_adapter.search(
             query=query,
             top_k=max_results * 2,
             namespace=namespace,
@@ -252,13 +218,12 @@ class SurfacingEngine:
             "Surfacing %d memories for %s/%s (query=%s)", len(relevant), server, tool, query[:50]
         )
 
-        # Session context (working memory)
+        # Session context (working memory): temporarily disabled.
+        # The previous in-process implementation called SqliteBackend.scratch_list()
+        # directly. After the remote-only refactor it must go through the MCP
+        # adapter (mem_scratch_get). Tracked as follow-up: see
+        # McpClientSearchAdapter.scratch_list() task.
         scratch_items = None
-        if self._config.include_session_context and self._storage:
-            try:
-                scratch_items = await self._storage.scratch_list()
-            except Exception:
-                logger.debug("Failed to fetch scratch items", exc_info=True)
 
         # Generate surfacing ID and record event
         surfacing_id = uuid.uuid4().hex[:12]

--- a/packages/memtomem-stm/tests/_fake_memtomem_server.py
+++ b/packages/memtomem-stm/tests/_fake_memtomem_server.py
@@ -1,0 +1,34 @@
+"""Tiny stdio MCP server used by integration tests.
+
+Stands in for `memtomem-server` so that STM's McpClientSearchAdapter can be
+exercised end-to-end without depending on a real memtomem installation. The
+server exposes a single tool, `mem_search`, that returns canned content in the
+format the adapter knows how to parse.
+
+Run with: `python <path-to-this-file>`
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("fake-memtomem")
+
+
+@mcp.tool()
+async def mem_search(
+    query: str,
+    top_k: int | None = None,
+    namespace: str | list[str] | None = None,
+) -> str:
+    """Return canned search hits in the format McpClientSearchAdapter parses."""
+    return (
+        "--- [0.92] /notes/auth.md ---\n"
+        "JWT authentication uses HS256 with rotating secrets every 24 hours.\n"
+        "--- [0.87] /notes/api.md ---\n"
+        "All API responses include rate limit headers (X-RateLimit-*).\n"
+    )
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/packages/memtomem-stm/tests/bench/judge.py
+++ b/packages/memtomem-stm/tests/bench/judge.py
@@ -7,7 +7,7 @@ import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .harness import BenchTask, QAPair
+    from .harness import BenchTask
 
 
 def _normalize(text: str) -> str:

--- a/packages/memtomem-stm/tests/bench/report.py
+++ b/packages/memtomem-stm/tests/bench/report.py
@@ -170,7 +170,7 @@ def format_stage_breakdown(breakdown: StageBreakdown) -> str:
         lines.append(f"  {s.stage:<12} {s.chars:>8} {s.quality_score:>7.1f} {qa_str:>10}")
 
     # Deltas
-    lines.append(f"  ---")
+    lines.append("  ---")
     lines.append(f"  Clean info loss:    {breakdown.clean_info_loss:+.1f}")
     lines.append(f"  Compress info loss: {breakdown.compress_info_loss:+.1f}")
     lines.append(f"  Surfacing value:    {breakdown.surfacing_value:+.1f}")
@@ -198,7 +198,7 @@ def format_surfacing_value(values: list[SurfacingValue]) -> str:
 
     if values:
         n = len(values)
-        lines.append(f"  ---")
+        lines.append("  ---")
         lines.append(f"  Avg quality delta: {total_delta / n:+.1f}")
         lines.append(f"  Total QA gain:     +{total_qa_delta} answers")
 

--- a/packages/memtomem-stm/tests/test_auto_compression.py
+++ b/packages/memtomem-stm/tests/test_auto_compression.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import pytest
 
 from memtomem_stm.proxy.config import (
     CompressionStrategy,

--- a/packages/memtomem-stm/tests/test_bench_pipeline.py
+++ b/packages/memtomem-stm/tests/test_bench_pipeline.py
@@ -7,7 +7,6 @@ surfacing integration, and regression gates.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from pathlib import Path
@@ -22,7 +21,6 @@ from memtomem_stm.proxy.compression import (
     FieldExtractCompressor,
     HybridCompressor,
     TruncateCompressor,
-    auto_select_strategy,
 )
 from memtomem_stm.proxy.config import CleaningConfig, CompressionStrategy
 from memtomem_stm.proxy.metrics import CallMetrics, TokenTracker
@@ -34,12 +32,9 @@ from bench.harness import (
     BenchResult,
     BenchTask,
     ComparisonReport,
-    CurvePoint,
     QAPair,
     SelectiveResult,
-    StageBreakdown,
     StageMetrics,
-    StageScore,
     StrategyResult,
     SurfacingValue,
     resolve_auto_strategy,
@@ -59,10 +54,8 @@ from bench.tasks import (
     CODE_FILE,
     DEPLOY_MEMORIES,
     HTML_MIXED,
-    LARGE_DIFF_OUTPUT,
     MARKDOWN_WITH_LINKS,
     MEETING_NOTES,
-    MULTILINGUAL_KR_EN,
     OPTIMAL_STRATEGIES,
     SHORT_RESPONSE,
     TASK_CATEGORIES,
@@ -100,8 +93,6 @@ from bench.datasets_expanded import (
 from bench.llm_judge import (
     LLMJudge,
     LLMJudgeResult,
-    JudgeDimension,
-    CorrelationResult,
     compute_correlation,
 )
 from bench.stats import (
@@ -113,8 +104,6 @@ from bench.stats import (
     format_latex_table,
     format_strategy_table,
     ConfidenceInterval,
-    WilcoxonResult,
-    CategoryStats,
     BenchmarkSummary,
 )
 
@@ -205,10 +194,10 @@ def _make_surfacing_config(**overrides) -> SurfacingConfig:
     return SurfacingConfig(**defaults)
 
 
-def _make_search_pipeline(results=None):
-    pipeline = AsyncMock()
-    pipeline.search = AsyncMock(return_value=(results or [], {}))
-    return pipeline
+def _make_mcp_adapter(results=None):
+    adapter = AsyncMock()
+    adapter.search = AsyncMock(return_value=(results or [], {}))
+    return adapter
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -700,8 +689,8 @@ class TestSurfacingIntegration:
             ),
         ]
         config = _make_surfacing_config()
-        pipeline = _make_search_pipeline(memories)
-        engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+        pipeline = _make_mcp_adapter(memories)
+        engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
 
         h = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
@@ -723,8 +712,8 @@ class TestSurfacingIntegration:
             for i in range(3)
         ]
         config = _make_surfacing_config()
-        pipeline = _make_search_pipeline(memories)
-        engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+        pipeline = _make_mcp_adapter(memories)
+        engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
 
         h = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
@@ -1074,7 +1063,6 @@ class TestProxyManagerIntegration:
         return ProxyManager(config=config, tracker=tracker)
 
     def _inject_mock_upstream(self, manager, server_name, response_text):
-        from dataclasses import dataclass as _dc
         from unittest.mock import AsyncMock, MagicMock
 
         from memtomem_stm.proxy.manager import UpstreamConnection
@@ -1281,8 +1269,8 @@ class TestStageBreakdown:
             ),
         ]
         config = _make_surfacing_config()
-        pipeline = _make_search_pipeline(memories)
-        engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+        pipeline = _make_mcp_adapter(memories)
+        engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
         h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
 
         task = [t for t in get_all_tasks() if t.task_id == "code_file_large"][0]
@@ -1366,8 +1354,8 @@ class TestSurfacingValue:
             for i, m in enumerate(AUTH_MEMORIES)
         ]
         config = _make_surfacing_config()
-        pipeline = _make_search_pipeline(memories)
-        engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+        pipeline = _make_mcp_adapter(memories)
+        engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
 
         h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         value = await h.measure_surfacing_value(task)
@@ -1388,8 +1376,8 @@ class TestSurfacingValue:
             for i, m in enumerate(DEPLOY_MEMORIES)
         ]
         config = _make_surfacing_config()
-        pipeline = _make_search_pipeline(memories)
-        engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+        pipeline = _make_mcp_adapter(memories)
+        engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
 
         h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
         value = await h.measure_surfacing_value(task)
@@ -1413,8 +1401,8 @@ class TestSurfacingValue:
                 for m in (task.surfacing_memories or [])
             ]
             config = _make_surfacing_config()
-            pipeline = _make_search_pipeline(memories)
-            engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+            pipeline = _make_mcp_adapter(memories)
+            engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
             h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
             value = await h.measure_surfacing_value(task)
             # Surfacing should never reduce quality (it only adds content)
@@ -1518,8 +1506,8 @@ class TestDistractorRobustness:
                 for m in task.surfacing_memories
             ]
             config = _make_surfacing_config()
-            pipeline = _make_search_pipeline(memories)
-            engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+            pipeline = _make_mcp_adapter(memories)
+            engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
             h = BenchHarness(
                 cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
             )
@@ -1538,8 +1526,8 @@ class TestDistractorRobustness:
             for i, m in enumerate(task.surfacing_memories)
         ]
         config = _make_surfacing_config()
-        pipeline = _make_search_pipeline(memories)
-        engine = SurfacingEngine(config=config, search_pipeline=pipeline)
+        pipeline = _make_mcp_adapter(memories)
+        engine = SurfacingEngine(config=config, mcp_adapter=pipeline)
         h = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
         )
@@ -1559,7 +1547,7 @@ class TestDistractorRobustness:
             for m in AUTH_MEMORIES
         ]
         config = _make_surfacing_config()
-        clean_engine = SurfacingEngine(config=config, search_pipeline=_make_search_pipeline(clean_mems))
+        clean_engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(clean_mems))
         h_clean = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=clean_engine, judge=judge
         )
@@ -1571,7 +1559,7 @@ class TestDistractorRobustness:
             FakeSearchResult(chunk=FakeChunk(content=m), score=0.5)
             for m in DISTRACTOR_MEMORIES_AUTH
         ]
-        noisy_engine = SurfacingEngine(config=config, search_pipeline=_make_search_pipeline(noisy_mems))
+        noisy_engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(noisy_mems))
         h_noisy = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=noisy_engine, judge=judge
         )
@@ -1617,7 +1605,7 @@ class TestMultihop:
             for i, m in enumerate(MULTIHOP_MEMORIES)
         ]
         config = _make_surfacing_config()
-        engine = SurfacingEngine(config=config, search_pipeline=_make_search_pipeline(memories))
+        engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
         h = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
         )
@@ -1635,7 +1623,7 @@ class TestMultihop:
             for i, m in enumerate(MULTIHOP_MEMORIES)
         ]
         config = _make_surfacing_config()
-        engine = SurfacingEngine(config=config, search_pipeline=_make_search_pipeline(memories))
+        engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
         h = BenchHarness(
             cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge
         )
@@ -1739,7 +1727,7 @@ class TestStructuredDatasets:
                 for i, m in enumerate(task.surfacing_memories)
             ]
             config = _make_surfacing_config()
-            engine = SurfacingEngine(config=config, search_pipeline=_make_search_pipeline(memories))
+            engine = SurfacingEngine(config=config, mcp_adapter=_make_mcp_adapter(memories))
             h = BenchHarness(cleaner=cleaner, compressor=truncate, surfacing_engine=engine, judge=judge)
             value = await h.measure_surfacing_value(task)
             assert value.qa_delta > 0, f"{task.task_id}: surfacing added no QA answers"
@@ -2196,7 +2184,7 @@ class TestExpandedDatasets:
             ]
             config = _make_surfacing_config()
             engine = SurfacingEngine(
-                config=config, search_pipeline=_make_search_pipeline(memories)
+                config=config, mcp_adapter=_make_mcp_adapter(memories)
             )
             h = BenchHarness(
                 cleaner=cleaner, compressor=truncate,

--- a/packages/memtomem-stm/tests/test_bench_report.py
+++ b/packages/memtomem-stm/tests/test_bench_report.py
@@ -12,7 +12,7 @@ from memtomem_stm.proxy.cleaning import DefaultContentCleaner
 from memtomem_stm.proxy.compression import TruncateCompressor
 
 from bench.datasets_expanded import full_benchmark_suite, full_category_map
-from bench.harness import BenchHarness, ComparisonReport
+from bench.harness import BenchHarness
 from bench.judge import RuleBasedJudge
 from bench.stats import compute_summary
 

--- a/packages/memtomem-stm/tests/test_config_persistence.py
+++ b/packages/memtomem-stm/tests/test_config_persistence.py
@@ -4,11 +4,9 @@ from __future__ import annotations
 
 import json
 import time
-from pathlib import Path
 
-import pytest
 
-from memtomem_stm.proxy.config import ProxyConfig, ProxyConfigLoader, CompressionStrategy
+from memtomem_stm.proxy.config import ProxyConfig, ProxyConfigLoader
 from memtomem_stm.proxy.metrics import CallMetrics, TokenTracker
 from memtomem_stm.proxy.metrics_store import MetricsStore
 from memtomem_stm.proxy.privacy import contains_sensitive_content

--- a/packages/memtomem-stm/tests/test_context_window.py
+++ b/packages/memtomem-stm/tests/test_context_window.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import pytest
 
 from memtomem_stm.proxy.config import (
     MODEL_CONTEXT_WINDOWS,

--- a/packages/memtomem-stm/tests/test_cross_session_dedup.py
+++ b/packages/memtomem-stm/tests/test_cross_session_dedup.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
 
-import pytest
 
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.engine import SurfacingEngine
@@ -64,10 +63,10 @@ def _make_config(**overrides) -> SurfacingConfig:
     return SurfacingConfig(**defaults)
 
 
-def _make_search_pipeline(results=None):
-    pipeline = AsyncMock()
-    pipeline.search = AsyncMock(return_value=(results or [], {}))
-    return pipeline
+def _make_mcp_adapter(results=None):
+    adapter = AsyncMock()
+    adapter.search = AsyncMock(return_value=(results or [], {}))
+    return adapter
 
 
 LONG_RESPONSE = "x" * 200
@@ -208,7 +207,7 @@ class TestCrossSessionDedup:
         ]
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
             feedback_tracker=tracker,
         )
 
@@ -234,7 +233,7 @@ class TestCrossSessionDedup:
         results = [FakeSearchResult(chunk=chunk, score=0.5)]
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
             feedback_tracker=tracker,
         )
 
@@ -266,7 +265,7 @@ class TestCrossSessionDedup:
 
         engine = SurfacingEngine(
             config=_make_config(dedup_ttl_seconds=500),
-            search_pipeline=_make_search_pipeline([]),
+            mcp_adapter=_make_mcp_adapter([]),
             feedback_tracker=tracker,
         )
 
@@ -288,7 +287,7 @@ class TestCrossSessionDedup:
 
         engine = SurfacingEngine(
             config=_make_config(dedup_ttl_seconds=0),
-            search_pipeline=_make_search_pipeline([]),
+            mcp_adapter=_make_mcp_adapter([]),
             feedback_tracker=tracker,
         )
 
@@ -302,7 +301,7 @@ class TestCrossSessionDedup:
         results = [FakeSearchResult(chunk=chunk, score=0.5)]
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
         )
 
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)

--- a/packages/memtomem-stm/tests/test_effectiveness.py
+++ b/packages/memtomem-stm/tests/test_effectiveness.py
@@ -11,11 +11,7 @@ These tests verify that STM delivers actual value:
 
 from __future__ import annotations
 
-import time
-from pathlib import Path
-from unittest.mock import AsyncMock
 
-import pytest
 
 from memtomem_stm.proxy.cleaning import DefaultContentCleaner
 from memtomem_stm.proxy.compression import (
@@ -488,155 +484,12 @@ class TestAutoTunerColdStart:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-class TestFeedbackBoost:
-    """Verify helpful feedback boosts memory access count for future search ranking."""
-
-    async def test_helpful_feedback_increments_access(self):
-        """'helpful' rating increments access_count on surfaced memories."""
-        from dataclasses import dataclass
-        from pathlib import Path
-        from uuid import uuid4
-
-        from memtomem_stm.surfacing.config import SurfacingConfig
-        from memtomem_stm.surfacing.engine import SurfacingEngine
-
-        # Mock storage with increment_access tracking
-        mock_storage = AsyncMock()
-        mock_storage.increment_access = AsyncMock()
-        mock_storage.scratch_list = AsyncMock(return_value=[])
-
-        # Mock search pipeline
-        @dataclass
-        class FakeMeta:
-            source_file: Path = Path("/test.md")
-            namespace: str = "default"
-
-        @dataclass
-        class FakeChunk:
-            id: str = ""
-            content: str = "test memory"
-            metadata: FakeMeta = None
-            def __post_init__(self):
-                if not self.id: self.id = str(uuid4())
-                if not self.metadata: self.metadata = FakeMeta()
-
-        @dataclass
-        class FakeResult:
-            chunk: FakeChunk = None
-            score: float = 0.5
-            rank: int = 1
-            def __post_init__(self):
-                if not self.chunk: self.chunk = FakeChunk()
-
-        chunk = FakeChunk()
-        results = [FakeResult(chunk=chunk)]
-        pipeline = AsyncMock()
-        pipeline.search = AsyncMock(return_value=(results, {}))
-
-        config = SurfacingConfig(
-            enabled=True, min_response_chars=10, cooldown_seconds=0,
-            max_surfacings_per_minute=1000, auto_tune_enabled=False,
-            include_session_context=False, fire_webhook=False,
-            feedback_enabled=True,
-        )
-
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmp:
-            tracker = FeedbackTracker(config, Path(tmp) / "fb.db")
-            engine = SurfacingEngine(
-                config, search_pipeline=pipeline,
-                storage=mock_storage, feedback_tracker=tracker,
-            )
-
-            # Trigger surfacing to get a surfacing_id
-            response = "x" * 200
-            output = await engine.surface(
-                "gh", "read_file",
-                {"path": "/src/app.py", "_context_query": "Flask authentication"},
-                response,
-            )
-            assert "Relevant Memories" in output
-
-            # Extract surfacing_id from output
-            import re
-            match = re.search(r"Surfacing ID: (\w+)", output)
-            assert match, "Surfacing ID should be in output"
-            sid = match.group(1)
-
-            # Give helpful feedback
-            result = await engine.handle_feedback(sid, "helpful")
-            assert "helpful" in result.lower() or "recorded" in result.lower()
-
-            # Verify access_count was incremented
-            mock_storage.increment_access.assert_called_once()
-            called_ids = mock_storage.increment_access.call_args[0][0]
-            assert len(called_ids) >= 1
-
-    async def test_double_helpful_only_boosts_once(self):
-        """Same surfacing rated helpful twice → access_count incremented only once."""
-        from pathlib import Path
-        from unittest.mock import AsyncMock
-
-        from memtomem_stm.surfacing.config import SurfacingConfig
-        from memtomem_stm.surfacing.engine import SurfacingEngine
-
-        mock_storage = AsyncMock()
-        mock_storage.increment_access = AsyncMock()
-
-        config = SurfacingConfig(
-            enabled=True, auto_tune_enabled=False, feedback_enabled=True,
-        )
-
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmp:
-            tracker = FeedbackTracker(config, Path(tmp) / "fb.db")
-            engine = SurfacingEngine(
-                config, storage=mock_storage, feedback_tracker=tracker,
-            )
-
-            # Register event via tracker (goes to same store engine uses)
-            from uuid import uuid4
-            mid = str(uuid4())
-            tracker.record_surfacing("dup-id", "gh", "read_file", "query", [mid], [0.5])
-
-            r1 = await engine.handle_feedback("dup-id", "helpful")
-            r2 = await engine.handle_feedback("dup-id", "helpful")
-
-            assert "recorded" in r1.lower() or "helpful" in r1.lower()
-            # Second call may record feedback but should NOT boost again
-            assert mock_storage.increment_access.call_count == 1
-
-    async def test_not_relevant_does_not_boost(self):
-        """'not_relevant' rating does NOT increment access_count."""
-        from pathlib import Path
-        from unittest.mock import AsyncMock
-
-        from memtomem_stm.surfacing.config import SurfacingConfig
-        from memtomem_stm.surfacing.engine import SurfacingEngine
-
-        mock_storage = AsyncMock()
-        mock_storage.increment_access = AsyncMock()
-
-        config = SurfacingConfig(
-            enabled=True, auto_tune_enabled=False, feedback_enabled=True,
-        )
-
-        import tempfile
-        with tempfile.TemporaryDirectory() as tmp:
-            tracker = FeedbackTracker(config, Path(tmp) / "fb.db")
-            engine = SurfacingEngine(
-                config, storage=mock_storage, feedback_tracker=tracker,
-            )
-
-            # Record a fake surfacing event
-            from uuid import uuid4
-            tracker.record_surfacing("test-id", "gh", "read_file", "query", [str(uuid4())], [0.5])
-
-            # Give negative feedback
-            await engine.handle_feedback("test-id", "not_relevant")
-
-            # Access should NOT be incremented
-            mock_storage.increment_access.assert_not_called()
+# NOTE: TestFeedbackBoost was removed when STM moved to remote-only LTM access.
+# The previous in-process implementation called SqliteBackend.increment_access
+# directly when a surfacing was rated "helpful". Restoring this behaviour over
+# MCP requires a new core action (mem_increment_access) — tracked as follow-up.
+# Once that lands, this class should be reintroduced using McpClientSearchAdapter
+# instead of a SqliteBackend mock.
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/packages/memtomem-stm/tests/test_extraction.py
+++ b/packages/memtomem-stm/tests/test_extraction.py
@@ -82,28 +82,25 @@ class TestParseFactsJson:
 
 
 class TestExtractHeuristic:
-    def test_extracts_entities(self):
-        text = "Decision: We will use PostgreSQL for the database. Author: John Smith"
-        facts = _extract_heuristic(text, max_facts=10)
-        assert len(facts) > 0
-        categories = {f.category for f in facts}
-        assert "decision" in categories or "person" in categories
+    """Heuristic fallback is currently stubbed (returns empty list).
 
-    def test_respects_max_facts(self):
-        text = (
-            "TODO: fix auth\nTODO: add logging\nTODO: update docs\n"
-            "TODO: refactor\nTODO: test\nTODO: deploy"
-        )
-        facts = _extract_heuristic(text, max_facts=3)
-        assert len(facts) <= 3
+    The previous implementation imported memtomem.tools.entity_extraction,
+    which created an unwanted core dependency. A native STM heuristic is
+    tracked as follow-up work; until then this stub keeps the LLM extractor
+    as the sole extraction path.
+    """
 
-    def test_empty_text(self):
+    def test_stub_returns_empty(self):
+        text = "Decision: PostgreSQL chosen. Author: John Smith. TODO: ship by Friday."
+        assert _extract_heuristic(text, max_facts=10) == []
+
+    def test_stub_handles_empty_text(self):
         assert _extract_heuristic("", max_facts=10) == []
 
-    def test_no_entities(self):
-        facts = _extract_heuristic("just a simple sentence", max_facts=10)
-        # May or may not find entities, but should not crash
-        assert isinstance(facts, list)
+    def test_stub_returns_list_type(self):
+        result = _extract_heuristic("any text", max_facts=3)
+        assert isinstance(result, list)
+        assert len(result) <= 3
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem-stm/tests/test_formatter.py
+++ b/packages/memtomem-stm/tests/test_formatter.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from uuid import uuid4
 
-import pytest
 
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.formatter import SurfacingFormatter

--- a/packages/memtomem-stm/tests/test_information_loss.py
+++ b/packages/memtomem-stm/tests/test_information_loss.py
@@ -12,9 +12,7 @@ can still do its job with the compressed output.
 from __future__ import annotations
 
 import json
-import re
 
-import pytest
 
 from memtomem_stm.proxy.compression import (
     FieldExtractCompressor,

--- a/packages/memtomem-stm/tests/test_latency_percentiles.py
+++ b/packages/memtomem-stm/tests/test_latency_percentiles.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from memtomem_stm.proxy.metrics import CallMetrics, TokenTracker, _percentile
 

--- a/packages/memtomem-stm/tests/test_pending_store.py
+++ b/packages/memtomem-stm/tests/test_pending_store.py
@@ -6,9 +6,7 @@ import json
 import threading
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock
 
-import pytest
 
 from memtomem_stm.proxy.compression import PendingSelection, SelectiveCompressor
 from memtomem_stm.proxy.pending_store import InMemoryPendingStore, SQLitePendingStore

--- a/packages/memtomem-stm/tests/test_progressive.py
+++ b/packages/memtomem-stm/tests/test_progressive.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import time
 
-import pytest
 
 from memtomem_stm.proxy.compression import PendingSelection
 from memtomem_stm.proxy.config import (

--- a/packages/memtomem-stm/tests/test_proxy_error_paths.py
+++ b/packages/memtomem-stm/tests/test_proxy_error_paths.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/packages/memtomem-stm/tests/test_proxy_manager.py
+++ b/packages/memtomem-stm/tests/test_proxy_manager.py
@@ -2,15 +2,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 
 import pytest
 
 from memtomem_stm.proxy.config import (
     CleaningConfig,
     CompressionStrategy,
-    HybridConfig,
-    ProxyConfig,
     SelectiveConfig,
     ToolOverrideConfig,
     UpstreamServerConfig,

--- a/packages/memtomem-stm/tests/test_remote_ltm_integration.py
+++ b/packages/memtomem-stm/tests/test_remote_ltm_integration.py
@@ -1,0 +1,59 @@
+"""End-to-end: SurfacingEngine talks to a remote MCP server via stdio.
+
+After the move to remote-only LTM access, STM's surfacing engine reaches the
+LTM exclusively through `McpClientSearchAdapter`, which spawns (or connects
+to) a memtomem MCP server over stdio. This test exercises that path against a
+tiny fake MCP server (_fake_memtomem_server.py) so the integration runs in
+under a second and doesn't require memtomem core to be installed.
+
+What this proves:
+1. McpClientSearchAdapter can spawn and initialise a child stdio MCP process.
+2. SurfacingEngine routes search through the adapter only — there is no
+   in-process SearchPipeline fallback path anymore.
+3. The canned hits returned by the child server flow back through the
+   adapter, the surfacing pipeline, and into the injected response.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from memtomem_stm.surfacing.config import SurfacingConfig
+from memtomem_stm.surfacing.engine import SurfacingEngine
+from memtomem_stm.surfacing.mcp_client import McpClientSearchAdapter
+
+_FAKE_SERVER = Path(__file__).parent / "_fake_memtomem_server.py"
+
+LONG_RESPONSE = "x" * 200
+VALID_ARGS = {"path": "src/auth.py", "_context_query": "JWT authentication"}
+
+
+@pytest.mark.asyncio
+async def test_surfacing_via_remote_stdio_mcp_server():
+    config = SurfacingConfig(
+        enabled=True,
+        min_response_chars=10,
+        cooldown_seconds=0,
+        max_surfacings_per_minute=1000,
+        auto_tune_enabled=False,
+        include_session_context=False,
+        fire_webhook=False,
+        feedback_enabled=False,
+        ltm_mcp_command=sys.executable,
+        ltm_mcp_args=[str(_FAKE_SERVER)],
+    )
+
+    adapter = McpClientSearchAdapter(config)
+    await adapter.start()
+    try:
+        engine = SurfacingEngine(config, mcp_adapter=adapter)
+        output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
+    finally:
+        await adapter.stop()
+
+    assert "Relevant Memories" in output, output
+    # Canned content from the fake server should land in the surfaced response
+    assert "JWT authentication" in output

--- a/packages/memtomem-stm/tests/test_stm_integration.py
+++ b/packages/memtomem-stm/tests/test_stm_integration.py
@@ -7,15 +7,13 @@ from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
-import pytest
 
 from memtomem_stm.proxy.cleaning import DefaultContentCleaner
 from memtomem_stm.proxy.compression import HybridCompressor, SelectiveCompressor
-from memtomem_stm.proxy.config import CleaningConfig, HybridConfig, SelectiveConfig
+from memtomem_stm.proxy.config import CleaningConfig
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.engine import SurfacingEngine
 from memtomem_stm.surfacing.feedback import AutoTuner, FeedbackTracker
-from memtomem_stm.surfacing.feedback_store import FeedbackStore
 
 
 @dataclass
@@ -82,7 +80,7 @@ class TestFullPipeline:
                 include_session_context=False,
                 fire_webhook=False,
             ),
-            search_pipeline=AsyncMock(search=AsyncMock(return_value=(results, {}))),
+            mcp_adapter=AsyncMock(search=AsyncMock(return_value=(results, {}))),
         )
         final = await engine.surface(
             "api", "read_file",

--- a/packages/memtomem-stm/tests/test_stm_remaining.py
+++ b/packages/memtomem-stm/tests/test_stm_remaining.py
@@ -374,7 +374,7 @@ class TestMcpClientSearchAdapter:
     def test_init_stores_config(self) -> None:
         from memtomem_stm.surfacing.config import SurfacingConfig
 
-        cfg = SurfacingConfig(ltm_mode="mcp_client", ltm_mcp_command="test-server")
+        cfg = SurfacingConfig(ltm_mcp_command="test-server")
         adapter = McpClientSearchAdapter(cfg)
         assert adapter._config is cfg
         assert adapter._session is None

--- a/packages/memtomem-stm/tests/test_stress_concurrency.py
+++ b/packages/memtomem-stm/tests/test_stress_concurrency.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
-import pytest
 
 from memtomem_stm.proxy.config import (
     CompressionStrategy,

--- a/packages/memtomem-stm/tests/test_surfacing_engine.py
+++ b/packages/memtomem-stm/tests/test_surfacing_engine.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
-import pytest
 
 from memtomem_stm.surfacing.config import SurfacingConfig
 from memtomem_stm.surfacing.engine import SurfacingEngine
@@ -61,10 +60,11 @@ def _make_config(**overrides) -> SurfacingConfig:
     return SurfacingConfig(**defaults)
 
 
-def _make_search_pipeline(results: list[FakeSearchResult] | None = None):
-    pipeline = AsyncMock()
-    pipeline.search = AsyncMock(return_value=(results or [], {}))
-    return pipeline
+def _make_mcp_adapter(results: list[FakeSearchResult] | None = None):
+    """Build a mock McpClientSearchAdapter that returns the given results."""
+    adapter = AsyncMock()
+    adapter.search = AsyncMock(return_value=(results or [], {}))
+    return adapter
 
 
 LONG_RESPONSE = "x" * 200  # above min_response_chars=10
@@ -81,7 +81,7 @@ class TestSurfacingBasic:
         results = [FakeSearchResult(chunk=FakeChunk(content="Flask chosen"), score=0.5)]
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
         )
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "Relevant Memories" in output
@@ -90,7 +90,7 @@ class TestSurfacingBasic:
     async def test_empty_results_returns_original(self):
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline([]),
+            mcp_adapter=_make_mcp_adapter([]),
         )
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert output == LONG_RESPONSE
@@ -98,22 +98,16 @@ class TestSurfacingBasic:
     async def test_disabled_returns_original(self):
         engine = SurfacingEngine(
             config=_make_config(enabled=False),
-            search_pipeline=_make_search_pipeline([FakeSearchResult(FakeChunk(), 0.9)]),
+            mcp_adapter=_make_mcp_adapter([FakeSearchResult(FakeChunk(), 0.9)]),
         )
         output = await engine.surface("gh", "tool", {}, LONG_RESPONSE)
         assert output == LONG_RESPONSE
-
-    async def test_no_search_pipeline_returns_original(self):
-        engine = SurfacingEngine(config=_make_config())
-        output = await engine.surface("gh", "tool", {}, LONG_RESPONSE)
-        assert output == LONG_RESPONSE
-
 
 class TestSurfacingGating:
     async def test_short_response_skipped(self):
         engine = SurfacingEngine(
             config=_make_config(min_response_chars=1000),
-            search_pipeline=_make_search_pipeline([FakeSearchResult(FakeChunk(), 0.9)]),
+            mcp_adapter=_make_mcp_adapter([FakeSearchResult(FakeChunk(), 0.9)]),
         )
         output = await engine.surface("gh", "tool", {}, "short")
         assert output == "short"
@@ -121,7 +115,7 @@ class TestSurfacingGating:
     async def test_write_tool_skipped(self):
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline([FakeSearchResult(FakeChunk(), 0.9)]),
+            mcp_adapter=_make_mcp_adapter([FakeSearchResult(FakeChunk(), 0.9)]),
         )
         output = await engine.surface("fs", "write_file", {"path": "x", "_context_query": "test"}, LONG_RESPONSE)
         assert output == LONG_RESPONSE
@@ -129,7 +123,7 @@ class TestSurfacingGating:
     async def test_delete_tool_skipped(self):
         engine = SurfacingEngine(
             config=_make_config(),
-            search_pipeline=_make_search_pipeline([FakeSearchResult(FakeChunk(), 0.9)]),
+            mcp_adapter=_make_mcp_adapter([FakeSearchResult(FakeChunk(), 0.9)]),
         )
         output = await engine.surface("fs", "delete_file", {"path": "x", "_context_query": "test"}, LONG_RESPONSE)
         assert output == LONG_RESPONSE
@@ -140,7 +134,7 @@ class TestSurfacingScoreFilter:
         results = [FakeSearchResult(chunk=FakeChunk(), score=0.01)]
         engine = SurfacingEngine(
             config=_make_config(min_score=0.02),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
         )
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert output == LONG_RESPONSE  # filtered, no injection
@@ -149,7 +143,7 @@ class TestSurfacingScoreFilter:
         results = [FakeSearchResult(chunk=FakeChunk(content="exactly at threshold"), score=0.02)]
         engine = SurfacingEngine(
             config=_make_config(min_score=0.02),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
         )
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "exactly at threshold" in output
@@ -161,7 +155,7 @@ class TestSurfacingScoreFilter:
         ]
         engine = SurfacingEngine(
             config=_make_config(max_results=2),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
         )
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "result-0" in output
@@ -171,23 +165,23 @@ class TestSurfacingScoreFilter:
 
 class TestSurfacingCircuitBreaker:
     async def test_circuit_breaker_opens_after_failures(self):
-        failing_pipeline = AsyncMock()
-        failing_pipeline.search = AsyncMock(side_effect=RuntimeError("boom"))
+        failing_adapter = AsyncMock()
+        failing_adapter.search = AsyncMock(side_effect=RuntimeError("boom"))
 
         engine = SurfacingEngine(
             config=_make_config(circuit_max_failures=2, circuit_reset_seconds=60),
-            search_pipeline=failing_pipeline,
+            mcp_adapter=failing_adapter,
         )
 
         # First 2 failures should still return original (caught by except)
         await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         await engine.surface("gh", "read_file", {"path": "y"}, LONG_RESPONSE)
 
-        # Circuit should now be open — pipeline.search NOT called
-        failing_pipeline.search.reset_mock()
+        # Circuit should now be open — adapter.search NOT called
+        failing_adapter.search.reset_mock()
         output = await engine.surface("gh", "read_file", {"path": "z"}, LONG_RESPONSE)
         assert output == LONG_RESPONSE
-        failing_pipeline.search.assert_not_called()
+        failing_adapter.search.assert_not_called()
 
 
 class TestSurfacingTimeout:
@@ -196,12 +190,12 @@ class TestSurfacingTimeout:
             await asyncio.sleep(10)
             return [], {}
 
-        pipeline = AsyncMock()
-        pipeline.search = slow_search
+        adapter = AsyncMock()
+        adapter.search = slow_search
 
         engine = SurfacingEngine(
             config=_make_config(timeout_seconds=0.1),
-            search_pipeline=pipeline,
+            mcp_adapter=adapter,
         )
         output = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert output == LONG_RESPONSE
@@ -220,7 +214,7 @@ class TestSessionDedup:
         ]
         engine = SurfacingEngine(
             config=_make_config(cooldown_seconds=0),
-            search_pipeline=_make_search_pipeline(results),
+            mcp_adapter=_make_mcp_adapter(results),
         )
 
         out1 = await engine.surface("s", "read_file", VALID_ARGS, LONG_RESPONSE)
@@ -242,19 +236,19 @@ class TestSessionDedup:
 class TestSurfacingCache:
     async def test_cache_hit_skips_search(self):
         results = [FakeSearchResult(chunk=FakeChunk(content="cached memory"), score=0.5)]
-        pipeline = _make_search_pipeline(results)
+        adapter = _make_mcp_adapter(results)
 
         engine = SurfacingEngine(
             config=_make_config(cooldown_seconds=0),
-            search_pipeline=pipeline,
+            mcp_adapter=adapter,
         )
 
         # First call — searches
         out1 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "cached memory" in out1
-        assert pipeline.search.call_count == 1
+        assert adapter.search.call_count == 1
 
         # Second call — cache hit, no search
         out2 = await engine.surface("gh", "read_file", VALID_ARGS, LONG_RESPONSE)
         assert "cached memory" in out2
-        assert pipeline.search.call_count == 1  # not called again
+        assert adapter.search.call_count == 1  # not called again

--- a/packages/memtomem-stm/tests/test_tool_metadata.py
+++ b/packages/memtomem-stm/tests/test_tool_metadata.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-import pytest
 
 from memtomem_stm.proxy.config import (
     ProxyConfig,

--- a/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
@@ -139,7 +139,11 @@ async def _watchdog_history(check_name: str, hours: float) -> None:
 # ── Formatting helpers ─────────────────────────────────────────────
 
 
-_MARKERS = {"ok": click.style("OK", fg="green"), "warning": click.style("WARN", fg="yellow"), "critical": click.style("CRIT", fg="red")}
+_MARKERS = {
+    "ok": click.style("OK", fg="green"),
+    "warning": click.style("WARN", fg="yellow"),
+    "critical": click.style("CRIT", fg="red"),
+}
 
 
 def _status_marker(status: str) -> str:

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -502,11 +502,7 @@ def _merge_short_chunks(
         cur_tokens = _estimate_tokens(c.content)
 
         # Accumulate short chunks by merging forward
-        while (
-            cur_tokens < min_tokens
-            and i + 1 < len(chunks)
-            and _can_merge(c, chunks[i + 1])
-        ):
+        while cur_tokens < min_tokens and i + 1 < len(chunks) and _can_merge(c, chunks[i + 1]):
             nxt = chunks[i + 1]
             nxt_tokens = _estimate_tokens(nxt.content)
             merged_tokens = cur_tokens + nxt_tokens + 1  # +1 for separator

--- a/packages/memtomem/src/memtomem/server/health_checks.py
+++ b/packages/memtomem/src/memtomem/server/health_checks.py
@@ -188,9 +188,7 @@ async def check_full_health_report(app: AppContext) -> HealthSnapshot:
     )
 
 
-async def check_trend_comparison(
-    app: AppContext, store: HealthStore
-) -> HealthSnapshot:
+async def check_trend_comparison(app: AppContext, store: HealthStore) -> HealthSnapshot:
     """Compare current dead_memory_pct to 24h-ago baseline."""
     now = time.time()
     trend = store.get_trend("dead_memory_pct", hours=24.0)
@@ -237,7 +235,12 @@ async def check_db_fragmentation(app: AppContext) -> HealthSnapshot:
     return HealthSnapshot(
         tier="deep",
         check_name="db_fragmentation",
-        value={"page_count": page_count, "freelist": freelist, "frag_pct": frag_pct, "db_mb": db_mb},
+        value={
+            "page_count": page_count,
+            "freelist": freelist,
+            "frag_pct": frag_pct,
+            "db_mb": db_mb,
+        },
         status="warning" if frag_pct > 20 else "ok",
         created_at=now,
     )

--- a/packages/memtomem/src/memtomem/server/health_store.py
+++ b/packages/memtomem/src/memtomem/server/health_store.py
@@ -77,9 +77,7 @@ class HealthStore:
             self._db.commit()
             self._trim()
 
-    def get_latest(
-        self, check_name: str | None = None, limit: int = 1
-    ) -> list[HealthSnapshot]:
+    def get_latest(self, check_name: str | None = None, limit: int = 1) -> list[HealthSnapshot]:
         if self._db is None:
             return []
         if check_name:

--- a/packages/memtomem/src/memtomem/server/health_watchdog.py
+++ b/packages/memtomem/src/memtomem/server/health_watchdog.py
@@ -84,9 +84,7 @@ class HealthWatchdog:
                 await self._run_tier("deep", DEEP_CHECKS)
                 # Trend comparison needs store
                 if self._store:
-                    await self._run_check(
-                        lambda app: check_trend_comparison(app, self._store)
-                    )
+                    await self._run_check(lambda app: check_trend_comparison(app, self._store))
                 last_deep = now
 
             await asyncio.sleep(min(self._config.heartbeat_interval_seconds, 10.0))
@@ -109,13 +107,13 @@ class HealthWatchdog:
                 if self._config.auto_maintenance and self._maintenance:
                     await self._auto_maintain(snapshot)
             elif snapshot.status == "warning":
-                logger.info(
-                    "Health check WARNING: %s — %s", snapshot.check_name, snapshot.value
-                )
+                logger.info("Health check WARNING: %s — %s", snapshot.check_name, snapshot.value)
         except asyncio.TimeoutError:
             logger.warning("Health check timed out: %s", getattr(check_fn, "__name__", "?"))
         except Exception:
-            logger.error("Health check failed: %s", getattr(check_fn, "__name__", "?"), exc_info=True)
+            logger.error(
+                "Health check failed: %s", getattr(check_fn, "__name__", "?"), exc_info=True
+            )
 
     async def _auto_maintain(self, snapshot: HealthSnapshot) -> None:
         if not self._maintenance:

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -145,9 +145,7 @@ async def mem_add(
         import asyncio
 
         asyncio.create_task(
-            app.webhook_manager.fire(
-                "add", {"file": str(target), "chunks_indexed": 1}
-            )
+            app.webhook_manager.fire("add", {"file": str(target), "chunks_indexed": 1})
         )
 
     return result

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -110,7 +110,7 @@ async def mem_add(
 
     # Index as a single chunk — mem_add entries are short and self-contained,
     # so chunking would only split frontmatter from content unnecessarily.
-    chunk = await app.index_engine.index_entry(
+    await app.index_engine.index_entry(
         entry_text,
         target,
         heading_hierarchy=heading_hierarchy,

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -77,7 +77,9 @@ async def mem_status(
         source_files = await app.storage.get_all_source_files()
         orphaned = sum(1 for sf in source_files if not sf.exists())
         if orphaned:
-            lines[-1] = f"Source files:  {stats['total_sources']} ({orphaned} orphaned — run mem_cleanup_orphans)"
+            lines[-1] = (
+                f"Source files:  {stats['total_sources']} ({orphaned} orphaned — run mem_cleanup_orphans)"
+            )
     except Exception:
         pass
 

--- a/packages/memtomem/src/memtomem/web/routes/watchdog.py
+++ b/packages/memtomem/src/memtomem/web/routes/watchdog.py
@@ -39,6 +39,8 @@ async def watchdog_run_now(request: Request) -> JSONResponse:
     """Force an immediate health check run."""
     wd = _get_watchdog(request)
     if wd is None:
-        return JSONResponse({"enabled": False, "message": "watchdog not configured"}, status_code=400)
+        return JSONResponse(
+            {"enabled": False, "message": "watchdog not configured"}, status_code=400
+        )
     results = await wd.run_now()
     return JSONResponse(results)

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -469,8 +469,14 @@ class TestEstimateTokens:
 # ===========================================================================
 
 
+@pytest.mark.ollama
 class TestIndexEntry:
-    """Tests for index_entry — stores a single chunk without chunking."""
+    """Tests for index_entry — stores a single chunk without chunking.
+
+    Marked as `ollama` because index_entry triggers an embedding call against
+    a real Ollama instance; CI's `not ollama` filter excludes it when Ollama
+    is unavailable.
+    """
 
     async def test_basic_entry(self, components, memory_dir):
         """index_entry creates a single chunk with embedding."""


### PR DESCRIPTION
## Summary

- STM의 LTM 접근 path를 두 가지(in-process import / mcp_client)에서 **remote-only via MCP 프로토콜** 단일 path로 통합
- STM이 core 내부 심볼(`SearchPipeline`, `SqliteBackend`, `extract_entities`, `create_components`, `Mem2MemConfig`)에 직접 의존하던 부분을 모두 제거 — 이제 `McpClientSearchAdapter`만이 LTM 통신 통로
- langchain + langgraph 패턴으로 향후 별도 저장소 분리 (`memtomem-stm`) 사전 작업

## Why

STM은 본질적으로 MCP 프록시 게이트웨이입니다 (`ProxyManager`가 임의 개수 upstream MCP server를 받음 — brave-search/github/memtomem 등). 이전엔 memtomem만 in-process import로 특별 취급했는데, 이는 STM이 memtomem-server 역할까지 겸하는 architectural mismatch였습니다. remote-only로 단일화하면:

- STM의 core 의존이 **MCP 프로토콜 한 점**으로 좁혀져 core 내부 리팩토링이 STM을 깨뜨리지 않음
- memtomem 크래시 시에도 STM의 다른 upstream(brave-search 등)은 정상 동작 (fault isolation)
- 향후 `git filter-repo`로 별도 저장소 분리할 때 cross-repo dependency가 깔끔

## Changes

**Removed**:
- `SurfacingEngine.search_pipeline` / `storage` 생성자 인자 (이제 `mcp_adapter` keyword-only required)
- `SurfacingConfig.ltm_mode` 필드 (remote가 유일한 모드)
- `server.py`의 in-process bootstrap 분기 + try/except fallback 로직
- `_extract_heuristic`의 `memtomem.tools.entity_extraction` import (빈 list stub)
- `TestFeedbackBoost` 테스트 클래스 3개 (`SqliteBackend.increment_access` 직접 호출에 의존)
- `_boosted_surfacings` 추적 set (access boost 분기와 함께)

**Added**:
- `tests/_fake_memtomem_server.py` — 가벼운 stdio MCP fake server (32줄)
- `tests/test_remote_ltm_integration.py` — end-to-end integration test, fake server에 child process로 연결해서 SurfacingEngine 동작 검증 (0.36s)

**Updated**:
- `README.md` "LTM Connection Modes" → "LTM Connection" (단일 모드 설명)
- 6개 테스트 파일에서 `_make_search_pipeline` → `_make_mcp_adapter` rename, `search_pipeline=` → `mcp_adapter=` 일괄 전환
- ruff `--fix`로 정리된 unused imports

## Follow-ups (별도 PR)

이 PR은 in-process 전용 부수 기능 3개를 임시 비활성화합니다. 0.1.0 알파에서 사용자 거의 없으므로 안전하지만 후속 작업 필요:

1. **Access boost on \"helpful\" feedback** — core에 `mem_increment_access` mem_do action을 추가한 후, `McpClientSearchAdapter.increment_access(ids)` 메서드로 복원
2. **Session context (working memory) injection** — `McpClientSearchAdapter.scratch_list()` 메서드 추가 (`mem_scratch_get(key=None)` 호출 + 파싱)
3. **Heuristic fact extraction fallback** — STM 자체 정규식 휴리스틱(URL/식별자/명사구) 작성 (현재는 빈 list stub)

## Test plan

- [x] STM 단독 테스트 731 passing (`uv run pytest packages/memtomem-stm/tests/ -m \"not ollama\"`)
- [x] core 단독 테스트 857 passing (regression 0)
- [x] 합쳐서 1588 passing
- [x] 새 integration test 통과 (0.36s)
- [x] STM source ruff clean (`uv run ruff check packages/memtomem-stm/src`)
- [ ] 빈 venv에서 `pip install memtomem-stm` 후 `memtomem-stm` 기동 (Phase 4 PyPI 배포 시)

## Phase roadmap

이 PR은 4단계 분리 작업의 **Phase 1**입니다:

1. **Phase 1 (이 PR)**: STM 코드 리팩토링 — in-process 분기 제거, mcp_adapter 단일 path
2. Phase 2: core 잔여물 정리 — `cli/stm_cmd.py`, `StmProxyConfig`, `web/routes/proxy.py`, `lifespan.py` STM bootstrapping 제거
3. Phase 3: `git filter-repo`로 `packages/memtomem-stm/` → 별도 저장소(`https://github.com/memtomem/memtomem-stm.git`) 추출, 모노레포에서 디렉터리 제거
4. Phase 4: 양쪽 PyPI 배포, lockstep release, compat range

🤖 Generated with [Claude Code](https://claude.com/claude-code)