### PR TITLE
refactor: deduplicate webhook_error_cb into webhooks module (#147)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/ask.py
+++ b/packages/memtomem/src/memtomem/server/tools/ask.py
@@ -9,17 +9,9 @@ from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.validation import MAX_QUERY_LENGTH
+from memtomem.server.webhooks import webhook_error_cb
 
 logger = logging.getLogger(__name__)
-
-
-def _webhook_error_cb(task: asyncio.Task) -> None:
-    """Log errors from fire-and-forget webhook tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Webhook fire failed: %s", exc)
 
 
 @mcp.tool()
@@ -125,6 +117,6 @@ async def mem_ask(
                 },
             )
         )
-        task.add_done_callback(_webhook_error_cb)
+        task.add_done_callback(webhook_error_cb)
 
     return "\n".join(lines)

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -13,20 +13,12 @@ from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.server.validation import MAX_CONTENT_LENGTH
+from memtomem.server.webhooks import webhook_error_cb
 
 if TYPE_CHECKING:
     from memtomem.models import IndexingStats
 
 logger = logging.getLogger(__name__)
-
-
-def _webhook_error_cb(task: asyncio.Task) -> None:
-    """Log errors from fire-and-forget webhook tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Webhook fire failed: %s", exc)
 
 
 def _validate_path(path_str: str, memory_dirs: list) -> tuple[Path | None, str | None]:
@@ -134,7 +126,7 @@ async def _mem_add_core(
         task = asyncio.create_task(
             app.webhook_manager.fire("add", {"file": str(target), "chunks_indexed": 1})
         )
-        task.add_done_callback(_webhook_error_cb)
+        task.add_done_callback(webhook_error_cb)
 
     return (result, stats)
 

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -14,17 +14,9 @@ from memtomem.server.formatters import _display_path, _format_results, _format_s
 from memtomem.server.tool_registry import register
 from memtomem.config import MAX_CONTEXT_WINDOW_CHUNKS
 from memtomem.server.validation import MAX_QUERY_LENGTH
+from memtomem.server.webhooks import webhook_error_cb
 
 logger = logging.getLogger(__name__)
-
-
-def _webhook_error_cb(task: asyncio.Task) -> None:
-    """Log errors from fire-and-forget webhook tasks."""
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Webhook fire failed: %s", exc)
 
 
 @mcp.tool()
@@ -137,7 +129,7 @@ async def mem_search(
         task = asyncio.create_task(
             app.webhook_manager.fire("search", {"query": query, "result_count": len(results)})
         )
-        task.add_done_callback(_webhook_error_cb)
+        task.add_done_callback(webhook_error_cb)
 
     return output
 

--- a/packages/memtomem/src/memtomem/server/webhooks.py
+++ b/packages/memtomem/src/memtomem/server/webhooks.py
@@ -17,6 +17,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def webhook_error_cb(task: asyncio.Task) -> None:
+    """Log errors from fire-and-forget webhook tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc:
+        logger.warning("Webhook fire failed: %s", exc)
+
+
 def _validate_webhook_url(url: str) -> str | None:
     """Return an error message if the URL is unsafe, or None if valid."""
     try:


### PR DESCRIPTION
## Summary

- Move `_webhook_error_cb` to `server/webhooks.py` as `webhook_error_cb`
- Replace 3 identical copies in ask.py, search.py, memory_crud.py with imports
- Net -15 lines, no behavior change

Closes #147