### PR TITLE
fix(web): serialize context-gateway writes under a dedicated asyncio lock (closes #277)

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -190,17 +190,19 @@ def _safe_load_json(path: Path) -> dict | object:
         return _MALFORMED
 
 
-def _read_with_mtime(path: Path) -> tuple[dict | None | object, float]:
-    """Read JSON + capture mtime for concurrent-write guard.
+def _read_with_mtime(path: Path) -> tuple[dict | None | object, int]:
+    """Read JSON + capture mtime in nanoseconds for concurrent-write guard.
 
-    Returns ``(None, 0.0)`` when *path* does not exist and
-    ``(_MALFORMED, mtime)`` when the file is not valid JSON.
+    Returns ``(None, 0)`` when *path* does not exist and
+    ``(_MALFORMED, mtime_ns)`` when the file is not valid JSON. Nanosecond
+    precision matches :mod:`memtomem.web.hot_reload` and detects
+    sub-second writes that ``st_mtime`` (float seconds) misses.
     """
     if not path.is_file():
-        return None, 0.0
-    mtime = path.stat().st_mtime
+        return None, 0
+    mtime_ns = path.stat().st_mtime_ns
     data = _safe_load_json(path)
-    return data, mtime
+    return data, mtime_ns
 
 
 def _write_json(path: Path, data: dict) -> None:
@@ -248,8 +250,8 @@ def generate_all_settings(
 
         target_path = gen.target_file(project_root)
 
-        # Step 1: read existing + capture mtime
-        existing_raw, existing_mtime = _read_with_mtime(target_path)
+        # Step 1: read existing + capture mtime (ns)
+        existing_raw, existing_mtime_ns = _read_with_mtime(target_path)
         if existing_raw is _MALFORMED:
             results[name] = SettingsSyncResult(
                 status="error",
@@ -264,7 +266,7 @@ def generate_all_settings(
         merged, warnings = gen.merge(existing, contributions)
 
         # Step 3: mtime check (concurrent-write guard)
-        if target_path.is_file() and target_path.stat().st_mtime != existing_mtime:
+        if target_path.is_file() and target_path.stat().st_mtime_ns != existing_mtime_ns:
             results[name] = SettingsSyncResult(
                 status="aborted",
                 reason=f"{target_path} was modified by another "

--- a/packages/memtomem/src/memtomem/web/routes/_locks.py
+++ b/packages/memtomem/src/memtomem/web/routes/_locks.py
@@ -1,0 +1,34 @@
+"""Module-level asyncio locks shared across web route handlers.
+
+Two independent locks serialize different write paths:
+
+* ``_config_lock`` — guards every write path that touches
+  ``~/.memtomem/config.json`` and/or mutates ``app.state.config``. Used by
+  PATCH/save/memory-dirs handlers in :mod:`memtomem.web.routes.system`.
+  History: started life as ``_config_patch_lock`` (PATCH-only); hot-reload
+  in #267 extended it to ``/config/save``, ``/memory-dirs/add``, and
+  ``/memory-dirs/remove`` so a concurrent disk edit + UI save can't
+  interleave.
+
+* ``_gateway_lock`` — guards every context-gateway write path that touches
+  ``.memtomem/{settings,agents,commands,skills}/`` or fans out to runtime
+  targets like ``~/.claude/settings.json``. Wraps POST handlers in
+  :mod:`memtomem.web.routes.settings_sync`,
+  :mod:`memtomem.web.routes.context_agents`,
+  :mod:`memtomem.web.routes.context_commands`, and
+  :mod:`memtomem.web.routes.context_skills`. Without it two concurrent
+  ``POST /api/settings-sync`` (or a Web UI + ``mm context sync`` racing
+  in the same loop) can interleave on the same target file. The mtime
+  guards in those handlers narrow the race window but do not close it
+  for sub-second writes.
+
+The two locks are independent: ``config.json`` operations never block
+gateway operations and vice versa.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+_config_lock = asyncio.Lock()
+_gateway_lock = asyncio.Lock()

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -21,6 +22,7 @@ from memtomem.context.agents import (
     parse_canonical_agent,
 )
 from memtomem.web.deps import get_project_root
+from memtomem.web.routes._locks import _gateway_lock
 
 logger = logging.getLogger(__name__)
 
@@ -191,11 +193,16 @@ async def create_agent(
     agent_path = _validate_name(body.name, project_root)
     if agent_path is None:
         raise ValueError(f"Invalid agent name: {body.name}")
-    if agent_path.exists():
-        raise ValueError(f"Agent '{body.name}' already exists")
 
-    agent_path.parent.mkdir(parents=True, exist_ok=True)
-    agent_path.write_text(body.content, encoding="utf-8")
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                if agent_path.exists():
+                    raise ValueError(f"Agent '{body.name}' already exists")
+                agent_path.parent.mkdir(parents=True, exist_ok=True)
+                agent_path.write_text(body.content, encoding="utf-8")
+    except TimeoutError:
+        raise HTTPException(503, "Agent create timed out — another sync may be in progress")
     return {"name": body.name, "canonical_path": str(agent_path.relative_to(project_root))}
 
 
@@ -322,7 +329,12 @@ async def sync_agents(
     project_root: Path = Depends(get_project_root),
 ) -> dict:
     on_drop = body.on_drop if body else "warn"
-    result = generate_all_agents(project_root, on_drop=on_drop)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = generate_all_agents(project_root, on_drop=on_drop)
+    except TimeoutError:
+        raise HTTPException(503, "Agents sync timed out — another sync may be in progress")
 
     def _safe_rel(p: Path) -> str:
         try:
@@ -352,7 +364,12 @@ async def import_agents(
     project_root: Path = Depends(get_project_root),
 ) -> dict:
     overwrite = body.overwrite if body else False
-    result = extract_agents_to_canonical(project_root, overwrite=overwrite)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = extract_agents_to_canonical(project_root, overwrite=overwrite)
+    except TimeoutError:
+        raise HTTPException(503, "Agents import timed out — another sync may be in progress")
     return {
         "imported": [
             {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -20,6 +21,7 @@ from memtomem.context.commands import (
     parse_canonical_command,
 )
 from memtomem.web.deps import get_project_root
+from memtomem.web.routes._locks import _gateway_lock
 
 logger = logging.getLogger(__name__)
 
@@ -172,11 +174,16 @@ async def create_command(
     cmd_path = _validate_name(body.name, project_root)
     if cmd_path is None:
         raise ValueError(f"Invalid command name: {body.name}")
-    if cmd_path.exists():
-        raise ValueError(f"Command '{body.name}' already exists")
 
-    cmd_path.parent.mkdir(parents=True, exist_ok=True)
-    cmd_path.write_text(body.content, encoding="utf-8")
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                if cmd_path.exists():
+                    raise ValueError(f"Command '{body.name}' already exists")
+                cmd_path.parent.mkdir(parents=True, exist_ok=True)
+                cmd_path.write_text(body.content, encoding="utf-8")
+    except TimeoutError:
+        raise HTTPException(503, "Command create timed out — another sync may be in progress")
     return {"name": body.name, "canonical_path": str(cmd_path.relative_to(project_root))}
 
 
@@ -305,7 +312,12 @@ async def sync_commands(
     project_root: Path = Depends(get_project_root),
 ) -> dict:
     on_drop = body.on_drop if body else "warn"
-    result = generate_all_commands(project_root, on_drop=on_drop)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = generate_all_commands(project_root, on_drop=on_drop)
+    except TimeoutError:
+        raise HTTPException(503, "Commands sync timed out — another sync may be in progress")
     return {
         "generated": [
             {"runtime": rt, "path": str(p.relative_to(project_root))}
@@ -345,7 +357,12 @@ async def import_commands(
     project_root: Path = Depends(get_project_root),
 ) -> dict:
     overwrite = body.overwrite if body else False
-    result = extract_commands_to_canonical(project_root, overwrite=overwrite)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = extract_commands_to_canonical(project_root, overwrite=overwrite)
+    except TimeoutError:
+        raise HTTPException(503, "Commands import timed out — another sync may be in progress")
     return {
         "imported": [
             {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -20,6 +21,7 @@ from memtomem.context.skills import (
     list_canonical_skills,
 )
 from memtomem.web.deps import get_project_root
+from memtomem.web.routes._locks import _gateway_lock
 
 logger = logging.getLogger(__name__)
 
@@ -134,12 +136,17 @@ async def create_skill(
     skill_dir = _validate_name(body.name, project_root)
     if skill_dir is None:
         raise ValueError(f"Invalid skill name: {body.name}")
-    if skill_dir.exists():
-        raise ValueError(f"Skill '{body.name}' already exists")
 
-    skill_dir.mkdir(parents=True)
-    manifest = skill_dir / SKILL_MANIFEST
-    manifest.write_text(body.content, encoding="utf-8")
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                if skill_dir.exists():
+                    raise ValueError(f"Skill '{body.name}' already exists")
+                skill_dir.mkdir(parents=True)
+                manifest = skill_dir / SKILL_MANIFEST
+                manifest.write_text(body.content, encoding="utf-8")
+    except TimeoutError:
+        raise HTTPException(503, "Skill create timed out — another sync may be in progress")
     return {"name": body.name, "canonical_path": str(skill_dir.relative_to(project_root))}
 
 
@@ -274,7 +281,12 @@ async def sync_skills(
     project_root: Path = Depends(get_project_root),
 ) -> dict:
     """Fan out canonical skills to all runtimes."""
-    result = generate_all_skills(project_root)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = generate_all_skills(project_root)
+    except TimeoutError:
+        raise HTTPException(503, "Skills sync timed out — another sync may be in progress")
     return {
         "generated": [
             {"runtime": rt, "path": str(p.relative_to(project_root))} for rt, p in result.generated
@@ -297,7 +309,12 @@ async def import_skills(
 ) -> dict:
     """Import runtime skills into canonical .memtomem/skills/."""
     overwrite = body.overwrite if body else False
-    result = extract_skills_to_canonical(project_root, overwrite=overwrite)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = extract_skills_to_canonical(project_root, overwrite=overwrite)
+    except TimeoutError:
+        raise HTTPException(503, "Skills import timed out — another sync may be in progress")
     return {
         "imported": [
             {"name": p.name, "canonical_path": str(p.relative_to(project_root))}

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from memtomem.context.settings import (
     generate_all_settings,
 )
 from memtomem.web.deps import get_project_root
+from memtomem.web.routes._locks import _gateway_lock
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +149,12 @@ async def apply_settings_sync(
     project_root: Path = Depends(get_project_root),
 ) -> dict:
     """Run the full settings merge (generate_all_settings)."""
-    results = generate_all_settings(project_root)
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                results = generate_all_settings(project_root)
+    except TimeoutError:
+        raise HTTPException(503, "Settings sync timed out — another sync may be in progress")
     out: list[dict] = []
     for name, r in results.items():
         out.append(
@@ -183,55 +190,66 @@ async def resolve_conflict(
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
     target_path = _claude_target()
 
-    # Read canonical rule
-    if not canonical_path.is_file():
-        raise HTTPException(404, detail="Canonical source does not exist")
-    canonical = _safe_load_json(canonical_path)
-    if not isinstance(canonical, dict):
-        raise HTTPException(422, detail="Canonical source is not valid JSON")
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                # Read canonical rule
+                if not canonical_path.is_file():
+                    raise HTTPException(404, detail="Canonical source does not exist")
+                canonical = _safe_load_json(canonical_path)
+                if not isinstance(canonical, dict):
+                    raise HTTPException(422, detail="Canonical source is not valid JSON")
 
-    proposed = None
-    canonical_hooks: dict = canonical.get("hooks", {})
-    for rule in canonical_hooks.get(body.event, []):
-        if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
-            proposed = rule
-            break
-    if proposed is None:
-        raise HTTPException(404, detail=f"Rule '{label}' not in canonical source")
+                proposed = None
+                canonical_hooks: dict = canonical.get("hooks", {})
+                for rule in canonical_hooks.get(body.event, []):
+                    if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
+                        proposed = rule
+                        break
+                if proposed is None:
+                    raise HTTPException(404, detail=f"Rule '{label}' not in canonical source")
 
-    # Read target + mtime guard
-    if not target_path.is_file():
-        raise HTTPException(404, detail="Target settings file does not exist")
+                # Read target + mtime guard. ``st_mtime_ns`` matches
+                # ``hot_reload.py`` precision and detects sub-second writes
+                # that ``st_mtime`` (float seconds) misses.
+                if not target_path.is_file():
+                    raise HTTPException(404, detail="Target settings file does not exist")
 
-    mtime = target_path.stat().st_mtime
-    target = _safe_load_json(target_path)
-    if not isinstance(target, dict):
-        raise HTTPException(422, detail="Target settings is not valid JSON")
+                mtime_ns = target_path.stat().st_mtime_ns
+                target = _safe_load_json(target_path)
+                if not isinstance(target, dict):
+                    raise HTTPException(422, detail="Target settings is not valid JSON")
 
-    # Replace the rule in-place
-    target_hooks: dict = target.get("hooks", {})
-    if not isinstance(target_hooks, dict):
-        raise HTTPException(422, detail="Target hooks is not a record")
+                # Replace the rule in-place
+                target_hooks: dict = target.get("hooks", {})
+                if not isinstance(target_hooks, dict):
+                    raise HTTPException(422, detail="Target hooks is not a record")
 
-    rules = target_hooks.get(body.event, [])
-    replaced = False
-    for i, rule in enumerate(rules):
-        if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
-            rules[i] = proposed
-            replaced = True
-            break
+                rules = target_hooks.get(body.event, [])
+                replaced = False
+                for i, rule in enumerate(rules):
+                    if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
+                        rules[i] = proposed
+                        replaced = True
+                        break
 
-    if not replaced:
-        raise HTTPException(404, detail=f"Rule '{label}' not found in target")
+                if not replaced:
+                    raise HTTPException(404, detail=f"Rule '{label}' not found in target")
 
-    # mtime check before write
-    if target_path.stat().st_mtime != mtime:
-        return {
-            "status": "aborted",
-            "reason": "Target file was modified by another process. Retry.",
-        }
+                # mtime check before write — protects against cross-process
+                # writers (CLI, manual edit) that the in-process lock can't see.
+                if target_path.stat().st_mtime_ns != mtime_ns:
+                    return {
+                        "status": "aborted",
+                        "reason": "Target file was modified by another process. Retry.",
+                    }
 
-    target_hooks[body.event] = rules
-    target["hooks"] = target_hooks
-    _write_json(target_path, target)
-    return {"status": "ok", "reason": f"Rule '{label}' replaced with memtomem's version"}
+                target_hooks[body.event] = rules
+                target["hooks"] = target_hooks
+                _write_json(target_path, target)
+                return {
+                    "status": "ok",
+                    "reason": f"Rule '{label}' replaced with memtomem's version",
+                }
+    except TimeoutError:
+        raise HTTPException(503, "Resolve timed out — another sync may be in progress")

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -27,6 +27,7 @@ from memtomem.web.deps import (
     get_search_pipeline,
     get_storage,
 )
+from memtomem.web.routes._locks import _config_lock
 from memtomem.web.schemas.config import (
     BuiltinExcludePatternsResponse,
     ConfigDecayOut,
@@ -57,12 +58,6 @@ from memtomem.web.schemas.sources import StatsResponse
 logger = logging.getLogger(__name__)
 
 _LOCALHOST_ADDRS = {"127.0.0.1", "::1", "localhost"}
-# Guards every write path that touches ``~/.memtomem/config.json`` and/or
-# mutates ``app.state.config``. Before #258+#259 this was PATCH-only
-# (``_config_patch_lock``); hot-reload extends it to /config/save,
-# /memory-dirs/add, and /memory-dirs/remove so a concurrent disk edit + UI
-# save can't interleave.
-_config_lock = _asyncio.Lock()
 
 
 def _check_reload_block(request: Request) -> None:

--- a/packages/memtomem/tests/test_web_routes_context_locks.py
+++ b/packages/memtomem/tests/test_web_routes_context_locks.py
@@ -1,0 +1,474 @@
+"""Regression tests for context-gateway write serialization (#277).
+
+Two concurrent POSTs to ``/api/settings-sync`` (or any other gateway
+mutator) must execute serially under ``_gateway_lock``. Without the
+lock, two concurrent ``POST /api/settings-sync/resolve`` for the same
+rule could interleave inside the read-merge-write region — the second
+writer would see the pre-first-write snapshot, race past the
+``st_mtime`` (float-second) CAS for sub-second writes, and silently
+clobber the first.
+
+These tests follow the same instrumentation pattern as
+``test_web_hot_reload.py::test_concurrent_patches_are_serialised_by_lock``:
+wrap a sync helper inside the lock with a small ``time.sleep`` and
+assert ``writer_1.exit <= writer_2.enter``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.context.skills import SKILL_MANIFEST
+from memtomem.web.app import create_app
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — sandbox HOME so ~/.claude writes stay inside tmp_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gateway_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin ``HOME`` to ``tmp_path`` so settings-sync writes stay sandboxed."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # ClaudeSettingsGenerator.is_available() requires the dir to exist.
+    (tmp_path / ".claude").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture
+def app(gateway_home: Path):
+    application = create_app(lifespan=None)
+    application.state.project_root = gateway_home
+    application.state.storage = AsyncMock()
+    application.state.config = None
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _rule(matcher: str = "", command: str = "echo ok") -> dict:
+    return {"matcher": matcher, "hooks": [{"type": "command", "command": command}]}
+
+
+def _make_canonical_settings(home: Path, hooks: dict) -> Path:
+    canonical = home / ".memtomem" / "settings.json"
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    canonical.write_text(json.dumps({"hooks": hooks}))
+    return canonical
+
+
+def _make_target_settings(home: Path, hooks: dict) -> Path:
+    target = home / ".claude" / "settings.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps({"hooks": hooks}))
+    return target
+
+
+# ---------------------------------------------------------------------------
+# settings-sync POST serialisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_concurrent_settings_sync_serialised_by_lock(
+    gateway_home: Path,
+    app,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two concurrent POST /api/settings-sync run serially under _gateway_lock.
+
+    Without the lock both calls would invoke ``generate_all_settings``
+    concurrently and the second's read+merge+write would interleave
+    with the first. We instrument the sync function with a 50 ms hold
+    and assert the spans don't overlap.
+    """
+    rule = _rule("Write", "echo ok")
+    _make_canonical_settings(gateway_home, {"PostToolUse": [rule]})
+    _make_target_settings(gateway_home, {})
+
+    spans: list[tuple[str, float, float]] = []
+
+    import memtomem.web.routes.settings_sync as _ss
+
+    real_generate = _ss.generate_all_settings
+    counter = {"n": 0}
+
+    def instrumented(project_root, *args, **kwargs):
+        counter["n"] += 1
+        label = f"sync_{counter['n']}"
+        enter = time.perf_counter()
+        # Hold the critical section long enough that a concurrent
+        # request would overlap if serialisation were broken.
+        time.sleep(0.05)
+        out = real_generate(project_root, *args, **kwargs)
+        exit_t = time.perf_counter()
+        spans.append((label, enter, exit_t))
+        return out
+
+    monkeypatch.setattr(_ss, "generate_all_settings", instrumented)
+
+    async def do_post() -> int:
+        resp = await client.post("/api/settings-sync")
+        return resp.status_code
+
+    s1, s2 = await asyncio.gather(do_post(), do_post())
+    assert s1 == 200 and s2 == 200
+
+    assert len(spans) == 2, spans
+    spans.sort(key=lambda s: s[1])
+    (_, _, first_exit), (_, second_enter, _) = spans
+    assert first_exit <= second_enter + 1e-3, (
+        f"settings-sync overlapped: first exit {first_exit}, second enter {second_enter}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve same-rule serialisation + file integrity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_concurrent_resolve_same_rule_serialised_by_lock(
+    gateway_home: Path,
+    app,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Two concurrent POST /api/settings-sync/resolve for the same rule
+    serialise under ``_gateway_lock`` and produce a well-formed file.
+
+    Without the lock the second writer could read the pre-first-write
+    target, race past the float-second mtime CAS, and clobber the
+    first writer with stale state. With the lock, the second handler
+    runs after the first completes, sees the freshly-applied rule,
+    and replaces it again with the same canonical value (idempotent).
+    """
+    canonical_rule = _rule("Write", "echo new")
+    target_rule = _rule("Write", "echo old")
+    _make_canonical_settings(gateway_home, {"PostToolUse": [canonical_rule]})
+    _make_target_settings(gateway_home, {"PostToolUse": [target_rule]})
+
+    spans: list[tuple[str, float, float]] = []
+
+    import memtomem.web.routes.settings_sync as _ss
+
+    real_write = _ss._write_json
+    counter = {"n": 0}
+
+    def instrumented_write(path, data, *args, **kwargs):
+        counter["n"] += 1
+        label = f"write_{counter['n']}"
+        enter = time.perf_counter()
+        time.sleep(0.05)
+        real_write(path, data, *args, **kwargs)
+        exit_t = time.perf_counter()
+        spans.append((label, enter, exit_t))
+
+    monkeypatch.setattr(_ss, "_write_json", instrumented_write)
+
+    body = {"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"}
+
+    async def do_resolve() -> dict:
+        resp = await client.post("/api/settings-sync/resolve", json=body)
+        return resp.json()
+
+    r1, r2 = await asyncio.gather(do_resolve(), do_resolve())
+    # With the lock, both calls succeed: the second one runs after the
+    # first releases, re-reads the freshly-applied rule, and replaces
+    # it with the same canonical value (idempotent). The mtime CAS
+    # holds because nothing modifies the file between the second
+    # handler's capture and check.
+    assert r1["status"] == "ok"
+    assert r2["status"] == "ok"
+
+    # Both writes happened serially under the lock.
+    assert len(spans) == 2, spans
+    spans.sort(key=lambda s: s[1])
+    (_, _, first_exit), (_, second_enter, _) = spans
+    assert first_exit <= second_enter + 1e-3, (
+        f"resolve writes overlapped: first exit {first_exit}, second enter {second_enter}"
+    )
+
+    # File is well-formed: a single rule with the canonical command.
+    final = json.loads((gateway_home / ".claude" / "settings.json").read_text())
+    rules = final["hooks"]["PostToolUse"]
+    assert len(rules) == 1
+    assert rules[0]["hooks"][0]["command"] == "echo new"
+
+
+# ---------------------------------------------------------------------------
+# Per-resource sync POST — smoke gather
+# ---------------------------------------------------------------------------
+
+
+def _make_canonical_skill(home: Path, name: str, content: str = "# Test\n") -> Path:
+    skill_dir = home / ".memtomem" / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / SKILL_MANIFEST).write_text(content)
+    return skill_dir
+
+
+def _make_canonical_agent(
+    home: Path,
+    name: str,
+    body: str = "---\nname: a\ndescription: d\n---\n# A\n",
+) -> Path:
+    agent_path = home / ".memtomem" / "agents" / f"{name}.md"
+    agent_path.parent.mkdir(parents=True, exist_ok=True)
+    agent_path.write_text(body)
+    return agent_path
+
+
+def _make_canonical_command(home: Path, name: str, body: str = "# command body\n") -> Path:
+    cmd_path = home / ".memtomem" / "commands" / f"{name}.md"
+    cmd_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd_path.write_text(body)
+    return cmd_path
+
+
+@pytest.mark.anyio
+async def test_concurrent_skills_sync_both_succeed(gateway_home: Path, app, client: AsyncClient):
+    _make_canonical_skill(gateway_home, "alpha")
+    _make_canonical_skill(gateway_home, "beta")
+
+    async def do_sync() -> int:
+        resp = await client.post("/api/context/skills/sync")
+        return resp.status_code
+
+    s1, s2 = await asyncio.gather(do_sync(), do_sync())
+    assert s1 == 200 and s2 == 200
+
+
+@pytest.mark.anyio
+async def test_concurrent_agents_sync_both_succeed(gateway_home: Path, app, client: AsyncClient):
+    _make_canonical_agent(gateway_home, "agent1")
+
+    async def do_sync() -> int:
+        resp = await client.post("/api/context/agents/sync")
+        return resp.status_code
+
+    s1, s2 = await asyncio.gather(do_sync(), do_sync())
+    assert s1 == 200 and s2 == 200
+
+
+@pytest.mark.anyio
+async def test_concurrent_commands_sync_both_succeed(gateway_home: Path, app, client: AsyncClient):
+    _make_canonical_command(gateway_home, "cmd1")
+
+    async def do_sync() -> int:
+        resp = await client.post("/api/context/commands/sync")
+        return resp.status_code
+
+    s1, s2 = await asyncio.gather(do_sync(), do_sync())
+    assert s1 == 200 and s2 == 200
+
+
+# ---------------------------------------------------------------------------
+# Cross-resource serialisation — single shared lock
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_settings_sync_and_skills_sync_share_lock(
+    gateway_home: Path,
+    app,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A settings-sync POST and a skills-sync POST serialise via the same lock.
+
+    Proves the lock isn't keyed per-resource — any two gateway mutators
+    are mutually exclusive, which is the whole point of a single
+    ``_gateway_lock``.
+    """
+    rule = _rule("Write", "echo ok")
+    _make_canonical_settings(gateway_home, {"PostToolUse": [rule]})
+    _make_target_settings(gateway_home, {})
+    _make_canonical_skill(gateway_home, "alpha")
+
+    spans: list[tuple[str, float, float]] = []
+
+    import memtomem.web.routes.settings_sync as _ss
+    import memtomem.web.routes.context_skills as _cs
+
+    real_generate_settings = _ss.generate_all_settings
+    real_generate_skills = _cs.generate_all_skills
+
+    def make_instrumented(label: str, real):
+        def wrapped(*args, **kwargs):
+            enter = time.perf_counter()
+            time.sleep(0.05)
+            out = real(*args, **kwargs)
+            exit_t = time.perf_counter()
+            spans.append((label, enter, exit_t))
+            return out
+
+        return wrapped
+
+    monkeypatch.setattr(
+        _ss, "generate_all_settings", make_instrumented("settings", real_generate_settings)
+    )
+    monkeypatch.setattr(
+        _cs, "generate_all_skills", make_instrumented("skills", real_generate_skills)
+    )
+
+    async def do_settings() -> int:
+        resp = await client.post("/api/settings-sync")
+        return resp.status_code
+
+    async def do_skills() -> int:
+        resp = await client.post("/api/context/skills/sync")
+        return resp.status_code
+
+    s1, s2 = await asyncio.gather(do_settings(), do_skills())
+    assert s1 == 200 and s2 == 200
+
+    assert len(spans) == 2, spans
+    spans.sort(key=lambda s: s[1])
+    (_, _, first_exit), (_, second_enter, _) = spans
+    assert first_exit <= second_enter + 1e-3, (
+        f"settings-sync and skills-sync overlapped: first exit {first_exit}, "
+        f"second enter {second_enter}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lock-held assertion — fails fast if the wrapper is removed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_gateway_lock_is_held_during_each_post_handler(
+    gateway_home: Path,
+    app,
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Every wrapped POST handler must hold ``_gateway_lock`` when it runs.
+
+    Stronger than the timing tests: this asserts the lock is *actually
+    acquired* inside the handler. If a future refactor drops the
+    ``async with _gateway_lock`` wrapper from any handler, this test
+    fails immediately rather than passing on coincidental serialisation.
+    """
+    rule = _rule("Write", "echo ok")
+    _make_canonical_settings(gateway_home, {"PostToolUse": [rule]})
+    _make_target_settings(gateway_home, {})
+    _make_canonical_skill(gateway_home, "alpha")
+    _make_canonical_agent(gateway_home, "agent1")
+    _make_canonical_command(gateway_home, "cmd1")
+
+    from memtomem.web.routes._locks import _gateway_lock
+
+    observed: dict[str, bool] = {}
+
+    def make_probe(label: str, real):
+        def wrapped(*args, **kwargs):
+            observed[label] = _gateway_lock.locked()
+            return real(*args, **kwargs)
+
+        return wrapped
+
+    import memtomem.web.routes.context_agents as _ca
+    import memtomem.web.routes.context_commands as _cc
+    import memtomem.web.routes.context_skills as _cs
+    import memtomem.web.routes.settings_sync as _ss
+
+    monkeypatch.setattr(
+        _ss, "generate_all_settings", make_probe("settings_sync", _ss.generate_all_settings)
+    )
+    monkeypatch.setattr(
+        _cs, "generate_all_skills", make_probe("skills_sync", _cs.generate_all_skills)
+    )
+    monkeypatch.setattr(
+        _ca, "generate_all_agents", make_probe("agents_sync", _ca.generate_all_agents)
+    )
+    monkeypatch.setattr(
+        _cc, "generate_all_commands", make_probe("commands_sync", _cc.generate_all_commands)
+    )
+    monkeypatch.setattr(
+        _cs,
+        "extract_skills_to_canonical",
+        make_probe("skills_import", _cs.extract_skills_to_canonical),
+    )
+    monkeypatch.setattr(
+        _ca,
+        "extract_agents_to_canonical",
+        make_probe("agents_import", _ca.extract_agents_to_canonical),
+    )
+    monkeypatch.setattr(
+        _cc,
+        "extract_commands_to_canonical",
+        make_probe("commands_import", _cc.extract_commands_to_canonical),
+    )
+
+    # Every POST that the issue scopes — fire each, assert the lock
+    # was held when the inner generator ran.
+    assert (await client.post("/api/settings-sync")).status_code == 200
+    assert (await client.post("/api/context/skills/sync")).status_code == 200
+    assert (await client.post("/api/context/agents/sync")).status_code == 200
+    assert (await client.post("/api/context/commands/sync")).status_code == 200
+    assert (await client.post("/api/context/skills/import")).status_code == 200
+    assert (await client.post("/api/context/agents/import")).status_code == 200
+    assert (await client.post("/api/context/commands/import")).status_code == 200
+
+    expected = {
+        "settings_sync",
+        "skills_sync",
+        "agents_sync",
+        "commands_sync",
+        "skills_import",
+        "agents_import",
+        "commands_import",
+    }
+    missing = expected - set(observed)
+    assert not missing, f"handlers never invoked the inner generator: {missing}"
+
+    not_locked = [k for k, v in observed.items() if not v]
+    assert not not_locked, f"lock NOT held during: {not_locked}"
+
+
+# ---------------------------------------------------------------------------
+# Lock object identity — every route imports the same singleton
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_lock_is_module_singleton():
+    """All gateway routes import the same ``_gateway_lock`` instance."""
+    from memtomem.web.routes import _locks
+    from memtomem.web.routes.context_agents import _gateway_lock as ca_lock
+    from memtomem.web.routes.context_commands import _gateway_lock as cc_lock
+    from memtomem.web.routes.context_skills import _gateway_lock as cs_lock
+    from memtomem.web.routes.settings_sync import _gateway_lock as ss_lock
+
+    assert ss_lock is _locks._gateway_lock
+    assert cs_lock is _locks._gateway_lock
+    assert cc_lock is _locks._gateway_lock
+    assert ca_lock is _locks._gateway_lock
+
+
+def test_config_lock_is_module_singleton():
+    """``system.py`` imports the same ``_config_lock`` from ``_locks``."""
+    from memtomem.web.routes import _locks
+    from memtomem.web.routes.system import _config_lock as sys_lock
+
+    assert sys_lock is _locks._config_lock


### PR DESCRIPTION
## Summary

- Move `_config_lock` to a new `web/routes/_locks.py`; add a sibling `_gateway_lock` (independent — config.json writes don't block gateway writes and vice versa).
- Wrap `apply_settings_sync`, `resolve_conflict`, and the create/sync/import POST handlers in `context_{agents,commands,skills}.py` with `async with asyncio.timeout(60) / _gateway_lock`. Without the lock, two concurrent `POST /api/settings-sync` (or a Web UI + `mm context sync` racing) could interleave on `~/.claude/settings.json` since Python's `st_mtime` (float seconds) loses sub-second resolution.
- Switch the two server-internal mtime guards (`context/settings.py:267`, `settings_sync.py:228`) to `st_mtime_ns` for precision consistency with `hot_reload.py`. PUT update_* handlers' API mtime stays as `float` — JS `Number` precision (~9e15) can't represent ns since epoch (~1.79e18) without lossy rounding, so any `int` ns over the wire would break the browser CAS round-trip; the in-process lock + float CAS already cover the same-process race.

## Scope decisions

- Wrapped only the POST handlers the issue lists. PUT update_* and DELETE intentionally left out — PUT has its own mtime CAS, DELETE is idempotent, and both are out of issue scope.
- Cross-process file lock (CLI + Web UI racing) explicitly not in scope per the issue's non-goals.

## Test plan

- [x] `uv run pytest -m "not ollama"` — **1772 passed / 0 regressions** (was 1763 + 9 new)
- [x] `uv run ruff check && ruff format --check` — passes
- [x] `uv run mypy` — no new issues
- [x] New `test_web_routes_context_locks.py` (9 tests) covers:
  - timing-based serialisation: settings-sync, resolve, cross-resource (settings + skills)
  - file integrity after concurrent same-rule resolves
  - positive lock-held assertion on every wrapped POST handler — verified to fail when the wrapper is removed (negative-tested by stashing context_skills.py changes; assertion correctly identified `lock NOT held during: ['skills_sync', 'skills_import']`)
  - singleton identity for both `_gateway_lock` and `_config_lock`

Closes #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
