### PR TITLE
fix(web): use HTTPException for error responses in settings-sync resolve

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -184,6 +184,8 @@ async def resolve_conflict(
     target_path = _claude_target()
 
     # Read canonical rule
+    if not canonical_path.is_file():
+        raise HTTPException(404, detail="Canonical source does not exist")
     canonical = _safe_load_json(canonical_path)
     if not isinstance(canonical, dict):
         raise HTTPException(422, detail="Canonical source is not valid JSON")

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from memtomem.context.settings import (
@@ -176,7 +176,7 @@ async def resolve_conflict(
 ) -> dict:
     """Resolve a single hook conflict by replacing the target's rule."""
     if body.action != "use_proposed":
-        return {"status": "error", "reason": f"Unknown action: {body.action}"}
+        raise HTTPException(400, detail=f"Unknown action: {body.action}")
 
     label = _rule_label(body.event, body.matcher)
 
@@ -186,7 +186,7 @@ async def resolve_conflict(
     # Read canonical rule
     canonical = _safe_load_json(canonical_path)
     if not isinstance(canonical, dict):
-        return {"status": "error", "reason": "Canonical source is not valid JSON"}
+        raise HTTPException(422, detail="Canonical source is not valid JSON")
 
     proposed = None
     canonical_hooks: dict = canonical.get("hooks", {})
@@ -195,21 +195,21 @@ async def resolve_conflict(
             proposed = rule
             break
     if proposed is None:
-        return {"status": "error", "reason": f"Rule '{label}' not in canonical source"}
+        raise HTTPException(404, detail=f"Rule '{label}' not in canonical source")
 
     # Read target + mtime guard
     if not target_path.is_file():
-        return {"status": "error", "reason": "Target settings file does not exist"}
+        raise HTTPException(404, detail="Target settings file does not exist")
 
     mtime = target_path.stat().st_mtime
     target = _safe_load_json(target_path)
     if not isinstance(target, dict):
-        return {"status": "error", "reason": "Target settings is not valid JSON"}
+        raise HTTPException(422, detail="Target settings is not valid JSON")
 
     # Replace the rule in-place
     target_hooks: dict = target.get("hooks", {})
     if not isinstance(target_hooks, dict):
-        return {"status": "error", "reason": "Target hooks is not a record"}
+        raise HTTPException(422, detail="Target hooks is not a record")
 
     rules = target_hooks.get(body.event, [])
     replaced = False
@@ -220,7 +220,7 @@ async def resolve_conflict(
             break
 
     if not replaced:
-        return {"status": "error", "reason": f"Rule '{label}' not found in target"}
+        raise HTTPException(404, detail=f"Rule '{label}' not found in target")
 
     # mtime check before write
     if target_path.stat().st_mtime != mtime:

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -121,12 +121,17 @@ async function loadHooksSync() {
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({event, matcher, action: 'use_proposed'}),
           });
+          if (!r.ok) {
+            const err = await r.json().catch(() => ({}));
+            showToast(err.detail || 'Request failed', 'error');
+            return;
+          }
           const result = await r.json();
           if (result.status === 'ok') {
             showToast(result.reason);
             loadHooksSync();
           } else {
-            showToast(result.reason, 'error');
+            showToast(result.reason || 'Unexpected response', 'error');
           }
         } finally { btnLoading(btn, false); }
       });

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -617,9 +617,7 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
-    async def test_resolve_missing_canonical_returns_404(
-        self, app, client: AsyncClient, tmp_path
-    ):
+    async def test_resolve_missing_canonical_returns_404(self, app, client: AsyncClient, tmp_path):
         """POST /resolve when canonical file doesn't exist returns HTTP 404."""
         # No .memtomem/settings.json created in tmp_path
         app.state.project_root = tmp_path

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -617,6 +617,19 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
+    async def test_resolve_missing_canonical_returns_404(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """POST /resolve when canonical file doesn't exist returns HTTP 404."""
+        # No .memtomem/settings.json created in tmp_path
+        app.state.project_root = tmp_path
+        resp = await client.post(
+            "/api/settings-sync/resolve",
+            json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+        )
+        assert resp.status_code == 404
+        assert "Canonical source does not exist" in resp.json()["detail"]
+
     async def test_resolve_unknown_action_returns_400(self, app, client: AsyncClient, tmp_path):
         """POST /resolve with invalid action returns HTTP 400."""
         app.state.project_root = tmp_path

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -617,6 +617,41 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
+    async def test_resolve_unknown_action_returns_400(self, app, client: AsyncClient, tmp_path):
+        """POST /resolve with invalid action returns HTTP 400."""
+        app.state.project_root = tmp_path
+        resp = await client.post(
+            "/api/settings-sync/resolve",
+            json={"event": "PostToolUse", "matcher": "Write", "action": "bad_action"},
+        )
+        assert resp.status_code == 400
+        assert "Unknown action" in resp.json()["detail"]
+
+    async def test_resolve_missing_rule_returns_404(self, app, client: AsyncClient, tmp_path):
+        """POST /resolve for non-existent rule returns HTTP 404."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(json.dumps({"hooks": {}}))
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text() if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps({"hooks": {}}))
+            app.state.project_root = tmp_path
+
+            resp = await client.post(
+                "/api/settings-sync/resolve",
+                json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+            )
+            assert resp.status_code == 404
+            assert "not in canonical source" in resp.json()["detail"]
+        finally:
+            if backup is not None:
+                target.write_text(backup)
+            elif target.is_file():
+                target.unlink()
+
     # -- URL alias tests (/api/context/settings/*) ----------------------------
 
     async def test_alias_get_context_settings(self, app, client: AsyncClient, tmp_path):


### PR DESCRIPTION
## Summary

- Convert 7 error returns in `POST /settings-sync/resolve` from
  `{"status": "error", "reason": "..."}` (HTTP 200) to proper
  `HTTPException` raises with `{"detail": "..."}` and appropriate
  status codes (400/404/422)
- Update the JS caller to check `response.ok` before parsing JSON
  and display `err.detail` on failure
- Add 2 error-path tests: unknown action → 400, missing rule → 404

The `_compare_hooks` GET response schema (`status: "error"` as a
domain status field) is unchanged — it's part of the sync overview
structure, not an error response.

## Test plan

- [x] 10 TestSettingsSync tests pass (including 2 new error-path tests)
- [x] ruff check + format clean
- [ ] Manual: trigger a conflict in Web UI, click "Use memtomem's"
  → verify toast shows on success; break canonical JSON → verify
  error toast shows with detail message

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)