### PR TITLE
feat(rerank): oversample multiplier + runtime-tunable pool knobs (#309)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -342,15 +342,72 @@ class RerankConfig(BaseSettings):
     enabled: bool = False
     provider: str = "fastembed"  # "cohere" | "local" | "fastembed"
     model: str = "Xenova/ms-marco-MiniLM-L-6-v2"
-    top_k: int = 20  # candidates to pass to reranker
     api_key: str = ""
 
-    @field_validator("top_k")
+    # Candidate pool (Stage 3b oversample) — the reranker sees
+    # ``max(min_pool, min(max_pool, int(oversample * response_top_k)))``
+    # items, then returns the caller's response top_k. Defaults give the
+    # classic 2× oversample at top_k=10 (pool=20) while scaling with
+    # larger requests.
+    oversample: float = 2.0
+    min_pool: int = 20
+    max_pool: int = 200
+
+    # Deprecated: superseded by oversample/min_pool/max_pool. Kept as a
+    # field so legacy config.json and MEMTOMEM_RERANK__TOP_K env vars
+    # still load without errors; ``_migrate_legacy_top_k`` rewrites it
+    # to ``min_pool`` during validation. Slated for removal in 0.3.
+    top_k: int = 20
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_top_k(cls, data: object) -> object:
+        if not isinstance(data, dict) or "top_k" not in data:
+            return data
+        import warnings
+
+        if "min_pool" in data:
+            warnings.warn(
+                "rerank.top_k is deprecated and is ignored when rerank.min_pool "
+                "is set. Remove rerank.top_k from your config. "
+                "(Slated for removal in memtomem 0.3.)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data.pop("top_k")
+        else:
+            warnings.warn(
+                "rerank.top_k is deprecated; migrating to rerank.min_pool. "
+                "Use rerank.oversample + rerank.min_pool + rerank.max_pool to "
+                "scale the reranker candidate pool with the request top_k. "
+                "(Slated for removal in memtomem 0.3.)",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["min_pool"] = data.pop("top_k")
+        return data
+
+    @field_validator("top_k", "min_pool", "max_pool")
     @classmethod
     def must_be_positive(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
+
+    @field_validator("oversample")
+    @classmethod
+    def oversample_must_be_positive(cls, v: float, info: ValidationInfo) -> float:
+        if v <= 0:
+            raise ValueError(f"{info.field_name} must be positive, got {v}")
+        return v
+
+    @model_validator(mode="after")
+    def _check_pool_bounds(self) -> "RerankConfig":
+        if self.max_pool < self.min_pool:
+            raise ValueError(
+                f"rerank.max_pool ({self.max_pool}) must be >= rerank.min_pool ({self.min_pool})"
+            )
+        return self
 
 
 class QueryExpansionConfig(BaseSettings):
@@ -544,6 +601,10 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
     "decay": {"enabled", "half_life_days"},
     "mmr": {"enabled", "lambda_param"},
     "namespace": {"default_namespace", "enable_auto_ns", "rules"},
+    # ``provider``/``model``/``api_key`` require a restart (reranker
+    # instance is cached on startup), so only the pool-sizing knobs are
+    # runtime-mutable.
+    "rerank": {"enabled", "oversample", "min_pool", "max_pool"},
 }
 
 FIELD_CONSTRAINTS: dict[str, dict] = {
@@ -574,6 +635,10 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     "namespace.default_namespace": {"type": str},
     "namespace.enable_auto_ns": {"type": bool},
     "namespace.rules": {"type": list, "item_type": NamespacePolicyRule},
+    "rerank.enabled": {"type": bool},
+    "rerank.oversample": {"type": float, "min": 0.1, "max": 10.0},
+    "rerank.min_pool": {"type": int, "min": 1, "max": 1000},
+    "rerank.max_pool": {"type": int, "min": 1, "max": 1000},
 }
 
 

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -116,11 +116,10 @@ class SearchPipeline:
 
         ctx_win = self._resolve_context_window(context_window)
         if self._reranker is not None and self._rerank_config is not None:
-            rerank_active = True
-            rerank_pool_key = self._rerank_config.top_k
+            rcfg = self._rerank_config
+            rerank_signal = f"on:{rcfg.oversample}:{rcfg.min_pool}:{rcfg.max_pool}"
         else:
-            rerank_active = False
-            rerank_pool_key = 0
+            rerank_signal = "off"
         raw = (
             f"{query}|{top_k}|{source_filter}|{tag_filter}|{namespace}"
             f"|bm25={self._config.enable_bm25}:{self._config.bm25_candidates}"
@@ -129,7 +128,7 @@ class SearchPipeline:
             f"|decay={self._decay_config.enabled}:{self._decay_config.half_life_days}"
             f"|mmr={self._mmr_config.enabled}:{self._mmr_config.lambda_param}"
             f"|ctx_win={ctx_win}"
-            f"|rerank={rerank_active}:{rerank_pool_key}"
+            f"|rerank={rerank_signal}"
         )
         return hashlib.md5(raw.encode()).hexdigest()
 
@@ -317,9 +316,16 @@ class SearchPipeline:
         # Stage 3: fusion (or single-retriever passthrough)
         # When reranking is active, widen the candidate pool so the
         # cross-encoder can rescue items RRF ranked just outside top_k.
-        # Collapses to top_k when reranking is disabled — no behavior change.
+        # pool = clamp(oversample * top_k, [min_pool, max_pool]) — scales
+        # with the request and bounded by cost controls. Collapses to
+        # top_k when reranking is disabled so single-retriever passthrough
+        # size is unchanged.
         if self._reranker is not None and self._rerank_config is not None:
-            rerank_pool = max(self._rerank_config.top_k, top_k)
+            rcfg = self._rerank_config
+            rerank_pool = max(
+                rcfg.min_pool,
+                min(rcfg.max_pool, int(rcfg.oversample * top_k)),
+            )
         else:
             rerank_pool = top_k
 

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -350,6 +350,9 @@ class SearchPipeline:
                 fused = await self._reranker.rerank(query, fused, top_k=top_k)
             except Exception as exc:
                 logger.warning("Reranking failed, using original order: %s", exc)
+                # Fallback must still honor the caller's response size —
+                # fused is at rerank_pool (e.g. 20) right now, not top_k.
+                fused = fused[:top_k]
 
         # Filter by source file if requested
         if source_filter:

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -367,6 +367,32 @@ class TestRerankCandidatePool:
         with pytest.raises(ValueError, match="oversample"):
             RerankConfig(enabled=True, oversample=0.0)
 
+    @pytest.mark.asyncio
+    async def test_rerank_failure_falls_back_to_top_k_not_rerank_pool(self):
+        """If the reranker raises, the caller must still get ``top_k`` items —
+        not the wider ``rerank_pool`` that fusion produced upstream.
+
+        Regression guard: PR #308 widened fusion to rerank_pool but the
+        ``except`` branch left ``fused`` at that wider size, leaking pool
+        size as response size.
+        """
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+
+        class BrokenReranker:
+            async def rerank(self, query, results, top_k):
+                raise RuntimeError("model unavailable")
+
+        pipeline = self._make_pipeline(
+            fused_input,
+            reranker=BrokenReranker(),
+            rerank_config=RerankConfig(enabled=True),
+        )
+
+        results, _ = await pipeline.search("anything", top_k=10)
+        assert len(results) == 10
+
     def test_pool_knobs_registered_as_mutable(self):
         """Runtime mutation via `mm config set` / Web UI PATCH must accept
         oversample/min_pool/max_pool (provider/model still need restart)."""

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -206,26 +206,17 @@ class TestRerankCandidatePool:
             rerank_config=rerank_config,
         )
 
-    @pytest.mark.asyncio
-    async def test_reranker_receives_widened_pool_rescuing_outranked_chunk(self):
-        """RRF ranks the relevant chunk at position 15; rerank_config.top_k=20
-        must let the cross-encoder see it and surface it into the response."""
-        from memtomem.config import RerankConfig
-
-        # 20 candidates, relevant one at BM25 rank 15 (0-indexed: 14)
-        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
-        relevant = fused_input[14]
-
-        received_pool_size: list[int] = []
-
-        class ScoringReranker:
+    @staticmethod
+    def _probe_reranker(received: list[int], target_chunk_id=None):
+        class _Probe:
             async def rerank(self, query, results, top_k):
-                received_pool_size.append(len(results))
-                # Score the "relevant" chunk highest, everything else near zero.
+                received.append(len(results))
+                if target_chunk_id is None:
+                    return results[:top_k]
                 scored = [
                     SearchResult(
                         chunk=r.chunk,
-                        score=1.0 if r.chunk.id == relevant.chunk.id else 0.01,
+                        score=1.0 if r.chunk.id == target_chunk_id else 0.01,
                         rank=r.rank,
                         source="reranked",
                     )
@@ -234,18 +225,29 @@ class TestRerankCandidatePool:
                 scored.sort(key=lambda r: r.score, reverse=True)
                 return scored[:top_k]
 
+        return _Probe()
+
+    @pytest.mark.asyncio
+    async def test_reranker_receives_widened_pool_rescuing_outranked_chunk(self):
+        """RRF ranks the relevant chunk at position 15; the default
+        ``oversample=2.0`` + ``min_pool=20`` must let the cross-encoder see
+        it and surface it into the response."""
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(20)]
+        relevant = fused_input[14]
+
+        received_pool_size: list[int] = []
         pipeline = self._make_pipeline(
             fused_input,
-            reranker=ScoringReranker(),
-            rerank_config=RerankConfig(enabled=True, top_k=20),
+            reranker=self._probe_reranker(received_pool_size, relevant.chunk.id),
+            rerank_config=RerankConfig(enabled=True),
         )
 
         results, _ = await pipeline.search("anything", top_k=10)
 
-        # Reranker must receive the widened pool, not the response top_k.
+        # Default pool = max(20, min(200, 2.0*10)) = 20.
         assert received_pool_size == [20]
-        # And the relevant chunk — originally at RRF position 15 — must now
-        # be first in the response.
         assert results[0].chunk.id == relevant.chunk.id
         assert len(results) == 10
 
@@ -258,8 +260,46 @@ class TestRerankCandidatePool:
         results, _ = await pipeline.search("anything", top_k=10)
         assert len(results) == 10
 
-    def test_cache_key_changes_when_rerank_top_k_changes(self):
-        """Enabling rerank or changing ``rerank.top_k`` must bust the cache."""
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "top_k,oversample,min_pool,max_pool,expected_pool",
+        [
+            (10, 2.0, 20, 200, 20),  # default knobs at default top_k → 20
+            (5, 2.0, 20, 200, 20),  # tiny request → floored at min_pool
+            (20, 2.0, 20, 200, 40),  # scales with request (was stuck at 20 pre-fix)
+            (50, 2.0, 20, 200, 100),  # scales with request
+            (150, 2.0, 20, 200, 200),  # capped at max_pool
+            (10, 1.5, 20, 200, 20),  # 1.5× * 10 = 15, floored to 20
+            (40, 1.5, 20, 200, 60),  # 1.5× at mid-size
+            (10, 2.0, 1, 200, 20),  # min_pool=1 → 2×10 wins
+            (10, 2.0, 50, 200, 50),  # elevated floor wins
+        ],
+    )
+    async def test_pool_size_scaling_table(
+        self, top_k, oversample, min_pool, max_pool, expected_pool
+    ):
+        """Pool formula: ``max(min_pool, min(max_pool, int(oversample*top_k)))``."""
+        from memtomem.config import RerankConfig
+
+        fused_input = [self._make_result(f"chunk{i}", rank=i + 1) for i in range(250)]
+        received: list[int] = []
+        pipeline = self._make_pipeline(
+            fused_input,
+            reranker=self._probe_reranker(received),
+            rerank_config=RerankConfig(
+                enabled=True,
+                oversample=oversample,
+                min_pool=min_pool,
+                max_pool=max_pool,
+            ),
+        )
+
+        await pipeline.search("q", top_k=top_k)
+        assert received == [expected_pool]
+
+    def test_cache_key_changes_when_pool_knobs_change(self):
+        """Enabling rerank or changing any of oversample/min_pool/max_pool
+        must bust the cache."""
         from memtomem.config import RerankConfig
 
         class DummyReranker:
@@ -267,21 +307,73 @@ class TestRerankCandidatePool:
                 return results[:top_k]
 
         base = self._make_pipeline([], reranker=None, rerank_config=None)
-        key_no_rerank = base._cache_key("q", 10, None, None, None)
+        key_off = base._cache_key("q", 10, None, None, None)
 
-        with_20 = self._make_pipeline(
-            [],
-            reranker=DummyReranker(),
-            rerank_config=RerankConfig(enabled=True, top_k=20),
+        def _key_for(**kwargs):
+            pipe = self._make_pipeline(
+                [],
+                reranker=DummyReranker(),
+                rerank_config=RerankConfig(enabled=True, **kwargs),
+            )
+            return pipe._cache_key("q", 10, None, None, None)
+
+        key_default = _key_for()
+        key_oversample = _key_for(oversample=3.0)
+        key_min = _key_for(min_pool=30)
+        key_max = _key_for(max_pool=100)
+
+        assert len({key_off, key_default, key_oversample, key_min, key_max}) == 5
+
+    def test_legacy_top_k_migrates_to_min_pool_with_deprecation(self):
+        """``{rerank.top_k: 30}`` in legacy configs must warn and forward to min_pool."""
+        import warnings
+
+        from memtomem.config import RerankConfig
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RerankConfig(enabled=True, top_k=30)
+
+        assert cfg.min_pool == 30
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "rerank.top_k" in str(w.message)
+            for w in caught
         )
-        key_20 = with_20._cache_key("q", 10, None, None, None)
 
-        with_50 = self._make_pipeline(
-            [],
-            reranker=DummyReranker(),
-            rerank_config=RerankConfig(enabled=True, top_k=50),
+    def test_legacy_top_k_ignored_when_min_pool_also_set(self):
+        import warnings
+
+        from memtomem.config import RerankConfig
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cfg = RerankConfig(enabled=True, top_k=99, min_pool=30)
+
+        assert cfg.min_pool == 30
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "ignored" in str(w.message)
+            for w in caught
         )
-        key_50 = with_50._cache_key("q", 10, None, None, None)
 
-        assert key_no_rerank != key_20
-        assert key_20 != key_50
+    def test_max_pool_must_be_at_least_min_pool(self):
+        from memtomem.config import RerankConfig
+
+        with pytest.raises(ValueError, match="max_pool.*must be >= .*min_pool"):
+            RerankConfig(enabled=True, min_pool=50, max_pool=10)
+
+    def test_oversample_must_be_positive(self):
+        from memtomem.config import RerankConfig
+
+        with pytest.raises(ValueError, match="oversample"):
+            RerankConfig(enabled=True, oversample=0.0)
+
+    def test_pool_knobs_registered_as_mutable(self):
+        """Runtime mutation via `mm config set` / Web UI PATCH must accept
+        oversample/min_pool/max_pool (provider/model still need restart)."""
+        from memtomem.config import FIELD_CONSTRAINTS, MUTABLE_FIELDS
+
+        assert MUTABLE_FIELDS["rerank"] == {"enabled", "oversample", "min_pool", "max_pool"}
+        assert FIELD_CONSTRAINTS["rerank.oversample"]["type"] is float
+        assert FIELD_CONSTRAINTS["rerank.min_pool"]["type"] is int
+        assert FIELD_CONSTRAINTS["rerank.max_pool"]["type"] is int
+        assert FIELD_CONSTRAINTS["rerank.enabled"]["type"] is bool


### PR DESCRIPTION
## Summary

Closes #309. PR #308 wired `rerank.top_k=20` as an absolute candidate-pool size — that gave the canonical 2× oversample at `top_k=10` but silently collapsed to 1× for any request at or above the static limit:

| Caller `top_k` | Old pool | New pool (oversample=2.0, min=20, max=200) |
|---|---|---|
| 5 | 20 | **20** (floor) |
| 10 | 20 | **20** |
| 20 | 20 (1×) | **40** (2×) |
| 50 | 50 (1×) | **100** (2×) |
| 150 | 150 (1×) | **200** (cap) |

And there was no runtime knob — `rerank.*` wasn't in `MUTABLE_FIELDS`, so tuning required editing `config.json` + restart.

**Second commit (4a58669) on this branch fixes a latent #308 regression** that this PR surfaced on review: when the reranker throws, `fused` stays at `rerank_pool` size instead of being sliced to `top_k`, leaking pool size as response size. Pre-#308 this was fine because fusion itself capped at `top_k`; #308 widened fusion without adding the compensating fallback slice. Trivial 1-line fix + 1 regression test.

## What changed

### A — multiplier (auto-scale)

`search/pipeline.py` now computes:

```python
rerank_pool = max(min_pool, min(max_pool, int(oversample * top_k)))
```

New `RerankConfig` fields (defaults preserve PR #308 behavior at `top_k=10`):
- `oversample: float = 2.0`
- `min_pool: int = 20`
- `max_pool: int = 200`

Legacy `rerank.top_k` is migrated to `min_pool` via `model_validator(mode='before')` with a `DeprecationWarning`. The field stays so env vars (`MEMTOMEM_RERANK__TOP_K=30`) and existing `config.json` files still load. Slated for removal in 0.3.

Cross-field validation: `max_pool >= min_pool` enforced; `oversample > 0`; `min_pool`/`max_pool` must be positive.

### B — runtime tuning

Added to `MUTABLE_FIELDS`:
```python
"rerank": {"enabled", "oversample", "min_pool", "max_pool"}
```

Added to `FIELD_CONSTRAINTS`:
- `rerank.enabled: bool`
- `rerank.oversample: float, [0.1, 10.0]`
- `rerank.min_pool: int, [1, 1000]`
- `rerank.max_pool: int, [1, 1000]`

`provider`/`model`/`api_key` are intentionally not mutable — the reranker instance is cached on startup, so changing those requires a restart.

### Cache key

`_cache_key` now includes `oversample:min_pool:max_pool` (was just `top_k`). Changing any knob busts the cache.

### Reranker-failure fallback (2nd commit)

On review I traced the "reranker off" vs "reranker enabled + fails" paths and found that PR #308's `except` branch left `fused` at `rerank_pool` size. Added a `fused = fused[:top_k]` in the except branch + a regression test that raises from the reranker and asserts `len(results) == 10` (not 20).

## Scope boundaries

- `config.py` + `search/pipeline.py` touched. No reranker provider changes.
- Default behavior at `top_k=10` is unchanged — same pool=20.
- `_revert_to_stored` constructs the pipeline without a reranker so no propagation needed there.
- Old `RerankConfig.top_k` field kept as a deprecated shim — removal in 0.3.

## Tests

15 new tests in `TestRerankCandidatePool`:

- `test_pool_size_scaling_table` — parameterized 9-row table covering floor / scale / cap / elevated-floor / custom-oversample. **Negative-tested** by degrading the pipeline formula to `rerank_pool = min_pool` — the `top_k=20 → pool=40` row fails with `assert [20] == [40]`, confirming the scaling logic is exercised.
- `test_reranker_receives_widened_pool_rescuing_outranked_chunk` — PR #308's rescue test, now using default config (no `top_k` kwarg).
- `test_pool_collapses_to_top_k_when_rerank_disabled` — regression guard.
- `test_rerank_failure_falls_back_to_top_k_not_rerank_pool` — **NEW (2nd commit)**, negative-tested by reverting the slice (`assert len(results=20) == 10` fails).
- `test_cache_key_changes_when_pool_knobs_change` — 5 distinct keys for {off, default, oversample=3.0, min=30, max=100}.
- `test_legacy_top_k_migrates_to_min_pool_with_deprecation` — `{top_k: 30}` → `min_pool=30` + DeprecationWarning.
- `test_legacy_top_k_ignored_when_min_pool_also_set` — both set → warn + drop top_k.
- `test_max_pool_must_be_at_least_min_pool` — cross-validation.
- `test_oversample_must_be_positive` — field validator.
- `test_pool_knobs_registered_as_mutable` — MUTABLE_FIELDS / FIELD_CONSTRAINTS wiring.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1886 passed (was 1871; +15 new)
- [x] `uv run ruff check` + `ruff format --check`
- [x] `uv run mypy packages/memtomem/src/memtomem/config.py packages/memtomem/src/memtomem/search/pipeline.py`
- [x] Negative test on pool formula (confirmed scaling table row fails under degraded formula)
- [x] Negative test on failure-fallback slice (confirmed regression test fails when slice is removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
