### PR TITLE
fix: improve Windows compatibility — enforce UTF-8 encoding

### DIFF
--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -27,24 +27,15 @@ def _state_file() -> Path:
 def _read_current_session() -> str | None:
     """Read the active session ID from the state file, or None."""
     try:
-<<<<<<< HEAD
         text = _state_file().read_text().strip()
-=======
-        text = _STATE_FILE.read_text(encoding="utf-8").strip()
->>>>>>> b33e7df (fix: improve Windows compatibility)
         return text if text else None
     except FileNotFoundError:
         return None
 
 
 def _write_current_session(session_id: str) -> None:
-<<<<<<< HEAD
     _state_dir().mkdir(parents=True, exist_ok=True)
     _state_file().write_text(session_id + "\n")
-=======
-    _STATE_DIR.mkdir(parents=True, exist_ok=True)
-    _STATE_FILE.write_text(session_id + "\n", encoding="utf-8")
->>>>>>> b33e7df (fix: improve Windows compatibility)
 
 
 def _clear_current_session() -> None:

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -27,15 +27,24 @@ def _state_file() -> Path:
 def _read_current_session() -> str | None:
     """Read the active session ID from the state file, or None."""
     try:
+<<<<<<< HEAD
         text = _state_file().read_text().strip()
+=======
+        text = _STATE_FILE.read_text(encoding="utf-8").strip()
+>>>>>>> b33e7df (fix: improve Windows compatibility)
         return text if text else None
     except FileNotFoundError:
         return None
 
 
 def _write_current_session(session_id: str) -> None:
+<<<<<<< HEAD
     _state_dir().mkdir(parents=True, exist_ok=True)
     _state_file().write_text(session_id + "\n")
+=======
+    _STATE_DIR.mkdir(parents=True, exist_ok=True)
+    _STATE_FILE.write_text(session_id + "\n", encoding="utf-8")
+>>>>>>> b33e7df (fix: improve Windows compatibility)
 
 
 def _clear_current_session() -> None:

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -27,7 +27,7 @@ def _state_file() -> Path:
 def _read_current_session() -> str | None:
     """Read the active session ID from the state file, or None."""
     try:
-        text = _state_file().read_text().strip()
+        text = _state_file().read_text(encoding="utf-8").strip()
         return text if text else None
     except FileNotFoundError:
         return None
@@ -35,7 +35,7 @@ def _read_current_session() -> str | None:
 
 def _write_current_session(session_id: str) -> None:
     _state_dir().mkdir(parents=True, exist_ok=True)
-    _state_file().write_text(session_id + "\n")
+    _state_file().write_text(session_id + "\n", encoding="utf-8")
 
 
 def _clear_current_session() -> None:

--- a/packages/memtomem/tests/test_chunkers_extended.py
+++ b/packages/memtomem/tests/test_chunkers_extended.py
@@ -331,7 +331,7 @@ class TestContentHash:
 
     def test_file_hash(self, tmp_path):
         p = tmp_path / "sample.txt"
-        p.write_text("hello world")
+        p.write_text("hello world", encoding="utf-8")
         h = file_hash(str(p))
         assert len(h) == 64
 

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -439,21 +439,8 @@ class TestSaveConfigOverrides:
         """Invalid values in config.json should be skipped with warning, not crash."""
         import json
 
-<<<<<<< HEAD
         isolated["config_file"].write_text(
             json.dumps({"search": {"default_top_k": -5}})  # violates min=1
-=======
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
-        config_file.write_text(
-            json.dumps(
-                {
-                    "search": {"default_top_k": -5},  # violates min=1
-                }
-            ),
-            encoding="utf-8",
->>>>>>> b33e7df (fix: improve Windows compatibility)
         )
 
         cfg = Mem2MemConfig()
@@ -731,16 +718,8 @@ class TestSaveConfigOverrides:
         # Case 1: whole value is a repr-ish string (not even JSON).
         isolated["config_file"].write_text(
             json.dumps(
-<<<<<<< HEAD
                 {"namespace": {"rules": "<NamespacePolicyRule path_glob='x' namespace='y'>"}}
             )
-=======
-                {
-                    "indexing": {"memory_dirs": ["/pre/existing"]},
-                }
-            ),
-            encoding="utf-8",
->>>>>>> b33e7df (fix: improve Windows compatibility)
         )
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)
@@ -774,7 +753,6 @@ class TestSaveConfigOverrides:
         cfg.mmr.enabled = True  # force a non-comparand write
         save_config_overrides(cfg)
 
-<<<<<<< HEAD
         assert config_file.exists()
         assert nested_dir.is_dir()
 
@@ -1025,10 +1003,6 @@ class TestConfigUnset:
             if p.name.startswith(".config.") and p.name.endswith(".tmp")
         ]
         assert not orphans
-=======
-        data = json.loads(config_file.read_text(encoding="utf-8"))
-        assert "/pre/existing" in [str(p) for p in data["indexing"]["memory_dirs"]]
->>>>>>> b33e7df (fix: improve Windows compatibility)
 
 
 # ── Other subcommands (help text) ───────────────────────────────────────

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -439,8 +439,21 @@ class TestSaveConfigOverrides:
         """Invalid values in config.json should be skipped with warning, not crash."""
         import json
 
+<<<<<<< HEAD
         isolated["config_file"].write_text(
             json.dumps({"search": {"default_top_k": -5}})  # violates min=1
+=======
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        config_file.write_text(
+            json.dumps(
+                {
+                    "search": {"default_top_k": -5},  # violates min=1
+                }
+            ),
+            encoding="utf-8",
+>>>>>>> b33e7df (fix: improve Windows compatibility)
         )
 
         cfg = Mem2MemConfig()
@@ -459,7 +472,8 @@ class TestSaveConfigOverrides:
                     "search": {"default_top_k": -5, "rrf_k": 80},
                     "decay": {"enabled": True},
                 }
-            )
+            ),
+            encoding="utf-8",
         )
 
         cfg = Mem2MemConfig()
@@ -717,8 +731,16 @@ class TestSaveConfigOverrides:
         # Case 1: whole value is a repr-ish string (not even JSON).
         isolated["config_file"].write_text(
             json.dumps(
+<<<<<<< HEAD
                 {"namespace": {"rules": "<NamespacePolicyRule path_glob='x' namespace='y'>"}}
             )
+=======
+                {
+                    "indexing": {"memory_dirs": ["/pre/existing"]},
+                }
+            ),
+            encoding="utf-8",
+>>>>>>> b33e7df (fix: improve Windows compatibility)
         )
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)
@@ -752,6 +774,7 @@ class TestSaveConfigOverrides:
         cfg.mmr.enabled = True  # force a non-comparand write
         save_config_overrides(cfg)
 
+<<<<<<< HEAD
         assert config_file.exists()
         assert nested_dir.is_dir()
 
@@ -1002,6 +1025,10 @@ class TestConfigUnset:
             if p.name.startswith(".config.") and p.name.endswith(".tmp")
         ]
         assert not orphans
+=======
+        data = json.loads(config_file.read_text(encoding="utf-8"))
+        assert "/pre/existing" in [str(p) for p in data["indexing"]["memory_dirs"]]
+>>>>>>> b33e7df (fix: improve Windows compatibility)
 
 
 # ── Other subcommands (help text) ───────────────────────────────────────

