### PR TITLE
feat(web): return memory_dir category from server (closes #299)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal, cast
@@ -941,7 +942,35 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
                         )
 
 
-PROVIDER_DIR_CATEGORIES: tuple[str, ...] = ("claude-memory", "claude-plans", "codex")
+# Single source of truth for provider-dir classification. Each row ties a
+# category name to the regex that recognises paths in that category. The
+# Web UI's ``/api/memory-dirs/status`` response carries the resulting
+# ``category`` field so the client does not maintain a parallel regex.
+_PROVIDER_CATEGORY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("claude-memory", re.compile(r"/\.claude/projects/[^/]+/memory/?$")),
+    ("claude-plans", re.compile(r"/\.claude/plans/?$")),
+    ("codex", re.compile(r"/\.codex/memories/?$")),
+)
+
+# Derived from ``_PROVIDER_CATEGORY_PATTERNS`` — do NOT edit independently.
+# Add a new pattern row above and this tuple picks it up automatically.
+PROVIDER_DIR_CATEGORIES: tuple[str, ...] = tuple(cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS)
+
+
+def categorize_memory_dir(path: str | Path) -> str:
+    """Return the category string for a ``memory_dir`` path.
+
+    Returns one of ``PROVIDER_DIR_CATEGORIES`` or ``"user"`` for anything
+    that doesn't match a known provider layout. Classification only —
+    does not check existence or validity. Uses forward-slash regex, so
+    on Windows a backslash-normalised path will fall through to
+    ``"user"`` until a future path-sep-agnostic pass lands.
+    """
+    s = str(path).rstrip("/")
+    for cat, pat in _PROVIDER_CATEGORY_PATTERNS:
+        if pat.search(s):
+            return cat
+    return "user"
 
 
 def _detect_provider_dirs() -> dict[str, list[Path]]:
@@ -949,7 +978,9 @@ def _detect_provider_dirs() -> dict[str, list[Path]]:
 
     Each category maps to zero or more existing directories. Empty
     categories are still present as ``[]`` so callers can render
-    "(none found)" deterministically.
+    "(none found)" deterministically. Discovered paths are classified
+    via :func:`categorize_memory_dir` so discovery and classification
+    stay locked to the same pattern table.
 
     Categories (verified against official docs):
 
