### PR TITLE
fix(web): memory_dirs row button label tracks state (closes #302)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1224,7 +1224,7 @@
   <script src="/i18n.js?v=2"></script>
   <script src="/app.js?v=70"></script>
   <script src="/settings-config.js?v=3"></script>
-  <script src="/sources-memory-dirs.js?v=5"></script>
+  <script src="/sources-memory-dirs.js?v=6"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=2"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -561,6 +561,7 @@
   "sources.memory_dirs.reindex_title": "Reindex this directory",
   "sources.memory_dirs.delete_title": "Remove from memory_dirs",
   "sources.memory_dirs.action_index": "Index",
+  "sources.memory_dirs.action_reindex": "Reindex",
   "sources.memory_dirs.action_delete": "Delete",
   "sources.memory_dirs.action_reindex_group": "Reindex",
   "sources.memory_dirs.status_empty": "not indexed",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -561,6 +561,7 @@
   "sources.memory_dirs.reindex_title": "이 디렉터리만 재인덱스",
   "sources.memory_dirs.delete_title": "memory_dirs 에서 제거",
   "sources.memory_dirs.action_index": "인덱스",
+  "sources.memory_dirs.action_reindex": "재인덱스",
   "sources.memory_dirs.action_delete": "삭제",
   "sources.memory_dirs.action_reindex_group": "재인덱스",
   "sources.memory_dirs.status_empty": "인덱싱 안 됨",

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -362,7 +362,14 @@ function _buildMemoryDirsPanel(initialDirs) {
         const reindexBtn = document.createElement('button');
         reindexBtn.type = 'button';
         reindexBtn.className = 'btn btn-xs btn-ghost memory-dirs-reindex-btn';
-        reindexBtn.textContent = t('sources.memory_dirs.action_index');
+        // Label tracks state: "Index" before first index / when missing or
+        // empty, "Reindex" once chunks exist. Tooltip stays generic since
+        // the action is a reindex in both cases (force:false, recursive).
+        const hasChunks =
+          statusLoaded && st && st.exists !== false && (st.chunk_count || 0) > 0;
+        reindexBtn.textContent = t(
+          hasChunks ? 'sources.memory_dirs.action_reindex' : 'sources.memory_dirs.action_index',
+        );
         reindexBtn.title = t('sources.memory_dirs.reindex_title');
         reindexBtn.addEventListener('click', () => handleReindexOne(path, reindexBtn));
         item.appendChild(reindexBtn);


### PR DESCRIPTION
Closes #302.

## Problem

The per-row action button in the Sources-tab `memory_dirs` panel reads
`"Index"` (`sources.memory_dirs.action_index`) regardless of state, while
its tooltip reads `"Reindex this directory"` (`reindex_title`). They
disagree once the directory has chunks — and the action itself
(`POST /api/index` with `recursive:true, force:false`) is a reindex
whether or not chunks already exist. The group-level button in the
category summary already reads `"Reindex"` (`action_reindex_group`), so
the per-row label was the last remaining "Index" string.

## Fix

State-dependent label on the per-row button, rendered from existing
`/api/memory-dirs/status` data:

- `statusLoaded && st.exists !== false && st.chunk_count > 0` →
  `"Reindex"` (new key `action_reindex` in en/ko).
- otherwise (pre-fetch, missing path, empty) → `"Index"` (existing
  `action_index` key).

Tooltip is left as `reindex_title` — it already describes reindex-style
semantics and reads correctly in either state. No change to the POST
payload; `force:false` means the "Index" branch is a no-op reindex when
chunks already exist anyway, but that path is now impossible because
the label only shows "Index" before any chunks exist.

## Scope

- `sources-memory-dirs.js` — 8-line patch at the button-render site;
  cache-bust `v=5 → v=6` in `index.html`.
- `locales/{en,ko}.json` — one new key per locale; placeholder-free
  string, no interpolation parity concerns.
- No test changes: `test_i18n.py` validates key parity structurally
  (the new `action_reindex` key is added to both files so parity holds)
  and does not pin specific business-logic strings.

## Test plan

- [x] `uv run ruff check && ruff format --check` — clean.
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 11 passed.
- [ ] Manual: `uv run mm web`, open Sources tab, confirm per-row button
      reads "Reindex" for already-indexed dirs and "Index" for
      unindexed ones; tooltip stays "Reindex this directory" in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
