### PR TITLE
fix: add logging to silent except-pass blocks in sqlite_backend and status_config

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,8 @@ from memtomem.server.helpers import _set_config_key
 
 if TYPE_CHECKING:
     from memtomem.server.context import AppContext
+
+logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
@@ -88,7 +91,7 @@ async def mem_status(
                 f"Source files:  {stats['total_sources']} ({orphaned} orphaned — run mem_cleanup_orphans)"
             )
     except Exception:
-        pass
+        logger.debug("Orphan detection failed", exc_info=True)
 
     mismatch = getattr(app.storage, "embedding_mismatch", None)
     if mismatch is not None:

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -146,14 +146,14 @@ class SqliteBackend(
             try:
                 rconn.close()
             except Exception:
-                pass
+                logger.debug("Failed to close read pool connection", exc_info=True)
         if hasattr(self, "_read_pool"):
             self._read_pool.clear()
         if self._db:
             try:
                 self._db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             except Exception:
-                pass
+                logger.debug("WAL checkpoint failed during close", exc_info=True)
             self._db.close()
             self._db = None
 
@@ -615,7 +615,11 @@ class SqliteBackend(
             try:
                 result[row[0]] = deserialize_f32(row[1])
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to deserialize embedding for chunk %s",
+                    row[0],
+                    exc_info=True,
+                )
         return result
 
     # ---- search --------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace 4 silent `except Exception: pass` blocks with appropriate logging
- `logger.debug` for best-effort cleanup (connection close, WAL checkpoint, orphan detection)
- `logger.warning` for embedding deserialization failures (silent data loss)

## Test plan

- [x] `uv run ruff check` passes
- [x] 1367 tests pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)