### PR TITLE
docs(changelog): note #313 vocabulary lock in #312 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   user-authored rules with the same `path_glob` but a different namespace
   are preserved rather than overwritten. The flag-driven non-interactive
   path (`--include-provider`) matches the interactive behavior. Labels are
-  deliberately flat pending RFC #304 (`{provider, product}` hierarchy).
+  deliberately flat pending RFC #304 (`{provider, product}` hierarchy). The
+  four-entry vocabulary (`user`, `claude-memory`, `claude-plans`, `codex`)
+  is locked against silent expansion via an import-time assertion (#313).
 - **Reranker candidate-pool scaling**: `rerank.oversample` (default `2.0`),
   `rerank.min_pool` (default `20`), and `rerank.max_pool` (default `200`).
   The cross-encoder now sees


### PR DESCRIPTION
## Summary

Extend the Unreleased **"Wizard preset namespace rules"** entry (originally for #296/#312) with a one-sentence reference to #313.

## Why

The existing bullet ends with:

> Labels are deliberately flat pending RFC #304 (`{provider, product}` hierarchy).

That's a forward-reference without a companion "and how is the flat vocabulary defended in the meantime" note. #313 answered that question (import-time assertion on `_PROVIDER_CATEGORY_PATTERNS` so a fourth row can't silently expand the vocabulary before the RFC decides a hierarchy), so mention it inline to close the narrative in one bullet rather than scattering related context across two entries.

No new bullet under `### Added` / `### Changed` — the current Unreleased section is all user-facing, and a standalone entry for an internal guard would break that pattern. Surgical append keeps the RFC #304 thread coherent without adding noise.

## Diff

```diff
   path (`--include-provider`) matches the interactive behavior. Labels are
-  deliberately flat pending RFC #304 (`{provider, product}` hierarchy).
+  deliberately flat pending RFC #304 (`{provider, product}` hierarchy). The
+  four-entry vocabulary (`user`, `claude-memory`, `claude-plans`, `codex`)
+  is locked against silent expansion via an import-time assertion (#313).
```

## Test plan

- [x] Pure CHANGELOG edit; no code, no tests, no behavior change.
- [x] Follows the existing `docs(changelog):` scope pattern (#263, #264, #266).

Co-Authored-By: Claude <noreply@anthropic.com>
