### PR TITLE
fix(cli): run wizard steps 7 and 8 in numeric order

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -596,8 +596,8 @@ def init(
             _step_namespace,
             _step_search,
             _step_language,
-            _step_mcp,
             _step_settings,
+            _step_mcp,
         ]
         run_steps(steps, state)
 


### PR DESCRIPTION
## Summary
- Swap the order of `_step_settings` and `_step_mcp` in the `run_steps` list inside `init_cmd.py:592-601` so the two wizard steps execute in the order their `step_header(...)` calls announce.

## Why
`_step_settings` declares `step_header(7, "Claude Code Hooks")` and `_step_mcp` declares `step_header(8, "Connect to AI Editor")`, but the step list placed `_step_mcp` first. Users running `mm init` saw step numbers print as **1 → 2 → 3 → 4 → 5 → 6 → 8 → 7**, which looks like a skipped or typo'd step.

No functional change: `_step_settings` is a conditional skip (it bails out when `~/.claude/` is missing), and `_step_mcp` does not read any state written by `_step_settings`. Only the displayed step numbers are affected.

Found during the doc audit in #212 – #216 when cross-checking the wizard flow against `docs/guides/getting-started.md`.

## Test plan
- [ ] `uv run ruff check packages/memtomem/src/memtomem/cli/init_cmd.py` (already green locally).
- [ ] Run `uv run mm init` in a fresh checkout and confirm step numbers print 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8.
- [ ] Confirm `_step_settings` still short-circuits when `~/.claude/` is absent (no change expected).