### PR TITLE
feat(context): Phase D — Claude settings.json hook integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- **Phase D: Claude `settings.json` integration** — new `SettingsGenerator`
+  protocol and `ClaudeSettingsGenerator` implementation for merging memtomem
+  hooks into `~/.claude/settings.json`. Completes the LTM Manager roadmap
+  (Phases A → A.5 → B → C → D) and absorbs context-gateway Phase 4.
+  - New `--include=settings` flag for `mm context {generate,sync,diff,detect}`
+    (CLI and MCP `mem_context_*` tools).
+  - New `mm init` wizard step (Step 8) prompts for Claude Code hooks setup.
+  - Canonical source: `.memtomem/settings.json` with a `hooks` array.
+  - Additive-only merge: hooks are appended by name; on collision the user's
+    existing hook wins and a guided warning is emitted.
+  - Formatting: `json.dumps(indent=2)` normalization — byte-for-byte
+    preservation of hand-edited formatting is explicitly not guaranteed.
+  - Malformed `~/.claude/settings.json` is skipped with an error message
+    (not silently overwritten).
+  - If Claude Code is not installed (`~/.claude/` missing), the settings
+    runtime is silently skipped — memtomem never creates `~/.claude/`.
+  - Basic concurrent-write guard via mtime comparison between read and write.
+
 ## [0.1.5] — 2026-04-12
 
 ### Added

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1149,6 +1149,8 @@ mm context init                        # create unified context.md
 mm context generate --agent all        # generate all agent files
 mm context diff                        # check sync status
 mm context sync                        # sync context.md → agent files
+mm context generate --include=settings # merge hooks → ~/.claude/settings.json
+mm context diff --include=settings     # check hook sync status
 
 # Utilities
 mm shell                               # interactive REPL
