### PR TITLE
fix: remove redundant imports, dead code, and add event type validation

### DIFF
--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -198,8 +198,9 @@ def activity() -> None:
 @click.option(
     "--type",
     "event_type",
+    type=click.Choice(["tool_call", "subagent_start", "subagent_stop", "decision", "error"]),
     default="tool_call",
-    help="Event type (tool_call, subagent_start, subagent_stop, decision, error)",
+    help="Event type",
 )
 @click.option("--content", "-c", required=True, help="Event description")
 @click.option("--meta", default=None, help="JSON metadata")

--- a/packages/memtomem/src/memtomem/server/tools/ask.py
+++ b/packages/memtomem/src/memtomem/server/tools/ask.py
@@ -115,8 +115,6 @@ async def mem_ask(
 
     # Fire webhook
     if app.webhook_manager:
-        import asyncio
-
         task = asyncio.create_task(
             app.webhook_manager.fire(
                 "ask",

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -130,8 +130,6 @@ async def _mem_add_core(
 
     # Fire webhook
     if app.webhook_manager:
-        import asyncio
-
         task = asyncio.create_task(
             app.webhook_manager.fire("add", {"file": str(target), "chunks_indexed": 1})
         )

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -132,8 +132,6 @@ async def mem_search(
 
     # Fire webhook
     if app.webhook_manager:
-        import asyncio
-
         task = asyncio.create_task(
             app.webhook_manager.fire("search", {"query": query, "result_count": len(results)})
         )

--- a/packages/memtomem/src/memtomem/tools/memory_writer.py
+++ b/packages/memtomem/src/memtomem/tools/memory_writer.py
@@ -31,8 +31,6 @@ def append_entry(
         block = f"\n{heading}\n\n> created: {now}{tag_str}\n\n{stripped}\n"
 
     with open(file_path, "a", encoding="utf-8") as f:
-        if file_path.stat().st_size == 0 if file_path.exists() else True:
-            pass  # append normally
         f.write(block)
 
 


### PR DESCRIPTION
## Summary

- Remove redundant inner `import asyncio` in 3 webhook fire blocks (search.py, ask.py, memory_crud.py) — module-level import already in scope (#68)
- Remove dead `if/pass` block in `memory_writer.py` that evaluated a condition but discarded the result (#70)
- Add `click.Choice` validation to `session activity log --type` so invalid event types are rejected at parse time (#72)

## Test plan

- [x] `uv run ruff check` passes
- [x] 1367 tests pass

Closes #68, closes #70, closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)