### PR TITLE
fix(watcher): use asyncio.get_running_loop() in async start() (closes #99)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -75,7 +75,7 @@ class FileWatcher:
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         handler = _MarkdownEventHandler(self._queue, loop, self._config.supported_extensions)
         self._observer = Observer()
 


### PR DESCRIPTION
## Summary

Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in `Watcher.start()` — the enclosing function is `async def`, so a running loop is guaranteed.

Closes #99.

## Test plan

- [x] `uv run ruff check packages/memtomem/src/memtomem/indexing/watcher.py`
- [x] `uv run ruff format --check ...`
- [x] `uv run pytest -k watcher -q` → 2 passed, 1411 deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)