### PR TITLE
feat(chunking): semantic packing + tail sweep for short merged chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `Xenova/ms-marco-MiniLM-L-6-v2`,
   `jinaai/jina-reranker-v2-base-multilingual`) plus custom ONNX exports
   via `TextCrossEncoder.add_custom_model()`.
+- **Chunking semantic pack**: new `indexing.target_chunk_tokens` (default
+  384) drives a greedy Pass 2 that packs short hierarchy-compatible
+  siblings/ancestor-descendants up to the target, plus a Pass 3 tail
+  backward sweep for final-chunk orphans. Short orphans in Pass 1 are now
+  rescued across sub-heading divergence as long as they share a top-level
+  root (mem_add entries with distinct roots still stay separate). Set
+  `target_chunk_tokens=0` to restore the pre-PR merge behaviour.
 - **ReStructuredText chunker**: `.rst` section-header-aware splitting.
 - **Web UI `--open` flag**: opt-in browser launch with configurable timeout
   (replaces the old always-open default).

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -113,12 +113,19 @@ class IndexingConfig(BaseSettings):
     )
     max_chunk_tokens: int = 512
     min_chunk_tokens: int = 128
+    # Soft goal for semantic packing: merge adjacent short siblings while
+    # cur < target and combined <= max. Set to 0 to disable Pass 2 packing.
+    target_chunk_tokens: int = 384
     chunk_overlap_tokens: int = 0
     structured_chunk_mode: str = "original"  # "original" or "recursive"
     paragraph_split_threshold: int = 800  # split long prose into paragraphs above this token count
 
     @field_validator(
-        "max_chunk_tokens", "min_chunk_tokens", "chunk_overlap_tokens", "paragraph_split_threshold"
+        "max_chunk_tokens",
+        "min_chunk_tokens",
+        "target_chunk_tokens",
+        "chunk_overlap_tokens",
+        "paragraph_split_threshold",
     )
     @classmethod
     def must_be_non_negative(cls, v: int, info: ValidationInfo) -> int:
@@ -131,6 +138,11 @@ class IndexingConfig(BaseSettings):
         if self.min_chunk_tokens > self.max_chunk_tokens:
             raise ValueError(
                 f"min_chunk_tokens ({self.min_chunk_tokens}) must be "
+                f"<= max_chunk_tokens ({self.max_chunk_tokens})"
+            )
+        if self.target_chunk_tokens > self.max_chunk_tokens:
+            raise ValueError(
+                f"target_chunk_tokens ({self.target_chunk_tokens}) must be "
                 f"<= max_chunk_tokens ({self.max_chunk_tokens})"
             )
         return self
@@ -367,6 +379,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
     "indexing": {
         "max_chunk_tokens",
         "min_chunk_tokens",
+        "target_chunk_tokens",
         "chunk_overlap_tokens",
         "structured_chunk_mode",
     },
@@ -386,6 +399,7 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     "search.tokenizer": {"type": str, "allowed": {"unicode61", "kiwipiepy"}},
     "indexing.max_chunk_tokens": {"type": int, "min": 64, "max": 8192},
     "indexing.min_chunk_tokens": {"type": int, "min": 0, "max": 256},
+    "indexing.target_chunk_tokens": {"type": int, "min": 0, "max": 8192},
     "indexing.chunk_overlap_tokens": {"type": int, "min": 0, "max": 512},
     "indexing.structured_chunk_mode": {"type": str, "allowed": {"original", "recursive"}},
     "embedding.batch_size": {"type": int, "min": 1, "max": 1024},

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -268,6 +268,7 @@ class IndexEngine:
             new_chunks,
             self._config.min_chunk_tokens,
             self._config.max_chunk_tokens,
+            self._config.target_chunk_tokens,
         )
         if self._config.chunk_overlap_tokens > 0:
             new_chunks = _add_overlap(new_chunks, self._config.chunk_overlap_tokens)
