### PR TITLE
test(ci): add ONNX golden-path + llm marker split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+  # schedule:
+  #   - cron: "17 5 * * *"   # nightly — enable once LLM secrets are provisioned
 
 jobs:
   lint:
@@ -38,7 +41,42 @@ jobs:
         with:
           version: "latest"
       - run: uv sync --frozen
-      - run: uv run pytest -m "not ollama" --tb=short -q
+      - run: >-
+          uv run pytest
+          --ignore=packages/memtomem/tests/test_golden_path.py
+          -m "not ollama and not llm"
+          --tb=short -q
+
+  test-golden-path:
+    name: golden-path (ONNX bge-m3)
+    runs-on: ubuntu-latest
+    env:
+      FASTEMBED_CACHE_PATH: ${{ github.workspace }}/.fastembed-cache
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - name: Cache fastembed model (paraphrase-multilingual-MiniLM-L12-v2, ~220 MB)
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.FASTEMBED_CACHE_PATH }}
+          key: ${{ runner.os }}-fastembed-multilingual-minilm-l12
+      - run: uv sync --frozen
+      - run: uv run pytest packages/memtomem/tests/test_golden_path.py --tb=short -q
+
+  test-llm-nightly:
+    name: llm-nightly (optional)
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - run: uv sync --frozen
+      - run: uv run pytest -m "llm" --tb=short -q
 
   notebooks:
     runs-on: ubuntu-latest

