### PR TITLE
fix(wizard): clarify .mcp.json scope + add per-editor paste hints

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -351,10 +351,28 @@ def _step_mcp(state: dict) -> None:
     step_header(9, "Connect to AI Editor")
     click.echo("  How do you want to connect memtomem?")
     click.echo("    [1] Claude Code (run 'claude mcp add' automatically)")
-    click.echo("    [2] Generate .mcp.json (for Cursor, Windsurf, etc.)")
+    click.echo("    [2] Generate .mcp.json here (Claude Code project scope;")
+    click.echo("        copy into your editor's config file for Cursor / Windsurf / others)")
     click.echo("    [3] Skip — I'll configure it manually")
     state["mcp_choice"] = nav_prompt("  Select", type=click.IntRange(1, 3), default=1)
     click.echo()
+
+
+def _emit_mcp_paste_hints() -> None:
+    """Print per-editor paste targets for the generated ``.mcp.json``.
+
+    Claude Code auto-loads a project-root ``.mcp.json``; other editors do not
+    and expect their own config file. Shown after every path that writes the
+    file so users know the generated JSON is a template, not a drop-in config
+    for Cursor/Windsurf/Claude Desktop/Gemini CLI."""
+    click.echo("    Cursor          → paste into ~/.cursor/mcp.json")
+    click.echo("    Windsurf        → paste into ~/.codeium/windsurf/mcp_config.json")
+    click.echo(
+        "    Claude Desktop  → paste into "
+        "~/Library/Application Support/Claude/claude_desktop_config.json"
+    )
+    click.echo("    Gemini CLI      → paste into ~/.gemini/settings.json")
+    click.echo("  (Claude Code picks up ./.mcp.json in this project automatically.)")
 
 
 # ── Write config & summary ────────────────────────────────────────────
@@ -755,14 +773,17 @@ def _write_config_and_summary(
             else:
                 click.echo("  Claude Code: 'claude' not found. Use .mcp.json instead.")
                 _write_mcp_json(server_cmd, server_args, mcp_env)
-                click.echo("  MCP config: .mcp.json")
+                click.echo("  MCP config: wrote ./.mcp.json")
+                _emit_mcp_paste_hints()
         except (FileNotFoundError, subprocess.TimeoutExpired):
             click.echo("  Claude Code: 'claude' not found. Use .mcp.json instead.")
             _write_mcp_json(server_cmd, server_args, mcp_env)
-            click.echo("  MCP config: .mcp.json")
+            click.echo("  MCP config: wrote ./.mcp.json")
+            _emit_mcp_paste_hints()
     elif mcp_choice == 2:
         _write_mcp_json(server_cmd, server_args, mcp_env)
-        click.echo("  MCP config: .mcp.json")
+        click.echo("  MCP config: wrote ./.mcp.json")
+        _emit_mcp_paste_hints()
 
     # Summary
     click.echo()

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -753,6 +753,84 @@ class TestFreshFlag:
         assert not orphans, f"orphan tmp file(s) after failed atomic write: {orphans}"
 
 
+class TestMcpPasteHints:
+    """The wizard's MCP step writes a Claude-Code-scoped ``.mcp.json`` and must
+    surface what the user still has to do for Cursor / Windsurf / Claude
+    Desktop / Gemini CLI (none of which auto-load the project file).
+
+    Regression for #246: earlier wording implied ``.mcp.json`` is the config
+    file for those editors, which it isn't — each has its own canonical path."""
+
+    def test_choice_2_emits_per_editor_paste_hints(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+
+        state = _make_init_state(tmp_path)
+        state["mcp_choice"] = 2
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "MCP config: wrote ./.mcp.json" in out
+        assert "Cursor" in out and "~/.cursor/mcp.json" in out
+        assert "Windsurf" in out and "~/.codeium/windsurf/mcp_config.json" in out
+        assert "Claude Desktop" in out
+        assert "Library/Application Support/Claude/claude_desktop_config.json" in out
+        assert "Gemini CLI" in out and "~/.gemini/settings.json" in out
+        assert "Claude Code picks up ./.mcp.json in this project automatically" in out
+
+    def test_choice_3_skip_emits_no_hints(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Skipping MCP setup must not print paste hints — there's no file
+        yet for the user to paste."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)  # mcp_choice = 3 by default
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "MCP config:" not in out
+        assert "~/.cursor/mcp.json" not in out
+
+    def test_step_mcp_menu_does_not_imply_autoload(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The ``[2]`` menu line must scope ``.mcp.json`` to Claude Code and
+        frame other editors as "copy into". The old "(for Cursor, Windsurf,
+        etc.)" wording implied auto-compat and is explicitly ruled out."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _step_mcp
+
+        # Stub the interactive prompt so the menu renders without stdin.
+        monkeypatch.setattr("memtomem.cli.init_cmd.nav_prompt", lambda *a, **kw: 3)
+
+        state: dict = {}
+        _step_mcp(state)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "(for Cursor, Windsurf, etc.)" not in out, "old auto-compat wording leaked back in"
+        assert "Claude Code project scope" in out
+        assert "copy into your editor's config file" in out
+
+
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be
     encoded as a JSON array string. A bare path crashes pydantic-settings.


### PR DESCRIPTION
## Summary

- Reword the `mm init` wizard `[2]` menu line so it no longer implies Cursor / Windsurf / Claude Desktop / Gemini CLI auto-load a project-root `.mcp.json` — it's Claude Code's project-scope file; other editors expect their own canonical path.
- Add `_emit_mcp_paste_hints()` after every `_write_mcp_json` call site so users see where to paste the generated block for each non-Claude-Code editor.
- No on-disk behavior change — `_write_mcp_json` still writes `./.mcp.json`.

Closes #246.

## Before / after

**Menu (`_step_mcp`):**

Before:
```
    [2] Generate .mcp.json (for Cursor, Windsurf, etc.)
```

After:
```
    [2] Generate .mcp.json here (Claude Code project scope;
        copy into your editor's config file for Cursor / Windsurf / others)
```

**After `_write_mcp_json`** (choice 2 or Claude-CLI fallback):

```
  MCP config: wrote ./.mcp.json
    Cursor          → paste into ~/.cursor/mcp.json
    Windsurf        → paste into ~/.codeium/windsurf/mcp_config.json
    Claude Desktop  → paste into ~/Library/Application Support/Claude/claude_desktop_config.json
    Gemini CLI      → paste into ~/.gemini/settings.json
  (Claude Code picks up ./.mcp.json in this project automatically.)
```

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py` — 37 pass (3 new in `TestMcpPasteHints`)
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 1746 pass, 0 regression
- [x] `uv run ruff check && uv run ruff format --check` — green
- [ ] Follow-up (not in this PR): Option B — prompt for target editor and write directly to its native config path. Issue #246 explicitly scopes that to a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
