### PR TITLE
typing: fix 3 internal signature/variable-reuse mypy errors

### DIFF
--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -84,6 +84,7 @@ def config_set(key: str, value: str) -> None:
     if key == "search.tokenizer":
         from memtomem.storage.fts_tokenizer import set_tokenizer
 
+        assert isinstance(coerced, str)
         set_tokenizer(coerced)
 
         from memtomem.storage.factory import create_storage

--- a/packages/memtomem/src/memtomem/cli/wizard.py
+++ b/packages/memtomem/src/memtomem/cli/wizard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Callable
 
 import click
@@ -64,7 +65,7 @@ def nav_confirm(text: str, default: bool = False) -> bool:
 
 
 def run_steps(
-    steps: list[Callable[[dict], None]],
+    steps: Sequence[Callable[[dict], None]],
     state: dict | None = None,
 ) -> dict:
     """Run a list of step functions with back/cancel support.

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -341,8 +341,8 @@ class SearchPipeline:
         if self._access_config.enabled and fused:
             from memtomem.search.access import apply_access_boost
 
-            chunk_ids = [r.chunk.id for r in fused]
-            access_counts = await self._storage.get_access_counts(chunk_ids)
+            access_chunk_ids = [r.chunk.id for r in fused]
+            access_counts = await self._storage.get_access_counts(access_chunk_ids)
             fused = apply_access_boost(
                 fused, access_counts, max_boost=self._access_config.max_boost
             )


### PR DESCRIPTION
## Summary

- **wizard.py**: widen `run_steps()` first param from `list` to
  `Sequence` — `list` is invariant, `Sequence` is covariant.
- **config_cmd.py**: `assert isinstance(coerced, str)` before
  `set_tokenizer()` call — runtime value is always `str` but mypy
  lost the narrowing through the upstream `_coerce_and_validate` flow.
- **pipeline.py**: rename Stage 6 `chunk_ids` → `access_chunk_ids` to
  avoid reassigning a `list[str]` name with `list[UUID]` elements
  (Stage 7 already used the separate-name pattern).

Closes #135