### PR TITLE
feat(llm): add LLM generation infrastructure + consolidation consumer

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -282,6 +282,30 @@ class HealthWatchdogConfig(BaseSettings):
     auto_maintenance: bool = True
 
 
+class LLMConfig(BaseSettings):
+    enabled: bool = False
+    provider: str = "ollama"
+    model: str = ""  # empty = provider-specific default resolved in factory
+    base_url: str = "http://localhost:11434"
+    api_key: str = ""
+    max_tokens: int = 1024
+    timeout: float = 60.0
+
+    @field_validator("max_tokens")
+    @classmethod
+    def max_tokens_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+    @field_validator("timeout")
+    @classmethod
+    def timeout_positive(cls, v: float) -> float:
+        if v <= 0:
+            raise ValueError("must be positive")
+        return v
+
+
 class Mem2MemConfig(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="MEMTOMEM_",
@@ -309,6 +333,7 @@ class Mem2MemConfig(BaseSettings):
     entity_extraction: EntityExtractionConfig = Field(default_factory=EntityExtractionConfig)
     context_window: ContextWindowConfig = Field(default_factory=ContextWindowConfig)
     health_watchdog: HealthWatchdogConfig = Field(default_factory=HealthWatchdogConfig)
+    llm: LLMConfig = Field(default_factory=LLMConfig)
     timezone: str = "UTC"  # Display timezone (e.g. "Asia/Seoul"). Storage remains UTC.
 
 

--- a/packages/memtomem/src/memtomem/errors.py
+++ b/packages/memtomem/src/memtomem/errors.py
@@ -21,6 +21,10 @@ class IndexingError(Mem2MemError):
     """Indexing error."""
 
 
+class LLMError(Mem2MemError):
+    """LLM provider error."""
+
+
 class ConfigError(Mem2MemError):
     """Configuration error."""
 

--- a/packages/memtomem/src/memtomem/llm/__init__.py
+++ b/packages/memtomem/src/memtomem/llm/__init__.py
@@ -1,0 +1,1 @@
+"""LLM generation providers for memtomem."""

--- a/packages/memtomem/src/memtomem/llm/anthropic.py
+++ b/packages/memtomem/src/memtomem/llm/anthropic.py
@@ -1,0 +1,91 @@
+"""Anthropic LLM provider using httpx."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from memtomem.config import LLMConfig
+from memtomem.embedding.retry import with_retry
+from memtomem.errors import LLMError
+
+logger = logging.getLogger(__name__)
+
+# Hardcoded — users should never change this; incorrect values break the API.
+_ANTHROPIC_VERSION = "2023-06-01"
+_DEFAULT_BASE_URL = "https://api.anthropic.com"
+
+
+class AnthropicLLM:
+    def __init__(self, config: LLMConfig) -> None:
+        self._config = config
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            base_url = self._config.base_url
+            # Use Anthropic's default when base_url points at Ollama's default
+            if base_url == "http://localhost:11434":
+                base_url = _DEFAULT_BASE_URL
+            self._client = httpx.AsyncClient(
+                base_url=base_url,
+                headers={
+                    "x-api-key": self._config.api_key,
+                    "anthropic-version": _ANTHROPIC_VERSION,
+                    "content-type": "application/json",
+                },
+                timeout=self._config.timeout,
+            )
+        return self._client
+
+    @with_retry(
+        max_attempts=3,
+        base_delay=1.0,
+        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException),
+    )
+    async def _generate_with_retry(self, prompt: str, *, system: str, max_tokens: int) -> str:
+        client = self._get_client()
+        payload: dict = {
+            "model": self._config.model,
+            "max_tokens": max_tokens,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if system:
+            payload["system"] = system
+        resp = await client.post("/v1/messages", json=payload)
+        if resp.status_code == 429:
+            raise LLMError(
+                f"Anthropic rate limit exceeded. "
+                f"Retry-After: {resp.headers.get('Retry-After', 'unknown')}"
+            )
+        if resp.status_code == 401:
+            raise LLMError("Anthropic authentication failed. Check your API key.")
+        resp.raise_for_status()
+        data = resp.json()
+        content = data.get("content")
+        if not content:
+            raise LLMError(
+                f"Anthropic API returned unexpected response (no content): {list(data.keys())}"
+            )
+        return content[0]["text"]
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        try:
+            return await self._generate_with_retry(prompt, system=system, max_tokens=max_tokens)
+        except httpx.ConnectError as e:
+            raise LLMError(
+                f"Cannot connect to Anthropic at {self._config.base_url}. Error: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise LLMError(f"Anthropic request timed out. Error: {e}") from e
+        except httpx.HTTPError as e:
+            raise LLMError(f"Anthropic generation failed: {e}") from e
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception:
+                logger.debug("Failed to close HTTP client", exc_info=True)
+            self._client = None

--- a/packages/memtomem/src/memtomem/llm/base.py
+++ b/packages/memtomem/src/memtomem/llm/base.py
@@ -1,0 +1,11 @@
+"""LLM provider protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class LLMProvider(Protocol):
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str: ...
+
+    async def close(self) -> None: ...

--- a/packages/memtomem/src/memtomem/llm/factory.py
+++ b/packages/memtomem/src/memtomem/llm/factory.py
@@ -1,0 +1,49 @@
+"""LLM factory: instantiates the right LLMProvider from config."""
+
+from __future__ import annotations
+
+from memtomem.config import LLMConfig
+from memtomem.errors import ConfigError
+
+# Provider-specific default models, used when config.model is empty.
+_DEFAULT_MODELS: dict[str, str] = {
+    "ollama": "llama3.2",
+    "openai": "gpt-4o-mini",
+    "anthropic": "claude-sonnet-4-20250514",
+}
+
+
+def create_llm(config: LLMConfig) -> object | None:
+    """Return the LLM provider for the configured provider name.
+
+    Returns ``None`` when ``config.enabled`` is ``False``.
+    """
+    if not config.enabled:
+        return None
+
+    provider = config.provider.lower()
+
+    # Resolve provider-specific default model when not explicitly set.
+    if not config.model:
+        default_model = _DEFAULT_MODELS.get(provider)
+        if default_model:
+            config.model = default_model
+
+    if provider == "ollama":
+        from memtomem.llm.ollama import OllamaLLM
+
+        return OllamaLLM(config)
+
+    if provider == "openai":
+        from memtomem.llm.openai import OpenAILLM
+
+        return OpenAILLM(config)
+
+    if provider == "anthropic":
+        from memtomem.llm.anthropic import AnthropicLLM
+
+        return AnthropicLLM(config)
+
+    raise ConfigError(
+        f"Unknown LLM provider: {config.provider!r}. Supported: ollama, openai, anthropic"
+    )

--- a/packages/memtomem/src/memtomem/llm/ollama.py
+++ b/packages/memtomem/src/memtomem/llm/ollama.py
@@ -1,0 +1,84 @@
+"""Ollama LLM provider using httpx."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from memtomem.config import LLMConfig
+from memtomem.embedding.retry import with_retry
+from memtomem.errors import LLMError
+
+logger = logging.getLogger(__name__)
+
+
+class OllamaLLM:
+    def __init__(self, config: LLMConfig) -> None:
+        self._config = config
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._config.base_url,
+                timeout=self._config.timeout,
+            )
+        return self._client
+
+    @with_retry(
+        max_attempts=3,
+        base_delay=1.0,
+        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException),
+    )
+    async def _generate_with_retry(self, prompt: str, *, system: str, max_tokens: int) -> str:
+        client = self._get_client()
+        payload: dict = {
+            "model": self._config.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"num_predict": max_tokens},
+        }
+        if system:
+            payload["system"] = system
+        resp = await client.post("/api/generate", json=payload)
+        resp.raise_for_status()
+        data = resp.json()
+        response_text = data.get("response")
+        if response_text is None:
+            raise LLMError(
+                f"Ollama API returned unexpected response (missing 'response' key): "
+                f"{list(data.keys())}"
+            )
+        return response_text
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        try:
+            return await self._generate_with_retry(prompt, system=system, max_tokens=max_tokens)
+        except httpx.ConnectError as e:
+            raise LLMError(
+                f"Cannot connect to Ollama at {self._config.base_url}. "
+                f"Please verify 'ollama serve' is running. Error: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise LLMError(
+                f"Ollama generation request timed out. "
+                f"The model '{self._config.model}' may still be loading. Error: {e}"
+            ) from e
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                raise LLMError(
+                    f"Model '{self._config.model}' not found in Ollama. "
+                    f"Run 'ollama pull {self._config.model}' to download it."
+                ) from e
+            raise LLMError(f"Ollama generation failed: {e}") from e
+        except httpx.HTTPError as e:
+            raise LLMError(f"Ollama generation failed: {e}") from e
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception:
+                logger.debug("Failed to close HTTP client", exc_info=True)
+            self._client = None

--- a/packages/memtomem/src/memtomem/llm/openai.py
+++ b/packages/memtomem/src/memtomem/llm/openai.py
@@ -1,0 +1,86 @@
+"""OpenAI-compatible LLM provider using httpx."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from memtomem.config import LLMConfig
+from memtomem.embedding.retry import with_retry
+from memtomem.errors import LLMError
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAILLM:
+    def __init__(self, config: LLMConfig) -> None:
+        self._config = config
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            headers: dict[str, str] = {}
+            if self._config.api_key:
+                headers["Authorization"] = f"Bearer {self._config.api_key}"
+            self._client = httpx.AsyncClient(
+                base_url=self._config.base_url,
+                headers=headers,
+                timeout=self._config.timeout,
+            )
+        return self._client
+
+    @with_retry(
+        max_attempts=3,
+        base_delay=1.0,
+        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException),
+    )
+    async def _generate_with_retry(self, prompt: str, *, system: str, max_tokens: int) -> str:
+        client = self._get_client()
+        messages: list[dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": self._config.model,
+                "messages": messages,
+                "max_tokens": max_tokens,
+            },
+        )
+        if resp.status_code == 429:
+            raise LLMError(
+                f"OpenAI rate limit exceeded. "
+                f"Retry-After: {resp.headers.get('Retry-After', 'unknown')}"
+            )
+        if resp.status_code == 401:
+            raise LLMError("OpenAI authentication failed. Check your API key.")
+        resp.raise_for_status()
+        data = resp.json()
+        choices = data.get("choices")
+        if not choices:
+            raise LLMError(
+                f"OpenAI API returned unexpected response (no choices): {list(data.keys())}"
+            )
+        return choices[0]["message"]["content"]
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        try:
+            return await self._generate_with_retry(prompt, system=system, max_tokens=max_tokens)
+        except httpx.ConnectError as e:
+            raise LLMError(
+                f"Cannot connect to OpenAI at {self._config.base_url}. Error: {e}"
+            ) from e
+        except httpx.TimeoutException as e:
+            raise LLMError(f"OpenAI request timed out. Error: {e}") from e
+        except httpx.HTTPError as e:
+            raise LLMError(f"OpenAI generation failed: {e}") from e
+
+    async def close(self) -> None:
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception:
+                logger.debug("Failed to close HTTP client", exc_info=True)
+            self._client = None

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -19,6 +19,7 @@ from memtomem.storage.sqlite_backend import SqliteBackend
 
 if TYPE_CHECKING:
     from memtomem.embedding.base import EmbeddingProvider