@@ -966,15 +997,13 @@ def _detect_provider_dirs() -> dict[str, list[Path]]:
     file ``~/.gemini/GEMINI.md`` (doesn't fit the directory abstraction)
     and the parent directory contains secrets like ``oauth_creds.json``.
     Use ``mm ingest gemini-memory`` for one-shot Gemini import instead.
-
-    .. warning::
-       The Web UI mirrors this categorization client-side in
-       ``web/static/sources-memory-dirs.js`` (``_categorizeMemoryDir``).
-       Keep the two in sync when adding a new category — consolidation
-       into a server-returned field on ``GET /api/memory-dirs/status``
-       is tracked in https://github.com/memtomem/memtomem/issues/299.
     """
     grouped: dict[str, list[Path]] = {cat: [] for cat in PROVIDER_DIR_CATEGORIES}
+
+    def _bucket(p: Path) -> None:
+        cat = categorize_memory_dir(p)
+        if cat in grouped:
+            grouped[cat].append(p)
 
     claude_projects = Path("~/.claude/projects").expanduser()
     if claude_projects.is_dir():
@@ -983,15 +1012,15 @@ def _detect_provider_dirs() -> dict[str, list[Path]]:
                 continue
             mem = project / "memory"
             if mem.is_dir() and any(mem.glob("*.md")):
-                grouped["claude-memory"].append(mem)
+                _bucket(mem)
 
     plans = Path("~/.claude/plans").expanduser()
     if plans.is_dir():
-        grouped["claude-plans"].append(plans)
+        _bucket(plans)
 
     codex = Path("~/.codex/memories").expanduser()
     if codex.is_dir():
-        grouped["codex"].append(codex)
+        _bucket(codex)
 
     return grouped
 

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -16,7 +16,12 @@ from memtomem.chunking.markdown import MarkdownChunker
 from memtomem.chunking.registry import ChunkerRegistry
 from memtomem.chunking.restructured_text import ReStructuredTextChunker
 from memtomem.chunking.structured import StructuredChunker
-from memtomem.config import IndexingConfig, NamespaceConfig, NamespacePolicyRule
+from memtomem.config import (
+    IndexingConfig,
+    NamespaceConfig,
+    NamespacePolicyRule,
+    categorize_memory_dir,
+)
 from memtomem.indexing.differ import compute_diff
 from memtomem.models import Chunk, ChunkMetadata, IndexingStats
 
@@ -98,12 +103,14 @@ async def memory_dir_stats(
 ) -> list[dict[str, object]]:
     """Return per-dir index status for each configured ``memory_dir``.
 
-    Shape: ``[{path, chunk_count, source_file_count, exists}]`` in the
-    same order as ``memory_dirs``. Drives the web UI's "(N chunks)" /
-    "(not indexed)" badges so the user can see which dirs still need a
+    Shape: ``[{path, chunk_count, source_file_count, exists, category}]``
+    in the same order as ``memory_dirs``. Drives the web UI's "(N chunks)"
+    / "(not indexed)" badges so the user can see which dirs still need a
     manual reindex (the file watcher only reacts to change events, so
     pre-existing files in a newly added ``memory_dir`` stay invisible
-    until the user clicks the ↻ button).
+    until the user clicks the ↻ button). ``category`` is provided by
+    :func:`~memtomem.config.categorize_memory_dir` so the Web UI can
+    group entries without maintaining its own regex.
 
     Aggregation: one ``get_source_files_with_counts()`` call over the
     whole ``chunks`` table, bucketed in Python by normalised-path prefix
@@ -136,6 +143,7 @@ async def memory_dir_stats(
                 "chunk_count": chunk_count,
                 "source_file_count": source_file_count,
                 "exists": exists,
+                "category": categorize_memory_dir(d),
             }
         )
     return out

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1224,7 +1224,7 @@
   <script src="/i18n.js?v=2"></script>
   <script src="/app.js?v=70"></script>
   <script src="/settings-config.js?v=3"></script>
-  <script src="/sources-memory-dirs.js?v=4"></script>
+  <script src="/sources-memory-dirs.js?v=5"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=2"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1224,7 +1224,7 @@
   <script src="/i18n.js?v=2"></script>
   <script src="/app.js?v=70"></script>
   <script src="/settings-config.js?v=3"></script>
-  <script src="/sources-memory-dirs.js?v=3"></script>
+  <script src="/sources-memory-dirs.js?v=4"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=2"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -10,19 +10,11 @@
  * Depends on globals from app.js (api, showToast, showConfirm, t, qs,
  * STATE, btnLoading, loadStats). Loaded AFTER app.js.
  *
- * Categorization mirrors ``_detect_provider_dirs`` in ``config.py``;
- * keep the two in sync when adding a new provider category.
- * Consolidation into a server-returned field is tracked in
- * https://github.com/memtomem/memtomem/issues/299.
+ * Classification is now server-owned: each entry on
+ * ``GET /api/memory-dirs/status`` carries a ``category`` field produced
+ * by ``categorize_memory_dir`` in ``config.py``. The constants below are
+ * presentation-only (group order, i18n label keys, default-collapse set).
  */
