### PR TITLE
feat(config): add indexing.auto_discover flag to opt out of well-known dir auto-discovery (refs #260)

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -314,6 +314,13 @@ override `memory_dirs` manually. This means `mem_index` and the file
 watcher accept paths under these directories without requiring explicit
 `MEMORY_DIRS` configuration.
 
+To opt out of auto-discovery entirely, set `indexing.auto_discover = false`
+in `config.json` or export `MEMTOMEM_INDEXING__AUTO_DISCOVER=false`. When
+disabled, only the `memory_dirs` you configure explicitly are indexed — the
+three well-known directories above are ignored even if they exist on disk.
+You can also toggle this per-field from the Web UI or via
+`mm config set indexing.auto_discover false`.
+
 > **Tip:** Use `mm ingest claude-memory`, `mm ingest gemini-memory`, or
 > `mm ingest codex-memory` for richer ingestion with per-tool tagging and
 > namespace assignment. Auto-discovery only removes the path restriction —

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -118,11 +118,14 @@ class SearchConfig(BaseSettings):
 
 
 def _default_memory_dirs() -> list[Path]:
-    """Build default memory_dirs, auto-discovering well-known AI tool directories."""
-    dirs: list[Path] = [Path("~/.memtomem/memories")]
-    for d in _auto_discovered_memory_dirs():
-        dirs.append(d)
-    return dirs
+    """Build default memory_dirs.
+
+    Only the single canonical user dir ``~/.memtomem/memories`` is returned
+    here; auto-discovery of well-known AI tool directories is applied
+    separately by :func:`ensure_auto_discovered_dirs` so that the
+    ``indexing.auto_discover`` flag has a single gate point.
+    """
+    return [Path("~/.memtomem/memories")]
 
 
 class IndexingConfig(BaseSettings):
@@ -152,6 +155,7 @@ class IndexingConfig(BaseSettings):
     structured_chunk_mode: str = "original"  # "original" or "recursive"
     paragraph_split_threshold: int = 800  # split long prose into paragraphs above this token count
     exclude_patterns: Annotated[list[str], APPEND] = Field(default_factory=list)
+    auto_discover: bool = True
 
     @field_validator(
         "max_chunk_tokens",
@@ -499,6 +503,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
         "chunk_overlap_tokens",
         "structured_chunk_mode",
         "exclude_patterns",
+        "auto_discover",
     },
     "embedding": {"batch_size"},
     "decay": {"enabled", "half_life_days"},
@@ -524,6 +529,7 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
         "item_type": str,
         "validator": _validate_exclude_patterns,
     },
+    "indexing.auto_discover": {"type": bool},
     "embedding.batch_size": {"type": int, "min": 1, "max": 1024},
     "decay.enabled": {"type": bool},
     "decay.half_life_days": {"type": float, "min": 0.1},
@@ -927,7 +933,13 @@ def ensure_auto_discovered_dirs(config: Mem2MemConfig) -> None:
 
     Call *after* ``load_config_overrides`` so that user overrides don't
     suppress auto-discovery of AI tool directories like ``~/.claude/projects``.
