### PR TITLE
feat(rerank): add fastembed provider and default to local ONNX reranker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- **FastEmbed reranker provider**: new `rerank.provider="fastembed"` routes
+  reranking through `fastembed.rerank.cross_encoder.TextCrossEncoder` —
+  local ONNX, no external service, no PyTorch dependency. Reuses the
+  existing `memtomem[onnx]` extra so enabling reranking adds no new
+  packages. Supports the built-in fastembed catalog (e.g.
+  `Xenova/ms-marco-MiniLM-L-6-v2`,
+  `jinaai/jina-reranker-v2-base-multilingual`) plus custom ONNX exports
+  via `TextCrossEncoder.add_custom_model()`.
 - **ReStructuredText chunker**: `.rst` section-header-aware splitting.
 - **Web UI `--open` flag**: opt-in browser launch with configurable timeout
   (replaces the old always-open default).
@@ -50,6 +58,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   mean pooling. Users who indexed with fastembed <0.5.1 and this model
   should re-index for consistent dense-search quality; new installs are
   unaffected.
+- **Reranker default**: `rerank.provider` now defaults to `fastembed`
+  (local ONNX, ~80 MB download on first use) instead of `cohere`
+  (external API); `rerank.model` default is now
+  `Xenova/ms-marco-MiniLM-L-6-v2`. Installs that had
+  `rerank.enabled=true` with the implicit `cohere` default must now set
+  `provider: "cohere"` (and `api_key`) explicitly to keep prior behavior.
+  `rerank.enabled=false` installs (the shipped default) are unaffected.
+  Non-English content should set
+  `model="jinaai/jina-reranker-v2-base-multilingual"` — the English
+  default degrades non-English quality.
 - Refactored truncation magic numbers in consolidation engine;
   watcher queue maxsize extracted to constant.
 - CI: ruff lint/format scope extended to `tests/`; notebooks CI job

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -155,12 +155,20 @@ without requiring explicit `MEMORY_DIRS` configuration.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MEMTOMEM_RERANK__ENABLED` | `false` | Enable cross-encoder reranking after fusion |
-| `MEMTOMEM_RERANK__PROVIDER` | `cohere` | `cohere` (cloud) or `local` |
-| `MEMTOMEM_RERANK__MODEL` | `rerank-english-v3.0` | Reranker model name |
+| `MEMTOMEM_RERANK__PROVIDER` | `fastembed` | `fastembed` (local ONNX), `cohere` (cloud), or `local` (sentence-transformers) |
+| `MEMTOMEM_RERANK__MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Reranker model name (provider-specific — see below) |
 | `MEMTOMEM_RERANK__TOP_K` | `20` | Candidates passed to the reranker (must be > 0) |
 | `MEMTOMEM_RERANK__API_KEY` | _(empty)_ | API key (required for Cohere) |
 
-Reranking runs as Stage 3b in the search pipeline — after BM25 + dense fusion, before source/tag filters. If the reranker call fails, the pipeline falls back to the original fused order with a warning.
+Reranking runs as Stage 3b in the search pipeline — after BM25 + dense fusion, before source/tag filters. If reranking fails with a runtime error the pipeline falls back to the original fused order with a warning; configuration errors (unsupported model name, missing fastembed install) surface directly so the misconfiguration is visible.
+
+### Provider-specific models
+
+- **`fastembed`** (default): local ONNX via the `memtomem[onnx]` extra — no external service, no PyTorch. Built-in catalog includes `Xenova/ms-marco-MiniLM-L-6-v2` (EN, ~80 MB), `jinaai/jina-reranker-v2-base-multilingual` (multilingual, ~1.1 GB), `jinaai/jina-reranker-v1-tiny-en` (EN, 8K context). Custom ONNX exports must be registered via `TextCrossEncoder.add_custom_model()` before the server starts.
+- **`cohere`**: Cohere Rerank API (`rerank-english-v3.0`, `rerank-multilingual-v3.0`). Requires `MEMTOMEM_RERANK__API_KEY`.
+- **`local`**: sentence-transformers `CrossEncoder` (e.g. `cross-encoder/ms-marco-MiniLM-L-6-v2`). Requires `sentence-transformers` to be installed separately — the `fastembed` provider is usually preferable.
+
+> **Multilingual content:** the default `Xenova/ms-marco-MiniLM-L-6-v2` is English-only. For Korean, Chinese, Japanese, or other non-English content set `MEMTOMEM_RERANK__MODEL=jinaai/jina-reranker-v2-base-multilingual` — the English default noticeably degrades non-English reranking quality.
 
 ## Access Frequency Boost
 

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -178,9 +178,33 @@ class NamespaceConfig(BaseSettings):
 
 
 class RerankConfig(BaseSettings):
