### PR TITLE
feat(search): add mem_increment_access for external feedback boost

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -156,3 +156,45 @@ async def mem_expand(
             parts.append(f"{header}\n```\n{c.content}\n```")
 
     return "\n\n".join(parts)
+
+
+@register("search")
+async def mem_increment_access(
+    chunk_ids: list[str],
+    ctx: CtxType = None,  # type: ignore[assignment]
+) -> str:
+    """Increment access_count for the given chunks (drives access-frequency boost in search ranking).
+
+    Used by external surfacing systems (e.g. memtomem-stm) to record positive
+    feedback as a future search-ranking boost. Each call increments the count
+    by 1 per chunk; the search pipeline applies a logarithmic transform with
+    ``max_boost`` capping (default 1.5×) so this never produces runaway scores.
+
+    Idempotency / per-event capping is the caller's responsibility — this
+    action just forwards the IDs to storage.
+
+    Args:
+        chunk_ids: List of chunk UUIDs (strings) to boost
+    """
+    app = _get_app(ctx)
+
+    if not chunk_ids:
+        return "No chunk_ids provided."
+
+    valid: list[UUID] = []
+    invalid: list[str] = []
+    for cid in chunk_ids:
+        try:
+            valid.append(UUID(cid))
+        except (ValueError, TypeError):
+            invalid.append(str(cid))
+
+    if not valid:
+        return f"Error: no valid UUIDs in chunk_ids (rejected: {len(invalid)})."
+
+    await app.storage.increment_access(valid)
+
+    msg = f"Incremented access_count for {len(valid)} chunk(s)."
+    if invalid:
+        msg += f" Skipped {len(invalid)} invalid id(s)."
+    return msg

--- a/packages/memtomem/tests/test_context_window.py
+++ b/packages/memtomem/tests/test_context_window.py
@@ -299,6 +299,94 @@ class TestMemExpand:
         assert "not found" in result
 
 
+# ── mem_increment_access action tests ──────────────────────────────────
+
+
+class TestMemIncrementAccess:
+    """Tests for mem_increment_access — used by external surfacing systems
+    (e.g. memtomem-stm) to record positive feedback as a search-ranking boost.
+    """
+
+    async def test_action_registered_in_search_category(self):
+        """The action should be discoverable via the mem_do registry."""
+        from memtomem.server.tool_registry import ACTIONS
+
+        assert "increment_access" in ACTIONS
+        assert ACTIONS["increment_access"].category == "search"
+        assert "chunk_ids" in ACTIONS["increment_access"].params
+
+    async def test_empty_chunk_ids_returns_message(self):
+        """Empty list short-circuits with a friendly message — no storage call."""
+        from memtomem.server.tools.search import mem_increment_access
+
+        app = MagicMock()
+        app.storage.increment_access = AsyncMock()
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            result = await mem_increment_access(chunk_ids=[], ctx=SimpleNamespace())
+
+        assert "No chunk_ids" in result
+        app.storage.increment_access.assert_not_called()
+
+    async def test_all_invalid_uuids_rejected(self):
+        """All-invalid input returns error and never touches storage."""
+        from memtomem.server.tools.search import mem_increment_access
+
+        app = MagicMock()
+        app.storage.increment_access = AsyncMock()
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            result = await mem_increment_access(
+                chunk_ids=["not-a-uuid", "also-bad"],
+                ctx=SimpleNamespace(),
+            )
+
+        assert "no valid UUIDs" in result
+        assert "rejected: 2" in result
+        app.storage.increment_access.assert_not_called()
+
+    async def test_valid_uuids_increments_storage(self):
+        """Valid UUIDs are converted and forwarded to storage.increment_access."""
+        from memtomem.server.tools.search import mem_increment_access
+
+        app = MagicMock()
+        app.storage.increment_access = AsyncMock()
+
+        ids = [str(uuid4()), str(uuid4()), str(uuid4())]
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            result = await mem_increment_access(chunk_ids=ids, ctx=SimpleNamespace())
+
+        assert "3 chunk(s)" in result
+        app.storage.increment_access.assert_awaited_once()
+        called_ids = app.storage.increment_access.call_args.args[0]
+        assert len(called_ids) == 3
+        assert all(isinstance(c, UUID) for c in called_ids)
+
+    async def test_mixed_valid_invalid_partial_increment(self):
+        """Mixed input increments the valid ones and reports the skipped count."""
+        from memtomem.server.tools.search import mem_increment_access
+
+        app = MagicMock()
+        app.storage.increment_access = AsyncMock()
+
+        valid_id = str(uuid4())
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            result = await mem_increment_access(
+                chunk_ids=[valid_id, "not-a-uuid"],
+                ctx=SimpleNamespace(),
+            )
+
+        assert "1 chunk(s)" in result
+        assert "Skipped 1 invalid" in result
+        app.storage.increment_access.assert_awaited_once()
+        called_ids = app.storage.increment_access.call_args.args[0]
+        assert len(called_ids) == 1
+
+
 # ── Formatter tests ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Adds a new ``increment_access`` action under the ``search`` category. External surfacing systems (memtomem-stm) call ``mem_do(action="increment_access", params={"chunk_ids": [...]})`` to record positive feedback as a search-ranking boost.
- The action just forwards parsed UUIDs to the existing ``SqliteBackend.increment_access`` so the established search-pipeline access boost (logarithmic, capped at ``max_boost=1.5×``) handles them on the next search — no new ranking math.
- This is the **core half of follow-up 3** in the STM repo's `project_stm_next_actions.md`: restoring the access boost that was severed when STM moved to remote-only LTM access. The STM-side adapter call lands in a separate PR on memtomem-stm right after this merges.

## Design

- **Internal-only action**: only ``@register("search")``, no ``@mcp.tool()``. Reachable via ``mem_do`` in any tool mode (core/standard/full) without bloating the user-facing tool list.
- **UUID parsing in the action layer**: invalid IDs are rejected with a count-aware message instead of raising. Mixed valid/invalid input still increments the valid ones and reports the skipped count.
- **Per-event capping is the caller's responsibility**: STM's FeedbackTracker already enforces "at most one boost per surfacing event" — duplicating that here would just hide bugs. The action's contract is "increment everything you're given".

## Test plan

- [x] ``uv run pytest`` — 891 passed (886 → 891, +5 new tests for the action)
- [x] ``uv run ruff check packages/memtomem/src`` + ``ruff format --check`` — clean
- [x] mypy: pre-existing 39 errors unchanged; new code is clean
- [x] Tests live in ``test_context_window.py`` next to the existing ``mem_expand`` mock-based tests, covering: registry discovery, empty input, all-invalid, all-valid (3 chunks), and mixed valid/invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)