### PR TITLE
fix: log swallowed query_history error in get_knowledge_gaps (follow-up #67)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/mixins/analytics.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/analytics.py
@@ -132,6 +132,7 @@ class AnalyticsMixin:
             ).fetchall()
             return [{"query": r[0], "count": r[1]} for r in rows]
         except Exception:
+            logger.debug("query_history query failed (table may not exist yet)", exc_info=True)
             return []
 
     async def get_most_connected(self, limit: int = 5) -> list[dict]:


### PR DESCRIPTION
## Summary

- Add `logger.debug(..., exc_info=True)` to the broad `except Exception` in `AnalyticsMixin.get_knowledge_gaps`.
- Keep `return []` so callers (`server/tools/reflection.py`) continue to see the empty-list sentinel on DB failure.

Missed instance of the #67 pattern. #67 fixed `sqlite_backend.py` and `status_config.py`; this one lives in `storage/mixins/analytics.py` and survived the original sweep.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_analytics.py -q` (16 passed)
- [x] `uv run ruff check` + `ruff format --check` on the edited file

🤖 Generated with [Claude Code](https://claude.com/claude-code)