### PR TITLE
fix(logging): surface silenced errors in health, pipeline, and consolidation

### DIFF
--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -363,10 +363,7 @@ class SearchPipeline:
         if fused:
 
             async def _increment():
-                try:
-                    await self._storage.increment_access([r.chunk.id for r in fused])
-                except Exception:
-                    logger.debug("Failed to increment access counts", exc_info=True)
+                await self._storage.increment_access([r.chunk.id for r in fused])
 
             t = asyncio.create_task(_increment())
             t.add_done_callback(_bg_task_error_cb)
@@ -375,16 +372,13 @@ class SearchPipeline:
 
         # Save to query history (fire-and-forget)
         async def _save_history():
-            try:
-                emb = query_embedding if use_dense else []
-                await self._storage.save_query_history(
-                    query,
-                    emb,
-                    [str(r.chunk.id) for r in fused[:top_k]],
-                    [r.score for r in fused[:top_k]],
-                )
-            except Exception:
-                logger.debug("Failed to save query history", exc_info=True)
+            emb = query_embedding if use_dense else []
+            await self._storage.save_query_history(
+                query,
+                emb,
+                [str(r.chunk.id) for r in fused[:top_k]],
+                [r.score for r in fused[:top_k]],
+            )
 
         t2 = asyncio.create_task(_save_history())
         t2.add_done_callback(_bg_task_error_cb)

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -317,7 +317,7 @@ async def source_has_consolidation_relations(
         try:
             related = await storage.get_related(cid)
         except Exception:
-            logger.debug("get_related failed for %r", cid, exc_info=True)
+            logger.warning("get_related failed for %r", cid, exc_info=True)
             continue
         if any(rel == "consolidated_into" for _, rel in related):
             return True

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -73,12 +73,14 @@ async def health(storage=Depends(get_storage), embedder=Depends(get_embedder)):
         await storage.get_stats()
         checks["storage"] = "ok"
     except Exception:
+        logger.warning("Health check failed: storage", exc_info=True)
         checks["storage"] = "error"
 
     try:
         await embedder.embed_texts(["health check"])
         checks["embedding"] = "ok"
     except Exception:
+        logger.warning("Health check failed: embedding", exc_info=True)
         checks["embedding"] = "error"
 
     all_ok = all(v == "ok" for v in checks.values())

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -1,5 +1,7 @@
 """Tests for search pipeline stages (expansion, reranker, importance integration)."""
 
+import asyncio
+
 import pytest
 from pathlib import Path
 from uuid import uuid4
@@ -77,6 +79,50 @@ class TestPipelineImportanceBoost:
         boosted = apply_importance_boost([r1, r2], scores)
         assert boosted[0].chunk.id == r1.chunk.id
         assert boosted[0].score == pytest.approx(0.8)
+
+
+class TestBgTaskErrorCallback:
+    """_bg_task_error_cb must log at warning when a fire-and-forget task raises."""
+
+    @pytest.mark.asyncio
+    async def test_callback_logs_warning_on_exception(self, caplog):
+        import logging
+        from memtomem.search.pipeline import _bg_task_error_cb
+
+        async def _failing():
+            raise RuntimeError("storage down")
+
+        task = asyncio.create_task(_failing())
+        task.add_done_callback(_bg_task_error_cb)
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.pipeline"):
+            # Wait for the task to complete and the callback to fire.
+            try:
+                await task
+            except RuntimeError:
+                pass
+            # The callback runs synchronously after the task finishes, but we
+            # need a brief event-loop tick for it to execute.
+            await asyncio.sleep(0)
+
+        assert any("storage down" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_callback_silent_on_success(self, caplog):
+        import logging
+        from memtomem.search.pipeline import _bg_task_error_cb
+
+        async def _ok():
+            return 42
+
+        task = asyncio.create_task(_ok())
+        task.add_done_callback(_bg_task_error_cb)
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.pipeline"):
+            await task
+            await asyncio.sleep(0)
+
+        assert not any("Background task" in r.message for r in caplog.records)
 
 
 class TestImportanceCompute:

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -916,6 +916,29 @@ class TestConsolidationEngineUnit:
         assert parse_source_hash(without_hash) is None
 
 
+class TestSourceHasConsolidationRelationsLogging:
+    @pytest.mark.asyncio
+    async def test_get_related_failure_logs_warning(self, caplog):
+        """get_related errors must be visible at warning level."""
+        import logging
+        from unittest.mock import AsyncMock
+        from uuid import uuid4
+
+        from memtomem.tools.consolidation_engine import source_has_consolidation_relations
+
+        storage = AsyncMock()
+        storage.get_related = AsyncMock(side_effect=RuntimeError("db error"))
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.tools.consolidation_engine"):
+            result = await source_has_consolidation_relations(storage, [uuid4()])
+
+        assert result is False
+        assert any("get_related failed" in r.message for r in caplog.records)
+        assert all(
+            r.levelno >= logging.WARNING for r in caplog.records if "get_related" in r.message
+        )
+
+
 # ── auto_consolidate handler (integration with storage) ──────────────
 
 

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -227,6 +227,15 @@ class TestHealth:
         # Exception class name must not leak to the response (see #75).
         assert "RuntimeError" not in resp.text
 
+    async def test_health_degraded_logs_warning(self, app, client: AsyncClient, caplog):
+        """Failures must be logged server-side so operators can diagnose."""
+        import logging
+
+        app.state.storage.get_stats.side_effect = RuntimeError("db down")
+        with caplog.at_level(logging.WARNING, logger="memtomem.web.routes.system"):
+            await client.get("/api/health")
+        assert any("storage" in r.message for r in caplog.records)
+
 
 # ---------------------------------------------------------------------------
 # GET /api/stats


### PR DESCRIPTION
Closes #163

## Summary

- **pipeline.py**: Remove inner `try/except` from `_increment()` and `_save_history()` — these caught all errors at debug level, making the warning-level `_bg_task_error_cb` callback dead code. Errors now propagate to the callback as intended.
- **system.py**: Add `logger.warning` to `/health` endpoint's storage and embedding check failures — previously returned "degraded" with zero server-side logging.
- **consolidation_engine.py**: Bump `get_related` failure log from debug to warning in `source_has_consolidation_relations` — makes idempotency-check false negatives visible.

Priority: Finding 1 (pipeline dead callback) > Finding 2 (health) > Finding 3 (consolidation).

## Test plan

- [x] `test_health_degraded_logs_warning` — verifies health check failures produce warning-level log
- [x] `test_callback_logs_warning_on_exception` — verifies `_bg_task_error_cb` fires on task exception
- [x] `test_callback_silent_on_success` — verifies callback is silent on success (no false warnings)
- [x] `test_get_related_failure_logs_warning` — verifies consolidation idempotency failures log at warning
- [x] Full suite: 1447 passed, 46 deselected


🤖 Generated with [Claude Code](https://claude.com/claude-code)