### PR TITLE
feat(cli): add preset picker to mm init — minimal/english/korean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+- **`mm init` preset picker**: interactive `mm init` now opens with a preset
+  picker (`Minimal` / `English (Recommended)` / `Korean-optimized`) plus an
+  `Advanced` entry that runs the full 10-step wizard. Preset paths only
+  prompt for the memory directory and MCP registration; embedding /
+  reranker / tokenizer / namespace defaults come from the preset bundle.
+  New CLI flags `--preset <name>` and `--advanced` expose the same choices
+  non-interactively; `--preset` and `--advanced` are mutually exclusive.
+- **Non-TTY guard for `mm init`**: running the default interactive path
+  with piped stdin (no `--preset`, no `--advanced`, no `-y`) now exits
+  cleanly with a usage error pointing at those flags, instead of hanging
+  on a closed prompt.
+
+### Changed
+- **`mm init -y` behavior**: scripted `mm init -y` (with no other flags)
+  is now equivalent to `mm init --preset minimal -y` — same defaults as
+  before this release (provider=none, BM25-only, unicode61 tokenizer), so
+  existing CI / automation calls continue to work unchanged. Existing
+  explicit flags (`--provider`, `--model`, `--tokenizer`, ...) override
+  the preset baseline in both interactive and non-interactive paths.
+
 ## [0.1.13] — 2026-04-20
 
 memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces

--- a/README.md
+++ b/README.md
@@ -48,10 +48,20 @@ uv tool install memtomem             # or: pipx install memtomem
 ### 2. Setup
 
 ```bash
-mm init                               # 9-step wizard (or: mm init -y for CI)
+mm init                               # preset picker, then memory_dir + MCP
 ```
 
-The wizard picks your embedding provider, points at the folder you want indexed, and registers memtomem with your AI editor. The default is **keyword-only** (BM25, no external dependencies) — you can also pick ONNX (local, no server), Ollama (local server), or OpenAI (cloud). See [Embeddings](docs/guides/embeddings.md) for details.
+The interactive picker starts with three presets — **Minimal** (BM25, no downloads), **English (Recommended)** (ONNX `bge-small-en-v1.5` + English reranker + auto-discover providers), **Korean-optimized** (ONNX `bge-m3` + `kiwipiepy` tokenizer + multilingual reranker) — plus an **Advanced** entry that opens the full 10-step wizard. Preset paths only ask about the memory directory and MCP registration; everything else is set from the preset.
+
+For automation / CI:
+
+```bash
+mm init -y                            # minimal preset, same as before
+mm init --preset korean -y            # Korean-optimized bundle, no prompts
+mm init --advanced                    # force the full 10-step wizard
+```
+
+See [Embeddings](docs/guides/embeddings.md) for the full model/provider matrix.
 
 ### 3. Use
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -118,15 +118,31 @@ mm init         # PyPI global install
 uv run mm init  # Project or source install
 ```
 
-The wizard walks you through 10 steps. Type `b` to go back, `q` to quit at any step.
+`mm init` starts with a preset picker — pick one of three bundled setups (**Minimal**, **English (Recommended)**, **Korean-optimized**) or choose **Advanced** for the full 10-step wizard. Preset paths only ask about the memory directory and MCP registration.
+
+### Choose your setup
+
+| Preset | What it bundles | When to pick |
+|---|---|---|
+| **Minimal** | BM25 keyword search, no downloads, unicode61 tokenizer, no reranker | Want the lightest possible install, or starting from scratch to explore |
+| **English (Recommended)** | ONNX `bge-small-en-v1.5` (384d, ~33 MB) + English reranker (`Xenova/ms-marco-MiniLM-L-6-v2`) + auto-discover provider memory folders | Most English-language setups — good default if you're unsure |
+| **Korean-optimized** | ONNX `bge-m3` (1024d, ~1.2 GB) + multilingual reranker (`jinaai/jina-reranker-v2-base-multilingual`) + `kiwipiepy` tokenizer + auto-discover | Korean content (or Korean/Chinese/Japanese mixed) |
+| **Advanced** | — (10-step wizard, full control) | Need to set every knob — custom model, separate DB path, decay, etc. |
+
+Type `b` to go back or `q` to quit at any prompt.
 
 #### Non-interactive mode (CI / automation)
 
-Skip the wizard entirely with `-y`. All settings have sensible defaults:
+Skip prompting with `-y`. `mm init -y` alone applies the **Minimal** preset (same defaults as before this feature landed); pass `--preset` for the others:
 
 ```bash
-mm init -y                                              # all defaults (keyword-only, BM25)
-mm init -y --provider onnx --model all-MiniLM-L6-v2     # local dense embeddings, no server
+mm init -y                                              # Minimal preset (BM25-only)
+mm init --preset english -y                             # English recommended
+mm init --preset korean -y                              # Korean-optimized
+mm init --advanced                                      # Force the full 10-step wizard
+
+# Explicit flags override preset values:
+mm init -y --provider onnx --model all-MiniLM-L6-v2     # custom ONNX model
 mm init -y --provider ollama --model nomic-embed-text   # Ollama (requires `ollama serve`)
 mm init -y --provider openai --api-key sk-...           # OpenAI
 mm init -y --memory-dir ~/notes --mcp claude            # custom dir + Claude Code auto-setup
