### PR TITLE
fix(web): hot-reload config.json + extend write lock to all mutators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `config.d/` fragment.
 
 ### Fixed
+- **Web UI config hot-reload**: `~/.memtomem/config.json` and `config.d/*.json`
+  are re-read on every `GET /api/config` and at the top of every config-
+  writing endpoint (`PATCH /api/config`, `POST /api/config/save`,
+  `POST /api/memory-dirs/add|remove`). Previously, external edits
+  (`mm config set`, manual editor) were invisible to the running server
+  and got silently clobbered on the next UI save. The writer lock was
+  extended from PATCH to all four write handlers (closing a pre-existing
+  gap). If `config.json` becomes invalid on disk, the UI keeps the last
+  known-good config, surfaces `config_reload_error` in the response, and
+  refuses writes with HTTP 409 until the file is fixed.
 - **ONNX `bge-m3`**: fastembed 0.8.0 dropped `BAAI/bge-m3` from its built-in
   `TextEmbedding` catalog — re-registered via `add_custom_model` against the
   official HF ONNX export (1024-dim, CLS pooling, normalized). Existing

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -49,6 +49,28 @@ top of the default:
 explicit-user-override layer. Use a fragment in `config.d/` if you want
 APPEND semantics.
 
+### External edits while the Web UI is running
+
+The Web UI server re-reads `config.json` and `config.d/*.json` on every
+`GET /api/config` and at the top of every config-writing endpoint
+(`PATCH /api/config`, `POST /api/config/save`, `POST /api/memory-dirs/add`,
+`POST /api/memory-dirs/remove`). This means:
+
+- `mm config set ...` or a manual editor save while the server is running
+  becomes visible on the next UI interaction (or when the tab regains
+  focus), without a restart.
+- A subsequent UI save merges against the *current* disk state rather
+  than overwriting the external change with a stale in-memory copy.
+- If `config.json` is truncated or otherwise invalid when the server
+  tries to reload it, the Web UI keeps the last-known-good in-memory
+  config, surfaces a red banner on the Config tab, and refuses to save
+  (HTTP 409) until the file is fixed. Run `mm init --fresh` or edit
+  the file by hand to recover.
+
+Change detection is a cheap `os.stat` on `config.json` plus every
+fragment in `config.d/`, so GET latency is effectively unchanged. No
+filesystem watchdog is involved.
+
 ### Delta-only save semantics
 
 `config.json` stores only values that differ from the merged lower

--- a/docs/guides/web-ui.md
+++ b/docs/guides/web-ui.md
@@ -51,7 +51,11 @@ The home tab shows a real-time overview:
 The settings hub is organized into groups:
 
 ### System
