### PR TITLE
feat(context): add dual-scope generators for all runtimes

### DIFF
--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1035,7 +1035,30 @@ memtomem treats `.memtomem/` as the single source of truth for four artifact kin
 | Project memory | `.memtomem/context.md` | `CLAUDE.md`, `.cursorrules`, `GEMINI.md`, `AGENTS.md`, `.github/copilot-instructions.md` |
 | Agent skills (Phase 1) | `.memtomem/skills/<name>/SKILL.md` | `.claude/skills/`, `.gemini/skills/`, `.agents/skills/` |
 | Sub-agents (Phase 2) | `.memtomem/agents/<name>.md` | `.claude/agents/<name>.md`, `.gemini/agents/<name>.md`, `~/.codex/agents/<name>.toml` |
-| Slash commands (Phase 3) | `.memtomem/commands/<name>.md` | `.claude/commands/<name>.md`, `.gemini/commands/<name>.toml`, `~/.codex/prompts/<name>.md` |
+| Slash commands (Phase 3) | `.memtomem/commands/<name>.md` | `.claude/commands/<name>.md`, `.gemini/commands/<name>.toml` |
+
+### Understanding scope
+
+Every fan-out target is either **project-scope** or **user-scope**:
+
+| Scope | Written relative to | Isolation | Example path |
+|---|---|---|---|
+| **Project** | project root (`.`) | Each project gets its own copy | `.claude/agents/reviewer.md` |
+| **User** | home directory (`~`) | Shared across every project on the machine | `~/.claude/agents/reviewer.md` |
+
+All three runtimes (Claude Code, Gemini CLI, Codex CLI) support **both scopes** for agents, skills, and commands. By default, `mm context sync` generates only project-scope targets. Use `--scope` to control which scope to write to:
+
+```bash
+mm context sync --include=agents                # project-scope only (default)
+mm context sync --include=agents --scope=user   # user-scope only
+mm context sync --include=agents --scope=all    # both scopes
+```
+
+**Cross-project collision warning.** User-scope targets live under `~`, so running `mm context sync --scope=user` in two projects that define an agent with the same name will overwrite each other. To avoid surprises:
+
+- Use project-specific prefixes for names (e.g., `myapp-reviewer` instead of `reviewer`).
+- Run `mm context diff --include=agents --scope=user` after switching projects.
+- `mm context init --include=agents` imports from project-scope only — user-scope artifacts are never reverse-imported to avoid cross-project leakage.
 
 ```mermaid
 flowchart TB
@@ -1260,7 +1283,7 @@ mm context sync --include=agents --strict
 # Aborted.
 ```
 
