### PR TITLE
feat(chunking): protect code fences from heading-split and size-split

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/markdown.py
+++ b/packages/memtomem/src/memtomem/chunking/markdown.py
@@ -11,6 +11,10 @@ from memtomem.models import Chunk, ChunkMetadata, ChunkType
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 _FRONT_MATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
 _WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+# Code fence opener/closer: up to 3 leading spaces, then ``` or ~~~ (length is
+# the matched run). Language tag after opener is allowed; closer must be the
+# same character and at least as long (CommonMark §4.5).
+_FENCE_OPEN_RE = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})(.*)$")
 
 
 _TOKEN_CHAR_RATIO = 4  # rough chars-per-token estimate (English-oriented)
@@ -19,6 +23,105 @@ _SENTENCE_RE = re.compile(r"(?<=[.!?])\s+")
 # Used as a soft split boundary when paragraph splitting did not produce enough
 # granularity — common in FAQ, changelog, and structured-note formats.
 _BOLD_LABEL_RE = re.compile(r"^[ \t]*\*\*[^*\n]+\*\*", re.MULTILINE)
+
+
+def _fence_line_set(text: str) -> frozenset[int]:
+    """Return 1-indexed line numbers that sit *inside* a code fence (exclusive of
+    the opener/closer lines themselves — those are marker lines that should not
+    carry interior content like heading-looking strings).
+
+    Opener and closer lines are also included so that a ``# heading``-shaped
+    fence-marker metadata row is never treated as a true markdown heading.
+
+    Handles unclosed fences at EOF by treating the rest of the file as fenced.
+    """
+    lines = text.splitlines()
+    inside: set[int] = set()
+    i = 0
+    while i < len(lines):
+        m = _FENCE_OPEN_RE.match(lines[i])
+        if not m:
+            i += 1
+            continue
+        run = m.group(1)
+        fence_char = run[0]
+        min_len = len(run)
+        start = i
+        j = i + 1
+        while j < len(lines):
+            m2 = _FENCE_OPEN_RE.match(lines[j])
+            if m2:
+                run2 = m2.group(1)
+                if run2[0] == fence_char and len(run2) >= min_len and not m2.group(2).strip():
+                    break
+            j += 1
+        end = j if j < len(lines) else len(lines) - 1
+        for k in range(start, end + 1):
+            inside.add(k + 1)  # 1-indexed
+        i = end + 1
+    return frozenset(inside)
+
+
+def _split_paragraphs_fence_aware(text: str) -> list[str]:
+    """Split *text* on blank lines, but keep each code fence as one atomic block.
+
+    Equivalent to ``text.split("\\n\\n")`` when no fences are present. When a
+    fence spans blank lines (e.g. code with empty lines inside), the entire
+    fenced region — opener through closer — is emitted as a single part so the
+    downstream merger cannot cut a code block in half.
+
+    Unclosed fences at EOF absorb the rest of the text, matching the protective
+    convention used by ``_fence_line_set``.
+    """
+    lines = text.splitlines(keepends=True)
+    parts: list[str] = []
+    buf: list[str] = []
+    i = 0
+    while i < len(lines):
+        m = _FENCE_OPEN_RE.match(lines[i].rstrip("\n"))
+        if m:
+            # Flush current paragraph before the fence.
+            if buf:
+                joined = "".join(buf).strip("\n")
+                if joined:
+                    parts.append(joined)
+                buf = []
+            run = m.group(1)
+            fence_char = run[0]
+            min_len = len(run)
+            start = i
+            j = i + 1
+            while j < len(lines):
+                m2 = _FENCE_OPEN_RE.match(lines[j].rstrip("\n"))
+                if (
+                    m2
+                    and m2.group(1)[0] == fence_char
+                    and len(m2.group(1)) >= min_len
+                    and not m2.group(2).strip()
+                ):
+                    break
+                j += 1
+            end = j if j < len(lines) else len(lines) - 1
+            fence_text = "".join(lines[start : end + 1]).rstrip("\n")
+            if fence_text:
+                parts.append(fence_text)
+            i = end + 1
+            continue
+        if lines[i].strip() == "":
+            if buf:
+                joined = "".join(buf).strip("\n")
+                if joined:
+                    parts.append(joined)
+                buf = []
+            i += 1
+            continue
+        buf.append(lines[i])
+        i += 1
+    if buf:
+        joined = "".join(buf).strip("\n")
+        if joined:
+            parts.append(joined)
+    return parts if parts else [text]
 
 
 def _split_on_bold_labels(text: str) -> list[str]:
