### PR TITLE
feat(wizard): add optional reranker step with EN/multilingual choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ uv tool install memtomem             # or: pipx install memtomem
 ### 2. Setup
 
 ```bash
-mm init                               # 8-step wizard (or: mm init -y for CI)
+mm init                               # 9-step wizard (or: mm init -y for CI)
 ```
 
 The wizard picks your embedding provider, points at the folder you want indexed, and registers memtomem with your AI editor. The default is **keyword-only** (BM25, no external dependencies) — you can also pick ONNX (local, no server), Ollama (local server), or OpenAI (cloud). See [Embeddings](docs/guides/embeddings.md) for details.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -118,7 +118,7 @@ mm init         # PyPI global install
 uv run mm init  # Project or source install
 ```
 
-The wizard walks you through 8 steps. Type `b` to go back, `q` to quit at any step.
+The wizard walks you through 9 steps. Type `b` to go back, `q` to quit at any step.
 
 #### Non-interactive mode (CI / automation)
 
@@ -133,13 +133,14 @@ mm init -y --memory-dir ~/notes --mcp claude            # custom dir + Claude Co
 ```
 
 1. **Embedding provider** — BM25-only (default, zero-dependency), Local ONNX (no server), Ollama (local server), or OpenAI (cloud)
-2. **Memory directory** — where your notes live (e.g., `~/notes`, `~/memories`)
-3. **Storage** — SQLite database path (default: `~/.memtomem/memtomem.db`)
-4. **Namespace** — auto-assign namespace from folder name (e.g., `~/docs` → `docs`)
-5. **Search** — number of results per query (default: 10), time-decay toggle
-6. **Language** — tokenizer selection: Unicode (default) or Korean (kiwipiepy)
-7. **Claude Code hooks** — optional hook integration via settings.json
-8. **Editor connection** — Claude Code auto-setup, .mcp.json generation, or manual
+2. **Reranker (optional)** — off by default; opt-in to a local fastembed cross-encoder. Korean/Chinese/Japanese/mixed content should pick the multilingual model
+3. **Memory directory** — where your notes live (e.g., `~/notes`, `~/memories`)
+4. **Storage** — SQLite database path (default: `~/.memtomem/memtomem.db`)
+5. **Namespace** — auto-assign namespace from folder name (e.g., `~/docs` → `docs`)
+6. **Search** — number of results per query (default: 10), time-decay toggle
+7. **Language** — tokenizer selection: Unicode (default) or Korean (kiwipiepy)
+8. **Claude Code hooks** — optional hook integration via settings.json
+9. **Editor connection** — Claude Code auto-setup, .mcp.json generation, or manual
 
 After the wizard, your MCP server is ready. Skip to [First use](#first-use) if you ran the wizard.
 

--- a/docs/guides/hands-on-tutorial.md
+++ b/docs/guides/hands-on-tutorial.md
@@ -37,7 +37,9 @@ ollama pull nomic-embed-text     # English-primary (768d, 270MB)
 
 The wizard (`mm init`) writes the chosen provider into
 `~/.memtomem/config.json`; for this tutorial you can also leave the
-default and skip ahead.
+default and skip ahead. The wizard also offers an optional **reranker**
+step right after embedding — press Enter to skip, or opt in and pick the
+multilingual model if you work with Korean/Chinese/Japanese content.
 
 ### 1.2 Connect the MCP Server
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -1,7 +1,7 @@
 # MCP Client Configuration Guide
 
 **Audience**: Users who want to connect memtomem to a specific AI editor
-**Prerequisite**: [Getting Started](getting-started.md) complete (embedding path picked — BM25 default, or ONNX / Ollama / OpenAI via the wizard)
+**Prerequisite**: [Getting Started](getting-started.md) complete (embedding path picked — BM25 default, or ONNX / Ollama / OpenAI via the wizard; optional cross-encoder reranker)
 **Estimated Time**: ~5 minutes
 
 > **Which editor should I use?**

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -15,8 +15,8 @@ Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + s
 # 1. Install memtomem (requires Python 3.12+)
 uv tool install memtomem        # or: pipx install memtomem
 
-# 2. Run the 8-step setup wizard
-#    (picks embedding provider, memory folder, MCP editor)
+# 2. Run the 9-step setup wizard
+#    (picks embedding provider, optional reranker, memory folder, MCP editor)
 mm init    # on PATH after `uv tool install` — no `uv run` needed
 ```
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -214,8 +214,36 @@ def _step_embedding(state: dict) -> None:
     click.echo()
 
 
+def _step_reranker(state: dict) -> None:
+    step_header(2, "Reranker (optional)")
+    click.echo("  Cross-encoder reranking sharpens search relevance after BM25+dense fusion.")
+    click.echo("  Runs locally via fastembed ONNX — no API key, no server.")
+    enabled = nav_confirm("  Enable reranker?", default=False)
+    if not enabled:
+        state["rerank_enabled"] = False
+        click.echo()
+        return
+
+    click.echo()
+    click.echo("  Available models:")
+    click.echo("    [1] English (Xenova/ms-marco-MiniLM-L-6-v2) — 80 MB")
+    click.echo("    [2] Multilingual (jinaai/jina-reranker-v2-base-multilingual) — 1.1 GB")
+    click.echo("        Recommended for Korean/Chinese/Japanese/mixed content.")
+    choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
+
+    models = {
+        1: "Xenova/ms-marco-MiniLM-L-6-v2",
+        2: "jinaai/jina-reranker-v2-base-multilingual",
+    }
+    state["rerank_enabled"] = True
+    state["rerank_model"] = models[choice]
+    click.secho(f"  Reranker '{models[choice]}' selected.", fg="green")
+    click.echo("  Model downloads on first search (~/.cache/fastembed/).")
+    click.echo()
+
+
 def _step_memory_dir(state: dict) -> None:
-    step_header(2, "Memory Directory")
+    step_header(3, "Memory Directory")
     click.echo("  Where are the files you want to index?")
     memory_dir = nav_prompt("  Directory", default="~/memories")
     memory_path = Path(memory_dir).expanduser()
@@ -229,7 +257,7 @@ def _step_memory_dir(state: dict) -> None:
 
 
 def _step_storage(state: dict) -> None:
-    step_header(3, "Storage")
+    step_header(4, "Storage")
     config_dir = Path("~/.memtomem").expanduser()
     db_default = str(config_dir / "memtomem.db")
     state["db_path"] = nav_prompt("  SQLite DB path", default=db_default)
@@ -237,7 +265,7 @@ def _step_storage(state: dict) -> None:
 
 
 def _step_namespace(state: dict) -> None:
-    step_header(4, "Namespace")
+    step_header(5, "Namespace")
     click.echo("  Organize memories into scoped groups (work, personal, project).")
     state["enable_auto_ns"] = nav_confirm(
         "  Auto-assign namespace from folder name? (~/docs → 'docs')", default=False
@@ -247,7 +275,7 @@ def _step_namespace(state: dict) -> None:
 
 
 def _step_search(state: dict) -> None:
-    step_header(5, "Search")
+    step_header(6, "Search")
     state["top_k"] = nav_prompt("  Results per search", type=click.INT, default=10)
     state["decay_enabled"] = nav_confirm(
         "  Enable time-decay? (older memories rank lower)", default=False
@@ -256,7 +284,7 @@ def _step_search(state: dict) -> None:
 
 
 def _step_language(state: dict) -> None:
-    step_header(6, "Language")
+    step_header(7, "Language")
     click.echo("  Search tokenizer:")
     click.echo("    [1] Unicode (default — English and most languages)")
     click.echo("    [2] Korean (kiwipiepy — better Korean word splitting)")
@@ -275,7 +303,7 @@ def _step_language(state: dict) -> None:
 
 
 def _step_settings(state: dict) -> None:
-    step_header(7, "Claude Code Hooks")
+    step_header(8, "Claude Code Hooks")
 
     # Skip entirely if Claude Code is not installed
     claude_dir = Path.home() / ".claude"
@@ -318,7 +346,7 @@ def _step_settings(state: dict) -> None:
 
 
 def _step_mcp(state: dict) -> None:
-    step_header(8, "Connect to AI Editor")
+    step_header(9, "Connect to AI Editor")
     click.echo("  How do you want to connect memtomem?")
     click.echo("    [1] Claude Code (run 'claude mcp add' automatically)")
     click.echo("    [2] Generate .mcp.json (for Cursor, Windsurf, etc.)")
@@ -374,6 +402,12 @@ def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None
         init_data["embedding"]["base_url"] = "http://localhost:11434"
     if state.get("api_key"):
         init_data["embedding"]["api_key"] = state["api_key"]
+    if state.get("rerank_enabled"):
+        init_data["rerank"] = {
+            "enabled": True,
+            "provider": "fastembed",
+            "model": state["rerank_model"],
+        }
 
     # Merge: init fields overwrite, non-init sections/fields preserved
     for section, fields in init_data.items():
@@ -436,6 +470,8 @@ def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None
         click.echo("  Provider:   none (BM25 keyword search only)")
     else:
         click.echo(f"  Provider:   {state['provider']}/{state['model']} ({state['dimension']}d)")
+    if state.get("rerank_enabled"):
+        click.echo(f"  Reranker:   fastembed/{state['rerank_model']}")
     click.echo(f"  Storage:    {state['db_path']}")
     click.echo(f"  Memory:     {state['memory_dir']}")
     ns_label = "auto" if state["enable_auto_ns"] else "manual"
@@ -578,6 +614,7 @@ def init(
                 "model": _model,
                 "dimension": _dimension,
                 "api_key": api_key or "",
+                "rerank_enabled": False,
                 "memory_dir": _memory_dir,
                 "db_path": db_path or str(Path("~/.memtomem").expanduser() / "memtomem.db"),
                 "enable_auto_ns": auto_ns,
@@ -591,6 +628,7 @@ def init(
     else:
         steps = [
             _step_embedding,
+            _step_reranker,
             _step_memory_dir,
             _step_storage,
             _step_namespace,

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -61,6 +61,7 @@ def _make_init_state(tmp_path: Path) -> dict:
         "top_k": 10,
         "tokenizer": "unicode61",
         "decay_enabled": False,
+        "rerank_enabled": False,
         # Non-config keys required by _write_config_and_summary
         "mcp_choice": 3,  # skip MCP setup
         "settings_hooks": False,
@@ -130,6 +131,68 @@ class TestInitConfigMerge:
         data = json.loads(config_path.read_text(encoding="utf-8"))
         assert data["embedding"]["provider"] == "none"
         assert data["search"]["default_top_k"] == 10
+
+
+class TestRerankerStep:
+    """`_step_reranker` writes an optional `rerank` section into config.json."""
+
+    def test_rerank_disabled_writes_no_section(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the user skips the reranker step, config.json must not gain a
+        `rerank` section (so defaults remain in effect and re-init doesn't
+        resurrect a stale enabled flag)."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert "rerank" not in data
+
+    def test_rerank_enabled_writes_multilingual_model(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Enabling reranker with multilingual model writes provider=fastembed
+        and the jina multilingual model ID."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)
+        state["rerank_enabled"] = True
+        state["rerank_model"] = "jinaai/jina-reranker-v2-base-multilingual"
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert data["rerank"] == {
+            "enabled": True,
+            "provider": "fastembed",
+            "model": "jinaai/jina-reranker-v2-base-multilingual",
+        }
+
+    def test_rerank_disabled_preserves_existing_rerank_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-running init with reranker disabled must not clobber a rerank
+        section the user added manually (e.g. custom top_k)."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps({"rerank": {"enabled": True, "top_k": 50}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["rerank"]["enabled"] is True
+        assert data["rerank"]["top_k"] == 50
 
 
 def test_write_config_and_summary_without_base_dir_falls_back_to_home(


### PR DESCRIPTION
## Summary
- `mm init` asks **Enable reranker?** right after the embedding step. Opt-in only — default stays disabled.
- When enabled, the user picks between fastembed EN default (`Xenova/ms-marco-MiniLM-L-6-v2`, 80 MB) and the jina multilingual model (`jinaai/jina-reranker-v2-base-multilingual`, 1.1 GB). Multilingual is clearly flagged as the right choice for Korean/Chinese/Japanese/mixed content, where the EN default noticeably degrades quality.
- Provider is fixed to `fastembed` (local ONNX, no API key, no server). Cohere and sentence-transformers remain available via manual config edits.
- Config merge is conservative: re-running the wizard with reranker disabled does **not** remove an existing `rerank` section (user-tuned `top_k`, or manual enable, survives re-init).
- Non-interactive `mm init -y` is unchanged — no new CLI flags.
- Docs fanout (5 files) updates the step count 8 → 9 and mentions the new step: getting-started walkthrough, hands-on tutorial Step 1, mcp-clients prerequisite line, root README, `packages/memtomem/README.md`.

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -v` — 9 pass (3 new in `TestRerankerStep`)
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean
- [x] Manual `mm init` in isolated worktree (HOME override): embedding BM25 → reranker enable → multilingual → `config.json.rerank == {enabled: true, provider: "fastembed", model: "jinaai/jina-reranker-v2-base-multilingual"}`; summary line `Reranker: fastembed/jinaai/jina-reranker-v2-base-multilingual` shown
- [x] Back-nav: `b` at the reranker step returns to the embedding step; `q` cancels cleanly
- [x] `mm init -y` writes no `rerank` section (regression) — verified with `jq 'has("rerank")' == false`

## Out of scope
- Ollama-based reranker (separate need-design issue)
- Cohere / sentence-transformers provider selection inside the wizard (stays manual)