### PR TITLE
feat(cli): mm ingest claude-memory (Phase B)

### DIFF
--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -494,6 +494,37 @@ How Obsidian files are processed:
 mem_do(action="import_notion", params={"path": "~/notion-export.zip", "namespace": "notion"})
 ```
 
+### Ingesting Claude Code auto-memory
+
+`mm ingest claude-memory` takes a **read-only snapshot** of a Claude Code
+auto-memory directory (`~/.claude/projects/<slug>/memory/`) and makes it
+searchable under namespace `claude-memory:<slug>`. Unlike the Obsidian/Notion
+importers, source files are **not copied** — `source_file` points at the
+original absolute path, so the files stay under Claude's control.
+
+```
+mm ingest claude-memory --source ~/.claude/projects/<slug>/memory/ --dry-run
+mm ingest claude-memory --source ~/.claude/projects/<slug>/memory/
+```
+
+How Claude memory files are processed:
+- **Namespace**: `claude-memory:<slug>`, where `<slug>` is the directory
+  name under `~/.claude/projects/`. Characters outside the namespace
+  allowlist are replaced with `_`.
+- **Tags**: every chunk gets `claude-memory`. Files matching a known
+  prefix also get a type tag: `feedback_*` → `feedback`, `project_*` →
+  `project`, `user_*` → `user`, `reference_*` → `reference`.
+- **Excluded**: `MEMORY.md` and `README.md` are skipped — the first is a
+  table of contents, the second is meta documentation. Indexing either
+  would pollute search with a high-score duplicate on every query.
+- **Delta on re-run**: `mm ingest claude-memory` uses content-hash
+  comparison just like `mem_index`, so re-running on the same directory
+  only re-indexes files whose content actually changed.
+- **One-way**: there is no sync back. memtomem never writes to the source
+  directory. If you edit a feedback note in memtomem's web UI, Claude's
+  auto-memory on disk is unchanged — and vice versa, new Claude memories
+  appear only after you re-run `mm ingest claude-memory`.
+
 ---
 
 ## 7. Config — `mem_stats`, `mem_status`, `mem_config`, `mem_embedding_reset`

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -19,6 +19,7 @@ def _register() -> None:
     from memtomem.cli.context_cmd import context
     from memtomem.cli.embedding_cmd import embedding_reset
     from memtomem.cli.indexing import index
+    from memtomem.cli.ingest_cmd import ingest
     from memtomem.cli.memory import add, recall
     from memtomem.cli.search import search
     from memtomem.cli.init_cmd import init
@@ -32,6 +33,7 @@ def _register() -> None:
     cli.add_command(add)
     cli.add_command(recall)
     cli.add_command(index)
+    cli.add_command(ingest)
     cli.add_command(config)
     cli.add_command(context)
     cli.add_command(embedding_reset)

--- a/packages/memtomem/src/memtomem/cli/ingest_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/ingest_cmd.py
@@ -1,0 +1,246 @@
+"""CLI: mm ingest claude-memory — read-only Claude auto-memory snapshot."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from memtomem.models import Chunk
+    from memtomem.server.component_factory import Components
+    from memtomem.storage.base import StorageBackend
+
+
+# Files that sit inside a Claude memory directory but should never be
+# indexed as memory content. MEMORY.md is an index (table of contents) whose
+# text is just pointers to the other files — indexing it would surface a
+# high-score duplicate on every query. README.md is usually meta/how-to-read.
+_EXCLUDE_FILENAMES = frozenset({"MEMORY.md", "README.md"})
+
+# Filename prefix → tag. Trailing underscore is required so we only match
+# the prefix component, not any substring (``feedbackXYZ.md`` is not a
+# feedback note).
+_TAG_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("feedback_", "feedback"),
+    ("project_", "project"),
+    ("user_", "user"),
+    ("reference_", "reference"),
+)
+
+# Mirrors _NS_NAME_RE in storage/sqlite_namespace.py. Any character outside
+# this set in the derived slug is replaced with ``_`` before we hand the
+# namespace to the index engine.
+_NS_SAFE_RE = re.compile(r"[^\w\-.:@ ]")
+
+_NAMESPACE_PREFIX = "claude-memory:"
+
+
+@click.group()
+def ingest() -> None:
+    """Ingest memories from external sources."""
+
+
+@ingest.command("claude-memory")
+@click.option(
+    "--source",
+    "source_path",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    help=("Path to a Claude auto-memory directory, typically ~/.claude/projects/<slug>/memory/"),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be indexed without writing to storage.",
+)
+def claude_memory(source_path: Path, dry_run: bool) -> None:
+    """Index a Claude Code auto-memory directory into memtomem.
+
+    Read-only snapshot: the source files stay where they are — memtomem
+    records the absolute path as ``source_file`` and indexes the content
+    under namespace ``claude-memory:<slug>``. Re-run to pick up new or
+    changed files; unchanged files are skipped via content hash.
+    """
+    try:
+        asyncio.run(_run_claude_ingest(source_path, dry_run))
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+
+
+async def _run_claude_ingest(source_path: Path, dry_run: bool) -> None:
+    resolved = source_path.expanduser().resolve()
+    slug = _derive_slug(resolved)
+    namespace = _build_namespace(slug)
+
+    files = _discover_files(resolved)
+    if not files:
+        click.echo(
+            click.style(
+                f"No indexable markdown files found in {resolved}",
+                fg="yellow",
+            )
+        )
+        return
+
+    if dry_run:
+        click.echo(f"Would ingest {len(files)} file(s) into namespace '{namespace}' (dry-run):")
+        for f in files:
+            tags = sorted(_tags_for_file(f))
+            click.echo(f"  {f.name}  tags=[{', '.join(tags)}]")
+        return
+
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        summary = await _ingest_files_with_components(comp, files, namespace)
+
+    click.echo(
+        f"Ingested {len(files)} file(s) into '{namespace}': "
+        f"{summary.indexed} new, {summary.skipped} unchanged, "
+        f"{summary.deleted} deleted."
+    )
+    for err in summary.errors:
+        click.echo(click.style(f"  ERROR: {err}", fg="red"))
+
+
+@dataclass(frozen=True)
+class IngestSummary:
+    """Aggregate result of ingesting a batch of files."""
+
+    indexed: int
+    skipped: int
+    deleted: int
+    errors: tuple[str, ...]
+
+
+async def _ingest_files_with_components(
+    comp: Components,
+    files: list[Path],
+    namespace: str,
+) -> IngestSummary:
+    """Index *files* via *comp.index_engine* and tag each freshly-indexed file.
+
+    Split out from ``_run_claude_ingest`` so tests can drive the ingestion
+    loop with a real ``components`` fixture instead of going through
+    ``cli_components()`` (which requires a global ~/.memtomem/config.json).
+    """
+    total_indexed = 0
+    total_skipped = 0
+    total_deleted = 0
+    errors: list[str] = []
+    for f in files:
+        stats = await comp.index_engine.index_file(f, namespace=namespace)
+        total_indexed += stats.indexed_chunks
+        total_skipped += stats.skipped_chunks
+        total_deleted += stats.deleted_chunks
+        if stats.errors:
+            errors.extend(stats.errors)
+
+        if stats.indexed_chunks > 0:
+            await _apply_tags(comp.storage, f, _tags_for_file(f))
+
+    comp.search_pipeline.invalidate_cache()
+    return IngestSummary(
+        indexed=total_indexed,
+        skipped=total_skipped,
+        deleted=total_deleted,
+        errors=tuple(errors),
+    )
+
+
+def _discover_files(source_root: Path) -> list[Path]:
+    """Return indexable ``.md`` files directly under *source_root*.
+
+    Flat (non-recursive) — Claude memory directories are a single level by
+    convention. Sorted for deterministic output. Skips hidden files and the
+    known index/readme exclusion list.
+    """
+    files: list[Path] = []
+    for f in sorted(source_root.iterdir()):
+        if not f.is_file():
+            continue
+        if f.suffix != ".md":
+            continue
+        if f.name.startswith("."):
+            continue
+        if f.name in _EXCLUDE_FILENAMES:
+            continue
+        files.append(f)
+    return files
+
+
+def _derive_slug(source_path: Path) -> str:
+    """Extract the project slug from a Claude memory path.
+
+    Expected layout is ``.../projects/<slug>/memory/``; in that case the
+    slug is the parent directory's name. For any other layout we fall back
+    to the source directory's own name so the caller still gets a
+    stable namespace.
+    """
+    if source_path.name == "memory":
+        return source_path.parent.name or "default"
+    return source_path.name or "default"
+
+
+def _build_namespace(slug: str) -> str:
+    """Return ``claude-memory:<slug>`` with *slug* sanitized for storage.
+
+    Characters outside the SQLite namespace allowlist (``_NS_NAME_RE``) are
+    replaced with ``_`` so downstream storage never rejects the namespace.
+    """
+    safe = _NS_SAFE_RE.sub("_", slug)
+    return f"{_NAMESPACE_PREFIX}{safe}"
+
+
+def _tags_for_file(file_path: Path) -> set[str]:
+    """Return the tag set to apply to every chunk from *file_path*.
+
+    Always includes ``claude-memory`` (source marker). Files whose name
+    starts with a known prefix (``feedback_``, ``project_``, ``user_``,
+    ``reference_``) also get a type tag derived from the prefix.
+    """
+    tags = {"claude-memory"}
+    for prefix, tag in _TAG_PREFIXES:
+        if file_path.name.startswith(prefix):
+            tags.add(tag)
+            break
+    return tags
+
+
+async def _apply_tags(
+    storage: StorageBackend,
+    source_file: Path,
+    new_tags: set[str],
+) -> None:
+    """Merge *new_tags* into every chunk for *source_file* and upsert.
+
+    No-op when the chunk already has the full tag set. Mirrors the tag
+    application pattern in ``server/tools/importers.py`` so behavior is
+    consistent across Notion/Obsidian/Claude ingestion paths.
+    """
+    chunks = await storage.list_chunks_by_source(source_file)
+    if not chunks:
+        return
+
+    dirty: list[Chunk] = []
+    for c in chunks:
+        existing = set(c.metadata.tags)
+        merged = existing | new_tags
+        if merged == existing:
+            continue
+        c.metadata = c.metadata.__class__(
+            **{
+                **{field: getattr(c.metadata, field) for field in c.metadata.__dataclass_fields__},
+                "tags": tuple(sorted(merged)),
+            }
+        )
+        dirty.append(c)
+    if dirty:
+        await storage.upsert_chunks(dirty)

--- a/packages/memtomem/tests/test_cli_ingest.py
+++ b/packages/memtomem/tests/test_cli_ingest.py
@@ -1,0 +1,281 @@
+"""Tests for ``mm ingest claude-memory`` (Phase B: one-way Claude ingestion).
+
+Split into two layers:
+
+* **Unit** — pure functions (_discover_files / _derive_slug / _build_namespace /
+  _tags_for_file). No fixtures, fast, always runs in CI.
+* **Integration** — full index_engine + storage loop via ``components``
+  fixture; marked ``@pytest.mark.ollama`` because indexing calls embedders.
+  Tests that ingest is read-only (source files untouched), delta re-runs
+  skip unchanged content, edits are picked up, and namespace/tags land on
+  the real chunks.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.cli.ingest_cmd import (
+    _NAMESPACE_PREFIX,
+    _build_namespace,
+    _derive_slug,
+    _discover_files,
+    _ingest_files_with_components,
+    _tags_for_file,
+)
+
+
+# ── Unit tests ───────────────────────────────────────────────────────
+
+
+class TestDiscoverFiles:
+    def test_returns_sorted_markdown_files(self, tmp_path):
+        (tmp_path / "project_b.md").write_text("b")
+        (tmp_path / "feedback_a.md").write_text("a")
+        (tmp_path / "user_c.md").write_text("c")
+
+        files = _discover_files(tmp_path)
+        assert [f.name for f in files] == [
+            "feedback_a.md",
+            "project_b.md",
+            "user_c.md",
+        ]
+
+    def test_excludes_memory_md_and_readme(self, tmp_path):
+        """MEMORY.md and README.md are indexes / docs, not memory content."""
+        (tmp_path / "feedback_a.md").write_text("keep")
+        (tmp_path / "MEMORY.md").write_text("- [a](feedback_a.md)")
+        (tmp_path / "README.md").write_text("# how to read")
+
+        files = _discover_files(tmp_path)
+        names = [f.name for f in files]
+        assert names == ["feedback_a.md"]
+
+    def test_excludes_hidden_and_non_markdown(self, tmp_path):
+        (tmp_path / "project_a.md").write_text("keep")
+        (tmp_path / ".DS_Store").write_text("mac")
+        (tmp_path / ".hidden.md").write_text("hidden")
+        (tmp_path / "notes.txt").write_text("wrong ext")
+        (tmp_path / "script.py").write_text("code")
+
+        files = _discover_files(tmp_path)
+        assert [f.name for f in files] == ["project_a.md"]
+
+    def test_non_recursive(self, tmp_path):
+        """Claude memory dirs are flat — don't walk subdirectories."""
+        (tmp_path / "project_a.md").write_text("top")
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (sub / "project_b.md").write_text("nested")
+
+        files = _discover_files(tmp_path)
+        assert [f.name for f in files] == ["project_a.md"]
+
+    def test_empty_directory(self, tmp_path):
+        assert _discover_files(tmp_path) == []
+
+
+class TestDeriveSlug:
+    def test_memory_subdir_returns_parent_name(self, tmp_path):
+        """Canonical ~/.claude/projects/<slug>/memory/ layout."""
+        slug_dir = tmp_path / "-Users-me-Work-foo" / "memory"
+        slug_dir.mkdir(parents=True)
+        assert _derive_slug(slug_dir) == "-Users-me-Work-foo"
+
+    def test_non_memory_leaf_falls_back_to_leaf_name(self, tmp_path):
+        """When the user points at a non-canonical path, at least stay
+        deterministic — slug is the leaf directory name."""
+        leaf = tmp_path / "custom-project-notes"
+        leaf.mkdir()
+        assert _derive_slug(leaf) == "custom-project-notes"
+
+    def test_empty_name_defaults(self, tmp_path):
+        """Guard against a bare root path producing an empty slug."""
+        # Path("/") has name == ""; _derive_slug must degrade gracefully.
+        assert _derive_slug(Path("/")) == "default"
+
+
+class TestBuildNamespace:
+    def test_simple_slug_passes_through(self):
+        assert _build_namespace("my-project") == f"{_NAMESPACE_PREFIX}my-project"
+
+    def test_real_claude_slug_passes_through(self):
+        """Real Claude project slugs start with '-' and use hyphens as
+        the flattened path separator — must stay intact."""
+        slug = "-Users-me-Work-agent-harness-memtomem"
+        assert _build_namespace(slug) == f"{_NAMESPACE_PREFIX}{slug}"
+
+    def test_unsafe_chars_replaced_with_underscore(self):
+        """Anything outside _NS_NAME_RE gets sanitized so storage accepts it."""
+        ns = _build_namespace("weird/slug$with!chars")
+        assert ns == f"{_NAMESPACE_PREFIX}weird_slug_with_chars"
+
+    def test_safe_punctuation_kept(self):
+        """Word chars, dot, colon, @, hyphen, underscore, space are allowed."""
+        ns = _build_namespace("ok.slug_1:v2@host")
+        assert ns == f"{_NAMESPACE_PREFIX}ok.slug_1:v2@host"
+
+
+class TestTagsForFile:
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("feedback_docs_as_tests.md", {"claude-memory", "feedback"}),
+            ("project_ltm_manager_roadmap.md", {"claude-memory", "project"}),
+            ("user_language.md", {"claude-memory", "user"}),
+            ("reference_memtomem_ssh.md", {"claude-memory", "reference"}),
+        ],
+    )
+    def test_known_prefixes_get_type_tag(self, filename, expected):
+        assert _tags_for_file(Path(filename)) == expected
+
+    def test_unknown_prefix_still_gets_claude_memory_tag(self):
+        """Files without a recognized prefix are still ingested under the
+        ``claude-memory`` source tag — just without a type classifier."""
+        assert _tags_for_file(Path("mystery.md")) == {"claude-memory"}
+
+    def test_substring_does_not_match_prefix(self):
+        """``feedbackXYZ.md`` starts with 'feedback' but is not a feedback
+        note — the trailing underscore guard in _TAG_PREFIXES enforces this."""
+        assert _tags_for_file(Path("feedbackXYZ.md")) == {"claude-memory"}
+
+
+# ── Integration tests ────────────────────────────────────────────────
+
+
+@pytest.mark.ollama
+class TestIngestFilesWithComponents:
+    """End-to-end coverage via the real index_engine + storage.
+
+    Uses the ``components`` fixture from conftest.py — same pattern as the
+    other ``_mem_*_core`` integration tests in test_tools_logic.py.
+    """
+
+    async def _make_claude_memory_dir(self, tmp_path: Path) -> Path:
+        """Build a fake ~/.claude/projects/<slug>/memory/ layout outside
+        the configured memtomem memory_dirs, so we exercise the
+        read-only ingestion path (no file copy)."""
+        claude_root = tmp_path / "fake_home" / ".claude" / "projects"
+        slug_dir = claude_root / "-Users-test-Work-demo-project" / "memory"
+        slug_dir.mkdir(parents=True)
+
+        (slug_dir / "feedback_a.md").write_text(
+            "# Feedback A\n\nAlways use bge-m3 for Korean text embeddings "
+            "because the vocabulary coverage is wider than bge-small.\n"
+        )
+        (slug_dir / "project_b.md").write_text(
+            "# Project B\n\nPhase B adds a claude-memory ingestion path "
+            "that treats the source directory as a read-only snapshot.\n"
+        )
+        # MEMORY.md must be ignored even though it lives in the same dir.
+        (slug_dir / "MEMORY.md").write_text(
+            "- [Feedback A](feedback_a.md)\n- [Project B](project_b.md)\n"
+        )
+        return slug_dir
+
+    async def test_happy_path_indexes_with_namespace_and_tags(self, components, tmp_path):
+        slug_dir = await self._make_claude_memory_dir(tmp_path)
+        files = _discover_files(slug_dir)
+        # Sanity: discovery already drops MEMORY.md.
+        assert {f.name for f in files} == {"feedback_a.md", "project_b.md"}
+
+        summary = await _ingest_files_with_components(
+            components,
+            files,
+            namespace="claude-memory:-Users-test-Work-demo-project",
+        )
+
+        assert summary.indexed >= 2, summary
+        assert summary.errors == ()
+
+        # Every chunk lives under the expected namespace and has
+        # both the source tag and its per-file type tag.
+        for f in files:
+            chunks = await components.storage.list_chunks_by_source(f)
+            assert chunks, f"no chunks indexed for {f.name}"
+            for c in chunks:
+                assert c.metadata.namespace == ("claude-memory:-Users-test-Work-demo-project")
+                assert "claude-memory" in c.metadata.tags
+                if f.name.startswith("feedback_"):
+                    assert "feedback" in c.metadata.tags
+                elif f.name.startswith("project_"):
+                    assert "project" in c.metadata.tags
+
+    async def test_ingest_is_read_only_source_files_untouched(self, components, tmp_path):
+        """After ingestion the source files must still exist at their
+        original absolute path and have unchanged content — no copy, no
+        move, no rewrite."""
+        slug_dir = await self._make_claude_memory_dir(tmp_path)
+        files = _discover_files(slug_dir)
+        original_bytes = {f: f.read_bytes() for f in files}
+
+        await _ingest_files_with_components(
+            components,
+            files,
+            namespace="claude-memory:-Users-test-Work-demo-project",
+        )
+
+        for f, data in original_bytes.items():
+            assert f.exists(), f"{f} disappeared after ingest"
+            assert f.read_bytes() == data, f"{f} content was mutated"
+
+        # And chunk source_file must point at the original absolute path,
+        # not some copy under memtomem's memory_dirs.
+        for f in files:
+            chunks = await components.storage.list_chunks_by_source(f)
+            assert chunks
+            for c in chunks:
+                assert Path(c.metadata.source_file).resolve() == f.resolve()
+
+    async def test_rerun_skips_unchanged_files(self, components, tmp_path):
+        """Content-hash delta: a second identical ingest indexes 0 new
+        chunks and marks the existing ones as skipped."""
+        slug_dir = await self._make_claude_memory_dir(tmp_path)
+        files = _discover_files(slug_dir)
+
+        first = await _ingest_files_with_components(
+            components,
+            files,
+            namespace="claude-memory:-Users-test-Work-demo-project",
+        )
+        assert first.indexed >= 2
+
+        second = await _ingest_files_with_components(
+            components,
+            files,
+            namespace="claude-memory:-Users-test-Work-demo-project",
+        )
+        assert second.indexed == 0, second
+        assert second.skipped >= 2, second
+        assert second.errors == ()
+
+    async def test_edited_file_is_reindexed_on_rerun(self, components, tmp_path):
+        """When a single file's content changes, the next ingest
+        re-indexes that file while leaving the others on skip."""
+        slug_dir = await self._make_claude_memory_dir(tmp_path)
+        files = _discover_files(slug_dir)
+
+        await _ingest_files_with_components(
+            components,
+            files,
+            namespace="claude-memory:-Users-test-Work-demo-project",
+        )
+
+        edited = slug_dir / "feedback_a.md"
+        edited.write_text(
+            "# Feedback A\n\nRevised guidance: prefer bge-m3 for multilingual "
+            "corpora — the Korean coverage is measurably better than bge-small, "
+            "and the English quality is comparable.\n"
+        )
+
+        summary = await _ingest_files_with_components(
+            components,
+            files,
+            namespace="claude-memory:-Users-test-Work-demo-project",
+        )
+        # At least one chunk from feedback_a.md should be re-upserted; the
+        # untouched project_b.md should show up as skipped.
+        assert summary.indexed >= 1, summary
+        assert summary.skipped >= 1, summary


### PR DESCRIPTION
## Summary

Phase B of the LTM Manager roadmap — one-way ingestion of a Claude Code
per-project auto-memory directory (`~/.claude/projects/<slug>/memory/`)
as a **read-only snapshot** so it's searchable alongside the rest of a
user's LTM corpus. `project_ltm_manager_roadmap.md` has the full
rationale; dogfooding our own project's auto-memory is the obvious
next step after Phase A+A.5 stabilized the archival policy pipeline.

**New CLI**: `mm ingest claude-memory --source ~/.claude/projects/<slug>/memory/ [--dry-run]`

## What's different from the existing Notion/Obsidian importers

- **Read-only**. `source_file` points at the original absolute path
  under `~/.claude/projects/<slug>/memory/`. No copy lands in
  `~/.memtomem/memories/_imported/`. Claude stays in charge of its own
  directory — editing a file on the Claude side then re-running
  `mm ingest claude-memory` picks up the change via content hash.
- **CLI-only**. The sync model is "rerun to refresh", not "streamed via
  an agent", so there's no new MCP tool.
- **Delta is free**: `IndexEngine.index_file`'s `compute_diff` already
  skips unchanged chunks when `source_file` is stable, which it is.

## Namespace / tags

- `claude-memory:<slug>`, where `<slug>` is the parent of `memory/`.
  Characters outside `_NS_NAME_RE` are replaced with `_` defensively
  (real Claude slugs already fit the allowlist, but the sanitizer
  guards against future drift).
- Every chunk gets the `claude-memory` source tag plus a per-file type
  tag derived from the filename prefix:
  - `feedback_*` → `feedback`
  - `project_*` → `project`
  - `user_*` → `user`
  - `reference_*` → `reference`
- Trailing underscore in `_TAG_PREFIXES` means `feedbackXYZ.md` does
  **not** get the feedback tag — only true `feedback_*` files do.

## What's excluded

- `MEMORY.md` — it's an index (table of contents); indexing it would
  surface a high-score duplicate on every query.
- `README.md` — meta docs, not memory content.
- Hidden files, non-markdown, subdirectories. Claude memory dirs are
  flat by convention.

## Implementation split for testability

- `_run_claude_ingest` handles argument parsing, dry-run mode, and the
  `cli_components` bootstrap (which requires a real
  `~/.memtomem/config.json`).
- `_ingest_files_with_components` is the inner loop: takes an
  already-built `Components` + file list. Integration tests use the
  shared `components` fixture from `conftest.py` to drive this directly.

## Tests (22 new)

**18 unit tests** — always run in CI, no fixtures:

- `_discover_files`: sort order, `MEMORY.md`/`README.md`/hidden/non-md
  exclusion, non-recursive, empty dir.
- `_derive_slug`: canonical `<slug>/memory/` layout, non-canonical
  fallback, bare-root default.
- `_build_namespace`: real Claude slug pass-through, unsafe chars
  replaced, safe punctuation kept.
- `_tags_for_file`: all four prefix → tag mappings, unknown prefix
  still gets `claude-memory`, substring guard (`feedbackXYZ.md`).

**4 integration tests** — `@pytest.mark.ollama`, use `components` fixture:

- Happy path: namespace + tags land on real chunks.
- Read-only invariant: source bytes unchanged after ingest,
  `source_file` points at the original absolute path (not a copy).
- Re-run delta: second run indexes 0 new, marks unchanged as skipped.
- Edited file: rerun re-indexes only the changed file.

## Test plan

- [x] `uv run pytest -m "not ollama" -q` → 1038 passed, 40 deselected
- [x] `uv run ruff check packages/memtomem/src` → clean
- [x] `uv run ruff format --check packages/memtomem/src` → clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/ingest_cmd.py` → clean
- [x] Local integration: `uv run pytest packages/memtomem/tests/test_cli_ingest.py -q` → 22 passed (with Ollama up)
- [x] Dry-run against real dir: 50 files, correct namespace + tags, `MEMORY.md` excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)