+    """Cross-encoder reranker settings (Stage 3b in the search pipeline).
+
+    Default is a lightweight English fastembed cross-encoder (~80 MB ONNX,
+    local, no external service). For Korean/Chinese/Japanese/other
+    non-English content set
+    ``model="jinaai/jina-reranker-v2-base-multilingual"`` (1.1 GB) — the
+    English default noticeably degrades non-English reranking quality.
+
+    Provider-specific model IDs:
+
+    - ``fastembed``: fastembed catalog ID. Supported built-ins include
+      ``Xenova/ms-marco-MiniLM-L-6-v2`` (EN, 80 MB),
+      ``jinaai/jina-reranker-v2-base-multilingual`` (multilingual, 1.1 GB),
+      ``jinaai/jina-reranker-v1-tiny-en`` (EN, 8K context). Custom ONNX
+      exports can be registered via
+      ``TextCrossEncoder.add_custom_model()`` before the server starts.
+    - ``cohere``: Cohere Rerank API model (e.g. ``rerank-english-v3.0``,
+      ``rerank-multilingual-v3.0``). Requires ``api_key``.
+    - ``local``: sentence-transformers ``CrossEncoder`` model name (e.g.
+      ``cross-encoder/ms-marco-MiniLM-L-6-v2``). Requires
+      ``sentence-transformers`` to be installed separately; the
+      ``fastembed`` provider is usually preferable.
+    """
+
     enabled: bool = False
-    provider: str = "cohere"  # "cohere" | "local"
-    model: str = "rerank-english-v3.0"
+    provider: str = "fastembed"  # "cohere" | "local" | "fastembed"
+    model: str = "Xenova/ms-marco-MiniLM-L-6-v2"
     top_k: int = 20  # candidates to pass to reranker
     api_key: str = ""
 

--- a/packages/memtomem/src/memtomem/search/reranker/factory.py
+++ b/packages/memtomem/src/memtomem/search/reranker/factory.py
@@ -26,4 +26,11 @@ def create_reranker(config: RerankConfig) -> Reranker | None:
 
         return LocalReranker(config)
 
