### PR TITLE
chore(tests): apply ruff format + lint fixes to packages/memtomem/tests (prep for CI scope expansion)

### DIFF
--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -71,6 +71,7 @@ async def components(tmp_path):
 
     # Monkey-patch to skip config.json loading
     import memtomem.config as _cfg
+
     _orig = _cfg.load_config_overrides
     _cfg.load_config_overrides = lambda c: None
     comp = await create_components(config)
@@ -78,8 +79,12 @@ async def components(tmp_path):
     yield comp
     await close_components(comp)
 
-    for key in ("MEMTOMEM_STORAGE__SQLITE_PATH", "MEMTOMEM_INDEXING__MEMORY_DIRS",
-                "MEMTOMEM_EMBEDDING__MODEL", "MEMTOMEM_EMBEDDING__DIMENSION"):
+    for key in (
+        "MEMTOMEM_STORAGE__SQLITE_PATH",
+        "MEMTOMEM_INDEXING__MEMORY_DIRS",
+        "MEMTOMEM_EMBEDDING__MODEL",
+        "MEMTOMEM_EMBEDDING__DIMENSION",
+    ):
         os.environ.pop(key, None)
 
 

--- a/packages/memtomem/tests/test_ask.py
+++ b/packages/memtomem/tests/test_ask.py
@@ -40,7 +40,11 @@ class TestMemAskFormatting:
 
         sources_cited = []
         for r in results:
-            heading = " > ".join(r.chunk.metadata.heading_hierarchy) if r.chunk.metadata.heading_hierarchy else ""
+            heading = (
+                " > ".join(r.chunk.metadata.heading_hierarchy)
+                if r.chunk.metadata.heading_hierarchy
+                else ""
+            )
             source = str(r.chunk.metadata.source_file).split("/")[-1]
             label = heading or source
             lines.append(f"### [{r.rank}] {label} (relevance: {r.score:.2f})")
@@ -63,10 +67,7 @@ class TestMemAskFormatting:
 
     def test_no_results_message(self):
         question = "something unknown"
-        output = (
-            f'No relevant memories found for: "{question}"\n\n'
-            "Try broader keywords"
-        )
+        output = f'No relevant memories found for: "{question}"\n\nTry broader keywords'
         assert "No relevant memories" in output
         assert "broader keywords" in output
 
@@ -92,7 +93,8 @@ class TestMemAskIntegration:
 
         # Search (simulating what mem_ask does)
         results, stats = await components.search_pipeline.search(
-            "deployment strategy", top_k=5,
+            "deployment strategy",
+            top_k=5,
         )
 
         assert len(results) >= 1
@@ -117,7 +119,9 @@ class TestMemAskIntegration:
         await components.index_engine.index_file(test_file)
 
         results, _ = await components.search_pipeline.search(
-            "redis cache", top_k=3, tag_filter="redis",
+            "redis cache",
+            top_k=3,
+            tag_filter="redis",
         )
         # May or may not find results depending on auto-tagging
         # but the pipeline should not error
