### PR TITLE
fix(indexing): apply built-in + user excludes at index_file entry point and against absolute paths

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -41,7 +41,12 @@ _BUILTIN_SECRET_PATTERNS: tuple[str, ...] = (
     "**/.ssh/**",
 )
 
-_BUILTIN_NOISE_PATTERNS: tuple[str, ...] = ("**/.claude/**/*.meta.json",)
+_BUILTIN_NOISE_PATTERNS: tuple[str, ...] = (
+    "**/.claude/**/*.meta.json",
+    # Same target via root-relative match for when ``~/.claude/projects`` itself
+    # is the auto-discovered memory_dir root and the rel path drops ``.claude/``.
+    "**/subagents/*.meta.json",
+)
 
 
 def _build_exclude_spec(patterns: Iterable[str]) -> pathspec.GitIgnoreSpec:
@@ -52,6 +57,39 @@ def _build_exclude_spec(patterns: Iterable[str]) -> pathspec.GitIgnoreSpec:
 
 
 _BUILTIN_EXCLUDE_SPEC = _build_exclude_spec((*_BUILTIN_SECRET_PATTERNS, *_BUILTIN_NOISE_PATTERNS))
+
+
+def _exclude_match_keys(file_path: Path, memory_dirs: Iterable[str | Path]) -> list[str]:
+    """Build the lowercase path strings to feed an exclude spec.
+
+    Includes the absolute path and one entry per ``memory_dirs`` parent the
+    file lives under (rel-to-root). Either match counts as excluded — this
+    is what prevents a built-in pattern like ``**/.claude/**/*.meta.json``
+    from being silently bypassed when ``~/.claude/projects`` itself is the
+    indexed root, or when ``index_file`` is invoked from the file watcher
+    (which doesn't go through ``_discover_files``).
+    """
+    resolved = file_path.resolve()
+    keys: list[str] = [resolved.as_posix().lower()]
+    for mem_dir in memory_dirs:
+        try:
+            rel = resolved.relative_to(Path(mem_dir).expanduser().resolve())
+        except ValueError:
+            continue
+        keys.append(rel.as_posix().lower())
+    return keys
+
+
+def _path_is_excluded(
+    file_path: Path,
+    memory_dirs: Iterable[str | Path],
+    user_spec: pathspec.GitIgnoreSpec,
+) -> bool:
+    """True if ``file_path`` matches any built-in or user exclude pattern."""
+    for key in _exclude_match_keys(file_path, memory_dirs):
+        if _BUILTIN_EXCLUDE_SPEC.match_file(key) or user_spec.match_file(key):
+            return True
+    return False
 
 
 class _IndexFileBase(TypedDict):
@@ -163,6 +201,21 @@ class IndexEngine:
         namespace: str | None = None,
     ) -> IndexingStats:
         """Index a single file. Convenience wrapper for external callers."""
+        # Apply exclude patterns at the entry point so callers that bypass
+        # ``_discover_files`` (file watcher, direct API consumers) cannot
+        # smuggle credentials or noise into the index.
+        user_spec = _build_exclude_spec(self._config.exclude_patterns)
+        if _path_is_excluded(file_path, self._config.memory_dirs, user_spec):
+            logger.debug("Skipping excluded file %s", file_path)
+            return IndexingStats(
+                total_files=0,
+                total_chunks=0,
+                indexed_chunks=0,
+                skipped_chunks=0,
+                deleted_chunks=0,
+                duration_ms=0.0,
+                new_chunk_ids=(),
+            )
         async with self._index_lock:
             start = time.monotonic()
             result = await self._index_file(file_path.resolve(), force, namespace=namespace)
@@ -499,12 +552,16 @@ class IndexEngine:
     def _discover_files(self, directory: Path, recursive: bool) -> list[Path]:
         supported = self._registry.supported_extensions() & self._config.supported_extensions
         user_spec = _build_exclude_spec(self._config.exclude_patterns)
+        memory_dirs = self._config.memory_dirs
 
-        def is_pattern_excluded(rel: Path) -> bool:
-            # Built-in spec is evaluated independently from the user spec —
-            # user negation cannot override built-in exclusions.
-            key = rel.as_posix().lower()
-            return _BUILTIN_EXCLUDE_SPEC.match_file(key) or user_spec.match_file(key)
+        def is_excluded(fp: Path, rel: Path | None) -> bool:
+            # User negation cannot override built-in exclusions.
+            # ``_path_is_excluded`` checks both the absolute path and the rel
+            # path under each memory_dir, which keeps built-in patterns
+            # (e.g. ``**/.claude/**/*.meta.json``) effective even when
+            # ``directory`` is the auto-discovered ``~/.claude/projects`` root
+            # and the rel path no longer contains ``.claude/``.
+            return _path_is_excluded(fp, memory_dirs, user_spec)
 
         files: list[Path] = []
         if recursive:
@@ -516,13 +573,13 @@ class IndexEngine:
                 rel = fp.relative_to(directory)
                 if any(self._is_excluded_part(part) for part in rel.parts):
                     continue
-                if is_pattern_excluded(rel):
+                if is_excluded(fp, rel):
                     continue
                 files.append(fp)
         else:
             for ext in supported:
                 for fp in directory.glob(f"*{ext}"):
