### PR TITLE
fix(init): preserve non-init config fields on re-run

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -340,9 +340,20 @@ def _write_config_and_summary(state: dict) -> None:
     project_install = state.get("project_install", False)
     project_dir = state.get("project_dir")
 
-    # Write ~/.memtomem/config.json
+    # Write ~/.memtomem/config.json (read-merge-write to preserve non-init fields)
     click.secho("Writing configuration...", fg="green")
-    config_data: dict = {
+    config_path = config_dir / "config.json"
+
+    # Read existing config as merge base (preserves post-init user edits)
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    # Build init-target fields only
+    init_data: dict = {
         "embedding": {
             "provider": state["provider"],
             "model": state["model"],
@@ -358,11 +369,20 @@ def _write_config_and_summary(state: dict) -> None:
         "decay": {"enabled": state["decay_enabled"]},
     }
     if state["provider"] == "ollama":
-        config_data["embedding"]["base_url"] = "http://localhost:11434"
+        init_data["embedding"]["base_url"] = "http://localhost:11434"
     if state.get("api_key"):
-        config_data["embedding"]["api_key"] = state["api_key"]
-    config_path = config_dir / "config.json"
-    config_path.write_text(json.dumps(config_data, indent=2), encoding="utf-8")
+        init_data["embedding"]["api_key"] = state["api_key"]
+
+    # Merge: init fields overwrite, non-init sections/fields preserved
+    for section, fields in init_data.items():
+        if section not in existing:
+            existing[section] = {}
+        if isinstance(fields, dict) and isinstance(existing[section], dict):
+            existing[section].update(fields)
+        else:
+            existing[section] = fields
+
+    config_path.write_text(json.dumps(existing, indent=2, default=str), encoding="utf-8")
     click.echo(f"  Config: {config_path}")
 
     # Build MCP server command

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -48,6 +48,90 @@ def test_write_mcp_json_preserves_valid_env(
     assert data["mcpServers"]["memtomem"]["env"] == env
 
 
+def _make_init_state(tmp_path: Path) -> dict:
+    """Return a minimal wizard state dict pointing at *tmp_path*."""
+    return {
+        "provider": "none",
+        "model": "",
+        "dimension": 0,
+        "db_path": str(tmp_path / "memtomem.db"),
+        "memory_dir": str(tmp_path / "memories"),
+        "enable_auto_ns": False,
+        "default_ns": "default",
+        "top_k": 10,
+        "tokenizer": "unicode61",
+        "decay_enabled": False,
+        # Non-config keys required by _write_config_and_summary
+        "mcp_choice": 3,  # skip MCP setup
+        "settings_hooks": False,
+        "source_install": False,
+        "source_dir": None,
+        "project_install": False,
+        "project_dir": None,
+    }
+
+
+class TestInitConfigMerge:
+    """mm init must preserve non-init fields on re-run."""
+
+    def test_reinit_preserves_existing_mutable_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Post-init config changes (e.g. mmr.lambda_param) must survive re-init."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        # Redirect ~/.memtomem to tmp_path/.memtomem
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+
+        # First init
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state)
+
+        # User modifies config post-init (simulate mm config set)
+        config_path = config_dir / "config.json"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        data["mmr"] = {"enabled": True, "lambda_param": 0.3}
+        data["search"]["bm25_candidates"] = 200
+        config_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        # Re-run init (change provider)
+        state["provider"] = "onnx"
+        state["model"] = "all-MiniLM-L6-v2"
+        state["dimension"] = 384
+        _write_config_and_summary(state)
+
+        result = json.loads(config_path.read_text(encoding="utf-8"))
+
+        # Init fields updated
+        assert result["embedding"]["provider"] == "onnx"
+        assert result["embedding"]["dimension"] == 384
+
+        # Non-init fields preserved
+        assert result["mmr"]["enabled"] is True
+        assert result["mmr"]["lambda_param"] == 0.3
+        assert result["search"]["bm25_candidates"] == 200
+
+    def test_first_init_works_without_existing_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """First init (no config.json) must work exactly as before."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state)
+
+        config_path = config_dir / "config.json"
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["embedding"]["provider"] == "none"
+        assert data["search"]["default_top_k"] == 10
+
+
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be
     encoded as a JSON array string. A bare path crashes pydantic-settings.


### PR DESCRIPTION
## Summary

- `mm init` re-run now uses read-merge-write instead of overwriting `config.json`
- Init-target fields (embedding, storage, memory_dirs, namespace, top_k, tokenizer, decay) are updated from wizard input
- All other fields (mmr, rerank, indexing tuning, health watchdog, LLM config, etc.) are preserved from existing config
- First init (no existing file) behaves identically to before

Closes the last item from the config sync audit (issues A–D fixed in #40).

## Test plan

- [x] 1313 tests pass (`uv run pytest -m "not ollama"`)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Run `mm init`, change provider, verify non-init fields survive
- [ ] Run `mm init` on fresh machine (no config.json), verify normal behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)