### PR TITLE
fix(web): NFC-normalize path comparisons in sources/chunks (#235)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_helpers.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import struct
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -21,11 +22,20 @@ def deserialize_f32(data: bytes) -> list[float]:
 
 
 def norm_path(p: Path) -> str:
-    """Normalize path to a canonical string (resolves symlinks like /tmp -> /private/tmp on macOS)."""
+    """Normalize path to a canonical string.
+
+    Resolves symlinks (``/tmp`` → ``/private/tmp`` on macOS) and applies
+    Unicode NFC normalization so NFD (typically produced by macOS/APFS) and
+    NFC (typed by users or emitted by some cloud clients) forms of the same
+    path compare equal. Without NFC here, non-ASCII paths such as
+    ``~/Library/CloudStorage/GoogleDrive-.../내 드라이브/...`` can fail the
+    equality check used by the web routes (see issue #235).
+    """
     try:
-        return str(p.resolve())
+        resolved = str(p.resolve())
     except OSError:
-        return str(p)
+        resolved = str(p)
+    return unicodedata.normalize("NFC", resolved)
 
 
 def placeholders(n: int) -> str:

--- a/packages/memtomem/src/memtomem/web/deps.py
+++ b/packages/memtomem/src/memtomem/web/deps.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
-from fastapi import Request
+from fastapi import HTTPException, Request
+
+from memtomem.storage.sqlite_helpers import norm_path
 
 if TYPE_CHECKING:
     from memtomem.config import Mem2MemConfig
@@ -41,3 +43,17 @@ def get_dedup_scanner(request: Request):
 
 def get_project_root(request: Request) -> Path:
     return request.app.state.project_root
+
+
+def require_indexed_source(user_path: str, indexed_sources: Iterable[Path]) -> Path:
+    """Return the NFC-normalized Path for ``user_path`` if it matches any indexed source.
+
+    Raises 403 when the path is not indexed. Normalizes both sides with
+    ``norm_path`` (resolve + NFC) so an NFC user-typed path can still match
+    an NFD on-disk path on macOS/APFS (issue #235).
+    """
+    request_norm = norm_path(Path(user_path))
+    indexed_norms = {norm_path(p) for p in indexed_sources}
+    if request_norm not in indexed_norms:
+        raise HTTPException(status_code=403, detail="Path is not an indexed source file.")
+    return Path(request_norm)

--- a/packages/memtomem/src/memtomem/web/routes/chunks.py
+++ b/packages/memtomem/src/memtomem/web/routes/chunks.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from pathlib import Path
-
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from memtomem.tools.memory_writer import remove_lines, replace_lines
-from memtomem.web.deps import get_embedder, get_index_engine, get_storage
+from memtomem.web.deps import get_embedder, get_index_engine, get_storage, require_indexed_source
 from memtomem.web.schemas.core import (
     ChunkOut,
     DeleteResponse,
@@ -32,11 +30,8 @@ async def list_chunks(
     limit: int = Query(50, ge=1, le=500),
     storage=Depends(get_storage),
 ) -> ChunksListResponse:
-    request_path = Path(source).resolve()
     indexed_sources = await storage.get_all_source_files()
-    indexed_resolved = {p.resolve() for p in indexed_sources}
-    if request_path not in indexed_resolved:
-        raise HTTPException(status_code=403, detail="Path is not an indexed source file.")
+    request_path = require_indexed_source(source, indexed_sources)
     chunks = await storage.list_chunks_by_source(request_path, limit=limit)
     out = [chunk_to_out(c) for c in chunks]
     return ChunksListResponse(chunks=out, total=len(out))

--- a/packages/memtomem/src/memtomem/web/routes/sources.py
+++ b/packages/memtomem/src/memtomem/web/routes/sources.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from memtomem.web.deps import get_storage
+from memtomem.web.deps import get_storage, require_indexed_source
 from memtomem.web.schemas.core import DeleteResponse
 from memtomem.web.schemas.sources import ChunkSizeBucket, SourceOut, SourcesResponse
 
@@ -63,14 +63,7 @@ async def delete_source(
     storage=Depends(get_storage),
 ) -> DeleteResponse:
     indexed_sources = await storage.get_all_source_files()
-    request_path = Path(path).resolve()
-    indexed_resolved = {p.resolve() for p in indexed_sources}
-
-    if request_path not in indexed_resolved:
-        raise HTTPException(
-            status_code=403,
-            detail="Path is not an indexed source file.",
-        )
+    request_path = require_indexed_source(path, indexed_sources)
 
     deleted = await storage.delete_by_source(request_path)
     return DeleteResponse(deleted=deleted)
@@ -83,11 +76,7 @@ async def source_content(
 ):
     """Return the raw text content of an indexed source file (max 1 MB)."""
     indexed_sources = await storage.get_all_source_files()
-    request_path = Path(path).resolve()
-    indexed_resolved = {p.resolve() for p in indexed_sources}
-
-    if request_path not in indexed_resolved:
-        raise HTTPException(status_code=403, detail="Path is not an indexed source file.")
+    request_path = require_indexed_source(path, indexed_sources)
 
     if not request_path.exists():
         raise HTTPException(status_code=404, detail="Source file not found on disk.")

--- a/packages/memtomem/tests/test_storage.py
+++ b/packages/memtomem/tests/test_storage.py
@@ -1,9 +1,13 @@
 """Tests for storage backend operations."""
 
-import pytest
+import unicodedata
+from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
 from helpers import make_chunk as _make_chunk
+from memtomem.storage.sqlite_helpers import norm_path
 
 
 class TestChunkCRUD:
@@ -103,3 +107,33 @@ class TestRelations:
         removed = await storage.delete_relation(c1.id, c2.id)
         assert removed is True
         assert len(await storage.get_related(c1.id)) == 0
+
+
+class TestNormPathUnicode:
+    """Regression for #235: ``norm_path`` must collapse NFD and NFC into one form."""
+
+    def test_nfd_and_nfc_korean_paths_compare_equal(self, tmp_path):
+        nfd_path = tmp_path / unicodedata.normalize("NFD", "내 드라이브") / "file.md"
+        nfc_path = tmp_path / unicodedata.normalize("NFC", "내 드라이브") / "file.md"
+        # Sanity: the raw Path strings differ before normalization, so the
+        # equality below actually depends on the NFC step inside norm_path.
+        assert str(nfd_path) != str(nfc_path)
+        assert norm_path(nfd_path) == norm_path(nfc_path)
+
+    def test_norm_path_output_is_nfc(self, tmp_path):
+        nfd_path = tmp_path / unicodedata.normalize("NFD", "내 드라이브") / "file.md"
+        result = norm_path(nfd_path)
+        assert result == unicodedata.normalize("NFC", result)
+
+    def test_norm_path_osError_fallback_still_normalizes(self, monkeypatch):
+        # If ``Path.resolve`` raises, ``norm_path`` falls back to the input
+        # string — it must still NFC-normalize that fallback.
+        nfd = unicodedata.normalize("NFD", "/tmp/내 드라이브/file.md")
+
+        def _boom(self, strict=False):
+            raise OSError("boom")
+
+        monkeypatch.setattr(Path, "resolve", _boom)
+
+        out = norm_path(Path(nfd))
+        assert out == unicodedata.normalize("NFC", nfd)

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -7,6 +7,7 @@ full component initialization (embedding provider, SQLite, etc.).
 
 from __future__ import annotations
 
+import unicodedata
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -604,3 +605,73 @@ class TestLocaleEndpoints:
         resp = await client.get("/i18n.js")
         assert resp.status_code == 200
         assert "i18n" in resp.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Unicode path normalization (#235)
+# ---------------------------------------------------------------------------
+
+
+class TestUnicodePaths:
+    """Regression for #235: NFD on-disk vs NFC user-input path mismatch.
+
+    macOS APFS may store non-ASCII directory names (e.g. Google Drive's
+    Korean "내 드라이브" / "My Drive" localization) in NFD form while users
+    type the corresponding NFC form. Without Unicode normalization in
+    ``norm_path``, the equality check in the sources/chunks web routes
+    fails with 403 even when both strings refer to the same file.
+    """
+
+    @staticmethod
+    def _nfd(s: str) -> str:
+        return unicodedata.normalize("NFD", s)
+
+    @staticmethod
+    def _nfc(s: str) -> str:
+        return unicodedata.normalize("NFC", s)
+
+    def test_korean_nfd_nfc_byte_strings_differ(self):
+        # Guard: "내 드라이브" must decompose differently under NFC/NFD,
+        # otherwise the tests below don't actually exercise the bug.
+        assert self._nfd("내 드라이브") != self._nfc("내 드라이브")
+
+    async def test_delete_source_matches_nfd_indexed_with_nfc_query(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        nfd_path = tmp_path / self._nfd("내 드라이브") / "file.md"
+        app.state.storage.get_all_source_files.return_value = [nfd_path]
+
+        nfc_query = str(tmp_path / self._nfc("내 드라이브") / "file.md")
+        resp = await client.delete("/api/sources", params={"path": nfc_query})
+        assert resp.status_code == 200, resp.text
+
+    async def test_source_content_matches_nfd_indexed_with_nfc_query(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Create the on-disk file under the NFC name so ``Path.exists()``
+        # passes on Linux CI (ext4 has no normalization-insensitive lookup).
+        # The storage mock still reports the file under its NFD-encoded
+        # path — mirroring the macOS/APFS case where ``realpath`` hands back
+        # the stored NFD form while the user typed NFC.
+        nfc_dir = tmp_path / self._nfc("내 드라이브")
+        nfc_dir.mkdir()
+        real_file = nfc_dir / "file.md"
+        real_file.write_text("hello from NFC")
+
+        nfd_path = tmp_path / self._nfd("내 드라이브") / "file.md"
+        app.state.storage.get_all_source_files.return_value = [nfd_path]
+
+        resp = await client.get("/api/sources/content", params={"path": str(real_file)})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["content"] == "hello from NFC"
+
+    async def test_list_chunks_matches_nfd_indexed_with_nfc_query(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        nfd_path = tmp_path / self._nfd("내 드라이브") / "file.md"
+        app.state.storage.get_all_source_files.return_value = [nfd_path]
+
+        nfc_query = str(tmp_path / self._nfc("내 드라이브") / "file.md")
+        resp = await client.get("/api/chunks", params={"source": nfc_query})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["total"] == 1


### PR DESCRIPTION
## Summary

- Add Unicode NFC normalization inside `norm_path()` in
  `storage/sqlite_helpers.py` so macOS/APFS paths stored in decomposed
  (NFD) form compare equal to the composed (NFC) form that users
  typically type.
- Route `DELETE /sources`, `GET /sources/content`, and `GET /chunks`
  through a new `require_indexed_source()` helper in `web/deps.py` that
  normalizes both sides via `norm_path()` and raises 403 on mismatch.
- Regression coverage: three direct unit tests for `norm_path()`
  invariants and three end-to-end route tests with an NFD-indexed path
  + NFC query string.

## Why

See #235 for the full writeup. Short version: non-ASCII directory names
such as Google Drive's Korean "내 드라이브" / "My Drive" localization can
surface on disk in Unicode NFD form while users type the NFC form. Before
this change the two stringify differently, so
`Path(user).resolve() not in {p.resolve() for p in indexed_sources}`
returned True for the same file and the routes responded 403. Storage
writes and queries already go through `norm_path()`, so adding NFC there
is enough for indexing; the routes needed to switch off raw `.resolve()`.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — clean.
- [x] `uv run ruff format --check packages/memtomem/src` — clean.
- [x] `uv run mypy packages/memtomem/src` — 0 issues.
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 1606 passed.
- [x] New tests (`TestUnicodePaths`, `TestNormPathUnicode`) fail on `main`
  without the NFC step, pass with it.

## Out of scope

Five additional sibling sites found during the grep sweep are tracked in
#238 rather than addressed here, to keep this PR scoped per the original
issue:

- `web/routes/system.py:285` `add_memory_dir` (`in` set-equality)
- `web/routes/system.py:311` `remove_memory_dir` (`!=` per-element)
- `web/routes/system.py:444` `index_stream` (`startswith` — also has a
  prefix-boundary bug)
- `web/routes/system.py:479` `trigger_index` (`is_relative_to`)
- `web/routes/scratch.py:80` `promote_scratch` (`is_relative_to`)

Closes #235
Related: #238
