### PR TITLE
cli(init): add --fresh to drop wizard-untouched config leftovers

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -49,6 +49,28 @@ top of the default:
 explicit-user-override layer. Use a fragment in `config.d/` if you want
 APPEND semantics.
 
+### Resetting wizard-untouched leftovers (`--fresh`)
+
+Because the Web UI's "Save" buttons dump every mutable field into
+`config.json` (memory-dirs add/remove, section save), runtime values
+the user never deliberately set can pin themselves there permanently
+— a known case is `mmr.enabled=true` showing up after the user toggled
+MMR once in the UI. `mm init` flags such leftovers under a "Preserved"
+block so they don't disappear silently, but it does not remove them.
+
+`mm init --fresh` resets every wizard-untouched canonical key whose
+value differs from the built-in default, then proceeds with the
+normal wizard. Credentials (`api_key`, `secret`), endpoints
+(`base_url`, `webhook.url`), and user-curated lists
+(`indexing.exclude_patterns`, `namespace.rules`, etc.) are preserved
+unconditionally; user-added keys outside the canonical
+`Mem2MemConfig` shape are also preserved. A timestamped backup
+(`config.json.bak-<unix-ts>`) is written before any drop so the
+previous state is recoverable.
+
+If the web UI is running, restart it after `--fresh` so its
+in-memory cache doesn't re-pin the dropped values on the next save.
+
 ## Storage
 
 | Variable | Default | Description |

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -398,6 +398,143 @@ def _fmt_config_value(v: object) -> str:
     return json.dumps(v, default=str)
 
 