-**Codex is user-scope only.** Codex CLI's documented sub-agent path is `~/.codex/agents/*.toml`, so canonical agents fan out to your home directory regardless of which project you run `mm context sync` in. Be aware that multiple projects sharing agent names will overwrite each other — that's a limitation of Codex's user-scope model, not of memtomem.
+All three runtimes support both project-scope and user-scope sub-agents. Use `--scope=user` or `--scope=all` to write to user-scope paths. See [Understanding scope](#understanding-scope) for details.
 
 Reverse import from runtime files back into canonical (Claude/Gemini only — Codex TOML is deliberately *not* imported because the conversion is lossy and memtomem would have to guess dropped fields):
 
@@ -1277,14 +1300,15 @@ mm context diff --include=skills,agents
 
 ### Slash commands fan-out — `--include=commands`
 
-Custom slash commands (`/review`, `/fix-issue`, etc.) are the fourth artifact kind. Claude Code, Gemini CLI, and OpenAI Codex CLI all support user-authored commands, but they disagree on the file format: Claude and Codex use Markdown + YAML frontmatter, while Gemini uses TOML. memtomem parses one canonical Markdown file and emits the correct variant for each runtime, rewriting the argument placeholder only where needed (`$ARGUMENTS` ↔ `{{args}}` for Gemini; Codex supports `$ARGUMENTS` natively, so its body is passed through verbatim).
+Custom slash commands (`/review`, `/fix-issue`, etc.) are the fourth artifact kind. Claude Code and Gemini CLI support user-authored commands; Claude uses Markdown + YAML frontmatter while Gemini uses TOML. memtomem parses one canonical Markdown file and emits the correct variant for each runtime, rewriting the argument placeholder where needed (`$ARGUMENTS` ↔ `{{args}}` for Gemini).
+
+> **Note**: Codex CLI does not support custom slash commands. Its extensibility model uses **skills** (Phase 1) and **AGENTS.md** instructions instead.
 
 ```mermaid
 flowchart TB
     CMD[".memtomem/commands/&lt;name&gt;.md"]
     CMD -->|mm context sync --include=commands| C[".claude/commands/&lt;name&gt;.md"]
     CMD -->|mm context sync --include=commands| G[".gemini/commands/&lt;name&gt;.toml"]
-    CMD -->|mm context sync --include=commands| X["~/.codex/prompts/&lt;name&gt;.md (user-scope)"]
 ```
 
 Canonical `.memtomem/commands/review.md`:
@@ -1300,13 +1324,13 @@ model: sonnet
 Review the file at $ARGUMENTS and report issues.
 ```
 
-| Canonical field | `.claude/commands/*.md` | `.gemini/commands/*.toml` | `~/.codex/prompts/*.md` |
-|---|---|---|---|
-| `description` | ✓ | ✓ | ✓ |
-| body (prompt) | ✓ (`$ARGUMENTS` preserved) | → `prompt` (rewritten to `{{args}}`) | ✓ (`$ARGUMENTS` / `$1..$9` / `$NAME` / `$$` all native) |
-| `argument-hint` | ✓ | **dropped** | ✓ |
-| `allowed-tools` | ✓ | **dropped** | **dropped** |
-| `model` | ✓ | **dropped** | **dropped** |
+| Canonical field | `.claude/commands/*.md` | `.gemini/commands/*.toml` |
+|---|---|---|
+| `description` | ✓ | ✓ |
+| body (prompt) | ✓ (`$ARGUMENTS` preserved) | → `prompt` (rewritten to `{{args}}`) |
+| `argument-hint` | ✓ | **dropped** |
+| `allowed-tools` | ✓ | **dropped** |
+| `model` | ✓ | **dropped** |
 
 Resulting Gemini TOML:
 
@@ -1315,28 +1339,15 @@ description = "Review a file for issues"
 prompt = "Review the file at {{args}} and report issues."
 ```
 
-Resulting Codex prompt at `~/.codex/prompts/review.md`:
-
-```markdown
----
-description: Review a file for issues
-argument-hint: [file-path]
----
-
-Review the file at $ARGUMENTS and report issues.
-```
-
-The Gemini side is **lossless in both directions** (only two TOML fields; the `$ARGUMENTS` ↔ `{{args}}` rewrite is reversible), so `mm context init --include=commands` round-trips Gemini TOML back into canonical Markdown. The Codex side is **forward-only** — commands are fanned out to `~/.codex/prompts/` but never imported back, because the user-scope path spans projects and would break the "import runtime files from *this* project" semantic (matching the Phase 2 sub-agent policy for Codex TOML).
+The Gemini side is **lossless in both directions** (only two TOML fields; the `$ARGUMENTS` ↔ `{{args}}` rewrite is reversible), so `mm context init --include=commands` round-trips Gemini TOML back into canonical Markdown.
 
 Running sync prints every dropped field so you can see what each runtime lost:
 
 ```
-  Command fan-out: 3
+  Command fan-out: 2
     claude_commands    .claude/commands/review.md
     gemini_commands    .gemini/commands/review.toml
-    codex_commands     ~/.codex/prompts/review.md
   gemini_commands dropped ['argument-hint', 'allowed-tools', 'model'] from 'review'
-  codex_commands dropped ['allowed-tools', 'model'] from 'review'
 ```
 
 Use `--strict` to fail on any drop:
@@ -1347,7 +1358,7 @@ mm context sync --include=commands --strict
 # Aborted.
 ```
 
-> **Codex custom prompts are upstream-deprecated.** OpenAI's docs recommend migrating reusable command-like workflows to **skills** (which memtomem already fans out to Codex via `.agents/skills/` in Phase 1). memtomem still syncs canonical commands to `~/.codex/prompts/` for parity with Claude + Gemini, but for new authoring you should prefer a skill. Reverse import from `~/.codex/prompts/` is intentionally not supported — author under `.memtomem/commands/` and let fan-out populate Codex.
+Both runtimes support user-scope commands (`~/.claude/commands/`, `~/.gemini/commands/`). Use `--scope=user` or `--scope=all` to write to user-scope paths. See [Understanding scope](#understanding-scope).
 
 Combine every artifact kind in a single command:
 
@@ -1358,13 +1369,17 @@ mm context diff --include=skills,agents,commands
 
 ### Supported targets
 
-| Runtime | Project memory file | Skills directory | Sub-agents | Slash commands |
-|---|---|---|---|---|
-| Claude Code | `CLAUDE.md` | `.claude/skills/` | `.claude/agents/*.md` | `.claude/commands/*.md` |
-| Cursor | `.cursorrules` | — | — | — |
-| Gemini CLI | `GEMINI.md` | `.gemini/skills/` | `.gemini/agents/*.md` (experimental) | `.gemini/commands/*.toml` |
-| OpenAI Codex CLI | `AGENTS.md` | `.agents/skills/` | `~/.codex/agents/*.toml` (user-scope) | `~/.codex/prompts/*.md` (user-scope, deprecated upstream) |
-| GitHub Copilot | `.github/copilot-instructions.md` | — | — | — |
+All runtimes support both project-scope and user-scope for skills, agents, and commands (where applicable). Default `mm context sync` writes project-scope only; use `--scope=user` or `--scope=all` for user-scope.
+
+| Runtime | Project memory | Skills (P / U) | Sub-agents (P / U) | Commands (P / U) | Settings |
+|---|---|---|---|---|---|
+| Claude Code | `CLAUDE.md` | `.claude/skills/` / `~/.claude/skills/` | `.claude/agents/` / `~/.claude/agents/` | `.claude/commands/` / `~/.claude/commands/` | `~/.claude/settings.json` |
+| Cursor | `.cursorrules` | — | — | — | — |
+| Gemini CLI | `GEMINI.md` | `.gemini/skills/` / `~/.gemini/skills/` | `.gemini/agents/` / `~/.gemini/agents/` | `.gemini/commands/` / `~/.gemini/commands/` | — |
+| OpenAI Codex CLI | `AGENTS.md` | `.agents/skills/` / `~/.agents/skills/` | `.codex/agents/` / `~/.codex/agents/` | — | — |
+| GitHub Copilot | `.github/copilot-instructions.md` | — | — | — | — |
+
+**P** = project-scope, **U** = user-scope. See [Understanding scope](#understanding-scope) for implications.
 
 ---
 

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -363,9 +363,60 @@ class CodexAgentsGenerator:
         return _subagent_to_codex_toml(agent)
 
 
+@dataclass
+class ClaudeUserAgentsGenerator:
+    """User-scope: ``~/.claude/agents/<name>.md``."""
+
+    name: str = "claude_user_agents"
+    output_root: str = "~/.claude/agents"
+    scope: str = "user"
+    default: bool = False
+
+    def target_file(self, project_root: Path, agent_name: str) -> Path:
+        return Path.home() / ".claude/agents" / f"{agent_name}.md"
+
+    def render(self, agent: SubAgent) -> tuple[str, list[str]]:
+        return _subagent_to_claude_md(agent)
+
+
+@dataclass
+class GeminiUserAgentsGenerator:
+    """User-scope: ``~/.gemini/agents/<name>.md``."""
+
+    name: str = "gemini_user_agents"
+    output_root: str = "~/.gemini/agents"
+    scope: str = "user"
+    default: bool = False
+
+    def target_file(self, project_root: Path, agent_name: str) -> Path:
+        return Path.home() / ".gemini/agents" / f"{agent_name}.md"
+
+    def render(self, agent: SubAgent) -> tuple[str, list[str]]:
+        return _subagent_to_gemini_md(agent)
+
+
+@dataclass
+class CodexProjectAgentsGenerator:
+    """Project-scope: ``.codex/agents/<name>.toml``."""
+
+    name: str = "codex_project_agents"
+    output_root: str = ".codex/agents"
+    scope: str = "project"
+    default: bool = False
+
+    def target_file(self, project_root: Path, agent_name: str) -> Path:
+        return project_root / self.output_root / f"{agent_name}.toml"
+
+    def render(self, agent: SubAgent) -> tuple[str, list[str]]:
+        return _subagent_to_codex_toml(agent)
+
+
 _register(ClaudeAgentsGenerator())
 _register(GeminiAgentsGenerator())
 _register(CodexAgentsGenerator())
+_register(ClaudeUserAgentsGenerator())
+_register(GeminiUserAgentsGenerator())
+_register(CodexProjectAgentsGenerator())
 
 
 # ── Fan-out: canonical → runtimes ───────────────────────────────────
@@ -525,17 +576,13 @@ def extract_agents_to_canonical(
 
 
 def _runtime_agent_names(gen_name: str, project_root: Path) -> set[str]:
-    if gen_name == "codex_agents":
-        runtime_root = Path.home() / ".codex/agents"
-        suffix = ".toml"
-    elif gen_name == "claude_agents":
-        runtime_root = project_root / ".claude/agents"
-        suffix = ".md"
-    elif gen_name == "gemini_agents":
-        runtime_root = project_root / ".gemini/agents"
-        suffix = ".md"
-    else:
+    """Return agent stem names on disk for *gen_name* (data-driven)."""
+    gen = AGENT_GENERATORS.get(gen_name)
+    if gen is None:
         return set()
+    probe = gen.target_file(project_root, "__probe__")
+    runtime_root = probe.parent
+    suffix = probe.suffix
     if not runtime_root.is_dir():
         return set()
     return {p.stem for p in runtime_root.iterdir() if p.is_file() and p.suffix == suffix}

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -239,8 +239,42 @@ class GeminiCommandsGenerator:
         return _subcommand_to_gemini_toml(cmd)
 
 
+@dataclass
+class ClaudeUserCommandsGenerator:
+    """User-scope: ``~/.claude/commands/<name>.md``."""
+
+    name: str = "claude_user_commands"
+    output_root: str = "~/.claude/commands"
+    scope: str = "user"
+    default: bool = False
+
+    def target_file(self, project_root: Path, command_name: str) -> Path:
+        return Path.home() / ".claude/commands" / f"{command_name}.md"
+
+    def render(self, cmd: SlashCommand) -> tuple[str, list[str]]:
+        return _subcommand_to_claude_md(cmd)
+
+
+@dataclass
+class GeminiUserCommandsGenerator:
+    """User-scope: ``~/.gemini/commands/<name>.toml``."""
+
+    name: str = "gemini_user_commands"
+    output_root: str = "~/.gemini/commands"
+    scope: str = "user"
+    default: bool = False
+
+    def target_file(self, project_root: Path, command_name: str) -> Path:
+        return Path.home() / ".gemini/commands" / f"{command_name}.toml"
+
+    def render(self, cmd: SlashCommand) -> tuple[str, list[str]]:
+        return _subcommand_to_gemini_toml(cmd)
+
+
 _register(ClaudeCommandsGenerator())
 _register(GeminiCommandsGenerator())
+_register(ClaudeUserCommandsGenerator())
+_register(GeminiUserCommandsGenerator())
 
 
 # ── Fan-out: canonical → runtimes ───────────────────────────────────
@@ -438,15 +472,13 @@ def extract_commands_to_canonical(
 
 
 def _runtime_command_names(gen_name: str, project_root: Path) -> set[str]:
-    """Return the set of command ``stem`` names present on disk for a runtime."""
-    if gen_name == "claude_commands":
-        runtime_root = project_root / ".claude/commands"
-        suffix = ".md"
-    elif gen_name == "gemini_commands":
-        runtime_root = project_root / ".gemini/commands"
-        suffix = ".toml"
-    else:
+    """Return command stem names on disk for *gen_name* (data-driven)."""
+    gen = COMMAND_GENERATORS.get(gen_name)
+    if gen is None:
         return set()
+    probe = gen.target_file(project_root, "__probe__")
+    runtime_root = probe.parent
+    suffix = probe.suffix
     if not runtime_root.is_dir():
         return set()
     return {p.stem for p in runtime_root.iterdir() if p.is_file() and p.suffix == suffix}

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -89,9 +89,51 @@ class CodexSkillsGenerator:
         return project_root / self.output_root / skill_name
 
 
+@dataclass
+class ClaudeUserSkillsGenerator:
+    """User-scope: ``~/.claude/skills/<name>/``."""
+
+    name: str = "claude_user_skills"
+    output_root: str = "~/.claude/skills"
+    scope: str = "user"
+    default: bool = False
+
+    def target_dir(self, project_root: Path, skill_name: str) -> Path:
+        return Path.home() / ".claude/skills" / skill_name
+
+
+@dataclass
+class GeminiUserSkillsGenerator:
+    """User-scope: ``~/.gemini/skills/<name>/``."""
+
+    name: str = "gemini_user_skills"
+    output_root: str = "~/.gemini/skills"
+    scope: str = "user"
+    default: bool = False
+
+    def target_dir(self, project_root: Path, skill_name: str) -> Path:
+        return Path.home() / ".gemini/skills" / skill_name
+
+
+@dataclass
+class CodexUserSkillsGenerator:
+    """User-scope: ``~/.agents/skills/<name>/``."""
+
+    name: str = "codex_user_skills"
+    output_root: str = "~/.agents/skills"
+    scope: str = "user"
+    default: bool = False
+
+    def target_dir(self, project_root: Path, skill_name: str) -> Path:
+        return Path.home() / ".agents/skills" / skill_name
+
+
 _register(ClaudeSkillsGenerator())
 _register(GeminiSkillsGenerator())
 _register(CodexSkillsGenerator())
+_register(ClaudeUserSkillsGenerator())
+_register(GeminiUserSkillsGenerator())
+_register(CodexUserSkillsGenerator())
 
 
 # ── Canonical helpers ─────────────────────────────────────────────────

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -415,3 +415,65 @@ class TestRoundtrip:
         )
         assert reparsed.name == "helper"
         assert "Help with things." in reparsed.body
+
+
+class TestDualScopeGenerators:
+    """Tests for user-scope and project-scope generator variants."""
+
+    def test_registry_has_all_generators(self):
+        expected = {
+            "claude_agents", "gemini_agents", "codex_agents",
+            "claude_user_agents", "gemini_user_agents", "codex_project_agents",
+        }
+        assert expected == set(AGENT_GENERATORS.keys())
+
+    def test_scope_fields(self):
+        assert AGENT_GENERATORS["claude_agents"].scope == "project"
+        assert AGENT_GENERATORS["codex_agents"].scope == "user"
+        assert AGENT_GENERATORS["claude_user_agents"].scope == "user"
+        assert AGENT_GENERATORS["codex_project_agents"].scope == "project"
+
+    def test_default_fields(self):
+        assert AGENT_GENERATORS["claude_agents"].default is True
+        assert AGENT_GENERATORS["claude_user_agents"].default is False
+
+    def test_scope_none_backward_compat(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        result = generate_all_agents(tmp_path, scope=None)
+        names = {r for r, _ in result.generated}
+        assert names == {"claude_agents", "gemini_agents", "codex_agents"}
+
+    def test_scope_project_only(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        result = generate_all_agents(tmp_path, scope="project")
+        names = {r for r, _ in result.generated}
+        assert names == {"claude_agents", "gemini_agents", "codex_project_agents"}
+
+    def test_scope_user_only(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        result = generate_all_agents(tmp_path, scope="user")
+        names = {r for r, _ in result.generated}
+        assert names == {"codex_agents", "claude_user_agents", "gemini_user_agents"}
+
+    def test_scope_all(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        result = generate_all_agents(tmp_path, scope="all")
+        assert len(result.generated) == 6
+
+    def test_claude_user_writes_to_home(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        generate_all_agents(tmp_path, runtimes=["claude_user_agents"])
+        assert (codex_home / ".claude/agents/helper.md").is_file()
+        assert not (tmp_path / ".claude/agents/helper.md").exists()
+
+    def test_codex_project_writes_to_project(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        generate_all_agents(tmp_path, runtimes=["codex_project_agents"])
+        assert (tmp_path / ".codex/agents/helper.toml").is_file()
+
+    def test_diff_scope_project(self, tmp_path, codex_home):
+        _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
+        rows = diff_agents(tmp_path, scope="project")
+        runtimes = {r for r, _, _ in rows}
+        assert "codex_agents" not in runtimes
+        assert "claude_agents" in runtimes

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -367,3 +367,52 @@ class TestRoundtrip:
         assert "description: Simple prompt" in canonical
         assert "$ARGUMENTS" in canonical
         assert "{{args}}" not in canonical
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect HOME for user-scope command writes."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+class TestDualScopeCommands:
+    """Tests for user-scope command generator variants."""
+
+    def test_registry_has_all_generators(self):
+        expected = {
+            "claude_commands", "gemini_commands",
+            "claude_user_commands", "gemini_user_commands",
+        }
+        assert expected == set(COMMAND_GENERATORS.keys())
+
+    def test_scope_none_backward_compat(self, tmp_path):
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        result = generate_all_commands(tmp_path, scope=None)
+        names = {r for r, _ in result.generated}
+        assert names == {"claude_commands", "gemini_commands"}
+
+    def test_scope_user_only(self, tmp_path, fake_home):
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        result = generate_all_commands(tmp_path, scope="user")
+        names = {r for r, _ in result.generated}
+        assert names == {"claude_user_commands", "gemini_user_commands"}
+
+    def test_scope_all(self, tmp_path, fake_home):
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        result = generate_all_commands(tmp_path, scope="all")
+        assert len(result.generated) == 4
+
+    def test_claude_user_writes_to_home(self, tmp_path, fake_home):
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        generate_all_commands(tmp_path, runtimes=["claude_user_commands"])
+        assert (fake_home / ".claude/commands/hi.md").is_file()
+        assert not (tmp_path / ".claude/commands/hi.md").exists()
+
+    def test_gemini_user_writes_toml_to_home(self, tmp_path, fake_home):
+        _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
+        generate_all_commands(tmp_path, runtimes=["gemini_user_commands"])
+        assert (fake_home / ".gemini/commands/hi.toml").is_file()

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -287,3 +287,47 @@ class TestRoundtrip:
         assert md == SAMPLE_SKILL_MD
         script = (tmp_path / CANONICAL_SKILL_ROOT / "code-review/scripts/run.sh").read_text()
         assert script == SAMPLE_SCRIPT
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Redirect HOME for user-scope skill writes."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    return home
+
+
+class TestDualScopeSkills:
+    """Tests for user-scope skill generator variants."""
+
+    def test_registry_has_all_generators(self):
+        expected = {
+            "claude_skills", "gemini_skills", "codex_skills",
+            "claude_user_skills", "gemini_user_skills", "codex_user_skills",
+        }
+        assert expected == set(SKILL_GENERATORS.keys())
+
+    def test_scope_none_backward_compat(self, tmp_path):
+        _make_canonical_skill(tmp_path, "review")
+        result = generate_all_skills(tmp_path, scope=None)
+        names = {r for r, _ in result.generated}
+        assert names == {"claude_skills", "gemini_skills", "codex_skills"}
+
+    def test_scope_user_only(self, tmp_path, fake_home):
+        _make_canonical_skill(tmp_path, "review")
+        result = generate_all_skills(tmp_path, scope="user")
+        names = {r for r, _ in result.generated}
+        assert names == {"claude_user_skills", "gemini_user_skills", "codex_user_skills"}
+
+    def test_scope_all(self, tmp_path, fake_home):
+        _make_canonical_skill(tmp_path, "review")
+        result = generate_all_skills(tmp_path, scope="all")
+        assert len(result.generated) == 6
+
+    def test_claude_user_writes_to_home(self, tmp_path, fake_home):
+        _make_canonical_skill(tmp_path, "review")
+        generate_all_skills(tmp_path, runtimes=["claude_user_skills"])
+        assert (fake_home / ".claude/skills/review/SKILL.md").is_file()
+        assert not (tmp_path / ".claude/skills/review/SKILL.md").exists()


### PR DESCRIPTION
## Summary
Add 8 new generators (`default=False`) for the dual-scope fan-out that Claude Code, Gemini CLI, and Codex CLI officially support:

| Module | New generator | Scope | Target |
|---|---|---|---|
| agents | `claude_user_agents` | user | `~/.claude/agents/` |
| agents | `gemini_user_agents` | user | `~/.gemini/agents/` |
| agents | `codex_project_agents` | project | `.codex/agents/` |
| skills | `claude_user_skills` | user | `~/.claude/skills/` |
| skills | `gemini_user_skills` | user | `~/.gemini/skills/` |
| skills | `codex_user_skills` | user | `~/.agents/skills/` |
| commands | `claude_user_commands` | user | `~/.claude/commands/` |
| commands | `gemini_user_commands` | user | `~/.gemini/commands/` |

### Also in this PR
- Refactor `_runtime_agent_names` / `_runtime_command_names` from hardcoded `if/elif` dispatch to data-driven resolution via `generator.target_file()` — eliminates the need to update dispatch for each new generator
- 21 new tests for registry, scope filtering, path resolution, and backward compat

### Backward compatibility
All new generators have `default=False`, so `scope=None` (the default) produces identical output to before. Use `--scope=user` or `--scope=all` to activate them.

**Stacks on:** #33 → #32

## Test plan
- [x] 143 tests passed (122 existing + 21 new)
- [x] ruff check clean
- [ ] Manual: `mm context sync --include=agents --scope=all` writes to both project and user paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)