### PR TITLE
fix(web): eliminate GET-path signature overwrite race in hot_reload

### DIFF
--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -240,6 +240,15 @@ def reload_if_stale(
         _set_last_signature(app, sig)
         return False
 
+    # Compare-and-swap: while we were in _build_fresh_config (file I/O, can
+    # take milliseconds), a writer inside _config_lock may have already
+    # committed a fresh reload + signature bump via commit_writer_signature.
+    # That view is at least as fresh as ours; discard our rebuild so we
+    # don't revert the writer's signature and force a spurious next-GET
+    # reload. Race eliminated per issue #268.
+    if _get_last_signature(app) != last:
+        return False
+
     old_cfg = getattr(app.state, "config", None)
     app.state.config = new_cfg
     _set_last_signature(app, sig)

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -15,6 +15,8 @@ Covers (numbering matches ``project_web_hot_reload_bridge.md`` test plan):
 6. after fix → GET clears the error
 7. tokenizer change via reload triggers fanout (FTS rebuild + cache invalidate)
 8. concurrent PATCH + disk edit: lock serialisation
+9. V2 (issue #268): GET's lock-free reload yields to a concurrent writer's
+   signature bump via compare-and-swap
 """
 
 from __future__ import annotations
@@ -444,6 +446,79 @@ async def test_concurrent_patches_are_serialised_by_lock(
     # clobber the early one with stale state.
     on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
     assert on_disk["search"]["default_top_k"] in (42, 99)
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — V2: GET's lock-free reload must not overwrite a writer's bump
+# ---------------------------------------------------------------------------
+
+
+def test_reload_if_stale_cas_yields_to_concurrent_writer_bump(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Issue #268: the lock-free reader path had a race where its trailing
+    ``app.state.config = new_cfg; _set_last_signature(sig)`` could overwrite
+    a writer's commit that landed while ``_build_fresh_config`` was running.
+    The writer's view is at least as fresh, so we yield.
+
+    Proof: hook ``_build_fresh_config`` so that *between* its call and its
+    return, a simulated writer updates ``app.state.config_signature``.
+    Without CAS, ``reload_if_stale`` would then assign the reader-side
+    cfg + reset the signature to the older ``sig`` it observed at entry,
+    clobbering the writer's bump. With CAS, it detects the advance and
+    returns ``False`` with no state mutation.
+
+    Direct unit-level construction (no HTTP / no asyncio) keeps the race
+    window deterministic: the writer "lands" exactly where the reader
+    would race it, regardless of scheduler quirks.
+    """
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    _write_config(home, {"mmr": {"enabled": False}, "search": {"default_top_k": 10}})
+
+    # Baseline reader-visible state.
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+    app.state.last_reload_error = None
+
+    sig_before = app.state.config_signature
+    cfg_before = app.state.config
+
+    # External disk edit bumps current_signature() past sig_before. This
+    # is what triggers reload_if_stale to enter its rebuild branch at all.
+    _write_config(home, {"mmr": {"enabled": True}, "search": {"default_top_k": 10}})
+
+    # Simulate "a writer committed inside _config_lock while we were
+    # inside _build_fresh_config" by mutating app.state.config_signature
+    # from *within* the wrapped build call. When reload_if_stale returns
+    # from this call, it will find _get_last_signature(app) != last and
+    # must bail out without swapping.
+    real_build = _hot_reload._build_fresh_config
+    writer_sig = None
+
+    def build_and_interleave_writer():
+        nonlocal writer_sig
+        # Do one more disk touch so commit_writer_signature picks up a
+        # signature strictly newer than anything the reader saw.
+        _write_config(home, {"mmr": {"enabled": True}, "search": {"default_top_k": 99}})
+        _hot_reload.commit_writer_signature(app)
+        writer_sig = app.state.config_signature
+        return real_build()
+
+    monkeypatch.setattr(_hot_reload, "_build_fresh_config", build_and_interleave_writer)
+
+    swapped = _hot_reload.reload_if_stale(app)
+
+    # CAS must have fired: no swap happened.
+    assert swapped is False
+    assert app.state.config_signature == writer_sig, (
+        "writer's signature was overwritten by the reader's tail"
+    )
+    assert app.state.config is cfg_before, "writer's config view was clobbered"
+    # And of course the writer's signature must differ from what the
+    # reader saw at entry — otherwise there was no race to defend against.
+    assert writer_sig != sig_before
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

V2 of PR #267. Closes #268.

The hot-reload read path in `reload_if_stale` is intentionally lock-free
per bridge memo D3 ("readers tolerate stale view for one request").
PR #267 review identified a medium-severity race that goes beyond that
tradeoff: the reader's trailing state mutation could *overwrite* a
concurrent writer's signature bump, not merely serve stale data.

### The race (from #268)

1. GET: reads `sig = current_signature()` → T1, enters `_build_fresh_config` (file I/O, ~ms).
2. Writer: acquires `_config_lock`, reloads + merges + saves at T2, calls `commit_writer_signature()` → signature = T2.
3. GET: returns from `_build_fresh_config` with a cfg built from T1 disk, blindly assigns `app.state.config = that_cfg` and `_set_last_signature(T1)` — reverts the writer's bump to T2.
4. Next GET: sig mismatch → spurious re-reload from identical disk.

Worst case was one wasted file read on the next GET. No corruption,
but a violation of D3's "tolerate one-request staleness" contract
(the reader wasn't tolerating — it was actively regressing shared state).

### The fix (3 lines)

In `reload_if_stale`, after `_build_fresh_config` returns and before
the state mutation:

```python
# Compare-and-swap: while we were in _build_fresh_config (file I/O, can
# take milliseconds), a writer inside _config_lock may have already
# committed a fresh reload + signature bump via commit_writer_signature.
# That view is at least as fresh as ours; discard our rebuild so we
# don't revert the writer's signature and force a spurious next-GET
# reload. Race eliminated per issue #268.
if _get_last_signature(app) != last:
    return False
```

## Test plan

- [x] `uv run ruff check packages/memtomem`
- [x] `uv run ruff format --check packages/memtomem`
- [x] `uv run mypy packages/memtomem/src/memtomem/web/hot_reload.py`
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` → **1737 passed (+1 new), 46 deselected**
- [x] New `test_reload_if_stale_cas_yields_to_concurrent_writer_bump`:
  - Unit-level (no HTTP, no asyncio) so the race window is deterministic.
  - Monkeypatches `_build_fresh_config` to mutate `app.state.config_signature` via `commit_writer_signature` *between* call and return, simulating "writer committed while reader was in file I/O."
  - Asserts writer's bump survives + reader doesn't swap `app.state.config`.
- [x] **Negative-tested**: removing the CAS line flips the test from pass to fail, so it's a real regression guard not a no-op.

## Scope disclosure

- **Covered**: the GET path's CAS. PATCH/save/memory-dirs handlers run inside `_config_lock` so they don't need CAS — the lock serialises writer-vs-writer.
- **Not covered (explicit non-goals, same as V1)**: FS watcher push, multi-tab FE sync, auto-reindex on memory_dirs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
