### PR TITLE
fix(cli): add warning log to silent except in activity hook (#149)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import uuid
 from pathlib import Path
 
 import click
+
+logger = logging.getLogger(__name__)
 
 
 # Session state file — stores active session UUID.
@@ -221,7 +224,7 @@ def log_event(event_type: str, content: str, meta: str | None) -> None:
     try:
         asyncio.run(_log_event(session_id, event_type, content, metadata))
     except Exception:
-        pass  # hooks must never block
+        logger.warning("Activity hook failed", exc_info=True)
 
 
 async def _log_event(session_id: str, event_type: str, content: str, metadata: dict | None) -> None:


### PR DESCRIPTION
## Summary

- Replace bare `pass` with `logger.warning("Activity hook failed", exc_info=True)`
- Add `logging` import and module-level logger
- Hook still catches and continues (never blocks)

Closes #149