### PR TITLE
perf(storage): add indexes backing scratch_list and scratch_cleanup

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -279,6 +279,14 @@ def create_tables(
             promoted BOOLEAN DEFAULT 0
         )
     """)
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_working_session_created "
+        "ON working_memory(session_id, created_at)"
+    )
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_working_expires "
+        "ON working_memory(expires_at) WHERE expires_at IS NOT NULL"
+    )
 
     db.execute("""
         CREATE TABLE IF NOT EXISTS chunk_relations (

--- a/packages/memtomem/tests/test_scratch.py
+++ b/packages/memtomem/tests/test_scratch.py
@@ -66,3 +66,41 @@ class TestScratch:
         await storage.scratch_set("key", "v2")
         entry = await storage.scratch_get("key")
         assert entry["value"] == "v2"
+
+
+class TestWorkingMemoryIndexes:
+    """Verify schema declares indexes that back scratch_list (session_id +
+    created_at) and scratch_cleanup (expires_at IS NOT NULL)."""
+
+    @pytest.mark.asyncio
+    async def test_indexes_present(self, storage):
+        db = storage._get_db()
+        rows = db.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'working_memory'"
+        ).fetchall()
+        names = {r[0] for r in rows}
+        assert "idx_working_session_created" in names
+        assert "idx_working_expires" in names
+
+    @pytest.mark.asyncio
+    async def test_session_query_uses_index(self, storage):
+        db = storage._get_db()
+        plan = db.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT key FROM working_memory WHERE session_id = ? ORDER BY created_at",
+            ("sess-x",),
+        ).fetchall()
+        text = " ".join(str(row) for row in plan)
+        assert "idx_working_session_created" in text, plan
+
+    @pytest.mark.asyncio
+    async def test_expires_query_uses_index(self, storage):
+        db = storage._get_db()
+        plan = db.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT key FROM working_memory "
+            "WHERE expires_at IS NOT NULL AND expires_at < ? AND promoted = 0",
+            ("2030-01-01T00:00:00",),
+        ).fetchall()
+        text = " ".join(str(row) for row in plan)
+        assert "idx_working_expires" in text, plan


### PR DESCRIPTION
## Summary

Add two indexes on `working_memory` to back the existing scratch query
patterns:

- `idx_working_session_created` — composite `(session_id, created_at)`,
  serves `scratch_list(session_id=...)` (filter + sort) and
  `scratch_cleanup(session_id=...)` (filter only).
- `idx_working_expires` — partial index on `expires_at WHERE expires_at IS NOT NULL`,
  serves the TTL sweep in `scratch_cleanup`.

`CREATE INDEX IF NOT EXISTS`, idempotent on existing DBs at startup —
matches the established pattern elsewhere in `sqlite_schema.py`.

## Why

`working_memory` had zero indexes. `mixins/scratch.py:47` runs
`WHERE session_id = ? ORDER BY created_at` and `:78` runs
`WHERE expires_at IS NOT NULL ...` — both full-scan today. Painless at
small volumes, but degrades linearly under multi-session scratch usage.

## Why not health_snapshots(tier, created_at)

Grep across `health_store.py` shows no query filters by `tier` alone —
the existing `idx_health_snap_name (check_name, created_at)` already
covers all real call sites. Adding an unused index is just disk waste
(per `feedback_defensive_noise.md`).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_scratch.py -v` (8 existing + 3 new pass)
- [x] EXPLAIN QUERY PLAN tests confirm planner picks each index for its target query
- [x] `uv run pytest -m "not ollama" -k "scratch or storage or sqlite"` (91 pass, 0 regressions)
- [x] `uv run ruff check && uv run ruff format --check`
- [ ] Reviewer sanity: existing DB upgraded by `IF NOT EXISTS` on next startup (manual smoke recommended)