### PR TITLE
feat(context): add scope field and --scope CLI option

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -86,6 +86,18 @@ _INCLUDE_OPTION = click.option(
     ),
 )
 
+_SCOPE_OPTION = click.option(
+    "--scope",
+    "scope",
+    type=click.Choice(["project", "user", "all"]),
+    default=None,
+    help=(
+        "Scope filter for fan-out targets. "
+        "'project' = project-scope only, 'user' = user-scope only, "
+        "'all' = both. Default: run only the original (default) generators."
+    ),
+)
+
 
 # ── Skill sub-handlers (shared by the commands below) ───────────────
 
@@ -113,8 +125,8 @@ def _print_skills_init(root: Path, overwrite: bool) -> None:
         click.secho(f"    skipped {name}: {reason}", fg="yellow")
 
 
-def _print_skills_generate(root: Path) -> None:
-    result = generate_all_skills(root)
+def _print_skills_generate(root: Path, scope: str | None = None) -> None:
+    result = generate_all_skills(root, scope=scope)
     if result.generated:
         click.secho(f"  Skills fan-out: {len(result.generated)}", fg="green")
         for runtime, path in result.generated:
@@ -124,8 +136,8 @@ def _print_skills_generate(root: Path) -> None:
         click.secho(f"  skipped {runtime}: {reason}", fg="yellow")
 
 
-def _print_skills_diff(root: Path) -> None:
-    rows = diff_skills(root)
+def _print_skills_diff(root: Path, scope: str | None = None) -> None:
+    rows = diff_skills(root, scope=scope)
     if not rows:
         click.echo("  (no skills to compare)")
         return
@@ -162,9 +174,11 @@ def _print_agents_init(root: Path, overwrite: bool) -> None:
         click.secho(f"    skipped {name}: {reason}", fg="yellow")
 
 
-def _print_agents_generate(root: Path, strict: bool, on_drop: str = "ignore") -> None:
+def _print_agents_generate(
+    root: Path, strict: bool, on_drop: str = "ignore", scope: str | None = None
+) -> None:
     try:
-        result = generate_all_agents(root, strict=strict, on_drop=on_drop)
+        result = generate_all_agents(root, strict=strict, on_drop=on_drop, scope=scope)
     except StrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort()
@@ -186,8 +200,8 @@ def _print_agents_generate(root: Path, strict: bool, on_drop: str = "ignore") ->
         )
 
 
-def _print_agents_diff(root: Path) -> None:
-    rows = diff_agents(root)
+def _print_agents_diff(root: Path, scope: str | None = None) -> None:
+    rows = diff_agents(root, scope=scope)
     if not rows:
         click.echo("  (no sub-agents to compare)")
         return
@@ -224,9 +238,11 @@ def _print_commands_init(root: Path, overwrite: bool) -> None:
         click.secho(f"    skipped {name}: {reason}", fg="yellow")
 
 
-def _print_commands_generate(root: Path, strict: bool, on_drop: str = "ignore") -> None:
+def _print_commands_generate(
+    root: Path, strict: bool, on_drop: str = "ignore", scope: str | None = None
+) -> None:
     try:
-        result = generate_all_commands(root, strict=strict, on_drop=on_drop)
+        result = generate_all_commands(root, strict=strict, on_drop=on_drop, scope=scope)
     except CommandStrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort() from exc
@@ -248,8 +264,8 @@ def _print_commands_generate(root: Path, strict: bool, on_drop: str = "ignore") 
         )
 
 
-def _print_commands_diff(root: Path) -> None:
-    rows = diff_commands(root)
+def _print_commands_diff(root: Path, scope: str | None = None) -> None:
+    rows = diff_commands(root, scope=scope)
     if not rows:
         click.echo("  (no commands to compare)")
         return
@@ -272,8 +288,8 @@ def _print_settings_detect() -> None:
         click.echo(f"    {f.agent:17s}  {f.path}  {status}")
 
 
