### PR TITLE
feat(cli): wizard appends matching namespace rules for accepted providers (closes #296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- **Wizard preset namespace rules**: `mm init` now appends matching
+  `NamespacePolicyRule` entries to `namespace.rules` when you accept a
+  provider category, so auto-discovered Claude-projects memory dirs route
+  to a meaningful namespace instead of collapsing to `default` (#296).
+  `claude-memory` → `claude:{ancestor:1}` (picks the project-id folder
+  above the generic `memory` basename); `claude-plans` → `claude-plans`;
+  `codex` → `codex`. Rules are deduplicated by `path_glob` (with `~`
+  expansion on both sides) so re-running `mm init` is idempotent, and
+  user-authored rules with the same `path_glob` but a different namespace
+  are preserved rather than overwritten. The flag-driven non-interactive
+  path (`--include-provider`) matches the interactive behavior. Labels are
+  deliberately flat pending RFC #304 (`{provider, product}` hierarchy).
 - **Reranker candidate-pool scaling**: `rerank.oversample` (default `2.0`),
   `rerank.min_pool` (default `20`), and `rerank.max_pool` (default `200`).
   The cross-encoder now sees

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -258,6 +258,107 @@ def _step_memory_dir(state: dict) -> None:
     click.echo()
 
 
+# Namespace policy rule templates applied when the user accepts a provider
+# category. Pairs with ``indexing.memory_dirs`` entries added in the same
+# wizard step so auto_ns doesn't collapse ``~/.claude/projects/FOO/memory/**``
+# to the generic ``default`` namespace (issue #296).
+#
+# ``claude-memory`` uses ``{ancestor:1}`` (the project-id folder above the
+# generic ``memory`` basename); single-dir categories use literal namespaces.
+# The flat ``claude-plans`` / ``codex`` labels are deliberately conservative:
+# RFC #304 may migrate these into a vendor/product hierarchy later. Re-visit
+# when that issue settles a wire format.
+_PROVIDER_RULE_TEMPLATES: dict[str, tuple[str, str]] = {
+    "claude-memory": ("~/.claude/projects/*/memory/**", "claude:{ancestor:1}"),
+    "claude-plans": ("~/.claude/plans/**", "claude-plans"),
+    "codex": ("~/.codex/memories/**", "codex"),
+}
+
+# Lock placeholders permitted in the preset table until RFC #304 settles the
+# hierarchy format. New templates beyond ``{ancestor:1}`` should get an
+# explicit review rather than a silent extension.
+_VALID_PRESET_PLACEHOLDERS: frozenset[str] = frozenset({"{ancestor:1}"})
+
+assert all(
+    not any(tok in ns for tok in ("{", "}")) or any(tok in ns for tok in _VALID_PRESET_PLACEHOLDERS)
+    for _, ns in _PROVIDER_RULE_TEMPLATES.values()
+), "preset namespaces may only use _VALID_PRESET_PLACEHOLDERS until #304 decides the hierarchy"
+
+
+def _expand_glob_for_compare(path_glob: str) -> str:
+    """Return ``path_glob`` with ``~`` expanded for dedup comparison.
+
+    Storage keeps the literal ``~`` form (matches what the user typed and
+    what the current wizard writes), but dedup should treat
+    ``~/.codex/memories/**`` and ``/Users/foo/.codex/memories/**`` as the
+    same rule so re-running ``mm init`` is idempotent regardless of which
+    form earlier runs or manual edits produced.
+    """
+    v = path_glob.strip()
+    if v == "~" or v.startswith("~/"):
+        v = str(Path(v).expanduser())
+    return v
+
+
+def _rule_matches_existing(new_path_glob: str, existing_rules: list[dict]) -> bool:
+    """Return True if ``new_path_glob`` is already covered by an existing rule.
+
+    Comparison is on ``path_glob`` only (after ``~`` expansion on both sides).
+    When a user already has a rule for the same glob with a different
+    namespace, the wizard respects that rule and skips the preset — the
+    user's manual override wins. Returning True signals "skip the wizard
+    rule"; the caller reports it in the banner so the skip isn't silent.
+    """
+    target = _expand_glob_for_compare(new_path_glob)
+    for rule in existing_rules:
+        existing_glob = rule.get("path_glob")
+        if not isinstance(existing_glob, str):
+            continue
+        if _expand_glob_for_compare(existing_glob) == target:
+            return True
+    return False
+
+
+def _proposed_rule_for_category(category: str) -> dict | None:
+    """Return the ``{path_glob, namespace}`` dict for a category, or None."""
+    template = _PROVIDER_RULE_TEMPLATES.get(category)
+    if template is None:
+        return None
+    path_glob, namespace = template
+    return {"path_glob": path_glob, "namespace": namespace}
+
+
+def _emit_rules_banner(
+    proposed: list[tuple[str, dict]],
+    skipped: list[tuple[str, dict]],
+) -> None:
+    """Print the pre-write rules banner.
+
+    ``proposed`` and ``skipped`` carry ``(category, rule_dict)`` pairs.
+    Banner is emitted only when at least one rule was offered; an
+    all-skipped run still prints a one-liner so the user knows the wizard
+    looked at rules but decided existing ones covered them.
+    """
+    if not proposed and not skipped:
+        return
+    click.echo("  Namespace rules:")
+    if not proposed and skipped:
+        n = len(skipped)
+        click.secho(
+            f"    {n} rule(s) already managed, nothing to add.",
+            fg="yellow",
+        )
+        click.echo()
+        return
+    for _, rule in proposed:
+        line = f"    + {rule['path_glob']:<40} → {rule['namespace']}"
+        click.secho(line, fg="green")
+    for _, rule in skipped:
+        line = f"    ⏭ {rule['path_glob']:<40} (existing rule kept)"
+        click.secho(line, fg="yellow")
+    click.echo()
+
+
 def _step_provider_dirs(state: dict) -> None:
     """Opt-in indexing of provider memory folders detected on this machine.
 
@@ -266,6 +367,13 @@ def _step_provider_dirs(state: dict) -> None:
     let the user pick exactly which surfaces to make searchable. Categories
     with zero detected directories are skipped silently — the step is a
     no-op on machines without any of these tools installed.
+
+    When a category is accepted and has a matching preset in
+    ``_PROVIDER_RULE_TEMPLATES``, the corresponding ``NamespacePolicyRule``
+    is collected into ``state['provider_rules']`` for the write step to
+    merge into ``namespace.rules``. This addresses #296: auto_ns collapses
+    to ``default`` for memory_dirs whose basename is non-discriminating
+    (``memory`` / ``plans`` / ``memories``).
     """
     step_header(4, "Provider Memory Folders")
     from memtomem.config import _detect_provider_dirs
@@ -285,6 +393,7 @@ def _step_provider_dirs(state: dict) -> None:
     click.echo()
 
     selected: list[Path] = []
+    accepted_categories: list[str] = []
 
     if "claude-memory" in available:
         n = len(available["claude-memory"])
@@ -294,6 +403,7 @@ def _step_provider_dirs(state: dict) -> None:
             default=False,
         ):
             selected.extend(available["claude-memory"])
+            accepted_categories.append("claude-memory")
 
     if "claude-plans" in available:
         if nav_confirm(
@@ -301,6 +411,7 @@ def _step_provider_dirs(state: dict) -> None:
             default=False,
         ):
             selected.extend(available["claude-plans"])
+            accepted_categories.append("claude-plans")
 
     if "codex" in available:
         if nav_confirm(
@@ -308,8 +419,14 @@ def _step_provider_dirs(state: dict) -> None:
             default=False,
         ):
             selected.extend(available["codex"])
+            accepted_categories.append("codex")
 
     state["provider_dirs"] = [str(p) for p in selected]
+    state["provider_rules"] = [
+        (cat, _proposed_rule_for_category(cat))
+        for cat in accepted_categories
+        if _proposed_rule_for_category(cat) is not None
+    ]
     if selected:
         click.secho(f"  Added {len(selected)} provider folder(s) to memory_dirs.", fg="green")
         click.echo("  New Claude Code projects created later won't be auto-indexed —")
@@ -784,6 +901,36 @@ def _write_config_and_summary(
                 raise SystemExit(1) from exc
             _drop_flat_keys(existing, fresh_drops)
 
+    # Namespace preset rules from accepted provider categories — append to
+    # existing ``namespace.rules`` (dedup by ``path_glob``, user rules win
+    # per the A-2 decision in #296's design thread). Mutates ``existing``
+    # directly because ``init_data["namespace"]`` intentionally doesn't
+    # carry ``rules`` (the merge loop would overwrite user rules via
+    # ``update``). Banner is printed *before* write so a partial failure
+    # surfaces what was attempted.
+    proposed_rules: list[tuple[str, dict]] = state.get("provider_rules") or []
+    if proposed_rules:
+        existing_ns = existing.setdefault("namespace", {})
+        raw_rules = existing_ns.get("rules")
+        existing_rules: list[dict] = raw_rules if isinstance(raw_rules, list) else []
+        to_append: list[tuple[str, dict]] = []
+        to_skip: list[tuple[str, dict]] = []
+        for cat, rule in proposed_rules:
+            if _rule_matches_existing(rule["path_glob"], existing_rules):
+                to_skip.append((cat, rule))
+            else:
+                to_append.append((cat, rule))
+        _emit_rules_banner(to_append, to_skip)
+        if to_append:
+            merged_rules = list(existing_rules)
+            for _, rule in to_append:
+                merged_rules.append(dict(rule))
+            existing_ns["rules"] = merged_rules
+        # Mark as wizard-touched so the Preserved block doesn't flag the
+        # merged-rule list as "leftover from a prior config" on a clean
+        # re-run where every preset is already present.
+        wizard_touched_keys.add("namespace.rules")
+
     # Merge: init fields overwrite, non-init sections/fields preserved
     for section, fields in init_data.items():
         if section not in existing:
@@ -1041,9 +1188,18 @@ def init(
 
         grouped = _detect_provider_dirs()
         provider_dirs: list[str] = []
+        provider_rules: list[tuple[str, dict]] = []
         for category in include_providers:
-            for d in grouped.get(category, []):
+            dirs_for_category = grouped.get(category, [])
+            for d in dirs_for_category:
                 provider_dirs.append(str(d))
+            # Mirror interactive parity: only register a preset rule when the
+            # category actually had detected dirs. A ``claude-memory`` rule
+            # with no Claude projects present is dead config.
+            if dirs_for_category:
+                rule = _proposed_rule_for_category(category)
+                if rule is not None:
+                    provider_rules.append((category, rule))
 
         state.update(
             {
@@ -1054,6 +1210,7 @@ def init(
                 "rerank_enabled": False,
                 "memory_dir": _memory_dir,
                 "provider_dirs": provider_dirs,
+                "provider_rules": provider_rules,
                 "db_path": db_path or str(Path("~/.memtomem").expanduser() / "memtomem.db"),
                 "enable_auto_ns": auto_ns,
                 "default_ns": namespace or "default",

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1196,3 +1196,328 @@ def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", "~/notes")
     with pytest.raises(Exception):  # noqa: BLE001 — pydantic SettingsError wraps JSONDecodeError
         Mem2MemConfig()
+
+
+class TestProviderPresetRules:
+    """Wizard appends matching ``NamespacePolicyRule`` entries to
+    ``namespace.rules`` when the user accepts a provider category (#296).
+
+    Without the preset, ``auto_ns`` collapses paths like
+    ``~/.claude/projects/FOO/memory/foo.md`` to the ``default`` namespace
+    because ``memory`` is a non-discriminating basename. The preset routes
+    the file under ``claude:FOO`` via the ``{ancestor:1}`` placeholder.
+    """
+
+    @pytest.mark.parametrize(
+        ("category", "expected_glob", "expected_ns"),
+        [
+            ("claude-memory", "~/.claude/projects/*/memory/**", "claude:{ancestor:1}"),
+            ("claude-plans", "~/.claude/plans/**", "claude-plans"),
+            ("codex", "~/.codex/memories/**", "codex"),
+        ],
+    )
+    def test_step_collects_rule_for_accepted_category(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        category: str,
+        expected_glob: str,
+        expected_ns: str,
+    ) -> None:
+        from memtomem.cli import init_cmd
+
+        target = tmp_path / category
+        target.mkdir()
+        grouped = {"claude-memory": [], "claude-plans": [], "codex": []}
+        grouped[category] = [target]
+        monkeypatch.setattr("memtomem.config._detect_provider_dirs", lambda: grouped)
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+
+        rules = state.get("provider_rules", [])
+        assert len(rules) == 1
+        cat, rule = rules[0]
+        assert cat == category
+        assert rule == {"path_glob": expected_glob, "namespace": expected_ns}
+
+    def test_step_skips_rule_when_category_declined(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from memtomem.cli import init_cmd
+
+        codex = tmp_path / "codex"
+        codex.mkdir()
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": [codex]},
+        )
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: False)
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+        assert state.get("provider_rules") == []
+
+    def test_write_appends_preset_rules_to_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Accepted categories land as ``NamespacePolicyRule`` entries in
+        the persisted ``namespace.rules`` list."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            (
+                "claude-memory",
+                {"path_glob": "~/.claude/projects/*/memory/**", "namespace": "claude:{ancestor:1}"},
+            ),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        rules = data["namespace"]["rules"]
+        assert {
+            "path_glob": "~/.claude/projects/*/memory/**",
+            "namespace": "claude:{ancestor:1}",
+        } in rules
+        assert {"path_glob": "~/.codex/memories/**", "namespace": "codex"} in rules
+
+    def test_write_is_idempotent_on_rerun(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Running ``mm init`` twice with the same accepted categories does
+        not duplicate rules — dedup is by ``path_glob``."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+        ]
+
+        _write_config_and_summary(state, tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        rules = data["namespace"]["rules"]
+        matching = [r for r in rules if r.get("path_glob") == "~/.codex/memories/**"]
+        assert len(matching) == 1, f"expected one codex rule, got {matching}"
+
+    def test_write_preserves_user_rule_on_same_glob_diff_namespace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User-authored rule with the preset's ``path_glob`` but a custom
+        ``namespace`` wins — the wizard does not overwrite it."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Seed config with a user-authored rule using the preset's glob.
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "namespace": {
+                        "rules": [{"path_glob": "~/.codex/memories/**", "namespace": "my-codex"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        rules = data["namespace"]["rules"]
+        assert len(rules) == 1
+        assert rules[0]["namespace"] == "my-codex", "user override should be preserved"
+
+    def test_dedup_expanduser_normalizes_both_sides(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``~/.codex/memories/**`` and the expanded absolute form are
+        treated as the same rule for dedup purposes so manually edited
+        configs stay idempotent under ``mm init`` re-runs."""
+        from memtomem.cli.init_cmd import _rule_matches_existing
+
+        existing = [
+            {"path_glob": str(Path("~/.codex/memories/**").expanduser()), "namespace": "codex"},
+        ]
+        assert _rule_matches_existing("~/.codex/memories/**", existing) is True
+        assert _rule_matches_existing("~/.claude/plans/**", existing) is False
+
+    def test_include_provider_flag_writes_rule_when_dirs_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-interactive ``--include-provider`` parity: rule is appended
+        the same way as the interactive per-category prompt."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        codex = tmp_path / "codex"
+        codex.mkdir()
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": [codex]},
+        )
+
+        result = CliRunner().invoke(
+            init,
+            [
+                "--non-interactive",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--include-provider",
+                "codex",
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        rules = data["namespace"]["rules"]
+        assert any(r.get("path_glob") == "~/.codex/memories/**" for r in rules)
+
+    def test_include_provider_flag_skips_rule_when_no_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Asking for a category whose dirs don't exist on this machine
+        does NOT register a rule — parity with the interactive step skipping
+        empty categories keeps config clean of dead rules."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        result = CliRunner().invoke(
+            init,
+            [
+                "--non-interactive",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--include-provider",
+                "codex",
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        rules = data.get("namespace", {}).get("rules", [])
+        assert rules == []
+
+    def test_banner_lists_proposed_and_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Banner shows `+` for new rules and `⏭` for skipped (existing).
+        Pre-write output so a partial failure surfaces what was attempted."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Seed: codex rule already present, claude-plans not.
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "namespace": {
+                        "rules": [{"path_glob": "~/.codex/memories/**", "namespace": "codex"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            ("claude-plans", {"path_glob": "~/.claude/plans/**", "namespace": "claude-plans"}),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Namespace rules:" in out
+        assert "+ ~/.claude/plans/**" in out
+        assert "⏭ ~/.codex/memories/**" in out
+
+    def test_banner_silent_when_no_proposals(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No accepted categories → no banner noise."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = []
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Namespace rules:" not in out
+
+    def test_banner_all_skipped_one_liner(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Every proposed rule already exists → one-liner confirms the
+        wizard looked, instead of staying silent and leaving the user to
+        wonder whether rules were considered at all."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "namespace": {
+                        "rules": [{"path_glob": "~/.codex/memories/**", "namespace": "codex"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "already managed" in out
+        assert "nothing to add" in out
+
+    def test_preset_templates_only_use_allowed_placeholders(self) -> None:
+        """Lock the placeholder vocabulary until RFC #304 decides the
+        hierarchy format — extending the preset table beyond
+        ``{ancestor:1}`` needs an explicit review, not a silent edit."""
+        from memtomem.cli.init_cmd import (
+            _PROVIDER_RULE_TEMPLATES,
+            _VALID_PRESET_PLACEHOLDERS,
+        )
+
+        for _category, (_glob, namespace) in _PROVIDER_RULE_TEMPLATES.items():
+            if "{" in namespace or "}" in namespace:
+                # If placeholders are used, they must be one of the allowed set.
+                assert any(p in namespace for p in _VALID_PRESET_PLACEHOLDERS), (
+                    f"namespace {namespace!r} uses a placeholder outside "
+                    f"_VALID_PRESET_PLACEHOLDERS={_VALID_PRESET_PLACEHOLDERS}"
+                )


### PR DESCRIPTION
## Summary

`mm init` now appends matching `NamespacePolicyRule` entries to
`namespace.rules` when the user accepts a provider category. Auto-discovered
Claude-projects memory dirs stop collapsing to the `default` namespace —
the acute shape of #296, finishing direction (3) after #306 landed
direction (2) (`{ancestor:N}` placeholder primitive).

Preset table (deliberately flat pending RFC #304):

| Category       | `path_glob`                         | `namespace`              |
| -------------- | ----------------------------------- | ------------------------ |
| `claude-memory` | `~/.claude/projects/*/memory/**`   | `claude:{ancestor:1}`    |
| `claude-plans` | `~/.claude/plans/**`                | `claude-plans`           |
| `codex`        | `~/.codex/memories/**`              | `codex`                  |

## Key decisions (settled in design thread)

- **A-1 — Dedup normalization**: store literal `~` (matches what the user
  typed and what the current wizard writes), compare after `expanduser()`
  on both sides. `~/.codex/memories/**` and `/Users/foo/.codex/memories/**`
  are the same rule for idempotency.
- **A-2 — Conflict resolution**: same `path_glob` + different `namespace`
  → user rule wins, wizard skips, banner surfaces the skip with `⏭`.
  `_rule_matches_existing()` is a standalone helper so RFC #304 can reuse
  it.
- **B-1 — Non-interactive parity**: `--include-provider` registers the
  same rules as the interactive prompt, but only when the category had
  detected dirs on this machine (parallel to the interactive step
  skipping empty categories).
- **B-2 — Banner, not `--dry-run`**: pre-write banner lists proposed
  (`+`) and skipped (`⏭`) rules in both paths. Full `--dry-run` support
  for `mm init` is a separate scope — follow-up issue to file once this
  lands. The banner is the foundation.

## Scope boundary

- Placeholder vocabulary is locked to `{ancestor:1}` via
  `_VALID_PRESET_PLACEHOLDERS` + a test, so extending the table beyond
  the three rows above gets an explicit review rather than a silent edit.
  Revisit when RFC #304 settles the hierarchy format.
- `namespace.rules` stays in `_FRESH_PRESERVE_KEYS`. The wizard marks
  the key as wizard-touched only when proposals were considered, so the
  Preserved block doesn't flag merged rules as leftover on clean re-runs.
- No startup migration — users on existing installs re-run `mm init` to
  pick up the presets. Keeps the wizard as the single opt-in surface and
  avoids the "silent policy" failure mode flagged in prior RFCs.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest -m "not ollama"` — 1900 pass, 0 regressions
- [x] `mypy` clean on init_cmd.py
- [x] 12 new tests cover: per-category acceptance (parametrized ×3),
      decline, write-path merge, re-run idempotency, user-rule
      preservation on same-glob-diff-namespace, dedup normalizes
      expanduser, `--include-provider` parity (dirs present + absent),
      banner states (proposed+skipped / silent / all-skipped),
      placeholder vocabulary lock.

Closes #296.
