### PR TITLE
fixed watcher queue full logging

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -94,7 +94,7 @@ class FileWatcher:
             try:
                 self._queue.put_nowait(_STOP_SENTINEL)
             except asyncio.QueueFull:
-                pass
+                logger.warning("File watcher queue full; could not signal graceful shutdown")
             try:
                 await asyncio.wait_for(self._task, timeout=5.0)
             except (TimeoutError, asyncio.CancelledError):


### PR DESCRIPTION
## Description
Fix file watcher shutdown logging so a dropped shutdown sentinel is no longer silent.

## Changes made
- updated ` watcher.py `
- When ` FileWatcher.py ` fails to enqueue ` _STOP_SENTINEL ` because  the queue is full, it now logs a warning as "File watcher queue full; could not signal graceful shutdown"

Closes #83 
