### PR TITLE
feat(config): expose provider tag on memory_dir_stats (RFC #304 Phase 1)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1065,9 +1065,43 @@ assert ({cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS} | {"user"}) == _VALID_PR
     _VOCABULARY_LOCK_MESSAGE
 )
 
+# Vendor tag for each category. Exposed on ``memory_dir_stats()`` entries so
+# the Web UI can render a two-level vendor → product tree without duplicating
+# the category→vendor map in JS. RFC #304 Phase 1 — see plan #314 resolution.
+_CATEGORY_TO_PROVIDER: dict[str, str] = {
+    "user": "user",
+    "claude-memory": "claude",
+    "claude-plans": "claude",
+    "codex": "openai",
+}
+
+_VALID_PROVIDERS: frozenset[str] = frozenset({"user", "claude", "openai"})
+
+_PROVIDER_VOCABULARY_LOCK_MESSAGE = (
+    "Provider vocabulary changed without updating _VALID_PROVIDERS. "
+    "See RFC #304 before adding providers."
+)
+
+# Paired asserts: keys mirror the category vocabulary, values mirror the
+# provider vocabulary. Without the value-side lock a future
+# ``_CATEGORY_TO_PROVIDER["skills"] = "anthropic"`` would add a new provider
+# silently; #313 locks the category axis only.
+assert set(_CATEGORY_TO_PROVIDER.keys()) == _VALID_PROVIDER_CATEGORIES, _VOCABULARY_LOCK_MESSAGE
+assert set(_CATEGORY_TO_PROVIDER.values()) == _VALID_PROVIDERS, _PROVIDER_VOCABULARY_LOCK_MESSAGE
+
 # Derived from ``_PROVIDER_CATEGORY_PATTERNS`` — do NOT edit independently.
 # Add a new pattern row above and this tuple picks it up automatically.
 PROVIDER_DIR_CATEGORIES: tuple[str, ...] = tuple(cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS)
+
+
+def provider_for_category(category: str) -> str:
+    """Return the vendor tag for a ``memory_dir`` category.
+
+    Consumed by :func:`~memtomem.indexing.engine.memory_dir_stats` so the
+    Web UI can group entries by vendor. Unknown categories fall back to
+    ``"user"`` — mirrors :func:`categorize_memory_dir`'s user-default.
+    """
+    return _CATEGORY_TO_PROVIDER.get(category, "user")
 
 
 def categorize_memory_dir(path: str | Path) -> str:

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1082,11 +1082,22 @@ _PROVIDER_VOCABULARY_LOCK_MESSAGE = (
     "See RFC #304 before adding providers."
 )
 
+# Distinct message for the key-axis drift: when this assert fires the
+# category vocabulary itself is fine — what's out of sync is the tag
+# mapping, so point the contributor at the right file instead of
+# re-reading ``_VALID_PROVIDER_CATEGORIES``.
+_CATEGORY_TO_PROVIDER_KEY_DRIFT_MESSAGE = (
+    "_CATEGORY_TO_PROVIDER keys out of sync with _VALID_PROVIDER_CATEGORIES. "
+    "Add or remove the matching key in _CATEGORY_TO_PROVIDER. See RFC #304."
+)
+
 # Paired asserts: keys mirror the category vocabulary, values mirror the
 # provider vocabulary. Without the value-side lock a future
 # ``_CATEGORY_TO_PROVIDER["skills"] = "anthropic"`` would add a new provider
 # silently; #313 locks the category axis only.
-assert set(_CATEGORY_TO_PROVIDER.keys()) == _VALID_PROVIDER_CATEGORIES, _VOCABULARY_LOCK_MESSAGE
+assert set(_CATEGORY_TO_PROVIDER.keys()) == _VALID_PROVIDER_CATEGORIES, (
+    _CATEGORY_TO_PROVIDER_KEY_DRIFT_MESSAGE
+)
 assert set(_CATEGORY_TO_PROVIDER.values()) == _VALID_PROVIDERS, _PROVIDER_VOCABULARY_LOCK_MESSAGE
 
 # Derived from ``_PROVIDER_CATEGORY_PATTERNS`` — do NOT edit independently.

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -21,6 +21,7 @@ from memtomem.config import (
     NamespaceConfig,
     NamespacePolicyRule,
     categorize_memory_dir,
+    provider_for_category,
 )
 from memtomem.indexing.differ import compute_diff
 from memtomem.models import Chunk, ChunkMetadata, IndexingStats
