### PR TITLE
typing: drop 12 union-attr ignores by narrowing signatures (closes #100)

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/registry.py
+++ b/packages/memtomem/src/memtomem/chunking/registry.py
@@ -4,19 +4,20 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from memtomem.chunking.base import Chunker
 from memtomem.models import Chunk
 
 
 class ChunkerRegistry:
     """Maps file extensions to chunkers and dispatches chunk_file calls."""
 
-    def __init__(self, chunkers: list[object]) -> None:
-        self._map: dict[str, object] = {}
+    def __init__(self, chunkers: list[Chunker]) -> None:
+        self._map: dict[str, Chunker] = {}
         for chunker in chunkers:
-            for ext in chunker.supported_extensions():  # type: ignore[union-attr]
+            for ext in chunker.supported_extensions():
                 self._map[ext] = chunker
 
-    def get(self, extension: str) -> object | None:
+    def get(self, extension: str) -> Chunker | None:
         return self._map.get(extension)
 
     def supported_extensions(self) -> frozenset[str]:
@@ -26,4 +27,4 @@ class ChunkerRegistry:
         chunker = self._map.get(file_path.suffix)
         if chunker is None:
             return []
-        return chunker.chunk_file(file_path, content)  # type: ignore[union-attr]
+        return chunker.chunk_file(file_path, content)

--- a/packages/memtomem/src/memtomem/search/decay.py
+++ b/packages/memtomem/src/memtomem/search/decay.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from memtomem.models import SearchResult
+    from memtomem.storage.sqlite_backend import SqliteBackend
 
 
 def decay_factor(age_days: float, half_life_days: float) -> float:
@@ -82,7 +83,7 @@ class ExpireStats:
 
 
 async def expire_chunks(
-    storage: object,
+    storage: SqliteBackend,
     max_age_days: float,
     dry_run: bool = False,
     source_filter: str | None = None,
@@ -106,7 +107,7 @@ async def expire_chunks(
     now = datetime.now(timezone.utc)
     cutoff_seconds = max_age_days * 86400
 
-    sources = await storage.get_all_source_files()  # type: ignore[union-attr]
+    sources = await storage.get_all_source_files()
     if source_filter:
         sources = {s for s in sources if source_filter in str(s)}
 
@@ -114,9 +115,7 @@ async def expire_chunks(
     to_delete: list[UUID] = []
 
     for source in sorted(sources):
-        chunks = await storage.list_chunks_by_source(  # type: ignore[union-attr]
-            source, limit=10_000
-        )
+        chunks = await storage.list_chunks_by_source(source, limit=10_000)
         for chunk in chunks:
             total += 1
             updated_at = chunk.updated_at
@@ -127,7 +126,7 @@ async def expire_chunks(
 
     deleted = 0
     if not dry_run and to_delete:
-        deleted = await storage.delete_chunks(to_delete)  # type: ignore[union-attr]
+        deleted = await storage.delete_chunks(to_delete)
 
     return ExpireStats(
         total_chunks=total,

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import logging
 
+from memtomem.chunking.base import Chunker
 from memtomem.chunking.markdown import MarkdownChunker
 from memtomem.chunking.registry import ChunkerRegistry
 from memtomem.chunking.restructured_text import ReStructuredTextChunker
@@ -63,7 +64,7 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         raise
 
     # Build chunker registry with optional code chunkers
-    chunkers: list[object] = [
+    chunkers: list[Chunker] = [
         MarkdownChunker(indexing_config=config.indexing),
         StructuredChunker(indexing_config=config.indexing),
         ReStructuredTextChunker(),

--- a/packages/memtomem/src/memtomem/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/tools/auto_tag.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from memtomem.llm.base import LLMProvider
+    from memtomem.storage.sqlite_backend import SqliteBackend
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +241,7 @@ async def _extract_tags_with_fallback(
     text: str,
     max_tags: int = 5,
     heading_hierarchy: tuple[str, ...] = (),
-    llm_provider: object | None = None,
+    llm_provider: LLMProvider | None = None,
 ) -> list[str]:
     """Try LLM tagging; fall back to keyword heuristic on failure."""
     if llm_provider is not None:
@@ -249,7 +250,7 @@ async def _extract_tags_with_fallback(
                 text,
                 llm_provider,
                 max_tags,
-                heading_hierarchy,  # type: ignore[arg-type]
+                heading_hierarchy,
             )
         except Exception:
             logger.warning("LLM tagging failed, using keyword fallback", exc_info=True)
@@ -266,13 +267,13 @@ class AutoTagStats:
 
 
 async def auto_tag_storage(
-    storage: object,
+    storage: SqliteBackend,
     source_filter: str | None = None,
     namespace_filter: str | None = None,
     max_tags: int = 5,
     overwrite: bool = False,
     dry_run: bool = False,
-    llm_provider: object | None = None,
+    llm_provider: LLMProvider | None = None,
 ) -> AutoTagStats:
     """Apply keyword-based tags to chunks in storage.
 
@@ -295,7 +296,7 @@ async def auto_tag_storage(
     """
     from memtomem.models import Chunk, ChunkMetadata
 
-    sources = await storage.get_all_source_files()  # type: ignore[union-attr]
+    sources = await storage.get_all_source_files()
     if source_filter:
         sources = {s for s in sources if source_filter in str(s)}
 
@@ -304,9 +305,7 @@ async def auto_tag_storage(
     skipped = 0
 
     for source in sorted(sources):
-        chunks: list[Chunk] = await storage.list_chunks_by_source(  # type: ignore[union-attr]
-            source, limit=10_000
-        )
+        chunks: list[Chunk] = await storage.list_chunks_by_source(source, limit=10_000)
         if namespace_filter is not None:
             chunks = [c for c in chunks if c.metadata.namespace == namespace_filter]
         for chunk in chunks:
@@ -347,7 +346,7 @@ async def auto_tag_storage(
                     created_at=chunk.created_at,
                     updated_at=datetime.now(timezone.utc),
                 )
-                await storage.upsert_chunks([updated])  # type: ignore[union-attr]
+                await storage.upsert_chunks([updated])
 
             tagged += 1
 

--- a/packages/memtomem/src/memtomem/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/tools/export_import.py
@@ -11,9 +11,14 @@ import logging
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from memtomem.models import Chunk, ChunkMetadata, ChunkType
+
+if TYPE_CHECKING:
+    from memtomem.embedding.base import EmbeddingProvider
+    from memtomem.storage.sqlite_backend import SqliteBackend
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +66,7 @@ class ImportStats:
 
 
 async def export_chunks(
-    storage: object,
+    storage: SqliteBackend,
     output_path: Path | None = None,
     source_filter: str | None = None,
     tag_filter: str | None = None,
@@ -79,13 +84,13 @@ async def export_chunks(
     Returns:
         ExportBundle with the selected chunks.
     """
-    source_files = await storage.get_all_source_files()  # type: ignore[union-attr]
+    source_files = await storage.get_all_source_files()
 
     records: list[dict] = []
     for source in sorted(source_files):
         if source_filter and source_filter not in str(source):
             continue
-        chunks = await storage.list_chunks_by_source(source, limit=100_000)  # type: ignore[union-attr]
+        chunks = await storage.list_chunks_by_source(source, limit=100_000)
         for chunk in chunks:
             if tag_filter and tag_filter not in chunk.metadata.tags:
                 continue
@@ -131,8 +136,8 @@ def _chunk_to_dict(chunk: Chunk) -> dict:
 
 
 async def import_chunks(
-    storage: object,
-    embedder: object,
+    storage: SqliteBackend,
+    embedder: EmbeddingProvider,
     input_path: Path,
     namespace: str | None = None,
 ) -> ImportStats:
@@ -178,7 +183,7 @@ async def import_chunks(
         # Embed in one shot for efficiency
         contents = [c.content for c in batch]
         try:
-            embeddings = await embedder.embed_texts(contents)  # type: ignore[union-attr]
+            embeddings = await embedder.embed_texts(contents)
             for chunk, emb in zip(batch, embeddings):
                 chunk.embedding = emb
         except Exception as exc:
@@ -191,7 +196,7 @@ async def import_chunks(
             )
 
         try:
-            await storage.upsert_chunks(batch)  # type: ignore[union-attr]
+            await storage.upsert_chunks(batch)
             imported = len(batch)
         except Exception as exc:
             logger.error("Upsert failed during import: %s", exc)


### PR DESCRIPTION
## Summary

- 12 `# type: ignore[union-attr]` markers across `search/decay.py`, `chunking/registry.py`, `tools/auto_tag.py`, and `tools/export_import.py` removed by typing parameters as concrete `SqliteBackend` / `EmbeddingProvider` / `LLMProvider` / `Chunker` instead of `object`.
- One related baseline `# type: ignore[arg-type]` on `auto_tag.py:250` becomes redundant once `llm_provider: object | None` is narrowed to `LLMProvider | None`, so it is removed too.
- `server/component_factory.py` declares the local `chunkers` list as `list[Chunker]` to keep `ChunkerRegistry(chunkers)` valid after the constructor signature tightens.

## Root cause vs. issue body

The issue body suggested introducing a `_get_app_checked(ctx)` helper or per-call `assert app.storage is not None`. That is not the right model — `AppContext.storage` is already non-Optional (`SqliteBackend`). The real cause was that these standalone functions accept `storage: object` / `embedder: object` and lose the type when callers pass `app.storage` etc. Narrowing the signatures resolves the ignores at the source, no helper needed.

## Risk

- No behavior change; only typing.
- All call sites already pass the concrete types, so the narrower signatures don't constrain anything new.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` → 1440 passed
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check` → clean
- [x] `uv run mypy packages/memtomem/src` → net -1 error (43 → 42; the auto_tag.py:250 baseline)
- [x] `grep -c "type: ignore\[union-attr\]"` on the 4 target files → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)