### PR TITLE
feat(server): surface archive hint and dim warning from mem_recall

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.formatters import _display_path
-from memtomem.server.helpers import _parse_recall_date
+from memtomem.server.helpers import _announce_dim_mismatch_once, _parse_recall_date
+
+logger = logging.getLogger(__name__)
 
 
 @mcp.tool()
@@ -68,6 +72,30 @@ async def mem_recall(
         namespace_filter=ns_filter,
     )
 
+    # Build trust-UX hints: archive count when no namespace was pinned, plus a
+    # one-shot embedding mismatch notice. Mirrors mem_search behaviour so
+    # archived/auto-consolidated memories are visible to the caller.
+    hints: list[str] = []
+    if effective_ns is None:
+        try:
+            hidden_count = await app.storage.count_chunks_by_ns_prefix(
+                tuple(app.config.search.system_namespace_prefixes)
+            )
+        except Exception:
+            logger.debug("count_chunks_by_ns_prefix failed; skipping hint", exc_info=True)
+            hidden_count = 0
+        if hidden_count > 0:
+            noun = "memory" if hidden_count == 1 else "memories"
+            hints.append(
+                f"{hidden_count} {noun} hidden in system namespaces "
+                f'(pass namespace="archive:..." to include them).'
+            )
+    dim_notice = await _announce_dim_mismatch_once(app)
+    if dim_notice:
+        hints.append(dim_notice)
+
+    tail = "\n\n" + "\n".join(f"({h})" for h in hints) if hints else ""
+
     if not chunks:
         filters = []
         if since:
@@ -79,7 +107,7 @@ async def mem_recall(
         if effective_ns:
             filters.append(f"namespace={effective_ns!r}")
         suffix = f" ({', '.join(filters)})" if filters else ""
-        return f"No memories found{suffix}."
+        return f"No memories found{suffix}." + tail
 
     parts: list[str] = []
     for i, chunk in enumerate(chunks, 1):
@@ -98,4 +126,4 @@ async def mem_recall(
     header = f"Found {len(chunks)} memor{'y' if len(chunks) == 1 else 'ies'}"
     if since or until:
         header += f" ({since or '…'} → {until or 'now'})"
-    return header + ":\n\n" + "\n\n".join(parts)
+    return header + ":\n\n" + "\n\n".join(parts) + tail

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -120,6 +120,52 @@ class TestArchiveHint:
         # relative to that request — so no hint is warranted.
         assert stats.hidden_system_ns == 0
 
+    async def test_recall_emits_hidden_archive_hint(self, trust_components):
+        """mem_recall mirrors mem_search: when no namespace is pinned and
+        archive chunks exist, the response must include a hidden-count hint."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        visible = make_chunk("a visible note", namespace="default")
+        archived_a = make_chunk("first archived note", namespace="archive:old")
+        archived_b = make_chunk("second archived note", namespace="archive:old")
+        await comp.storage.upsert_chunks([visible, archived_a, archived_b])
+
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(limit=10, ctx=ctx)
+
+        assert "2 memories hidden in system namespaces" in out
+        assert 'pass namespace="archive:..." to include them' in out
+
+    async def test_recall_no_hint_when_namespace_pinned(self, trust_components):
+        """When the caller pins a namespace, no archive hint is emitted —
+        the archive filter never engaged. Mirrors mem_search behaviour."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        visible = make_chunk("a visible note", namespace="default")
+        archived = make_chunk("an archived note", namespace="archive:old")
+        await comp.storage.upsert_chunks([visible, archived])
+
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(namespace="archive:old", limit=10, ctx=ctx)
+
+        assert "hidden in system namespaces" not in out
+
+    async def test_recall_singular_hint_when_one_archived(self, trust_components):
+        """The hint must use 'memory' (singular) when count == 1."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        archived = make_chunk("only one archived note", namespace="archive:old")
+        await comp.storage.upsert_chunks([archived])
+
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(limit=10, ctx=ctx)
+
+        assert "1 memory hidden in system namespaces" in out
+        assert "1 memories" not in out
+
     def test_structured_formatter_emits_hints_field(self):
         meta = ChunkMetadata(source_file=Path("/tmp/x.md"), namespace="default")
         chunk = Chunk(content="hi", metadata=meta, embedding=[])
@@ -189,6 +235,22 @@ class TestDimMismatchHint:
         # actually appears it will still be surfaced.
         assert app._dim_mismatch_announced is False
 
+    async def test_recall_announces_dim_mismatch_once(self, trust_components):
+        """mem_recall must surface the dim-mismatch notice on first call only,
+        sharing the same once-per-session gate as mem_search and mem_add."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        _install_mismatch(comp.storage)
+
+        ctx = _recall_ctx(comp)
+        first = await mem_recall(limit=5, ctx=ctx)
+        second = await mem_recall(limit=5, ctx=ctx)
+
+        assert "embedding-reset" in first
+        assert "configuration.md#reset-flow" in first
+        assert "embedding-reset" not in second  # dedup gate held
+
 
 # ---------------------------------------------------------------------------
 # Smoke flow — status → index → search → add → recall
@@ -256,3 +318,23 @@ class _StubApp:
         self.storage = storage
         self._dim_mismatch_announced = announced
         self._config_lock = asyncio.Lock()
+
+
+def _recall_ctx(components):
+    """Build an MCP-style ctx wrapping ``trust_components`` for mem_recall.
+
+    The recall tool only touches ``app.config``, ``app.storage``,
+    ``app.current_namespace``, ``app._dim_mismatch_announced``, and
+    ``app._config_lock``. Everything else can be stubbed cheaply.
+    """
+    import asyncio
+    from types import SimpleNamespace
+
+    app = SimpleNamespace(
+        config=components.config,
+        storage=components.storage,
+        current_namespace=None,
+        _dim_mismatch_announced=False,
+        _config_lock=asyncio.Lock(),
+    )
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))


### PR DESCRIPTION
## Summary

Extend the trust-UX surfaces from #203 to `mem_recall`. Two parallel
hints, sharing the formatting pattern from `mem_search`:

- **Archive hint (per-call)**: when no namespace is pinned and the DB
  has chunks under any `system_namespace_prefixes`, append
  `N memor(y/ies) hidden in system namespaces (pass namespace="archive:..." to include them).`
- **Dim-mismatch notice (once-per-session)**: reuse
  `_announce_dim_mismatch_once(app)` so the warning appears at most once
  per MCP session across `mem_search` / `mem_add` / `mem_recall`.

Hint construction reuses `app.storage.count_chunks_by_ns_prefix` and the
`_announce_dim_mismatch_once` helper added in #203 — no new abstractions.

## Why

Before this PR, `mem_recall` silently dropped archived/auto-consolidated
memories whenever the caller didn't pin a namespace. Same gap that #203
closed for `mem_search`. Recall is the natural next surface because
agents often use it as a "show me what's in here" probe.

## Dedup policy

- archive hint: emitted **every call** it applies — the user toggles it
  on/off by pinning a namespace.
- dim warning: emitted **once per AppContext** via the existing
  `_dim_mismatch_announced` flag — shared with `mem_search` and `mem_add`.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_trust_ux.py -v` (9 existing + 4 new pass)
- [x] `uv run pytest -m "not ollama" -k "recall or trust_ux or validation"` (62 pass, 0 regressions)
- [x] `uv run ruff check && uv run ruff format --check` on changed files
- [ ] Reviewer sanity: `mem_recall` output retains the existing layout when no hint applies