### PR TITLE
fix: remove exception class names from web error responses

### DIFF
--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -82,7 +82,7 @@ def create_app(lifespan=None) -> FastAPI:
 
     @app.exception_handler(KeyError)
     async def key_error_handler(request: Request, exc: KeyError) -> JSONResponse:
-        return JSONResponse(status_code=404, content={"detail": f"Not found: {exc}"})
+        return JSONResponse(status_code=404, content={"detail": "Not found"})
 
     @app.exception_handler(Exception)
     async def generic_error_handler(request: Request, exc: Exception) -> JSONResponse:

--- a/packages/memtomem/src/memtomem/web/routes/search.py
+++ b/packages/memtomem/src/memtomem/web/routes/search.py
@@ -40,9 +40,7 @@ async def search(
         )
     except Exception as exc:
         logger.error("Search failed: %s", exc, exc_info=True)
-        raise HTTPException(
-            status_code=500, detail=f"Search failed ({type(exc).__name__})"
-        ) from exc
+        raise HTTPException(status_code=500, detail="Search failed") from exc
     out = [to_result_out(r) for r in results]
     return SearchResponse(
         results=out,

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -108,7 +108,7 @@ async def embed_text(request: Request, embedder=Depends(get_embedder)):
         vectors = await embedder.embed_texts([text])
         return {"embedding": vectors[0]}
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Embedding failed: {type(exc).__name__}")
+        raise HTTPException(status_code=500, detail="Embedding failed") from exc
 
 
 def _build_config_response(cfg) -> ConfigResponse:


### PR DESCRIPTION
## Summary

- Remove `type(exc).__name__` from HTTP 500 error details in `search.py` and `system.py`
- Remove `KeyError` value from HTTP 404 detail in `app.py`
- Exceptions are already logged server-side; exposing class names leaks implementation details

## Test plan

- [x] `uv run ruff check` passes
- [x] 1367 tests pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)