@@ -134,7 +138,10 @@ class TestShellCommands:
         test_cases = [
             ("search deployment", ("search", ["deployment"])),
             ("s deploy blue-green", ("s", ["deploy", "blue-green"])),
-            ("ask what is our deploy strategy?", ("ask", ["what", "is", "our", "deploy", "strategy?"])),
+            (
+                "ask what is our deploy strategy?",
+                ("ask", ["what", "is", "our", "deploy", "strategy?"]),
+            ),
             ("add new memory content", ("add", ["new", "memory", "content"])),
             ("recall --days 7", ("recall", ["--days", "7"])),
             ("tags", ("tags", [])),
@@ -157,7 +164,23 @@ class TestShellCommands:
         line = "deployment blue-green strategy"
         parts = shlex.split(line)
         cmd = parts[0].lower()
-        known = {"search", "s", "ask", "add", "recall", "r", "tags", "stats", "status", "index", "idx", "quit", "exit", "q", "help"}
+        known = {
+            "search",
+            "s",
+            "ask",
+            "add",
+            "recall",
+            "r",
+            "tags",
+            "stats",
+            "status",
+            "index",
+            "idx",
+            "quit",
+            "exit",
+            "q",
+            "help",
+        }
         assert cmd not in known  # should fall through to implicit search
 
     def test_quoted_args(self):
@@ -177,14 +200,17 @@ class TestShellCommands:
 class TestShellImport:
     def test_shell_command_exists(self):
         from memtomem.cli.shell import shell
+
         assert shell.name == "shell"
 
     def test_cli_has_shell(self):
         from memtomem.cli import cli
+
         commands = {cmd for cmd in cli.commands}
         assert "shell" in commands
 
     def test_help_function(self):
         from memtomem.cli.shell import _show_help
+
         # Should not raise
         _show_help()

--- a/packages/memtomem/tests/test_chunkers_extended.py
+++ b/packages/memtomem/tests/test_chunkers_extended.py
@@ -24,12 +24,14 @@ from helpers import make_chunk
 try:
     import tree_sitter  # noqa: F401
     import tree_sitter_python  # noqa: F401
+
     HAS_TS_PYTHON = True
 except ImportError:
     HAS_TS_PYTHON = False
 
 try:
     import tree_sitter_javascript  # noqa: F401
+
     HAS_TS_JS = True
 except ImportError:
     HAS_TS_JS = False
@@ -42,12 +44,14 @@ needs_ts_js = pytest.mark.skipif(not HAS_TS_JS, reason="tree-sitter-javascript n
 # PythonChunker
 # ===================================================================
 
+
 class TestPythonChunker:
     """Tests for chunking/python_code.py."""
 
     @pytest.fixture
     def chunker(self):
         from memtomem.chunking.python_code import PythonChunker
+
         return PythonChunker()
 
     def test_supported_extensions(self, chunker):
@@ -72,11 +76,11 @@ def greet(name):
 
     @needs_ts_python
     def test_module_with_class(self, chunker):
-        code = '''\
+        code = """\
 class Dog:
     def bark(self):
         return "woof"
-'''
+"""
         chunks = chunker.chunk_file(Path("/animals.py"), code)
         class_chunks = [c for c in chunks if c.metadata.chunk_type == ChunkType.PYTHON_CLASS]
         assert len(class_chunks) == 1
@@ -115,12 +119,14 @@ def foo():
 # JavaScriptChunker
 # ===================================================================
 
+
 class TestJavaScriptChunker:
     """Tests for chunking/javascript.py."""
 
     @pytest.fixture
     def chunker(self):
         from memtomem.chunking.javascript import JavaScriptChunker
+
         return JavaScriptChunker()
 
     def test_supported_extensions(self, chunker):
@@ -147,7 +153,7 @@ class TestJavaScriptChunker:
 
     @needs_ts_js
     def test_const_arrow_function(self, chunker):
-        code = 'const add = (a, b) => a + b;\n'
+        code = "const add = (a, b) => a + b;\n"
         chunks = chunker.chunk_file(Path("/math.js"), code)
         assert len(chunks) >= 1
 
@@ -160,7 +166,7 @@ class TestJavaScriptChunker:
 
     @needs_ts_js
     def test_js_language_metadata(self, chunker):
-        code = 'function f() {}\n'
+        code = "function f() {}\n"
         chunks = chunker.chunk_file(Path("/app.js"), code)
         assert all(c.metadata.language == "javascript" for c in chunks)
 
@@ -173,6 +179,7 @@ class TestJavaScriptChunker:
 # ===================================================================
 # StructuredChunker
 # ===================================================================
+
 
 class TestStructuredChunker:
     """Tests for chunking/structured.py."""
@@ -257,6 +264,7 @@ class TestStructuredChunker:
 # ChunkerRegistry
 # ===================================================================
 
+
 class TestChunkerRegistry:
     """Tests for chunking/registry.py."""
 
@@ -266,15 +274,18 @@ class TestChunkerRegistry:
         from memtomem.chunking.javascript import JavaScriptChunker
         from memtomem.chunking.markdown import MarkdownChunker
 
-        return ChunkerRegistry([
-            PythonChunker(),
-            JavaScriptChunker(),
-            StructuredChunker(),
-            MarkdownChunker(),
-        ])
+        return ChunkerRegistry(
+            [
+                PythonChunker(),
+                JavaScriptChunker(),
+                StructuredChunker(),
+                MarkdownChunker(),
+            ]
+        )
 
     def test_get_python(self, registry):
         from memtomem.chunking.python_code import PythonChunker
+
         assert isinstance(registry.get(".py"), PythonChunker)
 
     def test_get_unknown_returns_none(self, registry):
@@ -302,6 +313,7 @@ class TestChunkerRegistry:
 # Indexing: hasher
 # ===================================================================
 
+
 class TestContentHash:
     """Tests for indexing/hasher.py."""
 
@@ -328,6 +340,7 @@ class TestContentHash:
 # Indexing: differ
 # ===================================================================
 
+
 class TestComputeDiff:
     """Tests for indexing/differ.py."""
 
@@ -336,6 +349,7 @@ class TestComputeDiff:
         c = make_chunk(content=content)
         if chunk_id is not None:
             from uuid import UUID
+
             c.id = UUID(chunk_id)
         return c
 
@@ -393,6 +407,7 @@ class TestComputeDiff:
         assert len(diff.to_delete) == 1  # hash_b is gone
         # Unchanged chunk gets the old ID
         from uuid import UUID
+
         assert diff.unchanged[0].id == UUID(id_a)
         # Deleted is chunk B
         assert str(diff.to_delete[0]) == id_b

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -48,8 +48,19 @@ class TestCLIGroup:
     def test_registered_subcommands(self, runner: CliRunner) -> None:
         """All expected subcommands appear in help output."""
         result = runner.invoke(cli, ["--help"])
-        for cmd in ("search", "add", "recall", "index", "config", "context",
-                     "embedding-reset", "reset", "web", "shell", "init"):
+        for cmd in (
+            "search",
+            "add",
+            "recall",
+            "index",
+            "config",
+            "context",
+            "embedding-reset",
+            "reset",
+            "web",
+            "shell",
+            "init",
+        ):
             assert cmd in result.output, f"'{cmd}' not found in help output"
 
     def test_unknown_command(self, runner: CliRunner) -> None:
@@ -298,9 +309,13 @@ class TestSaveConfigOverrides:
         config_file = tmp_path / "config.json"
         monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
 
-        config_file.write_text(json.dumps({
-            "search": {"default_top_k": -5},  # violates min=1
-        }))
+        config_file.write_text(
+            json.dumps(
+                {
+                    "search": {"default_top_k": -5},  # violates min=1
+                }
+            )
+        )
 
         cfg = Mem2MemConfig()
         default_top_k = cfg.search.default_top_k
@@ -316,10 +331,14 @@ class TestSaveConfigOverrides:
         config_file = tmp_path / "config.json"
         monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
 
-        config_file.write_text(json.dumps({
-            "search": {"default_top_k": -5, "rrf_k": 80},
-            "decay": {"enabled": True},
-        }))
+        config_file.write_text(
+            json.dumps(
+                {
+                    "search": {"default_top_k": -5, "rrf_k": 80},
+                    "decay": {"enabled": True},
+                }
+            )
+        )
 
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)
@@ -336,9 +355,13 @@ class TestSaveConfigOverrides:
         monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
 
         # Simulate mm init having written memory_dirs
-        config_file.write_text(json.dumps({
-            "indexing": {"memory_dirs": ["/pre/existing"]},
-        }))
+        config_file.write_text(
+            json.dumps(
+                {
+                    "indexing": {"memory_dirs": ["/pre/existing"]},
+                }
+            )
+        )
 
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)

--- a/packages/memtomem/tests/test_conflict.py
+++ b/packages/memtomem/tests/test_conflict.py
@@ -33,7 +33,12 @@ class TestConflictCandidate:
     def test_conflict_score(self):
         from pathlib import Path
         from memtomem.models import Chunk, ChunkMetadata
-        chunk = Chunk(content="test", metadata=ChunkMetadata(source_file=Path("/t.md")), embedding=[])
-        c = ConflictCandidate(existing_chunk=chunk, similarity=0.9, text_overlap=0.1, conflict_score=0.8)
+
+        chunk = Chunk(
+            content="test", metadata=ChunkMetadata(source_file=Path("/t.md")), embedding=[]
+        )
+        c = ConflictCandidate(
+            existing_chunk=chunk, similarity=0.9, text_overlap=0.1, conflict_score=0.8
+        )
         assert c.conflict_score == pytest.approx(0.8)
         assert c.similarity > c.text_overlap

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -113,12 +113,8 @@ class TestListCanonicalAgents:
         assert list_canonical_agents(tmp_path) == []
 
     def test_sorted(self, tmp_path):
-        _make_canonical_agent(
-            tmp_path, "zeta", SAMPLE_MINIMAL_AGENT.replace("helper", "zeta")
-        )
-        _make_canonical_agent(
-            tmp_path, "alpha", SAMPLE_MINIMAL_AGENT.replace("helper", "alpha")
-        )
+        _make_canonical_agent(tmp_path, "zeta", SAMPLE_MINIMAL_AGENT.replace("helper", "zeta"))
+        _make_canonical_agent(tmp_path, "alpha", SAMPLE_MINIMAL_AGENT.replace("helper", "alpha"))
         names = [p.stem for p in list_canonical_agents(tmp_path)]
         assert names == ["alpha", "zeta"]
 
@@ -361,9 +357,7 @@ class TestOnDrop:
     def test_on_drop_warn_logs(self, tmp_path, caplog):
         _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
         with caplog.at_level("WARNING"):
-            result = generate_all_agents(
-                tmp_path, runtimes=["claude_agents"], on_drop="warn"
-            )
+            result = generate_all_agents(tmp_path, runtimes=["claude_agents"], on_drop="warn")
         # Claude drops kind + temperature — should still generate.
         assert len(result.generated) == 1
         assert result.dropped
@@ -372,16 +366,12 @@ class TestOnDrop:
     def test_on_drop_error_raises(self, tmp_path):
         _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
         with pytest.raises(StrictDropError):
-            generate_all_agents(
-                tmp_path, runtimes=["claude_agents"], on_drop="error"
-            )
+            generate_all_agents(tmp_path, runtimes=["claude_agents"], on_drop="error")
 
     def test_on_drop_ignore_is_silent(self, tmp_path, caplog):
         _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
         with caplog.at_level("WARNING"):
-            result = generate_all_agents(
-                tmp_path, runtimes=["claude_agents"], on_drop="ignore"
-            )
+            result = generate_all_agents(tmp_path, runtimes=["claude_agents"], on_drop="ignore")
         assert len(result.generated) == 1
         assert result.dropped
         assert not any("dropped" in r.message for r in caplog.records)
@@ -410,8 +400,6 @@ class TestRoundtrip:
         shutil.rmtree(tmp_path / CANONICAL_AGENT_ROOT)
         result = extract_agents_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        reparsed = parse_canonical_agent(
-            tmp_path / CANONICAL_AGENT_ROOT / "helper.md"
-        )
+        reparsed = parse_canonical_agent(tmp_path / CANONICAL_AGENT_ROOT / "helper.md")
         assert reparsed.name == "helper"
         assert "Help with things." in reparsed.body

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -19,8 +19,6 @@ from memtomem.context.commands import (
 from memtomem.context.detector import detect_command_dirs
 
 
-
-
 SAMPLE_FULL_COMMAND = """---
 description: Review a file for issues
 argument-hint: [file-path]
@@ -246,6 +244,7 @@ class TestExtractCommandsToCanonical:
         assert len(result.imported) == 1
         assert "UPDATED" in canonical.read_text()
 
+
 class TestDiffCommands:
     def test_empty_project(self, tmp_path):
         assert diff_commands(tmp_path) == []
@@ -278,6 +277,7 @@ class TestDiffCommands:
         rows = diff_commands(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
 
+
 class TestDetectCommandDirs:
     def test_empty(self, tmp_path):
         assert detect_command_dirs(tmp_path) == []
@@ -308,13 +308,12 @@ class TestDetectCommandDirs:
         found = detect_command_dirs(tmp_path)
         assert found == []
 
+
 class TestOnDrop:
     def test_on_drop_warn_logs(self, tmp_path, caplog):
         _make_canonical_command(tmp_path, "review", SAMPLE_FULL_COMMAND)
         with caplog.at_level("WARNING"):
-            result = generate_all_commands(
-                tmp_path, runtimes=["gemini_commands"], on_drop="warn"
-            )
+            result = generate_all_commands(tmp_path, runtimes=["gemini_commands"], on_drop="warn")
         assert len(result.generated) == 1
         assert result.dropped
         assert any("dropped" in r.message for r in caplog.records)
@@ -322,16 +321,12 @@ class TestOnDrop:
     def test_on_drop_error_raises(self, tmp_path):
         _make_canonical_command(tmp_path, "review", SAMPLE_FULL_COMMAND)
         with pytest.raises(StrictDropError):
-            generate_all_commands(
-                tmp_path, runtimes=["gemini_commands"], on_drop="error"
-            )
+            generate_all_commands(tmp_path, runtimes=["gemini_commands"], on_drop="error")
 
     def test_on_drop_ignore_is_silent(self, tmp_path, caplog):
         _make_canonical_command(tmp_path, "review", SAMPLE_FULL_COMMAND)
         with caplog.at_level("WARNING"):
-            result = generate_all_commands(
-                tmp_path, runtimes=["gemini_commands"], on_drop="ignore"
-            )
+            result = generate_all_commands(tmp_path, runtimes=["gemini_commands"], on_drop="ignore")
         assert len(result.generated) == 1
         assert result.dropped
         assert not any("dropped" in r.message for r in caplog.records)

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -7,17 +7,12 @@ Uses record-format hooks (Claude Code ≥ 2.1.104):
 from __future__ import annotations
 
 import json
-import os
-import re
 
 import pytest
 from click.testing import CliRunner
 
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
-    ClaudeSettingsGenerator,
-    SETTINGS_GENERATORS,
-    SettingsSyncResult,
     diff_settings,
     generate_all_settings,
 )
@@ -28,7 +23,10 @@ from memtomem.context.settings import (
 
 def _rule(matcher: str = "", command: str = "echo ok", timeout: int = 5000) -> dict:
     """Build a single hook rule in record format."""
-    return {"matcher": matcher, "hooks": [{"type": "command", "command": command, "timeout": timeout}]}
+    return {
+        "matcher": matcher,
+        "hooks": [{"type": "command", "command": command, "timeout": timeout}],
+    }
 
 
 # ── Fixtures ────────────────────────────────────────────────────────
@@ -139,9 +137,7 @@ class TestClaudeSettingsMergeAdditive:
         """Multiple rules under the same event with different matchers."""
         target = claude_home / ".claude" / "settings.json"
         user_rule = _rule("Bash", "echo user")
-        target.write_text(
-            json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n"
-        )
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n")
 
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
@@ -161,9 +157,7 @@ class TestClaudeSettingsMergeConflict:
     def test_user_rule_wins_on_matcher_collision(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
         user_rule = _rule("Write", "echo custom")
-        target.write_text(
-            json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n"
-        )
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n")
 
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
@@ -181,9 +175,7 @@ class TestClaudeSettingsMergeConflict:
         """If the user's rule is byte-identical, no warning is emitted."""
         rule = _rule("Write", "mm index")
         target = claude_home / ".claude" / "settings.json"
-        target.write_text(
-            json.dumps({"hooks": {"PostToolUse": [rule]}}) + "\n"
-        )
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [rule]}}) + "\n")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [rule]}})
         results = generate_all_settings(tmp_path)
