### PR TITLE
feat(policy): rule-based auto_archive with categorized buckets

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -63,8 +63,7 @@ def _parse_include(include_tuple: tuple[str, ...]) -> set[str]:
                 continue
             if token not in _KNOWN_INCLUDES:
                 raise click.BadParameter(
-                    f"Unknown --include value '{token}'. "
-                    f"Supported: {sorted(_KNOWN_INCLUDES)}"
+                    f"Unknown --include value '{token}'. Supported: {sorted(_KNOWN_INCLUDES)}"
                 )
             values.add(token)
     return values
@@ -99,9 +98,7 @@ def _print_skills_detect(root: Path) -> None:
 def _print_skills_init(root: Path, overwrite: bool) -> None:
     imported = extract_skills_to_canonical(root, overwrite=overwrite)
     if imported:
-        click.secho(
-            f"  Imported {len(imported)} skill(s) → .memtomem/skills/", fg="green"
-        )
+        click.secho(f"  Imported {len(imported)} skill(s) → .memtomem/skills/", fg="green")
         for p in imported:
             click.echo(f"    {p.name}")
     else:
@@ -146,9 +143,7 @@ def _print_agents_detect(root: Path) -> None:
 def _print_agents_init(root: Path, overwrite: bool) -> None:
     imported = extract_agents_to_canonical(root, overwrite=overwrite)
     if imported:
-        click.secho(
-            f"  Imported {len(imported)} sub-agent(s) → .memtomem/agents/", fg="green"
-        )
+        click.secho(f"  Imported {len(imported)} sub-agent(s) → .memtomem/agents/", fg="green")
         for p in imported:
             click.echo(f"    {p.stem}")
     else:
@@ -206,9 +201,7 @@ def _print_commands_detect(root: Path) -> None:
 def _print_commands_init(root: Path, overwrite: bool) -> None:
     imported = extract_commands_to_canonical(root, overwrite=overwrite)
     if imported:
-        click.secho(
-            f"  Imported {len(imported)} command(s) → .memtomem/commands/", fg="green"
-        )
+        click.secho(f"  Imported {len(imported)} command(s) → .memtomem/commands/", fg="green")
         for p in imported:
             click.echo(f"    {p.stem}")
     else:
@@ -388,9 +381,7 @@ def generate_cmd(agent: str, include: tuple[str, ...], strict: bool) -> None:
         click.secho(f"{CONTEXT_FILENAME} not found. Run 'mm context init' first.", fg="red")
         return
     else:
-        click.secho(
-            f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow"
-        )
+        click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
     if "skills" in inc:
         click.echo("")
@@ -431,18 +422,14 @@ def diff_cmd(include: tuple[str, ...]) -> None:
                 if current == expected:
                     click.secho(f"  {f.agent:10s}  {f.path.name}  [in sync]", fg="green")
                 else:
-                    click.secho(
-                        f"  {f.agent:10s}  {f.path.name}  [out of sync]", fg="yellow"
-                    )
+                    click.secho(f"  {f.agent:10s}  {f.path.name}  [out of sync]", fg="yellow")
         else:
             click.echo("No agent files to compare.")
     elif not inc:
         click.secho(f"{CONTEXT_FILENAME} not found.", fg="red")
         return
     else:
-        click.secho(
-            f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow"
-        )
+        click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
     if "skills" in inc:
         click.echo("")
@@ -488,16 +475,13 @@ def sync_cmd(include: tuple[str, ...], strict: bool) -> None:
                 click.echo(f"  {agent_name:10s}  {gen.output_path}")
         else:
             click.echo(
-                "No agent files detected. "
-                "Use 'mm context generate --agent all' to create them."
+                "No agent files detected. Use 'mm context generate --agent all' to create them."
             )
     elif not inc:
         click.secho(f"{CONTEXT_FILENAME} not found. Run 'mm context init' first.", fg="red")
         return
     else:
