### PR TITLE
typing(server): narrow Path | None via assert in memory_crud.py

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -93,6 +93,7 @@ async def _mem_add_core(
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         target = Path(base).expanduser().resolve() / f"{date_str}.md"
 
+    assert target is not None
     await asyncio.to_thread(append_entry, target, content, title=title, tags=tags)
 
     effective_ns = namespace or app.current_namespace
@@ -294,6 +295,7 @@ async def mem_delete(
         sf_path, sf_err = _validate_path(source_file, app.config.indexing.memory_dirs)
         if sf_err:
             return sf_err
+        assert sf_path is not None
         deleted = await app.storage.delete_by_source(sf_path)
         app.search_pipeline.invalidate_cache()
         return f"Removed {deleted} chunks from index for {source_file}"
@@ -345,6 +347,7 @@ async def mem_batch_add(
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
         target = Path(base).expanduser().resolve() / f"{date_str}.md"
 
+    assert target is not None
     skipped = 0
     for entry in entries:
         key = entry.get("key") or entry.get("title", "")


### PR DESCRIPTION
## Summary

- Add 3 \`assert target is not None\` / \`assert sf_path is not None\`
  guards in \`mem_add\`, \`mem_delete\`, and \`mem_batch_add\` — fixes
  all 6 mypy \`[arg-type]\` errors where \`_validate_path\`'s
  \`Path | None\` return reaches a \`Path\`-only parameter.

All 6 sites are **Case A** (None genuinely unreachable): each caller
does \`if err: return ...\` immediately after destructuring, so the
\`Path | None\` leg is dead code after the guard. Mypy cannot correlate
tuple components through destructuring, so the inline assert is the
minimal fix (Option 2 from the issue).

Closes #113