-                    if is_pattern_excluded(fp.relative_to(directory)):
+                    if is_excluded(fp, fp.relative_to(directory)):
                         continue
                     files.append(fp)
         return sorted(files)

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -240,6 +240,56 @@ class TestExcludePatterns:
         assert "keep.md" in names
         assert "config.toml" not in names
 
+    async def test_builtin_blocks_subagent_meta_when_root_is_claude_projects(
+        self, components, memory_dir
+    ):
+        """REGRESSION: when ``~/.claude/projects`` itself is the memory_dir root,
+        the rel path drops the ``.claude/`` token. The built-in noise pattern
+        must still match — either via the ``**/subagents/*.meta.json`` rel form
+        or via the absolute-path key. Previously these files were silently
+        indexed because only the rel path was checked against the
+        ``.claude/``-prefixed pattern.
+        """
+        sub = memory_dir / "abc123-uuid" / "subagents"
+        sub.mkdir(parents=True)
+        (sub / "agent-x.meta.json").write_text('{"agentType": "Explore"}')
+        (memory_dir / "keep.md").write_text("# Keep")
+
+        files = components.index_engine._discover_files(memory_dir, recursive=True)
+        names = {f.name for f in files}
+        assert "keep.md" in names
+        assert "agent-x.meta.json" not in names
+
+    async def test_builtin_blocks_oauth_at_memory_dir_root(self, components, memory_dir):
+        """REGRESSION: a credential file sitting directly at the memory_dir root
+        must still be caught. Previously this depended on pathspec matching
+        ``**/oauth_creds.json`` against a zero-directory rel key (``oauth_creds.json``);
+        the absolute-path key path closes that gap.
+        """
+        (memory_dir / "oauth_creds.json").write_text('{"token": "x"}')
+        (memory_dir / "keep.md").write_text("# Keep")
+
+        files = components.index_engine._discover_files(memory_dir, recursive=True)
+        names = {f.name for f in files}
+        assert "keep.md" in names
+        assert "oauth_creds.json" not in names
+
+    async def test_index_file_entry_point_blocks_excluded(self, components, memory_dir):
+        """REGRESSION: ``index_file`` is the file-watcher entry point and was
+        previously bypassing exclude checks entirely (only ``_discover_files``
+        was guarded). A watcher event for an OAuth credential file would have
+        indexed it. The fix applies the same exclude policy at this entry
+        point — the call returns ``total_files=0`` without touching storage.
+        """
+        creds_path = memory_dir / "oauth_creds.json"
+        creds_path.write_text('{"token": "secret"}')
+
+        stats = await components.index_engine.index_file(creds_path)
+
+        assert stats.total_files == 0
+        assert stats.total_chunks == 0
+        assert stats.indexed_chunks == 0
+
 
 # ===========================================================================
 # 2. _resolve_namespace


### PR DESCRIPTION
## Summary

The built-in exclude denylist had two related gaps that let credentials and noise reach the index in real-world setups:

1. **\`IndexEngine.index_file\` bypassed exclude checks entirely.** It is the entry point used by \`FileWatcher._reindex\` (and any direct API caller); only \`_discover_files\` was guarded. A watchdog event for \`~/.gemini/oauth_creds.json\` would index the credential.
2. **Patterns were matched only against the memory_dir-relative path.** When \`~/.claude/projects\` itself is the auto-discovered memory_dir root, the rel path drops the \`.claude/\` token, so the built-in noise pattern \`**/.claude/**/*.meta.json\` never matched the subagent metadata Claude Code drops under \`<UUID>/subagents/\`.

## Change

- New module-level helpers \`_exclude_match_keys\` (builds candidate keys: absolute path + rel-to-each-memory_dir) and \`_path_is_excluded\` (checks built-in OR user spec against any candidate key).
- \`IndexEngine.index_file\` now applies the same exclude policy at the entry point — returns \`IndexingStats(total_files=0, ...)\` for excluded paths without touching storage.
- \`IndexEngine._discover_files\` switches to the same helper, gaining the absolute-path key (additive, more permissive — same direction as desired).
- New built-in noise pattern \`**/subagents/*.meta.json\` so the rel-path form also matches when \`.claude/\` is missing.

## Test plan

- [x] Three new regression tests under \`TestExcludePatterns\`:
  - \`test_builtin_blocks_subagent_meta_when_root_is_claude_projects\`
  - \`test_builtin_blocks_oauth_at_memory_dir_root\`
  - \`test_index_file_entry_point_blocks_excluded\`
- [x] All existing \`TestExcludePatterns\` tests still pass (10/10)
- [x] Full suite \`uv run pytest -m \"not ollama\"\` green: 1636 passed, 46 deselected
- [x] \`uv run ruff check\` + \`ruff format --check\` clean
- [x] \`uv run mypy packages/memtomem/src/memtomem/indexing/engine.py\` clean

## Related

- Companion to #251 (docs). That PR documents the workaround (add user \`exclude_patterns\` rules + \`mm purge --matching-excluded --apply\` to retroactively drop affected entries). After this fix lands, the workaround is no longer required for new indexing — only for cleaning up entries that landed before the fix.