### PR TITLE
feat(cli): add `mm --version` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm --version` flag** — Click's idiomatic entry point for version output,
+  added via `click.version_option` at the group level. Emits
+  `memtomem X.Y.Z`. (#330)
+
 ## [0.1.14] — 2026-04-21
 
 memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -9,6 +9,11 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
+@click.version_option(
+    package_name="memtomem",
+    prog_name="memtomem",
+    message="%(prog)s %(version)s",
+)
 def cli() -> None:
     """memtomem — markdown-first memory infrastructure for AI agents."""
 

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -45,6 +45,11 @@ class TestCLIGroup:
         assert result.exit_code == 0
         assert "markdown-first memory infrastructure" in result.output
 
+    def test_version_flag_prints_package_version(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert result.output.strip().startswith("memtomem ")
+
     def test_registered_subcommands(self, runner: CliRunner) -> None:
         """All expected subcommands appear in help output."""
         result = runner.invoke(cli, ["--help"])


### PR DESCRIPTION
## Summary

Add `mm --version` via Click's `version_option` on the top-level group. Emits `memtomem X.Y.Z` from the installed package metadata.

- Single decorator added at `packages/memtomem/src/memtomem/cli/__init__.py` — no subcommand introduced. LTM has no prior `mm version` surface to preserve (unlike sibling `memtomem-stm` which has both subcommand since memtomem-stm#152 and the flag pending in memtomem-stm#220), so the flag alone keeps the CLI minimal.
- Additive: no existing output, exit code, or flag shape changes.

Closes #330.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_cli.py -k "version or help or registered"` — 18 passed (1 new: `test_version_flag_prints_package_version`)
- [x] `uv run ruff check packages/memtomem` + `ruff format --check packages/memtomem` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/__init__.py` — clean (advisory)
- [x] Manual: `uv run mm --version` → `memtomem 0.1.14`
- [x] Manual: `uv run mm -h` — `--version` line appears above `-h, --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
