### PR TITLE
fix(uv.lock): sync memtomem version to 0.1.10

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

One-line follow-up to #263. The version bump in `packages/memtomem/pyproject.toml` (`0.1.9` → `0.1.10`) updated the source package but `uv.lock` still pinned the editable install at `0.1.9`, leaving `main` in an inconsistent state where `uv sync` / `uv lock --check` would disagree with the source.

## Diff

```
-version = "0.1.9"
+version = "0.1.10"
```

Inside the `[[package]] name = "memtomem"` block. No dependency changes, no resolver re-run, no other lock entries touched.

## Rationale for separate PR

Scope too narrow to bundle with either #263 (0.1.10 security prep — already merged) or #264 (CHANGELOG hygiene — CHANGELOG-only per "one change per PR"). Clean 1-line fix restores main consistency before the release session (tag + GitHub Release + PyPI publish) kicks off.