### PR TITLE
feat(onboarding): BM25-only default — zero-dependency quick start

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -94,48 +94,63 @@ def _detect_project_dir() -> str | None:
 def _step_embedding(state: dict) -> None:
     step_header(1, "Embedding Provider")
     click.echo("  Choose how to generate embeddings:")
-    click.echo("    [1] Ollama — local, free, needs GPU (recommended)")
-    click.echo("    [2] OpenAI — cloud, paid, no GPU needed")
-    choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
+    click.echo("    [1] Quick start — keyword search only, no setup needed (recommended)")
+    click.echo("    [2] Ollama — local dense embeddings, needs GPU")
+    click.echo("    [3] OpenAI — cloud dense embeddings, needs API key")
+    choice = nav_prompt("  Select", type=click.IntRange(1, 3), default=1)
     click.echo()
 
-    provider = "ollama" if choice == 1 else "openai"
     api_key = ""
 
-    if provider == "ollama":
+    if choice == 1:
+        # BM25-only mode: no embeddings, no external dependencies
+        provider = "none"
+        model = ""
+        dimension = 0
+        click.secho("  BM25 keyword search — ready to go, no setup needed.", fg="green")
+        click.echo("  You can add dense embeddings later by re-running 'mm init'.")
+
+    elif choice == 2:
+        provider = "ollama"
         if not _ollama_available():
-            click.secho("  Ollama not found.", fg="red")
-            click.echo("  Install from https://ollama.com then re-run 'mm init'.")
-            raise SystemExit(1)
-
-        if not _ollama_running():
-            click.secho("  Ollama not running. Starting 'ollama serve'...", fg="yellow")
-            click.echo("  Run 'ollama serve' in another terminal if this fails.")
+            click.secho("  Ollama not found.", fg="yellow")
+            click.echo("  Install from https://ollama.com, then run 'mm index' to embed.")
+            click.echo("  Saving Ollama config now so you're ready after install.")
             click.echo()
-
-        click.echo("  Available models:")
-        click.echo("    [1] nomic-embed-text — English, fast (768d)")
-        click.echo("    [2] bge-m3 — multilingual, higher accuracy (1024d)")
-        model_choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
-
-        models = {1: ("nomic-embed-text", 768), 2: ("bge-m3", 1024)}
-        model, dimension = models[model_choice]
-
-        if _ollama_has_model(model):
-            click.secho(f"  Model '{model}' is ready.", fg="green")
+            # Record intent — config is written, embedding runs when Ollama is available.
+            model = "nomic-embed-text"
+            dimension = 768
         else:
-            pull = nav_confirm(f"  Model '{model}' not found. Pull now?", default=True)
-            if pull:
-                click.echo(f"  Pulling {model}... (this may take a few minutes)")
-                result = _run(["ollama", "pull", model], timeout=600)
-                if result.returncode == 0:
-                    click.secho(f"  Model '{model}' pulled successfully.", fg="green")
-                else:
-                    click.secho(f"  Pull failed: {result.stderr.strip()}", fg="red")
-                    click.echo("  You can pull manually: ollama pull " + model)
+            if not _ollama_running():
+                click.secho("  Ollama not running. Starting 'ollama serve'...", fg="yellow")
+                click.echo("  Run 'ollama serve' in another terminal if this fails.")
+                click.echo()
+
+            click.echo("  Available models:")
+            click.echo("    [1] nomic-embed-text — English, fast (768d)")
+            click.echo("    [2] bge-m3 — multilingual, higher accuracy (1024d)")
+            model_choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
+
+            models = {1: ("nomic-embed-text", 768), 2: ("bge-m3", 1024)}
+            model, dimension = models[model_choice]
+
+            if _ollama_has_model(model):
+                click.secho(f"  Model '{model}' is ready.", fg="green")
             else:
-                click.echo(f"  Remember to run: ollama pull {model}")
+                pull = nav_confirm(f"  Model '{model}' not found. Pull now?", default=True)
+                if pull:
+                    click.echo(f"  Pulling {model}... (this may take a few minutes)")
+                    result = _run(["ollama", "pull", model], timeout=600)
+                    if result.returncode == 0:
+                        click.secho(f"  Model '{model}' pulled successfully.", fg="green")
+                    else:
+                        click.secho(f"  Pull failed: {result.stderr.strip()}", fg="red")
+                        click.echo("  You can pull manually: ollama pull " + model)
+                else:
+                    click.echo(f"  Remember to run: ollama pull {model}")
+
     else:
+        provider = "openai"
         click.echo("  Available models:")
         click.echo("    [1] text-embedding-3-small — balanced (1536d)")
         click.echo("    [2] text-embedding-3-large — highest accuracy (3072d)")
