### PR TITLE
fix(indexing): move exclude guard into _index_file (closes #270)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -205,9 +205,10 @@ class IndexEngine:
         namespace: str | None = None,
     ) -> IndexingStats:
         """Index a single file. Convenience wrapper for external callers."""
-        # Apply exclude patterns at the entry point so callers that bypass
-        # ``_discover_files`` (file watcher, direct API consumers) cannot
-        # smuggle credentials or noise into the index.
+        # Defense-in-depth: the primary guard lives at the top of
+        # ``_index_file`` (covers every caller — watcher, stream endpoint,
+        # CLI, MCP tools). This public-entry check is kept so the call
+        # returns early with zeroed stats without entering the lock.
         user_spec = _build_exclude_spec(self._config.exclude_patterns)
         if _path_is_excluded(file_path, self._config.memory_dirs, user_spec):
             logger.debug("Skipping excluded file %s", file_path)
@@ -337,6 +338,18 @@ class IndexEngine:
         # Return shape: total/indexed/skipped/deleted (ints), errors (list[str]),
         # new_chunk_ids (list[UUID]). Early zero-result paths may omit
         # new_chunk_ids — consumers must tolerate missing keys.
+
+        # Primary exclude guard — every caller (index_file, _index_path_inner
+        # after _discover_files, index_path_stream single-file branch) funnels
+        # through here, so a single check closes all entry points including
+        # ones added later. ``_discover_files`` still filters upstream for
+        # directory walks, but this guard ensures single-file callers like
+        # ``index_path_stream(file)`` cannot smuggle credentials or noise.
+        user_spec = _build_exclude_spec(self._config.exclude_patterns)
+        if _path_is_excluded(file_path, self._config.memory_dirs, user_spec):
+            logger.debug("Skipping excluded file %s", file_path)
+            return {"total": 0, "indexed": 0, "skipped": 0, "deleted": 0, "errors": []}
+
         try:
             file_size = file_path.stat().st_size
         except OSError:

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -292,6 +292,64 @@ class TestExcludePatterns:
         assert stats.total_chunks == 0
         assert stats.indexed_chunks == 0
 
+    async def test_index_path_stream_single_file_blocks_excluded(self, components, memory_dir):
+        """REGRESSION: ``index_path_stream`` has a single-file branch
+        (``if path.is_file(): files = [path]``) that skips ``_discover_files``
+        and calls guard-free ``_index_file`` directly. Exposed via the Web UI
+        ``GET /api/index/stream?path=...`` endpoint. The primary guard at
+        ``_index_file`` closes this entry point; a chunker spy proves the
+        guard fires *before* parsing so ``stored==0`` alone is not relied on
+        (NoopEmbedder's sqlite-vec insert can roll back and mask a bypass).
+        """
+        creds_path = memory_dir / "oauth_creds.json"
+        creds_path.write_text('{"token": "secret"}')
+
+        engine = components.index_engine
+        chunker_calls: list[Path] = []
+        orig = engine._registry.chunk_file
+
+        def spy(fp: Path, content: str):
+            chunker_calls.append(fp)
+            return orig(fp, content)
+
+        engine._registry.chunk_file = spy  # type: ignore[method-assign]
+        try:
+            events = [ev async for ev in engine.index_path_stream(creds_path, recursive=False)]
+        finally:
+            engine._registry.chunk_file = orig  # type: ignore[method-assign]
+
+        assert all("oauth_creds" not in str(c) for c in chunker_calls)
+        complete = next(e for e in events if e.get("type") == "complete")
+        assert complete["indexed_chunks"] == 0
+        assert complete["total_chunks"] == 0
+
+    async def test_index_path_stream_dir_still_filters_excluded(self, components, memory_dir):
+        """REGRESSION: the directory-walk path of ``index_path_stream``
+        still funnels filtered files through ``_index_file``. Ensure
+        legitimate files are indexed while the excluded sibling is skipped.
+        """
+        (memory_dir / "oauth_creds.json").write_text('{"token": "x"}')
+        (memory_dir / "notes.md").write_text("# Keep\n\nContent to index.")
+
+        engine = components.index_engine
+        chunker_calls: list[str] = []
+        orig = engine._registry.chunk_file
+
+        def spy(fp: Path, content: str):
+            chunker_calls.append(fp.name)
+            return orig(fp, content)
+
+        engine._registry.chunk_file = spy  # type: ignore[method-assign]
+        try:
+            events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        finally:
+            engine._registry.chunk_file = orig  # type: ignore[method-assign]
+
+        assert "oauth_creds.json" not in chunker_calls
+        assert "notes.md" in chunker_calls
+        complete = next(e for e in events if e.get("type") == "complete")
+        assert complete["indexed_chunks"] >= 1
+
 
 # ===========================================================================
 # 2. _resolve_namespace

