### PR TITLE
docs(mcp): document Claude Code install scopes (local/project/user)

### DIFF
--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -26,20 +26,45 @@ The most powerful automation pipeline is achieved when combined with Claude Code
 
 ## MCP Server Setup
 
-### Add via Command
+### Pick an installation scope
+
+Claude Code offers three MCP configuration scopes. Pick the one that
+matches how you want to share this server:
+
+| Scope | Storage | Shared with | When to use |
+|-------|---------|-------------|-------------|
+| `local` (default) | `~/.claude.json` → `projects."<cwd>".mcpServers` | Only this project × this user | Personal setup — private paths/tokens, or testing before committing |
+| `project` | `<project-root>/.mcp.json` (committed to git) | Everyone who clones the repo | Team-wide shared server |
+| `user` | `~/.claude.json` → top-level `mcpServers` | This user across every project | General-purpose server not tied to one project |
+
+**Precedence** when the same server name exists in multiple scopes:
+`local` > `project` > `user` > plugins > Claude.ai connectors. Adding a
+`local` entry lets you override a shared `project` server with personal
+credentials without editing the committed file.
+
+**Trust prompt**: `project` servers from `.mcp.json` require
+workspace-trust approval on first use — cloning an unknown repo never
+silently spawns an MCP server.
+
+### Add via command (`local` / `user`)
 
 ```bash
-# PyPI (recommended)
+# User scope — install once, available in every project
 claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
 
-# Source (if running from git clone)
+# Local scope — this project only, not committed (omitting -s is the same)
+claude mcp add memtomem -s local -- uvx --from memtomem memtomem-server
+
+# Source install (running from a git clone)
 # claude mcp add memtomem -s user -- uv run --directory /path/to/memtomem memtomem-server
 ```
 
-### Direct Configuration via `.mcp.json`
+Both `-s local` and `-s user` write to `~/.claude.json` — no need to edit
+that file by hand.
 
-For project-scope registration, create a `.mcp.json` file in the project
-root:
+### Project scope via `.mcp.json`
+
+For a team-shared setup, commit a `.mcp.json` at the project root:
 
 ```json
 {
@@ -57,9 +82,9 @@ root:
 }
 ```
 
-> User-scope settings live in `~/.claude.json` (not a separate `.mcp.json`).
-> Manage those through `claude mcp add` rather than editing the file by
-> hand.
+Teammates see this server after approving the workspace-trust prompt on
+first use. To run against personal credentials without touching the
+shared file, add a `-s local` entry with the same name — local wins.
 
 ---
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -20,25 +20,41 @@
 
 ## 1. Claude Code
 
-### MCP Server
+### Pick a scope
+
+Claude Code has three install scopes — pick one based on how you want to
+share the server:
+
+| Scope | Flag | Shared with | Storage |
+|-------|------|-------------|---------|
+| local (default) | `-s local` (or omit `-s`) | This project × this user only | `~/.claude.json` → `projects."<cwd>".mcpServers` |
+| project | `-s project` (or commit `.mcp.json`) | Everyone who clones the repo | `<project-root>/.mcp.json` |
+| user | `-s user` | This user across every project | `~/.claude.json` → top-level `mcpServers` |
+
+Precedence is `local > project > user`, so a `local` entry can override
+a shared team `project` server when you need to test with personal
+credentials.
+
+### Add via command (`local` / `user`)
 
 ```bash
-# PyPI (recommended)
+# Local scope (default) — this project only, not committed
+claude mcp add memtomem -- uvx --from memtomem memtomem-server
+
+# User scope — available in every project
 claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
 
 # Source (if running from git clone)
 # claude mcp add memtomem -s user -- uv run --directory /path/to/memtomem memtomem-server
 ```
 
+Both write to `~/.claude.json` — no need to edit that file by hand.
+
 For the full plugin experience (slash commands, automation hooks, memory curator agent), see the [Claude Code integration guide](integrations/claude-code.md).
 
-### Where Claude Code stores MCP config
+### Project scope — commit a `.mcp.json`
 
-Claude Code saves MCP server settings in `~/.claude.json` (user scope) or per-project inside the same file. You don't need to edit this file directly — `claude mcp add` handles it.
-
-### Alternative: Direct Configuration via `.mcp.json`
-
-Or create a `.mcp.json` file in your project root:
+For a team-shared setup, create a `.mcp.json` at the project root:
 
 ```json
 {
@@ -53,6 +69,9 @@ Or create a `.mcp.json` file in your project root:
   }
 }
 ```
+
+Teammates see this server after approving Claude Code's workspace-trust
+prompt on first use.
 
 ### Verify Connection
 


### PR DESCRIPTION
## Summary

- Adds a scope-comparison table (`local` / `project` / `user`) to the Claude Code MCP setup sections in `docs/guides/mcp-clients.md` and `docs/guides/integrations/claude-code.md`, covering storage location, sharing scope, and when to use each.
- Documents precedence (`local > project > user > plugins > Claude.ai connectors`) and the workspace-trust prompt for `project` servers — both missing from the existing docs.
- Adds a `-s local` example so readers know the default scope exists and when to prefer it over `project` or `user`.

## Why

The existing sections only showed `-s user` commands plus a project-scope `.mcp.json` block, with no mention of `-s local` — which is actually the default when `-s` is omitted. A user with a per-project setup containing private paths/credentials had no documented path; they ended up either committing personal config to a shared `.mcp.json` or adding it to user scope and affecting every project.

## Verification

- `claude mcp add --help` — confirmed `--scope` options are `local, user, or project` with `local` as the default.
- Inspected local `~/.claude.json` — confirmed `projects."<cwd>".mcpServers` (local) and top-level `mcpServers` (user) are the actual storage shapes.
- Cross-checked https://code.claude.com/docs/en/mcp-configuration — precedence order and workspace-trust behavior match the docs.

## Test plan

- [x] Docs-only change — no code paths touched
- [x] `ruff check packages/memtomem/src` still passes (no diff in that tree)
- [ ] Render both pages on GitHub after merge and confirm the tables format correctly