### PR TITLE
fix(release): merge build and publish into a single job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,14 @@ name: Publish
 #   v0.1.0          → PyPI                (production)
 #   test-v0.1.0a1   → TestPyPI            (dry run)
 #
-# Both paths share the same `pypi` GitHub environment, which is gated to
-# tag pushes matching `v*` only (see Settings → Environments → pypi).
+# Both paths share the same `pypi` GitHub environment, gated to tag
+# pushes matching `v*` and `test-v*` only.
+#
+# Build and publish run in a single job — actions/upload-artifact@v4
+# scopes artifacts per run-attempt, so a partial rerun cannot reuse the
+# previous attempt's build artifact. Keeping everything in one job means
+# every (re)run rebuilds locally and avoids the cross-attempt artifact
+# lookup entirely.
 
 on:
   push:
@@ -17,9 +23,14 @@ on:
       - "test-v[0-9]*"   # TestPyPI dry-run
 
 jobs:
-  build:
-    name: Build sdist + wheel
+  publish:
+    name: Build and publish to ${{ startsWith(github.ref_name, 'test-') && 'TestPyPI' || 'PyPI' }}
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: ${{ startsWith(github.ref_name, 'test-') && 'https://test.pypi.org/p/memtomem' || 'https://pypi.org/p/memtomem' }}
+    permissions:
+      id-token: write   # required for OIDC token
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
@@ -28,32 +39,14 @@ jobs:
       - name: Build distribution
         working-directory: packages/memtomem
         run: uv build
-      - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: packages/memtomem/dist/
-
-  publish:
-    name: Publish to ${{ startsWith(github.ref_name, 'test-') && 'TestPyPI' || 'PyPI' }}
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: ${{ startsWith(github.ref_name, 'test-') && 'https://test.pypi.org/p/memtomem' || 'https://pypi.org/p/memtomem' }}
-    permissions:
-      id-token: write   # required for OIDC token
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
       - name: Publish to PyPI
         if: ${{ !startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/memtomem/dist
       - name: Publish to TestPyPI
         if: ${{ startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          packages-dir: packages/memtomem/dist


### PR DESCRIPTION
## Problem

The two-job design (\`build\` → upload-artifact → download-artifact → \`publish\`) added in #9 breaks under any kind of rerun because \`actions/upload-artifact@v4\` scopes artifacts **per run attempt**, not per run.

- **\`gh run rerun --failed\`** skips \`build\`, leaving the new attempt with no artifact in scope.
- **\`gh run rerun\`** (full) rebuilds, but the new build artifact lives in a new attempt namespace, which the publish step still can't find under the artifact name without explicit cross-attempt lookup.

Discovered while running the first TestPyPI dry-run for \`v0.1.0\` — both partial and full reruns hit:

\`\`\`
Publish to TestPyPI
Unable to download artifact(s): Artifact not found for name: dist
\`\`\`

## Fix

Merge \`build\` and \`publish\` into one job. The artifact handoff is removed entirely — every (re)run rebuilds locally and the resulting \`packages/memtomem/dist/\` is consumed by \`pypa/gh-action-pypi-publish\` in the same job.

### Trade-off

The environment's \`Required reviewers\` gate now blocks \`build\` too, but build is fast (~20s) and reviewer approval happens once per (re)run anyway.

## Test plan

- [ ] After merge, push \`test-v0.1.0a2\` tag → workflow runs → review deployment → publish reaches TestPyPI

## Companion PR

Pairs with memtomem/memtomem-stm fix PR (same architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)