@@ -165,10 +268,12 @@ class MarkdownChunker:
         overlap_chars = self._overlap_tokens * _TOKEN_CHAR_RATIO
         base_line = section["start_line"]
 
-        # Try paragraph-level splitting first
+        # Try paragraph-level splitting first. Fence-aware so code blocks
+        # (including ones with blank lines inside) stay atomic — otherwise the
+        # size-based merger below could slice a ``` block mid-code.
         est_tokens = len(text) // _TOKEN_CHAR_RATIO
         if est_tokens >= self._para_threshold:
-            parts = text.split("\n\n")
+            parts = _split_paragraphs_fence_aware(text)
         else:
             parts = [text]
 
@@ -181,8 +286,14 @@ class MarkdownChunker:
             if len(bold_parts) > 1:
                 parts = bold_parts
 
-        # Last resort: split by sentences
-        if len(parts) == 1 and len(parts[0]) > max_chars:
+        # Last resort: split by sentences. Skipped entirely when the whole
+        # section is inside one fenced block — sentence splitting a code
+        # block would mangle it. The block is accepted as oversize instead.
+        if (
+            len(parts) == 1
+            and len(parts[0]) > max_chars
+            and not _FENCE_OPEN_RE.match(parts[0].lstrip("\n").splitlines()[0] if parts[0] else "")
+        ):
             parts = _SENTENCE_RE.split(text)
 
         # Merge small parts into chunks respecting max_chars
@@ -238,13 +349,14 @@ class MarkdownChunker:
 
     def _split_by_headings(self, content: str) -> list[dict]:
         lines = content.splitlines()
+        fence_lines = _fence_line_set(content)
         sections: list[dict] = []
         current_hierarchy: list[str] = []
         current_lines: list[str] = []
         current_start = 1
 
         for i, line in enumerate(lines, 1):
-            match = _HEADING_RE.match(line)
+            match = _HEADING_RE.match(line) if i not in fence_lines else None
             if match:
                 # Flush previous section
                 if current_lines:

