### PR TITLE
release: v0.1.13 — bundled release since v0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.13] — 2026-04-20
+
 ### Added
 - **`mm agent migrate` CLI**: renames legacy `agent/{id}` namespaces to
   `agent-runtime:{id}` (see `### Changed` below). Pass `--dry-run` to preview

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.12"
+version = "0.1.13"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bump `memtomem` 0.1.12 → 0.1.13. `CHANGELOG` `[Unreleased]` → `[0.1.13] — 2026-04-20`.

Covers 20 commits since v0.1.12 (#295–#323). No code changes in this PR beyond version + lockfile + CHANGELOG.

## Highlights

- **`mm agent migrate` CLI** — rename legacy `agent/{id}` → `agent-runtime:{id}` (#318)
- **Wizard preset namespace rules** for accepted provider categories (#296/#312)
- **Reranker candidate-pool scaling** — `oversample` / `min_pool` / `max_pool` knobs, runtime-tunable via `mm config set` (#309/#310)
- **Memory Dirs vendor → product grouping** in the Sources tab (#321 + #322)
- **Namespace validation** enforced on write paths (#317/#319)
- **Provider vocabulary** typed as `Literal` with frozensets derived via `get_args()` (#313, #323)

Full entry: [`CHANGELOG.md` § `[0.1.13] — 2026-04-20`](../blob/release/v0.1.13/CHANGELOG.md).

## Test plan

- [ ] CI green on this PR
- [ ] Merge
- [ ] Push `test-v0.1.13a1` tag; verify TestPyPI artifact
- [ ] Fresh-env install smoke from TestPyPI (`uv tool install --index https://test.pypi.org/simple/ --from memtomem memtomem`)
- [ ] Push `v0.1.13` production tag; approve `pypi` env in GH Actions
- [ ] Publish GH Release with notes lifted from CHANGELOG

🤖 Generated with [Claude Code](https://claude.com/claude-code)
