### PR TITLE
fix(search): return JSON on empty results for structured format (#210)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -96,6 +96,30 @@ async def mem_search(
         hints.append(dim_notice)
 
     if not results:
+        # Collect the filter/error context that compact/verbose embed in the
+        # empty-result text. For structured mode these are surfaced through
+        # the JSON ``hints`` array so machine consumers get the same notice.
+        empty_hints: list[str] = []
+        if (source_filter or tag_filter) and stats.fused_total > 0:
+            empty_hints.append(
+                f"No results match your filters "
+                f"({stats.fused_total} results found before filtering). "
+                f"Try broader filters or remove source_filter/tag_filter."
+            )
+        if stats.bm25_error and stats.dense_error:
+            empty_hints.append(
+                "Search unavailable: both keyword and semantic search failed. "
+                f"BM25: {stats.bm25_error}; Dense: {stats.dense_error}"
+            )
+        elif stats.bm25_error:
+            empty_hints.append(f"keyword search unavailable: {stats.bm25_error}")
+        elif stats.dense_error:
+            empty_hints.append(f"semantic search unavailable: {stats.dense_error}")
+
+        if effective_format == "structured":
+            all_hints = hints + empty_hints
+            return _format_structured_results([], hints=all_hints or None)
+
         if (source_filter or tag_filter) and stats.fused_total > 0:
             return (
                 f"No results match your filters "

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -257,8 +257,8 @@ class TestArchiveHint:
         a machine consumer hitting a zero-hit recall still gets a valid
         payload (with the archive hint if applicable) rather than text.
 
-        This is an intentional improvement over mem_search, which currently
-        returns text "No results found." even when ``output_format="structured"``.
+        mem_search mirrors this behaviour — see
+        ``test_search_structured_returns_json_on_empty`` in the sibling class.
         """
         from memtomem.server.tools.recall import mem_recall
 
@@ -277,6 +277,56 @@ class TestArchiveHint:
         assert parsed["kind"] == "recall"
         assert parsed["results"] == []
         assert "hints" not in parsed  # namespace pinned → archive hint suppressed
+
+    async def test_search_structured_returns_json_on_empty(self, trust_components):
+        """mem_search with ``output_format="structured"`` must return a parseable
+        JSON payload on empty results — not the plain text "No results found."
+        that compact/verbose return. Regression for issue #210.
+        """
+        from memtomem.server.tools.search import mem_search
+
+        comp, _ = trust_components
+        # Seed one chunk so the FTS index is non-empty; query targets a term
+        # that won't match so results come back empty via the normal path.
+        await comp.storage.upsert_chunks([make_chunk("unrelated note", namespace="default")])
+
+        ctx = _search_ctx(comp)
+        out = await mem_search(query="nonexistent-term-xyz", output_format="structured", ctx=ctx)
+
+        parsed = json.loads(out)  # Must not raise JSONDecodeError.
+        assert parsed["results"] == []
+        # No archive chunks, no dim mismatch, no filter → no hints key.
+        assert "hints" not in parsed
+
+    async def test_search_structured_empty_surfaces_archive_hint(self, trust_components):
+        """When archive chunks exist but none match the query, the structured
+        empty payload must still include the archive-hidden hint so the caller
+        knows there are memories they could reach by pinning a namespace."""
+        from memtomem.server.tools.search import mem_search
+
+        comp, _ = trust_components
+        archived = make_chunk("archived note about pipelines", namespace="archive:old")
+        await comp.storage.upsert_chunks([archived])
+
+        ctx = _search_ctx(comp)
+        out = await mem_search(query="nonexistent-term-xyz", output_format="structured", ctx=ctx)
+
+        parsed = json.loads(out)
+        assert parsed["results"] == []
+        assert any("hidden in system namespaces" in h for h in parsed["hints"])
+
+    async def test_search_compact_empty_unchanged(self, trust_components):
+        """Compact format must still return the plain-text "No results found."
+        message on empty — the structured fix is scoped to structured only."""
+        from memtomem.server.tools.search import mem_search
+
+        comp, _ = trust_components
+        await comp.storage.upsert_chunks([make_chunk("unrelated note", namespace="default")])
+
+        ctx = _search_ctx(comp)
+        out = await mem_search(query="nonexistent-term-xyz", ctx=ctx)
+
+        assert out.startswith("No results found.")
 
     async def test_recall_invalid_output_format(self, trust_components):
         """Invalid output_format must return an error that names the supported
@@ -439,6 +489,27 @@ def _recall_ctx(components):
         config=components.config,
         storage=components.storage,
         current_namespace=None,
+        _dim_mismatch_announced=False,
+        _config_lock=asyncio.Lock(),
+    )
+    return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
+
+
+def _search_ctx(components):
+    """Build an MCP-style ctx wrapping ``trust_components`` for mem_search.
+
+    Adds ``search_pipeline`` (required for the retrieval path) and
+    ``webhook_manager=None`` on top of the recall-compatible stub.
+    """
+    import asyncio
+    from types import SimpleNamespace
+
+    app = SimpleNamespace(
+        config=components.config,
+        storage=components.storage,
+        search_pipeline=components.search_pipeline,
+        current_namespace=None,
+        webhook_manager=None,
         _dim_mismatch_announced=False,
         _config_lock=asyncio.Lock(),
     )


### PR DESCRIPTION
## Summary

- `mem_search(output_format="structured")` returned plain text `"No results found."` on empty result sets — violating the structured contract (machine consumers hit `JSONDecodeError`)
- Short-circuit the structured branch before the text paths (matches `mem_recall` pattern from `recall.py:103-104`) so empty returns `{"results": []}` with any applicable hints
- Surface filter/BM25/dense error context as JSON `hints` so structured callers get the same trust-UX notices compact/verbose embed in the empty text

Closes #210.

## Scope

- Compact/verbose empty output is unchanged — they remain human-readable text contracts (covered by new regression test).
- No changes to non-empty output shape for any format.
- `hints` key is still omitted when the list is empty (backwards-compat with existing formatter invariant).

## Test plan

- [x] New `test_search_structured_returns_json_on_empty` — empty result set returns parseable JSON with `{"results": []}` and no `hints` key when nothing is applicable
- [x] New `test_search_structured_empty_surfaces_archive_hint` — archive chunks hidden → `hints` array contains the hidden-count notice
- [x] New `test_search_compact_empty_unchanged` — compact format still returns `"No results found."` text
- [x] Updated stale docstring in `test_recall_structured_returns_json_on_empty` that referenced the bug we just fixed
- [x] `uv run pytest packages/memtomem/tests/test_trust_ux.py packages/memtomem/tests/test_server_tools_core.py packages/memtomem/tests/test_server_helpers.py -m "not ollama"` — 156 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)