### PR TITLE
docs(mcp): make MCP config target file explicit in JSON examples

### DIFF
--- a/docs/guides/google-drive.md
+++ b/docs/guides/google-drive.md
@@ -55,6 +55,14 @@ For teams, share the `memtomem-memories` folder with members.
 
 Point `MEMORY_DIRS` to the Google Drive sync path. Keep the DB local.
 
+Add the block below to your editor's MCP config file — the path depends on
+the editor. Common locations: `~/.cursor/mcp.json` (Cursor),
+`~/.codeium/windsurf/mcp_config.json` (Windsurf),
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+(Claude Desktop), `~/.gemini/settings.json` (Gemini CLI), or use
+`claude mcp add` for Claude Code. See
+[MCP Client Configuration](mcp-clients.md) for the full list.
+
 **macOS** (Drive syncs to `~/Library/CloudStorage/GoogleDrive-{email}/My Drive/` or `~/Google Drive/My Drive/`):
 
 ```json

--- a/docs/guides/hands-on-tutorial.md
+++ b/docs/guides/hands-on-tutorial.md
@@ -45,7 +45,26 @@ multilingual model if you work with Korean/Chinese/Japanese content.
 
 No installation needed — `uvx` handles everything automatically.
 
-Add the following to your editor's MCP configuration file (`.mcp.json`):
+For Claude Code, use the CLI (it edits `~/.claude.json` for you):
+
+```bash
+# PyPI
+claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
+
+# Source (if running from git clone)
+# claude mcp add memtomem -s user -- uv run --directory /path/to/memtomem memtomem-server
+```
+
+For other editors, add the block below to the MCP config file. The path
+depends on the editor:
+
+| Editor | Config file |
+|--------|-------------|
+| Cursor | `~/.cursor/mcp.json` |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
+| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Gemini CLI | `~/.gemini/settings.json` |
+| Antigravity | opens `mcp_config.json` via the GUI (Agent panel → MCP Servers → View raw config) |
 
 ```json
 {
@@ -56,15 +75,6 @@ Add the following to your editor's MCP configuration file (`.mcp.json`):
     }
   }
 }
-```
-
-Or for Claude Code:
-```bash
-# PyPI
-claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
-
-# Source (if running from git clone)
-# claude mcp add memtomem -s user -- uv run --directory /path/to/memtomem memtomem-server
 ```
 
 > **Note**: MCP clients run `memtomem-server` via `uvx`. `memtomem` (the CLI) is for terminal commands only.

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -38,7 +38,8 @@ claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
 
 ### Direct Configuration via `.mcp.json`
 
-Create a `.mcp.json` file in the project root or `~/.claude/`:
+For project-scope registration, create a `.mcp.json` file in the project
+root:
 
 ```json
 {
@@ -55,6 +56,10 @@ Create a `.mcp.json` file in the project root or `~/.claude/`:
   }
 }
 ```
+
+> User-scope settings live in `~/.claude.json` (not a separate `.mcp.json`).
+> Manage those through `claude mcp add` rather than editing the file by
+> hand.
 
 ---
 

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -85,6 +85,14 @@ Any server implementing `/v1/chat/completions` works:
 
 ### MCP Config Example
 
+Add the following to your editor's MCP config file — e.g.,
+`~/.cursor/mcp.json` (Cursor),
+`~/.codeium/windsurf/mcp_config.json` (Windsurf),
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+(Claude Desktop), or `~/.gemini/settings.json` (Gemini CLI). For Claude
+Code, use `claude mcp add` instead of editing a file. See
+[MCP Client Configuration](mcp-clients.md) for the full list.
+
 ```json
 {
   "mcpServers": {

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -63,7 +63,7 @@ Call the mem_status tool
 
 ---
 
-# MCP Client Configuration Guide > ## 1. Claude Code > ### Configure Directly with `.mcp.json` > ## 2. Cursor
+## 2. Cursor
 
 Create or edit the `~/.cursor/mcp.json` file:
 

--- a/docs/guides/use-cases.md
+++ b/docs/guides/use-cases.md
@@ -62,7 +62,7 @@ Restart Cursor, then in chat: "Call mem_stats to check the memtomem connection s
 
 ### Antigravity
 
-Agent panel > `...` > **MCP Servers** > **Manage MCP Servers** > **View raw config**, then add:
+Agent panel > `...` > **MCP Servers** > **Manage MCP Servers** > **View raw config** opens `mcp_config.json`. Add:
 
 ```json
 {

--- a/packages/memtomem-claude-plugin/README.md
+++ b/packages/memtomem-claude-plugin/README.md
@@ -56,7 +56,12 @@ The plugin uses sensible defaults. Customize via environment variables or the `m
 
 **Tool mode**: Controls how many tools are exposed to the AI agent. `core` (9 tools, default) for minimal context usage -- includes `mem_do` meta-tool to access all other actions via `mem_do(action="...", params={...})`. `standard` (~32 + `mem_do`) for normal use, `full` (73) for everything. Fewer tools = less context tokens, better accuracy.
 
-To set env vars for the MCP server, edit `.mcp.json` in the plugin directory:
+To set env vars for the MCP server, either re-run `claude mcp add` with
+`--env` flags, or add a `.mcp.json` at your project root (project scope).
+User-scope settings live in `~/.claude.json` but should be managed through
+`claude mcp add`, not edited by hand.
+
+Example `.mcp.json` (project scope):
 
 ```json
 {

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -46,7 +46,11 @@ If you'd rather skip the CLI install, `uvx` will download and run memtomem on de
 claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
 ```
 
-Or add to `.mcp.json` for Cursor / Windsurf / Claude Desktop:
+Or add the following to your MCP client config file — the path depends on
+the editor: `~/.cursor/mcp.json` (Cursor),
+`~/.codeium/windsurf/mcp_config.json` (Windsurf),
+`~/Library/Application Support/Claude/claude_desktop_config.json`
+(Claude Desktop), or `~/.gemini/settings.json` (Gemini CLI):
 
 ```json
 {


### PR DESCRIPTION
## Summary

Several docs showed `mcpServers` JSON blocks without naming the target
config file, which left readers guessing which path to paste into.

Fixed blocks:

- `docs/guides/google-drive.md` Step 2 — lists per-editor config paths before the macOS/Windows examples
- `docs/guides/llm-providers.md` "MCP Config Example" — adds per-editor path hint
- `docs/guides/hands-on-tutorial.md` Step 1.2 — replaces generic `.mcp.json` with an editor → path table (Cursor / Windsurf / Claude Desktop / Gemini CLI / Antigravity) + moves Claude Code CLI hint up front
- `docs/guides/use-cases.md` Antigravity — names the `mcp_config.json` file the GUI opens
- `docs/guides/integrations/claude-code.md` — corrects "`~/.claude/`" (Claude Code's user-scope config is `~/.claude.json`, managed via `claude mcp add`, not a `.mcp.json` under `~/.claude/`)
- `packages/memtomem/README.md` — lists per-editor paths in the uvx MCP snippet
- `packages/memtomem-claude-plugin/README.md` — replaces the misleading "edit `.mcp.json` in the plugin directory" (the plugin tree has no such file) with project-scope `.mcp.json` + `claude mcp add --env`

No behavior changes; docs-only.

## Test plan

- [ ] Render each modified page on GitHub and confirm the target config path appears directly above every `mcpServers` JSON block
- [ ] Skim the tutorial + google-drive flows end to end to confirm the new per-editor hints read naturally
- [ ] Confirm no code / lint / test touchpoints (docs-only)