@@ -494,14 +495,28 @@ def _estimate_tokens(text: str) -> int:
     return max(1, len(text) // ratio)
 
 
-def _can_merge(current: Chunk, nxt: Chunk) -> bool:
+def _is_strict_prefix(shorter: tuple[str, ...], longer: tuple[str, ...]) -> bool:
+    """True when ``shorter`` is a proper prefix of ``longer`` (ancestor→descendant)."""
+    return len(shorter) < len(longer) and longer[: len(shorter)] == shorter
+
+
+def _can_merge(current: Chunk, nxt: Chunk, *, current_is_short: bool = False) -> bool:
     """Check if two chunks can be merged.
 
-    Same-file + same-hierarchy is always allowed.
-    A headingless chunk (empty hierarchy, e.g. frontmatter) can merge into
-    the next chunk, adopting its hierarchy.
-    Sibling headings (same parent, depth >= 2) can merge when short.
-    Top-level headings (depth 1, e.g. mem_add entries) stay independent.
+    Guiding principle: "작을 때 관대, 클 때 엄격" — short chunks relax the
+    hierarchy gate down to "shares a top-level root"; larger chunks still
+    need structural kinship (identical / headingless / sibling / same-path
+    ancestor-descendant).
+
+    Why "shares a top-level root" rather than full hierarchy bypass:
+    distinct top-level entries in the same file (e.g. mem_add writes H2
+    entries like ``## Cache Decision`` / ``## Database Decision``) are
+    semantically independent and must stay separate even when short.
+    Cross-subsection orphans within the same document share the same H1
+    root and therefore still get rescued.
+
+    ``current_is_short=True`` is set by Pass 1 and Pass 3 (tail sweep); Pass 2
+    (greedy packing) uses the strict kinship rules only.
     """
     if current.metadata.source_file != nxt.metadata.source_file:
         return False
@@ -510,25 +525,39 @@ def _can_merge(current: Chunk, nxt: Chunk) -> bool:
     # Allow headingless short chunk to merge forward into the next section
     if not current.metadata.heading_hierarchy:
         return True
-    # Allow sibling heading merge (same parent, depth >= 2)
     ch = current.metadata.heading_hierarchy
     nh = nxt.metadata.heading_hierarchy
+    # Sibling: same direct parent, depth >= 2
     if len(ch) >= 2 and len(nh) >= 2 and ch[:-1] == nh[:-1]:
+        return True
+    # Same-path ancestor-descendant: parent section body next to its own
+    # subsection (e.g. ``## 4`` intro body + ``## 4 > ### X``).
+    if _is_strict_prefix(ch, nh) or _is_strict_prefix(nh, ch):
+        return True
+    # Short-chunk leniency: merge across sub-heading divergence as long as
+    # both chunks live under the same top-level root.
+    if current_is_short and nh and ch[0] == nh[0]:
         return True
     return False
 
 
 def _merged_hierarchy(current: Chunk, nxt: Chunk) -> tuple[str, ...]:
-    """Pick the appropriate heading hierarchy when merging two chunks.
+    """Pick the heading hierarchy for a merged chunk.
 
-    For identical or headingless merges, use the more specific one.
-    For sibling merges, keep only the common parent prefix.
+    - Identical / headingless: use the more specific one.
+    - Otherwise: keep the common prefix; diverging leaves on either side are
+      dropped from the hierarchy and restored inline via
+      ``_build_merged_content``.
+
+    Common-prefix unification (rather than descendant promotion) keeps chained
+    merges honest: once a sibling-merge has already collapsed a hierarchy to
+    its common ancestor, a later ancestor→descendant step could otherwise
+    relabel the merged chunk with just one child's heading.
     """
     ch = current.metadata.heading_hierarchy
     nh = nxt.metadata.heading_hierarchy
     if ch == nh or not ch:
         return nh or ch
-    # Sibling merge: keep common parent headings only
     common: list[str] = []
     for a, b in zip(ch, nh):
         if a == b:
@@ -538,65 +567,130 @@ def _merged_hierarchy(current: Chunk, nxt: Chunk) -> tuple[str, ...]:
     return tuple(common) if common else nh
 
 
+def _prepend_dropped_headings(content: str, dropped: tuple[str, ...]) -> str:
+    """Prefix ``content`` with heading lines that would otherwise be lost.
+
+    Used on sibling merges where the common-prefix resolution drops each
+    chunk's diverging leaf heading(s).
+    """
+    if not dropped:
+        return content
+    header = "\n".join(dropped)
+    return f"{header}\n\n{content}"
+
+
+def _build_merged_content(current: Chunk, nxt: Chunk, merged_hierarchy: tuple[str, ...]) -> str:
+    """Concatenate two chunks' bodies, restoring any headings dropped by
+    hierarchy resolution so retrieval keeps the breadcrumb signal.
+    """
+    ch = current.metadata.heading_hierarchy
+    nh = nxt.metadata.heading_hierarchy
+    dropped_ch = ch[len(merged_hierarchy) :]
+    dropped_nh = nh[len(merged_hierarchy) :]
+    left = _prepend_dropped_headings(current.content, dropped_ch)
+    right = _prepend_dropped_headings(nxt.content, dropped_nh)
+    return f"{left}\n\n{right}"
+
+
+def _merge_pair(current: Chunk, nxt: Chunk) -> Chunk:
+    """Produce a single Chunk by merging ``current`` and ``nxt``."""
+    hierarchy = _merged_hierarchy(current, nxt)
+    content = _build_merged_content(current, nxt, hierarchy)
+    return Chunk(
+        content=content,
+        metadata=ChunkMetadata(
+            source_file=current.metadata.source_file,
+            heading_hierarchy=hierarchy,
+            chunk_type=current.metadata.chunk_type,
+            start_line=current.metadata.start_line,
+            end_line=nxt.metadata.end_line,
+            language=current.metadata.language,
+            tags=tuple(set(current.metadata.tags) | set(nxt.metadata.tags)),
+            namespace=current.metadata.namespace,
+        ),
+    )
+
+
 def _merge_short_chunks(
     chunks: list[Chunk],
     min_tokens: int,
     max_tokens: int = 0,
+    target_tokens: int = 0,
 ) -> list[Chunk]:
-    """Merge consecutive same-source chunks so each is >= min_tokens and < max_tokens.
+    """Merge consecutive same-source chunks into semantically coherent groups.
 
-    Strategy:
-    - Walk forward through chunks.
-    - While the current accumulated chunk is below min_tokens, merge the next
-      chunk — but only if the result stays below max_tokens.
-    - Headingless chunks (e.g. frontmatter) are merged into the following
-      section so they don't become orphan micro-chunks.
-    - If merging would exceed max_tokens, stop and emit what we have.
+    Three passes:
+    - Pass 1 (min enforcement): forward-merge while cur < min_tokens, ignoring
+      the hierarchy gate so orphan micro-chunks (frontmatter, stray short
+      sections) always get absorbed.
+    - Pass 2 (greedy packing): when ``target_tokens`` > 0, keep packing adjacent
+      hierarchy-compatible siblings/descendants while cur < target AND
+      combined <= max. Set ``target_tokens=0`` to disable.
+    - Pass 3 (tail backward sweep): if the final chunk is still < min, try
+      merging it into its predecessor once.
+
+    ``max_tokens`` caps every merge; ``min_tokens <= 0`` skips all passes.
     """
     if min_tokens <= 0 or len(chunks) <= 1:
         return chunks
 
-    # When max_tokens is not set or too small, use a generous default
     if max_tokens <= min_tokens:
         max_tokens = max(min_tokens * 4, 512)
 
-    result: list[Chunk] = []
+    # ---- Pass 1: min enforcement (hierarchy-agnostic) ----
+    pass1: list[Chunk] = []
     i = 0
     while i < len(chunks):
         c = chunks[i]
         cur_tokens = _estimate_tokens(c.content)
-
-        # Accumulate short chunks by merging forward
-        while cur_tokens < min_tokens and i + 1 < len(chunks) and _can_merge(c, chunks[i + 1]):
+        while (
+            cur_tokens < min_tokens
+            and i + 1 < len(chunks)
+            and _can_merge(c, chunks[i + 1], current_is_short=True)
+        ):
             nxt = chunks[i + 1]
-            nxt_tokens = _estimate_tokens(nxt.content)
-            merged_tokens = cur_tokens + nxt_tokens + 1  # +1 for separator
-
-            # Stop merging if result would exceed max_tokens
-            if merged_tokens >= max_tokens:
+            merged_tokens = cur_tokens + _estimate_tokens(nxt.content) + 1
+            if merged_tokens > max_tokens:
                 break
-
-            hierarchy = _merged_hierarchy(c, nxt)
-            merged_content = c.content + "\n\n" + nxt.content
-            c = Chunk(
-                content=merged_content,
-                metadata=ChunkMetadata(
-                    source_file=c.metadata.source_file,
-                    heading_hierarchy=hierarchy,
-                    chunk_type=c.metadata.chunk_type,
-                    start_line=c.metadata.start_line,
-                    end_line=nxt.metadata.end_line,
-                    language=c.metadata.language,
-                    tags=tuple(set(c.metadata.tags) | set(nxt.metadata.tags)),
-                    namespace=c.metadata.namespace,
-                ),
-            )
+            c = _merge_pair(c, nxt)
             cur_tokens = _estimate_tokens(c.content)
             i += 1
-
-        result.append(c)
+        pass1.append(c)
         i += 1
-    return result
+
+    # ---- Pass 2: greedy packing (hierarchy-respecting) ----
+    if target_tokens > min_tokens and len(pass1) > 1:
+        pass2: list[Chunk] = []
+        i = 0
+        while i < len(pass1):
+            c = pass1[i]
+            cur_tokens = _estimate_tokens(c.content)
+            while cur_tokens < target_tokens and i + 1 < len(pass1) and _can_merge(c, pass1[i + 1]):
+                nxt = pass1[i + 1]
+                merged_tokens = cur_tokens + _estimate_tokens(nxt.content) + 1
+                if merged_tokens > max_tokens:
+                    break
+                c = _merge_pair(c, nxt)
+                cur_tokens = _estimate_tokens(c.content)
+                i += 1
+            pass2.append(c)
+            i += 1
+    else:
+        pass2 = pass1
+
+    # ---- Pass 3: tail backward sweep ----
+    if len(pass2) >= 2:
+        last = pass2[-1]
+        last_tokens = _estimate_tokens(last.content)
+        if last_tokens < min_tokens:
+            prev = pass2[-2]
+            prev_tokens = _estimate_tokens(prev.content)
+            combined = prev_tokens + last_tokens + 1
+            if combined <= max_tokens and _can_merge(prev, last, current_is_short=True):
+                pass2[-2] = _merge_pair(prev, last)
+                pass2.pop()
+
+    return pass2
 
 
 def _add_overlap(chunks: list[Chunk], overlap_tokens: int) -> list[Chunk]:

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -144,6 +144,7 @@ def _build_config_response(cfg) -> ConfigResponse:
             supported_extensions=sorted(cfg.indexing.supported_extensions),
             max_chunk_tokens=cfg.indexing.max_chunk_tokens,
             min_chunk_tokens=cfg.indexing.min_chunk_tokens,
+            target_chunk_tokens=cfg.indexing.target_chunk_tokens,
             chunk_overlap_tokens=cfg.indexing.chunk_overlap_tokens,
             structured_chunk_mode=cfg.indexing.structured_chunk_mode,
         ),

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -38,6 +38,7 @@ class ConfigIndexingOut(BaseModel):
     supported_extensions: list[str]
     max_chunk_tokens: int
     min_chunk_tokens: int = 0
