### PR TITLE
fix(web): add response.ok checks to settings-hooks-watchdog.js fetches

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -26,6 +26,10 @@ async function loadHooksSync() {
 
   try {
     const res = await fetch('/api/settings-sync');
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || `Request failed: ${res.status}`);
+    }
     const data = await res.json();
 
     // Status badge
@@ -154,6 +158,10 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
   btnLoading(btn, true);
   try {
     const res = await fetch('/api/settings-sync', {method: 'POST', headers: {'Content-Type': 'application/json'}});
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.detail || `Request failed: ${res.status}`);
+    }
     const data = await res.json();
     const warnings = data.results?.flatMap(r => r.warnings || []) || [];
     if (warnings.length) {


### PR DESCRIPTION
## Summary

Adds `response.ok` checks before `.json()` in the two `/api/settings-sync` fetch calls in `settings-hooks-watchdog.js`. JSON-formatted error responses (e.g. HTTP 500 with `{"detail": "..."}`) previously resolved successfully, and the UI silently fell through to the generic `error` badge — losing the server-provided detail.

Pattern mirrors #77 (context-gateway.js) and the resolve handler that #156 already fixed in this same file.

## Sites fixed

- `loadHooksSync` GET `/api/settings-sync` (line 28)
- Sync Now POST `/api/settings-sync` (line 156)

## Note on issue body

Issue #82 also lists the resolve button handler at lines 119-124, but that site was already fixed in #156 (`fix(web): use HTTPException for error responses in settings-sync resolve`) — the `if (!r.ok)` check is in place there. No change needed.

## Test plan

- Manual smoke test skipped — JS-only change following the validated pattern from #77 and #156. Reviewer may optionally verify against a dev server if desired.

Closes #82