### PR TITLE
ci: add release workflow for PyPI publish via Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Publish
+
+# Publishes the memtomem distribution to PyPI (or TestPyPI for dry-runs)
+# via PyPI Trusted Publishers (OIDC). No API tokens are stored.
+#
+# Tag conventions:
+#   v0.1.0          → PyPI                (production)
+#   test-v0.1.0a1   → TestPyPI            (dry run)
+#
+# Both paths share the same `pypi` GitHub environment, which is gated to
+# tag pushes matching `v*` only (see Settings → Environments → pypi).
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"        # production
+      - "test-v[0-9]*"   # TestPyPI dry-run
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - name: Build distribution
+        working-directory: packages/memtomem
+        run: uv build
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/memtomem/dist/
+
+  publish:
+    name: Publish to ${{ startsWith(github.ref_name, 'test-') && 'TestPyPI' || 'PyPI' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: ${{ startsWith(github.ref_name, 'test-') && 'https://test.pypi.org/p/memtomem' || 'https://pypi.org/p/memtomem' }}
+    permissions:
+      id-token: write   # required for OIDC token
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        if: ${{ !startsWith(github.ref_name, 'test-') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to TestPyPI
+        if: ${{ startsWith(github.ref_name, 'test-') }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\` that builds memtomem and publishes it to PyPI (or TestPyPI for dry-runs) via PyPI Trusted Publishers (OIDC). No API tokens are stored in the repo.

## Tag conventions

| Tag | Target |
|---|---|
| \`v0.1.0\`, \`v0.2.0\`, ... | PyPI (production) |
| \`test-v0.1.0a1\`, \`test-v0.1.0rc1\`, ... | TestPyPI (dry run) |

Both run inside the \`pypi\` GitHub environment, gated to \`v*\` tags only with required reviewer approval.

## Workflow

1. **build** — \`uv build\` from \`packages/memtomem\` → uploads sdist+wheel as job artifact
2. **publish** — downloads the artifact, dispatches to PyPI or TestPyPI based on tag prefix via \`pypa/gh-action-pypi-publish@release/v1\`

## Verification (after merge)

1. Tag a TestPyPI dry run: \`git tag test-v0.1.0a1 && git push origin test-v0.1.0a1\`
2. Approve the deployment in GitHub (Actions → workflow run → Review deployments)
3. Confirm the package appears at https://test.pypi.org/p/memtomem
4. Tag production: \`git tag v0.1.0 && git push origin v0.1.0\`

## Companion PR

Pairs with memtomem/memtomem-stm release.yml PR. Core publishes first (it's a runtime dependency of memtomem-stm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)