### PR TITLE
build: add 'Typing :: Typed' classifier to match existing py.typed marker

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

`packages/memtomem/src/memtomem/py.typed` exists (PEP 561 inline-types marker), but `packages/memtomem/pyproject.toml` doesn't advertise it via the corresponding PyPI classifier.

## Changes

Added `"Typing :: Typed"` to the classifiers list.

## Why

The classifier is the explicit PyPI signal that this package ships inline type hints. Without it, type-aware tooling and downstream readers of the PyPI page may not realize `py.typed` is present.

Fixes #97