--- a/packages/memtomem/tests/test_markdown_pattern_protection.py
+++ b/packages/memtomem/tests/test_markdown_pattern_protection.py
@@ -1,0 +1,117 @@
+"""Fence / pattern protection for the Markdown chunker.
+
+Pins the behaviour added to stop code-fence content from being split mid-block
+or mis-read as a heading. Previously, ``# heading`` lines inside a ``` fence
+triggered a section split, and long fenced blocks were sliced by the size-based
+merger — producing chunks with unbalanced ``` markers that showed up as
+truncated code snippets in retrieval.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.chunking.markdown import MarkdownChunker
+
+
+class _Cfg:
+    # Tight thresholds so test docs trigger splitting paths without being huge.
+    max_chunk_tokens = 200
+    chunk_overlap_tokens = 0
+    paragraph_split_threshold = 50
+
+
+def _chunk(text: str) -> list:
+    return MarkdownChunker(indexing_config=_Cfg()).chunk_file(Path("/tmp/test.md"), text)
+
+
+class TestFenceProtection:
+    def test_heading_inside_fence_is_not_a_section_boundary(self):
+        """``# foo`` inside a ``` block is code, not a heading."""
+        text = (
+            "# Real Heading\n\n"
+            "Intro paragraph.\n\n"
+            "```python\n"
+            "# this is a comment, not a heading\n"
+            "def f():\n"
+            "    pass\n"
+            "```\n\n"
+            "Closing paragraph.\n"
+        )
+        chunks = _chunk(text)
+        assert len(chunks) == 1
+        assert "# this is a comment" in chunks[0].content
+        assert chunks[0].metadata.heading_hierarchy == ("# Real Heading",)
+
+    def test_tilde_fence_supported(self):
+        """``~~~`` fences protect interior headings just like backtick fences."""
+        text = "# Top\n\n~~~\n# not a heading\n~~~\n"
+        chunks = _chunk(text)
+        assert len(chunks) == 1
+        assert "# not a heading" in chunks[0].content
+
+    def test_large_fence_stays_atomic(self):
+        """A single fenced block larger than max_chunk_tokens is emitted whole."""
+        body = "print('x')\n" * 400  # ~4800 chars → ~1200 tokens, well above max
+        text = "# Section\n\n```python\n" + body + "```\n"
+        chunks = _chunk(text)
+        # All fence content lives in one chunk; counting fence markers in that
+        # chunk should be balanced (both opener and closer present).
+        fence_markers = [c for c in chunks if c.content.count("```") > 0]
+        assert len(fence_markers) == 1
+        c = fence_markers[0]
+        assert c.content.count("```") == 2, (
+            f"expected opener+closer in one chunk, got {c.content.count('```')}"
+        )
+        assert "print('x')" in c.content
+
+    def test_fence_with_blank_lines_is_not_paragraph_split(self):
+        """Blank lines inside a fence must not break it across paragraphs."""
+        body = "line1\n\nline2\n\nline3\n" * 80  # forces paragraph_split_threshold
+        text = "# S\n\n```\n" + body + "```\n"
+        chunks = _chunk(text)
+        # Every chunk that touches the fence must have balanced markers.
+        for c in chunks:
+            markers = c.content.count("```")
+            assert markers % 2 == 0, (
+                f"chunk has unbalanced ``` count={markers}: {c.content[:120]!r}"
+            )
+
+    def test_unclosed_fence_absorbs_rest_of_file(self):
+        """An opener without a closer protects the tail; no split inside it."""
+        text = "# Top\n\n```python\n# still code, not heading\n# another commented line\nx = 1\n"
+        chunks = _chunk(text)
+        assert len(chunks) == 1
+        assert "# still code" in chunks[0].content
+        assert "# another commented line" in chunks[0].content
+
+    def test_fence_with_language_tag(self):
+        """Opener with language tag (```python) closes on bare ``` only."""
+        text = "# T\n\n```python\n# nope\n```\n\nafter\n"
+        chunks = _chunk(text)
+        assert len(chunks) == 1
+        assert "# nope" in chunks[0].content
+        assert "after" in chunks[0].content
+
+
+class TestTableSurvivesExistingSplits:
+    """Sanity: tables already survive paragraph/sentence split because rows
+    have no blank lines or sentence terminators. This test locks the behaviour
+    in so future changes to the split fallbacks do not silently start slicing
+    tables mid-row.
+    """
+
+    def test_table_kept_intact_even_when_section_is_large(self):
+        table = "| Col A | Col B | Col C |\n| --- | --- | --- |\n" + "".join(
+            f"| row{i}a | row{i}b | row{i}c |\n" for i in range(200)
+        )
+        text = "# S\n\n" + table
+        chunks = _chunk(text)
+        # No chunk should contain a partial header row without its separator,
+        # and no chunk should start with a data row while the header lives
+        # elsewhere.
+        for c in chunks:
+            if "| Col A | Col B |" in c.content:
+                assert "| --- | --- |" in c.content, (
+                    "table header split away from its separator row"
+                )

