### PR TITLE
chore: normalize Stage 3b, clarify core-9 invariant, expose immutable fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,13 @@ for `memtomem` and both resolve to `memtomem.cli:cli`.
   `packages/memtomem/src/memtomem/search/pipeline.py` without updating the
   Stage comments in that file.
 - **MCP tools go through the registry.** New tools use `@register` from
-  `server/tool_registry.py` + `@tool_handler` — no direct `@mcp.tool()`. Add
-  imports in `server/__init__.py` and classify the tool into
-  `_CORE_TOOLS` / `_STANDARD_TOOLS` / full; the `mem_do` meta-tool routes
-  non-core actions. Don't change the default mode (`core` = 9 tools).
+  `server/tool_registry.py` + `@tool_handler`. The core-9 tools (`mem_search`,
+  `mem_add`, `mem_index`, `mem_recall`, `mem_status`, `mem_stats`, `mem_list`,
+  `mem_read`, `mem_do`) are registered directly via `@mcp.tool()` by design;
+  everything else MUST use `@register`. Add imports in `server/__init__.py`
+  and classify the tool into `_CORE_TOOLS` / `_STANDARD_TOOLS` / full; the
+  `mem_do` meta-tool routes non-core actions. Don't change the default mode
+  (`core` = 9 tools).
 - **Line length 100**, target `py312` (`tool.ruff`, `tool.mypy` in root
   `pyproject.toml`). `.claude/`, `scripts/`, and `CLAUDE.local.md` are
   gitignored — don't commit anything under them, and don't assume other

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -113,7 +113,7 @@ without requiring explicit `MEMORY_DIRS` configuration.
 | `MEMTOMEM_RERANK__TOP_K` | `20` | Candidates passed to the reranker (must be > 0) |
 | `MEMTOMEM_RERANK__API_KEY` | _(empty)_ | API key (required for Cohere) |
 
-Reranking runs as Stage 3.5 in the search pipeline — after BM25 + dense fusion, before source/tag filters. If the reranker call fails, the pipeline falls back to the original fused order with a warning.
+Reranking runs as Stage 3b in the search pipeline — after BM25 + dense fusion, before source/tag filters. If the reranker call fails, the pipeline falls back to the original fused order with a warning.
 
 ## Access Frequency Boost
 

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -301,7 +301,7 @@ class SearchPipeline:
             fused = []
         stats.fused_total = len(fused)
 
-        # Stage 3.5: Cross-encoder reranking
+        # Stage 3b: Cross-encoder reranking
         if self._reranker is not None and fused:
             try:
                 fused = await self._reranker.rerank(query, fused, top_k=top_k)

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -93,6 +93,22 @@ async def mem_status(
     except Exception:
         logger.debug("Orphan detection failed", exc_info=True)
 
+    # Immutable fields — these cannot be changed via mem_config at runtime.
+    # Surfacing them here so operators are not surprised when a `mm config set`
+    # on one of these paths fails silently.
+    lines.append("")
+    lines.append("Immutable fields (set once at init)")
+    lines.append("------------------------------------")
+    lines.append(f"embedding.provider:  {config.embedding.provider}")
+    lines.append(f"embedding.model:     {config.embedding.model or '(unset)'}")
+    lines.append(f"embedding.dimension: {config.embedding.dimension}")
+    lines.append(f"search.tokenizer:    {config.search.tokenizer}")
+    lines.append(f"storage.backend:     {config.storage.backend}")
+    lines.append(
+        "  -> To change: re-run `mm init` for provider/tokenizer/backend, "
+        "or `mm embedding-reset` to switch embedder (re-index required)."
+    )
+
     mismatch = getattr(app.storage, "embedding_mismatch", None)
     if mismatch is not None:
         cfg = mismatch["configured"]


### PR DESCRIPTION
## Summary
Three low-cost cleanups from the core-module review (G5 + G6 + G7):

- **G5 — Stage labeling.** \`search/pipeline.py\` and \`docs/guides/configuration.md\` called reranking \"Stage 3.5\", which reads as \"half a stage\". Rename to \"Stage 3b\" so the ordering relative to Stage 3 (fusion) and Stage 4 (time decay) is unambiguous. Grep confirms the rename touched exactly the two files that had the old label.
- **G6 — Immutable fields visibility.** \`mem_status\` gains an \"Immutable fields (set once at init)\" block listing \`embedding.provider\`, \`embedding.model\`, \`embedding.dimension\`, \`search.tokenizer\`, and \`storage.backend\` — the values that \`mm config set\` silently refuses — plus a remediation hint (\`mm init\` / \`mm embedding-reset\`).
- **G7 — Core-9 registration invariant.** \`CLAUDE.md\` invariant (b) now names the nine core tools explicitly and clarifies that they register via \`@mcp.tool()\` directly by design; everything else MUST use \`@register\`. Prevents a contributor from \"helpfully\" migrating a core tool to \`@register\` and inadvertently dropping it from the default tool mode.

## Independence from PR #1 / PR #2
- PR #1 (ONNX golden path) and PR #2 (trust-UX hints) are still open; this branch was cut from main, so the diff is safe regardless of merge order.
- The only overlap with PR #2 is \`packages/memtomem/src/memtomem/server/tools/status_config.py\` — PR #2 adds a \`Warnings\` block, PR #3 adds an \`Immutable fields\` block, both with their own anchor lines. Whichever merges first, the other needs a trivial rebase (no semantic conflict).
- The immutable-fields hint intentionally does **not** link to \`docs/guides/configuration.md#reset-flow\` (created by PR #2). Avoiding the cross-PR dependency keeps this PR valid on its own.

## Test plan
- [x] \`uv run ruff check packages/memtomem/src packages/memtomem/tests\`
- [x] \`uv run ruff format --check packages/memtomem/src packages/memtomem/tests\`
- [x] \`uv run pytest -m \"not ollama\"\` — 1448 passed, 46 deselected
- [x] Grep re-run — zero \"Stage 3.5\" / \"stage_3_5\" matches post-edit
- [ ] CI: all jobs green