### PR TITLE
typing(rst-chunker): correct current_hierarchy / level_order / has_overline annotations (closes #126)

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/restructured_text.py
+++ b/packages/memtomem/src/memtomem/chunking/restructured_text.py
@@ -65,7 +65,7 @@ class ReStructuredTextChunker:
         lines = content.splitlines()
         # Detect section headers and their levels.
         # level_order maps adornment character to its depth (0-indexed).
-        level_order: dict[str, int] = {}
+        level_order: dict[tuple[str, bool], int] = {}
         headers: list[tuple[int, str, int]] = []  # (line_idx, title, depth)
 
         for i, line in enumerate(lines):
@@ -79,7 +79,7 @@ class ReStructuredTextChunker:
                 title = lines[i - 1].strip()
                 if adorn_len >= len(title):
                     # Check for optional overline (line above title)
-                    has_overline = (
+                    has_overline = bool(
                         i >= 2 and _ADORNMENT_RE.match(lines[i - 2]) and lines[i - 2][0] == char
                     )
                     key = (char, has_overline)
@@ -102,7 +102,7 @@ class ReStructuredTextChunker:
             ]
 
         sections: list[dict] = []
-        current_hierarchy: list[str] = []
+        current_hierarchy: list[tuple[int, str]] = []
 
         # Content before first header
         if headers[0][0] > 0:
@@ -119,12 +119,8 @@ class ReStructuredTextChunker:
 
         for idx, (hdr_start, title, depth) in enumerate(headers):
             # Update hierarchy: keep only levels shallower than current
-            current_hierarchy = [
-                h
-                for h in current_hierarchy
-                if h[0] < depth  # type: ignore[index]
-            ]
-            current_hierarchy.append((depth, title))  # type: ignore[arg-type]
+            current_hierarchy = [h for h in current_hierarchy if h[0] < depth]
+            current_hierarchy.append((depth, title))
 
             # Section body starts after the underline
             # Find the underline: it's either hdr_start+1 (no overline) or hdr_start+2 (overline)


### PR DESCRIPTION
## Summary

Three related annotation mistakes in `chunking/restructured_text.py::_split_by_headings`. The first one was hidden by 2 `# type: ignore` markers; the others only became visible after the ignores came off.

| What | Was | Now | Why |
|---|---|---|---|
| `current_hierarchy` | `list[str]` | `list[tuple[int, str]]` | Always populated with `(depth, title)` tuples; runtime only works because the first iteration's filter sees an empty list |
| `level_order` | `dict[str, int]` | `dict[tuple[str, bool], int]` | The only insertion site uses `key = (char, has_overline)` — keyed by tuple from day one |
| `has_overline` | implicit `bool \| Match \| None` (short-circuit `and`) | `bool(...)` | Needed so the dict key matches its declared type |

Net: −2 `# type: ignore` markers, 3 latent advisory mypy errors fixed.

## Risk

None. Pure annotation correction — runtime semantics unchanged.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_rst_chunker.py -v` → 16 passed
- [x] `uv run mypy packages/memtomem/src/memtomem/chunking/restructured_text.py` → clean
- [x] `uv run ruff check` + `ruff format --check` on the file → clean

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)