### PR TITLE
typing(ingest): introduce IngestComponents Protocol (fixes #132)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/ingest_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/ingest_cmd.py
@@ -6,16 +6,35 @@ import asyncio
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 import click
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from memtomem.indexing.engine import IndexEngine
     from memtomem.models import Chunk
-    from memtomem.server.component_factory import Components
+    from memtomem.search.pipeline import SearchPipeline
     from memtomem.storage.base import StorageBackend
+    from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+class IngestComponents(Protocol):
+    """Structural contract consumed by :func:`_ingest_files_with_components`.
+
+    Both :class:`memtomem.server.component_factory.Components` and
+    :class:`memtomem.server.context.AppContext` conform: the helper only
+    reads ``index_engine``, ``storage``, and ``search_pipeline``, all of
+    which are present on both dataclasses.
+    """
+
+    @property
+    def index_engine(self) -> IndexEngine: ...
+    @property
+    def storage(self) -> SqliteBackend: ...
+    @property
+    def search_pipeline(self) -> SearchPipeline: ...
 
 
 # Files that sit inside a Claude memory directory but should never be
@@ -215,7 +234,7 @@ class IngestSummary:
 
 
 async def _ingest_files_with_components(
-    comp: Components,
+    comp: IngestComponents,
     files: list[Path],
     namespace: str,
     *,


### PR DESCRIPTION
## Summary

- Define a 3-field `IngestComponents` Protocol in `cli/ingest_cmd.py` that captures exactly what `_ingest_files_with_components` reads (`index_engine`, `storage`, `search_pipeline`)
- Retype the helper from `comp: Components` to `comp: IngestComponents` so both `Components` and `AppContext` structurally conform — no adapter, no union
- Fixes 3 `[arg-type]` mypy errors at `server/tools/ingest.py:103,152,193` (Claude multi-slug / Gemini / Codex paths) with no new `type: ignore`

## Why Protocol (not inheritance or adapter)

Issue #132 listed three options. I picked the Protocol approach for these reasons:

- **Minimal contract.** The helper only touches 3 fields. The 5-field Protocol the issue mentioned as "overkill" was the concern; a 3-field Protocol is right-sized to the actual read set.
- **No lifecycle coupling.** `AppContext` extending `Components` via inheritance would propagate every `Components` change into the server context automatically, and the two already drift (`Components.llm` vs `AppContext.llm_provider`) — that's a signal they're not the same type.
- **No per-call conversion.** An `AppContext.to_components()` adapter would run on every ingest; Protocol is pure static typing with zero runtime cost.
- **Future-proof.** A new `Components`-only field won't silently break the call sites under duck typing the way it does today.

Read-only `@property` declarations keep the contract covariant, so future narrowing on either dataclass (e.g. a `SqliteBackend` subclass) stays compatible.

## Verification

- `uv run mypy packages/memtomem/src` — 13 → 10 errors; the three `ingest.py` `[arg-type]` errors listed in #132 are gone; remaining 10 are the out-of-scope items (`#116` `create_embedder`, `#115`-style TypedDict gaps, etc.) already tracked separately
- `uv run pytest -m "not ollama"` — 1447 passed, 46 deselected
- `uv run ruff check packages/memtomem/src` + `ruff format --check` — clean

## Test plan

- [x] mypy no longer reports `ingest.py:103`, `:152`, `:193`
- [x] No new `# type: ignore` introduced
- [x] Full test suite passes under `-m "not ollama"`
- [x] Lint + format clean

Closes #132.