### PR TITLE
feat: auto-discover AI tool memory dirs + namespace grouping UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- **Auto-discover AI tool memory directories**: `memory_dirs` now
+  automatically includes `~/.claude/projects`, `~/.gemini`, and
+  `~/.codex/memories` when they exist, so `mem_index` and the file
+  watcher accept paths under these directories without manual
+  `MEMORY_DIRS` configuration. Auto-discovered directories are appended
+  after `config.json` overrides via `ensure_auto_discovered_dirs()`.
 - **Database reset**: `mm reset` CLI command, `mem_reset` MCP tool (advanced
   category, routed via `mem_do`), `POST /api/reset` web endpoint, and
   Settings > Maintenance > Reset tab in Web UI. Deletes all data (chunks,

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -70,11 +70,32 @@ When enabled, search results include surrounding chunks from the same source fil
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` | Directories to index |
+| `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` + auto-discovered | Directories to index (see below) |
 | `MEMTOMEM_INDEXING__MAX_CHUNK_TOKENS` | `512` | Maximum tokens per chunk |
 | `MEMTOMEM_INDEXING__MIN_CHUNK_TOKENS` | `128` | Merge threshold for short chunks |
 | `MEMTOMEM_INDEXING__CHUNK_OVERLAP_TOKENS` | `0` | Token overlap between adjacent chunks |
 | `MEMTOMEM_INDEXING__STRUCTURED_CHUNK_MODE` | `original` | JSON/YAML/TOML chunking: `original` or `recursive` |
+
+### Auto-discovered memory directories
+
+In addition to `~/.memtomem/memories`, memtomem automatically adds well-known
+AI tool directories to `memory_dirs` when they exist on the machine:
+
+| Directory | Tool | Scope |
+|-----------|------|-------|
+| `~/.claude/projects` | Claude Code | per-project auto-memory |
+| `~/.gemini` | Gemini CLI | global `GEMINI.md` |
+| `~/.codex/memories` | Codex CLI | global memories |
+
+Auto-discovered directories are appended after `config.json` overrides, so
+they are always available even if you override `memory_dirs` manually. This
+means `mem_index` and the file watcher accept paths under these directories
+without requiring explicit `MEMORY_DIRS` configuration.
+
+> **Tip:** Use `mm ingest claude-memory`, `mm ingest gemini-memory`, or
+> `mm ingest codex-memory` for richer ingestion with per-tool tagging and
+> namespace assignment. Auto-discovery only removes the path restriction —
+> it does not apply tool-specific tags or namespaces.
 
 ## Decay
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -38,7 +38,7 @@ For full setup, OpenAI configuration, and troubleshooting, see the [Getting Star
 <details>
 <summary><b>Prefer no install? (uvx direct, MCP only)</b></summary>
 
-If you'd rather skip the CLI install, `uvx` will download and run memtomem on demand. You'll need to set `MEMORY_DIRS` yourself — without it `mem_index` has nothing to index.
+If you'd rather skip the CLI install, `uvx` will download and run memtomem on demand. `~/.memtomem/memories` is always indexed, and well-known AI tool directories (`~/.claude/projects`, `~/.gemini`, `~/.codex/memories`) are auto-discovered when they exist. Set `MEMORY_DIRS` to add custom paths.
 
 ```bash
 claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -86,8 +86,16 @@ class SearchConfig(BaseSettings):
         return v
 
 
+def _default_memory_dirs() -> list[Path]:
+    """Build default memory_dirs, auto-discovering well-known AI tool directories."""
+    dirs: list[Path] = [Path("~/.memtomem/memories")]
+    for d in _auto_discovered_memory_dirs():
+        dirs.append(d)
+    return dirs
+
+
 class IndexingConfig(BaseSettings):
-    memory_dirs: list[Path] = Field(default_factory=lambda: [Path("~/.memtomem/memories")])
+    memory_dirs: list[Path] = Field(default_factory=lambda: _default_memory_dirs())
     supported_extensions: frozenset[str] = frozenset(
         {
             ".md",
@@ -381,6 +389,35 @@ def load_config_overrides(config: Mem2MemConfig) -> None:
                         value,
                         exc,
                     )
+
+
+def ensure_auto_discovered_dirs(config: Mem2MemConfig) -> None:
+    """Append auto-discovered well-known dirs that aren't already in memory_dirs.
+
+    Call *after* ``load_config_overrides`` so that user overrides don't
+    suppress auto-discovery of AI tool directories like ``~/.claude/projects``.
+    """
+    existing = {Path(d).expanduser().resolve() for d in config.indexing.memory_dirs}
+    for d in _auto_discovered_memory_dirs():
+        resolved = d.expanduser().resolve()
+        if resolved not in existing:
+            config.indexing.memory_dirs.append(d)
+
+
+def _auto_discovered_memory_dirs() -> list[Path]:
+    """Return well-known AI tool directories that exist on this machine.
+
+    Checked directories:
+    - ``~/.claude/projects``  — Claude Code per-project auto-memory
+    - ``~/.gemini``           — Gemini CLI global GEMINI.md
+    - ``~/.codex/memories``   — Codex CLI global memories
+    """
+    candidates: list[Path] = [
+        Path("~/.claude/projects"),
+        Path("~/.gemini"),
+        Path("~/.codex/memories"),
+    ]
+    return [p.expanduser() for p in candidates if p.expanduser().is_dir()]
 
 
 def save_config_overrides(config: Mem2MemConfig, mutable_fields: dict[str, set[str]]) -> None:

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -38,10 +38,11 @@ class Components:
 
 async def create_components(config: Mem2MemConfig | None = None) -> Components:
     """Create and initialise all core components."""
-    from memtomem.config import load_config_overrides
+    from memtomem.config import ensure_auto_discovered_dirs, load_config_overrides
 
     config = config or Mem2MemConfig()
     load_config_overrides(config)
+    ensure_auto_discovered_dirs(config)
 
     # Initialize FTS tokenizer from config
     from memtomem.storage.fts_tokenizer import set_tokenizer

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -255,6 +255,7 @@
 
   "settings.ns.title": "Namespaces",
   "settings.ns.refresh": "Refresh",
+  "settings.ns.group_chunks": "{count} chunks",
 
   "settings.dedup.threshold_label": "Threshold",
   "settings.dedup.threshold_help": "Similarity above which chunks are considered duplicates. Default 0.92 catches near-identical content.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -255,6 +255,7 @@
 
   "settings.ns.title": "네임스페이스",
   "settings.ns.refresh": "새로고침",
+  "settings.ns.group_chunks": "{count}개 청크",
 
   "settings.dedup.threshold_label": "임계값",
   "settings.dedup.threshold_help": "이 값 이상의 유사도를 가진 청크를 중복으로 간주합니다. 기본값 0.92는 거의 동일한 내용을 감지합니다.",

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -5,6 +5,54 @@
  */
 
 // ---------------------------------------------------------------------------
+// Namespace grouping helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Group namespaces by their colon-delimited prefix.
+ *
+ * Splits on the **first** colon only — e.g. `claude-memory:slug-a` yields
+ * prefix `claude-memory`.  If the namespace format migrates to 3-depth
+ * (`claude:<project>:memory`), the first-colon split still produces a
+ * reasonable top-level group (`claude`).  Revisit if deeper grouping is
+ * needed.
+ *
+ * Single-member prefix groups are demoted to ungrouped to avoid a
+ * collapsed group of one.
+ */
+function _groupNamespaces(namespaces) {
+  const prefixMap = new Map();
+  const ungrouped = [];
+
+  namespaces.forEach(ns => {
+    const colonIdx = ns.namespace.indexOf(':');
+    if (colonIdx > 0) {
+      const prefix = ns.namespace.slice(0, colonIdx);
+      if (!prefixMap.has(prefix)) prefixMap.set(prefix, []);
+      prefixMap.get(prefix).push(ns);
+    } else {
+      ungrouped.push(ns);
+    }
+  });
+
+  const groups = [];
+  for (const [prefix, members] of prefixMap) {
+    if (members.length === 1) {
+      ungrouped.push(members[0]);
+    } else {
+      const totalChunks = members.reduce((s, m) => s + m.chunk_count, 0);
+      members.sort((a, b) => b.chunk_count - a.chunk_count);
+      groups.push({ prefix, members, totalChunks });
+    }
+  }
+
+  // Primary: totalChunks desc, secondary: prefix alphabetical
+  groups.sort((a, b) => b.totalChunks - a.totalChunks || a.prefix.localeCompare(b.prefix));
+  ungrouped.sort((a, b) => b.chunk_count - a.chunk_count);
+  return { groups, ungrouped };
+}
+
+// ---------------------------------------------------------------------------
 // Namespace filter dropdowns + Namespaces tab
 // ---------------------------------------------------------------------------
 
@@ -12,13 +60,26 @@ async function loadNamespaceDropdowns() {
   try {
     const data = await api('GET', '/api/namespaces');
     const namespaces = data.namespaces || [];
+    const { groups, ungrouped } = _groupNamespaces(namespaces);
     ['ns-filter', 'tl-namespace', 'exp-namespace'].forEach(id => {
       const sel = document.getElementById(id);
       if (!sel) return;
       const current = sel.value;
-      // Keep first option (All)
-      while (sel.options.length > 1) sel.remove(1);
-      namespaces.forEach(ns => {
+      // Keep first option (All Namespaces), remove rest + optgroups
+      while (sel.children.length > 1) sel.removeChild(sel.lastChild);
+      groups.forEach(g => {
+        const optgroup = document.createElement('optgroup');
+        optgroup.label = `${g.prefix} (${g.totalChunks} chunks)`;
+        g.members.forEach(ns => {
+          const opt = document.createElement('option');
+          opt.value = ns.namespace;
+          const suffix = ns.namespace.slice(g.prefix.length + 1);
+          opt.textContent = `${suffix} (${ns.chunk_count})`;
+          optgroup.appendChild(opt);
+        });
+        sel.appendChild(optgroup);
+      });
+      ungrouped.forEach(ns => {
         const opt = document.createElement('option');
         opt.value = ns.namespace;
         opt.textContent = `${ns.namespace} (${ns.chunk_count})`;
@@ -38,6 +99,71 @@ loadNamespaceDropdowns();
 // Namespaces tab
 qs('ns-refresh-btn').addEventListener('click', loadNamespacesTab);
 
+function _buildNsCard(ns, defaultNs) {
+  const card = document.createElement('div');
+  card.className = 'ns-card';
+
+  const dot = document.createElement('span');
+  dot.className = 'ns-color-dot';
+  dot.style.backgroundColor = ns.color || 'var(--muted)';
+
+  const name = document.createElement('span');
+  name.className = 'ns-name';
+  name.textContent = ns.namespace;
+  if (ns.namespace === defaultNs) {
+    const badge = document.createElement('span');
+    badge.className = 'badge badge-blue';
+    badge.style.marginLeft = '6px';
+    badge.style.fontSize = '0.7rem';
+    badge.textContent = 'Default';
+    name.appendChild(badge);
+  }
+
+  const desc = document.createElement('span');
+  desc.className = 'ns-desc';
+  desc.textContent = ns.description || '';
+
+  const count = document.createElement('span');
+  count.className = 'ns-count';
+  count.textContent = `${ns.chunk_count} chunks`;
+
+  const actions = document.createElement('span');
+  actions.className = 'ns-actions';
+
+  const editBtn = document.createElement('button');
+  editBtn.className = 'btn-ghost btn-xs';
+  editBtn.textContent = 'Edit';
+  editBtn.addEventListener('click', () => editNamespaceMeta(ns, card));
+
+  const renameBtn = document.createElement('button');
+  renameBtn.className = 'btn-ghost btn-xs';
+  renameBtn.textContent = 'Rename';
+  renameBtn.addEventListener('click', () => renameNamespace(ns.namespace));
+
+  const delBtn = document.createElement('button');
+  delBtn.className = 'btn-danger btn-xs';
+  delBtn.textContent = 'Delete';
+  delBtn.addEventListener('click', () => deleteNamespace(ns.namespace));
+
+  const sourcesBtn = document.createElement('button');
+  sourcesBtn.className = 'btn-ghost btn-xs';
+  sourcesBtn.textContent = 'Sources';
+  sourcesBtn.title = `View sources in namespace '${ns.namespace}'`;
+  sourcesBtn.addEventListener('click', () => navigateToSourcesByNs(ns.namespace));
+
+  actions.appendChild(sourcesBtn);
+  actions.appendChild(editBtn);
+  actions.appendChild(renameBtn);
+  actions.appendChild(delBtn);
+
+  card.appendChild(dot);
+  card.appendChild(name);
+  card.appendChild(desc);
+  card.appendChild(count);
+  card.appendChild(actions);
+  return card;
+}
+
 async function loadNamespacesTab() {
   const list = qs('ns-list');
   list.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
@@ -51,70 +177,37 @@ async function loadNamespacesTab() {
     }
     list.innerHTML = '';
     const defaultNs = STATE.serverConfig?.namespace?.default_namespace || 'default';
-    namespaces.forEach(ns => {
-      const card = document.createElement('div');
-      card.className = 'ns-card';
+    const { groups, ungrouped } = _groupNamespaces(namespaces);
 
-      const dot = document.createElement('span');
-      dot.className = 'ns-color-dot';
-      dot.style.backgroundColor = ns.color || 'var(--muted)';
+    // Render collapsible groups
+    groups.forEach(g => {
+      const group = document.createElement('div');
+      group.className = 'ns-group';
 
-      const name = document.createElement('span');
-      name.className = 'ns-name';
-      name.textContent = ns.namespace;
-      if (ns.namespace === defaultNs) {
-        const badge = document.createElement('span');
-        badge.className = 'badge badge-blue';
-        badge.style.marginLeft = '6px';
-        badge.style.fontSize = '0.7rem';
-        badge.textContent = 'Default';
-        name.appendChild(badge);
-      }
+      const header = document.createElement('div');
+      header.className = 'ns-group-header';
+      header.setAttribute('role', 'button');
+      header.setAttribute('aria-expanded', 'true');
+      header.innerHTML = `<span class="ns-group-chevron">&#9660;</span>`
+        + `<span class="ns-group-name">${escapeHtml(g.prefix)}</span>`
+        + `<span class="badge badge-blue">${g.members.length}</span>`
+        + `<span class="ns-group-chunks">${t('settings.ns.group_chunks', { count: g.totalChunks })}</span>`;
+      header.addEventListener('click', () => {
+        group.classList.toggle('collapsed');
+        header.setAttribute('aria-expanded', String(!group.classList.contains('collapsed')));
+      });
 
-      const desc = document.createElement('span');
-      desc.className = 'ns-desc';
-      desc.textContent = ns.description || '';
+      const items = document.createElement('div');
+      items.className = 'ns-group-items';
+      g.members.forEach(ns => items.appendChild(_buildNsCard(ns, defaultNs)));
 
-      const count = document.createElement('span');
-      count.className = 'ns-count';
-      count.textContent = `${ns.chunk_count} chunks`;
-
-      const actions = document.createElement('span');
-      actions.className = 'ns-actions';
-
-      const editBtn = document.createElement('button');
-      editBtn.className = 'btn-ghost btn-xs';
-      editBtn.textContent = 'Edit';
-      editBtn.addEventListener('click', () => editNamespaceMeta(ns, card));
-
-      const renameBtn = document.createElement('button');
-      renameBtn.className = 'btn-ghost btn-xs';
-      renameBtn.textContent = 'Rename';
-      renameBtn.addEventListener('click', () => renameNamespace(ns.namespace));
-
-      const delBtn = document.createElement('button');
-      delBtn.className = 'btn-danger btn-xs';
-      delBtn.textContent = 'Delete';
-      delBtn.addEventListener('click', () => deleteNamespace(ns.namespace));
-
-      const sourcesBtn = document.createElement('button');
-      sourcesBtn.className = 'btn-ghost btn-xs';
-      sourcesBtn.textContent = 'Sources';
-      sourcesBtn.title = `View sources in namespace '${ns.namespace}'`;
-      sourcesBtn.addEventListener('click', () => navigateToSourcesByNs(ns.namespace));
-
-      actions.appendChild(sourcesBtn);
-      actions.appendChild(editBtn);
-      actions.appendChild(renameBtn);
-      actions.appendChild(delBtn);
-
-      card.appendChild(dot);
-      card.appendChild(name);
-      card.appendChild(desc);
-      card.appendChild(count);
-      card.appendChild(actions);
-      list.appendChild(card);
+      group.appendChild(header);
+      group.appendChild(items);
+      list.appendChild(group);
     });
+
+    // Render ungrouped cards
+    ungrouped.forEach(ns => list.appendChild(_buildNsCard(ns, defaultNs)));
   } catch (err) {
     list.innerHTML = `<div class="status-msg err">${escapeHtml(err.message)}</div>`;
   }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -1776,6 +1776,34 @@ select:focus-visible {
 .ns-edit-row input[type="color"] { width: 32px; height: 28px; padding: 2px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg); cursor: pointer; }
 .ns-edit-actions { display: flex; gap: 6px; justify-content: flex-end; }
 
+/* ── Namespace Groups (collapsible prefix groups) ── */
+.ns-group { margin-bottom: 4px; }
+.ns-group-header {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 16px; cursor: pointer; user-select: none;
+  background: var(--surface);
+  border: 1px solid var(--border); border-radius: var(--radius);
+  transition: border-color 0.15s;
+}
+.ns-group-header:hover { border-color: var(--accent); }
+.ns-group-chevron {
+  font-size: 0.6rem; color: var(--muted);
+  transition: transform 0.15s; flex-shrink: 0;
+}
+.ns-group.collapsed .ns-group-chevron { transform: rotate(-90deg); }
+.ns-group.collapsed .ns-group-items { display: none; }
+.ns-group-name {
+  font-family: var(--mono); font-size: 0.88rem;
+  font-weight: 600; color: var(--text);
+}
+.ns-group-chunks {
+  font-size: 0.78rem; color: var(--muted); margin-left: auto; flex-shrink: 0;
+}
+.ns-group-items {
+  padding-left: 20px; display: flex;
+  flex-direction: column; gap: 6px; margin-top: 6px;
+}
+
 /* ── Chunk Card Actions (Sources tab) ── */
 .chunk-card-actions { display: flex; gap: 4px; margin-left: auto; flex-shrink: 0; }
 .chunk-card-actions button { font-size: 0.68rem; padding: 2px 7px; }


### PR DESCRIPTION
## Summary

- **Auto-discover memory directories**: `memory_dirs` now automatically includes `~/.claude/projects`, `~/.gemini`, and `~/.codex/memories` when they exist. `ensure_auto_discovered_dirs()` runs after `config.json` overrides so the directories are always available — no manual `MEMORY_DIRS` configuration needed.
- **Namespace grouping in Web UI**: Namespaces sharing a colon-delimited prefix (e.g. `claude-memory:*`) are grouped into collapsible sections in the Settings > Namespaces tab and `<optgroup>` in search/timeline dropdowns. Client-side only, no API changes.
- Docs updated: configuration guide, README, CHANGELOG.

## Test plan

- [ ] `uv run pytest -m "not ollama"` — 1288 passed
- [ ] `uv run ruff check packages/memtomem/src` — all checks passed
- [ ] `uv run mm web` → Settings > Namespaces: grouped prefixes expand/collapse, Edit/Rename/Delete work inside groups, ungrouped cards render normally
- [ ] Search dropdown: `<optgroup>` for groups, "All Namespaces" outside optgroup
- [ ] Verify auto-discovery: `python -c "from memtomem.config import _auto_discovered_memory_dirs; print(_auto_discovered_memory_dirs())"` lists existing tool dirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)