### PR TITLE
feat(web): per-field reset-to-default (↺) button in Config tab

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -810,7 +810,7 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
     semantics.
 
     ``quiet=True`` suppresses *warning* output only — used by
-    ``_build_comparand`` which calls this on every save and would
+    ``build_comparand`` which calls this on every save and would
     otherwise repeat "malformed fragment" / "unknown section" messages
     for every PATCH. Exceptions that represent real errors still raise
     (pydantic validation etc. are already caught + logged here, not
@@ -962,7 +962,7 @@ def _auto_discovered_memory_dirs() -> list[Path]:
 # "always-persist" semantics to protect env-dependent factory defaults
 # from being dropped on save (see
 # ``feedback_env_dependent_factory_equality.md``). Z (delta-vs-comparand
-# via ``_build_comparand``) removed that need because the comparand itself
+# via ``build_comparand``) removed that need because the comparand itself
 # incorporates factory output. The set was renamed to reflect its remaining
 # role — marking the mutation/save asymmetry — rather than deleted.
 _EXTRA_MUTATION_FIELDS: dict[str, set[str]] = {
@@ -1013,14 +1013,23 @@ def _atomic_write_json(path: Path, data: dict) -> None:
         raise
 
 
-def _build_comparand(*, quiet: bool = True) -> "Mem2MemConfig":
+def build_comparand(*, quiet: bool = True) -> "Mem2MemConfig":
     """Build a fresh config reflecting everything *except* user overrides.
 
     Comparand = built-in defaults + ``MEMTOMEM_*`` env vars + ``config.d/``
-    fragments + env-dependent factory output (``memory_dirs`` etc.).
-    ``save_config_overrides`` persists only fields where the live config
-    differs from this comparand — closing fragment/env/factory drag-in at
-    the source (see ``project_fragment_dragin_gap.md``).
+    fragments + env-dependent factory output (``memory_dirs`` etc.). This is
+    **not** "pristine code default" — it represents the value that would
+    apply to a field if ``~/.memtomem/config.json`` did not pin it.
+
+    Two consumers:
+
+    - ``save_config_overrides`` persists only fields where the live config
+      differs from this comparand — closing fragment/env/factory drag-in at
+      the source (see ``project_fragment_dragin_gap.md``).
+    - ``GET /api/config/defaults`` (Web UI reset-to-default button) returns
+      these values so the UI can pre-fill a field with "what applies if this
+      override didn't exist." After Save, ``save_config_overrides`` drops
+      the matching entry so env/fragment values continue to flow through.
 
     ``Mem2MemConfig()`` construction reads env automatically via pydantic-
     settings and runs field ``default_factory`` callables, so env + factory
@@ -1064,7 +1073,7 @@ def save_config_overrides(
 
     _log = logging.getLogger(__name__)
     base_fields: dict[str, set[str]] = mutable_fields or MUTABLE_FIELDS
-    comparand = _build_comparand(quiet=True)
+    comparand = build_comparand(quiet=True)
 
     path = _override_path()
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -13,6 +13,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from memtomem.config import (
     FIELD_CONSTRAINTS,
     MUTABLE_FIELDS,
+    build_comparand,
     coerce_and_validate,
     save_config_overrides,
 )
@@ -219,6 +220,23 @@ async def get_config_endpoint(request: Request) -> ConfigResponse:
         mtime_ns=_hot_reload.get_config_mtime_ns(),
         reload_error=err.message if err is not None else None,
     )
+
+
+@router.get("/config/defaults", response_model=ConfigResponse)
+async def get_config_defaults() -> ConfigResponse:
+    """Return the comparand config (defaults + env + ``config.d/`` fragments).
+
+    Powers the Web UI per-field reset-to-default button: the client fetches
+    these values to pre-fill a field when the user clicks ↺. Note that this
+    is not "pristine code default" — if ``MEMTOMEM_MMR__ENABLED=true`` is in
+    the environment, the comparand reflects ``true``, so ↺ shows what the
+    field would revert to if ``~/.memtomem/config.json`` didn't pin it.
+    After the user clicks Save, ``save_config_overrides`` drops the entry
+    (now equal to comparand) and env/fragment values continue to flow.
+
+    Read-only; no reload interaction needed.
+    """
+    return _build_config_response(build_comparand(quiet=True))
 
 
 @router.get(

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -33,6 +33,7 @@ const STATE = {
   tagsView: 'cloud',
   tagsSortBy: 'count-desc',
   serverConfig: null,
+  serverDefaults: null,
   lastRetrievalStats: null,
   groupMode: false,
   cmdPaletteOpen: false,

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -493,5 +493,7 @@
   "settings.exclude_patterns.err_empty": "Pattern cannot be empty",
   "settings.exclude_patterns.err_duplicate": "Duplicate pattern: {pattern}",
   "settings.exclude_patterns.err_syntax": "Invalid pathspec pattern: {pattern}",
-  "settings.exclude_patterns.err_save_blocked": "Fix the highlighted exclude patterns before saving"
+  "settings.exclude_patterns.err_save_blocked": "Fix the highlighted exclude patterns before saving",
+  "settings.reset.aria_label": "Reset to default",
+  "settings.reset.title": "Reset to default (preview; press Save to apply)"
 }

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -493,5 +493,7 @@
   "settings.exclude_patterns.err_empty": "빈 패턴은 사용할 수 없습니다",
   "settings.exclude_patterns.err_duplicate": "중복된 패턴: {pattern}",
   "settings.exclude_patterns.err_syntax": "잘못된 pathspec 패턴: {pattern}",
-  "settings.exclude_patterns.err_save_blocked": "저장하기 전에 표시된 exclude 패턴 오류를 수정하세요"
+  "settings.exclude_patterns.err_save_blocked": "저장하기 전에 표시된 exclude 패턴 오류를 수정하세요",
+  "settings.reset.aria_label": "기본값으로 되돌리기",
+  "settings.reset.title": "기본값으로 되돌리기 (미리보기 — Save 를 눌러야 적용됨)"
 }

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -288,7 +288,17 @@ async function loadConfig() {
   show(loadingEl); hide(contentEl);
 
   try {
-    STATE.serverConfig = await api('GET', '/api/config');
+    // Fetch live config + comparand defaults in parallel. ``/config/defaults``
+    // returns the value each field would revert to if the user cleared their
+    // ``config.json`` override (defaults + env + fragments), powering the per-
+    // field ↺ button below. Missing it is non-fatal — reset buttons simply
+    // stay disabled.
+    const [live, defaults] = await Promise.all([
+      api('GET', '/api/config'),
+      api('GET', '/api/config/defaults').catch(() => null),
+    ]);
+    STATE.serverConfig = live;
+    STATE.serverDefaults = defaults;
     contentEl.innerHTML = '';
     _renderReloadBanner(STATE.serverConfig);
 
@@ -345,6 +355,18 @@ async function loadConfig() {
           td.appendChild(_buildConfigInput(section, key, val));
         }
         tr.appendChild(td);
+
+        // Reset-to-default button (↺): pre-fills the field with the comparand
+        // value so the user sees the new value before pressing Save. Skipped
+        // for read-only rows and when the comparand fetch failed.
+        const resetTd = document.createElement('td');
+        resetTd.className = 'config-reset';
+        if (!fieldReadonly && STATE.serverDefaults) {
+          const btn = _buildResetButton(section, key);
+          if (btn) resetTd.appendChild(btn);
+        }
+        tr.appendChild(resetTd);
+
         table.appendChild(tr);
       });
 
@@ -696,7 +718,22 @@ function _buildRRFWeightsWidget(section, key, val) {
   });
   wrap.appendChild(hidden);
 
+  // Reset-to-default hook for the ↺ button (comparandVal = [bm25W, denseW]).
+  // Projects the weights back onto the 0..100 slider, updates the display
+  // and the ``_saveSection``-backing hidden input.
+  hidden._reset = (comparandVal) => _resetRRFWeights(comparandVal, slider, hidden, updateDisplay);
+
   return wrap;
+}
+
+function _resetRRFWeights(comparandVal, slider, hidden, updateDisplay) {
+  const bW = Array.isArray(comparandVal) ? Number(comparandVal[0]) : 1.0;
+  const dW = Array.isArray(comparandVal) ? Number(comparandVal[1]) : 1.0;
+  const total = bW + dW || 2;
+  const pct = Math.round((dW / total) * 100);
+  slider.value = String(pct);
+  updateDisplay(pct);
+  hidden.value = `${bW}, ${dW}`;
 }
 
 function _buildExcludePatternsWidget(section, key, val) {
@@ -804,6 +841,11 @@ function _buildExcludePatternsWidget(section, key, val) {
 
   userPatterns.forEach(p => _addRow(p));
 
+  // Reset-to-default hook for the ↺ button (comparandVal = string[] of user
+  // patterns — typically ``[]`` for a fresh install). Clears all rows and
+  // rebuilds from the comparand so validation + sync state stay consistent.
+  hidden._reset = (comparandVal) => _resetExcludePatterns(comparandVal, listEl, _addRow, _syncHidden);
+
   _fetchBuiltinExcludePatterns().then(data => {
     const builtinList = builtinBlock.querySelector('.exclude-builtin-list');
     builtinList.removeAttribute('aria-busy');
@@ -826,6 +868,13 @@ function _buildExcludePatternsWidget(section, key, val) {
   if (typeof I18N !== 'undefined') I18N.applyDOM();
 
   return wrap;
+}
+
+function _resetExcludePatterns(comparandVal, listEl, addRow, syncHidden) {
+  while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
+  const patterns = Array.isArray(comparandVal) ? comparandVal : [];
+  patterns.forEach(p => addRow(p));
+  syncHidden();
 }
 
 function _buildConfigInput(section, key, val) {
@@ -913,6 +962,114 @@ function _buildConfigInput(section, key, val) {
 function _markConfigDirty(section) {
   const btn = document.querySelector(`.config-save-btn[data-section="${section}"]`);
   if (btn) btn.disabled = false;
+  // Keep each row's ↺ button in sync with the live value: disabled when
+  // the current value already matches the comparand (nothing to reset).
+  _refreshResetButtons(section);
+}
+
+// ── Reset-to-default (↺) ──────────────────────────────────────────────────
+//
+// Each editable row gets a ↺ button that pre-fills the field with the
+// comparand value (``GET /api/config/defaults`` — defaults + env +
+// ``config.d/`` fragments). The user still has to press Save; after save,
+// ``save_config_overrides`` drops the entry because it now equals the
+// comparand, so env/fragment values continue to flow through.
+//
+// Deliberately *not* an auto-PATCH: same-section dirty edits stay safe, and
+// the user previews the value before committing.
+
+function _resolveComparand(section, key) {
+  const defaults = STATE.serverDefaults;
+  if (!defaults) return undefined;
+  const sec = defaults[section];
+  if (!sec || typeof sec !== 'object') return undefined;
+  return sec[key];
+}
+
+function _valuesEqual(a, b) {
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+  return a === b;
+}
+
+function _currentInputValue(input) {
+  if (!input) return undefined;
+  if (input.type === 'checkbox') return input.checked;
+  if (input.type === 'number') return parseFloat(input.value);
+  if (input.dataset.valType === 'json') {
+    try { return JSON.parse(input.value); } catch { return input.value; }
+  }
+  if (input.dataset.valType === 'array') {
+    return input.value.split(',').map(s => {
+      const n = parseFloat(s.trim());
+      return isNaN(n) ? s.trim() : n;
+    });
+  }
+  return input.value;
+}
+
+function _buildResetButton(section, key) {
+  const comparand = _resolveComparand(section, key);
+  if (comparand === undefined) return null;
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'btn-ghost btn-sm config-reset-btn';
+  btn.dataset.section = section;
+  btn.dataset.key = key;
+  btn.textContent = '↺';
+  btn.setAttribute('aria-label', t('settings.reset.aria_label'));
+  btn.title = t('settings.reset.title');
+  btn.addEventListener('click', () => _resetField(section, key));
+  // Initial disabled state: computed after the input is in the DOM.
+  queueMicrotask(() => _updateResetButton(btn));
+  return btn;
+}
+
+function _findFieldInput(section, key) {
+  const card = document.querySelector(`.config-card[data-section="${section}"]`);
+  if (!card) return null;
+  return card.querySelector(
+    `input[data-section="${section}"][data-key="${key}"],` +
+    `select[data-section="${section}"][data-key="${key}"]`
+  );
+}
+
+function _updateResetButton(btn) {
+  const section = btn.dataset.section;
+  const key = btn.dataset.key;
+  const comparand = _resolveComparand(section, key);
+  if (comparand === undefined) { btn.disabled = true; return; }
+  const input = _findFieldInput(section, key);
+  if (!input) { btn.disabled = true; return; }
+  btn.disabled = _valuesEqual(_currentInputValue(input), comparand);
+}
+
+function _refreshResetButtons(section) {
+  const card = document.querySelector(`.config-card[data-section="${section}"]`);
+  if (!card) return;
+  card.querySelectorAll('.config-reset-btn').forEach(_updateResetButton);
+}
+
+function _resetField(section, key) {
+  const comparand = _resolveComparand(section, key);
+  if (comparand === undefined) return;
+  const input = _findFieldInput(section, key);
+  if (!input) return;
+
+  // Custom widgets opt in by attaching ``_reset`` to their hidden input.
+  if (typeof input._reset === 'function') {
+    input._reset(comparand);
+  } else if (input.type === 'checkbox') {
+    input.checked = Boolean(comparand);
+  } else if (Array.isArray(comparand) && input.dataset.valType === 'array') {
+    input.value = comparand.join(', ');
+  } else {
+    input.value = String(comparand);
+  }
+  _markConfigDirty(section);
 }
 
 async function _saveSection(section) {
@@ -968,7 +1125,12 @@ async function _saveSection(section) {
       showToast(`${resp.applied.length} settings updated`, 'success');
       resp.applied.forEach(c => {
         const [sec, key] = c.field.split('.');
-        const inp = document.getElementById(`cfg-${sec}-${key}`);
+        // Use dataset-based lookup (covers both regular inputs and the
+        // hidden inputs of custom widgets, which don't set ``id``). Falling
+        // back to ``getElementById`` here would leave custom-widget
+        // ``dataset.original`` stale across saves — the next ↺+Save cycle
+        // would see current === original and silently skip the patch.
+        const inp = _findFieldInput(sec, key);
         if (inp) inp.dataset.original = inp.type === 'checkbox' ? String(inp.checked) : inp.value;
       });
       // Re-sync all UI from updated config

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -936,6 +936,14 @@ button:active { opacity: 0.7; }
   border-radius: 4px; font-size: 0.84rem; box-sizing: border-box;
 }
 .config-table input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); }
+.config-reset { width: 28px; padding-left: 6px; text-align: center; }
+.config-reset-btn {
+  min-width: 24px; padding: 2px 6px; font-size: 0.9rem; line-height: 1;
+  color: var(--muted); background: transparent; border: 1px solid transparent;
+  border-radius: 4px; cursor: pointer;
+}
+.config-reset-btn:hover:not(:disabled) { color: var(--accent); border-color: var(--border); }
+.config-reset-btn:disabled { opacity: 0.25; cursor: default; }
 .config-select-hint { font-size: 0.72rem; color: var(--muted); margin-top: 3px; line-height: 1.3; }
 .rrf-weights-widget { display: flex; flex-direction: column; gap: 4px; }
 .rrf-balance-labels { display: flex; justify-content: space-between; font-size: 0.72rem; color: var(--muted); }

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -397,7 +397,7 @@ class TestSaveConfigOverrides:
     def isolated(self, tmp_path, monkeypatch):
         """Isolate both config.json and config.d/ to tmp_path.
 
-        Without this, ``_build_comparand`` reads the developer's real
+        Without this, ``build_comparand`` reads the developer's real
         ``~/.memtomem/config.d/`` fragments during tests, producing
         per-machine comparand differences that mask the intended behavior.
         """
@@ -666,18 +666,18 @@ class TestSaveConfigOverrides:
         assert "memory_dirs" not in data2.get("indexing", {})
 
     def test_comparand_build_suppresses_warnings(self, isolated, caplog):
-        """_build_comparand(quiet=True) must not emit WARNING-level logs
+        """build_comparand(quiet=True) must not emit WARNING-level logs
         for malformed fragments. Without this, every save on a machine
         with any malformed fragment prints the same warning repeatedly."""
         import logging
 
-        from memtomem.config import _build_comparand
+        from memtomem.config import build_comparand
 
         # Malformed fragment that would normally warn on each load.
         (isolated["config_d"] / "bad.json").write_text('{"unknown_section": {"foo": 1}}')
 
         caplog.set_level(logging.WARNING, logger="memtomem.config")
-        _build_comparand(quiet=True)
+        build_comparand(quiet=True)
         assert not caplog.records, (
             f"comparand build should not emit warnings; got {[r.message for r in caplog.records]}"
         )

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -298,6 +298,61 @@ class TestConfig:
         # Sample a known built-in secret pattern to detect silent removals.
         assert any(p.endswith("/id_rsa*") for p in data["secret"])
 
+    async def test_config_defaults_returns_comparand(self, client: AsyncClient):
+        """GET /api/config/defaults returns the comparand config shape.
+
+        The endpoint must pull from ``build_comparand`` (defaults + env +
+        fragments), not ``app.state.config`` — otherwise the Web UI reset
+        button would "reset" to the pinned value, i.e. do nothing.
+        """
+        from memtomem.config import Mem2MemConfig
+
+        # Construct a comparand with a non-default value so we can tell it
+        # apart from app.state.config (which has FakeConfig mmr.enabled=False).
+        fake_comparand = Mem2MemConfig()
+        fake_comparand.mmr.enabled = True
+        fake_comparand.search.default_top_k = 25
+
+        with patch("memtomem.web.routes.system.build_comparand", return_value=fake_comparand):
+            resp = await client.get("/api/config/defaults")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # Shape matches ConfigResponse (same as GET /api/config).
+        assert set(data.keys()) >= {
+            "embedding",
+            "storage",
+            "search",
+            "indexing",
+            "decay",
+            "mmr",
+            "namespace",
+        }
+        # Comparand values come through, not app.state.config values.
+        assert data["mmr"]["enabled"] is True
+        assert data["search"]["default_top_k"] == 25
+
+    async def test_config_defaults_independent_of_live_config(self, app, client: AsyncClient):
+        """Live config mutations must not leak into /config/defaults.
+
+        Regression guard: if the endpoint ever accidentally reads
+        ``app.state.config``, this test fails because the fake comparand
+        would report the mutated value.
+        """
+        from memtomem.config import Mem2MemConfig
+
+        fake_comparand = Mem2MemConfig()
+        fake_comparand.search.default_top_k = 7
+
+        # Mutate live config to a distinct value.
+        app.state.config.search.default_top_k = 999
+
+        with patch("memtomem.web.routes.system.build_comparand", return_value=fake_comparand):
+            resp = await client.get("/api/config/defaults")
+
+        assert resp.status_code == 200
+        assert resp.json()["search"]["default_top_k"] == 7
+
     async def test_patch_exclude_patterns_accepts_valid(self, app, client: AsyncClient):
         with patch("memtomem.web.routes.system.save_config_overrides"):
             resp = await client.patch(


### PR DESCRIPTION
## Summary

- New `GET /api/config/defaults` endpoint returns the comparand (defaults + env + `config.d/` fragments + factories) as the existing `ConfigResponse` shape. Same helper (`build_comparand`, promoted from `_build_comparand`) that the server already uses for delta-only save, so ↺ + Save cleanly drops the `config.json` pin via `save_config_overrides`.
- `↺` button on each editable row in the Settings → Config tab, with per-widget reset helpers for RRF weights and exclude patterns. Preview-only: the user still has to press Save — no auto-PATCH, no surprise wipes of in-flight edits in the same section.
- Closes the last Web UI gap from the #256 / #258 / #259 / #262 silent-policy chain. Server already auto-prunes defaults on save and `mm config unset` covers the CLI path; this finishes the UX story for users who don't know what the default value is.

## Why

The server drops pinned-equal-to-default fields on every save (#256 + #258), but that only helps if the user already typed the default value. Before this PR there was no way to *find out* what the default is from the UI — the ↺ button pre-fills the field so Save can then drop it.

Comparand semantics: ↺ restores "the value that would apply if `config.json` didn't pin this field", not "pristine code default". If `MEMTOMEM_MMR__ENABLED=true` is in env, ↺ shows `true` and Save drops the pin; the env value continues to flow through. This matches `save_config_overrides` exactly.

## Notable

- `_build_comparand` → `build_comparand` rename. Now read by two consumers (save path + defaults endpoint); the underscore was misleading and would have been fair game to break.
- Post-save `dataset.original` sync moved from `getElementById('cfg-${sec}-${key}')` to dataset-based lookup. Custom-widget hidden inputs don't carry an `id`, so the old lookup missed them and a second ↺+Save cycle in the same session would silently skip the patch. Caught during smoke testing.

## Scope out

- Section-level "reset all" button — per-field is enough and safer.
- `memory_dirs` reset — already managed via dedicated `/memory-dirs/add|remove` endpoints + rendered read-only.
- Row-level dirty indicator — repo has no existing pattern; not adding one here.

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` pass
- [x] `uv run pytest -m "not ollama"` — 1738 passed, 0 regression
- [x] New backend tests: `test_config_defaults_returns_comparand`, `test_config_defaults_independent_of_live_config`
- [x] Manual smoke (isolated worktree + `HOME=` override per `feedback_wizard_smoke_home_override.md`):
  - `mmr.enabled` — toggle → Save → ↺ → Save → `mmr` section dropped from `config.json`
  - `search.default_top_k` — 10 → 25 → Save → ↺ shows 10 → Save → `search` section dropped
  - RRF weights slider — drag → Save → ↺ → slider snaps to `Balanced (1:1)` → Save → `search.rrf_weights` dropped
  - Exclude patterns widget — add `**/*.log` → Save → ↺ clears user rows → Save → `indexing.exclude_patterns` dropped
  - ↺ correctly disabled when current value equals comparand

🤖 Generated with [Claude Code](https://claude.com/claude-code)