### PR TITLE
fix: sanitize exception class names in /health endpoint

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -72,14 +72,14 @@ async def health(storage=Depends(get_storage), embedder=Depends(get_embedder)):
     try:
         await storage.get_stats()
         checks["storage"] = "ok"
-    except Exception as exc:
-        checks["storage"] = type(exc).__name__
+    except Exception:
+        checks["storage"] = "error"
 
     try:
         await embedder.embed_texts(["health check"])
         checks["embedding"] = "ok"
-    except Exception as exc:
-        checks["embedding"] = type(exc).__name__
+    except Exception:
+        checks["embedding"] = "error"
 
     all_ok = all(v == "ok" for v in checks.values())
     if all_ok:

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -223,7 +223,9 @@ class TestHealth:
         assert resp.status_code == 503
         data = resp.json()
         assert data["status"] == "degraded"
-        assert data["checks"]["storage"] == "RuntimeError"
+        assert data["checks"]["storage"] == "error"
+        # Exception class name must not leak to the response (see #75).
+        assert "RuntimeError" not in resp.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Follow-up to #80: the `/health` endpoint was missed from issue #75's listed scope but shares the identical info-disclosure pattern (`type(exc).__name__` leaked in response JSON for `checks.storage` / `checks.embedding`).
- Replace with generic `"error"` string and preserve the response schema so monitoring tools keying off the existing keys continue to work.
- Existing test previously documented the leak (asserting `== "RuntimeError"`); now updated to assert `== "error"` and adds a negative check that no exception class name appears anywhere in the response body.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` passes
- [x] `uv run ruff format --check packages/memtomem/src` passes
- [x] `uv run pytest packages/memtomem/tests/test_web_routes.py` passes (33/33)
- [ ] CI green

Refs #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)