@@ -1245,6 +1247,65 @@ pip install memtomem-stm
 ```
 
 For setup, CLI usage, compression strategies, surfacing configuration, and the full tool list, see the [memtomem-stm README](https://github.com/memtomem/memtomem-stm#readme).
+
+---
+
+## Settings Hooks Integration (Phase D)
+
+memtomem can manage Claude Code hooks via a canonical
+`.memtomem/settings.json` file.  The `--include=settings` flag on
+`mm context generate/sync/diff` merges your hooks into
+`~/.claude/settings.json` additively.
+
+### Quick start
+
+```bash
+# 1. Create the canonical source (or let mm init create it)
+mkdir -p .memtomem
+echo '{"hooks": []}' > .memtomem/settings.json
+
+# 2. Add your hooks to .memtomem/settings.json, then sync
+mm context sync --include=settings
+
+# 3. Check sync status
+mm context diff --include=settings
+```
+
+### Merge rules
+
+- **Additive-only**: hooks are appended to the target, never overwritten.
+- **Name-based conflict detection**: if a hook with the same `name` already
+  exists in `~/.claude/settings.json`, memtomem skips it and emits a warning
+  with a concrete remediation step.
+- **User wins**: on conflict, your existing hook is preserved verbatim.
+- **`mm context diff --include=settings`** shows the merge plan without
+  writing (dry-run).
+
+### Caveats
+
+- **Formatting is not preserved.**  After `mm context sync --include=settings`,
+  `~/.claude/settings.json` is normalized to `json.dumps(indent=2)`.  If you
+  hand-edit the file with custom indentation or key order, expect the layout
+  to change on sync.
+- **Malformed JSON is skipped.**  If `~/.claude/settings.json` is not valid
+  JSON, the sync reports an error and does **not** modify the file.  Fix it
+  manually, then re-run the sync.
+- **Claude Code must be installed.**  If `~/.claude/` does not exist, the
+  settings runtime is silently skipped.  memtomem never creates `~/.claude/`.
+- **Concurrent writes.**  A basic mtime guard detects if another process
+  modifies `~/.claude/settings.json` during the merge and aborts rather than
+  overwriting.  Re-run the sync to retry.
+
+### MCP usage
+
+The same functionality is available through MCP tools:
+
+```
+mem_context_generate(include="settings")
+mem_context_sync(include="settings")
+mem_context_diff(include="settings")
+mem_context_detect(include="settings")
+```
 
 ---
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -22,6 +22,7 @@ from memtomem.context.detector import (
     detect_agent_dirs,
     detect_agent_files,
     detect_command_dirs,
+    detect_settings_files,
     detect_skill_dirs,
 )
 from memtomem.context.generator import (
@@ -29,14 +30,18 @@ from memtomem.context.generator import (
     extract_sections_from_agent_file,
 )
 from memtomem.context.parser import CONTEXT_FILENAME, parse_context, sections_to_markdown
+from memtomem.context.settings import (
+    diff_settings,
+    generate_all_settings,
+)
 from memtomem.context.skills import (
     diff_skills,
     extract_skills_to_canonical,
     generate_all_skills,
 )
 
-# Phase 1-3 supports --include={skills,agents,commands}. Phase 4 will add hooks / mcp.
-_KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands"})
+# Phase 1-3 supports skills/agents/commands; Phase D adds settings.
+_KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
 
 
 def _find_project_root() -> Path:
@@ -242,6 +247,50 @@ def _print_commands_diff(root: Path) -> None:
         click.secho(f"  {runtime:17s}  {name}  [{status}]", fg=color)
 
 
+# ── Settings sub-handlers (Phase D) ─────────────────────────────────
+
+
+def _print_settings_detect() -> None:
+    files = detect_settings_files()
+    if not files:
+        click.echo("  (no settings files detected)")
+        return
+    click.secho(f"  {len(files)} settings file(s):", fg="cyan")
+    for f in files:
+        status = f"({f.size} bytes)" if f.size else "(not yet created)"
+        click.echo(f"    {f.agent:17s}  {f.path}  {status}")
+
+
+def _print_settings_generate(root: Path) -> None:
+    results = generate_all_settings(root)
+    for name, r in results.items():
+        if r.status == "ok":
+            click.secho(f"  Settings: {name} → {r.target}", fg="green")
+            for w in r.warnings:
+                click.secho(f"    warning: {w}", fg="yellow")
+        elif r.status == "skipped":
+            click.secho(f"  skipped {name}: {r.reason}", fg="yellow")
+        elif r.status in ("error", "aborted"):
+            click.secho(f"  {r.status} {name}: {r.reason}", fg="red")
+
+
+def _print_settings_diff(root: Path) -> None:
+    results = diff_settings(root)
+    if not results:
+        click.echo("  (no settings to compare)")
+        return
+    for name, r in results.items():
+        if r.status in ("in sync", "out of sync", "missing target"):
+            color = "green" if r.status == "in sync" else "yellow"
+            click.secho(f"  {name:17s}  [{r.status}]", fg=color)
+            for w in r.warnings:
+                click.secho(f"    warning: {w}", fg="yellow")
+        elif r.status == "skipped":
+            click.secho(f"  skipped {name}: {r.reason}", fg="yellow")
+        elif r.status == "error":
+            click.secho(f"  error {name}: {r.reason}", fg="red")
+
+
 @click.group("context")
 def context() -> None:
     """Manage unified agent context (CLAUDE.md, .cursorrules, GEMINI.md, etc.)."""
@@ -276,6 +325,10 @@ def detect_cmd(include: tuple[str, ...]) -> None:
     if "commands" in inc:
         click.echo("")
         _print_commands_detect(root)
+
+    if "settings" in inc:
+        click.echo("")
+        _print_settings_detect()
 
 
 @context.command("init")
@@ -395,6 +448,10 @@ def generate_cmd(agent: str, include: tuple[str, ...], strict: bool) -> None:
         click.echo("")
         _print_commands_generate(root, strict=strict)
 
+    if "settings" in inc:
+        click.echo("")
+        _print_settings_generate(root)
+
     click.secho("Done.", fg="green")
 
 
@@ -442,6 +499,10 @@ def diff_cmd(include: tuple[str, ...]) -> None:
     if "commands" in inc:
         click.echo("")
         _print_commands_diff(root)
+
+    if "settings" in inc:
+        click.echo("")
+        _print_settings_diff(root)
 
 
 @context.command("sync")
@@ -494,5 +555,9 @@ def sync_cmd(include: tuple[str, ...], strict: bool) -> None:
     if "commands" in inc:
         click.echo("")
         _print_commands_generate(root, strict=strict)
+
+    if "settings" in inc:
+        click.echo("")
+        _print_settings_generate(root)
 
     click.secho("Synced.", fg="green")

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -221,6 +221,49 @@ def _step_language(state: dict) -> None:
     click.echo()
 
 
+def _step_settings(state: dict) -> None:
+    step_header(8, "Claude Code Hooks")
+
+    # Skip entirely if Claude Code is not installed
+    claude_dir = Path.home() / ".claude"
+    if not claude_dir.is_dir():
+        click.echo("  Claude Code not detected (~/.claude/ missing). Skipping.")
+        state["settings_hooks"] = False
+        click.echo()
+        return
+
+    click.echo("  memtomem can manage Claude Code hooks via .memtomem/settings.json.")
+    click.echo("  Hooks are merged into ~/.claude/settings.json additively.")
+    state["settings_hooks"] = nav_confirm(
+        "  Configure Claude Code hooks via memtomem?", default=False
+    )
+
+    if state["settings_hooks"]:
+        from memtomem.context.settings import CANONICAL_SETTINGS_FILE, generate_all_settings
+
+        project_root = Path.cwd()
+        canonical = project_root / CANONICAL_SETTINGS_FILE
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        if not canonical.exists():
+            canonical.write_text(
+                json.dumps({"hooks": []}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            click.secho(f"  Created {CANONICAL_SETTINGS_FILE}", fg="green")
+
+        results = generate_all_settings(project_root)
+        for name, r in results.items():
+            if r.status == "ok":
+                click.secho(f"  Merged → {r.target}", fg="green")
+            elif r.status == "skipped":
+                click.secho(f"  skipped {name}: {r.reason}", fg="yellow")
+
+        click.echo()
+        click.echo("  Empty hooks file created. Add hooks to .memtomem/settings.json,")
+        click.echo("  then run 'mm context sync --include=settings' to apply.")
+    click.echo()
+
+
 def _step_mcp(state: dict) -> None:
     step_header(7, "Connect to AI Editor")
     click.echo("  How do you want to connect memtomem?")
@@ -462,6 +505,7 @@ def init(
             _step_search,
             _step_language,
             _step_mcp,
+            _step_settings,
         ]
         run_steps(steps, state)
 

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -62,6 +62,12 @@ COMMAND_DIRS: dict[str, tuple[str, str]] = {
     "gemini_commands": (".gemini/commands", ".toml"),
 }
 
+# Settings runtimes are detected via the generators registered in
+# ``context/settings.py``.  Unlike the dicts above there is no static
+# mapping here — ``detect_settings_files()`` delegates to each
+# generator's ``is_available()`` / ``target_file()`` at call time so
+# that ``monkeypatch``-based HOME overrides in tests work correctly.
+
 
 def detect_agent_files(project_root: Path) -> list[DetectedFile]:
     """Scan project root for known agent configuration files.
@@ -179,13 +185,55 @@ def detect_command_dirs(project_root: Path) -> list[DetectedFile]:
     return sorted(found, key=lambda f: (f.agent, str(f.path)))
 
 
+def detect_settings_files() -> list[DetectedFile]:
+    """Detect user-scope settings files for registered runtimes.
+
+    Unlike the other ``detect_*`` functions this does **not** take a
+    *project_root* because settings files live in the user's home directory.
+    A runtime is reported only when its home directory exists (e.g.
+    ``~/.claude/``), matching :meth:`ClaudeSettingsGenerator.is_available`.
+
+    Delegates to generators from ``context/settings.py`` at call time (lazy
+    import) to ensure ``monkeypatch``-based HOME overrides in tests work.
+    """
+    from memtomem.context.settings import SETTINGS_GENERATORS
+
+    found: list[DetectedFile] = []
+    for name, gen in SETTINGS_GENERATORS.items():
+        if not gen.is_available():
+            continue
+        # project_root is not used by user-scope generators, but the
+        # protocol requires it — pass cwd as a harmless default.
+        target = gen.target_file(Path.cwd())
+        if target.is_file():
+            found.append(
+                DetectedFile(
+                    agent=name,
+                    path=target,
+                    size=target.stat().st_size,
+                    kind="file",
+                )
+            )
+        else:
+            found.append(
+                DetectedFile(
+                    agent=name,
+                    path=target,
+                    size=0,
+                    kind="file",
+                )
+            )
+    return sorted(found, key=lambda f: (f.agent, str(f.path)))
+
+
 def detect_all(project_root: Path) -> list[DetectedFile]:
-    """Return project-memory files, skill directories, sub-agent files, and commands."""
+    """Return project-memory files, skill dirs, sub-agents, commands, and settings."""
     return (
         detect_agent_files(project_root)
         + detect_skill_dirs(project_root)
         + detect_agent_dirs(project_root)
         + detect_command_dirs(project_root)
+        + detect_settings_files()
     )
 
 
@@ -200,5 +248,6 @@ __all__ = [
     "detect_agent_files",
     "detect_all",
     "detect_command_dirs",
+    "detect_settings_files",
     "detect_skill_dirs",
 ]

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -1,0 +1,334 @@
+"""Canonical → runtime settings.json integration (Phase D).
+
+Phase D of the "memtomem as canonical context gateway" plan.  A project's
+canonical settings live at ``.memtomem/settings.json`` with a ``hooks``
+array.  From that single canonical source we fan out to:
+
+* ``~/.claude/settings.json`` — Claude Code (JSON deep-merge into ``hooks``)
+
+Gemini and Codex have no known settings-file equivalent as of 2026-04-12;
+runtimes can be added by implementing :class:`SettingsGenerator` and
+registering in :data:`SETTINGS_GENERATORS`.
+
+Merge semantics
+---------------
+* **Additive-only**: memtomem contributions are appended, never overwritten.
+* **Hook name key**: entries in the ``hooks`` array are matched by ``name``.
+  On collision the user's existing hook wins and a guided warning is emitted.
+* **Formatting**: ``json.dumps(indent=2, sort_keys=False)`` + trailing
+  newline.  Byte-for-byte preservation of the user's original formatting is
+  explicitly **not** guaranteed — semantic equality is the contract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+CANONICAL_SETTINGS_FILE = ".memtomem/settings.json"
+
+# Sentinel for malformed JSON detection (identity-compared via ``is``)
+_MALFORMED = object()
+
+
+# ── Protocol + Result ───────────────────────────────────────────────
+
+
+class SettingsGenerator(Protocol):
+    """Protocol for runtime-specific settings generators."""
+
+    name: str
+
+    def is_available(self) -> bool:
+        """``True`` if the runtime is installed (e.g. ``~/.claude/`` exists).
+
+        Used to skip generators whose runtime isn't installed.  Generators
+        must **not** auto-create the runtime's home directory.
+        """
+        ...
+
+    def target_file(self, project_root: Path) -> Path:
+        """Return the path to the runtime's settings file."""
+        ...
+
+    def canonical_source(self, project_root: Path) -> Path:
+        """Return the path to ``.memtomem/settings.json``."""
+        ...
+
+    def merge(
+        self,
+        existing: dict | None,
+        contributions: dict,
+    ) -> tuple[dict, list[str]]:
+        """Deep-merge *contributions* into *existing*.
+
+        Returns ``(merged_dict, warning_messages)``.  Each warning must
+        contain: (a) the conflicting hook name, (b) the reason for
+        skipping, (c) a concrete remediation step.
+        """
+        ...
+
+
+@dataclass
+class SettingsSyncResult:
+    """Result of a settings generate/sync/diff operation."""
+
+    status: str  # "ok", "skipped", "error", "aborted", "in sync", etc.
+    reason: str = ""
+    warnings: list[str] = field(default_factory=list)
+    target: Path | None = None
+
+
+# ── Generators ──────────────────────────────────────────────────────
+
+SETTINGS_GENERATORS: dict[str, SettingsGenerator] = {}
+
+
+def _register(gen: SettingsGenerator) -> SettingsGenerator:
+    SETTINGS_GENERATORS[gen.name] = gen
+    return gen
+
+
+@dataclass
+class ClaudeSettingsGenerator:
+    """Fan out canonical hooks to ``~/.claude/settings.json``."""
+
+    name: str = "claude_settings"
+
+    def is_available(self) -> bool:
+        return (Path.home() / ".claude").is_dir()
+
+    def target_file(self, project_root: Path) -> Path:
+        return Path.home() / ".claude" / "settings.json"
+
+    def canonical_source(self, project_root: Path) -> Path:
+        return project_root / CANONICAL_SETTINGS_FILE
+
+    def merge(
+        self,
+        existing: dict | None,
+        contributions: dict,
+    ) -> tuple[dict, list[str]]:
+        """Additive merge of ``hooks``.  User keys always win."""
+        warnings: list[str] = []
+        merged = dict(existing) if existing else {}
+
+        contrib_hooks: list[dict] = contributions.get("hooks", [])
+        existing_hooks: list = list(merged.get("hooks", []))
+
+        # Index existing hooks by name for conflict detection
+        existing_by_name: dict[str, dict] = {}
+        for hook in existing_hooks:
+            if isinstance(hook, dict) and "name" in hook:
+                existing_by_name[hook["name"]] = hook
+
+        for hook in contrib_hooks:
+            if not isinstance(hook, dict):
+                continue
+            hook_name = hook.get("name", "")
+            if hook_name and hook_name in existing_by_name:
+                # Check if semantically identical (already in sync)
+                if existing_by_name[hook_name] == hook:
+                    continue
+                warnings.append(
+                    f"Hook '{hook_name}' already exists in the target "
+                    f"settings with different config. To use memtomem's "
+                    f"version, rename or remove your hook, then re-run "
+                    f"`mm context sync --include=settings`."
+                )
+                continue
+            existing_hooks.append(hook)
+
+        merged["hooks"] = existing_hooks
+        return merged, warnings
+
+
+_register(ClaudeSettingsGenerator())
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+
+def _safe_load_json(path: Path) -> dict | object:
+    """Load JSON from *path*, returning :data:`_MALFORMED` on parse error."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return _MALFORMED
+
+
+def _read_with_mtime(path: Path) -> tuple[dict | None | object, float]:
+    """Read JSON + capture mtime for concurrent-write guard.
+
+    Returns ``(None, 0.0)`` when *path* does not exist and
+    ``(_MALFORMED, mtime)`` when the file is not valid JSON.
+    """
+    if not path.is_file():
+        return None, 0.0
+    mtime = path.stat().st_mtime
+    data = _safe_load_json(path)
+    return data, mtime
+
+
+def _write_json(path: Path, data: dict) -> None:
+    """Write *data* as formatted JSON with trailing newline."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, indent=2, sort_keys=False, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ── Fan-out: canonical → runtimes ───────────────────────────────────
+
+
+def generate_all_settings(
+    project_root: Path,
+) -> dict[str, SettingsSyncResult]:
+    """Fan out ``.memtomem/settings.json`` to registered runtimes."""
+    results: dict[str, SettingsSyncResult] = {}
+
+    for name, gen in SETTINGS_GENERATORS.items():
+        if not gen.is_available():
+            results[name] = SettingsSyncResult(
+                status="skipped",
+                reason=(f"{name} runtime not installed (target dir missing)"),
+            )
+            continue
+
+        canonical_path = gen.canonical_source(project_root)
+        if not canonical_path.exists():
+            results[name] = SettingsSyncResult(
+                status="skipped",
+                reason="no canonical source (.memtomem/settings.json)",
+            )
+            continue
+
+        raw = _safe_load_json(canonical_path)
+        if raw is _MALFORMED:
+            results[name] = SettingsSyncResult(
+                status="error",
+                reason=f"{canonical_path} is not valid JSON. Fix the file manually.",
+            )
+            continue
+        contributions: dict = raw  # type: ignore[assignment]
+
+        target_path = gen.target_file(project_root)
+
+        # Step 1: read existing + capture mtime
+        existing_raw, existing_mtime = _read_with_mtime(target_path)
+        if existing_raw is _MALFORMED:
+            results[name] = SettingsSyncResult(
+                status="error",
+                reason=f"{target_path} is not valid JSON. "
+                f"Fix the file manually, then re-run "
+                f"`mm context sync --include=settings`.",
+            )
+            continue
+        existing: dict | None = existing_raw  # type: ignore[assignment]
+
+        # Step 2: merge in memory
+        merged, warnings = gen.merge(existing, contributions)
+
+        # Step 3: mtime check (concurrent-write guard)
+        if target_path.is_file() and target_path.stat().st_mtime != existing_mtime:
+            results[name] = SettingsSyncResult(
+                status="aborted",
+                reason=f"{target_path} was modified by another "
+                f"process during merge. Re-run "
+                f"`mm context sync --include=settings` to retry.",
+            )
+            continue
+
+        # Step 4: write
+        _write_json(target_path, merged)
+        results[name] = SettingsSyncResult(
+            status="ok",
+            warnings=warnings,
+            target=target_path,
+        )
+
+    return results
+
+
+def diff_settings(
+    project_root: Path,
+) -> dict[str, SettingsSyncResult]:
+    """Dry-run: compute what :func:`generate_all_settings` would do."""
+    results: dict[str, SettingsSyncResult] = {}
+
+    for name, gen in SETTINGS_GENERATORS.items():
+        if not gen.is_available():
+            results[name] = SettingsSyncResult(
+                status="skipped",
+                reason=f"{name} runtime not installed",
+            )
+            continue
+
+        canonical_path = gen.canonical_source(project_root)
+        if not canonical_path.exists():
+            results[name] = SettingsSyncResult(
+                status="skipped",
+                reason="no canonical source",
+            )
+            continue
+
+        raw = _safe_load_json(canonical_path)
+        if raw is _MALFORMED:
+            results[name] = SettingsSyncResult(
+                status="error",
+                reason=f"{canonical_path} is not valid JSON",
+            )
+            continue
+        contributions: dict = raw  # type: ignore[assignment]
+
+        target_path = gen.target_file(project_root)
+        existing_raw, _ = _read_with_mtime(target_path)
+        if existing_raw is _MALFORMED:
+            results[name] = SettingsSyncResult(
+                status="error",
+                reason=f"{target_path} is not valid JSON",
+            )
+            continue
+        existing: dict | None = existing_raw  # type: ignore[assignment]
+
+        merged, warnings = gen.merge(existing, contributions)
+
+        if existing is not None:
+            existing_norm = json.dumps(existing, sort_keys=True)
+            merged_norm = json.dumps(merged, sort_keys=True)
+            if existing_norm == merged_norm:
+                status = "in sync"
+            else:
+                status = "out of sync"
+        else:
+            status = "missing target"
+
+        results[name] = SettingsSyncResult(
+            status=status,
+            warnings=warnings,
+            target=target_path,
+        )
+
+    return results
+
+
+# sync is the same operation as generate for settings
+sync_all_settings = generate_all_settings
+
+
+__all__ = [
+    "CANONICAL_SETTINGS_FILE",
+    "ClaudeSettingsGenerator",
+    "SETTINGS_GENERATORS",
+    "SettingsGenerator",
+    "SettingsSyncResult",
+    "diff_settings",
+    "generate_all_settings",
+    "sync_all_settings",
+]

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -10,7 +10,7 @@ from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
 # Known --include values (mirrors cli.context_cmd._KNOWN_INCLUDES).
-_KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands"})
+_KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
 
 
 def _find_project_root() -> Path:
@@ -107,6 +107,20 @@ async def mem_context_detect(
                 lines.append(f"  {c.agent}: {rel} ({c.size} bytes)")
         else:
             lines.append("No slash-command files found.")
+
+    if "settings" in inc:
+        from memtomem.context.detector import detect_settings_files
+
+        settings = detect_settings_files()
+        if lines:
+            lines.append("")
+        if settings:
+            lines.append(f"{len(settings)} settings file(s):")
+            for s in settings:
+                status = f"({s.size} bytes)" if s.size else "(not yet created)"
+                lines.append(f"  {s.agent}: {s.path} {status}")
+        else:
+            lines.append("No settings files detected.")
 
     return "\n".join(lines) if lines else "Nothing detected."
 
@@ -214,6 +228,20 @@ async def mem_context_generate(
         for runtime, cmd_name, dropped in command_result.dropped:
             results.append(f"  {runtime} dropped {dropped} from '{cmd_name}'")
 
+    if "settings" in inc:
+        from memtomem.context.settings import generate_all_settings
+
+        settings_results = generate_all_settings(root)
+        for sname, sr in settings_results.items():
+            if sr.status == "ok":
+                results.append(f"\nSettings: {sname} → {sr.target}")
+                for w in sr.warnings:
+                    results.append(f"  warning: {w}")
+            elif sr.status == "skipped":
+                results.append(f"  skipped {sname}: {sr.reason}")
+            elif sr.status in ("error", "aborted"):
+                results.append(f"  {sr.status} {sname}: {sr.reason}")
+
     return "Generated:\n" + "\n".join(results)
 
 
@@ -294,6 +322,24 @@ async def mem_context_diff(
                 lines.append(f"  {runtime}: {name} [{status}]")
         else:
             lines.append("No commands to compare.")
+
+    if "settings" in inc:
+        from memtomem.context.settings import diff_settings as _diff_settings
+
+        settings_results = _diff_settings(root)
+        if settings_results:
+            if lines:
+                lines.append("")
+            lines.append("Settings:")
+            for sname, sr in settings_results.items():
+                if sr.status in ("in sync", "out of sync", "missing target"):
+                    lines.append(f"  {sname} [{sr.status}]")
+                    for w in sr.warnings:
+                        lines.append(f"    warning: {w}")
+                elif sr.status == "skipped":
+                    lines.append(f"  skipped {sname}: {sr.reason}")
+                elif sr.status == "error":
+                    lines.append(f"  error {sname}: {sr.reason}")
 
     return "\n".join(lines) if lines else "Nothing to compare."
 
@@ -404,5 +450,21 @@ async def mem_context_sync(
             results.append(f"  skipped {runtime}: {reason}")
         for runtime, cmd_name, dropped in command_result.dropped:
             results.append(f"  {runtime} dropped {dropped} from '{cmd_name}'")
+
+    if "settings" in inc:
+        from memtomem.context.settings import generate_all_settings
+
+        settings_results = generate_all_settings(root)
+        for sname, sr in settings_results.items():
+            if sr.status == "ok":
+                if results:
+                    results.append("")
+                results.append(f"Settings: {sname} → {sr.target}")
+                for w in sr.warnings:
+                    results.append(f"  warning: {w}")
+            elif sr.status == "skipped":
+                results.append(f"  skipped {sname}: {sr.reason}")
+            elif sr.status in ("error", "aborted"):
+                results.append(f"  {sr.status} {sname}: {sr.reason}")
 
     return "Synced:\n" + "\n".join(results) if results else "Nothing to sync."

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -1,0 +1,342 @@
+"""Tests for context/settings.py — canonical → runtime settings.json fan-out (Phase D)."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.context.settings import (
+    CANONICAL_SETTINGS_FILE,
+    ClaudeSettingsGenerator,
+    SETTINGS_GENERATORS,
+    SettingsSyncResult,
+    diff_settings,
+    generate_all_settings,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def claude_home(tmp_path, monkeypatch):
+    """Redirect HOME so writes target a temp dir.  Creates ``~/.claude/``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".claude").mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    return fake_home
+
+
+@pytest.fixture
+def claude_home_missing(tmp_path, monkeypatch):
+    """Redirect HOME **without** creating ``~/.claude/``."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    return fake_home
+
+
+def _make_canonical_settings(project_root, content: dict | str | None = None):
+    """Write ``.memtomem/settings.json`` with the given content."""
+    if content is None:
+        content = {"hooks": []}
+    path = project_root / CANONICAL_SETTINGS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(content, str):
+        path.write_text(content, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(content, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _read_target(claude_home) -> dict:
+    """Read the merged settings.json from the fake HOME."""
+    path = claude_home / ".claude" / "settings.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ── Merge tests ─────────────────────────────────────────────────────
+
+
+class TestClaudeSettingsMergeEmpty:
+    """No existing settings.json — merge creates a new file."""
+
+    def test_creates_file_from_canonical(self, claude_home, tmp_path):
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": [{"event": "PostToolUse", "name": "mm-log", "command": "echo ok"}]},
+        )
+        results = generate_all_settings(tmp_path)
+        assert results["claude_settings"].status == "ok"
+
+        written = _read_target(claude_home)
+        assert len(written["hooks"]) == 1
+        assert written["hooks"][0]["name"] == "mm-log"
+
+
+class TestClaudeSettingsMergeSemantic:
+    """Existing keys not owned by memtomem are preserved semantically.
+
+    Formatting (key order, indentation) is intentionally not preserved —
+    see the "Resolved design decisions" in the Phase D plan.
+    """
+
+    def test_preserves_unrelated_keys(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        existing = {
+            "permissions": {"allow": ["Read", "Edit"]},
+            "env": {"FOO": "bar"},
+            "mcpServers": {"example": {"command": "echo"}},
+        }
+        target.write_text(json.dumps(existing, indent=4) + "\n")
+
+        _make_canonical_settings(tmp_path, {"hooks": []})
+        results = generate_all_settings(tmp_path)
+        assert results["claude_settings"].status == "ok"
+
+        written = _read_target(claude_home)
+        assert written["permissions"] == existing["permissions"]
+        assert written["env"] == existing["env"]
+        assert written["mcpServers"] == existing["mcpServers"]
+        assert written["hooks"] == []
+
+
+class TestClaudeSettingsMergeAdditive:
+    """Existing user hooks are preserved; memtomem hooks are appended."""
+
+    def test_appends_without_touching_user_hooks(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        user_hook = {"event": "Notification", "name": "my-notify", "command": "say done"}
+        target.write_text(json.dumps({"hooks": [user_hook]}) + "\n")
+
+        mm_hook = {"event": "PostToolUse", "name": "mm-watch", "command": "mm watchdog"}
+        _make_canonical_settings(tmp_path, {"hooks": [mm_hook]})
+
+        results = generate_all_settings(tmp_path)
+        assert results["claude_settings"].status == "ok"
+
+        written = _read_target(claude_home)
+        assert len(written["hooks"]) == 2
+        assert written["hooks"][0] == user_hook
+        assert written["hooks"][1] == mm_hook
+
+
+class TestClaudeSettingsMergeConflict:
+    """Name collision → skip + emit warning.  User's hook wins."""
+
+    def test_user_hook_wins_on_name_collision(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        user_hook = {"event": "Notification", "name": "mm-watch", "command": "custom"}
+        target.write_text(json.dumps({"hooks": [user_hook]}) + "\n")
+
+        mm_hook = {"event": "PostToolUse", "name": "mm-watch", "command": "mm watchdog"}
+        _make_canonical_settings(tmp_path, {"hooks": [mm_hook]})
+
+        results = generate_all_settings(tmp_path)
+        r = results["claude_settings"]
+        assert r.status == "ok"
+        assert len(r.warnings) == 1
+
+        written = _read_target(claude_home)
+        assert len(written["hooks"]) == 1
+        assert written["hooks"][0] == user_hook  # user wins
+
+    def test_identical_hook_is_silently_skipped(self, claude_home, tmp_path):
+        """If the user's hook is byte-identical, no warning is emitted."""
+        hook = {"event": "PostToolUse", "name": "mm-watch", "command": "mm watchdog"}
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": [hook]}) + "\n")
+
+        _make_canonical_settings(tmp_path, {"hooks": [hook]})
+        results = generate_all_settings(tmp_path)
+        assert results["claude_settings"].status == "ok"
+        assert results["claude_settings"].warnings == []
+
+
+class TestClaudeSettingsMergeWarningContent:
+    """Warning messages must contain the hook name, reason, and remediation."""
+
+    def test_warning_includes_required_parts(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": [{"name": "mm-watch", "x": 1}]}) + "\n")
+
+        _make_canonical_settings(tmp_path, {"hooks": [{"name": "mm-watch", "x": 2}]})
+        results = generate_all_settings(tmp_path)
+        w = results["claude_settings"].warnings[0]
+
+        # (a) hook name verbatim
+        assert "'mm-watch'" in w
+        # (b) reason
+        assert "already exists" in w
+        # (c) concrete remediation step
+        assert "rename or remove" in w
+        assert "mm context sync --include=settings" in w
+
+
+class TestClaudeSettingsMergeMalformed:
+    """Existing settings.json is not valid JSON → skip, don't crash."""
+
+    def test_malformed_target_returns_error(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text('{"hooks":[', encoding="utf-8")  # truncated
+
+        _make_canonical_settings(tmp_path, {"hooks": []})
+        results = generate_all_settings(tmp_path)
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "not valid JSON" in r.reason
+
+        # File should NOT have been modified
+        assert target.read_text() == '{"hooks":['
+
+    def test_malformed_canonical_returns_error(self, claude_home, tmp_path):
+        _make_canonical_settings(tmp_path, "{bad json")
+        results = generate_all_settings(tmp_path)
+        r = results["claude_settings"]
+        assert r.status == "error"
+        assert "not valid JSON" in r.reason
+
+
+class TestClaudeSettingsMergeConcurrent:
+    """Mtime changed between read and write → abort."""
+
+    def test_aborts_on_mtime_change(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": []}) + "\n")
+
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": [{"name": "new-hook", "event": "PostToolUse", "command": "echo"}]},
+        )
+
+        # Monkey-patch os.stat to simulate mtime change after first read.
+        # We wrap generate_all_settings so the target file is modified
+        # between the read and the write.
+        original_text = target.read_text()
+        call_count = {"stat": 0}
+        orig_stat = target.stat
+
+        # Simulate: after the generator reads the file, something else
+        # writes to it, bumping the mtime.
+        import memtomem.context.settings as settings_mod
+
+        orig_read_with_mtime = settings_mod._read_with_mtime
+
+        def patched_read_with_mtime(path):
+            result = orig_read_with_mtime(path)
+            if path == target:
+                # Bump mtime after read by re-writing with a small change
+                target.write_text(json.dumps({"hooks": [], "_bumped": True}) + "\n")
+            return result
+
+        import unittest.mock
+
+        with unittest.mock.patch.object(settings_mod, "_read_with_mtime", patched_read_with_mtime):
+            results = generate_all_settings(tmp_path)
+
+        r = results["claude_settings"]
+        assert r.status == "aborted"
+        assert "modified by another process" in r.reason
+
+
+class TestClaudeSettingsNoClaudeCodeInstalled:
+    """``~/.claude/`` does not exist → skip, never create it."""
+
+    def test_skips_when_claude_not_installed(self, claude_home_missing, tmp_path):
+        _make_canonical_settings(tmp_path, {"hooks": []})
+        results = generate_all_settings(tmp_path)
+        r = results["claude_settings"]
+        assert r.status == "skipped"
+        assert "not installed" in r.reason
+
+        # Must NOT have created ~/.claude/
+        assert not (claude_home_missing / ".claude").exists()
+
+
+# ── Diff tests ──────────────────────────────────────────────────────
+
+
+class TestClaudeSettingsDryRun:
+    """diff_settings reports merge plan without writing."""
+
+    def test_reports_missing_target(self, claude_home, tmp_path):
+        _make_canonical_settings(tmp_path, {"hooks": [{"name": "x", "e": "PostToolUse"}]})
+        results = diff_settings(tmp_path)
+        assert results["claude_settings"].status == "missing target"
+
+    def test_reports_in_sync(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        content = {"hooks": [{"name": "x", "e": "PostToolUse"}]}
+        target.write_text(json.dumps(content, indent=2) + "\n")
+
+        _make_canonical_settings(tmp_path, content)
+        results = diff_settings(tmp_path)
+        assert results["claude_settings"].status == "in sync"
+
+    def test_reports_out_of_sync(self, claude_home, tmp_path):
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": []}) + "\n")
+
+        _make_canonical_settings(
+            tmp_path, {"hooks": [{"name": "new", "e": "PostToolUse"}]}
+        )
+        results = diff_settings(tmp_path)
+        assert results["claude_settings"].status == "out of sync"
+
+    def test_does_not_write(self, claude_home, tmp_path):
+        """diff must never modify the target file."""
+        target = claude_home / ".claude" / "settings.json"
+        original = json.dumps({"hooks": []}) + "\n"
+        target.write_text(original)
+
+        _make_canonical_settings(
+            tmp_path, {"hooks": [{"name": "new", "e": "PostToolUse"}]}
+        )
+        diff_settings(tmp_path)
+        assert target.read_text() == original
+
+
+# ── CLI integration ─────────────────────────────────────────────────
+
+
+class TestClaudeSettingsCliInclude:
+    """``mm context generate --include=settings`` end-to-end via CliRunner."""
+
+    def test_generate_includes_settings(self, claude_home, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # Create a minimal .git so _find_project_root works
+        (tmp_path / ".git").mkdir()
+
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": [{"name": "test-hook", "event": "PostToolUse", "command": "echo"}]},
+        )
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        result = runner.invoke(context, ["generate", "--include=settings"])
+        assert result.exit_code == 0
+        assert "Settings" in result.output or "settings" in result.output
+
+        # Verify the file was actually written
+        target = claude_home / ".claude" / "settings.json"
+        assert target.is_file()
+        written = json.loads(target.read_text())
+        assert any(h.get("name") == "test-hook" for h in written.get("hooks", []))
+
+    def test_include_settings_validation(self):
+        """Unknown include values are rejected."""
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        result = runner.invoke(context, ["generate", "--include=bogus"])
+        assert result.exit_code != 0
+        assert "Unknown" in result.output or "bogus" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -628,7 +628,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **Phase D: Claude `settings.json` integration** — new `SettingsGenerator` protocol + `ClaudeSettingsGenerator` for additive hook merging into `~/.claude/settings.json`
- Closes the LTM Manager roadmap (A → A.5 → B → C → **D**) and absorbs context-gateway Phase 4
- `--include=settings` flag wired into all 5 CLI commands + 4 MCP `mem_context_*` tools
- `mm init` wizard Step 8 prompts for Claude Code hooks setup
- 16 new tests (1054 total, 0 regressions), lint/format clean

## Design decisions (resolved during plan review)

| Decision | Resolution |
|---|---|
| Scope | Claude only (Gemini/Codex deferred — no known settings schemas) |
| Owned keys | `hooks` only (`mcpServers` → `claude mcp add`, `permissions`/`apiKeyHelper` → user) |
| Canonical source | `.memtomem/settings.json` (target-based naming, extensible) |
| Conflict policy | Additive-only, name-based skip, guided warnings. No `--force` flag. |
| Formatting | `json.dumps(indent=2)` normalization, byte preservation NOT guaranteed |
| Malformed JSON | Skip + error message, never silently overwrite |
| Missing Claude Code | Skip, never auto-create `~/.claude/` |
| Concurrent writes | mtime guard between read and write |

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_settings.py -v` — 16 passed
- [x] `uv run pytest -m "not ollama"` — 1054 passed, 40 deselected, 0 regressions
- [x] `uv run ruff check && ruff format --check` — all clean
- [ ] Manual: `mm context generate --include=settings` against a real `~/.claude/settings.json`
- [ ] Manual: `mm init` wizard Step 8 with Claude Code installed
- [ ] Manual: conflict scenario (existing hook with same name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)