### PR TITLE
fix(web): NFC-normalize memory-dirs add/remove routes (#238)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -16,6 +16,7 @@ from memtomem.config import (
     coerce_and_validate,
     save_config_overrides,
 )
+from memtomem.storage.sqlite_helpers import norm_path
 from memtomem.tools.memory_writer import append_entry
 from memtomem.web.deps import (
     get_config,
@@ -282,7 +283,7 @@ async def add_memory_dir(request: Request, config=Depends(get_config)):
         resolved.mkdir(parents=True, exist_ok=True)
 
     current = [Path(p).expanduser().resolve() for p in config.indexing.memory_dirs]
-    if resolved in current:
+    if norm_path(resolved) in {norm_path(p) for p in current}:
         return {
             "ok": True,
             "message": "Already in memory_dirs",
@@ -307,8 +308,9 @@ async def remove_memory_dir(request: Request, config=Depends(get_config)):
         raise HTTPException(status_code=400, detail="path is required")
 
     resolved = Path(dir_path).expanduser().resolve()
+    resolved_norm = norm_path(resolved)
     new_dirs = [
-        p for p in config.indexing.memory_dirs if Path(p).expanduser().resolve() != resolved
+        p for p in config.indexing.memory_dirs if norm_path(Path(p).expanduser()) != resolved_norm
     ]
     if len(new_dirs) == len(config.indexing.memory_dirs):
         raise HTTPException(status_code=404, detail="Directory not in memory_dirs")

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -608,18 +608,21 @@ class TestLocaleEndpoints:
 
 
 # ---------------------------------------------------------------------------
-# Unicode path normalization (#235)
+# Unicode path normalization (#235, #238)
 # ---------------------------------------------------------------------------
 
 
 class TestUnicodePaths:
-    """Regression for #235: NFD on-disk vs NFC user-input path mismatch.
+    """Regression for #235 and #238: NFD on-disk vs NFC user-input path mismatch.
 
-    macOS APFS may store non-ASCII directory names (e.g. Google Drive's
-    Korean "내 드라이브" / "My Drive" localization) in NFD form while users
-    type the corresponding NFC form. Without Unicode normalization in
-    ``norm_path``, the equality check in the sources/chunks web routes
-    fails with 403 even when both strings refer to the same file.
+    Non-ASCII directory names (e.g. Google Drive's Korean "내 드라이브" /
+    "My Drive" localization) can surface on disk in decomposed (NFD) form
+    while users type the composed (NFC) form. Without Unicode normalization
+    in ``norm_path``, equality checks in the web routes fail even when both
+    strings refer to the same path:
+
+    - #235 (sources/chunks routes) — raw ``.resolve()`` 403 mismatch.
+    - #238 (memory-dirs routes) — ``in`` / ``!=`` dedup/remove mismatch.
     """
 
     @staticmethod
@@ -675,3 +678,43 @@ class TestUnicodePaths:
         resp = await client.get("/api/chunks", params={"source": nfc_query})
         assert resp.status_code == 200, resp.text
         assert resp.json()["total"] == 1
+
+    async def test_add_memory_dir_deduplicates_nfd_and_nfc(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Config already holds the directory under an NFD-encoded path
+        # (representative of macOS/APFS paths returned by ``realpath`` when the
+        # dirent is stored decomposed). The user POSTs the same directory in
+        # NFC form; without NFC normalization the route would treat it as new
+        # and append a duplicate entry (#238).
+        nfd_dir = tmp_path / self._nfd("내 드라이브")
+        app.state.config.indexing.memory_dirs = [nfd_dir]
+
+        nfc_dir = tmp_path / self._nfc("내 드라이브")
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(nfc_dir)},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["message"] == "Already in memory_dirs"
+        assert len(app.state.config.indexing.memory_dirs) == 1
+
+    async def test_remove_memory_dir_matches_nfd_and_nfc(self, app, client: AsyncClient, tmp_path):
+        # Config has the target dir in NFD form plus a second entry (the
+        # route refuses to remove the last remaining memory_dir). The user
+        # POSTs the NFC form — without NFC normalization the filter keeps
+        # the NFD entry and the route returns 404 "Directory not in
+        # memory_dirs" (#238).
+        nfd_dir = tmp_path / self._nfd("내 드라이브")
+        other_dir = tmp_path / "other"
+        app.state.config.indexing.memory_dirs = [nfd_dir, other_dir]
+
+        nfc_dir = tmp_path / self._nfc("내 드라이브")
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/remove",
+                json={"path": str(nfc_dir)},
+            )
+        assert resp.status_code == 200, resp.text
+        assert app.state.config.indexing.memory_dirs == [other_dir]


### PR DESCRIPTION
## Summary

- Extend the NFC normalization landed in #239 (for #235) to the two
  `memory-dirs` web routes — `POST /api/memory-dirs/add` and
  `POST /api/memory-dirs/remove` — by routing both sides of their
  equality/filter checks through `norm_path()`.
- Add two regression tests under `TestUnicodePaths`:
  `test_add_memory_dir_deduplicates_nfd_and_nfc` and
  `test_remove_memory_dir_matches_nfd_and_nfc`.

## Why

Both routes compare a user-typed path against
`config.indexing.memory_dirs` via raw Python path equality
(`resolved in current` / `resolved != p`), which preserves the input
Unicode form. Without NFC:

- `add_memory_dir` misses the duplicate check when the stored entry is
  NFD and the user POSTs the same directory in NFC → duplicate entry.
- `remove_memory_dir` returns 404 "Directory not in memory_dirs" even
  when the target is present under a different normalization form.

Both are group (1) + (2) of the #238 audit; fix shape matches the
existing `require_indexed_source` pattern (resolve + NFC on both sides),
but the error semantics differ (add wants the *absent* branch to
proceed, remove wants the *present* branch with 404 otherwise), so
`norm_path` is called inline rather than reusing the helper — keeps the
change tight and avoids forcing the helper into a shape that doesn't
fit.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run mypy packages/memtomem/src` — 0 issues.
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 1615 passed.
- [x] New tests fail on `main` (without NFC step) and pass on this branch.

## Out of scope

Three sibling sites remain in #238 and are not addressed here:

- `web/routes/system.py:444` `index_stream` — `startswith` prefix check
  plus a prefix-boundary bug (`/foo/bar` memory_dir matches `/foo/barbaz`),
  so the fix should switch to `is_relative_to`-style and then normalize.
- `web/routes/system.py:479` `trigger_index` — `is_relative_to`;
  needs a reproducer before we patch.
- `web/routes/scratch.py:80` `promote_scratch` — `is_relative_to`;
  same reproducer requirement.

Related: #238
