### PR TITLE
typing: clear 3 library-interop mypy advisory errors (watcher / url_fetcher / yaml)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/url_fetcher.py
+++ b/packages/memtomem/src/memtomem/indexing/url_fetcher.py
@@ -114,11 +114,16 @@ def _html_to_markdown(html: str) -> str:
     text = re.sub(r"<nav[^>]*>.*?</nav>", "", text, flags=re.DOTALL | re.IGNORECASE)
     text = re.sub(r"<footer[^>]*>.*?</footer>", "", text, flags=re.DOTALL | re.IGNORECASE)
 
-    # Headers
+    # Headers — loop from h6 down so inner tags render before their
+    # enclosing outer tag consumes them.
     for i in range(6, 0, -1):
+
+        def _replace_header(m: re.Match[str], lvl: int = i) -> str:
+            return f"\n{'#' * lvl} {m.group(1).strip()}\n"
+
         text = re.sub(
             rf"<h{i}[^>]*>(.*?)</h{i}>",
-            lambda m, lvl=i: f"\n{'#' * lvl} {m.group(1).strip()}\n",
+            _replace_header,
             text,
             flags=re.DOTALL | re.IGNORECASE,
         )

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -13,6 +13,8 @@ from watchdog.observers import Observer
 from memtomem.config import IndexingConfig
 
 if TYPE_CHECKING:
+    from watchdog.observers.api import BaseObserver
+
     from memtomem.indexing.engine import IndexEngine
 
 logger = logging.getLogger(__name__)
@@ -76,7 +78,7 @@ class FileWatcher:
         self._engine = index_engine
         self._config = config
         self._debounce_s = debounce_ms / 1000.0
-        self._observer: Observer | None = None
+        self._observer: BaseObserver | None = None
         self._queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=_WATCHER_QUEUE_MAXSIZE)
         self._task: asyncio.Task[None] | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,5 @@ dev = [
     "pytest-cov>=6.0",
     "ruff>=0.9",
     "mypy>=1.14",
+    "types-PyYAML>=6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -902,6 +902,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -914,6 +915,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "pytest-cov", specifier = ">=6.0" },
     { name = "ruff", specifier = ">=0.9" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -1922,6 +1924,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three small library-interop mypy cleanups bundled together — each is a distinct library quirk, but all share the theme *"mypy needs help with external / stdlib types"* and together finish the library-specific leg of the remaining advisory errors.

- **``watcher.py:79``** — use ``BaseObserver`` from ``watchdog.observers.api`` for the type hint; keep ``Observer()`` as the runtime factory
- **``url_fetcher.py:121``** — convert the ``lambda m, lvl=i: ...`` to a named inner function so mypy can type it, preserving the h6→h1 loop order
- **``structured.py:340``** — add ``types-PyYAML>=6.0`` to the dev dependency group

Net effect: mypy 8 → 5 errors, no new ``type: ignore``.

## Why bundled

They're unrelated files, but the change shape is identical in each: a one-to-three line adjustment that tells mypy how to interpret an external API. Splitting into three one-commit PRs would triple the review overhead for ~20 lines total. If that's the wrong call I'm happy to split.

## Details

### ``watcher.py`` — watchdog ``Observer`` as a type

``from watchdog.observers import Observer`` rebinds ``Observer`` to a platform-specific class at runtime (inotify on Linux, FSEvents on macOS, etc.). mypy sees that as a *variable*, not a type, so ``self._observer: Observer | None = None`` tripped ``[valid-type]``.

Fix: import ``BaseObserver`` from ``watchdog.observers.api`` (the common base class) under ``TYPE_CHECKING`` and use it for the annotation. The runtime call ``Observer()`` is unchanged and still returns a ``BaseObserver`` subclass.

### ``url_fetcher.py`` — two-parameter lambda inference

``re.sub(..., lambda m, lvl=i: f"\n{'#' * lvl} {m.group(1).strip()}\n", ...)`` used the ``lvl=i`` default-argument trick to capture ``i`` at lambda creation time, avoiding late binding inside the h6→h1 loop. mypy can't infer lambda types with default-capture parameters.

Fix: define a named inner function inside the loop with ``lvl: int = i`` — the same late-binding trick, but typed:

```python
for i in range(6, 0, -1):
    def _replace_header(m: re.Match[str], lvl: int = i) -> str:
        return f"\n{'#' * lvl} {m.group(1).strip()}\n"
    text = re.sub(rf"<h{i}[^>]*>(.*?)</h{i}>", _replace_header, text, ...)
```

Kept the outer h6→h1 loop deliberately: collapsing it into one regex with a backreference (``<h([1-6])[^>]*>(.*?)</h\1>``) would change nested-header behavior — an outer ``<h2><h3>inner</h3></h2>`` match would consume the inner ``<h3>`` in a single left-to-right pass, whereas the h6→h1 loop renders inner headers first. Rare in real HTML but real.

### ``pyproject.toml`` — ``types-PyYAML``

``ignore_missing_imports = true`` is already on globally, but mypy still warns ``[import-untyped]`` when a typed stub package *exists* but isn't installed. Adding ``types-PyYAML>=6.0`` to the dev group is the lightweight fix (~15 kB stub-only package, no runtime impact).

## Verification

- ``uv run mypy packages/memtomem/src`` — 8 → 5 errors; watcher / url_fetcher / structured all cleared; no new errors
- ``uv run pytest -m "not ollama"`` — 1448 passed, 46 deselected (unchanged)
- ``uv run ruff check`` + ``ruff format --check`` — clean

## Test plan

- [x] ``watcher.py:79`` ``[valid-type]`` cleared
- [x] ``url_fetcher.py:121`` ``[misc]`` cleared
- [x] ``structured.py:340`` ``[import-untyped]`` cleared
- [x] No new ``# type: ignore`` introduced
- [x] Full test suite passes
- [x] URL fetcher tests (``test_url_fetcher.py`` — 13) pass, confirming named-function refactor is semantically equivalent to the previous lambda