### PR TITLE
docs(getting-started): align Prerequisites with wizard default

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -21,27 +21,24 @@ memtomem gives your AI coding agent (Claude Code, Cursor, etc.) **long-term memo
 | Requirement | Install | Verify |
 |-------------|---------|--------|
 | **Python 3.12+** | [python.org](https://python.org) | `python3 --version` |
-| **Ollama** | [ollama.com](https://ollama.com) | `ollama list` |
 | **An AI editor** | Claude Code, Cursor, Windsurf, etc. | Any one is enough |
 
-> **No Ollama?** You can use OpenAI embeddings instead. The setup wizard will guide you — skip the `ollama pull` step below.
+### Pick an embedding path (optional)
 
-### Pull the embedding model
+memtomem ships with four embedding options. The setup wizard in the next
+section asks which one you want and writes the config for you — you
+don't have to decide now.
 
-```bash
-# English-only or light multilingual use:
-ollama pull nomic-embed-text
+| Option | Setup | When to pick it |
+|--------|-------|-----------------|
+| **Keyword-only (BM25)** | None | Default. Fast, no external deps. Great for short, exact-term notes. |
+| **ONNX (local, no server)** | `uv tool install 'memtomem[onnx]'` | Semantic search without running a server. ~22 MB–1.2 GB model on first use. |
+| **Ollama (local server)** | Install [Ollama](https://ollama.com), then `ollama pull nomic-embed-text` (English) or `ollama pull bge-m3` (multilingual, 1.2 GB). | Semantic search with full local control; best Korean/JP/CN quality with `bge-m3`. |
+| **OpenAI (cloud)** | `OPENAI_API_KEY` env var. | No local model to manage; pay-per-call. |
 
-# Korean, Japanese, Chinese, or heavy multilingual use (recommended):
-ollama pull bge-m3
-```
-
-| Model | Size | Dimensions | Best for |
-|-------|------|------------|----------|
-| `nomic-embed-text` | 270MB | 768 | English-primary, fast, lightweight |
-| `bge-m3` | 1.2GB | 1024 | Multilingual, cross-language search (KR/EN/JP/CN) |
-
-> **Multilingual tip**: `bge-m3` significantly outperforms `nomic-embed-text` for cross-language search (e.g., Korean query finding English content). If you work with multiple languages, use `bge-m3`.
+> **Multilingual tip**: if you work with Korean, Japanese, or Chinese,
+> pick Ollama with `bge-m3` or OpenAI `text-embedding-3-small` — both
+> significantly outperform English-only models for cross-language search.
 
 ---
 
@@ -128,7 +125,9 @@ The wizard walks you through 8 steps. Type `b` to go back, `q` to quit at any st
 Skip the wizard entirely with `-y`. All settings have sensible defaults:
 
 ```bash
-mm init -y                                              # all defaults (Ollama + nomic-embed-text)
+mm init -y                                              # all defaults (keyword-only, BM25)
+mm init -y --provider onnx --model all-MiniLM-L6-v2     # local dense embeddings, no server
+mm init -y --provider ollama --model nomic-embed-text   # Ollama (requires `ollama serve`)
 mm init -y --provider openai --api-key sk-...           # OpenAI
 mm init -y --memory-dir ~/notes --mcp claude            # custom dir + Claude Code auto-setup
 ```


### PR DESCRIPTION
## Summary
- Drop Ollama from the Prerequisites requirements table.
- Replace the "Pull the embedding model" subsection with a four-row "Pick an embedding path" overview (Keyword-only / ONNX / Ollama / OpenAI) that matches the wizard's actual choices.
- Fix the `mm init -y` comment that labelled the non-interactive default as "Ollama + nomic-embed-text"; the actual default is `provider = "none"` (BM25).

## Why
The setup wizard (`packages/memtomem/src/memtomem/cli/init_cmd.py:97`) offers four choices and recommends `[1] Quick start — keyword search only, no setup needed`. Prerequisites listed Ollama as a hard requirement alongside Python 3.12+, the `mm init -y` example claimed a non-existent Ollama default, and a separate "Pull the embedding model" subsection walked users through `ollama pull` before they had even chosen a provider. Together these made Ollama look mandatory instead of one of four options.

## Test plan
- [ ] Render the markdown on the PR and confirm the Requirements table no longer mentions Ollama.
- [ ] Verify the `mm init -y` examples match `packages/memtomem/src/memtomem/cli/init_cmd.py:505-555` (provider choices: none / onnx / ollama / openai).