### PR TITLE
cli(init): surface non-default values preserved from previous config

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import shutil
 import subprocess
+import time
 from pathlib import Path
 
 import click
@@ -358,6 +360,95 @@ def _step_mcp(state: dict) -> None:
 # ── Write config & summary ────────────────────────────────────────────
 
 
+def _flatten_config(d: dict, prefix: str = "") -> dict[str, object]:
+    """Flatten nested dict into `"section.key": value` pairs (one level deep
+    is enough for this codebase's config shape)."""
+    out: dict[str, object] = {}
+    for k, v in d.items():
+        key = f"{prefix}{k}"
+        if isinstance(v, dict):
+            out.update(_flatten_config(v, prefix=f"{key}."))
+        else:
+            out[key] = v
+    return out
+
+
+def _flatten_init_data_keys(init_data: dict) -> set[str]:
+    """Flat `section.key` set for every field the wizard actively wrote this
+    run — used to exclude them from the Preserved summary."""
+    keys: set[str] = set()
+    for section, fields in init_data.items():
+        if isinstance(fields, dict):
+            for k in fields:
+                keys.add(f"{section}.{k}")
+        else:
+            keys.add(section)
+    return keys
+
+
+def _fmt_config_value(v: object) -> str:
+    """Render a config value for the summary — keep bools lowercase so they
+    match how they appear in config.json."""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if v is None:
+        return "null"
+    if isinstance(v, str):
+        return v
+    return json.dumps(v, default=str)
+
+
+def _emit_preserved_block(
+    existing_before: dict,
+    written: dict,
+    wizard_touched: set[str],
+) -> None:
+    """Flag values that (a) were already in the previous config, (b) the
+    wizard did not touch this run, and (c) differ from the built-in default.
+
+    Silent preservation is the main way Web UI dumps of the full mutable
+    config (memory-dirs add/remove, section save, etc.) accumulate non-default
+    values the user didn't consciously set. Surfacing them here is the
+    cheapest way to close that loop."""
+    from memtomem.config import Mem2MemConfig
+
+    defaults_flat = _flatten_config(Mem2MemConfig().model_dump(mode="json"))
+    before_flat = _flatten_config(existing_before)
+    written_flat = _flatten_config(written)
+
+    flagged: list[tuple[str, object, object]] = []
+    for key, value in written_flat.items():
+        if key in wizard_touched:
+            continue
+        if key not in before_flat:
+            continue
+        if before_flat[key] != value:
+            continue
+        default_val = defaults_flat.get(key)
+        if default_val == value:
+            continue
+        flagged.append((key, value, default_val))
+
+    if not flagged:
+        return
+
+    click.echo()
+    click.secho(
+        "  Preserved from existing config (wizard didn't ask about these):",
+        fg="yellow",
+    )
+    for key, value, default_val in sorted(flagged):
+        click.secho(
+            f"    [!] {key} = {_fmt_config_value(value)}   "
+            f"(built-in default: {_fmt_config_value(default_val)})",
+            fg="yellow",
+        )
+    click.echo()
+    click.echo("  If any of these are unexpected, edit ~/.memtomem/config.json")
+    click.echo('  and remove the flagged keys (e.g. delete the "mmr" section')
+    click.echo("  to restore mmr.enabled=false).")
+
+
 def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None:
     """Write config files and show summary (runs after all steps)."""
     if base_dir is None:
@@ -374,13 +465,31 @@ def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None
     click.secho("Writing configuration...", fg="green")
     config_path = config_dir / "config.json"
 