@@ -196,9 +188,7 @@ class TestClaudeSettingsMergeWarningContent:
 
     def test_warning_includes_required_parts(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
-        target.write_text(
-            json.dumps({"hooks": {"PostToolUse": [_rule("Write", "old")]}}) + "\n"
-        )
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [_rule("Write", "old")]}}) + "\n")
 
         _make_canonical_settings(
             tmp_path,
@@ -313,9 +303,7 @@ class TestClaudeSettingsDryRun:
         target = claude_home / ".claude" / "settings.json"
         target.write_text(json.dumps({"hooks": {}}) + "\n")
 
-        _make_canonical_settings(
-            tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}}
-        )
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}})
         results = diff_settings(tmp_path)
         assert results["claude_settings"].status == "out of sync"
 
@@ -325,9 +313,7 @@ class TestClaudeSettingsDryRun:
         original = json.dumps({"hooks": {}}) + "\n"
         target.write_text(original)
 
-        _make_canonical_settings(
-            tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}}
-        )
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}})
         diff_settings(tmp_path)
         assert target.read_text() == original
 

--- a/packages/memtomem/tests/test_context_window.py
+++ b/packages/memtomem/tests/test_context_window.py
@@ -166,10 +166,12 @@ class TestExpandContext:
         chunks_b = _make_file_chunks("/tmp/b.md", 4)
 
         results = [_make_result(chunks_a[1], rank=1), _make_result(chunks_b[2], rank=2)]
-        pipeline = _make_pipeline({
-            Path("/tmp/a.md"): chunks_a,
-            Path("/tmp/b.md"): chunks_b,
-        })
+        pipeline = _make_pipeline(
+            {
+                Path("/tmp/a.md"): chunks_a,
+                Path("/tmp/b.md"): chunks_b,
+            }
+        )
 
         expanded = await pipeline._expand_context(results, window=1)
 

--- a/packages/memtomem/tests/test_e2e_pipeline.py
+++ b/packages/memtomem/tests/test_e2e_pipeline.py
@@ -181,9 +181,7 @@ class TestCrossLanguageE2E:
         )
         await components.index_engine.index_file(doc)
 
-        results, _ = await components.search_pipeline.search(
-            "기술 스택", top_k=1, context_window=1
-        )
+        results, _ = await components.search_pipeline.search("기술 스택", top_k=1, context_window=1)
         assert len(results) >= 1
 
 
@@ -199,9 +197,7 @@ class TestFullPipelineE2E:
 
         doc = memory_dir / "format_test.md"
         doc.write_text(
-            "## Intro\n\nWelcome.\n\n"
-            "## Core\n\nMain content here.\n\n"
-            "## Conclusion\n\nSummary.\n"
+            "## Intro\n\nWelcome.\n\n## Core\n\nMain content here.\n\n## Conclusion\n\nSummary.\n"
         )
         await components.index_engine.index_file(doc)
 

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -405,9 +405,7 @@ class TestOnnxEmbedder:
         """embed_texts returns list of float lists via mocked fastembed."""
         config = _onnx_config(dimension=3)
         embedder = OnnxEmbedder(config)
-        embedder._model = _make_fake_embedding_model(
-            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
-        )
+        embedder._model = _make_fake_embedding_model([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]])
 
         result = await embedder.embed_texts(["hello", "world"])
 

