### PR TITLE
chore: add Issues URL to project metadata

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -50,6 +50,7 @@ memtomem-web = "memtomem.web.app:main"
 [project.urls]
 Homepage = "https://github.com/memtomem/memtomem"
 Repository = "https://github.com/memtomem/memtomem"
+Issues = "https://github.com/memtomem/memtomem/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary

Adds an \`Issues\` entry to \`pyproject.toml [project.urls]\` so PyPI's "Project links" sidebar exposes a direct path to the issue tracker. Existing \`Homepage\` and \`Repository\` URLs are correct (already point at memtomem/memtomem) and unchanged.

## Diff

\`\`\`diff
 [project.urls]
 Homepage = "https://github.com/memtomem/memtomem"
 Repository = "https://github.com/memtomem/memtomem"
+Issues = "https://github.com/memtomem/memtomem/issues"
\`\`\`

No version bump — fix lands on main and ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)