### PR TITLE
fix: surface silent conflict detection and analytics query failures

### DIFF
--- a/packages/memtomem/src/memtomem/search/conflict.py
+++ b/packages/memtomem/src/memtomem/search/conflict.py
@@ -60,8 +60,8 @@ async def detect_conflicts(
     try:
         embedding = await embedder.embed_query(content)
         results = await storage.dense_search(embedding, top_k=10)
-    except Exception as exc:
-        logger.debug("Conflict detection failed: %s", exc)
+    except Exception:
+        logger.warning("Conflict detection failed", exc_info=True)
         return []
 
     candidates: list[ConflictCandidate] = []

--- a/packages/memtomem/src/memtomem/storage/mixins/analytics.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/analytics.py
@@ -132,6 +132,7 @@ class AnalyticsMixin:
             ).fetchall()
             return [{"query": r[0], "count": r[1]} for r in rows]
         except Exception:
+            logger.debug("get_knowledge_gaps query failed", exc_info=True)
             return []
 
     async def get_most_connected(self, limit: int = 5) -> list[dict]:

--- a/packages/memtomem/tests/test_analytics.py
+++ b/packages/memtomem/tests/test_analytics.py
@@ -1,5 +1,7 @@
 """Tests for analytics storage mixin methods."""
 
+import logging
+
 import pytest
 from pathlib import Path
 from memtomem.models import Chunk, ChunkMetadata
@@ -97,6 +99,21 @@ class TestKnowledgeGaps:
         assert len(gaps) == 1
         assert gaps[0]["query"] == "missing topic"
         assert gaps[0]["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_db_error_logs_debug(self, storage, caplog):
+        # Drop the query_history table to force the query to fail — we want
+        # to verify the failure is logged (debug) rather than silently swallowed.
+        storage._get_db().execute("DROP TABLE IF EXISTS query_history")
+
+        with caplog.at_level(logging.DEBUG, logger="memtomem.storage.mixins.analytics"):
+            result = await storage.get_knowledge_gaps()
+
+        assert result == []
+        assert any(
+            rec.levelno == logging.DEBUG and "get_knowledge_gaps query failed" in rec.message
+            for rec in caplog.records
+        ), "Expected DEBUG log when get_knowledge_gaps query fails (not fully silent)"
 
 
 class TestMostConnected:

--- a/packages/memtomem/tests/test_conflict.py
+++ b/packages/memtomem/tests/test_conflict.py
@@ -1,7 +1,9 @@
 """Tests for conflict detection."""
 
+import logging
+
 import pytest
-from memtomem.search.conflict import _jaccard_tokens, ConflictCandidate
+from memtomem.search.conflict import _jaccard_tokens, ConflictCandidate, detect_conflicts
 
 
 class TestJaccardTokens:
@@ -42,3 +44,45 @@ class TestConflictCandidate:
         )
         assert c.conflict_score == pytest.approx(0.8)
         assert c.similarity > c.text_overlap
+
+
+class TestDetectConflictsFailure:
+    """Conflict detection failure must surface as WARNING, not silent debug."""
+
+    @pytest.mark.asyncio
+    async def test_embedder_failure_logs_warning(self, caplog):
+        class _BrokenEmbedder:
+            async def embed_query(self, _text: str):
+                raise RuntimeError("embedder unavailable")
+
+        class _DummyStorage:
+            async def dense_search(self, *args, **kwargs):
+                return []
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.conflict"):
+            result = await detect_conflicts("new content", _DummyStorage(), _BrokenEmbedder())
+
+        assert result == []
+        assert any(
+            rec.levelno == logging.WARNING and "Conflict detection failed" in rec.message
+            for rec in caplog.records
+        ), "Expected WARNING log when conflict detection fails (not silent debug)"
+
+    @pytest.mark.asyncio
+    async def test_storage_failure_logs_warning(self, caplog):
+        class _DummyEmbedder:
+            async def embed_query(self, _text: str):
+                return [0.0, 0.0, 0.0]
+
+        class _BrokenStorage:
+            async def dense_search(self, *args, **kwargs):
+                raise RuntimeError("storage unavailable")
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.conflict"):
+            result = await detect_conflicts("new content", _BrokenStorage(), _DummyEmbedder())
+
+        assert result == []
+        assert any(
+            rec.levelno == logging.WARNING and "Conflict detection failed" in rec.message
+            for rec in caplog.records
+        )


### PR DESCRIPTION
## Summary

Two dropped-signal cases where real failures were hidden under debug or swallowed entirely, so \"no results\" was indistinguishable from a crash.

- **`search/conflict.py`**: embedder/storage failures went to `logger.debug` + `return []`. Under default log levels this is silent — you can't tell whether there really are no conflicts or whether the embedder is broken.
- **`storage/mixins/analytics.py:134`** (`get_knowledge_gaps`): bare `except Exception: return []` with no log at all, making failures undiagnosable even with `-v`.

Same dropped-signal pattern that motivated #78 (silent except-pass in `sqlite_backend` / `status_config`) and #83 (watcher shutdown sentinel).

## Changes

- `search/conflict.py`: `logger.debug` → `logger.warning` with `exc_info=True` for the try block around `embed_query` / `dense_search`.
- `storage/mixins/analytics.py`: add `logger.debug(\"get_knowledge_gaps query failed\", exc_info=True)` to the existing `except Exception: return []`. Kept debug level (not warning) because this method is a best-effort reflection reporter — the table may legitimately not exist yet on a fresh DB, and we don't want to spam warnings for that case.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_conflict.py packages/memtomem/tests/test_analytics.py -v -m \"not ollama\"` — 26 passed
- [x] `uv run ruff check` + `ruff format --check` on the four modified files — clean
- [x] New tests use `caplog.at_level(..., logger=\"...\")` to assert the log is actually emitted at the right level (claim-test parity: the \"surface the failure\" promise is regression-guarded, not just stated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)