### PR TITLE
refactor(config): type provider vocabulary as Literal, derive frozensets

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Literal, cast
+from typing import Annotated, Literal, cast, get_args
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -1033,32 +1033,37 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
                         )
 
 
+# Typed vocabulary for provider-dir classification. ``ProviderCategory``
+# enumerates every category a ``memory_dir`` can be classified as;
+# ``ProviderName`` enumerates every vendor tag attached to a category.
+# Both are the *single source of truth* — ``_VALID_PROVIDER_CATEGORIES``
+# and ``_VALID_PROVIDERS`` are derived at module load via ``get_args``
+# so the frozensets can never drift from the ``Literal`` types mypy
+# sees at call sites. See RFC #304 Phase 1.
+ProviderCategory = Literal["user", "claude-memory", "claude-plans", "codex"]
+ProviderName = Literal["user", "claude", "openai"]
+
 # Single source of truth for provider-dir classification. Each row ties a
 # category name to the regex that recognises paths in that category. The
 # Web UI's ``/api/memory-dirs/status`` response carries the resulting
 # ``category`` field so the client does not maintain a parallel regex.
-_PROVIDER_CATEGORY_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+_PROVIDER_CATEGORY_PATTERNS: tuple[tuple[ProviderCategory, re.Pattern[str]], ...] = (
     ("claude-memory", re.compile(r"/\.claude/projects/[^/]+/memory/?$")),
     ("claude-plans", re.compile(r"/\.claude/plans/?$")),
     ("codex", re.compile(r"/\.codex/memories/?$")),
 )
 
