### PR TITLE
feat(cli): add mm config unset for targeted override removal

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -80,12 +80,34 @@ entry carries over as-is and is **not** auto-replaced by the new
 machine's auto-discovered paths. Reset it explicitly when migrating:
 
 ```bash
-# Option 1: remove the indexing section and let auto-discovery run
-#          (edit ~/.memtomem/config.json by hand)
+# Option 1: targeted removal of the carried-over entry
+mm config unset indexing.memory_dirs
 
 # Option 2: re-run the wizard with --fresh
 mm init --fresh
+
+# Option 3: remove the indexing section by hand
+#          (edit ~/.memtomem/config.json)
 ```
+
+### Removing individual overrides (`mm config unset`)
+
+`mm config unset <key>` drops a single pinned entry from
+`~/.memtomem/config.json`. Each key is `section.field` form and the
+command is idempotent — running it on a key that isn't pinned exits 0
+with an `(already at default)` note so scripts can re-run safely.
+Unknown keys exit 1 with a typo suggestion when one is nearby. When
+every override is removed the config file itself is deleted.
+
+```bash
+mm config unset mmr.enabled                    # drop one key
+mm config unset mmr.enabled search.default_top_k  # best-effort multi-key
+```
+
+Because `config.json` is delta-only (see above), the underlying
+`config.d/` fragment or built-in default immediately takes effect on
+the next load. For a wholesale reset of wizard-untouched keys, prefer
+`mm init --fresh`.
 
 ### Resetting wizard-untouched leftovers (`--fresh`)
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -282,6 +282,7 @@ mm add "some note"         # add a memory
 mm recall --since 2026-04  # recall by date
 mm config show             # view settings
 mm config set key value    # change a setting
+mm config unset key        # drop a pinned override (e.g., mmr.enabled)
 mm embedding-reset         # check/resolve embedding model mismatch
 mm reset                   # delete all data and reinitialize the DB
 mm context detect          # find agent config files

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -905,6 +905,7 @@ mm recall --since 2026-03-01           # recall by date
 # Configuration
 mm config show                         # view all settings
 mm config set search.default_top_k 20  # change a setting
+mm config unset mmr.enabled            # drop a pinned override
 mm embedding-reset                     # check/resolve embedding model mismatch
 mm reset                               # delete all data and reinitialize the DB
 mm reset --yes                         # skip confirmation prompt

--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -1,4 +1,4 @@
-"""CLI: memtomem config show / memtomem config set."""
+"""CLI: memtomem config show / memtomem config set / memtomem config unset."""
 
 from __future__ import annotations
 
@@ -6,7 +6,12 @@ import json
 
 import click
 
