### PR TITLE
feat(namespace): path-based policy rules for namespace auto-assignment

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -336,6 +336,74 @@ mem_index(path="~/.claude/projects/<...>/memory",
           namespace="claude:memory")
 ```
 
+### Namespace rules (path-based auto-tagging)
+
+Instead of passing `namespace=` on every `mem_index` call, declare
+path → namespace rules in your config so the indexer applies them
+automatically. Rules match **before** `enable_auto_ns` and lose to an
+explicit `namespace` argument.
+
+Example `~/.memtomem/config.d/10-namespace-rules.json`:
+
+```json
+{
+  "namespace": {
+    "rules": [
+      { "path_glob": "~/.claude/projects/*/memory/**",      "namespace": "claude:memory" },
+      { "path_glob": "~/.claude/projects/*/*/subagents/**", "namespace": "claude:subagents" },
+      { "path_glob": "~/.codex/memories/**",                "namespace": "codex:memories" },
+      { "path_glob": "~/.gemini/**",                        "namespace": "gemini:{parent}" },
+      { "path_glob": "~/Library/CloudStorage/GoogleDrive-*/**/memtomem-memories/*/**",
+        "namespace": "gdrive:{parent}" }
+    ]
+  }
+}
+```
+
+**Semantics:**
+
+- Patterns use **gitignore syntax** (`**` for recursive, `*` for a
+  single segment). Leading `~/` is expanded at load time.
+- Matching is **case-insensitive** and runs against the absolute
+  resolved file path — the same engine as `indexing.exclude_patterns`.
+- **First match wins.** Order rules from most specific to least within
+  a fragment.
+- `{parent}` in the namespace string expands to the immediate parent
+  folder name. If that name would be empty, the rule is skipped and the
+  next rule / `auto_ns` / `default_namespace` is tried.
+- Merge strategy is **APPEND**: multiple `config.d/*.json` fragments
+  contribute rules without overwriting. **Fragments load in
+  alphabetical filename order**, so use numeric prefixes
+  (`10-claude.json`, `20-gdrive.json`, `99-override.json`) to control
+  precedence across fragments.
+- Placeholder whitelist: only `{parent}` is supported in this release.
+  Unknown placeholders (e.g. `{unknown}`) cause config load to fail so
+  typos are caught at startup.
+
+**Verifying your rules:**
+
+```bash
+# Show effective config including merged rules:
+mm config show | grep -A 20 namespace
+
+# After editing rules, force re-index so existing chunks pick up the
+# new namespace:
+mm mem index ~/.claude/projects --force
+
+# Inspect namespace distribution:
+mm session list             # CLI
+# http://localhost:8080/#sources   # Web UI Sources view (colon prefixes
+                                   # group into collapsible sections)
+```
+
+Search results surface the namespace label, so you can confirm a rule
+fired:
+
+```bash
+mm mem search "your query"
+# → "[claude:memory] …"
+```
+
 ## Policy
 
 | Variable | Default | Description |

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -416,6 +416,8 @@ memory_dirs = ["~/notes"]
 
 Files at the root of a `memory_dir` get the default namespace. Only files inside subfolders get auto-derived namespaces. This prevents the memory_dir folder name itself from becoming an unintended namespace.
 
+For systematic tagging across auto-discovered directories (e.g. `~/.claude/projects`, cloud-sync roots), declare path → namespace rules in `namespace.rules` instead — see [Namespace rules in the configuration guide](configuration.md#namespace-rules-path-based-auto-tagging). Rules are evaluated before `enable_auto_ns` and cover use cases where the immediate parent folder name is opaque (UUIDs, generic labels like `memory`).
+
 ---
 
 ## 5. Maintenance — `mem_dedup_*`, `mem_decay_*`, `mem_auto_tag`

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -217,9 +217,62 @@ class AccessConfig(BaseSettings):
         return v
 
 
+_NAMESPACE_MAX_LEN = 128
+_ALLOWED_NS_PLACEHOLDERS: frozenset[str] = frozenset({"parent"})
+
+
+class NamespacePolicyRule(BaseSettings):
+    """Maps files matching a glob pattern to a namespace label.
+
+    ``path_glob`` uses gitignore-style patterns (via ``pathspec.GitIgnoreSpec``).
+    Leading ``~/`` is expanded at load time. Matching is case-insensitive and
+    runs against the absolute resolved file path with any leading ``/``
+    stripped — same semantics as ``IndexingConfig.exclude_patterns``.
+
+    ``namespace`` supports the ``{parent}`` placeholder, which expands to the
+    immediate parent folder name of the matched file. Unknown placeholders are
+    rejected at load time. When ``{parent}`` would expand to an empty string
+    the rule is skipped at runtime and the next rule is tried.
+    """
+
+    path_glob: str
+    namespace: str
+
+    @field_validator("path_glob")
+    @classmethod
+    def _expand_and_validate_glob(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("path_glob must be non-empty")
+        if v == "~" or v.startswith("~/"):
+            v = str(Path(v).expanduser())
+        return v
+
+    @field_validator("namespace")
+    @classmethod
+    def _validate_namespace(cls, v: str) -> str:
+        import string as _string
+
+        v = v.strip()
+        if not v:
+            raise ValueError("namespace must be non-empty")
+        if len(v) > _NAMESPACE_MAX_LEN:
+            raise ValueError(f"namespace must be <= {_NAMESPACE_MAX_LEN} chars, got {len(v)}")
+        for _lit, field_name, _spec, _conv in _string.Formatter().parse(v):
+            if field_name is not None and field_name not in _ALLOWED_NS_PLACEHOLDERS:
+                raise ValueError(
+                    f"unknown placeholder '{{{field_name}}}' in namespace; "
+                    f"supported: {sorted(_ALLOWED_NS_PLACEHOLDERS)}"
+                )
+        if any(ord(c) < 32 for c in v):
+            raise ValueError("namespace must not contain control characters")
+        return v
+
+
 class NamespaceConfig(BaseSettings):
     default_namespace: str = "default"
     enable_auto_ns: bool = False
+    rules: Annotated[list[NamespacePolicyRule], APPEND] = Field(default_factory=list)
 
 
 class RerankConfig(BaseSettings):
@@ -658,10 +711,43 @@ def _merge_strategy_for(section_cls: type, field_name: str) -> MergeStrategy | N
     return None
 
 
+def _list_item_type(section_cls: type, field_name: str) -> type | None:
+    """Return the element type of a ``list[X]`` field, or ``None`` for scalars.
+
+    Used by the fragment loader to coerce raw JSON dicts into ``BaseSettings``
+    instances before APPEND dedup, since ``setattr`` on a non-validating
+    BaseSettings won't re-validate the assigned list.
+    """
+    import typing
+
+    info = (
+        section_cls.model_fields.get(field_name) if hasattr(section_cls, "model_fields") else None
+    )
+    if info is None:
+        return None
+    args = typing.get_args(info.annotation)
+    if not args:
+        return None
+    item = args[0]
+    return item if isinstance(item, type) else None
+
+
 def _dedup_key(item: object) -> object:
-    """Stable equality key for APPEND dedup; normalises Path to its string form."""
+    """Stable equality key for APPEND dedup.
+
+    Normalises Path to its string form and dict/BaseSettings to a recursively
+    sorted tuple form so that ``list[dict]`` and ``list[BaseSettings]`` fields
+    (e.g. ``NamespaceConfig.rules``) can be deduped across a native default
+    list and raw JSON fragment entries.
+    """
     if isinstance(item, Path):
         return str(item)
+    if isinstance(item, BaseSettings):
+        return _dedup_key(item.model_dump(mode="json"))
+    if isinstance(item, dict):
+        return tuple(sorted((k, _dedup_key(v)) for k, v in item.items()))
+    if isinstance(item, list):
+        return tuple(_dedup_key(x) for x in item)
     return item
 
 
@@ -737,8 +823,28 @@ def load_config_d(config: Mem2MemConfig) -> None:
                         )
                         continue
                     current = list(getattr(section_obj, key))
+                    item_type = _list_item_type(section_cls, key)
+                    coerce = (
+                        item_type
+                        if item_type is not None
+                        and isinstance(item_type, type)
+                        and issubclass(item_type, BaseSettings)
+                        else None
+                    )
                     seen = {_dedup_key(x) for x in current}
                     for item in value:
+                        if coerce is not None and isinstance(item, dict):
+                            try:
+                                item = coerce.model_validate(item)
+                            except Exception as exc:
+                                _log.warning(
+                                    "Skipping invalid %s.%s entry in %s: %s",
+                                    section_name,
+                                    key,
+                                    path,
+                                    exc,
+                                )
+                                continue
                         k = _dedup_key(item)
                         if k not in seen:
                             current.append(item)

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -16,7 +16,7 @@ from memtomem.chunking.markdown import MarkdownChunker
 from memtomem.chunking.registry import ChunkerRegistry
 from memtomem.chunking.restructured_text import ReStructuredTextChunker
 from memtomem.chunking.structured import StructuredChunker
-from memtomem.config import IndexingConfig, NamespaceConfig
+from memtomem.config import IndexingConfig, NamespaceConfig, NamespacePolicyRule
 from memtomem.indexing.differ import compute_diff
 from memtomem.models import Chunk, ChunkMetadata, IndexingStats
 
@@ -117,6 +117,10 @@ class IndexEngine:
         self._embedder = embedder
         self._config = config
         self._ns_config = namespace_config or NamespaceConfig()
+        self._ns_rule_specs: list[tuple[pathspec.GitIgnoreSpec, NamespacePolicyRule]] = [
+            (_build_exclude_spec([rule.path_glob]), rule) for rule in self._ns_config.rules
+        ]
+        self._warned_empty_parent_rules: set[int] = set()
         self._registry = registry or ChunkerRegistry(
             [
                 MarkdownChunker(),
@@ -254,12 +258,22 @@ class IndexEngine:
     def _resolve_namespace(self, file_path: Path, explicit_ns: str | None) -> str | None:
         """Determine the namespace for a file.
 
-        Priority: explicit parameter > auto_ns (folder-based) > default_namespace.
-        Returns None only if default_namespace is "default" and auto_ns is off
-        (preserves backward compat — chunks without namespace stay untagged).
+        Priority: explicit parameter > policy rules (first valid match) >
+        auto_ns (folder-based) > default_namespace. Returns None only if
+        default_namespace is "default" and nothing else matched (preserves
+        backward compat — chunks without namespace stay untagged).
         """
         if explicit_ns is not None:
             return explicit_ns
+
+        if self._ns_rule_specs:
+            candidate = file_path.as_posix().lower().lstrip("/")
+            for i, (spec, rule) in enumerate(self._ns_rule_specs):
+                if not spec.match_file(candidate):
+                    continue
+                ns = self._format_namespace(rule.namespace, file_path, rule_index=i)
+                if ns is not None:
+                    return ns
 
         if self._ns_config.enable_auto_ns:
             # Derive namespace from the immediate parent folder name,
@@ -277,6 +291,27 @@ class IndexEngine:
             return default
 
         return None
+
+    def _format_namespace(self, template: str, file_path: Path, *, rule_index: int) -> str | None:
+        """Substitute ``{parent}`` in a rule's namespace template.
+
+        Returns ``None`` when ``{parent}`` is present but the file's parent
+        folder name is empty, so the caller can fall through to the next rule.
+        Logs a warning once per rule index to surface the skip without flooding.
+        """
+        if "{parent}" not in template:
+            return template
+        parent_name = file_path.parent.name
+        if not parent_name:
+            if rule_index not in self._warned_empty_parent_rules:
+                self._warned_empty_parent_rules.add(rule_index)
+                logger.warning(
+                    "namespace rule #%d skipped for %s: parent name empty",
+                    rule_index,
+                    file_path,
+                )
+            return None
+        return template.format(parent=parent_name)
 
     def _is_within_memory_dirs(self, path: Path) -> bool:
         """Check that *path* is within at least one configured memory_dir."""

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -321,6 +321,44 @@ def test_config_d_namespace_rules_alphabetical_order(
     assert [r.namespace for r in cfg.namespace.rules] == ["claude", "gdrive"]
 
 
+def test_config_d_namespace_rules_dedup_after_home_expansion(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Freeze the dedup semantics for NamespacePolicyRule: two fragments that
+    declare the same rule once with a leading ``~/`` and once with the expanded
+    absolute path must collapse to a single rule.
+
+    ``_dedup_key`` hashes ``BaseSettings.model_dump(mode="json")`` — i.e. the
+    *post-validator* field values. Since ``path_glob`` expands ``~/`` in its
+    validator, both forms share an identity after coercion, so they dedupe.
+    This test pins that contract: a future refactor that moved expansion out
+    of the validator (or the dedup key off ``model_dump``) would start
+    producing two rules and fail here.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    abs_form = str(Path("~/some/memtomem-test/**").expanduser())
+    (config_d_dir / "10-home.json").write_text(
+        json.dumps(
+            {
+                "namespace": {
+                    "rules": [
+                        {"path_glob": "~/some/memtomem-test/**", "namespace": "x"},
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (config_d_dir / "20-abs.json").write_text(
+        json.dumps({"namespace": {"rules": [{"path_glob": abs_form, "namespace": "x"}]}}),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert len(cfg.namespace.rules) == 1, [r.path_glob for r in cfg.namespace.rules]
+    assert cfg.namespace.rules[0].path_glob == abs_form
+
+
 # ---------------------------------------------------------------------------
 # Enforcement: every list[*] field must declare a merge strategy.
 #

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -257,6 +257,70 @@ def test_config_d_ignores_non_json_files(
     assert str(cfg.storage.sqlite_path) == "/ok.db"
 
 
+def test_config_d_namespace_rules_appends(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """APPEND merge: default empty rules + fragment rule → one loaded rule."""
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "claude.json").write_text(
+        json.dumps(
+            {
+                "namespace": {
+                    "rules": [
+                        {
+                            "path_glob": "**/.claude/**/memory/**",
+                            "namespace": "claude:memory",
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    assert cfg.namespace.rules == []
+    load_config_d(cfg)
+    assert len(cfg.namespace.rules) == 1
+    assert cfg.namespace.rules[0].namespace == "claude:memory"
+
+
+def test_config_d_namespace_rules_alphabetical_order(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fragments concatenate in alphabetical filename order — freeze this
+    contract so users can rely on numeric prefixes (``10-foo.json`` before
+    ``20-bar.json``) for first-match-wins precedence across fragments.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    (config_d_dir / "20-gdrive.json").write_text(
+        json.dumps(
+            {
+                "namespace": {
+                    "rules": [
+                        {"path_glob": "**/gdrive/**", "namespace": "gdrive"},
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (config_d_dir / "10-claude.json").write_text(
+        json.dumps(
+            {
+                "namespace": {
+                    "rules": [
+                        {"path_glob": "**/claude/**", "namespace": "claude"},
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert [r.namespace for r in cfg.namespace.rules] == ["claude", "gdrive"]
+
+
 # ---------------------------------------------------------------------------
 # Enforcement: every list[*] field must declare a merge strategy.
 #

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+import pytest
+from pydantic import ValidationError
 
-from memtomem.config import NamespaceConfig
+from memtomem.config import NamespaceConfig, NamespacePolicyRule
 from memtomem.indexing.engine import (
     IndexEngine,
     _merge_short_chunks,
@@ -348,6 +350,210 @@ class TestResolveNamespace:
         fp = memory_dir / "file.md"
         result = engine._resolve_namespace(fp, None)
         assert result == "work"
+
+
+# ===========================================================================
+# 2b. _resolve_namespace with NamespacePolicyRule
+# ===========================================================================
+
+
+def _install_rules(engine, rules, *, enable_auto_ns=False, default_namespace="default"):
+    """Swap an engine's namespace config + rebuild its pre-compiled rule specs.
+
+    Mirrors the constructor wiring in IndexEngine.__init__ so tests can exercise
+    different rule sets without standing up a fresh component stack.
+    """
+    from memtomem.indexing.engine import _build_exclude_spec
+
+    engine._ns_config = NamespaceConfig(
+        enable_auto_ns=enable_auto_ns,
+        default_namespace=default_namespace,
+        rules=rules,
+    )
+    engine._ns_rule_specs = [(_build_exclude_spec([rule.path_glob]), rule) for rule in rules]
+    engine._warned_empty_parent_rules = set()
+
+
+class TestNamespacePolicyRules:
+    """Tests for IndexEngine._resolve_namespace with rule-based policy."""
+
+    async def test_no_rules_preserves_existing_behavior(self, components, memory_dir):
+        """rules=[] → priority chain behaves exactly like the pre-rules path."""
+        engine = components.index_engine
+        _install_rules(engine, [])
+
+        fp = memory_dir / "notes.md"
+        assert engine._resolve_namespace(fp, None) is None
+        assert engine._resolve_namespace(fp, "explicit") == "explicit"
+
+    async def test_rule_match_returns_namespace(self, components, memory_dir):
+        """A matching rule returns its namespace."""
+        engine = components.index_engine
+        rule_glob = f"{memory_dir.as_posix()}/**"
+        _install_rules(
+            engine,
+            [NamespacePolicyRule(path_glob=rule_glob, namespace="matched")],
+        )
+
+        fp = memory_dir / "sub" / "notes.md"
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "matched"
+
+    async def test_first_match_wins(self, components, memory_dir):
+        """When multiple rules match, the earliest one wins."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(path_glob=f"{memory_dir.as_posix()}/**", namespace="first"),
+                NamespacePolicyRule(path_glob=f"{memory_dir.as_posix()}/**", namespace="second"),
+            ],
+        )
+
+        fp = memory_dir / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "first"
+
+    async def test_explicit_ns_beats_rules(self, components, memory_dir):
+        """Explicit namespace argument takes priority over any rule match."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(path_glob=f"{memory_dir.as_posix()}/**", namespace="ruled"),
+            ],
+        )
+
+        fp = memory_dir / "notes.md"
+        assert engine._resolve_namespace(fp, "explicit") == "explicit"
+
+    async def test_rules_beat_auto_ns(self, components, memory_dir):
+        """A rule match wins over enable_auto_ns folder derivation."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(path_glob=f"{memory_dir.as_posix()}/**", namespace="ruled"),
+            ],
+            enable_auto_ns=True,
+        )
+
+        sub = memory_dir / "project-x"
+        sub.mkdir()
+        fp = sub / "notes.md"
+        fp.write_text("# Notes")
+
+        # Without rules this would have returned "project-x" (see
+        # TestResolveNamespace.test_auto_ns_folder_based).
+        assert engine._resolve_namespace(fp, None) == "ruled"
+
+    async def test_parent_placeholder_substitution(self, components, memory_dir):
+        """``{parent}`` expands to the matched file's parent folder name."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**",
+                    namespace="gdrive:{parent}",
+                ),
+            ],
+        )
+
+        sub = memory_dir / "team-alpha"
+        sub.mkdir()
+        fp = sub / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "gdrive:team-alpha"
+
+    async def test_home_tilde_in_path_glob_expanded(self):
+        """Leading ``~/`` in path_glob expands at load time."""
+        rule = NamespacePolicyRule(path_glob="~/some/path/**", namespace="home")
+        assert not rule.path_glob.startswith("~"), rule.path_glob
+        assert rule.path_glob.endswith("/some/path/**")
+
+    async def test_parent_placeholder_empty_parent_falls_through(
+        self, components, memory_dir, caplog
+    ):
+        """When ``{parent}`` expands to an empty string the rule is skipped and
+        the next fallback (here: default_namespace) is returned. Also verifies
+        the skip is logged once per rule index.
+        """
+        import logging
+
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(path_glob="**", namespace="prefix:{parent}"),
+            ],
+            default_namespace="fallback",
+        )
+
+        # A path whose parent is "/" — parent.name == "" on POSIX.
+        fp = Path("/root-level.md")
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.indexing.engine"):
+            assert engine._resolve_namespace(fp, None) == "fallback"
+            # Second call on the same rule index must not re-log.
+            assert engine._resolve_namespace(fp, None) == "fallback"
+
+        skip_warnings = [r for r in caplog.records if "parent name empty" in r.getMessage()]
+        assert len(skip_warnings) == 1, [r.getMessage() for r in skip_warnings]
+
+    async def test_case_insensitive_matching(self, components, memory_dir):
+        """Glob matching is case-insensitive — same semantics as exclude_patterns."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**/.CLAUDE/**",
+                    namespace="claude",
+                ),
+            ],
+        )
+
+        sub = memory_dir / "proj" / ".claude"
+        sub.mkdir(parents=True)
+        fp = sub / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "claude"
+
+    async def test_literal_namespace_no_placeholder(self, components, memory_dir):
+        """A namespace template without ``{parent}`` is returned verbatim."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**",
+                    namespace="literal-label",
+                ),
+            ],
+        )
+
+        fp = memory_dir / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "literal-label"
+
+    def test_unknown_placeholder_rejected_at_load(self):
+        """``{unknown}`` in namespace raises a ValidationError at construction."""
+        with pytest.raises(ValidationError) as excinfo:
+            NamespacePolicyRule(path_glob="**", namespace="foo:{unknown}")
+        assert "unknown placeholder" in str(excinfo.value).lower()
+
+    def test_namespace_length_limit_rejected_at_load(self):
+        """A namespace over 128 chars raises a ValidationError."""
+        with pytest.raises(ValidationError) as excinfo:
+            NamespacePolicyRule(path_glob="**", namespace="x" * 129)
+        assert "128" in str(excinfo.value)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds `NamespacePolicyRule` to `NamespaceConfig` so users can declare path-glob → namespace mappings instead of passing `namespace=` on every `mem_index` call. Closes the practical gap in `enable_auto_ns`, which uses the immediate parent folder name and so produces opaque namespaces like `<UUID>` or `subagents` under auto-discovered roots (`~/.claude/projects/<UUID>/...`).

## Resolution priority

```
explicit param → rules (first valid match) → enable_auto_ns → default_namespace
```

Rules are evaluated between the explicit-argument check and the `enable_auto_ns` fallback. Default is `[]`, so existing users see no behavior change until they opt in via `config.json` or `config.d/*.json`.

## Design decisions

- **Pattern engine**: `pathspec.GitIgnoreSpec`, case-insensitive, matched against the absolute resolved file path with any leading `/` stripped. Same semantics as `IndexingConfig.exclude_patterns` so users learn one pattern language.
- **`{parent}` placeholder**: expands to the matched file's immediate parent folder name. Only `{parent}` is supported in this release; **unknown placeholders are rejected at load time** so typos fail loudly at startup rather than silently skipping rules at index time.
- **Empty-parent fall-through**: if `{parent}` would expand to an empty string at runtime, the rule is skipped (fall through to the next rule / `auto_ns` / `default_namespace`) with a one-time warning log per rule index.
- **APPEND merge**: `Annotated[list[NamespacePolicyRule], APPEND]` so `config.d/*.json` fragments can contribute rules independently. Fragments concatenate in alphabetical filename order — use numeric prefixes (`10-claude.json`, `20-gdrive.json`) for cross-fragment precedence.
- **Validation**: non-empty namespace after strip, ≤ 128 chars, no ASCII control chars; non-empty `path_glob` with `~/` expanded at load time.

## Incidental fixes to config merge machinery

This PR is the **first `list[BaseSettings]` field in the codebase** and surfaced two gaps in `load_config_d` that are fixed inline. Both are scoped to **load time** (`~/.memtomem/config.json` + `~/.memtomem/config.d/*.json` merging) and do not touch the mutation paths (`config_set` CLI, `PATCH /api/config`, future Web UI editors).

1. **`_dedup_key` now handles `dict` / `BaseSettings` / nested `list`.** Previously it only normalised `Path` → `str` and let everything else fall through to raw Python hashing, which raised `TypeError: unhashable type: 'dict'` the first time a list-of-objects field went through APPEND dedup. The new version recursively converts `BaseSettings` via `model_dump(mode="json")` and dicts into sorted tuples, so a native model instance and the raw JSON dict that produced it share a dedup key. Existing `list[str]` / `list[Path]` / `list[float]` fields are untouched.
2. **APPEND merge loop coerces JSON dicts to the declared item type before dedup.** A non-`validate_assignment` `BaseSettings` lets `setattr(section_obj, key, [<dict>])` succeed without coercing, so the merged list would contain raw dicts. The loop now introspects the field annotation, and if the item type is a `BaseSettings` subclass it calls `item_type.model_validate(item)` on each incoming dict before the dedup step. Invalid entries are logged and skipped rather than crashing the whole fragment.

**Dedup semantics freeze (commit 3):** `_dedup_key` intentionally hashes **post-validator** field values, so a rule written as `~/foo/**` and the same rule written as the expanded absolute path `/Users/X/foo/**` collide after construction and dedupe to one entry. A new test (`test_config_d_namespace_rules_dedup_after_home_expansion`) pins this contract so a future refactor that moved `~/` expansion out of the validator — or moved the dedup key off `model_dump` — would fail at PR time rather than surfacing as a confused bug report from a user who split their rules across two `config.d` fragments.

**Out of scope:** the mutation path still lacks nested-`BaseModel` support — `coerce_and_validate` in `config.py` can't consume a `list[BaseSettings]` today, so `config_set namespace.rules ...` is rejected and a Web UI editor can't persist rules via `PATCH /api/config` yet. Fixing that is a separate PR (see Intentionally deferred below).

## Intentionally deferred

- **Web UI rules editor** — blocked on the `coerce_and_validate` mutation-path gap above; attempting the editor before that fix would re-discover the same `list[BaseSettings]` problem on the mutate side.
- **`config_set namespace.rules` CLI** — same root cause as Web UI editor.
- **`{match:N}` capture group placeholder** — `{parent}` covers the common cases; add if evidence accrues.
- **Rule `priority: int` field** — alphabetical fragment ordering + in-fragment declaration order cover 99% of cases.
- **Rule debugging CLI (`mm namespace test <path>`)** — `mm config show` is enough for now.

Each is listed in the plan file's "Out of scope" block so the bounds are explicit.

## Test plan

- [x] 12 new `TestNamespacePolicyRules` cases (core 7 + edge 5): explicit-wins, rule-match, first-match-wins, rules-beat-auto_ns, `{parent}` substitution, `~/` expansion, empty-parent fall-through (with log-once assertion), case-insensitive matching, literal template, unknown-placeholder rejection, length-limit rejection.
- [x] 3 `test_config_overrides.py` cases covering APPEND merge, the alphabetical-order contract, and the home-expansion dedup freeze.
- [x] Existing `TestResolveNamespace` (5 tests) — regression-free.
- [x] Existing `test_every_list_field_declares_merge_strategy` — passes for the new field.
- [x] Full `uv run pytest -m "not ollama"` — 1650 + new 15 = 1651 passed, 46 deselected.
- [x] `uv run ruff check` + `uv run ruff format --check`.
- [x] `uv run mypy packages/memtomem/src/memtomem/config.py packages/memtomem/src/memtomem/indexing/engine.py` — no issues.

## Docs in the same PR

- `docs/guides/configuration.md` — "Namespace rules (path-based auto-tagging)" subsection under Namespace: JSON example, full semantics, "Verifying your rules" block.
- `docs/guides/user-guide.md` — cross-reference from the Auto-namespace section so readers land on the rules doc when the parent folder heuristic isn't enough.