### PR TITLE
cli(session): defer module-level _STATE_DIR expansion to runtime (#137)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -9,9 +9,14 @@ from pathlib import Path
 
 import click
 
+
 # Session state file — stores active session UUID.
-_STATE_DIR = Path("~/.memtomem").expanduser()
-_STATE_FILE = _STATE_DIR / ".current_session"
+def _state_dir() -> Path:
+    """Return the memtomem state directory, resolving HOME at call time."""
+    return Path.home() / ".memtomem"
+
+
+_STATE_FILE = _state_dir() / ".current_session"
 
 
 def _read_current_session() -> str | None:
@@ -24,7 +29,7 @@ def _read_current_session() -> str | None:
 
 
 def _write_current_session(session_id: str) -> None:
-    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _state_dir().mkdir(parents=True, exist_ok=True)
     _STATE_FILE.write_text(session_id + "\n")
 
 

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -16,13 +16,15 @@ def _state_dir() -> Path:
     return Path.home() / ".memtomem"
 
 
-_STATE_FILE = _state_dir() / ".current_session"
+def _state_file() -> Path:
+    """Return the path to the current-session state file (lazy — resolves HOME at call time)."""
+    return _state_dir() / ".current_session"
 
 
 def _read_current_session() -> str | None:
     """Read the active session ID from the state file, or None."""
     try:
-        text = _STATE_FILE.read_text().strip()
+        text = _state_file().read_text().strip()
         return text if text else None
     except FileNotFoundError:
         return None
@@ -30,12 +32,12 @@ def _read_current_session() -> str | None:
 
 def _write_current_session(session_id: str) -> None:
     _state_dir().mkdir(parents=True, exist_ok=True)
-    _STATE_FILE.write_text(session_id + "\n")
+    _state_file().write_text(session_id + "\n")
 
 
 def _clear_current_session() -> None:
     try:
-        _STATE_FILE.unlink()
+        _state_file().unlink()
     except FileNotFoundError:
         pass
 


### PR DESCRIPTION
## Summary

Fixes **#137** — Replace module-level `_STATE_DIR = Path("~/.memtomem").expanduser()` with a lazy `_state_dir() -> Path` helper that resolves `Path.home()` at each call.

## Problem

The old code captured `~` expansion once at import time:
```python
_STATE_DIR = Path("~/.memtomem").expanduser()  # frozen at import!
```

Any subsequent `monkeypatch.setenv("HOME", ...)` in test code cannot relocate it, limiting test isolation for the session CLI.

## Solution

```python
def _state_dir() -> Path:
    """Return the memtomem state directory, resolving HOME at call time."""
    return Path.home() / ".memtomem"
```

- `_STATE_FILE` still computed at module level (harmless — path construction only)
- `_STATE_DIR.mkdir(...)` call site updated to `_state_dir().mkdir(...)`
- Zero behavior change for production usage

## Test Plan

- [x] Import succeeds: `from memtomem.cli.session_cmd import _state_dir; _state_dir()` returns valid Path
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/session_cmd.py` — 0 errors
- [x] Existing tests pass: `uv run pytest -m "not ollama"` — 1272/1272 OK
- [x] No new `# type: ignore` lines

## AI Usage Disclosure
**None — human-authored.**

## Files Changed (1 file, +6/-3)
- `packages/memtomem/src/memtomem/cli/session_cmd.py`