### PR TITLE
feat: opt-in provider memory dirs + scope narrowing per official docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+- **Provider memory directories are now opt-in via `mm init`.** The wizard
+  has a new "Provider memory folders" step (Step 4 of 10) that detects
+  Claude Code per-project memory (`~/.claude/projects/<project>/memory/`),
+  Claude plans (`~/.claude/plans/`), and Codex memories
+  (`~/.codex/memories/`) and lets you accept each category. Accepted paths
+  land in `indexing.memory_dirs` directly, replacing the previous silent
+  runtime auto-discovery. Non-interactive mode supports the new repeatable
+  `--include-provider {claude-memory,claude-plans,codex}` flag.
+- **Auto-discovery scope narrowed** to canonical memory surfaces per each
+  provider's official documentation:
+  - Claude Code: only the `*/memory/` subdirectories with at least one
+    `.md` file (previously the entire `~/.claude/projects/` tree
+    including session JSONL transcripts and `staging/`).
+  - Codex: `~/.codex/memories/` (unchanged).
+- **Gemini CLI removed from auto-discovery.** Its memory is the single file
+  `~/.gemini/GEMINI.md` (incompatible with the directory-based
+  `memory_dirs` abstraction), and the parent dir contains secrets like
+  `oauth_creds.json`. Use `mm ingest gemini-memory` for one-shot manual
+  import — that command is unchanged.
+
+### Deprecated
+- `indexing.auto_discover` is now a one-shot migration trigger only, not a
+  runtime auto-discovery flag. Existing installs with the legacy default
+  (`true`) get migrated transparently on the next CLI/server startup —
+  canonical provider dirs that exist on the machine are appended to
+  `indexing.memory_dirs` and the flag flips to `false`. The field will be
+  removed in a future release.
+
+### Migration notes
+- After upgrading, run `mm index --rebuild` to clean up index entries left
+  over from the previous wider scan (session transcripts, staging dirs,
+  Gemini configs). The migration narrows `memory_dirs` but doesn't
+  retroactively prune already-indexed content.
+- New Claude Code projects created after running `mm init` are not
+  auto-indexed — re-run `mm init` or use
+  `mm config set indexing.memory_dirs` to add them when needed.
+
 ## [0.1.11] — 2026-04-19
 
 memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -98,8 +98,10 @@ the next save, provided the stale value now matches the comparand.
 `indexing.memory_dirs` participates in delta-only save, so on the
 machine where it was set the file typically omits it. When copying an
 existing `config.json` to a new machine, any `indexing.memory_dirs`
-entry carries over as-is and is **not** auto-replaced by the new
-machine's auto-discovered paths. Reset it explicitly when migrating:
+entry carries over as-is — provider memory paths from the source
+machine (e.g. `~/.claude/projects/<project-A>/memory/`) won't exist
+on the destination and won't be replaced by detection on the target.
+Reset it explicitly when migrating:
 
 ```bash
 # Option 1: targeted removal of the carried-over entry
@@ -255,7 +257,7 @@ When enabled, search results include surrounding chunks from the same source fil
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` + auto-discovered | Directories to index (see below) |
+| `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` (+ provider folders selected in `mm init`) | Directories to index (see below) |
 | `MEMTOMEM_INDEXING__SUPPORTED_EXTENSIONS` | `[".md",".json",".yaml",".yml",".toml",".py",".js",".ts",".tsx",".jsx"]` | File types accepted by the indexer and file watcher |
 | `MEMTOMEM_INDEXING__MAX_CHUNK_TOKENS` | `512` | Maximum tokens per chunk |
 | `MEMTOMEM_INDEXING__MIN_CHUNK_TOKENS` | `128` | Merge threshold for short chunks |
@@ -279,7 +281,8 @@ extend them but cannot override them.
     "exclude_patterns": [
       "**/subagents/**",         // Claude Code subagent metadata
       "**/antigravity-browser-profile/**",
-      "**/.gemini/**/*.json"     // .gemini auto-discover noise
+      "**/.gemini/**/*.json"     // defensive — only relevant if you manually
+                                 // add ~/.gemini/ to memory_dirs
     ]
   }
 }
@@ -293,46 +296,74 @@ extend them but cannot override them.
 > - **Match against root-relative paths.** Patterns are evaluated against
 >   `path.relative_to(memory_dir)`, so `**/*.json` works, but a pattern that
 >   assumes a specific parent (e.g. `**/.claude/**/*.json`) may miss matches
->   when `~/.claude/projects` itself is the auto-discovered memory_dir root.
->   When in doubt, add both root-relative (`oauth_creds.json`) and `**/X`
->   (`**/oauth_creds.json`) forms.
+>   when a Claude Code per-project memory dir is itself the `memory_dir`
+>   root. When in doubt, add both root-relative (`oauth_creds.json`) and
+>   `**/X` (`**/oauth_creds.json`) forms.
 
-### Auto-discovered memory directories
+### Provider memory folders (opt-in via `mm init`)
 
-In addition to `~/.memtomem/memories`, memtomem automatically adds well-known
-AI tool directories to `memory_dirs` when they exist on the machine:
+memtomem can index AI tool memory folders alongside `~/.memtomem/memories`,
+but only when you explicitly opt in during `mm init`. The wizard's
+"Provider memory folders" step shows whichever of these are detected on
+your machine and lets you accept them per category:
 
