### PR TITLE
chore(tests): remove unused chunk_factory fixture (closes #98)

### DIFF
--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -15,9 +15,6 @@ from memtomem.config import Mem2MemConfig
 from memtomem.server.component_factory import Components, create_components, close_components
 
 
-from helpers import make_chunk  # noqa: E402 — re-export for fixture below
-
-
 def _ollama_available() -> bool:
     """Check if Ollama is reachable at localhost:11434."""
     try:
@@ -38,12 +35,6 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "ollama" in item.keywords:
             item.add_marker(skip)
-
-
-@pytest.fixture
-def chunk_factory():
-    """Fixture that returns the make_chunk factory function."""
-    return make_chunk
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Delete the `chunk_factory` pytest fixture in `packages/memtomem/tests/conftest.py` and its dedicated `make_chunk` import. No test consumes the fixture — tests call `make_chunk` from `helpers.py` directly.

Closes #98.

## Test plan

- [x] Full-tree grep for `chunk_factory` finds only the (now-deleted) definition site.
- [x] `uv run pytest packages/memtomem/tests/conftest.py --collect-only` still collects without error.
- [x] No change to any test file.

## Note on format

Running `ruff format` on this file locally also wants to normalize two unrelated stretches of code (a blank line after an inline `import` and a multi-line tuple rewrite in the `components` fixture). Those are pre-existing format drift and are **not** included here, because (a) CI's ruff check scopes to `packages/memtomem/src` only, so tests aren't gated on format, and (b) bundling them would violate one-change-per-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)