### PR TITLE
fix(async): wrap blocking file I/O with asyncio.to_thread

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 from memtomem.server import mcp
@@ -170,7 +171,7 @@ async def mem_context_generate(
                 content = gen.generate(sections)
                 out_path = root / gen.output_path
                 out_path.parent.mkdir(parents=True, exist_ok=True)
-                out_path.write_text(content, encoding="utf-8")
+                await asyncio.to_thread(out_path.write_text, content, encoding="utf-8")
                 results.append(f"{name}: {gen.output_path}")
         else:
             results.append(f"{CONTEXT_FILENAME} is empty.")
@@ -279,7 +280,7 @@ async def mem_context_diff(
                 gen = GENERATORS.get(f.agent)
                 if not gen:
                     continue
-                current = f.path.read_text(encoding="utf-8").strip()
+                current = (await asyncio.to_thread(f.path.read_text, encoding="utf-8")).strip()
                 expected = gen.generate(sections).strip()
                 status = "in sync" if current == expected else "out of sync"
                 lines.append(f"{f.agent}: {f.path.name} [{status}]")
@@ -389,7 +390,7 @@ async def mem_context_sync(
                     continue
                 content = gen.generate(sections)
                 out_path = root / gen.output_path
-                out_path.write_text(content, encoding="utf-8")
+                await asyncio.to_thread(out_path.write_text, content, encoding="utf-8")
                 results.append(f"{f.agent}: {gen.output_path}")
                 agents_synced.add(f.agent)
         elif not inc:

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -215,13 +215,15 @@ async def mem_edit(
 
     meta = chunk.metadata
     # Backup for rollback on indexing failure
-    original = meta.source_file.read_text(encoding="utf-8")
+    original = await asyncio.to_thread(meta.source_file.read_text, encoding="utf-8")
     try:
-        replace_lines(meta.source_file, meta.start_line, meta.end_line, new_content)
+        await asyncio.to_thread(
+            replace_lines, meta.source_file, meta.start_line, meta.end_line, new_content
+        )
         stats = await app.index_engine.index_file(meta.source_file, force=True)
         app.search_pipeline.invalidate_cache()
     except Exception as exc:
-        meta.source_file.write_text(original, encoding="utf-8")
+        await asyncio.to_thread(meta.source_file.write_text, original, encoding="utf-8")
         try:
             await app.index_engine.index_file(meta.source_file, force=True)
         except Exception:
@@ -275,13 +277,13 @@ async def mem_delete(
 
         meta = chunk.metadata
         # Backup for rollback on indexing failure
-        original = meta.source_file.read_text(encoding="utf-8")
+        original = await asyncio.to_thread(meta.source_file.read_text, encoding="utf-8")
         try:
-            remove_lines(meta.source_file, meta.start_line, meta.end_line)
+            await asyncio.to_thread(remove_lines, meta.source_file, meta.start_line, meta.end_line)
             stats = await app.index_engine.index_file(meta.source_file, force=True)
             app.search_pipeline.invalidate_cache()
         except Exception as exc:
-            meta.source_file.write_text(original, encoding="utf-8")
+            await asyncio.to_thread(meta.source_file.write_text, original, encoding="utf-8")
             try:
                 await app.index_engine.index_file(meta.source_file, force=True)
             except Exception:

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -100,7 +100,7 @@ async def _mem_add_core(
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         target = Path(base).expanduser().resolve() / f"{date_str}.md"
 
-    append_entry(target, content, title=title, tags=tags)
+    await asyncio.to_thread(append_entry, target, content, title=title, tags=tags)
 
     effective_ns = namespace or app.current_namespace
 


### PR DESCRIPTION
## Summary
- Wrap 5 blocking file read/write calls in MCP tool handlers with `asyncio.to_thread` to prevent event loop starvation
- **context.py**: `write_text` in `mem_context_generate`, `read_text` in `mem_context_diff`, `write_text` in `mem_context_sync`
- **memory_crud.py**: backup `read_text` + `replace_lines`/`remove_lines` + rollback `write_text` in `mem_edit` and `mem_delete`
- Background SQLite blocking (health_watchdog) remains deferred per `project_async_sqlite_deferred.md`

Converts #165 from audit-only to fix — reconnaissance found ≤10 blocking sites, all on the MCP request hot path.

## Test plan
- [x] 241 context/CRUD tests pass
- [x] Full suite: 1447 passed
- [ ] Verify `mem_edit` rollback path still restores original content on indexing failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)