### PR TITLE
chore: gitignore context-gateway outputs + .memtomem state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,14 @@ coverage.json
 CLAUDE.local.md
 .claude-plugin/
 
+# Other agent harnesses — context gateway outputs (user-local, derived from
+# CLAUDE.md). Regenerate via `mm context init` + `mm context sync`.
+AGENTS.md
+GEMINI.md
+.cursorrules
+.github/copilot-instructions.md
+.memtomem/
+
 # macOS
 .DS_Store
 


### PR DESCRIPTION
## Summary

Five paths show up as untracked in any working tree that has run the `mm context` flow:

- `AGENTS.md`
- `GEMINI.md`
- `.cursorrules`
- `.github/copilot-instructions.md`
- `.memtomem/`

None are tracked on `main`, and all are derived: `CLAUDE.md` is the canonical source, `mm context init` produces `.memtomem/context.md` from it, and `mm context sync` fans that out to the per-agent files above. Leaving them untracked **and** un-ignored produces noise in `git status` and risks accidental `git add -A` commits of derived content that then drifts against `CLAUDE.md`.

## Change

Add the five patterns to `.gitignore`, grouped next to the existing "Claude Code" block so the per-harness pattern is discoverable.

```
# Other agent harnesses — context gateway outputs (user-local, derived from
# CLAUDE.md). Regenerate via `mm context init` + `mm context sync`.
AGENTS.md
GEMINI.md
.cursorrules
.github/copilot-instructions.md
.memtomem/
```

## Test plan

- [x] `git check-ignore -v` matches all five paths against the new rules
- [x] `git status` is clean in a working tree that had these paths untracked
- [ ] CI: lint/format/test green (mechanical `.gitignore` change, expected to pass)