### PR TITLE
docs: document MCP tool error response contract

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,16 @@ catches exceptions and returns one of four string prefixes:
   produce MCP protocol errors instead of user-friendly messages.
 - **`str(exc)` is the message surface.** `FileNotFoundError` and
   `PermissionError` include full file paths in their default `str()`.
-  This is acceptable for a local-only server but would need sanitisation
-  if the server were exposed over a network.
+  See "Deployment assumptions" below.
+
+**Deployment assumptions:** The error contract assumes a **local-only
+server** (stdio or localhost). `str(exc)` for `FileNotFoundError` and
+`PermissionError` exposes full filesystem paths in tool responses. If the
+server is deployed over a network (SSE/HTTP), these messages must be
+sanitised before reaching external clients — either by wrapping the
+exceptions in the decorator or by adding a response filter. Changing the
+deployment model without addressing this turns error messages into an
+information disclosure surface.
 
 ## Contributor License Agreement (CLA)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,33 @@ The STM proxy gateway lives in a separate repository: [memtomem/memtomem-stm](ht
 6. Write a clear commit message describing the "why"
 7. Sign the CLA on your first pull request (see below)
 
+## MCP Tool Error Response Contract
+
+All MCP tool handlers use `@tool_handler` (`server/error_handler.py`) which
+catches exceptions and returns one of four string prefixes:
+
+| Prefix | When |
+|--------|------|
+| `Error: {msg}` | Known exceptions (`ValueError`, `StorageError`, etc.) or manual validation returns |
+| `Error (retryable): {msg}` | `RetryableError` — transient failure, safe to retry |
+| `Error (permanent): {msg}` | `PermanentError` — will not resolve with retries |
+| `Error: internal error ({ExcType}: {msg})` | Unexpected exceptions |
+
+**Key design decisions:**
+
+- **Errors are always string returns, never raised exceptions.** The decorator
+  catches all `Exception` subclasses and converts them to `"Error: …"` strings.
+  This means the MCP protocol-level `isError` flag is never set by LTM tools.
+  The STM proxy detects errors via `result.isError` (protocol level), not by
+  parsing the `"Error: "` prefix — currently there is no programmatic consumer
+  of the prefix in the STM proxy.
+- **All new tools must use `@tool_handler`.** Without it, unhandled exceptions
+  produce MCP protocol errors instead of user-friendly messages.
+- **`str(exc)` is the message surface.** `FileNotFoundError` and
+  `PermissionError` include full file paths in their default `str()`.
+  This is acceptable for a local-only server but would need sanitisation
+  if the server were exposed over a network.
+
 ## Contributor License Agreement (CLA)
 
 Before we can merge your first pull request, you need to sign the


### PR DESCRIPTION
## Summary

- Add "MCP Tool Error Response Contract" section to CONTRIBUTING.md
- Documents the 4 error prefix variants enforced by `@tool_handler`
- Clarifies that MCP protocol-level `isError` is never set by LTM tools (all errors are string returns)
- Notes that STM proxy uses `result.isError` (protocol level), not `"Error: "` prefix parsing — currently no programmatic consumer of the prefix
- Flags `FileNotFoundError`/`PermissionError` path exposure as acceptable for local-only, would need sanitisation for network exposure

## Context

Reconnaissance of 10/68 registered tools found 100% consistency in error response format. The contract was already enforced by the decorator but existed only as implicit knowledge. This makes it explicit so new contributors have a reference, and so the prefix format is recognized as an intentional interface rather than an arbitrary convention that can be casually changed.

## Test plan

- [x] Documentation-only change, no code changes
- [x] Verified error_handler.py implementation matches documented contract
- [x] Verified STM proxy error detection mechanism (result.isError, not prefix parsing)


🤖 Generated with [Claude Code](https://claude.com/claude-code)