### PR TITLE
chore: add 'Typing :: Typed' classifier to pyproject (closes #97)

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Add the `"Typing :: Typed"` PyPI classifier to `packages/memtomem/pyproject.toml` so the already-shipped `py.typed` marker is discoverable from the PyPI page and by type-aware tooling.

Closes #97.

## Test plan

- [x] `uv build packages/memtomem` smoke-build (optional; classifiers are metadata-only and have no runtime effect)
- [x] Diff is one line inside the existing sorted-ish `classifiers` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)