### PR TITLE
fix: warn when code chunkers unavailable due to missing deps

### DIFF
--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -74,13 +74,19 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
 
         chunkers.append(PythonChunker())
     except Exception:
-        _log.debug("PythonChunker unavailable (missing tree-sitter deps)", exc_info=True)
+        _log.warning(
+            "PythonChunker unavailable — install memtomem[all] to enable tree-sitter code chunking",
+            exc_info=True,
+        )
     try:
         from memtomem.chunking.javascript import JavaScriptChunker
 
         chunkers.append(JavaScriptChunker())
     except Exception:
-        _log.debug("JavaScriptChunker unavailable (missing tree-sitter deps)", exc_info=True)
+        _log.warning(
+            "JavaScriptChunker unavailable — install memtomem[all] to enable tree-sitter code chunking",
+            exc_info=True,
+        )
     registry = ChunkerRegistry(chunkers)
 
     index_engine = IndexEngine(


### PR DESCRIPTION
Change log level from DEBUG to WARNING when PythonChunker or JavaScriptChunker fail to import. Include install hint for memtomem[all] so users see why code files fall back to plain chunking.

Fixes #140