--- a/packages/memtomem/tests/test_cli_ingest.py
+++ b/packages/memtomem/tests/test_cli_ingest.py
@@ -38,9 +38,9 @@ from memtomem.cli.ingest_cmd import (
 
 class TestDiscoverFiles:
     def test_returns_sorted_markdown_files(self, tmp_path):
-        (tmp_path / "project_b.md").write_text("b")
-        (tmp_path / "feedback_a.md").write_text("a")
-        (tmp_path / "user_c.md").write_text("c")
+        (tmp_path / "project_b.md").write_text("b", encoding="utf-8")
+        (tmp_path / "feedback_a.md").write_text("a", encoding="utf-8")
+        (tmp_path / "user_c.md").write_text("c", encoding="utf-8")
 
         files = _discover_files(tmp_path)
         assert [f.name for f in files] == [
@@ -51,30 +51,30 @@ class TestDiscoverFiles:
 
     def test_excludes_memory_md_and_readme(self, tmp_path):
         """MEMORY.md and README.md are indexes / docs, not memory content."""
-        (tmp_path / "feedback_a.md").write_text("keep")
-        (tmp_path / "MEMORY.md").write_text("- [a](feedback_a.md)")
-        (tmp_path / "README.md").write_text("# how to read")
+        (tmp_path / "feedback_a.md").write_text("keep", encoding="utf-8")
+        (tmp_path / "MEMORY.md").write_text("- [a](feedback_a.md)", encoding="utf-8")
+        (tmp_path / "README.md").write_text("# how to read", encoding="utf-8")
 
         files = _discover_files(tmp_path)
         names = [f.name for f in files]
         assert names == ["feedback_a.md"]
 
     def test_excludes_hidden_and_non_markdown(self, tmp_path):
-        (tmp_path / "project_a.md").write_text("keep")
-        (tmp_path / ".DS_Store").write_text("mac")
-        (tmp_path / ".hidden.md").write_text("hidden")
-        (tmp_path / "notes.txt").write_text("wrong ext")
-        (tmp_path / "script.py").write_text("code")
+        (tmp_path / "project_a.md").write_text("keep", encoding="utf-8")
+        (tmp_path / ".DS_Store").write_text("mac", encoding="utf-8")
+        (tmp_path / ".hidden.md").write_text("hidden", encoding="utf-8")
+        (tmp_path / "notes.txt").write_text("wrong ext", encoding="utf-8")
+        (tmp_path / "script.py").write_text("code", encoding="utf-8")
 
         files = _discover_files(tmp_path)
         assert [f.name for f in files] == ["project_a.md"]
 
     def test_non_recursive(self, tmp_path):
         """Claude memory dirs are flat — don't walk subdirectories."""
-        (tmp_path / "project_a.md").write_text("top")
+        (tmp_path / "project_a.md").write_text("top", encoding="utf-8")
         sub = tmp_path / "subdir"
         sub.mkdir()
-        (sub / "project_b.md").write_text("nested")
+        (sub / "project_b.md").write_text("nested", encoding="utf-8")
 
         files = _discover_files(tmp_path)
         assert [f.name for f in files] == ["project_a.md"]
@@ -156,7 +156,7 @@ class TestDiscoverClaudeSlugDirs:
         for slug in ("-Users-me-Work-alpha", "-Users-me-Work-beta"):
             mem = tmp_path / slug / "memory"
             mem.mkdir(parents=True)
-            (mem / "project_x.md").write_text("x")
+            (mem / "project_x.md").write_text("x", encoding="utf-8")
 
         dirs = _discover_claude_slug_dirs(tmp_path)
         assert len(dirs) == 2
@@ -168,11 +168,11 @@ class TestDiscoverClaudeSlugDirs:
         """Slug directories without a memory/ child are ignored."""
         good = tmp_path / "has-memory" / "memory"
         good.mkdir(parents=True)
-        (good / "note.md").write_text("ok")
+        (good / "note.md").write_text("ok", encoding="utf-8")
 
         bad = tmp_path / "no-memory"
         bad.mkdir()
-        (bad / "stray.md").write_text("stray")
+        (bad / "stray.md").write_text("stray", encoding="utf-8")
 
         dirs = _discover_claude_slug_dirs(tmp_path)
         assert len(dirs) == 1
@@ -181,7 +181,7 @@ class TestDiscoverClaudeSlugDirs:
     def test_skips_hidden_dirs(self, tmp_path):
         hidden = tmp_path / ".hidden" / "memory"
         hidden.mkdir(parents=True)
-        (hidden / "secret.md").write_text("hidden")
+        (hidden / "secret.md").write_text("hidden", encoding="utf-8")
 
         assert _discover_claude_slug_dirs(tmp_path) == []
 
@@ -197,7 +197,7 @@ class TestDiscoverClaudeSlugDirs:
 
     def test_file_not_dir(self, tmp_path):
         f = tmp_path / "not-a-dir.txt"
-        f.write_text("file")
+        f.write_text("file", encoding="utf-8")
         assert _discover_claude_slug_dirs(f) == []
 
 
@@ -222,15 +222,17 @@ class TestIngestFilesWithComponents:
 
         (slug_dir / "feedback_a.md").write_text(
             "# Feedback A\n\nAlways use bge-m3 for Korean text embeddings "
-            "because the vocabulary coverage is wider than bge-small.\n"
+            "because the vocabulary coverage is wider than bge-small.\n",
+            encoding="utf-8",
         )
         (slug_dir / "project_b.md").write_text(
             "# Project B\n\nPhase B adds a claude-memory ingestion path "
-            "that treats the source directory as a read-only snapshot.\n"
+            "that treats the source directory as a read-only snapshot.\n",
+            encoding="utf-8",
         )
         # MEMORY.md must be ignored even though it lives in the same dir.
         (slug_dir / "MEMORY.md").write_text(
-            "- [Feedback A](feedback_a.md)\n- [Project B](project_b.md)\n"
+            "- [Feedback A](feedback_a.md)\n- [Project B](project_b.md)\n", encoding="utf-8"
         )
         return slug_dir
 
@@ -326,7 +328,8 @@ class TestIngestFilesWithComponents:
         edited.write_text(
             "# Feedback A\n\nRevised guidance: prefer bge-m3 for multilingual "
             "corpora — the Korean coverage is measurably better than bge-small, "
-            "and the English quality is comparable.\n"
+            "and the English quality is comparable.\n",
+            encoding="utf-8",
         )
 
         summary = await _ingest_files_with_components(
@@ -348,27 +351,27 @@ class TestIngestFilesWithComponents:
 class TestGeminiDiscoverFiles:
     def test_file_path_returns_single_element(self, tmp_path):
         md = tmp_path / "GEMINI.md"
-        md.write_text("## Gemini Added Memories\n\n- fact one\n")
+        md.write_text("## Gemini Added Memories\n\n- fact one\n", encoding="utf-8")
         assert _gemini_discover_files(md) == [md]
 
     def test_directory_finds_gemini_md(self, tmp_path):
         md = tmp_path / "GEMINI.md"
-        md.write_text("memories")
+        md.write_text("memories", encoding="utf-8")
         files = _gemini_discover_files(tmp_path)
         assert files == [md]
 
     def test_directory_without_gemini_md_returns_empty(self, tmp_path):
-        (tmp_path / "other.md").write_text("not gemini")
+        (tmp_path / "other.md").write_text("not gemini", encoding="utf-8")
         assert _gemini_discover_files(tmp_path) == []
 
     def test_non_md_file_returns_empty(self, tmp_path):
         txt = tmp_path / "GEMINI.txt"
-        txt.write_text("wrong extension")
+        txt.write_text("wrong extension", encoding="utf-8")
         assert _gemini_discover_files(txt) == []
 
     def test_empty_file_still_discovered(self, tmp_path):
         md = tmp_path / "GEMINI.md"
-        md.write_text("")
+        md.write_text("", encoding="utf-8")
         assert _gemini_discover_files(md) == [md]
 
 
@@ -377,14 +380,14 @@ class TestGeminiDeriveSlug:
         gemini_dir = tmp_path / ".gemini"
         gemini_dir.mkdir()
         md = gemini_dir / "GEMINI.md"
-        md.write_text("")
+        md.write_text("", encoding="utf-8")
         assert _gemini_derive_slug(md) == "global"
 
     def test_project_root(self, tmp_path):
         project = tmp_path / "my-cool-project"
         project.mkdir()
         md = project / "GEMINI.md"
-        md.write_text("")
+        md.write_text("", encoding="utf-8")
         assert _gemini_derive_slug(md) == "my-cool-project"
 
     def test_root_path_defaults(self):
@@ -416,29 +419,29 @@ class TestGeminiTagsForFile:
 
 class TestCodexDiscoverFiles:
     def test_returns_sorted_md_files(self, tmp_path):
-        (tmp_path / "note_b.md").write_text("b")
-        (tmp_path / "fact_a.md").write_text("a")
+        (tmp_path / "note_b.md").write_text("b", encoding="utf-8")
+        (tmp_path / "fact_a.md").write_text("a", encoding="utf-8")
         files = _codex_discover_files(tmp_path)
         assert [f.name for f in files] == ["fact_a.md", "note_b.md"]
 
     def test_excludes_readme(self, tmp_path):
-        (tmp_path / "fact.md").write_text("keep")
-        (tmp_path / "README.md").write_text("docs")
+        (tmp_path / "fact.md").write_text("keep", encoding="utf-8")
+        (tmp_path / "README.md").write_text("docs", encoding="utf-8")
         files = _codex_discover_files(tmp_path)
         assert [f.name for f in files] == ["fact.md"]
 
     def test_excludes_hidden_and_non_markdown(self, tmp_path):
-        (tmp_path / "fact.md").write_text("keep")
-        (tmp_path / ".hidden.md").write_text("skip")
-        (tmp_path / "data.json").write_text("{}")
+        (tmp_path / "fact.md").write_text("keep", encoding="utf-8")
+        (tmp_path / ".hidden.md").write_text("skip", encoding="utf-8")
+        (tmp_path / "data.json").write_text("{}", encoding="utf-8")
         files = _codex_discover_files(tmp_path)
         assert [f.name for f in files] == ["fact.md"]
 
     def test_non_recursive(self, tmp_path):
-        (tmp_path / "fact.md").write_text("top")
+        (tmp_path / "fact.md").write_text("top", encoding="utf-8")
         sub = tmp_path / "sub"
         sub.mkdir()
-        (sub / "nested.md").write_text("nested")
+        (sub / "nested.md").write_text("nested", encoding="utf-8")
         files = _codex_discover_files(tmp_path)
         assert [f.name for f in files] == ["fact.md"]
 
@@ -499,7 +502,8 @@ class TestGeminiIngestIntegration:
             "## Gemini Added Memories\n\n"
             "- User prefers Korean for discussion but English for code.\n"
             "- The project uses uv for dependency management.\n"
-            "- Always run ruff check before committing.\n"
+            "- Always run ruff check before committing.\n",
+            encoding="utf-8",
         )
 
         files = _gemini_discover_files(md)
@@ -524,7 +528,7 @@ class TestGeminiIngestIntegration:
         project = tmp_path / "demo"
         project.mkdir()
         md = project / "GEMINI.md"
-        md.write_text("## Memories\n\n- Fact alpha\n- Fact beta\n")
+        md.write_text("## Memories\n\n- Fact alpha\n- Fact beta\n", encoding="utf-8")
 
         files = _gemini_discover_files(md)
         ns = "gemini-memory:demo"
@@ -550,12 +554,12 @@ class TestCodexIngestIntegration:
         mem_dir = tmp_path / "codex_memories"
         mem_dir.mkdir()
         (mem_dir / "fact_a.md").write_text(
-            "# Workspace preference\n\nAlways use workspace-write sandbox mode.\n"
+            "# Workspace preference\n\nAlways use workspace-write sandbox mode.\n", encoding="utf-8"
         )
         (mem_dir / "fact_b.md").write_text(
-            "# Git convention\n\nCommit messages should start with a verb.\n"
+            "# Git convention\n\nCommit messages should start with a verb.\n", encoding="utf-8"
         )
-        (mem_dir / "README.md").write_text("# Index\nDo not index this.\n")
+        (mem_dir / "README.md").write_text("# Index\nDo not index this.\n", encoding="utf-8")
 
         files = _codex_discover_files(mem_dir)
         assert {f.name for f in files} == {"fact_a.md", "fact_b.md"}
@@ -579,7 +583,7 @@ class TestCodexIngestIntegration:
     async def test_rerun_skips_unchanged(self, components, tmp_path):
         mem_dir = tmp_path / "codex_memories"
         mem_dir.mkdir()
-        (mem_dir / "fact.md").write_text("# Fact\n\nSome important fact.\n")
+        (mem_dir / "fact.md").write_text("# Fact\n\nSome important fact.\n", encoding="utf-8")
 
         files = _codex_discover_files(mem_dir)
         ns = "codex-memory:global"
@@ -611,10 +615,12 @@ class TestMultiSlugIngestIntegration:
             mem = projects / slug / "memory"
             mem.mkdir(parents=True)
             (mem / "feedback_x.md").write_text(
-                f"# Feedback\n\nAlways lint before commit in {slug}.\n"
+                f"# Feedback\n\nAlways lint before commit in {slug}.\n", encoding="utf-8"
             )
-            (mem / "project_y.md").write_text(f"# Project\n\nPhase 1 for {slug} is complete.\n")
-            (mem / "MEMORY.md").write_text("- [x](feedback_x.md)\n")
+            (mem / "project_y.md").write_text(
+                f"# Project\n\nPhase 1 for {slug} is complete.\n", encoding="utf-8"
+            )
+            (mem / "MEMORY.md").write_text("- [x](feedback_x.md)\n", encoding="utf-8")
         return projects
 
     async def test_multi_slug_indexes_all_slugs(self, components, tmp_path):

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -39,7 +39,7 @@ Monorepo with src/ and tests/.
 class TestParser:
     def test_parse_sections(self, tmp_path):
         ctx = tmp_path / "context.md"
-        ctx.write_text(SAMPLE_CONTEXT)
+        ctx.write_text(SAMPLE_CONTEXT, encoding="utf-8")
         sections = parse_context(ctx)
 
         assert "Project" in sections
@@ -55,26 +55,26 @@ class TestParser:
 
     def test_roundtrip(self, tmp_path):
         ctx = tmp_path / "context.md"
-        ctx.write_text(SAMPLE_CONTEXT)
+        ctx.write_text(SAMPLE_CONTEXT, encoding="utf-8")
         sections = parse_context(ctx)
         output = sections_to_markdown(sections)
         reparsed = parse_context(tmp_path / "out.md")
-        (tmp_path / "out.md").write_text(output)
+        (tmp_path / "out.md").write_text(output, encoding="utf-8")
         reparsed = parse_context(tmp_path / "out.md")
         assert reparsed.keys() == sections.keys()
 
 
 class TestDetector:
     def test_detect_claude(self, tmp_path):
-        (tmp_path / "CLAUDE.md").write_text("# CLAUDE.md")
+        (tmp_path / "CLAUDE.md").write_text("# CLAUDE.md", encoding="utf-8")
         files = detect_agent_files(tmp_path)
         assert len(files) == 1
         assert files[0].agent == "claude"
 
     def test_detect_multiple(self, tmp_path):
-        (tmp_path / "CLAUDE.md").write_text("# CLAUDE.md")
-        (tmp_path / ".cursorrules").write_text("rules")
-        (tmp_path / "GEMINI.md").write_text("# GEMINI.md")
+        (tmp_path / "CLAUDE.md").write_text("# CLAUDE.md", encoding="utf-8")
+        (tmp_path / ".cursorrules").write_text("rules", encoding="utf-8")
+        (tmp_path / "GEMINI.md").write_text("# GEMINI.md", encoding="utf-8")
         files = detect_agent_files(tmp_path)
         agents = {f.agent for f in files}
         assert agents == {"claude", "cursor", "gemini"}
@@ -84,14 +84,14 @@ class TestDetector:
         assert files == []
 
     def test_detect_codex(self, tmp_path):
-        (tmp_path / "AGENTS.md").write_text("# AGENTS.md")
+        (tmp_path / "AGENTS.md").write_text("# AGENTS.md", encoding="utf-8")
         files = detect_agent_files(tmp_path)
         assert files[0].agent == "codex"
 
     def test_detect_copilot(self, tmp_path):
         gh = tmp_path / ".github"
         gh.mkdir()
-        (gh / "copilot-instructions.md").write_text("instructions")
+        (gh / "copilot-instructions.md").write_text("instructions", encoding="utf-8")
         files = detect_agent_files(tmp_path)
         assert files[0].agent == "copilot"
 

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -58,7 +58,7 @@ def _make_canonical_agent(project_root, name, body=SAMPLE_FULL_AGENT):
     root = project_root / CANONICAL_AGENT_ROOT
     root.mkdir(parents=True, exist_ok=True)
     path = root / f"{name}.md"
-    path.write_text(body)
+    path.write_text(body, encoding="utf-8")
     return path
 
 
@@ -90,7 +90,7 @@ class TestParseCanonicalAgent:
 
     def test_missing_frontmatter_raises(self, tmp_path):
         p = tmp_path / "bad.md"
-        p.write_text("no frontmatter at all")
+        p.write_text("no frontmatter at all", encoding="utf-8")
         with pytest.raises(AgentParseError):
             parse_canonical_agent(p)
 
@@ -125,7 +125,8 @@ class TestParseCanonicalAgent:
             "  - Read\n"
             "  - Grep\n"
             "---\n\n"
-            "body\n"
+            "body\n",
+            encoding="utf-8",
         )
         agent = parse_canonical_agent(p)
         assert agent.tools == ["Read", "Grep"]
@@ -146,7 +147,7 @@ class TestClaudeRendering:
     def test_passes_through_all_fields(self, tmp_path):
         _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
         generate_all_agents(tmp_path, runtimes=["claude_agents"])
-        out = (tmp_path / ".claude/agents/code-reviewer.md").read_text()
+        out = (tmp_path / ".claude/agents/code-reviewer.md").read_text(encoding="utf-8")
         assert "name: code-reviewer" in out
         assert "tools: [Read, Grep, Glob]" in out
         assert "model: sonnet" in out
@@ -168,7 +169,7 @@ class TestGeminiRendering:
     def test_passes_through_gemini_fields(self, tmp_path):
         _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
         generate_all_agents(tmp_path, runtimes=["gemini_agents"])
-        out = (tmp_path / ".gemini/agents/code-reviewer.md").read_text()
+        out = (tmp_path / ".gemini/agents/code-reviewer.md").read_text(encoding="utf-8")
         assert "kind: reviewer" in out
         assert "temperature: 0.2" in out
         assert "tools: [Read, Grep, Glob]" in out
@@ -190,7 +191,7 @@ class TestCodexRendering:
         generate_all_agents(tmp_path, runtimes=["codex_agents"])
         toml_path = codex_home / ".codex/agents/code-reviewer.toml"
         assert toml_path.is_file()
-        parsed = tomllib.loads(toml_path.read_text())
+        parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert parsed["name"] == "code-reviewer"
         assert "quality" in parsed["description"]
         assert "meticulous" in parsed["developer_instructions"]
@@ -211,7 +212,7 @@ class TestCodexRendering:
         result = generate_all_agents(tmp_path, runtimes=["codex_agents"])
         assert result.dropped == []
         toml_path = codex_home / ".codex/agents/helper.toml"
-        parsed = tomllib.loads(toml_path.read_text())
+        parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert parsed["name"] == "helper"
         assert parsed["description"] == "Generic helper"
 
@@ -219,7 +220,7 @@ class TestCodexRendering:
         _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
         generate_all_agents(tmp_path, runtimes=["codex_agents"])
         toml_path = codex_home / ".codex/agents/helper.toml"
-        parsed = tomllib.loads(toml_path.read_text())
+        parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert "Help with things." in parsed["developer_instructions"]
 
 
@@ -268,7 +269,7 @@ class TestExtractAgentsToCanonical:
     def test_imports_claude_agent(self, tmp_path):
         claude_dir = tmp_path / ".claude/agents"
         claude_dir.mkdir(parents=True)
-        (claude_dir / "helper.md").write_text(SAMPLE_MINIMAL_AGENT)
+        (claude_dir / "helper.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
         result = extract_agents_to_canonical(tmp_path)
         assert len(result.imported) == 1
         assert (tmp_path / CANONICAL_AGENT_ROOT / "helper.md").is_file()
@@ -278,7 +279,7 @@ class TestExtractAgentsToCanonical:
         for runtime in (".claude/agents", ".gemini/agents"):
             d = tmp_path / runtime
             d.mkdir(parents=True)
-            (d / "helper.md").write_text(SAMPLE_MINIMAL_AGENT)
+            (d / "helper.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
         result = extract_agents_to_canonical(tmp_path)
         assert len(result.imported) == 1
         # Gemini copy was skipped because Claude already imported it.
@@ -290,26 +291,26 @@ class TestExtractAgentsToCanonical:
         claude_dir = tmp_path / ".claude/agents"
         claude_dir.mkdir(parents=True)
         new_content = SAMPLE_MINIMAL_AGENT.replace("Generic helper", "UPDATED")
-        (claude_dir / "helper.md").write_text(new_content)
+        (claude_dir / "helper.md").write_text(new_content, encoding="utf-8")
 
         canonical = tmp_path / CANONICAL_AGENT_ROOT / "helper.md"
         canonical.parent.mkdir(parents=True)
-        canonical.write_text("old")
+        canonical.write_text("old", encoding="utf-8")
 
         result = extract_agents_to_canonical(tmp_path)
         assert result.imported == []
         assert len(result.skipped) == 1
         assert "canonical exists" in result.skipped[0][1]
-        assert canonical.read_text() == "old"
+        assert canonical.read_text(encoding="utf-8") == "old"
 
         result = extract_agents_to_canonical(tmp_path, overwrite=True)
         assert len(result.imported) == 1
-        assert "UPDATED" in canonical.read_text()
+        assert "UPDATED" in canonical.read_text(encoding="utf-8")
 
     def test_ignores_codex_toml(self, tmp_path, codex_home):
         # Even when a Codex TOML exists, extract does not try to import it.
         (codex_home / ".codex/agents").mkdir(parents=True)
-        (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n')
+        (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n', encoding="utf-8")
         result = extract_agents_to_canonical(tmp_path)
         assert result.imported == []
 
@@ -353,7 +354,7 @@ class TestDiffAgents:
     def test_out_of_sync(self, tmp_path, codex_home):
         _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
         generate_all_agents(tmp_path)
-        (tmp_path / ".claude/agents/helper.md").write_text("mutated")
+        (tmp_path / ".claude/agents/helper.md").write_text("mutated", encoding="utf-8")
         rows = diff_agents(tmp_path)
         status_by_runtime = {r: s for r, _, s in rows}
         assert status_by_runtime["claude_agents"] == "out of sync"
@@ -363,7 +364,7 @@ class TestDiffAgents:
     def test_missing_canonical(self, tmp_path, codex_home):
         claude_dir = tmp_path / ".claude/agents"
         claude_dir.mkdir(parents=True)
-        (claude_dir / "runtime-only.md").write_text(SAMPLE_MINIMAL_AGENT)
+        (claude_dir / "runtime-only.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
         rows = diff_agents(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
 
@@ -375,7 +376,7 @@ class TestDetectAgentDirs:
     def test_detects_claude(self, tmp_path):
         d = tmp_path / ".claude/agents"
         d.mkdir(parents=True)
-        (d / "reviewer.md").write_text(SAMPLE_FULL_AGENT)
+        (d / "reviewer.md").write_text(SAMPLE_FULL_AGENT, encoding="utf-8")
         found = detect_agent_dirs(tmp_path)
         assert len(found) == 1
         assert found[0].agent == "claude_agents"
@@ -385,13 +386,13 @@ class TestDetectAgentDirs:
     def test_detects_gemini(self, tmp_path):
         d = tmp_path / ".gemini/agents"
         d.mkdir(parents=True)
-        (d / "tester.md").write_text(SAMPLE_MINIMAL_AGENT)
+        (d / "tester.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
         found = detect_agent_dirs(tmp_path)
         assert found[0].agent == "gemini_agents"
 
     def test_codex_user_scope_not_in_project_detect(self, tmp_path, codex_home):
         (codex_home / ".codex/agents").mkdir(parents=True)
-        (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n')
+        (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n', encoding="utf-8")
         found = detect_agent_dirs(tmp_path)
         assert found == []
 

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -43,7 +43,7 @@ def _make_canonical_command(project_root, name, body=SAMPLE_FULL_COMMAND):
     root = project_root / CANONICAL_COMMAND_ROOT
     root.mkdir(parents=True, exist_ok=True)
     path = root / f"{name}.md"
-    path.write_text(body)
+    path.write_text(body, encoding="utf-8")
     return path
 
 
@@ -70,7 +70,7 @@ class TestParseCanonicalCommand:
 
     def test_tolerates_missing_frontmatter(self, tmp_path):
         p = tmp_path / "bare.md"
-        p.write_text("Just a bare prompt with $ARGUMENTS.")
+        p.write_text("Just a bare prompt with $ARGUMENTS.", encoding="utf-8")
         cmd = parse_canonical_command(p)
         assert cmd.name == "bare"
         assert cmd.description == ""
@@ -112,7 +112,7 @@ class TestClaudeCommandRendering:
     def test_passes_through_all_fields(self, tmp_path):
         _make_canonical_command(tmp_path, "review", SAMPLE_FULL_COMMAND)
         generate_all_commands(tmp_path, runtimes=["claude_commands"])
-        out = (tmp_path / ".claude/commands/review.md").read_text()
+        out = (tmp_path / ".claude/commands/review.md").read_text(encoding="utf-8")
         assert "description: Review a file for issues" in out
         assert "argument-hint: [file-path]" in out
         assert "allowed-tools: [Read, Grep]" in out
@@ -128,9 +128,9 @@ class TestClaudeCommandRendering:
         body = "Just the prompt with $ARGUMENTS.\n"
         p = tmp_path / CANONICAL_COMMAND_ROOT / "bare.md"
         p.parent.mkdir(parents=True)
-        p.write_text(body)  # no frontmatter at all
+        p.write_text(body, encoding="utf-8")  # no frontmatter at all
         generate_all_commands(tmp_path, runtimes=["claude_commands"])
-        out = (tmp_path / ".claude/commands/bare.md").read_text()
+        out = (tmp_path / ".claude/commands/bare.md").read_text(encoding="utf-8")
         assert out.startswith("Just the prompt")
         assert "---" not in out
 
@@ -141,7 +141,7 @@ class TestGeminiCommandRendering:
         generate_all_commands(tmp_path, runtimes=["gemini_commands"])
         toml_path = tmp_path / ".gemini/commands/review.toml"
         assert toml_path.is_file()
-        parsed = tomllib.loads(toml_path.read_text())
+        parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert parsed["description"] == "Review a file for issues"
         assert "prompt" in parsed
         assert "Review the file at {{args}}" in parsed["prompt"]
@@ -149,7 +149,9 @@ class TestGeminiCommandRendering:
     def test_rewrites_arguments_placeholder(self, tmp_path):
         _make_canonical_command(tmp_path, "review", SAMPLE_FULL_COMMAND)
         generate_all_commands(tmp_path, runtimes=["gemini_commands"])
-        parsed = tomllib.loads((tmp_path / ".gemini/commands/review.toml").read_text())
+        parsed = tomllib.loads(
+            (tmp_path / ".gemini/commands/review.toml").read_text(encoding="utf-8")
+        )
         assert "$ARGUMENTS" not in parsed["prompt"]
         assert "{{args}}" in parsed["prompt"]
 
@@ -208,7 +210,7 @@ class TestExtractCommandsToCanonical:
     def test_imports_claude_command(self, tmp_path):
         d = tmp_path / ".claude/commands"
         d.mkdir(parents=True)
-        (d / "review.md").write_text(SAMPLE_FULL_COMMAND)
+        (d / "review.md").write_text(SAMPLE_FULL_COMMAND, encoding="utf-8")
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
         assert (tmp_path / CANONICAL_COMMAND_ROOT / "review.md").is_file()
@@ -218,11 +220,12 @@ class TestExtractCommandsToCanonical:
         d = tmp_path / ".gemini/commands"
         d.mkdir(parents=True)
         (d / "review.toml").write_text(
-            'description = "Review a file"\nprompt = "Review {{args}} and report issues."\n'
+            'description = "Review a file"\nprompt = "Review {{args}} and report issues."\n',
+            encoding="utf-8",
         )
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "review.md").read_text()
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "review.md").read_text(encoding="utf-8")
         assert "description: Review a file" in canonical
         # {{args}} rewritten back to $ARGUMENTS
         assert "$ARGUMENTS" in canonical
@@ -235,10 +238,10 @@ class TestExtractCommandsToCanonical:
         ):
             d = tmp_path / runtime
             d.mkdir(parents=True)
-            (d / filename).write_text(content)
+            (d / filename).write_text(content, encoding="utf-8")
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "shared.md").read_text()
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "shared.md").read_text(encoding="utf-8")
         assert "Simple prompt" in canonical  # claude version won
         # Gemini copy was skipped.
         assert len(result.skipped) == 1
@@ -249,21 +252,21 @@ class TestExtractCommandsToCanonical:
         d = tmp_path / ".claude/commands"
         d.mkdir(parents=True)
         new = SAMPLE_MINIMAL_COMMAND.replace("Simple prompt", "UPDATED")
-        (d / "hi.md").write_text(new)
+        (d / "hi.md").write_text(new, encoding="utf-8")
 
         canonical = tmp_path / CANONICAL_COMMAND_ROOT / "hi.md"
         canonical.parent.mkdir(parents=True)
-        canonical.write_text("old")
+        canonical.write_text("old", encoding="utf-8")
 
         result = extract_commands_to_canonical(tmp_path)
         assert result.imported == []
         assert len(result.skipped) == 1
         assert "canonical exists" in result.skipped[0][1]
-        assert canonical.read_text() == "old"
+        assert canonical.read_text(encoding="utf-8") == "old"
 
         result = extract_commands_to_canonical(tmp_path, overwrite=True)
         assert len(result.imported) == 1
-        assert "UPDATED" in canonical.read_text()
+        assert "UPDATED" in canonical.read_text(encoding="utf-8")
 
     def test_skips_hostile_runtime_filename(self, tmp_path):
         """#276: runtime filenames are interpolated into canonical paths."""
@@ -298,7 +301,7 @@ class TestDiffCommands:
     def test_out_of_sync(self, tmp_path):
         _make_canonical_command(tmp_path, "hi", SAMPLE_MINIMAL_COMMAND)
         generate_all_commands(tmp_path)
-        (tmp_path / ".claude/commands/hi.md").write_text("mutated")
+        (tmp_path / ".claude/commands/hi.md").write_text("mutated", encoding="utf-8")
         rows = diff_commands(tmp_path)
         status_by_runtime = {r: s for r, _, s in rows}
         assert status_by_runtime["claude_commands"] == "out of sync"
@@ -307,7 +310,7 @@ class TestDiffCommands:
     def test_missing_canonical(self, tmp_path):
         d = tmp_path / ".claude/commands"
         d.mkdir(parents=True)
-        (d / "runtime-only.md").write_text(SAMPLE_MINIMAL_COMMAND)
+        (d / "runtime-only.md").write_text(SAMPLE_MINIMAL_COMMAND, encoding="utf-8")
         rows = diff_commands(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
 
@@ -319,7 +322,7 @@ class TestDetectCommandDirs:
     def test_detects_claude(self, tmp_path):
         d = tmp_path / ".claude/commands"
         d.mkdir(parents=True)
-        (d / "review.md").write_text(SAMPLE_MINIMAL_COMMAND)
+        (d / "review.md").write_text(SAMPLE_MINIMAL_COMMAND, encoding="utf-8")
         found = detect_command_dirs(tmp_path)
         assert len(found) == 1
         assert found[0].agent == "claude_commands"
@@ -328,7 +331,7 @@ class TestDetectCommandDirs:
     def test_detects_gemini_toml(self, tmp_path):
         d = tmp_path / ".gemini/commands"
         d.mkdir(parents=True)
-        (d / "review.toml").write_text('prompt = "hi"\n')
+        (d / "review.toml").write_text('prompt = "hi"\n', encoding="utf-8")
         found = detect_command_dirs(tmp_path)
         assert len(found) == 1
         assert found[0].agent == "gemini_commands"
@@ -338,7 +341,7 @@ class TestDetectCommandDirs:
         # .md inside .gemini/commands is NOT a Gemini command — skip it.
         d = tmp_path / ".gemini/commands"
         d.mkdir(parents=True)
-        (d / "stray.md").write_text("not a toml command")
+        (d / "stray.md").write_text("not a toml command", encoding="utf-8")
         found = detect_command_dirs(tmp_path)
         assert found == []
 
@@ -392,7 +395,7 @@ class TestRoundtrip:
         shutil.rmtree(tmp_path / CANONICAL_COMMAND_ROOT)
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "hi.md").read_text()
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "hi.md").read_text(encoding="utf-8")
         assert "description: Simple prompt" in canonical
         assert "$ARGUMENTS" in canonical
         assert "{{args}}" not in canonical

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -102,7 +102,7 @@ class TestClaudeSettingsMergeSemantic:
             "env": {"FOO": "bar"},
             "mcpServers": {"example": {"command": "echo"}},
         }
-        target.write_text(json.dumps(existing, indent=4) + "\n")
+        target.write_text(json.dumps(existing, indent=4) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {}})
         results = generate_all_settings(tmp_path)
@@ -121,7 +121,7 @@ class TestClaudeSettingsMergeAdditive:
     def test_appends_without_touching_user_rules(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
         user_rule = _rule("", "say done")
-        target.write_text(json.dumps({"hooks": {"Stop": [user_rule]}}) + "\n")
+        target.write_text(json.dumps({"hooks": {"Stop": [user_rule]}}) + "\n", encoding="utf-8")
 
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
@@ -137,7 +137,9 @@ class TestClaudeSettingsMergeAdditive:
         """Multiple rules under the same event with different matchers."""
         target = claude_home / ".claude" / "settings.json"
         user_rule = _rule("Bash", "echo user")
-        target.write_text(json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n", encoding="utf-8"
+        )
 
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
@@ -157,7 +159,9 @@ class TestClaudeSettingsMergeConflict:
     def test_user_rule_wins_on_matcher_collision(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
         user_rule = _rule("Write", "echo custom")
-        target.write_text(json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n", encoding="utf-8"
+        )
 
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
@@ -175,7 +179,7 @@ class TestClaudeSettingsMergeConflict:
         """If the user's rule is byte-identical, no warning is emitted."""
         rule = _rule("Write", "mm index")
         target = claude_home / ".claude" / "settings.json"
-        target.write_text(json.dumps({"hooks": {"PostToolUse": [rule]}}) + "\n")
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [rule]}}) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [rule]}})
         results = generate_all_settings(tmp_path)
