### PR TITLE
docs(changelog): set 0.1.10 release date (2026-04-19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   configuration reference (#170 high tier).
 - MCP tool error response contract documented (#167).
 
-## [0.1.10] - UNRELEASED
+## [0.1.10] — 2026-04-19
 
 ### Security
 


### PR DESCRIPTION
Fills the UNRELEASED date placeholder in the 0.1.10 changelog block
with the actual release date, and switches the dash style to em dash
for consistency with prior release headings ([0.1.9] — 2026-04-13).

This is the date-fill step of the 0.1.10 release sequence:
1. Date fill (this PR)
2. `git tag v0.1.10` + push → triggers PyPI publish workflow
3. GitHub Release creation
4. Manual approval at the `pypi` environment gate → Trusted Publishers OIDC publish

Text-only diff; CI runs standard gates for convention.

Does not modify the `[Unreleased]` header or the 8 backfill bullets
below it — those belong to the next release.