-def _print_settings_generate(root: Path) -> None:
-    results = generate_all_settings(root)
+def _print_settings_generate(root: Path, scope: str | None = None) -> None:
+    results = generate_all_settings(root, scope=scope)
     for name, r in results.items():
         if r.status == "ok":
             click.secho(f"  Settings: {name} → {r.target}", fg="green")
@@ -285,8 +301,8 @@ def _print_settings_generate(root: Path) -> None:
             click.secho(f"  {r.status} {name}: {r.reason}", fg="red")
 
 
-def _print_settings_diff(root: Path) -> None:
-    results = diff_settings(root)
+def _print_settings_diff(root: Path, scope: str | None = None) -> None:
+    results = diff_settings(root, scope=scope)
     if not results:
         click.echo("  (no settings to compare)")
         return
@@ -409,6 +425,7 @@ def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
 @context.command("generate")
 @click.option("--agent", "-a", default="all", help="Agent name or 'all'")
 @_INCLUDE_OPTION
+@_SCOPE_OPTION
 @click.option(
     "--strict",
     is_flag=True,
@@ -421,7 +438,9 @@ def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
     default="ignore",
     help="Severity when fields are dropped: ignore (default), warn, or error.",
 )
-def generate_cmd(agent: str, include: tuple[str, ...], strict: bool, on_drop: str) -> None:
+def generate_cmd(
+    agent: str, include: tuple[str, ...], scope: str | None, strict: bool, on_drop: str
+) -> None:
     """Generate agent files from .memtomem/context.md."""
     inc = _parse_include(include)
     root = _find_project_root()
@@ -456,26 +475,27 @@ def generate_cmd(agent: str, include: tuple[str, ...], strict: bool, on_drop: st
 
     if "skills" in inc:
         click.echo("")
-        _print_skills_generate(root)
+        _print_skills_generate(root, scope=scope)
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_generate(root, strict=strict, on_drop=on_drop)
+        _print_agents_generate(root, strict=strict, on_drop=on_drop, scope=scope)
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_generate(root, strict=strict, on_drop=on_drop)
+        _print_commands_generate(root, strict=strict, on_drop=on_drop, scope=scope)
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_generate(root)
+        _print_settings_generate(root, scope=scope)
 
     click.secho("Done.", fg="green")
 
 
 @context.command("diff")
 @_INCLUDE_OPTION
-def diff_cmd(include: tuple[str, ...]) -> None:
+@_SCOPE_OPTION
+def diff_cmd(include: tuple[str, ...], scope: str | None) -> None:
     """Show differences between context.md and agent files."""
     inc = _parse_include(include)
     root = _find_project_root()
@@ -508,23 +528,24 @@ def diff_cmd(include: tuple[str, ...]) -> None:
 
     if "skills" in inc:
         click.echo("")
-        _print_skills_diff(root)
+        _print_skills_diff(root, scope=scope)
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_diff(root)
+        _print_agents_diff(root, scope=scope)
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_diff(root)
+        _print_commands_diff(root, scope=scope)
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_diff(root)
+        _print_settings_diff(root, scope=scope)
 
 
 @context.command("sync")
 @_INCLUDE_OPTION
+@_SCOPE_OPTION
 @click.option(
     "--strict",
     is_flag=True,
@@ -537,7 +558,7 @@ def diff_cmd(include: tuple[str, ...]) -> None:
     default="ignore",
     help="Severity when fields are dropped: ignore (default), warn, or error.",
 )
-def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str) -> None:
+def sync_cmd(include: tuple[str, ...], scope: str | None, strict: bool, on_drop: str) -> None:
     """Sync context.md to all detected agent files."""
     inc = _parse_include(include)
     root = _find_project_root()
@@ -571,18 +592,18 @@ def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str) -> None:
 
     if "skills" in inc:
         click.echo("")
-        _print_skills_generate(root)
+        _print_skills_generate(root, scope=scope)
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_generate(root, strict=strict, on_drop=on_drop)
+        _print_agents_generate(root, strict=strict, on_drop=on_drop, scope=scope)
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_generate(root, strict=strict, on_drop=on_drop)
+        _print_commands_generate(root, strict=strict, on_drop=on_drop, scope=scope)
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_generate(root)
+        _print_settings_generate(root, scope=scope)
 
     click.secho("Synced.", fg="green")

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -296,6 +296,8 @@ class AgentGenerator(Protocol):
     """Protocol for runtime-specific sub-agent generators."""
 
     name: str