@@ -134,6 +150,12 @@ mm init -y --memory-dir ~/notes --mcp claude            # custom dir + Claude Co
 # Pull in AI tool memory folders (repeat per category):
 mm init -y --include-provider claude-memory --include-provider codex
 ```
+
+`--preset` and `--advanced` are mutually exclusive. Running without `-y` / `--preset` / `--advanced` from a non-TTY (e.g., piped stdin) exits with an error — pass one of those flags explicitly.
+
+#### Advanced (10-step wizard) step list
+
+Selecting **Advanced** (from the picker or `--advanced`) runs all ten steps:
 
 1. **Embedding provider** — BM25-only (default, zero-dependency), Local ONNX (no server), Ollama (local server), or OpenAI (cloud)
 2. **Reranker (optional)** — off by default; opt-in to a local fastembed cross-encoder. Korean/Chinese/Japanese/mixed content should pick the multilingual model
@@ -279,7 +301,7 @@ mm recall --since 2026-04-01
 All commands support `-h` and `--help`. Interactive wizards support `b` (back) and `q` (quit).
 
 ```bash
-mm init                    # 9-step setup wizard
+mm init                    # preset picker (or `--advanced` for the full 10-step wizard)
 mm search "query"          # hybrid search
 mm index ~/notes           # index files
 mm add "some note"         # add a memory

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -17,14 +17,20 @@ Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + s
 # 1. Install memtomem (requires Python 3.12+)
 uv tool install memtomem        # or: pipx install memtomem
 
