### PR TITLE
indexing(watcher): extract _WATCHER_QUEUE_MAXSIZE constant

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -19,6 +19,12 @@ logger = logging.getLogger(__name__)
 
 _STOP_SENTINEL = Path("/dev/null/__stop__")
 
+# Max pending file-change events buffered between the watchdog thread and the
+# async processor. When this fills (indexer is slower than the change rate),
+# new events — including the shutdown sentinel — are dropped and a warning
+# is logged. Raise this if you watch a very large tree with a slow indexer.
+_WATCHER_QUEUE_MAXSIZE = 1000
+
 
 class _MarkdownEventHandler(FileSystemEventHandler):
     """Watchdog event handler that enqueues changed .md files."""
@@ -71,7 +77,7 @@ class FileWatcher:
         self._config = config
         self._debounce_s = debounce_ms / 1000.0
         self._observer: Observer | None = None
-        self._queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=1000)
+        self._queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=_WATCHER_QUEUE_MAXSIZE)
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:


### PR DESCRIPTION
## Summary

Addresses #95 Step 1. Extract the hardcoded `asyncio.Queue(maxsize=1000)` in `FileWatcher` into a module-level constant so the size is discoverable and documented.

No config change, no behavior change — this is purely the "Step 1 — required" half of the issue. Step 2 (promoting to `IndexingConfig.watcher_queue_maxsize`) is intentionally left for a follow-up PR.

## Changes

- `packages/memtomem/src/memtomem/indexing/watcher.py`
  - Introduce `_WATCHER_QUEUE_MAXSIZE = 1000` with a comment explaining when an operator would want to raise it
  - Reference the constant in the `asyncio.Queue(maxsize=...)` call

## Test plan

- [x] `uv run ruff check` — clean
- [x] `uv run ruff format --check` — clean
- [x] `uv run pytest -m "not ollama"` — 1367 passed, 46 deselected (no test changes since there's no behavior change)

Fixes #95