### PR TITLE
fix(config): coerce list[BaseSettings] on mutation path

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -703,7 +703,9 @@ def _write_config_and_summary(
         else:
             existing[section] = fields
 
-    config_path.write_text(json.dumps(existing, indent=2, default=str), encoding="utf-8")
+    from memtomem.config import _json_default
+
+    config_path.write_text(json.dumps(existing, indent=2, default=_json_default), encoding="utf-8")
     click.echo(f"  Config: {config_path}")
 
     if fresh:

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -503,7 +503,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
     "embedding": {"batch_size"},
     "decay": {"enabled", "half_life_days"},
     "mmr": {"enabled", "lambda_param"},
-    "namespace": {"default_namespace", "enable_auto_ns"},
+    "namespace": {"default_namespace", "enable_auto_ns", "rules"},
 }
 
 FIELD_CONSTRAINTS: dict[str, dict] = {
@@ -532,6 +532,7 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     "search.rrf_weights": {"type": list, "item_type": float, "length": 2},
     "namespace.default_namespace": {"type": str},
     "namespace.enable_auto_ns": {"type": bool},
+    "namespace.rules": {"type": list, "item_type": NamespacePolicyRule},
 }
 
 
@@ -576,18 +577,55 @@ def coerce_and_validate(value: object, constraint: dict | None) -> object:
     elif expected_type is list:
         item_type = constraint.get("item_type", float)
         expected_len = constraint.get("length")
-        if isinstance(value, str):
-            parts = [s.strip() for s in value.split(",")]
-        elif isinstance(value, (list, tuple)):
-            parts = list(value)
+        # ``list[BaseSettings]`` (e.g. ``namespace.rules``): accept a JSON
+        # string or list of dicts/model instances and validate each entry
+        # via ``model_validate``. Mirrors ``load_config_d``'s APPEND
+        # coercion so mutation paths (PATCH /api/config, mm config set)
+        # stay in sync with the load path.
+        if isinstance(item_type, type) and issubclass(item_type, BaseSettings):
+            if isinstance(value, str):
+                import json as _json
+
+                try:
+                    parsed = _json.loads(value)
+                except _json.JSONDecodeError as exc:
+                    raise ValueError(f"cannot parse JSON: {exc}") from exc
+            else:
+                parsed = value
+            if not isinstance(parsed, list):
+                raise ValueError(
+                    f"cannot convert {type(parsed).__name__} to list[{item_type.__name__}]"
+                )
+            coerced_items: list[object] = []
+            for idx, item in enumerate(parsed):
+                if isinstance(item, item_type):
+                    coerced_items.append(item)
+                elif isinstance(item, dict):
+                    try:
+                        coerced_items.append(item_type.model_validate(item))
+                    except Exception as exc:
+                        raise ValueError(f"item[{idx}]: {exc}") from exc
+                else:
+                    raise ValueError(
+                        f"item[{idx}]: expected dict or {item_type.__name__}, "
+                        f"got {type(item).__name__}"
+                    )
+            coerced = coerced_items
+            if expected_len is not None and len(coerced) != expected_len:
+                raise ValueError(f"expected length {expected_len}, got {len(coerced)}")
         else:
-            raise ValueError(f"cannot convert {type(value).__name__} to list")
-        try:
-            coerced = [item_type(p) for p in parts]
-        except (TypeError, ValueError):
-            raise ValueError(f"cannot convert list items to {item_type.__name__}")
-        if expected_len is not None and len(coerced) != expected_len:
-            raise ValueError(f"expected length {expected_len}, got {len(coerced)}")
+            if isinstance(value, str):
+                parts = [s.strip() for s in value.split(",")]
+            elif isinstance(value, (list, tuple)):
+                parts = list(value)
+            else:
+                raise ValueError(f"cannot convert {type(value).__name__} to list")
+            try:
+                coerced = [item_type(p) for p in parts]
+            except (TypeError, ValueError):
+                raise ValueError(f"cannot convert list items to {item_type.__name__}")
+            if expected_len is not None and len(coerced) != expected_len:
+                raise ValueError(f"expected length {expected_len}, got {len(coerced)}")
     else:
         coerced = cast("bool | int | float | str | list[object]", value)
 
@@ -923,6 +961,22 @@ _EXTRA_PERSIST_FIELDS: dict[str, set[str]] = {
 }
 
 
