### PR TITLE
fix(indexing): add the warning log in is_duplicate exception (#139)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -152,6 +152,7 @@ class IndexEngine:
             )
             return bool(results and results[0].score >= threshold)
         except Exception:
+            logger.warning("is_duplicate failed; treating as non-duplicate", exc_info=True)
             return False
 
     def _resolve_namespace(self, file_path: Path, explicit_ns: str | None) -> str | None:


### PR DESCRIPTION
## Summary
This PR adds a warning log inside the `is_duplicate` exception handler to improve observability when failures occur.

## Changes
- Added `logger.warning(..., exc_info=True)` inside exception block
- No change in behavior (still returns False on failure)

## Related Issue
Closes #139

## Notes
This improves debugging and follows existing logging patterns in the codebase.