### PR TITLE
chore: extract DECAY_FACTOR constant (#148)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -156,6 +156,7 @@ async def mem_consolidate_apply(
     from datetime import datetime, timezone
 
     from memtomem.tools.consolidation_engine import (
+        DECAY_FACTOR,
         DECAY_FLOOR,
         link_consolidation_relations,
     )
@@ -239,7 +240,7 @@ async def mem_consolidate_apply(
     if not keep_originals and group["chunk_ids"]:
         scores = await app.storage.get_importance_scores(group["chunk_ids"])
         if scores:
-            floored = {cid: max(score * 0.5, DECAY_FLOOR) for cid, score in scores.items()}
+            floored = {cid: max(score * DECAY_FACTOR, DECAY_FLOOR) for cid, score in scores.items()}
             await app.storage.update_importance_scores(floored)
 
     app.search_pipeline.invalidate_cache()

--- a/packages/memtomem/src/memtomem/tools/consolidation_engine.py
+++ b/packages/memtomem/src/memtomem/tools/consolidation_engine.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 # ── Constants ────────────────────────────────────────────────────────
 
 DEFAULT_SUMMARY_NAMESPACE = "archive:summary"
+DECAY_FACTOR = 0.5  # keep_originals=False → halve importance score
 DECAY_FLOOR = 0.3  # keep_originals=False → importance_score floor (never below)
 CONSOLIDATED_SUFFIX = ".consolidated.md"
 SUMMARY_MAX_LEN = 160
@@ -404,7 +405,7 @@ async def apply_consolidation(
     if not keep_originals and source_ids:
         scores = await storage.get_importance_scores(source_ids)
         if scores:
-            floored = {cid: max(score * 0.5, DECAY_FLOOR) for cid, score in scores.items()}
+            floored = {cid: max(score * DECAY_FACTOR, DECAY_FLOOR) for cid, score in scores.items()}
             await storage.update_importance_scores(floored)
 
     return summary_chunk.id


### PR DESCRIPTION
## Summary

- Extract hardcoded `0.5` decay multiplier into `DECAY_FACTOR` constant alongside existing `DECAY_FLOOR`
- Update both `consolidation_engine.py` and `server/tools/consolidation.py`

Closes #148