### PR TITLE
refactor(multi-agent): unify namespace format to agent-runtime:{id} (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ## [Unreleased]
 
 ### Added
+- **`mm agent migrate` CLI**: renames legacy `agent/{id}` namespaces to
+  `agent-runtime:{id}` (see `### Changed` below). Pass `--dry-run` to preview
+  without applying. Safe to re-run — namespaces already in the new format
+  are skipped (#318).
 - **Wizard preset namespace rules**: `mm init` now appends matching
   `NamespacePolicyRule` entries to `namespace.rules` when you accept a
   provider category, so auto-discovered Claude-projects memory dirs route
@@ -29,6 +33,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   three knobs plus `rerank.enabled` are runtime-tunable via `mm config set`
   and the Web UI — no restart required. `provider`/`model`/`api_key` still
   need a restart (reranker instance is cached).
+
+### Changed
+- **Multi-agent namespace format**: `mem_agent_register` / `mem_agent_search`
+  now generate `agent-runtime:{agent_id}` instead of the legacy
+  `agent/{agent_id}`, aligning with the `{bucket}-{kind}:` convention used by
+  `claude-memory:` and `codex-memory:` (#318). `/` is dropped from
+  `_NS_NAME_RE` (reverting the temporary widening in #319) since no live
+  caller needs it, and the duplicated `_NS_SAFE_RE` (ingest) +
+  `_AGENT_ID_SAFE_RE` (multi-agent) sanitizers are consolidated into
+  `sanitize_namespace_segment` in `storage/sqlite_namespace.py` (no allowlist
+  change). Existing `agent/{id}` namespaces can be migrated with
+  `mm agent migrate`.
 
 ### Fixed
 - **Reranker candidate pool is now actually wired**: `RerankConfig.top_k`

--- a/packages/memtomem-openclaw-plugin/src/tools.ts
+++ b/packages/memtomem-openclaw-plugin/src/tools.ts
@@ -556,7 +556,7 @@ export const TOOLS: ToolDef[] = [
   {
     name: "mem_agent_register",
     description:
-      "Register an agent with its own namespace (agent/{id}) for memory isolation",
+      "Register an agent with its own namespace (agent-runtime:{id}) for memory isolation",
     parameters: schema(
       {
         agent_id: Str("Unique agent identifier"),
@@ -588,7 +588,7 @@ export const TOOLS: ToolDef[] = [
       {
         chunk_id: Str("UUID of chunk to share"),
         target: {
-          ...Str("Target namespace (shared or agent/{id})"),
+          ...Str("Target namespace (shared or agent-runtime:{id})"),
           default: "shared",
         },
       },

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -15,6 +15,7 @@ def cli() -> None:
 
 # Register subcommands (lazy imports to keep startup fast)
 def _register() -> None:
+    from memtomem.cli.agent_cmd import agent
     from memtomem.cli.config_cmd import config
     from memtomem.cli.context_cmd import context
     from memtomem.cli.embedding_cmd import embedding_reset
@@ -46,6 +47,7 @@ def _register() -> None:
     cli.add_command(watchdog)
     cli.add_command(web)
     cli.add_command(shell)
+    cli.add_command(agent)
 
 
 _register()

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -1,0 +1,74 @@
+"""CLI: mm agent — multi-agent namespace management."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from memtomem.storage.sqlite_backend import SqliteBackend
+
+_LEGACY_PREFIX = "agent/"
+_CURRENT_PREFIX = "agent-runtime:"
+
+
+@click.group()
+def agent() -> None:
+    """Multi-agent memory management commands."""
+
+
+@agent.command("migrate")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the planned renames without making changes.",
+)
+def migrate(dry_run: bool) -> None:
+    """Rename legacy ``agent/{id}`` namespaces to ``agent-runtime:{id}``.
+
+    Moves multi-agent namespaces from the pre-#318 format (``agent/{id}``)
+    to the current ``agent-runtime:{id}`` format. Safe to re-run — rows that
+    are already in the new format are left untouched.
+    """
+    asyncio.run(_run_migrate(dry_run=dry_run))
+
+
+async def _run_migrate(dry_run: bool) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        mapping = await _collect_legacy_mapping(comp.storage)
+        if not mapping:
+            click.echo("No legacy `agent/` namespaces found. Nothing to migrate.")
+            return
+
+        click.echo(f"Legacy namespaces to migrate: {len(mapping)}")
+        for old, new in mapping:
+            click.echo(f"  {old}  ->  {new}")
+
+        if dry_run:
+            click.echo("\n(dry-run — no changes made. Re-run without --dry-run to apply.)")
+            return
+
+        total = 0
+        for old, new in mapping:
+            renamed = await comp.storage.rename_namespace(old, new)
+            total += renamed
+            click.echo(f"Renamed: {old}  ->  {new}  ({renamed} chunk(s))")
+
+        click.echo(f"\nMigration complete. {len(mapping)} namespace(s), {total} chunk(s) updated.")
+
+
+async def _collect_legacy_mapping(storage: SqliteBackend) -> list[tuple[str, str]]:
+    """Return ``[(old, new), ...]`` pairs for namespaces needing migration."""
+    pairs = await storage.list_namespaces()
+    out: list[tuple[str, str]] = []
+    for ns, _count in pairs:
+        if not ns.startswith(_LEGACY_PREFIX):
+            continue
+        suffix = ns[len(_LEGACY_PREFIX) :]
+        out.append((ns, f"{_CURRENT_PREFIX}{suffix}"))
+    return out

--- a/packages/memtomem/src/memtomem/cli/ingest_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/ingest_cmd.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 import click
+
+from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -52,11 +53,6 @@ _TAG_PREFIXES: tuple[tuple[str, str], ...] = (
     ("user_", "user"),
     ("reference_", "reference"),
 )
-
-# Mirrors _NS_NAME_RE in storage/sqlite_namespace.py. Any character outside
-# this set in the derived slug is replaced with ``_`` before we hand the
-# namespace to the index engine.
-_NS_SAFE_RE = re.compile(r"[^\w\-.:@ ]")
 
 _NAMESPACE_PREFIX = "claude-memory:"
 
@@ -314,8 +310,7 @@ def _build_namespace(slug: str, prefix: str = _NAMESPACE_PREFIX) -> str:
     replaced with ``_`` so downstream storage never rejects the namespace.
     Default *prefix* is ``claude-memory:`` for backward compatibility.
     """
-    safe = _NS_SAFE_RE.sub("_", slug)
-    return f"{prefix}{safe}"
+    return f"{prefix}{sanitize_namespace_segment(slug)}"
 
 
 def _tags_for_file(file_path: Path) -> set[str]:

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -2,27 +2,16 @@
 
 from __future__ import annotations
 
-import re
-
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
+from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
-# Characters not in the namespace allowlist (mirrors ``_NS_SAFE_RE`` in
-# ``cli/ingest_cmd.py``). Substituted to ``_`` so a caller-supplied
-# ``agent_id`` cannot smuggle a second ``/`` separator into the generated
-# ``agent/{agent_id}`` namespace — keeping the agent namespace at depth 1.
-_AGENT_ID_SAFE_RE = re.compile(r"[^\w\-.:@ ]")
-
-
-def _sanitize_agent_id(agent_id: str) -> str:
-    """Strip surrounding whitespace and replace disallowed chars with ``_``.
-
-    Returns the sanitized form; emptiness check is the caller's responsibility
-    so the sanitizer itself has no error paths.
-    """
-    return _AGENT_ID_SAFE_RE.sub("_", agent_id.strip())
+# Automatic namespace prefix for the multi-agent tool. Follows the
+# ``{bucket}-{kind}:`` convention used by the ingest pipeline
+# (``claude-memory:``, ``codex-memory:``) — see #318 for the rule.
+_AGENT_NAMESPACE_PREFIX = "agent-runtime:"
 
 
 @mcp.tool()
@@ -36,8 +25,9 @@ async def mem_agent_register(
 ) -> str:
     """Register an agent in the multi-agent memory system.
 
-    Creates a namespace for the agent (agent/{agent_id}) and optionally
-    registers metadata. If the agent is already registered, updates metadata.
+    Creates a namespace for the agent (``agent-runtime:{agent_id}``) and
+    optionally registers metadata. If the agent is already registered,
+    updates metadata.
 
     Args:
         agent_id: Unique identifier for the agent
@@ -46,11 +36,11 @@ async def mem_agent_register(
     """
     if not agent_id or not agent_id.strip():
         return "Error: agent_id must be non-empty."
-    agent_id = _sanitize_agent_id(agent_id)
+    agent_id = sanitize_namespace_segment(agent_id)
     if not agent_id:
         return "Error: agent_id must contain at least one allowed character."
     app = _get_app(ctx)
-    namespace = f"agent/{agent_id}"
+    namespace = f"{_AGENT_NAMESPACE_PREFIX}{agent_id}"
 
     await app.storage.set_namespace_meta(namespace, description=description, color=color)
 
@@ -94,13 +84,13 @@ async def mem_agent_search(
     if agent_id is not None and not agent_id.strip():
         return "Error: agent_id must be non-empty if provided."
     if agent_id is not None:
-        agent_id = _sanitize_agent_id(agent_id)
+        agent_id = sanitize_namespace_segment(agent_id)
         if not agent_id:
             return "Error: agent_id must contain at least one allowed character."
     app = _get_app(ctx)
     from memtomem.server.formatters import _format_results
 
-    agent_ns = f"agent/{agent_id}" if agent_id else app.current_namespace
+    agent_ns = f"{_AGENT_NAMESPACE_PREFIX}{agent_id}" if agent_id else app.current_namespace
 
     # Build namespace filter
     if include_shared and agent_ns:
@@ -138,7 +128,7 @@ async def mem_agent_share(
 
     Args:
         chunk_id: UUID of the chunk to share
-        target: Target namespace — 'shared' or 'agent/{agent_id}'
+        target: Target namespace — 'shared' or 'agent-runtime:{agent_id}'
     """
     from uuid import UUID
 

--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -9,30 +9,43 @@ from typing import Callable, Sequence
 from memtomem.errors import StorageError
 from memtomem.storage.sqlite_helpers import escape_like, now_iso, placeholders
 
-# Namespace names: alphanumeric, hyphens, underscores, dots, colons, @, spaces,
-# and ``/`` (max 255). The ``/`` is permitted so the multi-agent tool's
-# ``agent/{agent_id}`` namespace passes validation; callers that generate
-# namespaces with ``/`` as a separator must sanitize the remainder themselves
-# so a single ``/`` acts as the separator rather than allowing arbitrary depth.
-# See #318 for the separator-unification discussion — if that issue settles on
-# ``:``, this character class should drop ``/`` again.
-_NS_NAME_RE = re.compile(r"^[\w\-./:@ ]{1,255}$", re.UNICODE)
+# Namespace names: alphanumeric, hyphens, underscores, dots, colons, @, spaces
+# (max 255). Automatic namespace generators use a ``{bucket}-{kind}:`` format
+# (``claude-memory:``, ``codex-memory:``, ``agent-runtime:``); the second
+# segment is sanitized through :func:`sanitize_namespace_segment` so callers
+# never smuggle a stray separator character through.
+_NS_NAME_RE = re.compile(r"^[\w\-.:@ ]{1,255}$", re.UNICODE)
+
+# Characters outside the namespace allowlist — substituted to ``_`` by
+# :func:`sanitize_namespace_segment`.
+_SEGMENT_SAFE_RE = re.compile(r"[^\w\-.:@ ]")
 
 
 def validate_namespace(name: str) -> bool:
     """Check whether *name* is a valid namespace identifier.
 
-    Valid names contain word characters, hyphens, dots, colons, slashes, @,
-    and spaces, with a maximum length of 255.
+    Valid names contain word characters, hyphens, dots, colons, @, and spaces,
+    with a maximum length of 255.
     """
     return bool(_NS_NAME_RE.match(name))
+
+
+def sanitize_namespace_segment(name: str) -> str:
+    """Strip whitespace and replace disallowed characters with ``_``.
+
+    Shared by the ingest pipeline (``cli/ingest_cmd.py``) and the multi-agent
+    tool (``server/tools/multi_agent.py``) so both produce namespace segments
+    that satisfy :data:`_NS_NAME_RE`. Empty-input handling is the caller's
+    responsibility so this helper has no error path.
+    """
+    return _SEGMENT_SAFE_RE.sub("_", name.strip())
 
 
 def _ensure_valid_namespace(name: str) -> None:
     """Raise ``StorageError`` if *name* fails :func:`validate_namespace`."""
     if not validate_namespace(name):
         raise StorageError(
-            f"Invalid namespace: {name!r} (allowed characters: word, -, ., :, /, @, space; max 255)"
+            f"Invalid namespace: {name!r} (allowed characters: word, -, ., :, @, space; max 255)"
         )
 
 

--- a/packages/memtomem/tests/test_agent_cmd.py
+++ b/packages/memtomem/tests/test_agent_cmd.py
@@ -1,0 +1,76 @@
+"""Tests for ``mm agent migrate``."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+
+def _mock_components(legacy_namespaces, existing_new_namespaces=()):
+    """Storage stub: ``list_namespaces`` returns the given namespace set.
+
+    Each entry is ``(namespace, chunk_count)`` — mirrors the real
+    ``NamespaceOps.list_namespaces`` shape.  ``rename_namespace`` returns a
+    fixed count so the CLI sees non-zero chunk updates.
+    """
+    pairs = [(ns, 2) for ns in legacy_namespaces]
+    pairs.extend((ns, 1) for ns in existing_new_namespaces)
+    storage = SimpleNamespace(
+        list_namespaces=AsyncMock(return_value=pairs),
+        rename_namespace=AsyncMock(return_value=2),
+    )
+    return SimpleNamespace(storage=storage)
+
+
+def _patched_cli_components(comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake
+
+
+class TestAgentMigrate:
+    def test_no_legacy_namespaces_nothing_to_do(self, monkeypatch):
+        comp = _mock_components([])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = CliRunner().invoke(cli, ["agent", "migrate"])
+        assert result.exit_code == 0
+        assert "Nothing to migrate" in result.output
+        comp.storage.rename_namespace.assert_not_awaited()
+
+    def test_dry_run_lists_without_renaming(self, monkeypatch):
+        comp = _mock_components(["agent/alpha", "agent/beta"])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = CliRunner().invoke(cli, ["agent", "migrate", "--dry-run"])
+        assert result.exit_code == 0
+        assert "agent/alpha  ->  agent-runtime:alpha" in result.output
+        assert "agent/beta  ->  agent-runtime:beta" in result.output
+        assert "dry-run" in result.output
+        comp.storage.rename_namespace.assert_not_awaited()
+
+    def test_apply_renames_each_namespace(self, monkeypatch):
+        comp = _mock_components(["agent/alpha", "agent/beta"])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = CliRunner().invoke(cli, ["agent", "migrate"])
+        assert result.exit_code == 0
+        assert comp.storage.rename_namespace.await_count == 2
+        comp.storage.rename_namespace.assert_any_await("agent/alpha", "agent-runtime:alpha")
+        comp.storage.rename_namespace.assert_any_await("agent/beta", "agent-runtime:beta")
+        assert "Migration complete" in result.output
+
+    def test_ignores_already_migrated_namespaces(self, monkeypatch):
+        comp = _mock_components(
+            legacy_namespaces=[],
+            existing_new_namespaces=["agent-runtime:alpha", "claude-memory:x"],
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = CliRunner().invoke(cli, ["agent", "migrate"])
+        assert result.exit_code == 0
+        assert "Nothing to migrate" in result.output
+        comp.storage.rename_namespace.assert_not_awaited()

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -1,13 +1,20 @@
-"""Tests for multi-agent tool helpers (``mem_agent_*``)."""
+"""Tests for multi-agent namespace helpers (``mem_agent_*``).
+
+The sanitizer used by ``mem_agent_register`` / ``mem_agent_search`` lives in
+``storage/sqlite_namespace.py`` as ``sanitize_namespace_segment`` — shared
+with the ingest pipeline. These tests pin the behavior the multi-agent tool
+relies on (single-segment `agent_id` sanitization so the generated
+``agent-runtime:{id}`` namespace stays at depth 1).
+"""
 
 from __future__ import annotations
 
 import pytest
 
-from memtomem.server.tools.multi_agent import _sanitize_agent_id
+from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
 
-class TestSanitizeAgentId:
+class TestSanitizeNamespaceSegment:
     @pytest.mark.parametrize(
         "raw, expected",
         [
@@ -22,12 +29,12 @@ class TestSanitizeAgentId:
         ],
     )
     def test_sanitize_replaces_disallowed(self, raw, expected):
-        assert _sanitize_agent_id(raw) == expected
+        assert sanitize_namespace_segment(raw) == expected
 
     def test_sanitize_preserves_allowed_chars(self):
         allowed = "abc_123-xyz.foo:bar@host"
-        assert _sanitize_agent_id(allowed) == allowed
+        assert sanitize_namespace_segment(allowed) == allowed
 
-    def test_sanitize_pure_separator_collapses_to_underscore(self):
-        """``agent_id="/"`` must not produce ``agent//`` (double separator)."""
-        assert _sanitize_agent_id("/") == "_"
+    def test_sanitize_pure_slash_collapses_to_underscore(self):
+        """``agent_id="/"`` must not produce ``agent-runtime://`` (double separator)."""
+        assert sanitize_namespace_segment("/") == "_"

--- a/packages/memtomem/tests/test_server_tools_org.py
+++ b/packages/memtomem/tests/test_server_tools_org.py
@@ -101,17 +101,20 @@ class TestNamespace:
         assert ns["ns-a"] == 2
         assert ns["ns-b"] == 1
 
-    @pytest.mark.parametrize("bad", ["bad name!", "no\ttab", 'quote"here', "a" * 256])
+    @pytest.mark.parametrize(
+        "bad",
+        ["bad name!", "no\ttab", 'quote"here', "a" * 256, "agent/legacy"],
+    )
     async def test_set_namespace_meta_rejects_invalid(self, storage, bad):
         with pytest.raises(StorageError, match="Invalid namespace"):
             await storage.set_namespace_meta(bad, description="x")
 
-    async def test_set_namespace_meta_accepts_agent_slash_form(self, storage):
-        """``agent/{id}`` passes validation after widening ``_NS_NAME_RE``."""
-        await storage.set_namespace_meta("agent/alpha", description="multi-agent ns")
-        meta = await storage.get_namespace_meta("agent/alpha")
+    async def test_set_namespace_meta_accepts_agent_runtime_form(self, storage):
+        """``agent-runtime:{id}`` is the canonical multi-agent namespace format (#318)."""
+        await storage.set_namespace_meta("agent-runtime:alpha", description="multi-agent ns")
+        meta = await storage.get_namespace_meta("agent-runtime:alpha")
         assert meta is not None
-        assert meta["namespace"] == "agent/alpha"
+        assert meta["namespace"] == "agent-runtime:alpha"
 
     async def test_rename_namespace_rejects_invalid_target(self, storage):
         chunks = [make_chunk(content="x", namespace="source-ns")]


### PR DESCRIPTION
Closes #318.

## Summary
Unifies the multi-agent namespace format on `agent-runtime:{agent_id}`,
retiring the legacy `agent/{id}` format. Follow-up to the decision comment
in #318 (2026-04-20).

## Changes
- `mem_agent_register` / `mem_agent_search` emit `agent-runtime:{id}`
  instead of `agent/{id}`. `mem_agent_share` docstring updated.
- `_NS_NAME_RE` drops `/` — reverts the transitional widening from #319
  now that no live caller produces `/` in a namespace.
- `_NS_SAFE_RE` (ingest) and `_AGENT_ID_SAFE_RE` (multi-agent) are
  consolidated into `sanitize_namespace_segment` in
  `storage/sqlite_namespace.py`. Same allowlist, one source.
- New CLI: `mm agent migrate` renames legacy `agent/{id}` namespaces to
  `agent-runtime:{id}` using the existing
  `NamespaceOps.rename_namespace`. Default behavior applies; pass
  `--dry-run` to preview. Safe to re-run.
- `memtomem-openclaw-plugin` tool descriptions updated.
- `CHANGELOG.md` Unreleased updated.

## Why user-triggered migration (not startup auto)
Startup-auto migrations would write to the DB silently on boot and
surprise users running multiple memtomem instances. `mm agent migrate`
follows the pull-based rule (see `feedback_pullbased_vs_startup_scan.md`
in author's local memo) — user opts in, can preview with `--dry-run`, and
the rename is idempotent.

## Compatibility
- Legacy `agent/{id}` rows in storage are **not** auto-migrated. Users
  running `mem_agent_register` with the new code create `agent-runtime:`
  rows; their old `agent/` data remains readable (read paths don't
  validate) but lives at a different namespace until `mm agent migrate`
  is run.
- `_NS_NAME_RE` now rejects `/` on write paths, so any future attempt to
  create `agent/{id}` manually via `set_namespace_meta` will raise
  `StorageError`. Intentional — we want migration to be the one path.

## Test plan
- [x] `test_server_tools_org.py::TestNamespace` — updated parametrized
  bad set (`agent/legacy` now rejected); agent-runtime form accepted.
- [x] `test_multi_agent.py` — sanitizer pinned under the shared helper
  name.
- [x] `test_agent_cmd.py` (new) — 4 cases: no-legacy, dry-run, apply,
  ignore-already-migrated. CliRunner + patched `cli_components`.
- [x] Broad regression: 385 passed across `test_server_tools_org`,
  `test_multi_agent`, `test_agent_cmd`, `test_storage`,
  `test_storage_extended`, `test_server_tools_advanced`, `test_cli`,
  `test_cli_ingest`, `test_tool_registration`,
  `test_web_routes_extended`, `test_purge_cli`.
- [x] `ruff check` + `ruff format --check` on touched files — clean.
- [x] `mypy` on touched files — 0 errors.

## NS grouping UI
`web/static/settings-namespaces.js` groups by first-colon split and uses
the prefix verbatim as the optgroup label — `agent-runtime:` shows up as
"agent-runtime (N chunks)" automatically. No JS changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
