### PR TITLE
fix(config): close cross-path config sync gaps

### DIFF
--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -6,72 +6,7 @@ import json
 
 import click
 
-
-# ---------------------------------------------------------------------------
-# Mutable field definitions and validation (used by `config set`)
-# ---------------------------------------------------------------------------
-
-_MUTABLE_FIELDS: dict[str, set[str]] = {
-    "search": {"default_top_k", "bm25_candidates", "dense_candidates", "rrf_k"},
-    "indexing": {"max_chunk_tokens"},
-    "embedding": {"batch_size"},
-}
-
-_FIELD_CONSTRAINTS: dict[str, dict] = {
-    "search.default_top_k": {"type": int, "min": 1, "max": 500},
-    "search.bm25_candidates": {"type": int, "min": 1, "max": 1000},
-    "search.dense_candidates": {"type": int, "min": 1, "max": 1000},
-    "search.rrf_k": {"type": int, "min": 1, "max": 1000},
-    "indexing.max_chunk_tokens": {"type": int, "min": 64, "max": 8192},
-    "embedding.batch_size": {"type": int, "min": 1, "max": 1024},
-}
-
-
-def _coerce_and_validate(value, constraint: dict | None):
-    """Coerce value to expected type and validate constraints."""
-    if constraint is None:
-        return value
-
-    expected_type = constraint["type"]
-
-    if expected_type is bool:
-        if isinstance(value, bool):
-            coerced = value
-        elif isinstance(value, str):
-            low = value.lower()
-            if low in ("true", "1", "yes"):
-                coerced = True
-            elif low in ("false", "0", "no"):
-                coerced = False
-            else:
-                raise ValueError(f"cannot convert '{value}' to bool")
-        elif isinstance(value, (int, float)):
-            coerced = bool(value)
-        else:
-            raise ValueError(f"cannot convert to bool: {value}")
-    elif expected_type is int:
-        try:
-            coerced = int(value)
-        except (TypeError, ValueError):
-            raise ValueError(f"cannot convert '{value}' to int")
-    elif expected_type is float:
-        try:
-            coerced = float(value)
-        except (TypeError, ValueError):
-            raise ValueError(f"cannot convert '{value}' to float")
-    elif expected_type is str:
-        coerced = str(value)
-    else:
-        coerced = value
-
-    if "min" in constraint and coerced < constraint["min"]:
-        raise ValueError(f"must be >= {constraint['min']}")
-    if "max" in constraint and coerced > constraint["max"]:
-        raise ValueError(f"must be <= {constraint['max']}")
-    if "allowed" in constraint and coerced not in constraint["allowed"]:
-        raise ValueError(f"must be one of {constraint['allowed']}")
-
-    return coerced
+from memtomem.config import FIELD_CONSTRAINTS, MUTABLE_FIELDS, coerce_and_validate
 
 
 # ---------------------------------------------------------------------------
@@ -123,14 +58,14 @@ def config_set(key: str, value: str) -> None:
         raise SystemExit(1)
 
     section_name, field_name = parts
-    allowed = _MUTABLE_FIELDS.get(section_name, set())
+    allowed = MUTABLE_FIELDS.get(section_name, set())
     if field_name not in allowed:
         click.echo(click.style(f"{key}: not a mutable field", fg="red"))
         raise SystemExit(1)
 
-    constraint = _FIELD_CONSTRAINTS.get(key)
+    constraint = FIELD_CONSTRAINTS.get(key)
     try:
-        coerced = _coerce_and_validate(value, constraint)
+        coerced = coerce_and_validate(value, constraint)
     except ValueError as e:
         click.echo(click.style(f"{key}: {e}", fg="red"))
         raise SystemExit(1)
@@ -142,5 +77,5 @@ def config_set(key: str, value: str) -> None:
     old_val = getattr(section_obj, field_name)
     setattr(section_obj, field_name, coerced)
 
-    save_config_overrides(cfg, _MUTABLE_FIELDS)
+    save_config_overrides(cfg)
     click.echo(f"{key}: {old_val} -> {coerced}")

--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -79,3 +79,15 @@ def config_set(key: str, value: str) -> None:
 
     save_config_overrides(cfg)
     click.echo(f"{key}: {old_val} -> {coerced}")
+
+    # Rebuild FTS index when tokenizer changes (matches Web UI / MCP behaviour)
+    if key == "search.tokenizer":
+        from memtomem.storage.fts_tokenizer import set_tokenizer
+
+        set_tokenizer(coerced)
+
+        from memtomem.storage.factory import create_storage
+
+        storage = create_storage(cfg)
+        count = storage.rebuild_fts()
+        click.echo(f"FTS index rebuilt ({count} chunks).")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -346,6 +346,105 @@ class Mem2MemConfig(BaseSettings):
 
 
 # ---------------------------------------------------------------------------