-# 2. Run the 9-step setup wizard
-#    (picks embedding provider, optional reranker, memory folder, MCP editor)
+# 2. Run the setup (preset picker → memory_dir + MCP)
 mm init    # on PATH after `uv tool install` — no `uv run` needed
 ```
 
-The wizard's default is **keyword-only** (BM25, no external deps). Pick
-ONNX (local, no server), Ollama (local server), or OpenAI (cloud) for
-semantic search — see [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md).
+The picker offers three presets and an Advanced fallback:
+
+| Preset | Embedding | Reranker | Tokenizer |
+|---|---|---|---|
+| Minimal | BM25 only (no download) | — | unicode61 |
+| English (Recommended) | ONNX `bge-small-en-v1.5` (~33 MB, 384d) | English (`ms-marco-MiniLM-L-6-v2`) | unicode61 |
+| Korean-optimized | ONNX `bge-m3` (~1.2 GB, 1024d) | Multilingual (`jina-reranker-v2`) | `kiwipiepy` |
+| Advanced | — | — | — (full 10-step wizard, all options) |
+
+Pick a preset interactively, or use `mm init -y` (minimal), `mm init --preset korean -y`, or `mm init --advanced` for scripted runs. See [Embeddings](https://github.com/memtomem/memtomem/blob/main/docs/guides/embeddings.md) for the full model matrix.
 
 Then in your AI editor, ask:
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -6,11 +6,13 @@ import copy
 import json
 import shutil
 import subprocess
+import sys
 import time
 from pathlib import Path
 
 import click
 
+from memtomem.cli.init_presets import PRESETS, _VALID_PRESETS, get_preset
 from memtomem.cli.wizard import nav_confirm, nav_prompt, run_steps, step_header
 
 
@@ -1066,6 +1068,230 @@ def _write_mcp_json(server_cmd: str, server_args: list[str], mcp_env: dict[str, 
         mcp_path.write_text(json.dumps(mcp_config, indent=2), encoding="utf-8")
 
 
+# ── Preset quick-setup helpers ────────────────────────────────────────
+
+
+def _step_preset_picker(state: dict) -> None:
+    """First step of the default interactive path — pick a preset or Advanced.
+
+    Writes ``state["_preset_choice"]`` = one of ``"minimal" | "english" |
+    "korean" | "advanced"``. The Advanced entry falls through to the full
+    10-step wizard; the other three bundle embedding/reranker/tokenizer/
+    namespace defaults via ``_apply_preset`` so the user only sees the
+    essential memory-dir and MCP questions afterwards.
+    """
+    click.secho("  Choose setup style:", fg="yellow", bold=True)
+    click.echo(click.style("  (b: back, q: quit)", dim=True))
+    click.echo()
+
+    ordered: list[str] = ["minimal", "english", "korean"]
+    for i, name in enumerate(ordered, start=1):
+        spec = PRESETS[name]  # type: ignore[index]
+        click.echo(f"    [{i}] {spec.label}")
+        click.echo(f"        {spec.description}")
+    advanced_idx = len(ordered) + 1
+    click.echo(f"    [{advanced_idx}] Advanced — full 10-step wizard (all options)")
+    click.echo()
+
+    choice = nav_prompt("  Select", type=click.IntRange(1, advanced_idx), default=2)
+    click.echo()
+
+    if choice == advanced_idx:
+        state["_preset_choice"] = "advanced"
+    else:
+        state["_preset_choice"] = ordered[choice - 1]
+
+
+def _apply_preset(state: dict, preset_name: str) -> None:
+    """Populate ``state`` with a preset's bundled defaults.
+
+    Mirrors the flat keys individual ``_step_*`` functions write so the
+    downstream ``_write_config_and_summary`` merge path is unchanged.
+    Does NOT touch ``memory_dir`` or ``mcp_choice`` — those remain asked
+    interactively (or come from explicit CLI flags).
+    """
+    spec = get_preset(preset_name)
+    state["provider"] = spec.provider
+    state["model"] = spec.model
+    state["dimension"] = spec.dimension
+    state["api_key"] = ""
+    state["rerank_enabled"] = spec.rerank_enabled
+    if spec.rerank_enabled and spec.rerank_model is not None:
+        state["rerank_model"] = spec.rerank_model
+    state["tokenizer"] = spec.tokenizer
+    state["top_k"] = spec.default_top_k
+    state["enable_auto_ns"] = spec.enable_auto_ns
+    state["default_ns"] = spec.default_namespace
+    state["decay_enabled"] = spec.decay_enabled
+    state["db_path"] = str(Path("~/.memtomem").expanduser() / "memtomem.db")
+    state["settings_hooks"] = False
+    state["_preset_applied"] = preset_name
+
+
+def _step_provider_dirs_auto(state: dict) -> None:
+    """Auto-apply detected provider memory folders for preset 2/3.
+
+    Respects the preset's ``autodetect_providers`` flag: when False (minimal),
+    skips without scanning. When True, scans via ``_detect_provider_dirs``,
+    adds every detected category, emits a banner listing what was added (or
+    a one-line message when nothing was detected so the skip isn't silent).
+    """
+    preset_name = state.get("_preset_applied")
+    if preset_name is None:
+        state.setdefault("provider_dirs", [])
+        state.setdefault("provider_rules", [])
+        return
+
+    spec = get_preset(preset_name)
+    if not spec.autodetect_providers:
+        state["provider_dirs"] = []
+        state["provider_rules"] = []
+        return
+
+    from memtomem.config import _detect_provider_dirs
+
+    grouped = _detect_provider_dirs()
+    available = {cat: dirs for cat, dirs in grouped.items() if dirs}
+
+    if not available:
+        click.echo(
+            "  No provider memory folders detected (checked: ~/.claude/projects, "
+            "~/.claude/plans, ~/.codex/memories)."
+        )
+        click.echo("  Run 'mm init --advanced' later to add custom paths.")
+        click.echo()
+        state["provider_dirs"] = []
+        state["provider_rules"] = []
+        return
+
+    selected: list[Path] = []
+    accepted_categories: list[str] = []
+    for cat in ("claude-memory", "claude-plans", "codex"):
+        dirs_for_cat = available.get(cat, [])
+        if dirs_for_cat:
+            selected.extend(dirs_for_cat)
+            accepted_categories.append(cat)
+
+    state["provider_dirs"] = [str(p) for p in selected]
+    state["provider_rules"] = [
+        (cat, _proposed_rule_for_category(cat))
+        for cat in accepted_categories
+        if _proposed_rule_for_category(cat) is not None
+    ]
+    click.secho(
+        f"  Auto-added {len(selected)} provider folder(s) "
+        f"from {len(accepted_categories)} categor"
+        f"{'y' if len(accepted_categories) == 1 else 'ies'}.",
+        fg="green",
+    )
+    for cat in accepted_categories:
+        n = len(available[cat])
+        suffix = "dir" if n == 1 else "dirs"
+        click.echo(f"    • {cat} ({n} {suffix})")
+    click.echo()
+
+
+def _resolve_provider_dirs_non_interactive(
+    state: dict,
+    preset_name: str,
+    include_providers: tuple[str, ...],
+) -> None:
+    """Compute ``provider_dirs`` / ``provider_rules`` for the scripted path.
+
+    Union of the preset's autodetect set (when ``autodetect_providers`` is
+    True) and any categories named via ``--include-provider``. Categories
+    without detected dirs are silently skipped — mirrors the legacy
+    non-interactive policy (no error if a user asks for ``codex`` on a
+    Claude-only box).
+    """
+    from memtomem.config import _detect_provider_dirs
+
+    spec = get_preset(preset_name)
+    grouped = _detect_provider_dirs()
+    categories_to_add: set[str] = set()
+    if spec.autodetect_providers:
+        categories_to_add.update(cat for cat, dirs in grouped.items() if dirs)
+    for explicit in include_providers:
+        if grouped.get(explicit):
+            categories_to_add.add(explicit)
+
+    provider_dirs: list[str] = []
+    provider_rules: list[tuple[str, dict]] = []
+    for cat in ("claude-memory", "claude-plans", "codex"):
+        if cat in categories_to_add:
+            for d in grouped.get(cat, []):
+                provider_dirs.append(str(d))
+            rule = _proposed_rule_for_category(cat)
+            if rule is not None:
+                provider_rules.append((cat, rule))
+    state["provider_dirs"] = provider_dirs
+    state["provider_rules"] = provider_rules
+
+
+def _override_from_flags(
+    state: dict,
+    *,
+    provider: str | None,
+    model: str | None,
+    tokenizer: str | None,
+    memory_dir: str | None,
+    db_path: str | None,
+    namespace: str | None,
+    auto_ns: bool,
+    top_k: int | None,
+    decay: bool,
+    api_key: str | None,
+    mcp_mode: str | None,
+) -> None:
+    """Apply explicit CLI flag values over preset-populated state.
+
+    Called after ``_apply_preset`` in every preset branch (non-interactive,
+    explicit ``--preset``, interactive picker) so flag precedence is
+    consistent: preset sets the baseline, explicit flags win. ``--provider``
+    also refreshes ``dimension`` via ``_MODEL_DIMS`` to match the
+    non-interactive block's behavior.
+    """
+    if provider is not None:
+        state["provider"] = provider
+        if provider == "none":
+            if model is None:
+                state["model"] = ""
+                state["dimension"] = 0
+        elif model is None:
+            # Pick a sensible default model per provider when --provider is
+            # given without --model, mirroring the non-interactive branch.
+            defaults = {
+                "onnx": ("all-MiniLM-L6-v2", 384),
+                "ollama": ("nomic-embed-text", 768),
+                "openai": ("text-embedding-3-small", 1536),
+            }
+            if provider in defaults:
+                default_model, default_dim = defaults[provider]
+                state["model"] = default_model
+                state["dimension"] = default_dim
+    if model is not None:
+        state["model"] = model
+        state["dimension"] = _MODEL_DIMS.get(model, state.get("dimension", 0))
+    if tokenizer is not None:
+        state["tokenizer"] = tokenizer
+    if memory_dir is not None:
+        state["memory_dir"] = memory_dir
+    if db_path is not None:
+        state["db_path"] = db_path
+    if namespace is not None:
+        state["default_ns"] = namespace
+    if auto_ns:
+        state["enable_auto_ns"] = True
+    if top_k is not None:
+        state["top_k"] = top_k
+    if decay:
+        state["decay_enabled"] = True
+    if api_key is not None:
+        state["api_key"] = api_key
+    if mcp_mode is not None:
+        state["mcp_choice"] = {"claude": 1, "json": 2, "skip": 3}.get(mcp_mode, 3)
+
+
 # ── CLI entry point ───────────────────────────────────────────────────
 
 
@@ -1120,6 +1346,26 @@ _MODEL_DIMS: dict[str, int] = {
         "the web UI."
     ),
 )
+@click.option(
+    "--preset",
+    type=click.Choice(sorted(_VALID_PRESETS)),
+    default=None,
+    help=(
+        "Apply a preset bundle (minimal | english | korean) of embedding, "
+        "reranker, tokenizer, and namespace defaults. Without this flag, the "
+        "interactive picker asks at startup; `mm init -y` alone behaves as "
+        "`--preset minimal -y`. Mutually exclusive with --advanced."
+    ),
+)
+@click.option(
+    "--advanced",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force the full 10-step wizard (skip the preset picker). Useful for "
+        "fine-grained control over every step. Mutually exclusive with --preset."
+    ),
+)
 def init(
     non_interactive: bool,
     provider: str | None,
@@ -1135,6 +1381,8 @@ def init(
     mcp_mode: str | None,
     include_providers: tuple[str, ...],
     fresh: bool,
+    preset: str | None,
+    advanced: bool,
 ) -> None:
     """Set up memtomem with an interactive wizard."""
     click.echo()
@@ -1160,79 +1408,96 @@ def init(
         click.echo(f"  Project directory: {state['project_dir']}")
         click.echo()
 
-    if non_interactive:
-        _provider = provider or "none"
-        if _provider == "none":
-            _model = ""
-            _dimension = 0
-        elif _provider == "onnx":
-            _model = model or "all-MiniLM-L6-v2"
-            _dimension = _MODEL_DIMS.get(_model, 384)
-        elif _provider == "ollama":
-            _model = model or "nomic-embed-text"
-            _dimension = _MODEL_DIMS.get(_model, 768)
-        else:
-            _model = model or "text-embedding-3-small"
-            _dimension = _MODEL_DIMS.get(_model, 1536)
-        _memory_dir = memory_dir or "~/memories"
+    if preset and advanced:
+        raise click.UsageError("--preset and --advanced are mutually exclusive")
 
-        # Auto-create memory directory
-        memory_path = Path(_memory_dir).expanduser()
+    advanced_steps = [
+        _step_embedding,
+        _step_reranker,
+        _step_memory_dir,
+        _step_provider_dirs,
+        _step_storage,
+        _step_namespace,
+        _step_search,
+        _step_language,
+        _step_settings,
+        _step_mcp,
+    ]
+
+    if non_interactive:
+        # `mm init -y` alone behaves as `--preset minimal -y`; minimal's defaults
+        # match the previous non-interactive block's (provider="none", no rerank,
+        # unicode61, auto_ns=False, top_k=10). Explicit flags then override the
+        # preset baseline, preserving the prior `-y --provider onnx --model X`
+        # contract.
+        effective_preset = preset or "minimal"
+        _apply_preset(state, effective_preset)
+        _override_from_flags(
+            state,
+            provider=provider,
+            model=model,
+            tokenizer=tokenizer,
+            memory_dir=memory_dir,
+            db_path=db_path,
+            namespace=namespace,
+            auto_ns=auto_ns,
+            top_k=top_k,
+            decay=decay,
+            api_key=api_key,
+            mcp_mode=mcp_mode,
+        )
+        if "memory_dir" not in state:
+            state["memory_dir"] = "~/memories"
+        if "mcp_choice" not in state:
+            state["mcp_choice"] = 3  # skip — scripted runs don't touch Claude
+
+        memory_path = Path(state["memory_dir"]).expanduser()
         if not memory_path.exists():
             memory_path.mkdir(parents=True, exist_ok=True)
 
-        # Resolve --include-provider into concrete dirs that exist on this machine.
-        # Categories with no detected dirs are silently skipped — non-interactive
-        # callers don't get an error if they ask for codex on a Claude-only box.
-        from memtomem.config import _detect_provider_dirs
-
-        grouped = _detect_provider_dirs()
-        provider_dirs: list[str] = []
-        provider_rules: list[tuple[str, dict]] = []
-        for category in include_providers:
-            dirs_for_category = grouped.get(category, [])
-            for d in dirs_for_category:
-                provider_dirs.append(str(d))
-            # Mirror interactive parity: only register a preset rule when the
-            # category actually had detected dirs. A ``claude-memory`` rule
-            # with no Claude projects present is dead config.
-            if dirs_for_category:
-                rule = _proposed_rule_for_category(category)
-                if rule is not None:
-                    provider_rules.append((category, rule))
-
-        state.update(
-            {
-                "provider": _provider,
-                "model": _model,
-                "dimension": _dimension,
-                "api_key": api_key or "",
-                "rerank_enabled": False,
-                "memory_dir": _memory_dir,
-                "provider_dirs": provider_dirs,
-                "provider_rules": provider_rules,
-                "db_path": db_path or str(Path("~/.memtomem").expanduser() / "memtomem.db"),
-                "enable_auto_ns": auto_ns,
-                "default_ns": namespace or "default",
-                "top_k": top_k or 10,
-                "tokenizer": tokenizer or "unicode61",
-                "decay_enabled": decay,
-                "mcp_choice": {"claude": 1, "json": 2, "skip": 3}.get(mcp_mode or "skip", 3),
-            }
+        _resolve_provider_dirs_non_interactive(state, effective_preset, include_providers)
+    elif advanced:
+        run_steps(advanced_steps, state)
+    elif preset:
+        _apply_preset(state, preset)
+        _override_from_flags(
+            state,
+            provider=provider,
+            model=model,
+            tokenizer=tokenizer,
+            memory_dir=memory_dir,
+            db_path=db_path,
+            namespace=namespace,
+            auto_ns=auto_ns,
+            top_k=top_k,
+            decay=decay,
+            api_key=api_key,
+            mcp_mode=mcp_mode,
         )
+        run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)
     else:
-        steps = [
-            _step_embedding,
-            _step_reranker,
-            _step_memory_dir,
-            _step_provider_dirs,
-            _step_storage,
-            _step_namespace,
-            _step_search,
-            _step_language,
-            _step_settings,
-            _step_mcp,
-        ]
-        run_steps(steps, state)
+        # Default interactive path: show the preset picker, dispatch on choice.
+        if not sys.stdin.isatty():
+            raise click.UsageError("Non-interactive terminal detected. Pass --preset <name> or -y.")
+        run_steps([_step_preset_picker], state)
+        if state["_preset_choice"] == "advanced":
+            run_steps(advanced_steps, state)
+        else:
+            _apply_preset(state, state["_preset_choice"])
+            _override_from_flags(
+                state,
+                provider=provider,
+                model=model,
+                tokenizer=tokenizer,
+                memory_dir=memory_dir,
+                db_path=db_path,
+                namespace=namespace,
+                auto_ns=auto_ns,
+                top_k=top_k,
+                decay=decay,
+                api_key=api_key,
+                mcp_mode=mcp_mode,
+            )
+            run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)
 
     _write_config_and_summary(state, fresh=fresh)

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1080,8 +1080,12 @@ def _step_preset_picker(state: dict) -> None:
     namespace defaults via ``_apply_preset`` so the user only sees the
     essential memory-dir and MCP questions afterwards.
     """
+    # First step — no prior step to return to, so only surface 'q: quit'.
+    # 'b' still works (nav_prompt intercepts it before IntRange), but
+    # run_steps treats back-on-step-0 as a no-op, which would confuse
+    # users if advertised.
     click.secho("  Choose setup style:", fg="yellow", bold=True)
-    click.echo(click.style("  (b: back, q: quit)", dim=True))
+    click.echo(click.style("  (q: quit)", dim=True))
     click.echo()
 
     ordered: list[str] = ["minimal", "english", "korean"]
@@ -1252,23 +1256,27 @@ def _override_from_flags(
     non-interactive block's behavior.
     """
     if provider is not None:
+        # Only reset the preset-populated model/dimension when the user
+        # actually switches to a different provider AND hasn't supplied
+        # their own --model. `mm init --preset korean --provider onnx`
+        # must keep korean's bge-m3 (same provider); `--preset korean
+        # --provider ollama` must fall back to ollama's default model.
+        provider_changed = provider != state.get("provider")
         state["provider"] = provider