+    from memtomem.llm.base import LLMProvider
 
 _log = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class Components:
     embedder: EmbeddingProvider
     index_engine: IndexEngine
     search_pipeline: SearchPipeline
+    llm: LLMProvider | None = None
 
 
 async def create_components(config: Mem2MemConfig | None = None) -> Components:
@@ -104,17 +106,27 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         context_window_config=config.context_window,
     )
 
+    # Create optional LLM provider
+    llm = None
+    if config.llm.enabled:
+        from memtomem.llm.factory import create_llm
+
+        llm = create_llm(config.llm)
+
     return Components(
         config=config,
         storage=storage,
         embedder=embedder,
         index_engine=index_engine,
         search_pipeline=search_pipeline,
+        llm=llm,
     )
 
 
 async def close_components(comp: Components) -> None:
     """Shut down components in reverse order."""
+    if comp.llm is not None:
+        await comp.llm.close()
     await comp.search_pipeline.close()
     await comp.embedder.close()
     await comp.storage.close()

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -18,6 +18,7 @@ from memtomem.storage.sqlite_backend import SqliteBackend
 
 if TYPE_CHECKING:
     from memtomem.embedding.base import EmbeddingProvider
+    from memtomem.llm.base import LLMProvider
 
 
 @dataclass
@@ -33,6 +34,7 @@ class AppContext:
     dedup_scanner: DedupScanner | None = None
     webhook_manager: object | None = None
     health_watchdog: object | None = None
