### PR TITLE
typing: drop 2 stray type:ignore comments in chunks.py and retry.py (closes #128)

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/retry.py
+++ b/packages/memtomem/src/memtomem/embedding/retry.py
@@ -71,7 +71,8 @@ def with_retry(
                             exc,
                         )
                         await asyncio.sleep(delay)
-            raise last_exc  # type: ignore[misc]
+            assert last_exc is not None  # max_attempts >= 1 guarantees the loop ran
+            raise last_exc
 
         return wrapper
 

--- a/packages/memtomem/src/memtomem/web/routes/chunks.py
+++ b/packages/memtomem/src/memtomem/web/routes/chunks.py
@@ -116,8 +116,7 @@ async def update_chunk_tags(
     if chunk is None:
         raise HTTPException(status_code=404, detail="Chunk not found")
 
-    seen: set[str] = set()
-    deduped = [t for t in body.tags if not (t in seen or seen.add(t))]  # type: ignore[func-returns-value]
+    deduped = list(dict.fromkeys(body.tags))
 
     new_meta = chunk.metadata.__class__(
         source_file=chunk.metadata.source_file,


### PR DESCRIPTION
## Summary

Two unrelated 1-line `# type: ignore` markers removed by rewriting the underlying expression — same theme, too small for separate PRs.

| File | Was | Now |
|---|---|---|
| `web/routes/chunks.py:120` | `[t for t in body.tags if not (t in seen or seen.add(t))]  # type: ignore[func-returns-value]` | `list(dict.fromkeys(body.tags))` |
| `embedding/retry.py:74` | `raise last_exc  # type: ignore[misc]` | `assert last_exc is not None` then `raise last_exc` |

Both are behavior-preserving:
- `dict.fromkeys` matches the original first-occurrence dedup order; the helper `seen` set goes away.
- The assert in `retry.py` only fires on a code path the `max_attempts >= 1` validation at line 45 already prevents — it makes the invariant visible to mypy without changing runtime behavior.

## Out of scope

`search/pipeline.py:233` was the third candidate from the same sweep but is blocked by #118 — the same call has a baseline `self._llm_provider: object | None` error that needs the broader narrowing in #118 to clear.

## Test plan

- [x] `uv run pytest -m "not ollama" -k "retry or chunks or tags"` → 116 passed
- [x] `uv run mypy` on both files → clean
- [x] `uv run ruff check` + `ruff format --check` → clean

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)