-    # Read existing config as merge base (preserves post-init user edits)
+    # Read existing config as merge base (preserves post-init user edits).
+    # If the file is unreadable we save a timestamped backup and start fresh —
+    # better than silently wiping what might be salvageable by hand.
     existing: dict = {}
     if config_path.exists():
         try:
             existing = json.loads(config_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            pass
+        except (OSError, json.JSONDecodeError) as exc:
+            backup_path = config_path.with_suffix(f".json.bak-{int(time.time())}")
+            try:
+                shutil.copy2(config_path, backup_path)
+                click.secho(
+                    f"  Note: {config_path.name} was unreadable ({exc.__class__.__name__}); "
+                    f"backed up to {backup_path.name} and starting from empty.",
+                    fg="yellow",
+                )
+            except OSError as backup_exc:
+                click.secho(
+                    f"  Warning: {config_path.name} unreadable and backup failed "
+                    f"({backup_exc}); proceeding with empty base.",
+                    fg="yellow",
+                )
+    # Snapshot for the preserved-values summary below — must happen BEFORE
+    # merge so we can diff pre-merge vs post-write.
+    existing_before = copy.deepcopy(existing)
 
     # Build init-target fields only
     init_data: dict = {
@@ -420,6 +529,16 @@ def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None
 
     config_path.write_text(json.dumps(existing, indent=2, default=str), encoding="utf-8")
     click.echo(f"  Config: {config_path}")
+
+    # Flag non-default values preserved from the previous config that the
+    # wizard never asked about — e.g. mmr.enabled=true left over from the
+    # Web UI's full-config dump. See docs/config-lifecycle.md (follow-up).
+    wizard_touched_keys = _flatten_init_data_keys(init_data)
+    try:
+        written = json.loads(config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        written = existing  # unreachable in practice; stay safe
+    _emit_preserved_block(existing_before, written, wizard_touched_keys)
 
     # Build MCP server command
     if source_install and source_dir:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -216,6 +216,159 @@ def test_write_config_and_summary_without_base_dir_falls_back_to_home(
     assert (tmp_path / ".memtomem" / "config.json").exists()
 
 
+class TestPreservedSummary:
+    """`_write_config_and_summary` flags non-default values that the wizard
+    inherited from a previous config but did not ask about this run.
+
+    Primary driver: Web UI's `save_config_overrides` dumps all mutable fields
+    to config.json whenever memory-dirs are changed or a section is saved,
+    silently persisting runtime values (e.g. mmr.enabled) that the user may
+    not have deliberately set. The wizard cannot fix the write path, but it
+    can surface the leftovers on the next `mm init`."""
+
+    def test_fresh_init_no_mmr_section(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh init must not create an ``mmr`` section in config.json.
+
+        This is the load-bearing guard: if anyone later wires the wizard to
+        write to ``mmr.*``, this test fails and forces a deliberate update to
+        the preserved-summary logic (since ``wizard_touched_keys`` would then
+        need to include ``mmr.*`` to avoid flagging the user's own choice)."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert "mmr" not in data, (
+            "wizard must not create an mmr section on fresh init — "
+            "if you intentionally added an MMR step, update wizard_touched_keys"
+        )
+
+    def test_preserved_non_default_shown_in_summary(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A pre-existing ``mmr.enabled=true`` (non-default) must surface in
+        the Preserved block with the ``[!]`` marker."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"mmr": {"enabled": True, "lambda_param": 0.7}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Preserved from existing config" in out
+        assert "[!] mmr.enabled = true" in out
+        assert "built-in default: false" in out
+
+    def test_preserved_default_not_shown(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A preserved value equal to the built-in default must NOT be flagged
+        — otherwise the Preserved block becomes noise on every re-run."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            # mmr.enabled=False is the built-in default — should stay silent.
+            json.dumps({"mmr": {"enabled": False, "lambda_param": 0.7}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Preserved from existing config" not in out
+        assert "mmr.enabled" not in out
+
+    def test_wizard_choice_overrides_preserved(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A field the wizard actively writes this run (e.g. search.tokenizer)
+        must appear in the normal summary, never in Preserved — even if the
+        previous config had the same key set."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps({"search": {"tokenizer": "unicode61"}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        state["tokenizer"] = "kiwipiepy"
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        # Preserved block, if emitted, must NOT list tokenizer — wizard owns it
+        preserved_idx = out.find("Preserved from existing config")
+        if preserved_idx != -1:
+            preserved_tail = out[preserved_idx:]
+            assert "search.tokenizer" not in preserved_tail
+        # And the normal summary shows the new choice
+        assert "tokenizer=kiwipiepy" in out
+
+    def test_malformed_config_graceful(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A corrupt config.json must not crash the wizard. The bad file gets
+        backed up with a ``.bak-<ts>`` suffix and the run proceeds as if
+        ``existing`` were empty."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text("{this is not json", encoding="utf-8")
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "unreadable" in out
+        # Backup created (suffix .json.bak-<ts>)
+        backups = list(config_dir.glob("config.json.bak-*"))
+        assert len(backups) == 1, f"expected exactly one backup, got {backups}"
+        # New config is valid JSON
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["embedding"]["provider"] == "none"
+
+
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be
     encoded as a JSON array string. A bare path crashes pydantic-settings.


### PR DESCRIPTION
## Summary

- `mm init` uses read-merge-write on `~/.memtomem/config.json` so post-init edits survive re-runs. The Web UI's `save_config_overrides` also dumps the full mutable config on section save / memory-dirs change, silently persisting runtime values the user may not have consciously set (observed case: `mmr.enabled=true` on a user who reports never toggling MMR).
- Before this PR there was no way to notice such leftovers — the wizard's Setup-complete summary was built from `state` only and skipped every section it didn't ask about.
- This PR adds a Preserved block to the wizard's summary that flags keys which (a) were present in the previous config unchanged, (b) the wizard didn't write this run, and (c) differ from the built-in `Mem2MemConfig()` default. The behaviour of the write itself is unchanged — this is transparency only.

## What changed

- `_write_config_and_summary` now snapshots `existing` before merging and re-reads the written file after, then compares against flattened defaults. The flag uses a built-in-default diff, not a bool heuristic, so non-bool leftovers (e.g. `search.rrf_k=120`) surface too.
- Malformed `config.json` is now backed up to `config.json.bak-<unix-ts>` instead of being silently overwritten — manual recovery stays possible.
- `NO_COLOR` is respected via click's built-in handling; `[!]` is a plain marker so the output stays legible without ANSI.
- Five new regression tests in `TestPreservedSummary`. The load-bearing one is `test_fresh_init_no_mmr_section`: if any future wizard step starts writing to `mmr.*`, that test fails and forces the author to add those keys to `wizard_touched_keys` (otherwise the user's own choice would be mis-flagged as Preserved).

## Out of scope / follow-ups

This PR only improves visibility. The underlying \"silent persistence\" pattern has three open threads worth tracking separately:

1. **`save_config_overrides` dumps the full `_MUTABLE_FIELDS` set.** Memory-dirs add/remove writes every mutable key to `config.json`, so runtime values (incl. defaults loaded from `config.d/`) get pinned into the override file. Precedence would still work if only the changed keys were persisted — worth revisiting the design choice.
2. **Web UI has no reset-to-default.** A user who unchecks MMR and saves writes `mmr.enabled=false` into `config.json`, which then overrides any `config.d/` fragment permanently. Symmetric to (1); should be fixable by either per-field \"reset\" or by dropping keys equal to the default at write time.
3. **Planned `--fresh` flag only resolves wizard-driven leftovers.** Web-UI-written leftovers still require manual editing of `config.json` (or the fixes from (1)/(2)).

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run pytest -m \"not ollama\" packages/memtomem/tests/test_init_cmd.py` — 14 pass (9 existing + 5 new)
- [x] `uv run pytest -m \"not ollama\" packages/memtomem/tests/ -k \"init or config or cli or wizard\"` — 216 pass
- [x] Manual: fresh `HOME`, seed `{\"mmr\":{\"enabled\":true},\"search\":{\"rrf_k\":120}}`, run `mm init -y --provider none ...` — Preserved block lists both keys with correct defaults
- [x] Manual: same as above with `NO_COLOR=1` — ANSI codes gone, text layout intact
- [x] Manual: seed malformed JSON — wizard completes, `.json.bak-<ts>` created, Setup completes with a valid new config