### PR TITLE
fix(config): run ensure_auto_discovered_dirs on build_comparand (refs #260)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1053,6 +1053,12 @@ def build_comparand(*, quiet: bool = True) -> "Mem2MemConfig":
     """
     comparand = Mem2MemConfig()
     load_config_d(comparand, quiet=quiet)
+    # Auto-discovery is an env-dependent "factory" in spirit: it depends on
+    # the local filesystem, not on user choice. Running it here keeps the
+    # comparand apples-to-apples with the runtime config built by
+    # ``create_components`` so auto-discovered paths don't drag into
+    # ``config.json`` on unrelated saves.
+    ensure_auto_discovered_dirs(comparand)
     return comparand
 
 

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -395,17 +395,23 @@ class TestSaveConfigOverrides:
 
     @pytest.fixture
     def isolated(self, tmp_path, monkeypatch):
-        """Isolate both config.json and config.d/ to tmp_path.
+        """Isolate config.json, config.d/, and auto-discovery from the dev machine.
 
         Without this, ``build_comparand`` reads the developer's real
         ``~/.memtomem/config.d/`` fragments during tests, producing
         per-machine comparand differences that mask the intended behavior.
+        Auto-discovery is stubbed to ``[]`` so tests that exercise
+        ``memory_dirs`` delta semantics behave identically whether the dev
+        machine happens to have ``~/.claude/projects`` etc. Individual tests
+        can re-monkeypatch ``_auto_discovered_memory_dirs`` to exercise the
+        auto-discover path explicitly.
         """
         config_file = tmp_path / "config.json"
         config_d = tmp_path / "config.d"
         config_d.mkdir()
         monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
         monkeypatch.setattr("memtomem.config._config_d_path", lambda: config_d)
+        monkeypatch.setattr("memtomem.config._auto_discovered_memory_dirs", lambda: [])
         return {"config_file": config_file, "config_d": config_d, "tmp_path": tmp_path}
 
     # ── Load-path defensive tests (unrelated to delta semantic) ────────
@@ -610,6 +616,45 @@ class TestSaveConfigOverrides:
         data = json.loads(isolated["config_file"].read_text())
         assert "memory_dirs" not in data.get("indexing", {}), (
             f"factory-default memory_dirs must be dropped on save under Z; got {data}"
+        )
+
+    def test_auto_discovered_dirs_do_not_drag_into_config_json(
+        self, isolated, monkeypatch, tmp_path
+    ):
+        """Regression guard for the drag-in introduced by PR #282.
+
+        After PR #282 consolidated auto-discovery into
+        ``ensure_auto_discovered_dirs`` (removed from ``_default_memory_dirs``),
+        the comparand built by ``build_comparand`` contained only
+        ``~/.memtomem/memories`` while the runtime config contained the
+        auto-discovered well-known dirs on top. Unrelated saves pinned
+        those paths into ``config.json``, which meant a later
+        ``auto_discover = false`` still indexed them.
+
+        Fix: ``build_comparand`` must call ``ensure_auto_discovered_dirs``
+        on the comparand so the delta computation sees an apples-to-apples
+        runtime-vs-default comparison.
+        """
+        import json
+        from pathlib import Path
+
+        from memtomem import config as _cfg
+        from memtomem.config import ensure_auto_discovered_dirs
+
+        fake = tmp_path / "fake-auto-tool"
+        fake.mkdir()
+        monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+
+        cfg = Mem2MemConfig()
+        ensure_auto_discovered_dirs(cfg)  # simulates startup in create_components
+        assert fake.resolve() in {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+
+        cfg.mmr.enabled = True  # unrelated change to trigger a non-empty save
+        save_config_overrides(cfg)
+
+        data = json.loads(isolated["config_file"].read_text())
+        assert "memory_dirs" not in data.get("indexing", {}), (
+            f"auto-discovered dirs must drop on unrelated save; got {data}"
         )
 
     def test_save_is_idempotent(self, isolated):


### PR DESCRIPTION
## Summary

Follow-up to [PR #282](https://github.com/memtomem/memtomem/pull/282) closing a drag-in regression I missed during post-merge smoke.

PR #282 moved auto-discovery out of the `_default_memory_dirs` default factory and into the `ensure_auto_discovered_dirs` runtime gate. This single-sourced the behavior so the new `auto_discover` flag had one place to gate — but it also meant `build_comparand` (which only calls `Mem2MemConfig()` + `load_config_d`) no longer saw the auto-discovered paths that the runtime config had from the gate. Any unrelated save (e.g. toggling `mmr.enabled`) then treated those paths as "user changes" and pinned them into `config.json`. A later `auto_discover = false` still indexed the pinned paths because persisted values survive the opt-out gate.

## Fix

One line in `build_comparand`: call `ensure_auto_discovered_dirs(comparand)` after `load_config_d`, so the comparand and the runtime config go through the same auto-discover step. When `auto_discover = false`, the gate is a no-op on both sides, so delta computation stays correct in both modes.

## Test hygiene

- New regression test `test_auto_discovered_dirs_do_not_drag_into_config_json` that monkeypatches `_auto_discovered_memory_dirs` to a fake `tmp_path` entry and asserts the unrelated-save drag-in behavior. Verified to **fail** on the pre-fix code before landing the one-line fix (per `feedback_sync_sleep_in_async_test_deadlock.md` negative-test discipline).
- Hardens `TestSaveConfigOverrides.isolated` fixture: now stubs `_auto_discovered_memory_dirs` to `[]` by default so the existing factory-default tests behave identically regardless of whether the dev machine has `~/.claude/projects` / `~/.gemini` / `~/.codex/memories`. Individual tests that want to exercise the auto-discover path re-monkeypatch the helper.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 1755 passed (2 new), 0 regressions.
- [x] `uv run ruff check` + `uv run ruff format --check` → clean.
- [x] `uv run mypy` (advisory) → Success, no issues.
- [x] Reproducer `test_auto_discovered_dirs_do_not_drag_into_config_json` confirmed failing before the `build_comparand` fix, passing after.

## Out of scope

- The structural direction for RFC #260 (Options 1 / 2 / 3) — still open.
- The Web UI silent-restoration trap on `/memory-dirs/remove` — separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
