### PR TITLE
typing(factory): narrow embedder/llm factory returns and drop redundant casts

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/factory.py
+++ b/packages/memtomem/src/memtomem/embedding/factory.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from memtomem.config import EmbeddingConfig
 from memtomem.errors import ConfigError
 
+if TYPE_CHECKING:
+    from memtomem.embedding.base import EmbeddingProvider
 
-def create_embedder(config: EmbeddingConfig) -> object:
+
+def create_embedder(config: EmbeddingConfig) -> EmbeddingProvider:
     """Return the embedding provider for the configured provider name."""
     provider = config.provider.lower()
 

--- a/packages/memtomem/src/memtomem/llm/factory.py
+++ b/packages/memtomem/src/memtomem/llm/factory.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from memtomem.config import LLMConfig
 from memtomem.errors import ConfigError
+
+if TYPE_CHECKING:
+    from memtomem.llm.base import LLMProvider
 
 # Provider-specific default models, used when config.model is empty.
 _DEFAULT_MODELS: dict[str, str] = {
@@ -13,7 +18,7 @@ _DEFAULT_MODELS: dict[str, str] = {
 }
 
 
-def create_llm(config: LLMConfig) -> object | None:
+def create_llm(config: LLMConfig) -> LLMProvider | None:
     """Return the LLM provider for the configured provider name.
 
     Returns ``None`` when ``config.enabled`` is ``False``.

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import logging
 
@@ -55,7 +55,7 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
     storage = create_storage(config)
     embedder: EmbeddingProvider | None = None
     try:
-        embedder = cast("EmbeddingProvider", create_embedder(config.embedding))
+        embedder = create_embedder(config.embedding)
         await storage.initialize()
     except Exception:
         if embedder is not None:
@@ -109,7 +109,7 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
     if config.llm.enabled:
         from memtomem.llm.factory import create_llm
 
-        llm = cast("LLMProvider | None", create_llm(config.llm))
+        llm = create_llm(config.llm)
 
     search_pipeline = SearchPipeline(
         storage=storage,

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from memtomem import __version__
 from memtomem.server import mcp
@@ -15,7 +15,6 @@ from memtomem.server.tool_registry import register
 from memtomem.server.helpers import _set_config_key
 
 if TYPE_CHECKING:
-    from memtomem.embedding.base import EmbeddingProvider
     from memtomem.server.context import AppContext
 
 logger = logging.getLogger(__name__)
@@ -192,7 +191,7 @@ def _revert_to_stored(app: AppContext) -> str:
     config.embedding.model = stored["model"]
     config.embedding.dimension = stored["dimension"]
 
-    new_embedder: EmbeddingProvider = cast("EmbeddingProvider", create_embedder(config.embedding))
+    new_embedder = create_embedder(config.embedding)
     app.embedder = new_embedder
 
     app.search_pipeline = SearchPipeline(


### PR DESCRIPTION
## Summary

Phase 2 of the ``OpenAIEmbedder`` Protocol conformance work (Phase 1 was PR #196). With all four embedding providers now structurally satisfying ``EmbeddingProvider`` and the three LLM providers satisfying ``LLMProvider``, the factories can return the protocols directly, and the three ``cast(...)`` sites that were papering over the ``object`` returns become redundant.

- ``embedding/factory.py::create_embedder`` — ``-> object`` → ``-> EmbeddingProvider``
- ``llm/factory.py::create_llm`` — ``-> object | None`` → ``-> LLMProvider | None``
- Remove ``cast("EmbeddingProvider", ...)`` / ``cast("LLMProvider | None", ...)`` in ``server/component_factory.py`` (2 sites)
- Remove ``cast("EmbeddingProvider", ...)`` in ``server/tools/status_config.py``
- Drop the now-unused ``typing.cast`` import from both files, plus the unused ``EmbeddingProvider`` TYPE_CHECKING import from ``status_config.py``

Runtime: zero change — ``cast`` is a no-op, and the factory implementations already returned the right types.

## Before / after

**``embedding/factory.py`` (and symmetric ``llm/factory.py``)**

```diff
-def create_embedder(config: EmbeddingConfig) -> object:
+def create_embedder(config: EmbeddingConfig) -> EmbeddingProvider:
```

**``server/component_factory.py``**

```diff
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 ...
-    embedder = cast("EmbeddingProvider", create_embedder(config.embedding))
+    embedder = create_embedder(config.embedding)
 ...
-    llm = cast("LLMProvider | None", create_llm(config.llm))
+    llm = create_llm(config.llm)
```

**``server/tools/status_config.py``**

```diff
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 ...
 if TYPE_CHECKING:
-    from memtomem.embedding.base import EmbeddingProvider
     from memtomem.server.context import AppContext
 ...
-    new_embedder: EmbeddingProvider = cast("EmbeddingProvider", create_embedder(config.embedding))
+    new_embedder = create_embedder(config.embedding)
```

## mypy trajectory

This PR + the ones in flight together drive the repo to **0 mypy errors**:

- Before this session: 13 errors
- After PRs #193–#199 (all merged): 2 errors remaining (``langgraph.py:57`` ``[assignment]``, addressed by PR #200)
- After this PR: still 1 remaining (``langgraph.py:57``) — **this PR doesn't clear any mypy error directly**, but it removes three ``cast`` calls and their noise, and locks in the contract that was promised by #196.
- When PR #200 merges: 0 errors.

## Verification

- ``uv run mypy packages/memtomem/src`` — unchanged at 1 error (the langgraph ``[assignment]`` tracked separately)
- ``uv run pytest -m "not ollama"`` — 1448 passed, 46 deselected
- ``uv run ruff check`` + ``ruff format --check`` — clean

## Test plan

- [x] Factories now return the protocol types, not ``object``
- [x] Three ``cast`` sites removed; no new ``type: ignore`` anywhere
- [x] Unused ``typing.cast`` / ``EmbeddingProvider`` imports cleaned up
- [x] Full test suite passes
- [x] No runtime behavior change (cast is compile-time only)