### PR TITLE
fix(web): mirror CAS guard on reload_if_stale error branch (closes #273)

### DIFF
--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -236,8 +236,14 @@ def reload_if_stale(
             ),
         )
         # Update the signature we've seen so we don't re-try on every hit;
-        # we only retry once disk mtime changes again.
-        _set_last_signature(app, sig)
+        # we only retry once disk mtime changes again. Mirror of the
+        # success-path CAS (#269 / issue #273): if a writer's
+        # commit_writer_signature landed while _build_fresh_config was
+        # failing, don't revert their bump — their view is strictly fresher
+        # than the one we just failed to rebuild, and their signature will
+        # satisfy the stale check on the next read.
+        if _get_last_signature(app) == last:
+            _set_last_signature(app, sig)
         return False
 
     # Compare-and-swap: while we were in _build_fresh_config (file I/O, can

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -522,6 +522,77 @@ def test_reload_if_stale_cas_yields_to_concurrent_writer_bump(
 
 
 # ---------------------------------------------------------------------------
+# Test 10 — V2 error-branch mirror CAS (issue #273)
+# ---------------------------------------------------------------------------
+
+
+def test_reload_if_stale_error_branch_cas_yields_to_concurrent_writer_bump(
+    home: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Issue #273: the lock-free reader's *error* branch had the same
+    structural race as the success branch (#268 / #269). If
+    ``_build_fresh_config`` raises after a writer landed its
+    ``commit_writer_signature`` bump, the pre-fix code would overwrite the
+    writer's signature with the older ``sig`` observed at entry, forcing a
+    spurious re-reload on the next GET from identical disk state.
+
+    Proof: hook ``_build_fresh_config`` so that *between* its call and its
+    raise, a simulated writer updates ``app.state.config_signature``.
+    Without CAS, the error branch would assign the reader-side ``sig``,
+    clobbering the writer's bump. With CAS, it detects the advance and
+    returns ``False`` leaving writer_sig intact.
+
+    Direct unit-level construction (no HTTP / no asyncio) keeps the race
+    window deterministic — same rationale as Test 9.
+    """
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    _write_config(home, {"mmr": {"enabled": False}, "search": {"default_top_k": 10}})
+
+    # Baseline reader-visible state.
+    app.state.config = _hot_reload._build_fresh_config()
+    app.state.config_signature = _hot_reload.current_signature()
+    app.state.last_reload_error = None
+
+    sig_before = app.state.config_signature
+
+    # External disk edit bumps current_signature() past sig_before so
+    # reload_if_stale enters the rebuild branch.
+    _write_config(home, {"mmr": {"enabled": True}, "search": {"default_top_k": 10}})
+
+    # Simulate "writer committed inside _config_lock while we were inside
+    # _build_fresh_config" — then raise so we land in the error branch.
+    writer_sig: _hot_reload.Signature | None = None
+
+    def build_and_interleave_writer_then_raise() -> Any:
+        nonlocal writer_sig
+        _write_config(home, {"mmr": {"enabled": True}, "search": {"default_top_k": 99}})
+        _hot_reload.commit_writer_signature(app)
+        writer_sig = app.state.config_signature
+        raise ValueError("simulated build failure")
+
+    monkeypatch.setattr(_hot_reload, "_build_fresh_config", build_and_interleave_writer_then_raise)
+
+    swapped = _hot_reload.reload_if_stale(app)
+
+    # Error branch fires but CAS guard leaves writer's signature intact.
+    assert swapped is False
+    assert app.state.config_signature == writer_sig, (
+        "writer's signature was overwritten by the reader's error-branch tail"
+    )
+    # The reader legitimately hit a build failure, so the banner is set.
+    # It will self-clear on the next GET once disk mtime differs from
+    # err.at_mtime_ns (see the signature-match branch of reload_if_stale).
+    err = _hot_reload.get_reload_error(app)
+    assert err is not None
+    assert "simulated build failure" in err.message
+    # And the writer's signature must differ from what the reader observed
+    # at entry — otherwise there was no race to defend against.
+    assert writer_sig != sig_before
+
+
+# ---------------------------------------------------------------------------
 # Unit tests for the helper itself
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Follow-up to PR #269: the **error branch** of `reload_if_stale` had the same structural race as the success branch — a concurrent writer's `commit_writer_signature` bump could be overwritten by the reader's tail `_set_last_signature(app, sig)` if `_build_fresh_config` raised mid-reader.
- Mirror the #269 3-line compare-and-swap inside the `except` block: only pin our observed `sig` when no writer has advanced the signature.
- +8 prod lines (3 logic + 5 comment) · +71 test lines · 1 new test (Test 10 in the bridge memo numbering).

## Race being closed

1. Reader enters, `last = _get_last_signature(app)` → `sig_T1` (disk broken).
2. Writer lands inside `_config_lock`, calls `commit_writer_signature()` → signature = `sig_T2`.
3. Reader's already-inflight `_build_fresh_config()` raises on the pre-fix disk snapshot.
4. Error branch records `ReloadError` and (pre-fix) unconditionally calls `_set_last_signature(app, sig_T1)` — reverting writer's `sig_T2` bump.
5. Next GET: signature mismatch → spurious re-reload from identical disk state.

Worst case is identical to #268 / PR #269: one wasted next-GET file read, no data loss, no corruption.

## Why `_set_reload_error` stays outside the guard

The reader genuinely hit a `_build_fresh_config` failure on the snapshot it saw — the banner should surface. If the writer's write actually repaired disk, the error self-clears on the next GET via the existing signature-match branch check:

```python
if err is not None and err.at_mtime_ns != get_config_mtime_ns():
    _set_reload_error(app, None)
```

Keeping the error write unguarded also matches the inverted sense the issue body called out: we *want* the error surface, we just don't want to regress a writer's signature pin.

## Test plan

- [x] New unit test `test_reload_if_stale_error_branch_cas_yields_to_concurrent_writer_bump` — monkeypatches `_build_fresh_config` to (a) advance signature via `commit_writer_signature`, then (b) raise. Asserts writer's signature survives and the `ReloadError` banner is set.
- [x] **Negative-tested**: stashing the `if _get_last_signature(app) == last:` guard flips the test to FAIL (the `assert app.state.config_signature == writer_sig` line). Per `feedback_sync_sleep_in_async_test_deadlock.md`, unit-level construction — no asyncio, no HTTP — keeps the race window deterministic.
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] `uv run mypy packages/memtomem/src` — 0 errors.
- [x] Full suite: **1743 passed**, 46 deselected (ollama), 0 regressions. +1 test vs. post-#269 baseline of 1742.

Closes #273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)