### PR TITLE
chore: manually add K-Tanish CLA signature (unblocks #85)

### DIFF
--- a/signatures/v1/cla.json
+++ b/signatures/v1/cla.json
@@ -23,6 +23,14 @@
       "created_at": "2026-04-14T04:07:16Z",
       "repoId": 1194290694,
       "pullRequestNo": 45
+    },
+    {
+      "name": "K-Tanish",
+      "id": 182213180,
+      "comment_id": 4244637555,
+      "created_at": "2026-04-14T14:22:24Z",
+      "repoId": 1194290694,
+      "pullRequestNo": 85
     }
   ]
 }


### PR DESCRIPTION
## Summary

- @K-Tanish signed the CLA on PR #85 (comment 4244637555), and the CLA Assistant bot confirmed "All contributors have signed the CLA ✅" in the PR thread.
- However, the bot failed to persist the signature to `signatures/v1/cla.json`. Its `GITHUB_TOKEN` cannot push directly to `main` because branch protection requires a PR + 3 status checks (`lint`, `test`, `notebooks`).
- Workflow run logs:
  ```
  ##[error]Could not update the JSON file: Could not update file:
  Changes must be made through a pull request.
  3 of 3 required status checks are expected.
  ```
- Result: PR #85's `CLAAssistant` status check is stuck at `failure` even though the signing itself was valid.

This PR manually adds the K-Tanish entry matching the exact schema used by the bot for prior contributors (`name`, `id`, `comment_id`, `created_at`, `repoId`, `pullRequestNo`). Once merged, posting `recheck` on PR #85 will re-run the CLA workflow and the status check will go green.

## Follow-up

This will recur for every external contributor until the CLA bot can bypass branch protection. I'll open a separate issue recommending that `github-actions[bot]` be added to branch protection bypass allowances.

## Test plan

- [ ] `lint` / `test` / `notebooks` checks pass (JSON-only change, no code paths touched)
- [ ] After merge, `recheck` comment on #85 flips `CLAAssistant` to success

🤖 Generated with [Claude Code](https://claude.com/claude-code)