--- a/packages/memtomem/tests/test_entities.py
+++ b/packages/memtomem/tests/test_entities.py
@@ -28,12 +28,18 @@ class TestEntityMixin:
         chunk = make_chunk("some content")
         await storage.upsert_chunks([chunk])
 
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "Old"},
-        ])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "New"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Old"},
+            ],
+        )
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "New"},
+            ],
+        )
 
         result = await storage.get_entities_for_chunk(str(chunk.id))
         assert len(result) == 1
@@ -48,9 +54,12 @@ class TestEntityMixin:
     async def test_delete_entities(self, storage):
         chunk = make_chunk("test")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "tech", "entity_value": "Python"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "tech", "entity_value": "Python"},
+            ],
+        )
         deleted = await storage.delete_entities_for_chunk(str(chunk.id))
         assert deleted == 1
 
@@ -61,10 +70,13 @@ class TestEntityMixin:
     async def test_search_by_type(self, storage):
         chunk = make_chunk("Alice uses Python")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "Alice"},
-            {"entity_type": "tech", "entity_value": "Python"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Alice"},
+                {"entity_type": "tech", "entity_value": "Python"},
+            ],
+        )
 
         results = await storage.search_entities(entity_type="person")
         assert len(results) == 1
@@ -74,10 +86,13 @@ class TestEntityMixin:
     async def test_search_by_value(self, storage):
         chunk = make_chunk("Bob in Paris")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "Bob"},
-            {"entity_type": "location", "entity_value": "Paris"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Bob"},
+                {"entity_type": "location", "entity_value": "Paris"},
+            ],
+        )
 
         results = await storage.search_entities(value="Par")
         assert len(results) == 1
@@ -88,8 +103,12 @@ class TestEntityMixin:
         c1 = make_chunk("Alice", namespace="work")
         c2 = make_chunk("Bob", namespace="personal")
         await storage.upsert_chunks([c1, c2])
-        await storage.upsert_entities(str(c1.id), [{"entity_type": "person", "entity_value": "Alice"}])
-        await storage.upsert_entities(str(c2.id), [{"entity_type": "person", "entity_value": "Bob"}])
+        await storage.upsert_entities(
+            str(c1.id), [{"entity_type": "person", "entity_value": "Alice"}]
+        )
+        await storage.upsert_entities(
+            str(c2.id), [{"entity_type": "person", "entity_value": "Bob"}]
+        )
 
         results = await storage.search_entities(namespace="work")
         assert len(results) == 1
@@ -99,11 +118,14 @@ class TestEntityMixin:
     async def test_entity_type_counts(self, storage):
         chunk = make_chunk("test")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "A"},
-            {"entity_type": "person", "entity_value": "B"},
-            {"entity_type": "tech", "entity_value": "C"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "A"},
+                {"entity_type": "person", "entity_value": "B"},
+                {"entity_type": "tech", "entity_value": "C"},
+            ],
+        )
 
         counts = await storage.get_entity_type_counts()
         assert counts["person"] == 2

--- a/packages/memtomem/tests/test_expansion.py
+++ b/packages/memtomem/tests/test_expansion.py
@@ -6,6 +6,7 @@ from memtomem.search.expansion import expand_query_tags
 
 class FakeStorage:
     """Mock storage for tag-based expansion tests."""
+
     def __init__(self, tags):
         self._tags = tags
 

--- a/packages/memtomem/tests/test_health_watchdog.py
+++ b/packages/memtomem/tests/test_health_watchdog.py
@@ -253,9 +253,7 @@ class TestMaintenanceExecutor:
 
         app, _db = mock_app
         config = HealthWatchdogConfig(enabled=True)
-        app.search_pipeline._search_cache = {
-            str(i): (time.time() - i, [], None) for i in range(40)
-        }
+        app.search_pipeline._search_cache = {str(i): (time.time() - i, [], None) for i in range(40)}
 
         executor = MaintenanceExecutor(app, config)
         result = await executor.trim_search_cache(max_entries=10)

--- a/packages/memtomem/tests/test_importers.py
+++ b/packages/memtomem/tests/test_importers.py
@@ -83,11 +83,13 @@ class TestImportNotion:
         notion_dir = tmp_path / "notion_export"
         notion_dir.mkdir()
         (notion_dir / "My Page abc123def4567890123456789abcdef0.md").write_text(
-            "# My Page\n\nSome content here.", encoding="utf-8",
+            "# My Page\n\nSome content here.",
+            encoding="utf-8",
         )
         (notion_dir / "Sub").mkdir()
         (notion_dir / "Sub" / "Child def4567890123456789012345abcdef0.md").write_text(
-            "# Child Page\n\nNested content.", encoding="utf-8",
+            "# Child Page\n\nNested content.",
+            encoding="utf-8",
         )
 
         output = tmp_path / "output"
@@ -110,13 +112,16 @@ class TestImportNotion:
         notion_dir = tmp_path / "notion_src"
         notion_dir.mkdir()
         (notion_dir / "Note abc123def4567890123456789abcdef0.md").write_text(
-            "# Note\n\nContent.", encoding="utf-8",
+            "# Note\n\nContent.",
+            encoding="utf-8",
         )
 
         zip_path = tmp_path / "notion.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
-            zf.write(notion_dir / "Note abc123def4567890123456789abcdef0.md",
-                     "Note abc123def4567890123456789abcdef0.md")
+            zf.write(
+                notion_dir / "Note abc123def4567890123456789abcdef0.md",
+                "Note abc123def4567890123456789abcdef0.md",
+            )
 
         output = tmp_path / "output"
         imported = await import_notion(zip_path, output)
@@ -133,7 +138,8 @@ class TestImportObsidian:
             encoding="utf-8",
         )
         (vault / "Project Plan.md").write_text(
-            "# Project Plan\n\n![[Architecture Diagram]]", encoding="utf-8",
+            "# Project Plan\n\n![[Architecture Diagram]]",
+            encoding="utf-8",
         )
         # Create .obsidian config (should be skipped)
         (vault / ".obsidian").mkdir()

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -2,19 +2,24 @@
 
 from __future__ import annotations
 
-import pytest
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 
 from memtomem.config import NamespaceConfig
