### PR TITLE
refactor: extract importance decay multiplier into named constant

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -157,6 +157,7 @@ async def mem_consolidate_apply(
 
     from memtomem.tools.consolidation_engine import (
         DECAY_FLOOR,
+        IMPORTANCE_DECAY_MULTIPLIER,
         link_consolidation_relations,
     )
 
@@ -239,7 +240,7 @@ async def mem_consolidate_apply(
     if not keep_originals and group["chunk_ids"]:
         scores = await app.storage.get_importance_scores(group["chunk_ids"])
         if scores:
-            floored = {cid: max(score * 0.5, DECAY_FLOOR) for cid, score in scores.items()}
+            floored = {cid: max(score * IMPORTANCE_DECAY_MULTIPLIER, DECAY_FLOOR) for cid, score in scores.items()}
             await app.storage.update_importance_scores(floored)
 
     app.search_pipeline.invalidate_cache()

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -36,6 +36,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SUMMARY_NAMESPACE = "archive:summary"
 DECAY_FLOOR = 0.3  # keep_originals=False → importance_score floor (never below)
+IMPORTANCE_DECAY_MULTIPLIER = 0.5  # factor applied to importance scores during consolidation
 CONSOLIDATED_SUFFIX = ".consolidated.md"
 SUMMARY_MAX_LEN = 160
 KEYWORD_BOOST_MAX_LEN = 140
@@ -404,7 +405,7 @@ async def apply_consolidation(
     if not keep_originals and source_ids:
         scores = await storage.get_importance_scores(source_ids)
         if scores:
-            floored = {cid: max(score * 0.5, DECAY_FLOOR) for cid, score in scores.items()}
+            floored = {cid: max(score * IMPORTANCE_DECAY_MULTIPLIER, DECAY_FLOOR) for cid, score in scores.items()}
             await storage.update_importance_scores(floored)
 
     return summary_chunk.id


### PR DESCRIPTION
Fixes #148

Extracted the hardcoded `0.5` decay multiplier into `IMPORTANCE_DECAY_MULTIPLIER` constant in `consolidation_engine.py`, consistent with the existing `DECAY_FLOOR` pattern. Updated both occurrences (engine and server tool).