-    raise ValueError(f"Unknown reranker provider: {config.provider!r}. Supported: cohere, local")
+    if provider == "fastembed":
+        from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+        return FastEmbedReranker(config)
+
+    raise ValueError(
+        f"Unknown reranker provider: {config.provider!r}. Supported: cohere, local, fastembed"
+    )

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -1,0 +1,91 @@
+"""FastEmbed cross-encoder reranker — local ONNX, no external service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from memtomem.config import RerankConfig
+    from memtomem.models import SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+class FastEmbedReranker:
+    """Cross-encoder reranking via ``fastembed.rerank.cross_encoder.TextCrossEncoder``.
+
+    Runs on the CPU via ONNX Runtime — no external server and no PyTorch
+    dependency. Reuses the ``memtomem[onnx]`` extra so enabling this provider
+    adds no new packages. The model is downloaded on first use and cached in
+    ``~/.cache/fastembed/``.
+    """
+
+    def __init__(self, config: RerankConfig) -> None:
+        self._config = config
+        self._model: object | None = None
+
+    def _get_model(self) -> object:
+        """Lazily construct the ``TextCrossEncoder`` — downloads on first use."""
+        if self._model is not None:
+            return self._model
+        try:
+            from fastembed.rerank.cross_encoder import (  # type: ignore[import-untyped]
+                TextCrossEncoder,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "fastembed is required for the fastembed reranker. "
+                "Install it with: pip install memtomem[onnx]"
+            ) from exc
+
+        try:
+            self._model = TextCrossEncoder(model_name=self._config.model)
+        except ValueError as exc:
+            supported = [m.get("model", "") for m in TextCrossEncoder.list_supported_models()]
+            raise ValueError(
+                f"fastembed reranker model {self._config.model!r} is not supported. "
+                f"Built-in options: {', '.join(sorted(s for s in supported if s))}. "
+                "For Korean/Chinese/Japanese try "
+                "'jinaai/jina-reranker-v2-base-multilingual' (1.1 GB); for lightweight "
+                "English 'Xenova/ms-marco-MiniLM-L-6-v2' (80 MB). Custom ONNX exports "
+                "must be registered via TextCrossEncoder.add_custom_model() before the "
+                "reranker is invoked."
+            ) from exc
+        logger.info("Loaded fastembed reranker: %s", self._config.model)
+        return self._model
+
+    def _rerank_sync(self, query: str, documents: list[str]) -> list[float]:
+        """Run inference synchronously — called inside ``asyncio.to_thread``."""
+        model = self._get_model()
+        # ``rerank`` returns an iterable of floats; materialize inside the
+        # thread so the caller doesn't block on lazy evaluation.
+        return [float(s) for s in model.rerank(query, documents)]  # type: ignore[attr-defined]
+
+    async def rerank(
+        self, query: str, results: list[SearchResult], top_k: int
+    ) -> list[SearchResult]:
+        from memtomem.models import SearchResult as SR
+
+        if not results:
+            return results
+
+        documents = [r.chunk.content for r in results]
+        try:
+            scores = await asyncio.to_thread(self._rerank_sync, query, documents)
+        except (ImportError, ValueError):
+            # Setup/config errors carry actionable hints — surface, don't hide.
+            raise
+        except Exception as exc:
+            logger.warning("FastEmbed rerank failed, returning original order: %s", exc)
+            return results[:top_k]
+
+        scored = sorted(zip(scores, results), key=lambda x: x[0], reverse=True)
+        return [
+            SR(chunk=r.chunk, score=float(s), rank=i + 1, source="reranked")
+            for i, (s, r) in enumerate(scored[:top_k])
+        ]
+
+    async def close(self) -> None:
+        self._model = None

--- a/packages/memtomem/tests/test_reranker_fastembed.py
+++ b/packages/memtomem/tests/test_reranker_fastembed.py
@@ -1,0 +1,112 @@
+"""Tests for the fastembed cross-encoder reranker provider."""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip(
+    "fastembed",
+    reason="fastembed not installed — install with `pip install memtomem[onnx]`",
+)
+
+
+def test_factory_wires_fastembed_provider() -> None:
+    """create_reranker must route provider='fastembed' to FastEmbedReranker."""
+    from memtomem.config import RerankConfig
+    from memtomem.search.reranker.factory import create_reranker
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    reranker = create_reranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="Xenova/ms-marco-MiniLM-L-6-v2",
+        )
+    )
+    assert isinstance(reranker, FastEmbedReranker)
+
+
+def test_init_does_not_load_model() -> None:
+    """FastEmbedReranker must lazy-load (mirrors LocalReranker contract)."""
+    from memtomem.config import RerankConfig
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    reranker = FastEmbedReranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="Xenova/ms-marco-MiniLM-L-6-v2",
+        )
+    )
+    assert reranker._model is None
+
+
+@pytest.mark.asyncio
+async def test_empty_results_skips_model_load() -> None:
+    """Empty input must short-circuit before touching the model."""
+    from memtomem.config import RerankConfig
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    reranker = FastEmbedReranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="Xenova/ms-marco-MiniLM-L-6-v2",
+        )
+    )
+    assert await reranker.rerank("query", [], top_k=5) == []
+    assert reranker._model is None
+
+
+@pytest.mark.asyncio
+async def test_unknown_model_error_surfaces_supported_hint() -> None:
+    """Misconfigured model names must produce a helpful ValueError at rerank
+    time — setup/config errors carry actionable hints, they should not be
+    swallowed by the graceful-degrade path."""
+    from pathlib import Path
+    from uuid import uuid4
+
+    from memtomem.config import RerankConfig
+    from memtomem.models import Chunk, ChunkMetadata, SearchResult
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    reranker = FastEmbedReranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="nonexistent/definitely-not-a-real-model",
+        )
+    )
+    chunk = Chunk(
+        content="any content",
+        metadata=ChunkMetadata(source_file=Path("/tmp/test.md")),
+        id=uuid4(),
+        embedding=[],
+    )
+    candidate = SearchResult(chunk=chunk, score=1.0, rank=1, source="fused")
+
+    with pytest.raises(ValueError) as excinfo:
+        await reranker.rerank("query", [candidate], top_k=5)
+
+    msg = str(excinfo.value)
+    assert "not supported" in msg
+    assert "Xenova/ms-marco-MiniLM-L-6-v2" in msg
+    assert "jinaai/jina-reranker-v2-base-multilingual" in msg
+    assert "add_custom_model" in msg
+
+
+async def test_close_resets_model() -> None:
+    """close() must release the cached model so the reranker can be reused."""
+    from memtomem.config import RerankConfig
+    from memtomem.search.reranker.fastembed import FastEmbedReranker
+
+    reranker = FastEmbedReranker(
+        RerankConfig(
+            enabled=True,
+            provider="fastembed",
+            model="Xenova/ms-marco-MiniLM-L-6-v2",
+        )
+    )
+    reranker._model = object()  # simulate loaded state
+    await reranker.close()
+    assert reranker._model is None


### PR DESCRIPTION
## Summary

- Adds a third reranker provider — `fastembed` — wiring `fastembed.rerank.cross_encoder.TextCrossEncoder` through the existing `Reranker` protocol. Runs entirely on the CPU via ONNX Runtime, no external service, no PyTorch; reuses the `memtomem[onnx]` extra so there are **no new dependencies**.
- Flips the default rerank config from `cohere` / `rerank-english-v3.0` to `fastembed` / `Xenova/ms-marco-MiniLM-L-6-v2` (~80 MB). Turning reranking on is now a single `rerank.enabled=true` toggle for new installs.
- `TextCrossEncoder.add_custom_model()` escape hatch is documented and plumbed through the error path (mirrors the bge-m3 recovery pattern from #221).

## Why flip the default

`provider=cohere` as the out-of-the-box default meant "enable the feature" required four settings (enable + provider + model + API key). That sits awkwardly against memtomem's local-first story and next to the already-local ONNX embedder. `fastembed` gives us symmetric local embedding + reranking out of the box, and the 80 MB MiniLM-L-6-v2 first-download cost is negligible next to the embedder's own download.

## Migration impact

| Prior setup | After upgrade |
|---|---|
| `rerank.enabled=false` (shipped default) | **No change** |
| `rerank.enabled=true` + `provider="cohere"` explicit | **No change** |
| `rerank.enabled=true` + `provider` implicit (was Cohere default) + Cohere API key | **Behavior changes.** Must set `provider: "cohere"` explicitly to keep Cohere; otherwise first rerank call downloads the 80 MB fastembed model. |
| `rerank.enabled=true` + `provider="local"` | **No change** |

CHANGELOG documents the migration path under `### Changed`.

## Design note — error hint placement

Factory-level `try/except` would be dead code because `FastEmbedReranker` is lazy-loaded (mirrors `LocalReranker`). Instead:

- `_get_model()` catches fastembed's native `ValueError` on unsupported model names and re-raises with the supported-model list + `add_custom_model` pointer.
- `rerank()` lets `ImportError` / `ValueError` propagate (config/setup errors carry actionable hints — hiding them was the whole anti-pattern we avoided). Runtime errors still graceful-degrade to the original fused order with a warning, matching `LocalReranker` semantics.

One of the new tests asserts the error-hint path explicitly.

## Multilingual guardrail

The default is English-only. For Korean/Chinese/Japanese/multilingual content users should set `rerank.model="jinaai/jina-reranker-v2-base-multilingual"` (~1.1 GB). This guidance lives in:

- `RerankConfig` class docstring (visible in IDE hover + `config.py`)
- `docs/guides/configuration.md` Rerank section (blockquote warning)

So misconfigured KR users get the hint before silent quality loss, without requiring them to read the CHANGELOG.

## Changes

- `packages/memtomem/src/memtomem/search/reranker/fastembed.py` — new, ~90 lines. `LocalReranker` pattern with `asyncio.to_thread` around blocking ONNX calls.
- `packages/memtomem/src/memtomem/search/reranker/factory.py` — `"fastembed"` branch + updated error message listing all three providers.
- `packages/memtomem/src/memtomem/config.py` — `RerankConfig` default flip + class docstring with provider-specific model-ID guide.
- `packages/memtomem/tests/test_reranker_fastembed.py` — 5 new tests: factory routing, lazy init, empty-passthrough skips load, unknown-model error-hint surfacing, close resets model.
- `CHANGELOG.md` — `### Added` (fastembed provider) + `### Changed` (default flip with impact matrix).
- `docs/guides/configuration.md` — Rerank section rewrite: updated env-var table, provider-specific model IDs, multilingual warning.

Explicitly **not** touched (verified via grep): `README.md`, `packages/memtomem/README.md`, `docs/guides/search-pipeline.md` — none reference reranking (the last doesn't exist). Keeping scope tight per `feedback_one_change_per_pr`.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — passes.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — passes.
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — **1555 passed**, 46 deselected, 2 warnings (pre-existing fastembed MiniLM-L12 pooling notice documented in #221's CHANGELOG entry).
- [x] Existing 10 reranker tests still pass (`test_reranker.py::Test{Cohere,Local}Reranker`, `TestRerankerFactory::test_{disabled,cohere,local,unknown_raises}`) — confirms the default flip does not break explicit-provider config paths.

## Follow-ups (out of scope)

- **Ollama reranker** — opening as `need-design` issue. Three possible semantics (LLM-as-judge, embedding-cosine, community bge-reranker model) do not cleanly share the cross-encoder contract; design decision should gate any implementation.
- **`fastembed_version` marker in SQLite meta** — already tracked in auto-memory (`project_bge_m3_fastembed_regression.md`) as deferred; trigger is real drift evidence, not proactive implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)