### PR TITLE
docs: bump action count (63→64) and test count (886→891)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ For terminal use, install the CLI separately and run `mm init` for an interactiv
 - **🏷️ Namespaces** — organize memories into scoped groups, optional auto-derivation from folder names
 - **🧹 Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
 - **🌐 Web UI** — visual dashboard for search, sources, tags, sessions, health monitoring
-- **🛠️ 72 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing 63 actions in `core` mode (default) for minimal context usage
+- **🛠️ 72 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing 64 actions in `core` mode (default) for minimal context usage
 - **🧠 Optional STM** — proactive memory surfacing via the [memtomem-stm](https://github.com/memtomem/memtomem-stm) companion package (separate repo)
 
 ---
@@ -116,7 +116,7 @@ git clone https://github.com/memtomem/memtomem.git
 cd memtomem
 uv venv --python 3.12 && source .venv/bin/activate
 uv pip install -e "packages/memtomem[all]"
-uv run pytest                            # 886 tests (core only — STM has its own repo)
+uv run pytest                            # 891 tests (core only — STM has its own repo)
 uv run ruff check packages/memtomem/src  # lint
 ```
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -93,7 +93,7 @@ When enabled, search results include surrounding chunks from the same source fil
 |----------|---------|-------------|
 | `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (~32 + `mem_do`), `full` (72) |
 
-In `core` mode, use `mem_do(action="...", params={...})` to access any of the 63 non-core actions. Fewer tools means less context usage for AI agents.
+In `core` mode, use `mem_do(action="...", params={...})` to access any of the 64 non-core actions. Fewer tools means less context usage for AI agents.
 
 ## Querying and Modifying at Runtime
 

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -85,7 +85,7 @@ In **core** tool mode (default), most features are accessed through `mem_do(acti
 - **Maintenance** uses descriptive names: `dedup_scan`, `decay_expire`, `cleanup_orphans`
 - **Analytics** uses short names: `eval`, `activity`, `timeline`, `reflect`
 
-Use `mem_do(action="help")` to see all 63 actions, or `mem_do(action="help", params={"category": "sessions"})` for per-category details with parameter descriptions. Common aliases are supported (e.g. `health_report` → `eval`, `namespace_set` → `ns_set`).
+Use `mem_do(action="help")` to see all 64 actions, or `mem_do(action="help", params={"category": "sessions"})` for per-category details with parameter descriptions. Common aliases are supported (e.g. `health_report` → `eval`, `namespace_set` → `ns_set`).
 
 ---
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -63,7 +63,7 @@ That's it. Your agent now has a long-term memory built from plain markdown files
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
 - **🌐 Web UI** — full-featured SPA dashboard for search, sources, indexing, tags, sessions, health monitoring
-- **🛠️ 72 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing 63 actions in `core` mode (default) for minimal context usage
+- **🛠️ 72 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing 64 actions in `core` mode (default) for minimal context usage
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

PR #7 (`00559c2`) added the `mem_increment_access` action via `@register("search")`, which:
- Bumped the `mem_do` action count from **63 → 64**
- Bumped the test count from **886 → 891** (+5 mock-based tests in `test_context_window.py::TestMemIncrementAccess`)

Five doc references were not updated in that PR. This commit syncs them in 4 files.

## Ground truth (verified via Python import, not grep)

Documentation counts were verified by importing the registry directly — grep over-counts decorators because of dead modules (e.g. `tools/ask.py` has `@mcp.tool()` but is not imported in `server/__init__.py` so it never registers, making the grep \"73\" misleading vs the real \"72\" registered tools).

\`\`\`python
from memtomem.server.tool_registry import ACTIONS
len(ACTIONS)  # → 64

import os; os.environ['MEMTOMEM_TOOL_MODE'] = 'full'
from memtomem.server import mcp
len(mcp._tool_manager._tools)  # → 72
\`\`\`

The \"72 MCP tools\" figure is therefore left unchanged everywhere.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/ -q -m \"not ollama\"\` → 855 passed (855 + 36 ollama deselected = 891)
- [x] \`uv run pytest --collect-only -q\` → 891 tests collected
- [x] \`uv run ruff check packages/memtomem/src\` → 0 errors
- [x] \`uv build\` from packages/memtomem → sdist + wheel built

🤖 Generated with [Claude Code](https://claude.com/claude-code)