### PR TITLE
fix(cli): pass real index_engine/config to FileWatcher in watchdog run

### DIFF
--- a/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
@@ -92,7 +92,7 @@ async def _watchdog_run(as_json: bool) -> None:
             embedder=comp.embedder,
             index_engine=comp.index_engine,
             search_pipeline=comp.search_pipeline,
-            watcher=FileWatcher([], None),
+            watcher=FileWatcher(comp.index_engine, comp.config.indexing),
         )
         config = HealthWatchdogConfig(enabled=True)
         wd = HealthWatchdog(ctx, config)


### PR DESCRIPTION
## Summary
- `_watchdog_run` constructed `FileWatcher([], None)` purely to satisfy the required `AppContext.watcher` field, violating the constructor contract (`index_engine: IndexEngine`, `config: IndexingConfig`) and producing 2 mypy errors.
- `HealthWatchdog` does not invoke the watcher today, so the stub never crashed in practice — but it leaks invalid types into `AppContext` and would break the moment any future health check / webhook / scheduler sharing the context read `watcher._engine` or `watcher._config`.
- Fix mirrors the production `lifespan.py:107` pattern: `FileWatcher(comp.index_engine, comp.config.indexing)`. The watcher is constructed but **never started**, so no observer thread or reindex task is created — behavior of `mm watchdog run` is unchanged.

## Test plan
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/watchdog_cmd.py` → no issues
- [x] `uv run ruff check + format --check` → pass
- [x] `python -c "from memtomem.cli.watchdog_cmd import _watchdog_run"` → import OK
- [ ] CI green (full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)