### PR TITLE
fix: log dropped shutdown sentinel in watcher when queue is full

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -94,7 +94,7 @@ class FileWatcher:
             try:
                 self._queue.put_nowait(_STOP_SENTINEL)
             except asyncio.QueueFull:
-                pass
+                logger.warning("File watcher queue full; could not signal graceful shutdown")
             try:
                 await asyncio.wait_for(self._task, timeout=5.0)
             except (TimeoutError, asyncio.CancelledError):


### PR DESCRIPTION
## Summary

- Replace silent `pass` with `logger.warning` when the watcher queue rejects the shutdown sentinel in `AsyncFileWatcher.stop()`.
- Message mirrors the sibling `asyncio.QueueFull` handler at `watcher.py:42-43` (also `logger.warning`).
- Operators diagnosing a mysterious 5-second graceful-shutdown hang now see the cause at the default log level.

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` passes
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama" -k watcher` (2 passed)
- [ ] CI green

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)