### PR TITLE
docs(contributing): clarify CLA signing is per-repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,12 @@ with:
 
 > I have read the CLA Document and I hereby sign the CLA
 
-You only need to sign once per GitHub account. Your signature is stored in
-`signatures/v1/cla.json` in this repository.
+You only need to sign once per GitHub account per repository. Because
+memtomem and [memtomem-stm](https://github.com/memtomem/memtomem-stm) are
+separate repositories with independent signature stores, contributors who
+open pull requests against both projects need to sign in each repository
+(still one-time per account). Your signature is stored in
+`signatures/v1/cla.json` in whichever repository you signed.
 
 The CLA is adapted from the Apache Software Foundation Individual
 Contributor License Agreement with one additional section covering future


### PR DESCRIPTION
## Summary
- Clarify in `CONTRIBUTING.md` that CLA signing is per-repo, not global across the memtomem project family.
- CLA Assistant stores signatures in each repo's own `signatures/v1/cla.json`, so contributors opening PRs against both memtomem and memtomem-stm need to sign in each repo (one-time per account).

## Why
The "sign once per GitHub account" phrasing could be read as "one signature covers the whole project family". First-time contributors would hit a surprise signature prompt on their second PR. Making this explicit up front avoids the friction.

Incidentally, this PR also exercises the signing flow itself: it is the first PR opened by my personal account (`tsdata`) against this repo since the CLA Assistant workflow landed, so the bot will create `signatures/v1/cla.json` here for the first time.

## Test plan
- [ ] CI (lint / typecheck / test) stays green — no code changes
- [ ] CLA Assistant comments asking for signature
- [ ] After signing, `signatures/v1/cla.json` is created/updated and CLAAssistant check turns green

🤖 Generated with [Claude Code](https://claude.com/claude-code)