### PR TITLE
fix(config): lock provider category vocabulary (RFC #304 prep)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1043,6 +1043,28 @@ _PROVIDER_CATEGORY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("codex", re.compile(r"/\.codex/memories/?$")),
 )
 
+# Vocabulary lock: new patterns must not silently expand the category set.
+# Until RFC #304 decides the hierarchy (vendor/product), any change here
+# requires a coordinated update to ``_VALID_PROVIDER_CATEGORIES``. Mirrors the
+# ``_VALID_PRESET_PLACEHOLDERS`` pattern in ``cli/init_cmd.py``.
+_VALID_PROVIDER_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "user",
+        "claude-memory",
+        "claude-plans",
+        "codex",
+    }
+)
+
+_VOCABULARY_LOCK_MESSAGE = (
+    "Provider category vocabulary changed without updating "
+    "_VALID_PROVIDER_CATEGORIES. See RFC #304 before adding categories."
+)
+
+assert ({cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS} | {"user"}) == _VALID_PROVIDER_CATEGORIES, (
+    _VOCABULARY_LOCK_MESSAGE
+)
+
 # Derived from ``_PROVIDER_CATEGORY_PATTERNS`` — do NOT edit independently.
 # Add a new pattern row above and this tuple picks it up automatically.
 PROVIDER_DIR_CATEGORIES: tuple[str, ...] = tuple(cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS)

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1068,6 +1068,32 @@ class TestDetectProviderDirsRoundtrip:
         assert seen_any, "fixture should produce at least one discovered dir"
 
 
+def test_provider_categories_vocabulary_locked() -> None:
+    """Derived categories must match the declared vocabulary — regression
+    guard for silent expansion of ``_PROVIDER_CATEGORY_PATTERNS`` before
+    RFC #304 settles the hierarchy."""
+    from memtomem.config import (
+        _PROVIDER_CATEGORY_PATTERNS,
+        _VALID_PROVIDER_CATEGORIES,
+    )
+
+    derived = {cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS} | {"user"}
+    assert derived == _VALID_PROVIDER_CATEGORIES
+
+
+def test_vocabulary_lock_message_references_rfc() -> None:
+    """Assertion message itself must reference RFC #304 so a future breaker
+    following the ``AssertionError`` traceback finds the rationale.
+
+    Checks the exported ``_VOCABULARY_LOCK_MESSAGE`` constant directly (not
+    a wide ``inspect.getsource`` scan), so unrelated ``#304`` mentions
+    elsewhere in ``config.py`` cannot mask a regression where the RFC
+    reference is dropped from the actual assertion message."""
+    from memtomem.config import _VOCABULARY_LOCK_MESSAGE
+
+    assert "#304" in _VOCABULARY_LOCK_MESSAGE
+
+
 class TestIncludeProviderFlag:
     """Non-interactive ``--include-provider`` wires categories into
     ``indexing.memory_dirs`` without prompting."""


### PR DESCRIPTION
## Summary

- Add `_VALID_PROVIDER_CATEGORIES` frozenset + import-time `assert` in `config.py` so new rows in `_PROVIDER_CATEGORY_PATTERNS` cannot silently expand the category vocabulary while [RFC #304](https://github.com/memtomem/memtomem/issues/304) is still open.
- Extract the assertion message to `_VOCABULARY_LOCK_MESSAGE` and pin-test that the constant still contains `#304`, so a future rewrite that drops the RFC reference fails a test rather than surviving on an unrelated `#304` mention elsewhere in the file.
- Mirror the existing `_VALID_PRESET_PLACEHOLDERS` lock in `cli/init_cmd.py:280-285` — both axes (placeholder vocabulary and category vocabulary) are now guarded the same way.

## Why this is "prep", not "resolve"

RFC #304 has **7 unresolved design questions** (vendor vs source axis, wire format, user-bucket placement, collapse semantics, group-reindex scope, Codex rename, Gemini exclusion) and is staying OPEN. This PR **does not answer any of them**. It closes a separate defensive gap that would otherwise let an unrelated contributor silently expand the category vocabulary — pre-empting the RFC — by adding a fourth regex row.

## Non-goals / explicit follow-ups

These are **not** in this PR; each is a separate decision:

- `provider: str` response field (RFC Phase 1) — blocked on the RFC deciding the wire format.
- UI `byCategory` parallel literal in `sources-memory-dirs.js:249-259` — couples to Phase 2 tree design.
- Tighten `categorize_memory_dir` return type to `Literal[...]` — independent mypy-advisory sweep.
- Windows backslash-normalised path support — independent issue.

## Smoke evidence

The pin tests verify the **pass** condition. To prove the assertion actually **fails loudly** when violated, I manually added a stray row to `_PROVIDER_CATEGORY_PATTERNS` and re-imported:

```
$ uv run python -c "import memtomem.config"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import memtomem.config
  File ".../config.py", line 1065, in <module>
    assert ({cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS} | {"user"}) == _VALID_PROVIDER_CATEGORIES, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Provider category vocabulary changed without updating _VALID_PROVIDER_CATEGORIES. See RFC #304 before adding categories.
```

Confirms: (1) fires at **import time** (not at a later call site), and (2) the message points at RFC #304 so anyone hitting this traceback lands in the right issue. Stray row reverted.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — pass
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — pass
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -k "vocabulary_locked or references_rfc or TestCategorizeMemoryDir or TestDetectProviderDirsRoundtrip"` — 11 pass
- [x] `uv run pytest -m "not ollama"` — **1902 passed**, 46 deselected, 0 failures
- [x] Negative smoke (shown above)

Co-Authored-By: Claude <noreply@anthropic.com>
