### PR TITLE
fix(storage): fail fast when stored dim=0 meets real provider (closes #298)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/embedding_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/embedding_cmd.py
@@ -34,11 +34,16 @@ async def _run(mode: str) -> None:
     load_config_d(cfg)
     load_config_overrides(cfg)
 
+    # Relaxed mode: this CLI is explicitly the recovery tool for the
+    # dim=0 / real-provider mismatch that ``create_tables`` fails-fast on.
+    # Without ``strict_dim_check=False`` the user could not run
+    # ``embedding-reset`` to fix the state the gate is flagging.
     storage = SqliteBackend(
         cfg.storage,
         dimension=cfg.embedding.dimension,
         embedding_provider=cfg.embedding.provider,
         embedding_model=cfg.embedding.model,
+        strict_dim_check=False,
     )
     await storage.initialize()
 

--- a/packages/memtomem/src/memtomem/errors.py
+++ b/packages/memtomem/src/memtomem/errors.py
@@ -9,6 +9,19 @@ class StorageError(Mem2MemError):
     """Storage backend error."""
 
 
+class EmbeddingDimensionMismatchError(StorageError):
+    """Raised when stored embedding dimension is 0 but a real provider is configured.
+
+    This happens when a DB was initialized with ``provider=none`` (NoopEmbedder,
+    BM25-only) and the config was later switched to a real provider like
+    ``onnx``/``ollama`` without running ``mm embedding-reset``. In that state
+    ``chunks_vec`` was never created (it only exists when dimension > 0) but
+    the runtime embedder produces real vectors, so every ``upsert_chunks``
+    fails with ``no such table: chunks_vec``. Fail-fast at startup with a
+    remediation message instead of letting the cascade happen.
+    """
+
+
 class EmbeddingError(Mem2MemError):
     """Embedding provider error."""
 

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -77,11 +77,18 @@ class SqliteBackend(
         dimension: int = 768,
         embedding_provider: str = "",
         embedding_model: str = "",
+        *,
+        strict_dim_check: bool = True,
     ) -> None:
         self._config = config
         self._dimension = dimension
         self._embedding_provider = embedding_provider
         self._embedding_model = embedding_model
+        # Relaxed mode is used by recovery tooling (``mm embedding-reset``)
+        # to observe and fix a dim=0 / real-provider mismatch; production
+        # entry points keep the default strict behavior so startup fails
+        # fast with a remediation message. See issue #298.
+        self._strict_dim_check = strict_dim_check
         self._db: sqlite3.Connection | None = None
         self._dim_mismatch: tuple[int, int] | None = None  # (stored, configured)
         self._model_mismatch: tuple[str, str, str, str] | None = (
@@ -141,6 +148,7 @@ class SqliteBackend(
                 self._dimension,
                 self._embedding_provider,
                 self._embedding_model,
+                strict_dim_check=self._strict_dim_check,
             )
         except Exception:
             await self.close()

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -6,6 +6,7 @@ import logging
 import re
 import sqlite3
 
+from memtomem.errors import EmbeddingDimensionMismatchError
 from memtomem.storage.sqlite_meta import MetaManager
 
 logger = logging.getLogger(__name__)
@@ -17,8 +18,16 @@ def create_tables(
     dimension: int,
     embedding_provider: str,
     embedding_model: str,
+    *,
+    strict_dim_check: bool = True,
 ) -> tuple[int, tuple[int, int] | None, tuple[str, str, str, str] | None]:
     """Create all required tables and return effective (dimension, dim_mismatch, model_mismatch).
+
+    When ``strict_dim_check`` is True (default), a contradictory state —
+    effective ``dimension == 0`` with a non-``none`` configured provider —
+    raises :class:`EmbeddingDimensionMismatchError`. Recovery tooling
+    (``mm embedding-reset``) passes ``strict_dim_check=False`` so it can
+    observe the broken state and reset it.
 
     Returns:
         A 3-tuple of ``(effective_dimension, dim_mismatch_or_None, model_mismatch_or_None)``.
@@ -165,6 +174,30 @@ def create_tables(
             meta.set_meta("embedding_provider", embedding_provider)
         if embedding_model:
             meta.set_meta("embedding_model", embedding_model)
+
+    # ---- dim=0 / real-provider mismatch -- fail fast at startup ---------
+    # Catches the legacy NoopEmbedder → real-provider switch: stored
+    # dimension is 0 (so ``chunks_vec`` was never created) but the runtime
+    # embedder is configured to produce real vectors. Without this gate,
+    # startup succeeds and every subsequent ``upsert_chunks`` crashes with
+    # ``no such table: chunks_vec``. See issue #298.
+    if dimension == 0 and (embedding_provider or "").lower() not in ("", "none"):
+        if strict_dim_check:
+            raise EmbeddingDimensionMismatchError(
+                f"DB embedding_dimension=0 but configured provider is "
+                f"'{embedding_provider}'. This usually means the DB was "
+                f"initialized with provider=none (NoopEmbedder) and the "
+                f"config was later switched to a real provider without "
+                f"resetting. Run 'mm embedding-reset --mode apply-current' "
+                f"(CLI) or mem_embedding_reset (MCP) to recreate chunks_vec "
+                f"with the configured dimension."
+            )
+        logger.warning(
+            "DB embedding_dimension=0 but configured provider is '%s' — "
+            "continuing in recovery mode (strict_dim_check=False). "
+            "Run 'mm embedding-reset --mode apply-current' to fix.",
+            embedding_provider,
+        )
 
     if dimension > 0:
         db.execute(f"""

--- a/packages/memtomem/tests/test_sqlite_schema.py
+++ b/packages/memtomem/tests/test_sqlite_schema.py
@@ -1,0 +1,158 @@
+"""Tests for ``storage.sqlite_schema.create_tables`` startup invariants.
+
+Focused on issue #298: a DB with ``embedding_dimension=0`` but a non-``none``
+configured embedding provider indicates a legacy NoopEmbedder → real-provider
+switch without ``mm embedding-reset``. Without a fail-fast gate, startup
+would silently proceed and every subsequent ``upsert_chunks`` would crash
+with ``no such table: chunks_vec``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+import sqlite_vec
+
+from memtomem.errors import EmbeddingDimensionMismatchError
+from memtomem.storage.sqlite_meta import MetaManager
+from memtomem.storage.sqlite_schema import create_tables
+
+
+def _connect_with_vec() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    return db
+
+
+def _seed_legacy_meta(
+    db: sqlite3.Connection,
+    *,
+    stored_dim: int,
+    stored_provider: str,
+    stored_model: str,
+) -> None:
+    """Pre-create ``_memtomem_meta`` as a prior ``create_tables`` run would."""
+    db.execute(
+        "CREATE TABLE IF NOT EXISTS _memtomem_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+    )
+    db.executemany(
+        "INSERT OR REPLACE INTO _memtomem_meta(key, value) VALUES (?, ?)",
+        [
+            ("embedding_dimension", str(stored_dim)),
+            ("embedding_provider", stored_provider),
+            ("embedding_model", stored_model),
+        ],
+    )
+    db.commit()
+
+
+class TestDim0ProviderMismatch:
+    """Startup gate for the dim=0 / real-provider contradiction (#298)."""
+
+    def test_mismatch_raises_by_default(self) -> None:
+        """Legacy DB left at dim=0 + configured real provider must fail fast."""
+        db = _connect_with_vec()
+        try:
+            _seed_legacy_meta(db, stored_dim=0, stored_provider="onnx", stored_model="bge-m3")
+            meta = MetaManager(lambda: db)
+            with pytest.raises(EmbeddingDimensionMismatchError) as excinfo:
+                create_tables(
+                    db,
+                    meta,
+                    dimension=1024,
+                    embedding_provider="onnx",
+                    embedding_model="bge-m3",
+                )
+            msg = str(excinfo.value)
+            assert "embedding_dimension=0" in msg
+            assert "mm embedding-reset --mode apply-current" in msg
+        finally:
+            db.close()
+
+    def test_relaxed_check_allows_mismatch_for_recovery(self) -> None:
+        """``mm embedding-reset`` passes strict_dim_check=False so it can
+        observe and fix the broken state instead of tripping the gate."""
+        db = _connect_with_vec()
+        try:
+            _seed_legacy_meta(db, stored_dim=0, stored_provider="onnx", stored_model="bge-m3")
+            meta = MetaManager(lambda: db)
+            effective_dim, _, _ = create_tables(
+                db,
+                meta,
+                dimension=1024,
+                embedding_provider="onnx",
+                embedding_model="bge-m3",
+                strict_dim_check=False,
+            )
+            assert effective_dim == 0
+            vec_row = db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunks_vec'"
+            ).fetchone()
+            assert vec_row is None, "chunks_vec must not be created at dim=0"
+        finally:
+            db.close()
+
+    def test_bm25_only_install_ok(self) -> None:
+        """The legit pure-BM25 case (dim=0 + provider=none) must initialize
+        cleanly — stored provider is ``none``, so the gate does not trip."""
+        db = _connect_with_vec()
+        try:
+            _seed_legacy_meta(db, stored_dim=0, stored_provider="none", stored_model="")
+            meta = MetaManager(lambda: db)
+            effective_dim, _, _ = create_tables(
+                db,
+                meta,
+                dimension=0,
+                embedding_provider="none",
+                embedding_model="",
+            )
+            assert effective_dim == 0
+        finally:
+            db.close()
+
+    def test_bm25_upgrade_attempt_without_reset_raises(self) -> None:
+        """DB initialized with provider=none, config upgraded to onnx without
+        running embedding-reset: stored provider=none, stored dim=0, but
+        configured provider=onnx — gate still fires because the configured
+        runtime provider is non-``none`` and the stored dim is 0."""
+        db = _connect_with_vec()
+        try:
+            _seed_legacy_meta(db, stored_dim=0, stored_provider="none", stored_model="")
+            meta = MetaManager(lambda: db)
+            with pytest.raises(EmbeddingDimensionMismatchError):
+                create_tables(
+                    db,
+                    meta,
+                    dimension=1024,
+                    embedding_provider="onnx",
+                    embedding_model="bge-m3",
+                )
+        finally:
+            db.close()
+
+    def test_fresh_install_real_provider_ok(self) -> None:
+        """Fresh DB + real provider: no prior meta rows → stored_dim is None,
+        falls through to ``meta.store_dimension(configured)``, chunks_vec is
+        created with the configured dimension."""
+        db = _connect_with_vec()
+        try:
+            meta = MetaManager(lambda: db)
+            effective_dim, dim_mismatch, model_mismatch = create_tables(
+                db,
+                meta,
+                dimension=1024,
+                embedding_provider="onnx",
+                embedding_model="bge-m3",
+            )
+            assert effective_dim == 1024
+            assert dim_mismatch is None
+            assert model_mismatch is None
+            vec_row = db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunks_vec'"
+            ).fetchone()
+            assert vec_row is not None
+        finally:
+            db.close()


### PR DESCRIPTION
Closes #298.

## Problem

A DB initialized with `provider=none` (NoopEmbedder, BM25-only) stores
`embedding_dimension=0` in `_memtomem_meta`. If the config is later
switched to a real provider (`onnx`/`ollama`) without running
`mm embedding-reset`, startup silently loads that contradictory state:
`chunks_vec` was never created (it's gated on `dimension > 0` in
`sqlite_schema.py:169`) but the runtime embedder now produces real
vectors. Every subsequent `upsert_chunks` crashes with `no such table:
chunks_vec` — a flood of identical errors before the user sees anything
actionable (surfaced during PR #295 smoke, ~200 identical lines before
diagnosis).

## Fix

Add a startup gate in `create_tables`: if effective `dimension == 0`
but the configured provider is not `none`/empty, raise a new
`EmbeddingDimensionMismatchError` (subclass of `StorageError`) with a
remediation message pointing at `mm embedding-reset --mode apply-current`.

The legit pure-BM25 case (stored `dim=0` + configured `provider=none`)
still initializes cleanly because the gate requires a non-`none`
configured provider.

## Keeping the recovery tool usable

The gate blocks `SqliteBackend.initialize()`, but `mm embedding-reset`
itself needs to reach `reset_embedding_meta` to fix the state. To break
that chicken-and-egg:

- `create_tables` gains a `strict_dim_check: bool = True` kwarg.
- `SqliteBackend.__init__` gains the same kwarg, forwarded through
  `initialize` → `create_tables`.
- `mm embedding-reset` constructs its `SqliteBackend` with
  `strict_dim_check=False` so it can observe the broken state and
  call `reset_embedding_meta` in `--mode apply-current`.
- Production entry points (web, serve, indexing CLI, factory) keep the
  default strict behavior → fail-fast at startup.

`mm reset` deliberately keeps strict mode — running it on a
dim=0/mismatch DB should surface the gate pointing the user at
`embedding-reset` first, since `reset_all` preserves `_memtomem_meta`
and would leave the mismatch in place.

## Tests

New `tests/test_sqlite_schema.py` covers:

| Scenario | Strict | Expected |
| --- | --- | --- |
| Legacy DB `dim=0, provider=onnx` | True | raises |
| Same, recovery path | False | no raise, warning logged, chunks_vec not created |
| Pure BM25 (`dim=0, provider=none`) | True | clean init |
| Upgrade attempt (`stored=none, configured=onnx`) | True | raises |
| Fresh install (`provider=onnx, dim=1024`) | True | clean init, chunks_vec created |

**Negative-tested** by stashing the gate source change — 3/5 tests fail
without it (the two clean-path tests still pass, which is expected).

## Scope boundaries

- Startup-only gate; `upsert_chunks` and search paths unchanged.
- `mm embedding-reset` behavior is unchanged except that it now works
  on the state it was designed to fix.
- No schema migration; the gate is purely a validation/raise.

## Test plan

- [x] `uv run ruff check && ruff format --check` — clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/storage packages/memtomem/src/memtomem/cli/embedding_cmd.py` — no issues.
- [x] `uv run pytest packages/memtomem/tests/test_sqlite_schema.py` — 5 passed.
- [x] `uv run pytest packages/memtomem/tests/` — 1860 passed (no regressions).
- [x] Negative-test: stash `sqlite_schema.py` gate → 3/5 new tests fail as expected.
- [ ] Manual: construct a dim=0/provider=onnx DB, confirm `mm web` fails
      fast with remediation message, and `mm embedding-reset --mode
      apply-current` recovers.

## Related

- Recognition pattern captured in `feedback_chunks_vec_dim0_legacy.md`.
- Not blocking any open work; surfaced by #295 smoke but independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
