### PR TITLE
release: v0.1.14 — mm init preset picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.14] — 2026-04-21
+
+memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces
+may still shift between 0.1.x releases — external feedback and issue
+reports are especially welcome at
+[github.com/memtomem/memtomem/issues](https://github.com/memtomem/memtomem/issues).
+
 ### Added
 - **`mm init` preset picker**: interactive `mm init` now opens with a preset
   picker (`Minimal` / `English (Recommended)` / `Korean-optimized`) plus an
@@ -13,10 +20,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   reranker / tokenizer / namespace defaults come from the preset bundle.
   New CLI flags `--preset <name>` and `--advanced` expose the same choices
   non-interactively; `--preset` and `--advanced` are mutually exclusive.
+  (#326)
 - **Non-TTY guard for `mm init`**: running the default interactive path
   with piped stdin (no `--preset`, no `--advanced`, no `-y`) now exits
   cleanly with a usage error pointing at those flags, instead of hanging
-  on a closed prompt.
+  on a closed prompt. (#326)
 
 ### Changed
 - **`mm init -y` behavior**: scripted `mm init -y` (with no other flags)
@@ -25,6 +33,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   existing CI / automation calls continue to work unchanged. Existing
   explicit flags (`--provider`, `--model`, `--tokenizer`, ...) override
   the preset baseline in both interactive and non-interactive paths.
+  (#326)
 
 ## [0.1.13] — 2026-04-20
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.13"
+version = "0.1.14"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Version bump PR for the 0.1.14 release. Companion to the feature merged via #326 (preset picker for `mm init`).

- `packages/memtomem/pyproject.toml`: `0.1.13` → `0.1.14`
- `uv.lock`: workspace `[[package]] memtomem` entry bumped in the same commit so `uv sync` / `uv pip install -e` picks up the new version without a resolver round-trip (per the 0.1.10 → 0.1.11 lesson captured in `feedback_uv_lock_version_sync.md` / #263→#265).
- `CHANGELOG.md`: move the `[Unreleased]` block into a new `[0.1.14] — 2026-04-21` section with the alpha disclaimer and `(#326)` PR refs, leaving an empty `[Unreleased]` placeholder for the next cycle.

No code / behavior changes in this PR — all user-facing changes already landed via #326.

## Next steps (post-merge)

1. Tag `test-v0.1.14` → TestPyPI via trusted publisher (OIDC).
2. Fresh install from TestPyPI + `mm init --preset english -y` smoke (mirrors `/tmp/mm-smoke-eng` verification from #326 on a clean install).
3. Tag `v0.1.14` → production PyPI + GitHub Release (env approval required).

Workflow mirrors the 0.1.13 release (see `project_release_workflow.md`).

## Test plan

- [x] `uv lock --check` — lock file consistent, no drift.
- [x] `grep -rn "0\\.1\\.13"` across `.toml` files — no stale references.
- [ ] CI green on this PR before tag push.
- [ ] Post-merge TestPyPI smoke before production tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
