### PR TITLE
feat(web): add headless mode

### DIFF
--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -56,15 +56,16 @@ def web(host: str, port: int, headless: bool) -> None:
         while not server.started:
             await asyncio.sleep(0.1)
         import webbrowser
+
         webbrowser.open(f"http://{host}:{port}")
-    
+
     async def start_server() -> None:
         web_config = uvicorn.Config(create_app(lifespan=_lifespan), host=host, port=port)
         web_server = uvicorn.Server(web_config)
-        
+
         await asyncio.gather(
             web_server.serve(),
             after_started(web_server, headless),
         )
-    
+
     asyncio.run(start_server())

--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -25,7 +25,8 @@ def _web_install_hint() -> str:
 @click.command("web")
 @click.option("--host", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", default=8080, type=int, help="Port to bind to")
-def web(host: str, port: int) -> None:
+@click.option("--headless", is_flag=True, help="Run without opening the browser")
+def web(host: str, port: int, headless: bool) -> None:
     """Launch the memtomem Web UI (FastAPI + SPA)."""
     missing = _missing_web_deps()
     if missing is not None:
@@ -45,5 +46,25 @@ def web(host: str, port: int) -> None:
 
     from memtomem.web.app import _lifespan, create_app
 
+    import asyncio
+
     click.echo(f"Starting memtomem Web UI at http://{host}:{port}")
-    uvicorn.run(create_app(lifespan=_lifespan), host=host, port=port)
+
+    async def after_started(server: uvicorn.Server, headless: bool) -> None:
+        if headless:
+            return
+        while not server.started:
+            await asyncio.sleep(0.1)
+        import webbrowser
+        webbrowser.open(f"http://{host}:{port}")
+    
+    async def start_server() -> None:
+        web_config = uvicorn.Config(create_app(lifespan=_lifespan), host=host, port=port)
+        web_server = uvicorn.Server(web_config)
+        
+        await asyncio.gather(
+            web_server.serve(),
+            after_started(web_server, headless),
+        )
+    
+    asyncio.run(start_server())

--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -25,8 +25,11 @@ def _web_install_hint() -> str:
 @click.command("web")
 @click.option("--host", default="127.0.0.1", help="Host to bind to")
 @click.option("--port", default=8080, type=int, help="Port to bind to")
-@click.option("--headless", is_flag=True, help="Run without opening the browser")
-def web(host: str, port: int, headless: bool) -> None:
+@click.option("--open", "open_browser", is_flag=True, help="Run with opening the browser")
+@click.option(
+    "--timeout", default=30, type=int, help="Timeout for web opening (seconds). Zero is no timeout."
+)
+def web(host: str, port: int, open_browser: bool, timeout: int) -> None:
     """Launch the memtomem Web UI (FastAPI + SPA)."""
     missing = _missing_web_deps()
     if missing is not None:
@@ -50,10 +53,26 @@ def web(host: str, port: int, headless: bool) -> None:
 
     click.echo(f"Starting memtomem Web UI at http://{host}:{port}")
 
-    async def after_started(server: uvicorn.Server, headless: bool) -> None:
-        if headless:
+    async def after_started(server: uvicorn.Server, timeout: float) -> None:
+        if not open_browser:
             return
+        import time
+
+        if timeout == 0:
+            click.secho(
+                "Warning: No timeout for Web opening (timeout is set to 0).",
+                fg="yellow",
+            )
+            deadline = float("inf")
+        else:
+            deadline = time.monotonic() + timeout
         while not server.started:
+            if time.monotonic() >= deadline:
+                click.secho(
+                    "Warning: Web server did not start within the timeout period; not opening browser.",
+                    fg="yellow",
+                )
+                return
             await asyncio.sleep(0.1)
         import webbrowser
 
@@ -65,7 +84,7 @@ def web(host: str, port: int, headless: bool) -> None:
 
         await asyncio.gather(
             web_server.serve(),
-            after_started(web_server, headless),
+            after_started(web_server, timeout=float(timeout)),
         )
 
     asyncio.run(start_server())

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -108,10 +108,10 @@ def _patch_web_stack(server_mock: MagicMock):
     """Patch all external dependencies required to run ``web()``."""
     return [
         patch("memtomem.cli.web._missing_web_deps", return_value=None),
-        patch("memtomem.cli.web.uvicorn.Config", return_value=MagicMock()),
-        patch("memtomem.cli.web.uvicorn.Server", return_value=server_mock),
-        patch("memtomem.cli.web.create_app", return_value=MagicMock()),
-        patch("memtomem.cli.web._lifespan", MagicMock()),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("uvicorn.Server", return_value=server_mock),
+        patch("memtomem.web.app.create_app", return_value=MagicMock()),
+        patch("memtomem.web.app._lifespan", MagicMock())
     ]
 
 

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -9,7 +9,9 @@ extra wasn't installed — because the old error handler only caught missing
 from __future__ import annotations
 
 import sys
-from unittest.mock import patch
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -85,3 +87,118 @@ def test_wizard_next_steps_hint_respects_web_deps(
         from memtomem.cli.web import _missing_web_deps as check
 
         assert check() == "fastapi"
+
+
+def _make_server_mock(started: bool = True) -> MagicMock:
+    """Return a uvicorn.Server mock.
+
+    ``serve()`` completes immediately; ``started`` is fixed to the given value.
+    """
+    server = MagicMock()
+    server.started = started
+
+    async def _serve() -> None:
+        pass
+
+    server.serve = _serve
+    return server
+
+
+def _patch_web_stack(server_mock: MagicMock):
+    """Patch all external dependencies required to run ``web()``."""
+    return [
+        patch("memtomem.cli.web._missing_web_deps", return_value=None),
+        patch("memtomem.cli.web.uvicorn.Config", return_value=MagicMock()),
+        patch("memtomem.cli.web.uvicorn.Server", return_value=server_mock),
+        patch("memtomem.cli.web.create_app", return_value=MagicMock()),
+        patch("memtomem.cli.web._lifespan", MagicMock()),
+    ]
+
+
+def test_web_no_open_does_not_call_webbrowser() -> None:
+    """Without --open, webbrowser.open must never be called."""
+    runner = CliRunner()
+    server_mock = _make_server_mock(started=True)
+
+    with patch("webbrowser.open") as mock_browser:
+        with contextlib.ExitStack() as stack:
+            for p in _patch_web_stack(server_mock):
+                stack.enter_context(p)
+            result = runner.invoke(web, ["--host", "127.0.0.1", "--port", "9999"])
+
+    assert result.exit_code == 0
+    mock_browser.assert_not_called()
+
+
+def test_web_open_calls_webbrowser_when_server_starts() -> None:
+    """With --open, webbrowser.open must be called once the server is ready."""
+    runner = CliRunner()
+    server_mock = _make_server_mock(started=True)
+
+    with patch("webbrowser.open") as mock_browser:
+        with contextlib.ExitStack() as stack:
+            for p in _patch_web_stack(server_mock):
+                stack.enter_context(p)
+            result = runner.invoke(web, ["--host", "127.0.0.1", "--port", "9999", "--open"])
+
+    assert result.exit_code == 0
+    mock_browser.assert_called_once_with("http://127.0.0.1:9999")
+
+
+def test_web_open_timeout_warns_and_skips_browser() -> None:
+    """If the server never becomes ready within the timeout, emit a warning
+    and do not open the browser."""
+    runner = CliRunner()
+    server_mock = _make_server_mock(started=False)
+
+    with patch("webbrowser.open") as mock_browser:
+        with contextlib.ExitStack() as stack:
+            for p in _patch_web_stack(server_mock):
+                stack.enter_context(p)
+            result = runner.invoke(
+                web,
+                ["--host", "127.0.0.1", "--port", "9999", "--open", "--timeout", "1"],
+            )
+
+    assert result.exit_code == 0
+    mock_browser.assert_not_called()
+    assert "Warning" in result.output
+    assert "timeout" in result.output.lower()
+
+
+def test_web_open_zero_timeout_shows_warning() -> None:
+    """--timeout 0 means no timeout; a warning must be printed to inform the user."""
+    runner = CliRunner()
+    server_mock = _make_server_mock(started=True)
+
+    with patch("webbrowser.open"):
+        with contextlib.ExitStack() as stack:
+            for p in _patch_web_stack(server_mock):
+                stack.enter_context(p)
+            result = runner.invoke(
+                web,
+                ["--host", "127.0.0.1", "--port", "9999", "--open", "--timeout", "0"],
+            )
+
+    assert result.exit_code == 0
+    assert "Warning" in result.output
+    assert "timeout" in result.output.lower()
+
+
+def test_web_timeout_without_open_is_silent() -> None:
+    """Specifying --timeout without --open must exit cleanly with no warnings."""
+    runner = CliRunner()
+    server_mock = _make_server_mock(started=True)
+
+    with patch("webbrowser.open") as mock_browser:
+        with contextlib.ExitStack() as stack:
+            for p in _patch_web_stack(server_mock):
+                stack.enter_context(p)
+            result = runner.invoke(
+                web,
+                ["--host", "127.0.0.1", "--port", "9999", "--timeout", "5"],
+            )
+
+    assert result.exit_code == 0
+    mock_browser.assert_not_called()
+    assert "Warning" not in result.output


### PR DESCRIPTION
Now you can run the web interface with automatically opening the browser by default. If you want to disable this feature, you can use the `--headless` flag when starting the web interface.