### PR TITLE
feat: include offending value in MCP tool numeric validation errors (#47)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/ask.py
+++ b/packages/memtomem/src/memtomem/server/tools/ask.py
@@ -50,9 +50,9 @@ async def mem_ask(
     if not question.strip():
         return "Error: question cannot be empty."
     if len(question) > 10_000:
-        return "Error: question too long (max 10,000 characters)."
+        return f"Error: question too long (max 10,000 characters, got {len(question)})."
     if not 1 <= top_k <= 20:
-        return "Error: top_k must be between 1 and 20."
+        return f"Error: top_k must be between 1 and 20, got {top_k}."
 
     app = _get_app(ctx)
     effective_ns = namespace or app.current_namespace

--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -34,9 +34,9 @@ async def mem_consolidate(
         min_group_size: Minimum chunks per group (default 3)
     """
     if not 1 <= max_groups <= 50:
-        return "Error: max_groups must be between 1 and 50."
+        return f"Error: max_groups must be between 1 and 50, got {max_groups}."
     if min_group_size < 2:
-        return "Error: min_group_size must be at least 2."
+        return f"Error: min_group_size must be at least 2, got {min_group_size}."
 
     app = _get_app(ctx)
     effective_ns = namespace or app.current_namespace

--- a/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
+++ b/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
@@ -28,9 +28,9 @@ async def mem_dedup_scan(
         max_scan: Maximum chunks to inspect for near-duplicate search
     """
     if not 0.0 <= threshold <= 1.0:
-        return "Error: threshold must be between 0 and 1."
+        return f"Error: threshold must be between 0 and 1, got {threshold}."
     if not 1 <= limit <= 500:
-        return "Error: limit must be between 1 and 500."
+        return f"Error: limit must be between 1 and 500, got {limit}."
 
     app = _get_app(ctx)
     if app.dedup_scanner is None:
@@ -101,7 +101,7 @@ async def mem_decay_scan(
         source_filter: Only scan chunks from sources containing this substring.
     """
     if max_age_days <= 0:
-        return "Error: max_age_days must be positive."
+        return f"Error: max_age_days must be positive, got {max_age_days}."
 
     from memtomem.search.decay import expire_chunks
 
@@ -136,7 +136,7 @@ async def mem_decay_expire(
         dry_run: If True (default), preview without making any changes.
     """
     if max_age_days <= 0:
-        return "Error: max_age_days must be positive."
+        return f"Error: max_age_days must be positive, got {max_age_days}."
 
     from memtomem.search.decay import expire_chunks
 

--- a/packages/memtomem/src/memtomem/server/tools/entity.py
+++ b/packages/memtomem/src/memtomem/server/tools/entity.py
@@ -133,7 +133,7 @@ async def mem_entity_search(
         limit: Maximum results (default 20)
     """
     if not 1 <= limit <= 500:
-        return "Error: limit must be between 1 and 500."
+        return f"Error: limit must be between 1 and 500, got {limit}."
 
     app = _get_app(ctx)
     results = await app.storage.search_entities(

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -332,7 +332,7 @@ async def mem_batch_add(
         file: Target .md file.  If omitted, a timestamped file is created.
     """
     if len(entries) > 500:
-        return "Error: batch too large (max 500 entries)."
+        return f"Error: batch too large (max 500 entries, got {len(entries)})."
 
     from datetime import datetime, timezone
 

--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -37,7 +37,7 @@ async def mem_recall(
         mem_recall(namespace="work", limit=10)
     """
     if not 1 <= limit <= 500:
-        return "Error: limit must be between 1 and 500."
+        return f"Error: limit must be between 1 and 500, got {limit}."
 
     from memtomem.models import NamespaceFilter
 

--- a/packages/memtomem/src/memtomem/server/tools/reflection.py
+++ b/packages/memtomem/src/memtomem/server/tools/reflection.py
@@ -33,7 +33,7 @@ async def mem_reflect(
         limit: Maximum items per category
     """
     if not 1 <= limit <= 200:
-        return "Error: limit must be between 1 and 200."
+        return f"Error: limit must be between 1 and 200, got {limit}."
 
     app = _get_app(ctx)
     storage = app.storage

--- a/packages/memtomem/src/memtomem/server/tools/scratch.py
+++ b/packages/memtomem/src/memtomem/server/tools/scratch.py
@@ -30,7 +30,7 @@ async def mem_scratch_set(
     from datetime import datetime, timedelta, timezone
 
     if ttl_minutes is not None and ttl_minutes <= 0:
-        return "Error: ttl_minutes must be a positive number."
+        return f"Error: ttl_minutes must be a positive number, got {ttl_minutes}."
     app = _get_app(ctx)
     expires_at = None
     if ttl_minutes is not None and ttl_minutes > 0:

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -59,9 +59,9 @@ async def mem_search(
     if not query.strip():
         return "Error: query cannot be empty."
     if len(query) > 10_000:
-        return "Error: query too long (max 10,000 characters)."
+        return f"Error: query too long (max 10,000 characters, got {len(query)})."
     if not 1 <= top_k <= 100:
-        return "Error: top_k must be between 1 and 100."
+        return f"Error: top_k must be between 1 and 100, got {top_k}."
 
     # Resolve effective format: output_format takes precedence over verbose
     effective_format = output_format

--- a/packages/memtomem/src/memtomem/server/tools/search_history.py
+++ b/packages/memtomem/src/memtomem/server/tools/search_history.py
@@ -23,7 +23,7 @@ async def mem_search_history(
         since: ISO date filter — only queries after this date.
     """
     if not 1 <= limit <= 200:
-        return "Error: limit must be between 1 and 200."
+        return f"Error: limit must be between 1 and 200, got {limit}."
 
     app = _get_app(ctx)
     rows = await app.storage.get_query_history(limit=limit, since=since)

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -110,7 +110,7 @@ async def mem_session_list(
         limit: Maximum sessions to return (default 10)
     """
     if not 1 <= limit <= 200:
-        return "Error: limit must be between 1 and 200."
+        return f"Error: limit must be between 1 and 200, got {limit}."
 
     app = _get_app(ctx)
     sessions = await app.storage.list_sessions(agent_id=agent_id, since=since, limit=limit)

--- a/packages/memtomem/src/memtomem/server/tools/temporal.py
+++ b/packages/memtomem/src/memtomem/server/tools/temporal.py
@@ -38,7 +38,7 @@ async def mem_timeline(
         limit: Maximum chunks to analyze (default 50)
     """
     if not 1 <= limit <= 500:
-        return "Error: limit must be between 1 and 500."
+        return f"Error: limit must be between 1 and 500, got {limit}."
 
     from memtomem.tools.temporal import build_timeline, format_timeline
 

--- a/packages/memtomem/tests/test_validation_error_messages.py
+++ b/packages/memtomem/tests/test_validation_error_messages.py
@@ -1,0 +1,100 @@
+"""Tests that MCP tool numeric-range validation errors echo the actual input.
+
+Contract tested: when a tool rejects a numeric value as out of range, the
+returned "Error: ..." string includes the offending value so the caller can
+see what they actually passed. Closes #47.
+
+Each test hits the validation path directly (no MCP ctx / app needed —
+the bad-value checks run before any ctx access)."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestSearchValidation:
+    async def test_top_k_out_of_range_includes_value(self):
+        from memtomem.server.tools.search import mem_search
+
+        result = await mem_search(query="hello", top_k=0)
+        assert "got 0" in result
+        assert "top_k must be between 1 and 100" in result
+
+    async def test_query_too_long_includes_length(self):
+        from memtomem.server.tools.search import mem_search
+
+        long_query = "x" * 10_001
+        result = await mem_search(query=long_query)
+        assert "got 10001" in result
+        assert "query too long" in result
+
+
+class TestAskValidation:
+    async def test_top_k_out_of_range_includes_value(self):
+        from memtomem.server.tools.ask import mem_ask
+
+        result = await mem_ask(question="hi", top_k=99)
+        assert "got 99" in result
+        assert "top_k must be between 1 and 20" in result
+
+
+class TestConsolidateValidation:
+    async def test_max_groups_out_of_range_includes_value(self):
+        from memtomem.server.tools.consolidation import mem_consolidate
+
+        result = await mem_consolidate(max_groups=99)
+        assert "got 99" in result
+        assert "max_groups must be between 1 and 50" in result
+
+    async def test_min_group_size_too_small_includes_value(self):
+        from memtomem.server.tools.consolidation import mem_consolidate
+
+        result = await mem_consolidate(min_group_size=1)
+        assert "got 1" in result
+        assert "min_group_size must be at least 2" in result
+
+
+class TestDedupDecayValidation:
+    async def test_threshold_out_of_range_includes_value(self):
+        from memtomem.server.tools.dedup_decay import mem_dedup_scan
+
+        result = await mem_dedup_scan(threshold=1.5)
+        assert "got 1.5" in result
+        assert "threshold must be between 0 and 1" in result
+
+    async def test_max_age_days_non_positive_includes_value(self):
+        from memtomem.server.tools.dedup_decay import mem_decay_scan
+
+        result = await mem_decay_scan(max_age_days=0)
+        assert "got 0" in result
+        assert "max_age_days must be positive" in result
+
+
+class TestScratchValidation:
+    async def test_ttl_minutes_non_positive_includes_value(self):
+        from memtomem.server.tools.scratch import mem_scratch_set
+
+        result = await mem_scratch_set(key="k", value="v", ttl_minutes=-5)
+        assert "got -5" in result
+        assert "ttl_minutes must be a positive number" in result
+
+
+class TestRecallValidation:
+    async def test_limit_out_of_range_includes_value(self):
+        from memtomem.server.tools.recall import mem_recall
+
+        result = await mem_recall(limit=9999)
+        assert "got 9999" in result
+        assert "limit must be between 1 and 500" in result
+
+
+class TestMemoryCrudBatchValidation:
+    async def test_batch_too_large_includes_length(self):
+        from memtomem.server.tools.memory_crud import mem_batch_add
+
+        entries = [{"key": str(i), "value": "x"} for i in range(501)]
+        result = await mem_batch_add(entries=entries)
+        assert "got 501" in result
+        assert "batch too large" in result


### PR DESCRIPTION
## Summary

Closes #47. When a tool rejects a numeric argument as out of range, append `, got {value}` so the caller can see what they actually passed instead of only the allowed range.

```diff
- "Error: top_k must be between 1 and 100."
+ f"Error: top_k must be between 1 and 100, got {top_k}."
```

## Changed messages — 18 total across 12 files

- `server/tools/search.py` — `query` length, `top_k`
- `server/tools/ask.py` — `question` length, `top_k`
- `server/tools/consolidation.py` — `max_groups`, `min_group_size`
- `server/tools/dedup_decay.py` — `threshold`, `limit`, `max_age_days` (in both `mem_decay_scan` and `mem_decay_expire`)
- `server/tools/memory_crud.py` — batch size
- `server/tools/temporal.py`, `entity.py`, `recall.py`, `reflection.py`, `search_history.py`, `session.py` — `limit`
- `server/tools/scratch.py` — `ttl_minutes`

## Out of scope (handled vs unhandled)

Deliberately **not** touched in this PR:

- **"must be non-empty" checks** (tag_management, multi_agent, namespace, etc.) — echoing `''` adds no signal over the existing message.
- **`since >= until` datetime comparisons** (temporal, recall) — showing datetimes has formatting tradeoffs that belong in a separate change.

These can land separately — the issue specifically focuses on "numeric ranges or required parameters" where the actual value helps.

## Test plan

- [x] `test_validation_error_messages.py` added — 10 tests hitting representative validation paths (search, ask, consolidation, dedup_decay, scratch, recall, memory_crud batch). Each asserts the `got {value}` substring so the claim is regression-guarded (per `feedback_claim_test_parity`).
- [x] Full suite: `uv run pytest -m "not ollama"` — 1371 passed (no regressions from the message changes)
- [x] `uv run ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)