### PR TITLE
fix(web): NFC + boundary fix for index_stream (#238)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -441,9 +441,10 @@ async def index_stream(
     config=Depends(get_config),
 ) -> StreamingResponse:
     """Stream indexing progress as Server-Sent Events."""
-    resolved = Path(path).resolve()
-    memory_dirs = [Path(d).expanduser().resolve() for d in config.indexing.memory_dirs]
-    if not any(str(resolved).startswith(str(d)) for d in memory_dirs):
+    resolved = Path(path).expanduser().resolve()
+    resolved_norm = Path(norm_path(resolved))
+    memory_dirs = [Path(norm_path(Path(d).expanduser())) for d in config.indexing.memory_dirs]
+    if not any(resolved_norm.is_relative_to(d) for d in memory_dirs):
         raise HTTPException(
             status_code=403,
             detail="Path is outside configured memory_dirs",

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -718,3 +718,40 @@ class TestUnicodePaths:
             )
         assert resp.status_code == 200, resp.text
         assert app.state.config.indexing.memory_dirs == [other_dir]
+
+    async def test_index_stream_rejects_sibling_path_with_shared_prefix(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Regression for #238: the previous ``str.startswith`` check let a
+        # sibling path with a shared string prefix slip past the memory_dir
+        # gate (e.g. memory_dir ``/foo/bar`` accepted ``/foo/barbaz``).
+        # ``Path.is_relative_to`` compares parts, so the sibling is rejected.
+        bar_dir = tmp_path / "bar"
+        bar_dir.mkdir()
+        barbaz_dir = tmp_path / "barbaz"
+        barbaz_dir.mkdir()
+        app.state.config.indexing.memory_dirs = [bar_dir]
+
+        resp = await client.get("/api/index/stream", params={"path": str(barbaz_dir)})
+        assert resp.status_code == 403, resp.text
+
+    async def test_index_stream_matches_nfd_memory_dir_with_nfc_query(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Regression for #238: ``index_stream`` now NFC-normalizes both the
+        # request path and each configured memory_dir before the
+        # ``is_relative_to`` check, so an NFD-stored memory_dir matches an
+        # NFC-typed query (mirrors the macOS/APFS Korean Drive case).
+        nfd_dir = tmp_path / self._nfd("내 드라이브")
+        app.state.config.indexing.memory_dirs = [nfd_dir]
+
+        async def _fake_stream(*args, **kwargs):
+            yield {"type": "complete", "indexed": 0}
+
+        app.state.index_engine.index_path_stream = _fake_stream
+
+        nfc_path = tmp_path / self._nfc("내 드라이브") / "subdir"
+        resp = await client.get("/api/index/stream", params={"path": str(nfc_path)})
+        # Without normalization the route would 403 here; the streaming
+        # response itself is short-circuited by ``_fake_stream``.
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Fix two bugs in the `GET /api/index/stream` path-validation gate from
the #238 audit, in one PR (group 3 of the issue):

- **NFC drift** — route compared `Path(path).resolve()` strings without
  Unicode normalization, so an NFD-stored memory_dir (typical of
  macOS/APFS — e.g. Google Drive's Korean `내 드라이브`) failed to match
  an NFC-typed query and the route returned 403 even though both
  strings reference the same directory. Mirrors #235 / #239 / #240.
- **Prefix-boundary leak** — the existing check used
  `str(resolved).startswith(str(d))`, so memory_dir `/foo/bar` accepted
  the sibling `/foo/barbaz`. After the fix, `Path.is_relative_to` on
  NFC-normalized paths compares `.parts` and rejects the sibling.

The original (un-normalized) `resolved` Path is still what we hand to
`index_path_stream`, so the on-disk byte form passed downstream is
unchanged. `expanduser()` is added to match the adjacent
`trigger_index` route.

## Why one PR for both bugs

#238's audit explicitly lumps these together: \"Two bugs at once… switch
`index_stream` to the same style and then apply NFC.\" Splitting would
require the boundary fix to land first and then a noisier follow-up
that re-touches the same line; one PR keeps the diff minimal and the
review surface small.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run mypy packages/memtomem/src` — 0 issues.
- [x] `uv run pytest packages/memtomem/tests/test_web_routes.py` — 46 passed.
- [x] New tests fail on `main` (without the fix) and pass on this branch:
  - `test_index_stream_rejects_sibling_path_with_shared_prefix` — main 200 → here 403.
  - `test_index_stream_matches_nfd_memory_dir_with_nfc_query` — main 403 → here 200.

## Out of scope

Two sibling sites remain in #238 and are not addressed here:

- `web/routes/system.py:479` `trigger_index` — `is_relative_to` already,
  but the comparison itself is Unicode-form sensitive. Needs a
  reproducer first.
- `web/routes/scratch.py:80` `promote_scratch` — same shape, same
  reproducer requirement.

Related: #238