+    llm_provider: LLMProvider | None = None
     current_namespace: str | None = None
     current_session_id: str | None = None
     _config_lock: asyncio.Lock = field(default_factory=asyncio.Lock)

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -125,6 +125,7 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
         watcher=watcher,
         dedup_scanner=dedup_scanner,
         webhook_manager=webhook_mgr,
+        llm_provider=comp.llm,
     )
 
     # Auto-consolidation scheduler

--- a/packages/memtomem/src/memtomem/server/scheduler.py
+++ b/packages/memtomem/src/memtomem/server/scheduler.py
@@ -114,6 +114,7 @@ class PolicyScheduler:
                 self._app.storage,
                 dry_run=False,
                 max_actions=self._config.max_actions_per_run,
+                llm_provider=getattr(self._app, "llm_provider", None),
             )
             self._consecutive_failures = 0
         except Exception:

--- a/packages/memtomem/src/memtomem/server/tools/policy.py
+++ b/packages/memtomem/src/memtomem/server/tools/policy.py
@@ -181,13 +181,15 @@ async def mem_policy_run(
         policy = await app.storage.policy_get(name)
         if not policy:
             return f"Error: policy '{name}' not found."
-        result = await run_policy(app.storage, policy, dry_run=dry_run)
+        result = await run_policy(
+            app.storage, policy, dry_run=dry_run, llm_provider=app.llm_provider
+        )
         if not dry_run:
             await app.storage.policy_update_last_run(name)
             app.search_pipeline.invalidate_cache()
         return f"{'[DRY RUN] ' if dry_run else ''}{result.details}"
 
-    results = await run_all_enabled(app.storage, dry_run=dry_run)
+    results = await run_all_enabled(app.storage, dry_run=dry_run, llm_provider=app.llm_provider)
     if not results:
         return "No enabled policies to run."
 

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -27,6 +27,7 @@ from memtomem.models import Chunk, ChunkMetadata, ChunkType
 from memtomem.tools.entity_extraction import _ACTION_RE, _DECISION_RE
 
 if TYPE_CHECKING:
+    from memtomem.llm.base import LLMProvider
     from memtomem.storage.base import StorageBackend
 
 logger = logging.getLogger(__name__)
@@ -198,6 +199,66 @@ def make_heuristic_summary(
             "- Strategy: heuristic",
         ]
     )
