### PR TITLE
config: env wins over config.json + config.d/ fragment layer (fixes #248)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -12,6 +12,43 @@ export MEMTOMEM_EMBEDDING__API_KEY=sk-...
 
 For interactive setup, run `mm init` instead of editing env vars by hand.
 
+## Precedence and merge behaviour
+
+memtomem resolves each field from up to four sources at startup, in order
+of increasing priority:
+
+1. **Built-in defaults** — the values in `config.py`.
+2. **`~/.memtomem/config.d/*.json`** — drop-in fragments, applied in
+   lexicographic filename order. Intended for integration installers
+   (`mm init <client>` drops one fragment; removing the file reverses
+   the change). For `list[*]` fields, each fragment respects a per-field
+   merge strategy (see below).
+3. **`~/.memtomem/config.json`** — the user-managed override layer that
+   `mm init` writes to. Every key here replaces whatever earlier layers
+   produced for that field (REPLACE semantics across the board).
+4. **`MEMTOMEM_*` environment variables** — highest priority. If an
+   env var is set, the corresponding entries in `config.d/` and
+   `config.json` are skipped.
+
+### List field merge strategies
+
+`list[*]` fields declare either `APPEND` or `REPLACE` in the type
+annotation, and that strategy governs how `config.d/` fragments layer on
+top of the default:
+
+| Field | Strategy | Notes |
+|-------|----------|-------|
+| `indexing.memory_dirs` | APPEND | Each fragment contributes more roots, dedup by path string |
+| `indexing.exclude_patterns` | APPEND | Multiple denylists merge cleanly |
+| `search.system_namespace_prefixes` | APPEND | Integrations can add further hidden namespaces on top of `archive:` |
+| `webhook.events` | APPEND | Fragments can subscribe to additional event types |
+| `search.rrf_weights` | REPLACE | Positional tuning knob — appending would misalign `[BM25, Dense]` slots |
+| `importance.weights` | REPLACE | Same positional constraint |
+
+`config.json` always replaces, regardless of strategy — it's the
+explicit-user-override layer. Use a fragment in `config.d/` if you want
+APPEND semantics.
+
 ## Storage
 
 | Variable | Default | Description |
@@ -140,10 +177,11 @@ AI tool directories to `memory_dirs` when they exist on the machine:
 | `~/.gemini` | Gemini CLI | global `GEMINI.md` |
 | `~/.codex/memories` | Codex CLI | global memories |
 
-Auto-discovered directories are appended after `config.json` overrides, so
-they are always available even if you override `memory_dirs` manually. This
-means `mem_index` and the file watcher accept paths under these directories
-without requiring explicit `MEMORY_DIRS` configuration.
+Auto-discovered directories are appended after `config.d/` and
+`config.json` overrides, so they are always available even if you
+override `memory_dirs` manually. This means `mem_index` and the file
+watcher accept paths under these directories without requiring explicit
+`MEMORY_DIRS` configuration.
 
 > **Tip:** Use `mm ingest claude-memory`, `mm ingest gemini-memory`, or
 > `mm ingest codex-memory` for richer ingestion with per-tool tagging and

--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -23,9 +23,10 @@ def config() -> None:
 @click.option("--format", "fmt", type=click.Choice(["table", "json"]), default="table")
 def config_show(fmt: str) -> None:
     """Show current configuration (API keys masked)."""
-    from memtomem.config import Mem2MemConfig, load_config_overrides
+    from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
 
     cfg = Mem2MemConfig()
+    load_config_d(cfg)
     load_config_overrides(cfg)
     data = cfg.model_dump()
 

--- a/packages/memtomem/src/memtomem/cli/embedding_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/embedding_cmd.py
@@ -27,10 +27,11 @@ def embedding_reset(mode: str) -> None:
 
 
 async def _run(mode: str) -> None:
-    from memtomem.config import Mem2MemConfig, load_config_overrides
+    from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
     from memtomem.storage.sqlite_backend import SqliteBackend
 
     cfg = Mem2MemConfig()
+    load_config_d(cfg)
     load_config_overrides(cfg)
 
     storage = SqliteBackend(

--- a/packages/memtomem/src/memtomem/cli/reset_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/reset_cmd.py
@@ -19,10 +19,11 @@ def reset(yes: bool) -> None:
 
 
 async def _run(yes: bool) -> None:
-    from memtomem.config import Mem2MemConfig, load_config_overrides
+    from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
     from memtomem.storage.sqlite_backend import SqliteBackend
 
     cfg = Mem2MemConfig()
+    load_config_d(cfg)
     load_config_overrides(cfg)
 
     storage = SqliteBackend(

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -2,11 +2,37 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import Annotated, Literal, cast
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+@dataclass(frozen=True)
+class MergeStrategy:
+    """Declares how multiple sources contribute to a ``list[*]`` field.
+
+    Read at runtime by the ``config.d/`` fragment loader. Attach to list
+    fields via ``Annotated[list[X], APPEND]`` / ``Annotated[list[X], REPLACE]``
+    so the strategy is co-located with the field definition and enforced by
+    ``test_config_overrides.py`` (every ``list[*]`` field must declare one).
+
+    - ``APPEND`` — each source's values are concatenated, duplicates
+      removed. Use for lists where each element is independent (memory
+      directories, exclude patterns, webhook events).
+    - ``REPLACE`` — the highest-priority source wins; lower-priority
+      lists are discarded. Use for positional tuning knobs where element
+      order or length carries semantic meaning (RRF weights, importance
+      weights).
+    """
+
+    mode: Literal["append", "replace"]
+
+
+APPEND = MergeStrategy("append")
+REPLACE = MergeStrategy("replace")
 
 
 class EmbeddingConfig(BaseSettings):
@@ -47,7 +73,9 @@ class SearchConfig(BaseSettings):
     enable_bm25: bool = True
     enable_dense: bool = True
     tokenizer: str = "unicode61"  # "unicode61" or "kiwipiepy"
-    rrf_weights: list[float] = Field(default_factory=lambda: [1.0, 1.0])  # [BM25, Dense]
+    rrf_weights: Annotated[list[float], REPLACE] = Field(
+        default_factory=lambda: [1.0, 1.0]
+    )  # [BM25, Dense]
     cache_ttl: float = 30.0  # search result cache TTL in seconds
     # Namespaces starting with any of these prefixes are excluded from
     # *default* search (``namespace=None``) but remain retrievable with an
@@ -56,7 +84,9 @@ class SearchConfig(BaseSettings):
     # out of day-to-day results while preserving their audit trail.
     # Set to an empty list to restore the pre-Phase-A.5 behavior where every
     # namespace is searchable by default.
-    system_namespace_prefixes: list[str] = Field(default_factory=lambda: ["archive:"])
+    system_namespace_prefixes: Annotated[list[str], APPEND] = Field(
+        default_factory=lambda: ["archive:"]
+    )
 
     @field_validator("default_top_k", "bm25_candidates", "dense_candidates", "rrf_k")
     @classmethod
@@ -96,7 +126,9 @@ def _default_memory_dirs() -> list[Path]:
 
 
 class IndexingConfig(BaseSettings):
-    memory_dirs: list[Path] = Field(default_factory=lambda: _default_memory_dirs())
+    memory_dirs: Annotated[list[Path], APPEND] = Field(
+        default_factory=lambda: _default_memory_dirs()
+    )
     supported_extensions: frozenset[str] = frozenset(
         {
             ".md",
@@ -119,7 +151,7 @@ class IndexingConfig(BaseSettings):
     chunk_overlap_tokens: int = 0
     structured_chunk_mode: str = "original"  # "original" or "recursive"
     paragraph_split_threshold: int = 800  # split long prose into paragraphs above this token count
-    exclude_patterns: list[str] = Field(default_factory=list)
+    exclude_patterns: Annotated[list[str], APPEND] = Field(default_factory=list)
 
     @field_validator(
         "max_chunk_tokens",
@@ -245,7 +277,9 @@ class QueryExpansionConfig(BaseSettings):
 class ImportanceConfig(BaseSettings):
     enabled: bool = False
     max_boost: float = 1.5
-    weights: list[float] = Field(default_factory=lambda: [0.3, 0.2, 0.3, 0.2])
+    weights: Annotated[list[float], REPLACE] = Field(
+        default_factory=lambda: [0.3, 0.2, 0.3, 0.2]
+    )
 
     @field_validator("max_boost")
     @classmethod
@@ -258,7 +292,9 @@ class ImportanceConfig(BaseSettings):
 class WebhookConfig(BaseSettings):
     enabled: bool = False
     url: str = ""
-    events: list[str] = Field(default_factory=lambda: ["add", "delete", "search"])
+    events: Annotated[list[str], APPEND] = Field(
+        default_factory=lambda: ["add", "delete", "search"]
+    )
     secret: str = ""
     timeout_seconds: float = 10.0
 

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -640,6 +640,135 @@ def load_config_overrides(config: Mem2MemConfig) -> None:
                     )
 
 
+_CONFIG_D_PATH = Path("~/.memtomem/config.d")
+
+
+def _config_d_path() -> Path:
+    return _CONFIG_D_PATH.expanduser()
+
+
+def _merge_strategy_for(section_cls: type, field_name: str) -> MergeStrategy | None:
+    """Return the ``MergeStrategy`` annotated on a field, or None if scalar."""
+    info = section_cls.model_fields.get(field_name) if hasattr(section_cls, "model_fields") else None
+    if info is None:
+        return None
+    for m in info.metadata:
+        if isinstance(m, MergeStrategy):
+            return m
+    return None
+
+
+def _dedup_key(item: object) -> object:
+    """Stable equality key for APPEND dedup; normalises Path to its string form."""
+    if isinstance(item, Path):
+        return str(item)
+    return item
+
+
+def load_config_d(config: Mem2MemConfig) -> None:
+    """Apply fragments from ``~/.memtomem/config.d/*.json`` (if dir exists).
+
+    Intended for integration-installed fragments (``mm init <client>`` drops
+    one file, ``mm uninstall <client>`` removes it). Each fragment is a
+    partial ``Mem2MemConfig`` JSON. Fragments are applied in lexicographic
+    filename order. For each field:
+
+    - If ``MEMTOMEM_<SECTION>__<FIELD>`` env var is set → skip (env wins).
+    - If scalar → last fragment wins.
+    - If ``list[*]`` with ``APPEND`` strategy → values concatenated,
+      duplicates removed (first-seen order preserved).
+    - If ``list[*]`` with ``REPLACE`` strategy → last fragment wins; prior
+      list (incl. defaults) is discarded.
+
+    ``~/.memtomem/config.json`` is a separate layer applied *after* fragments
+    (see ``load_config_overrides``); that file remains a full REPLACE-on-set
+    for every field so the ``mm init`` wizard keeps unambiguous user-override
+    semantics.
+    """
+    import json as _json
+    import logging
+    import os
+
+    _log = logging.getLogger(__name__)
+
+    dir_ = _config_d_path()
+    if not dir_.is_dir():
+        return
+
+    fragments = sorted(p for p in dir_.iterdir() if p.is_file() and p.suffix == ".json")
+    for path in fragments:
+        try:
+            data = _json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, _json.JSONDecodeError) as exc:
+            _log.warning("Failed to read config fragment %s: %s", path, exc)
+            continue
+        if not isinstance(data, dict):
+            _log.warning("Config fragment %s is not a JSON object (ignored)", path)
+            continue
+        for section_name, updates in data.items():
+            section_obj = getattr(config, section_name, None)
+            if section_obj is None or not isinstance(updates, dict):
+                if section_obj is None and isinstance(updates, dict):
+                    _log.warning(
+                        "Unknown config section '%s' in %s (ignored)", section_name, path
+                    )
+                continue
+            section_cls = type(section_obj)
+            for key, value in updates.items():
+                if not hasattr(section_obj, key):
+                    continue
+                env_var = f"MEMTOMEM_{section_name.upper()}__{key.upper()}"
+                if env_var in os.environ:
+                    _log.debug(
+                        "Skipping %s.%s from %s: %s is set (env wins)",
+                        section_name,
+                        key,
+                        path,
+                        env_var,
+                    )
+                    continue
+                strategy = _merge_strategy_for(section_cls, key)
+                if strategy is not None and strategy.mode == "append":
+                    if not isinstance(value, list):
+                        _log.warning(
+                            "Expected list for %s.%s in %s (got %s); skipping",
+                            section_name,
+                            key,
+                            path,
+                            type(value).__name__,
+                        )
+                        continue
+                    current = list(getattr(section_obj, key))
+                    seen = {_dedup_key(x) for x in current}
+                    for item in value:
+                        k = _dedup_key(item)
+                        if k not in seen:
+                            current.append(item)
+                            seen.add(k)
+                    try:
+                        setattr(section_obj, key, current)
+                    except (TypeError, ValueError) as exc:
+                        _log.warning(
+                            "Skipping invalid fragment merge %s.%s from %s: %s",
+                            section_name,
+                            key,
+                            path,
+                            exc,
+                        )
+                else:
+                    try:
+                        setattr(section_obj, key, value)
+                    except (TypeError, ValueError) as exc:
+                        _log.warning(
+                            "Skipping invalid fragment value %s.%s=%r from %s: %s",
+                            section_name,
+                            key,
+                            value,
+                            path,
+                            exc,
+                        )
+
+
 def ensure_auto_discovered_dirs(config: Mem2MemConfig) -> None:
     """Append auto-discovered well-known dirs that aren't already in memory_dirs.
 

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -277,9 +277,7 @@ class QueryExpansionConfig(BaseSettings):
 class ImportanceConfig(BaseSettings):
     enabled: bool = False
     max_boost: float = 1.5
-    weights: Annotated[list[float], REPLACE] = Field(
-        default_factory=lambda: [0.3, 0.2, 0.3, 0.2]
-    )
+    weights: Annotated[list[float], REPLACE] = Field(default_factory=lambda: [0.3, 0.2, 0.3, 0.2])
 
     @field_validator("max_boost")
     @classmethod
@@ -649,7 +647,9 @@ def _config_d_path() -> Path:
 
 def _merge_strategy_for(section_cls: type, field_name: str) -> MergeStrategy | None:
     """Return the ``MergeStrategy`` annotated on a field, or None if scalar."""
-    info = section_cls.model_fields.get(field_name) if hasattr(section_cls, "model_fields") else None
+    info = (
+        section_cls.model_fields.get(field_name) if hasattr(section_cls, "model_fields") else None
+    )
     if info is None:
         return None
     for m in info.metadata:
@@ -709,9 +709,7 @@ def load_config_d(config: Mem2MemConfig) -> None:
             section_obj = getattr(config, section_name, None)
             if section_obj is None or not isinstance(updates, dict):
                 if section_obj is None and isinstance(updates, dict):
-                    _log.warning(
-                        "Unknown config section '%s' in %s (ignored)", section_name, path
-                    )
+                    _log.warning("Unknown config section '%s' in %s (ignored)", section_name, path)
                 continue
             section_cls = type(section_obj)
             for key, value in updates.items():

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -540,9 +540,15 @@ def _override_path() -> Path:
 
 
 def load_config_overrides(config: Mem2MemConfig) -> None:
-    """Apply persisted overrides from ~/.memtomem/config.json (if exists)."""
+    """Apply persisted overrides from ~/.memtomem/config.json (if exists).
+
+    Precedence: ``MEMTOMEM_<SECTION>__<FIELD>`` env vars win over
+    ``config.json``. If an env var is set for a field, the corresponding
+    ``config.json`` entry is skipped so the env-bound value remains in effect.
+    """
     import json as _json
     import logging
+    import os
 
     _log = logging.getLogger(__name__)
 
@@ -562,6 +568,16 @@ def load_config_overrides(config: Mem2MemConfig) -> None:
             continue
         for key, value in updates.items():
             if hasattr(section_obj, key):
+                env_var = f"MEMTOMEM_{section_name.upper()}__{key.upper()}"
+                if env_var in os.environ:
+                    _log.debug(
+                        "Skipping %s.%s from %s: %s is set in environment (env wins)",
+                        section_name,
+                        key,
+                        path,
+                        env_var,
+                    )
+                    continue
                 full_key = f"{section_name}.{key}"
                 constraint = FIELD_CONSTRAINTS.get(full_key)
                 if constraint:

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -40,9 +40,10 @@ class Components:
 
 async def create_components(config: Mem2MemConfig | None = None) -> Components:
     """Create and initialise all core components."""
-    from memtomem.config import ensure_auto_discovered_dirs, load_config_overrides
+    from memtomem.config import ensure_auto_discovered_dirs, load_config_d, load_config_overrides
 
     config = config or Mem2MemConfig()
+    load_config_d(config)
     load_config_overrides(config)
     ensure_auto_discovered_dirs(config)
 

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -1,0 +1,120 @@
+"""Tests for config precedence: env vars win over ~/.memtomem/config.json.
+
+Documents the invariant that ``MEMTOMEM_<SECTION>__<FIELD>`` env vars take
+precedence over persisted overrides in ``~/.memtomem/config.json``. Matches
+what every ``.mcp.json`` example in the docs assumes.
+
+Regression anchor for issue #248.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memtomem import config as _cfg
+from memtomem.config import Mem2MemConfig, load_config_overrides
+
+
+@pytest.fixture
+def override_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the override file to tmp_path to avoid touching ~/.memtomem/."""
+    p = tmp_path / "config.json"
+    monkeypatch.setattr(_cfg, "_override_path", lambda: p)
+    return p
+
+
+def _clear_all_memtomem_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip any ambient MEMTOMEM_* so the test env is fully deterministic."""
+    import os
+
+    for name in list(os.environ):
+        if name.startswith("MEMTOMEM_"):
+            monkeypatch.delenv(name, raising=False)
+
+
+def test_config_json_applies_when_no_env(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    override_path.write_text(
+        json.dumps({"storage": {"sqlite_path": "/from/config.db"}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert str(cfg.storage.sqlite_path) == "/from/config.db"
+
+
+def test_env_var_wins_over_config_json_scalar(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", "/from/env.db")
+    override_path.write_text(
+        json.dumps({"storage": {"sqlite_path": "/from/config.db"}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert str(cfg.storage.sqlite_path) == "/from/env.db"
+
+
+def test_env_var_wins_over_config_json_list(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", '["/from/env"]')
+    override_path.write_text(
+        json.dumps({"indexing": {"memory_dirs": ["/from/config"]}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert [str(p) for p in cfg.indexing.memory_dirs] == ["/from/env"]
+
+
+def test_env_and_config_coexist_on_different_fields(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Env on one field, config.json on another — both should take effect."""
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", "/from/env.db")
+    override_path.write_text(
+        json.dumps(
+            {
+                "storage": {"sqlite_path": "/from/config.db"},
+                "embedding": {"model": "from-config"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert str(cfg.storage.sqlite_path) == "/from/env.db"
+    assert cfg.embedding.model == "from-config"
+
+
+def test_regression_pr247_mcp_json_env_block(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The exact ``.mcp.json`` env block shipped in docs (integrations/claude-code.md
+    via PR #247) must work end-to-end after ``mm init`` has written a
+    ``config.json``. One scalar (``SQLITE_PATH``), one list (``MEMORY_DIRS``).
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", "~/.memtomem/memtomem.db")
+    monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", '["~/notes"]')
+    # Simulate mm init having persisted different values.
+    override_path.write_text(
+        json.dumps(
+            {
+                "storage": {"sqlite_path": "/tmp/wizard.db"},
+                "indexing": {"memory_dirs": ["/tmp/wizard-memories"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert str(cfg.storage.sqlite_path) == "~/.memtomem/memtomem.db"
+    assert [str(p) for p in cfg.indexing.memory_dirs] == ["~/notes"]

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from memtomem import config as _cfg
-from memtomem.config import Mem2MemConfig, load_config_overrides
+from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
 
 
 @pytest.fixture
@@ -24,6 +24,15 @@ def override_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     p = tmp_path / "config.json"
     monkeypatch.setattr(_cfg, "_override_path", lambda: p)
     return p
+
+
+@pytest.fixture
+def config_d_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the config.d directory to tmp_path/config.d."""
+    d = tmp_path / "config.d"
+    d.mkdir()
+    monkeypatch.setattr(_cfg, "_config_d_path", lambda: d)
+    return d
 
 
 def _clear_all_memtomem_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -104,7 +113,6 @@ def test_regression_pr247_mcp_json_env_block(
     _clear_all_memtomem_env(monkeypatch)
     monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", "~/.memtomem/memtomem.db")
     monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", '["~/notes"]')
-    # Simulate mm init having persisted different values.
     override_path.write_text(
         json.dumps(
             {
@@ -118,3 +126,140 @@ def test_regression_pr247_mcp_json_env_block(
     load_config_overrides(cfg)
     assert str(cfg.storage.sqlite_path) == "~/.memtomem/memtomem.db"
     assert [str(p) for p in cfg.indexing.memory_dirs] == ["~/notes"]
+
+
+# ---------------------------------------------------------------------------
+# config.d fragment loader (Phase 2b)
+# ---------------------------------------------------------------------------
+
+
+def test_config_d_append_merges_with_defaults(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """APPEND list field: fragment entries added on top of existing list."""
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "claude-desktop.json").write_text(
+        json.dumps({"indexing": {"memory_dirs": ["/from/fragment"]}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    before = list(cfg.indexing.memory_dirs)
+    load_config_d(cfg)
+    after = [str(p) for p in cfg.indexing.memory_dirs]
+    assert "/from/fragment" in after
+    for original in before:
+        assert str(original) in after
+
+
+def test_config_d_append_dedupes(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Duplicate APPEND entries across fragments collapse to one."""
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "01-a.json").write_text(
+        json.dumps({"indexing": {"exclude_patterns": ["*.tmp", "*.log"]}}), encoding="utf-8"
+    )
+    (config_d_dir / "02-b.json").write_text(
+        json.dumps({"indexing": {"exclude_patterns": ["*.log", "*.bak"]}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert cfg.indexing.exclude_patterns == ["*.tmp", "*.log", "*.bak"]
+
+
+def test_config_d_replace_overwrites(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REPLACE list field: last fragment wins, prior list discarded."""
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "01-a.json").write_text(
+        json.dumps({"search": {"rrf_weights": [0.5, 0.5]}}), encoding="utf-8"
+    )
+    (config_d_dir / "02-b.json").write_text(
+        json.dumps({"search": {"rrf_weights": [0.3, 0.7]}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert cfg.search.rrf_weights == [0.3, 0.7]
+
+
+def test_config_d_scalar_last_wins(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scalar field: last fragment applied wins."""
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "01-a.json").write_text(
+        json.dumps({"storage": {"sqlite_path": "/a.db"}}), encoding="utf-8"
+    )
+    (config_d_dir / "02-b.json").write_text(
+        json.dumps({"storage": {"sqlite_path": "/b.db"}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert str(cfg.storage.sqlite_path) == "/b.db"
+
+
+def test_config_d_env_wins_over_fragments(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Env var set → fragment value for that field skipped."""
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", "/from/env.db")
+    (config_d_dir / "a.json").write_text(
+        json.dumps({"storage": {"sqlite_path": "/from/fragment.db"}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert str(cfg.storage.sqlite_path) == "/from/env.db"
+
+
+def test_config_d_unknown_section_warned_but_not_fatal(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Fragment with unknown section logs a warning and is skipped; valid
+    fields in the same fragment still apply."""
+    import logging
+
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "a.json").write_text(
+        json.dumps(
+            {"storage": {"sqlite_path": "/ok.db"}, "nope_not_a_section": {"x": 1}}
+        ),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    with caplog.at_level(logging.WARNING, logger="memtomem.config"):
+        load_config_d(cfg)
+    assert str(cfg.storage.sqlite_path) == "/ok.db"
+    assert any("nope_not_a_section" in r.message for r in caplog.records)
+
+
+def test_config_d_invalid_json_warned(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Malformed JSON in a fragment is logged and skipped without killing startup."""
+    import logging
+
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "bad.json").write_text("{ not valid json", encoding="utf-8")
+    (config_d_dir / "good.json").write_text(
+        json.dumps({"storage": {"sqlite_path": "/ok.db"}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    with caplog.at_level(logging.WARNING, logger="memtomem.config"):
+        load_config_d(cfg)
+    assert str(cfg.storage.sqlite_path) == "/ok.db"
+    assert any("bad.json" in r.message for r in caplog.records)
+
+
+def test_config_d_ignores_non_json_files(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only *.json files in config.d/ are read; README.md etc. are ignored."""
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "README.md").write_text("not a fragment", encoding="utf-8")
+    (config_d_dir / "a.json").write_text(
+        json.dumps({"storage": {"sqlite_path": "/ok.db"}}), encoding="utf-8"
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert str(cfg.storage.sqlite_path) == "/ok.db"

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -263,3 +263,38 @@ def test_config_d_ignores_non_json_files(
     cfg = Mem2MemConfig()
     load_config_d(cfg)
     assert str(cfg.storage.sqlite_path) == "/ok.db"
+
+
+# ---------------------------------------------------------------------------
+# Enforcement: every list[*] field must declare a merge strategy.
+#
+# Guards against future contributors adding a ``list[X]`` field to a config
+# section without picking APPEND vs REPLACE. Without this test, the fragment
+# loader would silently fall through to the REPLACE branch for unannotated
+# list fields, letting a fragment clobber a positional list by accident.
+# ---------------------------------------------------------------------------
+
+
+def test_every_list_field_declares_merge_strategy() -> None:
+    """Fails loudly if a new ``list[*]`` field in any ``Mem2MemConfig`` section
+    is missing a ``MergeStrategy`` annotation.
+    """
+    from typing import get_origin
+
+    from memtomem.config import MergeStrategy
+
+    missing: list[str] = []
+    for section_name, section_field in Mem2MemConfig.model_fields.items():
+        sec_cls = section_field.annotation
+        if not (isinstance(sec_cls, type) and hasattr(sec_cls, "model_fields")):
+            continue
+        for field_name, info in sec_cls.model_fields.items():
+            if get_origin(info.annotation) is list:
+                has_strategy = any(isinstance(m, MergeStrategy) for m in info.metadata)
+                if not has_strategy:
+                    missing.append(f"{section_name}.{field_name}")
+    assert not missing, (
+        "These list[*] fields lack a MergeStrategy annotation — wrap the "
+        "type in Annotated[list[X], APPEND] or Annotated[list[X], REPLACE] "
+        "in config.py:\n  - " + "\n  - ".join(missing)
+    )

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -150,9 +150,7 @@ def test_config_d_append_merges_with_defaults(
         assert str(original) in after
 
 
-def test_config_d_append_dedupes(
-    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_d_append_dedupes(config_d_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Duplicate APPEND entries across fragments collapse to one."""
     _clear_all_memtomem_env(monkeypatch)
     (config_d_dir / "01-a.json").write_text(
@@ -166,9 +164,7 @@ def test_config_d_append_dedupes(
     assert cfg.indexing.exclude_patterns == ["*.tmp", "*.log", "*.bak"]
 
 
-def test_config_d_replace_overwrites(
-    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_d_replace_overwrites(config_d_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """REPLACE list field: last fragment wins, prior list discarded."""
     _clear_all_memtomem_env(monkeypatch)
     (config_d_dir / "01-a.json").write_text(
@@ -182,9 +178,7 @@ def test_config_d_replace_overwrites(
     assert cfg.search.rrf_weights == [0.3, 0.7]
 
 
-def test_config_d_scalar_last_wins(
-    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_config_d_scalar_last_wins(config_d_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Scalar field: last fragment applied wins."""
     _clear_all_memtomem_env(monkeypatch)
     (config_d_dir / "01-a.json").write_text(
@@ -221,9 +215,7 @@ def test_config_d_unknown_section_warned_but_not_fatal(
 
     _clear_all_memtomem_env(monkeypatch)
     (config_d_dir / "a.json").write_text(
-        json.dumps(
-            {"storage": {"sqlite_path": "/ok.db"}, "nope_not_a_section": {"x": 1}}
-        ),
+        json.dumps({"storage": {"sqlite_path": "/ok.db"}, "nope_not_a_section": {"x": 1}}),
         encoding="utf-8",
     )
     cfg = Mem2MemConfig()


### PR DESCRIPTION
Closes #248.

## Summary

Resolves the precedence bug where `~/.memtomem/config.json` silently
overrode `MEMTOMEM_*` env vars set in `.mcp.json` / MCP client `env`
blocks — i.e. every example our docs ship. Also adds the `config.d/`
drop-in layer discussed in #248 so integration installers can drop a
fragment without mutating shared state.

Five commits, each independently reviewable:

1. **Phase 1 — `fix(config): env vars win over ~/.memtomem/config.json`** — `load_config_overrides` now checks whether the matching `MEMTOMEM_<SECTION>__<FIELD>` env var is set and skips the override if so. Regression test pins PR #247's exact `.mcp.json` env block (1 scalar `SQLITE_PATH` + 1 list `MEMORY_DIRS`) — both must survive a full `mm init` + `config.json`.
2. **Phase 2a — `feat(config): add MergeStrategy annotations to list fields`** — co-locates the merge strategy with the field via `Annotated[list[X], APPEND | REPLACE]`. 4 APPEND (memory_dirs, exclude_patterns, system_namespace_prefixes, webhook.events), 2 REPLACE (rrf_weights, importance.weights) — REPLACE on positional tuning knobs where appending would misalign element slots. No runtime change on its own.
3. **Phase 2b — `feat(config): add ~/.memtomem/config.d/ fragment loader`** — scans `config.d/*.json` in lex order, respects per-field strategy, skips fields where env is set. `config.json` remains the REPLACE-on-set user-override layer (`mm init` UX unchanged).
4. **`test(config): enforce merge strategy declaration on all list fields`** — walks every `Mem2MemConfig` section and fails if a `list[*]` lacks a `MergeStrategy` in its metadata. Guards against silent "default-to-REPLACE" drift when new fields get added.
5. **`docs(config): document precedence and list merge strategies`** — adds a "Precedence and merge behaviour" section to `docs/guides/configuration.md` covering the full resolution order and the APPEND/REPLACE table. Other integration docs already advertised the env-wins semantic, so they now work as written.

## Resolution order (lowest → highest priority)

```
defaults → config.d/*.json (lex order, per-field strategy)
         → config.json (REPLACE for every field)
         → MEMTOMEM_* env vars
```

## Testing

- 14 new tests in `test_config_overrides.py` covering Phase 1 precedence, Phase 2b merge semantics (APPEND dedup, REPLACE last-wins, scalar last-wins, env-wins-over-fragments, unknown section warn, malformed JSON warn, non-JSON files ignored), and the enforcement test.
- Full suite: 1633 passed, 46 deselected (ollama marker), 0 failures.
- `ruff check` and `ruff format --check` both clean.
- `mypy` clean on the touched files.

## Release notes

> **Breaking:** `MEMTOMEM_*` environment variables now take precedence over `~/.memtomem/config.json`. Previously `config.json` silently clobbered env overrides set in `.mcp.json` blocks. Any setup that was actively relying on file-wins-over-env behaviour will see env take effect — delete the env var or remove the field from `config.json` to restore the old outcome.

> **New:** `~/.memtomem/config.d/*.json` drop-in fragments are now loaded at startup. Integration installers can drop a per-client fragment (e.g. `claude-desktop.json`) instead of mutating the shared `config.json`; removing the file reverses the change.

## Test plan

- [x] Unit tests: precedence + merge semantics
- [x] Regression test pinning #247's advertised `.mcp.json` env block
- [x] Enforcement test on list-field metadata
- [ ] Manual smoke: restart memtomem-server with a `config.d/test.json` + overlapping `config.json` + env, confirm resolution matches the documented order end-to-end