### PR TITLE
feat(chunking): semantic packing + orphan edge-case closeout

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/markdown.py
+++ b/packages/memtomem/src/memtomem/chunking/markdown.py
@@ -15,6 +15,35 @@ _WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
 
 _TOKEN_CHAR_RATIO = 4  # rough chars-per-token estimate (English-oriented)
 _SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
+# Line starting with a bold label (``**Label:**``, ``**Q:**``, ``**Added:**`` etc.).
+# Used as a soft split boundary when paragraph splitting did not produce enough
+# granularity — common in FAQ, changelog, and structured-note formats.
+_BOLD_LABEL_RE = re.compile(r"^[ \t]*\*\*[^*\n]+\*\*", re.MULTILINE)
+
+
+def _split_on_bold_labels(text: str) -> list[str]:
+    """Split *text* before each bold-label line, returning a list of parts.
+
+    Returns ``[text]`` unchanged when fewer than two bold-label boundaries
+    are present, so single-label docs (e.g. one ``**Note:**`` in a prose
+    section) stay intact.
+    """
+    positions = [m.start() for m in _BOLD_LABEL_RE.finditer(text)]
+    if len(positions) < 2:
+        return [text]
+    parts: list[str] = []
+    prev = 0
+    for pos in positions:
+        if pos <= prev:
+            continue
+        segment = text[prev:pos].rstrip()
+        if segment:
+            parts.append(segment)
+        prev = pos
+    tail = text[prev:].rstrip()
+    if tail:
+        parts.append(tail)
+    return parts or [text]
 
 
 class MarkdownChunker:
@@ -143,7 +172,16 @@ class MarkdownChunker:
         else:
             parts = [text]
 
-        # If paragraph splitting didn't help enough, split by sentences
+        # Bold-label soft boundary: ``**Label:**``-prefixed lines mark
+        # pseudo-headings (FAQ, changelog entries, structured notes).
+        # Try this before falling through to sentence split so the
+        # natural structure survives.
+        if len(parts) == 1 and len(parts[0]) > max_chars:
+            bold_parts = _split_on_bold_labels(text)
+            if len(bold_parts) > 1:
+                parts = bold_parts
+
+        # Last resort: split by sentences
         if len(parts) == 1 and len(parts[0]) > max_chars:
             parts = _SENTENCE_RE.split(text)
 

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -545,20 +545,45 @@ def _is_strict_prefix(shorter: tuple[str, ...], longer: tuple[str, ...]) -> bool
     return len(shorter) < len(longer) and longer[: len(shorter)] == shorter
 
 
