### PR TITLE
fix(config): include field name and value in validation error messages

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import Field, FieldValidationInfo, field_validator, model_validator
+from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -26,7 +26,7 @@ class EmbeddingConfig(BaseSettings):
 
     @field_validator("batch_size", "max_concurrent_batches")
     @classmethod
-    def must_be_positive(cls, v: int, info: FieldValidationInfo) -> int:
+    def must_be_positive(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
@@ -59,7 +59,7 @@ class SearchConfig(BaseSettings):
 
     @field_validator("default_top_k", "bm25_candidates", "dense_candidates", "rrf_k")
     @classmethod
-    def must_be_positive(cls, v: int, info: FieldValidationInfo) -> int:
+    def must_be_positive(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
@@ -120,7 +120,7 @@ class IndexingConfig(BaseSettings):
         "max_chunk_tokens", "min_chunk_tokens", "chunk_overlap_tokens", "paragraph_split_threshold"
     )
     @classmethod
-    def must_be_non_negative(cls, v: int, info: FieldValidationInfo) -> int:
+    def must_be_non_negative(cls, v: int, info: ValidationInfo) -> int:
         if v < 0:
             raise ValueError(f"{info.field_name} must be non-negative, got {v}")
         return v
@@ -141,7 +141,7 @@ class DecayConfig(BaseSettings):
 
     @field_validator("half_life_days")
     @classmethod
-    def must_be_positive(cls, v: float, info: FieldValidationInfo) -> float:
+    def must_be_positive(cls, v: float, info: ValidationInfo) -> float:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
@@ -185,7 +185,7 @@ class RerankConfig(BaseSettings):
 
     @field_validator("top_k")
     @classmethod
-    def must_be_positive(cls, v: int, info: FieldValidationInfo) -> int:
+    def must_be_positive(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
@@ -301,14 +301,14 @@ class LLMConfig(BaseSettings):
 
     @field_validator("max_tokens")
     @classmethod
-    def max_tokens_positive(cls, v: int, info: FieldValidationInfo) -> int:
+    def max_tokens_positive(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
     @field_validator("timeout")
     @classmethod
-    def timeout_positive(cls, v: float, info: FieldValidationInfo) -> float:
+    def timeout_positive(cls, v: float, info: ValidationInfo) -> float:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, FieldValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -26,9 +26,9 @@ class EmbeddingConfig(BaseSettings):
 
     @field_validator("batch_size", "max_concurrent_batches")
     @classmethod
-    def must_be_positive(cls, v: int) -> int:
+    def must_be_positive(cls, v: int, info: FieldValidationInfo) -> int:
         if v <= 0:
-            raise ValueError("must be positive")
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
 
@@ -59,9 +59,9 @@ class SearchConfig(BaseSettings):
 
     @field_validator("default_top_k", "bm25_candidates", "dense_candidates", "rrf_k")
     @classmethod
-    def must_be_positive(cls, v: int) -> int:
+    def must_be_positive(cls, v: int, info: FieldValidationInfo) -> int:
         if v <= 0:
-            raise ValueError("must be positive")
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
     @field_validator("tokenizer")
@@ -120,9 +120,9 @@ class IndexingConfig(BaseSettings):
         "max_chunk_tokens", "min_chunk_tokens", "chunk_overlap_tokens", "paragraph_split_threshold"
     )
     @classmethod
-    def must_be_non_negative(cls, v: int) -> int:
+    def must_be_non_negative(cls, v: int, info: FieldValidationInfo) -> int:
         if v < 0:
-            raise ValueError("must be non-negative")
+            raise ValueError(f"{info.field_name} must be non-negative, got {v}")
         return v
 
     @model_validator(mode="after")
@@ -141,9 +141,9 @@ class DecayConfig(BaseSettings):
 
     @field_validator("half_life_days")
     @classmethod
-    def must_be_positive(cls, v: float) -> float:
+    def must_be_positive(cls, v: float, info: FieldValidationInfo) -> float:
         if v <= 0:
-            raise ValueError("must be positive")
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
 
@@ -185,9 +185,9 @@ class RerankConfig(BaseSettings):
 
     @field_validator("top_k")
     @classmethod
-    def must_be_positive(cls, v: int) -> int:
+    def must_be_positive(cls, v: int, info: FieldValidationInfo) -> int:
         if v <= 0:
-            raise ValueError("must be positive")
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
 
@@ -301,16 +301,16 @@ class LLMConfig(BaseSettings):
 
     @field_validator("max_tokens")
     @classmethod
-    def max_tokens_positive(cls, v: int) -> int:
+    def max_tokens_positive(cls, v: int, info: FieldValidationInfo) -> int:
         if v <= 0:
-            raise ValueError("must be positive")
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
     @field_validator("timeout")
     @classmethod
-    def timeout_positive(cls, v: float) -> float:
+    def timeout_positive(cls, v: float, info: FieldValidationInfo) -> float:
         if v <= 0:
-            raise ValueError("must be positive")
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
 


### PR DESCRIPTION
## Summary

Improves Pydantic validators in `config.py` to include the failing field name and actual value in error messages, making configuration issues easier to debug.

**Before:**
```
ValueError: must be positive
```

**After:**
```
ValueError: batch_size must be positive, got -1
```

## Changes

- Added `FieldValidationInfo` import from pydantic
- Updated 7 validator methods across 6 config classes to use `info: FieldValidationInfo` parameter and include `{info.field_name}` and value in error strings:
  - `EmbeddingConfig.must_be_positive` (batch_size, max_concurrent_batches) — line 31
  - `SearchConfig.must_be_positive` (default_top_k, bm25_candidates, dense_candidates, rrf_k) — line 64
  - `IndexingConfig.must_be_non_negative` (max_chunk_tokens, min_chunk_tokens, chunk_overlap_tokens, paragraph_split_threshold) — line 125
  - `DecayConfig.must_be_positive` (half_life_days) — line 146
  - `RerankConfig.must_be_positive` (top_k) — line 190
  - `LLMConfig.max_tokens_positive` (max_tokens) — line 306
  - `LLMConfig.timeout_positive` (timeout) — line 313

## Testing

Verified that all updated validators produce the expected error messages with field name and value included.

Closes #46