### PR TITLE
fix(embedding): re-register BAAI/bge-m3 via fastembed add_custom_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   responses.
 
 ### Fixed
+- **ONNX `bge-m3`**: fastembed 0.8.0 dropped `BAAI/bge-m3` from its built-in
+  `TextEmbedding` catalog — re-registered via `add_custom_model` against the
+  official HF ONNX export (1024-dim, CLS pooling, normalized). Existing
+  `mm init` users keep working with no config change.
 - **Async I/O**: 6 blocking file read/write calls in MCP tool handlers
   (`mem_add`, `mem_edit`, `mem_delete`, `mem_context_*`) wrapped with
   `asyncio.to_thread` to prevent event loop starvation.
@@ -41,6 +45,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   tightened (#145).
 - Dead config sections removed (`conflict`, `entity_extraction`,
   `timezone`) — `extra="ignore"` ensures old config files still load.
+- **MiniLM pooling upstream change**: fastembed 0.8.0 switched
+  `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` from CLS to
+  mean pooling. Users who indexed with fastembed <0.5.1 and this model
+  should re-index for consistent dense-search quality; new installs are
+  unaffected.
 - Refactored truncation magic numbers in consolidation engine;
   watcher queue maxsize extracted to constant.
 - CI: ruff lint/format scope extended to `tests/`; notebooks CI job

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -28,6 +28,34 @@ def _resolve_model(name: str) -> str:
     return name  # pass through as raw fastembed model ID
 
 
+def _register_custom_models_if_needed() -> None:
+    """Register models that fastembed >=0.4 dropped from its built-in catalog.
+
+    fastembed 0.8.0's ``TextEmbedding`` no longer ships ``BAAI/bge-m3`` (the
+    model type split across dedicated classes none of which currently host
+    it). Re-register it from the official HF ONNX export so existing installs
+    keep working without changing the user-facing model name.
+    """
+    from fastembed import TextEmbedding  # type: ignore[import-untyped]
+    from fastembed.common.model_description import (  # type: ignore[import-untyped]
+        ModelSource,
+        PoolingType,
+    )
+
+    registered = {m.get("model") for m in TextEmbedding.list_supported_models()}
+    if "BAAI/bge-m3" not in registered:
+        TextEmbedding.add_custom_model(
+            model="BAAI/bge-m3",
+            pooling=PoolingType.CLS,
+            normalization=True,
+            sources=ModelSource(hf="BAAI/bge-m3"),
+            dim=1024,
+            model_file="onnx/model.onnx",
+            additional_files=["onnx/model.onnx_data"],
+            size_in_gb=2.3,
+        )
+
+
 class OnnxEmbedder:
     """Embedding provider backed by fastembed (ONNX Runtime).
 
@@ -51,6 +79,7 @@ class OnnxEmbedder:
                 "Install it with: pip install memtomem[onnx]"
             ) from exc
 
+        _register_custom_models_if_needed()
         model_id = _resolve_model(self._config.model)
         logger.info("Loading ONNX embedding model %s …", model_id)
         self._model = TextEmbedding(model_name=model_id)

--- a/packages/memtomem/tests/test_golden_path.py
+++ b/packages/memtomem/tests/test_golden_path.py
@@ -5,10 +5,10 @@ embedder (no external services required) for both English and Korean text,
 exercising the hybrid search pipeline (BM25 + dense).
 
 Model choice: ``sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2``
-(384-dim, ~220 MB, ~50 languages including Korean).  Chosen over ``bge-m3``
-because fastembed's ``TextEmbedding`` class does not support ``bge-m3`` —
-that model is multi-vector / sparse and lives on other fastembed classes.
-MiniLM-L12 keeps the CI cache small while still covering multilingual text.
+(384-dim, ~220 MB, ~50 languages including Korean).  ``bge-m3`` works via
+``_register_custom_models_if_needed`` in ``embedding/onnx.py`` but its ONNX
+export is ~2.3 GB, so MiniLM-L12 is used here to keep the CI cache small
+while still covering multilingual text.
 
 This test complements ``test_user_workflows.py`` (Ollama-gated) by providing
 a CI-safe equivalent of the add -> search -> recall round trip.  The fastembed

--- a/packages/memtomem/tests/test_onnx_custom_model.py
+++ b/packages/memtomem/tests/test_onnx_custom_model.py
@@ -1,0 +1,59 @@
+"""Tests for custom-model registration in the ONNX embedder.
+
+fastembed 0.8.0's built-in ``TextEmbedding`` catalog no longer ships
+``BAAI/bge-m3`` (the embedding classes were split per model family, and none
+of them currently host bge-m3). ``_register_custom_models_if_needed`` in
+``memtomem.embedding.onnx`` re-registers the model from its official HF ONNX
+export so existing installs keep working.
+
+These tests only verify the *registration* is wired up correctly — they do
+not download or load the model (the full ONNX export is ~2.3 GB; an
+Ollama-gated end-to-end test covers actual inference).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "fastembed",
+    reason="fastembed not installed — install with `pip install memtomem[onnx]`",
+)
+
+
+def _registered_model_ids() -> set[str]:
+    from fastembed import TextEmbedding  # type: ignore[import-untyped]
+
+    return {m.get("model") for m in TextEmbedding.list_supported_models()}
+
+
+def test_registration_adds_bge_m3() -> None:
+    """bge-m3 must appear in the supported-model list after registration."""
+    from memtomem.embedding.onnx import _register_custom_models_if_needed
+
+    _register_custom_models_if_needed()
+    assert "BAAI/bge-m3" in _registered_model_ids()
+
+
+def test_registration_is_idempotent() -> None:
+    """Calling the helper twice must not raise (guards against fastembed's
+    strict ValueError on duplicate ``add_custom_model``)."""
+    from memtomem.embedding.onnx import _register_custom_models_if_needed
+
+    _register_custom_models_if_needed()
+    _register_custom_models_if_needed()  # must not raise
+    assert "BAAI/bge-m3" in _registered_model_ids()
+
+
+def test_bge_m3_registration_has_expected_shape() -> None:
+    """Sanity-check the registered model metadata — dim 1024 CLS pooling."""
+    from fastembed import TextEmbedding  # type: ignore[import-untyped]
+
+    from memtomem.embedding.onnx import _register_custom_models_if_needed
+
+    _register_custom_models_if_needed()
+    entry = next(
+        m for m in TextEmbedding.list_supported_models() if m.get("model") == "BAAI/bge-m3"
+    )
+    assert entry.get("dim") == 1024
+    assert entry.get("model_file") == "onnx/model.onnx"


