### PR TITLE
ci(cla): wire PERSONAL_ACCESS_TOKEN so CLAAssistant can commit signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,12 @@ jobs:
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT from an admin account. The built-in GITHUB_TOKEN cannot push
+          # to `main` because branch protection requires status checks + a PR
+          # review, and GITHUB_TOKEN is not an admin actor. `enforce_admins`
+          # is false on this repo, so an admin PAT bypasses protection and
+          # lets the bot commit the signature JSON directly. See #87.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'signatures/v1/cla.json'
           path-to-document: 'https://github.com/memtomem/memtomem/blob/main/CLA.md'


### PR DESCRIPTION
## Summary

Wires an admin PAT into the CLA Assistant workflow so it can commit signature updates to `signatures/v1/cla.json` on `main`. Ports the same change already merged on `memtomem-stm` (its PR #90).

## Problem

`main` branch protection requires PRs + 3 status checks (`lint`/`test`/`notebooks`). The default `GITHUB_TOKEN` is not an admin actor, so when an external contributor signs the CLA the bot fails to persist the signature:

```
##[error]Could not update the JSON file: Could not update file:
Changes must be made through a pull request.
3 of 3 required status checks are expected.
```

Contributors see "All contributors have signed ✅" in the bot's PR comment, but `CLAAssistant` stays `failure`, blocking merge. Most recent incident: #85 (K-Tanish), resolved via manual `cla.json` PR #86.

## Change

Add `PERSONAL_ACCESS_TOKEN` to the workflow's `env`. The `contributor-assistant/github-action` picks this up and uses it for git pushes. `enforce_admins` is `false` on this repo, so an admin PAT bypasses the protection rules.

The `PERSONAL_ACCESS_TOKEN` secret is already set on this repo.

## Scope

- Workflow only; no code changes.
- Does not touch `allowlist`, paths, or bot comment text.
- #87 tracks the larger "should we migrate to Rulesets / GitHub App" question. This PR is the short-term unblock.

## Test plan

- [ ] CI green on this PR (`lint`/`test`/`notebooks`/`typecheck`)
- [ ] After merge, e2e smoke: an external-contributor-style signing comment triggers a `cla.json` commit from the bot (can be validated next time an external PR comes in, or via a throwaway test PR from a non-admin account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)