### PR TITLE
typing(web): annotate context list locals as list[dict[str, object]]

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -76,7 +76,7 @@ async def list_agents(
     for runtime, agent_name, status in diffs:
         by_name.setdefault(agent_name, []).append({"runtime": runtime, "status": status})
 
-    agents = []
+    agents: list[dict[str, object]] = []
     for agent_path in canonicals:
         name = agent_path.stem
         agents.append(

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -59,7 +59,7 @@ async def list_commands(
     for runtime, cmd_name, status in diffs:
         by_name.setdefault(cmd_name, []).append({"runtime": runtime, "status": status})
 
-    commands = []
+    commands: list[dict[str, object]] = []
     for cmd_path in canonicals:
         name = cmd_path.stem
         commands.append(

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -58,7 +58,7 @@ async def list_skills(
     for runtime, skill_name, status in diffs:
         by_name.setdefault(skill_name, []).append({"runtime": runtime, "status": status})
 
-    skills = []
+    skills: list[dict[str, object]] = []
     for skill_dir in canonicals:
         skills.append(
             {


### PR DESCRIPTION
## Summary

- Annotate ``skills`` / ``commands`` / ``agents`` list locals in the three context route list-handlers as ``list[dict[str, object]]``
- Clears 3 mypy ``[dict-item]`` errors (``context_skills.py:78``, ``context_commands.py:76``, ``context_agents.py:93``) with no new ``type: ignore``

## Why

Each of these handlers builds the response list in two phases:

1. Append canonical entries with ``canonical_path: str(...)``
2. Append runtime-only entries (missing canonical) with ``canonical_path: None``

Without an annotation, mypy infers the list's element type from the first append's dict shape, so the second append's ``None`` under the same key trips ``[dict-item]``. The three errors shared the exact same root cause across three files — fixing them in one PR keeps the pattern consistent.

## Fix

Add ``list[dict[str, object]]`` annotation up front on each list local. Uses ``object`` (not ``Any``) so callers that reach into the list values still get type-checked, but heterogeneous ``str | None | list`` values are accepted. No runtime behavior change — response shape is unchanged, and the frontend already treats ``canonical_path`` as nullable for runtime-only entries.

## Verification

- ``uv run mypy packages/memtomem/src`` — 8 → 5 errors (the 3 ``[dict-item]`` cleared, nothing new)
- ``uv run pytest -m "not ollama" test_web_routes_context.py`` — 42 passed
- ``uv run ruff check`` + ``ruff format --check`` — clean

## Test plan

- [x] Three ``[dict-item]`` errors removed from mypy output
- [x] No new ``# type: ignore`` introduced
- [x] Web context route tests pass