### PR TITLE
fix(web): NFC-normalize is_relative_to in trigger_index + promote_scratch (#238)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/scratch.py
+++ b/packages/memtomem/src/memtomem/web/routes/scratch.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException
 
+from memtomem.storage.sqlite_helpers import norm_path
 from memtomem.web.deps import get_config, get_storage
 from memtomem.web.schemas.scratch import (
     ScratchDeleteResponse,
@@ -73,11 +74,13 @@ async def promote_scratch(
     from memtomem.tools.memory_writer import append_entry
 
     bases = [Path(d).expanduser().resolve() for d in config.indexing.memory_dirs]
+    bases_norm = [Path(norm_path(b)) for b in bases]
     if body.file:
         target = Path(body.file).expanduser().resolve()
         if target.is_symlink():
             raise HTTPException(status_code=403, detail="Symlinked targets are not allowed")
-        if not any(target.is_relative_to(b) for b in bases):
+        target_norm = Path(norm_path(target))
+        if not any(target_norm.is_relative_to(b) for b in bases_norm):
             raise HTTPException(
                 status_code=403, detail="Path is outside configured memory directories"
             )

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -478,8 +478,9 @@ async def trigger_index(
     config=Depends(get_config),
 ) -> IndexResponse:
     resolved = Path(req.path).expanduser().resolve()
-    memory_dirs = [Path(d).expanduser().resolve() for d in config.indexing.memory_dirs]
-    if not any(resolved.is_relative_to(d) for d in memory_dirs):
+    resolved_norm = Path(norm_path(resolved))
+    memory_dirs = [Path(norm_path(Path(d).expanduser())) for d in config.indexing.memory_dirs]
+    if not any(resolved_norm.is_relative_to(d) for d in memory_dirs):
         raise HTTPException(status_code=403, detail="Path is outside configured memory directories")
     stats = await index_engine.index_path(
         resolved,

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -755,3 +755,41 @@ class TestUnicodePaths:
         # Without normalization the route would 403 here; the streaming
         # response itself is short-circuited by ``_fake_stream``.
         assert resp.status_code == 200, resp.text
+
+    async def test_trigger_index_matches_nfd_memory_dir_with_nfc_query(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Reproducer for #238 (4): trigger_index uses Path.is_relative_to
+        # after .resolve() on both sides. .resolve() does not Unicode-
+        # normalize, so an NFD config entry vs an NFC user query yields
+        # differing .parts and the is_relative_to check fails.
+        nfd_dir = tmp_path / self._nfd("내 드라이브")
+        nfd_dir.mkdir()
+        app.state.config.indexing.memory_dirs = [nfd_dir]
+
+        nfc_path = tmp_path / self._nfc("내 드라이브") / "subdir"
+        resp = await client.post("/api/index", json={"path": str(nfc_path)})
+        assert resp.status_code == 200, resp.text
+
+    async def test_promote_scratch_matches_nfd_memory_dir_with_nfc_target(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Reproducer for #238 (5): promote_scratch mirrors trigger_index —
+        # is_relative_to between resolved NFD base and resolved NFC target
+        # fails on parts comparison.
+        nfd_dir = tmp_path / self._nfd("내 드라이브")
+        nfd_dir.mkdir()
+        app.state.config.indexing.memory_dirs = [nfd_dir]
+
+        app.state.storage.scratch_get = AsyncMock(
+            return_value={"key": "note", "value": "promote me"}
+        )
+        app.state.storage.scratch_promote = AsyncMock()
+
+        nfc_target = tmp_path / self._nfc("내 드라이브") / "today.md"
+        with patch("memtomem.tools.memory_writer.append_entry"):
+            resp = await client.post(
+                "/api/scratch/note/promote",
+                json={"file": str(nfc_target)},
+            )
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Closes the last group of #238 (items 4 + 5): apply NFC normalization
to the ``Path.is_relative_to`` gate in
``POST /api/index`` (``trigger_index``) and
``POST /api/scratch/{key}/promote`` (``promote_scratch``).

## Why

Both routes compare a user path against ``config.indexing.memory_dirs``
via ``Path.is_relative_to`` after ``.resolve()`` on both sides. The
audit in #238 hedged on reachability — ``"the tuple comparison usually
matches when the OS returns the filesystem-stored form consistently for
both inputs"`` — but reproducers (committed under ``TestUnicodePaths``)
fail on ``main`` regardless of OS:

- ``test_trigger_index_matches_nfd_memory_dir_with_nfc_query`` — main
  returns 403, here 200.
- ``test_promote_scratch_matches_nfd_memory_dir_with_nfc_target`` —
  main returns 403, here 200.

The reason: ``Path.is_relative_to`` compares ``.parts`` element by
element, and ``.resolve()`` does not Unicode-normalize the path. An
NFD-stored memory_dir vs an NFC-typed user path yields differing parts
(""내"" decomposes to two code points in NFD vs one in NFC) and the
route returns 403 even though both strings refer to the same dir. Same
gap closed by #239 / #240 / #242 for the sibling routes.

## Fix shape

Mirrors #242 (item 3 of #238):

- Compare a ``Path(norm_path(...))``-wrapped copy of both sides for
  the gate, leaving the original ``resolved`` / ``target`` Path
  untouched for the downstream call (``index_engine.index_path``,
  ``append_entry``). On filesystems that don't normalize on lookup
  (Linux ext4) this preserves the on-disk byte form.
- ``promote_scratch``'s default target branch keeps the unnormalized
  ``bases`` for ``target = base / f""{date_str}.md""`` for the same
  reason — only ``bases_norm`` is used for the comparison.

## Test plan

- [x] ``uv run ruff check packages/memtomem/src packages/memtomem/tests`` — clean.
- [x] ``uv run ruff format --check packages/memtomem/src packages/memtomem/tests`` — clean.
- [x] ``uv run mypy packages/memtomem/src`` — 0 issues.
- [x] ``uv run pytest packages/memtomem/tests/test_web_routes.py packages/memtomem/tests/test_web_routes_extended.py`` — 102 passed.
- [x] New tests fail on ``main`` (403) and pass here (200).

## #238 closeout

| Group | Site | PR |
|-------|------|----|
| (1) | ``add_memory_dir`` | #240 |
| (2) | ``remove_memory_dir`` | #240 |
| (3) | ``index_stream`` (NFC + boundary) | #242 |
| (4) | ``trigger_index`` | this PR |
| (5) | ``promote_scratch`` | this PR |

After merge, #238 can be closed.

Related: #238, #235, #240, #242