-        click.secho(
-            f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow"
-        )
+        click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
     if "skills" in inc:
         click.echo("")

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -383,9 +383,7 @@ def generate_all_agents(
 
     canonicals = list_canonical_agents(project_root)
     if not canonicals:
-        return AgentSyncResult(
-            generated=[], dropped=[], skipped=[("<all>", "no canonical agents")]
-        )
+        return AgentSyncResult(generated=[], dropped=[], skipped=[("<all>", "no canonical agents")])
 
     targets = runtimes if runtimes is not None else list(AGENT_GENERATORS.keys())
     for target in targets:

--- a/packages/memtomem/src/memtomem/server/tools/policy.py
+++ b/packages/memtomem/src/memtomem/server/tools/policy.py
@@ -34,7 +34,25 @@ async def mem_policy_add(
         name: Unique policy name
         policy_type: One of 'auto_archive', 'auto_expire', 'auto_tag'
         config: JSON config string. Examples:
-            auto_archive: {"max_age_days": 30, "archive_namespace": "archive"}
+            auto_archive (flat — single target):
+              {"max_age_days": 30, "archive_namespace": "archive"}
+
+            auto_archive (rule + categorized buckets):
+              {
+                "max_age_days": 90,
+                "age_field": "last_accessed_at",
+                "min_access_count": 3,
+                "max_importance_score": 0.3,
+                "archive_namespace_template": "archive:{first_tag}"
+              }
+              - age_field: "created_at" (default) or "last_accessed_at"
+                (null-safe: falls back to created_at via COALESCE).
+              - min_access_count: only chunks with access_count <= this.
+              - max_importance_score: only chunks with importance_score < this.
+              - archive_namespace_template: per-chunk target. Supports the
+                {first_tag} placeholder (empty tags → "misc"). Chunks already
+                in their resolved target namespace are skipped.
+
             auto_expire: {"max_age_days": 90}
             auto_tag: {"max_tags": 5}
         namespace_filter: Only apply to chunks in this namespace

--- a/packages/memtomem/src/memtomem/tools/policy_engine.py
+++ b/packages/memtomem/src/memtomem/tools/policy_engine.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
+
+_NS_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
 
 _VALID_TYPES = {"auto_archive", "auto_promote", "auto_expire", "auto_consolidate", "auto_tag"}
 
@@ -20,41 +24,153 @@ class PolicyRunResult:
     details: str
 
 
+def _resolve_archive_ns(template: str, tags_json: str | None, fallback: str) -> str:
+    """Expand the ``{first_tag}`` placeholder in ``archive_namespace_template``.
+
+    Empty / non-string / invalid tags fall back to ``"misc"``. Characters that
+    are not namespace-safe (alphanumerics, dot, dash, underscore) are replaced
+    with ``_``. If ``template`` has no placeholder it is returned verbatim, or
+    ``fallback`` when ``template`` is empty.
+    """
+    if not template:
+        return fallback
+    if "{first_tag}" not in template:
+        return template
+
+    first_tag = "misc"
+    if tags_json:
+        try:
+            tags = json.loads(tags_json)
+            if isinstance(tags, list) and tags and isinstance(tags[0], str) and tags[0].strip():
+                first_tag = tags[0].strip()
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    first_tag = _NS_SAFE_RE.sub("_", first_tag) or "misc"
+    return template.replace("{first_tag}", first_tag)
+
+
 async def execute_auto_archive(
     storage: object,
     config: dict,
     namespace: str | None,
     dry_run: bool,
 ) -> PolicyRunResult:
-    """Move chunks older than max_age_days to archive namespace."""
+    """Move chunks matching an aging rule to an archive namespace.
+
+    Config fields (all but ``max_age_days`` are optional):
+
+    - ``max_age_days`` (int, default 30): chunks older than this many days
+      are candidates for archival.
+    - ``archive_namespace`` (str, default ``"archive"``): single target
+      namespace when ``archive_namespace_template`` is not set. Also acts as
+      the fallback if the template is empty.
+    - ``age_field`` (str, default ``"created_at"``): ``"created_at"`` or
+      ``"last_accessed_at"``. For ``"last_accessed_at"``, null values fall
+      back to ``created_at`` via ``COALESCE``.
+    - ``min_access_count`` (int | None, default None): only archive chunks
+      whose ``access_count`` is at most this value. None disables the filter.
+    - ``max_importance_score`` (float | None, default None): only archive
+      chunks whose ``importance_score`` is strictly below this value. None
+      disables the filter.
+    - ``archive_namespace_template`` (str | None, default None): per-chunk
+      target namespace template. Supports the ``{first_tag}`` placeholder,
+      which expands to the chunk's first tag (or ``"misc"`` when tags are
+      empty). Chunks already in their resolved target namespace are skipped.
+    """
     max_age = config.get("max_age_days", 30)
     archive_ns = config.get("archive_namespace", "archive")
+    age_field = config.get("age_field", "created_at")
+    min_access_count = config.get("min_access_count")
+    max_importance_score = config.get("max_importance_score")
+    ns_template = config.get("archive_namespace_template")
+
+    if age_field not in ("created_at", "last_accessed_at"):
+        return PolicyRunResult(
+            policy_name="",
+            policy_type="auto_archive",
+            affected_count=0,
+            dry_run=dry_run,
+            details=(
+                f"Error: age_field must be 'created_at' or 'last_accessed_at', got {age_field!r}"
+            ),
+        )
+
     cutoff = (datetime.now(timezone.utc) - timedelta(days=max_age)).isoformat()
 
     db = storage._get_db()  # type: ignore[attr-defined]
-    query = "SELECT id FROM chunks WHERE created_at < ? AND namespace != ?"
-    params: list = [cutoff, archive_ns]
+
+    # Template mode needs current namespace + tags per chunk to route and
+    # skip self-moves. Flat mode can fetch only ids.
+    select_cols = "id, namespace, tags" if ns_template is not None else "id"
+
+    where_parts: list[str] = []
+    params: list = []
+
+    if age_field == "last_accessed_at":
+        where_parts.append("COALESCE(last_accessed_at, created_at) < ?")
+    else:
+        where_parts.append("created_at < ?")
+    params.append(cutoff)
+
+    # Flat mode: exclude chunks already in the single target namespace. Template
+    # mode handles self-move exclusion per-chunk after resolution, because the
+    # target depends on each chunk's tag.
+    if ns_template is None:
+        where_parts.append("namespace != ?")
+        params.append(archive_ns)
+
+    if min_access_count is not None:
+        where_parts.append("access_count <= ?")
+        params.append(min_access_count)
+
+    if max_importance_score is not None:
+        where_parts.append("importance_score < ?")
+        params.append(max_importance_score)
+
     if namespace:
-        query += " AND namespace = ?"
+        where_parts.append("namespace = ?")
         params.append(namespace)
 
+    query = f"SELECT {select_cols} FROM chunks WHERE " + " AND ".join(where_parts)
     rows = db.execute(query, params).fetchall()
-    count = len(rows)
+
+    ids_by_target: dict[str, list[str]] = {}
+    if ns_template is None:
+        if rows:
+            ids_by_target[archive_ns] = [r[0] for r in rows]
+    else:
+        for chunk_id, current_ns, tags_json in rows:
+            target = _resolve_archive_ns(ns_template, tags_json, fallback=archive_ns)
+            if target == current_ns:
+                continue  # already in target bucket
+            ids_by_target.setdefault(target, []).append(chunk_id)
+
+    count = sum(len(ids) for ids in ids_by_target.values())
 
     if not dry_run and count > 0:
-        ids = [r[0] for r in rows]
-        db.executemany(
-            "UPDATE chunks SET namespace = ? WHERE id = ?",
-            [(archive_ns, cid) for cid in ids],
-        )
+        for target, ids in ids_by_target.items():
+            db.executemany(
+                "UPDATE chunks SET namespace = ? WHERE id = ?",
+                [(target, cid) for cid in ids],
+            )
         db.commit()
+
+    verb = "Would archive" if dry_run else "Archived"
+    if ns_template is not None and ids_by_target:
+        per_bucket = "; ".join(
+            f"{target}: {len(ids)}" for target, ids in sorted(ids_by_target.items())
+        )
+        details = f"{verb} {count} chunks older than {max_age} days ({per_bucket})"
+    else:
+        details = f"{verb} {count} chunks older than {max_age} days → '{archive_ns}'"
 
     return PolicyRunResult(
         policy_name="",
         policy_type="auto_archive",
         affected_count=count,
         dry_run=dry_run,
-        details=f"{'Would archive' if dry_run else 'Archived'} {count} chunks older than {max_age} days → '{archive_ns}'",
+        details=details,
     )
 
 

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -233,6 +233,231 @@ class TestPolicyEngine:
         )
         assert result.affected_count == 1
 
+    async def test_auto_archive_age_field_last_accessed_fallback(self, storage):
+        """age_field=last_accessed_at uses COALESCE with created_at for null values."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        recent_time = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
+
+        c_null = make_chunk("null last_access")
+        c_recent = make_chunk("recent last_access")
+        c_old = make_chunk("old last_access")
+        await storage.upsert_chunks([c_null, c_recent, c_old])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        # c_null: last_accessed_at stays NULL → COALESCE falls back to old created_at (eligible)
+        db.execute(
+            "UPDATE chunks SET last_accessed_at = ? WHERE id = ?",
+            [recent_time, str(c_recent.id)],
+        )
+        db.execute(
+            "UPDATE chunks SET last_accessed_at = ? WHERE id = ?",
+            [old_time, str(c_old.id)],
+        )
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {"max_age_days": 30, "age_field": "last_accessed_at"},
+            namespace=None,
+            dry_run=False,
+        )
+        assert result.affected_count == 2  # c_null + c_old, not c_recent
+
+        row = db.execute(
+            "SELECT namespace FROM chunks WHERE id = ?", [str(c_recent.id)]
+        ).fetchone()
+        assert row[0] == "default"
+
+    async def test_auto_archive_min_access_count_filter(self, storage):
+        """min_access_count excludes chunks accessed more than the threshold."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+
+        c_cold = make_chunk("never accessed")
+        c_hot = make_chunk("accessed a lot")
+        await storage.upsert_chunks([c_cold, c_hot])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        db.execute(
+            "UPDATE chunks SET access_count = 0 WHERE id = ?", [str(c_cold.id)]
+        )
+        db.execute(
+            "UPDATE chunks SET access_count = 10 WHERE id = ?", [str(c_hot.id)]
+        )
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {"max_age_days": 30, "min_access_count": 3},
+            namespace=None,
+            dry_run=True,
+        )
+        assert result.affected_count == 1  # only c_cold (0 <= 3)
+
+    async def test_auto_archive_max_importance_score_filter(self, storage):
+        """max_importance_score excludes chunks above the threshold."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+
+        c_low = make_chunk("low priority")
+        c_high = make_chunk("high priority")
+        await storage.upsert_chunks([c_low, c_high])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        db.execute(
+            "UPDATE chunks SET importance_score = 0.1 WHERE id = ?", [str(c_low.id)]
+        )
+        db.execute(
+            "UPDATE chunks SET importance_score = 0.8 WHERE id = ?", [str(c_high.id)]
+        )
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {"max_age_days": 30, "max_importance_score": 0.5},
+            namespace=None,
+            dry_run=True,
+        )
+        assert result.affected_count == 1  # only c_low (0.1 < 0.5)
+
+    async def test_auto_archive_namespace_template_first_tag(self, storage):
+        """archive_namespace_template expands {first_tag} per chunk."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+
+        c_dec = make_chunk("a decision", tags=("decisions", "important"))
+        c_tech = make_chunk("a tech note", tags=("tech",))
+        await storage.upsert_chunks([c_dec, c_tech])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {
+                "max_age_days": 30,
+                "archive_namespace_template": "archive:{first_tag}",
+            },
+            namespace=None,
+            dry_run=False,
+        )
+        assert result.affected_count == 2
+        assert "archive:decisions: 1" in result.details
+        assert "archive:tech: 1" in result.details
+
+        row = db.execute(
+            "SELECT namespace FROM chunks WHERE id = ?", [str(c_dec.id)]
+        ).fetchone()
+        assert row[0] == "archive:decisions"
+
+        row = db.execute(
+            "SELECT namespace FROM chunks WHERE id = ?", [str(c_tech.id)]
+        ).fetchone()
+        assert row[0] == "archive:tech"
+
+    async def test_auto_archive_template_misc_fallback(self, storage):
+        """Empty tags resolve {first_tag} to 'misc'."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+
+        c_empty = make_chunk("no tags")
+        await storage.upsert_chunks([c_empty])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {
+                "max_age_days": 30,
+                "archive_namespace_template": "archive:{first_tag}",
+            },
+            namespace=None,
+            dry_run=False,
+        )
+        assert result.affected_count == 1
+        assert "archive:misc: 1" in result.details
+
+        row = db.execute(
+            "SELECT namespace FROM chunks WHERE id = ?", [str(c_empty.id)]
+        ).fetchone()
+        assert row[0] == "archive:misc"
+
+    async def test_auto_archive_template_skips_self_moves(self, storage):
+        """Chunks already in their resolved target namespace are skipped."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+
+        c_already = make_chunk(
+            "already archived", tags=("decisions",), namespace="archive:decisions"
+        )
+        c_new = make_chunk("to archive", tags=("decisions",))
+        await storage.upsert_chunks([c_already, c_new])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {
+                "max_age_days": 30,
+                "archive_namespace_template": "archive:{first_tag}",
+            },
+            namespace=None,
+            dry_run=False,
+        )
+        assert result.affected_count == 1  # only c_new
+
+    async def test_auto_archive_combined_rule(self, storage):
+        """All new rule fields combine with AND semantics."""
+        old_time = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+
+        c_match = make_chunk("matches everything", tags=("misc",))
+        c_hot = make_chunk("access count too high", tags=("misc",))
+        c_important = make_chunk("importance too high", tags=("misc",))
+        await storage.upsert_chunks([c_match, c_hot, c_important])
+
+        db = storage._get_db()
+        db.execute("UPDATE chunks SET created_at = ?", [old_time])
+        db.execute(
+            "UPDATE chunks SET last_accessed_at=?, access_count=?, importance_score=? WHERE id=?",
+            [old_time, 1, 0.1, str(c_match.id)],
+        )
+        db.execute(
+            "UPDATE chunks SET last_accessed_at=?, access_count=?, importance_score=? WHERE id=?",
+            [old_time, 10, 0.1, str(c_hot.id)],
+        )
+        db.execute(
+            "UPDATE chunks SET last_accessed_at=?, access_count=?, importance_score=? WHERE id=?",
+            [old_time, 1, 0.8, str(c_important.id)],
+        )
+        db.commit()
+
+        result = await execute_auto_archive(
+            storage,
+            {
+                "max_age_days": 30,
+                "age_field": "last_accessed_at",
+                "min_access_count": 3,
+                "max_importance_score": 0.5,
+            },
+            namespace=None,
+            dry_run=True,
+        )
+        assert result.affected_count == 1  # only c_match passes every gate
+
+    async def test_auto_archive_invalid_age_field(self, storage):
+        """Invalid age_field returns a typed error result and mutates nothing."""
+        result = await execute_auto_archive(
+            storage,
+            {"max_age_days": 30, "age_field": "bogus"},
+            namespace=None,
+            dry_run=False,
+        )
+        assert result.affected_count == 0
+        assert "age_field must be" in result.details
+
     async def test_auto_expire_dry_run(self, storage):
         """Dry-run should count expired chunks but not delete."""
         old_time = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()


