### PR TITLE
chore(cla): set up Contributor License Agreement + CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,35 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Explicit permissions — repository default may be read-only.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/v1/cla.json'
+          path-to-document: 'https://github.com/memtomem/memtomem/blob/main/CLA.md'
+          branch: 'main'
+          allowlist: dependabot[bot],memtomem
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: |
+            Thank you for your contribution! Before we can merge, please sign the [Contributor License Agreement](https://github.com/memtomem/memtomem/blob/main/CLA.md).
+
+            To sign, comment on this pull request with the statement below. You only need to sign once per GitHub account.
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. ✍️ ✅'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,134 @@
+# memtomem Individual Contributor License Agreement
+
+Thank you for your interest in contributing to memtomem, a project maintained
+by **DAPADA Inc.** (주식회사 다파다, contact@dapada.co.kr) and the memtomem
+contributors.
+
+This Individual Contributor License Agreement ("Agreement") documents the
+rights granted by contributors to DAPADA Inc. ("DAPADA"). It is adapted from
+the Apache Software Foundation Individual Contributor License Agreement with
+a single added section (Section 4) covering future licensing rights.
+
+You accept and agree to the following terms and conditions for Your present
+and future Contributions submitted to memtomem. Except for the license
+granted herein to DAPADA and recipients of software distributed by DAPADA,
+You reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+"You" (or "Your") shall mean the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with DAPADA. For legal
+entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity
+are considered to be a single Contributor.
+
+"Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally
+submitted by You to DAPADA for inclusion in, or documentation of, any of
+the products owned or managed by DAPADA (the "Work"). For the purposes of
+this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to DAPADA or its representatives, including but
+not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on
+behalf of, DAPADA for the purpose of discussing and improving the Work,
+but excluding communication that is conspicuously marked or otherwise
+designated in writing by You as "Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+DAPADA and to recipients of software distributed by DAPADA a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright
+license to reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute Your Contributions and such
+derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to
+DAPADA and to recipients of software distributed by DAPADA a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as
+stated in this section) patent license to make, have made, use, offer to
+sell, sell, import, and otherwise transfer the Work, where such license
+applies only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Work to which such Contribution(s) was submitted.
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Work to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to
+that entity under this Agreement for that Contribution or Work shall
+terminate as of the date such litigation is filed.
+
+## 4. Grant of Future Licensing Rights
+
+You acknowledge and agree that DAPADA, at its sole discretion, may
+distribute the Work (including Your Contribution) under the license
+currently applied to the Work (as of the date of this Agreement,
+Apache License, Version 2.0) or under any additional or different license
+terms that DAPADA may adopt for the Work in the future, including but not
+limited to:
+
+  (a) any OSI-approved open source license (for example, AGPL-3.0,
+      GPL-3.0, MPL-2.0);
+  (b) any source-available license (for example, FSL, BUSL, ELv2);
+  (c) proprietary or commercial license terms offered alongside any of
+      the above ("dual licensing"); or
+  (d) any combination of the above.
+
+This grant is perpetual, worldwide, non-exclusive, and royalty-free. You
+understand that (i) DAPADA is not obligated to adopt any particular
+license for the Work, and (ii) this grant does not itself change the
+current license of the Work.
+
+## 5. Representations
+
+You represent that You are legally entitled to grant the above license.
+If Your employer(s) has rights to intellectual property that You create
+that includes Your Contributions, You represent that You have received
+permission to make Contributions on behalf of that employer, that Your
+employer has waived such rights for Your Contributions to DAPADA, or that
+Your employer has executed a separate Corporate CLA with DAPADA.
+
+You represent that each of Your Contributions is Your original creation
+(see Section 7 for submissions on behalf of others).
+
+## 6. Support
+
+You are not expected to provide support for Your Contributions, except to
+the extent You desire to provide support. You may provide support for
+free, for a fee, or not at all. Unless required by applicable law or
+agreed to in writing, You provide Your Contributions on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You
+may submit it to DAPADA separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking
+the work as "Submitted on behalf of a third-party: [named here]".
+
+## 8. Notification of Changed Circumstances
+
+You agree to notify DAPADA of any facts or circumstances of which You
+become aware that would make these representations inaccurate in any
+respect.
+
+---
+
+## How to sign
+
+When you open a pull request, the CLA Assistant bot will comment with
+instructions. To sign the CLA, reply on your pull request with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature will be stored in `signatures/v1/cla.json` in this
+repository. You only need to sign once per GitHub account; subsequent
+contributions from the same account are covered automatically.
+
+For questions about this CLA, contact contact@dapada.co.kr.