+
+    Users can opt out entirely by setting ``indexing.auto_discover = false`` in
+    ``config.json`` or exporting ``MEMTOMEM_INDEXING__AUTO_DISCOVER=false``.
+    When disabled, the caller's explicit ``memory_dirs`` list is left untouched.
     """
+    if not config.indexing.auto_discover:
+        return
     existing = {Path(d).expanduser().resolve() for d in config.indexing.memory_dirs}
     for d in _auto_discovered_memory_dirs():
         resolved = d.expanduser().resolve()

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -392,3 +392,69 @@ def test_every_list_field_declares_merge_strategy() -> None:
         "type in Annotated[list[X], APPEND] or Annotated[list[X], REPLACE] "
         "in config.py:\n  - " + "\n  - ".join(missing)
     )
+
+
+# ---------------------------------------------------------------------------
+# indexing.auto_discover opt-out (issue #260 Option 0)
+#
+# Regression guards for the boolean flag that lets users disable auto-discovery
+# of well-known AI tool directories (`~/.claude/projects`, `~/.gemini`,
+# `~/.codex/memories`). Default is True (preserves legacy behavior); False
+# short-circuits ``ensure_auto_discovered_dirs`` to a no-op so the caller's
+# explicit ``memory_dirs`` list is the complete list.
+# ---------------------------------------------------------------------------
+
+
+def test_auto_discover_default_true_appends_dirs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+    cfg = Mem2MemConfig()
+    assert cfg.indexing.auto_discover is True
+    _cfg.ensure_auto_discovered_dirs(cfg)
+    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+    assert fake.resolve() in resolved
+
+
+def test_auto_discover_false_is_noop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+    cfg = Mem2MemConfig()
+    cfg.indexing.auto_discover = False
+    before = [str(p) for p in cfg.indexing.memory_dirs]
+    _cfg.ensure_auto_discovered_dirs(cfg)
+    after = [str(p) for p in cfg.indexing.memory_dirs]
+    assert before == after
+    assert str(fake) not in after
+
+
+def test_auto_discover_env_var_disables(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_INDEXING__AUTO_DISCOVER", "false")
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+    cfg = Mem2MemConfig()
+    assert cfg.indexing.auto_discover is False
+    _cfg.ensure_auto_discovered_dirs(cfg)
+    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+    assert fake.resolve() not in resolved
+
+
+def test_auto_discover_config_json_disables(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    override_path.write_text(json.dumps({"indexing": {"auto_discover": False}}), encoding="utf-8")
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert cfg.indexing.auto_discover is False
+    _cfg.ensure_auto_discovered_dirs(cfg)
+    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+    assert fake.resolve() not in resolved


### PR DESCRIPTION
## Summary

- Adds `IndexingConfig.auto_discover: bool = True`. Setting it to `false` (via `config.json`, `MEMTOMEM_INDEXING__AUTO_DISCOVER=false`, or `mm config set indexing.auto_discover false`) stops memtomem from appending `~/.claude/projects`, `~/.gemini`, and `~/.codex/memories` to `memory_dirs`.
- Consolidates auto-discovery: `_default_memory_dirs()` returns just `[~/.memtomem/memories]`; `ensure_auto_discovered_dirs()` is now the single gate the flag governs. All production entry points (server lifespan, CLI bootstrap, web app, LangGraph) already route through `create_components → ensure_auto_discovered_dirs`, so default-`True` behavior is preserved.
- Registers the field in `MUTABLE_FIELDS` + `FIELD_CONSTRAINTS` so `mm config set` and the Web UI config mutator both accept it.

## Scope

This is the **Option 0 safety valve** I proposed on the [#260 RFC](https://github.com/memtomem/memtomem/issues/260#issuecomment-4275013534). It does **not** prejudge the three structural options still open for community input (allowlist default, JIT consent, `memory_dirs` vs `watch_dirs` split) — the RFC stays open, this just gives headless / CI / security-conscious users an explicit opt-out today instead of asking them to uninstall the owning CLI or rebuild from source.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 1747 passed, 0 regressions.
- [x] `uv run ruff check` + `uv run ruff format --check` → clean.
- [x] `uv run mypy` (advisory) → Success, no issues.
- [x] New tests in `test_config_overrides.py`:
  - `test_auto_discover_default_true_appends_dirs` — default behavior preserved.
  - `test_auto_discover_false_is_noop` — flag disables `ensure_auto_discovered_dirs`.
  - `test_auto_discover_env_var_disables` — `MEMTOMEM_INDEXING__AUTO_DISCOVER=false` works.
  - `test_auto_discover_config_json_disables` — `config.json` `{"indexing": {"auto_discover": false}}` works.
- [ ] (Optional follow-up, not in this PR) Web UI surface for the flag in the Config tab — the mutation path is already wired, but a dedicated widget with a clear label would help discoverability.

## Out of scope

- The structural direction for #260 (Options 1 / 2 / 3) — still open.
- The Web UI silent-restoration trap on `/memory-dirs/remove` — separate concern flagged in the #260 maintainer comment; fix belongs in its own PR.
- Changes to the built-in denylist contents or `indexing.exclude_patterns` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
