### PR TITLE
fix(web): defer initial tab activation to DOMContentLoaded (#230)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -383,14 +383,16 @@ qs('mobile-back-btn').addEventListener('click', () => {
 window.addEventListener('popstate', (e) => {
   if (e.state?.tab) activateTab(e.state.tab);
 });
-// Activate tab from URL hash on initial load (e.g. #sources)
-{
+// Activate tab from URL hash on initial load (e.g. #sources).
+// Deferred until DOMContentLoaded so sibling scripts (settings-config.js, etc.)
+// have parsed — activateTab('settings') calls loadConfig() defined there.
+document.addEventListener('DOMContentLoaded', () => {
   const hash = location.hash.slice(1);
   const validTabs = ['home', 'search', 'sources', 'index', 'tags', 'timeline', 'settings'];
   if (hash && validTabs.includes(hash)) {
     activateTab(hash);
   }
-}
+});
 
 // ---------------------------------------------------------------------------
 // Stats
@@ -2945,7 +2947,9 @@ function _loadSettings() {
   };
 }
 
-(function _applySettings() {
+// Deferred until DOMContentLoaded so sibling scripts (settings-config.js, etc.)
+// have parsed — activateTab('settings') calls loadConfig() defined there.
+document.addEventListener('DOMContentLoaded', () => {
   const s = _loadSettings();
   // top-k default is synced from server config via _syncSearchDefaults()
   // Apply default tab only if no hash deep link is present
@@ -2956,7 +2960,7 @@ function _loadSettings() {
       activateTab(s.defaultTab);
     }
   }
-})();
+});
 
 qs('settings-btn').addEventListener('click', () => {
   const s = _loadSettings();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1098,7 +1098,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=1"></script>
-  <script src="/app.js?v=68"></script>
+  <script src="/app.js?v=69"></script>
   <script src="/settings-config.js?v=2"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=2"></script>


### PR DESCRIPTION
## Summary

- `app.js`'s top-level hash-to-tab block ran at parse time, so `activateTab('settings')` → `loadConfig()` (defined in `settings-config.js`, loaded *after* `app.js`) threw `ReferenceError` on hard reload of `/#settings`.
- Same cascade hit the `_applySettings` IIFE when a user had `defaultTab === 'settings'` without a hash.
- Deferred both initial-activation blocks to `DOMContentLoaded` so sibling settings scripts have parsed by the time `activateTab()` runs. Bumped `app.js` cache-bust `v=68 → v=69`.

Closes #230.

## Test plan

Verified locally with Playwright against `mm web`:

- [x] `GET /#settings` + hard reload → 0 console errors (was: `ReferenceError: loadConfig is not defined`)
- [x] `tab-settings` panel active (`display: flex`); `#settings-config` sub-panel renders (`display: block`)
- [x] `#config-content` populated (7 rows)
- [x] `typeof loadConfig === 'function'` at panel render time
- [ ] Reviewer: re-check default-tab path by setting `localStorage['m2m-default-tab'] = 'settings'` with no hash and reloading