+    target_chunk_tokens: int = 0
     chunk_overlap_tokens: int = 0
     structured_chunk_mode: str = "original"
 

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -20,6 +20,7 @@ const _CONFIG_LABELS = {
   mmr:       { enabled: 'Enabled', lambda_param: 'Lambda' },
   indexing:  { memory_dirs: 'Memory Dirs', supported_extensions: 'Extensions',
                 max_chunk_tokens: 'Max Chunk Tokens', min_chunk_tokens: 'Min Chunk Tokens',
+                target_chunk_tokens: 'Target Chunk Tokens',
                 chunk_overlap_tokens: 'Chunk Overlap', structured_chunk_mode: 'Structured Chunk Mode' },
   namespace: { default_namespace: 'Default NS', enable_auto_ns: 'Auto NS' },
 };
@@ -783,8 +784,8 @@ async function _saveSection(section) {
 
 // Fields that require reindex or FTS rebuild after change
 const _REINDEX_FIELDS = new Set([
-  'indexing.max_chunk_tokens', 'indexing.min_chunk_tokens', 'indexing.chunk_overlap_tokens',
-  'indexing.structured_chunk_mode',
+  'indexing.max_chunk_tokens', 'indexing.min_chunk_tokens', 'indexing.target_chunk_tokens',
+  'indexing.chunk_overlap_tokens', 'indexing.structured_chunk_mode',
 ]);
 const _FTS_REBUILD_FIELDS = new Set([
   'search.tokenizer',

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -263,13 +263,30 @@ class TestMergeShortChunks:
         assert "short" in result[0].content
         assert "also short" in result[0].content
 
-    def test_no_merge_different_headings(self):
-        """Chunks from different headings should NOT merge (BUG-3 fix)."""
+    def test_distinct_root_short_chunks_stay_separate(self):
+        """Short chunks under distinct top-level roots (e.g. mem_add entries
+        ``## Cache Decision`` vs ``## Database Decision``) must not merge,
+        even when both are below min_tokens.
+        """
         c1 = _make_chunk_with("section one", heading=("H1",))
         c2 = _make_chunk_with("section two", heading=("H2",))
 
         result = _merge_short_chunks([c1, c2], min_tokens=50, max_tokens=2000)
         assert len(result) == 2
+
+    def test_short_cross_subsection_same_root_merges(self):
+        """Short orphan in a subsection merges with the next subsection
+        when both share the same top-level root (rescues audit-doc-style
+        cross-``##`` micro-chunks).
+        """
+        summary = _make_chunk_with("short summary", heading=("# Root", "## Summary"))
+        first = _make_chunk_with(
+            "section body " * 40,
+            heading=("# Root", "## 1. Findings", "### Critical Files"),
+        )
+
+        result = _merge_short_chunks([summary, first], min_tokens=128, max_tokens=2000)
+        assert len(result) == 1
 
     def test_no_merge_different_sources(self):
         """Chunks from different source files should NOT merge."""
@@ -356,11 +373,15 @@ class TestMergeShortChunks:
         result = _merge_short_chunks([big], min_tokens=50, max_tokens=2000)
         assert len(result) == 1
 
-    def test_two_different_headings_still_separate(self):
-        """Two chunks with different (non-empty) headings should NOT merge."""
-        c1 = _make_chunk_with("section one", heading=("## A",))
-        c2 = _make_chunk_with("section two", heading=("## B",))
-        result = _merge_short_chunks([c1, c2], min_tokens=50, max_tokens=2000)
+    def test_long_different_headings_stay_separate(self):
+        """Long chunks (above min) with different headings stay separate.
+
+        Pass 2 greedy packing respects the hierarchy gate — cross-heading
+        merges are only allowed while a chunk is below min_tokens.
+        """
+        c1 = _make_chunk_with("x" * 600, heading=("## A",))  # ~200 tokens
+        c2 = _make_chunk_with("y" * 600, heading=("## B",))  # ~200 tokens
+        result = _merge_short_chunks([c1, c2], min_tokens=128, max_tokens=512, target_tokens=384)
         assert len(result) == 2
 
     def test_headingless_respects_max_tokens(self):

--- a/packages/memtomem/tests/test_merge_semantic_pack.py
+++ b/packages/memtomem/tests/test_merge_semantic_pack.py
@@ -1,0 +1,125 @@
+"""Per-failure-mode tests for the three-pass merge in _merge_short_chunks.
+
+Each test pins one behaviour so regressions surface at the exact pass that
+broke: Pass 1 (min enforcement, hierarchy-agnostic), Pass 2 (greedy packing,
+hierarchy-respecting), Pass 3 (tail backward sweep).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.indexing.engine import _merge_short_chunks
+from memtomem.models import Chunk, ChunkMetadata
+
+
+def _chunk(
+    content: str,
+    heading: tuple[str, ...] = (),
+    source: str = "/tmp/t.md",
+) -> Chunk:
+    return Chunk(
+        content=content,
+        metadata=ChunkMetadata(
+            source_file=Path(source),
+            heading_hierarchy=heading,
+        ),
+    )
+
+
+class TestSemanticPack:
+    def test_ancestor_absorbs_short_parent(self):
+        """Pass 1: short parent absorbs descendant under same root.
+
+        Common-prefix unification keeps hierarchy honest across chained
+        merges; the dropped descendant heading is prepended to the body so
+        retrieval still picks up the subsection signal.
+        """
+        parent = _chunk("x" * 120, heading=("# A",))  # ~30 tokens
+        child = _chunk("y" * 1600, heading=("# A", "## B"))  # ~400 tokens
+
+        result = _merge_short_chunks(
+            [parent, child], min_tokens=128, max_tokens=512, target_tokens=0
+        )
+        assert len(result) == 1
+        # Common-prefix rule: hierarchy collapses to the shared ancestor.
+        assert result[0].metadata.heading_hierarchy == ("# A",)
+        # Both bodies preserved and dropped heading restored inline
+        assert "x" * 120 in result[0].content
+        assert "y" * 1600 in result[0].content
+        assert "## B" in result[0].content
+
+    def test_sibling_pack_up_to_target(self):
+        """Pass 2: 3× 200-token siblings with target=384 produce exactly 2 chunks.
+
+        Packing stops as soon as cur >= target (400 >= 384), leaving the
+        third sibling alone. Enforces the target-as-soft-goal semantics.
+        """
+        s1 = _chunk("x" * 800, heading=("# P", "## S1"))  # ~200 tokens
+        s2 = _chunk("y" * 800, heading=("# P", "## S2"))
+        s3 = _chunk("z" * 800, heading=("# P", "## S3"))
+
+        result = _merge_short_chunks(
+            [s1, s2, s3], min_tokens=128, max_tokens=512, target_tokens=384
+        )
+        assert len(result) == 2
+
+    def test_tail_orphan_merged_backward(self):
+        """Pass 3: final short chunk merges backward into its predecessor."""
+        head = _chunk("x" * 800, heading=("# A",))  # ~200 tokens, above min
+        tail = _chunk("y" * 120, heading=("# A",))  # ~30 tokens, below min, alone
+
+        result = _merge_short_chunks([head, tail], min_tokens=128, max_tokens=512, target_tokens=0)
+        assert len(result) == 1
+        assert "y" * 120 in result[0].content
+
+    def test_max_ceiling_respected(self):
+        """Pass 2: combined > max blocks merge even when cur < target."""
+        big1 = _chunk("x" * 1200, heading=("# P", "## S1"))  # ~300 tokens
+        big2 = _chunk("y" * 1200, heading=("# P", "## S2"))  # ~300 tokens
+        # target > max is nonsense at config level, but the function must
+        # still honour the max ceiling rather than merge greedily.
+        result = _merge_short_chunks(
+            [big1, big2], min_tokens=128, max_tokens=512, target_tokens=1000
+        )
+        assert len(result) == 2
+
+    def test_rollback_target_zero(self):
+        """target_tokens=0 disables Pass 2 packing (behavioural rollback)."""
+        s1 = _chunk("x" * 800, heading=("# P", "## S1"))
+        s2 = _chunk("y" * 800, heading=("# P", "## S2"))
+        s3 = _chunk("z" * 800, heading=("# P", "## S3"))
+
+        result = _merge_short_chunks([s1, s2, s3], min_tokens=128, max_tokens=512, target_tokens=0)
+        assert len(result) == 3
+
+    def test_target_equals_min_no_packing(self):
+        """target_tokens <= min_tokens disables Pass 2 (gate is strict >)."""
+        s1 = _chunk("x" * 600, heading=("# P", "## S1"))  # ~150 tokens
+        s2 = _chunk("y" * 600, heading=("# P", "## S2"))
+        s3 = _chunk("z" * 600, heading=("# P", "## S3"))
+
+        result = _merge_short_chunks(
+            [s1, s2, s3], min_tokens=128, max_tokens=512, target_tokens=128
+        )
+        assert len(result) == 3
+
+
+class TestSiblingMergeContentPreservation:
+    def test_sibling_merge_prepends_dropped_leaves(self):
+        """When sibling merge collapses to a common parent, each side's
+        diverging leaf heading is prepended to its body so retrieval keeps
+        the breadcrumb signal.
+        """
+        s1 = _chunk("alpha body", heading=("# P", "## S1"))
+        s2 = _chunk("beta body", heading=("# P", "## S2"))
+
+        result = _merge_short_chunks([s1, s2], min_tokens=128, max_tokens=512, target_tokens=0)
+        assert len(result) == 1
+        merged = result[0]
+        assert merged.metadata.heading_hierarchy == ("# P",)
+        # Dropped leaves restored in body
+        assert "## S1" in merged.content
+        assert "## S2" in merged.content
+        assert "alpha body" in merged.content
+        assert "beta body" in merged.content

--- a/packages/memtomem/tests/test_usability_fixes.py
+++ b/packages/memtomem/tests/test_usability_fixes.py
@@ -155,13 +155,18 @@ class TestFTS5HyphenQuoting:
 
 
 class TestHeadingMerge:
-    def test_different_headings_not_merged(self):
-        """Two short sections with different headings should stay separate."""
+    def test_long_different_headings_not_merged_by_packing(self):
+        """Long sections with different headings stay separate under Pass 2.
+
+        With target_tokens set, greedy packing would pull them together, but
+        the hierarchy gate only relaxes for chunks below min_tokens. This
+        guards against blurred retrieval context across unrelated sections.
+        """
         from memtomem.indexing.engine import _merge_short_chunks
         from memtomem.models import Chunk, ChunkMetadata, ChunkType
 
         c1 = Chunk(
-            content="Short entry one.",
+            content="Entry A body " * 60,  # ~200 tokens
             metadata=ChunkMetadata(
                 source_file=Path("/test.md"),
                 heading_hierarchy=("## Entry A",),
@@ -171,7 +176,7 @@ class TestHeadingMerge:
             ),
         )
         c2 = Chunk(
-            content="Short entry two.",
+            content="Entry B body " * 60,  # ~200 tokens
             metadata=ChunkMetadata(
                 source_file=Path("/test.md"),
                 heading_hierarchy=("## Entry B",),
@@ -180,8 +185,8 @@ class TestHeadingMerge:
                 end_line=6,
             ),
         )
-        result = _merge_short_chunks([c1, c2], min_tokens=128, max_tokens=512)
-        assert len(result) == 2, "Chunks with different headings should not merge"
+        result = _merge_short_chunks([c1, c2], min_tokens=128, max_tokens=512, target_tokens=384)
+        assert len(result) == 2, "Long chunks across headings must stay separate"
 
     def test_same_heading_can_merge(self):
         from memtomem.indexing.engine import _merge_short_chunks

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -83,6 +83,7 @@ class FakeConfig:
         supported_extensions = frozenset({".md", ".json"})
         max_chunk_tokens = 512
         min_chunk_tokens = 128
+        target_chunk_tokens = 384
         chunk_overlap_tokens = 0
         structured_chunk_mode = "original"
 

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -84,6 +84,7 @@ class FakeConfig:
         supported_extensions = frozenset({".md", ".json"})
         max_chunk_tokens = 512
         min_chunk_tokens = 128
+        target_chunk_tokens = 384
         chunk_overlap_tokens = 0
         structured_chunk_mode = "original"
 


### PR DESCRIPTION
## Summary

- Chunker post-processing is now three passes: min enforcement (Pass 1), greedy hierarchy-respecting packing up to a soft target (Pass 2, new), and tail backward sweep (Pass 3, new).
- Introduces `indexing.target_chunk_tokens` (default 384) to drive Pass 2; set it to `0` to fully revert to the pre-PR merge behaviour.
- Short orphans in Pass 1 now merge across sub-heading divergence when they share a top-level root, rescuing cross-subsection micro-chunks while keeping distinct top-level entries (e.g. mem_add `## Cache` vs `## Database`) independent.

## Why

Real-world docs fragmented into many 150–250 token chunks under a common H2 because the old merge loop stopped as soon as each chunk crossed `min_tokens`. Orphan subsection intros also stayed below the floor whenever their immediate neighbour sat on a different subsection path. Smoke against a 15-raw-chunk audit note shows the collapse from **12 → 10** post-processed chunks, with three `## 4` siblings merging into a single 454-token chunk.

## Design

- Guiding principle: **"작을 때 관대, 클 때 엄격"** — short chunks relax the hierarchy gate down to "shares a top-level root"; larger chunks still need structural kinship (identical / headingless / sibling / same-path ancestor-descendant).
- `_merged_hierarchy` always picks the common prefix for mixed-hierarchy merges. Dropped leaves are restored inline via `_build_merged_content` so retrieval keeps the breadcrumb signal even when metadata hierarchy collapses.
- Rollback: `target_chunk_tokens=0` disables Pass 2 entirely. Pass 3 only runs when the final chunk is below `min_tokens`, and is cost-free otherwise.

## Files (11)

- `packages/memtomem/src/memtomem/indexing/engine.py` — three-pass merge, `_can_merge(current_is_short=...)`, `_is_strict_prefix`, `_prepend_dropped_headings`, `_build_merged_content`, `_merge_pair`.
- `packages/memtomem/src/memtomem/config.py` — `target_chunk_tokens` field, validator, `MUTABLE_FIELDS`, `FIELD_CONSTRAINTS`.
- Web fanout: `web/schemas/config.py`, `web/routes/system.py`, `web/static/settings-config.js` (label + reindex-fields set).
- Tests: new `tests/test_merge_semantic_pack.py` (7 per-failure-mode cases), updated `test_indexing_engine.py` + `test_usability_fixes.py` to the new semantics (short cross-heading merges within same root; long cross-heading still blocked), fake `_Indexing` configs in `test_web_routes.py` / `test_web_routes_extended.py`.
- `CHANGELOG.md`.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 1558 passed, 46 deselected
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` → clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` → clean
- [x] `uv run mypy packages/memtomem/src` → `Success: no issues found in 187 source files`
- [x] Real-doc smoke on `/tmp/memories/2026-04-16.md`: 15 raw → 10 final chunks with default config
- [ ] Maintainer sanity-check: run indexing on your own corpus and eyeball chunk counts / retrieval quality before/after; flip `target_chunk_tokens=0` if needed

## Out of scope (follow-up issues)

- Wizard exposure of chunking tokens + evaluation of bumping `min_chunk_tokens` from 128 → 256 once greedy packing bakes in.
- Semantic-boundary split (`**Label:**` / `---` dividers) inside `_split_section` for over-max sections that currently fall back to paragraph split.
- Migration for already-indexed DBs: users who want the new chunking re-run `mem_index --force` themselves; no automatic re-chunking.