### PR TITLE
docs(pypi-readme): drop Ollama-as-prerequisite, list ONNX in providers

### DIFF
--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -12,15 +12,17 @@ Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + s
 ## Quick Start
 
 ```bash
-# 1. Prerequisites — Python 3.12+ and Ollama (ollama.com)
-ollama pull nomic-embed-text    # ~270MB, one-time
-
-# 2. Install memtomem
+# 1. Install memtomem (requires Python 3.12+)
 uv tool install memtomem        # or: pipx install memtomem
 
-# 3. Run the 8-step setup wizard (picks embedding, memory folder, editor)
+# 2. Run the 8-step setup wizard
+#    (picks embedding provider, memory folder, MCP editor)
 mm init    # on PATH after `uv tool install` — no `uv run` needed
 ```
+
+The wizard's default is **keyword-only** (BM25, no external deps). Pick
+ONNX (local, no server), Ollama (local server), or OpenAI (cloud) for
+semantic search — see [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md).
 
 Then in your AI editor, ask:
 
@@ -83,7 +85,7 @@ Full documentation lives in the [memtomem GitHub repo](https://github.com/memtom
 | [Hands-On Tutorial](https://github.com/memtomem/memtomem/blob/main/docs/guides/hands-on-tutorial.md) | Follow-along with example files |
 | [User Guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/user-guide.md) | Complete feature walkthrough — all tools and patterns |
 | [Configuration](https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md) | All `MEMTOMEM_*` environment variables |
-| [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) | Ollama and OpenAI providers, model dimensions, switching models |
+| [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) | ONNX, Ollama, and OpenAI providers, model dimensions, switching models |
 | [MCP Client Setup](https://github.com/memtomem/memtomem/blob/main/docs/guides/mcp-clients.md) | Editor-specific configuration |
 | [Agent Memory Guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/agent-memory-guide.md) | Sessions, working memory, procedures, multi-agent |
 | [Web UI Guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/web-ui.md) | Visual dashboard reference |


### PR DESCRIPTION
## Summary
- Rewrite the PyPI-facing `packages/memtomem/README.md` Quick Start to match the wizard's actual default (`provider = "none"`, no external deps) instead of labelling Ollama a "Prerequisite".
- Add ONNX to the Documentation table's Embeddings row, which previously only mentioned Ollama and OpenAI.

## Why
The PyPI landing page was the first surface many users hit. Its three-step snippet told readers to install Ollama and pull a 270MB model before installing memtomem, even though the wizard defaults to BM25 keyword-only (zero dependencies) and ONNX/Ollama/OpenAI are all opt-in through `[optional-dependencies]` in `packages/memtomem/pyproject.toml:34-37`.

ONNX has been a first-class provider since before the last publish; `docs/guides/embeddings.md` already puts the ONNX section first. The Documentation index was still describing embeddings.md as "Ollama and OpenAI providers".

## Test plan
- [ ] Render the markdown locally or on the PR and confirm the three-step snippet drops the Ollama prerequisite.
- [ ] Confirm the Documentation table's Embeddings row lists ONNX first, matching the actual `embeddings.md` structure.