-
-function _categorizeMemoryDir(p) {
-  const s = String(p).replace(/\/+$/, '');
-  if (/\/\.claude\/projects\/[^/]+\/memory$/.test(s)) return 'claude-memory';
-  if (/\/\.claude\/plans$/.test(s)) return 'claude-plans';
-  if (/\/\.codex\/memories$/.test(s)) return 'codex';
-  return 'user';
-}
 
 const _MEMORY_DIR_CATEGORY_ORDER = ['user', 'claude-memory', 'claude-plans', 'codex'];
 const _MEMORY_DIR_CATEGORY_LABEL_KEY = {
@@ -253,7 +245,13 @@ function _buildMemoryDirsPanel(initialDirs) {
 
     const byCategory = { 'user': [], 'claude-memory': [], 'claude-plans': [], 'codex': [] };
     for (const d of dirs) {
-      const cat = _categorizeMemoryDir(d);
+      // Server classifies via ``categorize_memory_dir`` and returns the
+      // result on ``/api/memory-dirs/status``. Before that fetch resolves
+      // (first paint / transient error) we fall back to ``user`` so the
+      // group layout renders without crashing; the next render settles
+      // each entry into its proper group.
+      const st = statusByPath[d];
+      const cat = (st && byCategory[st.category]) ? st.category : 'user';
       byCategory[cat].push(d);
     }
 

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -122,7 +122,10 @@ function _buildMemoryDirsPanel(initialDirs) {
   }
 
   async function handleReindexGroup(category, btn) {
-    const targets = dirs.filter(d => _categorizeMemoryDir(d) === category);
+    const targets = dirs.filter(d => {
+      const st = statusByPath[d];
+      return ((st && st.category) || 'user') === category;
+    });
     if (!targets.length) return;
     if (btn) btnLoading(btn, true);
     try {

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1259,6 +1259,30 @@ class TestMemoryDirStats:
         assert result[0]["exists"] is True
         assert result[0]["chunk_count"] == 0
         assert result[0]["source_file_count"] == 0
+        # ``category`` is always present so the Web UI never has to guess
+        # whether the server supplied it.
+        assert result[0]["category"] == "user"
+
+    async def test_category_reflects_provider_layout(self, tmp_path):
+        """A mix of provider-shaped and user paths produces the right
+        ``category`` on each entry — the Web UI consumes this verbatim
+        instead of running its own regex."""
+        from memtomem.indexing.engine import memory_dir_stats
+
+        user = tmp_path / "notes"
+        codex = tmp_path / ".codex" / "memories"
+        plans = tmp_path / ".claude" / "plans"
+        claude_mem = tmp_path / ".claude" / "projects" / "demo" / "memory"
+        for d in (user, codex, plans, claude_mem):
+            d.mkdir(parents=True)
+
+        storage = _FakeStorageForStats([])
+        result = await memory_dir_stats(storage, [user, codex, plans, claude_mem])
+        by_path = {r["path"]: r["category"] for r in result}
+        assert by_path[str(user)] == "user"
+        assert by_path[str(codex)] == "codex"
+        assert by_path[str(plans)] == "claude-plans"
+        assert by_path[str(claude_mem)] == "claude-memory"
 
     async def test_dir_with_indexed_files_is_aggregated(self, tmp_path):
         from memtomem.indexing.engine import memory_dir_stats

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -960,6 +960,117 @@ class TestProviderDirsStep:
         assert data["indexing"]["auto_discover"] is False
 
 
+class TestCategorizeMemoryDir:
+    """Per-path classifier that powers both wizard grouping and the Web
+    UI's ``category`` field on ``GET /api/memory-dirs/status``."""
+
+    def test_claude_memory_per_project(self) -> None:
+        from memtomem.config import categorize_memory_dir
+
+        assert (
+            categorize_memory_dir("/home/alice/.claude/projects/my-proj/memory")
+            == "claude-memory"
+        )
+
+    def test_claude_plans(self) -> None:
+        from memtomem.config import categorize_memory_dir
+
+        assert categorize_memory_dir("/home/alice/.claude/plans") == "claude-plans"
+
+    def test_codex_memories(self) -> None:
+        from memtomem.config import categorize_memory_dir
+
+        assert categorize_memory_dir("/home/alice/.codex/memories") == "codex"
+
+    def test_trailing_slash_normalisation(self) -> None:
+        from memtomem.config import categorize_memory_dir
+
+        # Trailing slash(es) should not change the category.
+        assert categorize_memory_dir("/u/.codex/memories/") == "codex"
+        assert categorize_memory_dir("/u/.codex/memories///") == "codex"
+        assert categorize_memory_dir("/u/.claude/plans/") == "claude-plans"
+
+    def test_user_fallback(self) -> None:
+        from memtomem.config import categorize_memory_dir
+
+        assert categorize_memory_dir("/home/alice/notes") == "user"
+        assert categorize_memory_dir("/srv/shared/memory") == "user"
+
+    def test_lookalike_paths_do_not_match(self) -> None:
+        """Paths that mention ``claude``/``codex`` but aren't the canonical
+        provider layout must stay in ``user`` — classification is anchored
+        at the end of the path, not a substring match."""
+        from memtomem.config import categorize_memory_dir
+
+        # Looks like a provider path but isn't — user took a backup/copy.
+        assert categorize_memory_dir("/archive/.codex/memories-backup") == "user"
+        # No leading dot — not the real ``.claude`` dir.
+        assert categorize_memory_dir("/work/claude/plans/foo") == "user"
+        # Extra suffix past the canonical name.
+        assert categorize_memory_dir("/u/.claude/plans/2024") == "user"
+
+    def test_pathlib_input(self, tmp_path: Path) -> None:
+        """Accepts ``Path`` as well as ``str`` — the indexing stats call
+        passes whatever is in the config list through verbatim."""
+        from memtomem.config import categorize_memory_dir
+
+        p = Path("/u/.codex/memories")
+        assert categorize_memory_dir(p) == "codex"
+        assert categorize_memory_dir(tmp_path) == "user"
+
+    def test_provider_categories_tuple_is_derived(self) -> None:
+        """Belt-and-suspenders: the exported category tuple is built from
+        the same pattern table, so adding a row can't silently diverge."""
+        from memtomem.config import (
+            PROVIDER_DIR_CATEGORIES,
+            _PROVIDER_CATEGORY_PATTERNS,
+        )
+
+        assert PROVIDER_DIR_CATEGORIES == tuple(
+            cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS
+        )
+
+
+class TestDetectProviderDirsRoundtrip:
+    """Drift guard: every path ``_detect_provider_dirs`` returns must
+    classify back to the same category via ``categorize_memory_dir``.
+
+    Without this, the "single source of truth" claim of issue #299 is
+    only enforced by code review — exactly the pattern called out in
+    ``feedback_silent_policy_enforcement_gap.md``.
+    """
+
+    def test_roundtrip_over_all_categories(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.config import _detect_provider_dirs, categorize_memory_dir
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        # Populate one entry per category so every branch of detection
+        # fires and every resulting Path goes through the classifier.
+        proj_mem = tmp_path / ".claude" / "projects" / "demo" / "memory"
+        proj_mem.mkdir(parents=True)
+        (proj_mem / "note.md").write_text("x", encoding="utf-8")
+        plans = tmp_path / ".claude" / "plans"
+        plans.mkdir(parents=True)
+        codex = tmp_path / ".codex" / "memories"
+        codex.mkdir(parents=True)
+
+        grouped = _detect_provider_dirs()
+
+        seen_any = False
+        for expected_cat, paths in grouped.items():
+            for p in paths:
+                seen_any = True
+                assert categorize_memory_dir(p) == expected_cat, (
+                    f"_detect_provider_dirs bucketed {p!r} as {expected_cat!r} "
+                    f"but categorize_memory_dir classifies it as "
+                    f"{categorize_memory_dir(p)!r}"
+                )
+        assert seen_any, "fixture should produce at least one discovered dir"
+
+
 class TestIncludeProviderFlag:
     """Non-interactive ``--include-provider`` wires categories into
     ``indexing.memory_dirs`` without prompting."""

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -968,8 +968,7 @@ class TestCategorizeMemoryDir:
         from memtomem.config import categorize_memory_dir
 
         assert (
-            categorize_memory_dir("/home/alice/.claude/projects/my-proj/memory")
-            == "claude-memory"
+            categorize_memory_dir("/home/alice/.claude/projects/my-proj/memory") == "claude-memory"
         )
 
     def test_claude_plans(self) -> None:
@@ -1026,9 +1025,7 @@ class TestCategorizeMemoryDir:
             _PROVIDER_CATEGORY_PATTERNS,
         )
 
-        assert PROVIDER_DIR_CATEGORIES == tuple(
-            cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS
-        )
+        assert PROVIDER_DIR_CATEGORIES == tuple(cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS)
 
 
 class TestDetectProviderDirsRoundtrip:


### PR DESCRIPTION
Closes #299. Follow-up to PR #300 / #297.

## Scope

Consolidates the `memory_dir` **classification** (regex mirror) into a
single server-side source. Presentation dicts (group order, i18n label
keys, default-collapsed set) stay on the client by design — new
providers still need the client-side ordering + i18n edits plus the
server pattern row. This PR only eliminates the duplicated regex.

## Changes

- `config.categorize_memory_dir(path)` — stateless per-path classifier.
  Returns one of `PROVIDER_DIR_CATEGORIES` or `"user"`.
- `_PROVIDER_CATEGORY_PATTERNS` — single source of truth for the
  category-to-regex mapping.
- `PROVIDER_DIR_CATEGORIES` is now **derived** from the same pattern
  table instead of a parallel hard-coded tuple, so adding a category
  can't open a new drift seam.
- `_detect_provider_dirs` delegates per-path classification to the
  helper (buckets by `categorize_memory_dir(p)`), so discovery and
  classification lock onto the same pattern table.
- `memory_dir_stats` (`indexing/engine.py`) emits `category` on every
  entry. The `/api/memory-dirs/status` handler is an untouched
  passthrough.
- `sources-memory-dirs.js` drops `_categorizeMemoryDir` and reads
  `statusByPath[path].category`. Drift-mirror warnings removed from
  both `config.py` docstring and the JS file header.

## Timing note (intentional behaviour change)

Classification was synchronous in the client; it is now async. Before
the first `/api/memory-dirs/status` response — first paint, or a
transient fetch error — every entry falls back to `'user'` and then
settles into its group on the next render. Locally the fetch is
sub-100ms so the flicker is not user-visible, but flagging it here so
the async shift isn't invisible in review.

## Tests

- `TestCategorizeMemoryDir` (8 cases): all four categories, trailing-
  slash normalisation, user fallback, look-alike paths that must NOT
  match (`/archive/.codex/memories-backup`, `/work/claude/plans/foo`),
  `Path` input, and an assertion that `PROVIDER_DIR_CATEGORIES` equals
  the derived tuple.
- `TestDetectProviderDirsRoundtrip` — drift guard: every path
  `_detect_provider_dirs` returns must classify back to the same
  category via `categorize_memory_dir`. Without this the "single source
  of truth" claim is code-review-only; this makes it CI-enforced
  (framing per `feedback_silent_policy_enforcement_gap.md`).
- `TestMemoryDirStats::test_category_reflects_provider_layout` — mix of
  provider-shaped and user paths produces the right `category` on each
  entry.

Full suite: 1855 passed, 0 regressions. Ruff + mypy clean on touched files.

## Out of scope

- Gemini (`~/.gemini/GEMINI.md`) — still excluded: single-file surface,
  secrets in parent directory.
- Pydantic response model typing for `/api/memory-dirs/status` — stays
  untyped dict-through; typing is its own sweep.
- Windows path-sep support — posix-style regex for now; documented in
  the helper docstring so a future Windows pass knows where to look.

## Test plan

- [x] `uv run pytest -m "not ollama"` green
- [x] `uv run ruff check` / `ruff format --check` clean
- [x] `uv run mypy` advisory clean on touched files
- [ ] Manual smoke: `uv run mm web` → Sources tab → confirm groups
  render correctly (Claude projects / Claude plans / Codex / User),
  DevTools Network shows `category` on each entry of
  `/api/memory-dirs/status`, adding a user path lands it in the `user`
  group, default-collapsed state unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
