### PR TITLE
fix(config): delta-only save against comparand to close fragment/env drag-in

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -49,14 +49,45 @@ top of the default:
 explicit-user-override layer. Use a fragment in `config.d/` if you want
 APPEND semantics.
 
-### Resetting wizard-untouched leftovers (`--fresh`)
+### Delta-only save semantics
 
-Because the Web UI's "Save" buttons dump every mutable field into
-`config.json` (memory-dirs add/remove, section save), runtime values
-the user never deliberately set can pin themselves there permanently
-— a known case is `mmr.enabled=true` showing up after the user toggled
-MMR once in the UI. `mm init` flags such leftovers under a "Preserved"
-block so they don't disappear silently, but it does not remove them.
+`config.json` stores only values that differ from the merged lower
+layers (defaults + env vars + `config.d/` fragments). When you save
+through any path — `mm config set`, `PATCH /api/config`, the Web UI's
+section "Save" buttons, or `memory-dirs/add|remove` — memtomem
+computes the difference against a freshly built comparand and writes
+only the delta. Three kinds of silent leftovers this prevents:
+
+- **Default leftovers.** Toggling "MMR enabled" on and back off in
+  the Web UI no longer pins `mmr.enabled=false` into `config.json`
+  (where it would shadow a `config.d/` fragment that set it True).
+- **Environment leftovers.** Running once with `MEMTOMEM_MMR__ENABLED=true`
+  and saving does not bake the env value into `config.json`; the
+  moment the env var is unset, the field reverts correctly.
+- **Fragment leftovers.** Saving an unrelated field does not copy
+  `config.d/` fragment values into `config.json`. Fragment edits stay
+  the source of truth and take effect on the next load.
+
+On-disk leftovers from older versions are cleaned up automatically on
+the next save, provided the stale value now matches the comparand.
+
+### Moving `config.json` between machines
+
+`indexing.memory_dirs` participates in delta-only save, so on the
+machine where it was set the file typically omits it. When copying an
+existing `config.json` to a new machine, any `indexing.memory_dirs`
+entry carries over as-is and is **not** auto-replaced by the new
+machine's auto-discovered paths. Reset it explicitly when migrating:
+
+```bash
+# Option 1: remove the indexing section and let auto-discovery run
+#          (edit ~/.memtomem/config.json by hand)
+
+# Option 2: re-run the wizard with --fresh
+mm init --fresh
+```
+
+### Resetting wizard-untouched leftovers (`--fresh`)
 
 `mm init --fresh` resets every wizard-untouched canonical key whose
 value differs from the built-in default, then proceeds with the

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -789,7 +789,7 @@ def _dedup_key(item: object) -> object:
     return item
 
 
-def load_config_d(config: Mem2MemConfig) -> None:
+def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
     """Apply fragments from ``~/.memtomem/config.d/*.json`` (if dir exists).
 
     Intended for integration-installed fragments (``mm init <client>`` drops
@@ -808,12 +808,23 @@ def load_config_d(config: Mem2MemConfig) -> None:
     (see ``load_config_overrides``); that file remains a full REPLACE-on-set
     for every field so the ``mm init`` wizard keeps unambiguous user-override
     semantics.
+
+    ``quiet=True`` suppresses *warning* output only — used by
+    ``_build_comparand`` which calls this on every save and would
+    otherwise repeat "malformed fragment" / "unknown section" messages
+    for every PATCH. Exceptions that represent real errors still raise
+    (pydantic validation etc. are already caught + logged here, not
+    raised, so this toggle is purely about log noise).
     """
     import json as _json
     import logging
     import os
 
     _log = logging.getLogger(__name__)
+
+    def _warn(msg: str, *args: object) -> None:
+        if not quiet:
+            _log.warning(msg, *args)
 
     dir_ = _config_d_path()
     if not dir_.is_dir():
@@ -824,16 +835,16 @@ def load_config_d(config: Mem2MemConfig) -> None:
         try:
             data = _json.loads(path.read_text(encoding="utf-8"))
         except (OSError, _json.JSONDecodeError) as exc:
-            _log.warning("Failed to read config fragment %s: %s", path, exc)
+            _warn("Failed to read config fragment %s: %s", path, exc)
             continue
         if not isinstance(data, dict):
-            _log.warning("Config fragment %s is not a JSON object (ignored)", path)
+            _warn("Config fragment %s is not a JSON object (ignored)", path)
             continue
         for section_name, updates in data.items():
             section_obj = getattr(config, section_name, None)
             if section_obj is None or not isinstance(updates, dict):
                 if section_obj is None and isinstance(updates, dict):
-                    _log.warning("Unknown config section '%s' in %s (ignored)", section_name, path)
+                    _warn("Unknown config section '%s' in %s (ignored)", section_name, path)
                 continue
             section_cls = type(section_obj)
             for key, value in updates.items():
@@ -852,7 +863,7 @@ def load_config_d(config: Mem2MemConfig) -> None:
                 strategy = _merge_strategy_for(section_cls, key)
                 if strategy is not None and strategy.mode == "append":
                     if not isinstance(value, list):
