### PR TITLE
docs(guides): stop calling Ollama nomic-embed-text the server default

### DIFF
--- a/docs/guides/hands-on-tutorial.md
+++ b/docs/guides/hands-on-tutorial.md
@@ -17,12 +17,27 @@
 
 ## Step 1 — Setup and First Run (5 min)
 
-### 1.1 Prepare the Embedding Model
+### 1.1 Pick an Embedding Path (optional)
+
+The MCP server runs out of the box in **keyword-only (BM25)** mode — no
+embedding model needed for this tutorial. If you want semantic search as
+well, pick one of the following before continuing:
 
 ```bash
+# Local dense embeddings, no server — add the onnx extra and memtomem
+# will download the model on first index.
+uv tool install 'memtomem[onnx]'
+
+# Local server — requires Ollama installed (ollama.com)
 ollama pull nomic-embed-text     # English-primary (768d, 270MB)
 # or: ollama pull bge-m3         # Multilingual recommended (1024d, 1.2GB)
+
+# Cloud — set OPENAI_API_KEY in the env passed to the MCP server.
 ```
+
+The wizard (`mm init`) writes the chosen provider into
+`~/.memtomem/config.json`; for this tutorial you can also leave the
+default and skip ahead.
 
 ### 1.2 Connect the MCP Server
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -1,7 +1,7 @@
 # MCP Client Configuration Guide
 
 **Audience**: Users who want to connect memtomem to a specific AI editor
-**Prerequisite**: [Getting Started](getting-started.md) complete (Ollama running, model pulled)
+**Prerequisite**: [Getting Started](getting-started.md) complete (embedding path picked — BM25 default, or ONNX / Ollama / OpenAI via the wizard)
 **Estimated Time**: ~5 minutes
 
 > **Which editor should I use?**
@@ -197,12 +197,13 @@ Ask the AI:
 Call the mem_status tool to show the current status
 ```
 
-Expected response example:
+Expected response example (keyword-only default — the embedding line
+changes depending on the provider picked in the wizard):
 ```
 memtomem status:
   - Storage backend: SQLite
   - Total chunks: 0 (not yet indexed)
-  - Embedding model: ollama/nomic-embed-text
+  - Embedding model: none (BM25 keyword search only)
 ```
 
 ### Available MCP Tools (74)
@@ -302,8 +303,12 @@ ollama pull bge-m3
 
 | Model | Dimension | Pull Command |
 |-------|-----------|-------------|
-| `nomic-embed-text` (default) | 768 | `ollama pull nomic-embed-text` |
-| `bge-m3` | 1024 | `ollama pull bge-m3` |
+| `nomic-embed-text` | 768 | `ollama pull nomic-embed-text` |
+| `bge-m3` (multilingual) | 1024 | `ollama pull bge-m3` |
+
+> The server default is `provider = "none"` (BM25 keyword-only, no
+> embedding model). The models above are Ollama-specific choices; the
+> wizard also exposes ONNX (`fastembed`) and OpenAI options.
 
 > **Important**: `MEMTOMEM_EMBEDDING__DIMENSION` must match the model's output dimension. Mismatched values will cause indexing errors.
 


### PR DESCRIPTION
## Summary
- Rewrite `hands-on-tutorial.md` Step 1.1 so the first thing readers do is pick an embedding path (BM25 default, or ONNX / Ollama / OpenAI) — not run `ollama pull nomic-embed-text` unconditionally.
- Update `mcp-clients.md`: drop the `(default)` marker from `nomic-embed-text` in the model table, rewrite the "Getting Started complete (Ollama running, model pulled)" prerequisite, and fix the `mem_status` example output that hard-coded `ollama/nomic-embed-text` as the embedding line.

## Why
The server default in `packages/memtomem/src/memtomem/config.py:13` is `provider = "none"` (BM25). Both guides were written before that default was introduced and still presented Ollama + `nomic-embed-text` as the only path. A first-time reader following the hands-on tutorial would install Ollama and pull a 270MB model before even reaching the MCP server connection step, despite the tutorial not requiring embeddings at all.

The `nomic-embed-text` model remains a reasonable Ollama-specific choice; it just isn't the server-level default.

## Test plan
- [ ] Render both markdown files on the PR and confirm the Step 1.1 block lists four provider options and that `mcp-clients.md`'s Prerequisite line and `mem_status` example no longer imply Ollama is always active.
- [ ] Walk through Step 1.1 with no Ollama installed to confirm the rest of the tutorial still runs (keyword-only search still works end-to-end).