--- a/tools/chunk_metrics.py
+++ b/tools/chunk_metrics.py
@@ -1,0 +1,265 @@
+"""Chunk-quality metrics for the Markdown + structured chunkers.
+
+Complements ``tools/chunking_smoke.py`` (orphan + heading-inversion focus) with
+five additional metrics tuned for tracking fence-split and size-distribution
+regressions across PRs:
+
+    1. orphan_ratio         — % of chunks with est_tokens < min_chunk_tokens
+    2. fence_split_ratio    — % of chunks whose content has an unbalanced ``` count
+    3. json_oversize_ratio  — % of JSON chunks with est_tokens > max_chunk_tokens
+    4. json_key_orphan      — % of JSON chunks with est_tokens < min_chunk_tokens
+    5. size_percentiles     — p10 / p50 / p90 / p99 of chunk token counts
+
+Run from repo root:
+    uv run python tools/chunk_metrics.py
+    uv run python tools/chunk_metrics.py --out /tmp/chunk_metrics.json
+    uv run python tools/chunk_metrics.py --paths docs packages/memtomem/tests/fixtures/corpus_v2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from memtomem.chunking.markdown import MarkdownChunker
+from memtomem.chunking.registry import ChunkerRegistry
+from memtomem.chunking.restructured_text import ReStructuredTextChunker
+from memtomem.chunking.structured import StructuredChunker
+from memtomem.indexing.engine import _estimate_tokens, _merge_short_chunks
+from memtomem.models import Chunk
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+DEFAULT_CORPUS = [
+    Path("docs"),
+    Path("README.md"),
+    Path("CONTRIBUTING.md"),
+    Path("CHANGELOG.md"),
+    Path("CLAUDE.md"),
+    Path("SECURITY.md"),
+    Path("CLA.md"),
+    Path("packages/memtomem/README.md"),
+    Path("packages/memtomem/tests/fixtures/corpus_v2"),
+    Path("examples/notebooks/README.md"),
+]
+
+MIN_TOKENS = 128
+MAX_TOKENS = 512
+TARGET_TOKENS = 384
+
+FENCE_LINE_RE = re.compile(r"^(?:```|~~~)", re.MULTILINE)
+
+
+@dataclass
+class Bucket:
+    """Per-extension tally of counts + token sizes."""
+
+    count: int = 0
+    tokens: list[int] = field(default_factory=list)
+    orphans: int = 0
+    oversize: int = 0
+    unbalanced_fence: int = 0
+    contains_fence: int = 0
+
+
+@dataclass
+class Metrics:
+    files_scanned: int = 0
+    files_unsupported: int = 0
+    pre_merge_total: int = 0
+    post_merge_total: int = 0
+    post_merge_by_ext: dict[str, Bucket] = field(default_factory=lambda: defaultdict(Bucket))
+    pre_merge_by_ext: dict[str, Bucket] = field(default_factory=lambda: defaultdict(Bucket))
+
+    def to_report(self) -> dict[str, Any]:
+        def bucket_report(buckets: dict[str, Bucket]) -> dict[str, Any]:
+            out: dict[str, Any] = {}
+            all_tokens: list[int] = []
+            for ext, b in sorted(buckets.items()):
+                if not b.count:
+                    continue
+                tokens = b.tokens
+                all_tokens.extend(tokens)
+                out[ext] = {
+                    "count": b.count,
+                    "orphan_ratio": round(b.orphans / b.count, 4),
+                    "oversize_ratio": round(b.oversize / b.count, 4),
+                    "contains_fence_ratio": round(b.contains_fence / b.count, 4),
+                    "unbalanced_fence_ratio": round(
+                        b.unbalanced_fence / max(1, b.contains_fence), 4
+                    ),
+                    "fence_split_vs_total": round(b.unbalanced_fence / b.count, 4),
+                    "tokens": _describe(tokens),
+                }
+            if all_tokens:
+                out["__all__"] = {"count": len(all_tokens), "tokens": _describe(all_tokens)}
+            return out
+
+        return {
+            "files_scanned": self.files_scanned,
+            "files_unsupported": self.files_unsupported,
+            "pre_merge_total": self.pre_merge_total,
+            "post_merge_total": self.post_merge_total,
+            "post_merge_by_ext": bucket_report(self.post_merge_by_ext),
+            "pre_merge_by_ext": bucket_report(self.pre_merge_by_ext),
+        }
+
+
+def _describe(tokens: list[int]) -> dict[str, Any]:
+    tokens = sorted(tokens)
+    if not tokens:
+        return {}
+    quantiles = statistics.quantiles(tokens, n=100) if len(tokens) >= 100 else []
+
+    def pct(p: int) -> int:
+        if quantiles:
+            return int(quantiles[p - 1])
+        k = max(0, min(len(tokens) - 1, round((p / 100) * (len(tokens) - 1))))
+        return tokens[k]
+
+    return {
+        "min": tokens[0],
+        "p10": pct(10),
+        "p50": pct(50),
+        "p90": pct(90),
+        "p99": pct(99),
+        "max": tokens[-1],
+        "mean": round(statistics.mean(tokens), 1),
+    }
+
+
+def _collect_files(paths: list[Path], supported: set[str]) -> list[Path]:
+    """Walk *paths* (files or dirs) and return all files with supported extensions."""
+    out: list[Path] = []
+    for p in paths:
+        if not p.exists():
+            print(f"WARN: path not found: {p}", file=sys.stderr)
+            continue
+        if p.is_file():
+            out.append(p)
+        else:
+            for child in sorted(p.rglob("*")):
+                if child.is_file() and child.suffix in supported:
+                    out.append(child)
+    return out
+
+
+def _bucket_for(ext: str, buckets: dict[str, Bucket]) -> Bucket:
+    return buckets[ext]
+
+
+def _tally(chunk: Chunk, ext: str, buckets: dict[str, Bucket]) -> None:
+    tokens = _estimate_tokens(chunk.content)
+    b = _bucket_for(ext, buckets)
+    b.count += 1
+    b.tokens.append(tokens)
+    if tokens < MIN_TOKENS:
+        b.orphans += 1
+    if tokens > MAX_TOKENS:
+        b.oversize += 1
+    fence_markers = FENCE_LINE_RE.findall(chunk.content)
+    if fence_markers:
+        b.contains_fence += 1
+        if len(fence_markers) % 2 == 1:
+            b.unbalanced_fence += 1
+
+
+def run(paths: list[Path], out: Path | None) -> dict[str, Any]:
+    registry = ChunkerRegistry(
+        [
+            MarkdownChunker(),
+            StructuredChunker(),
+            ReStructuredTextChunker(),
+        ]
+    )
+    supported = set(registry.supported_extensions())
+    files = _collect_files(paths, supported)
+    metrics = Metrics()
+
+    for f in files:
+        try:
+            content = f.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError) as exc:
+            print(f"SKIP {f}: {exc}", file=sys.stderr)
+            continue
+        pre_chunks = registry.chunk_file(f, content)
+        if not pre_chunks:
+            metrics.files_unsupported += 1
+            continue
+        metrics.files_scanned += 1
+        metrics.pre_merge_total += len(pre_chunks)
+        post_chunks = _merge_short_chunks(pre_chunks, MIN_TOKENS, MAX_TOKENS, TARGET_TOKENS)
+        metrics.post_merge_total += len(post_chunks)
+
+        ext = f.suffix
+        for c in pre_chunks:
+            _tally(c, ext, metrics.pre_merge_by_ext)
+        for c in post_chunks:
+            _tally(c, ext, metrics.post_merge_by_ext)
+
+    report = metrics.to_report()
+    if out:
+        out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print(f"metrics written to {out}")
+    return report
+
+
+def _print_human(report: dict[str, Any]) -> None:
+    print(
+        f"\nFiles scanned: {report['files_scanned']}"
+        f" (unsupported/empty: {report['files_unsupported']})"
+    )
+    print(f"Pre-merge chunks:  {report['pre_merge_total']}")
+    print(f"Post-merge chunks: {report['post_merge_total']}")
+    for label in ("post_merge_by_ext", "pre_merge_by_ext"):
+        print(f"\n=== {label} ===")
+        for ext, stats in report[label].items():
+            if ext == "__all__":
+                continue
+            t = stats["tokens"]
+            print(
+                f"  {ext:<10} n={stats['count']:<4} "
+                f"orphan={stats['orphan_ratio']:.1%}  "
+                f"oversize={stats['oversize_ratio']:.1%}  "
+                f"fence_split/total={stats['fence_split_vs_total']:.1%}  "
+                f"tokens p10/50/90/99={t['p10']}/{t['p50']}/{t['p90']}/{t['p99']}"
+            )
+        if "__all__" in report[label]:
+            t = report[label]["__all__"]["tokens"]
+            print(
+                f"  ALL        n={report[label]['__all__']['count']:<4} "
+                f"tokens p10/50/90/99={t['p10']}/{t['p50']}/{t['p90']}/{t['p99']}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        type=Path,
+        default=None,
+        help="Paths (files or dirs) to chunk. Defaults to self-corpus.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Write full JSON report to this path.",
+    )
+    args = parser.parse_args()
+    paths = args.paths or [REPO_ROOT / p for p in DEFAULT_CORPUS]
+    report = run(paths, args.out)
+    _print_human(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

The Markdown chunker was splitting sections at every `^#+ ` match — including `# comments` inside ` ```python ` fences — and sliced long fenced blocks at `\n\n` when code contained blank lines. This produced chunks with unbalanced ``` markers that surfaced in retrieval as truncated code snippets.

Self-corpus measurement (new `tools/chunk_metrics.py` over 85 files / 568 post-merge chunks) showed **9.5% of chunks had an odd number of ``` markers** — a correctness gap, not a tuning question.

**Fix**:
- `_fence_line_set(text)`: 1-indexed line numbers inside any ``` or `~~~` fence (CommonMark §4.5). Unclosed fences at EOF absorb the tail.
- `_split_by_headings`: skip heading regex matches on lines that belong to a fence.
- `_split_paragraphs_fence_aware(text)`: replaces `text.split("\n\n")` in `_split_section`. Each fence — opener through closer — is one atomic part, so the size-based merger cannot cut a code block in half.
- Fenced blocks that exceed `max_chunk_tokens` are emitted as a single oversized chunk rather than sentence-split (sentence-splitting a code block would mangle it).

**No new config knobs, no schema changes.** The `over_size` chunk metadata flag mentioned in the plan was deferred — oversize is already observable via `_estimate_tokens(chunk.content) > max_chunk_tokens`, and adding a field to frozen `ChunkMetadata` would ripple into storage serialization without a concrete consumer.

## Before / after on the self-corpus

Same 85 files, same `MIN/MAX/TARGET = 128/512/384` thresholds:

| metric | before | after |
| --- | --- | --- |
| fence_split ratio | 9.5% | **0.8%** |
| orphan ratio | 32.4% | 24.5% |
| p10 / p50 / p90 / p99 tokens | 70 / 203 / 478 / 544 | 100 / 272 / 482 / 624 |
| oversize ratio | 2.8% | 3.9% (intentional — large fences stay whole) |
| post-merge chunks | 568 | 507 |

The orphan drop is a side effect: fake headings inside fences were creating micro-sections that the 3-pass merger then had to clean up. Removing the fake cut leaves semantically complete chunks.

`orphan 24.5%` is still above the 10% threshold the earlier plan used to justify a density-based pre-scan — that work is tracked as a follow-up (not this PR).

## Test plan
- [x] `tests/test_markdown_pattern_protection.py` — 7 new cases: heading inside fence, tilde fence, large fence atomic, blank lines inside fence, unclosed fence, language tag, table integrity.
- [x] `tests/test_merge_semantic_pack.py` + `test_chunking.py` + `test_chunkers_extended.py` + `test_rst_chunker.py` — 75 existing tests green.
- [x] Full `uv run pytest -m "not ollama"` — 1602 passed.
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] `tools/chunk_metrics.py` runs from repo root: `uv run python tools/chunk_metrics.py`.

## Follow-ups (separate PRs)
- **Density pre-scan** — orphan ratio remains at 24.5%; a pre-scan that picks `primary_split_level` based on sibling density and direct-content size should close the rest.
- **JSON / structured chunker** — the self-corpus has no `.json` files so metrics (3)/(4) weren't exercised here. JSONL sniffer + AST-based tree walk will be a separate track; schema-aware splitting deferred further.

Co-authored-by: pandas-studio <pandasdataanalysis@gmail.com>