--- a/packages/memtomem/tests/test_web_exclude_guard.py
+++ b/packages/memtomem/tests/test_web_exclude_guard.py
@@ -1,0 +1,94 @@
+"""HTTP-layer regression: ``GET /api/index/stream?path=<excluded_file>``.
+
+Engine-level coverage of the same bypass lives in
+``test_indexing_engine.py`` (``test_index_path_stream_single_file_blocks_excluded``).
+This file asserts the guard also fires through the real route → real engine
+stack, because that's the actual entry point exposed to users via the Web UI.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import Mem2MemConfig
+from memtomem.server.component_factory import close_components, create_components
+from memtomem.web.app import create_app
+
+
+@pytest.fixture
+async def real_stack_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Minimal app wired to a real IndexEngine + storage (NoopEmbedder)."""
+    for k in list(os.environ):
+        if k.startswith("MEMTOMEM_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    cfg = Mem2MemConfig()
+    cfg.embedding.provider = "none"
+    cfg.storage.sqlite_path = tmp_path / "mm.db"
+    cfg.storage.sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+    mem_dir = tmp_path / "memories"
+    mem_dir.mkdir()
+    cfg.indexing.memory_dirs = [mem_dir]
+    cfg.indexing.exclude_patterns = []
+
+    comp = await create_components(cfg)
+    app = create_app(lifespan=None)
+    app.state.storage = comp.storage
+    app.state.embedder = comp.embedder
+    app.state.search_pipeline = comp.search_pipeline
+    app.state.index_engine = comp.index_engine
+    app.state.config = comp.config
+    app.state.dedup_scanner = getattr(comp, "dedup_scanner", None)
+    from memtomem.web import hot_reload as _hot_reload
+
+    app.state.config_signature = _hot_reload.current_signature()
+    app.state.last_reload_error = None
+
+    try:
+        yield app, comp, mem_dir
+    finally:
+        await close_components(comp)
+
+
+def _sse_events(body: str) -> list[dict]:
+    return [
+        json.loads(line[len("data: ") :]) for line in body.splitlines() if line.startswith("data: ")
+    ]
+
+
+async def test_index_stream_excluded_single_file_not_indexed(real_stack_app):
+    """GET /api/index/stream?path=<memory_dir>/oauth_creds.json —
+    the built-in denylist matches, so the stream completes with zero
+    indexed chunks and the chunker is never invoked.
+    """
+    app, comp, mem_dir = real_stack_app
+    creds = mem_dir / "oauth_creds.json"
+    creds.write_text('{"token": "secret"}')
+
+    chunker_calls: list[str] = []
+    orig = comp.index_engine._registry.chunk_file
+
+    def spy(fp: Path, content: str):
+        chunker_calls.append(fp.name)
+        return orig(fp, content)
+
+    comp.index_engine._registry.chunk_file = spy  # type: ignore[method-assign]
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/api/index/stream", params={"path": str(creds)})
+    finally:
+        comp.index_engine._registry.chunk_file = orig  # type: ignore[method-assign]
+
+    assert resp.status_code == 200, resp.text
+    events = _sse_events(resp.text)
+    complete = next(e for e in events if e.get("type") == "complete")
+    assert complete["indexed_chunks"] == 0
+    assert complete["total_chunks"] == 0
+    assert "oauth_creds.json" not in chunker_calls


### PR DESCRIPTION
## Summary

- Move the exclude guard from ``index_file`` into the internal ``_index_file``, so every entry point (watcher, ``index_path_stream``, CLI, MCP tools, future additions) picks it up in a single place.
- Keep the existing ``index_file`` check as defense-in-depth with a comment pointing at the primary guard.
- Three regression tests with a chunker spy (``_registry.chunk_file``) instead of stored-count assertions — stored-count can be masked by ``NoopEmbedder`` + ``sqlite-vec`` rollback (see #270).

Closes #270. Related investigation: #261 (closed as cannot-reproduce — see issue for details).

## What was broken

``IndexEngine.index_path_stream(path)`` has a single-file branch:

```python
# engine.py:469-472
if path.is_file():
    files = [path]              # no _discover_files, no exclude check
elif path.is_dir():
    files = self._discover_files(path, recursive)   # guarded
```

The directory branch filters excludes; the single-file branch did not, and then iterated into the guard-free internal ``_index_file`` at line 490. The Web UI ``GET /api/index/stream?path=...`` endpoint exposes this — its only validation is ``is_relative_to(memory_dir)``, which ``~/.gemini/oauth_creds.json`` satisfies once ``.gemini`` is auto-discovered. Result: credential file indexed despite matching the built-in ``**/oauth_creds.json`` denylist.

## Approach

Moving the guard to the top of ``_index_file`` is a single source of truth. ``_discover_files`` still filters upstream for directory walks (faster path — skips before ``_index_file`` is called at all), but the single-file path now has a proper guard too. The existing check at ``index_file`` is kept — it's an early zero-result that avoids acquiring ``_index_lock``, and it's a robust position for a future refactor that splits ``_index_file``. Cost is negligible (pathspec match on one file path).

Confirmed no caller legitimately needs to bypass excludes (grepped ``force_include``, ``bypass.*exclude``, ``skip.*exclude`` — nothing; the existing ``force`` param is "force-reindex ignoring diff hash", not "ignore excludes").

## Tests (1739 pass, 0 regression)

Three regression tests added, all use a chunker spy rather than stored-count so the guard's behavior is verified at the right layer:

- ``test_index_path_stream_single_file_blocks_excluded`` — engine-level, reproduces the bug. Spy confirms the chunker is never invoked on ``oauth_creds.json`` when passed as a single-file path.
- ``test_index_path_stream_dir_still_filters_excluded`` — engine-level, regression guard for the directory branch. Legitimate sibling ``notes.md`` is indexed while ``oauth_creds.json`` is skipped.
- ``test_index_stream_excluded_single_file_not_indexed`` — HTTP-layer (new file ``test_web_exclude_guard.py``). Real ``IndexEngine`` + real storage wired into a minimal app; hits ``GET /api/index/stream?path=<oauth>`` and asserts the SSE ``complete`` event reports ``indexed_chunks=0`` and the chunker spy was never called.

## Test plan

- [x] ``uv run ruff check packages/memtomem/src packages/memtomem/tests`` — all clean
- [x] ``uv run ruff format --check packages/memtomem/src packages/memtomem/tests`` — all clean
- [x] ``uv run pytest -m "not ollama"`` — 1739 passed, 46 ollama-deselected
- [x] Manual reproduction harness (``/tmp/mm-261-repro.py``, not checked in) — Phases A/B/C/D all PASS with the fix; Phase D FAILs without it

---

Co-Authored-By: Claude <noreply@anthropic.com>