### PR TITLE
fix(web,storage): singleton + thread offload for FTS rebuild (closes #278)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -41,6 +42,24 @@ from memtomem.storage.sqlite_schema import create_tables
 logger = logging.getLogger(__name__)
 
 __all__ = ["SqliteBackend", "validate_namespace"]
+
+
+# Batch size for streaming rebuild_fts — bounds peak memory regardless of
+# corpus size (issue #278). 1000 rows × typical chunk width stays well under
+# a megabyte while keeping round-trip overhead negligible.
+_REBUILD_FTS_BATCH_SIZE = 1000
+
+
+def _rebuild_fts_retrieval(content: str, hierarchy_json: str) -> str:
+    """Prefix ``content`` with its heading hierarchy for FTS indexing."""
+    if hierarchy_json:
+        try:
+            h = json.loads(hierarchy_json)
+            if h:
+                return " > ".join(h) + "\n\n" + content
+        except (ValueError, TypeError):
+            pass
+    return content
 
 
 class SqliteBackend(
@@ -570,33 +589,56 @@ class SqliteBackend(
         """Rebuild the FTS5 index from chunks table using current tokenizer.
 
         Returns the number of rows rebuilt.
+
+        Runs the heavy I/O in a worker thread via :func:`asyncio.to_thread`
+        so the event loop stays responsive during the rebuild, and streams
+        rows in batches of ``_REBUILD_FTS_BATCH_SIZE`` so memory stays bounded
+        even for corpora with hundreds of thousands of chunks (issue #278).
+        The worker opens its own writer connection against the same SQLite
+        file; WAL + SQLite's file-level lock serialise it against writes on
+        the main connection, so the rebuild is atomic and independent of any
+        transaction the main connection may hold.
         """
-        db = self._db
-        assert db is not None
-        db.execute("DELETE FROM chunks_fts")
-        rows = db.execute(
-            "SELECT rowid, content, source_file, heading_hierarchy FROM chunks"
-        ).fetchall()
-        if rows:
+        assert self._db is not None
+        db_path = str(Path(self._config.sqlite_path).expanduser())
 
-            def _retrieval(content: str, hierarchy_json: str) -> str:
-                if hierarchy_json:
-                    import json as _json
+        def _run() -> int:
+            conn = sqlite3.connect(db_path, timeout=10)
+            try:
+                conn.execute("PRAGMA journal_mode=WAL")
+                conn.execute("DELETE FROM chunks_fts")
+                cursor = conn.execute(
+                    "SELECT rowid, content, source_file, heading_hierarchy FROM chunks"
+                )
+                total = 0
+                try:
+                    while True:
+                        batch = cursor.fetchmany(_REBUILD_FTS_BATCH_SIZE)
+                        if not batch:
+                            break
+                        conn.executemany(
+                            "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?,?,?)",
+                            [
+                                (
+                                    r[0],
+                                    _fts.tokenize_for_fts(_rebuild_fts_retrieval(r[1], r[3])),
+                                    r[2],
+                                )
+                                for r in batch
+                            ],
+                        )
+                        total += len(batch)
+                finally:
+                    cursor.close()
+                conn.commit()
+                return total
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                conn.close()
 
-                    try:
-                        h = _json.loads(hierarchy_json)
-                        if h:
-                            return " > ".join(h) + "\n\n" + content
-                    except (ValueError, TypeError):
-                        pass
-                return content
-
-            db.executemany(
-                "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?,?,?)",
-                [(r[0], _fts.tokenize_for_fts(_retrieval(r[1], r[3])), r[2]) for r in rows],
-            )
-        db.commit()
-        return len(rows)
+        return await asyncio.to_thread(_run)
 
     async def get_embeddings_for_chunks(self, chunk_ids: list[str]) -> dict[str, list[float]]:
         """Fetch embeddings for a list of chunk IDs. Returns {id: embedding}."""

--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -262,7 +262,7 @@ def reload_if_stale(
 
     if old_cfg is not None and (storage is not None or search_pipeline is not None):
         apply_runtime_config_changes(
-            old_cfg, new_cfg, storage=storage, search_pipeline=search_pipeline
+            old_cfg, new_cfg, storage=storage, search_pipeline=search_pipeline, app=app
         )
 
     logger.info("Hot-reloaded config from %s", _override_path())
@@ -280,6 +280,7 @@ def apply_runtime_config_changes(
     *,
     storage: SqliteBackend | None = None,
     search_pipeline: SearchPipeline | None = None,
+    app: FastAPI | None = None,
 ) -> None:
     """Propagate runtime-mutable config changes to live components.
 
@@ -291,6 +292,12 @@ def apply_runtime_config_changes(
     ``storage`` / ``search_pipeline`` (rare), in which case the matching
     fanout step is skipped. This keeps the helper usable in unit tests and
     from non-web callers.
+
+    ``app`` is optional: when provided, the FTS rebuild is tracked on
+    ``app.state.fts_rebuild_task`` so back-to-back tokenizer changes coalesce
+    (issue #278) instead of spawning overlapping rebuilds. When omitted, the
+    rebuild is fire-and-forget without coalescing — preserved for non-web
+    callers and legacy unit tests.
     """
     try:
         tokenizer_changed = old_cfg.search.tokenizer != new_cfg.search.tokenizer
@@ -301,32 +308,68 @@ def apply_runtime_config_changes(
         from memtomem.storage.fts_tokenizer import set_tokenizer
 
         set_tokenizer(new_cfg.search.tokenizer)
-        _schedule_fts_rebuild(storage, new_cfg.search.tokenizer)
+        _schedule_fts_rebuild(storage, new_cfg.search.tokenizer, app=app)
 
     if search_pipeline is not None:
         search_pipeline.invalidate_cache()
 
 
-def _schedule_fts_rebuild(storage: SqliteBackend, tokenizer: str) -> None:
+def _schedule_fts_rebuild(
+    storage: SqliteBackend,
+    tokenizer: str,
+    *,
+    app: FastAPI | None = None,
+) -> None:
     """Kick off ``storage.rebuild_fts()`` as a background task if possible.
 
     When called from an async request handler the rebuild runs on the current
     loop; when called from a sync context without a running loop, it falls
     back to ``asyncio.run`` so non-web callers (tests, future CLIs) still
     work.
+
+    When ``app`` is provided, enforces a per-app singleton: at most one
+    rebuild task runs at a time (tracked on ``app.state.fts_rebuild_task``).
+    Any tokenizer change that lands while a rebuild is in flight stores the
+    tokenizer on ``app.state.fts_rebuild_pending`` — the running task picks
+    it up and runs one follow-up rebuild once the current pass completes.
+    Rapid back-to-back changes therefore collapse to at most two sequential
+    rebuilds (issue #278).
     """
     import asyncio
 
-    async def _runner() -> None:
+    async def _run_one(target: str) -> None:
         try:
             count = await storage.rebuild_fts()
-            logger.info("FTS index rebuilt with tokenizer=%s (%d chunks)", tokenizer, count)
+            logger.info("FTS index rebuilt with tokenizer=%s (%d chunks)", target, count)
         except Exception:
             logger.warning("FTS rebuild after tokenizer change failed", exc_info=True)
 
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        asyncio.run(_runner())
+        asyncio.run(_run_one(tokenizer))
         return
-    loop.create_task(_runner())
+
+    if app is None:
+        loop.create_task(_run_one(tokenizer))
+        return
+
+    in_flight = getattr(app.state, "fts_rebuild_task", None)
+    if in_flight is not None and not in_flight.done():
+        app.state.fts_rebuild_pending = tokenizer
+        logger.info("FTS rebuild already in flight, coalescing tokenizer=%s as pending", tokenizer)
+        return
+
+    async def _run_with_coalesce() -> None:
+        current = tokenizer
+        while True:
+            await _run_one(current)
+            pending = getattr(app.state, "fts_rebuild_pending", None)
+            if pending is None:
+                return
+            app.state.fts_rebuild_pending = None
+            current = pending
+            logger.info("FTS rebuild coalesce: running with pending tokenizer=%s", current)
+
+    app.state.fts_rebuild_pending = None
+    app.state.fts_rebuild_task = loop.create_task(_run_with_coalesce())

--- a/packages/memtomem/tests/test_storage_extended.py
+++ b/packages/memtomem/tests/test_storage_extended.py
@@ -137,6 +137,32 @@ class TestStorageExtended:
         count = await storage.rebuild_fts()
         assert count == 4
 
+    async def test_rebuild_fts_streams_across_batch_boundary(
+        self, components, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Corpora larger than ``_REBUILD_FTS_BATCH_SIZE`` rebuild correctly
+        (regression guard for the streaming implementation, issue #278).
+
+        Shrinks the batch size so we can cross the boundary with a small
+        corpus without slowing the test down.
+        """
+        from memtomem.storage import sqlite_backend
+
+        monkeypatch.setattr(sqlite_backend, "_REBUILD_FTS_BATCH_SIZE", 3)
+
+        storage = components.storage
+        chunks = [
+            make_chunk(content=f"streamed giraffe {i}", source=f"batch{i}.md") for i in range(10)
+        ]
+        await storage.upsert_chunks(chunks)
+
+        count = await storage.rebuild_fts()
+        assert count == 10
+
+        # Searchability must hold across the batch boundary.
+        results = await storage.bm25_search("giraffe", top_k=10)
+        assert len(results) >= 1
+
     # ---- get_chunk_hashes ----------------------------------------------------
 
     async def test_get_chunk_hashes_returns_mapping(self, components):

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -706,6 +706,147 @@ class TestApplyRuntimeConfigChanges:
         search_pipeline.invalidate_cache.assert_called_once()
 
 
+class TestScheduleFtsRebuildCoalescing:
+    """Singleton + coalescing for back-to-back tokenizer changes (issue #278).
+
+    These tests exercise ``_schedule_fts_rebuild`` directly so we can gate
+    the "in flight" window with an ``asyncio.Event``; using the public
+    ``apply_runtime_config_changes`` would still reach the same code path
+    but leaves less room to pin timing.
+    """
+
+    def _make_app(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(state=SimpleNamespace())
+
+    async def test_back_to_back_calls_coalesce_into_one_pending(self):
+        """Calls that land while a rebuild is in flight collapse into a single
+        follow-up rebuild using the most recent tokenizer (not one per call).
+        """
+        gate = asyncio.Event()
+        call_tokenizers: list[str] = []
+
+        async def _slow_rebuild():
+            # Snapshot "who ran" by reading the task-local state via the
+            # follow-up tokenizer the scheduler passes into _run_one. We
+            # can't intercept the argument directly (closure), so we use the
+            # number of calls as a proxy and assert pending transitions.
+            call_tokenizers.append("running")
+            await gate.wait()
+            return 0
+
+        storage = AsyncMock()
+        storage.rebuild_fts = _slow_rebuild
+
+        app = self._make_app()
+
+        # First call → starts a real task (gated).
+        _hot_reload._schedule_fts_rebuild(storage, "unicode61", app=app)
+        await asyncio.sleep(0)  # let task start + enter wait()
+
+        first_task = app.state.fts_rebuild_task
+        assert first_task is not None
+        assert not first_task.done()
+
+        # Second call lands while first is in flight → should coalesce.
+        _hot_reload._schedule_fts_rebuild(storage, "kiwipiepy", app=app)
+        assert app.state.fts_rebuild_task is first_task, "must not replace in-flight task"
+        assert app.state.fts_rebuild_pending == "kiwipiepy"
+
+        # Third call also coalesces — overwriting pending with the latest.
+        _hot_reload._schedule_fts_rebuild(storage, "unicode61", app=app)
+        assert app.state.fts_rebuild_task is first_task
+        assert app.state.fts_rebuild_pending == "unicode61"
+
+        # Release the gate — the first rebuild completes, then the coalesced
+        # follow-up runs once, then the loop exits.
+        gate.set()
+        await asyncio.wait_for(first_task, timeout=1.0)
+
+        # Exactly two rebuild passes: the original + one coalesced.
+        assert len(call_tokenizers) == 2, call_tokenizers
+        assert app.state.fts_rebuild_pending is None
+
+    async def test_rebuilds_do_not_run_in_parallel(self):
+        """Even with many rapid calls, rebuild intervals never overlap."""
+        intervals: list[tuple[float, float]] = []
+
+        async def _rebuild():
+            start = asyncio.get_event_loop().time()
+            # Tiny sleep to make overlap detectable if it were to happen.
+            await asyncio.sleep(0.02)
+            intervals.append((start, asyncio.get_event_loop().time()))
+            return 0
+
+        storage = AsyncMock()
+        storage.rebuild_fts = _rebuild
+
+        app = self._make_app()
+
+        for tok in ("a", "b", "c", "d"):
+            _hot_reload._schedule_fts_rebuild(storage, tok, app=app)
+            await asyncio.sleep(0)
+
+        # Wait for the running task chain to complete.
+        task = app.state.fts_rebuild_task
+        assert task is not None
+        await asyncio.wait_for(task, timeout=2.0)
+
+        # No overlap: each interval ends before the next begins.
+        intervals.sort()
+        for (s1, e1), (s2, _e2) in zip(intervals, intervals[1:]):
+            assert e1 <= s2, f"overlap: {(s1, e1)} vs {(s2, _e2)}"
+        # At most 2 rebuilds: the first + one coalesced follow-up covering
+        # everything queued after it (not one per call).
+        assert len(intervals) <= 2
+
+    async def test_finished_task_allows_new_rebuild(self):
+        """After the prior rebuild task is done, a new call starts a fresh one."""
+        count = 0
+
+        async def _rebuild():
+            nonlocal count
+            count += 1
+            return 0
+
+        storage = AsyncMock()
+        storage.rebuild_fts = _rebuild
+
+        app = self._make_app()
+
+        _hot_reload._schedule_fts_rebuild(storage, "a", app=app)
+        await asyncio.wait_for(app.state.fts_rebuild_task, timeout=1.0)
+        assert count == 1
+        first_task = app.state.fts_rebuild_task
+
+        _hot_reload._schedule_fts_rebuild(storage, "b", app=app)
+        await asyncio.wait_for(app.state.fts_rebuild_task, timeout=1.0)
+        assert count == 2
+        assert app.state.fts_rebuild_task is not first_task
+
+    async def test_legacy_call_without_app_preserves_fire_and_forget(self):
+        """Callers that don't pass ``app`` still get the old non-tracked behavior."""
+        calls = []
+
+        async def _rebuild():
+            calls.append(1)
+            return 0
+
+        storage = AsyncMock()
+        storage.rebuild_fts = _rebuild
+
+        _hot_reload._schedule_fts_rebuild(storage, "x")
+        _hot_reload._schedule_fts_rebuild(storage, "y")
+        # Let both scheduled tasks run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        # Without coalescing both run — acceptable as legacy behavior.
+        assert len(calls) == 2
+
+
 # ---------------------------------------------------------------------------
 # Mutex guard: the lock rename must keep the public name stable for other
 # call sites that may import it. Regression guard against silent drift.


### PR DESCRIPTION
Closes #278.

## Problem

`_schedule_fts_rebuild` spawned a fresh `asyncio.Task` on every tokenizer
change and `SqliteBackend.rebuild_fts` was declared `async def` but had no
`await` points — it ran `db.execute` / `fetchall` / `executemany` / `commit`
synchronously on the main connection. Three concrete consequences:

1. Two tokenizer changes within seconds (`mm config set search.tokenizer tok_a`
   then `tok_b`) created two overlapping tasks on the same connection; the
   second task's `DELETE FROM chunks_fts` could race the first task's
   `executemany`, leaving the FTS index empty until both finished.
2. Each task blocked the event loop for the duration of the rebuild.
3. `fetchall()` materialised the entire `chunks` table in memory.

## Fix

### Scheduling — `web/hot_reload.py`

`_schedule_fts_rebuild` now accepts an optional `app`. When provided, it
enforces a per-app singleton:

- The in-flight task lives on `app.state.fts_rebuild_task`.
- If a rebuild is already running, the new tokenizer is stored on
  `app.state.fts_rebuild_pending` (overwriting any prior pending value).
- The running task, once it finishes a pass, checks `fts_rebuild_pending`
  and runs exactly one follow-up rebuild with the latest tokenizer.

So N rapid back-to-back changes collapse to at most two sequential rebuilds
(the first + one coalesced follow-up), never parallel. `reload_if_stale`
passes `app` through; `apply_runtime_config_changes` keeps its legacy
signature for unit tests and non-web callers (no `app` → fire-and-forget,
preserved behaviour).

### Storage — `storage/sqlite_backend.py`

`rebuild_fts` runs its sync body via `asyncio.to_thread`, opening a
dedicated writer connection for the duration. WAL + SQLite's file-level
write lock serialise it against the main connection, so the rebuild is
atomic and independent of any transaction the main connection may hold.
Inside the worker, rows are streamed with `fetchmany(_REBUILD_FTS_BATCH_SIZE)`
(1000) so memory stays bounded regardless of corpus size.

## Acceptance criteria

- [x] Two back-to-back tokenizer changes result in at most two sequential
  rebuilds (not parallel) — covered by
  `test_back_to_back_calls_coalesce_into_one_pending` and
  `test_rebuilds_do_not_run_in_parallel`.
- [x] Rebuild no longer blocks the event loop — offloaded via
  `asyncio.to_thread` to a worker thread. (Latency spike verification under
  load is out of scope for unit tests; the mechanism is the standard asyncio
  escape hatch.)
- [x] Memory usage during rebuild is bounded — `fetchmany(1000)` loop;
  regression-guarded by `test_rebuild_fts_streams_across_batch_boundary`
  which shrinks the batch size to cross the boundary with a small corpus.

## Tests

- `TestScheduleFtsRebuildCoalescing` — 4 new tests pinning the singleton +
  coalescing behaviour.
- `test_rebuild_fts_streams_across_batch_boundary` — monkeypatches
  `_REBUILD_FTS_BATCH_SIZE` to 3 with 10 chunks, asserts `rebuild_fts`
  returns 10 and BM25 search still finds a known token after rebuild.

All existing rebuild_fts and hot-reload tests continue to pass (1759
passed, 46 deselected for the non-ollama filter).

## Non-goals

Per the issue: incremental FTS sync on tokenizer change. Full rebuild
remains the contract; only scheduling and backpressure are addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