@@ -103,14 +104,16 @@ async def memory_dir_stats(
 ) -> list[dict[str, object]]:
     """Return per-dir index status for each configured ``memory_dir``.
 
-    Shape: ``[{path, chunk_count, source_file_count, exists, category}]``
-    in the same order as ``memory_dirs``. Drives the web UI's "(N chunks)"
-    / "(not indexed)" badges so the user can see which dirs still need a
-    manual reindex (the file watcher only reacts to change events, so
-    pre-existing files in a newly added ``memory_dir`` stay invisible
-    until the user clicks the ↻ button). ``category`` is provided by
-    :func:`~memtomem.config.categorize_memory_dir` so the Web UI can
-    group entries without maintaining its own regex.
+    Shape: ``[{path, chunk_count, source_file_count, exists, category,
+    provider}]`` in the same order as ``memory_dirs``. Drives the web UI's
+    "(N chunks)" / "(not indexed)" badges so the user can see which dirs
+    still need a manual reindex (the file watcher only reacts to change
+    events, so pre-existing files in a newly added ``memory_dir`` stay
+    invisible until the user clicks the ↻ button). ``category`` is
+    provided by :func:`~memtomem.config.categorize_memory_dir` and
+    ``provider`` by :func:`~memtomem.config.provider_for_category`, so the
+    Web UI can build a vendor → product tree without maintaining its own
+    regex or mapping. RFC #304 Phase 1.
 
     Aggregation: one ``get_source_files_with_counts()`` call over the
     whole ``chunks`` table, bucketed in Python by normalised-path prefix
@@ -137,13 +140,15 @@ async def memory_dir_stats(
                 chunk_count += count
                 source_file_count += 1
 
+        category = categorize_memory_dir(d)
         out.append(
             {
                 "path": str(d),
                 "chunk_count": chunk_count,
                 "source_file_count": source_file_count,
                 "exists": exists,
-                "category": categorize_memory_dir(d),
+                "category": category,
+                "provider": provider_for_category(category),
             }
         )
     return out

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1379,9 +1379,10 @@ class TestMemoryDirStats:
         assert result[0]["exists"] is True
         assert result[0]["chunk_count"] == 0
         assert result[0]["source_file_count"] == 0
-        # ``category`` is always present so the Web UI never has to guess
-        # whether the server supplied it.
+        # ``category`` / ``provider`` are always present so the Web UI
+        # never has to guess whether the server supplied them.
         assert result[0]["category"] == "user"
+        assert result[0]["provider"] == "user"
 
     async def test_category_reflects_provider_layout(self, tmp_path):
         """A mix of provider-shaped and user paths produces the right
@@ -1403,6 +1404,30 @@ class TestMemoryDirStats:
         assert by_path[str(codex)] == "codex"
         assert by_path[str(plans)] == "claude-plans"
         assert by_path[str(claude_mem)] == "claude-memory"
+
+    async def test_provider_tags_every_entry(self, tmp_path):
+        """Every entry carries ``provider`` tagged per RFC #304 Phase 1:
+        ``{user→user, claude-memory→claude, claude-plans→claude,
+        codex→openai}``. Client-side vendor grouping consumes this field
+        so it must be present on every response row."""
+        from memtomem.indexing.engine import memory_dir_stats
+
+        user = tmp_path / "notes"
+        codex = tmp_path / ".codex" / "memories"
+        plans = tmp_path / ".claude" / "plans"
+        claude_mem = tmp_path / ".claude" / "projects" / "demo" / "memory"
+        for d in (user, codex, plans, claude_mem):
+            d.mkdir(parents=True)
+
+        storage = _FakeStorageForStats([])
+        result = await memory_dir_stats(storage, [user, codex, plans, claude_mem])
+        by_path = {r["path"]: r["provider"] for r in result}
+        assert by_path[str(user)] == "user"
+        assert by_path[str(codex)] == "openai"
+        assert by_path[str(plans)] == "claude"
+        assert by_path[str(claude_mem)] == "claude"
+        # Belt-and-suspenders: no entry should be missing ``provider``.
+        assert all("provider" in r for r in result)
 
     async def test_dir_with_indexed_files_is_aggregated(self, tmp_path):
         from memtomem.indexing.engine import memory_dir_stats

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1094,6 +1094,51 @@ def test_vocabulary_lock_message_references_rfc() -> None:
     assert "#304" in _VOCABULARY_LOCK_MESSAGE
 
 