+# Canonical mutable-field definitions and validation
+# ---------------------------------------------------------------------------
+# Single source of truth for which config fields can be modified at runtime
+# via CLI (``mm config set``), Web UI (``PATCH /api/config``), and MCP
+# (``mem_config``).  All three paths import from here.
+
+MUTABLE_FIELDS: dict[str, set[str]] = {
+    "search": {
+        "default_top_k",
+        "bm25_candidates",
+        "dense_candidates",
+        "rrf_k",
+        "enable_bm25",
+        "enable_dense",
+        "tokenizer",
+        "rrf_weights",
+    },
+    "indexing": {
+        "max_chunk_tokens",
+        "min_chunk_tokens",
+        "chunk_overlap_tokens",
+        "structured_chunk_mode",
+    },
+    "embedding": {"batch_size"},
+    "decay": {"enabled", "half_life_days"},
+    "mmr": {"enabled", "lambda_param"},
+    "namespace": {"default_namespace", "enable_auto_ns"},
+}
+
+FIELD_CONSTRAINTS: dict[str, dict] = {
+    "search.default_top_k": {"type": int, "min": 1, "max": 500},
+    "search.bm25_candidates": {"type": int, "min": 1, "max": 1000},
+    "search.dense_candidates": {"type": int, "min": 1, "max": 1000},
+    "search.rrf_k": {"type": int, "min": 1, "max": 1000},
+    "search.enable_bm25": {"type": bool},
+    "search.enable_dense": {"type": bool},
+    "search.tokenizer": {"type": str, "allowed": {"unicode61", "kiwipiepy"}},
+    "indexing.max_chunk_tokens": {"type": int, "min": 64, "max": 8192},
+    "indexing.min_chunk_tokens": {"type": int, "min": 0, "max": 256},
+    "indexing.chunk_overlap_tokens": {"type": int, "min": 0, "max": 512},
+    "indexing.structured_chunk_mode": {"type": str, "allowed": {"original", "recursive"}},
+    "embedding.batch_size": {"type": int, "min": 1, "max": 1024},
+    "decay.enabled": {"type": bool},
+    "decay.half_life_days": {"type": float, "min": 0.1},
+    "mmr.enabled": {"type": bool},
+    "mmr.lambda_param": {"type": float, "min": 0.0, "max": 1.0},
+    "namespace.default_namespace": {"type": str},
+    "namespace.enable_auto_ns": {"type": bool},
+}
+
+
+def coerce_and_validate(value: object, constraint: dict | None) -> object:
+    """Coerce *value* to the expected type and validate min/max/allowed constraints."""
+    if constraint is None:
+        return value
+
+    expected_type = constraint["type"]
+
+    if expected_type is bool:
+        if isinstance(value, bool):
+            coerced: object = value
+        elif isinstance(value, str):
+            low = value.lower()
+            if low in ("true", "1", "yes"):
+                coerced = True
+            elif low in ("false", "0", "no"):
+                coerced = False
+            else:
+                raise ValueError(f"cannot convert '{value}' to bool")
+        elif isinstance(value, (int, float)):
+            coerced = bool(value)
+        else:
+            raise ValueError(f"cannot convert to bool: {value}")
+    elif expected_type is int:
+        try:
+            coerced = int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValueError(f"cannot convert '{value}' to int")
+    elif expected_type is float:
+        try:
+            coerced = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise ValueError(f"cannot convert '{value}' to float")
+    elif expected_type is str:
+        coerced = str(value)
+    else:
+        coerced = value
+
+    if "min" in constraint and coerced < constraint["min"]:  # type: ignore[operator]
+        raise ValueError(f"must be >= {constraint['min']}")
+    if "max" in constraint and coerced > constraint["max"]:  # type: ignore[operator]
+        raise ValueError(f"must be <= {constraint['max']}")
+    if "allowed" in constraint and coerced not in constraint["allowed"]:
+        raise ValueError(f"must be one of {constraint['allowed']}")
+
+    return coerced
+
+
+# ---------------------------------------------------------------------------
 # Config persistence: ~/.memtomem/config.json override layer
 # ---------------------------------------------------------------------------
 
@@ -420,23 +519,46 @@ def _auto_discovered_memory_dirs() -> list[Path]:
     return [p.expanduser() for p in candidates if p.expanduser().is_dir()]
 
 
-def save_config_overrides(config: Mem2MemConfig, mutable_fields: dict[str, set[str]]) -> None:
-    """Persist mutable fields to ~/.memtomem/config.json."""
-    import json as _json
+def save_config_overrides(
+    config: Mem2MemConfig,
+    mutable_fields: dict[str, set[str]] | None = None,
+) -> None:
+    """Persist mutable fields to ~/.memtomem/config.json.
 
-    data: dict[str, dict[str, object]] = {}
+    Uses **read-merge-write** so that keys not in *mutable_fields* (e.g.
+    init-only settings like ``embedding.provider`` or ``storage.sqlite_path``)
+    are preserved across saves.
+    """
+    import json as _json
+    import logging
+
+    _log = logging.getLogger(__name__)
+    mutable_fields = mutable_fields or MUTABLE_FIELDS
+
+    path = _override_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ── Read existing config (merge base) ──
+    existing: dict = {}
+    if path.exists():
+        try:
+            existing = _json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, _json.JSONDecodeError) as exc:
+            _log.warning("Cannot read existing config at %s: %s — overwriting", path, exc)
+
+    # ── Merge mutable fields into existing data ──
     for section_name, fields in mutable_fields.items():
         section_obj = getattr(config, section_name, None)
         if section_obj is None:
             continue
-        section_data: dict[str, object] = {}
+        section_data: dict[str, object] = existing.get(section_name, {})
+        if not isinstance(section_data, dict):
+            section_data = {}
         for key in fields:
             val = getattr(section_obj, key, None)
             if val is not None:
                 section_data[key] = val
         if section_data:
-            data[section_name] = section_data
+            existing[section_name] = section_data
 
-    path = _override_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_json.dumps(data, indent=2, default=str), encoding="utf-8")
+    path.write_text(_json.dumps(existing, indent=2, default=str), encoding="utf-8")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -392,6 +392,7 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     "decay.half_life_days": {"type": float, "min": 0.1},
     "mmr.enabled": {"type": bool},
     "mmr.lambda_param": {"type": float, "min": 0.0, "max": 1.0},
+    "search.rrf_weights": {"type": list, "item_type": float, "length": 2},
     "namespace.default_namespace": {"type": str},
     "namespace.enable_auto_ns": {"type": bool},
 }
@@ -431,6 +432,21 @@ def coerce_and_validate(value: object, constraint: dict | None) -> object:
             raise ValueError(f"cannot convert '{value}' to float")
     elif expected_type is str:
         coerced = str(value)
+    elif expected_type is list:
+        item_type = constraint.get("item_type", float)
+        expected_len = constraint.get("length")
+        if isinstance(value, str):
+            parts = [s.strip() for s in value.split(",")]
+        elif isinstance(value, (list, tuple)):
+            parts = list(value)
+        else:
+            raise ValueError(f"cannot convert {type(value).__name__} to list")
+        try:
+            coerced = [item_type(p) for p in parts]
+        except (TypeError, ValueError):
+            raise ValueError(f"cannot convert list items to {item_type.__name__}")
+        if expected_len is not None and len(coerced) != expected_len:
+            raise ValueError(f"expected length {expected_len}, got {len(coerced)}")
     else:
         coerced = value
 
