### PR TITLE
typing(server): narrow embedder/llm types in component_factory and status_config

### DIFF
--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import logging
 
@@ -53,15 +53,16 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         set_tokenizer(config.search.tokenizer)
 
     storage = create_storage(config)
-    embedder = None
+    embedder: EmbeddingProvider | None = None
     try:
-        embedder = create_embedder(config.embedding)
+        embedder = cast("EmbeddingProvider", create_embedder(config.embedding))
         await storage.initialize()
     except Exception:
         if embedder is not None:
             await embedder.close()
         await storage.close()
         raise
+    assert embedder is not None
 
     # Build chunker registry with optional code chunkers
     chunkers: list[Chunker] = [
@@ -104,11 +105,11 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         reranker = create_reranker(config.rerank)
 
     # Create optional LLM provider (before SearchPipeline so it can be passed in)
-    llm = None
+    llm: LLMProvider | None = None
     if config.llm.enabled:
         from memtomem.llm.factory import create_llm
 
-        llm = create_llm(config.llm)
+        llm = cast("LLMProvider | None", create_llm(config.llm))
 
     search_pipeline = SearchPipeline(
         storage=storage,

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from memtomem import __version__
 from memtomem.server import mcp
@@ -15,6 +15,7 @@ from memtomem.server.tool_registry import register
 from memtomem.server.helpers import _set_config_key
 
 if TYPE_CHECKING:
+    from memtomem.embedding.base import EmbeddingProvider
     from memtomem.server.context import AppContext
 
 logger = logging.getLogger(__name__)
@@ -191,7 +192,7 @@ def _revert_to_stored(app: AppContext) -> str:
     config.embedding.model = stored["model"]
     config.embedding.dimension = stored["dimension"]
 
-    new_embedder = create_embedder(config.embedding)
+    new_embedder: EmbeddingProvider = cast("EmbeddingProvider", create_embedder(config.embedding))
     app.embedder = new_embedder
 
     app.search_pipeline = SearchPipeline(


### PR DESCRIPTION
## Summary

- Annotate \`embedder\` as \`EmbeddingProvider | None\` and \`llm\` as
  \`LLMProvider | None\` in \`component_factory.py\`, then \`cast\` the
  \`object\`-typed factory returns at the assignment sites.
- Add \`assert embedder is not None\` after the \`try\` block (failure
  path always re-raises, so the assertion is safe).
- Apply the same \`cast\` pattern in \`status_config.py\` for the
  config-reload path.

Fixes all 7 mypy errors (4 in \`component_factory.py\` + 3 cascading
in \`status_config.py\`). Option 1 from the issue — local annotation
+ cast, since \`create_embedder\` can raise and the factory return
type (\`object\`) is a separate concern (\`OpenAIEmbedder\` protocol
conformance needs its own issue).

Closes #116