+def _json_default(obj: object) -> object:
+    """``json.dumps`` fallback for values not natively JSON-serializable.
+
+    ``BaseSettings`` entries in fields like ``namespace.rules`` must be
+    written as dicts (via ``model_dump(mode="json")``) so the load path
+    can re-validate them on startup. ``Path`` gets ``str()``; unknown
+    types fall back to ``str()`` to preserve the original default=str
+    behaviour.
+    """
+    if isinstance(obj, BaseSettings):
+        return obj.model_dump(mode="json")
+    if isinstance(obj, Path):
+        return str(obj)
+    return str(obj)
+
+
 def _field_equals_default(section_obj: object, key: str) -> bool:
     """Return True if ``section_obj.key`` equals the class-level default.
 
@@ -1010,4 +1064,4 @@ def save_config_overrides(
         else:
             existing.pop(section_name, None)
 
-    path.write_text(_json.dumps(existing, indent=2, default=str), encoding="utf-8")
+    path.write_text(_json.dumps(existing, indent=2, default=_json_default), encoding="utf-8")

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -191,6 +191,37 @@ class TestConfigCLI:
         assert result.exit_code != 0
         assert "not a mutable field" in result.output
 
+    def test_config_set_namespace_rules_json(self, tmp_path, monkeypatch, runner: CliRunner):
+        """End-to-end: `mm config set namespace.rules '[...]'` persists + reloads."""
+        import json
+
+        from memtomem.config import Mem2MemConfig, load_config_overrides
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        payload = '[{"path_glob": "docs/**/*.md", "namespace": "docs"}]'
+        result = runner.invoke(cli, ["config", "set", "namespace.rules", payload])
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config_file.read_text())
+        assert data["namespace"]["rules"] == [{"path_glob": "docs/**/*.md", "namespace": "docs"}]
+
+        # Round-trip via load path: raw dict survives setattr + model_validate.
+        fresh = Mem2MemConfig()
+        load_config_overrides(fresh)
+        from memtomem.config import NamespacePolicyRule
+
+        rule = NamespacePolicyRule.model_validate(fresh.namespace.rules[0])
+        assert rule.path_glob == "docs/**/*.md"
+        assert rule.namespace == "docs"
+
+    def test_config_set_namespace_rules_rejects_malformed(self, runner: CliRunner) -> None:
+        """Malformed JSON for namespace.rules surfaces as CLI error."""
+        result = runner.invoke(cli, ["config", "set", "namespace.rules", "[not valid json"])
+        assert result.exit_code != 0
+        assert "cannot parse JSON" in result.output
+
 
 # ── Config validation helpers ───────────────────────────────────────────
 
@@ -270,6 +301,80 @@ class TestCoerceAndValidate:
     def test_rrf_weights_has_constraint(self) -> None:
         """search.rrf_weights must be registered in FIELD_CONSTRAINTS."""
         assert "search.rrf_weights" in FIELD_CONSTRAINTS
+
+    # ── list[BaseSettings] coercion (namespace.rules) ──────────────
+
+    def test_namespace_rules_from_json_string(self) -> None:
+        """CLI path: `mm config set namespace.rules '[{...}]'` passes a JSON string."""
+        from memtomem.config import NamespacePolicyRule
+
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        raw = '[{"path_glob": "docs/**/*.md", "namespace": "docs"}]'
+        result = coerce_and_validate(raw, constraint)
+        assert isinstance(result, list) and len(result) == 1
+        assert isinstance(result[0], NamespacePolicyRule)
+        assert result[0].path_glob == "docs/**/*.md"
+        assert result[0].namespace == "docs"
+
+    def test_namespace_rules_from_list_of_dicts_pr253_regression(self) -> None:
+        """Web UI path: PATCH /api/config sends a parsed list of dicts.
+
+        Regression guard for PR #253: before this fix, ``coerce_and_validate``
+        did not handle ``list[BaseSettings]``, so PATCH /api/config and
+        ``mm config set namespace.rules ...`` stored raw dicts in
+        ``cfg.namespace.rules``. That broke ``indexing/engine.py:121`` which
+        accesses ``rule.path_glob`` on each entry — AttributeError on a dict.
+        This test locks in that the mutation path produces model instances.
+        """
+        from memtomem.config import NamespacePolicyRule
+
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        payload = [
+            {"path_glob": "docs/**/*.md", "namespace": "docs"},
+            {"path_glob": "work/**/*.md", "namespace": "work"},
+        ]
+        result = coerce_and_validate(payload, constraint)
+        assert len(result) == 2
+        assert all(isinstance(r, NamespacePolicyRule) for r in result)
+        # Critical: the exact attribute access that was failing pre-PR.
+        assert result[0].path_glob == "docs/**/*.md"
+        assert [r.namespace for r in result] == ["docs", "work"]
+
+    def test_namespace_rules_passthrough_for_model_instances(self) -> None:
+        """Already-validated instances survive coercion unchanged."""
+        from memtomem.config import NamespacePolicyRule
+
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        rule = NamespacePolicyRule(path_glob="x/**", namespace="x")
+        result = coerce_and_validate([rule], constraint)
+        assert result == [rule]
+
+    def test_namespace_rules_empty_list(self) -> None:
+        """Empty list is valid (matches default_factory=list)."""
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        assert coerce_and_validate([], constraint) == []
+        assert coerce_and_validate("[]", constraint) == []
+
+    def test_namespace_rules_rejects_malformed_json(self) -> None:
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        with pytest.raises(ValueError, match="cannot parse JSON"):
+            coerce_and_validate("[not json", constraint)
+
+    def test_namespace_rules_rejects_non_list_json(self) -> None:
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        with pytest.raises(ValueError, match="to list"):
+            coerce_and_validate('{"path_glob": "x", "namespace": "y"}', constraint)
+
+    def test_namespace_rules_rejects_scalar_entry(self) -> None:
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        with pytest.raises(ValueError, match="item\\[0\\]: expected dict"):
+            coerce_and_validate(["just-a-string"], constraint)
+
+    def test_namespace_rules_propagates_model_validation_error(self) -> None:
+        """Pydantic validator errors (e.g. empty path_glob) surface as ValueError."""
+        constraint = FIELD_CONSTRAINTS["namespace.rules"]
+        with pytest.raises(ValueError, match="item\\[0\\]"):
+            coerce_and_validate([{"path_glob": "", "namespace": "x"}], constraint)
 
     def test_field_constraints_are_well_formed(self) -> None:
         """Sanity: every declared constraint has a type and consistent bounds."""
@@ -449,6 +554,67 @@ class TestSaveConfigOverrides:
             "memory_dirs must be persisted even when equal to default "
             "(environment-dependent factory, preserve user intent)"
         )
+
+    def test_legacy_repr_string_in_config_handled_gracefully(self, tmp_path, monkeypatch):
+        """Pre-fix installations may have serialized ``namespace.rules`` via
+        ``default=str`` → raw ``repr()`` strings in config.json. Loading such
+        a file on upgrade must not crash: coerce rejects the shape, load path
+        logs + skips, field falls back to its default. No data loss beyond
+        the already-corrupt entry.
+        """
+        import json
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        # Case 1: whole value is a repr-ish string (not even JSON).
+        config_file.write_text(
+            json.dumps(
+                {"namespace": {"rules": "<NamespacePolicyRule path_glob='x' namespace='y'>"}}
+            )
+        )
+        cfg = Mem2MemConfig()
+        load_config_overrides(cfg)
+        assert cfg.namespace.rules == []  # fell back to default, no crash
+
+        # Case 2: list of repr strings.
+        config_file.write_text(json.dumps({"namespace": {"rules": ["<legacy repr entry>"]}}))
+        cfg = Mem2MemConfig()
+        load_config_overrides(cfg)
+        assert cfg.namespace.rules == []
+
+    def test_namespace_rules_round_trip(self, tmp_path, monkeypatch):
+        """list[NamespacePolicyRule] survives save→load via model_dump/validate."""
+        import json
+
+        from memtomem.config import NamespacePolicyRule
+
+        config_file = tmp_path / "config.json"
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+
+        cfg = Mem2MemConfig()
+        cfg.namespace.rules = [
+            NamespacePolicyRule(path_glob="docs/**/*.md", namespace="docs"),
+            NamespacePolicyRule(path_glob="work/**/*.md", namespace="work"),
+        ]
+        save_config_overrides(cfg)
+
+        # Persisted as list of dicts — not BaseSettings repr().
+        data = json.loads(config_file.read_text())
+        assert data["namespace"]["rules"] == [
+            {"path_glob": "docs/**/*.md", "namespace": "docs"},
+            {"path_glob": "work/**/*.md", "namespace": "work"},
+        ]
+
+        # load_config_overrides runs coerce_and_validate on each field that
+        # has a FIELD_CONSTRAINTS entry. Because namespace.rules is now
+        # registered, the raw dicts on disk are validated back into
+        # NamespacePolicyRule instances — matching what downstream consumers
+        # (indexing/engine.py) require (attribute access like `rule.path_glob`).
+        fresh = Mem2MemConfig()
+        load_config_overrides(fresh)
+        assert all(isinstance(r, NamespacePolicyRule) for r in fresh.namespace.rules)
+        assert fresh.namespace.rules == cfg.namespace.rules
 
     def test_section_with_only_defaults_dropped_entirely(self, tmp_path, monkeypatch):
         """If every mutable key in a section equals its default, the whole

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -99,6 +99,7 @@ class FakeConfig:
     class _Namespace:
         default_namespace = "default"
         enable_auto_ns = False