-from memtomem.indexing.engine import IndexEngine, _merge_short_chunks, _add_overlap, _estimate_tokens
+from memtomem.indexing.engine import (
+    IndexEngine,
+    _merge_short_chunks,
+    _add_overlap,
+    _estimate_tokens,
+)
 from memtomem.models import Chunk, ChunkMetadata
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_chunk_with(
     content: str,
@@ -478,7 +483,9 @@ class TestIndexFile:
 
     async def test_index_markdown_file(self, components, memory_dir):
         """Index a markdown file with two headings; verify chunks stored."""
-        md_content = "# Section A\n\nContent for section A.\n\n# Section B\n\nContent for section B.\n"
+        md_content = (
+            "# Section A\n\nContent for section A.\n\n# Section B\n\nContent for section B.\n"
+        )
         md_path = memory_dir / "test_doc.md"
         md_path.write_text(md_content)
 
@@ -669,7 +676,7 @@ class TestIncrementalIndexing:
         components.index_engine._embedder = mock_embedder
 
         # First index
-        stats1 = await components.index_engine.index_file(md_path)
+        await components.index_engine.index_file(md_path)
         first_embed_count = mock_embedder.embed_texts.call_count
 
         # Modify the file — add a new section

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -8,19 +8,24 @@ import pytest
 class TestMemtomemStoreInit:
     def test_default_init(self):
         from memtomem.integrations.langgraph import MemtomemStore
+
         store = MemtomemStore()
         assert store._components is None
         assert store._config_overrides == {}
 
     def test_config_overrides(self):
         from memtomem.integrations.langgraph import MemtomemStore
-        store = MemtomemStore(config_overrides={
-            "storage": {"sqlite_path": "/tmp/test.db"},
-        })
+
+        store = MemtomemStore(
+            config_overrides={
+                "storage": {"sqlite_path": "/tmp/test.db"},
+            }
+        )
         assert store._config_overrides["storage"]["sqlite_path"] == "/tmp/test.db"
 
     def test_session_id_none_initially(self):
         from memtomem.integrations.langgraph import MemtomemStore
+
         store = MemtomemStore()
         assert store._current_session_id is None
 
@@ -95,6 +100,7 @@ class TestMemtomemStoreIntegration:
 
         # Prevent ~/.memtomem/config.json from overriding test settings
         import memtomem.config as _cfg
+
         _orig_load = _cfg.load_config_overrides
         _cfg.load_config_overrides = lambda c: None
 
@@ -120,8 +126,12 @@ class TestMemtomemStoreIntegration:
 
         finally:
             _cfg.load_config_overrides = _orig_load
-            for key in ("MEMTOMEM_STORAGE__SQLITE_PATH", "MEMTOMEM_INDEXING__MEMORY_DIRS",
-                        "MEMTOMEM_EMBEDDING__MODEL", "MEMTOMEM_EMBEDDING__DIMENSION"):
+            for key in (
+                "MEMTOMEM_STORAGE__SQLITE_PATH",
+                "MEMTOMEM_INDEXING__MEMORY_DIRS",
+                "MEMTOMEM_EMBEDDING__MODEL",
+                "MEMTOMEM_EMBEDDING__DIMENSION",
+            ):
                 os.environ.pop(key, None)
 
     @pytest.mark.asyncio
@@ -140,6 +150,7 @@ class TestMemtomemStoreIntegration:
         os.environ["MEMTOMEM_EMBEDDING__DIMENSION"] = "1024"
 
         import memtomem.config as _cfg
+
         _orig_load = _cfg.load_config_overrides
         _cfg.load_config_overrides = lambda c: None
 
@@ -159,6 +170,10 @@ class TestMemtomemStoreIntegration:
 
         finally:
             _cfg.load_config_overrides = _orig_load
-            for key in ("MEMTOMEM_STORAGE__SQLITE_PATH", "MEMTOMEM_INDEXING__MEMORY_DIRS",
-                        "MEMTOMEM_EMBEDDING__MODEL", "MEMTOMEM_EMBEDDING__DIMENSION"):
+            for key in (
+                "MEMTOMEM_STORAGE__SQLITE_PATH",
+                "MEMTOMEM_INDEXING__MEMORY_DIRS",
+                "MEMTOMEM_EMBEDDING__MODEL",
+                "MEMTOMEM_EMBEDDING__DIMENSION",
+            ):
                 os.environ.pop(key, None)

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -84,17 +84,20 @@ class TestImportanceCompute:
 
     def test_all_max(self):
         from memtomem.search.importance import compute_importance
+
         score = compute_importance(1000, 10, 50, 0.0)
         assert 0.8 <= score <= 1.0
 
     def test_all_zero_except_recency(self):
         from memtomem.search.importance import compute_importance
+
         score = compute_importance(0, 0, 0, 0.0)
         # recency factor = exp(0) = 1.0, weight = 0.2
         assert score == pytest.approx(0.2, abs=0.05)
 
     def test_very_old(self):
         from memtomem.search.importance import compute_importance
+
         score_new = compute_importance(10, 3, 2, 0.0)
         score_old = compute_importance(10, 3, 2, 1000.0)
         assert score_new > score_old

--- a/packages/memtomem/tests/test_policies.py
+++ b/packages/memtomem/tests/test_policies.py
@@ -18,7 +18,9 @@ class TestPolicyMixin:
 
     @pytest.mark.asyncio
     async def test_add_with_namespace(self, storage):
-        await storage.policy_add("ns-policy", "auto-tag", {"tags": ["old"]}, namespace_filter="archive")
+        await storage.policy_add(
+            "ns-policy", "auto-tag", {"tags": ["old"]}, namespace_filter="archive"
+        )
         policy = await storage.policy_get("ns-policy")
         assert policy is not None
         assert policy["namespace_filter"] == "archive"

--- a/packages/memtomem/tests/test_quality_fixes.py
+++ b/packages/memtomem/tests/test_quality_fixes.py
@@ -95,10 +95,12 @@ class TestBatchOperations:
         c2 = _make_chunk("imp2", source="i2.md")
         await storage.upsert_chunks([c1, c2])
 
-        updated = await storage.update_importance_scores({
-            str(c1.id): 0.8,
-            str(c2.id): 0.3,
-        })
+        updated = await storage.update_importance_scores(
+            {
+                str(c1.id): 0.8,
+                str(c2.id): 0.3,
+            }
+        )
         assert updated == 2
 
         scores = await storage.get_importance_scores([c1.id, c2.id])
@@ -427,6 +429,7 @@ class TestDatetimeNormalization:
     async def test_naive_datetime_gets_utc(self, storage):
         """Chunks with naive datetime stored should get UTC tzinfo on read."""
         from datetime import timezone
+
         chunk = _make_chunk("tz test")
         await storage.upsert_chunks([chunk])
 

--- a/packages/memtomem/tests/test_reranker.py
+++ b/packages/memtomem/tests/test_reranker.py
@@ -20,6 +20,7 @@ class TestCohereReranker:
     def test_init(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.cohere import CohereReranker
+
         config = RerankConfig(enabled=True, provider="cohere", api_key="test-key")
         reranker = CohereReranker(config)
         assert reranker._config.api_key == "test-key"
@@ -29,6 +30,7 @@ class TestCohereReranker:
     async def test_empty_results(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.cohere import CohereReranker
+
         config = RerankConfig(enabled=True, provider="cohere", api_key="test")
         reranker = CohereReranker(config)
         result = await reranker.rerank("query", [], top_k=5)
@@ -38,6 +40,7 @@ class TestCohereReranker:
     async def test_close(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.cohere import CohereReranker
+
         config = RerankConfig(enabled=True, provider="cohere", api_key="test")
         reranker = CohereReranker(config)
         await reranker.close()
@@ -48,7 +51,10 @@ class TestLocalReranker:
     def test_init(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.local import LocalReranker
-        config = RerankConfig(enabled=True, provider="local", model="cross-encoder/ms-marco-MiniLM-L-6-v2")
+
+        config = RerankConfig(
+            enabled=True, provider="local", model="cross-encoder/ms-marco-MiniLM-L-6-v2"
+        )
         reranker = LocalReranker(config)
         assert reranker._model is None  # lazy loaded
 
@@ -56,6 +62,7 @@ class TestLocalReranker:
     async def test_empty_results(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.local import LocalReranker
+
         config = RerankConfig(enabled=True, provider="local")
         reranker = LocalReranker(config)
         result = await reranker.rerank("query", [], top_k=5)
@@ -65,6 +72,7 @@ class TestLocalReranker:
     async def test_close(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.local import LocalReranker
+
         config = RerankConfig(enabled=True, provider="local")
         reranker = LocalReranker(config)
         await reranker.close()
@@ -75,12 +83,14 @@ class TestRerankerFactory:
     def test_disabled(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
+
         assert create_reranker(RerankConfig(enabled=False)) is None
 
     def test_cohere(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
         from memtomem.search.reranker.cohere import CohereReranker
+
         r = create_reranker(RerankConfig(enabled=True, provider="cohere"))
         assert isinstance(r, CohereReranker)
 
@@ -88,11 +98,13 @@ class TestRerankerFactory:
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
         from memtomem.search.reranker.local import LocalReranker
+
         r = create_reranker(RerankConfig(enabled=True, provider="local"))
         assert isinstance(r, LocalReranker)
 
     def test_unknown_raises(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
+
         with pytest.raises(ValueError):
             create_reranker(RerankConfig(enabled=True, provider="unknown"))

--- a/packages/memtomem/tests/test_retry.py
+++ b/packages/memtomem/tests/test_retry.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/packages/memtomem/tests/test_rst_chunker.py
+++ b/packages/memtomem/tests/test_rst_chunker.py
@@ -52,10 +52,7 @@ class TestUnderlineHeaders:
         assert "Second" in chunks[1].content
 
     def test_hierarchy(self):
-        content = (
-            "Top\n===\n\nIntro.\n\n"
-            "Sub\n---\n\nDetail."
-        )
+        content = "Top\n===\n\nIntro.\n\nSub\n---\n\nDetail."
         chunks = _chunk(content)
         assert len(chunks) == 2
         assert chunks[0].metadata.heading_hierarchy == ("Top",)
@@ -88,11 +85,7 @@ class TestAdornmentCharacters:
         assert len(chunks) == 1
 
     def test_different_chars_different_levels(self):
-        content = (
-            "H1\n==\n\nA.\n\n"
-            "H2\n--\n\nB.\n\n"
-            "H3\n~~\n\nC."
-        )
+        content = "H1\n==\n\nA.\n\nH2\n--\n\nB.\n\nH3\n~~\n\nC."
         chunks = _chunk(content)
         assert len(chunks) == 3
         assert chunks[2].metadata.heading_hierarchy == ("H1", "H2", "H3")

--- a/packages/memtomem/tests/test_search_history.py
+++ b/packages/memtomem/tests/test_search_history.py
@@ -48,7 +48,12 @@ class TestImportanceScores:
     async def test_update_and_get(self, storage, components):
         from pathlib import Path
         from memtomem.models import Chunk, ChunkMetadata
-        chunk = Chunk(content="test", metadata=ChunkMetadata(source_file=Path("/t.md")), embedding=[0.0] * components.config.embedding.dimension)
+
+        chunk = Chunk(
+            content="test",
+            metadata=ChunkMetadata(source_file=Path("/t.md")),
+            embedding=[0.0] * components.config.embedding.dimension,
+        )
         await storage.upsert_chunks([chunk])
 
         scores = {str(chunk.id): 0.75}

--- a/packages/memtomem/tests/test_search_stages.py
+++ b/packages/memtomem/tests/test_search_stages.py
@@ -15,8 +15,14 @@ from helpers import make_chunk
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _sr(content: str = "text", score: float = 1.0, rank: int = 1, source: str = "bm25",
-        embedding: list[float] | None = None) -> SearchResult:
+
+def _sr(
+    content: str = "text",
+    score: float = 1.0,
+    rank: int = 1,
+    source: str = "bm25",
+    embedding: list[float] | None = None,
+) -> SearchResult:
     """Create a SearchResult backed by a real Chunk."""
     chunk = make_chunk(content=content, embedding=embedding or [0.1] * 8)
     return SearchResult(chunk=chunk, score=score, rank=rank, source=source)
@@ -25,6 +31,7 @@ def _sr(content: str = "text", score: float = 1.0, rank: int = 1, source: str = 
 # ===================================================================
 # RRF fusion tests
 # ===================================================================
+
 
 class TestReciprocalRankFusion:
     """Tests for reciprocal_rank_fusion in search/fusion.py."""
@@ -78,9 +85,7 @@ class TestReciprocalRankFusion:
         doc_a = _sr("from_list1", score=1.0, rank=1)
         doc_b = _sr("from_list2", score=1.0, rank=1)
         # Weight list2 much higher
-        fused = reciprocal_rank_fusion(
-            [[doc_a], [doc_b]], k=60, top_k=2, weights=[1.0, 10.0]
-        )
+        fused = reciprocal_rank_fusion([[doc_a], [doc_b]], k=60, top_k=2, weights=[1.0, 10.0])
         assert fused[0].chunk.content == "from_list2"
 
     def test_empty_lists(self):
@@ -119,6 +124,7 @@ class TestReciprocalRankFusion:
 # Cosine similarity tests
 # ===================================================================
 
+
 class TestCosineSimilarity:
     """Tests for cosine_similarity in search/mmr.py."""
 
@@ -144,6 +150,7 @@ class TestCosineSimilarity:
 # ===================================================================
 # MMR tests
 # ===================================================================
+
 
 class TestApplyMMR:
     """Tests for apply_mmr in search/mmr.py."""

--- a/packages/memtomem/tests/test_server_helpers.py
+++ b/packages/memtomem/tests/test_server_helpers.py
@@ -399,7 +399,11 @@ class TestCheckEmbeddingMismatch:
         app = MagicMock()
         app.storage.embedding_mismatch = {
             "stored": {"provider": "ollama", "model": "nomic-embed-text", "dimension": 768},
-            "configured": {"provider": "openai", "model": "text-embedding-3-small", "dimension": 1536},
+            "configured": {
+                "provider": "openai",
+                "model": "text-embedding-3-small",
+                "dimension": 1536,
+            },
         }
         msg = _check_embedding_mismatch(app)
         assert msg is not None

--- a/packages/memtomem/tests/test_server_tools_advanced.py
+++ b/packages/memtomem/tests/test_server_tools_advanced.py
@@ -224,9 +224,12 @@ class TestEntities:
     async def test_search_by_value_substring(self, storage):
         chunk = _chunk("Meeting with Alice Smith")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "Alice Smith", "confidence": 0.9},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Alice Smith", "confidence": 0.9},
+            ],
+        )
 
         results = await storage.search_entities(value="Alice")
         assert len(results) == 1
@@ -237,12 +240,18 @@ class TestEntities:
         c2 = _chunk("Entity in ns2", namespace="ns2")
         await storage.upsert_chunks([c1, c2])
 
-        await storage.upsert_entities(str(c1.id), [
-            {"entity_type": "concept", "entity_value": "concept-1"},
-        ])
-        await storage.upsert_entities(str(c2.id), [
-            {"entity_type": "concept", "entity_value": "concept-2"},
-        ])
+        await storage.upsert_entities(
+            str(c1.id),
+            [
+                {"entity_type": "concept", "entity_value": "concept-1"},
+            ],
+        )
+        await storage.upsert_entities(
+            str(c2.id),
+            [
+                {"entity_type": "concept", "entity_value": "concept-2"},
+            ],
+        )
 
         results = await storage.search_entities(namespace="ns1")
         assert len(results) == 1
@@ -252,12 +261,18 @@ class TestEntities:
         chunk = _chunk("overwrite test")
         await storage.upsert_chunks([chunk])
 
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "Old"},
-        ])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "New"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Old"},
+            ],
+        )
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "New"},
+            ],
+        )
 
         result = await storage.get_entities_for_chunk(str(chunk.id))
         assert len(result) == 1
