### PR TITLE
chore(release): v0.1.4 — STM decoupling wrap-up + refactor + docs drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.4] — 2026-04-11
+
 ### Added
 - `examples/notebooks/` — six scenario-based Jupyter notebooks that walk
   through the Python API (`create_components()`, `search_pipeline.search()`,
@@ -33,7 +35,48 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `MEMTOMEM_TOOL_MODE` env var and which tutorial steps use the `mem_do`
   routing vs top-level calls.
 
+### Changed
+- `SqliteBackend.clear_embedding_mismatch()` is now a public method
+  (refactor 15136a0). The `needs_reindex_ids` and `needs_embed_ids`
+  tracking sets were previously reset via direct attribute mutation
+  through the protected `_backend` accessor, which leaked internal
+  state across module boundaries. Four writers (`_finalize_write`,
+  `_reset_all_state`, `web/app.py`'s force-reindex handler, and the
+  FTS rebuild path) now go through the public method, and the
+  protected-attribute touch is no longer needed outside storage.
+- STM decoupling CSS sweep — removed ~164 lines of orphan dashboard
+  CSS from `packages/memtomem/src/memtomem/web/static/style.css`.
+  The `.stm-*` block (59 lines, #15) and the parallel `.proxy-*`
+  plus `.trend-*` block (105 lines, #16, covering Proxy Settings,
+  Proxy Diff View, and Compression Trend Chart) had no HTML/JS
+  consumers — any rendering path for these selectors had already
+  moved to the external `memtomem-stm` package when STM was split
+  out. The six `--bg-*` / `--text-*` CSS aliases they previously
+  shared are retained since `.harness-*` sections still consume
+  them; the comment on `style.css` line 24 that documented their
+  purpose was rewritten to match the current consumers. The
+  `.health-*` rules are kept intact — `app.js` still uses them for
+  the generic system-health summary, which is unrelated to proxy.
+- `app_lifespan(server: FastMCP)` → `app_lifespan(_server: FastMCP)`
+  in `packages/memtomem/src/memtomem/server/lifespan.py`. The MCP
+  framework requires the parameter in the callback signature but
+  memtomem's lifespan never reads it; the underscore prefix makes
+  the "intentionally unused by framework contract" nature explicit
+  and silences dead-code detectors.
+
 ### Fixed
+- `docs/guides/user-guide.md` tab-overview table listed an **STM**
+  row (`Proxy monitoring — compression metrics, server status, call
+  history (only when STM installed)`) that described the dashboard
+  UI removed with the STM decoupling. The actual
+  `packages/memtomem/src/memtomem/web/static/index.html` has seven
+  tabs (Home, Search, Sources, Index, Tags, Timeline, More) — no
+  STM tab, and the styles backing the removed row were already
+  gone after #15 and #16. Dropped the stale row from the table.
+  The separate "STM: Proactive Memory Surfacing (Optional)" section
+  further down the same file is intentionally kept since it
+  correctly documents the external `memtomem-stm` package as a
+  cross-reference, not a core UI feature.
 - `MemtomemStore.index()` (LangGraph adapter) and the `mm` shell `index`
   command called a nonexistent `IndexEngine.index_directory()` method and
   would crash at runtime. Routed both to `index_path()` and added

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -565,7 +565,6 @@ memtomem-web --port 3000      # custom port
 | **Index** | Trigger indexing, upload files, add memories |
 | **Tags** | Tag cloud, auto-tagging, tag-based browsing |
 | **Timeline** | Chronological view of all chunks |
-| **STM** | Proxy monitoring — compression metrics, server status, call history (only when STM installed) |
 | **More** | Config, namespaces, dedup, decay, export/import, **harness** (sessions, working memory, procedures, health) |
 
 See [Web UI Guide](web-ui.md) for full details.

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.3"
+version = "0.1.4"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -94,7 +94,7 @@ async def _shutdown(watcher: FileWatcher, comp: Components) -> None:
 
 
 @asynccontextmanager
-async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
+async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     _load_dotenv()
     _setup_logging()
 

--- a/uv.lock
+++ b/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- **v0.1.3 → v0.1.4** — 14 commits accumulated, grouped into:
  - STM decoupling wrap-up cleanup (3 PRs including this one): #15 `.stm-*` CSS orphan (59 lines), #16 `.proxy-*` + `.trend-*` CSS orphan (105 lines), + user-guide.md stale STM tab row
  - `SqliteBackend` encapsulation refactor (15136a0) — `clear_embedding_mismatch()` public method, 4 writers migrated
  - Broad docs-vs-source drift sweep (75d7146 / ed6f7ce / c48aff6) across hands-on-tutorial, user-guide, use-cases, agent-memory-guide, claude-code/desktop integrations
  - Six scenario-based Jupyter notebooks under `examples/notebooks/` covering the Python API (hello, index, agent, tune, langgraph, lifecycle)
  - LangGraph `MemtomemStore.index()` + `mm index` CLI fix (nonexistent `index_directory()` → `index_path()`)
  - `app_lifespan` unused `server` param → `_server` (cosmetic, from dead-code audit)

## What's in this PR
3 commits on `release/v0.1.4`:
1. `0f7e820 docs(user-guide): drop stale STM tab row` — addresses docs drift ed6f7ce missed
2. `81c4523 chore(server): rename unused lifespan server param to _server` — cosmetic fix from the vulture audit (was the only true positive at 80% confidence)
3. `bdf49d1 chore(release): v0.1.4` — `pyproject.toml` 0.1.3 → 0.1.4, `uv.lock` regenerated, `CHANGELOG.md` promotes the existing `[Unreleased]` section to `[0.1.4] — 2026-04-11` and augments it with the missing `Changed` / `Fixed` entries

## Verification
- `uv run ruff check packages/memtomem/src` → **All checks passed!** (0 issues)
- `uv run pytest packages/memtomem/tests` → **911 passed in 11.92s** (no regressions across three sessions of edits: #15, #16, and the three commits in this PR)
- `uv run --with vulture vulture packages/memtomem/src/memtomem --min-confidence 80` → **0 findings** (the single true positive from the pre-release audit is now fixed by commit 2)
- `uv lock` → **Updated memtomem v0.1.3 -> v0.1.4** (lockfile in sync)

## Post-merge plan
Once this PR lands:
1. Tag `v0.1.4` on the merge commit and push the tag (triggers PyPI publish workflow via OIDC trusted publisher)
2. `pypi` GitHub Environment approval step — requires `memtomem` account (manual user action, per `reference_memtomem_repo_perms.md`)
3. `gh release create v0.1.4` with generated release notes pointing at the CHANGELOG section
4. Optional: merge `cleanup/*` branches are already deleted; no more post-cleanup needed

## Test plan
- [ ] CI green (lint + typecheck + test)
- [ ] Spot-check `CHANGELOG.md` rendering on GitHub — the new `[0.1.4]` section should be directly under an empty `[Unreleased]`
- [ ] After merge: verify `uv build` produces `memtomem-0.1.4-*.whl` + `memtomem-0.1.4.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)