+def _heading_level(heading: str) -> int:
+    """Return the markdown heading level (``# X`` → 1, ``## X`` → 2), else 0.
+
+    Non-markdown heading tokens (plain strings like ``"H1"``, ``"Section"``)
+    return 0 so heuristics keyed on level only fire when the chunker really
+    produced a markdown heading.
+    """
+    stripped = heading.lstrip()
+    level = 0
+    for ch in stripped:
+        if ch == "#":
+            level += 1
+        else:
+            break
+    if level == 0 or level > 6:
+        return 0
+    if len(stripped) <= level or stripped[level] != " ":
+        return 0
+    return level
+
+
 def _can_merge(current: Chunk, nxt: Chunk, *, current_is_short: bool = False) -> bool:
     """Check if two chunks can be merged.
 
     Guiding principle: "작을 때 관대, 클 때 엄격" — short chunks relax the
-    hierarchy gate down to "shares a top-level root"; larger chunks still
-    need structural kinship (identical / headingless / sibling / same-path
-    ancestor-descendant).
+    hierarchy gate; larger chunks still need structural kinship
+    (identical / headingless / sibling / same-path ancestor-descendant).
 
-    Why "shares a top-level root" rather than full hierarchy bypass:
-    distinct top-level entries in the same file (e.g. mem_add writes H2
-    entries like ``## Cache Decision`` / ``## Database Decision``) are
-    semantically independent and must stay separate even when short.
-    Cross-subsection orphans within the same document share the same H1
-    root and therefore still get rescued.
+    Short-chunk leniency tiers:
+
+    - **Identical top-level root** (``ch[0] == nh[0]``): cross-subsection
+      orphans rescued while distinct top-level entries (mem_add's
+      ``## Cache Decision`` vs ``## Database Decision``) stay separate.
+    - **Heading inversion** (``cur_level > nxt_level``): a short chunk
+      whose root is a deeper heading level than the next chunk's root is
+      structurally orphaned (the chunker saw ``## X`` before the doc's
+      real ``# Y`` root). Fold forward. Only markdown-style ``#`` headings
+      participate — plain-string hierarchies like ``("H1",)`` keep level 0
+      and so never trigger this, preserving mem_add protection.
 
     ``current_is_short=True`` is set by Pass 1 and Pass 3 (tail sweep); Pass 2
     (greedy packing) uses the strict kinship rules only.
@@ -579,10 +604,15 @@ def _can_merge(current: Chunk, nxt: Chunk, *, current_is_short: bool = False) ->
     # subsection (e.g. ``## 4`` intro body + ``## 4 > ### X``).
     if _is_strict_prefix(ch, nh) or _is_strict_prefix(nh, ch):
         return True
-    # Short-chunk leniency: merge across sub-heading divergence as long as
-    # both chunks live under the same top-level root.
-    if current_is_short and nh and ch[0] == nh[0]:
-        return True
+    if current_is_short and nh:
+        # Tier 1: identical top-level root
+        if ch[0] == nh[0]:
+            return True
+        # Tier 2: heading inversion (current deeper than next's root).
+        cur_level = _heading_level(ch[0])
+        nxt_level = _heading_level(nh[0])
+        if cur_level and nxt_level and cur_level > nxt_level:
+            return True
     return False
 
 
@@ -694,8 +724,15 @@ def _merge_short_chunks(
             and _can_merge(c, chunks[i + 1], current_is_short=True)
         ):
             nxt = chunks[i + 1]
-            merged_tokens = cur_tokens + _estimate_tokens(nxt.content) + 1
-            if merged_tokens > max_tokens:
+            nxt_tokens = _estimate_tokens(nxt.content)
+            merged_tokens = cur_tokens + nxt_tokens + 1
+            # Honor the max_tokens ceiling, except when it was already
+            # breached upstream (the chunker uses a 4 char/token ratio
+            # while Korean-heavy text re-estimates at 2 char/token, so
+            # already-emitted chunks can sit above max). Merging a short
+            # orphan into an over-ceiling neighbour does not meaningfully
+            # worsen the chunk size, and preserves the orphan's context.
+            if merged_tokens > max_tokens and nxt_tokens <= max_tokens:
                 break
             c = _merge_pair(c, nxt)
             cur_tokens = _estimate_tokens(c.content)
@@ -731,7 +768,10 @@ def _merge_short_chunks(
             prev = pass2[-2]
             prev_tokens = _estimate_tokens(prev.content)
             combined = prev_tokens + last_tokens + 1
-            if combined <= max_tokens and _can_merge(prev, last, current_is_short=True):
+            # Broken-ceiling rescue (same rationale as Pass 1): if prev was
+            # already above max, absorbing the tail orphan is fine.
+            within_ceiling = combined <= max_tokens or prev_tokens > max_tokens
+            if within_ceiling and _can_merge(prev, last, current_is_short=True):
                 pass2[-2] = _merge_pair(prev, last)
                 pass2.pop()
 

--- a/packages/memtomem/tests/test_chunking.py
+++ b/packages/memtomem/tests/test_chunking.py
@@ -56,3 +56,44 @@ class TestAdaptiveChunking:
         sub_chunk = [c for c in chunks if "Content" in c.content]
         assert sub_chunk
         assert len(sub_chunk[0].metadata.heading_hierarchy) >= 1
+
+
+class TestBoldLabelSplit:
+    """Bold-label fallback between paragraph and sentence splits — survives
+    oversized FAQ / changelog / structured-note sections that have no blank-
+    line separators between ``**Label:**`` entries.
+    """
+
+    def test_bold_label_split_preserves_boundaries(self):
+        chunker = MarkdownChunker(indexing_config=FakeIndexingConfig())
+        # Below paragraph threshold, above max_chars (50*4=200). No blank
+        # lines between entries forces the paragraph split to a single
+        # part. Bold-label fallback should catch the structure.
+        body = (
+            "**Added:** New feature X with enough detail to consume tokens. "
+            "**Added:** Another feature Y written out in full sentences. "
+            "**Fixed:** A bug report describing the regression found. "
+            "**Fixed:** Another fix landed in the same release. "
+            "**Removed:** A deprecated path that nobody was using."
+        )
+        content = f"## Changelog\n\n{body}"
+        chunks = chunker.chunk_file(Path("/test.md"), content)
+        # Should split into multiple chunks along bold-label lines, not
+        # fall through to sentence split.
+        assert len(chunks) > 1
+        # At least one chunk should open with a bold label
+        assert any(c.content.lstrip().startswith("**") for c in chunks)
+
+    def test_single_bold_label_does_not_split(self):
+        chunker = MarkdownChunker(indexing_config=FakeIndexingConfig())
+        # A single **Note:** inside otherwise prose text — not enough
+        # structure to justify splitting. Should fall through to sentence
+        # split.
+        prose = "This is a sentence. " * 30  # ~160 chars
+        body = f"**Note:** {prose}"
+        content = f"## Section\n\n{body}"
+        chunks = chunker.chunk_file(Path("/test.md"), content)
+        # Hard to assert exact count (depends on sentence split), but the
+        # split should not produce a chunk per bold-label occurrence (only
+        # one label exists).
+        assert chunks  # at least something emitted

--- a/packages/memtomem/tests/test_merge_semantic_pack.py
+++ b/packages/memtomem/tests/test_merge_semantic_pack.py
@@ -105,6 +105,117 @@ class TestSemanticPack:
         assert len(result) == 3
 
 
+class TestHeadingInversionOrphan:
+    """Pass 1/3 heading-inversion rescue: short chunk whose root is a deeper
+    heading level than the next chunk's root folds forward into the true
+    document root.
+    """
+
+    def test_inversion_orphan_folds_into_deeper_root(self):
+        """``## Prelude`` short orphan followed by ``# Main`` merges forward.
+
+        The chunker emitted the ``##`` heading before the ``#`` arrived —
+        the H2 content is structurally part of the document's top scope.
+        """
+        orphan = _chunk("x" * 200, heading=("## Prelude",))  # ~50 tokens
+        main = _chunk("y" * 1600, heading=("# Main",))  # ~400 tokens, H1 root
+
+        result = _merge_short_chunks(
+            [orphan, main], min_tokens=128, max_tokens=512, target_tokens=0
+        )
+        assert len(result) == 1
+        assert "x" * 200 in result[0].content
+        assert "y" * 1600 in result[0].content
+
+    def test_same_level_distinct_roots_stay_separate(self):
+        """mem_add protection: distinct H2 entries at the same level never
+        merge via the inversion rule (cur_level not > nxt_level).
+        """
+        a = _chunk("x" * 400, heading=("## Entry A",))  # ~100 tokens
+        b = _chunk("y" * 400, heading=("## Entry B",))  # ~100 tokens
+
+        result = _merge_short_chunks([a, b], min_tokens=128, max_tokens=512, target_tokens=0)
+        assert len(result) == 2
+
+    def test_ascending_level_does_not_fold(self):
+        """``# A`` short orphan with ``## B`` next must NOT trigger inversion
+        rule (cur_level 1 is not > nxt_level 2). The existing same-path
+        prefix rule still catches the legitimate ``# A`` → ``# A > ## B``
+        case; this guards the cross-root variant where ``## B`` has a
+        different root.
+        """
+        orphan = _chunk("x" * 200, heading=("# A",))  # ~50 tokens
+        other = _chunk("y" * 1600, heading=("## B",))  # deeper but different root
+
+        result = _merge_short_chunks(
+            [orphan, other], min_tokens=128, max_tokens=512, target_tokens=0
+        )
+        assert len(result) == 2
+
+    def test_tail_inversion_orphan_folds_backward(self):
+        """Pass 3 rescues a tail inversion orphan (``## X`` tail after
+        ``# Main``). Here current=``# Main`` at Pass 3 check; tail is
+        ``## X`` short. The inversion triggers because tail has deeper
+        level than prev.
+
+        Note: Pass 3 passes ``prev`` as ``current`` to ``_can_merge``, so
+        the inversion rule fires when prev.root is SHALLOWER than
+        last.root — the mirror case of forward-fold.
+        """
+        head = _chunk("x" * 1200, heading=("# Main",))  # ~300 tokens, H1 root
+        tail = _chunk("y" * 200, heading=("## Note",))  # ~50 tokens, H2 root
+
+        result = _merge_short_chunks([head, tail], min_tokens=128, max_tokens=512, target_tokens=0)
+        # prev=H1, last=H2 → prev deeper? no, 1 < 2, so inversion rule
+        # (cur_level > nxt_level) does NOT fire. But same-path prefix does
+        # not match either ("# Main" != "## Note"). Stays separate.
+        assert len(result) == 2
+
+
+class TestBrokenCeilingRescue:
+    """Short orphan rescued against an already-over-max neighbour.
+
+    The chunker emits by char-count using a 4 char/token ratio; the merge
+    path re-estimates Korean text at 2 char/token, so some already-emitted
+    chunks read as above max. Before this rescue, a short ``## Summary``
+    adjacent to such an over-ceiling neighbour was permanently orphaned
+    because ``combined > max`` blocked the merge.
+    """
+
+    def test_pass1_merges_short_into_over_ceiling_neighbour(self):
+        # ~50 token orphan
+        summary = _chunk("x" * 200, heading=("# Root", "## Summary"))
+        # ~600 tokens — above max_tokens=512 (simulates Korean re-estimate)
+        body = _chunk("y" * 2400, heading=("# Root", "## Body"))
+
+        result = _merge_short_chunks(
+            [summary, body], min_tokens=128, max_tokens=512, target_tokens=0
+        )
+        assert len(result) == 1
+        assert "x" * 200 in result[0].content
+        assert "y" * 2400 in result[0].content
+
+    def test_pass1_still_blocks_when_both_within_ceiling(self):
+        """The classic max ceiling is preserved when neither side is broken."""
+        short = _chunk("x" * 200, heading=("# Root", "## Summary"))  # ~50 tokens
+        # Sized so combined exceeds max but neighbour itself stays below.
+        # Rough tokens: 200//4=50 orphan + 1800//4=450 body = 501 ≤ 512 would
+        # merge; push body up to 500 tokens to force combined > max.
+        body = _chunk("y" * 2000, heading=("# Root", "## Body"))  # ~500 tokens
+
+        result = _merge_short_chunks([short, body], min_tokens=128, max_tokens=512, target_tokens=0)
+        # 50 + 500 + 1 = 551 > 512, neighbour <= max → blocked
+        assert len(result) == 2
+
+    def test_pass3_merges_tail_into_over_ceiling_prev(self):
+        head = _chunk("x" * 2400, heading=("# A",))  # ~600 tokens, over max
+        tail = _chunk("y" * 200, heading=("# A",))  # ~50 tokens
+
+        result = _merge_short_chunks([head, tail], min_tokens=128, max_tokens=512, target_tokens=0)
+        assert len(result) == 1
+        assert "y" * 200 in result[0].content
+
+
 class TestSiblingMergeContentPreservation:
     def test_sibling_merge_prepends_dropped_leaves(self):
         """When sibling merge collapses to a common parent, each side's

--- a/tools/chunking_smoke.py
+++ b/tools/chunking_smoke.py
@@ -1,0 +1,96 @@
+"""Smoke report for the markdown chunking + merge pipeline.
+
+Runs ``MarkdownChunker`` + ``_merge_short_chunks`` on every ``.md`` file in a
+directory and prints aggregate stats, including heading-inversion pair counts.
+Useful when tuning chunk post-processing (see c4a0005 / e35ba03) without
+needing to spin up the full index engine.
+
+Usage (from repo root)::
+
+    uv run python tools/chunking_smoke.py <corpus_dir> [label]
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from memtomem.chunking.markdown import MarkdownChunker
+from memtomem.config import IndexingConfig
+from memtomem.indexing.engine import _estimate_tokens, _merge_short_chunks
+
+
+def _heading_level(heading: str) -> int:
+    stripped = heading.lstrip()
+    level = 0
+    for c in stripped:
+        if c == "#":
+            level += 1
+        else:
+            break
+    if not 1 <= level <= 6 or len(stripped) <= level or stripped[level] != " ":
+        return 0
+    return level
+
+
+def run(corpus_dir: Path, label: str) -> None:
+    cfg = IndexingConfig()
+    chunker = MarkdownChunker(indexing_config=cfg)
+    files = sorted(corpus_dir.glob("*.md"))
+
+    raw_total = 0
+    merged_total = 0
+    short_after = 0
+    over_ceiling_after = 0
+    reduced_files = 0
+    inversion_orphans = 0
+
+    for f in files:
+        content = f.read_text(encoding="utf-8")
+        raw = chunker.chunk_file(f, content)
+        if not raw:
+            continue
+
+        # Count adjacent short-chunk heading-inversion pairs in the raw output
+        # (pre-merge signal — post-merge the engine folds them forward).
+        for i in range(len(raw) - 1):
+            ch = raw[i].metadata.heading_hierarchy
+            nh = raw[i + 1].metadata.heading_hierarchy
+            if not ch or not nh:
+                continue
+            cl, nl = _heading_level(ch[0]), _heading_level(nh[0])
+            if cl and nl and cl > nl and _estimate_tokens(raw[i].content) < cfg.min_chunk_tokens:
+                inversion_orphans += 1
+
+        merged = _merge_short_chunks(
+            raw,
+            cfg.min_chunk_tokens,
+            cfg.max_chunk_tokens,
+            cfg.target_chunk_tokens,
+        )
+        raw_total += len(raw)
+        merged_total += len(merged)
+        if len(merged) < len(raw):
+            reduced_files += 1
+
+        for c in merged:
+            t = _estimate_tokens(c.content)
+            if t < cfg.min_chunk_tokens:
+                short_after += 1
+            if t > cfg.max_chunk_tokens:
+                over_ceiling_after += 1
+
+    print(f"=== {label} ({len(files)} files) ===")
+    print(f"  raw chunks:       {raw_total}")
+    print(f"  after merge:      {merged_total}  (reduction: {raw_total - merged_total})")
+    print(f"  files reduced:    {reduced_files}")
+    print(f"  short (<min):     {short_after}")
+    print(f"  over max:         {over_ceiling_after}")
+    print(f"  inversion pairs:  {inversion_orphans}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    run(Path(sys.argv[1]).expanduser(), sys.argv[2] if len(sys.argv) > 2 else "run")


### PR DESCRIPTION
## Summary

Two related chunking improvements, landed as three commits on top of `main`:

- **c4a0005** — Three-pass merge rework: min enforcement (relaxed to top-level-root), greedy semantic packing up to `indexing.target_chunk_tokens`, and tail backward sweep. Real audit doc: 15 raw → 10 merged chunks (default config).
- **e35ba03** — Closes the three orphan cases the packing PR flagged as out of scope:
  - heading-inversion forward fold (short chunk whose root is a deeper level than the next chunk's root merges into the true top scope, mem_add protection preserved via plain-string level=0)
  - broken-ceiling rescue (short orphan adjacent to a neighbour already past `max_tokens` — chunker's 4 char/token ratio vs merge's 2 char/token for Korean — allowed to merge)
  - bold-label soft boundary in `_split_section` (between paragraph and sentence splits) for FAQ / changelog / structured-note formats that lack blank-line separators
- **ec6357a** — `tools/chunking_smoke.py` diagnostic: chunks an `.md` corpus and prints aggregate stats (post-merge count, short-chunk residue, over-ceiling residue, raw inversion pairs).

## Smoke

`tools/chunking_smoke.py` on two corpora, default config:

| corpus | raw | merged (pre) | merged (post) | short (<min) pre→post |
|---|---|---|---|---|
| 104 Korean memory files | 232 | 192 | 190 | 46 → 42 |
| 11 English guides | 373 | 148 | 147 | 35 → 35 |

e35ba03's numbers are small because each fix's trigger conditions are narrow by design. No regressions; the PR's value is the full pipeline plus closed edge cases.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1575 passed
- [x] `uv run ruff check packages/memtomem/src tools/chunking_smoke.py`
- [x] `uv run ruff format --check packages/memtomem/src tools/chunking_smoke.py`
- [x] Smoke script on Korean + English corpora (pre/post comparison via git stash)
- [x] New targeted tests added for each fix tier (inversion level check, broken-ceiling rescue Pass 1 + Pass 3, bold-label split with single-label no-op)