### PR TITLE
typing(policies): narrow auto_consolidate dispatch to direct call

### DIFF
--- a/packages/memtomem/src/memtomem/tools/policy_engine.py
+++ b/packages/memtomem/src/memtomem/tools/policy_engine.py
@@ -589,7 +589,7 @@ async def run_policy(
         )
 
     if ptype == "auto_consolidate":
-        result = await handler(
+        result = await execute_auto_consolidate(
             storage,
             policy.get("config", {}),
             policy.get("namespace_filter"),


### PR DESCRIPTION
## Summary

- Replace ``handler(..., llm_provider=...)`` with a direct ``execute_auto_consolidate(...)`` call inside the ``ptype == "auto_consolidate"`` branch of ``run_policy``
- Clears mypy ``[call-arg]: Unexpected keyword argument "llm_provider"`` at ``policy_engine.py:592`` with no new ``type: ignore``

## Why

``run_policy`` dispatches via ``handler = _HANDLERS.get(ptype)``, which mypy sees as a union of all five ``execute_auto_*`` signatures. Only ``execute_auto_consolidate`` declares ``llm_provider``, so mypy flagged the kwarg even though the runtime guard (``if ptype == "auto_consolidate"``) statically constrains which handler runs there. Narrowing via an ``if`` on ``ptype`` doesn't propagate into the ``handler`` variable — so either a ``cast``, a ``type: ignore``, or a direct call was needed. A direct call is the most honest option and doesn't hide the narrowing from readers.

The ``else`` branch still uses ``handler`` — all five handlers share the same 4-positional-arg shape, so the union dispatch is fine there.

## Not a runtime bug

Purely a static-typing cleanup. Before this change, the dispatch worked correctly at runtime; mypy just couldn't see that the ``ptype`` guard constrained the handler identity. Included in the ``# feedback_mypy_advisory_runtime_bugs`` spirit — the ``[call-arg]`` is advisory here (no except-Exception swallow), but still worth clearing so the real signal (``init_cmd.py:604`` runtime bug, being fixed in #194) isn't buried.

## Verification

- ``uv run mypy packages/memtomem/src`` — ``policy_engine.py:592`` gone; 12 → 11 total remaining
- ``uv run pytest -m "not ollama"`` — 1447 passed, 46 deselected
- ``uv run ruff check`` + ``ruff format --check`` — clean
- Policy-specific tests (``test_policies``, ``test_policy_scheduler``, ``test_tools_logic``, ``test_server_tools_advanced``): 58 pass

## Test plan

- [x] mypy no longer reports ``policy_engine.py:592`` ``[call-arg]``
- [x] No new ``type: ignore`` introduced
- [x] Full test suite passes
- [x] Policy dispatch logic unchanged — ``auto_consolidate`` still receives ``llm_provider``, others still receive 4 positional args