### PR TITLE
docs(uninstall): list config.d/ drop-in fragments alongside config.json

### DIFF
--- a/docs/guides/uninstall.md
+++ b/docs/guides/uninstall.md
@@ -47,6 +47,7 @@ This removes:
 |------|----------|
 | `memtomem.db` (+ `-wal`, `-journal`) | SQLite database (chunks, embeddings, sessions, history) |
 | `config.json` | Persisted configuration overrides |
+| `config.d/*.json` | Integration-installed drop-in fragments (if present) |
 | `memories/` | User-created memories from `mem_add` |
 | `uploads/` | Files uploaded via the Web UI |
 | `.current_session` | Active session marker |


### PR DESCRIPTION
## Summary

One-line follow-up to #249. The `uninstall.md` data-directory table enumerated every path under `~/.memtomem/` except the new `config.d/` fragment directory introduced by that PR. `rm -rf ~/.memtomem` still cleans it up, but the table is meant to be an accurate inventory for users who want to see what exists before they wipe the directory.

Found during a post-merge docs audit for #249.

## Test plan

- [x] Docs-only, no code paths touched