@@ -519,6 +535,14 @@ def _auto_discovered_memory_dirs() -> list[Path]:
     return [p.expanduser() for p in candidates if p.expanduser().is_dir()]
 
 
+# Fields persisted by ``save_config_overrides`` but NOT settable via the
+# generic ``mm config set`` / ``mem_config`` path.  Managed through dedicated
+# endpoints (e.g. Web UI ``/memory-dirs/*``).
+_EXTRA_PERSIST_FIELDS: dict[str, set[str]] = {
+    "indexing": {"memory_dirs"},
+}
+
+
 def save_config_overrides(
     config: Mem2MemConfig,
     mutable_fields: dict[str, set[str]] | None = None,
@@ -533,7 +557,12 @@ def save_config_overrides(
     import logging
 
     _log = logging.getLogger(__name__)
-    mutable_fields = mutable_fields or MUTABLE_FIELDS
+    base = mutable_fields or MUTABLE_FIELDS
+    # Merge extra-persist fields so they are always written alongside mutables.
+    effective: dict[str, set[str]] = {}
+    for section in {*base, *_EXTRA_PERSIST_FIELDS}:
+        effective[section] = base.get(section, set()) | _EXTRA_PERSIST_FIELDS.get(section, set())
+    mutable_fields = effective
 
     path = _override_path()
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -180,7 +180,7 @@ class SearchPipeline:
         rrf_weights: list[float] | None = None,
         context_window: int | None = None,
     ) -> tuple[list[SearchResult], RetrievalStats]:
-        top_k = top_k or self._config.default_top_k
+        top_k = self._config.default_top_k if top_k is None else top_k
         effective_weights = rrf_weights or self._config.rrf_weights
 
         # Check TTL cache for identical queries

--- a/packages/memtomem/src/memtomem/server/helpers.py
+++ b/packages/memtomem/src/memtomem/server/helpers.py
@@ -68,14 +68,17 @@ def _check_embedding_mismatch(app: object) -> str | None:
 
 
 def _set_config_key(config: Mem2MemConfig, key: str, value: str) -> str:
-    """Set a dot-notation config key to a new string value (runtime only).
+    """Set a dot-notation config key to a new string value.
 
     Only ``section.field`` format (exactly one dot) is supported.
-    Scalar types (bool, int, float, str) are coerced from the string value.
-    Complex types (list, set, frozenset, Path …) are rejected.
+    Uses :func:`~memtomem.config.coerce_and_validate` for type coercion
+    and constraint checking (min/max/allowed) when the field has a
+    registered constraint in :data:`~memtomem.config.FIELD_CONSTRAINTS`.
 
     Returns a human-readable confirmation or error message.
     """
+    from memtomem.config import FIELD_CONSTRAINTS, coerce_and_validate
+
     parts = key.split(".")
     if len(parts) != 2:
         return f"Key must be in 'section.field' format (e.g. 'search.default_top_k'). Got: '{key}'"
@@ -88,26 +91,32 @@ def _set_config_key(config: Mem2MemConfig, key: str, value: str) -> str:
     if not hasattr(section, field_name):
         return f"Field '{field_name}' not found in section '{section_name}'."
 
-    current = getattr(section, field_name)
-
-    # Coerce string → target type
-    try:
-        if isinstance(current, bool):
-            coerced: object = value.lower() in ("true", "1", "yes")
-        elif isinstance(current, int):
-            coerced = int(value)
-        elif isinstance(current, float):
-            coerced = float(value)
-        elif isinstance(current, str):
-            coerced = value
-        else:
-            return (
-                f"Cannot set '{key}': unsupported field type "
-                f"'{type(current).__name__}'. Only bool/int/float/str fields "
-                f"can be changed at runtime."
-            )
-    except (ValueError, TypeError) as exc:
-        return f"Invalid value '{value}' for {type(current).__name__} field '{key}': {exc}"
+    constraint = FIELD_CONSTRAINTS.get(key)
+    if constraint:
+        try:
+            coerced = coerce_and_validate(value, constraint)
+        except ValueError as exc:
+            return f"Invalid value '{value}' for '{key}': {exc}"
+    else:
+        # Fallback for fields without explicit constraints — coerce by current type
+        current = getattr(section, field_name)
+        try:
+            if isinstance(current, bool):
+                coerced = value.lower() in ("true", "1", "yes")
+            elif isinstance(current, int):
+                coerced = int(value)
+            elif isinstance(current, float):
+                coerced = float(value)
+            elif isinstance(current, str):
+                coerced = value
+            else:
+                return (
+                    f"Cannot set '{key}': unsupported field type "
+                    f"'{type(current).__name__}'. Only bool/int/float/str fields "
+                    f"can be changed at runtime."
+                )
+        except (ValueError, TypeError) as exc:
+            return f"Invalid value '{value}' for '{key}': {exc}"
 
     setattr(section, field_name, coerced)
-    return f"Set {key} = {coerced!r} (runtime only — not persisted)"
+    return f"Set {key} = {coerced!r}"

--- a/packages/memtomem/src/memtomem/server/helpers.py
+++ b/packages/memtomem/src/memtomem/server/helpers.py
@@ -77,7 +77,7 @@ def _set_config_key(config: Mem2MemConfig, key: str, value: str) -> str:
 
     Returns a human-readable confirmation or error message.
     """
-    from memtomem.config import FIELD_CONSTRAINTS, coerce_and_validate
+    from memtomem.config import FIELD_CONSTRAINTS, MUTABLE_FIELDS, coerce_and_validate
 
     parts = key.split(".")
     if len(parts) != 2:
@@ -90,6 +90,10 @@ def _set_config_key(config: Mem2MemConfig, key: str, value: str) -> str:
 
     if not hasattr(section, field_name):
         return f"Field '{field_name}' not found in section '{section_name}'."
+
+    allowed = MUTABLE_FIELDS.get(section_name, set())
+    if field_name not in allowed:
+        return f"'{key}' is not mutable at runtime (read-only). Use 'mm init' to change it."
 
     constraint = FIELD_CONSTRAINTS.get(key)
     if constraint:

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -104,14 +104,17 @@ async def mem_status(
 async def mem_config(
     key: str | None = None,
     value: str | None = None,
+    persist: bool = False,
     ctx: CtxType = None,  # type: ignore[assignment]
 ) -> str:
-    """View or update memtomem configuration values at runtime.
+    """View or update memtomem configuration values.
 
     Args:
         key: Dot-notation key to read or write (e.g. "search.default_top_k").
              If omitted, returns the full configuration as JSON.
         value: New value to assign. Omit to read the current value.
+        persist: If True, save the change to ~/.memtomem/config.json so it
+                 survives server restarts. Default is runtime-only.
     """
     app = _get_app(ctx)
 
@@ -128,6 +131,14 @@ async def mem_config(
                 set_tokenizer(app.config.search.tokenizer)
                 count = await app.storage.rebuild_fts()
                 result += f"\nFTS index rebuilt ({count} chunks)."
+            # Persist to disk if requested
+            if persist:
+                from memtomem.config import save_config_overrides
+
+                save_config_overrides(app.config)
+                result += " (persisted to config.json)"
+            else:
+                result += " (runtime only — not persisted)"
         return result
 
     config_dict = app.config.model_dump()

--- a/packages/memtomem/src/memtomem/web/routes/search.py
+++ b/packages/memtomem/src/memtomem/web/routes/search.py
@@ -18,7 +18,7 @@ router = APIRouter(tags=["search"])
 @router.get("/search", response_model=SearchResponse)
 async def search(
     q: str = Query(..., description="Search query", min_length=1, max_length=10_000),
-    top_k: int = Query(10, ge=1, le=100),
+    top_k: int | None = Query(None, ge=1, le=500),
     source_filter: str | None = Query(None),
     tag_filter: str | None = Query(None),
     namespace: str | None = Query(None),

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -10,6 +10,12 @@ from pathlib import Path
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from memtomem.config import (
+    FIELD_CONSTRAINTS,
+    MUTABLE_FIELDS,
+    coerce_and_validate,
+    save_config_overrides,
+)
 from memtomem.tools.memory_writer import append_entry
 from memtomem.web.deps import (
     get_config,
@@ -163,96 +169,9 @@ async def get_config_endpoint(config=Depends(get_config)) -> ConfigResponse:
 # PATCH /api/config — runtime configuration update
 # ---------------------------------------------------------------------------
 
-_MUTABLE_FIELDS: dict[str, set[str]] = {
-    "search": {
-        "default_top_k",
-        "bm25_candidates",
-        "dense_candidates",
-        "rrf_k",
-        "enable_bm25",
-        "enable_dense",
-        "tokenizer",
-        "rrf_weights",
-    },
-    "indexing": {
-        "max_chunk_tokens",
-        "min_chunk_tokens",
-        "chunk_overlap_tokens",
-        "structured_chunk_mode",
-    },
-    "embedding": {"batch_size"},
-    "decay": {"enabled", "half_life_days"},
-    "mmr": {"enabled", "lambda_param"},
-    "namespace": {"default_namespace", "enable_auto_ns"},
-}
 
-_FIELD_CONSTRAINTS: dict[str, dict] = {
-    "search.default_top_k": {"type": int, "min": 1, "max": 500},
-    "search.bm25_candidates": {"type": int, "min": 1, "max": 1000},
-    "search.dense_candidates": {"type": int, "min": 1, "max": 1000},
-    "search.rrf_k": {"type": int, "min": 1, "max": 1000},
-    "search.enable_bm25": {"type": bool},
-    "search.enable_dense": {"type": bool},
-    "search.tokenizer": {"type": str, "allowed": {"unicode61", "kiwipiepy"}},
-    "indexing.max_chunk_tokens": {"type": int, "min": 64, "max": 8192},
-    "indexing.min_chunk_tokens": {"type": int, "min": 0, "max": 256},
-    "indexing.chunk_overlap_tokens": {"type": int, "min": 0, "max": 512},
-    "indexing.structured_chunk_mode": {"type": str, "allowed": {"original", "recursive"}},
-    "embedding.batch_size": {"type": int, "min": 1, "max": 1024},
-    "decay.enabled": {"type": bool},
-    "decay.half_life_days": {"type": float, "min": 0.1},
-    "mmr.enabled": {"type": bool},
-    "mmr.lambda_param": {"type": float, "min": 0.0, "max": 1.0},
-    "namespace.default_namespace": {"type": str},
-    "namespace.enable_auto_ns": {"type": bool},
-}
-
-
-def _coerce_and_validate(value, constraint: dict | None):
-    """Coerce value to expected type and validate constraints."""
-    if constraint is None:
-        return value
-
-    expected_type = constraint["type"]
-
-    if expected_type is bool:
-        if isinstance(value, bool):
-            coerced = value
-        elif isinstance(value, str):
-            low = value.lower()
-            if low in ("true", "1", "yes"):
-                coerced = True
-            elif low in ("false", "0", "no"):
-                coerced = False
-            else:
-                raise ValueError(f"cannot convert '{value}' to bool")
-        elif isinstance(value, (int, float)):
-            coerced = bool(value)
-        else:
-            raise ValueError(f"cannot convert to bool: {value}")
-    elif expected_type is int:
-        try:
-            coerced = int(value)
-        except (TypeError, ValueError):
-            raise ValueError(f"cannot convert '{value}' to int")
-    elif expected_type is float:
-        try:
-            coerced = float(value)
-        except (TypeError, ValueError):
-            raise ValueError(f"cannot convert '{value}' to float")
-    elif expected_type is str:
-        coerced = str(value)
-    else:
-        coerced = value
-
-    if "min" in constraint and coerced < constraint["min"]:
-        raise ValueError(f"must be >= {constraint['min']}")
-    if "max" in constraint and coerced > constraint["max"]:
-        raise ValueError(f"must be <= {constraint['max']}")
-    if "allowed" in constraint and coerced not in constraint["allowed"]:
-        raise ValueError(f"must be one of {constraint['allowed']}")
-
-    return coerced
+# _MUTABLE_FIELDS, _FIELD_CONSTRAINTS, _coerce_and_validate are imported
+# from memtomem.config (canonical single source of truth).
 
 
 @router.patch("/config", response_model=ConfigPatchResponse)
@@ -271,7 +190,7 @@ async def patch_config(
         async with _asyncio.timeout(60):
             async with _config_patch_lock:
                 for section_name, updates in req.model_dump(exclude_none=True).items():
-                    allowed = _MUTABLE_FIELDS.get(section_name, set())
+                    allowed = MUTABLE_FIELDS.get(section_name, set())
                     section_obj = getattr(config, section_name, None)
                     if section_obj is None:
                         rejected.append(f"{section_name}: unknown section")
@@ -283,9 +202,9 @@ async def patch_config(
                             rejected.append(f"{full_key}: read-only field")
                             continue
 
-                        constraint = _FIELD_CONSTRAINTS.get(full_key)
+                        constraint = FIELD_CONSTRAINTS.get(full_key)
                         try:
-                            coerced = _coerce_and_validate(value, constraint)
+                            coerced = coerce_and_validate(value, constraint)
                         except ValueError as e:
                             rejected.append(f"{full_key}: {e}")
                             continue
@@ -317,9 +236,7 @@ async def patch_config(
                     search_pipeline.invalidate_cache()
 
                 if persist:
-                    from memtomem.config import save_config_overrides
-
-                    save_config_overrides(config, _MUTABLE_FIELDS)
+                    save_config_overrides(config)
     except TimeoutError:
         raise HTTPException(503, "Config update timed out — another update may be in progress")
 
@@ -329,9 +246,7 @@ async def patch_config(
 @router.post("/config/save")
 async def save_config(config=Depends(get_config)):
     """Persist current mutable config to ~/.memtomem/config.json."""
-    from memtomem.config import save_config_overrides
-
-    save_config_overrides(config, _MUTABLE_FIELDS)
+    save_config_overrides(config)
     return {"ok": True, "message": "Config saved to ~/.memtomem/config.json"}
 
 
@@ -356,9 +271,7 @@ async def add_memory_dir(request: Request, config=Depends(get_config)):
         }
 
     config.indexing.memory_dirs.append(resolved)
-    from memtomem.config import save_config_overrides
-
-    save_config_overrides(config, _MUTABLE_FIELDS)
+    save_config_overrides(config)
     return {
         "ok": True,
         "message": f"Added {resolved}",
@@ -384,9 +297,7 @@ async def remove_memory_dir(request: Request, config=Depends(get_config)):
         raise HTTPException(status_code=400, detail="Cannot remove last memory_dir")
 
     config.indexing.memory_dirs = new_dirs
-    from memtomem.config import save_config_overrides
-
-    save_config_overrides(config, _MUTABLE_FIELDS)
+    save_config_overrides(config)
     return {
         "ok": True,
         "message": f"Removed {resolved}",

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2942,13 +2942,12 @@ qs('d-pin-btn').addEventListener('click', () => {
 function _loadSettings() {
   return {
     defaultTab: localStorage.getItem('m2m-default-tab') || 'search',
-    defaultTopK: localStorage.getItem('m2m-default-top-k') || '10',
   };
 }
 
 (function _applySettings() {
   const s = _loadSettings();
-  qs('top-k').value = s.defaultTopK;
+  // top-k default is synced from server config via _syncSearchDefaults()
   // Apply default tab only if no hash deep link is present
   if (!location.hash.slice(1)) {
     const currentActive = document.querySelector('.tab-btn.active');
@@ -2962,24 +2961,36 @@ function _loadSettings() {
 qs('settings-btn').addEventListener('click', () => {
   const s = _loadSettings();
   qs('settings-default-tab').value = s.defaultTab;
-  qs('settings-default-topk').value = s.defaultTopK;
+  // Show current server config top-k (or UI value as fallback)
+  const curTopK = STATE.serverConfig?.search?.default_top_k || STATE.currentTopK || 10;
+  qs('settings-default-topk').value = String(curTopK);
   show(qs('settings-modal'));
 });
 qs('settings-close-btn').addEventListener('click', () => hide(qs('settings-modal')));
 qs('settings-modal').addEventListener('click', e => {
   if (e.target === qs('settings-modal')) hide(qs('settings-modal'));
 });
-qs('settings-save-btn').addEventListener('click', () => {
+qs('settings-save-btn').addEventListener('click', async () => {
   localStorage.setItem('m2m-default-tab', qs('settings-default-tab').value);
-  localStorage.setItem('m2m-default-top-k', qs('settings-default-topk').value);
+  const newTopK = parseInt(qs('settings-default-topk').value, 10);
+  // Sync top-k to server config so all paths see the same value
+  try {
+    await api('PATCH', '/api/config?persist=true', { search: { default_top_k: newTopK } });
+    if (STATE.serverConfig?.search) STATE.serverConfig.search.default_top_k = newTopK;
+    qs('top-k').value = String(newTopK);
+    STATE.currentTopK = newTopK;
+  } catch (e) {
+    console.warn('Failed to persist top-k to server config:', e);
+  }
   showToast(t('toast.settings_saved'), 'success');
   hide(qs('settings-modal'));
 });
 qs('settings-reset-btn').addEventListener('click', () => {
   localStorage.removeItem('m2m-default-tab');
-  localStorage.removeItem('m2m-default-top-k');
   qs('settings-default-tab').value = 'search';
-  qs('settings-default-topk').value = '10';
+  // Reset top-k to server default
+  const serverTopK = STATE.serverConfig?.search?.default_top_k || 10;
+  qs('settings-default-topk').value = String(serverTopK);
   showToast(t('toast.settings_reset'), 'info');
 });
 

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -47,18 +47,15 @@ function _syncSearchDefaults() {
   if (!STATE.serverConfig?.search) return;
   const topK = STATE.serverConfig.search.default_top_k;
   if (topK) {
-    const saved = localStorage.getItem('m2m-default-top-k');
-    if (!saved) {
-      const sel = qs('top-k');
-      if (![...sel.options].some(o => o.value == topK)) {
-        const opt = document.createElement('option');
-        opt.value = topK;
-        opt.textContent = `Top ${topK}`;
-        sel.appendChild(opt);
-      }
-      sel.value = String(topK);
-      STATE.currentTopK = topK;
+    const sel = qs('top-k');
+    if (![...sel.options].some(o => o.value == topK)) {
+      const opt = document.createElement('option');
+      opt.value = topK;
+      opt.textContent = `Top ${topK}`;
+      sel.appendChild(opt);
     }
+    sel.value = String(topK);
+    STATE.currentTopK = topK;
   }
 }
 

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -12,7 +12,7 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
-from memtomem.cli.config_cmd import _coerce_and_validate, _FIELD_CONSTRAINTS
+from memtomem.config import FIELD_CONSTRAINTS, coerce_and_validate
 
 
 @pytest.fixture
@@ -139,62 +139,62 @@ class TestConfigCLI:
 
 
 class TestCoerceAndValidate:
-    """Test the _coerce_and_validate helper directly."""
+    """Test the coerce_and_validate helper directly."""
 
     def test_none_constraint(self) -> None:
-        assert _coerce_and_validate("hello", None) == "hello"
+        assert coerce_and_validate("hello", None) == "hello"
 
     def test_int_coercion(self) -> None:
         constraint = {"type": int, "min": 1, "max": 100}
-        assert _coerce_and_validate("42", constraint) == 42
+        assert coerce_and_validate("42", constraint) == 42
 
     def test_int_below_min(self) -> None:
         constraint = {"type": int, "min": 1, "max": 100}
         with pytest.raises(ValueError, match=">= 1"):
-            _coerce_and_validate("0", constraint)
+            coerce_and_validate("0", constraint)
 
     def test_int_above_max(self) -> None:
         constraint = {"type": int, "min": 1, "max": 100}
         with pytest.raises(ValueError, match="<= 100"):
-            _coerce_and_validate("200", constraint)
+            coerce_and_validate("200", constraint)
 
     def test_int_not_numeric(self) -> None:
         constraint = {"type": int}
         with pytest.raises(ValueError, match="cannot convert"):
-            _coerce_and_validate("abc", constraint)
+            coerce_and_validate("abc", constraint)
 
     def test_bool_true_variants(self) -> None:
         constraint = {"type": bool}
         for v in ("true", "1", "yes", True):
-            assert _coerce_and_validate(v, constraint) is True
+            assert coerce_and_validate(v, constraint) is True
 
     def test_bool_false_variants(self) -> None:
         constraint = {"type": bool}
         for v in ("false", "0", "no", False):
-            assert _coerce_and_validate(v, constraint) is False
+            assert coerce_and_validate(v, constraint) is False
 
     def test_bool_invalid(self) -> None:
         constraint = {"type": bool}
         with pytest.raises(ValueError, match="cannot convert"):
-            _coerce_and_validate("maybe", constraint)
+            coerce_and_validate("maybe", constraint)
 
     def test_float_coercion(self) -> None:
         constraint = {"type": float, "min": 0.0, "max": 1.0}
-        assert _coerce_and_validate("0.5", constraint) == 0.5
+        assert coerce_and_validate("0.5", constraint) == 0.5
 
     def test_allowed_constraint(self) -> None:
         constraint = {"type": str, "allowed": {"a", "b"}}
-        assert _coerce_and_validate("a", constraint) == "a"
+        assert coerce_and_validate("a", constraint) == "a"
         with pytest.raises(ValueError, match="must be one of"):
-            _coerce_and_validate("c", constraint)
+            coerce_and_validate("c", constraint)
 
     def test_field_constraints_are_well_formed(self) -> None:
-        """Sanity: every declared constraint has type, min, and max."""
-        for key, c in _FIELD_CONSTRAINTS.items():
+        """Sanity: every declared constraint has a type and consistent bounds."""
+        for key, c in FIELD_CONSTRAINTS.items():
             assert "type" in c, f"{key} missing type"
-            assert "min" in c, f"{key} missing min"
-            assert "max" in c, f"{key} missing max"
-            assert c["min"] < c["max"], f"{key} min >= max"
+            # When both min and max are present, min must be < max
+            if "min" in c and "max" in c:
+                assert c["min"] < c["max"], f"{key} min >= max"
 
 
 # ── Other subcommands (help text) ───────────────────────────────────────

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -12,7 +12,13 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
-from memtomem.config import FIELD_CONSTRAINTS, coerce_and_validate
+from memtomem.config import (
+    FIELD_CONSTRAINTS,
+    Mem2MemConfig,
+    coerce_and_validate,
+    load_config_overrides,
+    save_config_overrides,
+)
 
 
 @pytest.fixture
@@ -128,6 +134,46 @@ class TestConfigCLI:
         result = runner.invoke(cli, ["config", "set", "noperiod", "10"])
         assert result.exit_code != 0
 
+    @patch("memtomem.config.save_config_overrides")
+    @patch("memtomem.config.load_config_overrides")
+    @patch("memtomem.config.Mem2MemConfig")
+    def test_config_set_tokenizer_triggers_fts_rebuild(
+        self, mock_cfg_cls, mock_load, mock_save, runner: CliRunner
+    ) -> None:
+        """Changing search.tokenizer via CLI must trigger set_tokenizer + FTS rebuild."""
+        mock_cfg = MagicMock()
+        mock_cfg.search.tokenizer = "unicode61"
+        mock_cfg_cls.return_value = mock_cfg
+
+        mock_storage = MagicMock()
+        mock_storage.rebuild_fts = MagicMock(return_value=42)
+
+        with (
+            patch("memtomem.storage.fts_tokenizer.set_tokenizer") as mock_set_tok,
+            patch("memtomem.storage.factory.create_storage", return_value=mock_storage),
+        ):
+            result = runner.invoke(cli, ["config", "set", "search.tokenizer", "kiwipiepy"])
+            assert result.exit_code == 0
+
+            mock_set_tok.assert_called_once_with("kiwipiepy")
+            mock_storage.rebuild_fts.assert_called_once()
+
+    @patch("memtomem.config.save_config_overrides")
+    @patch("memtomem.config.load_config_overrides")
+    @patch("memtomem.config.Mem2MemConfig")
+    def test_config_set_non_tokenizer_no_fts_rebuild(
+        self, mock_cfg_cls, mock_load, mock_save, runner: CliRunner
+    ) -> None:
+        """Non-tokenizer config changes must NOT trigger FTS rebuild."""
+        mock_cfg = MagicMock()
+        mock_cfg.search.default_top_k = 10
+        mock_cfg_cls.return_value = mock_cfg
+
+        with patch("memtomem.storage.fts_tokenizer.set_tokenizer") as mock_set_tok:
+            result = runner.invoke(cli, ["config", "set", "search.default_top_k", "20"])
+            assert result.exit_code == 0
+            mock_set_tok.assert_not_called()
+
     def test_config_set_immutable_field(self, runner: CliRunner) -> None:
         """Attempting to set a non-mutable field is rejected."""
         result = runner.invoke(cli, ["config", "set", "search.nonexistent_field", "10"])
@@ -188,6 +234,32 @@ class TestCoerceAndValidate:
         with pytest.raises(ValueError, match="must be one of"):
             coerce_and_validate("c", constraint)
 
+    def test_list_float_coercion_from_string(self) -> None:
+        """CSV string should be coerced to list[float]."""
+        constraint = {"type": list, "item_type": float, "length": 2}
+        result = coerce_and_validate("1.5,0.8", constraint)
+        assert result == [1.5, 0.8]
+
+    def test_list_float_coercion_from_list(self) -> None:
+        """Passing an actual list should work (Web UI path)."""
+        constraint = {"type": list, "item_type": float, "length": 2}
+        result = coerce_and_validate([1.5, 0.8], constraint)
+        assert result == [1.5, 0.8]
+
+    def test_list_float_wrong_length(self) -> None:
+        constraint = {"type": list, "item_type": float, "length": 2}
+        with pytest.raises(ValueError, match="length 2"):
+            coerce_and_validate("1.0,2.0,3.0", constraint)
+
+    def test_list_float_invalid_element(self) -> None:
+        constraint = {"type": list, "item_type": float, "length": 2}
+        with pytest.raises(ValueError, match="cannot convert"):
+            coerce_and_validate("abc,1.0", constraint)
+
+    def test_rrf_weights_has_constraint(self) -> None:
+        """search.rrf_weights must be registered in FIELD_CONSTRAINTS."""
+        assert "search.rrf_weights" in FIELD_CONSTRAINTS
+
     def test_field_constraints_are_well_formed(self) -> None:
         """Sanity: every declared constraint has a type and consistent bounds."""
         for key, c in FIELD_CONSTRAINTS.items():
@@ -195,6 +267,49 @@ class TestCoerceAndValidate:
             # When both min and max are present, min must be < max
             if "min" in c and "max" in c:
                 assert c["min"] < c["max"], f"{key} min >= max"
+
+
+# ── save_config_overrides persistence ──────────────────────────────────
+
+
+class TestSaveConfigOverrides:
+    """Verify save→load round-trip for mutable and special fields."""
+
+    def test_memory_dirs_survives_save_load(self, tmp_path, monkeypatch):
+        """memory_dirs added via Web UI must survive a save→load cycle."""
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        cfg = Mem2MemConfig()
+        cfg.indexing.memory_dirs = [tmp_path / "a", tmp_path / "b"]
+        save_config_overrides(cfg)
+
+        fresh = Mem2MemConfig()
+        load_config_overrides(fresh)
+
+        loaded_dirs = [str(p) for p in fresh.indexing.memory_dirs]
+        assert str(tmp_path / "a") in loaded_dirs
+        assert str(tmp_path / "b") in loaded_dirs
+
+    def test_existing_memory_dirs_not_clobbered(self, tmp_path, monkeypatch):
+        """Saving mutable fields must not destroy pre-existing memory_dirs."""
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        # Simulate mm init having written memory_dirs
+        config_file.write_text(json.dumps({
+            "indexing": {"memory_dirs": ["/pre/existing"]},
+        }))
+
+        cfg = Mem2MemConfig()
+        load_config_overrides(cfg)
+        cfg.search.default_top_k = 42
+        save_config_overrides(cfg)
+
+        data = json.loads(config_file.read_text())
+        assert "/pre/existing" in [str(p) for p in data["indexing"]["memory_dirs"]]
 
 
 # ── Other subcommands (help text) ───────────────────────────────────────

--- a/packages/memtomem/tests/test_server_helpers.py
+++ b/packages/memtomem/tests/test_server_helpers.py
@@ -466,9 +466,36 @@ class TestSetConfigKey:
 
     def test_unsupported_type_rejected(self):
         config = Mem2MemConfig()
-        # memory_dirs is a list, which cannot be set via _set_config_key
+        # memory_dirs is not in MUTABLE_FIELDS, so it's rejected as read-only
         msg = _set_config_key(config, "indexing.memory_dirs", "/tmp")
-        assert "unsupported" in msg.lower() or "Cannot set" in msg
+        assert "not mutable" in msg.lower() or "read-only" in msg.lower()
+
+    def test_init_only_field_rejected(self):
+        """_set_config_key must reject fields not in MUTABLE_FIELDS."""
+        config = Mem2MemConfig()
+        original = config.embedding.provider
+        msg = _set_config_key(config, "embedding.provider", "openai")
+        assert "not mutable" in msg.lower() or "read-only" in msg.lower()
+        assert config.embedding.provider == original  # unchanged
+
+    def test_init_only_storage_backend_rejected(self):
+        config = Mem2MemConfig()
+        msg = _set_config_key(config, "storage.backend", "postgres")
+        assert "not mutable" in msg.lower() or "read-only" in msg.lower()
+
+    def test_mutable_field_still_works(self):
+        """Mutable fields should still be accepted after adding the guard."""
+        config = Mem2MemConfig()
+        msg = _set_config_key(config, "search.default_top_k", "25")
+        assert msg.startswith("Set ")
+        assert config.search.default_top_k == 25
+
+    def test_set_rrf_weights_from_csv(self):
+        """MCP path: rrf_weights as CSV string → list[float]."""
+        config = Mem2MemConfig()
+        msg = _set_config_key(config, "search.rrf_weights", "1.5,0.8")
+        assert msg.startswith("Set ")
+        assert config.search.rrf_weights == [1.5, 0.8]
 
 
 # ===========================================================================

--- a/packages/memtomem/tests/test_server_helpers.py
+++ b/packages/memtomem/tests/test_server_helpers.py
@@ -430,19 +430,19 @@ class TestSetConfigKey:
         config = Mem2MemConfig()
         msg = _set_config_key(config, "decay.enabled", "true")
         assert config.decay.enabled is True
-        assert "runtime only" in msg
+        assert msg.startswith("Set ")
 
     def test_set_float_field(self):
         config = Mem2MemConfig()
         result = _set_config_key(config, "mmr.lambda_param", "0.5")
         assert config.mmr.lambda_param == pytest.approx(0.5)
-        assert "runtime only" in result
+        assert result.startswith("Set ")
 
     def test_set_string_field(self):
         config = Mem2MemConfig()
         result = _set_config_key(config, "namespace.default_namespace", "work")
         assert config.namespace.default_namespace == "work"
-        assert "runtime only" in result
+        assert result.startswith("Set ")
 
     def test_invalid_key_format_no_dot(self):
         config = Mem2MemConfig()

--- a/packages/memtomem/tests/test_server_tools_core.py
+++ b/packages/memtomem/tests/test_server_tools_core.py
@@ -307,9 +307,16 @@ class TestSetConfigKey:
         assert config.decay.half_life_days == 7.5
 
     def test_set_string_field(self):
+        """Mutable string field (namespace.default_namespace) should be settable."""
+        config = Mem2MemConfig()
+        msg = _set_config_key(config, "namespace.default_namespace", "work")
+        assert config.namespace.default_namespace == "work"
+
+    def test_init_only_field_rejected(self):
+        """Init-only fields like embedding.provider must be rejected."""
         config = Mem2MemConfig()
         msg = _set_config_key(config, "embedding.provider", "openai")
-        assert config.embedding.provider == "openai"
+        assert "not mutable" in msg.lower()
 
     def test_invalid_section(self):
         config = Mem2MemConfig()
@@ -331,11 +338,17 @@ class TestSetConfigKey:
         msg = _set_config_key(config, "a.b.c", "val")
         assert "section.field" in msg
 
-    def test_unsupported_complex_type(self):
+    def test_set_rrf_weights_csv(self):
+        """rrf_weights accepts CSV string and coerces to list[float]."""
         config = Mem2MemConfig()
-        # rrf_weights is a list[float], should be rejected
-        msg = _set_config_key(config, "search.rrf_weights", "[1.0, 2.0]")
-        assert "unsupported" in msg.lower() or "Cannot set" in msg
+        msg = _set_config_key(config, "search.rrf_weights", "1.5,0.8")
+        assert msg.startswith("Set ")
+        assert config.search.rrf_weights == [1.5, 0.8]
+
+    def test_set_rrf_weights_wrong_length(self):
+        config = Mem2MemConfig()
+        msg = _set_config_key(config, "search.rrf_weights", "1.0,2.0,3.0")
+        assert "Invalid" in msg or "length" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_server_tools_core.py
+++ b/packages/memtomem/tests/test_server_tools_core.py
@@ -293,7 +293,7 @@ class TestSetConfigKey:
         config = Mem2MemConfig()
         msg = _set_config_key(config, "decay.enabled", "true")
         assert config.decay.enabled is True
-        assert "runtime only" in msg
+        assert msg.startswith("Set ")
 
     def test_set_bool_field_false(self):
         config = Mem2MemConfig()


### PR DESCRIPTION
## Summary

- **Prevent data loss on save**: `save_config_overrides` now uses read-merge-write so init-only keys (`embedding.provider`, `storage.sqlite_path`, etc.) are preserved. Canonical `MUTABLE_FIELDS` / `FIELD_CONSTRAINTS` / `coerce_and_validate` moved to `config.py` as single source of truth for CLI, Web UI, and MCP.
- **MCP MUTABLE_FIELDS guard**: `_set_config_key` now rejects init-only fields at runtime instead of silently mutating them.
- **memory_dirs persistence**: `_EXTRA_PERSIST_FIELDS` ensures Web UI `/memory-dirs/add|remove` changes survive restart (previously silently lost because `memory_dirs ∉ MUTABLE_FIELDS`).
- **CLI tokenizer FTS rebuild**: `mm config set search.tokenizer` now calls `set_tokenizer()` + `rebuild_fts()`, matching Web UI / MCP behaviour.
- **rrf_weights coercion**: Added `FIELD_CONSTRAINTS` entry + list-type coercion in `coerce_and_validate` — CLI previously corrupted the field to a string, MCP rejected it as "unsupported type".

## Test plan

- [x] 1311 tests pass (`uv run pytest -m "not ollama"`)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Verify `mm config set search.tokenizer kiwipiepy` rebuilds FTS
- [ ] Verify `mm config set search.rrf_weights 1.5,0.8` stores `[1.5, 0.8]`
- [ ] Verify Web UI memory-dirs add persists across server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)