+def test_category_to_provider_keys_cover_categories() -> None:
+    """``_CATEGORY_TO_PROVIDER`` must tag every known category — the Web UI
+    relies on ``memory_dir_stats()`` emitting a non-empty ``provider`` on
+    every row. Without this lock, adding a category row without tagging
+    its vendor would silently fall back to ``"user"``."""
+    from memtomem.config import _CATEGORY_TO_PROVIDER, _VALID_PROVIDER_CATEGORIES
+
+    assert set(_CATEGORY_TO_PROVIDER.keys()) == _VALID_PROVIDER_CATEGORIES
+
+
+def test_providers_vocabulary_locked() -> None:
+    """Declared vendor set must match the tags used by
+    ``_CATEGORY_TO_PROVIDER``. Mirror of
+    :func:`test_provider_categories_vocabulary_locked` on the vendor axis
+    — without this, a future ``_CATEGORY_TO_PROVIDER["skills"] =
+    "anthropic"`` would introduce a new provider silently."""
+    from memtomem.config import _CATEGORY_TO_PROVIDER, _VALID_PROVIDERS
+
+    assert set(_CATEGORY_TO_PROVIDER.values()) == _VALID_PROVIDERS
+
+
+def test_provider_vocabulary_lock_message_references_rfc() -> None:
+    """Provider-axis lock message must reference RFC #304 for the same
+    reason as the category-axis message: an ``AssertionError`` traceback
+    should lead a future reader straight to the rationale."""
+    from memtomem.config import _PROVIDER_VOCABULARY_LOCK_MESSAGE
+
+    assert "#304" in _PROVIDER_VOCABULARY_LOCK_MESSAGE
+
+
+def test_provider_for_category_roundtrip() -> None:
+    """Public helper must agree with the internal mapping for every known
+    category and fall back to ``"user"`` for anything unknown (mirrors
+    :func:`~memtomem.config.categorize_memory_dir`'s user-default)."""
+    from memtomem.config import (
+        _CATEGORY_TO_PROVIDER,
+        _VALID_PROVIDER_CATEGORIES,
+        provider_for_category,
+    )
+
+    for cat in _VALID_PROVIDER_CATEGORIES:
+        assert provider_for_category(cat) == _CATEGORY_TO_PROVIDER[cat]
+    assert provider_for_category("not-a-real-category") == "user"
+
+
 class TestIncludeProviderFlag:
     """Non-interactive ``--include-provider`` wires categories into
     ``indexing.memory_dirs`` without prompting."""

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1124,6 +1124,18 @@ def test_provider_vocabulary_lock_message_references_rfc() -> None:
     assert "#304" in _PROVIDER_VOCABULARY_LOCK_MESSAGE
 
 
