### PR TITLE
fix(watcher): replace asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -75,7 +75,7 @@ class FileWatcher:
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         handler = _MarkdownEventHandler(self._queue, loop, self._config.supported_extensions)
         self._observer = Observer()
 


### PR DESCRIPTION
## Summary

`asyncio.get_event_loop()` is legacy and emits `DeprecationWarning` in Python 3.14+. Since this is called inside an `async def`, `get_running_loop()` is the correct modern API.

## Changes

- `packages/memtomem/src/memtomem/indexing/watcher.py:78`: `asyncio.get_event_loop()` → `asyncio.get_running_loop()`

## Why

- `get_event_loop()` semantics in a running-loop context are already discouraged in Python 3.12+
- `get_running_loop()` is the documented replacement when you know a loop is running
- Only call site in the whole tree

Fixes #99