### PR TITLE
fix(search): emit WARNING when query expansion fails

### DIFF
--- a/packages/memtomem/src/memtomem/search/expansion.py
+++ b/packages/memtomem/src/memtomem/search/expansion.py
@@ -23,7 +23,7 @@ async def expand_query_tags(
     try:
         tag_counts = await storage.get_tag_counts()
     except Exception:
-        logger.debug("Tag expansion failed, returning original query", exc_info=True)
+        logger.warning("Tag expansion failed; returning original query", exc_info=True)
         return query
 
     query_lower = query.lower()
@@ -54,7 +54,7 @@ async def expand_query_headings(
         embedding = await embedder.embed_query(query)
         results = await storage.dense_search(embedding, top_k=3)
     except Exception:
-        logger.debug("Heading expansion failed, returning original query", exc_info=True)
+        logger.warning("Heading expansion failed; returning original query", exc_info=True)
         return query
 
     terms: list[str] = []

--- a/packages/memtomem/tests/test_expansion.py
+++ b/packages/memtomem/tests/test_expansion.py
@@ -1,7 +1,9 @@
 """Tests for query expansion."""
 
+import logging
+
 import pytest
-from memtomem.search.expansion import expand_query_tags
+from memtomem.search.expansion import expand_query_headings, expand_query_tags
 
 
 class FakeStorage:
@@ -47,3 +49,61 @@ class TestExpandQueryTags:
         storage = FakeStorage([])
         result = await expand_query_tags("test query", storage)
         assert result == "test query"
+
+
+class _RaisingTagStorage:
+    async def get_tag_counts(self):
+        raise RuntimeError("tag store unavailable")
+
+
+class _RaisingEmbedder:
+    async def embed_query(self, query):
+        raise RuntimeError("embedder offline")
+
+
+class _RaisingDenseStorage:
+    async def dense_search(self, embedding, top_k=3):
+        raise RuntimeError("dense index offline")
+
+
+class _OkEmbedder:
+    async def embed_query(self, query):
+        return [0.0, 0.0, 0.0]
+
+
+class TestExpansionFailureLogging:
+    """Expansion failures must be visible (WARNING) so degraded search quality
+    is observable in production. See feedback_silent_except_log_level."""
+
+    @pytest.mark.asyncio
+    async def test_tag_failure_emits_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.expansion"):
+            result = await expand_query_tags("hello world", _RaisingTagStorage())
+
+        assert result == "hello world"
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Tag expansion failed" in r.getMessage() for r in warnings), (
+            f"Expected a WARNING about tag expansion; got {[r.getMessage() for r in warnings]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_heading_failure_emits_warning_when_embedder_fails(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.expansion"):
+            result = await expand_query_headings(
+                "hello world", _RaisingDenseStorage(), _RaisingEmbedder()
+            )
+
+        assert result == "hello world"
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Heading expansion failed" in r.getMessage() for r in warnings)
+
+    @pytest.mark.asyncio
+    async def test_heading_failure_emits_warning_when_storage_fails(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="memtomem.search.expansion"):
+            result = await expand_query_headings(
+                "hello world", _RaisingDenseStorage(), _OkEmbedder()
+            )
+
+        assert result == "hello world"
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Heading expansion failed" in r.getMessage() for r in warnings)


### PR DESCRIPTION
## Summary

- Promote `expansion.py:26, 57` from `logger.debug` → `logger.warning` so silent
  query-expansion failures are observable in production.
- Aligns BM25/dense expansion sites with `pipeline.py:265-268` LLM-expansion
  path (already WARNING with `exc_info=True`).
- No behavior change beyond log visibility; success-path DEBUG logs untouched.

## Why

`expand_query_tags` and `expand_query_headings` both swallow exceptions and
return the original query unchanged — search quality degrades silently because
the log level was DEBUG. Operators have no signal when the tag store or
embedding backend goes intermittently bad. WARNING surfaces the degradation
without breaking results.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_expansion.py -v` (5 existing + 3 new pass)
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama" -k "expansion or pipeline or search"` (108 pass, 0 regressions)
- [x] `uv run ruff check` + `uv run ruff format --check` on changed files
- [ ] Reviewer sanity check: WARNING surfaces in `caplog` for both failure branches