### PR TITLE
feat(server): add structured output format to mem_recall

### DIFF
--- a/packages/memtomem/src/memtomem/server/formatters.py
+++ b/packages/memtomem/src/memtomem/server/formatters.py
@@ -132,3 +132,39 @@ def _format_structured_results(results: list, hints: list[str] | None = None) ->
     if hints:
         payload["hints"] = list(hints)
     return json.dumps(payload, ensure_ascii=False)
+
+
+def _format_recall_structured(chunks: list, hints: list[str] | None = None) -> str:
+    """JSON structured format for ``mem_recall`` output.
+
+    Recall returns bare ``Chunk`` objects (no rank/score), so this shares the
+    shared-meaning field names with ``_format_structured_results`` — namely
+    ``chunk_id``, ``namespace``, ``source``, ``hierarchy``, ``content`` — and
+    adds ``created_at`` + ``tags`` which are recall-specific. The top-level
+    ``kind`` field lets consumers distinguish recall from search payloads on
+    the first property; search remains ``kind``-less for backwards compat.
+
+    Matches ``_format_structured_results`` on two invariants:
+    * content is untruncated (machine consumer gets the full chunk)
+    * ``hints`` key is omitted when the hint list is empty, so clients do not
+      render an empty-array UI badge.
+    """
+    out = []
+    for c in chunks:
+        meta = c.metadata
+        hierarchy = " > ".join(meta.heading_hierarchy) if meta.heading_hierarchy else ""
+        out.append(
+            {
+                "chunk_id": str(c.id),
+                "namespace": meta.namespace,
+                "source": _short_path(meta.source_file),
+                "hierarchy": hierarchy,
+                "content": c.content,
+                "created_at": c.created_at.isoformat(),
+                "tags": list(meta.tags),
+            }
+        )
+    payload: dict[str, object] = {"kind": "recall", "results": out}
+    if hints:
+        payload["hints"] = list(hints)
+    return json.dumps(payload, ensure_ascii=False)

--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
-from memtomem.server.formatters import _display_path
+from memtomem.server.formatters import _display_path, _format_recall_structured
 from memtomem.server.helpers import _announce_dim_mismatch_once, _parse_recall_date
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,7 @@ async def mem_recall(
     source_filter: str | None = None,
     namespace: str | None = None,
     limit: int = 20,
+    output_format: Literal["compact", "structured"] = "compact",
     ctx: CtxType = None,
 ) -> str:
     """Recall memories created within a date range.
@@ -33,6 +35,8 @@ async def mem_recall(
         source_filter: Filter by source file path (substring match, or glob pattern with *, ?, [])
         namespace: Namespace scope — single, comma-separated, or glob (e.g. "project:*")
         limit: Maximum number of chunks to return (default 20)
+        output_format: Output format — "compact" (default, human-readable) or "structured"
+            (JSON for machine parsing, includes trust-UX hints as a "hints" field).
 
     Examples::
 
@@ -42,6 +46,8 @@ async def mem_recall(
     """
     if not 1 <= limit <= 500:
         return f"Error: limit must be between 1 and 500, got {limit}."
+    if output_format not in ("compact", "structured"):
+        return f"Error: invalid output_format '{output_format}'. Supported: compact, structured."
 
     from memtomem.models import NamespaceFilter
 
