### PR TITLE
chore: remove dead config sections (conflict, entity_extraction, timezone)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -118,12 +118,6 @@ without requiring explicit `MEMORY_DIRS` configuration.
 | `MEMTOMEM_NAMESPACE__DEFAULT_NAMESPACE` | `default` | Default namespace for new chunks |
 | `MEMTOMEM_NAMESPACE__ENABLE_AUTO_NS` | `false` | Auto-derive namespace from folder name |
 
-## Timezone
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MEMTOMEM_TIMEZONE` | `UTC` | Display timezone for timestamps (e.g. `Asia/Seoul`). Storage remains UTC |
-
 ## Policy
 
 | Variable | Default | Description |

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -217,12 +217,6 @@ class ImportanceConfig(BaseSettings):
         return v
 
 
-class ConflictConfig(BaseSettings):
-    enabled: bool = False
-    threshold: float = 0.75
-    auto_check: bool = False  # auto-check on mem_add
-
-
 class WebhookConfig(BaseSettings):
     enabled: bool = False
     url: str = ""
@@ -244,24 +238,6 @@ class PolicyConfig(BaseSettings):
     enabled: bool = False
     scheduler_interval_minutes: float = 60.0
     max_actions_per_run: int = 100
-
-
-class EntityExtractionConfig(BaseSettings):
-    """Entity extraction from chunk content."""
-
-    enabled: bool = False
-    extract_on_index: bool = False
-    entity_types: list[str] = Field(
-        default_factory=lambda: [
-            "person",
-            "date",
-            "decision",
-            "action_item",
-            "technology",
-            "concept",
-        ]
-    )
-    min_confidence: float = 0.5
 
 
 class ContextWindowConfig(BaseSettings):
@@ -332,17 +308,14 @@ class Mem2MemConfig(BaseSettings):
     rerank: RerankConfig = Field(default_factory=RerankConfig)
     query_expansion: QueryExpansionConfig = Field(default_factory=QueryExpansionConfig)
     importance: ImportanceConfig = Field(default_factory=ImportanceConfig)
-    conflict: ConflictConfig = Field(default_factory=ConflictConfig)
     webhook: WebhookConfig = Field(default_factory=WebhookConfig)
     consolidation_schedule: ConsolidationScheduleConfig = Field(
         default_factory=ConsolidationScheduleConfig
     )
     policy: PolicyConfig = Field(default_factory=PolicyConfig)
-    entity_extraction: EntityExtractionConfig = Field(default_factory=EntityExtractionConfig)
     context_window: ContextWindowConfig = Field(default_factory=ContextWindowConfig)
     health_watchdog: HealthWatchdogConfig = Field(default_factory=HealthWatchdogConfig)
     llm: LLMConfig = Field(default_factory=LLMConfig)
-    timezone: str = "UTC"  # Display timezone (e.g. "Asia/Seoul"). Storage remains UTC.
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_webhooks.py
+++ b/packages/memtomem/tests/test_webhooks.py
@@ -80,7 +80,6 @@ class TestConfigSections:
         assert c.rerank.enabled is False
         assert c.query_expansion.enabled is False
         assert c.importance.enabled is False
-        assert c.conflict.enabled is False
         assert c.webhook.enabled is False
         assert c.consolidation_schedule.enabled is False
 


### PR DESCRIPTION
Closes #168

## Summary

- Remove `ConflictConfig` (3 fields) — `mem_conflict_check` uses hardcoded defaults, not config
- Remove `EntityExtractionConfig` (4 fields) — extraction functions take parameters directly
- Remove `Mem2MemConfig.timezone` — documented in configuration.md but never read by any code
- Remove timezone section from `docs/guides/configuration.md`
- Update test assertion in `test_webhooks.py` that referenced `conflict.enabled`

Found via config-key cross-reference audit (84 keys / 19 sections). All removals are dead code with zero runtime effect.

## Test plan

- [x] 1443 passed, 46 deselected
- [x] Verified no `getattr`/dynamic access patterns for removed keys
- [x] Verified test references: only `test_webhooks.py:83` (`conflict.enabled`) — updated
- [x] `EntityExtractionConfig`: 0 test references
- [x] `timezone`: 0 test references, git blame confirms never-implemented feature (eb55a1e)


🤖 Generated with [Claude Code](https://claude.com/claude-code)