### PR TITLE
fix(security): parameterize namespace in execute_auto_tag SQL query

### DIFF
--- a/packages/memtomem/src/memtomem/tools/policy_engine.py
+++ b/packages/memtomem/src/memtomem/tools/policy_engine.py
@@ -227,10 +227,12 @@ async def execute_auto_tag(
     max_tags = config.get("max_tags", 5)
 
     db = storage._get_read_db()
-    query = "SELECT COUNT(*) FROM chunks WHERE tags = '[]' OR tags = ''"
+    query = "SELECT COUNT(*) FROM chunks WHERE (tags = '[]' OR tags = '')"
+    params: list = []
     if namespace:
-        query += f" AND namespace = '{namespace}'"
-    count = db.execute(query).fetchone()[0]
+        query += " AND namespace = ?"
+        params.append(namespace)
+    count = db.execute(query, params).fetchone()[0]
 
     if not dry_run and count > 0:
         try:


### PR DESCRIPTION
## Summary

- Replace f-string SQL interpolation with parameterized query in
  `policy_engine.py:232`, closing a SQL injection vector reachable
  from MCP tool input (`mem_policy_add` → `mem_policy_run` →
  `execute_auto_tag`)
- The same file already uses the correct parameterized pattern at
  lines 139–141; this aligns the remaining call site

## Test plan

- [x] Existing policy/auto_tag tests pass (70 passed)
- [x] ruff check + format clean
- [ ] Verify `mem_policy_add(policy_type="auto_tag", namespace_filter="test")` +
  `mem_policy_run` still counts untagged chunks correctly

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)