+# Canonical config keys that hold credentials, endpoints, or user-curated
+# data the wizard does not ask about. ``--fresh`` MUST preserve these even
+# when they're non-default and wizard-untouched, otherwise a single
+# `mm init --fresh` would silently wipe API keys, custom endpoints, exclude
+# patterns, namespace rules, etc.
+#
+# Derivation (re-runnable): grep for credential/endpoint/list patterns in
+# ``packages/memtomem/src/memtomem/config.py`` (commit 0e61e7d):
+#   credentials → ``api_key|secret|token|password|bearer|credential``
+#   endpoints   → ``base_url|endpoint|_url|host``
+#   user data   → list/dict fields that aren't pure tuning numbers
+#
+# Maintenance: when adding a new config field that holds credentials,
+# endpoints, or user-curated data the wizard doesn't ask about, add it
+# here. Verify with ``pytest -k fresh_preserves_user_data_keys``.
+_FRESH_PRESERVE_KEYS: frozenset[str] = frozenset(
+    {
+        # Credentials
+        "embedding.api_key",
+        "rerank.api_key",
+        "llm.api_key",
+        "webhook.secret",
+        # Endpoints
+        "embedding.base_url",
+        "llm.base_url",
+        "webhook.url",
+        # User-curated lists / rules (wizard doesn't ask)
+        "indexing.exclude_patterns",
+        "indexing.supported_extensions",
+        "namespace.rules",
+        "search.system_namespace_prefixes",
+        "webhook.events",
+    }
+)
+
+
+def _compute_fresh_drops(
+    existing: dict,
+    wizard_touched: set[str],
+) -> list[tuple[str, object, object]]:
+    """Return ``[(flat_key, current_value, default_value), ...]`` for the
+    keys ``--fresh`` will reset to the built-in default.
+
+    A key is a drop candidate iff ALL hold:
+      - present in ``Mem2MemConfig().model_dump()`` flat-key set — keys
+        outside this canonical shape are user custom extensions and are
+        preserved unconditionally;
+      - NOT in ``wizard_touched`` — those get overwritten by ``init_data``
+        anyway, no need to drop them first;
+      - NOT in :data:`_FRESH_PRESERVE_KEYS` — credentials, endpoints,
+        user-curated data are never auto-dropped;
+      - current value differs from the built-in default — already-default
+        values are no-ops on disk after merge.
+    """
+    from memtomem.config import Mem2MemConfig
+
+    defaults_flat = _flatten_config(Mem2MemConfig().model_dump(mode="json"))
+    existing_flat = _flatten_config(existing)
+    drops: list[tuple[str, object, object]] = []
+    for key, value in existing_flat.items():
+        if key not in defaults_flat:
+            continue
+        if key in wizard_touched:
+            continue
+        if key in _FRESH_PRESERVE_KEYS:
+            continue
+        default_val = defaults_flat[key]
+        if default_val == value:
+            continue
+        drops.append((key, value, default_val))
+    return drops
+
+
+def _drop_flat_keys(existing: dict, drops: list[tuple[str, object, object]]) -> None:
+    """Remove each flat key from the nested ``existing`` dict, then prune
+    parent dicts that become empty."""
+    for flat_key, _, _ in drops:
+        parts = flat_key.split(".")
+        path: list[tuple[dict, str]] = []
+        cur: object = existing
+        for p in parts[:-1]:
+            if not isinstance(cur, dict) or p not in cur:
+                cur = None
+                break
+            path.append((cur, p))
+            cur = cur[p]
+        if isinstance(cur, dict) and parts[-1] in cur:
+            del cur[parts[-1]]
+            for parent, key in reversed(path):
+                if isinstance(parent[key], dict) and not parent[key]:
+                    del parent[key]
+                else:
+                    break
+
+
+def _emit_reset_block(
+    drops: list[tuple[str, object, object]],
+    backup_path: Path | None,
+) -> None:
+    """Print the ``--fresh`` outcome — which keys were reset to default,
+    where the backup lives, and the web-UI restart caveat.
+
+    With zero drops we still print one informational line so the user knows
+    why ``--fresh`` produced no visible change."""
+    if not drops:
+        click.echo()
+        click.secho(
+            "  --fresh: no wizard-untouched leftovers to reset.",
+            fg="cyan",
+        )
+        return
+
+    click.echo()
+    click.secho(
+        "  Reset to default (--fresh dropped wizard-untouched leftovers):",
+        fg="cyan",
+    )
+    for key, value, default_val in sorted(drops):
+        click.secho(
+            f"    [-] {key}: {_fmt_config_value(value)} → "
+            f"{_fmt_config_value(default_val)} (default)",
+            fg="cyan",
+        )
+    if backup_path is not None:
+        click.echo()
+        click.echo(f"  Backup saved to: {backup_path}")
+    click.echo()
+    click.secho(
+        "  [!] If the web UI is running, restart it to pick up the new config.",
+        fg="yellow",
+    )
+    click.secho(
+        "      Otherwise a web save may restore the reset values.",
+        fg="yellow",
+    )
+
+
 def _emit_preserved_block(
     existing_before: dict,
     written: dict,
@@ -449,8 +586,18 @@ def _emit_preserved_block(
     click.echo("  to restore mmr.enabled=false).")
 
 
-def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None:
-    """Write config files and show summary (runs after all steps)."""
+def _write_config_and_summary(
+    state: dict, base_dir: Path | None = None, fresh: bool = False
+) -> None:
+    """Write config files and show summary (runs after all steps).
+
+    When ``fresh=True``, drop wizard-untouched canonical settings whose
+    value differs from the built-in default before merging the wizard's
+    choices. Credentials, endpoints, and user-curated lists in
+    :data:`_FRESH_PRESERVE_KEYS` are preserved unconditionally; user-added
+    custom keys outside the canonical ``Mem2MemConfig`` shape are also
+    preserved. A timestamped backup is written first iff at least one key
+    is going to be dropped — otherwise the run is a no-op on disk."""
     if base_dir is None:
         base_dir = Path.home()
     config_dir = base_dir / ".memtomem"
@@ -518,6 +665,35 @@ def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None
             "model": state["rerank_model"],
         }
 
+    # Compute wizard-touched keys upfront — both --fresh drop logic and the
+    # post-write Preserved block need them.
+    wizard_touched_keys = _flatten_init_data_keys(init_data)
+
+    # --fresh: drop wizard-untouched non-default canonical leftovers from
+    # `existing` BEFORE merge so they don't survive the round-trip. Always
+    # back up first, but only if there's at least one drop — otherwise we'd
+    # litter ~/.memtomem/ with redundant `.bak-<ts>` files on every re-run.
+    fresh_drops: list[tuple[str, object, object]] = []
+    fresh_backup_path: Path | None = None
+    if fresh:
+        fresh_drops = _compute_fresh_drops(existing, wizard_touched_keys)
+        if fresh_drops and config_path.exists():
+            fresh_backup_path = config_path.with_suffix(f".json.bak-{int(time.time())}")
+            try:
+                shutil.copy2(config_path, fresh_backup_path)
+            except OSError as exc:
+                # --fresh is destructive; refuse to drop without a recovery
+                # path. The user can re-run without --fresh, or fix the
+                # backup target (disk full / permission) and retry.
+                click.secho(
+                    f"  Error: --fresh requires a successful backup but "
+                    f"copy to {fresh_backup_path} failed ({exc}). "
+                    "Aborting to avoid data loss.",
+                    fg="red",
+                )
+                raise SystemExit(1) from exc
+            _drop_flat_keys(existing, fresh_drops)
+
     # Merge: init fields overwrite, non-init sections/fields preserved
     for section, fields in init_data.items():
         if section not in existing:
@@ -530,15 +706,20 @@ def _write_config_and_summary(state: dict, base_dir: Path | None = None) -> None
     config_path.write_text(json.dumps(existing, indent=2, default=str), encoding="utf-8")
     click.echo(f"  Config: {config_path}")
 
-    # Flag non-default values preserved from the previous config that the
-    # wizard never asked about — e.g. mmr.enabled=true left over from the
-    # Web UI's full-config dump. See docs/config-lifecycle.md (follow-up).
-    wizard_touched_keys = _flatten_init_data_keys(init_data)
-    try:
-        written = json.loads(config_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        written = existing  # unreachable in practice; stay safe
-    _emit_preserved_block(existing_before, written, wizard_touched_keys)
+    if fresh:
+        # Reset block replaces Preserved when --fresh was passed; the keys it
+        # would have flagged are exactly what we just dropped (modulo the
+        # preserve list).
+        _emit_reset_block(fresh_drops, fresh_backup_path)
+    else:
+        # Flag non-default values preserved from the previous config that
+        # the wizard never asked about — e.g. mmr.enabled=true left over
+        # from the Web UI's full-config dump.
+        try:
+            written = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            written = existing  # unreachable in practice; stay safe
+        _emit_preserved_block(existing_before, written, wizard_touched_keys)
 
     # Build MCP server command
     if source_install and source_dir:
@@ -668,6 +849,20 @@ _MODEL_DIMS: dict[str, int] = {
 @click.option("--decay", is_flag=True, default=False, help="Enable time-decay")
 @click.option("--api-key", default=None, help="OpenAI API key")
 @click.option("--mcp", "mcp_mode", type=click.Choice(["claude", "json", "skip"]), default=None)
+@click.option(
+    "--fresh",
+    is_flag=True,
+    default=False,
+    help=(
+        "Reset wizard-untouched canonical settings to their built-in defaults. "
+        "Preserves user-added custom keys, credentials (api_key/secret), "
+        "endpoints (base_url/url), and user-curated lists (exclude_patterns, "
+        "namespace.rules, etc). Backs up the previous config.json to "
+        "config.json.bak-<ts> only if at least one key is dropped. For "
+        "fine-grained control, edit ~/.memtomem/config.json directly or use "
+        "the web UI."
+    ),
+)
 def init(
     non_interactive: bool,
     provider: str | None,
@@ -681,6 +876,7 @@ def init(
     decay: bool,
     api_key: str | None,
     mcp_mode: str | None,
+    fresh: bool,
 ) -> None:
     """Set up memtomem with an interactive wizard."""
     click.echo()
@@ -758,4 +954,4 @@ def init(
         ]
         run_steps(steps, state)
 
-    _write_config_and_summary(state)
+    _write_config_and_summary(state, fresh=fresh)

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -369,6 +369,348 @@ class TestPreservedSummary:
         assert data["embedding"]["provider"] == "none"
 
 
+class TestFreshFlag:
+    """``mm init --fresh`` drops wizard-untouched canonical leftovers
+    instead of merely flagging them in the Preserved block.
+
+    Phase 2 of the leftover-cleanup work (Phase 1 = surface; Phase 2 =
+    reset). Critical guards:
+      - never wipes user data / credentials (preserve list)
+      - always backs up before dropping anything
+      - idempotent: second run with nothing to drop is a no-op on disk
+      - keys outside the canonical Mem2MemConfig shape are preserved"""
+
+    def test_fresh_drops_preserved_mmr(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Seed ``mmr.enabled=true`` (non-default, wizard-untouched) and run
+        ``--fresh``: the key disappears, the section is pruned, a backup is
+        written, and the Reset block names the change in
+        ``before → after (default)`` form."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        # Seed only the non-default key — default-matching siblings (e.g.
+        # lambda_param=0.7) wouldn't be dropped by --fresh anyway, and would
+        # keep the section from being pruned, hiding the assertion below.
+        config_path.write_text(
+            json.dumps({"mmr": {"enabled": True}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path, fresh=True)
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        # mmr.enabled non-default → dropped; section becomes empty → pruned.
+        assert "mmr" not in data, "mmr section should be pruned after --fresh"
+
+        backups = list(config_dir.glob("config.json.bak-*"))
+        assert len(backups) == 1, f"expected one backup, got {backups}"
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Reset to default" in out
+        assert "[-] mmr.enabled: true → false (default)" in out
+        assert f"Backup saved to: {backups[0]}" in out
+        assert "restart it to pick up the new config" in out
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            # Credentials
+            ("embedding.api_key", "sk-test-xxx"),
+            ("rerank.api_key", "voyage-xxx"),
+            ("llm.api_key", "anthropic-xxx"),
+            ("webhook.secret", "hmac-secret"),
+            # Endpoints
+            ("embedding.base_url", "https://my-openai-proxy/v1"),
+            ("llm.base_url", "http://my-llm:8080"),
+            ("webhook.url", "https://ops.example.com/hook"),
+            # User-curated lists / rules
+            ("indexing.exclude_patterns", ["*.tmp", "node_modules/"]),
+            ("indexing.supported_extensions", [".rst", ".org"]),
+            (
+                "namespace.rules",
+                [{"path_glob": "work/**", "namespace": "work"}],
+            ),
+            ("search.system_namespace_prefixes", ["__system__:"]),
+            ("webhook.events", ["add"]),
+        ],
+    )
+    def test_fresh_preserves_user_data_keys(
+        self,
+        key: str,
+        value: object,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Each key in ``_FRESH_PRESERVE_KEYS`` must survive ``--fresh`` even
+        when it's non-default and wizard-untouched. This is the structural
+        guard tying the parametrize list to the preserve-list constant —
+        adding a new key to one without the other will fail this test."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+
+        # Seed the single user-data key into a nested config dict.
+        seed: dict = {}
+        cur: dict = seed
+        parts = key.split(".")
+        for p in parts[:-1]:
+            cur = cur.setdefault(p, {})
+        cur[parts[-1]] = value
+        config_path.write_text(json.dumps(seed), encoding="utf-8")
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path, fresh=True)
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        cur2: object = data
+        for p in parts:
+            assert isinstance(cur2, dict) and p in cur2, (
+                f"--fresh wiped preserve-list key {key!r}; preserve list and "
+                "test parametrize have drifted apart"
+            )
+            cur2 = cur2[p]
+        assert cur2 == value, f"value for {key!r} mutated: {cur2!r} != {value!r}"
+
+    def test_fresh_preserves_memory_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``indexing.memory_dirs`` is wizard-touched (the wizard always
+        rewrites it from ``state['memory_dir']``), so ``--fresh`` must NOT
+        list it as a drop candidate. The wizard's overwrite is independent
+        of ``--fresh`` and is not under test here.
+
+        Guard against a future refactor that moves memory_dirs out of
+        ``init_data`` — that would silently make ``--fresh`` a memory-dir
+        wiper, which is the most surprising data-loss path."""
+        from memtomem.cli.init_cmd import (
+            _compute_fresh_drops,
+            _flatten_init_data_keys,
+            _write_config_and_summary,
+        )
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps({"indexing": {"memory_dirs": ["~/notes", "~/docs"]}}),
+            encoding="utf-8",
+        )
+
+        # Verify _compute_fresh_drops never selects memory_dirs (wizard-touched).
+        state = _make_init_state(tmp_path)
+        init_data_shape = {
+            "embedding": {},
+            "indexing": {"memory_dirs": []},
+            "namespace": {},
+            "search": {},
+            "decay": {},
+            "storage": {},
+        }
+        wizard_touched = _flatten_init_data_keys(init_data_shape)
+        assert "indexing.memory_dirs" in wizard_touched, (
+            "wizard_touched_keys must include indexing.memory_dirs — if it "
+            "doesn't, --fresh would wipe user memory dirs"
+        )
+
+        existing_seed = {"indexing": {"memory_dirs": ["~/notes", "~/docs"]}}
+        drops = _compute_fresh_drops(existing_seed, wizard_touched)
+        assert all(k != "indexing.memory_dirs" for k, _, _ in drops), (
+            "indexing.memory_dirs leaked into --fresh drop set"
+        )
+
+        # End-to-end: --fresh with memory_dirs seed completes without wiping
+        # data (the wizard then overwrites it from state, which is expected).
+        _write_config_and_summary(state, tmp_path, fresh=True)
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "indexing" in data and "memory_dirs" in data["indexing"]
+
+    def test_fresh_keeps_user_custom_keys(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A custom key outside the canonical ``Mem2MemConfig`` shape must
+        survive ``--fresh`` regardless of preserve-list contents — drop logic
+        only considers canonical keys."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "my_extension": {"foo": 1, "bar": "two"},
+                    "mmr": {"enabled": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path, fresh=True)
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data.get("my_extension") == {"foo": 1, "bar": "two"}
+        # Canonical leftover still gets dropped.
+        assert "mmr" not in data
+
+    def test_fresh_no_op_when_nothing_to_reset(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If the existing config has no wizard-untouched non-default keys,
+        ``--fresh`` writes no backup and prints the no-leftovers message."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        # Seed only fields the wizard will overwrite — nothing untouched
+        # that differs from default.
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps({"embedding": {"provider": "ollama"}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path, fresh=True)
+
+        backups = list(config_dir.glob("config.json.bak-*"))
+        assert backups == [], f"unexpected backup created: {backups}"
+
+        out = unstyle(capsys.readouterr().out)
+        assert "no wizard-untouched leftovers to reset" in out
+        assert "Reset to default" not in out
+
+    def test_fresh_with_non_interactive(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--fresh`` is compatible with ``-y`` (non-interactive) — drops
+        proceed without any prompt, the Reset block still prints, and the
+        normal Setup-complete summary is unaffected."""
+        from click import unstyle
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps({"mmr": {"enabled": True}}),
+            encoding="utf-8",
+        )
+
+        result = CliRunner().invoke(
+            init,
+            ["-y", "--fresh", "--provider", "none", "--memory-dir", str(tmp_path / "mem")],
+        )
+        assert result.exit_code == 0, result.output
+
+        out = unstyle(result.output)
+        assert "Reset to default" in out
+        assert "Setup complete!" in out  # Phase 1 summary still emitted
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert "mmr" not in data
+
+    def test_fresh_handles_malformed_config(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Malformed ``config.json`` + ``--fresh`` falls through to the
+        existing unreadable-config recovery path (timestamped backup +
+        empty merge base) and emits the no-leftovers Reset message — the
+        post-recovery ``existing`` is empty so nothing is droppable."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text("{not valid json", encoding="utf-8")
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path, fresh=True)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "unreadable" in out  # malformed-config recovery hit
+        # The unreadable-config path creates exactly one backup (.bak-<ts>);
+        # --fresh's own backup logic skips because no drops were possible.
+        backups = list(config_dir.glob("config.json.bak-*"))
+        assert len(backups) == 1, f"expected one backup, got {backups}"
+        assert "no wizard-untouched leftovers to reset" in out
+
+    def test_fresh_is_idempotent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Running ``--fresh`` twice in a row: first run drops + backs up,
+        second run is a pure no-op on disk (no second backup, config
+        bit-identical). Guard against accidental backup churn."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        # Pin time.time so a same-second double-invoke can't collide on
+        # the .bak-<ts> filename even on fast machines.
+        clock = {"t": 1_700_000_000}
+        monkeypatch.setattr("memtomem.cli.init_cmd.time.time", lambda: clock["t"])
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps({"mmr": {"enabled": True}, "search": {"rrf_k": 120}}),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+
+        _write_config_and_summary(state, tmp_path, fresh=True)
+        first_pass = config_path.read_text(encoding="utf-8")
+        first_backups = sorted(config_dir.glob("config.json.bak-*"))
+        assert len(first_backups) == 1
+
+        clock["t"] += 1  # second run gets a different ts in case it backs up
+        _write_config_and_summary(state, tmp_path, fresh=True)
+        second_pass = config_path.read_text(encoding="utf-8")
+        second_backups = sorted(config_dir.glob("config.json.bak-*"))
+
+        assert second_pass == first_pass, "second --fresh run mutated config"
+        assert second_backups == first_backups, (
+            "second --fresh run created a backup despite zero drops"
+        )
+
+
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be
     encoded as a JSON array string. A bare path crashes pydantic-settings.


### PR DESCRIPTION
## Summary

Phase 2 of the config-leftover-cleanup work. PR #254 added a Preserved
block to `mm init` that flagged non-default keys inherited from a
previous config but never asked about by the wizard — typically
runtime values pinned by the Web UI's `save_config_overrides` dump
(memory-dirs add/remove, section save), with `mmr.enabled=true` as
the canonical example. Surfacing them helped diagnose the silent
persistence pattern, but cleanup still required hand-editing
`~/.memtomem/config.json`.

`mm init --fresh` resets every wizard-untouched canonical key whose
value differs from the built-in default, then runs the normal wizard.
Default behaviour is unchanged — `--fresh` is opt-in.

## What this does

A key is dropped iff ALL three gates hold:

1. **Canonical only** — present in `Mem2MemConfig().model_dump()` flat
   key set. Keys outside this shape (manual user additions,
   downgrade-scenario sections, plugin extensions) are preserved
   unconditionally.
2. **Wizard-untouched** — not in `_flatten_init_data_keys(init_data)`.
   Wizard-touched keys get overwritten by the merge anyway, so dropping
   them first is redundant.
3. **Not in preserve list** — `_FRESH_PRESERVE_KEYS` (12 keys) holds
   credentials (`api_key`, `secret`), endpoints (`base_url`,
   `webhook.url`), and user-curated lists
   (`indexing.exclude_patterns`, `namespace.rules`,
   `indexing.supported_extensions`, `search.system_namespace_prefixes`,
   `webhook.events`). Derivation is documented inline (grep methodology
   against `config.py` at this commit) so the list can be re-audited
   when new fields land.

A timestamped `config.json.bak-<unix-ts>` is written before any drop
so the previous state is recoverable. Backup is skipped when the drop
set is empty — avoids cluttering `~/.memtomem/` on repeated `--fresh`
runs and makes `--fresh` idempotent on disk. If backup itself fails,
the run aborts before merge with a red error rather than silently
proceeding without recovery.

## What this doesn't do

- **Web UI persistence path is unchanged.** A web save after `--fresh`
  can re-pin the dropped values; the Reset block prints a restart
  caveat. Surface fix; root cause stays in follow-ups (1) and (2).
- **No partial drop.** All-or-nothing on the drop set. For
  fine-grained control, edit `config.json` directly or use the web UI.
- **User custom keys preserved.** `--fresh` is "reset wizard-untouched
  canonical settings", not "factory reset".

## `--help` output

```
  --fresh                         Reset wizard-untouched canonical settings to
                                  their built-in defaults. Preserves user-
                                  added custom keys, credentials
                                  (api_key/secret), endpoints (base_url/url),
                                  and user-curated lists (exclude_patterns,
                                  namespace.rules, etc). Backs up the previous
                                  config.json to config.json.bak-<ts> only if
                                  at least one key is dropped. For fine-
                                  grained control, edit
                                  ~/.memtomem/config.json directly or use the
                                  web UI.
```

## Reset block (example)

```
Reset to default (--fresh dropped wizard-untouched leftovers):
  [-] mmr.enabled: true → false (default)

Backup saved to: ~/.memtomem/config.json.bak-1776517180

[!] If the web UI is running, restart it to pick up the new config.
    Otherwise a web save may restore the reset values.
```

Zero-drop case collapses to a single line:

```
--fresh: no wizard-untouched leftovers to reset.
```

## Tests

`TestFreshFlag` adds 7 cases (parametrize expands to 18 sub-tests):

- `test_fresh_drops_preserved_mmr` — end-to-end happy path, asserts
  Reset block format, backup creation, and section pruning.
- `test_fresh_preserves_user_data_keys` (parametrize × 12) —
  structural lockstep between `_FRESH_PRESERVE_KEYS` and the test
  parametrize: adding a key to one without the other fails this test.
  Each case asserts both path-existence and value equality after a
  round-trip through `--fresh`.
- `test_fresh_preserves_memory_dirs` — `indexing.memory_dirs` is the
  most surprising data-loss path if it ever leaves `init_data`.
  Verifies via direct `_compute_fresh_drops` call that the drop set
  never contains it, plus end-to-end that the seed survives.
- `test_fresh_keeps_user_custom_keys` — keys outside the canonical
  shape (`my_extension`) survive `--fresh` while sibling canonical
  leftovers (`mmr`) get dropped.
- `test_fresh_no_op_when_nothing_to_reset` — zero drops → no backup,
  no Reset block, the no-leftovers message instead.
- `test_fresh_with_non_interactive` — `mm init -y --fresh` via
  `CliRunner`; verifies the Phase-1 Setup-complete summary still
  prints alongside the Reset block.
- `test_fresh_handles_malformed_config` — corrupt `config.json` +
  `--fresh` falls into the existing unreadable-config recovery path
  (one backup from there, none from `--fresh` since the post-recovery
  base is empty).
- `test_fresh_is_idempotent` — second `--fresh` run with same state
  produces no second backup and a bit-identical config.
  `time.time` is monkeypatched so a same-second double-invoke can't
  mask the assertion via filename collision.

### Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` (advisory) — 0 issues
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_init_cmd.py` — 33 passed (14 existing + 19 new incl. parametrize)
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/ -k "init or config or cli or wizard"` — 238 passed
- [x] Manual: `uv run mm init --help` — `--fresh` documented as above
- [x] Manual: seed `{"mmr":{"enabled":true},"search":{"rrf_k":120}}`, `mm init -y --fresh --provider none` — both keys reset, Reset block + backup path printed, second run reports no leftovers

## Out of scope / follow-ups

This PR closes the wizard-side leak. The underlying silent-persistence
pattern still needs work in three other places, plus one
maintainability cleanup of `--fresh` itself:

1. **`save_config_overrides` dumps the full `_MUTABLE_FIELDS` set.**
   Memory-dirs add/remove writes every mutable key to `config.json`,
   so runtime values (incl. defaults loaded from `config.d/`) get
   pinned into the override file. Persisting only changed keys would
   keep precedence working without `--fresh`.
2. **Web UI has no reset-to-default.** Symmetric to (1): a user who
   unchecks MMR and saves writes `mmr.enabled=false` into
   `config.json`, permanently overriding any `config.d/` fragment.
   Per-field reset or drop-equal-to-default-on-write would fix.
3. **Web UI hot-reload of `config.json`.** After `mm init --fresh`,
   a running web instance still holds the old values in memory; a
   subsequent web save can re-pin the dropped values. mtime watcher
   on `config.json` would invalidate the cache. (The Reset block's
   "restart the web UI" caveat is the workaround.)
4. **`_FRESH_PRESERVE_KEYS` is hardcoded and goes stale.** New
   credential/endpoint/user-data fields require manual additions to
   the constant; nothing enforces this at PR time. Schema-driven
   alternative: Pydantic `Field(json_schema_extra={"fresh_preserve": True})`
   or class-level `PRESERVE_ON_FRESH: ClassVar[set[str]]` collected
   into the constant at import. Defer until preserve list grows or
   drift incident occurs.
5. **`--fresh` write-after-backup atomicity.** If `config_path.write_text`
   fails after backup succeeds, the orphan `.bak-<ts>` survives next
   to an unmodified original. Not data-lossy (original intact), but
   the leftover file is confusing. Tempfile + atomic rename, or
   delete-on-write-failure, would tighten this.

## Breaking changes

None. `--fresh` is opt-in; default `mm init` behaviour is unchanged.