### PR TITLE
fix(release): build dist at workspace root + skip-existing on retry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ name: Publish
 # previous attempt's build artifact. Keeping everything in one job means
 # every (re)run rebuilds locally and avoids the cross-attempt artifact
 # lookup entirely.
+#
+# `uv build` is given an explicit source path AND --out-dir so the
+# resulting dist/ lands at the workspace root regardless of monorepo
+# layout (uv otherwise picks the workspace root, not the cwd, when
+# building a workspace member).
 
 on:
   push:
@@ -37,16 +42,17 @@ jobs:
         with:
           version: "latest"
       - name: Build distribution
-        working-directory: packages/memtomem
-        run: uv build
+        run: uv build packages/memtomem --out-dir dist
       - name: Publish to PyPI
         if: ${{ !startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages-dir: packages/memtomem/dist
+          packages-dir: dist
+          skip-existing: true
       - name: Publish to TestPyPI
         if: ${{ startsWith(github.ref_name, 'test-') }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          packages-dir: packages/memtomem/dist
+          packages-dir: dist
+          skip-existing: true


### PR DESCRIPTION
## Two fixes from the second TestPyPI dry-run

### 1. Build path mismatch — \`FileNotFoundError\` on publish

\`uv build\` produced \`dist/\` at the **workspace root** regardless of the step's \`working-directory: packages/memtomem\`, because memtomem is a uv workspace and uv resolves the workspace root for build output. The publish step looked under \`packages/memtomem/dist/\`, which never existed:

\`\`\`
FileNotFoundError: [Errno 2] No such file or directory: '/github/workspace/packages/memtomem/dist'
\`\`\`

The build log confirmed dist/ landed at the root:
\`\`\`
Successfully built /home/runner/work/memtomem/memtomem/dist/memtomem-0.1.0.tar.gz
Successfully built /home/runner/work/memtomem/memtomem/dist/memtomem-0.1.0-py3-none-any.whl
\`\`\`

**Fix**: pass source path AND \`--out-dir\` explicitly so the dist lands where we tell it, and align the publish step:
\`\`\`yaml
- run: uv build packages/memtomem --out-dir dist
- uses: pypa/gh-action-pypi-publish@release/v1
  with:
    packages-dir: dist
\`\`\`

### 2. \`skip-existing: true\` for retry safety

PyPI/TestPyPI files are immutable: a partial upload (e.g. wheel succeeded, sdist 500'd) leaves the next retry hitting \"400 File already exists\" because uv build is largely reproducible — the same source produces a byte-identical sdist with the same blake2_256 hash that's already on the index.

\`skip-existing: true\` tells \`pypa/gh-action-pypi-publish\` to swallow the conflict and treat existing files as no-ops.

**Production behaviour is unaffected**: on a clean version bump no files exist server-side yet.

## Test plan

- [ ] After merge, push \`test-v0.1.0a3\` → workflow runs → review deployment → publish reaches https://test.pypi.org/p/memtomem

🤖 Generated with [Claude Code](https://claude.com/claude-code)