### PR TITLE
refactor: widen CtxType to Optional, drop 82 type: ignore (closes #66)

### DIFF
--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -40,8 +40,11 @@ class AppContext:
     _config_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 
-CtxType = Context[ServerSession, AppContext]
+CtxType = Context[ServerSession, AppContext] | None
 
 
 def _get_app(ctx: CtxType) -> AppContext:
+    # FastMCP always injects the context at call time; the None default on
+    # tool signatures exists only so the param isn't positional-required.
+    assert ctx is not None, "MCP framework must inject ctx at call time"
     return ctx.request_context.lifespan_context

--- a/packages/memtomem/src/memtomem/server/resources.py
+++ b/packages/memtomem/src/memtomem/server/resources.py
@@ -10,7 +10,7 @@ from memtomem.server.context import CtxType, _get_app
 
 
 @mcp.resource("memtomem://sources")
-async def sources_resource(ctx: CtxType = None) -> str:  # type: ignore[assignment]
+async def sources_resource(ctx: CtxType = None) -> str:
     """List all indexed source files with chunk counts."""
     app = _get_app(ctx)
     rows = await app.storage.get_source_files_with_counts()
@@ -29,7 +29,7 @@ async def sources_resource(ctx: CtxType = None) -> str:  # type: ignore[assignme
 
 
 @mcp.resource("memtomem://namespaces")
-async def namespaces_resource(ctx: CtxType = None) -> str:  # type: ignore[assignment]
+async def namespaces_resource(ctx: CtxType = None) -> str:
     """List all namespaces and their chunk counts."""
     app = _get_app(ctx)
     ns_list = await app.storage.list_namespaces()
@@ -38,7 +38,7 @@ async def namespaces_resource(ctx: CtxType = None) -> str:  # type: ignore[assig
 
 
 @mcp.resource("memtomem://tags")
-async def tags_resource(ctx: CtxType = None) -> str:  # type: ignore[assignment]
+async def tags_resource(ctx: CtxType = None) -> str:
     """List all tags and their usage counts."""
     app = _get_app(ctx)
     tag_counts = await app.storage.get_tag_counts()
@@ -47,7 +47,7 @@ async def tags_resource(ctx: CtxType = None) -> str:  # type: ignore[assignment]
 
 
 @mcp.resource("memtomem://stats")
-async def stats_resource(ctx: CtxType = None) -> str:  # type: ignore[assignment]
+async def stats_resource(ctx: CtxType = None) -> str:
     """Current index statistics."""
     app = _get_app(ctx)
     stats = await app.storage.get_stats()
@@ -55,7 +55,7 @@ async def stats_resource(ctx: CtxType = None) -> str:  # type: ignore[assignment
 
 
 @mcp.resource("memtomem://chunks/{chunk_id}")
-async def chunk_resource(chunk_id: str, ctx: CtxType = None) -> str:  # type: ignore[assignment]
+async def chunk_resource(chunk_id: str, ctx: CtxType = None) -> str:
     """Read a specific chunk by UUID."""
     app = _get_app(ctx)
     chunk = await app.storage.get_chunk(UUID(chunk_id))

--- a/packages/memtomem/src/memtomem/server/tools/ask.py
+++ b/packages/memtomem/src/memtomem/server/tools/ask.py
@@ -29,7 +29,7 @@ async def mem_ask(
     namespace: str | None = None,
     source_filter: str | None = None,
     tag_filter: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Ask a question and get an answer grounded in your memories.
 

--- a/packages/memtomem/src/memtomem/server/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/server/tools/auto_tag.py
@@ -16,7 +16,7 @@ async def mem_auto_tag(
     max_tags: int = 5,
     overwrite: bool = False,
     dry_run: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Extract and apply keyword-based tags to indexed memory chunks.
 

--- a/packages/memtomem/src/memtomem/server/tools/browse.py
+++ b/packages/memtomem/src/memtomem/server/tools/browse.py
@@ -15,7 +15,7 @@ from memtomem.server.formatters import _display_path
 async def mem_list(
     source_filter: str | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List all indexed source files with chunk counts and metadata.
 
@@ -67,7 +67,7 @@ async def mem_list(
 @tool_handler
 async def mem_read(
     chunk_id: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Read the full content and metadata of a specific chunk by its UUID.
 

--- a/packages/memtomem/src/memtomem/server/tools/conflict.py
+++ b/packages/memtomem/src/memtomem/server/tools/conflict.py
@@ -14,7 +14,7 @@ from memtomem.server.tool_registry import register
 async def mem_conflict_check(
     content: str,
     threshold: float = 0.75,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Check for potential contradictions with existing memories.
 

--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -20,7 +20,7 @@ async def mem_consolidate(
     source_filter: str | None = None,
     max_groups: int = 5,
     min_group_size: int = 3,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Find groups of related chunks that could be consolidated into summaries.
 
@@ -128,7 +128,7 @@ async def mem_consolidate_apply(
     group_id: int,
     summary: str,
     keep_originals: bool = True,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Apply a consolidation by creating a summary chunk for a group.
 

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -43,7 +43,7 @@ def _parse_include(include: str) -> set[str]:
 @register("context")
 async def mem_context_detect(
     include: str = "",
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Detect agent configuration files in the current project.
 
@@ -132,7 +132,7 @@ async def mem_context_generate(
     agent: str = "all",
     include: str = "",
     strict: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Generate agent configuration files from .memtomem/context.md.
 
@@ -250,7 +250,7 @@ async def mem_context_generate(
 @register("context")
 async def mem_context_diff(
     include: str = "",
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Show sync status between context.md and agent files.
 
@@ -350,7 +350,7 @@ async def mem_context_diff(
 async def mem_context_sync(
     include: str = "",
     strict: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Sync .memtomem/context.md to all detected agent files.
 

--- a/packages/memtomem/src/memtomem/server/tools/cross_ref.py
+++ b/packages/memtomem/src/memtomem/server/tools/cross_ref.py
@@ -17,7 +17,7 @@ async def mem_link(
     source_id: str,
     target_id: str,
     relation_type: str = "related",
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Create a bidirectional link between two chunks.
 
@@ -65,7 +65,7 @@ async def mem_link(
 async def mem_unlink(
     source_id: str,
     target_id: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Remove a link between two chunks.
 
@@ -92,7 +92,7 @@ async def mem_unlink(
 @register("relations")
 async def mem_related(
     chunk_id: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Find all chunks linked to the given chunk.
 

--- a/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
+++ b/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
@@ -18,7 +18,7 @@ async def mem_dedup_scan(
     threshold: float = 0.92,
     limit: int = 50,
     max_scan: int = 500,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Scan for duplicate chunk candidates (dry-run, no mutations).
 
@@ -62,7 +62,7 @@ async def mem_dedup_scan(
 async def mem_dedup_merge(
     keep_id: str,
     delete_ids: list[str],
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Merge duplicate chunks: keep keep_id, delete delete_ids.
 
@@ -92,7 +92,7 @@ async def mem_dedup_merge(
 async def mem_decay_scan(
     max_age_days: float = 90,
     source_filter: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Preview chunks that would be expired by TTL (dry-run, no deletions).
 
@@ -124,7 +124,7 @@ async def mem_decay_expire(
     max_age_days: float = 90,
     source_filter: str | None = None,
     dry_run: bool = True,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Delete chunks older than max_age_days from the index.
 
@@ -160,7 +160,7 @@ async def mem_decay_expire(
 @register("maintenance")
 async def mem_cleanup_orphans(
     dry_run: bool = True,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Find and remove orphaned chunks whose source files no longer exist.
 

--- a/packages/memtomem/src/memtomem/server/tools/entity.py
+++ b/packages/memtomem/src/memtomem/server/tools/entity.py
@@ -21,7 +21,7 @@ async def mem_entity_scan(
     entity_types: list[str] | None = None,
     overwrite: bool = False,
     dry_run: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Scan indexed chunks and extract structured entities (people, dates, decisions, etc.).
 
@@ -120,7 +120,7 @@ async def mem_entity_search(
     value: str | None = None,
     namespace: str | None = None,
     limit: int = 20,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Search for chunks containing specific entities.
 

--- a/packages/memtomem/src/memtomem/server/tools/evaluation.py
+++ b/packages/memtomem/src/memtomem/server/tools/evaluation.py
@@ -14,7 +14,7 @@ from memtomem.server.tool_registry import register
 async def mem_eval(
     since: str | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Evaluate memory system health and effectiveness.
 

--- a/packages/memtomem/src/memtomem/server/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/server/tools/export_import.py
@@ -20,7 +20,7 @@ async def mem_export(
     tag_filter: str | None = None,
     since: str | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Export indexed memory chunks to a JSON bundle file.
 
@@ -65,7 +65,7 @@ async def mem_export(
 async def mem_import(
     input_file: str,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Import memory chunks from a JSON bundle file (produced by mem_export).
 

--- a/packages/memtomem/src/memtomem/server/tools/importance.py
+++ b/packages/memtomem/src/memtomem/server/tools/importance.py
@@ -13,7 +13,7 @@ from memtomem.server.tool_registry import register
 @register("advanced")
 async def mem_importance_scan(
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Compute and update importance scores for all chunks.
 

--- a/packages/memtomem/src/memtomem/server/tools/importers.py
+++ b/packages/memtomem/src/memtomem/server/tools/importers.py
@@ -17,7 +17,7 @@ async def mem_import_notion(
     path: str,
     namespace: str | None = None,
     tags: list[str] | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Import a Notion export (ZIP or directory) into memtomem.
 
@@ -91,7 +91,7 @@ async def mem_import_obsidian(
     vault_path: str,
     namespace: str | None = None,
     tags: list[str] | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Import an Obsidian vault into memtomem.
 

--- a/packages/memtomem/src/memtomem/server/tools/indexing.py
+++ b/packages/memtomem/src/memtomem/server/tools/indexing.py
@@ -18,7 +18,7 @@ async def mem_index(
     force: bool = False,
     namespace: str | None = None,
     auto_tag: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Index or re-index markdown files for hybrid search.
 

--- a/packages/memtomem/src/memtomem/server/tools/ingest.py
+++ b/packages/memtomem/src/memtomem/server/tools/ingest.py
@@ -17,7 +17,7 @@ async def mem_ingest(
     source: str,
     source_type: str = "claude",
     dry_run: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Ingest external agent memories (Claude, Gemini, Codex) into memtomem.
 

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -147,7 +147,7 @@ async def mem_add(
     file: str | None = None,
     namespace: str | None = None,
     template: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Add a new memory entry to a markdown file and immediately index it.
 
@@ -186,7 +186,7 @@ async def mem_add(
 async def mem_edit(
     chunk_id: str,
     new_content: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Edit an existing memory entry in its source markdown file.
 
@@ -244,7 +244,7 @@ async def mem_delete(
     chunk_id: str | None = None,
     source_file: str | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Delete memory entries from the index (and optionally from the source file).
 
@@ -318,7 +318,7 @@ async def mem_batch_add(
     entries: list[dict],
     namespace: str | None = None,
     file: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Add multiple memory entries in one call (KV batch).
 

--- a/packages/memtomem/src/memtomem/server/tools/meta.py
+++ b/packages/memtomem/src/memtomem/server/tools/meta.py
@@ -29,7 +29,7 @@ _ALIASES: dict[str, str] = {
 async def mem_do(
     action: str,
     params: dict | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Execute a memtomem action by name.
 

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -15,7 +15,7 @@ async def mem_agent_register(
     agent_id: str,
     description: str | None = None,
     color: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Register an agent in the multi-agent memory system.
 
@@ -58,7 +58,7 @@ async def mem_agent_search(
     agent_id: str | None = None,
     include_shared: bool = True,
     top_k: int = 10,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Search memories with multi-agent scope awareness.
 
@@ -105,7 +105,7 @@ async def mem_agent_search(
 async def mem_agent_share(
     chunk_id: str,
     target: str = "shared",
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Share a memory chunk with another agent or the shared namespace.
 

--- a/packages/memtomem/src/memtomem/server/tools/namespace.py
+++ b/packages/memtomem/src/memtomem/server/tools/namespace.py
@@ -14,7 +14,7 @@ from memtomem.server.tool_registry import register
 @tool_handler
 @register("namespace")
 async def mem_ns_list(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List all namespaces and their chunk counts."""
     app = _get_app(ctx)
@@ -35,7 +35,7 @@ async def mem_ns_list(
 @register("namespace")
 async def mem_ns_delete(
     namespace: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Delete all chunks in a namespace from the index.
 
@@ -56,7 +56,7 @@ async def mem_ns_delete(
 @register("namespace")
 async def mem_ns_set(
     namespace: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Set the session-default namespace. Subsequent search/add/recall use this unless overridden.
 
@@ -76,7 +76,7 @@ async def mem_ns_set(
 @tool_handler
 @register("namespace")
 async def mem_ns_get(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Get the current session namespace."""
     app = _get_app(ctx)
@@ -92,7 +92,7 @@ async def mem_ns_get(
 async def mem_ns_rename(
     old: str,
     new: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Rename a namespace (SQL UPDATE, no re-indexing needed).
 
@@ -113,7 +113,7 @@ async def mem_ns_update(
     namespace: str,
     description: str | None = None,
     color: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Update namespace metadata (description and/or color).
 
@@ -134,7 +134,7 @@ async def mem_ns_assign(
     namespace: str,
     source_filter: str | None = None,
     old_namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Assign existing chunks to a namespace without re-indexing.
 

--- a/packages/memtomem/src/memtomem/server/tools/policy.py
+++ b/packages/memtomem/src/memtomem/server/tools/policy.py
@@ -23,7 +23,7 @@ async def mem_policy_add(
     policy_type: str,
     config: str = "{}",
     namespace_filter: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Create a memory lifecycle policy.
 
@@ -120,7 +120,7 @@ async def mem_policy_add(
 @tool_handler
 @register("policy")
 async def mem_policy_list(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List all memory lifecycle policies."""
     app = _get_app(ctx)
@@ -145,7 +145,7 @@ async def mem_policy_list(
 @register("policy")
 async def mem_policy_delete(
     name: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Delete a memory lifecycle policy.
 
@@ -165,7 +165,7 @@ async def mem_policy_delete(
 async def mem_policy_run(
     name: str | None = None,
     dry_run: bool = True,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Run memory lifecycle policies.
 

--- a/packages/memtomem/src/memtomem/server/tools/procedure.py
+++ b/packages/memtomem/src/memtomem/server/tools/procedure.py
@@ -17,7 +17,7 @@ async def mem_procedure_save(
     trigger: str | None = None,
     tags: list[str] | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Save a reusable procedure (workflow/pattern) to memory.
 
@@ -56,7 +56,7 @@ async def mem_procedure_save(
 @tool_handler
 @register("procedures")
 async def mem_procedure_list(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List all saved procedures."""
     app = _get_app(ctx)

--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -17,7 +17,7 @@ async def mem_recall(
     source_filter: str | None = None,
     namespace: str | None = None,
     limit: int = 20,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Recall memories created within a date range.
 

--- a/packages/memtomem/src/memtomem/server/tools/reflection.py
+++ b/packages/memtomem/src/memtomem/server/tools/reflection.py
@@ -19,7 +19,7 @@ async def mem_reflect(
     namespace: str | None = None,
     since: str | None = None,
     limit: int = 20,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Analyze recent memory activity and surface patterns for reflection.
 
@@ -114,7 +114,7 @@ async def mem_reflect_save(
     insight: str,
     related_chunks: list[str] | None = None,
     tags: list[str] | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Save a reflection insight derived from memory analysis.
 

--- a/packages/memtomem/src/memtomem/server/tools/scratch.py
+++ b/packages/memtomem/src/memtomem/server/tools/scratch.py
@@ -15,7 +15,7 @@ async def mem_scratch_set(
     key: str,
     value: str,
     ttl_minutes: int | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Store a value in working memory (scratchpad).
 
@@ -55,7 +55,7 @@ async def mem_scratch_set(
 @register("scratch")
 async def mem_scratch_get(
     key: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Retrieve a value from working memory, or list all entries if no key given.
 
@@ -96,7 +96,7 @@ async def mem_scratch_promote(
     title: str | None = None,
     tags: list[str] | None = None,
     file: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Promote a working memory entry to long-term memory.
 

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -38,7 +38,7 @@ async def mem_search(
     context_window: int = 0,
     verbose: bool = False,
     output_format: Literal["compact", "verbose", "structured"] = "compact",
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Search across indexed memory files using hybrid BM25 + semantic search.
 
@@ -146,7 +146,7 @@ async def mem_search(
 async def mem_expand(
     chunk_id: str,
     window: int = 2,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Expand a chunk with adjacent context from the same source file.
 
@@ -218,7 +218,7 @@ async def mem_expand(
 @register("search")
 async def mem_increment_access(
     chunk_ids: list[str],
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Increment access_count for the given chunks (drives access-frequency boost in search ranking).
 

--- a/packages/memtomem/src/memtomem/server/tools/search_history.py
+++ b/packages/memtomem/src/memtomem/server/tools/search_history.py
@@ -14,7 +14,7 @@ from memtomem.server.tool_registry import register
 async def mem_search_history(
     limit: int = 20,
     since: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List past search queries with result counts.
 
@@ -42,7 +42,7 @@ async def mem_search_history(
 async def mem_search_suggest(
     prefix: str,
     limit: int = 5,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Autocomplete search queries from history.
 

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -17,7 +17,7 @@ async def mem_session_start(
     agent_id: str = "default",
     title: str | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Start a new episodic memory session.
 
@@ -51,7 +51,7 @@ async def mem_session_start(
 @register("sessions")
 async def mem_session_end(
     summary: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """End the current episodic memory session.
 
@@ -100,7 +100,7 @@ async def mem_session_list(
     agent_id: str | None = None,
     since: str | None = None,
     limit: int = 10,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List recent episodic memory sessions.
 

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 @mcp.tool()
 @tool_handler
 async def mem_stats(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Return current memory index statistics: total chunks, sources, and storage backend.
 
@@ -46,7 +46,7 @@ async def mem_stats(
 @mcp.tool()
 @tool_handler
 async def mem_status(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Show indexing statistics and current configuration summary.
 
@@ -113,7 +113,7 @@ async def mem_config(
     key: str | None = None,
     value: str | None = None,
     persist: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """View or update memtomem configuration values.
 
@@ -225,7 +225,7 @@ def _revert_to_stored(app: AppContext) -> str:
 @register("advanced")
 async def mem_embedding_reset(
     mode: str = "status",
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Check or resolve embedding configuration mismatches between DB and current config.
 
@@ -282,7 +282,7 @@ async def mem_embedding_reset(
 @register("advanced")
 async def mem_reset(
     confirm: bool = False,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Delete ALL data (chunks, sessions, history, etc.) and reinitialize the DB.
 
@@ -310,7 +310,7 @@ async def mem_reset(
 @tool_handler
 @register("advanced")
 async def mem_version(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Return server version and supported capabilities for protocol negotiation.
 

--- a/packages/memtomem/src/memtomem/server/tools/tag_management.py
+++ b/packages/memtomem/src/memtomem/server/tools/tag_management.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @tool_handler
 @register("tags")
 async def mem_tag_list(
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """List all tags and their usage counts, ordered by frequency.
 
@@ -43,7 +43,7 @@ async def mem_tag_list(
 async def mem_tag_rename(
     old_tag: str,
     new_tag: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Rename a tag across all chunks that use it.
 
@@ -66,7 +66,7 @@ async def mem_tag_rename(
 @register("tags")
 async def mem_tag_delete(
     tag: str,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Remove a tag from all chunks that use it.
 

--- a/packages/memtomem/src/memtomem/server/tools/temporal.py
+++ b/packages/memtomem/src/memtomem/server/tools/temporal.py
@@ -23,7 +23,7 @@ async def mem_timeline(
     until: str | None = None,
     namespace: str | None = None,
     limit: int = 50,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Show how memories about a topic evolved over time.
 
@@ -97,7 +97,7 @@ async def mem_activity(
     since: str | None = None,
     until: str | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Show memory activity summary by day.
 

--- a/packages/memtomem/src/memtomem/server/tools/url_index.py
+++ b/packages/memtomem/src/memtomem/server/tools/url_index.py
@@ -17,7 +17,7 @@ async def mem_fetch(
     url: str,
     tags: list[str] | None = None,
     namespace: str | None = None,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Fetch a URL, convert to markdown, and index it for search.
 

--- a/packages/memtomem/src/memtomem/server/tools/watchdog.py
+++ b/packages/memtomem/src/memtomem/server/tools/watchdog.py
@@ -17,7 +17,7 @@ async def mem_watchdog(
     command: str = "status",
     check: str | None = None,
     hours: float = 24.0,
-    ctx: CtxType = None,  # type: ignore[assignment]
+    ctx: CtxType = None,
 ) -> str:
     """Health watchdog: view status, trends, or force a check run.
 


### PR DESCRIPTION
## Summary

- Every MCP tool / resource declared `ctx: CtxType = None,  # type: ignore[assignment]` because the alias was non-Optional while FastMCP requires a `None` default (the framework injects the real context at call time).
- Widened `CtxType` to `Context[ServerSession, AppContext] | None` and narrowed it back inside `_get_app` with a runtime `assert`.
- Dropped all 82 `# type: ignore[assignment]` suppressions across 33 files without touching call sites — the assert documents the framework guarantee and gives mypy what it needs to resolve `.request_context` on the narrowed type.

## Why this over the issue's Option A/B/C

The issue proposed a sentinel default, a Protocol overload, or an Optional alias. Widening + a single narrowing assert at the one resolver (`_get_app`) is the lightest-weight version of Option A: no call site changes, no runtime cost beyond an `assert`, and the rationale for the assert is documented inline.

## Out of scope

The 4 remaining `# type: ignore[assignment]` comments in `context/settings.py` are unrelated dict-casting suppressions and are left alone.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1367 passed
- [x] `uv run ruff check / format --check` — clean
- [x] `uv run mypy packages/memtomem/src` — 46 errors, same as baseline (pre-existing, unrelated)
- [x] `grep -rn "type: ignore\[assignment\]" packages/memtomem/src/memtomem/server` — 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)