@@ -188,7 +192,9 @@ class TestClaudeSettingsMergeWarningContent:
 
     def test_warning_includes_required_parts(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
-        target.write_text(json.dumps({"hooks": {"PostToolUse": [_rule("Write", "old")]}}) + "\n")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [_rule("Write", "old")]}}) + "\n", encoding="utf-8"
+        )
 
         _make_canonical_settings(
             tmp_path,
@@ -220,7 +226,7 @@ class TestClaudeSettingsMergeMalformed:
         assert "not valid JSON" in r.reason
 
         # File should NOT have been modified
-        assert target.read_text() == '{"hooks":{'
+        assert target.read_text(encoding="utf-8") == '{"hooks":{'
 
     def test_malformed_canonical_returns_error(self, claude_home, tmp_path):
         _make_canonical_settings(tmp_path, "{bad json")
@@ -235,7 +241,7 @@ class TestClaudeSettingsMergeConcurrent:
 
     def test_aborts_on_mtime_change(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
-        target.write_text(json.dumps({"hooks": {}}) + "\n")
+        target.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
 
         _make_canonical_settings(
             tmp_path,
@@ -249,7 +255,9 @@ class TestClaudeSettingsMergeConcurrent:
         def patched_read_with_mtime(path):
             result = orig_read_with_mtime(path)
             if path == target:
-                target.write_text(json.dumps({"hooks": {}, "_bumped": True}) + "\n")
+                target.write_text(
+                    json.dumps({"hooks": {}, "_bumped": True}) + "\n", encoding="utf-8"
+                )
             return result
 
         import unittest.mock
@@ -334,7 +342,7 @@ class TestClaudeSettingsDryRun:
     def test_reports_in_sync(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
         content = {"hooks": {"PostToolUse": [_rule("Write")]}}
-        target.write_text(json.dumps(content, indent=2) + "\n")
+        target.write_text(json.dumps(content, indent=2) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, content)
         results = diff_settings(tmp_path)
@@ -342,7 +350,7 @@ class TestClaudeSettingsDryRun:
 
     def test_reports_out_of_sync(self, claude_home, tmp_path):
         target = claude_home / ".claude" / "settings.json"
-        target.write_text(json.dumps({"hooks": {}}) + "\n")
+        target.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}})
         results = diff_settings(tmp_path)
@@ -352,11 +360,11 @@ class TestClaudeSettingsDryRun:
         """diff must never modify the target file."""
         target = claude_home / ".claude" / "settings.json"
         original = json.dumps({"hooks": {}}) + "\n"
-        target.write_text(original)
+        target.write_text(original, encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}})
         diff_settings(tmp_path)
