### PR TITLE
fix: update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ memtomem = { workspace = true }
 [tool.ruff]
 target-version = "py312"
 line-length = 100
+extend-exclude = ["*.ipynb"]
+force-exclude = true
 
 [tool.ruff.lint.per-file-ignores]
 "packages/memtomem/src/memtomem/server/__init__.py" = ["E402", "F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ memtomem = { workspace = true }
 target-version = "py312"
 line-length = 100
 extend-exclude = ["*.ipynb"]
-force-exclude = true
 
 [tool.ruff.lint.per-file-ignores]
 "packages/memtomem/src/memtomem/server/__init__.py" = ["E402", "F401"]


### PR DESCRIPTION
### Problem

Running Ruff formatting in bulk with commands such as `ruff format .` can also affect files that do not need to be reformatted.

Although formatting can be applied selectively, using a single `ruff format .` command is much faster and more convenient.

### Change

This PR adds an exclusion rule to `pyproject.toml` so that unnecessary files are automatically excluded from Ruff formatting. At the moment, this applies to `*.ipynb`.