@@ -355,7 +370,10 @@ def _write_config_and_summary(state: dict) -> None:
     click.echo()
     click.secho("  Setup complete!", fg="green", bold=True)
     click.echo()
-    click.echo(f"  Provider:   {state['provider']}/{state['model']} ({state['dimension']}d)")
+    if state["provider"] == "none":
+        click.echo("  Provider:   none (BM25 keyword search only)")
+    else:
+        click.echo(f"  Provider:   {state['provider']}/{state['model']} ({state['dimension']}d)")
     click.echo(f"  Storage:    {state['db_path']}")
     click.echo(f"  Memory:     {state['memory_dir']}")
     ns_label = "auto" if state["enable_auto_ns"] else "manual"
@@ -419,7 +437,7 @@ _MODEL_DIMS: dict[str, int] = {
 @click.option(
     "-y", "--non-interactive", is_flag=True, help="Skip wizard, use defaults or provided options"
 )
-@click.option("--provider", type=click.Choice(["ollama", "openai"]), default=None)
+@click.option("--provider", type=click.Choice(["none", "ollama", "openai"]), default=None)
 @click.option("--model", default=None, help="Embedding model name")
 @click.option("--memory-dir", default=None, help="Memory directory path")
 @click.option("--db-path", default=None, help="SQLite DB path")
@@ -469,10 +487,16 @@ def init(
         click.echo()
 
     if non_interactive:
-        _provider = provider or "ollama"
-        _model = model or (
-            "nomic-embed-text" if _provider == "ollama" else "text-embedding-3-small"
-        )
+        _provider = provider or "none"
+        if _provider == "none":
+            _model = ""
+            _dimension = 0
+        elif _provider == "ollama":
+            _model = model or "nomic-embed-text"
+            _dimension = _MODEL_DIMS.get(_model, 768)
+        else:
+            _model = model or "text-embedding-3-small"
+            _dimension = _MODEL_DIMS.get(_model, 1536)
         _memory_dir = memory_dir or "~/memories"
 
         # Auto-create memory directory
@@ -484,7 +508,7 @@ def init(
             {
                 "provider": _provider,
                 "model": _model,
-                "dimension": _MODEL_DIMS.get(_model, 768),
+                "dimension": _dimension,
                 "api_key": api_key or "",
                 "memory_dir": _memory_dir,
                 "db_path": db_path or str(Path("~/.memtomem").expanduser() / "memtomem.db"),

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -9,15 +9,22 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class EmbeddingConfig(BaseSettings):
-    provider: str = "ollama"
-    model: str = "nomic-embed-text"
-    dimension: int = 768
-    base_url: str = "http://localhost:11434"
+    provider: str = "none"
+    model: str = ""
+    dimension: int = 0
+    base_url: str = ""
     api_key: str = ""
     batch_size: int = 64
     max_concurrent_batches: int = 4
 
-    @field_validator("dimension", "batch_size", "max_concurrent_batches")
+    @field_validator("dimension")
+    @classmethod
+    def dimension_non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("must be non-negative (0 = no embeddings)")
+        return v
+
+    @field_validator("batch_size", "max_concurrent_batches")
     @classmethod
     def must_be_positive(cls, v: int) -> int:
         if v <= 0:

--- a/packages/memtomem/src/memtomem/embedding/factory.py
+++ b/packages/memtomem/src/memtomem/embedding/factory.py
@@ -10,6 +10,11 @@ def create_embedder(config: EmbeddingConfig) -> object:
     """Return the embedding provider for the configured provider name."""
     provider = config.provider.lower()
 
+    if provider == "none":
+        from memtomem.embedding.noop import NoopEmbedder
+
+        return NoopEmbedder()
+
     if provider == "ollama":
         from memtomem.embedding.ollama import OllamaEmbedder
 
@@ -20,4 +25,6 @@ def create_embedder(config: EmbeddingConfig) -> object:
 
         return OpenAIEmbedder(config)
 
-    raise ConfigError(f"Unknown embedding provider: {config.provider!r}. Supported: ollama, openai")
+    raise ConfigError(
+        f"Unknown embedding provider: {config.provider!r}. Supported: none, ollama, openai"
+    )

--- a/packages/memtomem/src/memtomem/embedding/noop.py
+++ b/packages/memtomem/src/memtomem/embedding/noop.py
@@ -1,0 +1,31 @@
+"""No-op embedding provider for BM25-only mode."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+
+class NoopEmbedder:
+    """Embedding provider that returns empty vectors.
+
+    Used when no embedding backend is configured (``provider="none"``).
+    The search pipeline falls back to BM25-only keyword search, and the
+    index engine skips vector storage entirely.
+    """
+
+    @property
+    def dimension(self) -> int:
+        return 0
+
+    @property
+    def model_name(self) -> str:
+        return "none"
+
+    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+        return [[] for _ in texts]
+
+    async def embed_query(self, query: str) -> list[float]:
+        return []
+
+    async def close(self) -> None:
+        pass

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -272,8 +272,9 @@ class IndexEngine:
             existing_hashes = await self._storage.get_chunk_hashes(file_path)
             diff_result = compute_diff(existing_hashes, new_chunks)
 
-        # Embed BEFORE any deletion — if embedding fails, DB stays untouched
-        if diff_result.to_upsert:
+        # Embed BEFORE any deletion — if embedding fails, DB stays untouched.
+        # Skip embedding entirely when using the noop provider (BM25-only mode).
+        if diff_result.to_upsert and self._embedder.dimension > 0:
             texts = [c.retrieval_content for c in diff_result.to_upsert]
             try:
                 embeddings = await self._embedder.embed_texts(texts)

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -17,6 +17,7 @@ import pytest
 
 from memtomem.config import EmbeddingConfig
 from memtomem.embedding.factory import create_embedder
+from memtomem.embedding.noop import NoopEmbedder
 from memtomem.embedding.ollama import OllamaEmbedder
 from memtomem.embedding.openai import OpenAIEmbedder
 from memtomem.embedding.retry import _parse_retry_after, with_retry
@@ -26,6 +27,7 @@ from memtomem.errors import ConfigError, EmbeddingError
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _ollama_config(**overrides) -> EmbeddingConfig:
     defaults = dict(
@@ -55,8 +57,9 @@ def _openai_config(**overrides) -> EmbeddingConfig:
     return EmbeddingConfig(**defaults)
 
 
-def _make_httpx_response(status_code: int = 200, json_data: dict | None = None,
-                         headers: dict | None = None) -> httpx.Response:
+def _make_httpx_response(
+    status_code: int = 200, json_data: dict | None = None, headers: dict | None = None
+) -> httpx.Response:
     """Build a minimal httpx.Response for mocking."""
     resp = httpx.Response(
         status_code=status_code,
@@ -70,6 +73,7 @@ def _make_httpx_response(status_code: int = 200, json_data: dict | None = None,
 # ---------------------------------------------------------------------------
 # 1. EmbeddingProvider protocol conformance
 # ---------------------------------------------------------------------------
+
 
 class TestEmbeddingProviderProtocol:
     """Verify that OllamaEmbedder and OpenAIEmbedder satisfy the Protocol."""
@@ -109,8 +113,8 @@ class TestEmbeddingProviderProtocol:
 # 2. OllamaEmbedder — mocked httpx
 # ---------------------------------------------------------------------------
 
-class TestOllamaEmbedder:
 
+class TestOllamaEmbedder:
     async def test_embed_batch_returns_vectors(self):
         """embed_texts with two texts returns two vectors."""
         config = _ollama_config(dimension=3)
@@ -245,8 +249,8 @@ class TestOllamaEmbedder:
 # 3. OpenAIEmbedder — mocked httpx
 # ---------------------------------------------------------------------------
 
-class TestOpenAIEmbedder:
 
+class TestOpenAIEmbedder:
     async def test_embed_batch_returns_vectors(self):
         """embed_texts returns sorted-by-index vectors."""
         config = _openai_config(dimension=3)
@@ -356,8 +360,8 @@ class TestOpenAIEmbedder:
 # 4. create_embedder factory
 # ---------------------------------------------------------------------------
 
-class TestCreateEmbedder:
 
+class TestCreateEmbedder:
     def test_ollama_provider(self):
         config = _ollama_config(provider="ollama")
         embedder = create_embedder(config)
@@ -373,6 +377,11 @@ class TestCreateEmbedder:
         embedder = create_embedder(config)
         assert isinstance(embedder, OllamaEmbedder)
 
+    def test_none_provider(self):
+        config = EmbeddingConfig(provider="none", model="", dimension=0, base_url="")
+        embedder = create_embedder(config)
+        assert isinstance(embedder, NoopEmbedder)
+
     def test_unknown_provider_raises_config_error(self):
         config = _ollama_config(provider="unknown_backend")
         with pytest.raises(ConfigError, match="Unknown embedding provider"):
@@ -380,11 +389,51 @@ class TestCreateEmbedder:
 
 
 # ---------------------------------------------------------------------------
+# 4.5. NoopEmbedder (BM25-only mode)
+# ---------------------------------------------------------------------------
+
+
+class TestNoopEmbedder:
+    """Verify NoopEmbedder satisfies the EmbeddingProvider protocol."""
+
+    def test_dimension_is_zero(self):
+        embedder = NoopEmbedder()
+        assert embedder.dimension == 0
+
+    def test_model_name_is_none(self):
+        embedder = NoopEmbedder()
+        assert embedder.model_name == "none"
+
+    @pytest.mark.anyio
+    async def test_embed_texts_returns_empty_lists(self):
+        embedder = NoopEmbedder()
+        result = await embedder.embed_texts(["hello", "world"])
+        assert result == [[], []]
+
+    @pytest.mark.anyio
+    async def test_embed_texts_empty_input(self):
+        embedder = NoopEmbedder()
+        result = await embedder.embed_texts([])
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_embed_query_returns_empty_list(self):
+        embedder = NoopEmbedder()
+        result = await embedder.embed_query("test query")
+        assert result == []
+
+    @pytest.mark.anyio
+    async def test_close_is_noop(self):
+        embedder = NoopEmbedder()
+        await embedder.close()  # should not raise
+
+
+# ---------------------------------------------------------------------------
 # 5. Retry logic — with_retry decorator and _parse_retry_after
 # ---------------------------------------------------------------------------
 
-class TestRetryDecorator:
 
+class TestRetryDecorator:
     async def test_succeeds_first_try(self):
         """Function succeeds on first attempt — no retries."""
         call_count = 0
@@ -444,6 +493,7 @@ class TestRetryDecorator:
     def test_invalid_max_attempts(self):
         """max_attempts < 1 raises ValueError at decoration time."""
         with pytest.raises(ValueError, match="max_attempts"):
+
             @with_retry(max_attempts=0)
             async def noop():
                 pass  # pragma: no cover
@@ -451,13 +501,13 @@ class TestRetryDecorator:
     def test_invalid_base_delay(self):
         """Negative base_delay raises ValueError at decoration time."""
         with pytest.raises(ValueError, match="base_delay"):
+
             @with_retry(base_delay=-1.0)
             async def noop():
                 pass  # pragma: no cover
 
 
 class TestParseRetryAfter:
-
     def test_none_input(self):
         assert _parse_retry_after(None) is None
 

--- a/packages/memtomem/tests/test_policy_scheduler.py
+++ b/packages/memtomem/tests/test_policy_scheduler.py
@@ -67,9 +67,7 @@ class TestPolicyScheduler:
             return_value=[_result("p1", 0)],
         ) as mock_run:
             await sched._run_policies()
-            mock_run.assert_called_once_with(
-                app.storage, dry_run=False, max_actions=100
-            )
+            mock_run.assert_called_once_with(app.storage, dry_run=False, max_actions=100)
 
     @pytest.mark.asyncio
     async def test_cache_invalidated_when_affected(self):
@@ -114,8 +112,11 @@ class TestPolicyScheduler:
 
         with patch("memtomem.tools.policy_engine.run_all_enabled", side_effect=_failing):
             await sched.start()
-            # Wait long enough for at least 2 ticks
-            await asyncio.sleep(0.2)
+            # Poll until at least 2 ticks happen (CI can be slow).
+            for _ in range(40):
+                await asyncio.sleep(0.05)
+                if call_count >= 2:
+                    break
             assert not sched._task.done(), "loop crashed after error"
             assert call_count >= 2, f"expected >= 2 calls, got {call_count}"
             await sched.stop()


### PR DESCRIPTION
## Summary

- Add `NoopEmbedder` (`embedding/noop.py`) implementing `EmbeddingProvider` protocol — returns empty vectors, dimension=0
- Change `EmbeddingConfig` defaults: `provider="none"`, `dimension=0` — new users start with BM25 keyword search, zero external dependencies
- Rewrite init wizard: 3 options (Quick start / Ollama / OpenAI), remove `SystemExit(1)` when Ollama not found
- Skip `embed_texts` in `IndexEngine` when `embedder.dimension == 0`
- `SearchConfig.enable_dense` stays `True` — `NoopEmbedder` returns empty vectors, so `SearchPipeline` naturally falls through to BM25 via existing RRF fusion

**Breaking:** default embedding provider changed from `"ollama"` to `"none"`. Existing users with `~/.memtomem/config.json` are unaffected (overrides apply). Users who relied on the old default without explicit config will need to set `MEMTOMEM_EMBEDDING__PROVIDER=ollama`.

## Test plan

- [x] `NoopEmbedder` protocol conformance tests (6 new)
- [x] Factory returns `NoopEmbedder` for `provider="none"`
- [x] 1132 tests passed (`pytest -m "not ollama"`)
- [x] `ruff check` + `ruff format` clean
- [ ] Manual: `mm init --yes` → verify `config.json` has `provider: "none"`
- [ ] Manual: `mm index <dir>` → indexes without embedding errors
- [ ] Manual: `mm search "keyword"` → returns BM25 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)