### PR TITLE
fix(config): migrate remaining config.json writes to atomic _atomic_write_json

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -703,9 +703,9 @@ def _write_config_and_summary(
         else:
             existing[section] = fields
 
-    from memtomem.config import _json_default
+    from memtomem.config import _atomic_write_json
 
-    config_path.write_text(json.dumps(existing, indent=2, default=_json_default), encoding="utf-8")
+    _atomic_write_json(config_path, existing)
     click.echo(f"  Config: {config_path}")
 
     if fresh:

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1067,7 +1067,6 @@ def save_config_overrides(
     comparand = _build_comparand(quiet=True)
 
     path = _override_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
 
     existing: dict = {}
     if path.exists():
@@ -1106,4 +1105,4 @@ def save_config_overrides(
         else:
             existing.pop(section_name, None)
 
-    path.write_text(_json.dumps(existing, indent=2, default=_json_default), encoding="utf-8")
+    _atomic_write_json(path, existing)

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -722,6 +722,29 @@ class TestSaveConfigOverrides:
         load_config_overrides(cfg)
         assert cfg.namespace.rules == []
 
+    def test_save_creates_parent_directory_if_missing(self, tmp_path, monkeypatch) -> None:
+        """Structural guard for the ``path.parent.mkdir`` removal in
+        ``save_config_overrides``: the helper is now responsible for creating
+        the config directory. Every other ``isolated`` test writes into the
+        already-existing ``tmp_path``, so without this test a future
+        regression (e.g. dropping the helper's ``mkdir`` too) would pass CI.
+        """
+        nested_dir = tmp_path / "brand" / "new" / ".memtomem"
+        config_file = nested_dir / "config.json"
+        config_d = tmp_path / "config.d"
+        config_d.mkdir()
+        monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
+        monkeypatch.setattr("memtomem.config._config_d_path", lambda: config_d)
+
+        assert not nested_dir.exists()
+
+        cfg = Mem2MemConfig()
+        cfg.mmr.enabled = True  # force a non-comparand write
+        save_config_overrides(cfg)
+
+        assert config_file.exists()
+        assert nested_dir.is_dir()
+
     def test_save_atomic_on_replace_failure(self, isolated, monkeypatch) -> None:
         """``save_config_overrides`` now writes via ``_atomic_write_json``.
         If ``os.replace`` fails mid-write, the existing ``config.json`` must

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -722,6 +722,37 @@ class TestSaveConfigOverrides:
         load_config_overrides(cfg)
         assert cfg.namespace.rules == []
 
+    def test_save_atomic_on_replace_failure(self, isolated, monkeypatch) -> None:
+        """``save_config_overrides`` now writes via ``_atomic_write_json``.
+        If ``os.replace`` fails mid-write, the existing ``config.json`` must
+        stay byte-identical and no ``.config.*.tmp`` orphan should linger.
+        Failure-mode complement to the happy-path coverage above.
+        """
+        import json as _json
+        import os as _os
+
+        original = _json.dumps({"mmr": {"enabled": True}}, indent=2)
+        isolated["config_file"].write_text(original, encoding="utf-8")
+
+        def fail_replace(*args, **kwargs):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(_os, "replace", fail_replace)
+
+        cfg = Mem2MemConfig()
+        cfg.search.default_top_k = 42  # force a non-comparand field to trigger a write
+
+        with pytest.raises(OSError, match="simulated replace failure"):
+            save_config_overrides(cfg)
+
+        assert isolated["config_file"].read_text(encoding="utf-8") == original
+        orphans = [
+            p
+            for p in isolated["tmp_path"].iterdir()
+            if p.name.startswith(".config.") and p.name.endswith(".tmp")
+        ]
+        assert not orphans, f"orphan tmp file(s) after failed atomic write: {orphans}"
+
     def test_namespace_rules_round_trip(self, isolated):
         """list[NamespacePolicyRule] survives save→load via model_dump/validate."""
         import json

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -710,6 +710,48 @@ class TestFreshFlag:
             "second --fresh run created a backup despite zero drops"
         )
 
+    def test_fresh_atomic_write_failure_keeps_backup_and_original(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``--fresh`` now writes via ``_atomic_write_json``. If the atomic
+        ``os.replace`` fails mid-write, both the pre-fresh ``config.json``
+        and the backup must stay intact, and no ``.config.*.tmp`` orphan
+        should linger in ``~/.memtomem/``. This is the failure-mode
+        complement to ``test_fresh_drops_preserved_mmr``: the happy path is
+        already covered there.
+        """
+        import os as _os
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        original = json.dumps({"mmr": {"enabled": True}})
+        config_path.write_text(original, encoding="utf-8")
+
+        def fail_replace(*args, **kwargs):
+            raise OSError("simulated replace failure")
+
+        monkeypatch.setattr(_os, "replace", fail_replace)
+
+        state = _make_init_state(tmp_path)
+        with pytest.raises(OSError, match="simulated replace failure"):
+            _write_config_and_summary(state, tmp_path, fresh=True)
+
+        assert config_path.read_text(encoding="utf-8") == original
+        backups = list(config_dir.glob("config.json.bak-*"))
+        assert len(backups) == 1, f"expected backup to survive, got {backups}"
+        orphans = [
+            p
+            for p in config_dir.iterdir()
+            if p.name.startswith(".config.") and p.name.endswith(".tmp")
+        ]
+        assert not orphans, f"orphan tmp file(s) after failed atomic write: {orphans}"
+
 
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be


### PR DESCRIPTION
## Summary

Closes wizard-leftovers follow-up **#4 (atomic-write migration)**.

PR #259 introduced `_atomic_write_json` (tempfile + `os.replace` with
tmp cleanup on failure) and used it only for `mm config unset`. Two
other paths still called `path.write_text(json.dumps(...))` directly,
so a mid-write failure could corrupt `config.json`:

- `save_config_overrides` (`config.py`) — every `mm config set`, Web
  UI PATCH, MCP `mem_config` save, and `memory-dirs/add|remove`
  routes here.
- `_write_config_and_summary` (`cli/init_cmd.py`) — both normal
  `init` and `init --fresh` share the same final write statement.
  The `--fresh` path is the worse case: `shutil.copy2` backup could
  succeed, then `write_text` fail halfway, leaving a half-written
  `config.json` next to a valid `.bak`, requiring manual recovery.

Swapping both call sites to `_atomic_write_json` gives the guarantee
`--fresh` already asked for: either `config.json` is wholly updated
or it is byte-identical to what it was before the call. Backup
semantics unchanged (still `copy2` *before* the atomic write), so the
failure-mode outcome improves to "backup == current original, user
can delete backup if desired" from "backup is the only valid state,
original is garbage."

## Helper signature fits both call sites

`_atomic_write_json(path: Path, data: dict)` uses `indent=2` + the
shared `_json_default` fallback internally — bit-identical to what
both former call sites passed to `json.dumps`. **No helper changes
needed.** The redundant `path.parent.mkdir` in `save_config_overrides`
was removed since the helper does it.

## Test layering

Three layers together cover the atomic-write contract:

1. **Helper self-tests (shipped in PR #259)** — establish that
   `_atomic_write_json` itself preserves originals on `os.replace`
   failure and cleans up its `.config.*.tmp` on success. Scope: the
   helper in isolation.
2. **This PR's integration failure tests** — confirm the two migrated
   call sites propagate that guarantee correctly: a mid-write failure
   through `save_config_overrides` or `--fresh` leaves real
   `config.json` / `.bak` state intact, with no orphan tmp.
3. **Structural parent-dir guard** — locks in that the helper now
   owns config-dir creation; removing the `mkdir` from either side
   without a replacement would be caught.

Happy path is already covered bit-identically by the 8 existing
`TestFreshFlag` tests and every test in `TestSaveConfigOverrides`;
those pass unchanged.

## Tests (3 new)

- **`TestSaveConfigOverrides::test_save_creates_parent_directory_if_missing`** —
  point `_override_path` at a nested path whose ancestors don't
  exist; assert `save_config_overrides` creates both directory and
  file. Guards the `path.parent.mkdir` removal.
- **`TestSaveConfigOverrides::test_save_atomic_on_replace_failure`** —
  monkeypatch `os.replace` to raise, write a config with a
  non-comparand field; assert existing `config.json` stays
  byte-identical and no `.config.*.tmp` orphan in `tmp_path`.
- **`TestFreshFlag::test_fresh_atomic_write_failure_keeps_backup_and_original`** —
  same mock through the `--fresh` path; assert both the pre-fresh
  `config.json` and the `.bak-<ts>` survive intact and no tmp orphan
  remains in `~/.memtomem/`.

## Scope

Small, mechanical tail of the wizard-leftovers sequence — 2
call-site swaps, 3 tests, no behaviour change on the happy path.
`+99 / -4`.

## Test plan

- [x] `uv run pytest -m "not ollama" -q` — 1715 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy packages/memtomem/src` — no issues