### PR TITLE
typing(chunking): drop 6 stray type:ignore[import] comments (#133)

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/javascript.py
+++ b/packages/memtomem/src/memtomem/chunking/javascript.py
@@ -43,15 +43,15 @@ class JavaScriptChunker:
             return self._fallback(file_path, content)
 
     def _ast_chunk(self, file_path: Path, content: str) -> list[Chunk]:
-        from tree_sitter import Language, Parser  # type: ignore[import]
+        from tree_sitter import Language, Parser
 
         if file_path.suffix in {".ts", ".tsx"}:
-            import tree_sitter_typescript as tsts  # type: ignore[import]
+            import tree_sitter_typescript as tsts
 
             lang = Language(tsts.language_typescript())
             lang_name = "typescript"
         else:
-            import tree_sitter_javascript as tsjs  # type: ignore[import]
+            import tree_sitter_javascript as tsjs
 
             lang = Language(tsjs.language())
             lang_name = "javascript"

--- a/packages/memtomem/src/memtomem/chunking/python_code.py
+++ b/packages/memtomem/src/memtomem/chunking/python_code.py
@@ -32,8 +32,8 @@ class PythonChunker:
             return self._fallback(file_path, content)
 
     def _ast_chunk(self, file_path: Path, content: str) -> list[Chunk]:
-        import tree_sitter_python as tspython  # type: ignore[import]
-        from tree_sitter import Language, Parser  # type: ignore[import]
+        import tree_sitter_python as tspython
+        from tree_sitter import Language, Parser
 
         lang = Language(tspython.language())
         parser = Parser(lang)

--- a/packages/memtomem/src/memtomem/chunking/structured.py
+++ b/packages/memtomem/src/memtomem/chunking/structured.py
@@ -337,7 +337,7 @@ class StructuredChunker:
             return json.loads(content)
         if suffix in (".yaml", ".yml"):
             try:
-                import yaml  # type: ignore[import]
+                import yaml
             except ImportError as exc:
                 raise ImportError(
                     "PyYAML is required for YAML chunking: pip install pyyaml"


### PR DESCRIPTION
## Summary

- Remove 6 redundant `# type: ignore[import]` from javascript.py, python_code.py, structured.py
- Global `ignore_missing_imports = true` already covers these, and tree-sitter packages ship `py.typed`

Closes #133