### PR TITLE
refactor: deduplicate _webhook_error_cb into webhooks module

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/ask.py
+++ b/packages/memtomem/src/memtomem/server/tools/ask.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+
+from memtomem.server.webhooks import webhook_error_cb
 import logging
 
 from memtomem.server import mcp
@@ -11,14 +13,6 @@ from memtomem.server.error_handler import tool_handler
 
 logger = logging.getLogger(__name__)
 
-
-def _webhook_error_cb(task: asyncio.Task) -> None:
-    """Log errors from fire-and-forget webhook tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Webhook fire failed: %s", exc)
 
 
 @mcp.tool()
@@ -124,6 +118,6 @@ async def mem_ask(
                 },
             )
         )
-        task.add_done_callback(_webhook_error_cb)
+        task.add_done_callback(webhook_error_cb)
 
     return "\n".join(lines)

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+
+from memtomem.server.webhooks import webhook_error_cb
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -18,14 +20,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-def _webhook_error_cb(task: asyncio.Task) -> None:
-    """Log errors from fire-and-forget webhook tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Webhook fire failed: %s", exc)
 
 
 def _validate_path(path_str: str, memory_dirs: list) -> tuple[Path | None, str | None]:
@@ -133,7 +127,7 @@ async def _mem_add_core(
         task = asyncio.create_task(
             app.webhook_manager.fire("add", {"file": str(target), "chunks_indexed": 1})
         )
-        task.add_done_callback(_webhook_error_cb)
+        task.add_done_callback(webhook_error_cb)
 
     return (result, stats)
 

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+
+from memtomem.server.webhooks import webhook_error_cb
 import logging
 from typing import Literal
 from uuid import UUID
@@ -15,14 +17,6 @@ from memtomem.server.tool_registry import register
 
 logger = logging.getLogger(__name__)
 
-
-def _webhook_error_cb(task: asyncio.Task) -> None:
-    """Log errors from fire-and-forget webhook tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Webhook fire failed: %s", exc)
 
 
 @mcp.tool()
@@ -135,7 +129,7 @@ async def mem_search(
         task = asyncio.create_task(
             app.webhook_manager.fire("search", {"query": query, "result_count": len(results)})
         )
-        task.add_done_callback(_webhook_error_cb)
+        task.add_done_callback(webhook_error_cb)
 
     return output
 

--- a/packages/memtomem/src/memtomem/server/webhooks.py
+++ b/packages/memtomem/src/memtomem/server/webhooks.py
@@ -17,6 +17,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def webhook_error_cb(task: asyncio.Task) -> None:
+    """Log errors from fire-and-forget webhook tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc:
+        logger.warning("Webhook fire failed: %s", exc)
+
+
 def _validate_webhook_url(url: str) -> str | None:
     """Return an error message if the URL is unsafe, or None if valid."""
     try:


### PR DESCRIPTION
Fixes #147

Moved the identical `_webhook_error_cb` function from `ask.py`, `memory_crud.py`, and `search.py` into the shared `server/webhooks.py` module as `webhook_error_cb`. Updated all three tool files to import from the shared location.