-from memtomem.config import FIELD_CONSTRAINTS, MUTABLE_FIELDS, coerce_and_validate
+from memtomem.config import (
+    FIELD_CONSTRAINTS,
+    MUTABLE_FIELDS,
+    _EXTRA_MUTATION_FIELDS,
+    coerce_and_validate,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -93,3 +98,119 @@ def config_set(key: str, value: str) -> None:
         storage = create_storage(cfg)
         count = storage.rebuild_fts()
         click.echo(f"FTS index rebuilt ({count} chunks).")
+
+
+def _canonical_unset_keys() -> set[str]:
+    """Union of generic mutable fields and dedicated-endpoint fields.
+
+    ``mm config set`` targets ``MUTABLE_FIELDS`` only (generic mutation
+    bypasses the indexing/validation side-effects those endpoints carry).
+    ``mm config unset`` additionally covers ``_EXTRA_MUTATION_FIELDS``
+    (currently ``indexing.memory_dirs``) — removal is not a mutation and
+    is precisely what resolves the machine-migration leftover case.
+    """
+    canonical = {f"{sec}.{f}" for sec, fs in MUTABLE_FIELDS.items() for f in fs}
+    canonical |= {f"{sec}.{f}" for sec, fs in _EXTRA_MUTATION_FIELDS.items() for f in fs}
+    return canonical
+
+
+def _suggest_key(key: str, canonical: set[str]) -> str | None:
+    import difflib
+
+    match = difflib.get_close_matches(key, list(canonical), n=1, cutoff=0.7)
+    return match[0] if match else None
+
+
+@config.command("unset")
+@click.argument("keys", nargs=-1, required=True)
+def config_unset(keys: tuple[str, ...]) -> None:
+    """Remove config.json overrides for the given KEYs (e.g., 'mmr.enabled').
+
+    Targeted, idempotent removal: each KEY is ``section.field`` form.
+    Canonical keys that aren't currently pinned exit 0 with an
+    informational note; unknown keys exit 1 (with a suggestion when close
+    to a canonical key). When every override is removed the config file
+    itself is deleted. For a wholesale reset of wizard-untouched keys, use
+    ``mm init --fresh``.
+    """
+    from memtomem.config import _atomic_write_json, _override_path
+
+    canonical = _canonical_unset_keys()
+    path = _override_path()
+
+    existing: dict = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            click.echo(
+                click.style(
+                    f"Cannot read {path}: malformed JSON ({exc}). "
+                    "Run 'mm init --fresh' or edit the file manually.",
+                    fg="red",
+                )
+            )
+            raise SystemExit(1) from None
+        if not isinstance(existing, dict):
+            click.echo(
+                click.style(
+                    f"Cannot read {path}: malformed top-level value "
+                    "(expected object). Run 'mm init --fresh' or edit the "
+                    "file manually.",
+                    fg="red",
+                )
+            )
+            raise SystemExit(1)
+
+    lines: list[str] = []
+    removed_extra_mutation = False
+    any_skip = False
+
+    for key in keys:
+        if key not in canonical:
+            any_skip = True
+            suggestion = _suggest_key(key, canonical)
+            if suggestion is not None:
+                lines.append(
+                    click.style(
+                        f"Skipped {key}: not set (did you mean '{suggestion}'?)",
+                        fg="yellow",
+                    )
+                )
+            else:
+                lines.append(click.style(f"Skipped {key}: not set", fg="yellow"))
+            continue
+
+        section, field = key.split(".", 1)
+        section_data = existing.get(section)
+        if isinstance(section_data, dict) and field in section_data:
+            section_data.pop(field)
+            if not section_data:
+                existing.pop(section, None)
+            lines.append(f"Removed: {key}")
+            if field in _EXTRA_MUTATION_FIELDS.get(section, set()):
+                removed_extra_mutation = True
+        else:
+            lines.append(f"Unset: {key} (already at default)")
+
+    if existing:
+        _atomic_write_json(path, existing)
+    elif path.exists():
+        path.unlink()
+        lines.append("Note: config.json now empty, file removed.")
+
+    for line in lines:
+        click.echo(line)
+
+    if removed_extra_mutation:
+        click.echo(
+            click.style(
+                "Warning: indexing.memory_dirs is normally managed via "
+                "dedicated endpoints. Run 'mm memory-dirs list' to verify; "
+                "run 'mm index' if the directory list changed materially.",
+                fg="yellow",
+            )
+        )
+
+    if any_skip:
+        raise SystemExit(1)

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -986,6 +986,33 @@ def _json_default(obj: object) -> object:
     return str(obj)
 
 
+def _atomic_write_json(path: Path, data: dict) -> None:
+    """Write JSON atomically via tempfile in the same directory + os.replace.
+
+    Prevents partial writes from corrupting config.json when the process
+    dies mid-write or disk fills up. The tempfile lives in ``path.parent``
+    so ``os.replace`` is a same-filesystem rename (atomic on POSIX + Windows).
+
+    Used by ``mm config unset``. Follow-up work will migrate
+    ``save_config_overrides`` and ``cli/init_cmd.py``'s ``--fresh`` write
+    path onto this helper as well.
+    """
+    import json as _json
+    import os
+    import tempfile
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".config.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            _json.dump(data, f, indent=2, default=_json_default)
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def _build_comparand(*, quiet: bool = True) -> "Mem2MemConfig":
     """Build a fresh config reflecting everything *except* user overrides.
 

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -747,6 +747,199 @@ class TestSaveConfigOverrides:
         assert fresh.namespace.rules == cfg.namespace.rules
 
 
+# ── Config unset ────────────────────────────────────────────────────────
+
+
+class TestConfigUnset:
+    """Output matrix + idempotence + atomic write + fragment-reappearance
+    regression coverage for ``mm config unset``.
+    """
+
+    @pytest.fixture
+    def isolated(self, tmp_path, monkeypatch):
+        config_file = tmp_path / "config.json"
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+        monkeypatch.setattr("memtomem.config._config_d_path", lambda: config_d)
+        return {"config_file": config_file, "config_d": config_d, "tmp_path": tmp_path}
+
+    def test_unset_removes_pinned_key(self, isolated, runner: CliRunner) -> None:
+        import json as _json
+
+        isolated["config_file"].write_text(
+            _json.dumps({"mmr": {"enabled": True, "lambda_param": 0.5}})
+        )
+
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled"])
+        assert result.exit_code == 0, result.output
+        assert "Removed: mmr.enabled" in result.output
+
+        data = _json.loads(isolated["config_file"].read_text())
+        assert "enabled" not in data["mmr"]
+        assert data["mmr"]["lambda_param"] == 0.5
+
+    def test_unset_removes_empty_section(self, isolated, runner: CliRunner) -> None:
+        import json as _json
+
+        isolated["config_file"].write_text(
+            _json.dumps({"mmr": {"enabled": True}, "search": {"default_top_k": 42}})
+        )
+
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled"])
+        assert result.exit_code == 0, result.output
+
+        data = _json.loads(isolated["config_file"].read_text())
+        assert "mmr" not in data
+        assert data["search"]["default_top_k"] == 42
+
+    def test_unset_deletes_empty_config_file(self, isolated, runner: CliRunner) -> None:
+        import json as _json
+
+        isolated["config_file"].write_text(_json.dumps({"mmr": {"enabled": True}}))
+
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled"])
+        assert result.exit_code == 0, result.output
+        assert not isolated["config_file"].exists()
+        assert "config.json now empty, file removed." in result.output
+
+    def test_unset_extra_mutation_field_allowed(self, isolated, runner: CliRunner) -> None:
+        """memory_dirs is not in MUTABLE_FIELDS but IS valid for unset."""
+        import json as _json
+
+        isolated["config_file"].write_text(
+            _json.dumps({"indexing": {"memory_dirs": ["/machine-a-only"]}})
+        )
+
+        result = runner.invoke(cli, ["config", "unset", "indexing.memory_dirs"])
+        assert result.exit_code == 0, result.output
+        assert "Removed: indexing.memory_dirs" in result.output
+
+    def test_unset_memory_dirs_emits_domain_warning(self, isolated, runner: CliRunner) -> None:
+        import json as _json
+
+        isolated["config_file"].write_text(
+            _json.dumps({"indexing": {"memory_dirs": ["/machine-a-only"]}})
+        )
+
+        result = runner.invoke(cli, ["config", "unset", "indexing.memory_dirs"])
+        assert result.exit_code == 0, result.output
+        assert "mm memory-dirs list" in result.output
+        assert "mm index" in result.output
+
+    def test_unset_typo_suggests_similar_canonical_key(self, isolated, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabld"])
+        assert result.exit_code == 1
+        assert "Skipped mmr.enabld" in result.output
+        assert "did you mean 'mmr.enabled'" in result.output
+
+    def test_unset_unknown_key_without_suggestion(self, isolated, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["config", "unset", "completely_unrelated_xyz"])
+        assert result.exit_code == 1
+        assert "Skipped completely_unrelated_xyz" in result.output
+        assert "did you mean" not in result.output
+
+    def test_unset_multiple_keys_best_effort(self, isolated, runner: CliRunner) -> None:
+        import json as _json
+
+        isolated["config_file"].write_text(
+            _json.dumps({"mmr": {"enabled": True}, "search": {"default_top_k": 42}})
+        )
+
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled", "foo.bar"])
+        assert result.exit_code == 1
+        assert "Removed: mmr.enabled" in result.output
+        assert "Skipped foo.bar" in result.output
+
+        data = _json.loads(isolated["config_file"].read_text())
+        assert "mmr" not in data
+        assert data["search"]["default_top_k"] == 42
+
+    def test_unset_canonical_already_unset_is_idempotent_success(
+        self, isolated, runner: CliRunner
+    ) -> None:
+        """Canonical key not pinned → exit 0 + ``(already at default)``."""
+        # config.json doesn't exist — simulating a fresh install.
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled"])
+        assert result.exit_code == 0, result.output
+        assert "already at default" in result.output
+        assert not isolated["config_file"].exists()
+
+    def test_unset_on_malformed_config_reports_error(self, isolated, runner: CliRunner) -> None:
+        isolated["config_file"].write_text("{not valid json")
+
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled"])
+        assert result.exit_code == 1
+        assert "malformed" in result.output.lower()
+        assert "mm init --fresh" in result.output
+
+    def test_unset_fragment_value_reappears(self, isolated, runner: CliRunner) -> None:
+        """End-to-end: fragment mmr.enabled=true shadowed by config.json=false;
+        after unset, fragment layer wins on reload."""
+        import json as _json
+
+        (isolated["config_d"] / "noise.json").write_text(_json.dumps({"mmr": {"enabled": True}}))
+        isolated["config_file"].write_text(_json.dumps({"mmr": {"enabled": False}}))
+
+        # Confirm the shadowing baseline before unset.
+        from memtomem.config import load_config_d
+
+        baseline = Mem2MemConfig()
+        load_config_d(baseline)
+        load_config_overrides(baseline)
+        assert baseline.mmr.enabled is False
+
+        result = runner.invoke(cli, ["config", "unset", "mmr.enabled"])
+        assert result.exit_code == 0, result.output
+
+        fresh = Mem2MemConfig()
+        load_config_d(fresh)
+        load_config_overrides(fresh)
+        assert fresh.mmr.enabled is True
+
+    def test_atomic_write_preserves_original_on_failure(self, tmp_path, monkeypatch):
+        import os as _os
+
+        from memtomem.config import _atomic_write_json
+
+        path = tmp_path / "config.json"
+        original = '{"original": true}'
+        path.write_text(original)
+
+        def fail_replace(*args, **kwargs):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(_os, "replace", fail_replace)
+
+        with pytest.raises(OSError, match="simulated replace failure"):
+            _atomic_write_json(path, {"new": True})
+
+        assert path.read_text() == original
+        orphans = [
+            p
+            for p in tmp_path.iterdir()
+            if p.name.startswith(".config.") and p.name.endswith(".tmp")
+        ]
+        assert not orphans, f"orphan tmp file(s) left behind: {orphans}"
+
+    def test_atomic_write_cleans_up_tmp_on_success(self, tmp_path) -> None:
+        import json as _json
+
+        from memtomem.config import _atomic_write_json
+
+        path = tmp_path / "config.json"
+        _atomic_write_json(path, {"ok": True})
+
+        assert path.exists()
+        assert _json.loads(path.read_text()) == {"ok": True}
+        orphans = [
+            p
+            for p in tmp_path.iterdir()
+            if p.name.startswith(".config.") and p.name.endswith(".tmp")
+        ]
+        assert not orphans
+
+
 # ── Other subcommands (help text) ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes wizard-leftovers follow-up: **CLI `mm config unset`/reset**.

PR #258 closed the fragment/env/factory drag-in for *new* saves, but
left a known limitation — historical `config.json` entries that don't
match the local comparand (e.g., machine-A paths in `memory_dirs`
carried to machine-B, or `mmr.enabled=false` shadowing a `config.d`
fragment that sets it `true`) stay pinned until actively reset. The
existing escape hatches were hand-edit or `mm init --fresh`, both too
heavy for a single stale key.

`mm config unset <key>` is the targeted affordance. Distinct from
`mm init --fresh` (single-key vs bulk; no backup vs backup;
idempotent scripting vs wizard re-run). Both commands stay.

## Behaviour (6 locked decisions)

1. **Ambient cleanup: no.** Unset touches exactly the named keys.
   Default-equal leftovers in other fields get pruned on the next
   normal save via #258's delta-only write.
2. **Valid-key set = `MUTABLE_FIELDS` ∪ `_EXTRA_MUTATION_FIELDS`.**
   `indexing.memory_dirs` is accepted (removal isn't a mutation, and
   the migration case is exactly what motivates this command) even
   though `mm config set memory_dirs …` stays rejected.
3. **Already-unset canonical key → exit 0 + `(already at default)`.**
   Idempotent re-runs are safe.
4. **Unknown key → exit 1 with a `difflib` suggestion** (cutoff 0.7)
   when a canonical key is nearby, otherwise just `Skipped`.
5. **Malformed `config.json` → exit 1**, no auto-recovery, message
   points at `mm init --fresh`. Unset is raw-edit semantic; hiding
   malformed state behind a backup would confuse.
6. **Empty `config.json` after removal is deleted** with a note line
   (`load_config_overrides` short-circuits on missing file).

`_EXTRA_MUTATION_FIELDS` (currently just `indexing.memory_dirs`)
triggers a domain warning pointing at dedicated endpoints
(`mm memory-dirs list` / `mm index`) after successful removal.

## Output matrix

| Case | Message | Exit |
|---|---|---|
| Canonical + pinned → removed | `Removed: mmr.enabled` | 0 |
| Canonical + already unset | `Unset: mmr.enabled (already at default)` | 0 |
| Non-canonical + similar canonical exists | `Skipped mmr.enabld: not set (did you mean 'mmr.enabled'?)` | 1 |
| Non-canonical + no close match | `Skipped foo.bar: not set` | 1 |

Multi-key input is best-effort: iterate, collect Removed /
Already-unset / Skipped buckets, emit per-key lines. Exit 0 if no
skips, 1 otherwise.

## `_atomic_write_json`

Introduced in `config.py` next to `_json_default` — tempfile in
`path.parent` + `os.replace`, with tmp cleanup on failure. Used by
`unset` as initial consumer. `save_config_overrides` and
`cli/init_cmd.py`'s `--fresh` write path still call `write_text`
directly; migrating them is the remaining wizard-leftovers follow-up
on "`--fresh` write-after-backup atomicity" and reduces to swapping
those two call sites once this PR lands.

## Tests (13 in `TestConfigUnset`)

Full output matrix, empty-file deletion, `_EXTRA_MUTATION_FIELDS`
allowance + domain warning, malformed JSON handling, multi-key
best-effort, atomic-write-preserves-original-on-`os.replace`-failure
+ cleans-up-tmp-on-success, plus a fragment-reappearance end-to-end
regression guard (fragment sets `mmr.enabled=true`, `config.json`
pins `false`, unset → reload → fragment layer wins).

## Docs

- `docs/guides/configuration.md`: new "Removing individual
  overrides" subsection; the existing machine-migration section
  now lists `mm config unset indexing.memory_dirs` as Option 1.
- `docs/guides/getting-started.md` + `docs/guides/user-guide.md`:
  cheatsheets updated.

## Test plan

- [x] `uv run pytest -m "not ollama" -q` — 1712 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy packages/memtomem/src` — success, no issues
- [x] 13 new `TestConfigUnset` tests all green