### PR TITLE
docs: rerank candidate-pool knobs + CHANGELOG for #308/#310

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- **Reranker candidate-pool scaling**: `rerank.oversample` (default `2.0`),
+  `rerank.min_pool` (default `20`), and `rerank.max_pool` (default `200`).
+  The cross-encoder now sees
+  `max(min_pool, min(max_pool, int(oversample * top_k)))` candidates, so the
+  classic 2× oversample holds at `top_k=10` (pool=20) and scales with
+  larger requests (`top_k=50` → pool=100, `top_k=150` → pool=200). All
+  three knobs plus `rerank.enabled` are runtime-tunable via `mm config set`
+  and the Web UI — no restart required. `provider`/`model`/`api_key` still
+  need a restart (reranker instance is cached).
+
+### Fixed
+- **Reranker candidate pool is now actually wired**: `RerankConfig.top_k`
+  was declared but never read, so the cross-encoder only ever saw the
+  response `top_k` and could not rescue items RRF ranked just outside it
+  (#307).
+- **Reranker-failure fallback now honors response size**: when the
+  cross-encoder raises, `fused` is trimmed to the caller's `top_k`
+  instead of leaking the wider pool size through the remaining pipeline
+  stages (#309).
+
+### Deprecated
+- `rerank.top_k` (env var `MEMTOMEM_RERANK__TOP_K`) is superseded by
+  `rerank.oversample` + `rerank.min_pool` + `rerank.max_pool`. Legacy
+  configs are migrated to `rerank.min_pool` with a `DeprecationWarning`.
+  Slated for removal in 0.3.
+
 ## [0.1.12] — 2026-04-19
 
 memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -378,10 +378,22 @@ the wider scan, run `mm index --rebuild` after the migration.
 | `MEMTOMEM_RERANK__ENABLED` | `false` | Enable cross-encoder reranking after fusion |
 | `MEMTOMEM_RERANK__PROVIDER` | `fastembed` | `fastembed` (local ONNX), `cohere` (cloud), or `local` (sentence-transformers) |
 | `MEMTOMEM_RERANK__MODEL` | `Xenova/ms-marco-MiniLM-L-6-v2` | Reranker model name (provider-specific — see below) |
-| `MEMTOMEM_RERANK__TOP_K` | `20` | Candidates passed to the reranker (must be > 0) |
+| `MEMTOMEM_RERANK__OVERSAMPLE` | `2.0` | Candidate-pool multiplier applied to response `top_k` |
+| `MEMTOMEM_RERANK__MIN_POOL` | `20` | Lower bound on the candidate pool (floor for small queries) |
+| `MEMTOMEM_RERANK__MAX_POOL` | `200` | Upper bound on the candidate pool (cost cap for large queries) |
 | `MEMTOMEM_RERANK__API_KEY` | _(empty)_ | API key (required for Cohere) |
 
-Reranking runs as Stage 3b in the search pipeline — after BM25 + dense fusion, before source/tag filters. If reranking fails with a runtime error the pipeline falls back to the original fused order with a warning; configuration errors (unsupported model name, missing fastembed install) surface directly so the misconfiguration is visible.
+Reranking runs as Stage 3b in the search pipeline — after BM25 + dense fusion, before source/tag filters. The candidate pool passed to the cross-encoder is
+
+```
+pool = max(min_pool, min(max_pool, int(oversample * response_top_k)))
+```
+
+so the pool scales with the caller's requested `top_k` while staying bounded by both the floor (rescues small queries) and the cap (controls cost on large ones). The reranker then returns the caller's `top_k` — pool sizing only controls how many items it gets to choose from. If reranking fails with a runtime error the pipeline falls back to the original fused order, trimmed to the caller's `top_k`, with a warning; configuration errors (unsupported model name, missing fastembed install) surface directly so the misconfiguration is visible.
+
+`rerank.enabled`, `rerank.oversample`, `rerank.min_pool`, and `rerank.max_pool` are runtime-tunable via `mm config set` or the Web UI Settings panel — no restart required. `rerank.provider` / `rerank.model` / `rerank.api_key` are load-time only because the reranker instance is cached on startup.
+
+> **Deprecated:** earlier releases exposed `MEMTOMEM_RERANK__TOP_K` / `rerank.top_k` as an absolute candidate-pool size. The field still loads (legacy configs are migrated to `rerank.min_pool` with a `DeprecationWarning`) but will be removed in 0.3. Use `rerank.oversample` + `rerank.min_pool` + `rerank.max_pool` instead.
 
 ### Provider-specific models
 


### PR DESCRIPTION
## Summary

Follow-up to PR #308 (#307) and PR #310 (#309). Updates the user-facing docs now that the reranker candidate pool has shipped and `rerank.top_k` is deprecated:

- `docs/guides/configuration.md` — replace the single `MEMTOMEM_RERANK__TOP_K` row with `OVERSAMPLE` / `MIN_POOL` / `MAX_POOL`, document the pool formula, note which knobs are runtime-tunable vs restart-required, and flag `top_k` as deprecated with the migration path.
- `CHANGELOG.md` — `Unreleased` entry covering both the wiring fix (#307/#308) and the scaling redesign + failure-fallback slice (#309/#310), plus the deprecation.

## Doc-as-test check

Every default and field name was verified against `packages/memtomem/src/memtomem/config.py:342-410` before writing — per the local policy that committed docs are checked against source. The env var names follow the existing `MEMTOMEM_<SECTION>__<FIELD>` convention (double underscore from `env_nested_delimiter="__"`).

## Scope boundaries

- No source or test changes — docs-only PR.
- `packages/memtomem/README.md` (PyPI) and the top-level `README.md` don't mention the rerank knobs, so no edits there.
- The deprecation warning itself lives in the `model_validator` from #310; this PR just documents it.

## Test plan

- [x] Field names / defaults match `config.py`
- [x] Formula matches `search/pipeline.py:325`
- [x] Env var names match `env_nested_delimiter` convention
- [x] `ruff`/`pytest` unchanged — docs-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