@@ -270,9 +285,12 @@ class TestEntities:
     async def test_delete_entities_for_chunk(self, storage):
         chunk = _chunk("deletable")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "Gone"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "Gone"},
+            ],
+        )
         deleted = await storage.delete_entities_for_chunk(str(chunk.id))
         assert deleted == 1
 
@@ -282,11 +300,14 @@ class TestEntities:
     async def test_entity_type_counts(self, storage):
         chunk = _chunk("mixed entities")
         await storage.upsert_chunks([chunk])
-        await storage.upsert_entities(str(chunk.id), [
-            {"entity_type": "person", "entity_value": "A"},
-            {"entity_type": "person", "entity_value": "B"},
-            {"entity_type": "org", "entity_value": "C"},
-        ])
+        await storage.upsert_entities(
+            str(chunk.id),
+            [
+                {"entity_type": "person", "entity_value": "A"},
+                {"entity_type": "person", "entity_value": "B"},
+                {"entity_type": "org", "entity_value": "C"},
+            ],
+        )
 
         counts = await storage.get_entity_type_counts()
         assert counts["person"] == 2
@@ -446,10 +467,7 @@ class TestAnalytics:
 
     async def test_consolidation_groups(self, storage):
         # Create 3+ chunks from same source to form a group
-        chunks = [
-            _chunk(f"content {i}", source="big_file.md")
-            for i in range(4)
-        ]
+        chunks = [_chunk(f"content {i}", source="big_file.md") for i in range(4)]
         await storage.upsert_chunks(chunks)
 
         groups = await storage.get_consolidation_groups(min_size=3)