-| Directory | Tool | Scope |
-|-----------|------|-------|
-| `~/.claude/projects` | Claude Code | per-project auto-memory |
-| `~/.gemini` | Gemini CLI | global `GEMINI.md` |
-| `~/.codex/memories` | Codex CLI | global memories |
+| Category | Source | Scope |
+|----------|--------|-------|
+| `claude-memory` | `~/.claude/projects/<project>/memory/` | Claude Code per-project auto-memory ([official docs](https://code.claude.com/docs/en/memory)) |
+| `claude-plans` | `~/.claude/plans/` | Claude Code plan files (local convention) |
+| `codex` | `~/.codex/memories/` | Codex CLI memories ([official docs](https://developers.openai.com/codex/memories)) |
 
-Auto-discovered directories are appended after `config.d/` and
-`config.json` overrides, so they are always available even if you
-override `memory_dirs` manually. This means `mem_index` and the file
-watcher accept paths under these directories without requiring explicit
-`MEMORY_DIRS` configuration.
+Accepted categories get appended directly to `indexing.memory_dirs` in
+`~/.memtomem/config.json`. Per-project Claude memory subdirs without any
+`*.md` files are skipped so empty session scaffolding doesn't pollute your
+index. New Claude Code projects created after the wizard runs are **not**
+auto-indexed — re-run `mm init` or use
+`mm config set indexing.memory_dirs` to add them when you want them
+searchable.
 
-To opt out of auto-discovery entirely, set `indexing.auto_discover = false`
-in `config.json` or export `MEMTOMEM_INDEXING__AUTO_DISCOVER=false`. When
-disabled, only the `memory_dirs` you configure explicitly are indexed — the
-three well-known directories above are ignored even if they exist on disk.
-You can also toggle this per-field from the Web UI or via
-`mm config set indexing.auto_discover false`.
+Non-interactive mode supports `--include-provider` (repeatable):
 
-> **Tip:** Use `mm ingest claude-memory`, `mm ingest gemini-memory`, or
-> `mm ingest codex-memory` for richer ingestion with per-tool tagging and
-> namespace assignment. Auto-discovery only removes the path restriction —
-> it does not apply tool-specific tags or namespaces.
+```bash
+mm init -y --include-provider claude-memory --include-provider codex
+```
 
-> **Watch out for noise under auto-discovered roots.** `~/.claude/projects`
-> sweeps in subagent metadata (`*/subagents/*.meta.json`) and `~/.gemini`
-> sweeps in browser profile + OAuth artifacts. The built-in denylist covers
-> common credentials but does not filter Claude subagent metadata or
-> browser-profile JSON — add a `config.d/` fragment with the
-> [`exclude_patterns`](#exclude-patterns) rules above so those don't bloat
-> your index.
+Asking for a category with no detected dirs is a silent no-op, not an
+error.
+
+#### Why Gemini is not in the list
+
+Gemini CLI's memory surface is the single file `~/.gemini/GEMINI.md`,
+which doesn't fit a `memory_dirs` (directory) abstraction, and the parent
+`~/.gemini/` directory contains secrets like `oauth_creds.json`. For
+Gemini users, run `mm ingest gemini-memory` for a one-shot import — it
+applies tool-specific tags and skips the noise.
+
+#### Migrating from `auto_discover` (legacy)
+
+Earlier releases used a runtime flag (`indexing.auto_discover`, default
+True) that silently appended provider home directories on every startup.
+That flag is now **deprecated** and serves only as a one-shot migration
+trigger:
+
+- If your existing `~/.memtomem/config.json` carries `auto_discover: true`
+  (or omits it, in which case it defaults True), the next CLI/server
+  startup converts the canonical provider memory dirs that exist on your
+  machine into explicit `memory_dirs` entries, then flips the flag to
+  False and persists both changes atomically.
+- The migration prints a single INFO log line. Subsequent startups see
+  `auto_discover: false` and do nothing.
+- Brand-new installs (no `config.json` yet) skip migration entirely —
+  the wizard is the only path that adds provider dirs.
+
+If your old install was indexing `~/.claude/projects/` wholesale (session
+JSONL transcripts, staging dirs, etc.), the migration narrows that to the
+canonical `*/memory/` subdirs only. To clean stale entries left over from
+the wider scan, run `mm index --rebuild` after the migration.
+
+> **Tip:** `mm ingest claude-memory`, `mm ingest gemini-memory`, and
+> `mm ingest codex-memory` apply per-tool tagging and namespace assignment
+> on top of indexing — useful when you want richer metadata than the plain
+> `memory_dirs` path-based indexing provides.
 
 > **Cloud-sync mounts** (Google Drive Stream, OneDrive Files-On-Demand ON,
 > iCloud Optimize Storage) generally do **not** emit fs watcher events to
@@ -422,7 +453,7 @@ the namespace, except for files sitting directly in a `memory_dirs` root
 (those fall back to `default_namespace`). This works well for shallow
 folder trees like `memtomem-memories/team/X.md` → `team`, but produces
 low-signal namespaces (`subagents`, `<UUID>`) when applied blindly under
-auto-discovered roots like `~/.claude/projects`.
+opt-in provider roots like `~/.claude/projects/<project>/memory/`.
 
 > **Recommendation.** Filter noise via `exclude_patterns` *before* enabling
 > `auto_ns`, otherwise opaque parent-folder names (like a Claude Code

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -118,7 +118,7 @@ mm init         # PyPI global install
 uv run mm init  # Project or source install
 ```
 
-The wizard walks you through 9 steps. Type `b` to go back, `q` to quit at any step.
+The wizard walks you through 10 steps. Type `b` to go back, `q` to quit at any step.
 
 #### Non-interactive mode (CI / automation)
 
@@ -130,17 +130,21 @@ mm init -y --provider onnx --model all-MiniLM-L6-v2     # local dense embeddings
 mm init -y --provider ollama --model nomic-embed-text   # Ollama (requires `ollama serve`)
 mm init -y --provider openai --api-key sk-...           # OpenAI
 mm init -y --memory-dir ~/notes --mcp claude            # custom dir + Claude Code auto-setup
+
+# Pull in AI tool memory folders (repeat per category):
+mm init -y --include-provider claude-memory --include-provider codex
 ```
 
 1. **Embedding provider** — BM25-only (default, zero-dependency), Local ONNX (no server), Ollama (local server), or OpenAI (cloud)
 2. **Reranker (optional)** — off by default; opt-in to a local fastembed cross-encoder. Korean/Chinese/Japanese/mixed content should pick the multilingual model
 3. **Memory directory** — where your notes live (e.g., `~/notes`, `~/memories`)
-4. **Storage** — SQLite database path (default: `~/.memtomem/memtomem.db`)
-5. **Namespace** — auto-assign namespace from folder name (e.g., `~/docs` → `docs`)
-6. **Search** — number of results per query (default: 10), time-decay toggle
-7. **Language** — tokenizer selection: Unicode (default) or Korean (kiwipiepy)
-8. **Claude Code hooks** — optional hook integration via settings.json
-9. **Editor connection** — Claude Code auto-setup, .mcp.json generation, or manual
+4. **Provider memory folders** — opt in (per category) to indexing Claude Code per-project memory (`~/.claude/projects/*/memory/`), Claude plans (`~/.claude/plans/`), and/or Codex memories (`~/.codex/memories/`). Skipped silently if none are present. Nothing is added without your confirmation
+5. **Storage** — SQLite database path (default: `~/.memtomem/memtomem.db`)
+6. **Namespace** — auto-assign namespace from folder name (e.g., `~/docs` → `docs`)
+7. **Search** — number of results per query (default: 10), time-decay toggle
+8. **Language** — tokenizer selection: Unicode (default) or Korean (kiwipiepy)
+9. **Claude Code hooks** — optional hook integration via settings.json
+10. **Editor connection** — Claude Code auto-setup, .mcp.json generation, or manual
 
 After the wizard, your MCP server is ready. Skip to [First use](#first-use) if you ran the wizard.
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -416,7 +416,7 @@ memory_dirs = ["~/notes"]
 
 Files at the root of a `memory_dir` get the default namespace. Only files inside subfolders get auto-derived namespaces. This prevents the memory_dir folder name itself from becoming an unintended namespace.
 
-For systematic tagging across auto-discovered directories (e.g. `~/.claude/projects`, cloud-sync roots), declare path → namespace rules in `namespace.rules` instead — see [Namespace rules in the configuration guide](configuration.md#namespace-rules-path-based-auto-tagging). Rules are evaluated before `enable_auto_ns` and cover use cases where the immediate parent folder name is opaque (UUIDs, generic labels like `memory`).
+For systematic tagging across opt-in provider directories (e.g. the per-project `~/.claude/projects/<project>/memory/` paths added via `mm init`, or cloud-sync roots), declare path → namespace rules in `namespace.rules` instead — see [Namespace rules in the configuration guide](configuration.md#namespace-rules-path-based-auto-tagging). Rules are evaluated before `enable_auto_ns` and cover use cases where the immediate parent folder name is opaque (UUIDs, generic labels like `memory`).
 
 ---
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -42,7 +42,7 @@ For full setup, OpenAI configuration, and troubleshooting, see the [Getting Star
 <details>
 <summary><b>Prefer no install? (uvx direct, MCP only)</b></summary>
 
-If you'd rather skip the CLI install, `uvx` will download and run memtomem on demand. `~/.memtomem/memories` is always indexed, and well-known AI tool directories (`~/.claude/projects`, `~/.gemini`, `~/.codex/memories`) are auto-discovered when they exist. Set `MEMTOMEM_INDEXING__MEMORY_DIRS` to add custom paths.
+If you'd rather skip the CLI install, `uvx` will download and run memtomem on demand. `~/.memtomem/memories` is always indexed; for AI tool memory folders (Claude Code per-project memory, Claude plans, Codex memories), run `mm init` once and pick the surfaces you want indexed — nothing is added silently. Set `MEMTOMEM_INDEXING__MEMORY_DIRS` to add custom paths.
 
 ```bash
 claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -258,8 +258,67 @@ def _step_memory_dir(state: dict) -> None:
     click.echo()
 
 
+def _step_provider_dirs(state: dict) -> None:
+    """Opt-in indexing of provider memory folders detected on this machine.
+
+    Replaces the legacy silent ``ensure_auto_discovered_dirs`` runtime path.
+    Per-category prompts (Claude Code memory, Claude plans, Codex memories)
+    let the user pick exactly which surfaces to make searchable. Categories
+    with zero detected directories are skipped silently — the step is a
+    no-op on machines without any of these tools installed.
+    """
+    step_header(4, "Provider Memory Folders")
+    from memtomem.config import _detect_provider_dirs
+
+    grouped = _detect_provider_dirs()
+    available = {cat: dirs for cat, dirs in grouped.items() if dirs}
+
+    if not available:
+        click.echo("  No AI tool memory folders detected on this machine.")
+        click.echo("  (Skipping — re-run `mm init` after installing Claude Code or Codex CLI.)")
+        state["provider_dirs"] = []
+        click.echo()
+        return
+
+    click.echo("  Make memory from other AI tools searchable through memtomem?")
+    click.echo("  Each option is opt-in; declined folders stay out of search.")
+    click.echo()
+
+    selected: list[Path] = []
+
+    if "claude-memory" in available:
+        n = len(available["claude-memory"])
+        suffix = "project" if n == 1 else "projects"
+        if nav_confirm(
+            f"  Claude Code per-project memory ({n} {suffix} with .md content)?",
+            default=False,
+        ):
+            selected.extend(available["claude-memory"])
+
+    if "claude-plans" in available:
+        if nav_confirm(
+            "  Claude Code plans (~/.claude/plans/)?",
+            default=False,
+        ):
+            selected.extend(available["claude-plans"])
+
+    if "codex" in available:
+        if nav_confirm(
+            "  Codex CLI memories (~/.codex/memories/)?",
+            default=False,
+        ):
+            selected.extend(available["codex"])
+
+    state["provider_dirs"] = [str(p) for p in selected]
+    if selected:
+        click.secho(f"  Added {len(selected)} provider folder(s) to memory_dirs.", fg="green")
+        click.echo("  New Claude Code projects created later won't be auto-indexed —")
+        click.echo("  re-run `mm init` or use `mm config set indexing.memory_dirs` to add them.")
+    click.echo()
+
+
 def _step_storage(state: dict) -> None:
-    step_header(4, "Storage")
+    step_header(5, "Storage")
     config_dir = Path("~/.memtomem").expanduser()
     db_default = str(config_dir / "memtomem.db")
     state["db_path"] = nav_prompt("  SQLite DB path", default=db_default)
@@ -267,7 +326,7 @@ def _step_storage(state: dict) -> None:
 
 
 def _step_namespace(state: dict) -> None:
-    step_header(5, "Namespace")
+    step_header(6, "Namespace")
     click.echo("  Organize memories into scoped groups (work, personal, project).")
     state["enable_auto_ns"] = nav_confirm(
         "  Auto-assign namespace from folder name? (~/docs → 'docs')", default=False
@@ -277,7 +336,7 @@ def _step_namespace(state: dict) -> None:
 
 
 def _step_search(state: dict) -> None:
-    step_header(6, "Search")
+    step_header(7, "Search")
     state["top_k"] = nav_prompt("  Results per search", type=click.INT, default=10)
     state["decay_enabled"] = nav_confirm(
         "  Enable time-decay? (older memories rank lower)", default=False
@@ -286,7 +345,7 @@ def _step_search(state: dict) -> None:
 
 
 def _step_language(state: dict) -> None:
-    step_header(7, "Language")
+    step_header(8, "Language")
     click.echo("  Search tokenizer:")
     click.echo("    [1] Unicode (default — English and most languages)")
     click.echo("    [2] Korean (kiwipiepy — better Korean word splitting)")
@@ -305,7 +364,7 @@ def _step_language(state: dict) -> None:
 
 
 def _step_settings(state: dict) -> None:
-    step_header(8, "Claude Code Hooks")
+    step_header(9, "Claude Code Hooks")
 
     # Skip entirely if Claude Code is not installed
     claude_dir = Path.home() / ".claude"
@@ -348,7 +407,7 @@ def _step_settings(state: dict) -> None:
 
 
 def _step_mcp(state: dict) -> None:
-    step_header(9, "Connect to AI Editor")
+    step_header(10, "Connect to AI Editor")
     click.echo("  How do you want to connect memtomem?")
     click.echo("    [1] Claude Code (run 'claude mcp add' automatically)")
     click.echo("    [2] Generate .mcp.json here (Claude Code project scope;")
@@ -656,7 +715,20 @@ def _write_config_and_summary(
     # merge so we can diff pre-merge vs post-write.
     existing_before = copy.deepcopy(existing)
 
-    # Build init-target fields only
+    # Build init-target fields only. ``memory_dirs`` combines the user's
+    # primary directory with any provider folders accepted in Step 4
+    # (Claude memory, Claude plans, Codex memories), deduped while
+    # preserving order so the primary dir always lists first.
+    provider_dirs = state.get("provider_dirs", []) or []
+    combined_dirs: list[str] = []
+    seen: set[str] = set()
+    for entry in [state["memory_dir"], *provider_dirs]:
+        key = str(Path(entry).expanduser())
+        if key in seen:
+            continue
+        seen.add(key)
+        combined_dirs.append(entry)
+
     init_data: dict = {
         "embedding": {
             "provider": state["provider"],
@@ -664,7 +736,7 @@ def _write_config_and_summary(
             "dimension": state["dimension"],
         },
         "storage": {"backend": "sqlite", "sqlite_path": state["db_path"]},
-        "indexing": {"memory_dirs": [state["memory_dir"]]},
+        "indexing": {"memory_dirs": combined_dirs, "auto_discover": False},
         "namespace": {
             "enable_auto_ns": state["enable_auto_ns"],
             "default_namespace": state["default_ns"],
@@ -797,6 +869,9 @@ def _write_config_and_summary(
         click.echo(f"  Reranker:   fastembed/{state['rerank_model']}")
     click.echo(f"  Storage:    {state['db_path']}")
     click.echo(f"  Memory:     {state['memory_dir']}")
+    provider_dirs = state.get("provider_dirs", []) or []
+    if provider_dirs:
+        click.echo(f"  Providers:  {len(provider_dirs)} folder(s) added")
     ns_label = "auto" if state["enable_auto_ns"] else "manual"
     click.echo(f"  Namespace:  {ns_label} (default: {state['default_ns']})")
     click.echo(f"  Search:     top_k={state['top_k']}, tokenizer={state['tokenizer']}")
@@ -873,6 +948,18 @@ _MODEL_DIMS: dict[str, int] = {
 @click.option("--api-key", default=None, help="OpenAI API key")
 @click.option("--mcp", "mcp_mode", type=click.Choice(["claude", "json", "skip"]), default=None)
 @click.option(
+    "--include-provider",
+    "include_providers",
+    type=click.Choice(["claude-memory", "claude-plans", "codex"]),
+    multiple=True,
+    help=(
+        "Include provider memory folders in indexing (repeatable). Without this "
+        "flag, non-interactive runs add no provider folders. Options: "
+        "claude-memory (~/.claude/projects/*/memory/), claude-plans "
+        "(~/.claude/plans/), codex (~/.codex/memories/)."
+    ),
+)
+@click.option(
     "--fresh",
     is_flag=True,
     default=False,
@@ -899,6 +986,7 @@ def init(
     decay: bool,
     api_key: str | None,
     mcp_mode: str | None,
+    include_providers: tuple[str, ...],
     fresh: bool,
 ) -> None:
     """Set up memtomem with an interactive wizard."""
@@ -946,6 +1034,17 @@ def init(
         if not memory_path.exists():
             memory_path.mkdir(parents=True, exist_ok=True)
 
+        # Resolve --include-provider into concrete dirs that exist on this machine.
+        # Categories with no detected dirs are silently skipped — non-interactive
+        # callers don't get an error if they ask for codex on a Claude-only box.
+        from memtomem.config import _detect_provider_dirs
+
+        grouped = _detect_provider_dirs()
+        provider_dirs: list[str] = []
+        for category in include_providers:
+            for d in grouped.get(category, []):
+                provider_dirs.append(str(d))
+
         state.update(
             {
                 "provider": _provider,
@@ -954,6 +1053,7 @@ def init(
                 "api_key": api_key or "",
                 "rerank_enabled": False,
                 "memory_dir": _memory_dir,
+                "provider_dirs": provider_dirs,
                 "db_path": db_path or str(Path("~/.memtomem").expanduser() / "memtomem.db"),
                 "enable_auto_ns": auto_ns,
                 "default_ns": namespace or "default",
@@ -968,6 +1068,7 @@ def init(
             _step_embedding,
             _step_reranker,
             _step_memory_dir,
+            _step_provider_dirs,
             _step_storage,
             _step_namespace,
             _step_search,

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1004,8 +1004,8 @@ def _migrate_auto_discover_once(config: Mem2MemConfig) -> None:
     """One-shot migration from legacy ``indexing.auto_discover`` to explicit
     ``memory_dirs`` entries.
 
-    Pre-Z behaviour ran :func:`ensure_auto_discovered_dirs` on every startup
-    to silently append three provider home dirs (``~/.claude/projects``,
+    Releases 0.1.11 and earlier ran ``ensure_auto_discovered_dirs`` on every
+    startup to silently append three provider home dirs (``~/.claude/projects``,
     ``~/.gemini``, ``~/.codex/memories``) whenever the flag was True. That
     was both too wide (transcripts + secrets) and too quiet (no opt-in
     surface). The replacement is a wizard step in ``mm init`` that picks

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -120,10 +120,12 @@ class SearchConfig(BaseSettings):
 def _default_memory_dirs() -> list[Path]:
     """Build default memory_dirs.
 
-    Only the single canonical user dir ``~/.memtomem/memories`` is returned
-    here; auto-discovery of well-known AI tool directories is applied
-    separately by :func:`ensure_auto_discovered_dirs` so that the
-    ``indexing.auto_discover`` flag has a single gate point.
+    Only the single canonical user dir ``~/.memtomem/memories`` is returned.
+    Provider memory dirs (Claude Code per-project memory, Claude plans, Codex
+    memories) are added explicitly via the ``mm init`` wizard's
+    "Provider memory folders" step; existing installs that previously relied
+    on the legacy ``indexing.auto_discover`` flag get a one-shot migration
+    from :func:`_migrate_auto_discover_once`.
     """
     return [Path("~/.memtomem/memories")]
 
@@ -155,6 +157,12 @@ class IndexingConfig(BaseSettings):
     structured_chunk_mode: str = "original"  # "original" or "recursive"
     paragraph_split_threshold: int = 800  # split long prose into paragraphs above this token count
     exclude_patterns: Annotated[list[str], APPEND] = Field(default_factory=list)
+    # DEPRECATED: superseded by explicit ``mm init`` opt-in (provider memory dirs
+    # are added directly to ``memory_dirs``). Kept as a one-shot migration trigger
+    # for legacy installs — :func:`_migrate_auto_discover_once` discovers canonical
+    # provider paths, appends them to ``memory_dirs``, then flips this flag to
+    # False. Default stays True so existing users without an explicit value
+    # still trigger migration on next startup. Will be removed in a future release.
     auto_discover: bool = True
 
     @field_validator(
@@ -734,6 +742,11 @@ def load_config_overrides(config: Mem2MemConfig) -> None:
                         exc,
                     )
 
+    # One-shot migration of legacy auto_discover=True installs to explicit
+    # provider memory_dirs entries. No-op for fresh installs (no config.json)
+    # and for already-migrated installs (auto_discover=False).
+    _migrate_auto_discover_once(config)
+
 
 _CONFIG_D_PATH = Path("~/.memtomem/config.d")
 
@@ -928,39 +941,161 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
                         )
 
 
-def ensure_auto_discovered_dirs(config: Mem2MemConfig) -> None:
-    """Append auto-discovered well-known dirs that aren't already in memory_dirs.
+PROVIDER_DIR_CATEGORIES: tuple[str, ...] = ("claude-memory", "claude-plans", "codex")
 
-    Call *after* ``load_config_overrides`` so that user overrides don't
-    suppress auto-discovery of AI tool directories like ``~/.claude/projects``.
 
-    Users can opt out entirely by setting ``indexing.auto_discover = false`` in
-    ``config.json`` or exporting ``MEMTOMEM_INDEXING__AUTO_DISCOVER=false``.
-    When disabled, the caller's explicit ``memory_dirs`` list is left untouched.
+def _detect_provider_dirs() -> dict[str, list[Path]]:
+    """Group canonical provider memory dirs by category for wizard prompting.
+
+    Each category maps to zero or more existing directories. Empty
+    categories are still present as ``[]`` so callers can render
+    "(none found)" deterministically.
+
+    Categories (verified against official docs):
+
+    - ``claude-memory``: ``~/.claude/projects/<project>/memory/`` per-project
+      auto-memory (https://code.claude.com/docs/en/memory). Subdirs without
+      any ``*.md`` files are skipped to avoid pulling in empty session
+      scaffolding from projects Claude visited but never wrote memory for.
+    - ``claude-plans``: ``~/.claude/plans/`` (local convention, not in
+      official docs but commonly used for plan-mode artifacts).
+    - ``codex``: ``~/.codex/memories/``
+      (https://developers.openai.com/codex/memories).
+
+    Gemini CLI is intentionally excluded: its memory surface is the single
+    file ``~/.gemini/GEMINI.md`` (doesn't fit the directory abstraction)
+    and the parent directory contains secrets like ``oauth_creds.json``.
+    Use ``mm ingest gemini-memory`` for one-shot Gemini import instead.
+    """
+    grouped: dict[str, list[Path]] = {cat: [] for cat in PROVIDER_DIR_CATEGORIES}
+
+    claude_projects = Path("~/.claude/projects").expanduser()
+    if claude_projects.is_dir():
+        for project in sorted(claude_projects.iterdir()):
+            if not project.is_dir():
+                continue
+            mem = project / "memory"
+            if mem.is_dir() and any(mem.glob("*.md")):
+                grouped["claude-memory"].append(mem)
+
+    plans = Path("~/.claude/plans").expanduser()
+    if plans.is_dir():
+        grouped["claude-plans"].append(plans)
+
+    codex = Path("~/.codex/memories").expanduser()
+    if codex.is_dir():
+        grouped["codex"].append(codex)
+
+    return grouped
+
+
+def _canonical_provider_dirs() -> list[Path]:
+    """Flat list of all canonical provider dirs that exist on this machine.
+
+    Used by the legacy ``auto_discover`` migration. The wizard uses
+    :func:`_detect_provider_dirs` directly so it can group prompts by
+    category. See that function's docstring for scope rationale.
+    """
+    grouped = _detect_provider_dirs()
+    return [d for cat in PROVIDER_DIR_CATEGORIES for d in grouped[cat]]
+
+
+def _migrate_auto_discover_once(config: Mem2MemConfig) -> None:
+    """One-shot migration from legacy ``indexing.auto_discover`` to explicit
+    ``memory_dirs`` entries.
+
+    Pre-Z behaviour ran :func:`ensure_auto_discovered_dirs` on every startup
+    to silently append three provider home dirs (``~/.claude/projects``,
+    ``~/.gemini``, ``~/.codex/memories``) whenever the flag was True. That
+    was both too wide (transcripts + secrets) and too quiet (no opt-in
+    surface). The replacement is a wizard step in ``mm init`` that picks
+    canonical provider memory dirs explicitly.
+
+    For existing installs with the legacy flag still True, this helper:
+
+    1. Enumerates :func:`_canonical_provider_dirs` (narrowed scope).
+    2. Appends each one not already in ``memory_dirs``.
+    3. Flips ``auto_discover`` to False in-memory.
+    4. Persists the result to ``~/.memtomem/config.json`` (atomic write)
+       so subsequent startups see the explicit entries and skip migration.
+
+    Brand-new installs (no ``config.json`` yet) skip migration: the wizard
+    is the only path that adds provider dirs there. The flag's deprecated
+    True default still applies in-memory but never triggers without a
+    config.json on disk to update — startup runtime no longer reads it.
     """
     if not config.indexing.auto_discover:
-        return
+        return  # already migrated, or explicitly opted out
+
+    config_path = _override_path()
+    if not config_path.exists():
+        return  # fresh install — wizard handles provider dirs explicitly
+
     existing = {Path(d).expanduser().resolve() for d in config.indexing.memory_dirs}
-    for d in _auto_discovered_memory_dirs():
-        resolved = d.expanduser().resolve()
-        if resolved not in existing:
-            config.indexing.memory_dirs.append(d)
+    new_dirs = [d for d in _canonical_provider_dirs() if d.expanduser().resolve() not in existing]
+
+    config.indexing.memory_dirs.extend(new_dirs)
+    config.indexing.auto_discover = False
+
+    # Persist the full post-migration memory_dirs list (factory default + any
+    # pre-existing entries + newly discovered dirs) so that the explicit
+    # config.json layer reflects the same effective list the migration just
+    # mutated in-memory. Without the full list we'd persist only ``new_dirs``,
+    # the REPLACE-on-set semantics of the config.json layer would drop the
+    # factory default on the next load, and users would lose
+    # ``~/.memtomem/memories`` silently.
+    _persist_auto_discover_migration(config_path, list(config.indexing.memory_dirs))
+
+    import logging
+
+    logging.getLogger(__name__).info(
+        "Migrated auto_discover -> explicit memory_dirs: added %d provider path(s). "
+        "See %s (auto_discover is deprecated and will be removed).",
+        len(new_dirs),
+        config_path,
+    )
 
 
-def _auto_discovered_memory_dirs() -> list[Path]:
-    """Return well-known AI tool directories that exist on this machine.
+def _persist_auto_discover_migration(config_path: Path, full_memory_dirs: list[Path]) -> None:
+    """Write the migration result to ``config.json`` atomically.
 
-    Checked directories:
-    - ``~/.claude/projects``  — Claude Code per-project auto-memory
-    - ``~/.gemini``           — Gemini CLI global GEMINI.md
-    - ``~/.codex/memories``   — Codex CLI global memories
+    Persists the *complete* post-migration ``memory_dirs`` list (factory
+    default included) and sets ``indexing.auto_discover`` to False so the
+    one-shot migration becomes idempotent. Read-merge-write so non-migrated
+    sections survive untouched.
     """
-    candidates: list[Path] = [
-        Path("~/.claude/projects"),
-        Path("~/.gemini"),
-        Path("~/.codex/memories"),
-    ]
-    return [p.expanduser() for p in candidates if p.expanduser().is_dir()]
+    import json as _json
+    import logging
+
+    _log = logging.getLogger(__name__)
+
+    existing: dict = {}
+    if config_path.exists():
+        try:
+            existing = _json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, _json.JSONDecodeError) as exc:
+            _log.warning(
+                "Cannot read %s during auto_discover migration (%s); skipping persist",
+                config_path,
+                exc,
+            )
+            return
+
+    if not isinstance(existing, dict):
+        return
+
+    indexing = existing.get("indexing")
+    if not isinstance(indexing, dict):
+        indexing = {}
+        existing["indexing"] = indexing
+
+    indexing["memory_dirs"] = [str(d) for d in full_memory_dirs]
+    indexing["auto_discover"] = False
+
+    try:
+        _atomic_write_json(config_path, existing)
+    except OSError as exc:
+        _log.warning("Failed to persist auto_discover migration to %s: %s", config_path, exc)
 
 
 # Fields that ``save_config_overrides`` persists but ``MUTABLE_FIELDS`` does
@@ -1053,12 +1188,12 @@ def build_comparand(*, quiet: bool = True) -> "Mem2MemConfig":
     """
     comparand = Mem2MemConfig()
     load_config_d(comparand, quiet=quiet)
-    # Auto-discovery is an env-dependent "factory" in spirit: it depends on
-    # the local filesystem, not on user choice. Running it here keeps the
-    # comparand apples-to-apples with the runtime config built by
-    # ``create_components`` so auto-discovered paths don't drag into
-    # ``config.json`` on unrelated saves.
-    ensure_auto_discovered_dirs(comparand)
+    # Provider memory dirs are now explicit ``memory_dirs`` entries (added by
+    # the ``mm init`` wizard or migrated once from legacy ``auto_discover``),
+    # not env-dependent factory output — so the comparand no longer needs a
+    # discovery step here. Runtime and comparand both reflect the same
+    # explicit list, and delta-only save still drops anything that matches
+    # defaults + env + fragments.
     return comparand
 
 

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -40,12 +40,11 @@ class Components:
 
 async def create_components(config: Mem2MemConfig | None = None) -> Components:
     """Create and initialise all core components."""
-    from memtomem.config import ensure_auto_discovered_dirs, load_config_d, load_config_overrides
+    from memtomem.config import load_config_d, load_config_overrides
 
     config = config or Mem2MemConfig()
     load_config_d(config)
     load_config_overrides(config)
-    ensure_auto_discovered_dirs(config)
 
     # Initialize FTS tokenizer from config
     from memtomem.storage.fts_tokenizer import set_tokenizer

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -395,23 +395,27 @@ class TestSaveConfigOverrides:
 
     @pytest.fixture
     def isolated(self, tmp_path, monkeypatch):
-        """Isolate config.json, config.d/, and auto-discovery from the dev machine.
+        """Isolate config.json, config.d/, and provider-dir discovery from the
+        dev machine.
 
-        Without this, ``build_comparand`` reads the developer's real
-        ``~/.memtomem/config.d/`` fragments during tests, producing
+        Without isolation, ``build_comparand`` reads the developer's real
+        ``~/.memtomem/config.d/`` fragments and the legacy auto_discover
+        migration could pull in ``~/.claude/projects`` etc., producing
         per-machine comparand differences that mask the intended behavior.
-        Auto-discovery is stubbed to ``[]`` so tests that exercise
-        ``memory_dirs`` delta semantics behave identically whether the dev
-        machine happens to have ``~/.claude/projects`` etc. Individual tests
-        can re-monkeypatch ``_auto_discovered_memory_dirs`` to exercise the
-        auto-discover path explicitly.
+        Provider-dir detection is stubbed to ``[]`` so tests that exercise
+        ``memory_dirs`` delta semantics behave identically regardless of
+        what AI tools the dev machine has installed.
         """
         config_file = tmp_path / "config.json"
         config_d = tmp_path / "config.d"
         config_d.mkdir()
         monkeypatch.setattr("memtomem.config._override_path", lambda: config_file)
         monkeypatch.setattr("memtomem.config._config_d_path", lambda: config_d)
-        monkeypatch.setattr("memtomem.config._auto_discovered_memory_dirs", lambda: [])
+        monkeypatch.setattr("memtomem.config._canonical_provider_dirs", lambda: [])
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
         return {"config_file": config_file, "config_d": config_d, "tmp_path": tmp_path}
 
     # ── Load-path defensive tests (unrelated to delta semantic) ────────
@@ -616,45 +620,6 @@ class TestSaveConfigOverrides:
         data = json.loads(isolated["config_file"].read_text())
         assert "memory_dirs" not in data.get("indexing", {}), (
             f"factory-default memory_dirs must be dropped on save under Z; got {data}"
-        )
-
-    def test_auto_discovered_dirs_do_not_drag_into_config_json(
-        self, isolated, monkeypatch, tmp_path
-    ):
-        """Regression guard for the drag-in introduced by PR #282.
-
-        After PR #282 consolidated auto-discovery into
-        ``ensure_auto_discovered_dirs`` (removed from ``_default_memory_dirs``),
-        the comparand built by ``build_comparand`` contained only
-        ``~/.memtomem/memories`` while the runtime config contained the
-        auto-discovered well-known dirs on top. Unrelated saves pinned
-        those paths into ``config.json``, which meant a later
-        ``auto_discover = false`` still indexed them.
-
-        Fix: ``build_comparand`` must call ``ensure_auto_discovered_dirs``
-        on the comparand so the delta computation sees an apples-to-apples
-        runtime-vs-default comparison.
-        """
-        import json
-        from pathlib import Path
-
-        from memtomem import config as _cfg
-        from memtomem.config import ensure_auto_discovered_dirs
-
-        fake = tmp_path / "fake-auto-tool"
-        fake.mkdir()
-        monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
-
-        cfg = Mem2MemConfig()
-        ensure_auto_discovered_dirs(cfg)  # simulates startup in create_components
-        assert fake.resolve() in {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
-
-        cfg.mmr.enabled = True  # unrelated change to trigger a non-empty save
-        save_config_overrides(cfg)
-
-        data = json.loads(isolated["config_file"].read_text())
-        assert "memory_dirs" not in data.get("indexing", {}), (
-            f"auto-discovered dirs must drop on unrelated save; got {data}"
         )
 
     def test_save_is_idempotent(self, isolated):

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -433,9 +433,7 @@ def test_migration_noop_when_auto_discover_false(
     fake = tmp_path / "fake-tool"
     fake.mkdir()
     monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
-    override_path.write_text(
-        json.dumps({"indexing": {"auto_discover": False}}), encoding="utf-8"
-    )
+    override_path.write_text(json.dumps({"indexing": {"auto_discover": False}}), encoding="utf-8")
 
     cfg = Mem2MemConfig()
     load_config_overrides(cfg)
@@ -483,6 +481,41 @@ def test_migration_appends_dirs_and_flips_flag(
     resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
     assert fake.resolve() in resolved
     assert cfg.indexing.auto_discover is False
+
+
+def test_migration_preserves_existing_user_memory_dirs(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The most common legacy install has user-set ``memory_dirs`` *and*
+    ``auto_discover`` defaulted True. Migration must preserve the explicit
+    user entries alongside the newly-discovered provider dirs — dropping
+    them would silently shrink the indexed corpus on first post-upgrade
+    startup. Directly guards the ``_persist_auto_discover_migration``
+    invariant flagged in its docstring.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    user_dir = tmp_path / "user-explicit"
+    user_dir.mkdir()
+    fake_provider = tmp_path / "fake-provider"
+    fake_provider.mkdir()
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake_provider])
+    override_path.write_text(
+        json.dumps({"indexing": {"memory_dirs": [str(user_dir)]}}), encoding="utf-8"
+    )
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+
+    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+    assert user_dir.resolve() in resolved, "user-set memory_dirs dropped by migration"
+    assert fake_provider.resolve() in resolved, "provider dir not appended"
+    assert cfg.indexing.auto_discover is False
+
+    persisted = json.loads(override_path.read_text(encoding="utf-8"))
+    persisted_dirs = set(persisted["indexing"]["memory_dirs"])
+    assert str(user_dir) in persisted_dirs
+    assert str(fake_provider) in persisted_dirs
+    assert persisted["indexing"]["auto_discover"] is False
 
 
 def test_migration_persists_to_config_json(

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -36,12 +36,30 @@ def config_d_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 
 def _clear_all_memtomem_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Strip any ambient MEMTOMEM_* so the test env is fully deterministic."""
+    """Strip ambient MEMTOMEM_* and stub provider-dir discovery to ``[]`` so
+    the test env is fully deterministic.
+
+    Stubbing ``_canonical_provider_dirs`` here (rather than autouse) prevents
+    the auto_discover migration triggered by ``load_config_overrides`` from
+    pulling in the dev machine's real ``~/.claude/projects/*/memory/`` etc.,
+    which would otherwise pollute unrelated ``memory_dirs`` assertions.
+
+    Migration tests that need a controlled fake list call
+    ``monkeypatch.setattr(_cfg, "_canonical_provider_dirs", ...)`` AFTER
+    invoking this helper — last-write-wins on monkeypatch means their
+    explicit fake takes effect during the actual test logic.
+
+    Detection tests (those exercising ``_detect_provider_dirs`` /
+    ``_canonical_provider_dirs`` directly to validate scope and category
+    structure) deliberately do NOT call this helper, so they hit the real
+    implementation against an isolated ``HOME`` they set themselves.
+    """
     import os
 
     for name in list(os.environ):
         if name.startswith("MEMTOMEM_"):
             monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [])
 
 
 def test_config_json_applies_when_no_env(
@@ -395,66 +413,198 @@ def test_every_list_field_declares_merge_strategy() -> None:
 
 
 # ---------------------------------------------------------------------------
-# indexing.auto_discover opt-out (issue #260 Option 0)
+# indexing.auto_discover migration (legacy → explicit memory_dirs)
 #
-# Regression guards for the boolean flag that lets users disable auto-discovery
-# of well-known AI tool directories (`~/.claude/projects`, `~/.gemini`,
-# `~/.codex/memories`). Default is True (preserves legacy behavior); False
-# short-circuits ``ensure_auto_discovered_dirs`` to a no-op so the caller's
-# explicit ``memory_dirs`` list is the complete list.
+# Pre-Z, ``auto_discover=True`` was a runtime flag that silently appended
+# provider home dirs on every startup. Post-Z it's a one-shot migration
+# trigger: ``load_config_overrides`` calls ``_migrate_auto_discover_once``,
+# which converts legacy installs to explicit ``memory_dirs`` entries and
+# flips the flag to False. Brand-new installs (no ``config.json``) skip
+# migration so the wizard opt-in remains the only way provider dirs land
+# in ``memory_dirs``.
 # ---------------------------------------------------------------------------
 
 
-def test_auto_discover_default_true_appends_dirs(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+def test_migration_noop_when_auto_discover_false(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    """Explicit auto_discover=False in config.json → migration skipped."""
+    _clear_all_memtomem_env(monkeypatch)
     fake = tmp_path / "fake-tool"
     fake.mkdir()
-    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
+    override_path.write_text(
+        json.dumps({"indexing": {"auto_discover": False}}), encoding="utf-8"
+    )
+
     cfg = Mem2MemConfig()
-    assert cfg.indexing.auto_discover is True
-    _cfg.ensure_auto_discovered_dirs(cfg)
+    load_config_overrides(cfg)
+
+    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+    assert fake.resolve() not in resolved
+
+
+def test_migration_noop_when_no_config_json(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Brand-new install (no config.json) skips migration even with
+    auto_discover defaulting to True. Provider dirs stay opt-in via the
+    wizard.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
+    # override_path fixture sets the path but does NOT write the file
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)  # config.json doesn't exist
+
+    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
+    assert fake.resolve() not in resolved
+    assert cfg.indexing.auto_discover is True  # not flipped — migration skipped
+
+
+def test_migration_appends_dirs_and_flips_flag(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Legacy install (config.json present + auto_discover defaults True)
+    migrates: discovered dirs append to memory_dirs and flag flips to False.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
+    override_path.write_text("{}", encoding="utf-8")
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+
     resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
     assert fake.resolve() in resolved
+    assert cfg.indexing.auto_discover is False
 
 
-def test_auto_discover_false_is_noop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_migration_persists_to_config_json(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Migration writes both new memory_dirs entries and the False flag to disk."""
+    _clear_all_memtomem_env(monkeypatch)
     fake = tmp_path / "fake-tool"
     fake.mkdir()
-    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
+    override_path.write_text("{}", encoding="utf-8")
+
     cfg = Mem2MemConfig()
-    cfg.indexing.auto_discover = False
-    before = [str(p) for p in cfg.indexing.memory_dirs]
-    _cfg.ensure_auto_discovered_dirs(cfg)
-    after = [str(p) for p in cfg.indexing.memory_dirs]
-    assert before == after
-    assert str(fake) not in after
+    load_config_overrides(cfg)
+
+    persisted = json.loads(override_path.read_text(encoding="utf-8"))
+    assert persisted["indexing"]["auto_discover"] is False
+    assert str(fake) in persisted["indexing"]["memory_dirs"]
 
 
-def test_auto_discover_env_var_disables(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_migration_idempotent(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Second load_config_overrides after migration is a no-op (flag is False)."""
+    _clear_all_memtomem_env(monkeypatch)
+    fake = tmp_path / "fake-tool"
+    fake.mkdir()
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
+    override_path.write_text("{}", encoding="utf-8")
+
+    cfg1 = Mem2MemConfig()
+    load_config_overrides(cfg1)
+    first_dirs = sorted(str(p) for p in cfg1.indexing.memory_dirs)
+
+    cfg2 = Mem2MemConfig()
+    load_config_overrides(cfg2)
+    second_dirs = sorted(str(p) for p in cfg2.indexing.memory_dirs)
+
+    assert first_dirs == second_dirs
+
+
+def test_migration_env_var_false_skips(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """MEMTOMEM_INDEXING__AUTO_DISCOVER=false short-circuits migration even
+    when a config.json exists (env wins over the default True)."""
     _clear_all_memtomem_env(monkeypatch)
     monkeypatch.setenv("MEMTOMEM_INDEXING__AUTO_DISCOVER", "false")
     fake = tmp_path / "fake-tool"
     fake.mkdir()
-    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
-    cfg = Mem2MemConfig()
-    assert cfg.indexing.auto_discover is False
-    _cfg.ensure_auto_discovered_dirs(cfg)
-    resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
-    assert fake.resolve() not in resolved
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [fake])
+    override_path.write_text("{}", encoding="utf-8")
 
-
-def test_auto_discover_config_json_disables(
-    override_path: Path, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    _clear_all_memtomem_env(monkeypatch)
-    override_path.write_text(json.dumps({"indexing": {"auto_discover": False}}), encoding="utf-8")
-    fake = tmp_path / "fake-tool"
-    fake.mkdir()
-    monkeypatch.setattr(_cfg, "_auto_discovered_memory_dirs", lambda: [fake])
     cfg = Mem2MemConfig()
     load_config_overrides(cfg)
-    assert cfg.indexing.auto_discover is False
-    _cfg.ensure_auto_discovered_dirs(cfg)
+
     resolved = {Path(p).expanduser().resolve() for p in cfg.indexing.memory_dirs}
     assert fake.resolve() not in resolved
+    assert cfg.indexing.auto_discover is False
+
+
+# ---------------------------------------------------------------------------
+# _detect_provider_dirs / _canonical_provider_dirs scope (narrowed per
+# official provider docs).
+# ---------------------------------------------------------------------------
+
+
+def test_detect_provider_dirs_categories_are_fixed() -> None:
+    """The wizard step iterates these categories — no surprise additions."""
+    grouped = _cfg._detect_provider_dirs()
+    assert set(grouped) == {"claude-memory", "claude-plans", "codex"}
+
+
+def test_detect_provider_dirs_excludes_gemini(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Gemini (~/.gemini/) is intentionally out of scope — its memory is a
+    single GEMINI.md file (doesn't fit the directory abstraction) and the
+    parent dir contains oauth credentials. ``mm ingest gemini-memory``
+    remains the supported path for Gemini users."""
+    home = tmp_path / "home"
+    (home / ".gemini").mkdir(parents=True)
+    (home / ".gemini" / "GEMINI.md").write_text("# memory", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+
+    grouped = _cfg._detect_provider_dirs()
+    assert "gemini" not in grouped
+    flat = _cfg._canonical_provider_dirs()
+    assert all("gemini" not in str(d) for d in flat)
+
+
+def test_detect_provider_dirs_filters_empty_claude_memory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Per-project ``memory/`` subdirs without any *.md files are skipped
+    so empty session scaffolding doesn't get added to memory_dirs."""
+    home = tmp_path / "home"
+    proj_with = home / ".claude" / "projects" / "p1" / "memory"
+    proj_without = home / ".claude" / "projects" / "p2" / "memory"
+    proj_with.mkdir(parents=True)
+    (proj_with / "MEMORY.md").write_text("# index", encoding="utf-8")
+    proj_without.mkdir(parents=True)  # empty memory dir
+    monkeypatch.setenv("HOME", str(home))
+
+    grouped = _cfg._detect_provider_dirs()
+    paths = {str(p) for p in grouped["claude-memory"]}
+    assert str(proj_with) in paths
+    assert str(proj_without) not in paths
+
+
+def test_detect_provider_dirs_finds_claude_plans_and_codex(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``~/.claude/plans/`` and ``~/.codex/memories/`` land in their
+    respective categories when present on disk."""
+    home = tmp_path / "home"
+    plans = home / ".claude" / "plans"
+    codex = home / ".codex" / "memories"
+    plans.mkdir(parents=True)
+    codex.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    grouped = _cfg._detect_provider_dirs()
+    assert grouped["claude-plans"] == [plans]
+    assert grouped["codex"] == [codex]

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -994,9 +994,7 @@ class TestIncludeProviderFlag:
         )
         assert result.exit_code == 0, result.output
 
-        data = json.loads(
-            (tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
         assert str(codex) in data["indexing"]["memory_dirs"]
 
     def test_flag_silently_skips_unavailable_categories(
@@ -1027,9 +1025,7 @@ class TestIncludeProviderFlag:
             ],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(
-            (tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
         # Only the user's primary memory_dir survives; no fake codex path.
         assert data["indexing"]["memory_dirs"] == [str(tmp_path / "memories")]
 
@@ -1063,9 +1059,7 @@ class TestIncludeProviderFlag:
             ],
         )
         assert result.exit_code == 0, result.output
-        data = json.loads(
-            (tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8")
-        )
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
         assert str(codex) not in data["indexing"]["memory_dirs"]
 
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -831,6 +831,244 @@ class TestMcpPasteHints:
         assert "copy into your editor's config file" in out
 
 
+class TestProviderDirsStep:
+    """Step 4 — opt-in indexing of provider memory folders.
+
+    Replaces the legacy ``ensure_auto_discovered_dirs`` runtime path. The
+    step is wizard-driven (per-category nav_confirm), and a non-interactive
+    counterpart is exposed via ``--include-provider``.
+    """
+
+    def test_step_skips_when_no_provider_dirs_detected(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Detection returns all-empty → step records [] without prompting."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+        # Failing nav_confirm guarantees the test breaks if a prompt fires.
+        monkeypatch.setattr(
+            init_cmd,
+            "nav_confirm",
+            lambda *a, **kw: pytest.fail("nav_confirm called when no dirs detected"),
+        )
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+        assert state["provider_dirs"] == []
+
+    def test_step_appends_only_accepted_categories(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """User says yes to Claude memory and Codex, no to plans → only the
+        accepted categories land in state["provider_dirs"]."""
+        from memtomem.cli import init_cmd
+
+        claude_mem = tmp_path / "claude-mem"
+        plans = tmp_path / "plans"
+        codex = tmp_path / "codex"
+        for p in (claude_mem, plans, codex):
+            p.mkdir()
+
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {
+                "claude-memory": [claude_mem],
+                "claude-plans": [plans],
+                "codex": [codex],
+            },
+        )
+        # Order of prompts in _step_provider_dirs: claude-memory, claude-plans, codex
+        answers = iter([True, False, True])
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: next(answers))
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+        assert state["provider_dirs"] == [str(claude_mem), str(codex)]
+
+    def test_step_skips_categories_with_no_dirs(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Categories with no detected dirs do NOT get a prompt — only the
+        present categories show up. Counts from the answers iterator are a
+        load-bearing guard against an extra prompt sneaking in."""
+        from memtomem.cli import init_cmd
+
+        plans = tmp_path / "plans"
+        plans.mkdir()
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [plans], "codex": []},
+        )
+        answers = iter([True])  # exactly one prompt expected (plans only)
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: next(answers))
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+        assert state["provider_dirs"] == [str(plans)]
+        with pytest.raises(StopIteration):
+            next(answers)  # no extra prompts fired
+
+    def test_step_includes_multiple_claude_memory_projects(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A single 'yes' to Claude memory adds every detected per-project dir,
+        not just the first — grouping the prompt avoids per-project noise."""
+        from memtomem.cli import init_cmd
+
+        p1 = tmp_path / "p1" / "memory"
+        p2 = tmp_path / "p2" / "memory"
+        for p in (p1, p2):
+            p.mkdir(parents=True)
+            (p / "MEMORY.md").write_text("# index", encoding="utf-8")
+
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [p1, p2], "claude-plans": [], "codex": []},
+        )
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+        assert state["provider_dirs"] == [str(p1), str(p2)]
+
+    def test_write_merges_provider_dirs_into_memory_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``_write_config_and_summary`` concatenates ``state["memory_dir"]``
+        with ``state["provider_dirs"]`` (deduped) when persisting
+        ``indexing.memory_dirs``. Also pins ``auto_discover: false`` so a
+        fresh wizard run on a legacy install doesn't keep migrating."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        provider_dir = tmp_path / "claude-mem"
+        provider_dir.mkdir()
+
+        state = _make_init_state(tmp_path)
+        state["provider_dirs"] = [str(provider_dir)]
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        dirs = data["indexing"]["memory_dirs"]
+        assert state["memory_dir"] in dirs
+        assert str(provider_dir) in dirs
+        assert dirs.count(state["memory_dir"]) == 1  # no duplicates
+        assert data["indexing"]["auto_discover"] is False
+
+
+class TestIncludeProviderFlag:
+    """Non-interactive ``--include-provider`` wires categories into
+    ``indexing.memory_dirs`` without prompting."""
+
+    def test_flag_resolves_categories_to_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        codex = tmp_path / "codex"
+        codex.mkdir()
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": [codex]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--include-provider",
+                "codex",
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(
+            (tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8")
+        )
+        assert str(codex) in data["indexing"]["memory_dirs"]
+
+    def test_flag_silently_skips_unavailable_categories(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Asking for a category with no detected dirs is a no-op, not an error."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--include-provider",
+                "codex",
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(
+            (tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8")
+        )
+        # Only the user's primary memory_dir survives; no fake codex path.
+        assert data["indexing"]["memory_dirs"] == [str(tmp_path / "memories")]
+
+    def test_no_flag_writes_no_provider_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without ``--include-provider``, non-interactive mode adds zero
+        provider dirs even if the dev machine has them."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Pretend a Codex dir exists; the test asserts it's NOT pulled in.
+        codex = tmp_path / "codex"
+        codex.mkdir()
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": [codex]},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(
+            (tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8")
+        )
+        assert str(codex) not in data["indexing"]["memory_dirs"]
+
+
 def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) -> None:
     """Documentation examples of MEMTOMEM_INDEXING__MEMORY_DIRS must be
     encoded as a JSON array string. A bare path crashes pydantic-settings.


### PR DESCRIPTION
## Summary

Replace silent `ensure_auto_discovered_dirs` runtime indexing with an explicit opt-in wizard step, narrow scope to canonical memory surfaces per each provider's official docs, and migrate legacy `auto_discover=True` installs transparently.

## Motivation

The previous default silently indexed three provider home directories on every startup:

- `~/.claude/projects/` — but this contains huge per-session `.jsonl` transcripts (1MB+ each, 200+ files) + `staging/`, not just memory
- `~/.gemini/` — contains `oauth_creds.json`, browser profile dirs, `history/`, `tmp/` — most of it isn't memory and some is sensitive
- `~/.codex/memories/` — this one was correctly scoped

Users were never asked. The scope was much wider than intended even though `supported_extensions` filtered most transcript/JSON noise — the directory walks were still happening on every index/watch.

## Changes

### Wizard (user-facing)

New Step 4 "Provider memory folders" — detects canonical paths on disk and prompts per-category. Non-existent categories are skipped silently.

```
Step 4: Provider Memory Folders
  Make memory from other AI tools searchable through memtomem?
  Each option is opt-in; declined folders stay out of search.

  Claude Code per-project memory (3 projects with .md content)? [y/N]
  Claude Code plans (~/.claude/plans/)?                          [y/N]
  Codex CLI memories (~/.codex/memories/)?                       [y/N]
```

Non-interactive: `mm init -y --include-provider claude-memory --include-provider codex` (repeatable flag).

### Narrowed scope (verified against official docs)

| Provider | Path | Source |
|---|---|---|
| Claude Code auto-memory | `~/.claude/projects/<project>/memory/` (with `*.md` content) | https://code.claude.com/docs/en/memory |
| Claude Code plans | `~/.claude/plans/` | local convention |
| Codex CLI | `~/.codex/memories/` | https://developers.openai.com/codex/memories |

**Gemini CLI removed.** Its memory is a single file `~/.gemini/GEMINI.md` that doesn't fit the `memory_dirs` directory abstraction; the parent dir contains `oauth_creds.json`. `mm ingest gemini-memory` (one-shot import) is unchanged for Gemini users.

### Migration

`indexing.auto_discover` becomes a one-shot migration trigger. For existing installs with the flag True (default or explicit) AND a `config.json` on disk:

1. Detect canonical provider dirs that exist.
2. Append to `memory_dirs`.
3. Flip flag to False.
4. Atomic write. Single INFO-level log line.

Brand-new installs (no `config.json`) skip migration entirely — the wizard is the only path that adds provider dirs. Subsequent startups see `auto_discover: false` → no-op.

## Verification

- **Automated**: 1837 tests pass (46 ollama-marker skipped), `ruff check` / `ruff format --check` clean, `mypy` 0 errors across 193 source files.
- **New tests**:
  - `TestProviderDirsStep` — wizard step: no-detect skip, mixed accept/reject, empty-subdir filter, per-project enumeration via single prompt, `state["provider_dirs"]` → `memory_dirs` merge with dedup + `auto_discover: false` pin.
  - `TestIncludeProviderFlag` — non-interactive: category-to-dir resolution, silent skip when unavailable, no-flag = no provider dirs.
  - Migration tests: noop when flag False, noop when no config.json, appends + flips + persists, idempotent, env-var `MEMTOMEM_INDEXING__AUTO_DISCOVER=false` short-circuits.
  - `_detect_provider_dirs` structural tests: fixed categories, excludes Gemini, filters empty Claude memory subdirs, finds plans + codex.
- **Manual** (4 paths with isolated `HOME=/tmp/...`):
  1. Fresh install with `--include-provider codex` → opt-in works, only selected dirs in `memory_dirs`, `auto_discover: false` persisted ✓
  2. Skip wizard (no `config.json`) → factory default only, no auto-indexing despite fake `~/.claude/projects/<proj>/memory/` present ✓
  3. Legacy install with `auto_discover: true` → all 3 canonical categories migrated, full list persisted (factory + discovered), flag flipped ✓
  4. Idempotent re-run → no log, no re-migration ✓

## Test plan

- [x] Wizard flow with mixed provider combinations
- [x] Migration on legacy config
- [x] Fresh install with no config.json
- [x] Idempotent second load
- [x] Full test suite + lint + typecheck
- [ ] Reviewer: confirm CHANGELOG migration note is clear (recommends `mm index --rebuild` after upgrade for cleanest index state)

## Breaking change notes

- Users whose old installs relied on auto-discovery of `~/.gemini/` will lose that surface. Documented in CHANGELOG + configuration.md; `mm ingest gemini-memory` is the replacement.
- `~/.claude/projects/` previously walked wholesale (transcripts skipped only by `supported_extensions`, not excluded at walk time); now only the `*/memory/` subdirs appear in `memory_dirs`. Index entries for paths no longer in `memory_dirs` won't be auto-pruned — recommend `mm index --rebuild` post-upgrade for the cleanest state.
- `indexing.auto_discover` field is deprecated; removal scheduled for a future minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
