### PR TITLE
harden(context): CRLF tolerance, unknown-key warn, full TOML escape (closes #279)

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -159,13 +159,26 @@ def _coerce_list(value: Any) -> list[str]:
     return [str(value).strip()] if str(value).strip() else []
 
 
+_KNOWN_AGENT_KEYS = frozenset(
+    {"name", "description", "tools", "model", "skills", "isolation", "kind", "temperature"}
+)
+
+
 def parse_canonical_agent(path: Path) -> SubAgent:
     """Parse a canonical agent file into a :class:`SubAgent`."""
     content = path.read_text(encoding="utf-8")
+    # Normalize CRLF → LF so ``_FRONT_MATTER_RE`` (which anchors on ``\n``) matches
+    # files authored on Windows or by editors that emit CRLF.
+    content = content.replace("\r\n", "\n")
     m = _FRONT_MATTER_RE.match(content)
     if not m:
         raise AgentParseError(f"missing YAML frontmatter: {path}")
     frontmatter = _parse_flat_yaml(m.group(1))
+
+    unknown = sorted(set(frontmatter) - _KNOWN_AGENT_KEYS)
+    if unknown:
+        logger.warning("unknown frontmatter keys %s in %s (ignored)", unknown, path)
+
     body = content[m.end() :].lstrip("\n").rstrip() + "\n"
 
     name = frontmatter.get("name") or path.stem
@@ -254,8 +267,62 @@ def _subagent_to_gemini_md(agent: SubAgent) -> tuple[str, list[str]]:
 
 
 def _toml_escape_basic_string(s: str) -> str:
-    # TOML basic strings: " delimited, \\, \", control chars need escaping.
-    return s.replace("\\", "\\\\").replace('"', '\\"')
+    """Escape ``s`` for a TOML basic (single-line, ``"``-delimited) string.
+
+    TOML basic strings require ``\\b \\t \\n \\f \\r \\" \\\\`` for those
+    characters and ``\\uXXXX`` for any other C0 control or DEL. Leaving raw
+    control chars produces TOML that ``tomllib.loads`` rejects.
+    """
+    out: list[str] = []
+    for ch in s:
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == '"':
+            out.append('\\"')
+        elif ch == "\b":
+            out.append("\\b")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\f":
+            out.append("\\f")
+        elif ch == "\r":
+            out.append("\\r")
+        else:
+            code = ord(ch)
+            if code < 0x20 or code == 0x7F:
+                out.append(f"\\u{code:04x}")
+            else:
+                out.append(ch)
+    return "".join(out)
+
+
+def _toml_escape_multiline_string(s: str) -> str:
+    """Escape ``s`` for a TOML multi-line basic (``\"\"\"``-delimited) string.
+
+    Literal newlines and tabs are permitted; ``\\r`` and other C0 controls
+    still need escaping, and any stray ``\"\"\"`` must be broken up.
+    """
+    out: list[str] = []
+    for ch in s:
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == "\n" or ch == "\t":
+            out.append(ch)
+        elif ch == "\b":
+            out.append("\\b")
+        elif ch == "\f":
+            out.append("\\f")
+        elif ch == "\r":
+            out.append("\\r")
+        else:
+            code = ord(ch)
+            if code < 0x20 or code == 0x7F:
+                out.append(f"\\u{code:04x}")
+            else:
+                out.append(ch)
+    return "".join(out).replace('"""', '""\\"')
 
 
 def _toml_scalar(value: Any) -> str:
@@ -265,10 +332,7 @@ def _toml_scalar(value: Any) -> str:
         return str(value)
     if isinstance(value, str):
         if "\n" in value:
-            # Triple-quoted multi-line basic string. Any stray \"\"\" is
-            # escaped by breaking one of the quotes.
-            escaped = value.replace("\\", "\\\\").replace('"""', '""\\"')
-            return f'"""\n{escaped}"""'
+            return f'"""\n{_toml_escape_multiline_string(value)}"""'
         return f'"{_toml_escape_basic_string(value)}"'
     raise TypeError(f"unsupported TOML scalar: {type(value).__name__}")
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -73,6 +73,10 @@ class CommandParseError(ValueError):
 def parse_canonical_command(path: Path) -> SlashCommand:
     """Parse a canonical command file into a :class:`SlashCommand`."""
     content = path.read_text(encoding="utf-8")
+    # Share agents.py's CRLF normalization — the shared ``_FRONT_MATTER_RE``
+    # anchors on ``\n`` only, so a CRLF file would otherwise parse as "no
+    # frontmatter" and silently fall through to the filename-based default.
+    content = content.replace("\r\n", "\n")
     m = _FRONT_MATTER_RE.match(content)
     if m is None:
         # Commands without frontmatter are tolerated — treat the whole file

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -10,6 +10,8 @@ from memtomem.context.agents import (
     CANONICAL_AGENT_ROOT,
     AgentParseError,
     StrictDropError,
+    _toml_escape_basic_string,
+    _toml_escape_multiline_string,
     diff_agents,
     extract_agents_to_canonical,
     generate_all_agents,
@@ -444,3 +446,165 @@ class TestRoundtrip:
         reparsed = parse_canonical_agent(tmp_path / CANONICAL_AGENT_ROOT / "helper.md")
         assert reparsed.name == "helper"
         assert "Help with things." in reparsed.body
+
+
+class TestCrlfParsing:
+    """#279: frontmatter regex anchors on ``\\n`` — CRLF files must still parse."""
+
+    def test_crlf_frontmatter_parses(self, tmp_path):
+        p = tmp_path / "crlf.md"
+        p.write_bytes(SAMPLE_FULL_AGENT.replace("\n", "\r\n").encode("utf-8"))
+        agent = parse_canonical_agent(p)
+        assert agent.name == "code-reviewer"
+        assert agent.tools == ["Read", "Grep", "Glob"]
+        assert agent.model == "sonnet"
+        # Body is LF-normalized after parse; no raw \r should leak through.
+        assert "\r" not in agent.body
+
+    def test_crlf_roundtrip_is_idempotent(self, tmp_path):
+        """Canonical (CRLF on disk) → runtime → canonical must be byte-stable."""
+        p = tmp_path / CANONICAL_AGENT_ROOT / "helper.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(SAMPLE_MINIMAL_AGENT.replace("\n", "\r\n").encode("utf-8"))
+
+        generate_all_agents(tmp_path, runtimes=["claude_agents"])
+        rendered_first = (tmp_path / ".claude/agents/helper.md").read_bytes()
+
+        # Re-parse the canonical (still CRLF on disk) and regenerate.
+        generate_all_agents(tmp_path, runtimes=["claude_agents"])
+        rendered_second = (tmp_path / ".claude/agents/helper.md").read_bytes()
+
+        assert rendered_first == rendered_second
+        # And the rendered runtime file uses LF, not CRLF.
+        assert b"\r\n" not in rendered_first
+
+
+class TestUnknownFrontmatterKeys:
+    def test_unknown_key_warns_with_path(self, tmp_path, caplog):
+        body = (
+            "---\n"
+            "name: odd\n"
+            "description: has a future key\n"
+            "future_field: value\n"
+            "another_unknown: [a, b]\n"
+            "---\n\n"
+            "body\n"
+        )
+        p = tmp_path / "odd.md"
+        p.write_text(body)
+        with caplog.at_level("WARNING"):
+            agent = parse_canonical_agent(p)
+        # Known fields still parse; unknowns are dropped (not stored on SubAgent).
+        assert agent.name == "odd"
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("unknown frontmatter keys" in m for m in messages)
+        assert any(str(p) in m for m in messages)
+        # Alphabetized for stable output.
+        assert any("another_unknown" in m and "future_field" in m for m in messages)
+
+    def test_known_keys_do_not_warn(self, tmp_path, caplog):
+        _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
+        with caplog.at_level("WARNING"):
+            parse_canonical_agent(tmp_path / CANONICAL_AGENT_ROOT / "full.md")
+        assert not any("unknown frontmatter" in r.getMessage() for r in caplog.records)
+
+
+class TestCodexTomlControlChars:
+    """#279: Codex TOML must parse back under ``tomllib.loads`` even when the
+    canonical body contains raw C0 control characters."""
+
+    def test_body_with_c0_controls_parses(self, tmp_path, codex_home):
+        """Bodies routed into a multiline TOML string must escape C0 controls
+        that the TOML spec still requires escaping even inside triple quotes
+        (sub-0x20 chars aside from ``\\n``/``\\t``). ``\\r`` is pre-normalized
+        by ``Path.read_text`` (universal newlines), so it can't reach here on
+        the read path — it's exercised directly in :class:`TestTomlEscape`."""
+        body = (
+            "---\n"
+            "name: odd-body\n"
+            "description: has control chars\n"
+            "---\n\n"
+            "line with NUL: \x00 and ESC: \x1b and BS: \x08\n"
+        )
+        p = tmp_path / CANONICAL_AGENT_ROOT / "odd-body.md"
+        p.parent.mkdir(parents=True)
+        p.write_text(body)
+
+        generate_all_agents(tmp_path, runtimes=["codex_agents"])
+        toml_path = codex_home / ".codex/agents/odd-body.toml"
+        parsed = tomllib.loads(toml_path.read_text())
+        # Control chars survive the round-trip through tomllib.
+        assert "\x00" in parsed["developer_instructions"]
+        assert "\x1b" in parsed["developer_instructions"]
+        assert "\x08" in parsed["developer_instructions"]
+
+    def test_multiline_body_with_triple_quote_is_escaped(self, tmp_path, codex_home):
+        body = (
+            "---\n"
+            "name: triple\n"
+            "description: body contains triple quote\n"
+            '---\n\nHere is a stray triple: """ inside text\nSecond line.\n'
+        )
+        p = tmp_path / CANONICAL_AGENT_ROOT / "triple.md"
+        p.parent.mkdir(parents=True)
+        p.write_text(body)
+
+        generate_all_agents(tmp_path, runtimes=["codex_agents"])
+        toml_path = codex_home / ".codex/agents/triple.toml"
+        parsed = tomllib.loads(toml_path.read_text())
+        assert '"""' in parsed["developer_instructions"]
+
+
+class TestTomlEscape:
+    """Direct unit tests for the TOML escape helpers — documents which chars
+    get which escape form so future edits don't silently narrow the set."""
+
+    def test_basic_string_named_escapes(self):
+        s = 'back\\slash, quote", bs\b, tab\t, lf\n, ff\f, cr\r'
+        escaped = _toml_escape_basic_string(s)
+        assert "\\\\" in escaped
+        assert '\\"' in escaped
+        assert "\\b" in escaped
+        assert "\\t" in escaped
+        assert "\\n" in escaped
+        assert "\\f" in escaped
+        assert "\\r" in escaped
+        # Round-trips through tomllib.
+        parsed = tomllib.loads(f'v = "{escaped}"')
+        assert parsed["v"] == s
+
+    def test_basic_string_other_c0_uses_uxxxx(self):
+        s = "nul\x00, soh\x01, esc\x1b, del\x7f"
+        escaped = _toml_escape_basic_string(s)
+        assert "\\u0000" in escaped
+        assert "\\u0001" in escaped
+        assert "\\u001b" in escaped
+        assert "\\u007f" in escaped
+        parsed = tomllib.loads(f'v = "{escaped}"')
+        assert parsed["v"] == s
+
+    def test_multiline_keeps_newline_and_tab_literal(self):
+        s = "line1\nline2\twith tab"
+        escaped = _toml_escape_multiline_string(s)
+        # Newline/tab stay literal in triple-quoted form.
+        assert "\n" in escaped
+        assert "\t" in escaped
+        assert "\\n" not in escaped
+        assert "\\t" not in escaped
+
+    def test_multiline_still_escapes_cr_and_c0(self):
+        s = "cr\r middle nul\x00 end\x1b"
+        escaped = _toml_escape_multiline_string(s)
+        assert "\\r" in escaped
+        assert "\\u0000" in escaped
+        assert "\\u001b" in escaped
+        parsed = tomllib.loads(f'v = """\n{escaped}"""')
+        assert parsed["v"] == s
+
+    def test_multiline_breaks_triple_quote(self):
+        s = 'prefix """ suffix'
+        escaped = _toml_escape_multiline_string(s)
+        # Raw ``"""`` would close the string — must be broken.
+        assert '"""' not in escaped
+        parsed = tomllib.loads(f'v = """\n{escaped}"""')
+        assert '"""' in parsed["v"]

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -396,3 +396,20 @@ class TestRoundtrip:
         assert "description: Simple prompt" in canonical
         assert "$ARGUMENTS" in canonical
         assert "{{args}}" not in canonical
+
+
+class TestCrlfParsing:
+    """#279: command parser shares agents.py's frontmatter regex — CRLF files
+    must parse the same way they do on LF systems."""
+
+    def test_crlf_frontmatter_parses(self, tmp_path):
+        p = tmp_path / CANONICAL_COMMAND_ROOT / "crlf.md"
+        p.parent.mkdir(parents=True)
+        p.write_bytes(SAMPLE_FULL_COMMAND.replace("\n", "\r\n").encode("utf-8"))
+        cmd = parse_canonical_command(p)
+        assert cmd.name == "crlf"
+        assert cmd.description == "Review a file for issues"
+        assert cmd.argument_hint == "[file-path]"
+        assert cmd.allowed_tools == ["Read", "Grep"]
+        assert "$ARGUMENTS" in cmd.body
+        assert "\r" not in cmd.body


### PR DESCRIPTION
## Summary

- `context/agents.py` + `context/commands.py`: normalize CRLF → LF before `_FRONT_MATTER_RE`, so canonical files authored on Windows / CRLF-emitting editors parse the same as LF files.
- `context/agents.py`: `parse_canonical_agent` now emits `logger.warning` (with file path) for any frontmatter key outside the known set, so a newer memtomem field doesn't get silently dropped on round-trip.
- `context/agents.py`: `_toml_escape_basic_string` now escapes `\b \t \n \f \r \" \\` by name and any other sub-0x20 / `0x7F` code point as `\uXXXX`. Multi-line branch moved into `_toml_escape_multiline_string` (literal `\n`/`\t`, still escapes `\r` and other controls, breaks stray `"""`). Previously raw control characters in the body produced TOML that `tomllib.loads` rejects.

Closes #279.

## Notes

- `Path.read_text()` already does universal newlines, so the explicit `replace("\r\n", "\n")` is defense-in-depth; it's kept so future read-path refactors (e.g. switching to `read_bytes().decode()`) don't silently re-open the regex gap.
- `_parse_flat_yaml` is shared with `commands.py`, so the unknown-key warning was scoped to `parse_canonical_agent` where the frontmatter schema is fixed; slash-command keys (`argument-hint`, `allowed-tools`, …) have their own accepted set and stay out of scope here.
- Single-line TOML `description` can't carry a raw `\r` on the read path (stripped by `splitlines()`), so the `\r` escape is covered by the direct unit tests in `TestTomlEscape` rather than a body-integration test.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 1824 passed (was 1812).
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy packages/memtomem/src/memtomem/context` — clean.
- New tests: `TestCrlfParsing` (agents + commands), `TestUnknownFrontmatterKeys`, `TestCodexTomlControlChars`, `TestTomlEscape`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