+    scope: str  # "project" or "user"
+    default: bool  # included when scope filter is None (backward compat)
 
     def target_file(self, project_root: Path, agent_name: str) -> Path:
         """Return the file that should hold the rendered agent."""
@@ -318,6 +320,8 @@ def _register(gen: AgentGenerator) -> AgentGenerator:
 class ClaudeAgentsGenerator:
     name: str = "claude_agents"
     output_root: str = ".claude/agents"
+    scope: str = "project"
+    default: bool = True
 
     def target_file(self, project_root: Path, agent_name: str) -> Path:
         return project_root / self.output_root / f"{agent_name}.md"
@@ -330,6 +334,8 @@ class ClaudeAgentsGenerator:
 class GeminiAgentsGenerator:
     name: str = "gemini_agents"
     output_root: str = ".gemini/agents"
+    scope: str = "project"
+    default: bool = True
 
     def target_file(self, project_root: Path, agent_name: str) -> Path:
         return project_root / self.output_root / f"{agent_name}.md"
@@ -345,6 +351,8 @@ class CodexAgentsGenerator:
     # ``Path.home()`` inside ``target_file``. We keep a visible root string for
     # CLI / MCP output consistency.
     output_root: str = "~/.codex/agents"
+    scope: str = "user"
+    default: bool = True
 
     def target_file(self, project_root: Path, agent_name: str) -> Path:
         # project_root is intentionally ignored — Codex stores custom agents
@@ -386,11 +394,29 @@ class StrictDropError(ValueError):
 ON_DROP_LEVELS = ("ignore", "warn", "error")
 
 
+def _select_generators(
+    generators: dict[str, AgentGenerator],
+    scope: str | None,
+) -> list[str]:
+    """Return generator names matching *scope*.
+
+    - ``None`` — default generators only (backward-compatible).
+    - ``"all"`` — every registered generator.
+    - ``"project"`` / ``"user"`` — only matching scope.
+    """
+    if scope is None:
+        return [n for n, g in generators.items() if g.default]
+    if scope == "all":
+        return list(generators.keys())
+    return [n for n, g in generators.items() if g.scope == scope]
+
+
 def generate_all_agents(
     project_root: Path,
     runtimes: list[str] | None = None,
     strict: bool = False,
     on_drop: str = "ignore",
+    scope: str | None = None,
 ) -> AgentSyncResult:
     """Fan out every canonical sub-agent to the requested runtimes.
 
@@ -401,6 +427,8 @@ def generate_all_agents(
             ``"error"`` — raise :class:`StrictDropError` immediately.
         strict: Legacy alias for ``on_drop="error"``. If *both* are supplied,
             ``on_drop`` takes precedence unless it is still the default.
+        scope: ``"project"`` / ``"user"`` / ``"all"`` / ``None``.
+            ``None`` (default) runs only ``default=True`` generators.
     """
     # Resolve legacy ``strict`` flag.
     effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
