### PR TITLE
fix(init): restore base_dir=None default on _write_config_and_summary

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -330,7 +330,7 @@ def _step_mcp(state: dict) -> None:
 # ── Write config & summary ────────────────────────────────────────────
 
 
-def _write_config_and_summary(state: dict, base_dir: Path | None) -> None:
+def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None:
     """Write config files and show summary (runs after all steps)."""
     if base_dir is None:
         base_dir = Path.home()

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -132,6 +132,27 @@ class TestInitConfigMerge:
         assert data["search"]["default_top_k"] == 10
 
 
+def test_write_config_and_summary_without_base_dir_falls_back_to_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_write_config_and_summary`` must be callable without *base_dir*.
+
+    The interactive wizard's final step (``init_cmd.py:604``) invokes this
+    helper with no ``base_dir``, relying on the ``Path.home()`` fallback.
+    A previous refactor dropped the parameter default, making the call
+    crash with ``TypeError: missing 1 required positional argument`` —
+    this test pins the no-arg call as part of the contract.
+    """
+    from memtomem.cli.init_cmd import _write_config_and_summary
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    state = _make_init_state(tmp_path)
+    _write_config_and_summary(state)
+
+    assert (tmp_path / ".memtomem" / "config.json").exists()
+
+
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be
     encoded as a JSON array string. A bare path crashes pydantic-settings.


### PR DESCRIPTION
## Summary

- Runtime fix: interactive ``mm init`` currently crashes at the final step with ``TypeError: _write_config_and_summary() missing 1 required positional argument: 'base_dir'``
- Root cause: ``db6038a`` replaced the mutable default ``Path("~/").expanduser()`` with ``Path | None`` and added a ``Path.home()`` fallback inside the function, but dropped the ``= None`` from the signature — silently turning a defaulted kwarg into a required positional
- The sole non-test call site (``init_cmd.py:604``) still calls ``_write_config_and_summary(state)`` with no ``base_dir``, so it fails on every interactive run. Every existing test passes ``tmp_path`` explicitly, masking the regression.
- Also clears the corresponding mypy ``[call-arg]`` error (13 → 12 with no new ``type: ignore``)

## Fix

One-character change: add ``= None`` to the signature.  The ``if base_dir is None: base_dir = Path.home()`` fallback was already in place from ``db6038a`` — the signature was the only thing missing.

```diff
-def _write_config_and_summary(state: dict, base_dir: Path | None) -> None:
+def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None:
```

## Regression test

Added ``test_write_config_and_summary_without_base_dir_falls_back_to_home`` that calls the helper with no ``base_dir`` — pinning the no-arg call path as part of the contract so this class of drop-the-default refactor can't regress silently again.

## Verification

- ``uv run mypy packages/memtomem/src`` — ``init_cmd.py:604`` ``[call-arg]`` gone; 13 → 12 total
- ``uv run pytest -m "not ollama"`` — 1448 passed, 46 deselected (was 1447; +1 regression test)
- ``uv run ruff check`` + ``ruff format --check`` — clean

## Test plan

- [x] Interactive wizard path (``_write_config_and_summary(state)``) no longer crashes
- [x] Existing tests calling with explicit ``base_dir=tmp_path`` still pass
- [x] Regression test exercises the exact no-arg call shape from ``init_cmd.py:604``
- [x] mypy ``[call-arg]`` error at ``init_cmd.py:604`` removed