### PR DESCRIPTION
## Summary

- fastembed 0.8.0 removed `BAAI/bge-m3` from `TextEmbedding`'s built-in catalog — every existing `mm init` install with the multilingual default currently breaks on first query (fastembed raises "unsupported model"). Verified 0.5.1 is equally affected, so a version pin is not a viable fix.
- Re-register bge-m3 via fastembed's own escape hatch (`TextEmbedding.add_custom_model`) against the official HF ONNX export: `onnx/model.onnx` + `onnx/model.onnx_data`, CLS pooling, 1024-dim normalized output. Helper is idempotent (guarded by `list_supported_models()` to avoid the hard `ValueError` fastembed raises on duplicate registration).
- Users keep the same config (`embedding.model = "bge-m3"`), the same vector dim, the same CLS pooling semantics.

## Background — why add_custom_model, not version pin

The `fastembed>=0.4` range in `pyproject.toml` has no upper bound, so any fresh install picks 0.8.x. Probing the catalog directly:

| fastembed | `BAAI/bge-m3` in `TextEmbedding` | `LateInteractionTextEmbedding` |
|---|---|---|
| 0.5.1 | ❌ | colbert-ir / answerai / jinaai only |
| 0.8.0 | ❌ | colbert-ir / answerai / jinaai only |

Pinning to 0.5.1 does not recover bge-m3 — the regression predates it. `add_custom_model` is the only path that keeps the model accessible via `TextEmbedding` without changing the user-facing model name.

## Changes

- `packages/memtomem/src/memtomem/embedding/onnx.py` — new `_register_custom_models_if_needed()` helper called from `_get_model()`; idempotent guard via `list_supported_models()` membership.
- `packages/memtomem/tests/test_onnx_custom_model.py` — new, 3 tests covering registration, idempotency, and metadata shape. Does **not** download or load the 2.3 GB ONNX export (that stays on the Ollama-gated e2e path).
- `packages/memtomem/tests/test_golden_path.py` — docstring corrected (the old "bge-m3 not supported by TextEmbedding" note is now obsolete; kept MiniLM-L12 for the CI cache-size reason only).
- `CHANGELOG.md` — one entry for the bge-m3 re-register, plus a separate note on the upstream MiniLM-L12 CLS → MEAN pooling change in fastembed 0.8.0 (cannot override without a model-name collision; users who indexed earlier should re-index).

## Smoke test (local)

```
cos(KO paraphrase):     0.8818  (high, as expected)
cos(KO ↔ EN unrelated): 0.2989
cos(KO ↔ EN unrelated): 0.3434
dim: 1024
first load:             31.3 s (2.3 GB download)
cache hit re-load:       0.55 s
```

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — passes.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — passes.
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — **1550 passed**, 46 deselected, 2 warnings. The 2 warnings are the upstream fastembed MiniLM pooling notice that CHANGELOG documents.
- [x] Manual `add_custom_model` smoke test (KO paraphrase + KO↔EN similarity, 1024-dim shape).

## Follow-ups (out of scope)

- Record `fastembed_version` in the embedding metadata so `mem_status` can warn on silent pooling drift (currently the MiniLM CLS → MEAN upstream change is only surfaced via CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)