### PR TITLE
docs(readme): remove Ollama-as-required from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,8 @@ flowchart LR
 ### 1. Install
 
 ```bash
-ollama pull nomic-embed-text          # local embeddings (~270MB, free)
 uv tool install memtomem             # or: pipx install memtomem
 ```
-
-> No GPU? Pick OpenAI in the wizard — see [Embeddings](docs/guides/embeddings.md).
 
 ### 2. Setup
 
@@ -52,7 +49,7 @@ uv tool install memtomem             # or: pipx install memtomem
 mm init                               # 8-step wizard (or: mm init -y for CI)
 ```
 
-The wizard picks your embedding model, points at the folder you want indexed, and registers memtomem with your AI editor.
+The wizard picks your embedding provider, points at the folder you want indexed, and registers memtomem with your AI editor. The default is **keyword-only** (BM25, no external dependencies) — you can also pick ONNX (local, no server), Ollama (local server), or OpenAI (cloud). See [Embeddings](docs/guides/embeddings.md) for details.
 
 ### 3. Use
 


### PR DESCRIPTION
## Summary
- Drop the `ollama pull nomic-embed-text` step from the root README's Quick Start.
- Rewrite the wizard description to list all four provider options (BM25 default, ONNX, Ollama, OpenAI) so first-time readers can pick without thinking they need Ollama.

## Why
`EmbeddingConfig.provider` defaults to `"none"` (BM25 keyword-only, no external deps) in `packages/memtomem/src/memtomem/config.py:13`, and the setup wizard's recommended choice is `[1] Quick start — keyword search only, no setup needed` in `packages/memtomem/src/memtomem/cli/init_cmd.py:97`. The README was implying Ollama + a 270MB model download were required prerequisites, which is misleading for the default path.

## Test plan
- [ ] Read the rendered README on the PR — Quick Start installs memtomem before any provider setup, and the wizard note lists all four options.
- [ ] Confirm no remaining ollama-as-required language in the Install step.