### PR TITLE
fix(tools): exclude eval fixtures from chunk_metrics DEFAULT_CORPUS

### DIFF
--- a/tools/chunk_metrics.py
+++ b/tools/chunk_metrics.py
@@ -37,6 +37,11 @@ from memtomem.models import Chunk
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+# User-facing docs only. Retrieval-eval fixtures under
+# ``packages/memtomem/tests/fixtures/`` are intentionally composed of short,
+# atomic semantic units (postmortem / incident notes) and would skew orphan
+# ratios as if the chunker were underperforming. Pass them explicitly via
+# ``--paths`` when measuring the eval corpus itself.
 DEFAULT_CORPUS = [
     Path("docs"),
     Path("README.md"),
@@ -46,7 +51,6 @@ DEFAULT_CORPUS = [
     Path("SECURITY.md"),
     Path("CLA.md"),
     Path("packages/memtomem/README.md"),
-    Path("packages/memtomem/tests/fixtures/corpus_v2"),
     Path("examples/notebooks/README.md"),
 ]
 


### PR DESCRIPTION
## Summary

`tools/chunk_metrics.py` scanned `packages/memtomem/tests/fixtures/corpus_v2` alongside user-facing docs. That fixture set is composed of intentionally-short atomic semantic units (ops incident + postmortem notes) used by the B.2 v2 retrieval-eval harness, so its orphan ratio is meaningless as a chunk-quality signal — including it made the chunker look far worse than it actually is.

## Measurement

Self-corpus, same code, only the `DEFAULT_CORPUS` list differs:

| corpus | files | post-merge chunks | orphan ratio |
|---|---|---|---|
| default (polluted) | 86 | 511 | **24.5%** (118 of 125 orphans from fixtures) |
| docs-only (fixed) | 37 | 318 | **2.2%** |

On the docs-only baseline, 5 of the remaining 7 orphans are legitimate closing sections (`## Next Steps`, `## See also`, `## Consequences` — link lists), 1 is a `should_have_merged` candidate, 1 is an `other`. The real chunker is not producing a quality problem on user-facing docs.

## Change

- Remove the fixture path from `DEFAULT_CORPUS`.
- Add a comment explaining why (plus the escape hatch: `--paths` still accepts it).

No behavior change for `--paths` overrides, no API change, no test added (measurement script).

## Side observation (not addressed here)

The "orphan 32.4% → 24.5%" figure in PR #237's commit message was computed against the polluted default. Under the docs-only baseline, the delta looks different. Not changing #237 retroactively; flagging so future regression-tracking reads the right number.

## Test plan

- [x] `uv run python tools/chunk_metrics.py` reports 37 files, orphan 2.2%
- [x] `uv run python tools/chunk_metrics.py --paths packages/memtomem/tests/fixtures/corpus_v2` still works (explicit opt-in)
- [ ] CI: lint/format/pytest green