-        assert target.read_text() == original
+        assert target.read_text(encoding="utf-8") == original
 
 
 # ── CLI integration ─────────────────────────────────────────────────
@@ -385,7 +393,7 @@ class TestClaudeSettingsCliInclude:
         # Verify the file was actually written
         target = claude_home / ".claude" / "settings.json"
         assert target.is_file()
-        written = json.loads(target.read_text())
+        written = json.loads(target.read_text(encoding="utf-8"))
         assert "PostToolUse" in written.get("hooks", {})
 
     def test_include_settings_validation(self):

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -30,10 +30,10 @@ SAMPLE_SCRIPT = "#!/usr/bin/env bash\necho hi\n"
 def _make_canonical_skill(project_root, name, body=SAMPLE_SKILL_MD, with_scripts=False):
     skill = project_root / CANONICAL_SKILL_ROOT / name
     skill.mkdir(parents=True)
-    (skill / "SKILL.md").write_text(body)
+    (skill / "SKILL.md").write_text(body, encoding="utf-8")
     if with_scripts:
         (skill / "scripts").mkdir()
-        (skill / "scripts" / "run.sh").write_text(SAMPLE_SCRIPT)
+        (skill / "scripts" / "run.sh").write_text(SAMPLE_SCRIPT, encoding="utf-8")
     return skill
 
 