### PR DESCRIPTION
## Summary
- Extend `execute_auto_archive` with four optional, backward-compatible config fields so policies can archive by `last_accessed_at`, filter on `access_count` / `importance_score`, and route chunks into per-tag buckets via an `archive_namespace_template`.
- Motivated by LTM Manager Phase A (categorize old memories into `archive:<category>` namespaces before any hard-delete, rather than dumping into a single archive namespace or deleting outright).
- Fills the gap between `auto_archive` (too coarse) and `auto_expire` (destructive) without adding a new tool, config section, or registry category.

### New optional fields on `auto_archive`
- `age_field`: `"created_at"` (default) or `"last_accessed_at"`. The latter uses `COALESCE(last_accessed_at, created_at)` so never-accessed chunks fall back to creation time.
- `min_access_count`: only archive chunks with `access_count <= this`.
- `max_importance_score`: only archive chunks with `importance_score < this`.
- `archive_namespace_template`: per-chunk target namespace with a `{first_tag}` placeholder. Empty tags resolve to `"misc"`. Chunks already in their resolved target are skipped.

### Example
```json
{
  "max_age_days": 90,
  "age_field": "last_accessed_at",
  "min_access_count": 3,
  "max_importance_score": 0.3,
  "archive_namespace_template": "archive:{first_tag}"
}
```

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_tools_logic.py -v` — 54/54 pass (existing 4 `auto_archive` tests unchanged + 8 new)
- [x] `uv run pytest -m "not ollama"` — 994 passed, 32 deselected
- [x] `uv run ruff check packages/memtomem/src` — pass
- [x] `uv run ruff format --check packages/memtomem/src` — `tools/policy_engine.py` reformatted in this PR
- [ ] Manual smoke: `mem_policy_add(policy_type="auto_archive", config='{"archive_namespace_template":"archive:{first_tag}"}')` on a dev DB after merge

### New test coverage
1. `age_field=last_accessed_at` with null fallback to `created_at`
2. `min_access_count` gate
3. `max_importance_score` gate
4. `archive_namespace_template` expansion with `{first_tag}`
5. Empty tags → `"misc"` fallback
6. Self-move skip (chunk already in its resolved target bucket)
7. Combined rule AND semantics across all new fields
8. Invalid `age_field` returns a typed error result with no mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)