-- **Config**: View and edit all configuration sections (embedding, storage, indexing, search, decay)
+- **Config**: View and edit all configuration sections (embedding, storage, indexing, search, decay).
+  Picks up external edits (`mm config set`, manual editor saves) on the next
+  interaction — no restart needed. If `config.json` becomes invalid on disk,
+  the Config tab shows a banner and saves are disabled until the file is
+  fixed. See [configuration → external edits](configuration.md#external-edits-while-the-web-ui-is-running).
 - **Namespaces**: List, edit metadata, rename, delete namespaces
 
 ### Maintenance

--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -1,0 +1,296 @@
+"""Poll-on-request hot-reload of ``~/.memtomem/config.json`` + ``config.d/``.
+
+The web server loads the user's ``config.json`` / ``config.d`` fragments once
+at startup and caches the resulting :class:`Mem2MemConfig` on
+``app.state.config``. Without this module, CLI edits made while the server is
+running (``mm config set``, external editor, etc.) stay invisible to the
+running server AND get silently clobbered the next time a UI handler calls
+:func:`save_config_overrides` against its stale in-memory copy.
+
+Design (see ``project_web_hot_reload_bridge.md`` for the full rationale):
+
+* **Trigger**: every read/write handler calls :func:`reload_if_stale` which
+  compares a composite ``(path, mtime_ns)`` signature of ``config.json`` plus
+  every ``config.d/*.json`` entry to the last known signature. If anything
+  changed, a fresh :class:`Mem2MemConfig` is built via the canonical load path
+  (``Mem2MemConfig()`` → :func:`load_config_d` → :func:`load_config_overrides`)
+  and swapped into ``app.state.config``.
+* **Runtime fanout**: tokenizer changes rebuild the FTS5 index and every
+  config change invalidates the search cache — see
+  :func:`apply_runtime_config_changes`, shared between the PATCH handler and
+  the reload path so a hot-reload applies the same side-effects as an
+  in-process PATCH.
+* **Failure mode**: if the reload raises (bad JSON, pydantic validation,
+  permission error), the existing ``app.state.config`` is left in place and
+  the error is recorded on ``app.state.last_reload_error`` so the FE can
+  surface a banner. Write handlers refuse with HTTP 409 while the error is
+  active for the current on-disk mtime.
+
+The public surface is intentionally small: :func:`current_signature`,
+:func:`reload_if_stale`, :func:`apply_runtime_config_changes`, and the
+helpers :func:`get_config_mtime_ns`, :func:`get_reload_error`. Everything
+else is private.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from memtomem.config import (
+    Mem2MemConfig,
+    _config_d_path,
+    _override_path,
+    load_config_d,
+    load_config_overrides,
+)
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from memtomem.search.pipeline import SearchPipeline
+    from memtomem.storage.sqlite_backend import SqliteBackend
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Stale signature
+# ---------------------------------------------------------------------------
+
+# Signature is a tuple of (path_str, mtime_ns) pairs sorted by path, including
+# a sentinel for the config.d directory itself so newly created / removed
+# fragments are detected even when their own files weren't touched.
+Signature = tuple[tuple[str, int], ...]
+
+
+def current_signature() -> Signature:
+    """Build the composite ``(path, mtime_ns)`` signature for config state.
+
+    Includes ``~/.memtomem/config.json`` plus every ``~/.memtomem/config.d/
+    *.json`` entry plus the directory mtime itself. Missing files contribute
+    a ``-1`` mtime rather than being skipped, so their appearance or removal
+    still changes the signature.
+    """
+    entries: list[tuple[str, int]] = []
+
+    override = _override_path()
+    entries.append((str(override), _stat_mtime_ns(override)))
+
+    d_path = _config_d_path()
+    entries.append((str(d_path), _stat_mtime_ns(d_path) if d_path.is_dir() else -1))
+    if d_path.is_dir():
+        for frag in sorted(p for p in d_path.iterdir() if p.is_file() and p.suffix == ".json"):
+            entries.append((str(frag), _stat_mtime_ns(frag)))
+
+    return tuple(entries)
+
+
+def _stat_mtime_ns(path: Path) -> int:
+    try:
+        return path.stat().st_mtime_ns
+    except FileNotFoundError:
+        return -1
+    except OSError as exc:
+        logger.warning("stat(%s) failed during hot-reload check: %s", path, exc)
+        return -1
+
+
+def get_config_mtime_ns() -> int:
+    """Return the current ``config.json`` mtime in ns, or ``-1`` if missing."""
+    return _stat_mtime_ns(_override_path())
+
+
+# ---------------------------------------------------------------------------
+# Reload error surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReloadError:
+    """Captures a failed reload attempt for FE surfacing + write-handler gating."""
+
+    message: str
+    at_mtime_ns: int
+    timestamp: float
+
+
+def get_reload_error(app: FastAPI) -> ReloadError | None:
+    return getattr(app.state, "last_reload_error", None)
+
+
+def _set_reload_error(app: FastAPI, err: ReloadError | None) -> None:
+    app.state.last_reload_error = err
+
+
+def _get_last_signature(app: FastAPI) -> Signature | None:
+    return getattr(app.state, "config_signature", None)
+
+
+def _set_last_signature(app: FastAPI, sig: Signature) -> None:
+    app.state.config_signature = sig
+
+
+# ---------------------------------------------------------------------------
+# Reload
+# ---------------------------------------------------------------------------
+
+
+def _build_fresh_config() -> Mem2MemConfig:
+    """Replay the canonical load path used at startup.
+
+    Defaults (+ env via pydantic-settings) → ``config.d`` fragments →
+    ``config.json`` overrides. Raises on ``config.json`` JSON / OS errors
+    so the caller can switch to fail-closed mode.
+
+    :func:`load_config_overrides` itself swallows parse errors with a
+    warning log — startup historically wanted to boot with defaults
+    rather than crash on a bad user file. Hot-reload needs strict
+    behavior: a broken disk must surface as an error banner, not silently
+    fall back to defaults (which would then be written back by the next
+    save). So we pre-parse ``config.json`` here before delegating.
+    """
+    import json as _json
+
+    override = _override_path()
+    if override.exists():
+        # Strict pre-parse — raises on malformed JSON / OS errors.
+        _ = _json.loads(override.read_text(encoding="utf-8"))
+
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    load_config_overrides(cfg)
+    return cfg
+
+
+def reload_if_stale(
+    app: FastAPI,
+    *,
+    storage: SqliteBackend | None = None,
+    search_pipeline: SearchPipeline | None = None,
+) -> bool:
+    """Reload config from disk if the composite signature changed.
+
+    Returns ``True`` if ``app.state.config`` was swapped, ``False`` if the
+    signature matched and nothing changed. On failure, keeps the existing
+    config, records :class:`ReloadError` on ``app.state.last_reload_error``,
+    and returns ``False``.
+
+    ``storage`` / ``search_pipeline`` are optional; when provided, the
+    runtime fanout (tokenizer FTS rebuild + cache invalidation) runs against
+    them. Callers that already hold these (write handlers via ``Depends``)
+    should pass them through so a disk-triggered tokenizer change still
+    propagates.
+
+    Note: FTS rebuild is fire-and-forget scheduled on the running event loop
+    when invoked from an async context, so sync GET callers aren't blocked.
+    Callers in a lock-free read context should still see the Settings swap
+    immediately; the rebuild catches up out-of-band.
+    """
+    sig = current_signature()
+    last = _get_last_signature(app)
+    if last == sig:
+        # Signature matches; if a prior error was tied to a now-gone mtime,
+        # clear it defensively (matches the "retry once" spec).
+        err = get_reload_error(app)
+        if err is not None and err.at_mtime_ns != get_config_mtime_ns():
+            _set_reload_error(app, None)
+        return False
+
+    try:
+        new_cfg = _build_fresh_config()
+    except Exception as exc:
+        logger.warning(
+            "Hot-reload failed for config at %s: %s", _override_path(), exc, exc_info=True
+        )
+        _set_reload_error(
+            app,
+            ReloadError(
+                message=f"{type(exc).__name__}: {exc}",
+                at_mtime_ns=get_config_mtime_ns(),
+                timestamp=time.time(),
+            ),
+        )
+        # Update the signature we've seen so we don't re-try on every hit;
+        # we only retry once disk mtime changes again.
+        _set_last_signature(app, sig)
+        return False
+
+    old_cfg = getattr(app.state, "config", None)
+    app.state.config = new_cfg
+    _set_last_signature(app, sig)
+    _set_reload_error(app, None)
+
+    if old_cfg is not None and (storage is not None or search_pipeline is not None):
+        apply_runtime_config_changes(
+            old_cfg, new_cfg, storage=storage, search_pipeline=search_pipeline
+        )
+
+    logger.info("Hot-reloaded config from %s", _override_path())
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Runtime fanout — shared by PATCH handler and reload
+# ---------------------------------------------------------------------------
+
+
+def apply_runtime_config_changes(
+    old_cfg: Any,
+    new_cfg: Any,
+    *,
+    storage: SqliteBackend | None = None,
+    search_pipeline: SearchPipeline | None = None,
+) -> None:
+    """Propagate runtime-mutable config changes to live components.
+
+    * ``search.tokenizer`` changed → re-register global tokenizer + schedule
+      ``storage.rebuild_fts()`` (async, fire-and-forget on current loop).
+    * Any change → invalidate search cache.
+
+    Older callers of this helper (e.g. the PATCH handler) may not provide
+    ``storage`` / ``search_pipeline`` (rare), in which case the matching
+    fanout step is skipped. This keeps the helper usable in unit tests and
+    from non-web callers.
+    """
+    try:
+        tokenizer_changed = old_cfg.search.tokenizer != new_cfg.search.tokenizer
+    except AttributeError:
+        tokenizer_changed = False
+
+    if tokenizer_changed and storage is not None:
+        from memtomem.storage.fts_tokenizer import set_tokenizer
+
+        set_tokenizer(new_cfg.search.tokenizer)
+        _schedule_fts_rebuild(storage, new_cfg.search.tokenizer)
+
+    if search_pipeline is not None:
+        search_pipeline.invalidate_cache()
+
+
+def _schedule_fts_rebuild(storage: SqliteBackend, tokenizer: str) -> None:
+    """Kick off ``storage.rebuild_fts()`` as a background task if possible.
+
+    When called from an async request handler the rebuild runs on the current
+    loop; when called from a sync context without a running loop, it falls
+    back to ``asyncio.run`` so non-web callers (tests, future CLIs) still
+    work.
+    """
+    import asyncio
+
+    async def _runner() -> None:
+        try:
+            count = await storage.rebuild_fts()
+            logger.info("FTS index rebuilt with tokenizer=%s (%d chunks)", tokenizer, count)
+        except Exception:
+            logger.warning("FTS rebuild after tokenizer change failed", exc_info=True)
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_runner())
+        return
+    loop.create_task(_runner())

--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -134,6 +134,21 @@ def _set_last_signature(app: FastAPI, sig: Signature) -> None:
     app.state.config_signature = sig
 
 
+def commit_writer_signature(app: FastAPI) -> None:
+    """Record the current on-disk signature after a successful write.
+
+    Call this from any request handler that just invoked
+    :func:`memtomem.config.save_config_overrides` inside ``_config_lock``.
+    Without it, the next ``GET /api/config`` would see our own write as an
+    "external change" and trigger a spurious reload from the same file we
+    just wrote. The bump is cheap (one ``os.stat`` per fragment).
+
+    This is the public alternative to the internal ``_set_last_signature``
+    for the narrow "writer finalising its own change" use case.
+    """
+    _set_last_signature(app, current_signature())
+
+
 # ---------------------------------------------------------------------------
 # Reload
 # ---------------------------------------------------------------------------
@@ -188,13 +203,19 @@ def reload_if_stale(
     Note: FTS rebuild is fire-and-forget scheduled on the running event loop
     when invoked from an async context, so sync GET callers aren't blocked.
     Callers in a lock-free read context should still see the Settings swap
-    immediately; the rebuild catches up out-of-band.
+    immediately; the rebuild catches up out-of-band. The rebuild runs
+    concurrently with any writer inside ``_config_lock``: it touches the
+    FTS5 virtual table, not the ``config.json`` file, so there is no file-
+    level race with ``save_config_overrides``.
     """
     sig = current_signature()
     last = _get_last_signature(app)
     if last == sig:
-        # Signature matches; if a prior error was tied to a now-gone mtime,
-        # clear it defensively (matches the "retry once" spec).
+        # Signature matches; if a prior error was tied to a different
+        # on-disk mtime than what we see now, clear it — the user either
+        # fixed the file (mtime bumped forward) or the file vanished
+        # (mtime == -1). If both signature matches AND at_mtime_ns still
+        # equals current mtime, the error is still live, leave it.
         err = get_reload_error(app)
         if err is not None and err.at_mtime_ns != get_config_mtime_ns():
             _set_reload_error(app, None)

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -18,6 +18,7 @@ from memtomem.config import (
 )
 from memtomem.storage.sqlite_helpers import norm_path
 from memtomem.tools.memory_writer import append_entry
+from memtomem.web import hot_reload as _hot_reload
 from memtomem.web.deps import (
     get_config,
     get_embedder,
@@ -55,7 +56,33 @@ from memtomem.web.schemas.sources import StatsResponse
 logger = logging.getLogger(__name__)
 
 _LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
-_config_patch_lock = _asyncio.Lock()
+# Guards every write path that touches ``~/.memtomem/config.json`` and/or
+# mutates ``app.state.config``. Before #258+#259 this was PATCH-only
+# (``_config_patch_lock``); hot-reload extends it to /config/save,
+# /memory-dirs/add, and /memory-dirs/remove so a concurrent disk edit + UI
+# save can't interleave.
+_config_lock = _asyncio.Lock()
+
+
+def _check_reload_block(request: Request) -> None:
+    """Reject writes while a reload error is live for the current disk state.
+
+    Writing would call :func:`save_config_overrides`, overwriting the broken
+    disk file and destroying any recovery trail. User must fix disk first
+    (``mm init --fresh`` or manual edit).
+    """
+    err = _hot_reload.get_reload_error(request.app)
+    if err is None:
+        return
+    if err.at_mtime_ns != _hot_reload.get_config_mtime_ns():
+        # Disk was fixed since the error was recorded; let the next reload
+        # attempt clear it.
+        return
+    raise HTTPException(
+        status_code=409,
+        detail=f"Config file invalid on disk: {err.message}. "
+        "Fix it (or run `mm init --fresh`) before saving from the UI.",
+    )
 
 
 def _require_localhost(request: Request) -> None:
@@ -115,7 +142,9 @@ async def embed_text(request: Request, embedder=Depends(get_embedder)):
         raise HTTPException(status_code=500, detail="Embedding failed") from exc
 
 
-def _build_config_response(cfg) -> ConfigResponse:
+def _build_config_response(
+    cfg, *, mtime_ns: int = -1, reload_error: str | None = None
+) -> ConfigResponse:
     """Build ConfigResponse from a Mem2MemConfig instance."""
     return ConfigResponse(
         embedding=ConfigEmbeddingOut(
@@ -163,12 +192,33 @@ def _build_config_response(cfg) -> ConfigResponse:
             default_namespace=cfg.namespace.default_namespace,
             enable_auto_ns=cfg.namespace.enable_auto_ns,
         ),
+        config_mtime_ns=mtime_ns,
+        config_reload_error=reload_error,
     )
 
 
 @router.get("/config", response_model=ConfigResponse)
-async def get_config_endpoint(config=Depends(get_config)) -> ConfigResponse:
-    return _build_config_response(config)
+async def get_config_endpoint(request: Request) -> ConfigResponse:
+    # Read-through reload is opportunistic and lock-free: if a write is in
+    # flight, the writer will serve the fresh view on its own return. This
+    # keeps the common GET path cheap while still catching CLI-side edits.
+    app = request.app
+    try:
+        _hot_reload.reload_if_stale(
+            app,
+            storage=getattr(app.state, "storage", None),
+            search_pipeline=getattr(app.state, "search_pipeline", None),
+        )
+    except Exception:
+        logger.warning("reload_if_stale raised unexpectedly during GET /config", exc_info=True)
+
+    cfg = app.state.config
+    err = _hot_reload.get_reload_error(app)
+    return _build_config_response(
+        cfg,
+        mtime_ns=_hot_reload.get_config_mtime_ns(),
+        reload_error=err.message if err is not None else None,
+    )
 
 
 @router.get(
@@ -197,18 +247,28 @@ async def get_builtin_exclude_patterns() -> BuiltinExcludePatternsResponse:
 @router.patch("/config", response_model=ConfigPatchResponse)
 async def patch_config(
     req: ConfigPatchRequest,
+    request: Request,
     persist: bool = False,
-    config=Depends(get_config),
     storage=Depends(get_storage),
     search_pipeline=Depends(get_search_pipeline),
 ):
     """Update mutable runtime configuration fields."""
     applied: list[ConfigPatchChange] = []
     rejected: list[str] = []
+    tokenizer_changed = False
 
     try:
         async with _asyncio.timeout(60):
-            async with _config_patch_lock:
+            async with _config_lock:
+                # Re-read from disk before merging so a concurrent CLI edit
+                # is preserved. If disk is broken, refuse rather than
+                # overwrite it.
+                _hot_reload.reload_if_stale(
+                    request.app, storage=storage, search_pipeline=search_pipeline
+                )
+                _check_reload_block(request)
+                config = request.app.state.config
+
                 for section_name, updates in req.model_dump(exclude_none=True).items():
                     allowed = MUTABLE_FIELDS.get(section_name, set())
                     section_obj = getattr(config, section_name, None)
@@ -231,6 +291,8 @@ async def patch_config(
 
                         old_val = getattr(section_obj, key)
                         setattr(section_obj, key, coerced)
+                        if full_key == "search.tokenizer" and old_val != coerced:
+                            tokenizer_changed = True
                         applied.append(
                             ConfigPatchChange(
                                 field=full_key,
@@ -239,8 +301,11 @@ async def patch_config(
                             )
                         )
 
-                # Re-initialize tokenizer if changed — auto-rebuild FTS index
-                if any(c.field == "search.tokenizer" for c in applied):
+                # Runtime fanout: tokenizer FTS rebuild + cache invalidation.
+                # Shared with the reload path via
+                # ``apply_runtime_config_changes`` so a disk-triggered change
+                # fires the same side-effects as an in-process PATCH.
+                if tokenizer_changed:
                     from memtomem.storage.fts_tokenizer import set_tokenizer
 
                     set_tokenizer(config.search.tokenizer)
@@ -251,12 +316,15 @@ async def patch_config(
                         count,
                     )
 
-                # Invalidate search cache so config changes take effect immediately
                 if applied:
                     search_pipeline.invalidate_cache()
 
                 if persist:
                     save_config_overrides(config)
+                    # Our own write bumps mtime — update the signature so the
+                    # next GET doesn't trigger a spurious reload for our own
+                    # change.
+                    _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
     except TimeoutError:
         raise HTTPException(503, "Config update timed out — another update may be in progress")
 
@@ -264,14 +332,32 @@ async def patch_config(
 
 
 @router.post("/config/save")
-async def save_config(config=Depends(get_config)):
+async def save_config(
+    request: Request,
+    storage=Depends(get_storage),
+    search_pipeline=Depends(get_search_pipeline),
+):
     """Persist current mutable config to ~/.memtomem/config.json."""
-    save_config_overrides(config)
+    try:
+        async with _asyncio.timeout(60):
+            async with _config_lock:
+                _hot_reload.reload_if_stale(
+                    request.app, storage=storage, search_pipeline=search_pipeline
+                )
+                _check_reload_block(request)
+                save_config_overrides(request.app.state.config)
+                _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+    except TimeoutError:
+        raise HTTPException(503, "Config save timed out — another update may be in progress")
     return {"ok": True, "message": "Config saved to ~/.memtomem/config.json"}
 
 
 @router.post("/memory-dirs/add")
-async def add_memory_dir(request: Request, config=Depends(get_config)):
+async def add_memory_dir(
+    request: Request,
+    storage=Depends(get_storage),
+    search_pipeline=Depends(get_search_pipeline),
+):
     """Add a directory to memory_dirs watch list."""
     body = await request.json()
     dir_path = body.get("path", "").strip()
@@ -282,25 +368,43 @@ async def add_memory_dir(request: Request, config=Depends(get_config)):
     if not resolved.is_dir():
         resolved.mkdir(parents=True, exist_ok=True)
 
-    current = [Path(p).expanduser().resolve() for p in config.indexing.memory_dirs]
-    if norm_path(resolved) in {norm_path(p) for p in current}:
-        return {
-            "ok": True,
-            "message": "Already in memory_dirs",
-            "memory_dirs": [str(p) for p in current],
-        }
+    try:
+        async with _asyncio.timeout(60):
+            async with _config_lock:
+                _hot_reload.reload_if_stale(
+                    request.app, storage=storage, search_pipeline=search_pipeline
+                )
+                _check_reload_block(request)
+                config = request.app.state.config
 
-    config.indexing.memory_dirs.append(resolved)
-    save_config_overrides(config)
-    return {
-        "ok": True,
-        "message": f"Added {resolved}",
-        "memory_dirs": [str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs],
-    }
+                current = [Path(p).expanduser().resolve() for p in config.indexing.memory_dirs]
+                if norm_path(resolved) in {norm_path(p) for p in current}:
+                    return {
+                        "ok": True,
+                        "message": "Already in memory_dirs",
+                        "memory_dirs": [str(p) for p in current],
+                    }
+
+                config.indexing.memory_dirs.append(resolved)
+                save_config_overrides(config)
+                _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+                return {
+                    "ok": True,
+                    "message": f"Added {resolved}",
+                    "memory_dirs": [
+                        str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs
+                    ],
+                }
+    except TimeoutError:
+        raise HTTPException(503, "memory-dirs/add timed out — another update may be in progress")
 
 
 @router.post("/memory-dirs/remove")
-async def remove_memory_dir(request: Request, config=Depends(get_config)):
+async def remove_memory_dir(
+    request: Request,
+    storage=Depends(get_storage),
+    search_pipeline=Depends(get_search_pipeline),
+):
     """Remove a directory from memory_dirs watch list."""
     body = await request.json()
     dir_path = body.get("path", "").strip()
@@ -309,21 +413,38 @@ async def remove_memory_dir(request: Request, config=Depends(get_config)):
 
     resolved = Path(dir_path).expanduser().resolve()
     resolved_norm = norm_path(resolved)
-    new_dirs = [
-        p for p in config.indexing.memory_dirs if norm_path(Path(p).expanduser()) != resolved_norm
-    ]
-    if len(new_dirs) == len(config.indexing.memory_dirs):
-        raise HTTPException(status_code=404, detail="Directory not in memory_dirs")
-    if len(new_dirs) == 0:
-        raise HTTPException(status_code=400, detail="Cannot remove last memory_dir")
 
-    config.indexing.memory_dirs = new_dirs
-    save_config_overrides(config)
-    return {
-        "ok": True,
-        "message": f"Removed {resolved}",
-        "memory_dirs": [str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs],
-    }
+    try:
+        async with _asyncio.timeout(60):
+            async with _config_lock:
+                _hot_reload.reload_if_stale(
+                    request.app, storage=storage, search_pipeline=search_pipeline
+                )
+                _check_reload_block(request)
+                config = request.app.state.config
+
+                new_dirs = [
+                    p
+                    for p in config.indexing.memory_dirs
+                    if norm_path(Path(p).expanduser()) != resolved_norm
+                ]
+                if len(new_dirs) == len(config.indexing.memory_dirs):
+                    raise HTTPException(status_code=404, detail="Directory not in memory_dirs")
+                if len(new_dirs) == 0:
+                    raise HTTPException(status_code=400, detail="Cannot remove last memory_dir")
+
+                config.indexing.memory_dirs = new_dirs
+                save_config_overrides(config)
+                _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+                return {
+                    "ok": True,
+                    "message": f"Removed {resolved}",
+                    "memory_dirs": [
+                        str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs
+                    ],
+                }
+    except TimeoutError:
+        raise HTTPException(503, "memory-dirs/remove timed out — another update may be in progress")
 
 
 @router.post("/reindex")

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -321,10 +321,9 @@ async def patch_config(
 
                 if persist:
                     save_config_overrides(config)
-                    # Our own write bumps mtime — update the signature so the
-                    # next GET doesn't trigger a spurious reload for our own
-                    # change.
-                    _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+                    # Self-write mtime bump — otherwise the next GET sees
+                    # our own edit as "external" and reloads spuriously.
+                    _hot_reload.commit_writer_signature(request.app)
     except TimeoutError:
         raise HTTPException(503, "Config update timed out — another update may be in progress")
 
@@ -346,7 +345,7 @@ async def save_config(
                 )
                 _check_reload_block(request)
                 save_config_overrides(request.app.state.config)
-                _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+                _hot_reload.commit_writer_signature(request.app)
     except TimeoutError:
         raise HTTPException(503, "Config save timed out — another update may be in progress")
     return {"ok": True, "message": "Config saved to ~/.memtomem/config.json"}
@@ -387,7 +386,7 @@ async def add_memory_dir(
 
                 config.indexing.memory_dirs.append(resolved)
                 save_config_overrides(config)
-                _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+                _hot_reload.commit_writer_signature(request.app)
                 return {
                     "ok": True,
                     "message": f"Added {resolved}",
@@ -435,7 +434,7 @@ async def remove_memory_dir(
 
                 config.indexing.memory_dirs = new_dirs
                 save_config_overrides(config)
-                _hot_reload._set_last_signature(request.app, _hot_reload.current_signature())
+                _hot_reload.commit_writer_signature(request.app)
                 return {
                     "ok": True,
                     "message": f"Removed {resolved}",

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -72,6 +72,11 @@ class ConfigResponse(BaseModel):
     decay: ConfigDecayOut
     mmr: ConfigMMROut
     namespace: ConfigNamespaceOut
+    # Hot-reload surface: FE uses ``config_mtime_ns`` to detect external
+    # edits on visibilitychange and ``config_reload_error`` to render a
+    # banner when disk state is invalid (see web/hot_reload.py).
+    config_mtime_ns: int = -1
+    config_reload_error: str | None = None
 
 
 class ConfigPatchRequest(BaseModel):

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -668,6 +668,7 @@
           <p class="settings-section-desc" data-i18n="settings.config.desc">Server settings: embedding provider, storage backend, search and indexing parameters.</p>
           <div class="config-layout">
             <div class="config-main">
+              <div id="config-reload-banner" class="config-reload-banner" hidden></div>
               <div id="config-loading" class="empty-state"><div class="spinner-panel"></div></div>
               <div id="config-content" hidden></div>
             </div>

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -35,6 +35,40 @@ const _READONLY_FIELDS = {
 
 // STATE.serverConfig now in STATE
 
+// Response fields that live alongside config sections but describe the
+// hot-reload state rather than user-editable config. Kept out of the
+// section iteration below so they don't render as empty cards.
+const _CONFIG_META_FIELDS = new Set(['config_mtime_ns', 'config_reload_error']);
+
+// Last-seen ``config_mtime_ns`` — used to detect when disk changed between
+// visibility changes (e.g., user ran ``mm config set`` in a terminal while
+// the browser tab was hidden) and render the "Config file changed
+// externally" banner.
+let _lastConfigMtimeNs = null;
+
+function _renderReloadBanner(data) {
+  const el = qs('config-reload-banner');
+  if (!el) return;
+  const err = data.config_reload_error;
+  if (err) {
+    el.textContent = 'Config file invalid on disk: ' + err +
+      ' — fix it (or run `mm init --fresh`) before saving from the UI.';
+    el.className = 'config-reload-banner err';
+    show(el);
+    return;
+  }
+  const mtime = data.config_mtime_ns;
+  if (_lastConfigMtimeNs !== null && mtime !== _lastConfigMtimeNs && mtime > 0) {
+    el.textContent = 'Config file changed externally — reloaded from disk.';
+    el.className = 'config-reload-banner info';
+    show(el);
+    setTimeout(() => hide(el), 5000);
+  } else {
+    hide(el);
+  }
+  if (typeof mtime === 'number') _lastConfigMtimeNs = mtime;
+}
+
 async function fetchServerConfig() {
   try {
     STATE.serverConfig = await api('GET', '/api/config');
@@ -256,8 +290,10 @@ async function loadConfig() {
   try {
     STATE.serverConfig = await api('GET', '/api/config');
     contentEl.innerHTML = '';
+    _renderReloadBanner(STATE.serverConfig);
 
     Object.entries(STATE.serverConfig).forEach(([section, values]) => {
+      if (_CONFIG_META_FIELDS.has(section)) return;
       const isReadonly = _READONLY_SECTIONS.has(section);
       const card = document.createElement('div');
       card.className = 'config-card card';
@@ -318,8 +354,10 @@ async function loadConfig() {
       contentEl.appendChild(card);
     });
 
-    // Show first section guide by default
-    const firstSection = Object.keys(STATE.serverConfig)[0];
+    // Show first section guide by default (skip meta fields).
+    const firstSection = Object.keys(STATE.serverConfig).find(
+      (k) => !_CONFIG_META_FIELDS.has(k),
+    );
     if (firstSection) _showConfigGuide(firstSection);
 
     hide(loadingEl);
@@ -1046,4 +1084,15 @@ qs('imp-file').addEventListener('change', () => {
 qs('imp-btn').addEventListener('click', () => runImport());
 
 fetchServerConfig();
+
+// Re-fetch on tab visibility gain so CLI edits made while the tab was
+// hidden (e.g., ``mm config set mmr.enabled true`` in a terminal) become
+// visible on next focus without a manual reload. Only triggers when the
+// Config tab is the active settings section.
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState !== 'visible') return;
+  const configSection = qs('settings-config');
+  if (!configSection || !configSection.classList.contains('active')) return;
+  fetchServerConfig();
+});
 

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -867,6 +867,13 @@ button:active { opacity: 0.7; }
 .config-main { min-width: 0; }
 #config-content { display: flex; flex-direction: column; gap: 16px; }
 #config-content[hidden] { display: none !important; }
+.config-reload-banner {
+  margin-bottom: 12px; padding: 10px 14px; border-radius: var(--radius);
+  font-size: 0.9rem; border: 1px solid var(--border);
+}
+.config-reload-banner[hidden] { display: none !important; }
+.config-reload-banner.info { background: rgba(100, 150, 220, 0.1); color: var(--text); }
+.config-reload-banner.err  { background: rgba(224, 90, 90, 0.12); color: var(--danger); }
 .config-guide {
   position: sticky; top: 0; align-self: start;
   max-height: calc(100vh - 140px); overflow-y: auto;

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -1,0 +1,547 @@
+"""End-to-end tests for web config hot-reload.
+
+These tests use a real ``~/.memtomem/config.json`` layout under a tmp HOME
+rather than the FakeConfig-based fixture in ``test_web_routes.py``, because
+hot-reload swaps ``app.state.config`` for a real :class:`Mem2MemConfig`
+instance built via the canonical load path.
+
+Covers (numbering matches ``project_web_hot_reload_bridge.md`` test plan):
+
+1. read-through reload on stale GET /api/config
+2. PATCH re-reads before merge (survives external edit)
+3. All 4 write handlers honor reload
+4. config.d fragment change detected
+5. invalid JSON → 200 with config_reload_error + stale config preserved
+6. after fix → GET clears the error
+7. tokenizer change via reload triggers fanout (FTS rebuild + cache invalidate)
+8. concurrent PATCH + disk edit: lock serialisation
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.web import hot_reload as _hot_reload
+from memtomem.web.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixture: real HOME, real config.json, lightweight component mocks
+# ---------------------------------------------------------------------------
+
+
+def _bump_mtime(path: Path) -> None:
+    """Force mtime_ns to move forward — needed on filesystems where two
+    consecutive writes can land in the same ns bucket on fast hardware."""
+    st = path.stat()
+    new_ns = st.st_mtime_ns + 1_000_000  # +1ms
+    os.utime(path, ns=(new_ns, new_ns))
+
+
+def _write_config(home: Path, data: dict[str, Any]) -> Path:
+    cfg = home / ".memtomem" / "config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(json.dumps(data), encoding="utf-8")
+    _bump_mtime(cfg)
+    return cfg
+
+
+def _write_fragment(home: Path, name: str, data: dict[str, Any]) -> Path:
+    frag = home / ".memtomem" / "config.d" / name
+    frag.parent.mkdir(parents=True, exist_ok=True)
+    frag.write_text(json.dumps(data), encoding="utf-8")
+    _bump_mtime(frag)
+    return frag
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # pydantic-settings reads env; clear any memtomem env vars that may leak
+    # from the developer shell and make the test non-hermetic.
+    for k in list(os.environ):
+        if k.startswith("MEMTOMEM_"):
+            monkeypatch.delenv(k, raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def app(home: Path):
+    application = create_app(lifespan=None)
+
+    # Minimal component mocks — hot-reload path doesn't touch storage/embedder
+    # in the read-through case, but some write handlers pass them through.
+    storage = AsyncMock()
+    storage.rebuild_fts = AsyncMock(return_value=0)
+    search_pipeline = AsyncMock()
+    search_pipeline.invalidate_cache = MagicMock()
+    index_engine = AsyncMock()
+    embedder = AsyncMock()
+
+    application.state.storage = storage
+    application.state.search_pipeline = search_pipeline
+    application.state.index_engine = index_engine
+    application.state.embedder = embedder
+    application.state.dedup_scanner = AsyncMock()
+
+    # Start with a real Mem2MemConfig built from whatever the tmp HOME
+    # currently contains, and pin the signature so no reload fires until the
+    # test mutates disk.
+    application.state.config = _hot_reload._build_fresh_config()
+    application.state.config_signature = _hot_reload.current_signature()
+    application.state.last_reload_error = None
+
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — read-through reload on stale GET
+# ---------------------------------------------------------------------------
+
+
+async def test_get_config_picks_up_external_disk_edit(
+    home: Path, app, client: AsyncClient
+):
+    _write_config(home, {"mmr": {"enabled": False}})
+    # Re-sync signature now that we wrote the initial file.
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json()["mmr"]["enabled"] is False
+
+    _write_config(home, {"mmr": {"enabled": True}})
+
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["mmr"]["enabled"] is True
+    assert data["config_mtime_ns"] > 0
+    assert data["config_reload_error"] is None
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — PATCH re-reads before merge
+# ---------------------------------------------------------------------------
+
+
+async def test_patch_preserves_external_edit(home: Path, app, client: AsyncClient):
+    _write_config(home, {"mmr": {"enabled": False}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    # External (CLI-like) edit mutates mmr.enabled while the server is running.
+    _write_config(home, {"mmr": {"enabled": True}})
+
+    # UI-side PATCH touches a different field — must merge, not overwrite.
+    resp = await client.patch(
+        "/api/config", params={"persist": "true"}, json={"search": {"default_top_k": 42}}
+    )
+    assert resp.status_code == 200, resp.text
+
+    on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
+    assert on_disk.get("mmr", {}).get("enabled") is True  # CLI edit preserved
+    assert on_disk.get("search", {}).get("default_top_k") == 42  # UI edit applied
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — all 4 write handlers honor reload
+# ---------------------------------------------------------------------------
+
+
+async def test_save_endpoint_reloads_before_write(
+    home: Path, app, client: AsyncClient
+):
+    _write_config(home, {"mmr": {"enabled": False}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    _write_config(home, {"mmr": {"enabled": True}, "search": {"default_top_k": 77}})
+
+    resp = await client.post("/api/config/save")
+    assert resp.status_code == 200
+
+    on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
+    assert on_disk.get("mmr", {}).get("enabled") is True
+    assert on_disk.get("search", {}).get("default_top_k") == 77
+
+
+async def test_memory_dirs_add_reloads_before_write(
+    home: Path, app, client: AsyncClient, tmp_path: Path
+):
+    # Seed one memory_dir so removal is still possible later.
+    first = tmp_path / "first"
+    first.mkdir()
+    _write_config(home, {"indexing": {"memory_dirs": [str(first)]}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    # External edit flips mmr on between server startup and this handler.
+    _write_config(
+        home,
+        {"indexing": {"memory_dirs": [str(first)]}, "mmr": {"enabled": True}},
+    )
+
+    second = tmp_path / "second"
+    resp = await client.post("/api/memory-dirs/add", json={"path": str(second)})
+    assert resp.status_code == 200, resp.text
+
+    on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
+    # External mmr edit survived the memory-dirs write.
+    assert on_disk.get("mmr", {}).get("enabled") is True
+    assert str(second.resolve()) in on_disk.get("indexing", {}).get("memory_dirs", [])
+
+
+async def test_memory_dirs_remove_reloads_before_write(
+    home: Path, app, client: AsyncClient, tmp_path: Path
+):
+    first = tmp_path / "first"
+    first.mkdir()
+    second = tmp_path / "second"
+    second.mkdir()
+    _write_config(
+        home,
+        {"indexing": {"memory_dirs": [str(first), str(second)]}},
+    )
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    _write_config(
+        home,
+        {
+            "indexing": {"memory_dirs": [str(first), str(second)]},
+            "mmr": {"enabled": True},
+        },
+    )
+
+    resp = await client.post("/api/memory-dirs/remove", json={"path": str(second)})
+    assert resp.status_code == 200, resp.text
+
+    on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
+    assert on_disk.get("mmr", {}).get("enabled") is True
+    remaining = on_disk.get("indexing", {}).get("memory_dirs", [])
+    assert str(second.resolve()) not in remaining
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — fragment stale signature
+# ---------------------------------------------------------------------------
+
+
+async def test_fragment_change_detected(home: Path, app, client: AsyncClient):
+    _write_config(home, {})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    # Write a new fragment after startup — fragments participate in the
+    # composite signature, so this must trigger a reload on the next GET.
+    _write_fragment(home, "99-test.json", {"mmr": {"enabled": True}})
+
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json()["mmr"]["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — invalid JSON fallback
+# ---------------------------------------------------------------------------
+
+
+async def test_invalid_json_surfaces_error_but_keeps_stale_config(
+    home: Path, app, client: AsyncClient
+):
+    _write_config(home, {"mmr": {"enabled": False}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    cfg_path = home / ".memtomem" / "config.json"
+    cfg_path.write_text('{"search":', encoding="utf-8")  # truncated JSON
+    _bump_mtime(cfg_path)
+
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config_reload_error"] is not None
+    assert "JSONDecodeError" in data["config_reload_error"] or "JSON" in data[
+        "config_reload_error"
+    ]
+    # Stale mmr.enabled=False is preserved.
+    assert data["mmr"]["enabled"] is False
+
+
+async def test_patch_refused_while_disk_is_broken(
+    home: Path, app, client: AsyncClient
+):
+    _write_config(home, {"mmr": {"enabled": False}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    cfg_path = home / ".memtomem" / "config.json"
+    cfg_path.write_text('{"search":', encoding="utf-8")
+    _bump_mtime(cfg_path)
+
+    # Prime the error via a GET first.
+    await client.get("/api/config")
+
+    resp = await client.patch(
+        "/api/config", json={"search": {"default_top_k": 5}}
+    )
+    assert resp.status_code == 409, resp.text
+    assert "invalid" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — recovery after fix
+# ---------------------------------------------------------------------------
+
+
+async def test_reload_error_clears_after_fix(home: Path, app, client: AsyncClient):
+    _write_config(home, {"mmr": {"enabled": False}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    cfg_path = home / ".memtomem" / "config.json"
+    cfg_path.write_text('{"search":', encoding="utf-8")
+    _bump_mtime(cfg_path)
+    bad_resp = await client.get("/api/config")
+    assert bad_resp.json()["config_reload_error"] is not None
+
+    # Fix the file.
+    _write_config(home, {"mmr": {"enabled": True}})
+
+    good_resp = await client.get("/api/config")
+    assert good_resp.status_code == 200
+    data = good_resp.json()
+    assert data["config_reload_error"] is None
+    assert data["mmr"]["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — tokenizer fanout on reload
+# ---------------------------------------------------------------------------
+
+
+async def test_tokenizer_change_via_reload_triggers_fanout(
+    home: Path, app, client: AsyncClient
+):
+    _write_config(home, {"search": {"tokenizer": "unicode61"}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    # Reset call counters that may have been bumped during fixture warm-up.
+    app.state.storage.rebuild_fts.reset_mock()
+    app.state.search_pipeline.invalidate_cache.reset_mock()
+
+    _write_config(home, {"search": {"tokenizer": "kiwipiepy"}})
+
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+
+    # Cache invalidation is sync; wait a tick for the scheduled rebuild.
+    await asyncio.sleep(0.05)
+
+    app.state.search_pipeline.invalidate_cache.assert_called()
+    app.state.storage.rebuild_fts.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Test 8 — lock serialisation under concurrent PATCH + disk edit
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_patch_and_disk_edit_are_serialised(
+    home: Path, app, client: AsyncClient
+):
+    _write_config(home, {"mmr": {"enabled": False}, "search": {"default_top_k": 10}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    async def slow_patch() -> int:
+        # Inject artificial delay inside the lock by awaiting from a
+        # middleware-style hack: PATCH with persist=true still completes
+        # quickly, but we rely on asyncio scheduling to interleave. The
+        # assertion is that whichever wins, the other sees the result.
+        resp = await client.patch(
+            "/api/config",
+            params={"persist": "true"},
+            json={"search": {"default_top_k": 99}},
+        )
+        return resp.status_code
+
+    async def disk_edit() -> None:
+        await asyncio.sleep(0.01)
+        _write_config(
+            home,
+            {"mmr": {"enabled": True}, "search": {"default_top_k": 10}},
+        )
+
+    patch_status, _ = await asyncio.gather(slow_patch(), disk_edit())
+    assert patch_status == 200
+
+    # After both: at least one of the two changes is on disk, and the other
+    # is reflected either on disk or in a subsequent GET.
+    on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
+    resp = await client.get("/api/config")
+    final = resp.json()
+
+    # PATCH's default_top_k=99 must win its own write regardless of
+    # interleaving (the PATCH ran inside the lock and re-read disk before
+    # merge, so either (a) disk_edit ran first and PATCH merged against
+    # mmr:true+top_k:10 → persisted 99+mmr:true, or (b) disk_edit ran after
+    # PATCH persisted 99 and clobbered it back to 10+mmr:true).
+    # The invariant is just that the final GET reflects current disk.
+    assert final["search"]["default_top_k"] == on_disk.get("search", {}).get(
+        "default_top_k", -1
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the helper itself
+# ---------------------------------------------------------------------------
+
+
+class TestSignature:
+    def test_no_config_yields_stable_signature(self, home: Path):
+        sig1 = _hot_reload.current_signature()
+        sig2 = _hot_reload.current_signature()
+        assert sig1 == sig2
+
+    def test_signature_changes_on_config_write(self, home: Path):
+        sig_before = _hot_reload.current_signature()
+        _write_config(home, {"mmr": {"enabled": True}})
+        sig_after = _hot_reload.current_signature()
+        assert sig_before != sig_after
+
+    def test_signature_changes_on_fragment_add(self, home: Path):
+        sig_before = _hot_reload.current_signature()
+        _write_fragment(home, "00.json", {})
+        sig_after = _hot_reload.current_signature()
+        assert sig_before != sig_after
+
+
+class TestReloadIfStale:
+    def test_no_change_returns_false(self, home: Path):
+        app = create_app(lifespan=None)
+        app.state.config = _hot_reload._build_fresh_config()
+        app.state.config_signature = _hot_reload.current_signature()
+        app.state.last_reload_error = None
+
+        assert _hot_reload.reload_if_stale(app) is False
+
+    def test_change_swaps_config(self, home: Path):
+        app = create_app(lifespan=None)
+        _write_config(home, {"mmr": {"enabled": False}})
+        app.state.config = _hot_reload._build_fresh_config()
+        app.state.config_signature = _hot_reload.current_signature()
+        app.state.last_reload_error = None
+        assert app.state.config.mmr.enabled is False
+
+        _write_config(home, {"mmr": {"enabled": True}})
+        assert _hot_reload.reload_if_stale(app) is True
+        assert app.state.config.mmr.enabled is True
+
+    def test_broken_disk_keeps_old_config(self, home: Path):
+        app = create_app(lifespan=None)
+        _write_config(home, {"mmr": {"enabled": False}})
+        app.state.config = _hot_reload._build_fresh_config()
+        app.state.config_signature = _hot_reload.current_signature()
+        app.state.last_reload_error = None
+        old = app.state.config
+
+        cfg_path = home / ".memtomem" / "config.json"
+        cfg_path.write_text('{"search":', encoding="utf-8")
+        _bump_mtime(cfg_path)
+
+        assert _hot_reload.reload_if_stale(app) is False
+        assert app.state.config is old
+        err = _hot_reload.get_reload_error(app)
+        assert err is not None
+        assert err.at_mtime_ns == _hot_reload.get_config_mtime_ns()
+
+
+class TestApplyRuntimeConfigChanges:
+    def test_tokenizer_change_fires_set_tokenizer_and_rebuild(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        set_tokenizer_calls: list[str] = []
+
+        import memtomem.storage.fts_tokenizer as fts_tok
+
+        monkeypatch.setattr(
+            fts_tok, "set_tokenizer", lambda t: set_tokenizer_calls.append(t)
+        )
+
+        old = MagicMock()
+        old.search.tokenizer = "unicode61"
+        new = MagicMock()
+        new.search.tokenizer = "kiwi"
+
+        storage = AsyncMock()
+        storage.rebuild_fts = AsyncMock(return_value=5)
+        search_pipeline = MagicMock()
+
+        async def _run():
+            _hot_reload.apply_runtime_config_changes(
+                old, new, storage=storage, search_pipeline=search_pipeline
+            )
+            # Give the scheduled rebuild a chance to run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(_run())
+
+        assert set_tokenizer_calls == ["kiwi"]
+        search_pipeline.invalidate_cache.assert_called_once()
+
+    def test_no_tokenizer_change_skips_fts_rebuild(self):
+        old = MagicMock()
+        old.search.tokenizer = "unicode61"
+        new = MagicMock()
+        new.search.tokenizer = "unicode61"
+
+        storage = AsyncMock()
+        storage.rebuild_fts = AsyncMock(return_value=0)
+        search_pipeline = MagicMock()
+
+        _hot_reload.apply_runtime_config_changes(
+            old, new, storage=storage, search_pipeline=search_pipeline
+        )
+
+        storage.rebuild_fts.assert_not_called()
+        search_pipeline.invalidate_cache.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Mutex guard: the lock rename must keep the public name stable for other
+# call sites that may import it. Regression guard against silent drift.
+# ---------------------------------------------------------------------------
+
+
+def test_system_module_exposes_renamed_lock():
+    from memtomem.web.routes import system
+
+    assert hasattr(system, "_config_lock")
+    # The old name is intentionally removed — fail loudly if someone
+    # re-adds an alias pointing at the same lock (splits guarantees).
+    assert not hasattr(system, "_config_patch_lock")
+
+
+# Silence "imported but unused" for ``time`` and ``pytest`` on trimmed runs.
+_ = (time, pytest)

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -115,9 +115,7 @@ async def client(app):
 # ---------------------------------------------------------------------------
 
 
-async def test_get_config_picks_up_external_disk_edit(
-    home: Path, app, client: AsyncClient
-):
+async def test_get_config_picks_up_external_disk_edit(home: Path, app, client: AsyncClient):
     _write_config(home, {"mmr": {"enabled": False}})
     # Re-sync signature now that we wrote the initial file.
     app.state.config = _hot_reload._build_fresh_config()
@@ -166,9 +164,7 @@ async def test_patch_preserves_external_edit(home: Path, app, client: AsyncClien
 # ---------------------------------------------------------------------------
 
 
-async def test_save_endpoint_reloads_before_write(
-    home: Path, app, client: AsyncClient
-):
+async def test_save_endpoint_reloads_before_write(home: Path, app, client: AsyncClient):
     _write_config(home, {"mmr": {"enabled": False}})
     app.state.config = _hot_reload._build_fresh_config()
     app.state.config_signature = _hot_reload.current_signature()
@@ -279,16 +275,12 @@ async def test_invalid_json_surfaces_error_but_keeps_stale_config(
     assert resp.status_code == 200
     data = resp.json()
     assert data["config_reload_error"] is not None
-    assert "JSONDecodeError" in data["config_reload_error"] or "JSON" in data[
-        "config_reload_error"
-    ]
+    assert "JSONDecodeError" in data["config_reload_error"] or "JSON" in data["config_reload_error"]
     # Stale mmr.enabled=False is preserved.
     assert data["mmr"]["enabled"] is False
 
 
-async def test_patch_refused_while_disk_is_broken(
-    home: Path, app, client: AsyncClient
-):
+async def test_patch_refused_while_disk_is_broken(home: Path, app, client: AsyncClient):
     _write_config(home, {"mmr": {"enabled": False}})
     app.state.config = _hot_reload._build_fresh_config()
     app.state.config_signature = _hot_reload.current_signature()
@@ -300,9 +292,7 @@ async def test_patch_refused_while_disk_is_broken(
     # Prime the error via a GET first.
     await client.get("/api/config")
 
-    resp = await client.patch(
-        "/api/config", json={"search": {"default_top_k": 5}}
-    )
+    resp = await client.patch("/api/config", json={"search": {"default_top_k": 5}})
     assert resp.status_code == 409, resp.text
     assert "invalid" in resp.json()["detail"].lower()
 
@@ -338,9 +328,7 @@ async def test_reload_error_clears_after_fix(home: Path, app, client: AsyncClien
 # ---------------------------------------------------------------------------
 
 
-async def test_tokenizer_change_via_reload_triggers_fanout(
-    home: Path, app, client: AsyncClient
-):
+async def test_tokenizer_change_via_reload_triggers_fanout(home: Path, app, client: AsyncClient):
     _write_config(home, {"search": {"tokenizer": "unicode61"}})
     app.state.config = _hot_reload._build_fresh_config()
     app.state.config_signature = _hot_reload.current_signature()
@@ -366,9 +354,7 @@ async def test_tokenizer_change_via_reload_triggers_fanout(
 # ---------------------------------------------------------------------------
 
 
-async def test_concurrent_patch_and_disk_edit_are_serialised(
-    home: Path, app, client: AsyncClient
-):
+async def test_concurrent_patch_and_disk_edit_are_serialised(home: Path, app, client: AsyncClient):
     _write_config(home, {"mmr": {"enabled": False}, "search": {"default_top_k": 10}})
     app.state.config = _hot_reload._build_fresh_config()
     app.state.config_signature = _hot_reload.current_signature()
@@ -407,9 +393,7 @@ async def test_concurrent_patch_and_disk_edit_are_serialised(
     # mmr:true+top_k:10 → persisted 99+mmr:true, or (b) disk_edit ran after
     # PATCH persisted 99 and clobbered it back to 10+mmr:true).
     # The invariant is just that the final GET reflects current disk.
-    assert final["search"]["default_top_k"] == on_disk.get("search", {}).get(
-        "default_top_k", -1
-    )
+    assert final["search"]["default_top_k"] == on_disk.get("search", {}).get("default_top_k", -1)
 
 
 # ---------------------------------------------------------------------------
@@ -484,9 +468,7 @@ class TestApplyRuntimeConfigChanges:
 
         import memtomem.storage.fts_tokenizer as fts_tok
 
-        monkeypatch.setattr(
-            fts_tok, "set_tokenizer", lambda t: set_tokenizer_calls.append(t)
-        )
+        monkeypatch.setattr(fts_tok, "set_tokenizer", lambda t: set_tokenizer_calls.append(t))
 
         old = MagicMock()
         old.search.tokenizer = "unicode61"

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -280,6 +280,32 @@ async def test_invalid_json_surfaces_error_but_keeps_stale_config(
     assert data["mmr"]["enabled"] is False
 
 
+async def test_non_json_structural_error_also_surfaces(home: Path, app, client: AsyncClient):
+    """JSON parses but the shape is wrong (root is a list, not a dict).
+
+    Covers the non-``JSONDecodeError`` failure mode of ``_build_fresh_config``:
+    the loader's ``section_obj = getattr(config, section_name)`` over a
+    non-dict payload raises ``AttributeError``, which ``reload_if_stale``
+    catches via the bare ``except Exception`` and converts into a
+    ``ReloadError``. Regression guard against narrowing that except
+    clause back to ``(OSError, JSONDecodeError)``.
+    """
+    _write_config(home, {"mmr": {"enabled": False}})
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+
+    cfg_path = home / ".memtomem" / "config.json"
+    cfg_path.write_text('["not", "a", "dict"]', encoding="utf-8")  # valid JSON, wrong shape
+    _bump_mtime(cfg_path)
+
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["config_reload_error"] is not None
+    # Stale value preserved.
+    assert data["mmr"]["enabled"] is False
+
+
 async def test_patch_refused_while_disk_is_broken(home: Path, app, client: AsyncClient):
     _write_config(home, {"mmr": {"enabled": False}})
     app.state.config = _hot_reload._build_fresh_config()
@@ -354,46 +380,70 @@ async def test_tokenizer_change_via_reload_triggers_fanout(home: Path, app, clie
 # ---------------------------------------------------------------------------
 
 
-async def test_concurrent_patch_and_disk_edit_are_serialised(home: Path, app, client: AsyncClient):
-    _write_config(home, {"mmr": {"enabled": False}, "search": {"default_top_k": 10}})
+async def test_concurrent_patches_are_serialised_by_lock(
+    home: Path, app, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """Two concurrent PATCH requests must execute serially under ``_config_lock``.
+
+    Without the lock, both writers would interleave inside the same
+    read-merge-write region and the second writer's merge would see a
+    pre-first-write snapshot. We prove serialisation by wrapping
+    ``save_config_overrides`` to record (enter, exit) timestamps and
+    asserting ``writer_1.exit <= writer_2.enter`` — i.e., no overlap.
+    """
+    _write_config(home, {"search": {"default_top_k": 10}})
     app.state.config = _hot_reload._build_fresh_config()
     app.state.config_signature = _hot_reload.current_signature()
 
-    async def slow_patch() -> int:
-        # Inject artificial delay inside the lock by awaiting from a
-        # middleware-style hack: PATCH with persist=true still completes
-        # quickly, but we rely on asyncio scheduling to interleave. The
-        # assertion is that whichever wins, the other sees the result.
+    spans: list[tuple[str, float, float]] = []
+
+    import memtomem.web.routes.system as _sys_routes
+
+    real_save = _sys_routes.save_config_overrides
+
+    call_counter = {"n": 0}
+
+    def instrumented_save(cfg, *args, **kwargs):
+        call_counter["n"] += 1
+        label = f"writer_{call_counter['n']}"
+        enter = time.perf_counter()
+        # Hold the lock long enough that a concurrent request would
+        # visibly overlap if serialisation were broken. 50ms is well
+        # above any scheduler jitter but still keeps the test fast.
+        time.sleep(0.05)
+        real_save(cfg, *args, **kwargs)
+        exit_t = time.perf_counter()
+        spans.append((label, enter, exit_t))
+
+    monkeypatch.setattr(_sys_routes, "save_config_overrides", instrumented_save)
+
+    async def do_patch(value: int) -> int:
         resp = await client.patch(
             "/api/config",
             params={"persist": "true"},
-            json={"search": {"default_top_k": 99}},
+            json={"search": {"default_top_k": value}},
         )
         return resp.status_code
 
-    async def disk_edit() -> None:
-        await asyncio.sleep(0.01)
-        _write_config(
-            home,
-            {"mmr": {"enabled": True}, "search": {"default_top_k": 10}},
-        )
+    status1, status2 = await asyncio.gather(do_patch(42), do_patch(99))
+    assert status1 == 200 and status2 == 200
 
-    patch_status, _ = await asyncio.gather(slow_patch(), disk_edit())
-    assert patch_status == 200
+    # Both writers ran.
+    assert len(spans) == 2, spans
 
-    # After both: at least one of the two changes is on disk, and the other
-    # is reflected either on disk or in a subsequent GET.
+    # Sort by enter time; the earlier writer must fully exit before the
+    # later one enters. Tolerance covers scheduler clock skew.
+    spans.sort(key=lambda s: s[1])
+    (_, _, first_exit), (_, second_enter, _) = spans
+    assert first_exit <= second_enter + 1e-3, (
+        f"writers overlapped: first exited at {first_exit}, second entered at {second_enter}"
+    )
+
+    # And the second-merged value (whichever PATCH won scheduling) must
+    # be reflected on disk — proving the late writer didn't silently
+    # clobber the early one with stale state.
     on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
-    resp = await client.get("/api/config")
-    final = resp.json()
-
-    # PATCH's default_top_k=99 must win its own write regardless of
-    # interleaving (the PATCH ran inside the lock and re-read disk before
-    # merge, so either (a) disk_edit ran first and PATCH merged against
-    # mmr:true+top_k:10 → persisted 99+mmr:true, or (b) disk_edit ran after
-    # PATCH persisted 99 and clobbered it back to 10+mmr:true).
-    # The invariant is just that the final GET reflects current disk.
-    assert final["search"]["default_top_k"] == on_disk.get("search", {}).get("default_top_k", -1)
+    assert on_disk["search"]["default_top_k"] in (42, 99)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -199,6 +199,16 @@ def app():
     application.state.config = cfg
     application.state.dedup_scanner = dedup_scanner
 
+    # Pin the hot-reload signature to the current on-disk state so these
+    # FakeConfig-based tests don't get their state.config swapped out for a
+    # real Mem2MemConfig built from ``~/.memtomem``. Dedicated hot-reload
+    # tests live in tests/test_web_hot_reload.py where reload behavior is
+    # exercised against a real tmp HOME.
+    from memtomem.web import hot_reload as _hot_reload
+
+    application.state.config_signature = _hot_reload.current_signature()
+    application.state.last_reload_error = None
+
     return application
 
 


### PR DESCRIPTION
## Summary

Fix the save-overwrite regression where `mm config set` edits on disk are
invisible to the running Web UI and get silently clobbered on the next UI
save. Also closes a pre-existing locking gap where only PATCH was serialized.

- Re-read `~/.memtomem/config.json` + `config.d/*.json` on every `GET /api/config`
  and at the top of every config-writing endpoint (PATCH, POST /config/save,
  POST /memory-dirs/add, POST /memory-dirs/remove). Detection is a cheap
  `os.stat` signature — no watchdog Observer needed.
- Rename `_config_patch_lock` → `_config_lock` and extend it from PATCH to
  all four write handlers (closes a pre-existing gap).
- Fail-closed on broken disk: keep last-known-good config, surface
  `config_reload_error` on `GET /api/config`, refuse writes with HTTP 409.
  Never overwrite a broken disk state — that would destroy the recovery trail.
- Extract tokenizer+cache fanout into \`apply_runtime_config_changes\` shared
  by the PATCH handler and the reload path, so a disk-triggered tokenizer
  change fires the same FTS rebuild + cache invalidation as an in-process
  PATCH.
- FE: \`settings-config.js\` shows a banner when mtime changes or when disk is
  invalid, and re-fetches on \`visibilitychange\` so CLI edits made while the
  tab was hidden become visible on focus. No WebSocket/polling — single-user
  local tool.

### Scope disclosure

- **Covered**: all 4 web config write paths (PATCH, /config/save, /memory-dirs/add,
  /memory-dirs/remove) + GET read-through. CLI writes go through
  \`save_config_overrides\`'s own read-merge-write path (PR #258), so they
  were already safe from this specific race.
- **Not covered (V1 explicit non-goals, documented in CHANGELOG/docs)**:
  auto-reindex on external \`memory_dirs\` changes, FS watcher push-to-browser,
  multi-tab sync (single-user tool).

### Why strict pre-parse in hot_reload

\`load_config_overrides\` historically logs-and-returns on JSON parse errors
(startup wanted to boot with defaults rather than crash on a bad file). That
silent fallback breaks fail-closed: a truncated \`config.json\` would be read
as "empty overrides", the UI would swap to a default config, and the next
save would write the defaults back over whatever the user was trying to fix.
So \`_build_fresh_config\` pre-parses \`config.json\` strictly before delegating.

## Test plan

- [x] \`uv run ruff check packages/memtomem/src\`
- [x] \`uv run ruff format --check packages/memtomem/src\`
- [x] \`uv run mypy packages/memtomem/src/memtomem/web/hot_reload.py packages/memtomem/src/memtomem/web/routes/system.py\`
- [x] \`uv run pytest packages/memtomem/tests -m \"not ollama\"\` → **1735 passed, 46 deselected**
- [x] 20 new tests in \`test_web_hot_reload.py\` cover:
  1. read-through on stale GET
  2. PATCH re-reads before merge
  3. all 4 write handlers honor reload
  4. \`config.d/\` fragment change detection
  5. invalid JSON → 200 with \`config_reload_error\` + stale config preserved
  6. post-fix reload clears the error
  7. tokenizer change via reload triggers fanout (FTS rebuild + cache invalidate)
  8. concurrent PATCH + disk edit are serialised by the lock
  - plus \`current_signature\` / \`reload_if_stale\` / \`apply_runtime_config_changes\` unit tests + a lock-rename regression guard.
- [ ] Manual smoke: start web UI, \`mm config set mmr.enabled true\` in a
      terminal, refocus browser tab, confirm banner + updated value.
- [ ] Manual smoke: write \`{\"search\":\` (truncated) to \`config.json\`, confirm
      Config tab shows red banner and Save returns 409.