+    return "\n".join(lines)
+
+
+_CONSOLIDATION_SYSTEM_PROMPT = (
+    "You are a memory consolidation assistant. Given a set of memory chunks "
+    "from the same source file, produce a concise summary that preserves all "
+    "key facts, decisions, and action items. Output markdown. Do NOT invent "
+    "information not present in the input."
+)
+
+
+async def make_llm_summary(
+    chunks: list[Chunk],
+    source: Path,
+    llm: LLMProvider,
+    max_bullets: int = 20,
+    max_tokens: int = 1024,
+) -> str:
+    """Build an LLM-generated markdown summary for a group of chunks.
+
+    Wraps the LLM output in the same template as ``make_heuristic_summary``
+    so that idempotency (source hash) and metadata work identically.
+    """
+    if not chunks:
+        raise ValueError("make_llm_summary: cannot summarize empty chunk list")
+
+    # Build prompt with chunk content
+    chunk_texts = []
+    for i, c in enumerate(chunks[:max_bullets], 1):
+        chunk_texts.append(f"--- Chunk {i} ---\n{c.content[:2000]}")
+    prompt = (
+        f"Summarize the following {len(chunks)} memory chunks from `{source}`.\n\n"
+        + "\n\n".join(chunk_texts)
+    )
+
+    llm_output = await llm.generate(
+        prompt, system=_CONSOLIDATION_SYSTEM_PROMPT, max_tokens=max_tokens
+    )
+
+    # Wrap in same template as heuristic — same metadata block for idempotency.
+    created_ats = [c.created_at for c in chunks]
+    range_start = min(created_ats).date().isoformat()
+    range_end = max(created_ats).date().isoformat()
+    source_hash = compute_source_hash([c.id for c in chunks])
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    lines: list[str] = [
+        f"# Consolidated: {source.name}",
+        "",
+        llm_output.strip(),
+        "",
+        "## Metadata",
+        "",
+        f"- Source: `{source}`",
+        f"- Chunks: {len(chunks)}",
+        f"- Range: {range_start} ~ {range_end}",
+        f"- Source hash: `{source_hash}`",
+        f"- Generated: {now}",
+        "- Strategy: llm",
+    ]
     return "\n".join(lines)
 
 

