### PR TITLE
release: v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.12] — 2026-04-19
+
+memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces
+may still shift between 0.1.x releases — external feedback and issue
+reports are especially welcome at
+[github.com/memtomem/memtomem/issues](https://github.com/memtomem/memtomem/issues).
+
 ### Changed
 - **Provider memory directories are now opt-in via `mm init`.** The wizard
   has a new "Provider memory folders" step (Step 4 of 10) that detects

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.11"
+version = "0.1.12"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Patch release bundling #292 (opt-in provider memory dirs + scope narrowing per each provider's official docs).

- `packages/memtomem/pyproject.toml`: `0.1.11` → `0.1.12`
- `uv.lock`: workspace `memtomem` entry regenerated via `uv sync`
- `CHANGELOG.md`: `[Unreleased]` → `[0.1.12] — 2026-04-19`

No code changes beyond version + lockfile.

## What's in 0.1.12

See #292 for the implementation. User-visible changes:

- **Wizard Step 4 "Provider memory folders"** — opt-in per category (Claude Code per-project memory, Claude plans, Codex memories). Categories with no detected dirs are silently skipped.
- **Non-interactive `--include-provider {claude-memory,claude-plans,codex}`** — repeatable flag for scripted setup.
- **Auto-discovery scope narrowed** to canonical memory surfaces verified against each provider's official docs:
  - Claude Code: `~/.claude/projects/<project>/memory/` only (not the full projects tree with session JSONL transcripts + `staging/`).
  - Codex CLI: `~/.codex/memories/` (unchanged).
- **Gemini CLI removed** from auto-discovery (memory is a single file + parent dir has secrets). `mm ingest gemini-memory` remains as the supported one-shot path.
- **`indexing.auto_discover` is now a one-shot migration trigger** — legacy installs transparently migrate on next startup, then the flag flips to `false`. Deprecated; will be removed in a future release.

## Migration notes

After upgrading, run `mm index --rebuild` to clean up index entries from the previous wider scan (session transcripts, staging dirs, Gemini configs). The migration narrows `memory_dirs` but doesn't retroactively prune already-indexed content.

New Claude Code projects created after running `mm init` are not auto-indexed — re-run `mm init` or use `mm config set indexing.memory_dirs` to add them.

## Release mechanics

- PyPI publish via OIDC trusted publisher (`release.yml` → `pypi` environment). No API tokens.
- Tag push sequence runs after this PR merges:
  ```bash
  git tag v0.1.12 && git push origin v0.1.12
  ```
- `pypi` environment approval is manual (expected).

## Test plan

- [x] `uv sync` idempotent on release branch, `uv.lock` reflects new version
- [x] `ruff check` + `ruff format --check` clean against CI scope (`src tests tools`)
- [x] Version-only diff — no logic change to re-verify beyond #292's green CI
- [ ] Reviewer: confirm CHANGELOG rendering on the GitHub release page after tag push
- [ ] Optional: TestPyPI dry-run via `test-v0.1.12a1` tag before `v0.1.12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
