### PR TITLE
docs(contrib): CLI output convention + `--json` alias on `mm config show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **`mm --version` flag** — Click's idiomatic entry point for version output,
   added via `click.version_option` at the group level. Emits
   `memtomem X.Y.Z`. (#330)
+- **`mm config show --json`** — alias of `--format json`, added to align with
+  the documented CLI output convention (binary human/machine scenario uses
+  `--json`). Both flag forms emit identical output. (#332)
+
+### Changed
+
+- **Documented CLI output convention** — `CONTRIBUTING.md` now spells out
+  when to use `--json` (binary scenario) vs `--format [table|json|...]`
+  (genuine non-JSON modes like `plain` / `context` / `smart`), with a
+  forward-compatibility guidance to prefer `--format` when a command might
+  grow additional modes later. (#332)
 
 ## [0.1.14] — 2026-04-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,30 @@ exceptions in the decorator or by adding a response filter. Changing the
 deployment model without addressing this turns error messages into an
 information disclosure surface.
 
+## CLI output convention
+
+When a CLI command needs machine-readable output, pick the option shape by
+the command's output semantics, not by parity with any particular existing
+command:
+
+| When | Use |
+|------|-----|
+| The only meaningful alternative to default human-readable output is JSON (binary "human vs machine" scenario) | `--json` flag |
+| There are genuine non-JSON output modes beyond cosmetic variants — e.g. `plain`, `context`, `smart`, `diff` | `--format [table\|json\|...]` |
+
+Examples in the current CLI:
+
+- `--json` — `mm watchdog status`, `mm watchdog run`, `mm config show`
+  (alias of `--format json`).
+- `--format` — `mm search` (has `context`, `smart`), `mm recall` (has
+  `plain`), `mm config show` (keeps the original option alongside
+  `--json`).
+
+**If the two-mode nature of a new command is uncertain** — i.e. it's
+plausible a `context` / `digest` / `diff` mode gets added later — choose
+`--format` from the start. Migrating from `--json` flag to `--format` is a
+breaking change for scripts; going the other way isn't necessary.
+
 ## Contributor License Agreement (CLA)
 
 Before we can merge your first pull request, you need to sign the

--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -26,9 +26,16 @@ def config() -> None:
 
 @config.command("show")
 @click.option("--format", "fmt", type=click.Choice(["table", "json"]), default="table")
-def config_show(fmt: str) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Shortcut for --format json.")
+def config_show(fmt: str, *, as_json: bool = False) -> None:
     """Show current configuration (API keys masked)."""
     from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+
+    # --json is an alias for --format json (CONTRIBUTING "CLI output
+    # convention"); if both are passed, --json wins since it's the more
+    # specific intent.
+    if as_json:
+        fmt = "json"
 
     cfg = Mem2MemConfig()
     load_config_d(cfg)

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -145,6 +145,24 @@ class TestConfigCLI:
         assert result.exit_code == 0
         assert '"default_top_k": 10' in result.output
 
+    @patch("memtomem.config.load_config_overrides")
+    @patch("memtomem.config.Mem2MemConfig")
+    def test_config_show_json_flag_matches_format_json(
+        self, mock_cfg_cls, mock_load, runner: CliRunner
+    ) -> None:
+        """--json is a documented alias for --format json (CONTRIBUTING "CLI
+        output convention"). Both paths must emit identical output so the
+        alias can't quietly diverge."""
+        mock_cfg = MagicMock()
+        mock_cfg.model_dump.return_value = {"search": {"default_top_k": 10}}
+        mock_cfg_cls.return_value = mock_cfg
+
+        flag = runner.invoke(cli, ["config", "show", "--json"])
+        fmt = runner.invoke(cli, ["config", "show", "--format", "json"])
+        assert flag.exit_code == 0
+        assert fmt.exit_code == 0
+        assert flag.output == fmt.output
+
     def test_config_set_bad_key_format(self, runner: CliRunner) -> None:
         """Key without a dot separator is rejected."""
         result = runner.invoke(cli, ["config", "set", "noperiod", "10"])


### PR DESCRIPTION
## Summary

Codifies the `--json` flag vs `--format [table|json|...]` choice that came out of the discussion in #332, and removes the day-one grandfathered exception by adding `--json` as an alias of `--format json` on `mm config show`.

- **`CONTRIBUTING.md`** — new "CLI output convention" section stating the rule in semantic terms (binary human/machine → `--json`; genuine non-JSON modes like `plain`/`context`/`smart` → `--format`), plus a forward-compatibility guidance: prefer `--format` from the start when the two-mode nature of a new command is uncertain, since migrating from `--json` to `--format` breaks scripts.
- **`mm config show --json`** — 3-line additive alias of `--format json`. Both flag forms emit identical output (pinned by `test_config_show_json_flag_matches_format_json`).
- Nothing existing breaks — `--format` continues to work on every command that had it.

Closes #332.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_cli.py::TestConfigCLI -v` — 12 passed (1 new: `test_config_show_json_flag_matches_format_json`)
- [x] `uv run ruff check packages/memtomem` + `ruff format --check packages/memtomem` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/config_cmd.py` — clean (advisory)
- [x] Manual: `uv run mm config show --help` — `--json  Shortcut for --format json.` line present
- [x] Manual: `uv run mm config show --json` and `--format json` produce identical JSON output

## Follow-up

#331 (`session list`/`events`, `activity log` scripting output) proceeds with `--json` flag per the newly-documented rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