-# Vocabulary lock: new patterns must not silently expand the category set.
-# Until RFC #304 decides the hierarchy (vendor/product), any change here
-# requires a coordinated update to ``_VALID_PROVIDER_CATEGORIES``. Mirrors the
-# ``_VALID_PRESET_PLACEHOLDERS`` pattern in ``cli/init_cmd.py``.
-_VALID_PROVIDER_CATEGORIES: frozenset[str] = frozenset(
-    {
-        "user",
-        "claude-memory",
-        "claude-plans",
-        "codex",
-    }
-)
+# Derived from ``ProviderCategory`` — do NOT edit independently. Adding a
+# new category means adding it to the ``Literal`` above; the frozenset
+# (and mypy's exhaustiveness checking at call sites) picks it up for
+# free. Until RFC #304 decides a deeper hierarchy, any change here
+# requires a coordinated update to the pattern table + pin tests.
+# Mirrors the ``_VALID_PRESET_PLACEHOLDERS`` pattern in ``cli/init_cmd.py``.
+_VALID_PROVIDER_CATEGORIES: frozenset[str] = frozenset(get_args(ProviderCategory))
 
 _VOCABULARY_LOCK_MESSAGE = (
-    "Provider category vocabulary changed without updating "
-    "_VALID_PROVIDER_CATEGORIES. See RFC #304 before adding categories."
+    "Provider category patterns changed without updating the "
+    "ProviderCategory Literal. See RFC #304 before adding categories."
 )
 
 assert ({cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS} | {"user"}) == _VALID_PROVIDER_CATEGORIES, (
@@ -1068,14 +1073,15 @@ assert ({cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS} | {"user"}) == _VALID_PR
 # Vendor tag for each category. Exposed on ``memory_dir_stats()`` entries so
 # the Web UI can render a two-level vendor → product tree without duplicating
 # the category→vendor map in JS. RFC #304 Phase 1 — see plan #314 resolution.
-_CATEGORY_TO_PROVIDER: dict[str, str] = {
+_CATEGORY_TO_PROVIDER: dict[ProviderCategory, ProviderName] = {
     "user": "user",
     "claude-memory": "claude",
     "claude-plans": "claude",
     "codex": "openai",
 }
 
-_VALID_PROVIDERS: frozenset[str] = frozenset({"user", "claude", "openai"})
+# Derived from ``ProviderName`` — same discipline as ``_VALID_PROVIDER_CATEGORIES``.
+_VALID_PROVIDERS: frozenset[str] = frozenset(get_args(ProviderName))
 
 _PROVIDER_VOCABULARY_LOCK_MESSAGE = (
     "Provider vocabulary changed without updating _VALID_PROVIDERS. "
@@ -1102,27 +1108,34 @@ assert set(_CATEGORY_TO_PROVIDER.values()) == _VALID_PROVIDERS, _PROVIDER_VOCABU
 
 # Derived from ``_PROVIDER_CATEGORY_PATTERNS`` — do NOT edit independently.
 # Add a new pattern row above and this tuple picks it up automatically.
-PROVIDER_DIR_CATEGORIES: tuple[str, ...] = tuple(cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS)
+# Excludes ``"user"`` by design (user dirs have no pattern; they fall
+# through :func:`categorize_memory_dir`'s default).
+PROVIDER_DIR_CATEGORIES: tuple[ProviderCategory, ...] = tuple(
+    cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS
+)
 
 
-def provider_for_category(category: str) -> str:
+def provider_for_category(category: str) -> ProviderName:
     """Return the vendor tag for a ``memory_dir`` category.
 
     Consumed by :func:`~memtomem.indexing.engine.memory_dir_stats` so the
     Web UI can group entries by vendor. Unknown categories fall back to
     ``"user"`` — mirrors :func:`categorize_memory_dir`'s user-default.
+    Accepts ``str`` (not ``ProviderCategory``) so callers can pass
+    server-supplied strings without narrowing first.
     """
-    return _CATEGORY_TO_PROVIDER.get(category, "user")
+    return _CATEGORY_TO_PROVIDER.get(cast(ProviderCategory, category), "user")
 
 
-def categorize_memory_dir(path: str | Path) -> str:
-    """Return the category string for a ``memory_dir`` path.
+def categorize_memory_dir(path: str | Path) -> ProviderCategory:
+    """Return the category for a ``memory_dir`` path.
 
-    Returns one of ``PROVIDER_DIR_CATEGORIES`` or ``"user"`` for anything
-    that doesn't match a known provider layout. Classification only —
-    does not check existence or validity. Uses forward-slash regex, so
-    on Windows a backslash-normalised path will fall through to
-    ``"user"`` until a future path-sep-agnostic pass lands.
+    Returns one of ``ProviderCategory``'s literal values, defaulting to
+    ``"user"`` for anything that doesn't match a known provider layout.
+    Classification only — does not check existence or validity. Uses
+    forward-slash regex, so on Windows a backslash-normalised path will
+    fall through to ``"user"`` until a future path-sep-agnostic pass
+    lands (tracked in #316).
     """
     s = str(path).rstrip("/")
     for cat, pat in _PROVIDER_CATEGORY_PATTERNS:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1151,6 +1151,29 @@ def test_provider_for_category_roundtrip() -> None:
     assert provider_for_category("not-a-real-category") == "user"
 
 
+def test_provider_category_literal_matches_frozenset() -> None:
+    """``_VALID_PROVIDER_CATEGORIES`` is derived from
+    ``get_args(ProviderCategory)``, so by construction they cannot drift.
+    This test documents that contract — if a future refactor inlines the
+    frozenset back into a literal, the explicit ``get_args`` equality
+    failure will catch it before mypy's implicit exhaustiveness does."""
+    from typing import get_args
+
+    from memtomem.config import ProviderCategory, _VALID_PROVIDER_CATEGORIES
+
+    assert set(get_args(ProviderCategory)) == _VALID_PROVIDER_CATEGORIES
+
+
+def test_provider_name_literal_matches_frozenset() -> None:
+    """Mirror of :func:`test_provider_category_literal_matches_frozenset`
+    on the vendor axis."""
+    from typing import get_args
+
+    from memtomem.config import ProviderName, _VALID_PROVIDERS
+
+    assert set(get_args(ProviderName)) == _VALID_PROVIDERS
+
+
 class TestIncludeProviderFlag:
     """Non-interactive ``--include-provider`` wires categories into
     ``indexing.memory_dirs`` without prompting."""


### PR DESCRIPTION
## Summary

Deferred cleanup from the RFC #304 plan (Phase A audit): promote the provider vocabulary from hand-written frozensets to `Literal`-backed types, so the Literal is the single source of truth and the frozenset/pattern table can't drift silently.

## Changes

**New public type aliases** in `config.py`:
- `ProviderCategory = Literal["user", "claude-memory", "claude-plans", "codex"]`
- `ProviderName = Literal["user", "claude", "openai"]`

**Derivation** — `_VALID_PROVIDER_CATEGORIES` / `_VALID_PROVIDERS` are now `frozenset(get_args(X))`, so adding a new category requires adding it to the Literal (which mypy enforces at every call site).

**Function signatures tightened**:
- `categorize_memory_dir(path) -> ProviderCategory` (was `str`)
- `provider_for_category(category) -> ProviderName` (was `str`)
- Input stays `str` on `provider_for_category` so callers can pass server-supplied strings without narrowing first.

**Containers tightened**:
- `_PROVIDER_CATEGORY_PATTERNS: tuple[tuple[ProviderCategory, re.Pattern[str]], ...]`
- `_CATEGORY_TO_PROVIDER: dict[ProviderCategory, ProviderName]`
- `PROVIDER_DIR_CATEGORIES: tuple[ProviderCategory, ...]` (docstring now explicitly notes the `"user"` exclusion).

**Runtime asserts unchanged** — the paired-axis locks (#313 + Phase 1) still guard the pattern table and the tag mapping. The category-axis `_VOCABULARY_LOCK_MESSAGE` text was tweaked to name the Literal instead of the frozenset (they're the same source now).

## Tests

Two new pin tests in `test_init_cmd.py`:
- `test_provider_category_literal_matches_frozenset` — documents the `get_args(ProviderCategory) == _VALID_PROVIDER_CATEGORIES` contract.
- `test_provider_name_literal_matches_frozenset` — mirror on the vendor axis.

These are tautological by construction (frozensets are derived from the Literal), but they fail loudly if a future refactor inlines the frozenset back to a hand-written literal — mypy's implicit exhaustiveness would also trip, but an explicit Python-level failure is easier for a contributor to act on.

## Verification

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — 283 files formatted
- [x] `uv run mypy packages/memtomem/src` — **no issues found in 194 source files**
- [x] `uv run pytest -m "not ollama"` — **1934 passed, 46 deselected**

## Test plan

- [ ] CI green (ruff + mypy + pytest)
- [ ] Reviewer sanity-check the `cast(ProviderCategory, category)` in `provider_for_category` — the cast is intentional since the function accepts arbitrary strings, not just known categories; `.get()` with an unknown key returns the default (`"user"`).

## Links

- RFC #304 (CLOSED after Phase 1+2 merged)
- Phase 1 (server `provider` field): #321 merged
- Phase 2 (client vendor tree): #322 merged
- Plan: `~/.claude/plans/314-smooth-bubble.md` Phase A audit deferred list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