@@ -62,24 +62,24 @@ class TestCopySkill:
     def test_copies_manifest_only(self, tmp_path):
         src = tmp_path / "src"
         src.mkdir()
-        (src / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (src / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         dst = tmp_path / "dst"
         copy_skill(src, dst)
-        assert (dst / "SKILL.md").read_text() == SAMPLE_SKILL_MD
+        assert (dst / "SKILL.md").read_text(encoding="utf-8") == SAMPLE_SKILL_MD
 
     def test_copies_subdirectories(self, tmp_path):
         src = tmp_path / "src"
         src.mkdir()
-        (src / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (src / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         (src / "scripts").mkdir()
-        (src / "scripts" / "run.sh").write_text(SAMPLE_SCRIPT)
+        (src / "scripts" / "run.sh").write_text(SAMPLE_SCRIPT, encoding="utf-8")
         (src / "references").mkdir()
-        (src / "references" / "note.md").write_text("note")
+        (src / "references" / "note.md").write_text("note", encoding="utf-8")
         dst = tmp_path / "dst"
         copy_skill(src, dst)
-        assert (dst / "SKILL.md").read_text() == SAMPLE_SKILL_MD
-        assert (dst / "scripts" / "run.sh").read_text() == SAMPLE_SCRIPT
-        assert (dst / "references" / "note.md").read_text() == "note"
+        assert (dst / "SKILL.md").read_text(encoding="utf-8") == SAMPLE_SKILL_MD
+        assert (dst / "scripts" / "run.sh").read_text(encoding="utf-8") == SAMPLE_SCRIPT
+        assert (dst / "references" / "note.md").read_text(encoding="utf-8") == "note"
 
     def test_missing_manifest_raises(self, tmp_path):
         src = tmp_path / "src"
@@ -91,28 +91,28 @@ class TestCopySkill:
     def test_refuses_to_overwrite_non_skill_dir(self, tmp_path):
         src = tmp_path / "src"
         src.mkdir()
-        (src / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (src / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
 
         dst = tmp_path / "dst"
         dst.mkdir()
-        (dst / "unrelated.txt").write_text("do not delete")
+        (dst / "unrelated.txt").write_text("do not delete", encoding="utf-8")
 
         with pytest.raises(IsADirectoryError):
             copy_skill(src, dst)
-        assert (dst / "unrelated.txt").read_text() == "do not delete"
+        assert (dst / "unrelated.txt").read_text(encoding="utf-8") == "do not delete"
 
     def test_replaces_existing_skill_dir(self, tmp_path):
         src = tmp_path / "src"
         src.mkdir()
-        (src / "SKILL.md").write_text("new content")
+        (src / "SKILL.md").write_text("new content", encoding="utf-8")
 
         dst = tmp_path / "dst"
         dst.mkdir()
-        (dst / "SKILL.md").write_text("old content")
-        (dst / "stale.md").write_text("leftover")
+        (dst / "SKILL.md").write_text("old content", encoding="utf-8")
+        (dst / "stale.md").write_text("leftover", encoding="utf-8")
 
         copy_skill(src, dst)
-        assert (dst / "SKILL.md").read_text() == "new content"
+        assert (dst / "SKILL.md").read_text(encoding="utf-8") == "new content"
         # removed files propagate (stale files disappear)
         assert not (dst / "stale.md").exists()
 
@@ -156,7 +156,7 @@ class TestDetectSkillDirs:
     def test_detects_claude_skills(self, tmp_path):
         skill = tmp_path / ".claude/skills/a"
         skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         found = detect_skill_dirs(tmp_path)
         assert len(found) == 1
         assert found[0].agent == "claude_skills"
@@ -166,7 +166,7 @@ class TestDetectSkillDirs:
     def test_detects_gemini_skills(self, tmp_path):
         skill = tmp_path / ".gemini/skills/b"
         skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         found = detect_skill_dirs(tmp_path)
         assert len(found) == 1
         assert found[0].agent == "gemini_skills"
@@ -175,7 +175,7 @@ class TestDetectSkillDirs:
         # .agents/skills/ is Codex CLI's primary project-scope path.
         skill = tmp_path / ".agents/skills/c"
         skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         found = detect_skill_dirs(tmp_path)
         assert len(found) == 1
         assert found[0].agent == "codex_skills"
@@ -193,7 +193,7 @@ class TestExtractSkills:
     def test_imports_from_claude(self, tmp_path):
         skill = tmp_path / ".claude/skills/code-review"
         skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         result = extract_skills_to_canonical(tmp_path)
         assert len(result.imported) == 1
         assert (tmp_path / CANONICAL_SKILL_ROOT / "code-review/SKILL.md").exists()
@@ -203,7 +203,7 @@ class TestExtractSkills:
         for runtime_dir in (".claude/skills", ".gemini/skills"):
             skill = tmp_path / runtime_dir / "shared"
             skill.mkdir(parents=True)
-            (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+            (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         result = extract_skills_to_canonical(tmp_path)
         assert len(result.imported) == 1
         assert len(result.skipped) == 1
@@ -213,30 +213,30 @@ class TestExtractSkills:
     def test_does_not_overwrite_without_flag(self, tmp_path):
         src = tmp_path / ".claude/skills/existing"
         src.mkdir(parents=True)
-        (src / "SKILL.md").write_text("new")
+        (src / "SKILL.md").write_text("new", encoding="utf-8")
 
         canonical = tmp_path / CANONICAL_SKILL_ROOT / "existing"
         canonical.mkdir(parents=True)
-        (canonical / "SKILL.md").write_text("old")
+        (canonical / "SKILL.md").write_text("old", encoding="utf-8")
 
         result = extract_skills_to_canonical(tmp_path)
         assert result.imported == []
         assert len(result.skipped) == 1
         assert "canonical exists" in result.skipped[0][1]
-        assert (canonical / "SKILL.md").read_text() == "old"
+        assert (canonical / "SKILL.md").read_text(encoding="utf-8") == "old"
 
     def test_overwrite_flag(self, tmp_path):
         src = tmp_path / ".claude/skills/existing"
         src.mkdir(parents=True)
-        (src / "SKILL.md").write_text("new")
+        (src / "SKILL.md").write_text("new", encoding="utf-8")
 
         canonical = tmp_path / CANONICAL_SKILL_ROOT / "existing"
         canonical.mkdir(parents=True)
-        (canonical / "SKILL.md").write_text("old")
+        (canonical / "SKILL.md").write_text("old", encoding="utf-8")
 
         result = extract_skills_to_canonical(tmp_path, overwrite=True)
         assert len(result.imported) == 1
-        assert (canonical / "SKILL.md").read_text() == "new"
+        assert (canonical / "SKILL.md").read_text(encoding="utf-8") == "new"
 
 
 class TestDiffSkills:
@@ -253,7 +253,7 @@ class TestDiffSkills:
     def test_out_of_sync(self, tmp_path):
         _make_canonical_skill(tmp_path, "a")
         generate_all_skills(tmp_path)
-        (tmp_path / ".claude/skills/a/SKILL.md").write_text("mutated")
+        (tmp_path / ".claude/skills/a/SKILL.md").write_text("mutated", encoding="utf-8")
         rows = diff_skills(tmp_path)
         status_by_runtime = {runtime: status for runtime, _, status in rows}
         assert status_by_runtime["claude_skills"] == "out of sync"
@@ -268,7 +268,7 @@ class TestDiffSkills:
     def test_missing_canonical(self, tmp_path):
         skill = tmp_path / ".claude/skills/runtime-only"
         skill.mkdir(parents=True)
-        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD)
+        (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
         rows = diff_skills(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
 
@@ -283,7 +283,9 @@ class TestRoundtrip:
         result = extract_skills_to_canonical(tmp_path)
         assert len(result.imported) == 1
 
-        md = (tmp_path / CANONICAL_SKILL_ROOT / "code-review/SKILL.md").read_text()
+        md = (tmp_path / CANONICAL_SKILL_ROOT / "code-review/SKILL.md").read_text(encoding="utf-8")
         assert md == SAMPLE_SKILL_MD
-        script = (tmp_path / CANONICAL_SKILL_ROOT / "code-review/scripts/run.sh").read_text()
+        script = (tmp_path / CANONICAL_SKILL_ROOT / "code-review/scripts/run.sh").read_text(
+            encoding="utf-8"
+        )
         assert script == SAMPLE_SCRIPT

--- a/packages/memtomem/tests/test_e2e_pipeline.py
+++ b/packages/memtomem/tests/test_e2e_pipeline.py
@@ -33,7 +33,8 @@ class TestContextWindowE2E:
             "## Monitoring\n\n"
             "Prometheus + Grafana stack. Alerting via PagerDuty.\n\n"
             "## Deployment\n\n"
-            "Kubernetes on AWS EKS. Helm charts for all services.\n"
+            "Kubernetes on AWS EKS. Helm charts for all services.\n",
+            encoding="utf-8",
         )
         stats = await components.index_engine.index_file(doc)
         assert stats.indexed_chunks >= 3
@@ -59,7 +60,9 @@ class TestContextWindowE2E:
     async def test_context_window_zero_no_context(self, components, memory_dir):
         """context_window=0 (or omitted) returns no context."""
         doc = memory_dir / "simple.md"
-        doc.write_text("## Title\n\nSome content here.\n\n## Other\n\nMore content.")
+        doc.write_text(
+            "## Title\n\nSome content here.\n\n## Other\n\nMore content.", encoding="utf-8"
+        )
         await components.index_engine.index_file(doc)
 
         results, _ = await components.search_pipeline.search("content", top_k=3)
@@ -74,7 +77,8 @@ class TestContextWindowE2E:
             "## Section B\n\nBravo content unique.\n\n"
             "## Section C\n\nCharlie content unique.\n\n"
             "## Section D\n\nDelta content unique.\n\n"
-            "## Section E\n\nEcho content unique.\n"
+            "## Section E\n\nEcho content unique.\n",
+            encoding="utf-8",
         )
         stats = await components.index_engine.index_file(doc)
         assert stats.indexed_chunks >= 4
@@ -110,7 +114,8 @@ class TestMemExpandE2E:
             "## Prerequisites\n\nPython 3.12 and uv required.\n\n"
             "## Installation\n\npip install memtomem or uv pip install.\n\n"
             "## Configuration\n\nSet MEMTOMEM_ env vars.\n\n"
-            "## Usage\n\nRun mm search to find memories.\n"
+            "## Usage\n\nRun mm search to find memories.\n",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(doc)
 
@@ -155,7 +160,8 @@ class TestCrossLanguageE2E:
             "## 캐싱 전략\n\n"
             "Redis 캐시 레이어 도입. LRU 정책 적용.\n\n"
             "## API 설계\n\n"
-            "RESTful API with FastAPI. OpenAPI 자동 문서화.\n"
+            "RESTful API with FastAPI. OpenAPI 자동 문서화.\n",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(doc)
 
@@ -177,7 +183,8 @@ class TestCrossLanguageE2E:
             "## 기술 스택\n\n"
             "Python 3.12, FastAPI, SQLite with FTS5.\n\n"
             "## Architecture\n\n"
-            "Monorepo with uv workspace. Two packages.\n"
+            "Monorepo with uv workspace. Two packages.\n",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(doc)
 
@@ -197,7 +204,8 @@ class TestFullPipelineE2E:
 
         doc = memory_dir / "format_test.md"
         doc.write_text(
-            "## Intro\n\nWelcome.\n\n## Core\n\nMain content here.\n\n## Conclusion\n\nSummary.\n"
+            "## Intro\n\nWelcome.\n\n## Core\n\nMain content here.\n\n## Conclusion\n\nSummary.\n",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(doc)
 
@@ -221,7 +229,7 @@ class TestFullPipelineE2E:
         from memtomem.server.formatters import _format_single_result
 
         doc = memory_dir / "no_ctx.md"
-        doc.write_text("## Test\n\nSome searchable content.")
+        doc.write_text("## Test\n\nSome searchable content.", encoding="utf-8")
         await components.index_engine.index_file(doc)
 
         results, _ = await components.search_pipeline.search("searchable", top_k=1)
@@ -234,7 +242,7 @@ class TestFullPipelineE2E:
     async def test_incremental_reindex_preserves_search(self, components, memory_dir):
         """Adding content to a file → re-index → new content searchable."""
         doc = memory_dir / "evolving.md"
-        doc.write_text("## V1\n\nInitial content about authentication.")
+        doc.write_text("## V1\n\nInitial content about authentication.", encoding="utf-8")
         await components.index_engine.index_file(doc)
 
         results1, _ = await components.search_pipeline.search("authentication", top_k=3)
@@ -243,7 +251,8 @@ class TestFullPipelineE2E:
         # Add new section
         doc.write_text(
             "## V1\n\nInitial content about authentication.\n\n"
-            "## V2\n\nAdded OAuth2 with PKCE flow."
+            "## V2\n\nAdded OAuth2 with PKCE flow.",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(doc)
 

--- a/packages/memtomem/tests/test_health_watchdog.py
+++ b/packages/memtomem/tests/test_health_watchdog.py
@@ -159,7 +159,7 @@ class TestDiagnosticChecks:
 
         app, _db = mock_app
         existing = tmp_path / "note.md"
-        existing.write_text("hello")
+        existing.write_text("hello", encoding="utf-8")
         app.storage.get_all_source_files = AsyncMock(return_value={existing})
         snap = await check_orphan_count(app)
         assert snap.status == "ok"

--- a/packages/memtomem/tests/test_importers.py
+++ b/packages/memtomem/tests/test_importers.py
@@ -102,7 +102,7 @@ class TestImportNotion:
         assert "My Page.md" in names
         assert "Child.md" in names
         # Content should have import metadata
-        content = imported[0].read_text()
+        content = imported[0].read_text(encoding="utf-8")
         assert "imported_from: notion" in content
 
     @pytest.mark.asyncio
@@ -149,7 +149,7 @@ class TestImportObsidian:
         imported = await import_obsidian(vault, output)
 
         assert len(imported) == 2  # .obsidian skipped
-        content = (output / "Daily Note.md").read_text()
+        content = (output / "Daily Note.md").read_text(encoding="utf-8")
         assert "imported_from: obsidian" in content
         assert "[[Project Plan]]" not in content  # converted
         assert "[Project Plan]" in content

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -49,10 +49,10 @@ class TestDiscoverFiles:
 
     async def test_finds_supported_extensions(self, components, memory_dir):
         """Should discover .md, .json, .py files but not .txt."""
-        (memory_dir / "notes.md").write_text("# Notes")
-        (memory_dir / "data.json").write_text('{"key": "val"}')
-        (memory_dir / "script.py").write_text("print('hello')")
-        (memory_dir / "readme.txt").write_text("ignored")
+        (memory_dir / "notes.md").write_text("# Notes", encoding="utf-8")
+        (memory_dir / "data.json").write_text('{"key": "val"}', encoding="utf-8")
+        (memory_dir / "script.py").write_text("print('hello')", encoding="utf-8")
+        (memory_dir / "readme.txt").write_text("ignored", encoding="utf-8")
 
         engine = components.index_engine
         files = engine._discover_files(memory_dir, recursive=True)
@@ -67,8 +67,8 @@ class TestDiscoverFiles:
         """Recursive mode should find files in subdirectories."""
         sub = memory_dir / "sub" / "deep"
         sub.mkdir(parents=True)
-        (sub / "nested.md").write_text("# Nested")
-        (memory_dir / "top.md").write_text("# Top")
+        (sub / "nested.md").write_text("# Nested", encoding="utf-8")
+        (memory_dir / "top.md").write_text("# Top", encoding="utf-8")
 
         engine = components.index_engine
         files = engine._discover_files(memory_dir, recursive=True)
@@ -81,8 +81,8 @@ class TestDiscoverFiles:
         """Non-recursive mode should only find top-level files."""
         sub = memory_dir / "subdir"
         sub.mkdir()
-        (sub / "deep.md").write_text("# Deep")
-        (memory_dir / "surface.md").write_text("# Surface")
+        (sub / "deep.md").write_text("# Deep", encoding="utf-8")
+        (memory_dir / "surface.md").write_text("# Surface", encoding="utf-8")
 
         engine = components.index_engine
         files = engine._discover_files(memory_dir, recursive=False)
@@ -95,17 +95,17 @@ class TestDiscoverFiles:
         """Should skip .git/ and node_modules/ directories."""
         git_dir = memory_dir / ".git"
         git_dir.mkdir()
-        (git_dir / "config.md").write_text("# Git config")
+        (git_dir / "config.md").write_text("# Git config", encoding="utf-8")
 
         nm_dir = memory_dir / "node_modules"
         nm_dir.mkdir()
-        (nm_dir / "package.json").write_text('{"name": "pkg"}')
+        (nm_dir / "package.json").write_text('{"name": "pkg"}', encoding="utf-8")
 
         pycache = memory_dir / "__pycache__"
         pycache.mkdir()
-        (pycache / "cached.py").write_text("# cached")
+        (pycache / "cached.py").write_text("# cached", encoding="utf-8")
 
-        (memory_dir / "real.md").write_text("# Real")
+        (memory_dir / "real.md").write_text("# Real", encoding="utf-8")
 
         engine = components.index_engine
         files = engine._discover_files(memory_dir, recursive=True)
@@ -120,8 +120,8 @@ class TestDiscoverFiles:
         """Directories ending with .egg-info should be excluded."""
         egg = memory_dir / "mypackage.egg-info"
         egg.mkdir()
-        (egg / "PKG-INFO.md").write_text("# Info")
-        (memory_dir / "keep.md").write_text("# Keep")
+        (egg / "PKG-INFO.md").write_text("# Info", encoding="utf-8")
+        (memory_dir / "keep.md").write_text("# Keep", encoding="utf-8")
 
         engine = components.index_engine
         files = engine._discover_files(memory_dir, recursive=True)
@@ -132,9 +132,9 @@ class TestDiscoverFiles:
 
     async def test_returns_sorted_paths(self, components, memory_dir):
         """Discovered files should be sorted by path."""
-        (memory_dir / "b.md").write_text("B")
-        (memory_dir / "a.md").write_text("A")
-        (memory_dir / "c.md").write_text("C")
+        (memory_dir / "b.md").write_text("B", encoding="utf-8")
+        (memory_dir / "a.md").write_text("A", encoding="utf-8")
+        (memory_dir / "c.md").write_text("C", encoding="utf-8")
 
         engine = components.index_engine
         files = engine._discover_files(memory_dir, recursive=True)
@@ -374,7 +374,7 @@ class TestResolveNamespace:
         sub = memory_dir / "project-x"
         sub.mkdir()
         fp = sub / "notes.md"
-        fp.write_text("# Notes")
+        fp.write_text("# Notes", encoding="utf-8")
 
         result = engine._resolve_namespace(fp, None)
         assert result == "project-x"
@@ -385,7 +385,7 @@ class TestResolveNamespace:
         engine._ns_config = NamespaceConfig(enable_auto_ns=True)
 
         fp = memory_dir / "notes.md"
-        fp.write_text("# Notes")
+        fp.write_text("# Notes", encoding="utf-8")
 
         result = engine._resolve_namespace(fp, None)
         # Should fall back to default, not use memory_dir folder name
@@ -916,7 +916,7 @@ class TestIndexFile:
             "# Section A\n\nContent for section A.\n\n# Section B\n\nContent for section B.\n"
         )
         md_path = memory_dir / "test_doc.md"
-        md_path.write_text(md_content)
+        md_path.write_text(md_content, encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -935,7 +935,7 @@ class TestIndexFile:
     async def test_unchanged_file_skips_reembedding(self, components, memory_dir):
         """Re-indexing an unchanged file should skip embedding."""
         md_path = memory_dir / "stable.md"
-        md_path.write_text("# Title\n\nStable content here.\n")
+        md_path.write_text("# Title\n\nStable content here.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -960,7 +960,7 @@ class TestIndexFile:
     async def test_force_reindex_reembeds(self, components, memory_dir):
         """force=True should re-embed even unchanged content."""
         md_path = memory_dir / "forced.md"
-        md_path.write_text("# Force\n\nForce reindex content.\n")
+        md_path.write_text("# Force\n\nForce reindex content.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -979,7 +979,7 @@ class TestIndexFile:
     async def test_unsupported_extension_ignored(self, components, memory_dir):
         """Files with unsupported extensions should return zero chunks."""
         txt_path = memory_dir / "readme.txt"
-        txt_path.write_text("Plain text content")
+        txt_path.write_text("Plain text content", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1009,7 +1009,7 @@ class TestIndexFile:
     async def test_namespace_applied_to_indexed_chunks(self, components, memory_dir):
         """Explicit namespace should be applied to stored chunks."""
         md_path = memory_dir / "ns_test.md"
-        md_path.write_text("# NS Test\n\nNamespaced content.\n")
+        md_path.write_text("# NS Test\n\nNamespaced content.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1035,9 +1035,11 @@ class TestIndexPath:
 
     async def test_index_multiple_files(self, components, memory_dir):
         """Indexing a directory should process all supported files."""
-        (memory_dir / "file1.md").write_text("# File 1\n\nContent one.\n")
-        (memory_dir / "file2.md").write_text("# File 2\n\nContent two.\n")
-        (memory_dir / "file3.json").write_text('{"key": "value", "nested": {"a": 1}}')
+        (memory_dir / "file1.md").write_text("# File 1\n\nContent one.\n", encoding="utf-8")
+        (memory_dir / "file2.md").write_text("# File 2\n\nContent two.\n", encoding="utf-8")
+        (memory_dir / "file3.json").write_text(
+            '{"key": "value", "nested": {"a": 1}}', encoding="utf-8"
+        )
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1068,7 +1070,7 @@ class TestIndexPath:
 
     async def test_index_path_stats_correct(self, components, memory_dir):
         """Stats should accurately reflect total files and chunks."""
-        (memory_dir / "only.md").write_text("# Only\n\nSingle file.\n")
+        (memory_dir / "only.md").write_text("# Only\n\nSingle file.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1095,7 +1097,7 @@ class TestIncrementalIndexing:
     async def test_modify_adds_new_chunks(self, components, memory_dir):
         """Modifying a file should re-embed only new/changed chunks."""
         md_path = memory_dir / "evolving.md"
-        md_path.write_text("# Section 1\n\nOriginal content.\n")
+        md_path.write_text("# Section 1\n\nOriginal content.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1110,7 +1112,8 @@ class TestIncrementalIndexing:
 
         # Modify the file — add a new section
         md_path.write_text(
-            "# Section 1\n\nOriginal content.\n\n# Section 2\n\nBrand new section.\n"
+            "# Section 1\n\nOriginal content.\n\n# Section 2\n\nBrand new section.\n",
+            encoding="utf-8",
         )
 
         stats2 = await components.index_engine.index_file(md_path)
@@ -1122,7 +1125,7 @@ class TestIncrementalIndexing:
     async def test_delete_section_removes_chunks(self, components, memory_dir):
         """Removing a section should delete its chunks."""
         md_path = memory_dir / "shrinking.md"
-        md_path.write_text("# Keep\n\nKeep this.\n\n# Remove\n\nRemove this.\n")
+        md_path.write_text("# Keep\n\nKeep this.\n\n# Remove\n\nRemove this.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1135,7 +1138,7 @@ class TestIncrementalIndexing:
         hashes_before = await components.storage.get_chunk_hashes(md_path)
 
         # Remove the second section
-        md_path.write_text("# Keep\n\nKeep this.\n")
+        md_path.write_text("# Keep\n\nKeep this.\n", encoding="utf-8")
         stats = await components.index_engine.index_file(md_path)
 
         hashes_after = await components.storage.get_chunk_hashes(md_path)
@@ -1146,7 +1149,7 @@ class TestIncrementalIndexing:
     async def test_empty_file_clears_chunks(self, components, memory_dir):
         """Overwriting a file with empty content should delete all its chunks."""
         md_path = memory_dir / "clearme.md"
-        md_path.write_text("# Content\n\nSome data.\n")
+        md_path.write_text("# Content\n\nSome data.\n", encoding="utf-8")
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
@@ -1160,7 +1163,7 @@ class TestIncrementalIndexing:
         assert len(hashes) > 0
 
         # Clear the file
-        md_path.write_text("")
+        md_path.write_text("", encoding="utf-8")
         await components.index_engine.index_file(md_path)
 
         hashes_after = await components.storage.get_chunk_hashes(md_path)

--- a/packages/memtomem/tests/test_server_tools_advanced.py
+++ b/packages/memtomem/tests/test_server_tools_advanced.py
@@ -566,7 +566,7 @@ class TestExportImport:
         await export_chunks(storage, output_path=output_path)
 
         assert output_path.exists()
-        data = json.loads(output_path.read_text())
+        data = json.loads(output_path.read_text(encoding="utf-8"))
         assert data["total_chunks"] == 1
         assert data["chunks"][0]["content"] == "file export test"
 
@@ -637,7 +637,7 @@ class TestCleanupOrphans:
         """Chunks whose source_file does not exist on disk are orphans."""
         # Create a real file and a chunk pointing to it
         real_file = memory_dir / "real.md"
-        real_file.write_text("# Real content")
+        real_file.write_text("# Real content", encoding="utf-8")
 
         real_chunk = make_chunk(
             content="real content",

--- a/packages/memtomem/tests/test_server_tools_core.py
+++ b/packages/memtomem/tests/test_server_tools_core.py
@@ -364,7 +364,7 @@ class TestMemoryCRUD:
         append_entry(target, "Hello, world!", title="Greeting")
 
         assert target.exists()
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         assert "## Greeting" in text
         assert "Hello, world!" in text
 
@@ -372,7 +372,7 @@ class TestMemoryCRUD:
         target = memory_dir / "tagged.md"
         append_entry(target, "Tagged content", title="Tagged", tags=["python", "tips"])
 
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         assert "tags:" in text
         assert "python" in text
 
@@ -380,7 +380,7 @@ class TestMemoryCRUD:
         target = memory_dir / "auto.md"
         append_entry(target, "No explicit title given")
 
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         # Auto-generated title uses "Entry <timestamp>"
         assert "## Entry" in text
 
@@ -389,7 +389,7 @@ class TestMemoryCRUD:
         append_entry(target, "First entry", title="First")
         append_entry(target, "Second entry", title="Second")
 
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         assert "## First" in text
         assert "## Second" in text
         assert "First entry" in text
@@ -400,7 +400,7 @@ class TestMemoryCRUD:
         target = memory_dir / "heading.md"
         append_entry(target, "## Custom heading\n\nBody text")
 
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         assert text.count("## Custom heading") == 1
 
     async def test_upsert_then_delete_by_chunk_id(self, storage):
@@ -451,7 +451,7 @@ class TestMemoryCRUD:
         for title, content in entries:
             append_entry(target, content, title=title)
 
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         assert text.count("## Fact") == 3
         assert "The sky is blue" in text
         assert "Water is wet" in text

--- a/packages/memtomem/tests/test_user_workflows.py
+++ b/packages/memtomem/tests/test_user_workflows.py
@@ -97,10 +97,11 @@ class TestResearcherIndexing:
     async def test_directory_indexing(self, components, memory_dir):
         """Index a directory with multiple files, all become searchable."""
         (memory_dir / "paper1.md").write_text(
-            "# Scaling Laws\n\nChinchilla showed compute-optimal training."
+            "# Scaling Laws\n\nChinchilla showed compute-optimal training.", encoding="utf-8"
         )
         (memory_dir / "paper2.md").write_text(
-            "# RAG Patterns\n\nRetrieval-Augmented Generation improves factuality."
+            "# RAG Patterns\n\nRetrieval-Augmented Generation improves factuality.",
+            encoding="utf-8",
         )
 
         stats = await components.index_engine.index_path(memory_dir, recursive=True)
@@ -112,8 +113,12 @@ class TestResearcherIndexing:
 
     async def test_namespace_search(self, components, memory_dir):
         """Namespace isolates search results."""
-        (memory_dir / "work.md").write_text("# Work\n\nDeployment pipeline config.")
-        (memory_dir / "personal.md").write_text("# Personal\n\nGrocery list for Saturday.")
+        (memory_dir / "work.md").write_text(
+            "# Work\n\nDeployment pipeline config.", encoding="utf-8"
+        )
+        (memory_dir / "personal.md").write_text(
+            "# Personal\n\nGrocery list for Saturday.", encoding="utf-8"
+        )
 
         await components.index_engine.index_path(memory_dir, recursive=True)
 
@@ -129,8 +134,12 @@ class TestResearcherIndexing:
 
     async def test_source_filter(self, components, memory_dir):
         """source_filter restricts results to matching files."""
-        (memory_dir / "notes.md").write_text("# Notes\n\nImportant project notes here.")
-        (memory_dir / "archive.md").write_text("# Archive\n\nOld project notes archived.")
+        (memory_dir / "notes.md").write_text(
+            "# Notes\n\nImportant project notes here.", encoding="utf-8"
+        )
+        (memory_dir / "archive.md").write_text(
+            "# Archive\n\nOld project notes archived.", encoding="utf-8"
+        )
         await components.index_engine.index_path(memory_dir, recursive=True)
 
         results, _ = await components.search_pipeline.search(
@@ -180,7 +189,7 @@ class TestMultilingualSearch:
     async def test_same_language_search(self, components, memory_dir):
         """Korean query finds Korean content."""
         f = memory_dir / "kr.md"
-        f.write_text("## 모니터링\n\n쿠버네티스 클러스터 모니터링 설정 완료.")
+        f.write_text("## 모니터링\n\n쿠버네티스 클러스터 모니터링 설정 완료.", encoding="utf-8")
         await components.index_engine.index_file(f)
 
         results, _ = await components.search_pipeline.search("쿠버네티스 모니터링", top_k=3)
@@ -189,7 +198,9 @@ class TestMultilingualSearch:
     async def test_english_finds_english(self, components, memory_dir):
         """English query finds English content."""
         f = memory_dir / "en.md"
-        f.write_text("## Monitoring\n\nKubernetes cluster monitoring setup complete.")
+        f.write_text(
+            "## Monitoring\n\nKubernetes cluster monitoring setup complete.", encoding="utf-8"
+        )
         await components.index_engine.index_file(f)
 
         results, _ = await components.search_pipeline.search("kubernetes monitoring", top_k=3)
@@ -205,7 +216,9 @@ class TestPowerUserFeatures:
     async def test_frontmatter_tags_extracted(self, components, memory_dir):
         """YAML frontmatter tags are automatically applied to chunks."""
         f = memory_dir / "frontmatter.md"
-        f.write_text("---\ntags: [api, backend]\n---\n\n## API Design\n\nREST vs GraphQL.")
+        f.write_text(
+            "---\ntags: [api, backend]\n---\n\n## API Design\n\nREST vs GraphQL.", encoding="utf-8"
+        )
         await components.index_engine.index_file(f)
 
         chunks = await components.storage.list_chunks_by_source(f)
@@ -216,7 +229,10 @@ class TestPowerUserFeatures:
     async def test_wikilinks_resolved(self, components, memory_dir):
         """Obsidian wikilinks are cleaned from indexed content."""
         f = memory_dir / "obsidian.md"
-        f.write_text("## Notes\n\nSee [[other-page]] and [[link|display text]] for details.")
+        f.write_text(
+            "## Notes\n\nSee [[other-page]] and [[link|display text]] for details.",
+            encoding="utf-8",
+        )
         await components.index_engine.index_file(f)
 
         chunks = await components.storage.list_chunks_by_source(f)
@@ -227,7 +243,7 @@ class TestPowerUserFeatures:
     async def test_force_reindex(self, components, memory_dir):
         """force=True re-indexes unchanged files."""
         f = memory_dir / "stable.md"
-        f.write_text("## Stable\n\nThis content does not change.")
+        f.write_text("## Stable\n\nThis content does not change.", encoding="utf-8")
         stats1 = await components.index_engine.index_file(f)
         assert stats1.indexed_chunks >= 1
 
@@ -244,8 +260,8 @@ class TestPowerUserFeatures:
         """Identical content in two files produces separate indexed chunks."""
         f1 = memory_dir / "dup1.md"
         f2 = memory_dir / "dup2.md"
-        f1.write_text("## Config\n\nRedis connection pool size set to 20.")
-        f2.write_text("## Config\n\nRedis connection pool size set to 20.")
+        f1.write_text("## Config\n\nRedis connection pool size set to 20.", encoding="utf-8")
+        f2.write_text("## Config\n\nRedis connection pool size set to 20.", encoding="utf-8")
         await components.index_engine.index_file(f1)
         await components.index_engine.index_file(f2)
 
@@ -267,7 +283,8 @@ class TestMigrationObsidian:
         f = memory_dir / "vault-note.md"
         f.write_text(
             "---\ntitle: API Redesign\nstatus: in-progress\ntags: [project, api]\n---\n\n"
-            "## Overview\n\nMigrating from REST to GraphQL."
+            "## Overview\n\nMigrating from REST to GraphQL.",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(f)
 
@@ -285,7 +302,8 @@ class TestMigrationObsidian:
         f.write_text(
             "## Section A\n\nContent for section A with enough text.\n\n"
             "## Section B\n\nContent for section B with enough text.\n\n"
-            "## Section C\n\nContent for section C with enough text."
+            "## Section C\n\nContent for section C with enough text.",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(f)
 
@@ -299,7 +317,8 @@ class TestMigrationObsidian:
         f = memory_dir / "mixed.md"
         f.write_text(
             "## 프로젝트 개요\n\n이 프로젝트는 GraphQL API를 구축합니다.\n\n"
-            "## Technical Stack\n\nUsing Apollo Server with TypeScript."
+            "## Technical Stack\n\nUsing Apollo Server with TypeScript.",
+            encoding="utf-8",
         )
         await components.index_engine.index_file(f)
 

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -143,7 +143,7 @@ class TestReadSkill:
         _make_skill(tmp_path, "rich")
         scripts_dir = tmp_path / ".memtomem" / "skills" / "rich" / "scripts"
         scripts_dir.mkdir()
-        (scripts_dir / "run.sh").write_text("#!/bin/bash\necho hello\n")
+        (scripts_dir / "run.sh").write_text("#!/bin/bash\necho hello\n", encoding="utf-8")
         r = await client.get("/api/context/skills/rich")
         data = r.json()
         paths = [f["path"] for f in data["files"]]
@@ -206,7 +206,9 @@ class TestUpdateSkill:
         assert r.status_code == 200
         assert r.json()["name"] == "upd"
         # Verify content changed
-        content = (tmp_path / ".memtomem" / "skills" / "upd" / SKILL_MANIFEST).read_text()
+        content = (tmp_path / ".memtomem" / "skills" / "upd" / SKILL_MANIFEST).read_text(
+            encoding="utf-8"
+        )
         assert "Updated" in content
 
     @pytest.mark.anyio

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -513,13 +513,13 @@ class TestSettingsSync:
 
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps(hooks))
+        canonical.write_text(json.dumps(hooks), encoding="utf-8")
 
         target = Path.home() / ".claude" / "settings.json"
-        backup = target.read_text() if target.is_file() else None
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(json.dumps(hooks))
+            target.write_text(json.dumps(hooks), encoding="utf-8")
             app.state.project_root = tmp_path
 
             resp = await client.get("/api/settings-sync")
@@ -530,7 +530,7 @@ class TestSettingsSync:
             assert data["hooks"]["synced"][0]["matcher"] == "Write"
         finally:
             if backup is not None:
-                target.write_text(backup)
+                target.write_text(backup, encoding="utf-8")
             elif target.is_file():
                 target.unlink()
 
@@ -541,12 +541,16 @@ class TestSettingsSync:
 
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}))
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}), encoding="utf-8"
+        )
 
         target = Path.home() / ".claude" / "settings.json"
-        backup = target.read_text() if target.is_file() else None
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
         try:
-            target.write_text(json.dumps({"hooks": {"PostToolUse": [target_rule]}}))
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [target_rule]}}), encoding="utf-8"
+            )
             app.state.project_root = tmp_path
 
             resp = await client.get("/api/settings-sync")
@@ -560,7 +564,7 @@ class TestSettingsSync:
             assert c["proposed"]["hooks"][0]["command"] == "echo new"
         finally:
             if backup is not None:
-                target.write_text(backup)
+                target.write_text(backup, encoding="utf-8")
             elif target.is_file():
                 target.unlink()
 
@@ -570,12 +574,12 @@ class TestSettingsSync:
 
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps({"hooks": {"PostToolUse": [rule]}}))
+        canonical.write_text(json.dumps({"hooks": {"PostToolUse": [rule]}}), encoding="utf-8")
 
         target = Path.home() / ".claude" / "settings.json"
-        backup = target.read_text() if target.is_file() else None
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
         try:
-            target.write_text(json.dumps({"hooks": {}}))
+            target.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
             app.state.project_root = tmp_path
 
             resp = await client.get("/api/settings-sync")
@@ -585,7 +589,7 @@ class TestSettingsSync:
             assert data["hooks"]["pending"][0]["event"] == "PostToolUse"
         finally:
             if backup is not None:
-                target.write_text(backup)
+                target.write_text(backup, encoding="utf-8")
             elif target.is_file():
                 target.unlink()
 
@@ -596,12 +600,16 @@ class TestSettingsSync:
 
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}))
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}), encoding="utf-8"
+        )
 
         target = Path.home() / ".claude" / "settings.json"
-        backup = target.read_text() if target.is_file() else None
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
         try:
-            target.write_text(json.dumps({"hooks": {"PostToolUse": [target_rule]}}))
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [target_rule]}}), encoding="utf-8"
+            )
             app.state.project_root = tmp_path
 
             resp = await client.post(
@@ -611,11 +619,11 @@ class TestSettingsSync:
             data = resp.json()
             assert data["status"] == "ok"
 
-            updated = json.loads(target.read_text())
+            updated = json.loads(target.read_text(encoding="utf-8"))
             assert updated["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == "echo new"
         finally:
             if backup is not None:
-                target.write_text(backup)
+                target.write_text(backup, encoding="utf-8")
             elif target.is_file():
                 target.unlink()
 
@@ -644,13 +652,13 @@ class TestSettingsSync:
         """POST /resolve for non-existent rule returns HTTP 404."""
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps({"hooks": {}}))
+        canonical.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
 
         target = Path.home() / ".claude" / "settings.json"
-        backup = target.read_text() if target.is_file() else None
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(json.dumps({"hooks": {}}))
+            target.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
             app.state.project_root = tmp_path
 
             resp = await client.post(
@@ -661,7 +669,7 @@ class TestSettingsSync:
             assert "not in canonical source" in resp.json()["detail"]
         finally:
             if backup is not None:
-                target.write_text(backup)
+                target.write_text(backup, encoding="utf-8")
             elif target.is_file():
                 target.unlink()
 
@@ -678,7 +686,7 @@ class TestSettingsSync:
         """POST /api/context/settings/sync runs the settings merge."""
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps({"hooks": {}}))
+        canonical.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
         app.state.project_root = tmp_path
 
         resp = await client.post(
@@ -695,12 +703,16 @@ class TestSettingsSync:
 
         canonical = tmp_path / ".memtomem" / "settings.json"
         canonical.parent.mkdir()
-        canonical.write_text(json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}))
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}), encoding="utf-8"
+        )
 
         target = Path.home() / ".claude" / "settings.json"
