### PR TITLE
Log warning instead of silently swallowing exceptions in activity hook

### DIFF
--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import uuid
 from pathlib import Path
 
 import click
+
+logger = logging.getLogger(__name__)
 
 # Session state file — stores active session UUID.
 _STATE_DIR = Path("~/.memtomem").expanduser()
@@ -214,7 +217,7 @@ def log_event(event_type: str, content: str, meta: str | None) -> None:
     try:
         asyncio.run(_log_event(session_id, event_type, content, metadata))
     except Exception:
-        pass  # hooks must never block
+        logger.warning("activity hook failed for session %s", session_id, exc_info=True)
 
 
 async def _log_event(session_id: str, event_type: str, content: str, metadata: dict | None) -> None:


### PR DESCRIPTION
## Summary
- Replace bare `except: pass` in `session_cmd.py:log_event()` with `logger.warning(...)` so activity hook failures are logged instead of silently swallowed.
- Add `import logging` and a module-level `logger` to the file.

Fixes #149

## Test plan
- [ ] Verify `uv run ruff check packages/memtomem/src` passes (lint)
- [ ] Verify `uv run pytest -m "not ollama"` passes (tests)
- [ ] Trigger an activity hook failure and confirm the warning appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)