--- a/CLA.md
+++ b/CLA.md
@@ -73,8 +73,9 @@ limited to:
       GPL-3.0, MPL-2.0);
   (b) any source-available license (for example, FSL, BUSL, ELv2);
   (c) proprietary or commercial license terms offered alongside any of
-      the above ("dual licensing"); or
-  (d) any combination of the above.
+      the above ("dual licensing");
+  (d) any combination of the above; or
+  (e) any other license terms that DAPADA may elect.
 
 This grant is perpetual, worldwide, non-exclusive, and royalty-free. You
 understand that (i) DAPADA is not obligated to adopt any particular

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,29 @@ The STM proxy gateway lives in a separate repository: [memtomem/memtomem-stm](ht
 4. Ensure `uv run ruff check` and `uv run ruff format --check` pass
 5. Ensure `uv run pytest -m "not ollama"` passes
 6. Write a clear commit message describing the "why"
+7. Sign the CLA on your first pull request (see below)
+
+## Contributor License Agreement (CLA)
+
+Before we can merge your first pull request, you need to sign the
+[Contributor License Agreement](CLA.md). The CLA Assistant bot will
+automatically comment on your PR with instructions — you sign by replying
+with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+You only need to sign once per GitHub account. Your signature is stored in
+`signatures/v1/cla.json` in this repository.
+
+The CLA is adapted from the Apache Software Foundation Individual
+Contributor License Agreement with one additional section covering future
+licensing rights. This preserves DAPADA Inc.'s ability to adopt different
+license terms for the Work in the future (for example, a dual-licensing
+arrangement) without needing to re-collect consent from every contributor.
+The CLA does not change the current license of the Work, which remains
+Apache License 2.0.
+
+For questions about the CLA, contact contact@dapada.co.kr.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/memtomem)](https://pypi.org/project/memtomem/)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-green)](https://python.org)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue)](LICENSE)
+[![CLA](https://img.shields.io/badge/CLA-required-green)](CLA.md)
 
 **Give your AI agent a long-term memory.**
 
@@ -120,4 +121,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and the contributo
 
 ## License
 
-[Apache License 2.0](LICENSE)
+[Apache License 2.0](LICENSE). Contributions are accepted under the terms of the [Contributor License Agreement](CLA.md).


### PR DESCRIPTION
## Summary

- Add `CLA.md` — Apache ICLA variant with an added Section 4 "Grant of Future Licensing Rights" that preserves DAPADA Inc.'s option to adopt different license terms (dual licensing, AGPL, FSL, or any other future license) without re-collecting consent from every contributor.
- Add `.github/workflows/cla.yml` — `contributor-assistant/github-action@v2.6.1` workflow that collects signatures in `signatures/v1/cla.json` on incoming pull requests. `dependabot[bot]` and `memtomem` bot are allowlisted.
- Update `README.md` — add CLA badge next to the license badge and reference the CLA in the License section.
- Update `CONTRIBUTING.md` — add PR guideline item 7 and a dedicated "Contributor License Agreement (CLA)" section explaining the signing flow.

**License remains Apache-2.0.** The CLA does not change the current license; it only enables a future change if one is ever decided.

## Why now

- External contributor count is currently zero, making this a zero-cost setup window. Setting up a CLA after external contributors arrive is expensive (per-contributor consent collection — the trap HashiCorp / Redis / Elastic fell into).
- The current decision is to keep Apache-2.0 indefinitely and monetize via open-core + hosted SaaS (Phase 2 plan). The CLA is pure optionality insurance, not a commitment to relicense.

## Test plan

- [ ] Verify `Settings → Actions → General → Workflow permissions` is set to **Read and write permissions** (required for CLA Assistant to write `signatures/v1/cla.json`)
- [ ] Merge this PR
- [ ] Open a test pull request from a non-allowlisted account and confirm the CLA Assistant bot comments with signing instructions
- [ ] Sign the test PR by commenting `I have read the CLA Document and I hereby sign the CLA` and confirm the signature lands in `signatures/v1/cla.json`
- [ ] Confirm the CLA badge renders correctly on the README

## Follow-up (separate tracks, not in this PR)

- [ ] Apply the same CLA setup to `memtomem/memtomem-stm` (separate session, git worktree isolation per internal cross-repo cleanup rules)
- [ ] (Optional) Commission legal review of `CLA.md` Section 4 before v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)