-        backup = target.read_text() if target.is_file() else None
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
         try:
-            target.write_text(json.dumps({"hooks": {"PostToolUse": [target_rule]}}))
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [target_rule]}}), encoding="utf-8"
+            )
             app.state.project_root = tmp_path
 
             resp = await client.post(
@@ -710,11 +722,11 @@ class TestSettingsSync:
             data = resp.json()
             assert data["status"] == "ok"
 
-            updated = json.loads(target.read_text())
+            updated = json.loads(target.read_text(encoding="utf-8"))
             assert updated["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == "echo v2"
         finally:
             if backup is not None:
-                target.write_text(backup)
+                target.write_text(backup, encoding="utf-8")
             elif target.is_file():
                 target.unlink()
 


### PR DESCRIPTION
### Problem
Although memtomem uses UTF-8 encoding, Windows uses cp949 as the default encoding, which causes encoding conflicts.
Below are examples of actual errors that occurred:
```
self = WindowsPath('C:/Users/user/AppData/Local/Temp/pytest-of-user/pytest-30/test_edited_file_is_reindexed_0/fake_home/.claude/projects/-Users-test-Work-demo-project/memory/feedback_a.md')
data = '# Feedback A\n\nRevised guidance: prefer bge-m3 for multilingual corpora — the Korean coverage is measurably better than bge-small, and the English quality is comparable.\n'
encoding = 'locale', errors = None, newline = None

    def write_text(self, data, encoding=None, errors=None, newline=None):
        """
        Open the file in text mode, write to it, and close the file.
        """
        if not isinstance(data, str):
            raise TypeError('data must be str, not %s' %
                            data.__class__.__name__)
        with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
>           return f.write(data)
                   ^^^^^^^^^^^^^
E           UnicodeEncodeError: 'cp949' codec can't encode character '\u2014' in position 73: illegal multibyte sequence

..\..\AppData\Roaming\uv\python\cpython-3.13.5-windows-x86_64-none\Lib\pathlib\_abc.py:652: UnicodeEncodeError
```
This is a typical encoding conflict, and the error message clearly indicates that the issue is caused by an encoding mismatch.


```
self = <tests.test_e2e_pipeline.TestCrossLanguageE2E object at 0x0000021546BC6490>
components = Components(config=Mem2MemConfig(embedding=EmbeddingConfig(provider='none', model='bge-m3', dimension=1024, base_url=''... 0x0000021546BCFA50>, search_pipeline=<memtomem.search.pipeline.SearchPipeline object at 0x00000215477C2B30>, llm=None)
memory_dir = WindowsPath('C:/Users/user/AppData/Local/Temp/pytest-of-user/pytest-30/test_mixed_language_context0/memories')

    async def test_mixed_language_context(self, components, memory_dir):
        """Mixed-language doc with context expansion preserves both languages."""
        doc = memory_dir / "mixed.md"
        doc.write_text(
            "## Project Overview\n\n"
            "Building a knowledge management platform.\n\n"
            "## 기술 스택\n\n"
            "Python 3.12, FastAPI, SQLite with FTS5.\n\n"
            "## Architecture\n\n"
            "Monorepo with uv workspace. Two packages.\n"
        )
        await components.index_engine.index_file(doc)

        results, _ = await components.search_pipeline.search("기술 스택", top_k=1, context_window=1)
>       assert len(results) >= 1
E       assert 0 >= 1
E        +  where 0 = len([])

packages\memtomem\tests\test_e2e_pipeline.py:185: AssertionError
```
In this case, the immediate cause of the error is a search failure, but the underlying cause of that failure is an encoding mismatch. Therefore, this can also ultimately be considered an encoding conflict issue.


To address the various issues caused by this and reduce the likelihood of similar problems in the future, we discussed enforcing UTF-8 by adding `encoding="utf-8"` to `read_text()` and `write_text()`.


### Conclusion
Enforcing UTF-8 by adding `encoding="utf-8"` to every `read_text()` and `write_text()` call is not necessarily the cleanest approach and does have some drawbacks. However, at this point, it appears to be the fastest practical way to resolve the related issues.

For that reason, the code is being updated in this way for now, with the understanding that this approach may be revisited and changed at any time through further discussion.