-        if provider == "none":
-            if model is None:
+        if provider_changed and model is None:
+            if provider == "none":
                 state["model"] = ""
                 state["dimension"] = 0
-        elif model is None:
-            # Pick a sensible default model per provider when --provider is
-            # given without --model, mirroring the non-interactive branch.
-            defaults = {
-                "onnx": ("all-MiniLM-L6-v2", 384),
-                "ollama": ("nomic-embed-text", 768),
-                "openai": ("text-embedding-3-small", 1536),
-            }
-            if provider in defaults:
-                default_model, default_dim = defaults[provider]
-                state["model"] = default_model
-                state["dimension"] = default_dim
+            else:
+                defaults = {
+                    "onnx": ("all-MiniLM-L6-v2", 384),
+                    "ollama": ("nomic-embed-text", 768),
+                    "openai": ("text-embedding-3-small", 1536),
+                }
+                if provider in defaults:
+                    default_model, default_dim = defaults[provider]
+                    state["model"] = default_model
+                    state["dimension"] = default_dim
     if model is not None:
         state["model"] = model
         state["dimension"] = _MODEL_DIMS.get(model, state.get("dimension", 0))

--- a/packages/memtomem/src/memtomem/cli/init_presets.py
+++ b/packages/memtomem/src/memtomem/cli/init_presets.py
@@ -1,0 +1,112 @@
+"""Preset specs for the ``mm init`` quick-setup flow.
+
+The preset picker (new default path in ``mm init``) lets users pick a
+pre-configured bundle of embedding / reranker / tokenizer / namespace
+values instead of stepping through the full 10-step wizard. The advanced
+path remains available via the picker's ``Advanced`` entry or
+``mm init --advanced``.
+
+Presets are branded product defaults — not user-injected fragments — so
+they live in source (typed, mypy-checkable, pinned via ``_VALID_PRESETS``)
+rather than in ``~/.memtomem/config.d/``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, get_args
+
+PresetName = Literal["minimal", "english", "korean"]
+
+# Derived from ``PresetName`` — do NOT edit independently. Pattern mirrors
+# ``_VALID_PROVIDER_CATEGORIES`` in ``config.py:1062``. Adding a preset
+# means adding it to the ``Literal`` above; the frozenset and the pin test
+# ``test_valid_presets_frozenset_matches_literal`` pick it up for free.
+_VALID_PRESETS: frozenset[str] = frozenset(get_args(PresetName))
+
+
+@dataclass(frozen=True)
+class PresetSpec:
+    """Bundled defaults applied by a single preset selection.
+
+    Every field maps directly onto the flat state keys written by the
+    existing ``_step_*`` functions, so ``_apply_preset`` is a simple
+    dict-populate pass through the same ``_write_config_and_summary``
+    merge path the interactive wizard uses.
+    """
+
+    label: str
+    description: str
+    provider: str
+    model: str
+    dimension: int
+    rerank_enabled: bool
+    rerank_model: str | None
+    tokenizer: str
+    default_top_k: int
+    enable_auto_ns: bool
+    default_namespace: str
+    decay_enabled: bool
+    autodetect_providers: bool
+
+
+PRESETS: dict[PresetName, PresetSpec] = {
+    "minimal": PresetSpec(
+        label="Minimal",
+        description="BM25 keyword search — no downloads, no dependencies",
+        provider="none",
+        model="",
+        dimension=0,
+        rerank_enabled=False,
+        rerank_model=None,
+        tokenizer="unicode61",
+        default_top_k=10,
+        enable_auto_ns=False,
+        default_namespace="default",
+        decay_enabled=False,
+        autodetect_providers=False,
+    ),
+    "english": PresetSpec(
+        label="English (Recommended)",
+        description="ONNX bge-small-en-v1.5 + English rerank + auto-discover providers",
+        provider="onnx",
+        model="bge-small-en-v1.5",
+        dimension=384,
+        rerank_enabled=True,
+        rerank_model="Xenova/ms-marco-MiniLM-L-6-v2",
+        tokenizer="unicode61",
+        default_top_k=10,
+        enable_auto_ns=True,
+        default_namespace="default",
+        decay_enabled=False,
+        autodetect_providers=True,
+    ),
+    "korean": PresetSpec(
+        label="Korean-optimized",
+        description="ONNX bge-m3 + kiwipiepy tokenizer + multilingual rerank",
+        provider="onnx",
+        model="bge-m3",
+        dimension=1024,
+        rerank_enabled=True,
+        rerank_model="jinaai/jina-reranker-v2-base-multilingual",
+        tokenizer="kiwipiepy",
+        default_top_k=10,
+        enable_auto_ns=True,
+        default_namespace="default",
+        decay_enabled=False,
+        autodetect_providers=True,
+    ),
+}
+
+
+def get_preset(name: str) -> PresetSpec:
+    """Return the ``PresetSpec`` for ``name`` or raise ``ValueError``.
+
+    ``click.Choice`` already blocks invalid CLI input; this wrapper gives
+    programmatic callers (tests, future reuse) an explicit error listing
+    the valid names instead of a bare ``KeyError``.
+    """
+    try:
+        return PRESETS[name]  # type: ignore[index]
+    except KeyError as e:
+        raise ValueError(f"unknown preset: {name!r}; valid: {sorted(_VALID_PRESETS)}") from e

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1792,6 +1792,47 @@ class TestPresetSelection:
         # tokenizer still kiwipiepy from the preset — not overridden.
         assert data["search"]["tokenizer"] == "kiwipiepy"
 
+    def test_override_same_provider_preserves_preset_model(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--preset korean --provider onnx -y`` — ``--provider`` re-states
+        the preset's own provider, so the default-model reset must NOT fire.
+        Regression for a clobber where same-provider override dropped
+        korean's bge-m3 back to onnx's ``all-MiniLM-L6-v2`` default."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--preset",
+                "korean",
+                "--provider",
+                "onnx",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        # Preset's model/dimension survive because the provider didn't change.
+        assert data["embedding"]["provider"] == "onnx"
+        assert data["embedding"]["model"] == "bge-m3"
+        assert data["embedding"]["dimension"] == 1024
+        assert data["search"]["tokenizer"] == "kiwipiepy"
+
     def test_preset_plus_explicit_flag_override_interactive(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1627,3 +1627,403 @@ class TestProviderPresetRules:
                     f"namespace {namespace!r} uses a placeholder outside "
                     f"_VALID_PRESET_PLACEHOLDERS={_VALID_PRESET_PLACEHOLDERS}"
                 )
+
+
+def test_valid_presets_frozenset_matches_literal() -> None:
+    """``_VALID_PRESETS`` is derived from ``get_args(PresetName)``; adding a
+    preset means changing the Literal, and the frozenset picks it up via
+    the shared ``get_args`` path. Mirrors
+    :func:`test_provider_category_literal_matches_frozenset` for the
+    preset vocabulary."""
+    from typing import get_args
+
+    from memtomem.cli.init_presets import PresetName, _VALID_PRESETS
+
+    assert set(get_args(PresetName)) == _VALID_PRESETS
+
+
+class TestPresetSelection:
+    """``mm init`` preset picker and ``--preset`` / ``--advanced`` flags."""
+
+    def test_minimal_preset_applies_bm25_only(self) -> None:
+        """Minimal preset keeps the no-download baseline: provider=none,
+        no reranker, unicode61 tokenizer."""
+        from memtomem.cli.init_cmd import _apply_preset
+
+        state: dict = {}
+        _apply_preset(state, "minimal")
+
+        assert state["provider"] == "none"
+        assert state["model"] == ""
+        assert state["dimension"] == 0
+        assert state["rerank_enabled"] is False
+        assert state["tokenizer"] == "unicode61"
+        assert state["enable_auto_ns"] is False
+        assert state["_preset_applied"] == "minimal"
+
+    def test_english_preset_applies_onnx_and_rerank(self) -> None:
+        """English preset: ONNX bge-small-en-v1.5 + English rerank +
+        auto-discover providers (the recommended default)."""
+        from memtomem.cli.init_cmd import _apply_preset
+
+        state: dict = {}
+        _apply_preset(state, "english")
+
+        assert state["provider"] == "onnx"
+        assert state["model"] == "bge-small-en-v1.5"
+        assert state["dimension"] == 384
+        assert state["rerank_enabled"] is True
+        assert state["rerank_model"] == "Xenova/ms-marco-MiniLM-L-6-v2"
+        assert state["tokenizer"] == "unicode61"
+        assert state["enable_auto_ns"] is True
+
+    def test_korean_preset_applies_bge_m3_and_kiwipiepy(self) -> None:
+        """Korean preset: ONNX bge-m3 + kiwipiepy tokenizer + multilingual
+        reranker (the Korean-optimized bundle)."""
+        from memtomem.cli.init_cmd import _apply_preset
+
+        state: dict = {}
+        _apply_preset(state, "korean")
+
+        assert state["provider"] == "onnx"
+        assert state["model"] == "bge-m3"
+        assert state["dimension"] == 1024
+        assert state["rerank_enabled"] is True
+        assert state["rerank_model"] == "jinaai/jina-reranker-v2-base-multilingual"
+        assert state["tokenizer"] == "kiwipiepy"
+        assert state["enable_auto_ns"] is True
+
+    def test_preset_flag_non_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm init --preset korean -y`` writes the Korean preset's fields
+        into config.json with no prompting."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--preset",
+                "korean",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert data["embedding"]["provider"] == "onnx"
+        assert data["embedding"]["model"] == "bge-m3"
+        assert data["embedding"]["dimension"] == 1024
+        assert data["rerank"]["model"] == "jinaai/jina-reranker-v2-base-multilingual"
+        assert data["search"]["tokenizer"] == "kiwipiepy"
+        assert data["namespace"]["enable_auto_ns"] is True
+
+    def test_preset_flag_rejects_unknown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Invalid preset names are rejected by ``click.Choice`` (exit 2)."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--preset",
+                "invalid-name",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "invalid" in result.output.lower()
+
+    def test_preset_plus_explicit_flag_override_non_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--preset korean --provider ollama -y`` — preset sets the baseline
+        then the explicit ``--provider`` flag wins; tokenizer stays kiwipiepy
+        since there's no ``--tokenizer`` override."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--preset",
+                "korean",
+                "--provider",
+                "ollama",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert data["embedding"]["provider"] == "ollama"
+        # model defaulted to ollama's nomic-embed-text since no --model given.
+        assert data["embedding"]["model"] == "nomic-embed-text"
+        # tokenizer still kiwipiepy from the preset — not overridden.
+        assert data["search"]["tokenizer"] == "kiwipiepy"
+
+    def test_preset_plus_explicit_flag_override_interactive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same precedence rule applies when ``--preset`` is combined with
+        explicit flags in interactive mode (picker skipped because --preset
+        is given). Review-raised #2: both paths must call the override
+        pass so the combination behaves consistently."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        # Interactive preset branch: feed memory_dir accept + create=Y + mcp=3.
+        result = runner.invoke(
+            init,
+            [
+                "--preset",
+                "korean",
+                "--provider",
+                "ollama",
+            ],
+            input=f"{tmp_path / 'memories'}\ny\n3\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        # Flag wins over preset in the interactive preset path too.
+        assert data["embedding"]["provider"] == "ollama"
+        assert data["embedding"]["model"] == "nomic-embed-text"
+        # And the preset's tokenizer is still there.
+        assert data["search"]["tokenizer"] == "kiwipiepy"
+
+    def test_preset_and_advanced_mutually_exclusive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--preset`` and ``--advanced`` can't both be set — the user has
+        to pick one path."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            ["--preset", "korean", "--advanced"],
+        )
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output.lower()
+
+    def test_advanced_flag_runs_full_wizard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--advanced`` forces the 10-step wizard and skips the preset
+        picker entirely."""
+        from click.testing import CliRunner
+
+        import memtomem.cli.init_cmd as init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        recorded: dict[str, object] = {}
+
+        def fake_run_steps(steps, state):  # type: ignore[no-untyped-def]
+            recorded["step_count"] = len(steps)
+            recorded["step_names"] = [s.__name__ for s in steps]
+            # Populate a valid state dict so _write_config_and_summary succeeds.
+            state.update(
+                {
+                    "provider": "none",
+                    "model": "",
+                    "dimension": 0,
+                    "api_key": "",
+                    "rerank_enabled": False,
+                    "memory_dir": str(tmp_path / "memories"),
+                    "db_path": str(tmp_path / ".memtomem" / "memtomem.db"),
+                    "enable_auto_ns": False,
+                    "default_ns": "default",
+                    "top_k": 10,
+                    "tokenizer": "unicode61",
+                    "decay_enabled": False,
+                    "mcp_choice": 3,
+                    "settings_hooks": False,
+                    "provider_dirs": [],
+                    "provider_rules": [],
+                }
+            )
+
+        monkeypatch.setattr(init_cmd, "run_steps", fake_run_steps)
+
+        runner = CliRunner()
+        result = runner.invoke(init_cmd.init, ["--advanced"])
+        assert result.exit_code == 0, result.output
+
+        # Full 10-step wizard — not the 3-step preset follow-up.
+        assert recorded["step_count"] == 10
+        assert "_step_embedding" in recorded["step_names"]
+        assert "_step_reranker" in recorded["step_names"]
+        assert "_step_preset_picker" not in recorded["step_names"]
+
+    def test_provider_dirs_auto_with_no_detection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh machine with no Claude/Codex dirs — preset path emits an
+        explicit banner, not a silent skip (review #3)."""
+        from memtomem.cli.init_cmd import _apply_preset, _step_provider_dirs_auto
+
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        state: dict = {}
+        _apply_preset(state, "english")
+
+        # Capture click.echo output by running through a CliRunner-style
+        # isolated context; simpler: just call and assert state + rely on
+        # coverage (banner is cosmetic). Contract: empty lists, no crash.
+        _step_provider_dirs_auto(state)
+        assert state["provider_dirs"] == []
+        assert state["provider_rules"] == []
+
+    def test_non_tty_without_flag_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without ``--preset`` / ``-y`` / ``--advanced``, a non-TTY
+        invocation must error cleanly — not hang trying to read a
+        prompt from a closed stdin (review #5)."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        runner = CliRunner()
+        # CliRunner's stdin is a pipe → isatty() == False.
+        result = runner.invoke(init, [])
+        assert result.exit_code != 0
+        assert "non-interactive terminal" in result.output.lower()
+
+    def test_non_tty_with_y_flag_runs_minimal(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm init -y`` with no other flags still behaves as
+        ``--preset minimal -y`` — existing scripted callers unchanged."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        # Minimal defaults: BM25-only, no reranker.
+        assert data["embedding"]["provider"] == "none"
+        assert data["embedding"]["dimension"] == 0
+        assert "rerank" not in data
+        assert data["search"]["tokenizer"] == "unicode61"
+
+    def test_get_preset_raises_value_error_for_unknown(self) -> None:
+        """``click.Choice`` blocks invalid CLI input; the in-process helper
+        surfaces a clear ``ValueError`` listing valid names for programmatic
+        callers (tests, future reuse)."""
+        from memtomem.cli.init_presets import _VALID_PRESETS, get_preset
+
+        with pytest.raises(ValueError) as exc:
+            get_preset("nonsense")
+        assert "nonsense" in str(exc.value)
+        for name in _VALID_PRESETS:
+            assert name in str(exc.value)
+
+    def test_preset_rerun_preserves_non_init_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-running ``mm init --preset korean -y`` on a config with a
+        user-added ``mmr.enabled=true`` must leave ``mmr`` intact — preset
+        path inherits the ``_write_config_and_summary`` read-merge-write
+        contract covered by :class:`TestInitConfigMerge`."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        config_path = config_dir / "config.json"
+        config_path.write_text(
+            json.dumps({"mmr": {"enabled": True, "lambda_param": 0.3}}),
+            encoding="utf-8",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            init,
+            [
+                "--non-interactive",
+                "--preset",
+                "korean",
+                "--memory-dir",
+                str(tmp_path / "memories"),
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads(config_path.read_text(encoding="utf-8"))
+        assert data["embedding"]["model"] == "bge-m3"  # preset applied
+        assert data["mmr"]["enabled"] is True  # non-init field survived
+        assert data["mmr"]["lambda_param"] == 0.3


### PR DESCRIPTION
## Summary

- `mm init` now opens with an interactive preset picker — **Minimal** (BM25 only, no downloads), **English (Recommended)** (ONNX `bge-small-en-v1.5` + English reranker + auto-discover providers), **Korean-optimized** (ONNX `bge-m3` + `kiwipiepy` + multilingual reranker), plus an **Advanced** entry that runs the full 10-step wizard. Preset paths only ask for `memory_dir` + MCP registration, cutting first-time setup from 10 prompts to 2.
- Scripted equivalents: `--preset <name>` (mutually exclusive with `--advanced`); `mm init -y` alone remains `--preset minimal -y` — existing CI/automation unchanged. Explicit `--provider` / `--model` / `--tokenizer` / etc. override the preset baseline in both interactive and non-interactive paths.
- Default interactive invocation on a non-TTY (piped stdin, no flags) now exits with a usage error pointing at `--preset` / `-y`, instead of hanging on a closed prompt.

## Files

- **New** `packages/memtomem/src/memtomem/cli/init_presets.py` — `PresetName` Literal, `_VALID_PRESETS` frozenset (derived via `get_args`, same pattern as `_VALID_PROVIDER_CATEGORIES`), `PresetSpec` dataclass, `PRESETS` dict, `get_preset()` helper.
- **Modified** `packages/memtomem/src/memtomem/cli/init_cmd.py` — `_step_preset_picker`, `_apply_preset`, `_step_provider_dirs_auto`, `_override_from_flags`, `_resolve_provider_dirs_non_interactive`; `--preset` / `--advanced` CLI flags with mutex guard; dispatch rewrite routing through the preset path by default. The existing 10 `_step_*` functions are unchanged (Advanced regression risk = 0).
- **Modified** `packages/memtomem/tests/test_init_cmd.py` — new `TestPresetSelection` class (13 tests) + `test_valid_presets_frozenset_matches_literal` pin test.
- **Modified** `README.md`, `packages/memtomem/README.md`, `docs/guides/getting-started.md`, `CHANGELOG.md` — preset landing + backward-compat note (per the same-PR docs-fanout rule).

## Test plan

- [x] `uv run pytest -m "not ollama"` → **1949 passed**, 0 regressions (includes 14 new preset tests).
- [x] `uv run ruff check packages/memtomem` + `ruff format --check` → all green.
- [x] `uv run mypy packages/memtomem/src` → 0 errors.
- [x] Manual smoke: `HOME=/tmp/x mm init --preset korean -y ...` → config.json lands with `embedding.model=bge-m3` (dim=1024) + `rerank.model=jinaai/jina-reranker-v2-base-multilingual` + `search.tokenizer=kiwipiepy` + `namespace.enable_auto_ns=true`.
- [x] Manual smoke: bare `mm init -y ...` summary output is byte-identical to `--preset minimal -y ...` (backward compat).
- [ ] Post-review: worktree interactive smoke (`HOME=... uv run mm init` → pick picker options 1/2/3/4, verify each path).
- [ ] Post-review: TestPyPI dry-run before the next production `v*` tag (user-visible CLI change — `feedback_prerelease_dry_run.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