@@ -545,7 +563,7 @@ class TestExportImport:
         await storage.upsert_chunks([chunk])
 
         output_path = tmp_path / "export.json"
-        bundle = await export_chunks(storage, output_path=output_path)
+        await export_chunks(storage, output_path=output_path)
 
         assert output_path.exists()
         data = json.loads(output_path.read_text())
@@ -730,7 +748,9 @@ class TestAutoTag:
 
     async def test_auto_tag_storage_basic(self, storage):
         """auto_tag_storage should tag untagged chunks."""
-        chunk = _chunk("Python programming language for data science applications", source="code.md")
+        chunk = _chunk(
+            "Python programming language for data science applications", source="code.md"
+        )
         await storage.upsert_chunks([chunk])
 
         stats = await auto_tag_storage(storage, max_tags=3)

--- a/packages/memtomem/tests/test_server_tools_core.py
+++ b/packages/memtomem/tests/test_server_tools_core.py
@@ -298,18 +298,18 @@ class TestSetConfigKey:
     def test_set_bool_field_false(self):
         config = Mem2MemConfig()
         config.decay.enabled = True
-        msg = _set_config_key(config, "decay.enabled", "false")
+        _set_config_key(config, "decay.enabled", "false")
         assert config.decay.enabled is False
 
     def test_set_float_field(self):
         config = Mem2MemConfig()
-        msg = _set_config_key(config, "decay.half_life_days", "7.5")
+        _set_config_key(config, "decay.half_life_days", "7.5")
         assert config.decay.half_life_days == 7.5
 
     def test_set_string_field(self):
         """Mutable string field (namespace.default_namespace) should be settable."""
         config = Mem2MemConfig()
-        msg = _set_config_key(config, "namespace.default_namespace", "work")
+        _set_config_key(config, "namespace.default_namespace", "work")
         assert config.namespace.default_namespace == "work"
 
     def test_init_only_field_rejected(self):
@@ -663,7 +663,9 @@ class TestFormatResults:
                 metadata=ChunkMetadata(source_file=Path(f"/tmp/r{i}.md")),
                 embedding=[],
             )
-            results.append(SearchResult(chunk=chunk, score=0.9 - i * 0.1, rank=i + 1, source="fused"))
+            results.append(
+                SearchResult(chunk=chunk, score=0.9 - i * 0.1, rank=i + 1, source="fused")
+            )
 
         output = _format_results(results)
         assert "Found 3 results" in output

--- a/packages/memtomem/tests/test_storage_extended.py
+++ b/packages/memtomem/tests/test_storage_extended.py
@@ -19,6 +19,7 @@ from memtomem.models import NamespaceFilter
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _varied_embedding(seed: float = 0.1, dim: int = 1024) -> list[float]:
     """Return a deterministic but varied embedding vector."""
     return [seed + i * 0.0001 for i in range(dim)]
@@ -68,7 +69,9 @@ class TestStorageExtended:
     async def test_dense_search_respects_top_k(self, components):
         storage = components.storage
         chunks = [
-            make_chunk(content=f"chunk {i}", source=f"f{i}.md", embedding=_varied_embedding(0.1 + i * 0.01))
+            make_chunk(
+                content=f"chunk {i}", source=f"f{i}.md", embedding=_varied_embedding(0.1 + i * 0.01)
+            )
             for i in range(5)
         ]
         await storage.upsert_chunks(chunks)
@@ -80,8 +83,12 @@ class TestStorageExtended:
         storage = components.storage
         emb = _varied_embedding(0.3)
         chunk_a = make_chunk(content="ns-work", namespace="work", embedding=emb, source="w.md")
-        chunk_b = make_chunk(content="ns-personal", namespace="personal",
-                            embedding=_similar_embedding(emb), source="p.md")
+        chunk_b = make_chunk(
+            content="ns-personal",
+            namespace="personal",
+            embedding=_similar_embedding(emb),
+            source="p.md",
+        )
         await storage.upsert_chunks([chunk_a, chunk_b])
 
         ns_filter = NamespaceFilter.parse("work")
@@ -262,7 +269,9 @@ class TestStorageExtended:
         chunk = make_chunk(content="before reset", embedding=[0.1] * 1024)
         await storage.upsert_chunks([chunk])
 
-        await storage.reset_embedding_meta(dimension=768, provider="openai", model="text-embedding-3-small")
+        await storage.reset_embedding_meta(
+            dimension=768, provider="openai", model="text-embedding-3-small"
+        )
 
         # Old vector data is gone; DB should accept 768-dim vectors now
         new_chunk = make_chunk(content="after reset", embedding=[0.2] * 768, source="new.md")

--- a/packages/memtomem/tests/test_templates.py
+++ b/packages/memtomem/tests/test_templates.py
@@ -7,25 +7,35 @@ from memtomem.templates import render_template, list_templates, TEMPLATE_NAMES
 
 class TestRenderTemplate:
     def test_adr_with_json(self):
-        result = render_template("adr", json.dumps({
-            "title": "Use Redis",
-            "status": "accepted",
-            "context": "Need caching",
-            "decision": "Redis cluster",
-            "consequences": "Ops overhead",
-        }))
+        result = render_template(
+            "adr",
+            json.dumps(
+                {
+                    "title": "Use Redis",
+                    "status": "accepted",
+                    "context": "Need caching",
+                    "decision": "Redis cluster",
+                    "consequences": "Ops overhead",
+                }
+            ),
+        )
         assert "ADR: Use Redis" in result
         assert "**Status**: accepted" in result
         assert "**Decision**: Redis cluster" in result
 
     def test_meeting_auto_date(self):
-        result = render_template("meeting", json.dumps({
-            "title": "Standup",
-            "attendees": "Team",
-            "agenda": "Updates",
-            "decisions": "None",
-            "action_items": "None",
-        }))
+        result = render_template(
+            "meeting",
+            json.dumps(
+                {
+                    "title": "Standup",
+                    "attendees": "Team",
+                    "agenda": "Updates",
+                    "decisions": "None",
+                    "action_items": "None",
+                }
+            ),
+        )
         assert "Meeting: Standup" in result
         assert "2026-" in result  # auto-filled date
 
@@ -35,12 +45,17 @@ class TestRenderTemplate:
         assert "Debug:" in result
 
     def test_procedure_template(self):
-        result = render_template("procedure", json.dumps({
-            "title": "Deploy",
-            "trigger": "new release",
-            "steps": "1. Build\n2. Test",
-            "tags": "deploy",
-        }))
+        result = render_template(
+            "procedure",
+            json.dumps(
+                {
+                    "title": "Deploy",
+                    "trigger": "new release",
+                    "steps": "1. Build\n2. Test",
+                    "tags": "deploy",
+                }
+            ),
+        )
         assert "Procedure: Deploy" in result
         assert "Trigger" in result
 

--- a/packages/memtomem/tests/test_url_fetcher.py
+++ b/packages/memtomem/tests/test_url_fetcher.py
@@ -33,9 +33,7 @@ class TestHtmlToMarkdown:
         assert "- Second" in md
 
     def test_removes_script_style(self):
-        md = _html_to_markdown(
-            "<script>alert('xss')</script><style>body{}</style><p>Content</p>"
-        )
+        md = _html_to_markdown("<script>alert('xss')</script><style>body{}</style><p>Content</p>")
         assert "alert" not in md
         assert "body{}" not in md
         assert "Content" in md

