### PR TITLE
ci: extend ruff scope to packages/memtomem/tests (follow-up to #109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: uv run ruff check packages/memtomem/src
-      - run: uv run ruff format --check packages/memtomem/src
+      - run: uv run ruff check packages/memtomem/src packages/memtomem/tests
+      - run: uv run ruff format --check packages/memtomem/src packages/memtomem/tests
 
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `packages/memtomem/tests` to the two ruff commands in `.github/workflows/ci.yml` so that the lint job enforces `ruff check` and `ruff format --check` against tests as well as source.

```yaml
# .github/workflows/ci.yml (lint job)
- run: uv run ruff check packages/memtomem/src packages/memtomem/tests
- run: uv run ruff format --check packages/memtomem/src packages/memtomem/tests
```

## Why after #109

Before #109, `packages/memtomem/tests` had 34 files with format drift and 14 F401/F841 lint errors (originally surfaced during #107's `ruff format` output). Widening CI scope first would have been self-blocking — the scope-widening PR's own CI run would have failed on that drift and refused to merge until it was cleaned, but the cleanup PR (#109) was a separate change. So #109 landed first; now this PR can go in with a clean baseline.

## Scope limits

- **`mypy`** job left untouched. Expanding mypy to tests would require a separate typing refactor (tests use `Any` / `MagicMock` liberally); out of scope.
- **`pytest`** job unchanged. It already runs against tests.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` → All checks passed
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` → 249 files already formatted
- [ ] CI on this PR will re-run both commands against the new scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)