+def test_category_to_provider_key_drift_message_names_mapping() -> None:
+    """Key-axis drift message must name ``_CATEGORY_TO_PROVIDER`` so a
+    contributor following the ``AssertionError`` traceback edits the
+    mapping rather than re-reading the category vocabulary — the two
+    live in the same file but fixing the wrong one produces a confusing
+    second failure."""
+    from memtomem.config import _CATEGORY_TO_PROVIDER_KEY_DRIFT_MESSAGE
+
+    assert "_CATEGORY_TO_PROVIDER" in _CATEGORY_TO_PROVIDER_KEY_DRIFT_MESSAGE
+    assert "#304" in _CATEGORY_TO_PROVIDER_KEY_DRIFT_MESSAGE
+
+
 def test_provider_for_category_roundtrip() -> None:
     """Public helper must agree with the internal mapping for every known
     category and fall back to ``"user"`` for anything unknown (mirrors

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -858,3 +858,44 @@ class TestUnicodePaths:
                 json={"file": str(nfc_target)},
             )
         assert resp.status_code == 200, resp.text
+
+
+# ---------------------------------------------------------------------------
+# GET /api/memory-dirs/status
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryDirsStatus:
+    """Per-dir index status shape contract. The Web UI groups entries by
+    ``provider`` and ``category``, so both fields must be present on every
+    row returned by :func:`~memtomem.indexing.engine.memory_dir_stats`.
+    RFC #304 Phase 1."""
+
+    async def test_response_shape_includes_provider(
+        self, app, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        # Mix of provider-shaped and user paths so the route output exercises
+        # every category→provider branch in one call.
+        user = tmp_path / "notes"
+        codex = tmp_path / ".codex" / "memories"
+        plans = tmp_path / ".claude" / "plans"
+        claude_mem = tmp_path / ".claude" / "projects" / "demo" / "memory"
+        for d in (user, codex, plans, claude_mem):
+            d.mkdir(parents=True)
+
+        app.state.config.indexing.memory_dirs = [user, codex, plans, claude_mem]
+
+        resp = await client.get("/api/memory-dirs/status")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        dirs = data["dirs"]
+        assert len(dirs) == 4
+        # Every entry carries provider + category — Web UI consumes both.
+        for entry in dirs:
+            assert "category" in entry
+            assert "provider" in entry
+        by_path = {r["path"]: r for r in dirs}
+        assert by_path[str(user)]["provider"] == "user"
+        assert by_path[str(codex)]["provider"] == "openai"
+        assert by_path[str(plans)]["provider"] == "claude"
+        assert by_path[str(claude_mem)]["provider"] == "claude"


### PR DESCRIPTION
## Summary

RFC #304 Phase 1 — adds a `provider` vendor tag to every `memory_dir_stats()` entry so the Web UI can build a two-level vendor → product tree (Phase 2) without duplicating the category→vendor map in JS. Server-only change; no client consumers yet (field ships unused until Phase 2, per the #314 Q3 resolution).

- Add `_CATEGORY_TO_PROVIDER` mapping + `_VALID_PROVIDERS` frozenset + paired import-asserts on both axes in `config.py`. Without the value-side lock a future `_CATEGORY_TO_PROVIDER["skills"] = "anthropic"` would introduce a new provider silently — #313 locked the category axis only; symmetric lock on the provider axis follows the same stance.
- Emit `provider` on every `memory_dir_stats()` row next to the existing `category`. Mapping (Q6 resolution — keep `codex` category name, tag vendor as `openai`):
  - `user` → `user`
  - `claude-memory` → `claude`
  - `claude-plans` → `claude`
  - `codex` → `openai`
- Export `provider_for_category()` helper with user-default fallback (mirrors `categorize_memory_dir`'s fallback shape).

## Tests

- `TestMemoryDirStats` extended:
  - `test_empty_dir_has_zero_counts` now pins `provider == "user"` alongside `category`.
  - New `test_provider_tags_every_entry` — asserts the full mapping across all four categories + every entry has a `provider` key.
- `test_init_cmd.py` vocabulary locks (mirror of existing `test_provider_categories_vocabulary_locked`):
  - `test_category_to_provider_keys_cover_categories` — key-side parity.
  - `test_providers_vocabulary_locked` — value-side parity.
  - `test_provider_vocabulary_lock_message_references_rfc` — lock message references RFC #304.
  - `test_provider_for_category_roundtrip` — helper agrees with internal map and falls back for unknown.
- `TestMemoryDirsStatus` — new route smoke test on `GET /api/memory-dirs/status` verifying `provider` lands on every entry with the expected mapping.

## Verification

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — 283 files formatted
- [x] `uv run pytest -m "not ollama"` — **1930 passed, 46 deselected**

## Test plan

- [ ] CI green (ruff + pytest)
- [ ] Manual smoke: `uv run mm web` → DevTools Network → `/api/memory-dirs/status` shows `provider` on every entry

## Links

- RFC: #304 (design, Q1–Q6 resolved 2026-04-20)
- Working space: #314 (closed after resolution posted)
- Prep: #312 (wizard preset), #313 (vocabulary lock)
- Follow-up: Phase 2 client PR (separate) — refactor `sources-memory-dirs.js` to drive the two-level tree from this field; i18n keys `provider.{user,claude,openai}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
