### PR TITLE
feat(config): {ancestor:N} namespace placeholder for memory_dir rules (refs #296)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -231,7 +231,7 @@ class AccessConfig(BaseSettings):
 
 
 _NAMESPACE_MAX_LEN = 128
-_ALLOWED_NS_PLACEHOLDERS: frozenset[str] = frozenset({"parent"})
+_ALLOWED_NS_PLACEHOLDERS: frozenset[str] = frozenset({"parent", "ancestor"})
 
 
 class NamespacePolicyRule(BaseSettings):
@@ -242,10 +242,21 @@ class NamespacePolicyRule(BaseSettings):
     runs against the absolute resolved file path with any leading ``/``
     stripped — same semantics as ``IndexingConfig.exclude_patterns``.
 
-    ``namespace`` supports the ``{parent}`` placeholder, which expands to the
-    immediate parent folder name of the matched file. Unknown placeholders are
-    rejected at load time. When ``{parent}`` would expand to an empty string
-    the rule is skipped at runtime and the next rule is tried.
+    ``namespace`` supports two placeholders, both resolved against the matched
+    file's path:
+
+    - ``{parent}`` — the immediate parent folder name (equivalent to
+      ``{ancestor:0}``).
+    - ``{ancestor:N}`` — the folder name ``N`` levels above the immediate
+      parent. ``N=0`` is the immediate parent; ``N=1`` is the grandparent,
+      and so on. This lets rules for well-known memory_dir layouts (e.g.,
+      ``~/.claude/projects/*/memory/**``) pick out the project id rather
+      than the generic ``memory`` basename — see issue #296.
+
+    Unknown placeholders, non-integer or negative ``ancestor`` specs are
+    rejected at load time. If a placeholder would expand to an empty string
+    (e.g., root of filesystem) or ``N`` exceeds the available ancestors, the
+    rule is skipped at runtime and the next rule is tried.
     """
 
     path_glob: str
@@ -271,12 +282,27 @@ class NamespacePolicyRule(BaseSettings):
             raise ValueError("namespace must be non-empty")
         if len(v) > _NAMESPACE_MAX_LEN:
             raise ValueError(f"namespace must be <= {_NAMESPACE_MAX_LEN} chars, got {len(v)}")
-        for _lit, field_name, _spec, _conv in _string.Formatter().parse(v):
-            if field_name is not None and field_name not in _ALLOWED_NS_PLACEHOLDERS:
+        for _lit, field_name, spec, _conv in _string.Formatter().parse(v):
+            if field_name is None:
+                continue
+            if field_name not in _ALLOWED_NS_PLACEHOLDERS:
                 raise ValueError(
                     f"unknown placeholder '{{{field_name}}}' in namespace; "
                     f"supported: {sorted(_ALLOWED_NS_PLACEHOLDERS)}"
                 )
+            if field_name == "parent" and spec:
+                raise ValueError("{parent} does not accept a format spec; use {ancestor:N}")
+            if field_name == "ancestor":
+                if not spec:
+                    raise ValueError("{ancestor} requires an integer index, e.g. {ancestor:1}")
+                try:
+                    n = int(spec)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"{{ancestor:{spec}}} index must be a non-negative integer"
+                    ) from exc
+                if n < 0:
+                    raise ValueError(f"{{ancestor:{spec}}} index must be non-negative")
         if any(ord(c) < 32 for c in v):
             raise ValueError("namespace must not contain control characters")
         return v

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -351,25 +351,51 @@ class IndexEngine:
         return None
 
     def _format_namespace(self, template: str, file_path: Path, *, rule_index: int) -> str | None:
-        """Substitute ``{parent}`` in a rule's namespace template.
+        """Substitute ``{parent}`` and ``{ancestor:N}`` in a namespace template.
 
-        Returns ``None`` when ``{parent}`` is present but the file's parent
-        folder name is empty, so the caller can fall through to the next rule.
-        Logs a warning once per rule index to surface the skip without flooding.
+        ``{parent}`` resolves to the file's immediate parent folder name;
+        ``{ancestor:N}`` resolves to the folder ``N`` levels above the
+        immediate parent (``N=0`` is equivalent to ``{parent}``). Returns
+        ``None`` when a placeholder would expand to an empty string (root
+        of filesystem) or ``N`` exceeds the available ancestors, so the
+        caller can fall through to the next rule. Logs once per rule index
+        to surface skips without flooding.
         """
-        if "{parent}" not in template:
-            return template
-        parent_name = file_path.parent.name
-        if not parent_name:
-            if rule_index not in self._warned_empty_parent_rules:
-                self._warned_empty_parent_rules.add(rule_index)
-                logger.warning(
-                    "namespace rule #%d skipped for %s: parent name empty",
-                    rule_index,
-                    file_path,
-                )
-            return None
-        return template.format(parent=parent_name)
+        import string as _string
+
+        parts: list[str] = []
+        for literal, field_name, spec, _conv in _string.Formatter().parse(template):
+            parts.append(literal)
+            if field_name is None:
+                continue
+            if field_name == "parent":
+                name = file_path.parent.name
+                reason = "parent name empty"
+                index = 0
+            elif field_name == "ancestor":
+                # Config validator already enforced spec is a non-negative int.
+                index = int(spec) if spec else 0
+                try:
+                    name = file_path.parents[index].name
+                except IndexError:
+                    name = ""
+                reason = f"ancestor:{index} out of range"
+            else:
+                # Unknown placeholder — validator rejects these at load time,
+                # so this branch is defensive only.
+                return None
+            if not name:
+                if rule_index not in self._warned_empty_parent_rules:
+                    self._warned_empty_parent_rules.add(rule_index)
+                    logger.warning(
+                        "namespace rule #%d skipped for %s: %s",
+                        rule_index,
+                        file_path,
+                        reason,
+                    )
+                return None
+            parts.append(name)
+        return "".join(parts)
 
     def _is_within_memory_dirs(self, path: Path) -> bool:
         """Check that *path* is within at least one configured memory_dir."""

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -613,6 +613,126 @@ class TestNamespacePolicyRules:
             NamespacePolicyRule(path_glob="**", namespace="x" * 129)
         assert "128" in str(excinfo.value)
 
+    # ---- {ancestor:N} placeholder (issue #296) -----------------------------
+
+    async def test_ancestor_placeholder_grandparent(self, components, memory_dir):
+        """``{ancestor:1}`` picks the folder above the immediate parent —
+        the canonical #296 shape (``.../<project-id>/memory/<file>``)."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**",
+                    namespace="claude:{ancestor:1}",
+                ),
+            ],
+        )
+
+        proj = memory_dir / "FOO" / "memory"
+        proj.mkdir(parents=True)
+        fp = proj / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "claude:FOO"
+
+    async def test_ancestor_zero_equals_parent(self, components, memory_dir):
+        """``{ancestor:0}`` is equivalent to ``{parent}`` — the immediate
+        parent folder name. Codified so the two placeholders stay in sync."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**",
+                    namespace="a0:{ancestor:0}",
+                ),
+            ],
+        )
+
+        sub = memory_dir / "team-alpha"
+        sub.mkdir()
+        fp = sub / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "a0:team-alpha"
+
+    async def test_ancestor_out_of_range_falls_through(self, components, memory_dir, caplog):
+        """An out-of-range ``{ancestor:N}`` skips the rule and falls through,
+        logging once per rule index (same shape as the empty-parent skip)."""
+        import logging
+
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**",
+                    namespace="deep:{ancestor:99}",
+                ),
+            ],
+            default_namespace="fallback",
+        )
+
+        fp = memory_dir / "notes.md"
+        fp.write_text("# Notes")
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.indexing.engine"):
+            assert engine._resolve_namespace(fp, None) == "fallback"
+            # Second call on the same rule index must not re-log.
+            assert engine._resolve_namespace(fp, None) == "fallback"
+
+        skip_warnings = [r for r in caplog.records if "ancestor:99" in r.getMessage()]
+        assert len(skip_warnings) == 1, [r.getMessage() for r in skip_warnings]
+
+    async def test_ancestor_combined_with_literal(self, components, memory_dir):
+        """Ancestor placeholder composes with literal prefixes/suffixes like
+        ``{parent}`` does — template parsing is position-preserving."""
+        engine = components.index_engine
+        _install_rules(
+            engine,
+            [
+                NamespacePolicyRule(
+                    path_glob=f"{memory_dir.as_posix()}/**",
+                    namespace="{ancestor:1}/sub",
+                ),
+            ],
+        )
+
+        proj = memory_dir / "BAR" / "memory"
+        proj.mkdir(parents=True)
+        fp = proj / "notes.md"
+        fp.write_text("# Notes")
+
+        assert engine._resolve_namespace(fp, None) == "BAR/sub"
+
+    def test_ancestor_without_index_rejected_at_load(self):
+        """Bare ``{ancestor}`` without an integer spec is a configuration
+        error — the caller must say which level."""
+        with pytest.raises(ValidationError) as excinfo:
+            NamespacePolicyRule(path_glob="**", namespace="bad:{ancestor}")
+        assert "requires an integer index" in str(excinfo.value)
+
+    def test_ancestor_non_integer_spec_rejected_at_load(self):
+        """``{ancestor:abc}`` is rejected — spec must parse as int."""
+        with pytest.raises(ValidationError) as excinfo:
+            NamespacePolicyRule(path_glob="**", namespace="bad:{ancestor:abc}")
+        assert "non-negative integer" in str(excinfo.value)
+
+    def test_ancestor_negative_index_rejected_at_load(self):
+        """Negative indices would wrap into ``parents[-1]`` (filesystem
+        root) — reject explicitly instead of silently doing the wrong thing."""
+        with pytest.raises(ValidationError) as excinfo:
+            NamespacePolicyRule(path_glob="**", namespace="bad:{ancestor:-1}")
+        assert "non-negative" in str(excinfo.value)
+
+    def test_parent_with_format_spec_rejected_at_load(self):
+        """``{parent:N}`` is ambiguous — force users to switch to the
+        ``{ancestor:N}`` spelling rather than silently padding/truncating."""
+        with pytest.raises(ValidationError) as excinfo:
+            NamespacePolicyRule(path_glob="**", namespace="bad:{parent:1}")
+        assert "ancestor" in str(excinfo.value).lower()
+
 
 # ===========================================================================
 # 3. _apply_namespace


### PR DESCRIPTION
Refs #296 (primitive; wizard preset direction-3 deferred, see below).

## Problem

With `enable_auto_ns=true` applied to memory_dirs whose basename is
non-discriminating (`memory`, `memories`, `plans` — exactly the shape
produced by auto-discovered Claude/Codex provider dirs), the folder-based
fallback collapses every file to `default`. The guard in
`_resolve_namespace` suppresses the useless immediate-parent basename
but doesn't derive a useful alternative. The identifier users care
about lives one level up: `FOO` in `~/.claude/projects/FOO/memory/`.

The issue author's realistic workaround — hand-crafting a
`namespace.rules` entry per project — is defeated by the fact that
`NamespacePolicyRule.namespace` only supports `{parent}`, which is
still the useless `memory` basename.

## Fix (direction 2 of 3)

Add the `{ancestor:N}` placeholder to `NamespacePolicyRule.namespace`.
A rule like:

```json
{
  "path_glob": "~/.claude/projects/*/memory/**",
  "namespace": "claude:{ancestor:1}"
}
```

expands to `claude:FOO` for that layout.

**Semantics**: `{ancestor:N}` resolves to `file_path.parents[N].name`.

| N | Folder |
| --- | --- |
| 0 | immediate parent (equivalent to `{parent}`) |
| 1 | grandparent (the `FOO`-shaped project id for provider dirs) |
| 2 | great-grandparent |
| ... | ... |

**Validator extensions** (all load-time rejections):

- `{ancestor}` without an integer spec — caller must say which level.
- Non-integer spec (`{ancestor:abc}`) — must parse as int.
- Negative spec (`{ancestor:-1}`) — would silently wrap into filesystem
  root via `parents[-1]`.
- `{parent:N}` — format specs are ambiguous on the bare `parent`
  placeholder; force users onto `{ancestor:N}` for any positional lookup.

**Runtime**: `_format_namespace` is rewritten to walk
`string.Formatter().parse()` output, so `{parent}` and `{ancestor:N}`
can be mixed with literals in a single template. Out-of-range `N` or
empty folder names skip the rule and fall through (same shape as the
existing empty-`{parent}` skip), logged once per rule index.

## What this PR explicitly does NOT do

The #296 issue author proposed (2) + (3):

- **(2) — this PR**: primitive `{ancestor:N}` placeholder.
- **(3) — deferred**: wizard preset. `mm init`'s provider-dirs step
  should auto-append matching `NamespacePolicyRule` entries so the
  Claude/Codex memory dirs Just Work without users hand-crafting
  rules. Tracking remains on #296; this PR closes the primitive gap
  but does not close the issue.
- **(1) — rejected**: implicit fallback in `_resolve_namespace` for
  container-basename memory_dirs. The issue author explicitly didn't
  want this because it would silently change behavior for non-provider
  `memory_dirs` that legitimately rely on the current guard.

Sequencing (3) as a follow-up keeps the primitive reviewable on its
own (27-line validator + 34-line formatter rewrite + tests) and
separates the design questions in (3) (which provider dirs? what
namespace labels? migrating existing installs?) from the mechanical
change in (2).

## Tests

7 new cases in `test_indexing_engine.py`:

| Test | Asserts |
| --- | --- |
| `test_ancestor_placeholder_grandparent` | `{ancestor:1}` → grandparent folder name |
| `test_ancestor_zero_equals_parent` | `{ancestor:0}` ≡ `{parent}` |
| `test_ancestor_out_of_range_falls_through` | `{ancestor:99}` skips rule, logs once |
| `test_ancestor_combined_with_literal` | `{ancestor:1}/sub` composes with literals |
| `test_ancestor_without_index_rejected_at_load` | bare `{ancestor}` rejected |
| `test_ancestor_non_integer_spec_rejected_at_load` | `{ancestor:abc}` rejected |
| `test_ancestor_negative_index_rejected_at_load` | `{ancestor:-1}` rejected |
| `test_parent_with_format_spec_rejected_at_load` | `{parent:N}` rejected, points to `{ancestor:N}` |

**Negative-tested**: stashing the src changes → 7 ancestor tests fail
as expected. Existing `{parent}` tests remain green (no regressions in
the pre-existing behavior).

## Scope boundaries

- No change to `_resolve_namespace`'s priority chain (explicit → rules
  → `enable_auto_ns` → default). Only the rule-format step gains the
  new placeholder.
- No wizard / config-migration changes.
- No change to auto-discovery of memory_dirs.

## Test plan

- [x] `uv run ruff check && ruff format --check` — clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/indexing packages/memtomem/src/memtomem/config.py` — no issues.
- [x] `uv run pytest packages/memtomem/tests/test_indexing_engine.py` — 92 passed.
- [x] `uv run pytest packages/memtomem/tests/` — 1863 passed (no regressions).
- [x] Negative-test: stash `config.py` + `engine.py` changes → all 7 new ancestor tests fail.
- [ ] Manual: add a rule `{"path_glob": "~/.claude/projects/*/memory/**", "namespace": "claude:{ancestor:1}"}`, reindex a Claude project memory dir, confirm chunks land in `claude:<project-id>` namespace.

## Related

- Closes the primitive half of #296. Issue stays open until the wizard
  preset (direction 3) ships.
- Pairs naturally with the #304 provider-hierarchy RFC — if that
  lands first, the wizard preset would use the derived provider
  taxonomy to generate rules. Not coupled; either can ship first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
