### PR TITLE
feat(policy): auto_consolidate handler + system namespace filter (Phase A.5)

### DIFF
--- a/docs/guides/agent-memory-guide.md
+++ b/docs/guides/agent-memory-guide.md
@@ -319,12 +319,60 @@ flowchart LR
     }
   )
 → Consolidation applied for group 0.
-Memory added to ~/.memtomem/memories/2026-04-11.md
+Memory added to ~/.memtomem/memories/2026-04-12.md
 - Chunks indexed: 1
-- File: ~/.memtomem/memories/2026-04-11.md
-- Original chunks: 16
+- File: ~/.memtomem/memories/2026-04-12.md
+- Summary chunk id: 7f3a2b1c-9e8d-4f5a-a1b2-c3d4e5f6a7b8
+- Originals linked: 16/16
 - Originals kept: True
 ```
+
+The summary is appended to the first configured `memory_dirs` (daily notes
+file by default) so it shows up in filesystem browsing, rsync backups, and
+git-tracked memory vaults. Each original chunk is linked to the new summary
+chunk via a `consolidated_into` relation, so `mem_related` / `mem_expand`
+can walk back to the originals whenever needed.
+
+### Automate Consolidation via Policy
+
+Manual `mem_consolidate` / `mem_consolidate_apply` is ideal when you want
+LLM-quality summaries that the agent writes itself. For unattended
+background consolidation, register an `auto_consolidate` policy instead —
+it produces a deterministic heuristic summary per source file and runs on
+demand through `mem_policy_run`:
+
+```
+> mem_do(
+    action="policy_add",
+    params={
+      "name": "weekly-consolidate",
+      "policy_type": "auto_consolidate",
+      "config": "{\"min_group_size\": 5, \"max_groups\": 10, \"keep_originals\": true}"
+    }
+  )
+→ Policy 'weekly-consolidate' created (type=auto_consolidate, id=1)
+
+> mem_do(action="policy_run", params={"name": "weekly-consolidate", "dry_run": true})
+→ [DRY RUN] Would consolidate 3 groups: meeting-notes.md, daily-2026-04-10.md, project-roadmap.md
+```
+
+Key differences between the two paths:
+
+| Aspect               | `mem_consolidate_apply` (agent) | `auto_consolidate` policy |
+|----------------------|---------------------------------|---------------------------|
+| Summary quality      | LLM-written (agent supplies)    | Deterministic heuristic (keyword-boosted bullets) |
+| Storage              | Real markdown file in `memory_dirs` | Virtual chunk (no file on disk) |
+| Namespace            | Same as originals               | `archive:summary` (hidden from default search, see below) |
+| Idempotency          | Agent decides when to run       | Source hash comparison + `consolidated_into` check |
+| Best for             | High-value knowledge merges     | Bulk decluttering, recurring scans |
+
+Policy-driven summaries land in the `archive:summary` namespace and are
+**excluded from default search** by the `search.system_namespace_prefixes`
+config (defaults to `["archive:"]`). They stay retrievable via
+`mem_search(..., namespace="archive:summary")`, `mem_related`, and
+`mem_expand` — the consolidation audit trail is preserved without
+cluttering day-to-day results. If you prefer archived content to remain
+searchable by default, set `search.system_namespace_prefixes = []`.
 
 ### Reflect on Patterns
 

--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -112,7 +112,10 @@ async def _recall(
     until_dt = _parse_recall_date(until) if until else None
 
     async with cli_components() as comp:
-        ns_filter = NamespaceFilter.parse(namespace)
+        ns_filter = NamespaceFilter.parse(
+            namespace,
+            system_prefixes=tuple(comp.config.search.system_namespace_prefixes),
+        )
         chunks = await comp.storage.recall_chunks(
             since=since_dt,
             until=until_dt,

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -41,6 +41,14 @@ class SearchConfig(BaseSettings):
     tokenizer: str = "unicode61"  # "unicode61" or "kiwipiepy"
     rrf_weights: list[float] = Field(default_factory=lambda: [1.0, 1.0])  # [BM25, Dense]
     cache_ttl: float = 30.0  # search result cache TTL in seconds
+    # Namespaces starting with any of these prefixes are excluded from
+    # *default* search (``namespace=None``) but remain retrievable with an
+    # explicit namespace argument. Keeps system-generated buckets
+    # (auto_archive targets, auto_consolidate ``archive:summary`` summaries)
+    # out of day-to-day results while preserving their audit trail.
+    # Set to an empty list to restore the pre-Phase-A.5 behavior where every
+    # namespace is searchable by default.
+    system_namespace_prefixes: list[str] = Field(default_factory=lambda: ["archive:"])
 
     @field_validator("default_top_k", "bm25_candidates", "dense_candidates", "rrf_k")
     @classmethod
@@ -55,6 +63,19 @@ class SearchConfig(BaseSettings):
         allowed = {"unicode61", "kiwipiepy"}
         if v not in allowed:
             raise ValueError(f"tokenizer must be one of {allowed}")
+        return v
+
+    @field_validator("system_namespace_prefixes")
+    @classmethod
+    def prefix_count_capped(cls, v: list[str]) -> list[str]:
+        # Cap catches dynamic-generation mistakes at startup rather than
+        # emitting a runaway N × M LIKE clause every search call. 10 is
+        # generous — real configs are expected to have 1-3 entries.
+        if len(v) > 10:
+            raise ValueError(
+                f"system_namespace_prefixes has {len(v)} entries; cap is 10. "
+                "Did you accidentally generate prefixes dynamically?"
+            )
         return v
 
 

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -76,30 +76,39 @@ class IndexEngine:
 
         sem = asyncio.Semaphore(8)
 
-        async def _bounded(fp: Path) -> dict[str, int]:
+        async def _bounded(fp: Path) -> dict[str, object]:
             async with sem:
                 return await self._index_file(fp, force, namespace=namespace)
 
         raw_results = await asyncio.gather(*[_bounded(f) for f in files], return_exceptions=True)
-        file_results: list[dict[str, int]] = []
+        file_results: list[dict[str, object]] = []
         all_errors: list[str] = []
         for i, r in enumerate(raw_results):
             if isinstance(r, dict):
                 file_results.append(r)
-                all_errors.extend(r.get("errors", []))
+                all_errors.extend(r.get("errors", []))  # type: ignore[arg-type]
             elif isinstance(r, Exception):
                 logger.error("Indexing failed for %s: %s", files[i], r)
                 all_errors.append(f"{files[i].name}: {r}")
 
+        # Aggregate new_chunk_ids across all files — preserves per-file order
+        # so callers that sort/filter by source get a consistent ordering.
+        all_new_chunk_ids: list = []
+        for r in file_results:
+            ids = r.get("new_chunk_ids", ())
+            if ids:
+                all_new_chunk_ids.extend(ids)  # type: ignore[arg-type]
+
         duration = (time.monotonic() - start) * 1000
         return IndexingStats(
             total_files=len(files),
-            total_chunks=sum(r["total"] for r in file_results),
-            indexed_chunks=sum(r["indexed"] for r in file_results),
-            skipped_chunks=sum(r["skipped"] for r in file_results),
-            deleted_chunks=sum(r["deleted"] for r in file_results),
+            total_chunks=sum(r["total"] for r in file_results),  # type: ignore[misc]
+            indexed_chunks=sum(r["indexed"] for r in file_results),  # type: ignore[misc]
+            skipped_chunks=sum(r["skipped"] for r in file_results),  # type: ignore[misc]
+            deleted_chunks=sum(r["deleted"] for r in file_results),  # type: ignore[misc]
             duration_ms=duration,
             errors=tuple(all_errors),
+            new_chunk_ids=tuple(all_new_chunk_ids),
         )
 
     async def index_file(
@@ -115,11 +124,12 @@ class IndexEngine:
             duration = (time.monotonic() - start) * 1000
         return IndexingStats(
             total_files=1,
-            total_chunks=result["total"],
-            indexed_chunks=result["indexed"],
-            skipped_chunks=result["skipped"],
-            deleted_chunks=result["deleted"],
+            total_chunks=result["total"],  # type: ignore[arg-type]
+            indexed_chunks=result["indexed"],  # type: ignore[arg-type]
+            skipped_chunks=result["skipped"],  # type: ignore[arg-type]
+            deleted_chunks=result["deleted"],  # type: ignore[arg-type]
             duration_ms=duration,
+            new_chunk_ids=tuple(result.get("new_chunk_ids", ())),  # type: ignore[arg-type]
         )
 
     async def is_duplicate(
@@ -189,7 +199,10 @@ class IndexEngine:
         file_path: Path,
         force: bool,
         namespace: str | None = None,
-    ) -> dict[str, int]:
+    ) -> dict[str, object]:
+        # Return shape: total/indexed/skipped/deleted (ints), errors (list[str]),
+        # new_chunk_ids (list[UUID]). Early zero-result paths may omit
+        # new_chunk_ids — consumers must tolerate missing keys.
         try:
             file_size = file_path.stat().st_size
         except OSError:
@@ -298,6 +311,7 @@ class IndexEngine:
             "skipped": len(diff_result.unchanged),
             "deleted": len(diff_result.to_delete) if not force else 0,
             "errors": [],
+            "new_chunk_ids": [c.id for c in diff_result.to_upsert],
         }
 
     async def index_path_stream(

--- a/packages/memtomem/src/memtomem/models.py
+++ b/packages/memtomem/src/memtomem/models.py
@@ -124,3 +124,9 @@ class IndexingStats:
     deleted_chunks: int
     duration_ms: float
     errors: tuple[str, ...] = ()
+    # IDs of chunks actually upserted during this run. Empty when nothing new
+    # was written (all candidates were unchanged) or on the zero-result paths
+    # (missing file, too large, binary, etc). Consumers that need to act on
+    # freshly created chunks — e.g. ``mem_consolidate_apply`` linking a new
+    # summary — should read this instead of polling ``recall_chunks``.
+    new_chunk_ids: tuple[UUID, ...] = ()

--- a/packages/memtomem/src/memtomem/models.py
+++ b/packages/memtomem/src/memtomem/models.py
@@ -39,15 +39,36 @@ class ChunkMetadata:
 class NamespaceFilter:
     """Filter for namespace-scoped queries.
 
-    Supports exact match (single or union), glob patterns, and comma-separated lists.
+    Supports exact match (single or union), glob patterns, comma-separated
+    lists, and default-search exclusion of system namespace prefixes (e.g.
+    ``archive:``). Exclusion is applied *only* when no explicit namespace
+    is given — the idea is that callers who ask for ``archive:summary``
+    directly have already opted in.
     """
 
     namespaces: tuple[str, ...] = ()
     pattern: str | None = None
+    exclude_prefixes: tuple[str, ...] = ()
 
     @staticmethod
-    def parse(value: str | list[str] | None) -> NamespaceFilter | None:
+    def parse(
+        value: str | list[str] | None,
+        system_prefixes: tuple[str, ...] | list[str] | None = None,
+    ) -> NamespaceFilter | None:
+        """Parse a user-supplied namespace argument into a filter.
+
+        When ``value`` is ``None`` and ``system_prefixes`` is non-empty, the
+        returned filter carries ``exclude_prefixes`` so default searches
+        hide system-generated namespaces (``archive:*`` by default) without
+        affecting explicit queries. When ``value`` is any non-``None`` form
+        (exact string, comma list, glob), ``system_prefixes`` is ignored —
+        the caller explicitly opted into whatever namespace they named.
+        """
+        prefixes = tuple(system_prefixes) if system_prefixes else ()
+
         if value is None:
+            if prefixes:
+                return NamespaceFilter(exclude_prefixes=prefixes)
             return None
         if isinstance(value, list):
             return NamespaceFilter(namespaces=tuple(value))

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -190,7 +190,10 @@ class SearchPipeline:
 
         bm25_k = max(self._config.bm25_candidates, top_k)
         dense_k = max(self._config.dense_candidates, top_k)
-        ns_filter = NamespaceFilter.parse(namespace)
+        ns_filter = NamespaceFilter.parse(
+            namespace,
+            system_prefixes=tuple(self._config.system_namespace_prefixes),
+        )
 
         use_bm25 = self._config.enable_bm25
         use_dense = self._config.enable_dense

--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -132,15 +132,22 @@ async def mem_consolidate_apply(
 ) -> str:
     """Apply a consolidation by creating a summary chunk for a group.
 
-    The agent writes the summary; this tool persists it as a chunk in the
-    ``archive:summary`` namespace (outside default search) and links each
-    original via a ``consolidated_into`` relation. The summary is a
-    storage-level virtual chunk — nothing is written to disk — and can be
-    regenerated idempotently because its content embeds a source hash.
+    The agent writes the summary; this tool persists it via the normal
+    ``mem_add`` path — the summary becomes a real markdown entry in the
+    user's first ``memory_dirs`` daily notes file, and each original chunk
+    gets a ``consolidated_into`` relation pointing to the summary. This
+    preserves the file-based mental model: consolidation events are visible
+    in the filesystem and in git history, and the summary can be
+    hand-edited like any other markdown entry.
+
+    The policy-driven ``auto_consolidate`` flow deliberately takes a
+    different path (virtual chunk in the ``archive:summary`` namespace with
+    content-embedded source hash for idempotency). See
+    ``project_ltm_manager_roadmap.md`` Phase A.5 for the rationale.
 
     Args:
-        group_id: Group ID from mem_consolidate output
-        summary: The consolidated summary written by the agent
+        group_id: Group ID from mem_consolidate output.
+        summary: The consolidated summary written by the agent.
         keep_originals: Keep original chunks (default True). If False,
             originals are soft-decayed (``importance_score *= 0.5``, floor
             0.3); never a hard delete.
@@ -149,8 +156,8 @@ async def mem_consolidate_apply(
     from datetime import datetime, timezone
 
     from memtomem.tools.consolidation_engine import (
-        DEFAULT_SUMMARY_NAMESPACE,
-        apply_consolidation,
+        DECAY_FLOOR,
+        link_consolidation_relations,
     )
 
     app = _get_app(ctx)
@@ -172,28 +179,76 @@ async def mem_consolidate_apply(
     if group is None:
         return f"Error: group_id {group_id} not found. Run mem_consolidate again."
 
-    try:
-        summary_id = await apply_consolidation(
-            app.storage,
-            group,
-            summary,
-            keep_originals=keep_originals,
-            summary_namespace=DEFAULT_SUMMARY_NAMESPACE,
+    # Agent path is file-first: append to a daily notes file + index. We use
+    # ``_mem_add_core`` (not the MCP ``mem_add`` tool) so we can grab the
+    # IndexingStats and recover the new chunk id without the old
+    # ``recall_chunks(limit=1)`` trick, which raced with any concurrent
+    # write between mem_add and the lookup — silent data corruption
+    # territory.
+    from memtomem.server.tools.memory_crud import _mem_add_core
+
+    source_name = group["source"].split("/")[-1]
+    add_result, stats = await _mem_add_core(
+        content=summary,
+        title=f"Consolidated: {source_name}",
+        tags=["consolidated", "summary"],
+        file=None,
+        namespace=group.get("namespace"),
+        template=None,
+        ctx=ctx,
+    )
+
+    if stats is None or not stats.new_chunk_ids:
+        logger.warning(
+            "mem_consolidate_apply: mem_add produced no new chunk ids — "
+            "cannot link originals for group %s",
+            group_id,
         )
-    except Exception as exc:
-        logger.warning("mem_consolidate_apply failed for group %s", group_id, exc_info=True)
-        return f"Error: consolidation failed: {exc}"
+        await app.storage.scratch_delete("consolidation_groups")
+        return (
+            f"Consolidation applied for group {group_id} (unlinked).\n"
+            f"{add_result}\n"
+            f"- Original chunks: {group['chunk_count']}\n"
+            f"- Originals kept: {keep_originals}\n"
+            "- Warning: could not recover summary chunk id; relations not created."
+        )
 
-    # Invalidate caches so the new summary chunk is immediately searchable.
+    if len(stats.new_chunk_ids) > 1:
+        # Canary for chunker behavior drift. Today the Markdown chunker
+        # keeps a single ``Consolidated: ...`` H1 section together, so we
+        # expect exactly 1. If this warning ever fires, revisit the
+        # summary → chunk matching strategy (see Phase A.5 docs-review
+        # thread) — the current "take the first" rule is intentionally
+        # simple so the contract failure is loud.
+        logger.warning(
+            "mem_consolidate_apply: mem_add produced %d chunks, using first as summary_id",
+            len(stats.new_chunk_ids),
+        )
+
+    summary_id = stats.new_chunk_ids[0]
+
+    # Link originals → summary via the shared helper (same edge type that
+    # execute_auto_consolidate uses, so queries like mem_related / mem_expand
+    # work uniformly across both flows).
+    linked = await link_consolidation_relations(
+        app.storage,
+        group["chunk_ids"],
+        summary_id,
+    )
+
+    if not keep_originals and group["chunk_ids"]:
+        scores = await app.storage.get_importance_scores(group["chunk_ids"])
+        if scores:
+            floored = {cid: max(score * 0.5, DECAY_FLOOR) for cid, score in scores.items()}
+            await app.storage.update_importance_scores(floored)
+
     app.search_pipeline.invalidate_cache()
-
-    # Clean up scratch entry after successful apply
     await app.storage.scratch_delete("consolidation_groups")
 
     return (
         f"Consolidation applied for group {group_id}.\n"
+        f"{add_result}\n"
         f"- Summary chunk id: {summary_id}\n"
-        f"- Namespace: {DEFAULT_SUMMARY_NAMESPACE}\n"
-        f"- Original chunks: {group['chunk_count']}\n"
+        f"- Originals linked: {linked}/{group['chunk_count']}\n"
         f"- Originals kept: {keep_originals}"
     )

--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from uuid import UUID
 
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
@@ -133,16 +132,26 @@ async def mem_consolidate_apply(
 ) -> str:
     """Apply a consolidation by creating a summary chunk for a group.
 
-    The agent writes the summary; this tool creates it as a new chunk
-    and optionally links it to the originals via cross-references.
+    The agent writes the summary; this tool persists it as a chunk in the
+    ``archive:summary`` namespace (outside default search) and links each
+    original via a ``consolidated_into`` relation. The summary is a
+    storage-level virtual chunk — nothing is written to disk — and can be
+    regenerated idempotently because its content embeds a source hash.
 
     Args:
         group_id: Group ID from mem_consolidate output
         summary: The consolidated summary written by the agent
-        keep_originals: Keep original chunks (default True). If False, marks them for decay.
+        keep_originals: Keep original chunks (default True). If False,
+            originals are soft-decayed (``importance_score *= 0.5``, floor
+            0.3); never a hard delete.
     """
     import json
     from datetime import datetime, timezone
+
+    from memtomem.tools.consolidation_engine import (
+        DEFAULT_SUMMARY_NAMESPACE,
+        apply_consolidation,
+    )
 
     app = _get_app(ctx)
 
@@ -163,41 +172,28 @@ async def mem_consolidate_apply(
     if group is None:
         return f"Error: group_id {group_id} not found. Run mem_consolidate again."
 
-    # Create summary chunk via mem_add
-    from memtomem.server.tools.memory_crud import mem_add
+    try:
+        summary_id = await apply_consolidation(
+            app.storage,
+            group,
+            summary,
+            keep_originals=keep_originals,
+            summary_namespace=DEFAULT_SUMMARY_NAMESPACE,
+        )
+    except Exception as exc:
+        logger.warning("mem_consolidate_apply failed for group %s", group_id, exc_info=True)
+        return f"Error: consolidation failed: {exc}"
 
-    result = await mem_add(
-        content=summary,
-        title=f"Consolidated: {group['source'].split('/')[-1]}",
-        tags=["consolidated", "summary"],
-        namespace=group.get("namespace"),
-        ctx=ctx,
-    )
-
-    # Find the newly created summary chunk (most recently created)
-    linked = 0
-    recent = await app.storage.recall_chunks(limit=1)
-    if recent:
-        summary_id = recent[0].id
-        for cid in group["chunk_ids"]:
-            try:
-                await app.storage.add_relation(
-                    UUID(cid),
-                    summary_id,
-                    "consolidated_into",
-                )
-                linked += 1
-            except (ValueError, TypeError):
-                logger.debug("Skipping invalid UUID in consolidation: %s", cid)
-            except Exception:
-                logger.warning("Failed to link chunk %s in consolidation", cid, exc_info=True)
+    # Invalidate caches so the new summary chunk is immediately searchable.
+    app.search_pipeline.invalidate_cache()
 
     # Clean up scratch entry after successful apply
     await app.storage.scratch_delete("consolidation_groups")
 
     return (
         f"Consolidation applied for group {group_id}.\n"
-        f"{result}\n"
+        f"- Summary chunk id: {summary_id}\n"
+        f"- Namespace: {DEFAULT_SUMMARY_NAMESPACE}\n"
         f"- Original chunks: {group['chunk_count']}\n"
         f"- Originals kept: {keep_originals}"
     )

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
+
+if TYPE_CHECKING:
+    from memtomem.models import IndexingStats
 
 logger = logging.getLogger(__name__)
 
@@ -44,37 +48,28 @@ def _validate_path(path_str: str, memory_dirs: list) -> tuple[Path | None, str |
     return target, None
 
 
-@mcp.tool()
-@tool_handler
-async def mem_add(
+async def _mem_add_core(
     content: str,
-    title: str | None = None,
-    tags: list[str] | None = None,
-    file: str | None = None,
-    namespace: str | None = None,
-    template: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
-) -> str:
-    """Add a new memory entry to a markdown file and immediately index it.
+    title: str | None,
+    tags: list[str] | None,
+    file: str | None,
+    namespace: str | None,
+    template: str | None,
+    ctx: CtxType,
+) -> tuple[str, "IndexingStats | None"]:
+    """Core logic for ``mem_add`` — also usable from internal callers that
+    need the ``IndexingStats`` (e.g. ``mem_consolidate_apply`` linking new
+    summary chunks by id without the old ``recall_chunks(limit=1)`` race).
 
-    The entry is appended to the target file (or a new timestamped file is
-    created in the first configured memory directory). The file is then
-    re-indexed so the entry is immediately searchable.
-
-    Args:
-        content: The memory content to store
-        title: Optional heading title for the entry
-        tags: Optional tags for categorisation
-        file: Target .md filename (relative or absolute). If omitted, a
-              timestamped file is created in the first memory_dir.
-        namespace: Assign indexed chunks to this namespace (default: config default)
-        template: Use a built-in template (adr, meeting, debug, decision).
-                  Content can be JSON with field values or plain text.
+    Returns:
+        Tuple of ``(user_facing_message, stats)``. ``stats`` is ``None``
+        for early error returns (empty content, oversized content, template
+        failure, invalid path) so callers must tolerate ``None``.
     """
     if not content.strip():
-        return "Error: content cannot be empty."
+        return ("Error: content cannot be empty.", None)
     if len(content) > 100_000:
-        return "Error: content too large (max 100,000 characters)."
+        return ("Error: content too large (max 100,000 characters).", None)
 
     from datetime import datetime, timezone
 
@@ -91,14 +86,14 @@ async def mem_add(
             # Template already includes its own heading — don't duplicate
             title = None
         except ValueError as exc:
-            return f"Error: {exc}\n\nAvailable templates:\n{list_templates()}"
+            return (f"Error: {exc}\n\nAvailable templates:\n{list_templates()}", None)
 
     mdirs = app.config.indexing.memory_dirs
 
     if file:
         target, err = _validate_path(file, mdirs)
         if err:
-            return err
+            return (err, None)
     else:
         base = app.config.indexing.memory_dirs[0] if app.config.indexing.memory_dirs else Path(".")
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
@@ -141,7 +136,46 @@ async def mem_add(
         )
         task.add_done_callback(_webhook_error_cb)
 
-    return result
+    return (result, stats)
+
+
+@mcp.tool()
+@tool_handler
+async def mem_add(
+    content: str,
+    title: str | None = None,
+    tags: list[str] | None = None,
+    file: str | None = None,
+    namespace: str | None = None,
+    template: str | None = None,
+    ctx: CtxType = None,  # type: ignore[assignment]
+) -> str:
+    """Add a new memory entry to a markdown file and immediately index it.
+
+    The entry is appended to the target file (or a new timestamped file is
+    created in the first configured memory directory). The file is then
+    re-indexed so the entry is immediately searchable.
+
+    Args:
+        content: The memory content to store
+        title: Optional heading title for the entry
+        tags: Optional tags for categorisation
+        file: Target .md filename (relative or absolute). If omitted, a
+              timestamped file is created in the first memory_dir.
+        namespace: Assign indexed chunks to this namespace (default: config default)
+        template: Use a built-in template (adr, meeting, debug, decision).
+                  Content can be JSON with field values or plain text.
+    """
+    message, _stats = await _mem_add_core(
+        content=content,
+        title=title,
+        tags=tags,
+        file=file,
+        namespace=namespace,
+        template=template,
+        ctx=ctx,
+    )
+    return message
 
 
 @mcp.tool()

--- a/packages/memtomem/src/memtomem/server/tools/policy.py
+++ b/packages/memtomem/src/memtomem/server/tools/policy.py
@@ -12,7 +12,7 @@ from memtomem.server.tool_registry import register
 
 logger = logging.getLogger(__name__)
 
-_VALID_TYPES = {"auto_archive", "auto_expire", "auto_tag"}
+_VALID_TYPES = {"auto_archive", "auto_consolidate", "auto_expire", "auto_tag"}
 
 
 @mcp.tool()
@@ -28,11 +28,13 @@ async def mem_policy_add(
     """Create a memory lifecycle policy.
 
     Policies automate memory management: archiving old memories,
-    expiring unused ones, or auto-tagging untagged chunks.
+    expiring unused ones, auto-tagging untagged chunks, or consolidating
+    related chunks into heuristic summaries.
 
     Args:
         name: Unique policy name
-        policy_type: One of 'auto_archive', 'auto_expire', 'auto_tag'
+        policy_type: One of 'auto_archive', 'auto_consolidate',
+            'auto_expire', 'auto_tag'
         config: JSON config string. Examples:
             auto_archive (flat — single target):
               {"max_age_days": 30, "archive_namespace": "archive"}
@@ -52,6 +54,25 @@ async def mem_policy_add(
               - archive_namespace_template: per-chunk target. Supports the
                 {first_tag} placeholder (empty tags → "misc"). Chunks already
                 in their resolved target namespace are skipped.
+
+            auto_consolidate:
+              {
+                "min_group_size": 3,
+                "max_groups": 10,
+                "max_bullets": 20,
+                "keep_originals": true,
+                "summary_namespace": "archive:summary"
+              }
+              - Groups chunks by source file (min chunks = min_group_size)
+                and creates one deterministic heuristic summary per source,
+                linking originals via ``consolidated_into`` relations.
+              - Idempotent: re-runs with the same chunk set are a no-op;
+                added/removed chunks trigger regeneration.
+              - Mixed-namespace sources are skipped with a warning.
+              - keep_originals=false soft-decays originals
+                (importance_score *= 0.5, floor 0.3) instead of deleting.
+              - Summaries default to the ``archive:summary`` namespace so
+                they don't pollute default search results.
 
             auto_expire: {"max_age_days": 90}
             auto_tag: {"max_tags": 5}

--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -53,7 +53,13 @@ async def mem_recall(
         return "Error: 'since' must be earlier than 'until'."
 
     effective_ns = namespace or app.current_namespace
-    ns_filter = NamespaceFilter.parse(effective_ns)
+    # Mirror mem_search default behavior: when no explicit namespace is set,
+    # hide system namespaces (``archive:*`` by default) so archived and
+    # auto-consolidated chunks don't pollute the standard recall stream.
+    ns_filter = NamespaceFilter.parse(
+        effective_ns,
+        system_prefixes=tuple(app.config.search.system_namespace_prefixes),
+    )
     chunks = await app.storage.recall_chunks(
         since=since_dt,
         until=until_dt,

--- a/packages/memtomem/src/memtomem/storage/sqlite_helpers.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_helpers.py
@@ -46,11 +46,27 @@ def escape_like(value: str) -> str:
 
 
 def namespace_sql(ns: NamespaceFilter) -> tuple[str, list]:
-    """Build SQL WHERE fragment + params for a NamespaceFilter."""
+    """Build SQL WHERE fragment + params for a NamespaceFilter.
+
+    Explicit forms (``namespaces``, ``pattern``) take priority over the
+    default-search ``exclude_prefixes`` fallback — the parse layer is
+    responsible for never sending both at once, so this ordering is just
+    defensive.
+    """
     if ns.namespaces:
         ph = ",".join("?" * len(ns.namespaces))
         return f"namespace IN ({ph})", list(ns.namespaces)
     if ns.pattern:
         escaped = ns.pattern.replace("_", r"\_").replace("*", "%")
         return "namespace LIKE ? ESCAPE '\\'", [escaped]
+    if ns.exclude_prefixes:
+        # Belt-and-suspenders cap: the config validator already rejects
+        # >10, but if a caller constructs NamespaceFilter directly we still
+        # refuse to emit a pathologically long WHERE clause.
+        assert len(ns.exclude_prefixes) <= 10, (
+            f"namespace_sql: exclude_prefixes has {len(ns.exclude_prefixes)} entries, cap is 10"
+        )
+        clauses = " AND ".join("namespace NOT LIKE ? ESCAPE '\\'" for _ in ns.exclude_prefixes)
+        params = [f"{escape_like(p)}%" for p in ns.exclude_prefixes]
+        return clauses, params
     return "", []

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -204,12 +204,17 @@ def make_heuristic_summary(
 # ── Apply (storage mutations) ────────────────────────────────────────
 
 
-async def _link_consolidation_relations(
+async def link_consolidation_relations(
     storage: StorageBackend,
     source_ids: list[str],
     summary_id: UUID,
 ) -> int:
     """Link original chunks to the summary via ``consolidated_into`` edges.
+
+    Shared by both ``apply_consolidation`` (policy-driven path) and
+    ``mem_consolidate_apply`` (agent-driven path): they diverge in how they
+    create the summary chunk (virtual upsert vs. file-first via ``mem_add``)
+    but converge here to establish the relation graph.
 
     Invalid UUIDs are logged at DEBUG (harmless — they can appear if scratch
     state leaks stale data). Storage-level exceptions are logged at WARNING
@@ -225,6 +230,33 @@ async def _link_consolidation_relations(
         except Exception:
             logger.warning("consolidation: failed to link %r", cid, exc_info=True)
     return linked
+
+
+async def source_has_consolidation_relations(
+    storage: StorageBackend,
+    chunk_ids: list[UUID],
+) -> bool:
+    """Return True if any chunk in the group already has a ``consolidated_into``
+    edge — the idempotency fallback used by ``execute_auto_consolidate``.
+
+    Used specifically for the "has this source been consolidated by anyone?"
+    question when the policy handler's own virtual summary is absent (e.g.
+    the agent ran ``mem_consolidate_apply`` for this source already). The
+    ``any`` threshold is intentional: even a partial consolidation from the
+    agent's end is enough to defer to their work rather than overwriting it
+    with a heuristic summary. Source-hash staleness on the policy-owned
+    virtual summary is a separate signal and takes priority when the virtual
+    summary exists.
+    """
+    for cid in chunk_ids:
+        try:
+            related = await storage.get_related(cid)
+        except Exception:
+            logger.debug("get_related failed for %r", cid, exc_info=True)
+            continue
+        if any(rel == "consolidated_into" for _, rel in related):
+            return True
+    return False
 
 
 def _make_summary_chunk(
@@ -260,13 +292,19 @@ async def apply_consolidation(
     keep_originals: bool = True,
     summary_namespace: str = DEFAULT_SUMMARY_NAMESPACE,
 ) -> UUID:
-    """Create a summary chunk for ``group`` and link originals to it.
+    """Create a virtual summary chunk for ``group`` and link originals to it.
 
-    This is the out-of-ctx entry point for both ``mem_consolidate_apply``
-    (agent-written summary) and ``execute_auto_consolidate`` (heuristic
-    summary). It never touches the filesystem — the summary lives as a
-    virtual chunk identified by the ``.consolidated.md`` suffix, which the
-    policy handler later uses for idempotent re-runs.
+    Used by ``execute_auto_consolidate`` (policy-driven, unattended). The
+    agent-driven ``mem_consolidate_apply`` deliberately does NOT go through
+    here: it keeps the file-first flow via ``mem_add`` so the user's
+    ``memory_dirs`` reflect their own consolidation work in git / rsync /
+    plain file browsing. The two paths converge only in
+    ``link_consolidation_relations``.
+
+    The summary lives as a virtual chunk at ``<source>.consolidated.md``
+    under ``summary_namespace`` — nothing is written to disk — which gives
+    ``execute_auto_consolidate`` a stable lookup key for source-hash-based
+    idempotency and staleness regeneration.
 
     Args:
         storage: Storage backend implementing ``upsert_chunks``,
@@ -275,16 +313,15 @@ async def apply_consolidation(
         group: Dict with at minimum ``source`` (str path) and ``chunk_ids``
             (list of UUID strings). ``namespace`` / ``chunk_count`` are
             accepted but not required.
-        summary: The markdown summary text. For heuristic flows, use
-            ``make_heuristic_summary``; for agent flows, pass the
-            agent-written text as-is.
+        summary: The markdown summary text. The policy handler supplies
+            ``make_heuristic_summary`` output; custom callers may pass any
+            string with the expected Metadata block format.
         keep_originals: If ``False``, apply a soft decay to originals by
             halving their importance score with a ``DECAY_FLOOR`` floor of
             0.3 so already-low chunks don't get evicted instantly. Never a
             hard delete.
         summary_namespace: Namespace for the new summary chunk. Default
-            ``archive:summary`` keeps summaries out of regular search
-            results unless explicitly queried.
+            ``archive:summary``.
 
     Returns:
         The UUID of the newly created summary chunk.
@@ -297,7 +334,7 @@ async def apply_consolidation(
     await storage.upsert_chunks([summary_chunk])
 
     source_ids = [str(cid) for cid in group.get("chunk_ids", [])]
-    await _link_consolidation_relations(storage, source_ids, summary_chunk.id)
+    await link_consolidation_relations(storage, source_ids, summary_chunk.id)
 
     if not keep_originals and source_ids:
         scores = await storage.get_importance_scores(source_ids)

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -1,0 +1,308 @@
+"""Consolidation engine — heuristic summary generation + out-of-ctx apply.
+
+This module is callable from both MCP tool context (``mem_consolidate_apply``)
+and the policy engine (``execute_auto_consolidate``) because it only depends
+on the storage layer — no ``AppContext`` required.
+
+The summary is deterministic and chunk-type aware. Keyword-boosted regex
+(reused from ``entity_extraction``) picks decision/action lines over a plain
+first-sentence fallback, and checklist chunks are rendered as item counts
+rather than truncated prose. See ``docs/guides/user-guide.md`` "Consolidation"
+section and ``feedback_compression_priority.md`` for the rationale: nothing
+is lost, originals kept by default, source hash embedded for idempotent
+re-runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from memtomem.models import Chunk, ChunkMetadata, ChunkType
+from memtomem.tools.entity_extraction import _ACTION_RE, _DECISION_RE
+
+if TYPE_CHECKING:
+    from memtomem.storage.base import StorageBackend
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ────────────────────────────────────────────────────────
+
+DEFAULT_SUMMARY_NAMESPACE = "archive:summary"
+DECAY_FLOOR = 0.3  # keep_originals=False → importance_score floor (never below)
+CONSOLIDATED_SUFFIX = ".consolidated.md"
+_SOURCE_HASH_RE = re.compile(r"Source hash:\s*`([a-f0-9]+)`")
+_CHECKLIST_ITEM_RE = re.compile(r"^\s*-\s*\[\s*[ xX]?\s*\]\s+(.+)$", re.MULTILINE)
+
+
+# ── Bullet extraction ────────────────────────────────────────────────
+
+
+def _first_sentence(text: str, max_len: int = 160) -> str:
+    """Return the first sentence of ``text``, capped to ``max_len`` chars.
+
+    Splits on ``. ? !`` followed by whitespace, or a blank line. Leading
+    markdown list/heading markers are stripped so the caller doesn't get a
+    doubly-prefixed bullet like ``- - [ ] item``.
+    """
+    cleaned = text.strip().lstrip("-*#\t ").strip()
+    if not cleaned:
+        return ""
+    parts = re.split(r"(?<=[.?!])\s+|\n\n", cleaned, maxsplit=1)
+    return parts[0][:max_len].strip()
+
+
+def extract_bullet(chunk: Chunk) -> str:
+    """Return a single markdown bullet summarizing one chunk.
+
+    Extraction priority (first match wins):
+
+    1. **Label**: deepest ``heading_hierarchy`` entry, or the first ``#``-line
+       of content if no hierarchy.
+    2. **Keyword boost**: a "Decision: …" or "Action: …" line anywhere in
+       the body (regex reused from ``entity_extraction``). Wins over
+       first-sentence fallback because it usually carries the load.
+    3. **Checklist**: if two or more ``- [ ]`` / ``- [x]`` items exist, render
+       as ``N items (first, second…)`` instead of cutting the first line.
+    4. **First sentence**: as a last resort.
+
+    Output shape: ``**{label}** — {sentence}``, ``**{label}**``,
+    ``{sentence}``, or ``{first_120_chars}`` — whichever is populated.
+    """
+    h = chunk.metadata.heading_hierarchy
+    label: str | None = h[-1] if h else None
+    body = chunk.content.strip()
+
+    # If no heading_hierarchy but content starts with a heading, use that.
+    if label is None:
+        first_line = body.split("\n", 1)[0].strip()
+        if first_line.startswith("#"):
+            label = first_line.lstrip("#").strip() or None
+            body = body.split("\n", 1)[1].strip() if "\n" in body else ""
+
+    # 1. Keyword boost — decision wins over action wins over fallback.
+    boosted: str | None = None
+    dec = _DECISION_RE.search(body)
+    if dec:
+        boosted = f"Decision: {dec.group(1).strip()[:140]}"
+    else:
+        act = _ACTION_RE.search(body)
+        if act:
+            # _ACTION_RE has 3 capture groups (TODO:, -[ ], Action item:)
+            captured = (act.group(1) or act.group(2) or act.group(3) or "").strip()
+            if captured:
+                boosted = f"Action: {captured[:140]}"
+
+    # 2. Checklist fallback — only if no keyword boost landed.
+    if boosted is None:
+        items = _CHECKLIST_ITEM_RE.findall(body)
+        if len(items) >= 2:
+            previews = ", ".join(i.strip()[:60] for i in items[:2])
+            tail = "…" if len(items) > 2 else ""
+            boosted = f"{len(items)} items ({previews}{tail})"
+
+    sentence = boosted or _first_sentence(body, max_len=160)
+
+    if label and sentence:
+        return f"**{label}** — {sentence}"
+    if label:
+        return f"**{label}**"
+    if sentence:
+        return sentence
+    return body[:120].replace("\n", " ") or "(empty chunk)"
+
+
+# ── Source hash for idempotency ──────────────────────────────────────
+
+
+def compute_source_hash(chunk_ids: list[UUID] | list[str]) -> str:
+    """Return a stable 16-char SHA256 hash of a sorted chunk id list.
+
+    Sorting ensures the hash is order-independent so that two runs that
+    happen to receive chunks in different order still collide. 16 chars
+    (64 bits) is more than enough to distinguish incremental edits — we're
+    not defending against adversaries, just against stale re-runs.
+    """
+    ids_sorted = sorted(str(cid) for cid in chunk_ids)
+    joined = ",".join(ids_sorted).encode()
+    return hashlib.sha256(joined).hexdigest()[:16]
+
+
+def parse_source_hash(summary_content: str) -> str | None:
+    """Extract the ``Source hash`` value from a previously generated summary.
+
+    Returns ``None`` if the field is missing (e.g. hand-edited summary, or
+    a summary from before this feature). A missing hash is treated as stale
+    by the caller — the summary is regenerated.
+    """
+    m = _SOURCE_HASH_RE.search(summary_content)
+    return m.group(1) if m else None
+
+
+# ── Summary template ─────────────────────────────────────────────────
+
+
+def make_heuristic_summary(
+    chunks: list[Chunk],
+    source: Path,
+    max_bullets: int = 20,
+) -> str:
+    """Build a deterministic markdown summary for a group of chunks.
+
+    Bullet count is capped at ``max_bullets``; remaining chunks are counted
+    in an ellipsis line so the summary still faithfully reports group size.
+    The ``Source hash`` line is a load-bearing idempotency marker — don't
+    remove or move it without updating ``parse_source_hash``.
+    """
+    if not chunks:
+        raise ValueError("make_heuristic_summary: cannot summarize empty chunk list")
+
+    bullets = [extract_bullet(c) for c in chunks[:max_bullets]]
+    extra = max(0, len(chunks) - max_bullets)
+
+    # Temporal range — text-only. See feedback_compression_priority.md for why
+    # we don't add a typed ChunkMetadata field here.
+    created_ats = [c.created_at for c in chunks]
+    range_start = min(created_ats).date().isoformat()
+    range_end = max(created_ats).date().isoformat()
+
+    source_hash = compute_source_hash([c.id for c in chunks])
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    lines: list[str] = [
+        f"# Consolidated: {source.name}",
+        "",
+        f"Auto-generated consolidation of {len(chunks)} chunks from `{source}`.",
+        "",
+        "## Contents",
+        "",
+    ]
+    lines.extend(f"- {b}" for b in bullets)
+    if extra > 0:
+        lines.append(f"- … and {extra} more")
+    lines.extend(
+        [
+            "",
+            "## Metadata",
+            "",
+            f"- Source: `{source}`",
+            f"- Chunks: {len(chunks)}",
+            f"- Range: {range_start} ~ {range_end}",
+            f"- Source hash: `{source_hash}`",
+            f"- Generated: {now}",
+            "- Strategy: heuristic",
+        ]
+    )
+    return "\n".join(lines)
+
+
+# ── Apply (storage mutations) ────────────────────────────────────────
+
+
+async def _link_consolidation_relations(
+    storage: StorageBackend,
+    source_ids: list[str],
+    summary_id: UUID,
+) -> int:
+    """Link original chunks to the summary via ``consolidated_into`` edges.
+
+    Invalid UUIDs are logged at DEBUG (harmless — they can appear if scratch
+    state leaks stale data). Storage-level exceptions are logged at WARNING
+    and skipped so a single bad row can't tank the whole group.
+    """
+    linked = 0
+    for cid in source_ids:
+        try:
+            await storage.add_relation(UUID(cid), summary_id, "consolidated_into")
+            linked += 1
+        except (ValueError, TypeError):
+            logger.debug("consolidation: skipping invalid UUID %r", cid)
+        except Exception:
+            logger.warning("consolidation: failed to link %r", cid, exc_info=True)
+    return linked
+
+
+def _make_summary_chunk(
+    group: dict,
+    summary: str,
+    summary_namespace: str,
+) -> Chunk:
+    """Build the summary ``Chunk`` for ``apply_consolidation``.
+
+    The virtual ``source_file`` is ``{original}.consolidated.md`` so the
+    summary is reachable via ``list_chunks_by_source`` on the derived path
+    for idempotency checks, without ever touching the filesystem.
+    """
+    source = Path(group["source"])
+    source_name = source.name
+    virtual_path = source.parent / f"{source_name}{CONSOLIDATED_SUFFIX}"
+    return Chunk(
+        content=summary,
+        metadata=ChunkMetadata(
+            source_file=virtual_path,
+            chunk_type=ChunkType.MARKDOWN_SECTION,
+            tags=("consolidated", "summary", "heuristic"),
+            namespace=summary_namespace,
+            heading_hierarchy=(f"Consolidated: {source_name}",),
+        ),
+    )
+
+
+async def apply_consolidation(
+    storage: StorageBackend,
+    group: dict,
+    summary: str,
+    keep_originals: bool = True,
+    summary_namespace: str = DEFAULT_SUMMARY_NAMESPACE,
+) -> UUID:
+    """Create a summary chunk for ``group`` and link originals to it.
+
+    This is the out-of-ctx entry point for both ``mem_consolidate_apply``
+    (agent-written summary) and ``execute_auto_consolidate`` (heuristic
+    summary). It never touches the filesystem — the summary lives as a
+    virtual chunk identified by the ``.consolidated.md`` suffix, which the
+    policy handler later uses for idempotent re-runs.
+
+    Args:
+        storage: Storage backend implementing ``upsert_chunks``,
+            ``add_relation``, ``get_importance_scores``,
+            ``update_importance_scores``.
+        group: Dict with at minimum ``source`` (str path) and ``chunk_ids``
+            (list of UUID strings). ``namespace`` / ``chunk_count`` are
+            accepted but not required.
+        summary: The markdown summary text. For heuristic flows, use
+            ``make_heuristic_summary``; for agent flows, pass the
+            agent-written text as-is.
+        keep_originals: If ``False``, apply a soft decay to originals by
+            halving their importance score with a ``DECAY_FLOOR`` floor of
+            0.3 so already-low chunks don't get evicted instantly. Never a
+            hard delete.
+        summary_namespace: Namespace for the new summary chunk. Default
+            ``archive:summary`` keeps summaries out of regular search
+            results unless explicitly queried.
+
+    Returns:
+        The UUID of the newly created summary chunk.
+
+    Raises:
+        StorageError: if the summary upsert fails (caller should decide
+            whether to continue to the next group or abort).
+    """
+    summary_chunk = _make_summary_chunk(group, summary, summary_namespace)
+    await storage.upsert_chunks([summary_chunk])
+
+    source_ids = [str(cid) for cid in group.get("chunk_ids", [])]
+    await _link_consolidation_relations(storage, source_ids, summary_chunk.id)
+
+    if not keep_originals and source_ids:
+        scores = await storage.get_importance_scores(source_ids)
+        if scores:
+            floored = {cid: max(score * 0.5, DECAY_FLOOR) for cid, score in scores.items()}
+            await storage.update_importance_scores(floored)
+
+    return summary_chunk.id

--- a/packages/memtomem/src/memtomem/tools/policy_engine.py
+++ b/packages/memtomem/src/memtomem/tools/policy_engine.py
@@ -7,6 +7,7 @@ import logging
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -253,8 +254,163 @@ async def execute_auto_tag(
     )
 
 
+async def execute_auto_consolidate(
+    storage: object,
+    config: dict,
+    namespace: str | None,
+    dry_run: bool,
+) -> PolicyRunResult:
+    """Group related chunks by source file and create heuristic summary chunks.
+
+    Candidates are source files with at least ``min_group_size`` chunks. Each
+    candidate produces one summary chunk in ``summary_namespace`` (default
+    ``archive:summary``) with ``consolidated_into`` edges back to the
+    originals. The summary chunk's content embeds a source hash so re-runs
+    are idempotent: matching hash → skip, mismatched hash → delete old
+    summary and regenerate. Sources with mixed namespaces are skipped with
+    a warning (YAGNI — full per-namespace groupby can land in a follow-up
+    if anyone hits that case).
+
+    Config fields (all optional):
+
+    - ``min_group_size`` (int, default 3): minimum chunks per source file
+      to qualify as a consolidation candidate.
+    - ``max_groups`` (int, default 10): cap on groups processed per run.
+    - ``max_bullets`` (int, default 20): cap on bullets in the summary.
+    - ``keep_originals`` (bool, default True): if False, halve importance
+      scores of originals (floor 0.3) so decay can evict them later.
+      Never a hard delete — see ``feedback_compression_priority.md``.
+    - ``summary_namespace`` (str, default ``archive:summary``): target
+      namespace for summary chunks. Keeps summaries out of default search
+      unless explicitly queried.
+
+    The ``namespace`` arg (from ``namespace_filter`` on the policy row) acts
+    as a coarse gate: sources whose chunks aren't in that namespace are
+    skipped. For same-source mixed-namespace rows, the whole source is
+    skipped regardless of filter.
+    """
+    from memtomem.tools.consolidation_engine import (
+        DEFAULT_SUMMARY_NAMESPACE,
+        CONSOLIDATED_SUFFIX,
+        apply_consolidation,
+        compute_source_hash,
+        make_heuristic_summary,
+        parse_source_hash,
+    )
+
+    min_group_size = config.get("min_group_size", 3)
+    max_groups = config.get("max_groups", 10)
+    max_bullets = config.get("max_bullets", 20)
+    keep_originals = config.get("keep_originals", True)
+    summary_namespace = config.get("summary_namespace", DEFAULT_SUMMARY_NAMESPACE)
+
+    if min_group_size < 2:
+        return PolicyRunResult(
+            policy_name="",
+            policy_type="auto_consolidate",
+            affected_count=0,
+            dry_run=dry_run,
+            details="Error: min_group_size must be at least 2",
+        )
+
+    raw_groups = await storage.get_consolidation_groups(  # type: ignore[attr-defined]
+        min_size=min_group_size,
+        max_groups=max_groups,
+    )
+
+    applied = 0
+    detail_parts: list[str] = []
+
+    for g in raw_groups:
+        source_path = Path(g["source"])
+
+        chunks = await storage.list_chunks_by_source(source_path, limit=20)  # type: ignore[attr-defined]
+        if len(chunks) < min_group_size:
+            continue
+
+        # Mixed-namespace sources → skip + warn. See plan for rationale.
+        ns_set = {c.metadata.namespace for c in chunks}
+        if len(ns_set) > 1:
+            logger.warning(
+                "auto_consolidate: skipping %s — mixed namespaces %s",
+                source_path,
+                sorted(ns_set),
+            )
+            detail_parts.append(f"{source_path.name} (SKIP: mixed ns)")
+            continue
+        chunk_ns = next(iter(ns_set))
+
+        # namespace policy filter — skip sources outside the target ns.
+        if namespace and chunk_ns != namespace:
+            continue
+
+        # Idempotency via content-embedded source hash. The virtual path
+        # lives in the same parent dir as the original source.
+        current_hash = compute_source_hash([c.id for c in chunks])
+        virtual_path = source_path.parent / f"{source_path.name}{CONSOLIDATED_SUFFIX}"
+        existing = await storage.list_chunks_by_source(virtual_path, limit=1)  # type: ignore[attr-defined]
+        stale = False
+        if existing:
+            old_hash = parse_source_hash(existing[0].content)
+            if old_hash == current_hash:
+                continue  # idempotent — same inputs, same output
+            stale = True  # regenerate below
+
+        if dry_run:
+            applied += 1
+            tag = " (stale)" if stale else ""
+            detail_parts.append(f"{source_path.name}{tag}")
+            continue
+
+        if stale:
+            await storage.delete_chunks([existing[0].id])  # type: ignore[attr-defined]
+
+        try:
+            summary = make_heuristic_summary(chunks, source_path, max_bullets=max_bullets)
+            group_dict = {
+                "source": str(source_path),
+                "chunk_ids": [str(c.id) for c in chunks],
+                "namespace": chunk_ns,
+                "chunk_count": len(chunks),
+            }
+            await apply_consolidation(
+                storage,  # type: ignore[arg-type]
+                group_dict,
+                summary,
+                keep_originals=keep_originals,
+                summary_namespace=summary_namespace,
+            )
+        except Exception:
+            logger.warning(
+                "auto_consolidate: failed to consolidate %s",
+                source_path,
+                exc_info=True,
+            )
+            detail_parts.append(f"{source_path.name} (FAILED)")
+            continue
+
+        applied += 1
+        tag = " (regen)" if stale else ""
+        detail_parts.append(f"{source_path.name}{tag}")
+
+    verb = "Would consolidate" if dry_run else "Consolidated"
+    if detail_parts:
+        details = f"{verb} {applied} groups: {', '.join(detail_parts)}"
+    else:
+        details = f"{verb} 0 groups (no candidates)"
+
+    return PolicyRunResult(
+        policy_name="",
+        policy_type="auto_consolidate",
+        affected_count=applied,
+        dry_run=dry_run,
+        details=details,
+    )
+
+
 _HANDLERS = {
     "auto_archive": execute_auto_archive,
+    "auto_consolidate": execute_auto_consolidate,
     "auto_expire": execute_auto_expire,
     "auto_tag": execute_auto_tag,
 }

--- a/packages/memtomem/src/memtomem/tools/policy_engine.py
+++ b/packages/memtomem/src/memtomem/tools/policy_engine.py
@@ -296,6 +296,7 @@ async def execute_auto_consolidate(
         compute_source_hash,
         make_heuristic_summary,
         parse_source_hash,
+        source_has_consolidation_relations,
     )
 
     min_group_size = config.get("min_group_size", 3)
@@ -344,8 +345,10 @@ async def execute_auto_consolidate(
         if namespace and chunk_ns != namespace:
             continue
 
-        # Idempotency via content-embedded source hash. The virtual path
-        # lives in the same parent dir as the original source.
+        # Idempotency layer 1 — policy-owned virtual summary + source hash.
+        # This is the definitive signal for the policy's own prior work:
+        # matching hash means nothing to do, mismatched hash means an input
+        # changed (chunk added/removed) and we must regenerate.
         current_hash = compute_source_hash([c.id for c in chunks])
         virtual_path = source_path.parent / f"{source_path.name}{CONSOLIDATED_SUFFIX}"
         existing = await storage.list_chunks_by_source(virtual_path, limit=1)  # type: ignore[attr-defined]
@@ -355,6 +358,21 @@ async def execute_auto_consolidate(
             if old_hash == current_hash:
                 continue  # idempotent — same inputs, same output
             stale = True  # regenerate below
+        else:
+            # Idempotency layer 2 — agent-driven consolidation already covers
+            # this source. When there is no policy-owned virtual summary but
+            # some original chunk already carries a ``consolidated_into``
+            # edge, the agent ran ``mem_consolidate_apply`` for this source
+            # already. We defer to their work rather than overwriting it
+            # with a heuristic summary. Re-runs after the user adds more
+            # chunks will flow through layer 1 once the user creates a
+            # policy-owned summary again (or the agent regenerates theirs).
+            if await source_has_consolidation_relations(
+                storage,  # type: ignore[arg-type]
+                [c.id for c in chunks],
+            ):
+                detail_parts.append(f"{source_path.name} (SKIP: agent-consolidated)")
+                continue
 
         if dry_run:
             applied += 1

--- a/packages/memtomem/src/memtomem/web/routes/timeline.py
+++ b/packages/memtomem/src/memtomem/web/routes/timeline.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, Query
 
 from memtomem.models import NamespaceFilter
-from memtomem.web.deps import get_storage
+from memtomem.web.deps import get_config, get_storage
 from memtomem.web.schemas.core import chunk_to_out
 from memtomem.web.schemas import TimelineResponse
 
@@ -21,10 +21,14 @@ async def get_timeline(
     namespace: str | None = Query(None, description="Namespace filter"),
     limit: int = Query(200, ge=1, le=1000),
     storage=Depends(get_storage),
+    config=Depends(get_config),
 ) -> TimelineResponse:
     """Return chunks created within the last *days* days, newest first."""
     since = datetime.now(timezone.utc) - timedelta(days=days)
-    ns_filter = NamespaceFilter.parse(namespace)
+    ns_filter = NamespaceFilter.parse(
+        namespace,
+        system_prefixes=tuple(config.search.system_namespace_prefixes),
+    )
     chunks = await storage.recall_chunks(
         since=since,
         source_filter=source,

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -979,6 +979,7 @@ def _fake_ctx(components):
 
 
 class TestMemAddCoreIntegration:
+    @pytest.mark.ollama
     async def test_mem_add_core_returns_indexing_stats(self, components, memory_dir):
         """_mem_add_core returns (message, stats) and stats.new_chunk_ids is
         populated with the UUID(s) of chunks freshly upserted during indexing.
@@ -1025,6 +1026,7 @@ class TestMemAddCoreIntegration:
 
 
 class TestMemConsolidateApplyIntegration:
+    @pytest.mark.ollama
     async def test_agent_path_writes_to_disk_and_links_relations(self, components, memory_dir):
         """Full file-first agent flow: summary appears in a disk file, the new
         chunk is indexed, and each original has a consolidated_into edge
@@ -1174,6 +1176,7 @@ class TestSystemNamespacePrefixFilter:
         with pytest.raises(ValueError, match="cap is 10"):
             SearchConfig(system_namespace_prefixes=too_many)
 
+    @pytest.mark.ollama
     async def test_default_search_excludes_archive_summary(self, components, memory_dir):
         """End-to-end: an archive:summary chunk is NOT returned by a
         bare search (no namespace), but IS returned when explicitly asked."""
@@ -1218,6 +1221,7 @@ class TestSystemNamespacePrefixFilter:
         # Sanity: we do get at least one result from the regular chunk.
         assert len(results) >= 1
 
+    @pytest.mark.ollama
     async def test_explicit_archive_summary_namespace_is_retrievable(self, components, memory_dir):
         """The same chunk that default search hides is returned when the
         caller explicitly scopes to archive:summary."""

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -4,15 +4,25 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 import pytest
 from helpers import make_chunk
 
+from memtomem.tools.consolidation_engine import (
+    DEFAULT_SUMMARY_NAMESPACE,
+    apply_consolidation,
+    compute_source_hash,
+    extract_bullet,
+    make_heuristic_summary,
+    parse_source_hash,
+)
 from memtomem.tools.entity_extraction import extract_entities
 from memtomem.tools.policy_engine import (
     PolicyRunResult,
     _VALID_TYPES,
     execute_auto_archive,
+    execute_auto_consolidate,
     execute_auto_expire,
     execute_auto_tag,
     run_policy,
@@ -181,9 +191,7 @@ class TestPolicyEngine:
         assert "Would archive" in result.details
 
         # Chunk should still be in default namespace
-        row = db.execute(
-            "SELECT namespace FROM chunks WHERE id = ?", [str(chunk.id)]
-        ).fetchone()
+        row = db.execute("SELECT namespace FROM chunks WHERE id = ?", [str(chunk.id)]).fetchone()
         assert row[0] == "default"
 
     async def test_auto_archive_executes(self, storage):
@@ -203,9 +211,7 @@ class TestPolicyEngine:
         assert "Archived" in result.details
         assert "'old'" in result.details
 
-        row = db.execute(
-            "SELECT namespace FROM chunks WHERE id = ?", [str(chunk.id)]
-        ).fetchone()
+        row = db.execute("SELECT namespace FROM chunks WHERE id = ?", [str(chunk.id)]).fetchone()
         assert row[0] == "old"
 
     async def test_auto_archive_skips_recent(self, storage):
@@ -264,9 +270,7 @@ class TestPolicyEngine:
         )
         assert result.affected_count == 2  # c_null + c_old, not c_recent
 
-        row = db.execute(
-            "SELECT namespace FROM chunks WHERE id = ?", [str(c_recent.id)]
-        ).fetchone()
+        row = db.execute("SELECT namespace FROM chunks WHERE id = ?", [str(c_recent.id)]).fetchone()
         assert row[0] == "default"
 
     async def test_auto_archive_min_access_count_filter(self, storage):
@@ -279,12 +283,8 @@ class TestPolicyEngine:
 
         db = storage._get_db()
         db.execute("UPDATE chunks SET created_at = ?", [old_time])
-        db.execute(
-            "UPDATE chunks SET access_count = 0 WHERE id = ?", [str(c_cold.id)]
-        )
-        db.execute(
-            "UPDATE chunks SET access_count = 10 WHERE id = ?", [str(c_hot.id)]
-        )
+        db.execute("UPDATE chunks SET access_count = 0 WHERE id = ?", [str(c_cold.id)])
+        db.execute("UPDATE chunks SET access_count = 10 WHERE id = ?", [str(c_hot.id)])
         db.commit()
 
         result = await execute_auto_archive(
@@ -305,12 +305,8 @@ class TestPolicyEngine:
 
         db = storage._get_db()
         db.execute("UPDATE chunks SET created_at = ?", [old_time])
-        db.execute(
-            "UPDATE chunks SET importance_score = 0.1 WHERE id = ?", [str(c_low.id)]
-        )
-        db.execute(
-            "UPDATE chunks SET importance_score = 0.8 WHERE id = ?", [str(c_high.id)]
-        )
+        db.execute("UPDATE chunks SET importance_score = 0.1 WHERE id = ?", [str(c_low.id)])
+        db.execute("UPDATE chunks SET importance_score = 0.8 WHERE id = ?", [str(c_high.id)])
         db.commit()
 
         result = await execute_auto_archive(
@@ -346,14 +342,10 @@ class TestPolicyEngine:
         assert "archive:decisions: 1" in result.details
         assert "archive:tech: 1" in result.details
 
-        row = db.execute(
-            "SELECT namespace FROM chunks WHERE id = ?", [str(c_dec.id)]
-        ).fetchone()
+        row = db.execute("SELECT namespace FROM chunks WHERE id = ?", [str(c_dec.id)]).fetchone()
         assert row[0] == "archive:decisions"
 
-        row = db.execute(
-            "SELECT namespace FROM chunks WHERE id = ?", [str(c_tech.id)]
-        ).fetchone()
+        row = db.execute("SELECT namespace FROM chunks WHERE id = ?", [str(c_tech.id)]).fetchone()
         assert row[0] == "archive:tech"
 
     async def test_auto_archive_template_misc_fallback(self, storage):
@@ -379,9 +371,7 @@ class TestPolicyEngine:
         assert result.affected_count == 1
         assert "archive:misc: 1" in result.details
 
-        row = db.execute(
-            "SELECT namespace FROM chunks WHERE id = ?", [str(c_empty.id)]
-        ).fetchone()
+        row = db.execute("SELECT namespace FROM chunks WHERE id = ?", [str(c_empty.id)]).fetchone()
         assert row[0] == "archive:misc"
 
     async def test_auto_archive_template_skips_self_moves(self, storage):
@@ -522,9 +512,7 @@ class TestPolicyEngine:
         chunk = make_chunk("some untagged content")
         await storage.upsert_chunks([chunk])
 
-        result = await execute_auto_tag(
-            storage, {"max_tags": 3}, namespace=None, dry_run=True
-        )
+        result = await execute_auto_tag(storage, {"max_tags": 3}, namespace=None, dry_run=True)
         assert result.policy_type == "auto_tag"
         assert result.dry_run is True
         assert result.affected_count >= 1
@@ -578,6 +566,312 @@ class TestPolicyEngine:
         assert "auto_tag" in _VALID_TYPES
         assert "auto_promote" in _VALID_TYPES
         assert "auto_consolidate" in _VALID_TYPES
+
+    async def test_server_tools_valid_types_includes_auto_consolidate(self):
+        """server/tools/policy.py:_VALID_TYPES must accept auto_consolidate."""
+        from memtomem.server.tools.policy import _VALID_TYPES as _SERVER_VALID_TYPES
+
+        assert "auto_consolidate" in _SERVER_VALID_TYPES
+        assert "auto_archive" in _SERVER_VALID_TYPES
+        assert "auto_expire" in _SERVER_VALID_TYPES
+        assert "auto_tag" in _SERVER_VALID_TYPES
+
+
+# ── Consolidation engine (unit: bullet extraction + hash) ────────────
+
+
+class TestConsolidationEngineUnit:
+    def test_extract_bullet_with_heading_and_first_sentence(self):
+        """heading_hierarchy[-1] becomes the label; first sentence is the body."""
+        chunk = make_chunk(
+            content="Alice, Bob, Carol joined. Bob will lead the sprint.",
+            heading=("April Standup", "Attendees"),
+        )
+        bullet = extract_bullet(chunk)
+        assert bullet.startswith("**Attendees** — ")
+        assert "Alice, Bob, Carol joined" in bullet
+        # Second sentence should not leak into the single-sentence bullet.
+        assert "Bob will lead" not in bullet
+
+    def test_extract_bullet_no_heading_fallback(self):
+        """Chunks with no heading and no content heading fall back to first sentence."""
+        chunk = make_chunk(
+            content="Plain text with no structure. Something else.",
+            heading=(),
+        )
+        bullet = extract_bullet(chunk)
+        assert "Plain text with no structure" in bullet
+        assert not bullet.startswith("**")  # no label
+
+    def test_extract_bullet_keyword_boost_decision_wins(self):
+        """A ``Decision:`` line anywhere in the body beats the first-sentence fallback."""
+        chunk = make_chunk(
+            content=(
+                "The team met briefly to discuss roadmap blockers.\n"
+                "Decision: freeze main branch until 2026-04-10.\n"
+                "Followups to be tracked in #42."
+            ),
+            heading=("Sprint 12", "Notes"),
+        )
+        bullet = extract_bullet(chunk)
+        assert "Decision" in bullet
+        assert "freeze main branch" in bullet
+        # First-sentence fallback should not have fired.
+        assert "The team met briefly" not in bullet
+
+    def test_extract_bullet_checklist_count(self):
+        """Chunks with 2+ checklist items become ``N items (…)`` rather than truncated prose."""
+        chunk = make_chunk(
+            content=(
+                "Action items from the review:\n"
+                "- [ ] Alice: write tests for feature X\n"
+                "- [ ] Bob: unblock ticket #42\n"
+                "- [x] Carol: approve the RFC draft"
+            ),
+            heading=("Sprint 12", "Action items"),
+        )
+        bullet = extract_bullet(chunk)
+        # Keyword boost on Action: picks the first TODO line, so checklist path
+        # applies only when no Action/Decision keyword fires. Allow either
+        # outcome but require the label to be present and that the bullet is
+        # non-trivial.
+        assert "**Action items**" in bullet
+        assert len(bullet) > len("**Action items**")
+
+    def test_extract_bullet_checklist_without_keyword(self):
+        """Pure checklist (no Action/TODO keyword) → ``N items (preview…)``."""
+        chunk = make_chunk(
+            content=("- [ ] first task here\n- [ ] second task here\n- [ ] third task here"),
+            heading=("Tasks",),
+        )
+        bullet = extract_bullet(chunk)
+        assert "**Tasks**" in bullet
+        # Either keyword path (- [ ] pattern in _ACTION_RE) or checklist path
+        # is acceptable; both preserve the item content.
+        assert "first task" in bullet
+
+    def test_compute_source_hash_deterministic_and_order_independent(self):
+        """Same chunk id set → same hash regardless of order."""
+        ids_a = ["aaa-111", "bbb-222", "ccc-333"]
+        ids_b = ["ccc-333", "aaa-111", "bbb-222"]
+        assert compute_source_hash(ids_a) == compute_source_hash(ids_b)
+        assert compute_source_hash(ids_a) != compute_source_hash(ids_a + ["ddd-444"])
+        # 16 hex chars = 64 bits.
+        assert len(compute_source_hash(ids_a)) == 16
+
+    def test_parse_source_hash_present_and_missing(self):
+        """parse_source_hash returns the hash or None for legacy summaries."""
+        with_hash = (
+            "## Metadata\n\n"
+            "- Source: `/tmp/foo.md`\n"
+            "- Source hash: `a3f28b1c9e4d5f60`\n"
+            "- Generated: 2026-04-12T00:00:00+00:00\n"
+        )
+        assert parse_source_hash(with_hash) == "a3f28b1c9e4d5f60"
+
+        without_hash = "## Metadata\n\n- Source: `/tmp/foo.md`\n- Generated: 2026-04-12\n"
+        assert parse_source_hash(without_hash) is None
+
+
+# ── auto_consolidate handler (integration with storage) ──────────────
+
+
+class TestAutoConsolidate:
+    async def test_auto_consolidate_empty_no_candidates(self, storage):
+        """No source files with enough chunks → affected_count = 0."""
+        chunk = make_chunk("lonely", source="solo.md")
+        await storage.upsert_chunks([chunk])
+
+        result = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert result.policy_type == "auto_consolidate"
+        assert result.affected_count == 0
+        assert "0 groups" in result.details
+
+    async def test_auto_consolidate_dry_run_reports_candidates(self, storage):
+        """Dry run counts groups but does not create a summary chunk."""
+        source = "meeting-2026-04.md"
+        chunks = [
+            make_chunk(
+                content=f"Content chunk {i} with some text here.",
+                source=source,
+                heading=("April Standup", f"Section {i}"),
+            )
+            for i in range(3)
+        ]
+        await storage.upsert_chunks(chunks)
+
+        result = await execute_auto_consolidate(
+            storage,
+            {"min_group_size": 3},
+            namespace=None,
+            dry_run=True,
+        )
+        assert result.dry_run is True
+        assert result.affected_count == 1
+        assert "Would consolidate" in result.details
+        assert source in result.details
+
+        # No summary chunk should have been persisted.
+        summaries = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert summaries == []
+
+    async def test_auto_consolidate_happy_path(self, storage):
+        """Creates a summary chunk in archive:summary + links originals."""
+        source = "meeting-2026-04.md"
+        chunks = [
+            make_chunk(
+                content=(
+                    "Alice, Bob, Carol joined the standup session for April."
+                    if i == 0
+                    else f"Further notes from section {i} of the meeting."
+                ),
+                source=source,
+                heading=("April Standup", f"Section {i}"),
+            )
+            for i in range(3)
+        ]
+        await storage.upsert_chunks(chunks)
+
+        result = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert result.affected_count == 1
+        assert "Consolidated 1 groups" in result.details
+
+        # Summary chunk exists and contains expected markers.
+        summaries = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert len(summaries) == 1
+        summary_chunk = summaries[0]
+        assert summary_chunk.metadata.namespace == DEFAULT_SUMMARY_NAMESPACE
+        assert "consolidated" in summary_chunk.metadata.tags
+        assert "# Consolidated:" in summary_chunk.content
+        assert "Source hash:" in summary_chunk.content
+
+        # Each original should have a consolidated_into relation → summary.
+        related = await storage.get_related(chunks[0].id)
+        assert any(rel == "consolidated_into" for _, rel in related)
+
+    async def test_auto_consolidate_idempotent_same_hash_skips(self, storage):
+        """Second run on unchanged inputs must be a no-op."""
+        source = "meeting-idempotent.md"
+        chunks = [
+            make_chunk(f"Idempotency chunk {i}", source=source, heading=("Doc", f"§{i}"))
+            for i in range(3)
+        ]
+        await storage.upsert_chunks(chunks)
+
+        first = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert first.affected_count == 1
+
+        second = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert second.affected_count == 0
+        assert "0 groups" in second.details
+
+        # Only one summary chunk should exist.
+        summaries = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert len(summaries) == 1
+
+    async def test_auto_consolidate_staleness_regen(self, storage):
+        """Adding a chunk after first run → second run deletes old, creates new."""
+        source = "meeting-staleness.md"
+        first_batch = [
+            make_chunk(f"Stale chunk {i}", source=source, heading=("Doc", f"§{i}"))
+            for i in range(3)
+        ]
+        await storage.upsert_chunks(first_batch)
+
+        first = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert first.affected_count == 1
+        summaries_before = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert len(summaries_before) == 1
+        old_summary_id = summaries_before[0].id
+
+        # Add a new chunk → input hash changes.
+        new_chunk = make_chunk("Newly added chunk", source=source, heading=("Doc", "§new"))
+        await storage.upsert_chunks([new_chunk])
+
+        second = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert second.affected_count == 1
+        assert "regen" in second.details
+
+        # Exactly one summary (old one was replaced, not stacked).
+        summaries_after = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert len(summaries_after) == 1
+        assert summaries_after[0].id != old_summary_id
+
+    async def test_auto_consolidate_mixed_namespace_skips(self, storage, caplog):
+        """A source file whose chunks span multiple namespaces is skipped with a warn."""
+        source = "mixed-ns.md"
+        chunks = [
+            make_chunk(f"Chunk {i}", source=source, namespace="default" if i < 2 else "other")
+            for i in range(3)
+        ]
+        await storage.upsert_chunks(chunks)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.tools.policy_engine"):
+            result = await execute_auto_consolidate(
+                storage, {"min_group_size": 3}, namespace=None, dry_run=False
+            )
+
+        assert result.affected_count == 0
+        assert "mixed ns" in result.details
+        # The warning line should reference the source.
+        assert any("mixed namespaces" in rec.message for rec in caplog.records)
+
+        # No summary chunk should have been written.
+        summaries = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert summaries == []
+
+    async def test_apply_consolidation_decay_floor(self, storage):
+        """keep_originals=False applies decay but never drops below DECAY_FLOOR=0.3."""
+        chunks = [make_chunk(f"decay chunk {i}", source="decay-source.md") for i in range(3)]
+        await storage.upsert_chunks(chunks)
+
+        # Force one chunk to a very low importance score; the halving must
+        # floor at 0.3, not drop to 0.1.
+        low_id = str(chunks[0].id)
+        await storage.update_importance_scores({low_id: 0.2})
+
+        group = {
+            "source": "/tmp/decay-source.md",
+            "chunk_ids": [str(c.id) for c in chunks],
+            "namespace": "default",
+            "chunk_count": 3,
+        }
+        summary = make_heuristic_summary(chunks, Path("/tmp/decay-source.md"))
+        await apply_consolidation(storage, group, summary, keep_originals=False)
+
+        scores = await storage.get_importance_scores([str(c.id) for c in chunks])
+        # The 0.2 chunk should have been floored to 0.3, not halved to 0.1.
+        assert scores[low_id] == pytest.approx(0.3)
+        # Other chunks start at the default importance (let the storage layer
+        # decide the initial value — we just assert the floor held).
+        for cid in scores:
+            assert scores[cid] >= 0.3
 
 
 # ── Temporal ─────────────────────────────────────────────────────────
@@ -663,10 +957,20 @@ class TestTemporal:
 
     async def test_build_timeline_invalid_dates_skipped(self):
         chunks = [
-            {"content": "Good", "created_at": "2025-01-01T00:00:00+00:00", "source_file": "a.md",
-             "tags": [], "score": 0.5},
-            {"content": "Bad date", "created_at": "not-a-date", "source_file": "b.md",
-             "tags": [], "score": 0.5},
+            {
+                "content": "Good",
+                "created_at": "2025-01-01T00:00:00+00:00",
+                "source_file": "a.md",
+                "tags": [],
+                "score": 0.5,
+            },
+            {
+                "content": "Bad date",
+                "created_at": "not-a-date",
+                "source_file": "b.md",
+                "tags": [],
+                "score": 0.5,
+            },
             {"content": "Missing key", "source_file": "c.md", "tags": [], "score": 0.5},
         ]
         buckets = build_timeline(chunks)

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -873,6 +873,234 @@ class TestAutoConsolidate:
         for cid in scores:
             assert scores[cid] >= 0.3
 
+    async def test_auto_consolidate_defers_to_agent_consolidation(self, storage, caplog):
+        """Layer 2 (b) idempotency: if any chunk already has a consolidated_into
+        edge and there's no policy-owned virtual summary, skip with a tag. This
+        protects agent-written summaries from being overwritten by heuristic."""
+        source = "agent-consolidated.md"
+        chunks = [make_chunk(f"agent-done chunk {i}", source=source) for i in range(3)]
+        await storage.upsert_chunks(chunks)
+
+        # Simulate agent path having already consolidated this source: the
+        # agent's summary chunk is a real chunk in some other source file
+        # (e.g. the daily notes file written by mem_add). FK constraints on
+        # chunk_relations require both endpoints to exist.
+        agent_summary = make_chunk(
+            "Agent-written consolidated summary body.",
+            source="daily-2026-04-12.md",
+        )
+        await storage.upsert_chunks([agent_summary])
+        await storage.add_relation(chunks[0].id, agent_summary.id, "consolidated_into")
+
+        result = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert result.affected_count == 0
+        assert "agent-consolidated" in result.details
+
+        # No virtual summary was created.
+        summaries = await storage.list_chunks_by_source(
+            Path(f"/tmp/{source}.consolidated.md"), limit=5
+        )
+        assert summaries == []
+
+    async def test_auto_consolidate_agent_any_not_all(self, storage):
+        """Only one chunk in a group needs a consolidated_into edge for the
+        whole group to be deferred (``any``, not ``all``)."""
+        source = "partial-agent.md"
+        chunks = [make_chunk(f"partial {i}", source=source) for i in range(4)]
+        await storage.upsert_chunks(chunks)
+
+        # Agent consolidated only 1 of the 4 chunks. FK requires a real target.
+        agent_summary = make_chunk("Agent summary for 1 of 4.", source="daily-2026-04-12.md")
+        await storage.upsert_chunks([agent_summary])
+        await storage.add_relation(chunks[2].id, agent_summary.id, "consolidated_into")
+
+        result = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert result.affected_count == 0
+        assert "agent-consolidated" in result.details
+
+    async def test_auto_consolidate_own_relations_not_self_block(self, storage):
+        """A policy-owned virtual summary sets consolidated_into edges on its
+        originals. A subsequent re-run must find the virtual summary FIRST
+        (layer 1) and compare hashes, not match layer 2 on its own edges. The
+        first run creates + links, the second run must skip via hash match,
+        not via the ``source_has_consolidation_relations`` fallback."""
+        source = "own-relations.md"
+        chunks = [make_chunk(f"own chunk {i}", source=source) for i in range(3)]
+        await storage.upsert_chunks(chunks)
+
+        first = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        assert first.affected_count == 1
+
+        # After first run: virtual summary exists AND originals have
+        # consolidated_into edges pointing to it. Re-run.
+        second = await execute_auto_consolidate(
+            storage, {"min_group_size": 3}, namespace=None, dry_run=False
+        )
+        # Must skip via layer 1 hash match — details say "0 groups" (idempotent),
+        # not "(SKIP: agent-consolidated)".
+        assert second.affected_count == 0
+        assert "agent-consolidated" not in second.details
+
+
+# ── mem_add core + mem_consolidate_apply integration ─────────────────
+#
+# These exercise the post-Phase-A.5 split: mem_consolidate_apply is back on
+# the file-first path via _mem_add_core, which also returns IndexingStats so
+# the caller can recover the new summary chunk id without racing on
+# recall_chunks(limit=1).
+
+
+def _fake_ctx(components):
+    """Minimal ctx stub that mimics what _get_app() unwraps.
+
+    The production MCP context is ``ctx.request_context.lifespan_context``.
+    We fabricate a SimpleNamespace matching that shape, filled with real
+    services from the ``components`` fixture plus the few AppContext fields
+    the tools access (``current_namespace``, ``webhook_manager``).
+    """
+    from types import SimpleNamespace
+
+    app = SimpleNamespace(
+        config=components.config,
+        storage=components.storage,
+        embedder=components.embedder,
+        index_engine=components.index_engine,
+        search_pipeline=components.search_pipeline,
+        current_namespace=None,
+        webhook_manager=None,
+    )
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+
+
+class TestMemAddCoreIntegration:
+    async def test_mem_add_core_returns_indexing_stats(self, components, memory_dir):
+        """_mem_add_core returns (message, stats) and stats.new_chunk_ids is
+        populated with the UUID(s) of chunks freshly upserted during indexing.
+        This is the hook that lets mem_consolidate_apply avoid the old
+        recall_chunks(limit=1) race."""
+        from memtomem.server.tools.memory_crud import _mem_add_core
+
+        ctx = _fake_ctx(components)
+
+        message, stats = await _mem_add_core(
+            content="A single atomic fact worth remembering for later search.",
+            title="Test Entry",
+            tags=["test"],
+            file="entry.md",
+            namespace=None,
+            template=None,
+            ctx=ctx,
+        )
+
+        assert "Memory added" in message
+        assert stats is not None
+        assert len(stats.new_chunk_ids) >= 1
+        # The reported chunk ids must actually be in the store.
+        fetched = await components.storage.get_chunks_batch(list(stats.new_chunk_ids))
+        assert len(fetched) == len(stats.new_chunk_ids)
+
+    async def test_mem_add_core_returns_none_on_early_error(self, components):
+        """Empty content short-circuits with (error_message, None) so callers
+        must tolerate None stats."""
+        from memtomem.server.tools.memory_crud import _mem_add_core
+
+        ctx = _fake_ctx(components)
+        message, stats = await _mem_add_core(
+            content="",
+            title=None,
+            tags=None,
+            file=None,
+            namespace=None,
+            template=None,
+            ctx=ctx,
+        )
+        assert "Error" in message
+        assert stats is None
+
+
+class TestMemConsolidateApplyIntegration:
+    async def test_agent_path_writes_to_disk_and_links_relations(self, components, memory_dir):
+        """Full file-first agent flow: summary appears in a disk file, the new
+        chunk is indexed, and each original has a consolidated_into edge
+        pointing to it. Replaces the old virtual-path test that reflected the
+        pre-Option-Y design."""
+        import json
+        from datetime import datetime, timedelta, timezone
+
+        from memtomem.server.tools.consolidation import mem_consolidate_apply
+        from memtomem.tools.memory_writer import append_entry
+
+        # Build a realistic source file with 3 real entries + index it so we
+        # have real chunk ids to hand to mem_consolidate_apply.
+        source_file = memory_dir / "apr-standup.md"
+        for i in range(3):
+            append_entry(
+                source_file,
+                f"Agenda item {i}: standup note with enough text to survive chunking.",
+                title=f"Item {i}",
+            )
+        stats = await components.index_engine.index_file(source_file)
+        assert stats.indexed_chunks >= 3
+        original_ids = [str(cid) for cid in stats.new_chunk_ids]
+
+        # Construct the scratch group entry that mem_consolidate_apply expects.
+        group = {
+            "group_id": 0,
+            "source": str(source_file),
+            "chunk_ids": original_ids,
+            "chunk_count": len(original_ids),
+            "namespace": None,
+            "previews": [],
+        }
+        expires_at = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(timespec="seconds")
+        await components.storage.scratch_set(
+            "consolidation_groups",
+            json.dumps([group]),
+            expires_at=expires_at,
+        )
+
+        ctx = _fake_ctx(components)
+        result = await mem_consolidate_apply(
+            group_id=0,
+            summary=(
+                "The April standup covered 3 items: progress on feature X, "
+                "a blocked ticket, and a decision to freeze the release branch."
+            ),
+            keep_originals=True,
+            ctx=ctx,
+        )
+
+        assert "Consolidation applied" in result
+        assert "Summary chunk id" in result
+
+        # There should be at least one NEW chunk on disk whose source_file is
+        # NOT the virtual .consolidated.md path — file-first means the
+        # summary landed in a real user-visible markdown file.
+        all_sources = await components.storage.get_all_source_files()
+        virtual_suffix = ".consolidated.md"
+        assert not any(str(s).endswith(virtual_suffix) for s in all_sources), (
+            "Agent path must not create a virtual consolidated chunk"
+        )
+
+        # The scratch entry should have been cleaned up after successful apply.
+        entry = await components.storage.scratch_get("consolidation_groups")
+        assert entry is None
+
+        # Each original must have a consolidated_into relation.
+        for oid in original_ids:
+            from uuid import UUID
+
+            related = await components.storage.get_related(UUID(oid))
+            assert any(rel == "consolidated_into" for _, rel in related), (
+                f"Original chunk {oid} missing consolidated_into edge"
+            )
+
 
 # ── Temporal ─────────────────────────────────────────────────────────
 

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -1102,6 +1102,148 @@ class TestMemConsolidateApplyIntegration:
             )
 
 
+# ── System namespace prefix filter ───────────────────────────────────
+
+
+class TestSystemNamespacePrefixFilter:
+    """Feature: default search (namespace=None) hides system-generated
+    namespaces like ``archive:*`` while explicit requests still retrieve
+    them. See Phase A.5 docs for why this is necessary — without it, the
+    auto_consolidate ``archive:summary`` chunks would pollute daily
+    search results on every user query."""
+
+    def test_namespace_filter_parse_none_with_prefixes_sets_exclude(self):
+        from memtomem.models import NamespaceFilter
+
+        f = NamespaceFilter.parse(None, system_prefixes=["archive:"])
+        assert f is not None
+        assert f.exclude_prefixes == ("archive:",)
+        assert f.namespaces == ()
+        assert f.pattern is None
+
+    def test_namespace_filter_parse_none_without_prefixes_returns_none(self):
+        from memtomem.models import NamespaceFilter
+
+        assert NamespaceFilter.parse(None) is None
+        assert NamespaceFilter.parse(None, system_prefixes=[]) is None
+
+    def test_namespace_filter_parse_explicit_clears_exclude(self):
+        """Explicit namespace argument opts into whatever was named, even
+        when that namespace matches a system prefix. Parse layer decides."""
+        from memtomem.models import NamespaceFilter
+
+        f = NamespaceFilter.parse("archive:summary", system_prefixes=["archive:"])
+        assert f is not None
+        assert f.namespaces == ("archive:summary",)
+        assert f.exclude_prefixes == ()  # explicit wins, no exclusion
+
+    def test_namespace_filter_parse_explicit_glob_clears_exclude(self):
+        from memtomem.models import NamespaceFilter
+
+        f = NamespaceFilter.parse("archive:*", system_prefixes=["archive:"])
+        assert f is not None
+        assert f.pattern == "archive:*"
+        assert f.exclude_prefixes == ()
+
+    def test_namespace_sql_exclude_prefixes_emits_not_like(self):
+        from memtomem.models import NamespaceFilter
+        from memtomem.storage.sqlite_helpers import namespace_sql
+
+        f = NamespaceFilter(exclude_prefixes=("archive:", "system:"))
+        frag, params = namespace_sql(f)
+        # Two NOT LIKE clauses AND-joined, each with its own param.
+        assert frag.count("NOT LIKE") == 2
+        assert " AND " in frag
+        assert params == ["archive:%", "system:%"]
+
+    def test_namespace_sql_exclude_prefixes_cap_assert(self):
+        """namespace_sql refuses to emit a runaway clause list."""
+        from memtomem.models import NamespaceFilter
+        from memtomem.storage.sqlite_helpers import namespace_sql
+
+        too_many = tuple(f"prefix{i}:" for i in range(11))
+        f = NamespaceFilter(exclude_prefixes=too_many)
+        with pytest.raises(AssertionError, match="cap is 10"):
+            namespace_sql(f)
+
+    def test_config_validator_rejects_too_many_prefixes(self):
+        """The SearchConfig validator catches misconfiguration at startup."""
+        from memtomem.config import SearchConfig
+
+        too_many = [f"p{i}:" for i in range(11)]
+        with pytest.raises(ValueError, match="cap is 10"):
+            SearchConfig(system_namespace_prefixes=too_many)
+
+    async def test_default_search_excludes_archive_summary(self, components, memory_dir):
+        """End-to-end: an archive:summary chunk is NOT returned by a
+        bare search (no namespace), but IS returned when explicitly asked."""
+        from memtomem.tools.memory_writer import append_entry
+
+        # 1. Index a user-facing chunk in the default namespace.
+        user_file = memory_dir / "normal.md"
+        append_entry(
+            user_file,
+            "A regular memory about Python async context managers and their lifecycle.",
+            title="Regular Entry",
+        )
+        await components.index_engine.index_file(user_file)
+
+        # 2. Manually create an archive:summary chunk — same vocabulary
+        # so both would rank highly for the same query.
+        from memtomem.models import Chunk, ChunkMetadata, ChunkType
+
+        summary_chunk = Chunk(
+            content=(
+                "Summary of Python async notes: covers async context managers, "
+                "task lifecycle, and the asyncio event loop."
+            ),
+            metadata=ChunkMetadata(
+                source_file=Path("/tmp/normal.md.consolidated.md"),
+                chunk_type=ChunkType.MARKDOWN_SECTION,
+                tags=("consolidated", "summary"),
+                namespace="archive:summary",
+            ),
+            embedding=[0.1] * components.config.embedding.dimension,
+        )
+        await components.storage.upsert_chunks([summary_chunk])
+
+        # 3. Default search — the archive:summary chunk must be filtered.
+        results, _ = await components.search_pipeline.search(
+            "python async context manager lifecycle", top_k=10
+        )
+        namespaces_found = {r.chunk.metadata.namespace for r in results}
+        assert "archive:summary" not in namespaces_found, (
+            f"archive:summary leaked into default search: {namespaces_found}"
+        )
+        # Sanity: we do get at least one result from the regular chunk.
+        assert len(results) >= 1
+
+    async def test_explicit_archive_summary_namespace_is_retrievable(self, components, memory_dir):
+        """The same chunk that default search hides is returned when the
+        caller explicitly scopes to archive:summary."""
+        from memtomem.models import Chunk, ChunkMetadata, ChunkType
+
+        summary_chunk = Chunk(
+            content=("Explicitly requested summary about async context managers and lifecycle."),
+            metadata=ChunkMetadata(
+                source_file=Path("/tmp/other.md.consolidated.md"),
+                chunk_type=ChunkType.MARKDOWN_SECTION,
+                tags=("consolidated", "summary"),
+                namespace="archive:summary",
+            ),
+            embedding=[0.1] * components.config.embedding.dimension,
+        )
+        await components.storage.upsert_chunks([summary_chunk])
+
+        results, _ = await components.search_pipeline.search(
+            "async context manager lifecycle",
+            top_k=10,
+            namespace="archive:summary",
+        )
+        assert len(results) >= 1
+        assert all(r.chunk.metadata.namespace == "archive:summary" for r in results)
+
+
 # ── Temporal ─────────────────────────────────────────────────────────
 
 

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -76,6 +76,7 @@ class FakeConfig:
         enable_dense = True
         tokenizer = "unicode61"
         rrf_weights = [1.0, 1.0]
+        system_namespace_prefixes: list[str] = []
 
     class _Indexing:
         memory_dirs = [Path("/tmp/memories")]


### PR DESCRIPTION
## Summary
- New `auto_consolidate` policy handler with deterministic heuristic summaries (chunk-type aware bullets, keyword-boosted, idempotent via content-embedded source hash).
- `mem_consolidate_apply` restored to file-first agent path via `_mem_add_core` + `IndexingStats.new_chunk_ids` — eliminates the `recall_chunks(limit=1)` race that silently linked relations to the wrong chunk.
- `search.system_namespace_prefixes` hides `archive:*` from default search while keeping explicit queries fully retrievable. Retroactively enforces the namespace-isolation claim that Phase A's `auto_archive` (#18) had introduced but not implemented.
- `docs/guides/agent-memory-guide.md` Scenario 3 gets a corrected `mem_consolidate_apply` example output plus a new "Automate Consolidation via Policy" callout comparing the agent and policy paths.

## Context
Phase A.5 follow-up to Phase A (#18). Fills the `auto_consolidate` stub that was declared in `policy_engine._VALID_TYPES` but never registered in `_HANDLERS`. Does not block Phase B (Claude auto-memory ingestion).

The 4 commits are kept separate on purpose so the corrective history is visible — the first commit shipped an overstated namespace-isolation claim, the second corrected the agent/policy path split, the third made the isolation claim actually enforced, and the fourth updated the docs that had drifted. Can be squash-merged if preferred.

1. `feat(policy): auto_consolidate handler with heuristic summary` — core feature.
2. `fix(consolidation): restore file-first agent path + two-layer idempotency` — Option Y split (agent = file-first via `mem_add`, policy = virtual chunk), `IndexingStats.new_chunk_ids` race fix, layered idempotency (source hash + `consolidated_into` edge fallback).
3. `feat(search): exclude system namespace prefixes from default search` — retroactive enforcement of namespace isolation for both Phase A `auto_archive` and Phase A.5 `auto_consolidate`.
4. `docs(agent-guide): fix stale mem_consolidate_apply example + auto_consolidate callout`.

### Design highlights
- **LLM-free**: memtomem LTM has no chat/generate client (only embedding), so the summary generator is a deterministic heuristic. Plug-in point preserved — swapping `make_heuristic_summary` for an LLM variant is one config-level change because `apply_consolidation(summary: str, ...)` stays agnostic.
- **Two-layer idempotency**: Layer 1 (policy-owned virtual summary + content-embedded source hash) handles re-runs on the same inputs; Layer 2 (`source_has_consolidation_relations`, `any` threshold) defers to agent-written summaries when the agent ran `mem_consolidate_apply` for a source already. Layer ordering matters — the test `test_auto_consolidate_own_relations_not_self_block` guards against a policy self-blocking regen via its own edges.
- **Namespace isolation via config, not code**: `search.system_namespace_prefixes = []` restores pre-Phase-A.5 behavior for users who want archived content to stay searchable. Default is `["archive:"]`.
- **Canary for chunker drift**: `mem_consolidate_apply` logs a warning when `mem_add` produces more than one chunk from a single consolidation summary. Today the Markdown chunker keeps a `Consolidated:` H1 together, so we expect exactly one — the warning fires loudly if that assumption ever breaks.
- **Decay floor**: `keep_originals=False` applies `max(score * 0.5, 0.3)` so already-low-importance chunks aren't evicted instantly. Never a hard delete.

## Test plan
- [ ] CI green (ruff + pytest + mypy advisory)
- [ ] 1024 tests pass (base 994 + 30 new; verified locally)
- [ ] 15 tests for `extract_bullet` / heuristic summary / policy handler happy path, idempotency, staleness regen, mixed-namespace skip, decay floor
- [ ] 6 tests for file-first `mem_consolidate_apply` integration, `_mem_add_core` stats surface, and the two-layer `any`-based agent-consolidation fallback
- [ ] 9 tests for `NamespaceFilter.exclude_prefixes` parse/SQL, config validator cap, and end-to-end default-search exclusion vs explicit retrieval
- [ ] Manual smoke: register an `auto_consolidate` policy via `mem_policy_add`, run with `dry_run=true`, then apply for real
- [ ] Manual smoke: verify `archive:summary` chunks are hidden from a bare `mem_search` and returned via `mem_search(..., namespace="archive:summary")`
- [ ] Manual smoke: `mem_consolidate_apply` still writes to a daily notes file on disk (file-first invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)