--- a/packages/memtomem/tests/test_golden_path.py
+++ b/packages/memtomem/tests/test_golden_path.py
@@ -1,0 +1,141 @@
+"""ONNX golden-path integration test: mem_add -> mem_search -> mem_recall.
+
+Validates the README promise that memtomem works end-to-end with the ONNX
+embedder (no external services required) for both English and Korean text,
+exercising the hybrid search pipeline (BM25 + dense).
+
+Model choice: ``sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2``
+(384-dim, ~220 MB, ~50 languages including Korean).  Chosen over ``bge-m3``
+because fastembed's ``TextEmbedding`` class does not support ``bge-m3`` —
+that model is multi-vector / sparse and lives on other fastembed classes.
+MiniLM-L12 keeps the CI cache small while still covering multilingual text.
+
+This test complements ``test_user_workflows.py`` (Ollama-gated) by providing
+a CI-safe equivalent of the add -> search -> recall round trip.  The fastembed
+model is downloaded on first run; CI caches it via ``FASTEMBED_CACHE_PATH``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.config import Mem2MemConfig
+from memtomem.server.component_factory import close_components, create_components
+from memtomem.tools.memory_writer import append_entry
+
+pytest.importorskip(
+    "fastembed",
+    reason="fastembed not installed — install with `pip install memtomem[onnx]`",
+)
+
+
+@pytest.fixture
+async def onnx_components(tmp_path, monkeypatch):
+    """Boot a component stack with ONNX bge-m3 embeddings against a tmp DB.
+
+    Uses monkeypatch to bypass ``~/.memtomem/config.json`` loading so the
+    test stays hermetic regardless of the developer's local config.
+    """
+
+    db_path = tmp_path / "golden.db"
+    mem_dir = tmp_path / "memories"
+    mem_dir.mkdir()
+
+    # Drop any developer-set embedding env vars that could override the config
+    # set below. Required because Mem2MemConfig reads from env via pydantic.
+    for var in (
+        "MEMTOMEM_EMBEDDING__PROVIDER",
+        "MEMTOMEM_EMBEDDING__MODEL",
+        "MEMTOMEM_EMBEDDING__DIMENSION",
+        "MEMTOMEM_STORAGE__SQLITE_PATH",
+        "MEMTOMEM_INDEXING__MEMORY_DIRS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+    config.embedding.provider = "onnx"
+    # fastembed expects the full HF repo ID for models outside the short-name map;
+    # see memtomem.embedding.onnx._resolve_model (raw IDs pass through unchanged).
+    config.embedding.model = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+    config.embedding.dimension = 384
+
+    # Skip user-level config.json merge so tests run hermetically.
+    import memtomem.config as _cfg
+
+    monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
+
+    comp = await create_components(config)
+    try:
+        yield comp, mem_dir
+    finally:
+        await close_components(comp)
+
+
+class TestOnnxGoldenPath:
+    """End-to-end add -> search -> recall flow with ONNX bge-m3."""
+
+    async def test_english_roundtrip_top_1(self, onnx_components):
+        """English query returns the matching chunk at rank 1."""
+        comp, mem_dir = onnx_components
+
+        target = mem_dir / "english.md"
+        append_entry(
+            target,
+            "Chose Redis for caching due to its low latency and LRU eviction.",
+            title="Cache Decision",
+        )
+        append_entry(
+            target,
+            "PostgreSQL remains our primary relational database.",
+            title="Database Decision",
+        )
+        stats = await comp.index_engine.index_file(target)
+        assert stats.indexed_chunks >= 2
+
+        # mem_search — English query should rank Redis chunk first.
+        results, _ = await comp.search_pipeline.search("redis caching", top_k=5)
+        assert len(results) >= 1, "Hybrid search returned no results"
+        top_contents = [r.chunk.content for r in results[:3]]
+        assert "Redis" in results[0].chunk.content, (
+            f"Expected Redis chunk at rank 1, got top 3: {top_contents}"
+        )
+
+        # mem_recall — both entries must be reachable via recent-chunk listing.
+        recall = await comp.storage.recall_chunks(limit=10)
+        contents = " ".join(c.content for c in recall)
+        assert "Redis" in contents
+        assert "PostgreSQL" in contents
+
+    async def test_korean_roundtrip_top_3(self, onnx_components):
+        """Korean query finds the matching chunk within top-3.
+
+        Small corpora + multilingual models can exhibit rank flakiness, so we
+        assert membership in top-3 rather than top-1 to keep the test stable.
+        """
+        comp, mem_dir = onnx_components
+
+        target = mem_dir / "korean.md"
+        append_entry(
+            target,
+            "쿠버네티스 클러스터 모니터링 설정을 완료했다.",
+            title="모니터링",
+        )
+        append_entry(
+            target,
+            "그라파나 대시보드로 메트릭을 시각화한다.",
+            title="대시보드",
+        )
+        stats = await comp.index_engine.index_file(target)
+        assert stats.indexed_chunks >= 2
+
+        results, _ = await comp.search_pipeline.search("쿠버네티스 모니터링", top_k=3)
+        assert len(results) >= 1, "Hybrid search returned no results for Korean query"
+        contents = [r.chunk.content for r in results]
+        assert any("쿠버네티스" in c or "모니터링" in c for c in contents), (
+            f"Korean content missing from top-3: {[c[:30] for c in contents]}"
+        )
+
+        recall = await comp.storage.recall_chunks(limit=10)
+        assert len(recall) >= 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ asyncio_mode = "auto"
 testpaths = ["packages/memtomem/tests"]
 markers = [
     "ollama: requires a running Ollama instance (auto-skipped when unavailable)",
+    "llm: requires a live LLM API key (OpenAI/Anthropic); CI runs these in the nightly job only",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary
- Add `packages/memtomem/tests/test_golden_path.py` covering `mem_add → mem_search → mem_recall` with the ONNX embedder, validating the README promise that memtomem works end-to-end with no external services.
- Register the `llm` pytest marker and exclude it from the default `test` job so LLM-backed flows no longer block PRs.
- Two new CI jobs: `test-golden-path` (runs on every PR, caches the fastembed model via an explicit `FASTEMBED_CACHE_PATH`) and `test-llm-nightly` (optional, `workflow_dispatch` only — the `schedule:` trigger is commented until LLM secrets are provisioned).

## Design notes
- **Model**: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` (384-dim, ~220 MB, ~50 languages). The plan originally targeted `bge-m3` to match Ollama-backed tests, but fastembed's `TextEmbedding` class does not support `bge-m3` — it is multi-vector / sparse and lives on other fastembed classes. MiniLM-L12 keeps the CI cache small while still covering Korean.
- **Assertions**: English asserts top-1 ranking; Korean asserts top-3 membership to avoid small-corpus + multilingual ordering flakiness.
- **Cache path**: `FASTEMBED_CACHE_PATH` is set explicitly in the `test-golden-path` job env (and used as the `actions/cache` path) so the cache does not depend on fastembed's internal default.
- **`schedule:` commented out**: nightly is not enabled yet; a dedicated PR will turn it on once the LLM API secrets are available.

## Follow-ups (not in this PR)
- After this merges green on `main`, add `test-golden-path` to the required status checks via branch protection (one-green rule, per the team convention).
- PR #2 (Trust UX for silent archive filter + dim-mismatch warnings) and PR #3 (docs / config UX cleanup) from the core-module review plan.

## Test plan
- [x] \`uv run ruff check packages/memtomem/src packages/memtomem/tests\`
- [x] \`uv run ruff format --check packages/memtomem/src packages/memtomem/tests\`
- [x] \`uv run pytest packages/memtomem/tests/test_golden_path.py -v\` — cold cache: 10.65 s, 2 passed
- [x] \`uv run pytest --ignore=packages/memtomem/tests/test_golden_path.py -m "not ollama and not llm"\` — 1448 passed, 46 deselected
- [ ] CI: `test` green with the new `--ignore` flag
- [ ] CI: `test-golden-path` green (first run populates cache; subsequent runs hit it)
- [ ] CI: `test-llm-nightly` not triggered on normal PR