### PR TITLE
typing: tighten 4 incomplete list/dict element-type annotations (#138)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -1,6 +1,10 @@
 """CLI: memtomem search <query>."""
 
 from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from memtomem.models import SearchResult
 
 import asyncio
 import json
@@ -79,7 +83,7 @@ async def _search(
         if not results:
             return
         # Group by namespace, show tags, adjust detail by relevance
-        groups: dict[str, list] = {}
+        groups: dict[str, list[SearchResult]] = {}
         for r in results:
             ns = r.chunk.metadata.namespace or "default"
             groups.setdefault(ns, []).append(r)

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time
 from pathlib import Path
+from uuid import UUID
 from typing import TYPE_CHECKING
 
 from memtomem.chunking.markdown import MarkdownChunker
@@ -95,7 +96,7 @@ class IndexEngine:
 
         # Aggregate new_chunk_ids across all files — preserves per-file order
         # so callers that sort/filter by source get a consistent ordering.
-        all_new_chunk_ids: list = []
+        all_new_chunk_ids: list[UUID] = []
         for r in file_results:
             ids = r.get("new_chunk_ids", ())
             if ids:

--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -110,7 +110,7 @@ class NamespaceOps:
             )
         else:
             updates = []
-            params: list = []
+            params: list[object] = []
             if description is not None:
                 updates.append("description=?")
                 params.append(description)

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -35,7 +35,7 @@ async def context_overview(
     from memtomem.context.settings import diff_settings
     from memtomem.context.skills import diff_skills
 
-    result: dict = {}
+    result: dict[str, dict[str, int | bool | str]] = {}
 
     try:
         result["skills"] = _count_statuses(diff_skills(project_root))


### PR DESCRIPTION
Fixes #138 — Four bare list/dict annotations now have concrete element types.