### PR TITLE
harden(context): atomic writes + name validation (closes #275, closes #276)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -1,0 +1,58 @@
+"""Atomic write primitives for context-gateway fan-out targets.
+
+A crash, SIGKILL, or OOM between the truncate and the flush of a plain
+``Path.write_text`` leaves the target file empty or half-written — which, for
+``~/.claude/settings.json`` or ``.claude/agents/<name>.md``, reloads on the
+next runtime start as "no hooks / no agents configured". Every gateway write
+site funnels through the helpers in this module so the worst a crash can do
+is leave a ``.<name>.*.tmp`` sibling that the next successful write will
+overwrite.
+
+The pattern is ``tempfile.mkstemp`` in the same directory + ``os.replace``,
+which is an atomic rename on POSIX and Windows.
+
+Threat model is **accidental** (crash / kill), not adversarial — the
+``context/`` package is the boundary where that hardening lives.
+
+See also: :func:`memtomem.config._atomic_write_json`, which predates this
+module and covers ``~/.memtomem/config.json`` specifically.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+__all__ = ["atomic_write_bytes", "atomic_write_text"]
+
+
+def atomic_write_bytes(path: Path, data: bytes, mode: int = 0o600) -> None:
+    """Atomically write *data* to *path* with an explicit file mode.
+
+    ``mode`` is applied via ``os.fchmod`` on the tempfile before the rename,
+    so the result is independent of the process umask.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        os.fchmod(tmp_fd, mode)
+        with os.fdopen(tmp_fd, "wb") as f:
+            f.write(data)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def atomic_write_text(
+    path: Path,
+    text: str,
+    mode: int = 0o600,
+    encoding: str = "utf-8",
+) -> None:
+    """Atomically write *text* to *path* with an explicit file mode."""
+    atomic_write_bytes(path, text.encode(encoding), mode=mode)

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -1,0 +1,66 @@
+"""Name validation for context-gateway agent/command/skill identifiers.
+
+The canonical ``name:`` frontmatter on agents and commands, and the directory
+name of a canonical skill, are interpolated into a target path such as
+``.claude/agents/<name>.md`` or ``~/.codex/agents/<name>.toml``. Without
+validation, ``name: ../../etc/passwd`` would escape the target root. The same
+field is also emitted to log lines, so CR/LF injection is a log-injection
+vector.
+
+Canonical files *can* be authored by the user directly, but they are also
+populated by reverse-import (``extract_agents_to_canonical``) and by MCP
+``mem_context_*`` tools whose arguments are LLM-driven — so prompt injection
+or plain model mistakes can produce hostile names even in single-user flows.
+
+Validation happens at the dataclass boundary: parsers raise on invalid
+input, and fan-out generators route those errors into ``SyncResult.skipped``
+rather than aborting.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+__all__ = ["InvalidNameError", "validate_name"]
+
+_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_MAX_LEN = 64
+
+
+class InvalidNameError(ValueError):
+    """Raised when a context-gateway name fails validation."""
+
+
+def validate_name(s: object, *, kind: str = "name") -> str:
+    """Return *s* unchanged if it is a valid context-gateway identifier.
+
+    Enforces:
+
+    * type is ``str``,
+    * non-empty after ``strip()``,
+    * ``1 <= len(s) <= 64``,
+    * matches ``^[A-Za-z0-9._-]+$`` (no slash, backslash, null, control chars),
+    * not ``"."`` or ``".."`` (path-traversal tokens allowed by the regex),
+    * does not start with ``-`` (would collide with CLI flag parsing),
+    * ``Path(s).name == s`` (belt-and-suspenders against platform-specific
+      path parsing on Windows / weird separators).
+    """
+    if not isinstance(s, str):
+        raise InvalidNameError(f"invalid {kind}: expected str, got {type(s).__name__}")
+    if not s or not s.strip():
+        raise InvalidNameError(f"invalid {kind} {s!r}: empty")
+    if len(s) > _MAX_LEN:
+        raise InvalidNameError(f"invalid {kind} {s!r}: length {len(s)} exceeds {_MAX_LEN}")
+    if s in (".", ".."):
+        raise InvalidNameError(f"invalid {kind} {s!r}: reserved path token")
+    if s.startswith("-"):
+        raise InvalidNameError(f"invalid {kind} {s!r}: leading dash")
+    if not _NAME_RE.fullmatch(s):
+        raise InvalidNameError(
+            f"invalid {kind} {s!r}: must match [A-Za-z0-9._-]+ "
+            f"(no slash / backslash / whitespace / control chars)"
+        )
+    if Path(s).name != s:
+        raise InvalidNameError(f"invalid {kind} {s!r}: contains path separator")
+    return s

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -32,6 +32,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._names import InvalidNameError, validate_name
+
 logger = logging.getLogger(__name__)
 
 CANONICAL_AGENT_ROOT = ".memtomem/agents"
@@ -166,9 +169,13 @@ def parse_canonical_agent(path: Path) -> SubAgent:
     body = content[m.end() :].lstrip("\n").rstrip() + "\n"
 
     name = frontmatter.get("name") or path.stem
+    try:
+        name = validate_name(str(name), kind="agent name")
+    except InvalidNameError as exc:
+        raise AgentParseError(f"{exc} (source: {path})") from exc
     description = frontmatter.get("description") or ""
     return SubAgent(
-        name=str(name),
+        name=name,
         description=str(description),
         body=body,
         tools=_coerce_list(frontmatter.get("tools")),
@@ -434,8 +441,7 @@ def generate_all_agents(
                 if effective_drop == "warn":
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
             out_path = gen.target_file(project_root, agent.name)
-            out_path.parent.mkdir(parents=True, exist_ok=True)
-            out_path.write_text(content, encoding="utf-8")
+            atomic_write_text(out_path, content)
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, agent.name, dropped_fields))
@@ -473,6 +479,16 @@ def extract_agents_to_canonical(
         runtime_label = runtime_dir.relative_to(project_root).as_posix()
         for md_file in sorted(runtime_dir.glob("*.md")):
             agent_name = md_file.stem
+            try:
+                validate_name(agent_name, kind="agent name")
+            except InvalidNameError as exc:
+                skipped.append((agent_name, f"invalid name: {exc}"))
+                logger.warning(
+                    "skip %r from %s: invalid name",
+                    agent_name,
+                    runtime_label,
+                )
+                continue
             if agent_name in seen:
                 reason = f"already imported from {seen[agent_name]}"
                 skipped.append((agent_name, reason))
@@ -485,8 +501,7 @@ def extract_agents_to_canonical(
                 logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
                 seen[agent_name] = runtime_label
                 continue
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            dst.write_bytes(md_file.read_bytes())
+            atomic_write_bytes(dst, md_file.read_bytes())
             imported.append(dst)
             seen[agent_name] = runtime_label
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -38,6 +38,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
@@ -76,12 +78,20 @@ def parse_canonical_command(path: Path) -> SlashCommand:
         # Commands without frontmatter are tolerated — treat the whole file
         # as the prompt body with a filename-derived name.
         body = content.lstrip("\n").rstrip() + "\n"
-        return SlashCommand(name=path.stem, description="", body=body)
+        try:
+            stem = validate_name(path.stem, kind="command name")
+        except InvalidNameError as exc:
+            raise CommandParseError(f"{exc} (source: {path})") from exc
+        return SlashCommand(name=stem, description="", body=body)
 
     frontmatter = _parse_flat_yaml(m.group(1))
     body = content[m.end() :].lstrip("\n").rstrip() + "\n"
 
     name = str(frontmatter.get("name") or path.stem)
+    try:
+        name = validate_name(name, kind="command name")
+    except InvalidNameError as exc:
+        raise CommandParseError(f"{exc} (source: {path})") from exc
     description = str(frontmatter.get("description") or "")
     argument_hint_raw = frontmatter.get("argument-hint") or frontmatter.get("argument_hint")
     allowed_tools_raw = frontmatter.get("allowed-tools") or frontmatter.get("allowed_tools")
@@ -308,8 +318,7 @@ def generate_all_commands(
                 if effective_drop == "warn":
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
             out_path = gen.target_file(project_root, cmd.name)
-            out_path.parent.mkdir(parents=True, exist_ok=True)
-            out_path.write_text(content, encoding="utf-8")
+            atomic_write_text(out_path, content)
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, cmd.name, dropped_fields))
@@ -366,6 +375,12 @@ def extract_commands_to_canonical(
     if claude_dir.is_dir():
         for md_file in sorted(claude_dir.glob("*.md")):
             cmd_name = md_file.stem
+            try:
+                validate_name(cmd_name, kind="command name")
+            except InvalidNameError as exc:
+                skipped.append((cmd_name, f"invalid name: {exc}"))
+                logger.warning("skip %r from .claude/commands: invalid name", cmd_name)
+                continue
             if cmd_name in seen:
                 reason = f"already imported from {seen[cmd_name]}"
                 skipped.append((cmd_name, reason))
@@ -378,8 +393,7 @@ def extract_commands_to_canonical(
                 logger.warning("skip %s from .claude/commands: %s", cmd_name, reason)
                 seen[cmd_name] = ".claude/commands"
                 continue
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            dst.write_bytes(md_file.read_bytes())
+            atomic_write_bytes(dst, md_file.read_bytes())
             imported.append(dst)
             seen[cmd_name] = ".claude/commands"
 
@@ -388,6 +402,12 @@ def extract_commands_to_canonical(
     if gemini_dir.is_dir():
         for toml_file in sorted(gemini_dir.glob("*.toml")):
             cmd_name = toml_file.stem
+            try:
+                validate_name(cmd_name, kind="command name")
+            except InvalidNameError as exc:
+                skipped.append((cmd_name, f"invalid name: {exc}"))
+                logger.warning("skip %r from .gemini/commands: invalid name", cmd_name)
+                continue
             if cmd_name in seen:
                 reason = f"already imported from {seen[cmd_name]}"
                 skipped.append((cmd_name, reason))
@@ -406,8 +426,7 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, "TOML parse error"))
                 logger.warning("skip %s from .gemini/commands: TOML parse error", cmd_name)
                 continue
-            dst.parent.mkdir(parents=True, exist_ok=True)
-            dst.write_text(canonical_content, encoding="utf-8")
+            atomic_write_text(dst, canonical_content)
             imported.append(dst)
             seen[cmd_name] = ".gemini/commands"
 

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+from memtomem.context._atomic import atomic_write_text
+
 logger = logging.getLogger(__name__)
 
 CANONICAL_SETTINGS_FILE = ".memtomem/settings.json"
@@ -204,12 +206,9 @@ def _read_with_mtime(path: Path) -> tuple[dict | None | object, float]:
 
 
 def _write_json(path: Path, data: dict) -> None:
-    """Write *data* as formatted JSON with trailing newline."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(data, indent=2, sort_keys=False, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
+    """Write *data* as formatted JSON with trailing newline (atomic)."""
+    payload = json.dumps(data, indent=2, sort_keys=False, ensure_ascii=False) + "\n"
+    atomic_write_text(path, payload, mode=0o600)
 
 
 # ── Fan-out: canonical → runtimes ───────────────────────────────────

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -24,6 +24,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+from memtomem.context._atomic import atomic_write_bytes
+from memtomem.context._names import InvalidNameError, validate_name
+
 logger = logging.getLogger(__name__)
 
 CANONICAL_SKILL_ROOT = ".memtomem/skills"
@@ -99,6 +102,9 @@ def list_canonical_skills(project_root: Path) -> list[Path]:
     A sub-directory only counts as a skill if it contains ``SKILL.md``. This
     mirrors Gemini CLI's discovery rule and lets users drop auxiliary folders
     next to real skills without them being mistaken for skills.
+
+    Skill directory names are validated; entries that fail
+    :func:`memtomem.context._names.validate_name` are skipped with a warning.
     """
     root = canonical_skills_root(project_root)
     if not root.is_dir():
@@ -106,6 +112,11 @@ def list_canonical_skills(project_root: Path) -> list[Path]:
     skills: list[Path] = []
     for entry in sorted(root.iterdir()):
         if entry.is_dir() and (entry / SKILL_MANIFEST).is_file():
+            try:
+                validate_name(entry.name, kind="skill name")
+            except InvalidNameError as exc:
+                logger.warning("skip canonical skill %r: invalid name (%s)", entry.name, exc)
+                continue
             skills.append(entry)
     return skills
 
@@ -121,6 +132,11 @@ def copy_skill(src: Path, dst: Path) -> None:
     that removed files on the source side propagate. If ``dst`` exists but
     does NOT look like a skill directory, the copy aborts with ``IsADirectoryError``
     to avoid clobbering something the user put there by hand.
+
+    Individual files are written atomically via
+    :func:`memtomem.context._atomic.atomic_write_bytes` so a crash mid-copy
+    leaves each file either fully-written or absent, never truncated.
+    Directory-level atomicity (the rmtree+mkdir window) is out of scope here.
     """
     manifest = src / SKILL_MANIFEST
     if not manifest.is_file():
@@ -138,11 +154,18 @@ def copy_skill(src: Path, dst: Path) -> None:
         shutil.rmtree(dst)
 
     dst.mkdir(parents=True)
+    _copy_tree_atomic(src, dst)
+
+
+def _copy_tree_atomic(src: Path, dst: Path) -> None:
+    """Recursively mirror *src* → *dst*, each file via atomic_write_bytes."""
+    dst.mkdir(parents=True, exist_ok=True)
     for entry in src.iterdir():
+        target = dst / entry.name
         if entry.is_file():
-            shutil.copy2(entry, dst / entry.name)
+            atomic_write_bytes(target, entry.read_bytes())
         elif entry.is_dir():
-            shutil.copytree(entry, dst / entry.name)
+            _copy_tree_atomic(entry, target)
 
 
 # ── Fan-out: canonical → runtimes ─────────────────────────────────────
@@ -222,6 +245,16 @@ def extract_skills_to_canonical(
     for detected in detect_skill_dirs(project_root):
         skill_name = detected.path.name
         runtime_label = detected.agent  # e.g. "claude_skills"
+        try:
+            validate_name(skill_name, kind="skill name")
+        except InvalidNameError as exc:
+            skipped.append((skill_name, f"invalid name: {exc}"))
+            logger.warning(
+                "skip %r from %s: invalid name",
+                skill_name,
+                runtime_label,
+            )
+            continue
         if skill_name in seen:
             reason = f"already imported from {seen[skill_name]}"
             skipped.append((skill_name, reason))

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -92,6 +92,27 @@ class TestParseCanonicalAgent:
         with pytest.raises(AgentParseError):
             parse_canonical_agent(p)
 
+    @pytest.mark.parametrize(
+        "hostile_name",
+        [
+            "../../evil",
+            "../escape",
+            "a/b",
+            "a\\b",
+            ".",
+            "..",
+            "-x",
+            "A" * 65,
+            "name with space",
+        ],
+    )
+    def test_rejects_hostile_name_in_frontmatter(self, tmp_path, hostile_name):
+        """#276: ``name:`` frontmatter must not land us outside the target dir."""
+        p = tmp_path / "hostile.md"
+        p.write_text(f"---\nname: {hostile_name}\ndescription: x\n---\n\nbody\n")
+        with pytest.raises(AgentParseError, match="invalid agent name"):
+            parse_canonical_agent(p)
+
     def test_block_list_syntax(self, tmp_path):
         p = tmp_path / "blocky.md"
         p.write_text(
@@ -289,6 +310,26 @@ class TestExtractAgentsToCanonical:
         (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n')
         result = extract_agents_to_canonical(tmp_path)
         assert result.imported == []
+
+    def test_skips_hostile_runtime_filename(self, tmp_path):
+        """#276: a runtime directory containing ``-x.md`` (leading dash) round-trips
+        into a canonical filename that validate_name rejects, so we skip rather
+        than produce a canonical file we'd refuse to read back."""
+        claude_dir = tmp_path / ".claude/agents"
+        claude_dir.mkdir(parents=True)
+        # File name with leading dash — unusual but filesystem-legal.
+        (claude_dir / "-bad.md").write_text(SAMPLE_MINIMAL_AGENT)
+        (claude_dir / "ok.md").write_text(SAMPLE_MINIMAL_AGENT)
+
+        result = extract_agents_to_canonical(tmp_path)
+
+        # Only "ok" imported; "-bad" skipped with invalid-name reason.
+        imported_names = sorted(p.stem for p in result.imported)
+        assert imported_names == ["ok"]
+        skipped_names = sorted(name for name, _ in result.skipped)
+        assert "-bad" in skipped_names
+        reason = dict(result.skipped)["-bad"]
+        assert "invalid name" in reason
 
 
 class TestDiffAgents:

--- a/packages/memtomem/tests/test_context_atomic.py
+++ b/packages/memtomem/tests/test_context_atomic.py
@@ -1,0 +1,135 @@
+"""Tests for memtomem.context._atomic — crash safety + explicit mode."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+
+
+def _list_tmp_siblings(path: Path) -> list[Path]:
+    """Tempfiles created by atomic_write live in path.parent with a `.<name>.` prefix."""
+    return sorted(p for p in path.parent.iterdir() if p.name.startswith(f".{path.name}."))
+
+
+def test_atomic_write_text_writes_content(tmp_path: Path) -> None:
+    target = tmp_path / "out.txt"
+    atomic_write_text(target, "hello world")
+    assert target.read_text(encoding="utf-8") == "hello world"
+
+
+def test_atomic_write_bytes_writes_content(tmp_path: Path) -> None:
+    target = tmp_path / "out.bin"
+    atomic_write_bytes(target, b"\x00\x01\x02raw")
+    assert target.read_bytes() == b"\x00\x01\x02raw"
+
+
+def test_atomic_write_creates_parent_dirs(tmp_path: Path) -> None:
+    target = tmp_path / "sub" / "deep" / "out.txt"
+    atomic_write_text(target, "nested")
+    assert target.read_text(encoding="utf-8") == "nested"
+
+
+def test_atomic_write_replaces_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "out.txt"
+    target.write_text("old", encoding="utf-8")
+    atomic_write_text(target, "new")
+    assert target.read_text(encoding="utf-8") == "new"
+
+
+def test_atomic_write_explicit_mode_0o600(tmp_path: Path) -> None:
+    """Mode is applied via fchmod — independent of process umask."""
+    target = tmp_path / "secret.json"
+    old_umask = os.umask(0o077)
+    try:
+        atomic_write_text(target, "{}")
+    finally:
+        os.umask(old_umask)
+
+    perms = stat.S_IMODE(target.stat().st_mode)
+    assert perms == 0o600, f"expected 0o600, got {oct(perms)}"
+
+
+def test_atomic_write_respects_custom_mode(tmp_path: Path) -> None:
+    target = tmp_path / "public.md"
+    atomic_write_text(target, "readable", mode=0o644)
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+
+def test_crash_between_open_and_replace_preserves_old(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If os.replace raises, the pre-existing file is untouched and no .tmp sibling remains."""
+    target = tmp_path / "settings.json"
+    target.write_text('{"original": true}', encoding="utf-8")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated crash mid-replace")
+
+    monkeypatch.setattr("memtomem.context._atomic.os.replace", _boom)
+
+    with pytest.raises(OSError, match="simulated crash"):
+        atomic_write_text(target, '{"new": true}')
+
+    assert target.read_text(encoding="utf-8") == '{"original": true}'
+    assert _list_tmp_siblings(target) == []
+
+
+def test_crash_mid_payload_preserves_old(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the tempfile write raises partway, target is unchanged and tempfile is cleaned."""
+    target = tmp_path / "settings.json"
+    target.write_text('{"original": true}', encoding="utf-8")
+
+    real_fdopen = os.fdopen
+
+    class _ExplodingFile:
+        def __init__(self, real_file: object) -> None:
+            self._real = real_file
+
+        def __enter__(self) -> "_ExplodingFile":
+            return self
+
+        def __exit__(self, *_a: object) -> None:
+            self._real.__exit__(None, None, None)  # type: ignore[attr-defined]
+
+        def write(self, _data: bytes) -> int:
+            raise OSError("simulated mid-write crash")
+
+        def flush(self) -> None:
+            pass
+
+        def fileno(self) -> int:
+            return self._real.fileno()  # type: ignore[attr-defined]
+
+    def _fake_fdopen(fd: int, mode: str, **kwargs: object) -> _ExplodingFile:
+        return _ExplodingFile(real_fdopen(fd, mode, **kwargs))
+
+    monkeypatch.setattr("memtomem.context._atomic.os.fdopen", _fake_fdopen)
+
+    with pytest.raises(OSError, match="simulated mid-write"):
+        atomic_write_text(target, '{"new": true}')
+
+    assert target.read_text(encoding="utf-8") == '{"original": true}'
+    assert _list_tmp_siblings(target) == []
+
+
+def test_crash_with_no_preexisting_target_cleans_tempfile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When target does not exist yet, a crash mid-write still cleans up the tempfile."""
+    target = tmp_path / "never-written.json"
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise OSError("simulated")
+
+    monkeypatch.setattr("memtomem.context._atomic.os.replace", _boom)
+
+    with pytest.raises(OSError):
+        atomic_write_text(target, "{}")
+
+    assert not target.exists()
+    assert _list_tmp_siblings(target) == []

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -8,6 +8,7 @@ import pytest
 from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
     COMMAND_GENERATORS,
+    CommandParseError,
     CommandSyncResult,
     StrictDropError,
     diff_commands,
@@ -74,6 +75,26 @@ class TestParseCanonicalCommand:
         assert cmd.name == "bare"
         assert cmd.description == ""
         assert "Just a bare prompt" in cmd.body
+
+    @pytest.mark.parametrize(
+        "hostile_name",
+        [
+            "../../evil",
+            "a/b",
+            "a\\b",
+            ".",
+            "..",
+            "-x",
+            "A" * 65,
+            "name with space",
+        ],
+    )
+    def test_rejects_hostile_name_in_frontmatter(self, tmp_path, hostile_name):
+        """#276: ``name:`` frontmatter is interpolated into the output path."""
+        p = tmp_path / "hostile.md"
+        p.write_text(f"---\nname: {hostile_name}\ndescription: x\n---\n\nbody\n")
+        with pytest.raises(CommandParseError, match="invalid command name"):
+            parse_canonical_command(p)
 
 
 class TestListCanonicalCommands:
@@ -243,6 +264,19 @@ class TestExtractCommandsToCanonical:
         result = extract_commands_to_canonical(tmp_path, overwrite=True)
         assert len(result.imported) == 1
         assert "UPDATED" in canonical.read_text()
+
+    def test_skips_hostile_runtime_filename(self, tmp_path):
+        """#276: runtime filenames are interpolated into canonical paths."""
+        d = tmp_path / ".claude/commands"
+        d.mkdir(parents=True)
+        (d / "-bad.md").write_text(SAMPLE_MINIMAL_COMMAND)
+        (d / "ok.md").write_text(SAMPLE_MINIMAL_COMMAND)
+
+        result = extract_commands_to_canonical(tmp_path)
+        imported_names = sorted(p.stem for p in result.imported)
+        assert imported_names == ["ok"]
+        skipped_names = sorted(name for name, _ in result.skipped)
+        assert "-bad" in skipped_names
 
 
 class TestDiffCommands:

--- a/packages/memtomem/tests/test_context_names.py
+++ b/packages/memtomem/tests/test_context_names.py
@@ -1,0 +1,71 @@
+"""Tests for memtomem.context._names.validate_name."""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.context._names import InvalidNameError, validate_name
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "hello",
+        "a-b_c.d",
+        "x",  # single char
+        "A" * 64,  # max length
+        "123",  # all digits
+        "agent.v2",
+        "name_with_underscore",
+        "name-with-dash",
+    ],
+)
+def test_valid_names_pass_through(value: str) -> None:
+    assert validate_name(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "..",
+        "../x",
+        "a/b",
+        "a\\b",
+        "",
+        "   ",
+        ".",
+        "a\nb",
+        "a\rb",
+        "a\x00b",
+        "-x",  # leading dash
+        "/absolute",
+        "\\windows",
+        "控",  # non-ASCII / CJK
+        "name with space",
+    ],
+)
+def test_invalid_names_are_rejected(value: str) -> None:
+    with pytest.raises(InvalidNameError):
+        validate_name(value)
+
+
+def test_name_too_long() -> None:
+    with pytest.raises(InvalidNameError, match="exceeds 64"):
+        validate_name("A" * 65)
+
+
+def test_non_string_rejected() -> None:
+    with pytest.raises(InvalidNameError, match="expected str"):
+        validate_name(123)  # type: ignore[arg-type]
+
+
+def test_kind_appears_in_error_message() -> None:
+    with pytest.raises(InvalidNameError, match="invalid agent name"):
+        validate_name("../x", kind="agent name")
+
+
+def test_dot_and_dotdot_rejected_explicitly() -> None:
+    with pytest.raises(InvalidNameError, match="reserved path token"):
+        validate_name(".")
+    with pytest.raises(InvalidNameError, match="reserved path token"):
+        validate_name("..")

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -262,6 +262,47 @@ class TestClaudeSettingsMergeConcurrent:
         assert "modified by another process" in r.reason
 
 
+class TestClaudeSettingsAtomicWrite:
+    """_write_json is atomic — a crash between open() and replace() leaves the
+    pre-existing settings.json untouched instead of producing a truncated file
+    that reloads as 'no hooks configured' (issue #275)."""
+
+    def test_crash_mid_replace_preserves_old_settings(self, claude_home, tmp_path, monkeypatch):
+        target = claude_home / ".claude" / "settings.json"
+        original = {"hooks": {"PostToolUse": [_rule("Write", "echo original")]}}
+        target.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Edit", "echo new")]}},
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("simulated crash mid-replace")
+
+        monkeypatch.setattr("memtomem.context._atomic.os.replace", _boom)
+
+        with pytest.raises(OSError, match="simulated crash"):
+            generate_all_settings(tmp_path)
+
+        # Old file survives, no .tmp sibling leaked.
+        assert json.loads(target.read_text(encoding="utf-8")) == original
+        siblings = [p for p in target.parent.iterdir() if p.name.startswith(".settings.json.")]
+        assert siblings == []
+
+    def test_mode_is_0o600(self, claude_home, tmp_path):
+        import stat as _stat
+
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Edit", "echo")]}},
+        )
+        generate_all_settings(tmp_path)
+
+        target = claude_home / ".claude" / "settings.json"
+        assert _stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
 class TestClaudeSettingsNoClaudeCodeInstalled:
     """``~/.claude/`` does not exist → skip, never create it."""
 


### PR DESCRIPTION
## Summary

Tier 1 hardening of the context-gateway fan-out write pipeline. Closes #275 and #276 in a single PR because both issues target the exact same call sites in `context/{settings,agents,commands,skills}.py` and the web settings-conflict resolver — atomic rename is pointless if a `../evil` name already escapes the target dir, and name validation is weaker if a half-written file is left behind on crash. Framed by both issues as a follow-up to the hot-reload work (#267 / #269 / #274).

- **#275 atomic writes** — `context/_atomic.py::atomic_write_{bytes,text}` uses `tempfile.mkstemp` in the same directory + `os.replace` so a crash, SIGKILL, or OOM between open and flush cannot leave `~/.claude/settings.json` or `.claude/agents/<name>.md` as an empty/partial file. Mode is set via `os.fchmod` before the rename (default `0o600`), eliminating umask dependence per the AC.

- **#276 name validation** — `context/_names.py::validate_name` rejects `..`, path separators, control chars, empty / dot-only / leading-dash values, and anything over 64 chars. Applied at the dataclass boundary in `parse_canonical_{agent,command}` and on runtime filenames during reverse-import; `generate_all_*` routes rejections through the existing `SyncResult.skipped` path.

## Scope covered

All call paths identified in the two issues:

- `context/settings.py::_write_json` — now via `atomic_write_text` (web/routes/settings_sync.py inherits)
- `context/agents.py::generate_all_agents` write (`atomic_write_text`) + parse-time name validation + extract-time name validation
- `context/agents.py::extract_agents_to_canonical` write (`atomic_write_bytes`)
- `context/commands.py::generate_all_commands` write + parse-time validation
- `context/commands.py::extract_commands_to_canonical` (both Claude `md` and Gemini `toml` sides)
- `context/skills.py::copy_skill` — per-file `atomic_write_bytes` inside the tree
- `context/skills.py::list_canonical_skills` + `extract_skills_to_canonical` — invalid names filtered/skipped

## Not in scope (explicit)

- **Parent-directory fsync** — per #275 non-goals (POSIX `os.replace` provides ordering for our use case).
- **Skills directory-level atomicity** — the `rmtree + mkdir` window inside `copy_skill` needs a different pattern (copy into `<dst>.tmp-<rand>`, two-step rename through a `.old` side). Per-file atomicity is shipped here; dir-level atomicity is deferred and can be a follow-up if needed.
- `memtomem/config.py::_atomic_write_json` is left in place — it predates this module and covers `~/.memtomem/config.json` specifically. A docstring cross-reference is intentionally omitted to keep the diff tight.

## Test plan

- [x] New `tests/test_context_atomic.py` (9 cases): happy-path, crash-mid-replace, crash-mid-payload, no-preexisting-target cleanup, explicit `0o600` under hostile umask, custom mode override, nested parent dir creation.
- [x] New `tests/test_context_names.py` (27 cases): parametrized rejection of `..`, `../x`, `a/b`, `a\b`, empty / whitespace-only, `.`, `\n` / `\r` / `\0`, leading dash, absolute paths, non-ASCII, over-length, non-string input; positive cases for valid identifiers.
- [x] Augmented `tests/test_context_settings.py`: crash-mid-replace preserves old settings + `0o600` mode check.
- [x] Augmented `tests/test_context_agents.py`: parametrized hostile `name:` frontmatter + hostile runtime filename round-trip through `extract_agents_to_canonical`.
- [x] Augmented `tests/test_context_commands.py`: same two patterns.
- [x] Full suite: `uv run pytest -m "not ollama"` → **1800 passed** (up from 1743 baseline after #274, +57 new tests, 0 regressions).
- [x] `uv run ruff check` + `uv run ruff format --check` + `uv run mypy` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