--- a/packages/memtomem/src/memtomem/tools/policy_engine.py
+++ b/packages/memtomem/src/memtomem/tools/policy_engine.py
@@ -261,6 +261,8 @@ async def execute_auto_consolidate(
     config: dict,
     namespace: str | None,
     dry_run: bool,
+    *,
+    llm_provider: object | None = None,
 ) -> PolicyRunResult:
     """Group related chunks by source file and create heuristic summary chunks.
 
@@ -297,6 +299,7 @@ async def execute_auto_consolidate(
         apply_consolidation,
         compute_source_hash,
         make_heuristic_summary,
+        make_llm_summary,
         parse_source_hash,
         source_has_consolidation_relations,
     )
@@ -322,6 +325,7 @@ async def execute_auto_consolidate(
     )
 
     applied = 0
+    llm_fallback_count = 0
     detail_parts: list[str] = []
 
     for g in raw_groups:
@@ -386,7 +390,22 @@ async def execute_auto_consolidate(
             await storage.delete_chunks([existing[0].id])  # type: ignore[attr-defined]
 
         try:
-            summary = make_heuristic_summary(chunks, source_path, max_bullets=max_bullets)
+            # Try LLM summary first, fall back to heuristic on failure.
+            summary = None
+            if llm_provider is not None:
+                try:
+                    summary = await make_llm_summary(
+                        chunks, source_path, llm_provider, max_bullets=max_bullets
+                    )
+                except Exception:
+                    logger.warning(
+                        "auto_consolidate: LLM failed for %s, using heuristic",
+                        source_path,
+                        exc_info=True,
+                    )
+                    llm_fallback_count += 1
+            if summary is None:
+                summary = make_heuristic_summary(chunks, source_path, max_bullets=max_bullets)
             group_dict = {
                 "source": str(source_path),
                 "chunk_ids": [str(c.id) for c in chunks],
@@ -418,6 +437,8 @@ async def execute_auto_consolidate(
         details = f"{verb} {applied} groups: {', '.join(detail_parts)}"
     else:
         details = f"{verb} 0 groups (no candidates)"
+    if llm_fallback_count > 0:
+        details += f" (llm_fallback_count={llm_fallback_count})"
 
     return PolicyRunResult(
         policy_name="",
@@ -542,8 +563,13 @@ async def run_policy(
     storage: object,
     policy: dict,
     dry_run: bool = False,
+    *,
+    llm_provider: object | None = None,
 ) -> PolicyRunResult:
-    """Execute a single policy."""
+    """Execute a single policy.
+
+    ``llm_provider`` is forwarded to ``execute_auto_consolidate`` when set.
+    """
     ptype = policy["policy_type"]
     handler = _HANDLERS.get(ptype)
     if handler is None:
@@ -555,9 +581,21 @@ async def run_policy(
             details=f"Unknown policy type: {ptype}",
         )
 
-    result = await handler(
-        storage, policy.get("config", {}), policy.get("namespace_filter"), dry_run
-    )
+    if ptype == "auto_consolidate":
+        result = await handler(
+            storage,
+            policy.get("config", {}),
+            policy.get("namespace_filter"),
+            dry_run,
+            llm_provider=llm_provider,
+        )
+    else:
+        result = await handler(
+            storage,
+            policy.get("config", {}),
+            policy.get("namespace_filter"),
+            dry_run,
+        )
     return PolicyRunResult(
         policy_name=policy["name"],
         policy_type=result.policy_type,
@@ -571,6 +609,8 @@ async def run_all_enabled(
     storage: object,
     dry_run: bool = False,
     max_actions: int | None = None,
+    *,
+    llm_provider: object | None = None,
 ) -> list[PolicyRunResult]:
     """Run all enabled policies.
 
