### PR TITLE
fix(tests): avoid tmp_path/memories collision in Codex ingest tests

### DIFF
--- a/packages/memtomem/tests/test_cli_ingest.py
+++ b/packages/memtomem/tests/test_cli_ingest.py
@@ -547,7 +547,7 @@ class TestGeminiIngestIntegration:
 @pytest.mark.ollama
 class TestCodexIngestIntegration:
     async def test_happy_path_indexes_codex_memories(self, components, tmp_path):
-        mem_dir = tmp_path / "memories"
+        mem_dir = tmp_path / "codex_memories"
         mem_dir.mkdir()
         (mem_dir / "fact_a.md").write_text(
             "# Workspace preference\n\nAlways use workspace-write sandbox mode.\n"
@@ -577,7 +577,7 @@ class TestCodexIngestIntegration:
                 assert "codex-memory" in c.metadata.tags
 
     async def test_rerun_skips_unchanged(self, components, tmp_path):
-        mem_dir = tmp_path / "memories"
+        mem_dir = tmp_path / "codex_memories"
         mem_dir.mkdir()
         (mem_dir / "fact.md").write_text("# Fact\n\nSome important fact.\n")
 


### PR DESCRIPTION
## Summary
- `components` fixture in `conftest.py:48` already creates `tmp_path / "memories"`, so `TestCodexIngestIntegration`'s own `mkdir()` on the same path raises `FileExistsError` whenever Ollama is running locally.
- Rename the test-owned directory to `tmp_path / "codex_memories"` so the fixture and the two tests own disjoint paths.

## Why CI missed it
CI runs with `-m "not ollama"` so these Ollama-gated integration tests never execute. The failure surfaces on a dev machine with Ollama up.

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_cli_ingest.py::TestCodexIngestIntegration` — both cases pass (Ollama running)
- [x] `uv run pytest packages/memtomem/tests/test_cli_ingest.py` — 64 passed
- [x] `uv run ruff check` + `ruff format --check` on the touched file