### PR TITLE
typing(consolidation): annotate groups list as list[dict[str, Any]]

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
@@ -58,7 +59,7 @@ async def mem_consolidate(
         sources = [s for s in sources if s[3] and effective_ns in s[3].split(",")]
 
     # Find groups with enough chunks
-    groups = []
+    groups: list[dict[str, Any]] = []
     group_id = 0
     for path, count, updated, ns, avg_tok, _, _ in sources:
         if count < min_group_size:


### PR DESCRIPTION
## Summary

- Add ``list[dict[str, Any]]`` annotation to the ``groups`` list in ``mem_consolidate_plan``
- Clears the ``[arg-type]`` error at ``consolidation.py:106`` (``list.extend(object)``) with no new ``type: ignore``

## Why

``groups`` is built by appending dict literals that mix value types (int counters, str source/namespace, ``list[str]`` previews/chunk_ids). Without an up-front annotation, mypy widens the value type to ``object`` and refuses ``lines.extend(g["previews"])`` because ``list.extend`` expects ``Iterable[str]`` (and ``Iterable[object]`` isn't substitutable).

The value-level runtime contract is still honest at both ends — the list is serialized to JSON via ``scratch_set`` and the summary-printing loop already treats each value appropriately — so ``Any`` matches the existing loose-dict style for this handler rather than introducing a TypedDict for a single consumer.

## Verification

- ``uv run mypy packages/memtomem/src`` — ``consolidation.py:106`` cleared; 8 → 7 errors
- ``uv run pytest -m "not ollama" -k consolidat`` — 29 passed
- ``uv run ruff check`` + ``ruff format --check`` — clean

## Test plan

- [x] ``[arg-type]`` error at ``consolidation.py:106`` removed
- [x] No new ``# type: ignore`` introduced
- [x] Consolidation-related tests green
- [x] Response shape unchanged (JSON serialization is value-agnostic)