### PR TITLE
chore: extract context-window chunk cap constant (#92)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -240,6 +240,9 @@ class PolicyConfig(BaseSettings):
     max_actions_per_run: int = 100
 
 
+MAX_CONTEXT_WINDOW_CHUNKS = 10  # max ±N adjacent chunks around each hit
+
+
 class ContextWindowConfig(BaseSettings):
     """Context window expansion for search results (small-to-big retrieval)."""
 
@@ -249,8 +252,8 @@ class ContextWindowConfig(BaseSettings):
     @field_validator("window_size")
     @classmethod
     def must_be_in_range(cls, v: int) -> int:
-        if not 0 <= v <= 10:
-            raise ValueError("window_size must be 0-10")
+        if not 0 <= v <= MAX_CONTEXT_WINDOW_CHUNKS:
+            raise ValueError(f"window_size must be 0-{MAX_CONTEXT_WINDOW_CHUNKS}")
         return v
 
 

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -9,7 +9,14 @@ from typing import TYPE_CHECKING
 
 from dataclasses import dataclass
 
-from memtomem.config import AccessConfig, ContextWindowConfig, DecayConfig, MMRConfig, SearchConfig
+from memtomem.config import (
+    MAX_CONTEXT_WINDOW_CHUNKS,
+    AccessConfig,
+    ContextWindowConfig,
+    DecayConfig,
+    MMRConfig,
+    SearchConfig,
+)
 from memtomem.models import ContextInfo, NamespaceFilter, SearchResult
 from memtomem.search.fusion import reciprocal_rank_fusion
 
@@ -119,10 +126,10 @@ class SearchPipeline:
     def _resolve_context_window(self, override: int | None) -> int:
         """Return the effective context window size (0 = disabled)."""
         if override is not None:
-            return max(0, min(override, 10))
+            return max(0, min(override, MAX_CONTEXT_WINDOW_CHUNKS))
         cfg = self._context_window_config
         if cfg and cfg.enabled:
-            return max(0, min(cfg.window_size, 10))
+            return max(0, min(cfg.window_size, MAX_CONTEXT_WINDOW_CHUNKS))
         return 0
 
     async def _expand_context(self, results: list[SearchResult], window: int) -> list[SearchResult]:

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -12,6 +12,7 @@ from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.formatters import _display_path, _format_results, _format_structured_results
 from memtomem.server.tool_registry import register
+from memtomem.config import MAX_CONTEXT_WINDOW_CHUNKS
 from memtomem.server.validation import MAX_QUERY_LENGTH
 
 logger = logging.getLogger(__name__)
@@ -158,7 +159,7 @@ async def mem_expand(
         chunk_id: The UUID of the chunk to expand (from mem_search results)
         window: Number of adjacent chunks before and after (default 2, max 10)
     """
-    window = max(0, min(window, 10))
+    window = max(0, min(window, MAX_CONTEXT_WINDOW_CHUNKS))
     app = _get_app(ctx)
 
     try:


### PR DESCRIPTION
## Summary

- Define `MAX_CONTEXT_WINDOW_CHUNKS = 10` in `config.py`
- Update validator, pipeline clamp, and `mem_expand` tool to reference it
- 3 files, no behavior change

Closes #92