@@ -578,12 +618,13 @@ async def run_all_enabled(
         max_actions: If set, stop after cumulative affected_count reaches
             this limit.  The cap is checked between policies — individual
             handlers run atomically.
+        llm_provider: Optional LLM provider forwarded to consolidation.
     """
     policies = await storage.policy_get_enabled()  # type: ignore[attr-defined]
     results: list[PolicyRunResult] = []
     cumulative = 0
     for p in policies:
-        result = await run_policy(storage, p, dry_run=dry_run)
+        result = await run_policy(storage, p, dry_run=dry_run, llm_provider=llm_provider)
         if not dry_run:
             await storage.policy_update_last_run(p["name"])  # type: ignore[attr-defined]
         results.append(result)

--- a/packages/memtomem/tests/test_llm_providers.py
+++ b/packages/memtomem/tests/test_llm_providers.py
@@ -1,0 +1,419 @@
+"""Tests for memtomem LLM provider infrastructure.
+
+Covers:
+  - LLMProvider protocol conformance
+  - OllamaLLM, OpenAILLM, AnthropicLLM (mocked httpx)
+  - create_llm factory + provider-default model resolution
+  - make_llm_summary with FakeLLM
+  - Consolidation fallback paths
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from memtomem.config import LLMConfig
+from memtomem.errors import ConfigError, LLMError
+from memtomem.llm.anthropic import AnthropicLLM
+from memtomem.llm.factory import _DEFAULT_MODELS, create_llm
+from memtomem.llm.ollama import OllamaLLM
+from memtomem.llm.openai import OpenAILLM
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ollama_llm_config(**overrides) -> LLMConfig:
+    defaults = dict(
+        enabled=True,
+        provider="ollama",
+        model="llama3.2",
+        base_url="http://localhost:11434",
+        api_key="",
+        max_tokens=1024,
+        timeout=60.0,
+    )
+    defaults.update(overrides)
+    return LLMConfig(**defaults)
+
+
+def _openai_llm_config(**overrides) -> LLMConfig:
+    defaults = dict(
+        enabled=True,
+        provider="openai",
+        model="gpt-4o-mini",
+        base_url="https://api.openai.com",
+        api_key="sk-test",
+        max_tokens=1024,
+        timeout=60.0,
+    )
+    defaults.update(overrides)
+    return LLMConfig(**defaults)
+
+
+def _anthropic_llm_config(**overrides) -> LLMConfig:
+    defaults = dict(
+        enabled=True,
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        base_url="https://api.anthropic.com",
+        api_key="sk-ant-test",
+        max_tokens=1024,
+        timeout=60.0,
+    )
+    defaults.update(overrides)
+    return LLMConfig(**defaults)
+
+
+def _make_httpx_response(
+    status_code: int = 200, json_data: dict | None = None, headers: dict | None = None
+) -> httpx.Response:
+    resp = httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        headers=headers or {},
+        request=httpx.Request("POST", "http://test"),
+    )
+    return resp
+
+
+class FakeLLM:
+    """Minimal LLMProvider implementation for testing consumers."""
+
+    def __init__(self, response: str = "Fake summary") -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        self.calls.append({"prompt": prompt, "system": system, "max_tokens": max_tokens})
+        return self._response
+
+    async def close(self) -> None:
+        pass
+
+
+class FailingLLM:
+    """LLM provider that always raises LLMError."""
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        raise LLMError("simulated LLM failure")
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProviderProtocol:
+    def test_ollama_has_required_methods(self):
+        llm = OllamaLLM(_ollama_llm_config())
+        assert hasattr(llm, "generate")
+        assert hasattr(llm, "close")
+
+    def test_openai_has_required_methods(self):
+        llm = OpenAILLM(_openai_llm_config())
+        assert hasattr(llm, "generate")
+        assert hasattr(llm, "close")
+
+    def test_anthropic_has_required_methods(self):
+        llm = AnthropicLLM(_anthropic_llm_config())
+        assert hasattr(llm, "generate")
+        assert hasattr(llm, "close")
+
+    def test_fake_llm_satisfies_protocol(self):
+        llm = FakeLLM()
+        assert hasattr(llm, "generate")
+        assert hasattr(llm, "close")
+
+
+# ---------------------------------------------------------------------------
+# 2. OllamaLLM — mocked httpx
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaLLM:
+    @pytest.mark.anyio
+    async def test_generate_returns_response_text(self):
+        config = _ollama_llm_config()
+        llm = OllamaLLM(config)
+        fake_resp = _make_httpx_response(json_data={"response": "Hello from Ollama"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = fake_resp
+        llm._client = mock_client
+
+        result = await llm.generate("test prompt", system="sys")
+        assert result == "Hello from Ollama"
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/api/generate"
+        payload = call_args[1]["json"]
+        assert payload["model"] == "llama3.2"
+        assert payload["prompt"] == "test prompt"
+        assert payload["system"] == "sys"
+
+    @pytest.mark.anyio
+    async def test_connection_error_raises_llm_error(self):
+        config = _ollama_llm_config()
+        llm = OllamaLLM(config)
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+        llm._client = mock_client
+
+        with pytest.raises(LLMError, match="Cannot connect to Ollama"):
+            await llm.generate("test")
+
+    @pytest.mark.anyio
+    async def test_close_clears_client(self):
+        llm = OllamaLLM(_ollama_llm_config())
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        llm._client = mock_client
+        await llm.close()
+        mock_client.aclose.assert_awaited_once()
+        assert llm._client is None
+
+
+# ---------------------------------------------------------------------------
+# 3. OpenAILLM — mocked httpx
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAILLM:
+    @pytest.mark.anyio
+    async def test_generate_returns_message_content(self):
+        config = _openai_llm_config()
+        llm = OpenAILLM(config)
+        fake_resp = _make_httpx_response(
+            json_data={"choices": [{"message": {"content": "Hello from OpenAI"}}]}
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = fake_resp
+        llm._client = mock_client
+
+        result = await llm.generate("test prompt")
+        assert result == "Hello from OpenAI"
+
+    @pytest.mark.anyio
+    async def test_401_raises_auth_error(self):
+        config = _openai_llm_config()
+        llm = OpenAILLM(config)
+        fake_resp = _make_httpx_response(status_code=401)
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = fake_resp
+        llm._client = mock_client
+
+        with pytest.raises(LLMError, match="authentication failed"):
+            await llm.generate("test")
+
+    @pytest.mark.anyio
+    async def test_429_raises_rate_limit_error(self):
+        config = _openai_llm_config()
+        llm = OpenAILLM(config)
+        fake_resp = _make_httpx_response(status_code=429, headers={"Retry-After": "5"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = fake_resp
+        llm._client = mock_client
+
+        with pytest.raises(LLMError, match="rate limit"):
+            await llm.generate("test")
+
+
+# ---------------------------------------------------------------------------
+# 4. AnthropicLLM — mocked httpx
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicLLM:
+    @pytest.mark.anyio
+    async def test_generate_returns_content_text(self):
+        config = _anthropic_llm_config()
+        llm = AnthropicLLM(config)
+        fake_resp = _make_httpx_response(
+            json_data={"content": [{"type": "text", "text": "Hello from Claude"}]}
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = fake_resp
+        llm._client = mock_client
+
+        result = await llm.generate("test prompt", system="sys prompt")
+        assert result == "Hello from Claude"
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/v1/messages"
+        payload = call_args[1]["json"]
+        assert payload["system"] == "sys prompt"
+
+    @pytest.mark.anyio
+    async def test_ollama_base_url_overridden_to_anthropic_default(self):
+        config = _anthropic_llm_config(base_url="http://localhost:11434")
+        llm = AnthropicLLM(config)
+        client = llm._get_client()
+        assert str(client.base_url).rstrip("/") == "https://api.anthropic.com"
+        await llm.close()
+
+    @pytest.mark.anyio
+    async def test_401_raises_auth_error(self):
+        config = _anthropic_llm_config()
+        llm = AnthropicLLM(config)
+        fake_resp = _make_httpx_response(status_code=401)
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = fake_resp
+        llm._client = mock_client
+
+        with pytest.raises(LLMError, match="authentication failed"):
+            await llm.generate("test")
+
+
+# ---------------------------------------------------------------------------
+# 5. create_llm factory
+# ---------------------------------------------------------------------------
+
+
+class TestCreateLLM:
+    def test_disabled_returns_none(self):
+        config = LLMConfig(enabled=False)
+        assert create_llm(config) is None
+
+    def test_ollama_provider(self):
+        config = _ollama_llm_config()
+        llm = create_llm(config)
+        assert isinstance(llm, OllamaLLM)
+
+    def test_openai_provider(self):
+        config = _openai_llm_config()
+        llm = create_llm(config)
+        assert isinstance(llm, OpenAILLM)
+
+    def test_anthropic_provider(self):
+        config = _anthropic_llm_config()
+        llm = create_llm(config)
+        assert isinstance(llm, AnthropicLLM)
+
+    def test_unknown_provider_raises(self):
+        config = _ollama_llm_config(provider="unknown")
+        with pytest.raises(ConfigError, match="Unknown LLM provider"):
+            create_llm(config)
+
+    def test_empty_model_resolved_to_provider_default(self):
+        for provider, expected_model in _DEFAULT_MODELS.items():
+            config = LLMConfig(enabled=True, provider=provider, model="")
+            create_llm(config)
+            assert config.model == expected_model
+
+
+# ---------------------------------------------------------------------------
+# 6. make_llm_summary with FakeLLM
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLLMSummary:
+    @pytest.mark.anyio
+    async def test_produces_summary_with_llm_strategy(self):
+        from datetime import datetime, timezone
+        from uuid import uuid4
+
+        from memtomem.models import Chunk, ChunkMetadata, ChunkType
+        from memtomem.tools.consolidation_engine import make_llm_summary
+
+        chunks = [
+            Chunk(
+                id=uuid4(),
+                content="Decision: use BM25 as default",
+                metadata=ChunkMetadata(
+                    source_file=Path("/notes/design.md"),
+                    chunk_type=ChunkType.MARKDOWN_SECTION,
+                ),
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                embedding=[],
+            ),
+            Chunk(
+                id=uuid4(),
+                content="Action: implement NoopEmbedder",
+                metadata=ChunkMetadata(
+                    source_file=Path("/notes/design.md"),
+                    chunk_type=ChunkType.MARKDOWN_SECTION,
+                ),
+                created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                embedding=[],
+            ),
+        ]
+
+        fake = FakeLLM(response="## Summary\n- BM25 default\n- NoopEmbedder")
+        result = await make_llm_summary(chunks, Path("/notes/design.md"), fake)
+
+        assert "Strategy: llm" in result
+        assert "Consolidated: design.md" in result
+        assert "Source hash:" in result
+        assert "BM25 default" in result
+        assert len(fake.calls) == 1
+
+    @pytest.mark.anyio
+    async def test_empty_chunks_raises(self):
+        from memtomem.tools.consolidation_engine import make_llm_summary
+
+        with pytest.raises(ValueError, match="cannot summarize empty"):
+            await make_llm_summary([], Path("/notes/x.md"), FakeLLM())
+
+
+# ---------------------------------------------------------------------------
+# 7. Consolidation fallback: LLM=None → heuristic, LLM error → heuristic
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidationFallback:
+    @pytest.mark.anyio
+    async def test_heuristic_summary_has_heuristic_strategy(self):
+        from datetime import datetime, timezone
+        from uuid import uuid4
+
+        from memtomem.models import Chunk, ChunkMetadata, ChunkType
+        from memtomem.tools.consolidation_engine import make_heuristic_summary
+
+        chunks = [
+            Chunk(
+                id=uuid4(),
+                content="Some content here",
+                metadata=ChunkMetadata(
+                    source_file=Path("/a.md"),
+                    chunk_type=ChunkType.MARKDOWN_SECTION,
+                ),
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                embedding=[],
+            ),
+        ]
+        result = make_heuristic_summary(chunks, Path("/a.md"))
+        assert "Strategy: heuristic" in result
+
+    @pytest.mark.anyio
+    async def test_llm_failure_produces_heuristic_fallback(self):
+        """When LLM raises LLMError, make_llm_summary raises — caller handles fallback."""
+        from memtomem.tools.consolidation_engine import make_llm_summary
+
+        from datetime import datetime, timezone
+        from uuid import uuid4
+
+        from memtomem.models import Chunk, ChunkMetadata, ChunkType
+
+        chunks = [
+            Chunk(
+                id=uuid4(),
+                content="Test chunk",
+                metadata=ChunkMetadata(
+                    source_file=Path("/a.md"),
+                    chunk_type=ChunkType.MARKDOWN_SECTION,
+                ),
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                embedding=[],
+            ),
+        ]
+
+        failing = FailingLLM()
+        with pytest.raises(LLMError, match="simulated LLM failure"):
+            await make_llm_summary(chunks, Path("/a.md"), failing)

--- a/packages/memtomem/tests/test_policy_scheduler.py
+++ b/packages/memtomem/tests/test_policy_scheduler.py
@@ -67,7 +67,12 @@ class TestPolicyScheduler:
             return_value=[_result("p1", 0)],
         ) as mock_run:
             await sched._run_policies()
-            mock_run.assert_called_once_with(app.storage, dry_run=False, max_actions=100)
+            mock_run.assert_called_once_with(
+                app.storage,
+                dry_run=False,
+                max_actions=100,
+                llm_provider=app.llm_provider,
+            )
 
     @pytest.mark.asyncio
     async def test_cache_invalidated_when_affected(self):


### PR DESCRIPTION
## Summary

Stacked on #24. Merge #24 first.

- Add `LLMProvider` protocol (`llm/base.py`) mirroring `EmbeddingProvider` — `generate()` + `close()`
- Three providers: `OllamaLLM`, `OpenAILLM`, `AnthropicLLM` — all httpx, no SDK deps, reuse `with_retry`
- `LLMConfig` with `enabled=False` default; provider-specific default models resolved in factory (`ollama→llama3.2`, `openai→gpt-4o-mini`, `anthropic→claude-sonnet-4-20250514`)
- Wire into `Components` + `AppContext` → `PolicyScheduler` → `run_all_enabled` → `run_policy`
- First consumer: `make_llm_summary()` in `consolidation_engine.py` — LLM failure → heuristic fallback + warning log + `llm_fallback_count` in `PolicyRunResult.details`
- `anthropic-version` header is a hardcoded constant, not config-exposed

## Test plan

- [x] `FakeLLM` + `FailingLLM` test helpers
- [x] Protocol conformance for all 3 providers
- [x] Factory: disabled→None, unknown→ConfigError, empty model→provider default
- [x] `make_llm_summary` produces correct template with `Strategy: llm`
- [x] LLM error propagates as `LLMError` for caller fallback
- [x] 1155 tests passed (`pytest -m "not ollama"`, 23 new)
- [x] `ruff check` + `ruff format` clean
- [ ] Manual: `MEMTOMEM_LLM__ENABLED=true mm policy-run auto_consolidate --dry-run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)