### PR TITLE
chore: add 'Typing :: Typed' classifier (#97)

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Add `Typing :: Typed` PyPI classifier to match the existing `py.typed` marker

Closes #97