### PR TITLE
fix(auto-tag): add namespace_filter to auto_tag_storage to fix silent policy failure

### DIFF
--- a/packages/memtomem/src/memtomem/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/tools/auto_tag.py
@@ -268,6 +268,7 @@ class AutoTagStats:
 async def auto_tag_storage(
     storage: object,
     source_filter: str | None = None,
+    namespace_filter: str | None = None,
     max_tags: int = 5,
     overwrite: bool = False,
     dry_run: bool = False,
@@ -281,6 +282,10 @@ async def auto_tag_storage(
     Args:
         storage: StorageBackend instance.
         source_filter: Only process sources whose path contains this substring.
+        namespace_filter: Only process chunks whose metadata namespace matches
+            this value exactly. Applied per-chunk after source-level filtering;
+            chunks in other namespaces are excluded entirely (not counted in
+            total/skipped), mirroring the source_filter semantics.
         max_tags: Maximum tags to extract per chunk (default 5).
         overwrite: If False (default), skip chunks that already have tags.
         dry_run: If True, compute tags but do NOT write to storage.
@@ -302,6 +307,8 @@ async def auto_tag_storage(
         chunks: list[Chunk] = await storage.list_chunks_by_source(  # type: ignore[union-attr]
             source, limit=10_000
         )
+        if namespace_filter is not None:
+            chunks = [c for c in chunks if c.metadata.namespace == namespace_filter]
         for chunk in chunks:
             total += 1
 

--- a/packages/memtomem/tests/test_server_tools_advanced.py
+++ b/packages/memtomem/tests/test_server_tools_advanced.py
@@ -806,6 +806,21 @@ class TestAutoTag:
         assert stats.total_chunks == 1
         assert stats.tagged_chunks == 1
 
+    async def test_auto_tag_storage_namespace_filter(self, storage):
+        c1 = _chunk("Python code example function", namespace="proj_a", source="a.md")
+        c2 = _chunk("Rust memory safety ownership model", namespace="proj_b", source="b.md")
+        await storage.upsert_chunks([c1, c2])
+
+        stats = await auto_tag_storage(storage, namespace_filter="proj_a")
+        assert stats.total_chunks == 1
+        assert stats.tagged_chunks == 1
+
+        # Verify only the proj_a chunk was tagged
+        a_chunks = await storage.list_chunks_by_source(Path("/tmp/a.md"))
+        b_chunks = await storage.list_chunks_by_source(Path("/tmp/b.md"))
+        assert a_chunks[0].metadata.tags  # tagged
+        assert b_chunks[0].metadata.tags == ()  # untouched
+
 
 # ===================================================================
 # Dedup (DedupScanner) - basic exact duplicate detection


### PR DESCRIPTION
## Summary
- `policy_engine.run_policy` calls `auto_tag_storage(..., namespace_filter=namespace, ...)` (`tools/policy_engine.py:238`) for any `auto_tag` policy with a namespace scope, but the function never accepted that keyword.
- The resulting `TypeError: auto_tag_storage() got an unexpected keyword argument 'namespace_filter'` was swallowed by the surrounding `except Exception:` (line 245) and only surfaced as `details=\"Auto-tag failed: ...\"` in the policy result — every namespace-scoped auto_tag policy has been silently failing **100% of the time**, with no log/metric/test catching it.
- The mypy `[call-arg]` warning on this site turned out to be a real runtime bug, not a type-checker artifact.

## Fix
Add `namespace_filter: str | None = None` to `auto_tag_storage` and filter the per-source chunk list by `chunk.metadata.namespace` before tag extraction. Semantics mirror `source_filter`: chunks in other namespaces are excluded entirely (not counted in total/skipped), so stats remain meaningful when scoping to a single namespace.

**Why not rename `source_filter`?** `source_filter` is a *path substring match* on `Source.path` (file-level); `namespace_filter` is an *exact match* on chunk metadata (namespace-level). They are orthogonal axes — renaming would silently change the meaning of every existing caller.

## Backward compatibility
The other four callers — `web/routes/tags.py`, `server/tools/auto_tag.py`, `server/tools/indexing.py`, existing tests — do not pass the new parameter. Default `None` keeps them unchanged.

## Test plan
- [x] New test `test_auto_tag_storage_namespace_filter` covering positive match, exclusion of other namespaces, and that excluded chunks remain untagged
- [x] All existing `auto_tag_storage` tests still pass (6/6)
- [x] `uv run mypy packages/memtomem/src/memtomem/tools/auto_tag.py packages/memtomem/src/memtomem/tools/policy_engine.py` — the `namespace_filter` `[call-arg]` error is gone (other unrelated mypy errors in policy_engine remain — separate cluster, out of scope)
- [x] `uv run ruff check + format --check` pass
- [ ] CI green (full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)