### PR TITLE
typing(web): unify JSONResponse return in context route handlers

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -129,7 +129,7 @@ async def read_agent(
 async def rendered_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
-) -> dict:
+) -> JSONResponse:
     agent_path = _validate_name(name, project_root)
     if agent_path is None:
         raise ValueError(f"Invalid agent name: {name}")
@@ -164,13 +164,13 @@ async def rendered_agent(
         for f in _ALL_OPTIONAL_FIELDS:
             field_map[f][gen_name] = f not in dropped_set
 
-    return {
+    return JSONResponse(content={
         "name": name,
         "canonical_content": content,
         "fields": _agent_to_dict(parsed),
         "runtimes": runtimes,
         "field_map": field_map,
-    }
+    })
 
 
 # ── Create ───────────────────────────────────────────────────────────────
@@ -210,7 +210,7 @@ async def update_agent(
     name: str,
     body: AgentUpdateRequest,
     project_root: Path = Depends(get_project_root),
-) -> dict:
+) -> JSONResponse:
     agent_path = _validate_name(name, project_root)
     if agent_path is None:
         raise ValueError(f"Invalid agent name: {name}")
@@ -229,7 +229,7 @@ async def update_agent(
         )
 
     agent_path.write_text(body.content, encoding="utf-8")
-    return {"name": name, "mtime": agent_path.stat().st_mtime}
+    return JSONResponse(content={"name": name, "mtime": agent_path.stat().st_mtime})
 
 
 # ── Delete ───────────────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -164,13 +164,15 @@ async def rendered_agent(
         for f in _ALL_OPTIONAL_FIELDS:
             field_map[f][gen_name] = f not in dropped_set
 
-    return JSONResponse(content={
-        "name": name,
-        "canonical_content": content,
-        "fields": _agent_to_dict(parsed),
-        "runtimes": runtimes,
-        "field_map": field_map,
-    })
+    return JSONResponse(
+        content={
+            "name": name,
+            "canonical_content": content,
+            "fields": _agent_to_dict(parsed),
+            "runtimes": runtimes,
+            "field_map": field_map,
+        }
+    )
 
 
 # ── Create ───────────────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -118,7 +118,7 @@ async def read_command(
 async def rendered_command(
     name: str,
     project_root: Path = Depends(get_project_root),
-) -> dict:
+) -> JSONResponse:
     cmd_path = _validate_name(name, project_root)
     if cmd_path is None:
         raise ValueError(f"Invalid command name: {name}")
@@ -147,11 +147,11 @@ async def rendered_command(
             }
         )
 
-    return {
+    return JSONResponse(content={
         "name": name,
         "canonical_content": content,
         "runtimes": runtimes,
-    }
+    })
 
 
 # ── Create ───────────────────────────────────────────────────────────────
@@ -191,7 +191,7 @@ async def update_command(
     name: str,
     body: CommandUpdateRequest,
     project_root: Path = Depends(get_project_root),
-) -> dict:
+) -> JSONResponse:
     cmd_path = _validate_name(name, project_root)
     if cmd_path is None:
         raise ValueError(f"Invalid command name: {name}")
@@ -210,7 +210,7 @@ async def update_command(
         )
 
     cmd_path.write_text(body.content, encoding="utf-8")
-    return {"name": name, "mtime": cmd_path.stat().st_mtime}
+    return JSONResponse(content={"name": name, "mtime": cmd_path.stat().st_mtime})
 
 
 # ── Delete ───────────────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -147,11 +147,13 @@ async def rendered_command(
             }
         )
 
-    return JSONResponse(content={
-        "name": name,
-        "canonical_content": content,
-        "runtimes": runtimes,
-    })
+    return JSONResponse(
+        content={
+            "name": name,
+            "canonical_content": content,
+            "runtimes": runtimes,
+        }
+    )
 
 
 # ── Create ───────────────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -156,7 +156,7 @@ async def update_skill(
     name: str,
     body: SkillUpdateRequest,
     project_root: Path = Depends(get_project_root),
-) -> dict:
+) -> JSONResponse:
     """Update a canonical skill's SKILL.md (mtime-guarded)."""
     skill_dir = _validate_name(name, project_root)
     if skill_dir is None:
@@ -180,7 +180,7 @@ async def update_skill(
 
     manifest.write_text(body.content, encoding="utf-8")
     new_mtime = manifest.stat().st_mtime
-    return {"name": name, "mtime": new_mtime}
+    return JSONResponse(content={"name": name, "mtime": new_mtime})
 
 
 # ── Delete ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Change 5 route handlers (\`update_skill\`, \`rendered_command\`,
  \`update_command\`, \`rendered_agent\`, \`update_agent\`) from
  \`-> dict\` to \`-> JSONResponse\`.
- Wrap success-path \`return {...}\` in \`JSONResponse(content={...})\`.
- Error paths already returned \`JSONResponse\` (409 mtime conflict /
  422 parse error), so this unifies the return type.

Option 2 from the issue: uniform \`JSONResponse\` is more accurate
and self-documenting than a union type, and avoids pushing narrowing
burden to callers.  Response bodies are byte-for-byte equivalent —
FastAPI serialises \`dict\` and \`JSONResponse(content=dict)\` identically.

Closes #112