--- a/packages/memtomem/tests/test_usability_fixes.py
+++ b/packages/memtomem/tests/test_usability_fixes.py
@@ -92,27 +92,37 @@ class TestWikilinkResolution:
 
 class TestTemplatePlaceholders:
     def test_missing_fields_removed(self):
-        result = render_template("meeting", json.dumps({
-            "title": "Standup",
-            "attendees": "Team",
-            "decisions": "None",
-        }))
+        result = render_template(
+            "meeting",
+            json.dumps(
+                {
+                    "title": "Standup",
+                    "attendees": "Team",
+                    "decisions": "None",
+                }
+            ),
+        )
         assert "(fill:" not in result
         assert "Agenda" not in result  # removed because not provided
-        assert "Attendees" in result   # provided field stays
+        assert "Attendees" in result  # provided field stays
 
     def test_heading_with_placeholder_title_kept(self):
         result = render_template("debug", "Crash on boot")
         assert "Debug:" in result  # heading kept even if title is placeholder
 
     def test_all_fields_provided_no_removal(self):
-        result = render_template("meeting", json.dumps({
-            "title": "Sprint",
-            "attendees": "All",
-            "agenda": "Review",
-            "decisions": "Ship it",
-            "action_items": "Deploy",
-        }))
+        result = render_template(
+            "meeting",
+            json.dumps(
+                {
+                    "title": "Sprint",
+                    "attendees": "All",
+                    "agenda": "Review",
+                    "decisions": "Ship it",
+                    "action_items": "Deploy",
+                }
+            ),
+        )
         assert "Attendees" in result
         assert "Agenda" in result
         assert "Decisions" in result

--- a/packages/memtomem/tests/test_user_workflows.py
+++ b/packages/memtomem/tests/test_user_workflows.py
@@ -124,9 +124,7 @@ class TestResearcherIndexing:
         await components.storage.upsert_chunks(chunks)
 
         # Search within namespace
-        results, _ = await components.search_pipeline.search(
-            "pipeline", top_k=5, namespace="work"
-        )
+        results, _ = await components.search_pipeline.search("pipeline", top_k=5, namespace="work")
         assert all(r.chunk.metadata.namespace == "work" for r in results)
 
     async def test_source_filter(self, components, memory_dir):

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -9,9 +9,8 @@ extra wasn't installed — because the old error handler only caught missing
 from __future__ import annotations
 
 import sys
-import asyncio
 import contextlib
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -111,7 +110,7 @@ def _patch_web_stack(server_mock: MagicMock):
         patch("uvicorn.Config", return_value=MagicMock()),
         patch("uvicorn.Server", return_value=server_mock),
         patch("memtomem.web.app.create_app", return_value=MagicMock()),
-        patch("memtomem.web.app._lifespan", MagicMock())
+        patch("memtomem.web.app._lifespan", MagicMock()),
     ]
 
 

--- a/packages/memtomem/tests/test_webhooks.py
+++ b/packages/memtomem/tests/test_webhooks.py
@@ -19,6 +19,7 @@ class TestWebhookManager:
         """WebhookManager should be None when disabled."""
         from memtomem.config import WebhookConfig
         from memtomem.server.webhooks import WebhookManager
+
         config = WebhookConfig(enabled=False, url="https://example.com")
         mgr = WebhookManager(config)
         await mgr.fire("add", {})
@@ -28,6 +29,7 @@ class TestWebhookManager:
         """No URL configured should skip webhook."""
         from memtomem.config import WebhookConfig
         from memtomem.server.webhooks import WebhookManager
+
         config = WebhookConfig(enabled=True, url="")
         mgr = WebhookManager(config)
         await mgr.fire("add", {})
@@ -37,6 +39,7 @@ class TestWebhookManager:
         """Events not in the configured list should be skipped."""
         from memtomem.config import WebhookConfig
         from memtomem.server.webhooks import WebhookManager
+
         config = WebhookConfig(enabled=True, url="https://example.com", events=["add"])
         mgr = WebhookManager(config)
         await mgr.fire("search", {})
@@ -47,6 +50,7 @@ class TestRerankerFactory:
     def test_disabled_returns_none(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
+
         config = RerankConfig(enabled=False)
         assert create_reranker(config) is None
 
@@ -54,6 +58,7 @@ class TestRerankerFactory:
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
         from memtomem.search.reranker.cohere import CohereReranker
+
         config = RerankConfig(enabled=True, provider="cohere", api_key="test")
         reranker = create_reranker(config)
         assert isinstance(reranker, CohereReranker)
@@ -61,6 +66,7 @@ class TestRerankerFactory:
     def test_unknown_provider_raises(self):
         from memtomem.config import RerankConfig
         from memtomem.search.reranker.factory import create_reranker
+
         config = RerankConfig(enabled=True, provider="unknown")
         with pytest.raises(ValueError, match="Unknown reranker"):
             create_reranker(config)
@@ -69,6 +75,7 @@ class TestRerankerFactory:
 class TestConfigSections:
     def test_all_new_configs_default_disabled(self):
         from memtomem.config import Mem2MemConfig
+
         c = Mem2MemConfig()
         assert c.rerank.enabled is False
         assert c.query_expansion.enabled is False
@@ -79,15 +86,18 @@ class TestConfigSections:
 
     def test_rerank_config_validation(self):
         from memtomem.config import RerankConfig
+
         with pytest.raises(Exception):
             RerankConfig(top_k=0)
 
     def test_importance_max_boost_validation(self):
         from memtomem.config import ImportanceConfig
+
         with pytest.raises(Exception):
             ImportanceConfig(max_boost=0.5)
 
     def test_query_expansion_strategy_validation(self):
         from memtomem.config import QueryExpansionConfig
+
         with pytest.raises(Exception):
             QueryExpansionConfig(strategy="invalid")


### PR DESCRIPTION
## Summary

Preps `packages/memtomem/tests` for a follow-up PR that expands CI's `ruff check`/`ruff format --check` scope to include tests. Landing this one first avoids the deadlock where widening the scope would fail the scope-widening PR's own CI run on pre-existing drift.

## What changed

- **34 files reformatted by `ruff format`** — auto-applied, no logic change. Blank-line normalization around inline imports, multi-line tuple rewrites, trailing-comma insertion. Reviewers can skim; the diff is mechanical.
- **9 F401 auto-fixes** (`ruff check --fix`) — unused imports: `asyncio`, `os`, `pytest`, `re`, `unittest.mock.AsyncMock`, and three `memtomem.context.settings` re-imports that were never used.
- **5 manual F841 fixes** — worth looking at:
  | File | Line | Before → After |
  |---|---|---|
  | `tests/test_indexing_engine.py` | 671 | `stats1 = await …index_file(…)` → `await …index_file(…)` |
  | `tests/test_server_tools_advanced.py` | 548 | `bundle = await export_chunks(…)` → `await export_chunks(…)` |
  | `tests/test_server_tools_core.py` | 301 / 306 / 312 | `msg = _set_config_key(…)` → `_set_config_key(…)` |

  In each case the test captured a return value it never asserted on. The call has side effects (file I/O, DB write, config mutation), so the call stays — only the unused name is dropped. No assertion is added (out of scope for this cleanup PR).

## Why two PRs

CI currently scopes ruff to `packages/memtomem/src` only (`.github/workflows/ci.yml`). Bundling the scope expansion with the cleanup would deadlock: the scope-widening PR's own CI run would catch the pre-existing drift and refuse to merge until the drift is fixed — which is this PR. So this PR lands first, a follow-up PR adds `packages/memtomem/tests` to CI's lint/format step once main is clean.

## Test plan

- [x] `uv run ruff check packages/memtomem/tests` → All checks passed
- [x] `uv run ruff format --check packages/memtomem/tests` → clean
- [x] `uv run pytest -m "not ollama"` on the three files with manual F841 fixes → 194 passed
- [ ] Full test suite via CI (will run on this PR)

No behavior change expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)