### PR TITLE
fix(embedding): default Ollama base_url to localhost:11434 when empty

### DIFF
--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -52,12 +52,13 @@ export MEMTOMEM_EMBEDDING__DIMENSION=1024
 # Pull the default model (one-time, ~270MB)
 ollama pull nomic-embed-text
 
-# These are the defaults — no env vars needed
+# Minimal config — base_url defaults to http://localhost:11434
 MEMTOMEM_EMBEDDING__PROVIDER=ollama
 MEMTOMEM_EMBEDDING__MODEL=nomic-embed-text
 MEMTOMEM_EMBEDDING__DIMENSION=768
-MEMTOMEM_EMBEDDING__BASE_URL=http://localhost:11434
 ```
+
+> **`base_url` is optional.** When provider is `ollama` and `base_url` is empty or unset, it defaults to `http://localhost:11434`. Override only if Ollama runs on a different host or port.
 
 For multilingual content, switch to `bge-m3`:
 
@@ -101,6 +102,13 @@ mm embedding-reset --mode revert-to-stored
 ```
 
 The same operation is available as the `mem_embedding_reset` MCP tool.
+
+## Troubleshooting
+
+- **"Request URL is missing an 'http://' or 'https://' protocol"** — your config has `embedding.provider` set to `ollama` but `embedding.base_url` is empty. Upgrade to the latest version (which defaults to `http://localhost:11434`) or add `"base_url": "http://localhost:11434"` to the `embedding` section of `~/.memtomem/config.json`.
+- **"Cannot connect to Ollama"** — verify `ollama serve` is running.
+- **"Model not found"** — run `ollama pull <model>` to download it.
+- **Dimension mismatch after model switch** — use `mm embedding-reset --mode apply-current` then re-index.
 
 ## Tuning Throughput
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -357,6 +357,8 @@ def _write_config_and_summary(state: dict) -> None:
         "search": {"default_top_k": state["top_k"], "tokenizer": state["tokenizer"]},
         "decay": {"enabled": state["decay_enabled"]},
     }
+    if state["provider"] == "ollama":
+        config_data["embedding"]["base_url"] = "http://localhost:11434"
     if state.get("api_key"):
         config_data["embedding"]["api_key"] = state["api_key"]
     config_path = config_dir / "config.json"

--- a/packages/memtomem/src/memtomem/embedding/ollama.py
+++ b/packages/memtomem/src/memtomem/embedding/ollama.py
@@ -22,7 +22,7 @@ class OllamaEmbedder:
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = httpx.AsyncClient(
-                base_url=self._config.base_url,
+                base_url=self._config.base_url or "http://localhost:11434",
                 timeout=60.0,
             )
         return self._client


### PR DESCRIPTION
## Summary

- Default Ollama `base_url` to `http://localhost:11434` when the field is empty, preventing connection errors on fresh installs
- Update embeddings guide with Ollama setup instructions

## Test plan

- [ ] `mm init` with Ollama provider and empty base_url defaults correctly
- [ ] Existing configs with explicit base_url are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)