+        rules: list = []
 
     embedding = _Embedding()
     storage = _Storage()
@@ -765,6 +766,45 @@ class TestConfigPatch:
             assert resp.status_code == 200
             data = resp.json()
             assert data["ok"] is True
+
+    async def test_patch_namespace_rules(self, app, client: AsyncClient):
+        """PATCH /api/config accepts list[NamespacePolicyRule] as JSON-compatible dicts."""
+        from memtomem.config import NamespacePolicyRule
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.patch(
+                "/api/config",
+                json={
+                    "namespace": {
+                        "rules": [
+                            {"path_glob": "docs/**/*.md", "namespace": "docs"},
+                            {"path_glob": "work/**/*.md", "namespace": "work"},
+                        ]
+                    }
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data["applied"]) == 1
+        assert data["applied"][0]["field"] == "namespace.rules"
+        # Runtime config actually holds validated model instances.
+        rules = app.state.config.namespace.rules
+        assert len(rules) == 2
+        assert all(isinstance(r, NamespacePolicyRule) for r in rules)
+        assert rules[0].namespace == "docs"
+        assert rules[1].namespace == "work"
+
+    async def test_patch_namespace_rules_validation_error(self, client: AsyncClient):
+        """Invalid rule (empty path_glob) is reported in rejected list, not applied."""
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.patch(
+                "/api/config",
+                json={"namespace": {"rules": [{"path_glob": "", "namespace": "x"}]}},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["applied"]) == 0
+        assert any("namespace.rules" in r for r in data["rejected"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #253 introduced `NamespacePolicyRule` as memtomem's first `list[BaseSettings]` config field. The load path was wired to handle it correctly (via `_list_item_type` + `model_validate` in `load_config_d` and `_dedup_key`), but the **mutation path** was left asymmetric — `coerce_and_validate`, `PATCH /api/config`, `mm config set`, and the init wizard all silently passed raw dicts through. Downstream code (`indexing/engine.py:121`) accesses `rule.path_glob` on each entry and would `AttributeError` on a dict.

Adjacent to PR #256 (save-path drop-default); together #253 → #256 → this PR complete the config-layer round-trip.

## Root cause

PR #253 added the new `list[BaseSettings]` shape but only fixed the *read* side of the config pipeline. The *write* side — the three canonical mutation entry points plus the init wizard — kept validating only primitive lists. A user PATCH-ing `namespace.rules` or running `mm config set namespace.rules '[...]'` saw no validation error, but the runtime config held dicts where model instances were expected.

## What this does

### 1. `coerce_and_validate` handles `list[BaseSettings]`

New branch inside the existing `expected_type is list` path, gated by:

```python
if isinstance(item_type, type) and issubclass(item_type, BaseSettings):
```

The `isinstance(item_type, type)` guard is deliberate — it protects against `Union`, generic aliases, or other non-class item types that would `TypeError` inside `issubclass`. Existing primitive-list callers (`search.rrf_weights`, `importance.weights`) take the `else` path unchanged; all their existing tests still pass.

Inside the branch: JSON strings are parsed (CLI path), lists of dicts are `model_validate`-ed (Web UI path), already-instance entries pass through, scalars/malformed shapes raise `ValueError` that propagates as a `rejected` entry in PATCH or a non-zero CLI exit.

### 2. `MUTABLE_FIELDS["namespace"]` + `FIELD_CONSTRAINTS["namespace.rules"]`

Registers the field at both gates so `PATCH /api/config` no longer reports `namespace.rules: read-only field` and `mm config set` no longer prints `not a mutable field`. Frontend impact check: `grep FIELD_CONSTRAINTS packages/memtomem/src/memtomem/web/static/` → zero hits. UI rendering is unaffected.

### 3. Unified `_json_default` JSON serializer

`save_config_overrides` previously used `json.dumps(..., default=str)`, which would emit `BaseSettings.__repr__` for any nested model — a latent round-trip bug. Fixed with `_json_default` that returns `model_dump(mode="json")` for `BaseSettings` and `str()` for `Path`. **Scope audit** via `grep "default=str\|default=_json_default" packages/memtomem/src/` confirmed:

- `config.py` `save_config_overrides` → fixed (uses `_json_default`)
- `cli/init_cmd.py:706` wizard write → **also fixed** (imports + uses `_json_default`) for consistency across all config-write paths
- 7 other `default=str` call sites (`chunking/structured.py`, `cli/watchdog_cmd.py`, `cli/config_cmd.py` show, `server/scheduler.py`, `server/health_store.py`, `server/webhooks.py`, `server/tools/consolidation.py`) all serialize non-config payloads (scheduler state, webhook bodies, health snapshots, etc.) — unrelated to `BaseSettings` config models, intentionally left alone.

Though `namespace.rules` is currently the only `list[BaseSettings]` field in play, unifying the helper prevents a future nested model from silently re-introducing the same latent bug.

### 4. Migration safety for pre-fix installations

Any `config.json` written by a pre-fix wizard may contain repr-string leftovers for `namespace.rules`. On load:

- The entry hits `coerce_and_validate` via `FIELD_CONSTRAINTS["namespace.rules"]`.
- Malformed shape (scalar string, list-of-strings) → `ValueError`.
- `load_config_overrides` catches the `ValueError`, logs a warning, skips the key.
- The field falls back to its default `[]`. No crash, no data loss beyond the already-corrupt entry.

Test: `test_legacy_repr_string_in_config_handled_gracefully` covers both scalar-value and list-of-strings cases.

## Testing

- **1694 tests pass** (+14 new), ruff + format + mypy clean.
- New tests in `test_cli.py::TestCoerceAndValidate`:
  - `test_namespace_rules_from_json_string` — CLI path
  - `test_namespace_rules_from_list_of_dicts_pr253_regression` — Web PATCH path; docstring pins the `engine.py:121` failure mode that originally motivated this fix
  - `test_namespace_rules_passthrough_for_model_instances`
  - `test_namespace_rules_empty_list`
  - `test_namespace_rules_rejects_malformed_json`
  - `test_namespace_rules_rejects_non_list_json`
  - `test_namespace_rules_rejects_scalar_entry`
  - `test_namespace_rules_propagates_model_validation_error`
- New tests in `test_cli.py::TestSaveConfigOverrides`:
  - `test_legacy_repr_string_in_config_handled_gracefully` — migration safety
  - `test_namespace_rules_round_trip` — save → load returns validated instances (not dicts)
- New tests in `test_cli.py::TestConfigCLI`:
  - `test_config_set_namespace_rules_json` — end-to-end CLI persistence + reload
  - `test_config_set_namespace_rules_rejects_malformed`
- New tests in `test_web_routes_extended.py::TestConfigPatch`:
  - `test_patch_namespace_rules` — PATCH apply + runtime type check
  - `test_patch_namespace_rules_validation_error` — bad rule lands in `rejected`
- **Manual smoke** (4-step): `mm config set namespace.rules '[...]'` → reload produces `NamespacePolicyRule` instances → `_FRESH_PRESERVE_KEYS` contains `namespace.rules` (PR #255 preserve list) → subsequent `save_config_overrides` keeps the rules (non-default, so not dropped by PR #256 logic).

## Unblocks

- Web UI namespace rules editor (designed in `project_list_basesettings_config_gap.md`)
- `mm init` wizard rule presets
- Any future `list[BaseSettings]` config field

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1694 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src` — 0 issues
- [x] Manual smoke: `mm config set namespace.rules '[...]'` round-trip, reload produces model instances
- [x] Manual smoke: `_FRESH_PRESERVE_KEYS` contains `namespace.rules` (interop with PR #255)