### PR TITLE
docs(changelog): add alpha disclaimer to [0.1.13] entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [0.1.13] — 2026-04-20
 
+memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces
+may still shift between 0.1.x releases — external feedback and issue
+reports are especially welcome at
+[github.com/memtomem/memtomem/issues](https://github.com/memtomem/memtomem/issues).
+
 ### Added
 - **`mm agent migrate` CLI**: renames legacy `agent/{id}` namespaces to
   `agent-runtime:{id}` (see `### Changed` below). Pass `--dry-run` to preview


### PR DESCRIPTION
## Summary

Small consistency fix — the `[0.1.13]` CHANGELOG entry was missing the alpha disclaimer paragraph that `[0.1.12]` and `[0.1.11]` both carry. Surfaced while writing the GH Release body for v0.1.13 (which did include the disclaimer).

Docs-only, no code/behavior impact (+5 lines, all inside the `[0.1.13]` header).

## Test plan

- [x] `git diff` confirms only 5 added lines inside `[0.1.13]`
- [x] Visual diff vs `[0.1.12]` entry — wording identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
