### PR TITLE
fix(config): validate config.json values on load

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -494,6 +494,20 @@ def load_config_overrides(config: Mem2MemConfig) -> None:
             continue
         for key, value in updates.items():
             if hasattr(section_obj, key):
+                full_key = f"{section_name}.{key}"
+                constraint = FIELD_CONSTRAINTS.get(full_key)
+                if constraint:
+                    try:
+                        value = coerce_and_validate(value, constraint)
+                    except ValueError as exc:
+                        _log.warning(
+                            "Invalid config value %s=%r in %s: %s (using default)",
+                            full_key,
+                            value,
+                            path,
+                            exc,
+                        )
+                        continue
                 try:
                     setattr(section_obj, key, value)
                 except (TypeError, ValueError) as exc:

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -291,6 +291,43 @@ class TestSaveConfigOverrides:
         assert str(tmp_path / "a") in loaded_dirs
         assert str(tmp_path / "b") in loaded_dirs
 
+    def test_invalid_value_falls_back_to_default(self, tmp_path, monkeypatch):
+        """Invalid values in config.json should be skipped with warning, not crash."""
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        config_file.write_text(json.dumps({
+            "search": {"default_top_k": -5},  # violates min=1
+        }))
+
+        cfg = Mem2MemConfig()
+        default_top_k = cfg.search.default_top_k
+        load_config_overrides(cfg)
+
+        # Invalid value must be rejected; field keeps code default
+        assert cfg.search.default_top_k == default_top_k
+
+    def test_invalid_value_does_not_block_valid_ones(self, tmp_path, monkeypatch):
+        """One bad field must not prevent other valid fields from loading."""
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        config_file.write_text(json.dumps({
+            "search": {"default_top_k": -5, "rrf_k": 80},
+            "decay": {"enabled": True},
+        }))
+
+        cfg = Mem2MemConfig()
+        load_config_overrides(cfg)
+
+        # Valid fields applied, invalid one skipped
+        assert cfg.search.rrf_k == 80
+        assert cfg.decay.enabled is True
+
     def test_existing_memory_dirs_not_clobbered(self, tmp_path, monkeypatch):
         """Saving mutable fields must not destroy pre-existing memory_dirs."""
         import json


### PR DESCRIPTION
## Summary

- `load_config_overrides()` now validates values from `config.json` using `FIELD_CONSTRAINTS` + `coerce_and_validate()` before `setattr`
- Invalid values (e.g. `default_top_k: -5`) are logged as warnings and skipped — field keeps its code default
- One bad field does not block other valid fields from loading

Previously, manually-edited config.json with out-of-range values would load silently at startup and cause cryptic runtime errors during search.

## Test plan

- [x] 1315 tests pass (`uv run pytest -m "not ollama"`)
- [x] `ruff check` + `ruff format --check` clean
- [ ] Edit `~/.memtomem/config.json` with `default_top_k: -5`, verify startup warning + fallback to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)