### PR TITLE
fix(storage): enforce namespace validation on write paths (#317)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -2,10 +2,27 @@
 
 from __future__ import annotations
 
+import re
+
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
+
+# Characters not in the namespace allowlist (mirrors ``_NS_SAFE_RE`` in
+# ``cli/ingest_cmd.py``). Substituted to ``_`` so a caller-supplied
+# ``agent_id`` cannot smuggle a second ``/`` separator into the generated
+# ``agent/{agent_id}`` namespace — keeping the agent namespace at depth 1.
+_AGENT_ID_SAFE_RE = re.compile(r"[^\w\-.:@ ]")
+
+
+def _sanitize_agent_id(agent_id: str) -> str:
+    """Strip surrounding whitespace and replace disallowed chars with ``_``.
+
+    Returns the sanitized form; emptiness check is the caller's responsibility
+    so the sanitizer itself has no error paths.
+    """
+    return _AGENT_ID_SAFE_RE.sub("_", agent_id.strip())
 
 
 @mcp.tool()
@@ -29,6 +46,9 @@ async def mem_agent_register(
     """
     if not agent_id or not agent_id.strip():
         return "Error: agent_id must be non-empty."
+    agent_id = _sanitize_agent_id(agent_id)
+    if not agent_id:
+        return "Error: agent_id must contain at least one allowed character."
     app = _get_app(ctx)
     namespace = f"agent/{agent_id}"
 
@@ -73,6 +93,10 @@ async def mem_agent_search(
     """
     if agent_id is not None and not agent_id.strip():
         return "Error: agent_id must be non-empty if provided."
+    if agent_id is not None:
+        agent_id = _sanitize_agent_id(agent_id)
+        if not agent_id:
+            return "Error: agent_id must contain at least one allowed character."
     app = _get_app(ctx)
     from memtomem.server.formatters import _format_results
 

--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -9,17 +9,31 @@ from typing import Callable, Sequence
 from memtomem.errors import StorageError
 from memtomem.storage.sqlite_helpers import escape_like, now_iso, placeholders
 
-# Namespace names: alphanumeric, hyphens, underscores, dots, colons, @, spaces (max 255)
-_NS_NAME_RE = re.compile(r"^[\w\-.:@ ]{1,255}$", re.UNICODE)
+# Namespace names: alphanumeric, hyphens, underscores, dots, colons, @, spaces,
+# and ``/`` (max 255). The ``/`` is permitted so the multi-agent tool's
+# ``agent/{agent_id}`` namespace passes validation; callers that generate
+# namespaces with ``/`` as a separator must sanitize the remainder themselves
+# so a single ``/`` acts as the separator rather than allowing arbitrary depth.
+# See #318 for the separator-unification discussion — if that issue settles on
+# ``:``, this character class should drop ``/`` again.
+_NS_NAME_RE = re.compile(r"^[\w\-./:@ ]{1,255}$", re.UNICODE)
 
 
 def validate_namespace(name: str) -> bool:
     """Check whether *name* is a valid namespace identifier.
 
-    Valid names contain word characters, hyphens, dots, colons, @, and spaces,
-    with a maximum length of 255.
+    Valid names contain word characters, hyphens, dots, colons, slashes, @,
+    and spaces, with a maximum length of 255.
     """
     return bool(_NS_NAME_RE.match(name))
+
+
+def _ensure_valid_namespace(name: str) -> None:
+    """Raise ``StorageError`` if *name* fails :func:`validate_namespace`."""
+    if not validate_namespace(name):
+        raise StorageError(
+            f"Invalid namespace: {name!r} (allowed characters: word, -, ., :, /, @, space; max 255)"
+        )
 
 
 class NamespaceOps:
@@ -84,6 +98,7 @@ class NamespaceOps:
         return len(rows)
 
     async def rename_namespace(self, old: str, new: str) -> int:
+        _ensure_valid_namespace(new)
         db = self._get_db()
         cursor = db.execute("UPDATE chunks SET namespace=? WHERE namespace=?", (new, old))
         db.execute(
@@ -116,6 +131,7 @@ class NamespaceOps:
         description: str | None = None,
         color: str | None = None,
     ) -> None:
+        _ensure_valid_namespace(namespace)
         db = self._get_db()
         existing = await self.get_namespace_meta(namespace)
         now = now_iso()
@@ -173,6 +189,7 @@ class NamespaceOps:
         old_namespace: str | None = None,
     ) -> int:
         """Move chunks matching filters to *namespace*. Returns affected row count."""
+        _ensure_valid_namespace(namespace)
         db = self._get_db()
         conditions: list[str] = []
         params: list = [namespace]

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -1,0 +1,33 @@
+"""Tests for multi-agent tool helpers (``mem_agent_*``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.server.tools.multi_agent import _sanitize_agent_id
+
+
+class TestSanitizeAgentId:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("alpha", "alpha"),
+            ("  spaced  ", "spaced"),
+            ("foo/bar", "foo_bar"),
+            ("a/b/c", "a_b_c"),
+            ("name!with?specials", "name_with_specials"),
+            ("ok.chars-allowed:1@host", "ok.chars-allowed:1@host"),
+            ("with space", "with space"),
+            ("한글도허용", "한글도허용"),
+        ],
+    )
+    def test_sanitize_replaces_disallowed(self, raw, expected):
+        assert _sanitize_agent_id(raw) == expected
+
+    def test_sanitize_preserves_allowed_chars(self):
+        allowed = "abc_123-xyz.foo:bar@host"
+        assert _sanitize_agent_id(allowed) == allowed
+
+    def test_sanitize_pure_separator_collapses_to_underscore(self):
+        """``agent_id="/"`` must not produce ``agent//`` (double separator)."""
+        assert _sanitize_agent_id("/") == "_"

--- a/packages/memtomem/tests/test_server_tools_org.py
+++ b/packages/memtomem/tests/test_server_tools_org.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from helpers import make_chunk
+from memtomem.errors import StorageError
 
 
 # ---------------------------------------------------------------------------
@@ -97,6 +100,30 @@ class TestNamespace:
         ns = dict(await storage.list_namespaces())
         assert ns["ns-a"] == 2
         assert ns["ns-b"] == 1
+
+    @pytest.mark.parametrize("bad", ["bad name!", "no\ttab", 'quote"here', "a" * 256])
+    async def test_set_namespace_meta_rejects_invalid(self, storage, bad):
+        with pytest.raises(StorageError, match="Invalid namespace"):
+            await storage.set_namespace_meta(bad, description="x")
+
+    async def test_set_namespace_meta_accepts_agent_slash_form(self, storage):
+        """``agent/{id}`` passes validation after widening ``_NS_NAME_RE``."""
+        await storage.set_namespace_meta("agent/alpha", description="multi-agent ns")
+        meta = await storage.get_namespace_meta("agent/alpha")
+        assert meta is not None
+        assert meta["namespace"] == "agent/alpha"
+
+    async def test_rename_namespace_rejects_invalid_target(self, storage):
+        chunks = [make_chunk(content="x", namespace="source-ns")]
+        await storage.upsert_chunks(chunks)
+        with pytest.raises(StorageError, match="Invalid namespace"):
+            await storage.rename_namespace("source-ns", "bad!target")
+
+    async def test_assign_namespace_rejects_invalid_target(self, storage):
+        chunks = [make_chunk(content="x", namespace="orig")]
+        await storage.upsert_chunks(chunks)
+        with pytest.raises(StorageError, match="Invalid namespace"):
+            await storage.assign_namespace("bad\tname", old_namespace="orig")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #317.

## Summary
- `validate_namespace()` was defined in `storage/sqlite_namespace.py` but
  never called from any site. `rg -n 'validate_namespace\('` shows only the
  definition and re-export — zero callers. All `NamespaceOps` write paths
  accepted arbitrary strings.
- This PR routes `set_namespace_meta`, `rename_namespace`, and
  `assign_namespace` through a new `_ensure_valid_namespace` helper that
  raises `StorageError` on a regex miss.
- `_NS_NAME_RE` is widened to permit `/` so that the existing multi-agent
  format `agent/{agent_id}` passes validation.
- `mem_agent_register` and `mem_agent_search` now sanitize `agent_id`
  through `_AGENT_ID_SAFE_RE` (mirrors `_NS_SAFE_RE` in `cli/ingest_cmd.py`),
  collapsing any disallowed character — including `/` — to `_`.

## Separator semantics (for future reviewers)
The regex permits the single `/` that the multi-agent tool uses as a
separator; `agent_id` itself is sanitized to depth-1 before the namespace
string is built. So a caller passing `agent_id="foo/bar"` produces
`agent/foo_bar`, not `agent/foo/bar`. If #318 lands on `:` as the unified
separator, the regex change here should be reverted in the same PR that
migrates existing `agent/` namespaces.

## Read-path impact
None. `validate_namespace()` had zero callsites before this PR; this PR
only adds calls on write paths (`set_namespace_meta`, `rename_namespace`,
`assign_namespace`). Read helpers (`get_namespace_meta`,
`list_namespace_meta`, `list_namespaces`, `count_chunks_by_ns_prefix`) are
unchanged, so any previously stored data — including hypothetical
regex-violating rows — remains readable. `delete_by_namespace` is also
intentionally unchanged so operators can still clean up legacy rows that
would now fail validation.

## Out of scope
- The `agent/` vs `claude-memory:` / `codex-memory:` separator drift —
  tracked in #318.
- Chunk-level `namespace` writes via `INSERT INTO chunks`
  (`sqlite_backend.py:426`). Those receive `namespace` from
  `ChunkMetadata.namespace`, which originates upstream from a
  `NamespaceOps` write path or the ingest pipeline (which already
  sanitizes via `_NS_SAFE_RE`). Adding a second validation layer at the
  chunk-insert site is a separate design question and was not requested
  in #317.

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_server_tools_org.py::TestNamespace packages/memtomem/tests/test_multi_agent.py` — 28 passed
- [x] Broader regression: `test_server_tools_org`, `test_multi_agent`,
  `test_storage`, `test_storage_extended`, `test_server_tools_advanced`,
  `test_web_routes_extended` — 232 passed, 0 failed
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [x] `mypy` on touched files — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
