### PR TITLE
test: remove unused chunk_factory fixture in conftest.py

### DIFF
--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -41,12 +41,6 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture
-def chunk_factory():
-    """Fixture that returns the make_chunk factory function."""
-    return make_chunk
-
-
-@pytest.fixture
 async def components(tmp_path):
     """Create components with a temporary DB for isolated testing."""
     import json


### PR DESCRIPTION
## Summary

The `chunk_factory` fixture at `packages/memtomem/tests/conftest.py:43-46` was defined but no test consumed it. A full-tree grep (`chunk_factory`) finds only the definition site; tests call `make_chunk()` directly.

## Changes

- Removed 6 lines (decorator + function + docstring + blank lines)

## Scope

One file, no behavior change. Just cleanup of dead weight.

Fixes #98