### PR TITLE
typing(embedding): make OpenAIEmbedder fully conform to EmbeddingProvider Protocol

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/openai.py
+++ b/packages/memtomem/src/memtomem/embedding/openai.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Sequence
 
 import httpx
 
@@ -30,6 +31,14 @@ class OpenAIEmbedder:
     def __init__(self, config: EmbeddingConfig) -> None:
         self._config = config
         self._client: httpx.AsyncClient | None = None
+
+    @property
+    def dimension(self) -> int:
+        return self._config.dimension
+
+    @property
+    def model_name(self) -> str:
+        return self._config.model
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
@@ -64,14 +73,14 @@ class OpenAIEmbedder:
         data.sort(key=lambda x: x["index"])
         return [item["embedding"] for item in data]
 
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
         import asyncio
 
         if not texts:
             return []
 
         bs = self._config.batch_size
-        batches = [texts[i : i + bs] for i in range(0, len(texts), bs)]
+        batches = [list(texts[i : i + bs]) for i in range(0, len(texts), bs)]
         sem = asyncio.Semaphore(self._config.max_concurrent_batches)
 
         async def _safe_embed(batch: list[str]) -> list[list[float]]:
@@ -109,10 +118,10 @@ class OpenAIEmbedder:
             results.extend(br)
         return results
 
-    async def embed_query(self, text: str) -> list[float]:
-        if not text or not text.strip():
+    async def embed_query(self, query: str) -> list[float]:
+        if not query or not query.strip():
             raise EmbeddingError("Query text cannot be empty")
-        embeddings = await self.embed_texts([text])
+        embeddings = await self.embed_texts([query])
         if not embeddings:
             raise EmbeddingError("No embeddings returned for query")
         return embeddings[0]

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -111,12 +111,9 @@ class TestEmbeddingProviderProtocol:
         assert hasattr(embedder, "close")
 
     def test_openai_has_required_attributes(self):
-        """OpenAIEmbedder has embed_texts, embed_query, close.
-
-        Note: OpenAIEmbedder does not currently expose dimension/model_name
-        properties (unlike OllamaEmbedder), so only the core methods are checked.
-        """
         embedder = OpenAIEmbedder(_openai_config())
+        assert hasattr(embedder, "dimension")
+        assert hasattr(embedder, "model_name")
         assert hasattr(embedder, "embed_texts")
         assert hasattr(embedder, "embed_query")
         assert hasattr(embedder, "close")
@@ -126,11 +123,10 @@ class TestEmbeddingProviderProtocol:
         assert embedder.dimension == 768
         assert embedder.model_name == "nomic-embed-text"
 
-    def test_openai_stores_config(self):
-        """OpenAIEmbedder stores config; dimension/model accessible via _config."""
+    def test_openai_dimension_and_model(self):
         embedder = OpenAIEmbedder(_openai_config(dimension=1536, model="text-embedding-3-small"))
-        assert embedder._config.dimension == 1536
-        assert embedder._config.model == "text-embedding-3-small"
+        assert embedder.dimension == 1536
+        assert embedder.model_name == "text-embedding-3-small"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Close the structural-typing gap where ``OpenAIEmbedder`` did not fully implement ``EmbeddingProvider``:

- Missing ``dimension`` property
- Missing ``model_name`` property
- ``embed_texts`` took ``list[str]`` instead of the Protocol's ``Sequence[str]``
- ``embed_query`` parameter name (``text``) differed from the Protocol's ``query``

## Why this slipped mypy

The Protocol is declared in ``embedding/base.py`` but the factory that constructs each provider returns ``-> object``:

```python
def create_embedder(config: EmbeddingConfig) -> object:
    ...
```

With ``object`` as the declared return, every provider passes trivially — mypy doesn't compare individual implementations to the Protocol. The gap only becomes visible when you try to narrow ``create_embedder`` to ``-> EmbeddingProvider``, at which point ``OpenAIEmbedder`` is the only provider that fails (``OnnxEmbedder``, ``OllamaEmbedder``, and ``NoopEmbedder`` already conform). This was observed while working on #116 / PR #191 — the narrowing had to be reverted because of this specific provider.

## Changes

**``embedding/openai.py``**

- Add ``dimension`` / ``model_name`` ``@property`` accessors that mirror the ``OllamaEmbedder`` pattern (``return self._config.dimension`` / ``return self._config.model``). No new state — the config already carries both fields, they just weren't exposed.
- Change ``embed_texts(texts: list[str])`` → ``embed_texts(texts: Sequence[str])``. The internal ``_embed_batch_with_retry`` / ``_safe_embed`` helpers stay on ``list[str]``; the batch-slice comprehension gains a ``list(...)`` wrapper so the sequence-to-list boundary is explicit.
- Rename ``embed_query`` parameter ``text`` → ``query`` to match the Protocol. Verified via grep that no existing caller passes this argument by keyword.

**``test_embedding_providers.py``**

- ``test_openai_has_required_attributes``: drop the carve-out docstring ("does not currently expose dimension/model_name"), add ``dimension`` / ``model_name`` asserts so it matches the Ollama / ONNX shape.
- ``test_openai_stores_config`` → ``test_openai_dimension_and_model``: exercise the public properties directly (``embedder.dimension``, ``embedder.model_name``) instead of reaching into ``embedder._config``.

## Downstream unlocked

With this in place, a follow-up PR can:

1. Narrow ``create_embedder`` return type from ``-> object`` to ``-> EmbeddingProvider``
2. Remove the ``cast("EmbeddingProvider", ...)`` at ``server/component_factory.py:58``

Both are tracked as separate work, per one-change-per-PR.

## Verification

- ``uv run pytest -m "not ollama"`` — 1448 passed, 46 deselected (was 1448; net zero since one test was renamed)
- ``uv run ruff check`` + ``ruff format --check`` — clean
- ``uv run mypy packages/memtomem/src`` — unchanged at 8 errors (expected: the gap was hidden by ``-> object``, so fixing it doesn't clear any current mypy error; it unlocks the next narrowing step)

## Test plan

- [x] ``OpenAIEmbedder`` now exposes ``dimension``, ``model_name`` as properties
- [x] ``embed_texts`` accepts ``Sequence[str]`` (including tuple, list, any other sequence)
- [x] Updated tests encode the new Protocol contract as fail-if-missing assertions
- [x] No caller relies on ``embed_query(text=...)`` kwarg (grep-verified)
- [x] Full test suite green