### PR TITLE
fix(config): drop default-valued fields on save to prevent silent leftover pins

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -905,9 +905,39 @@ def _auto_discovered_memory_dirs() -> list[Path]:
 # Fields persisted by ``save_config_overrides`` but NOT settable via the
 # generic ``mm config set`` / ``mem_config`` path.  Managed through dedicated
 # endpoints (e.g. Web UI ``/memory-dirs/*``).
+#
+# These fields are also EXEMPT from the drop-equal-to-default rule in
+# ``save_config_overrides``. Criterion for inclusion: the field's
+# ``default_factory`` is environment-dependent — it reads filesystem,
+# network, hostname, or other runtime state, so "equal to default" on
+# machine A does not imply the same on machine B. Dropping such a field
+# on save would silently lose user-curated data across environments.
+#
+# Current members:
+# - ``indexing.memory_dirs`` — ``_default_memory_dirs()`` auto-discovers
+#   AI tool dirs via ``is_dir()`` fs checks.
+#
+# When adding a field whose default reads runtime state, add it here.
 _EXTRA_PERSIST_FIELDS: dict[str, set[str]] = {
     "indexing": {"memory_dirs"},
 }
+
+
+def _field_equals_default(section_obj: object, key: str) -> bool:
+    """Return True if ``section_obj.key`` equals the class-level default.
+
+    Default-valued fields are dropped from ``config.json`` on save so that
+    runtime toggles (e.g. a Web UI checkbox left at its default) don't pin
+    the default over ``config.d/`` fragments that set a different value.
+    """
+    model_fields = getattr(type(section_obj), "model_fields", None)
+    if not model_fields or key not in model_fields:
+        return False
+    try:
+        default = model_fields[key].get_default(call_default_factory=True)
+    except Exception:  # pragma: no cover - defensive; pydantic shouldn't raise
+        return False
+    return getattr(section_obj, key, None) == default
 
 
 def save_config_overrides(
@@ -919,17 +949,25 @@ def save_config_overrides(
     Uses **read-merge-write** so that keys not in *mutable_fields* (e.g.
     init-only settings like ``embedding.provider`` or ``storage.sqlite_path``)
     are preserved across saves.
+
+    Runtime-mutable fields (``MUTABLE_FIELDS``) whose current value equals
+    the class-level default are dropped (and pruned from any existing
+    entry). This prevents silent pins — e.g. a Web UI section save where
+    an unchecked default-False toggle would otherwise write
+    ``mmr.enabled=false`` and permanently shadow a ``config.d/`` fragment
+    that sets it True.
+
+    ``_EXTRA_PERSIST_FIELDS`` (currently ``indexing.memory_dirs``) are
+    exempt from drop-default. Their default factories are
+    environment-dependent (auto-discovered AI tool dirs), so "equal to
+    default" is not a stable signal across machines. Treat them as
+    user-curated data and always persist when present.
     """
     import json as _json
     import logging
 
     _log = logging.getLogger(__name__)
-    base = mutable_fields or MUTABLE_FIELDS
-    # Merge extra-persist fields so they are always written alongside mutables.
-    effective: dict[str, set[str]] = {}
-    for section in {*base, *_EXTRA_PERSIST_FIELDS}:
-        effective[section] = base.get(section, set()) | _EXTRA_PERSIST_FIELDS.get(section, set())
-    mutable_fields = effective
+    base_fields: dict[str, set[str]] = mutable_fields or MUTABLE_FIELDS
 
     path = _override_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -942,19 +980,34 @@ def save_config_overrides(
         except (OSError, _json.JSONDecodeError) as exc:
             _log.warning("Cannot read existing config at %s: %s — overwriting", path, exc)
 
-    # ── Merge mutable fields into existing data ──
-    for section_name, fields in mutable_fields.items():
+    # ── Merge fields into existing data ──
+    # drop_default applies only to runtime-mutable fields; extra-persist
+    # fields (memory_dirs) are always persisted when non-None.
+    sections = {*base_fields, *_EXTRA_PERSIST_FIELDS}
+    for section_name in sections:
         section_obj = getattr(config, section_name, None)
         if section_obj is None:
             continue
+        drop_default_keys = base_fields.get(section_name, set())
+        always_persist_keys = _EXTRA_PERSIST_FIELDS.get(section_name, set())
+
         section_data: dict[str, object] = existing.get(section_name, {})
         if not isinstance(section_data, dict):
             section_data = {}
-        for key in fields:
+
+        for key in drop_default_keys | always_persist_keys:
             val = getattr(section_obj, key, None)
-            if val is not None:
-                section_data[key] = val
+            if val is None:
+                section_data.pop(key, None)
+                continue
+            if key in drop_default_keys and _field_equals_default(section_obj, key):
+                section_data.pop(key, None)
+                continue
+            section_data[key] = val
+
         if section_data:
             existing[section_name] = section_data
+        else:
+            existing.pop(section_name, None)
 
     path.write_text(_json.dumps(existing, indent=2, default=str), encoding="utf-8")

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -371,6 +371,102 @@ class TestSaveConfigOverrides:
         data = json.loads(config_file.read_text())
         assert "/pre/existing" in [str(p) for p in data["indexing"]["memory_dirs"]]
 
+    def test_default_valued_field_not_persisted(self, tmp_path, monkeypatch):
+        """Fields whose current value equals the class-level default must not
+        be written. Otherwise a Web UI save would pin the default and shadow
+        a ``config.d/`` fragment that sets a different value.
+        """
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        cfg = Mem2MemConfig()
+        # mmr.enabled default is False — simulate a Web UI "save section"
+        # that dumps the whole section without the user touching mmr.
+        save_config_overrides(cfg)
+
+        data = json.loads(config_file.read_text()) if config_file.exists() else {}
+        assert "mmr" not in data, (
+            f"default-valued mmr section must not be persisted; got {data.get('mmr')!r}"
+        )
+
+    def test_existing_default_entry_pruned_on_save(self, tmp_path, monkeypatch):
+        """An existing leftover entry that matches the current-and-default
+        value must be removed on save, so the key stops shadowing fragments.
+        """
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        # Simulate a prior leak: mmr.enabled=false pinned into config.json.
+        config_file.write_text(json.dumps({"mmr": {"enabled": False}}))
+
+        cfg = Mem2MemConfig()
+        # cfg.mmr.enabled is False (default) and config.json has False too.
+        # Next save should prune the pinned key.
+        save_config_overrides(cfg)
+
+        data = json.loads(config_file.read_text())
+        assert "mmr" not in data
+
+    def test_non_default_value_still_persists(self, tmp_path, monkeypatch):
+        """Explicit non-default values must still be written."""
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        cfg = Mem2MemConfig()
+        cfg.mmr.enabled = True  # default is False
+        cfg.search.default_top_k = 42  # default is 10
+        save_config_overrides(cfg)
+
+        data = json.loads(config_file.read_text())
+        assert data["mmr"]["enabled"] is True
+        assert data["search"]["default_top_k"] == 42
+
+    def test_memory_dirs_equal_to_default_still_persisted(self, tmp_path, monkeypatch):
+        """memory_dirs is in _EXTRA_PERSIST_FIELDS and exempt from
+        drop-default because its factory auto-discovers AI tool dirs via
+        filesystem checks. "Equal to default" on machine A may not match
+        machine B's default — so we always persist user-curated dir lists.
+        """
+        import json
+
+        from memtomem.config import _default_memory_dirs
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        cfg = Mem2MemConfig()
+        cfg.indexing.memory_dirs = _default_memory_dirs()
+        save_config_overrides(cfg)
+
+        data = json.loads(config_file.read_text())
+        assert "memory_dirs" in data["indexing"], (
+            "memory_dirs must be persisted even when equal to default "
+            "(environment-dependent factory, preserve user intent)"
+        )
+
+    def test_section_with_only_defaults_dropped_entirely(self, tmp_path, monkeypatch):
+        """If every mutable key in a section equals its default, the whole
+        section is omitted from config.json (no orphan ``{}`` entries)."""
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        # Prior leak: entire decay section pinned at defaults.
+        config_file.write_text(json.dumps({"decay": {"enabled": False, "half_life_days": 30.0}}))
+
+        cfg = Mem2MemConfig()  # all defaults
+        save_config_overrides(cfg)
+
+        data = json.loads(config_file.read_text())
+        assert "decay" not in data
+
 
 # ── Other subcommands (help text) ───────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`save_config_overrides` blindly wrote every mutable field each call. A Web UI "save section" with default-False MMR thus pinned `mmr.enabled=false` into `~/.memtomem/config.json`, permanently shadowing any `config.d/` fragment that set it True. Memory-dirs add/remove and `mm config set` leaked the same way because all persist paths funnel through this one function.

Closes two follow-ups from #255: the memory-dirs dump leak (follow-up #1) and the Web UI section-save symmetric case (follow-up #2). The stated fix in both follow-ups was "Drop-equal-to-default-on-write" — same code change.

## What this does

- Compare each mutable field to its class-level default via `model_fields[key].get_default(call_default_factory=True)`.
- If equal, drop from the write dict **and** prune any matching existing entry (auto-cleans historical leftovers on next save).
- Empty sections are removed — no orphan `{}` survives.
- Covers every persist path: `mm config set`, `PATCH /api/config?persist=true`, `POST /api/config/save`, `/memory-dirs/add|remove`, `mem_config` MCP.

## What this does NOT do

- **No UX affordance.** Users still have no explicit "reset this field to default" button in the Web UI. Server auto-prunes defaults on save, but users need to know the current default to type it in. Tracked as a separate follow-up (new endpoint `GET /api/config/defaults` + `↺` buttons in `settings-config.js`, including custom widgets `rrf_weights`/`exclude_patterns`).
- **No schema-driven rewrite.** Two hardcoded sets still exist: `_FRESH_PRESERVE_KEYS` (12 keys) and `_EXTRA_PERSIST_FIELDS` (1 key). Unifying them via Pydantic field metadata is a follow-up, deferred until either list grows or a drift incident.

## Critical exemption: `_EXTRA_PERSIST_FIELDS`

`indexing.memory_dirs` is **excluded** from drop-default. Its factory `_default_memory_dirs()` auto-discovers AI tool dirs via `is_dir()` fs checks — **environment-dependent**. "Equal to default" on machine A does not hold on machine B. Dropping env-dependent defaults would silently lose user-curated dir lists across environments.

Criterion documented in the comment so future additions have an objective test: if a field's `default_factory` reads filesystem, network, hostname, or other runtime state, add it to `_EXTRA_PERSIST_FIELDS`.

## Before / after

### Before (leak)
User unchecks MMR in Web UI → section save:
```json
{
  "mmr": {"enabled": false},
  "indexing": {"memory_dirs": [...]}
}
```
`mmr.enabled=false` is the default, but it's now pinned and permanently overrides any `config.d/` fragment setting it True.

### After (clean)
```json
{
  "indexing": {"memory_dirs": [...]}
}
```
`mmr` section omitted — fragment precedence restored. Existing leaks from prior installs get pruned on the next save.

## Testing

- 1680 CI tests pass, ruff + format + mypy clean.
- 5 new tests in `TestSaveConfigOverrides`:
  - `test_default_valued_field_not_persisted` — fresh save omits default-only `mmr` section
  - `test_existing_default_entry_pruned_on_save` — pinned `mmr.enabled=false` leftover is pruned
  - `test_non_default_value_still_persists` — explicit non-defaults survive
  - `test_memory_dirs_equal_to_default_still_persisted` — **locks in the exemption** (test name reflects intentional asymmetry)
  - `test_section_with_only_defaults_dropped_entirely` — empty section removed, no orphan `{}`
- Manual smoke (check → uncheck → verify drop, memory_dirs stays) passed.

## Internal consumers

`grep` confirmed only internal readers touch `config.json` (`init_cmd` wizard read-merge-write, `policy.py` parses a separate config string, tests). No external parsers, no breaking change for library users.

## Follow-ups (after this PR)

Updated list in `project_wizard_leftovers_cleanup.md`:
1. Web UI per-field reset button + `GET /api/config/defaults` endpoint.
2. Web UI hot-reload of `config.json` (mtime watcher invalidates cache).
3. Schema-driven rewrite of `_FRESH_PRESERVE_KEYS` **and** `_EXTRA_PERSIST_FIELDS`.
4. `--fresh` write-after-backup atomicity (tempfile + atomic rename).

## Test plan
- [x] `uv run pytest -m "not ollama"` green (1680 passed)
- [x] `uv run ruff check` + `ruff format --check` clean
- [x] `uv run mypy packages/memtomem/src` clean
- [x] Manual smoke: check MMR → save → confirm `mmr.enabled=true` persisted; uncheck → save → confirm `mmr` section dropped
- [x] Manual smoke: `memory_dirs = _default_memory_dirs()` → save → confirm still persisted (exemption)