### PR TITLE
fix(watcher): replace deprecated get_event_loop (#99)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -81,7 +81,7 @@ class FileWatcher:
         self._task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         handler = _MarkdownEventHandler(self._queue, loop, self._config.supported_extensions)
         self._observer = Observer()
 


### PR DESCRIPTION
## Summary

- Replace `asyncio.get_event_loop()` → `asyncio.get_running_loop()` in `watcher.py:start()`
- Called inside `async def`, so a running loop is guaranteed
- `get_event_loop()` emits `DeprecationWarning` in Python 3.14+

Closes #99