@@ -413,7 +441,7 @@ def generate_all_agents(
     if not canonicals:
         return AgentSyncResult(generated=[], dropped=[], skipped=[("<all>", "no canonical agents")])
 
-    targets = runtimes if runtimes is not None else list(AGENT_GENERATORS.keys())
+    targets = runtimes if runtimes is not None else _select_generators(AGENT_GENERATORS, scope)
     for target in targets:
         gen = AGENT_GENERATORS.get(target)
         if gen is None:
@@ -513,8 +541,11 @@ def _runtime_agent_names(gen_name: str, project_root: Path) -> set[str]:
     return {p.stem for p in runtime_root.iterdir() if p.is_file() and p.suffix == suffix}
 
 
-def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
-    """Compare canonical agents against every registered runtime.
+def diff_agents(
+    project_root: Path,
+    scope: str | None = None,
+) -> list[tuple[str, str, str]]:
+    """Compare canonical agents against registered runtimes.
 
     Returns a list of ``(runtime, agent_name, status)`` where status is one of
     ``"in sync"``, ``"out of sync"``, ``"missing target"``, ``"missing canonical"``,
@@ -522,8 +553,11 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
     """
     results: list[tuple[str, str, str]] = []
     canonical_names = {p.stem for p in list_canonical_agents(project_root)}
+    selected = _select_generators(AGENT_GENERATORS, scope)
 
     for gen_name, gen in AGENT_GENERATORS.items():
+        if gen_name not in selected:
+            continue
         runtime_names = _runtime_agent_names(gen_name, project_root)
         for name in sorted(canonical_names | runtime_names):
             if name in canonical_names and name not in runtime_names:

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -191,6 +191,8 @@ class CommandGenerator(Protocol):
     """Protocol for runtime-specific command generators."""
 
     name: str
+    scope: str  # "project" or "user"
+    default: bool  # included when scope filter is None (backward compat)
 
     def target_file(self, project_root: Path, command_name: str) -> Path:
         """Return the file that should hold the rendered command."""
@@ -213,6 +215,8 @@ def _register(gen: CommandGenerator) -> CommandGenerator:
 class ClaudeCommandsGenerator:
     name: str = "claude_commands"
     output_root: str = ".claude/commands"
+    scope: str = "project"
+    default: bool = True
 
     def target_file(self, project_root: Path, command_name: str) -> Path:
         return project_root / self.output_root / f"{command_name}.md"
@@ -225,6 +229,8 @@ class ClaudeCommandsGenerator:
 class GeminiCommandsGenerator:
     name: str = "gemini_commands"
     output_root: str = ".gemini/commands"
+    scope: str = "project"
+    default: bool = True
 
     def target_file(self, project_root: Path, command_name: str) -> Path:
         return project_root / self.output_root / f"{command_name}.toml"
@@ -259,11 +265,24 @@ class StrictDropError(ValueError):
     """Raised under ``strict=True`` / ``on_drop="error"`` when a conversion would drop fields."""
 
 
+def _select_generators(
+    generators: dict[str, CommandGenerator],
+    scope: str | None,
+) -> list[str]:
+    """Return generator names matching *scope*."""
+    if scope is None:
+        return [n for n, g in generators.items() if g.default]
+    if scope == "all":
+        return list(generators.keys())
+    return [n for n, g in generators.items() if g.scope == scope]
+
+
 def generate_all_commands(
     project_root: Path,
     runtimes: list[str] | None = None,
     strict: bool = False,
     on_drop: str = "ignore",
+    scope: str | None = None,
 ) -> CommandSyncResult:
     """Fan out every canonical command to the requested runtimes.
 
@@ -274,6 +293,7 @@ def generate_all_commands(
             ``"error"`` — raise :class:`StrictDropError` immediately.
         strict: Legacy alias for ``on_drop="error"``. If *both* are supplied,
             ``on_drop`` takes precedence unless it is still the default.
+        scope: ``"project"`` / ``"user"`` / ``"all"`` / ``None``.
     """
     effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
 
@@ -287,7 +307,7 @@ def generate_all_commands(
             generated=[], dropped=[], skipped=[("<all>", "no canonical commands")]
         )
 
-    targets = runtimes if runtimes is not None else list(COMMAND_GENERATORS.keys())
+    targets = runtimes if runtimes is not None else _select_generators(COMMAND_GENERATORS, scope)
     for target in targets:
         gen = COMMAND_GENERATORS.get(target)
         if gen is None:
@@ -432,8 +452,11 @@ def _runtime_command_names(gen_name: str, project_root: Path) -> set[str]:
     return {p.stem for p in runtime_root.iterdir() if p.is_file() and p.suffix == suffix}
 
 
-def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
-    """Compare canonical commands against every registered runtime.
+def diff_commands(
+    project_root: Path,
+    scope: str | None = None,
+) -> list[tuple[str, str, str]]:
+    """Compare canonical commands against registered runtimes.
 
     Returns ``(runtime, command_name, status)`` where status is one of
     ``"in sync"``, ``"out of sync"``, ``"missing target"``,
@@ -442,8 +465,11 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
     results: list[tuple[str, str, str]] = []
     canonical_root = project_root / CANONICAL_COMMAND_ROOT
     canonical_names = {p.stem for p in list_canonical_commands(project_root)}
+    selected = _select_generators(COMMAND_GENERATORS, scope)
 
     for gen_name, gen in COMMAND_GENERATORS.items():
+        if gen_name not in selected:
+            continue
         runtime_names = _runtime_command_names(gen_name, project_root)
 
         for name in sorted(canonical_names | runtime_names):

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -57,6 +57,8 @@ class SettingsGenerator(Protocol):
     """Protocol for runtime-specific settings generators."""
 
     name: str
+    scope: str  # "project" or "user"
+    default: bool  # included when scope filter is None (backward compat)
 
     def is_available(self) -> bool:
         """``True`` if the runtime is installed (e.g. ``~/.claude/`` exists).
@@ -113,6 +115,8 @@ class ClaudeSettingsGenerator:
     """Fan out canonical hooks to ``~/.claude/settings.json``."""
 
     name: str = "claude_settings"
+    scope: str = "user"
+    default: bool = True
 
     def is_available(self) -> bool:
         return (Path.home() / ".claude").is_dir()
@@ -215,13 +219,29 @@ def _write_json(path: Path, data: dict) -> None:
 # ── Fan-out: canonical → runtimes ───────────────────────────────────
 
 
+def _select_generators(
+    generators: dict[str, SettingsGenerator],
+    scope: str | None,
+) -> list[str]:
+    """Return generator names matching *scope*."""
+    if scope is None:
+        return [n for n, g in generators.items() if g.default]
+    if scope == "all":
+        return list(generators.keys())
+    return [n for n, g in generators.items() if g.scope == scope]
+
+
 def generate_all_settings(
     project_root: Path,
+    scope: str | None = None,
 ) -> dict[str, SettingsSyncResult]:
     """Fan out ``.memtomem/settings.json`` to registered runtimes."""
     results: dict[str, SettingsSyncResult] = {}
+    selected = _select_generators(SETTINGS_GENERATORS, scope)
 
     for name, gen in SETTINGS_GENERATORS.items():
+        if name not in selected:
+            continue
         if not gen.is_available():
             results[name] = SettingsSyncResult(
                 status="skipped",
@@ -286,11 +306,15 @@ def generate_all_settings(
 
 def diff_settings(
     project_root: Path,
+    scope: str | None = None,
 ) -> dict[str, SettingsSyncResult]:
     """Dry-run: compute what :func:`generate_all_settings` would do."""
     results: dict[str, SettingsSyncResult] = {}
+    selected = _select_generators(SETTINGS_GENERATORS, scope)
 
     for name, gen in SETTINGS_GENERATORS.items():
+        if name not in selected:
+            continue
         if not gen.is_available():
             results[name] = SettingsSyncResult(
                 status="skipped",

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -35,6 +35,8 @@ class SkillGenerator(Protocol):
 
     name: str
     output_root: str  # relative to project root, e.g. ".claude/skills"
+    scope: str  # "project" or "user"
+    default: bool  # included when scope filter is None (backward compat)
 
     def target_dir(self, project_root: Path, skill_name: str) -> Path:
         """Return the directory that should hold the rendered skill."""
@@ -55,6 +57,8 @@ def _register(gen: SkillGenerator) -> SkillGenerator:
 class ClaudeSkillsGenerator:
     name: str = "claude_skills"
     output_root: str = ".claude/skills"
+    scope: str = "project"
+    default: bool = True
 
     def target_dir(self, project_root: Path, skill_name: str) -> Path:
         return project_root / self.output_root / skill_name
@@ -64,6 +68,8 @@ class ClaudeSkillsGenerator:
 class GeminiSkillsGenerator:
     name: str = "gemini_skills"
     output_root: str = ".gemini/skills"
+    scope: str = "project"
+    default: bool = True
 
     def target_dir(self, project_root: Path, skill_name: str) -> Path:
         return project_root / self.output_root / skill_name
@@ -76,6 +82,8 @@ class CodexSkillsGenerator:
     # as an alias, which is why fanning out to all three runtimes creates a
     # slight amount of on-disk overlap — Gemini will silently de-dup it).
     output_root: str = ".agents/skills"
+    scope: str = "project"
+    default: bool = True
 
     def target_dir(self, project_root: Path, skill_name: str) -> Path:
         return project_root / self.output_root / skill_name
@@ -162,16 +170,29 @@ class SkillSyncResult:
     skipped: list[tuple[str, str]]  # (runtime_name, reason)
 
 
+def _select_generators(
+    generators: dict[str, SkillGenerator],
+    scope: str | None,
+) -> list[str]:
+    """Return generator names matching *scope*."""
+    if scope is None:
+        return [n for n, g in generators.items() if g.default]
+    if scope == "all":
+        return list(generators.keys())
+    return [n for n, g in generators.items() if g.scope == scope]
+
+
 def generate_all_skills(
     project_root: Path,
     runtimes: list[str] | None = None,
+    scope: str | None = None,
 ) -> SkillSyncResult:
     """Fan out every canonical skill to the requested runtime targets.
 
     Args:
         project_root: project root containing ``.memtomem/skills/``.
-        runtimes: list of generator names. ``None`` means all registered
-            runtimes (currently ``claude_skills`` + ``gemini_skills``).
+        runtimes: list of generator names. ``None`` means all registered.
+        scope: ``"project"`` / ``"user"`` / ``"all"`` / ``None``.
     """
     generated: list[tuple[str, Path]] = []
     skipped: list[tuple[str, str]] = []
@@ -180,7 +201,7 @@ def generate_all_skills(
     if not canonicals:
         return SkillSyncResult(generated=generated, skipped=[("<all>", "no canonical skills")])
 
-    targets = runtimes if runtimes is not None else list(SKILL_GENERATORS.keys())
+    targets = runtimes if runtimes is not None else _select_generators(SKILL_GENERATORS, scope)
     for target in targets:
         gen = SKILL_GENERATORS.get(target)
         if gen is None:
@@ -265,8 +286,11 @@ def _skill_dirs_equal(a: Path, b: Path) -> bool:
     return True
 
 
-def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
-    """Compare canonical skills against every registered runtime.
+def diff_skills(
+    project_root: Path,
+    scope: str | None = None,
+) -> list[tuple[str, str, str]]:
+    """Compare canonical skills against registered runtimes.
 
     Returns a sorted list of ``(runtime, skill_name, status)`` tuples where
     status is one of:
@@ -279,8 +303,11 @@ def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
     results: list[tuple[str, str, str]] = []
     canonical_root = canonical_skills_root(project_root)
     canonical_names = {p.name for p in list_canonical_skills(project_root)}
+    selected = _select_generators(SKILL_GENERATORS, scope)
 
     for gen_name, gen in SKILL_GENERATORS.items():
+        if gen_name not in selected:
+            continue
         runtime_root = project_root / gen.output_root
         runtime_names: set[str] = set()
         if runtime_root.is_dir():


### PR DESCRIPTION
## Summary
- Add `scope` ("project"|"user") and `default` (bool) fields to all 4 generator protocols and 7 dataclasses
- Add `_select_generators()` helper to each module (agents, skills, commands, settings)
- Add `scope` parameter to `generate_all_*()` and `diff_*()` functions
- Wire `--scope` CLI option into `mm context generate/sync/diff`

## Design
- `scope=None` (default) → runs only `default=True` generators (backward-compatible)
- `--scope=project` → project-scope generators only
- `--scope=user` → user-scope generators only
- `--scope=all` → all registered generators

This is infrastructure for PR 3 (dual-scope generators). Currently all existing generators have `default=True`, so behavior is unchanged.

**Stacks on:** #32 (Codex commands removal)

## Test plan
- [x] 157 tests passed (context + CLI)
- [x] ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)