### PR TITLE
fix(cli): show OS-appropriate Claude Desktop config path in mm init paste hints

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -536,6 +536,19 @@ def _step_mcp(state: dict) -> None:
     click.echo()
 
 
+def _claude_desktop_config_hint() -> str:
+    """Return the Claude Desktop config path for the current OS.
+
+    Claude Desktop is the only editor in ``_emit_mcp_paste_hints`` whose
+    config location is OS-specific; Cursor / Windsurf / Gemini CLI all use
+    a single ``~/<dot-dir>/...`` layout that works on every platform."""
+    if sys.platform == "darwin":
+        return "~/Library/Application Support/Claude/claude_desktop_config.json"
+    if sys.platform == "win32":
+        return r"%APPDATA%\Claude\claude_desktop_config.json"
+    return "~/.config/Claude/claude_desktop_config.json"
+
+
 def _emit_mcp_paste_hints() -> None:
     """Print per-editor paste targets for the generated ``.mcp.json``.
 
@@ -545,10 +558,7 @@ def _emit_mcp_paste_hints() -> None:
     for Cursor/Windsurf/Claude Desktop/Gemini CLI."""
     click.echo("    Cursor          → paste into ~/.cursor/mcp.json")
     click.echo("    Windsurf        → paste into ~/.codeium/windsurf/mcp_config.json")
-    click.echo(
-        "    Claude Desktop  → paste into "
-        "~/Library/Application Support/Claude/claude_desktop_config.json"
-    )
+    click.echo(f"    Claude Desktop  → paste into {_claude_desktop_config_hint()}")
     click.echo("    Gemini CLI      → paste into ~/.gemini/settings.json")
     click.echo("  (Claude Code picks up ./.mcp.json in this project automatically.)")
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -769,7 +769,7 @@ class TestMcpPasteHints:
     ) -> None:
         from click import unstyle
 
-        from memtomem.cli.init_cmd import _write_config_and_summary
+        from memtomem.cli.init_cmd import _claude_desktop_config_hint, _write_config_and_summary
 
         monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
@@ -783,7 +783,7 @@ class TestMcpPasteHints:
         assert "Cursor" in out and "~/.cursor/mcp.json" in out
         assert "Windsurf" in out and "~/.codeium/windsurf/mcp_config.json" in out
         assert "Claude Desktop" in out
-        assert "Library/Application Support/Claude/claude_desktop_config.json" in out
+        assert _claude_desktop_config_hint() in out
         assert "Gemini CLI" in out and "~/.gemini/settings.json" in out
         assert "Claude Code picks up ./.mcp.json in this project automatically" in out
 
@@ -829,6 +829,56 @@ class TestMcpPasteHints:
         assert "(for Cursor, Windsurf, etc.)" not in out, "old auto-compat wording leaked back in"
         assert "Claude Code project scope" in out
         assert "copy into your editor's config file" in out
+
+
+class TestClaudeDesktopConfigHint:
+    """The Claude Desktop paste-hint must point at the real Claude Desktop
+    config path for the user's OS, not the macOS-only path that used to be
+    hardcoded.
+
+    Regression for #328: Linux/Windows users following the old hint created
+    an unused file at a macOS-specific path and left their real Claude
+    Desktop config untouched."""
+
+    @pytest.mark.parametrize(
+        "platform,expected",
+        [
+            ("darwin", "~/Library/Application Support/Claude/claude_desktop_config.json"),
+            ("linux", "~/.config/Claude/claude_desktop_config.json"),
+            ("linux2", "~/.config/Claude/claude_desktop_config.json"),
+            ("freebsd14", "~/.config/Claude/claude_desktop_config.json"),
+            ("win32", r"%APPDATA%\Claude\claude_desktop_config.json"),
+        ],
+    )
+    def test_helper_returns_per_os_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        platform: str,
+        expected: str,
+    ) -> None:
+        from memtomem.cli.init_cmd import _claude_desktop_config_hint
+
+        monkeypatch.setattr("memtomem.cli.init_cmd.sys.platform", platform)
+
+        assert _claude_desktop_config_hint() == expected
+
+    def test_emit_hints_does_not_leak_darwin_path_on_linux(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Negative guard for the actual bug — `_emit_mcp_paste_hints` must
+        not echo the macOS ``Library/Application Support`` path on Linux."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _emit_mcp_paste_hints
+
+        monkeypatch.setattr("memtomem.cli.init_cmd.sys.platform", "linux")
+        _emit_mcp_paste_hints()
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Library/Application Support" not in out
+        assert "~/.config/Claude/claude_desktop_config.json" in out
 
 
 class TestProviderDirsStep:


### PR DESCRIPTION
## Summary

- Adds `_claude_desktop_config_hint()` that returns the Claude Desktop config path for the current OS (`sys.platform` → darwin / win32 / else).
- Wires it into `_emit_mcp_paste_hints()` so Linux and Windows users see the correct path after `mm init` option 2.

## Why

The `mm init` wizard's MCP paste-hint block hardcoded `~/Library/Application Support/Claude/claude_desktop_config.json` — the macOS-only location. A user on:

- **Linux** should paste into `~/.config/Claude/claude_desktop_config.json`
- **Windows** should paste into `%APPDATA%\Claude\claude_desktop_config.json`

Following the old hint on either platform creates an unused file in a macOS-specific path and leaves their real Claude Desktop config untouched.

Cursor / Windsurf / Gemini CLI hints are unchanged — those use a single `~/<dot-dir>/...` layout that works on every OS.

Mirrors memtomem/memtomem-stm#219.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 1956 passed (6 new in `TestClaudeDesktopConfigHint` covering darwin / linux / linux2 / freebsd14 / win32 + integration via `_emit_mcp_paste_hints` with a negative `"Library/Application Support" not in out` assertion).
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)
