### PR TITLE
feat(llm): add LLM-powered query expansion, entity extraction, auto-tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 | [Interactive Notebooks](examples/notebooks/) | Jupyter notebooks for the Python API — hello, indexing, sessions, tuning, LangGraph |
 | [User Guide](docs/guides/user-guide.md) | Complete feature walkthrough |
 | [Configuration](docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
-| [Embeddings](docs/guides/embeddings.md) | Ollama and OpenAI providers |
+| [Embeddings](docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI embedding providers |
+| [LLM Providers](docs/guides/llm-providers.md) | Ollama, OpenAI, Anthropic, and compatible endpoints |
 | [MCP Client Setup](docs/guides/mcp-clients.md) | Editor-specific configuration |
 | [Agent Memory Guide](docs/guides/agent-memory-guide.md) | Sessions, working memory, procedures |
 | [Web UI](docs/guides/web-ui.md) | Visual dashboard |

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -139,6 +139,20 @@ depend on `policy_type`:
 | `keep_originals` | bool | `true` | Keep original chunks after consolidation (recommended) |
 | `summary_namespace` | str | `"archive:summary"` | Namespace for generated summary chunks |
 
+## LLM
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMTOMEM_LLM__ENABLED` | `false` | Enable LLM provider (required for LLM-powered features) |
+| `MEMTOMEM_LLM__PROVIDER` | `ollama` | `ollama` (local), `openai` (cloud/compatible), or `anthropic` |
+| `MEMTOMEM_LLM__MODEL` | _(empty)_ | Model name (empty uses provider default: ollama→llama3.2, openai→gpt-4o-mini, anthropic→claude-sonnet-4-20250514) |
+| `MEMTOMEM_LLM__BASE_URL` | `http://localhost:11434` | API endpoint URL |
+| `MEMTOMEM_LLM__API_KEY` | _(empty)_ | API key (required for OpenAI/Anthropic/OpenRouter) |
+| `MEMTOMEM_LLM__MAX_TOKENS` | `1024` | Maximum response tokens |
+| `MEMTOMEM_LLM__TIMEOUT` | `60.0` | Request timeout in seconds |
+
+The `openai` provider works with any OpenAI-compatible endpoint (LM Studio, vLLM, OpenRouter, etc.) — set `BASE_URL` to the server's address. See [LLM Providers](llm-providers.md) for setup examples.
+
 ## Tool Mode
 
 | Variable | Default | Description |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -384,9 +384,25 @@ See [Web UI Guide](web-ui.md) for details.
 
 ---
 
+## Optional: LLM Provider
+
+memtomem can use an LLM for enhanced features like consolidation summaries, semantic auto-tagging, and query expansion. LLM is disabled by default — basic search, indexing, and tagging work without it.
+
+To enable:
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=ollama    # or: openai, anthropic
+```
+
+See [LLM Providers](llm-providers.md) for full setup including local servers (LM Studio, vLLM) and cloud APIs (OpenRouter).
+
+---
+
 ## Next steps
 
 - [Hands-On Tutorial](hands-on-tutorial.md) — follow-along with example files
 - [User Guide](user-guide.md) — complete feature walkthrough
 - [Agent Memory Guide](agent-memory-guide.md) — sessions, working memory, procedures
+- [LLM Providers](llm-providers.md) — Ollama, OpenAI, and compatible endpoints
 - [MCP Client Setup](mcp-clients.md) — editor-specific configuration

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -1,0 +1,136 @@
+# LLM Providers
+
+memtomem can optionally use an LLM to enhance several features. LLM is **disabled by default** — all core functionality (search, indexing, tagging) works without it.
+
+## Quick Start
+
+The simplest path — local Ollama:
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=ollama
+# model defaults to llama3.2, base_url to localhost:11434
+```
+
+## Supported Providers
+
+### Ollama (local, default)
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=ollama
+export MEMTOMEM_LLM__MODEL=llama3.2        # default when empty
+export MEMTOMEM_LLM__BASE_URL=http://localhost:11434
+```
+
+### OpenAI (cloud)
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=openai
+export MEMTOMEM_LLM__MODEL=gpt-4o-mini     # default when empty
+export MEMTOMEM_LLM__API_KEY=sk-...
+```
+
+### Anthropic (cloud)
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=anthropic
+export MEMTOMEM_LLM__MODEL=claude-sonnet-4-20250514
+export MEMTOMEM_LLM__API_KEY=sk-ant-...
+```
+
+## OpenAI-Compatible Endpoints
+
+The `openai` provider works with **any server** that implements `/v1/chat/completions` — not just OpenAI's cloud API. Set `PROVIDER=openai` and point `BASE_URL` at your server.
+
+### LM Studio
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=openai
+export MEMTOMEM_LLM__BASE_URL=http://localhost:1234
+export MEMTOMEM_LLM__MODEL=<loaded-model-name>
+# No API key needed for local LM Studio
+```
+
+### vLLM
+
+```bash
+# Start vLLM: vllm serve meta-llama/Llama-3.1-8B-Instruct --port 8000
+
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=openai
+export MEMTOMEM_LLM__BASE_URL=http://localhost:8000
+export MEMTOMEM_LLM__MODEL=meta-llama/Llama-3.1-8B-Instruct
+```
+
+### OpenRouter
+
+```bash
+export MEMTOMEM_LLM__ENABLED=true
+export MEMTOMEM_LLM__PROVIDER=openai
+export MEMTOMEM_LLM__BASE_URL=https://openrouter.ai/api
+export MEMTOMEM_LLM__API_KEY=sk-or-v1-...
+export MEMTOMEM_LLM__MODEL=meta-llama/llama-3.1-8b-instruct
+```
+
+### Other Compatible Servers
+
+Any server implementing `/v1/chat/completions` works:
+
+- **text-generation-webui**: enable `--api`, `BASE_URL=http://localhost:5000`
+- **LocalAI**: `BASE_URL=http://localhost:8080`
+
+### MCP Config Example
+
+```json
+{
+  "mcpServers": {
+    "memtomem": {
+      "command": "uvx",
+      "args": ["--from", "memtomem", "memtomem-server"],
+      "env": {
+        "MEMTOMEM_LLM__ENABLED": "true",
+        "MEMTOMEM_LLM__PROVIDER": "openai",
+        "MEMTOMEM_LLM__BASE_URL": "http://localhost:1234",
+        "MEMTOMEM_LLM__MODEL": "loaded-model-name"
+      }
+    }
+  }
+}
+```
+
+## What LLM Powers
+
+| Feature | LLM enabled | LLM disabled (default) |
+|---------|-------------|------------------------|
+| Query expansion (`strategy="llm"`) | LLM synonym generation | Disabled — original query used |
+| Entity extraction (`mem_entity_scan`) | LLM structured extraction | Regex + pattern matching |
+| Auto-tagging (`mem_auto_tag`) | LLM semantic tagging | Keyword frequency heuristic |
+| Consolidation (`auto_consolidate`) | LLM summary | Bullet-point extraction |
+
+All features gracefully degrade: if LLM is enabled but a call fails, the heuristic fallback runs automatically.
+
+## Configuration Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMTOMEM_LLM__ENABLED` | `false` | Enable LLM provider |
+| `MEMTOMEM_LLM__PROVIDER` | `ollama` | `ollama`, `openai`, or `anthropic` |
+| `MEMTOMEM_LLM__MODEL` | _(empty)_ | Model name (empty = provider default) |
+| `MEMTOMEM_LLM__BASE_URL` | `http://localhost:11434` | API endpoint URL |
+| `MEMTOMEM_LLM__API_KEY` | _(empty)_ | API key (required for OpenAI/Anthropic/OpenRouter) |
+| `MEMTOMEM_LLM__MAX_TOKENS` | `1024` | Maximum response tokens |
+| `MEMTOMEM_LLM__TIMEOUT` | `60.0` | Request timeout in seconds |
+
+Provider defaults when `MODEL` is empty: ollama → `llama3.2`, openai → `gpt-4o-mini`, anthropic → `claude-sonnet-4-20250514`.
+
+## Troubleshooting
+
+- **"Cannot connect to …"** — check `BASE_URL` and that the server is running
+- **"Authentication failed"** — verify `API_KEY`
+- **"Model not found" (Ollama)** — run `ollama pull <model>`
+- **Consolidation falls back to heuristic** — LLM error is logged; check provider health
+- **Query expansion adds latency** — expansion has a 3-second hard timeout; consider switching to `strategy="tags"` if LLM is consistently slow

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -186,13 +186,13 @@ class RerankConfig(BaseSettings):
 class QueryExpansionConfig(BaseSettings):
     enabled: bool = False
     max_terms: int = 3
-    strategy: str = "tags"  # "tags" | "headings" | "both"
+    strategy: str = "tags"  # "tags" | "headings" | "both" | "llm"
 
     @field_validator("strategy")
     @classmethod
     def valid_strategy(cls, v: str) -> str:
-        if v not in ("tags", "headings", "both"):
-            raise ValueError("strategy must be 'tags', 'headings', or 'both'")
+        if v not in ("tags", "headings", "both", "llm"):
+            raise ValueError("strategy must be 'tags', 'headings', 'both', or 'llm'")
         return v
 
 

--- a/packages/memtomem/src/memtomem/llm/utils.py
+++ b/packages/memtomem/src/memtomem/llm/utils.py
@@ -1,0 +1,21 @@
+"""Shared helpers for parsing LLM responses."""
+
+from __future__ import annotations
+
+
+def strip_llm_response(raw: str) -> str:
+    """Strip markdown code fences and surrounding whitespace from LLM output.
+
+    Small models often wrap their output in ````...```` blocks (sometimes
+    with a language tag).  This helper peels that wrapper so downstream
+    parsers see only the payload.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first line (```lang) and last line (```)
+        if lines[-1].strip() == "```":
+            text = "\n".join(lines[1:-1]).strip()
+        else:
+            text = "\n".join(lines[1:]).strip()
+    return text

--- a/packages/memtomem/src/memtomem/search/expansion.py
+++ b/packages/memtomem/src/memtomem/search/expansion.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from memtomem.embedding.base import EmbeddingProvider
+    from memtomem.llm.base import LLMProvider
     from memtomem.storage.base import StorageBackend
 
 logger = logging.getLogger(__name__)
@@ -69,3 +71,52 @@ async def expand_query_headings(
         logger.debug("Query expanded (headings): %r -> %r", query, expanded)
         return expanded
     return query
+
+
+# ---------------------------------------------------------------------------
+# LLM-based expansion
+# ---------------------------------------------------------------------------
+
+_EXPANSION_SYSTEM_PROMPT = (
+    "You are a search query expansion assistant. Given a user's search "
+    "query, generate synonyms and closely related terms that would help "
+    "retrieve relevant documents. Output ONLY a comma-separated list of "
+    "terms, nothing else. Do not repeat words already in the query."
+)
+
+# Hard timeout to prevent search latency blow-up (seconds).
+_LLM_EXPANSION_TIMEOUT = 3.0
+
+
+async def expand_query_llm(
+    query: str,
+    llm_provider: LLMProvider,
+    max_terms: int = 3,
+) -> str:
+    """Expand query using an LLM to generate synonyms / related terms.
+
+    A hard timeout of 3 seconds prevents search from hanging when the
+    LLM provider is slow. On timeout the original query is returned
+    (handled by the caller).
+    """
+    from memtomem.llm.utils import strip_llm_response
+
+    prompt = f'Expand this search query with up to {max_terms} related terms:\n"{query}"'
+
+    raw = await asyncio.wait_for(
+        llm_provider.generate(prompt, system=_EXPANSION_SYSTEM_PROMPT, max_tokens=256),
+        timeout=_LLM_EXPANSION_TIMEOUT,
+    )
+    cleaned = strip_llm_response(raw)
+
+    query_words = set(query.lower().split())
+    terms: list[str] = []
+    for part in cleaned.split(","):
+        term = part.strip()
+        if term and term.lower() not in query_words:
+            terms.append(term)
+    if not terms:
+        return query
+    expanded = query + " " + " ".join(terms[:max_terms])
+    logger.debug("Query expanded (llm): %r -> %r", query, expanded)
+    return expanded

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -47,6 +47,9 @@ if TYPE_CHECKING:
     from memtomem.storage.base import StorageBackend
 
 
+_EXPANSION_CACHE_MAX = 100
+
+
 class SearchPipeline:
     def __init__(
         self,
@@ -60,6 +63,7 @@ class SearchPipeline:
         expansion_config: object | None = None,
         importance_config: object | None = None,
         context_window_config: ContextWindowConfig | None = None,
+        llm_provider: object | None = None,
     ) -> None:
         self._storage = storage
         self._embedder = embedder
@@ -71,12 +75,16 @@ class SearchPipeline:
         self._expansion_config = expansion_config
         self._importance_config = importance_config
         self._context_window_config = context_window_config
+        self._llm_provider = llm_provider
 
         # Search result TTL cache (per-instance) with version counter
         self._search_cache: dict[str, tuple[float, int, list[SearchResult], RetrievalStats]] = {}
         self._cache_ttl = config.cache_ttl
         self._cache_version = 0
         self._bg_tasks: set[asyncio.Task] = set()
+
+        # LLM query expansion cache (cleared on invalidate_cache)
+        self._expansion_cache: dict[str, str] = {}
 
     def _cache_key(
         self,
@@ -105,6 +113,7 @@ class SearchPipeline:
         """Clear the search result TTL cache (call after data/config changes)."""
         self._cache_version += 1
         self._search_cache.clear()
+        self._expansion_cache.clear()
 
     def _resolve_context_window(self, override: int | None) -> int:
         """Return the effective context window size (0 = disabled)."""
@@ -200,7 +209,11 @@ class SearchPipeline:
 
         # Stage 0: Query expansion
         if self._expansion_config and getattr(self._expansion_config, "enabled", False):
-            from memtomem.search.expansion import expand_query_tags, expand_query_headings
+            from memtomem.search.expansion import (
+                expand_query_headings,
+                expand_query_llm,
+                expand_query_tags,
+            )
 
             strategy = getattr(self._expansion_config, "strategy", "tags")
             max_terms = getattr(self._expansion_config, "max_terms", 3)
@@ -208,6 +221,25 @@ class SearchPipeline:
                 query = await expand_query_tags(query, self._storage, max_terms)
             if strategy in ("headings", "both"):
                 query = await expand_query_headings(query, self._storage, self._embedder, max_terms)
+            if strategy == "llm":
+                if query in self._expansion_cache:
+                    query = self._expansion_cache[query]
+                elif self._llm_provider is not None:
+                    try:
+                        original = query
+                        query = await expand_query_llm(
+                            query,
+                            self._llm_provider,
+                            max_terms,  # type: ignore[arg-type]
+                        )
+                        if len(self._expansion_cache) >= _EXPANSION_CACHE_MAX:
+                            self._expansion_cache.clear()
+                        self._expansion_cache[original] = query
+                    except Exception:
+                        logger.warning(
+                            "LLM query expansion failed, using original query",
+                            exc_info=True,
+                        )
 
         # Stage 1 + 2: run enabled retrievers concurrently
         bm25_results: list[SearchResult] = []

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -93,6 +93,13 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
 
         reranker = create_reranker(config.rerank)
 
+    # Create optional LLM provider (before SearchPipeline so it can be passed in)
+    llm = None
+    if config.llm.enabled:
+        from memtomem.llm.factory import create_llm
+
+        llm = create_llm(config.llm)
+
     search_pipeline = SearchPipeline(
         storage=storage,
         embedder=embedder,
@@ -104,14 +111,8 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         expansion_config=config.query_expansion,
         importance_config=config.importance,
         context_window_config=config.context_window,
+        llm_provider=llm,
     )
-
-    # Create optional LLM provider
-    llm = None
-    if config.llm.enabled:
-        from memtomem.llm.factory import create_llm
-
-        llm = create_llm(config.llm)
 
     return Components(
         config=config,

--- a/packages/memtomem/src/memtomem/server/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/server/tools/auto_tag.py
@@ -38,6 +38,7 @@ async def mem_auto_tag(
         max_tags=max_tags,
         overwrite=overwrite,
         dry_run=dry_run,
+        llm_provider=app.llm_provider,
     )
 
     mode = " (dry-run)" if dry_run else ""

--- a/packages/memtomem/src/memtomem/server/tools/entity.py
+++ b/packages/memtomem/src/memtomem/server/tools/entity.py
@@ -36,7 +36,7 @@ async def mem_entity_scan(
     """
     from fnmatch import fnmatch
 
-    from memtomem.tools.entity_extraction import extract_entities
+    from memtomem.tools.entity_extraction import extract_entities_with_llm
 
     app = _get_app(ctx)
     storage = app.storage
@@ -71,7 +71,9 @@ async def mem_entity_scan(
             if not overwrite and str(chunk.id) in already_extracted:
                 continue
 
-            entities = extract_entities(chunk.content, entity_types)
+            entities = await extract_entities_with_llm(
+                chunk.content, entity_types, app.llm_provider
+            )
             if not entities:
                 continue
 

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -181,6 +181,7 @@ def _revert_to_stored(app: AppContext) -> str:
         mmr_config=config.mmr,
         access_config=config.access,
         context_window_config=config.context_window,
+        llm_provider=app.llm_provider,
     )
     app.index_engine = IndexEngine(
         storage=storage,

--- a/packages/memtomem/src/memtomem/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/tools/auto_tag.py
@@ -1,7 +1,13 @@
-"""Automatic keyword-based tag extraction for memory chunks."""
+"""Automatic keyword-based tag extraction for memory chunks.
+
+When an LLM provider is available the ``extract_tags_llm`` function offers
+a semantically richer alternative; ``_extract_tags_with_fallback`` picks
+the LLM path when possible and gracefully degrades to keyword heuristics.
+"""
 
 from __future__ import annotations
 
+import logging
 import re
 from collections import Counter
 from dataclasses import dataclass
@@ -9,7 +15,9 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    pass
+    from memtomem.llm.base import LLMProvider
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +184,78 @@ def extract_tags_keyword(
     return [word for word, _ in counter.most_common(max_tags)]
 
 
+# ---------------------------------------------------------------------------
+# LLM-based tagging (optional upgrade over keyword heuristic)
+# ---------------------------------------------------------------------------
+
+_AUTO_TAG_SYSTEM_PROMPT = (
+    "Generate concise, lowercase tags that capture the key topics and themes. "
+    "Output ONLY a comma-separated list of tags, nothing else. "
+    "Tags should be single words or hyphenated compounds."
+)
+
+
+async def extract_tags_llm(
+    text: str,
+    llm_provider: LLMProvider,
+    max_tags: int = 5,
+    heading_hierarchy: tuple[str, ...] = (),
+) -> list[str]:
+    """Extract tags using an LLM for semantic understanding.
+
+    Args:
+        text: Content to extract tags from.
+        llm_provider: An initialised LLMProvider instance.
+        max_tags: Maximum number of tags to return.
+        heading_hierarchy: Heading breadcrumbs for additional context.
+
+    Returns:
+        List of lowercase tag strings, up to *max_tags*.
+    """
+    from memtomem.llm.utils import strip_llm_response
+
+    heading_ctx = ""
+    if heading_hierarchy:
+        heading_ctx = f"\nHeading context: {' > '.join(heading_hierarchy)}\n"
+
+    prompt = (
+        f"Generate up to {max_tags} tags for this content.{heading_ctx}\n---\n{text[:3000]}\n---"
+    )
+
+    raw = await llm_provider.generate(prompt, system=_AUTO_TAG_SYSTEM_PROMPT, max_tokens=256)
+    cleaned = strip_llm_response(raw)
+
+    # Parse comma-separated tags
+    seen: set[str] = set()
+    tags: list[str] = []
+    for part in cleaned.split(","):
+        tag = part.strip().lower()
+        if tag and tag not in seen:
+            seen.add(tag)
+            tags.append(tag)
+    return tags[:max_tags]
+
+
+async def _extract_tags_with_fallback(
+    text: str,
+    max_tags: int = 5,
+    heading_hierarchy: tuple[str, ...] = (),
+    llm_provider: object | None = None,
+) -> list[str]:
+    """Try LLM tagging; fall back to keyword heuristic on failure."""
+    if llm_provider is not None:
+        try:
+            return await extract_tags_llm(
+                text,
+                llm_provider,
+                max_tags,
+                heading_hierarchy,  # type: ignore[arg-type]
+            )
+        except Exception:
+            logger.warning("LLM tagging failed, using keyword fallback", exc_info=True)
+    return extract_tags_keyword(text, max_tags, heading_hierarchy=heading_hierarchy)
+
+
 @dataclass(frozen=True)
 class AutoTagStats:
     """Statistics returned by auto_tag_storage."""
@@ -191,6 +271,7 @@ async def auto_tag_storage(
     max_tags: int = 5,
     overwrite: bool = False,
     dry_run: bool = False,
+    llm_provider: object | None = None,
 ) -> AutoTagStats:
     """Apply keyword-based tags to chunks in storage.
 
@@ -229,10 +310,11 @@ async def auto_tag_storage(
                 skipped += 1
                 continue
 
-            new_tags = extract_tags_keyword(
+            new_tags = await _extract_tags_with_fallback(
                 chunk.content,
                 max_tags=max_tags,
                 heading_hierarchy=chunk.metadata.heading_hierarchy,
+                llm_provider=llm_provider,
             )
             if not new_tags:
                 skipped += 1

--- a/packages/memtomem/src/memtomem/tools/entity_extraction.py
+++ b/packages/memtomem/src/memtomem/tools/entity_extraction.py
@@ -1,9 +1,21 @@
-"""Entity extraction from unstructured text — regex + heuristic approach."""
+"""Entity extraction from unstructured text — regex + heuristic approach.
+
+When an LLM provider is available, ``extract_entities_with_llm`` tries the
+LLM first for higher-quality extraction (especially person names and
+decisions) and falls back to the regex heuristic.
+"""
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from memtomem.llm.base import LLMProvider
+
+logger = logging.getLogger(__name__)
 
 _MONTHS = (
     "January",
@@ -251,3 +263,104 @@ def _extract_concepts(text: str) -> list[ExtractedEntity]:
         if len(term) > 3:
             results.append(ExtractedEntity("concept", term, 0.7, m.start()))
     return results
+
+
+# ---------------------------------------------------------------------------
+# LLM-based entity extraction (optional upgrade over regex)
+# ---------------------------------------------------------------------------
+
+_VALID_ENTITY_TYPES = frozenset(
+    {"person", "date", "decision", "action_item", "technology", "concept"}
+)
+
+_ENTITY_SYSTEM_PROMPT = (
+    "You are an entity extraction assistant. Extract structured entities "
+    "from the given text. For each entity, output one line in the format:\n"
+    "TYPE|VALUE|CONFIDENCE\n"
+    "where TYPE is one of: person, date, decision, action_item, technology, "
+    "concept. CONFIDENCE is a float 0.0-1.0. Output ONLY the entity lines, "
+    "nothing else. If no entities are found, output NONE."
+)
+
+
+def _parse_entity_response(
+    raw: str,
+    entity_types: set[str] | None = None,
+) -> list[ExtractedEntity]:
+    """Parse TYPE|VALUE|CONFIDENCE lines from an LLM response."""
+    from memtomem.llm.utils import strip_llm_response
+
+    text = strip_llm_response(raw)
+    if not text or text.strip().upper() == "NONE":
+        return []
+
+    results: list[ExtractedEntity] = []
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line or line.upper() == "NONE":
+            continue
+        parts = line.split("|")
+        if len(parts) < 2:
+            continue  # malformed line — skip
+        etype = parts[0].strip().lower()
+        if etype not in _VALID_ENTITY_TYPES:
+            continue
+        if entity_types and etype not in entity_types:
+            continue
+        value = parts[1].strip()
+        if not value:
+            continue
+        try:
+            confidence = float(parts[2].strip()) if len(parts) >= 3 else 0.7
+            confidence = max(0.0, min(1.0, confidence))
+        except (ValueError, IndexError):
+            confidence = 0.7
+        results.append(ExtractedEntity(etype, value[:200], confidence, 0))
+    return results
+
+
+async def extract_entities_llm(
+    text: str,
+    llm_provider: LLMProvider,
+    entity_types: list[str] | None = None,
+) -> list[ExtractedEntity]:
+    """Extract entities using an LLM for higher-quality structured extraction.
+
+    Args:
+        text: Content to extract entities from (truncated to 3000 chars).
+        llm_provider: An initialised LLMProvider instance.
+        entity_types: Restrict to these entity types (default: all).
+
+    Returns:
+        List of :class:`ExtractedEntity` parsed from the LLM response.
+    """
+    type_hint = ""
+    if entity_types:
+        type_hint = f"\nOnly extract these types: {', '.join(entity_types)}\n"
+
+    prompt = f"Extract entities from the following text.{type_hint}\n---\n{text[:3000]}\n---"
+
+    raw = await llm_provider.generate(prompt, system=_ENTITY_SYSTEM_PROMPT, max_tokens=256)
+    types_set = set(entity_types) if entity_types else None
+    return _parse_entity_response(raw, types_set)
+
+
+async def extract_entities_with_llm(
+    text: str,
+    entity_types: list[str] | None = None,
+    llm_provider: LLMProvider | None = None,
+) -> list[ExtractedEntity]:
+    """Extract entities, preferring LLM when available.
+
+    Falls back to the regex heuristic when *llm_provider* is ``None`` or
+    when the LLM call fails.
+    """
+    if llm_provider is not None:
+        try:
+            return await extract_entities_llm(text, llm_provider, entity_types)
+        except Exception:
+            logger.warning(
+                "LLM entity extraction failed, using heuristic fallback",
+                exc_info=True,
+            )
+    return extract_entities(text, entity_types)

--- a/packages/memtomem/tests/test_auto_tag_llm.py
+++ b/packages/memtomem/tests/test_auto_tag_llm.py
@@ -1,0 +1,115 @@
+"""Tests for LLM-based auto-tagging (extract_tags_llm + fallback)."""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.errors import LLMError
+from memtomem.tools.auto_tag import (
+    _extract_tags_with_fallback,
+    extract_tags_keyword,
+    extract_tags_llm,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — replicated locally so this file is self-contained.
+# ---------------------------------------------------------------------------
+
+
+class FakeLLM:
+    def __init__(self, response: str = "") -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        self.calls.append({"prompt": prompt, "system": system, "max_tokens": max_tokens})
+        return self._response
+
+    async def close(self) -> None:
+        pass
+
+
+class FailingLLM:
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        raise LLMError("simulated LLM failure")
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# extract_tags_llm
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTagsLlm:
+    @pytest.mark.anyio
+    async def test_returns_tags(self):
+        llm = FakeLLM(response="python, memory, search")
+        tags = await extract_tags_llm("some text about python", llm)
+        assert tags == ["python", "memory", "search"]
+
+    @pytest.mark.anyio
+    async def test_respects_max_tags(self):
+        llm = FakeLLM(response="a, b, c, d, e, f")
+        tags = await extract_tags_llm("text", llm, max_tags=3)
+        assert len(tags) == 3
+
+    @pytest.mark.anyio
+    async def test_lowercases(self):
+        llm = FakeLLM(response="Python, SEARCH, Memory")
+        tags = await extract_tags_llm("text", llm)
+        assert tags == ["python", "search", "memory"]
+
+    @pytest.mark.anyio
+    async def test_deduplicates(self):
+        llm = FakeLLM(response="python, python, search, search")
+        tags = await extract_tags_llm("text", llm)
+        assert tags == ["python", "search"]
+
+    @pytest.mark.anyio
+    async def test_empty_response(self):
+        llm = FakeLLM(response="")
+        tags = await extract_tags_llm("text", llm)
+        assert tags == []
+
+    @pytest.mark.anyio
+    async def test_strips_code_fence(self):
+        llm = FakeLLM(response="```\npython, search\n```")
+        tags = await extract_tags_llm("text", llm)
+        assert tags == ["python", "search"]
+
+    @pytest.mark.anyio
+    async def test_heading_context_in_prompt(self):
+        llm = FakeLLM(response="tag1")
+        await extract_tags_llm("text", llm, heading_hierarchy=("H1", "H2"))
+        assert "H1 > H2" in llm.calls[0]["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# _extract_tags_with_fallback
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTagsWithFallback:
+    @pytest.mark.anyio
+    async def test_uses_llm_when_available(self):
+        llm = FakeLLM(response="llm-tag-1, llm-tag-2")
+        tags = await _extract_tags_with_fallback("some text", llm_provider=llm)
+        assert "llm-tag-1" in tags
+
+    @pytest.mark.anyio
+    async def test_falls_back_no_llm(self):
+        text = "python python python memory memory search"
+        tags = await _extract_tags_with_fallback(text, llm_provider=None)
+        # Should match keyword heuristic
+        expected = extract_tags_keyword(text)
+        assert tags == expected
+
+    @pytest.mark.anyio
+    async def test_falls_back_on_error(self):
+        text = "python python python memory memory search"
+        tags = await _extract_tags_with_fallback(text, llm_provider=FailingLLM())
+        expected = extract_tags_keyword(text)
+        assert tags == expected

--- a/packages/memtomem/tests/test_entity_extraction_llm.py
+++ b/packages/memtomem/tests/test_entity_extraction_llm.py
@@ -1,0 +1,165 @@
+"""Tests for LLM-based entity extraction."""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.errors import LLMError
+from memtomem.tools.entity_extraction import (
+    ExtractedEntity,
+    _parse_entity_response,
+    extract_entities,
+    extract_entities_llm,
+    extract_entities_with_llm,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeLLM:
+    def __init__(self, response: str = "") -> None:
+        self._response = response
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        self.calls.append({"prompt": prompt, "system": system, "max_tokens": max_tokens})
+        return self._response
+
+    async def close(self) -> None:
+        pass
+
+
+class FailingLLM:
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        raise LLMError("simulated LLM failure")
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# _parse_entity_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseEntityResponse:
+    def test_well_formed_response(self):
+        raw = "person|John Doe|0.9\ndate|2026-01-15|0.95\ntechnology|Python|0.85"
+        entities = _parse_entity_response(raw)
+        assert len(entities) == 3
+        assert entities[0] == ExtractedEntity("person", "John Doe", 0.9, 0)
+        assert entities[1] == ExtractedEntity("date", "2026-01-15", 0.95, 0)
+
+    def test_filters_by_type(self):
+        raw = "person|Jane|0.8\ntechnology|Python|0.9"
+        entities = _parse_entity_response(raw, entity_types={"person"})
+        assert len(entities) == 1
+        assert entities[0].entity_type == "person"
+
+    def test_none_response(self):
+        assert _parse_entity_response("NONE") == []
+
+    def test_empty_response(self):
+        assert _parse_entity_response("") == []
+
+    def test_malformed_lines_skipped(self):
+        raw = "person|John|0.8\ngarbage without pipes\ntechnology|React|0.7"
+        entities = _parse_entity_response(raw)
+        assert len(entities) == 2
+
+    def test_missing_confidence_defaults(self):
+        raw = "person|John Doe"
+        entities = _parse_entity_response(raw)
+        assert len(entities) == 1
+        assert entities[0].confidence == 0.7
+
+    def test_invalid_confidence_defaults(self):
+        raw = "person|John|notanumber"
+        entities = _parse_entity_response(raw)
+        assert entities[0].confidence == 0.7
+
+    def test_confidence_clamped(self):
+        raw = "person|John|2.5"
+        entities = _parse_entity_response(raw)
+        assert entities[0].confidence == 1.0
+
+    def test_strips_code_fence(self):
+        raw = "```\nperson|John|0.8\n```"
+        entities = _parse_entity_response(raw)
+        assert len(entities) == 1
+
+    def test_unknown_type_skipped(self):
+        raw = "unknown_type|value|0.9\nperson|Jane|0.8"
+        entities = _parse_entity_response(raw)
+        assert len(entities) == 1
+        assert entities[0].entity_type == "person"
+
+    def test_value_truncated_at_200(self):
+        long_value = "x" * 300
+        raw = f"concept|{long_value}|0.7"
+        entities = _parse_entity_response(raw)
+        assert len(entities[0].entity_value) == 200
+
+
+# ---------------------------------------------------------------------------
+# extract_entities_llm
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEntitiesLlm:
+    @pytest.mark.anyio
+    async def test_returns_parsed_entities(self):
+        llm = FakeLLM(response="person|Alice|0.9\ntechnology|Python|0.85")
+        entities = await extract_entities_llm("Alice uses Python", llm)
+        assert len(entities) == 2
+        assert entities[0].entity_value == "Alice"
+
+    @pytest.mark.anyio
+    async def test_filters_by_type(self):
+        llm = FakeLLM(response="person|Alice|0.9\ntechnology|Python|0.85")
+        entities = await extract_entities_llm("text", llm, entity_types=["person"])
+        assert len(entities) == 1
+
+    @pytest.mark.anyio
+    async def test_empty_llm_response(self):
+        llm = FakeLLM(response="NONE")
+        entities = await extract_entities_llm("text", llm)
+        assert entities == []
+
+    @pytest.mark.anyio
+    async def test_type_hint_in_prompt(self):
+        llm = FakeLLM(response="NONE")
+        await extract_entities_llm("text", llm, entity_types=["person", "date"])
+        assert "person, date" in llm.calls[0]["prompt"]
+
+
+# ---------------------------------------------------------------------------
+# extract_entities_with_llm (fallback logic)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEntitiesWithLlm:
+    @pytest.mark.anyio
+    async def test_uses_llm_when_available(self):
+        llm = FakeLLM(response="person|Alice|0.95")
+        entities = await extract_entities_with_llm("Alice joined", llm_provider=llm)
+        assert len(entities) == 1
+        assert entities[0].entity_value == "Alice"
+
+    @pytest.mark.anyio
+    async def test_falls_back_no_llm(self):
+        text = "Decision: use Python for the backend"
+        entities = await extract_entities_with_llm(text, llm_provider=None)
+        # Should get heuristic results
+        expected = extract_entities(text)
+        assert entities == expected
+
+    @pytest.mark.anyio
+    async def test_falls_back_on_error(self):
+        text = "Decision: use Python for the backend"
+        entities = await extract_entities_with_llm(text, llm_provider=FailingLLM())
+        expected = extract_entities(text)
+        assert entities == expected

--- a/packages/memtomem/tests/test_expansion_llm.py
+++ b/packages/memtomem/tests/test_expansion_llm.py
@@ -1,0 +1,110 @@
+"""Tests for LLM-based query expansion."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from memtomem.config import QueryExpansionConfig
+from memtomem.errors import LLMError
+from memtomem.search.expansion import expand_query_llm
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeLLM:
+    def __init__(self, response: str = "", delay: float = 0.0) -> None:
+        self._response = response
+        self._delay = delay
+        self.calls: list[dict] = []
+
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        self.calls.append({"prompt": prompt, "system": system, "max_tokens": max_tokens})
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        return self._response
+
+    async def close(self) -> None:
+        pass
+
+
+class FailingLLM:
+    async def generate(self, prompt: str, *, system: str = "", max_tokens: int = 1024) -> str:
+        raise LLMError("simulated LLM failure")
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# expand_query_llm
+# ---------------------------------------------------------------------------
+
+
+class TestExpandQueryLlm:
+    @pytest.mark.anyio
+    async def test_appends_terms(self):
+        llm = FakeLLM(response="synonym1, synonym2, synonym3")
+        result = await expand_query_llm("original query", llm, max_terms=3)
+        assert result.startswith("original query ")
+        assert "synonym1" in result
+
+    @pytest.mark.anyio
+    async def test_deduplicates_query_words(self):
+        llm = FakeLLM(response="original, new_term, query")
+        result = await expand_query_llm("original query", llm, max_terms=3)
+        # "original" and "query" are already in the query, should not be appended
+        parts = result.split()
+        assert parts.count("original") == 1
+        assert parts.count("query") == 1
+
+    @pytest.mark.anyio
+    async def test_respects_max_terms(self):
+        llm = FakeLLM(response="a, b, c, d, e")
+        result = await expand_query_llm("test", llm, max_terms=2)
+        added = result.replace("test ", "").split()
+        assert len(added) == 2
+
+    @pytest.mark.anyio
+    async def test_empty_response_returns_original(self):
+        llm = FakeLLM(response="")
+        result = await expand_query_llm("test query", llm)
+        assert result == "test query"
+
+    @pytest.mark.anyio
+    async def test_strips_code_fence(self):
+        llm = FakeLLM(response="```\nterm1, term2\n```")
+        result = await expand_query_llm("test", llm)
+        assert "term1" in result
+
+    @pytest.mark.anyio
+    async def test_llm_error_propagates(self):
+        """Caller is responsible for catching — function itself raises."""
+        with pytest.raises(LLMError):
+            await expand_query_llm("test", FailingLLM())
+
+    @pytest.mark.anyio
+    async def test_timeout_raises(self):
+        """LLM that exceeds 3s timeout raises TimeoutError."""
+        slow_llm = FakeLLM(response="slow answer", delay=5.0)
+        with pytest.raises(asyncio.TimeoutError):
+            await expand_query_llm("test", slow_llm)
+
+
+# ---------------------------------------------------------------------------
+# QueryExpansionConfig validator
+# ---------------------------------------------------------------------------
+
+
+class TestQueryExpansionConfig:
+    def test_llm_strategy_accepted(self):
+        config = QueryExpansionConfig(strategy="llm")
+        assert config.strategy == "llm"
+
+    def test_invalid_strategy_rejected(self):
+        with pytest.raises(ValueError, match="strategy"):
+            QueryExpansionConfig(strategy="invalid")


### PR DESCRIPTION
## Summary

Wire the LLMProvider (PR #26) into three features that previously relied on heuristics only, plus comprehensive LLM provider documentation.

- **Query expansion** (`strategy="llm"`): LLM generates synonyms/related terms pre-search. 3-second hard timeout + per-instance expansion cache (max 100 entries) to bound latency
- **Entity extraction** (`mem_entity_scan`): LLM structured extraction with `TYPE|VALUE|CONFIDENCE` format, falling back to regex heuristic
- **Auto-tagging** (`mem_auto_tag`): LLM semantic tagging via MCP tool path; policy handler stays heuristic-only (Phase A.5 constraint)
- **Docs**: New `llm-providers.md` covering Ollama, OpenAI, Anthropic, LM Studio, vLLM, OpenRouter with env var examples verified against source

All three features follow the `consolidation_engine.py` fallback pattern: try LLM → catch any exception → fall back to heuristic. Shared `llm/utils.py` `strip_llm_response()` normalizes small-model quirks (code fences, etc.).

## Key design decisions

| Decision | Rationale |
|----------|-----------|
| 3s hard timeout on expansion | Prevents search latency blow-up; `asyncio.wait_for` |
| Expansion cache (100 entries) | Same query → same expansion, no repeated LLM calls |
| Policy handler stays heuristic | Phase A.5 handler signature `(storage, config, ns, dry_run)` fixed |
| `strip_llm_response()` shared | Small models wrap output in code fences; 3 features reuse |
| `max_tokens=256` for all 3 | Short responses only (vs consolidation's 1024) |

## Files changed (17 files, +879 -18)

| Area | Files |
|------|-------|
| Shared | `llm/utils.py` (new) |
| Expansion | `search/expansion.py`, `search/pipeline.py`, `config.py` |
| Entity | `tools/entity_extraction.py`, `server/tools/entity.py` |
| Tagging | `tools/auto_tag.py`, `server/tools/auto_tag.py` |
| Wiring | `server/component_factory.py`, `server/tools/status_config.py` |
| Docs | `llm-providers.md` (new), `configuration.md`, `getting-started.md`, `README.md` |
| Tests | 3 new test files (37 tests total) |

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1192 passed, 0 failed
- [x] `uv run ruff check && ruff format --check` — clean
- [x] Fallback on `FailingLLM` verified for all 3 features
- [x] Timeout test: 5s FakeLLM → `asyncio.TimeoutError` raised
- [x] Code fence stripping tested (`"```\ndata\n```"` → `"data"`)
- [ ] Manual: enable LLM + set `strategy=llm` → verify expanded queries in search
- [ ] Manual: `mem_entity_scan` with LLM → verify higher-quality entity extraction
- [ ] Manual: `mem_auto_tag` with LLM → verify semantic tags vs keyword tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)