-                        _log.warning(
+                        _warn(
                             "Expected list for %s.%s in %s (got %s); skipping",
                             section_name,
                             key,
@@ -875,7 +886,7 @@ def load_config_d(config: Mem2MemConfig) -> None:
                             try:
                                 item = coerce.model_validate(item)
                             except Exception as exc:
-                                _log.warning(
+                                _warn(
                                     "Skipping invalid %s.%s entry in %s: %s",
                                     section_name,
                                     key,
@@ -890,7 +901,7 @@ def load_config_d(config: Mem2MemConfig) -> None:
                     try:
                         setattr(section_obj, key, current)
                     except (TypeError, ValueError) as exc:
-                        _log.warning(
+                        _warn(
                             "Skipping invalid fragment merge %s.%s from %s: %s",
                             section_name,
                             key,
@@ -901,7 +912,7 @@ def load_config_d(config: Mem2MemConfig) -> None:
                     try:
                         setattr(section_obj, key, value)
                     except (TypeError, ValueError) as exc:
-                        _log.warning(
+                        _warn(
                             "Skipping invalid fragment value %s.%s=%r from %s: %s",
                             section_name,
                             key,
@@ -940,23 +951,21 @@ def _auto_discovered_memory_dirs() -> list[Path]:
     return [p.expanduser() for p in candidates if p.expanduser().is_dir()]
 
 
-# Fields persisted by ``save_config_overrides`` but NOT settable via the
-# generic ``mm config set`` / ``mem_config`` path.  Managed through dedicated
-# endpoints (e.g. Web UI ``/memory-dirs/*``).
+# Fields that ``save_config_overrides`` persists but ``MUTABLE_FIELDS`` does
+# not expose to generic mutation paths (``mm config set``,
+# ``PATCH /api/config``). Managed by dedicated endpoints (e.g.
+# ``/memory-dirs/add|remove`` for ``memory_dirs``) because their updates
+# carry validation, indexing triggers, or filesystem side-effects that
+# generic mutation would bypass.
 #
-# These fields are also EXEMPT from the drop-equal-to-default rule in
-# ``save_config_overrides``. Criterion for inclusion: the field's
-# ``default_factory`` is environment-dependent — it reads filesystem,
-# network, hostname, or other runtime state, so "equal to default" on
-# machine A does not imply the same on machine B. Dropping such a field
-# on save would silently lose user-curated data across environments.
-#
-# Current members:
-# - ``indexing.memory_dirs`` — ``_default_memory_dirs()`` auto-discovers
-#   AI tool dirs via ``is_dir()`` fs checks.
-#
-# When adding a field whose default reads runtime state, add it here.
-_EXTRA_PERSIST_FIELDS: dict[str, set[str]] = {
+# Pre-Z history: this set was named ``_EXTRA_PERSIST_FIELDS`` and had
+# "always-persist" semantics to protect env-dependent factory defaults
+# from being dropped on save (see
+# ``feedback_env_dependent_factory_equality.md``). Z (delta-vs-comparand
+# via ``_build_comparand``) removed that need because the comparand itself
+# incorporates factory output. The set was renamed to reflect its remaining
+# role — marking the mutation/save asymmetry — rather than deleted.
+_EXTRA_MUTATION_FIELDS: dict[str, set[str]] = {
     "indexing": {"memory_dirs"},
 }
 
@@ -977,56 +986,62 @@ def _json_default(obj: object) -> object:
     return str(obj)
 
 
-def _field_equals_default(section_obj: object, key: str) -> bool:
-    """Return True if ``section_obj.key`` equals the class-level default.
+def _build_comparand(*, quiet: bool = True) -> "Mem2MemConfig":
+    """Build a fresh config reflecting everything *except* user overrides.
 
-    Default-valued fields are dropped from ``config.json`` on save so that
-    runtime toggles (e.g. a Web UI checkbox left at its default) don't pin
-    the default over ``config.d/`` fragments that set a different value.
+    Comparand = built-in defaults + ``MEMTOMEM_*`` env vars + ``config.d/``
+    fragments + env-dependent factory output (``memory_dirs`` etc.).
+    ``save_config_overrides`` persists only fields where the live config
+    differs from this comparand — closing fragment/env/factory drag-in at
+    the source (see ``project_fragment_dragin_gap.md``).
+
+    ``Mem2MemConfig()`` construction reads env automatically via pydantic-
+    settings and runs field ``default_factory`` callables, so env + factory
+    values land without extra work. ``load_config_d`` then merges fragments
+    on top, respecting per-field merge strategies.
+
+    Safe to call concurrently: only reads env/filesystem, no mutation.
+    Factory functions (e.g. ``_default_memory_dirs``) must remain pure.
     """
-    model_fields = getattr(type(section_obj), "model_fields", None)
-    if not model_fields or key not in model_fields:
-        return False
-    try:
-        default = model_fields[key].get_default(call_default_factory=True)
-    except Exception:  # pragma: no cover - defensive; pydantic shouldn't raise
-        return False
-    return getattr(section_obj, key, None) == default
+    comparand = Mem2MemConfig()
+    load_config_d(comparand, quiet=quiet)
+    return comparand
 
 
 def save_config_overrides(
     config: Mem2MemConfig,
     mutable_fields: dict[str, set[str]] | None = None,
 ) -> None:
-    """Persist mutable fields to ~/.memtomem/config.json.
+    """Persist user-set overrides to ~/.memtomem/config.json.
 
-    Uses **read-merge-write** so that keys not in *mutable_fields* (e.g.
-    init-only settings like ``embedding.provider`` or ``storage.sqlite_path``)
-    are preserved across saves.
+    **Delta-only write**: compare *config* to a freshly built comparand
+    (defaults + env + fragments + env-dependent factories). Only fields
+    that differ are written; fields that match the comparand are dropped
+    from the output (and any matching existing entry is pruned).
 
-    Runtime-mutable fields (``MUTABLE_FIELDS``) whose current value equals
-    the class-level default are dropped (and pruned from any existing
-    entry). This prevents silent pins — e.g. a Web UI section save where
-    an unchecked default-False toggle would otherwise write
-    ``mmr.enabled=false`` and permanently shadow a ``config.d/`` fragment
-    that sets it True.
+    This closes three silent-persistence patterns in one mechanism:
 
-    ``_EXTRA_PERSIST_FIELDS`` (currently ``indexing.memory_dirs``) are
-    exempt from drop-default. Their default factories are
-    environment-dependent (auto-discovered AI tool dirs), so "equal to
-    default" is not a stable signal across machines. Treat them as
-    user-curated data and always persist when present.
+    - default-equal fields (PR #256 drop-default) — comparand contains
+      the default value for fields not set by env/fragment.
+    - env-sourced values (e.g. ``MEMTOMEM_MMR__ENABLED=true`` no longer
+      drag-pins into ``config.json``).
+    - fragment-sourced values (e.g. ``config.d/noise.json`` contents
+      don't copy into ``config.json`` when an unrelated field is saved;
+      the fragment stays the source of truth).
+
+    Uses **read-merge-write** so non-mutable keys (init-only settings like
+    ``embedding.provider``, ``storage.sqlite_path``) carry across saves.
     """
     import json as _json
     import logging
 
     _log = logging.getLogger(__name__)
     base_fields: dict[str, set[str]] = mutable_fields or MUTABLE_FIELDS
+    comparand = _build_comparand(quiet=True)
 
     path = _override_path()
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    # ── Read existing config (merge base) ──
     existing: dict = {}
     if path.exists():
         try:
@@ -1034,30 +1049,30 @@ def save_config_overrides(
         except (OSError, _json.JSONDecodeError) as exc:
             _log.warning("Cannot read existing config at %s: %s — overwriting", path, exc)
 
-    # ── Merge fields into existing data ──
-    # drop_default applies only to runtime-mutable fields; extra-persist
-    # fields (memory_dirs) are always persisted when non-None.
-    sections = {*base_fields, *_EXTRA_PERSIST_FIELDS}
+    # Union with dedicated-endpoint fields (memory_dirs). No exemption —
+    # env-dependent factory output is already part of the comparand, so
+    # "current == factory" still drops cleanly.
+    sections = {*base_fields, *_EXTRA_MUTATION_FIELDS}
     for section_name in sections:
-        section_obj = getattr(config, section_name, None)
-        if section_obj is None:
+        live_section = getattr(config, section_name, None)
+        comp_section = getattr(comparand, section_name, None)
+        if live_section is None or comp_section is None:
             continue
-        drop_default_keys = base_fields.get(section_name, set())
-        always_persist_keys = _EXTRA_PERSIST_FIELDS.get(section_name, set())
+        keys = base_fields.get(section_name, set()) | _EXTRA_MUTATION_FIELDS.get(
+            section_name, set()
+        )
 
         section_data: dict[str, object] = existing.get(section_name, {})
         if not isinstance(section_data, dict):
             section_data = {}
 
-        for key in drop_default_keys | always_persist_keys:
-            val = getattr(section_obj, key, None)
-            if val is None:
+        for key in keys:
+            live_val = getattr(live_section, key, None)
+            comp_val = getattr(comp_section, key, None)
+            if live_val is None or live_val == comp_val:
                 section_data.pop(key, None)
-                continue
-            if key in drop_default_keys and _field_equals_default(section_obj, key):
-                section_data.pop(key, None)
-                continue
-            section_data[key] = val
+            else:
+                section_data[key] = live_val
 
         if section_data:
             existing[section_name] = section_data

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -389,12 +389,30 @@ class TestCoerceAndValidate:
 
 
 class TestSaveConfigOverrides:
-    """Verify save→load round-trip for mutable and special fields."""
+    """Verify delta-only save semantics: persisted values equal cfg minus the
+    comparand (defaults + env + config.d/ fragments + env-dependent factories).
+    """
 
-    def test_memory_dirs_survives_save_load(self, tmp_path, monkeypatch):
-        """memory_dirs added via Web UI must survive a save→load cycle."""
+    @pytest.fixture
+    def isolated(self, tmp_path, monkeypatch):
+        """Isolate both config.json and config.d/ to tmp_path.
+
+        Without this, ``_build_comparand`` reads the developer's real
+        ``~/.memtomem/config.d/`` fragments during tests, producing
+        per-machine comparand differences that mask the intended behavior.
+        """
         config_file = tmp_path / "config.json"
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
         monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+        monkeypatch.setattr("memtomem.config._config_d_path", lambda: config_d)
+        return {"config_file": config_file, "config_d": config_d, "tmp_path": tmp_path}
+
+    # ── Load-path defensive tests (unrelated to delta semantic) ────────
+
+    def test_memory_dirs_survives_save_load(self, isolated):
+        """User-added memory_dirs (distinct from factory) must survive save→load."""
+        tmp_path = isolated["tmp_path"]
 
         cfg = Mem2MemConfig()
         cfg.indexing.memory_dirs = [tmp_path / "a", tmp_path / "b"]
@@ -407,36 +425,25 @@ class TestSaveConfigOverrides:
         assert str(tmp_path / "a") in loaded_dirs
         assert str(tmp_path / "b") in loaded_dirs
 
-    def test_invalid_value_falls_back_to_default(self, tmp_path, monkeypatch):
+    def test_invalid_value_falls_back_to_default(self, isolated):
         """Invalid values in config.json should be skipped with warning, not crash."""
         import json
 
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
-        config_file.write_text(
-            json.dumps(
-                {
-                    "search": {"default_top_k": -5},  # violates min=1
-                }
-            )
+        isolated["config_file"].write_text(
+            json.dumps({"search": {"default_top_k": -5}})  # violates min=1
         )
 
         cfg = Mem2MemConfig()
         default_top_k = cfg.search.default_top_k
         load_config_overrides(cfg)
 
-        # Invalid value must be rejected; field keeps code default
         assert cfg.search.default_top_k == default_top_k
 
-    def test_invalid_value_does_not_block_valid_ones(self, tmp_path, monkeypatch):
+    def test_invalid_value_does_not_block_valid_ones(self, isolated):
         """One bad field must not prevent other valid fields from loading."""
         import json
 
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
-        config_file.write_text(
+        isolated["config_file"].write_text(
             json.dumps(
                 {
                     "search": {"default_top_k": -5, "rrf_k": 80},
@@ -448,24 +455,15 @@ class TestSaveConfigOverrides:
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)
 
-        # Valid fields applied, invalid one skipped
         assert cfg.search.rrf_k == 80
         assert cfg.decay.enabled is True
 
-    def test_existing_memory_dirs_not_clobbered(self, tmp_path, monkeypatch):
-        """Saving mutable fields must not destroy pre-existing memory_dirs."""
+    def test_existing_memory_dirs_not_clobbered(self, isolated):
+        """Saving an unrelated mutable field must not erase pinned memory_dirs."""
         import json
 
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
-        # Simulate mm init having written memory_dirs
-        config_file.write_text(
-            json.dumps(
-                {
-                    "indexing": {"memory_dirs": ["/pre/existing"]},
-                }
-            )
+        isolated["config_file"].write_text(
+            json.dumps({"indexing": {"memory_dirs": ["/pre/existing"]}})
         )
 
         cfg = Mem2MemConfig()
@@ -473,89 +471,231 @@ class TestSaveConfigOverrides:
         cfg.search.default_top_k = 42
         save_config_overrides(cfg)
 
-        data = json.loads(config_file.read_text())
+        data = json.loads(isolated["config_file"].read_text())
         assert "/pre/existing" in [str(p) for p in data["indexing"]["memory_dirs"]]
 
-    def test_default_valued_field_not_persisted(self, tmp_path, monkeypatch):
-        """Fields whose current value equals the class-level default must not
-        be written. Otherwise a Web UI save would pin the default and shadow
-        a ``config.d/`` fragment that sets a different value.
+    # ── Delta semantic (renamed from drop-default) ─────────────────────
+
+    def test_comparand_equal_field_not_persisted(self, isolated):
+        """Fields whose current value equals the comparand (default/env/fragment-
+        derived) must not be written. Prevents default-flush over config.d/
+        fragments — same coverage as pre-Z ``drop-default``, now generalized.
         """
         import json
-
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
 
         cfg = Mem2MemConfig()
         # mmr.enabled default is False — simulate a Web UI "save section"
         # that dumps the whole section without the user touching mmr.
         save_config_overrides(cfg)
 
-        data = json.loads(config_file.read_text()) if config_file.exists() else {}
+        data = (
+            json.loads(isolated["config_file"].read_text())
+            if isolated["config_file"].exists()
+            else {}
+        )
         assert "mmr" not in data, (
-            f"default-valued mmr section must not be persisted; got {data.get('mmr')!r}"
+            f"comparand-equal mmr section must not be persisted; got {data.get('mmr')!r}"
         )
 
-    def test_existing_default_entry_pruned_on_save(self, tmp_path, monkeypatch):
-        """An existing leftover entry that matches the current-and-default
-        value must be removed on save, so the key stops shadowing fragments.
-        """
+    def test_existing_comparand_equal_entry_pruned(self, isolated):
+        """An existing leftover entry that now matches the comparand must be
+        removed on the next save, so the key stops shadowing fragments."""
         import json
 
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
-        # Simulate a prior leak: mmr.enabled=false pinned into config.json.
-        config_file.write_text(json.dumps({"mmr": {"enabled": False}}))
+        isolated["config_file"].write_text(json.dumps({"mmr": {"enabled": False}}))
 
         cfg = Mem2MemConfig()
-        # cfg.mmr.enabled is False (default) and config.json has False too.
-        # Next save should prune the pinned key.
+        # cfg.mmr.enabled is False (matches comparand) → pruned on save.
         save_config_overrides(cfg)
 
-        data = json.loads(config_file.read_text())
+        data = json.loads(isolated["config_file"].read_text())
         assert "mmr" not in data
 
-    def test_non_default_value_still_persists(self, tmp_path, monkeypatch):
-        """Explicit non-default values must still be written."""
+    def test_non_default_value_still_persists(self, isolated):
+        """Explicit values that differ from the comparand must still be written."""
         import json
-
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
 
         cfg = Mem2MemConfig()
         cfg.mmr.enabled = True  # default is False
         cfg.search.default_top_k = 42  # default is 10
         save_config_overrides(cfg)
 
-        data = json.loads(config_file.read_text())
+        data = json.loads(isolated["config_file"].read_text())
         assert data["mmr"]["enabled"] is True
         assert data["search"]["default_top_k"] == 42
 
-    def test_memory_dirs_equal_to_default_still_persisted(self, tmp_path, monkeypatch):
-        """memory_dirs is in _EXTRA_PERSIST_FIELDS and exempt from
-        drop-default because its factory auto-discovers AI tool dirs via
-        filesystem checks. "Equal to default" on machine A may not match
-        machine B's default — so we always persist user-curated dir lists.
+    def test_section_with_only_comparand_equal_fields_dropped(self, isolated):
+        """If every mutable key in a section equals the comparand, the whole
+        section is omitted (no orphan ``{}`` entries)."""
+        import json
+
+        isolated["config_file"].write_text(
+            json.dumps({"decay": {"enabled": False, "half_life_days": 30.0}})
+        )
+
+        cfg = Mem2MemConfig()  # all defaults = comparand
+        save_config_overrides(cfg)
+
+        data = json.loads(isolated["config_file"].read_text())
+        assert "decay" not in data
+
+    # ── New tests for Z design ─────────────────────────────────────────
+
+    def test_fragment_value_not_dragged_to_config_json(self, isolated):
+        """Regression guard for fragment drag-in (`project_fragment_dragin_gap.md`).
+
+        Fragment defines ``exclude_patterns``; unrelated field save must not
+        copy the fragment value into config.json. Before Z, save persisted
+        the full effective value, which silently copied fragment contents
+        into the REPLACE layer and froze later fragment edits.
+        """
+        import json
+
+        (isolated["config_d"] / "noise.json").write_text(
+            json.dumps({"indexing": {"exclude_patterns": ["*.tmp", "node_modules/"]}})
+        )
+
+        # Match web/MCP in-process flow: fragments already merged.
+        cfg = Mem2MemConfig()
+        from memtomem.config import load_config_d
+
+        load_config_d(cfg)
+        load_config_overrides(cfg)
+        assert "*.tmp" in cfg.indexing.exclude_patterns  # fragment visible
+
+        cfg.search.default_top_k = 42  # unrelated mutation
+        save_config_overrides(cfg)
+
+        data = json.loads(isolated["config_file"].read_text())
+        assert "exclude_patterns" not in data.get("indexing", {}), (
+            f"fragment exclude_patterns must not drag into config.json; got {data}"
+        )
+
+    def test_env_value_not_dragged(self, isolated, monkeypatch):
+        """Env-sourced values must not copy into config.json on save."""
+        import json
+
+        monkeypatch.setenv("MEMTOMEM_MMR__ENABLED", "true")
+
+        cfg = Mem2MemConfig()  # picks up env at construction
+        assert cfg.mmr.enabled is True
+
+        cfg.search.default_top_k = 42
+        save_config_overrides(cfg)
+
+        data = json.loads(isolated["config_file"].read_text())
+        assert "mmr" not in data, (
+            f"env-sourced mmr.enabled must not drag into config.json; got {data}"
+        )
+
+    def test_memory_dirs_factory_default_not_persisted(self, isolated):
+        """memory_dirs == env-dependent factory output → dropped on save.
+
+        This flips the pre-Z ``_EXTRA_PERSIST_FIELDS`` exemption: the
+        factory output is now included in the comparand, so machine-A
+        save doesn't pin factory-specific paths into config.json for
+        migration to machine-B. Companion of
+        ``test_machine_migration_requires_active_reset`` (this test locks
+        the *drop* direction, the other locks the *active-reset* one).
         """
         import json
 
         from memtomem.config import _default_memory_dirs
 
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
         cfg = Mem2MemConfig()
-        cfg.indexing.memory_dirs = _default_memory_dirs()
+        cfg.indexing.memory_dirs = _default_memory_dirs()  # matches factory
+        cfg.mmr.enabled = True  # unrelated non-comparand so file is non-empty
         save_config_overrides(cfg)
 
-        data = json.loads(config_file.read_text())
-        assert "memory_dirs" in data["indexing"], (
-            "memory_dirs must be persisted even when equal to default "
-            "(environment-dependent factory, preserve user intent)"
+        data = json.loads(isolated["config_file"].read_text())
+        assert "memory_dirs" not in data.get("indexing", {}), (
+            f"factory-default memory_dirs must be dropped on save under Z; got {data}"
         )
 
-    def test_legacy_repr_string_in_config_handled_gracefully(self, tmp_path, monkeypatch):
+    def test_save_is_idempotent(self, isolated):
+        """Two consecutive saves produce byte-identical output.
+
+        Guards against order-dependency in comparand build (e.g. glob
+        ordering, set iteration) or diff computation.
+        """
+        cfg = Mem2MemConfig()
+        cfg.mmr.enabled = True
+        cfg.search.default_top_k = 42
+
+        save_config_overrides(cfg)
+        first = isolated["config_file"].read_text()
+        save_config_overrides(cfg)
+        second = isolated["config_file"].read_text()
+
+        assert first == second, f"idempotent save broken:\n---\n{first}\n---\n{second}"
+
+    def test_machine_migration_requires_active_reset(self, isolated):
+        """Machine-A config.json with machine-A-only paths carried to
+        machine-C keeps those paths pinned until the user actively resets.
+
+        Z doesn't auto-clean historical leftovers that don't match the
+        local comparand (the REPLACE layer semantics preclude that);
+        docs must tell users to run ``cfg.memory_dirs = _default_memory_dirs()``
+        + save, or (future) ``mm config unset memory_dirs``.
+        """
+        import json
+        from pathlib import Path
+
+        from memtomem.config import _default_memory_dirs
+
+        # Seed a config.json that pins a path not part of the local factory output.
+        machine_a_dirs = [str(Path("~/.memtomem/memories").expanduser()), "/machine-a-only"]
+        isolated["config_file"].write_text(
+            json.dumps({"indexing": {"memory_dirs": machine_a_dirs}})
+        )
+
+        cfg = Mem2MemConfig()
+        load_config_overrides(cfg)
+        cfg.search.default_top_k = 99  # unrelated save
+        save_config_overrides(cfg)
+
+        data = json.loads(isolated["config_file"].read_text())
+        assert "/machine-a-only" in [
+            str(p) for p in data.get("indexing", {}).get("memory_dirs", [])
+        ], "machine-A path must stay pinned on unrelated save (doc: user must reset actively)"
+
+        # Active reset: drops cleanly
+        cfg.indexing.memory_dirs = _default_memory_dirs()
+        save_config_overrides(cfg)
+        data2 = json.loads(isolated["config_file"].read_text())
+        assert "memory_dirs" not in data2.get("indexing", {})
+
+    def test_comparand_build_suppresses_warnings(self, isolated, caplog):
+        """_build_comparand(quiet=True) must not emit WARNING-level logs
+        for malformed fragments. Without this, every save on a machine
+        with any malformed fragment prints the same warning repeatedly."""
+        import logging
+
+        from memtomem.config import _build_comparand
+
+        # Malformed fragment that would normally warn on each load.
+        (isolated["config_d"] / "bad.json").write_text('{"unknown_section": {"foo": 1}}')
+
+        caplog.set_level(logging.WARNING, logger="memtomem.config")
+        _build_comparand(quiet=True)
+        assert not caplog.records, (
+            f"comparand build should not emit warnings; got {[r.message for r in caplog.records]}"
+        )
+
+        # Control: quiet=False still emits (proves the suppression is targeted).
+        from memtomem.config import load_config_d
+
+        caplog.clear()
+        probe = Mem2MemConfig()
+        load_config_d(probe, quiet=False)
+        assert any(
+            "unknown_section" in r.message.lower() or "unknown" in r.message.lower()
+            for r in caplog.records
+        ), f"quiet=False must still emit warnings; got {[r.message for r in caplog.records]}"
+
+    # ── Unchanged — unrelated to delta semantic ────────────────────────
+
+    def test_legacy_repr_string_in_config_handled_gracefully(self, isolated):
         """Pre-fix installations may have serialized ``namespace.rules`` via
         ``default=str`` → raw ``repr()`` strings in config.json. Loading such
         a file on upgrade must not crash: coerce rejects the shape, load path
@@ -564,33 +704,29 @@ class TestSaveConfigOverrides:
         """
         import json
 
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
         # Case 1: whole value is a repr-ish string (not even JSON).
-        config_file.write_text(
+        isolated["config_file"].write_text(
             json.dumps(
                 {"namespace": {"rules": "<NamespacePolicyRule path_glob='x' namespace='y'>"}}
             )
         )
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)
-        assert cfg.namespace.rules == []  # fell back to default, no crash
+        assert cfg.namespace.rules == []
 
         # Case 2: list of repr strings.
-        config_file.write_text(json.dumps({"namespace": {"rules": ["<legacy repr entry>"]}}))
+        isolated["config_file"].write_text(
+            json.dumps({"namespace": {"rules": ["<legacy repr entry>"]}})
+        )
         cfg = Mem2MemConfig()
         load_config_overrides(cfg)
         assert cfg.namespace.rules == []
 
-    def test_namespace_rules_round_trip(self, tmp_path, monkeypatch):
+    def test_namespace_rules_round_trip(self, isolated):
         """list[NamespacePolicyRule] survives save→load via model_dump/validate."""
         import json
 
         from memtomem.config import NamespacePolicyRule
-
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
 
         cfg = Mem2MemConfig()
         cfg.namespace.rules = [
@@ -599,39 +735,16 @@ class TestSaveConfigOverrides:
         ]
         save_config_overrides(cfg)
 
-        # Persisted as list of dicts — not BaseSettings repr().
-        data = json.loads(config_file.read_text())
+        data = json.loads(isolated["config_file"].read_text())
         assert data["namespace"]["rules"] == [
             {"path_glob": "docs/**/*.md", "namespace": "docs"},
             {"path_glob": "work/**/*.md", "namespace": "work"},
         ]
 
-        # load_config_overrides runs coerce_and_validate on each field that
-        # has a FIELD_CONSTRAINTS entry. Because namespace.rules is now
-        # registered, the raw dicts on disk are validated back into
-        # NamespacePolicyRule instances — matching what downstream consumers
-        # (indexing/engine.py) require (attribute access like `rule.path_glob`).
         fresh = Mem2MemConfig()
         load_config_overrides(fresh)
         assert all(isinstance(r, NamespacePolicyRule) for r in fresh.namespace.rules)
         assert fresh.namespace.rules == cfg.namespace.rules
-
-    def test_section_with_only_defaults_dropped_entirely(self, tmp_path, monkeypatch):
-        """If every mutable key in a section equals its default, the whole
-        section is omitted from config.json (no orphan ``{}`` entries)."""
-        import json
-
-        config_file = tmp_path / "config.json"
-        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
-
-        # Prior leak: entire decay section pinned at defaults.
-        config_file.write_text(json.dumps({"decay": {"enabled": False, "half_life_days": 30.0}}))
-
-        cfg = Mem2MemConfig()  # all defaults
-        save_config_overrides(cfg)
-
-        data = json.loads(config_file.read_text())
-        assert "decay" not in data
 
 
 # ── Other subcommands (help text) ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Save paths running in-process (Web UI `PATCH /api/config`, `/memory-dirs/*`, MCP `mem_config`) read `cfg.<field>` directly and wrote whatever the runtime config held. After `load_config_d`, that included fragment- and env-merged values. A user PATCHing an unrelated field silently copied `config.d/` fragment contents into `config.json`'s REPLACE layer, freezing subsequent fragment edits. Tracked in `project_fragment_dragin_gap.md` and the `feedback_silent_policy_enforcement_gap.md` "Known instances" entry (instance 2 — the canonical `[]` wipe, instance 1, was already resolved by #256 + #257).

**Reproduction** (Phase 0, 2026-04-19, 5 scenarios + 3 measurements, all PASS): `config.d/noise.json` defines `exclude_patterns`; `mm config set search.default_top_k 42` via the web flow drags the fragment values into `config.json`, and a subsequent fragment edit no longer takes effect. Phase 0 validated the Z design end-to-end without touching real code.

## Design — delta-only save against a comparand

`save_config_overrides` now builds a fresh comparand via `_build_comparand()`:

```python
comparand = Mem2MemConfig()   # defaults + env (BaseSettings auto)
load_config_d(comparand, quiet=True)  # + fragments
```

`Mem2MemConfig()` construction reads `MEMTOMEM_*` env and runs `default_factory` callables, so the comparand inherently reflects `defaults + env + fragments + env-dependent factory output`. Save persists only fields where `cfg.<field> != comparand.<field>`.

Three silent-persistence patterns collapse into one mechanism:

1. **Default-equal** (PR #256 drop-default) — the default is simply a comparand case.
2. **Env-sourced** — env is part of the comparand, so `MEMTOMEM_MMR__ENABLED=true` no longer drag-pins into `config.json`.
3. **Fragment-sourced** — `load_config_d` merges fragments into the comparand; fragment values stop copying into `config.json` on unrelated saves.

### Same concern, different angle

PR #256 introduced `_EXTRA_PERSIST_FIELDS` as a defensive exemption for env-dependent factories (documented in `feedback_env_dependent_factory_equality.md`). This PR addresses the same concern differently — by including factory output in the comparand itself. Machine A saves: factory matches → drops. Machine B loads: factory runs fresh, returns the right local value. No exemption needed; no machine-A-to-B pin either.

The set was **renamed to `_EXTRA_MUTATION_FIELDS`**, not deleted, because it retains a distinct role beyond the pre-Z always-persist semantics: marking fields that `save_config_overrides` persists even though they are absent from `MUTABLE_FIELDS` (managed by dedicated endpoints `/memory-dirs/add|remove` — generic mutation would bypass filesystem validation and indexing triggers). The rename reflects the semantic shift; an inline comment preserves the pre-Z history so future readers don't re-litigate.

## Secondary changes

- `load_config_d(quiet=False)` parameter added — suppresses WARNING-level logs only (malformed fragment, unknown section, etc.). Used by `_build_comparand` to prevent repeated warnings on every save. Errors still raise.
- `_field_equals_default` deleted — grep confirmed 0 external consumers. Delta comparison is a plain `cfg_val != comp_val` inline.
- `docs/guides/configuration.md` — new "Delta-only save semantics" subsection replacing the stale "Web UI dumps every mutable field" narrative (incorrect post-#256/#257), and a "Moving `config.json` between machines" note for Scenario-5 migration guidance.

## Performance

Comparand build: **1.88 ms** mean per call (100 iterations, real `~/.memtomem/config.d/` with 3 fragments). Save frequency under interactive use is far below any rate where this overhead matters; UI PATCH is rate-limited by user interaction.

## Migration safety

Existing `config.json` files with pinned values load normally. On the next save:

- Values that now match the local comparand → pruned automatically (ambient cleanup, same mechanism as #256 post-merge).
- Values that don't match (e.g. machine-A paths in `memory_dirs` carried to machine B) → **stay pinned** until user actively resets. Tested: `test_machine_migration_requires_active_reset`. Documented with an explicit reset recipe ("remove the `indexing` section" or `mm init --fresh`).

## Test plan

1699 tests pass (pre-branch 1694 → +5 net: +6 new, −1 deleted).

`TestSaveConfigOverrides` rewritten. Matrix:

| Action | Test | Note |
|---|---|---|
| RENAME | `test_default_valued_field_not_persisted` → `test_comparand_equal_field_not_persisted` | default ⊂ comparand |
| RENAME | `test_existing_default_entry_pruned_on_save` → `test_existing_comparand_equal_entry_pruned` | same |
| RENAME | `test_section_with_only_defaults_dropped_entirely` → `test_section_with_only_comparand_equal_fields_dropped` | same |
| DELETE | `test_memory_dirs_equal_to_default_still_persisted` | Z flips this semantic; replaced by `test_memory_dirs_factory_default_not_persisted` |
| KEEP | 7 tests (memory_dirs_survives, invalid_value ×2, existing_not_clobbered, non_default_persists, legacy_repr, namespace_rules_round_trip) | delta-unrelated |
| NEW | `test_fragment_value_not_dragged_to_config_json` | drag-in regression guard |
| NEW | `test_env_value_not_dragged` | env drag-in guard |
| NEW | `test_memory_dirs_factory_default_not_persisted` | Z core behavior (replaces the deleted test) |
| NEW | `test_save_is_idempotent` | 2× save byte-identical; order-dependency guard |
| NEW | `test_machine_migration_requires_active_reset` | Scenario-5 migration edge case, doc reference |
| NEW | `test_comparand_build_suppresses_warnings` | `quiet=True` contract (suppresses warnings, errors still raise) |

### New `isolated` fixture

Added to support multi-source test setup (config.json + config.d/ fragments + env vars in one place). Without it, `_build_comparand` reads the developer's real `~/.memtomem/config.d/` and tests pass accidentally — caught during Phase 1 rewrite. Centralizing the patching prevents every new test from repeating the boilerplate.

## Test plan checklist

- [x] `uv run pytest -m "not ollama"` — 1699 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src` — 0 issues
- [x] Manual: `_field_equals_default` grep in entire tree → 0 references (safe deletion)
- [x] Manual: comparand build benchmark → 1.88 ms/call, well under 5 ms
- [x] Manual: Phase 0 script (5 scenarios + 3 measurements) re-run after implementation → all PASS

## Refs

- PR #249 — `config.d/` precedence + the "config_set intentionally skips `load_config_d`" design that kept CLI safe from this flavor of drag-in.
- PR #256 — drop-default on save; introduced `_EXTRA_PERSIST_FIELDS` defensive exemption (now superseded by comparand inclusion).
- PR #257 — nested `list[BaseSettings]` coerce on mutation path; orthogonal.