@@ -93,6 +99,9 @@ async def mem_recall(
     dim_notice = await _announce_dim_mismatch_once(app)
     if dim_notice:
         hints.append(dim_notice)
+
+    if output_format == "structured":
+        return _format_recall_structured(chunks, hints=hints or None)
 
     tail = "\n\n" + "\n".join(f"({h})" for h in hints) if hints else ""
 

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -187,6 +187,111 @@ class TestArchiveHint:
         out_bare = _format_structured_results([r])
         assert "hints" not in json.loads(out_bare)
 
+    async def test_recall_structured_emits_hints_field(self, trust_components):
+        """When archive chunks are hidden, structured output must surface the
+        hint list alongside the empty result set — mirroring mem_search."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        visible = make_chunk("a visible note", namespace="default")
+        archived_a = make_chunk("archive one", namespace="archive:old")
+        archived_b = make_chunk("archive two", namespace="archive:old")
+        await comp.storage.upsert_chunks([visible, archived_a, archived_b])
+
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(limit=10, output_format="structured", ctx=ctx)
+        parsed = json.loads(out)
+
+        assert parsed["kind"] == "recall"
+        assert len(parsed["results"]) == 1
+        assert parsed["results"][0]["namespace"] == "default"
+        # Shared-meaning field names matching _format_structured_results.
+        assert set(parsed["results"][0]) == {
+            "chunk_id",
+            "namespace",
+            "source",
+            "hierarchy",
+            "content",
+            "created_at",
+            "tags",
+        }
+        assert parsed["hints"] == [
+            '2 memories hidden in system namespaces (pass namespace="archive:..." to include them).'
+        ]
+
+    async def test_recall_structured_omits_hints_when_empty(self, trust_components):
+        """No archive chunks + no dim mismatch → structured payload has no
+        "hints" key (not an empty array) so clients don't render empty UI."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        visible = make_chunk("only visible note", namespace="default")
+        await comp.storage.upsert_chunks([visible])
+
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(limit=10, output_format="structured", ctx=ctx)
+        parsed = json.loads(out)
+
+        assert parsed["kind"] == "recall"
+        assert len(parsed["results"]) == 1
+        assert "hints" not in parsed
+
+    async def test_recall_structured_content_untruncated(self, trust_components):
+        """Compact recall clips content to 400 chars; structured must not —
+        machine consumers need the whole chunk."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        long_content = "x" * 2000
+        chunk = make_chunk(long_content, namespace="default")
+        await comp.storage.upsert_chunks([chunk])
+
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(limit=10, output_format="structured", ctx=ctx)
+        parsed = json.loads(out)
+
+        assert parsed["results"][0]["content"] == long_content
+
+    async def test_recall_structured_returns_json_on_empty(self, trust_components):
+        """Structured mode must return parseable JSON even on empty results —
+        a machine consumer hitting a zero-hit recall still gets a valid
+        payload (with the archive hint if applicable) rather than text.
+
+        This is an intentional improvement over mem_search, which currently
+        returns text "No results found." even when ``output_format="structured"``.
+        """
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        archived = make_chunk("only archived", namespace="archive:old")
+        await comp.storage.upsert_chunks([archived])
+
+        ctx = _recall_ctx(comp)
+        # Pin a namespace with no chunks → zero results, but archive still
+        # hidden from the *default* view; since we pinned, no archive hint.
+        out = await mem_recall(
+            namespace="nonexistent", limit=10, output_format="structured", ctx=ctx
+        )
+        parsed = json.loads(out)
+
+        assert parsed["kind"] == "recall"
+        assert parsed["results"] == []
+        assert "hints" not in parsed  # namespace pinned → archive hint suppressed
+
+    async def test_recall_invalid_output_format(self, trust_components):
+        """Invalid output_format must return an error that names the supported
+        values — mem_search accepts 'verbose' but mem_recall intentionally does
+        not, so the message helps users unlearn that asymmetry."""
+        from memtomem.server.tools.recall import mem_recall
+
+        comp, _ = trust_components
+        ctx = _recall_ctx(comp)
+        out = await mem_recall(limit=10, output_format="verbose", ctx=ctx)
+
+        assert out.startswith("Error:")
+        assert "verbose" in out
+        assert "Supported: compact, structured" in out
+
 
 # ---------------------------------------------------------------------------
 # G3 — dim-mismatch hint wiring


### PR DESCRIPTION
## Summary

Follow-up to #209 — extend the trust-UX surface so machine consumers (agents, STM proxy, automation clients) can read recall hints as JSON fields instead of parsing text tails. Mirrors the structured format `mem_search` has had since #203, with a recall-specific shape.

- **New helper**: `_format_recall_structured(chunks, hints)` in `formatters.py`. Shared-meaning field names match search (`chunk_id`, `namespace`, `source`, `hierarchy`, `content`); recall-specific additions are `created_at` and `tags`. `rank`/`score` intentionally omitted — recall has no scoring, so faking 0.0 would mislead consumers into treating hits as zero-relevance.
- **`kind: "recall"`** top-level field discriminates from search payloads on the first property. Search stays kind-less for backwards compat; a follow-up can add `kind: "search"` separately.
- **`output_format: Literal["compact", "structured"]`** — no `verbose`. Search's verbose surfaces score/pipeline stats that don't apply to recall, so adding it here would be symmetry without a use case. Invalid-format error message names the supported set explicitly, so users who try `"verbose"` (knowing search accepts it) get a learn-friendly hint instead of silent fallback.

## Intentional deviation from mem_search

Recall returns structured JSON on empty results; `mem_search(output_format="structured")` currently returns plain text `"No results found."` on empty, which violates the structured contract (forces machine consumers into defensive `try/except json.loads`). Tracked separately in #210 — this PR fixes the behavior only for recall and cross-references the pattern there.

The `test_recall_structured_returns_json_on_empty` test locks this behavior in and the docstring flags it as an intentional improvement, so a future reviewer chasing "consistency with search" doesn't accidentally break the contract.

## Diff shape

| File | Change |
|------|--------|
| `formatters.py` | +36 — new helper, no changes to existing `_format_structured_results` |
| `tools/recall.py` | +10/-1 — signature param, validation, structured branch |
| `tests/test_trust_ux.py` | +105 — 5 new tests (hints field, omit-when-empty, untruncated content, empty→JSON, invalid-format error) |

~70% of the diff is tests; production code is ~46 lines.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_trust_ux.py -v` — 13 existing + 5 new pass
- [x] `uv run pytest -m "not ollama" -k "recall or trust_ux or search or format or validation"` — 188 pass, 0 regressions
- [x] `uv run ruff check && uv run ruff format --check` on changed files
- [x] `uv run mypy` on changed source files — clean
- [ ] Reviewer sanity: structured payload shape and field names feel right for a machine consumer