### PR TITLE
fix: single-source version via importlib.metadata and add Python 3.13 classifier

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/packages/memtomem/src/memtomem/__init__.py
+++ b/packages/memtomem/src/memtomem/__init__.py
@@ -1,3 +1,5 @@
 """memtomem: Markdown-first memory infrastructure for AI agents."""
 
-__version__ = "0.1.8"
+from importlib.metadata import version as _pkg_version
+
+__version__ = _pkg_version("memtomem")

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -13,6 +13,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from memtomem import __version__
 from memtomem.web.routes import (
     chunks,
     context_agents,
@@ -46,7 +47,7 @@ def create_app(lifespan=None) -> FastAPI:
     app = FastAPI(
         title="memtomem Web UI",
         description="Web UI for memtomem memory infrastructure",
-        version="0.1.0",
+        version=__version__,
         lifespan=lifespan,
         docs_url="/api/docs",
         redoc_url="/api/redoc",


### PR DESCRIPTION
## Summary

- Replace hardcoded `__version__` in `__init__.py` (stuck at 0.1.8) with `importlib.metadata.version()` so `pyproject.toml` is the single source of truth
- Wire `web/app.py` FastAPI spec version to `__version__` (was stuck at 0.1.0 since initial release)
- Add missing `Programming Language :: Python :: 3.13` classifier

## Test plan

- [x] `uv run python -c "import memtomem; print(memtomem.__version__)"` → 0.1.9
- [x] `uv run ruff check` passes
- [x] 1367 tests pass

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)