### PR TITLE
feat(cli): add `--json` to `mm session list` and `mm session events`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **`mm config show --json`** — alias of `--format json`, added to align with
   the documented CLI output convention (binary human/machine scenario uses
   `--json`). Both flag forms emit identical output. (#332)
+- **`mm session list --json`** — scriptable JSON output for the session list,
+  emitting `{sessions: [...], count: N}`. Closes the parity gap where
+  `watchdog` and `config show` were already scriptable but `session list`
+  required parsing the text table. (#331)
+- **`mm session events --json`** — same treatment for per-session event
+  output, emitting `{session_id, events: [...], count: N}`. When invoked
+  without a session argument and no active session, returns
+  `{error: "no_session"}` on stdout (exit 0) so scripts can parse the
+  failure instead of getting a Click exit-1 + stderr line. Text path is
+  unchanged. (#331)
 
 ### Changed
 

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -134,19 +134,38 @@ async def _end(session_id: str, summary: str | None, auto_summary: bool) -> None
 @click.option("--agent-id", "-a", default=None, help="Filter by agent ID")
 @click.option("--since", default=None, help="Filter by start date (YYYY-MM-DD)")
 @click.option("--limit", "-l", default=20, help="Max results")
-def list_sessions(agent_id: str | None, since: str | None, limit: int) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
+def list_sessions(
+    agent_id: str | None, since: str | None, limit: int, *, as_json: bool = False
+) -> None:
     """List sessions."""
     try:
-        asyncio.run(_list_sessions(agent_id, since, limit))
+        asyncio.run(_list_sessions(agent_id, since, limit, as_json=as_json))
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
 
-async def _list_sessions(agent_id: str | None, since: str | None, limit: int) -> None:
+async def _list_sessions(
+    agent_id: str | None, since: str | None, limit: int, *, as_json: bool = False
+) -> None:
     from memtomem.cli._bootstrap import cli_components
 
     async with cli_components() as comp:
         sessions = await comp.storage.list_sessions(agent_id=agent_id, since=since, limit=limit)
+
+    if as_json:
+        payload = [
+            {
+                "id": s["id"],
+                "agent_id": s["agent_id"],
+                "started_at": s["started_at"],
+                "ended_at": s["ended_at"],
+                "status": "ended" if s["ended_at"] else "active",
+            }
+            for s in sessions
+        ]
+        click.echo(json.dumps({"sessions": payload, "count": len(payload)}, indent=2))
+        return
 
     if not sessions:
         click.echo("No sessions found.")
@@ -163,23 +182,47 @@ async def _list_sessions(agent_id: str | None, since: str | None, limit: int) ->
 
 @session.command()
 @click.argument("session_id", default="")
-def events(session_id: str) -> None:
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON for scripting.")
+def events(session_id: str, *, as_json: bool = False) -> None:
     """Show events for a session. Uses current session if no ID given."""
     if not session_id:
         session_id = _read_current_session() or ""
     if not session_id:
+        # JSON callers get a parseable error shape instead of a Click exit-1
+        # so ``mm session events --json | jq`` doesn't break when no session
+        # is active. Text callers keep the original ClickException path.
+        if as_json:
+            click.echo(json.dumps({"error": "no_session"}))
+            return
         raise click.ClickException("No session ID provided and no active session.")
     try:
-        asyncio.run(_events(session_id))
+        asyncio.run(_events(session_id, as_json=as_json))
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
 
-async def _events(session_id: str) -> None:
+async def _events(session_id: str, *, as_json: bool = False) -> None:
     from memtomem.cli._bootstrap import cli_components
 
     async with cli_components() as comp:
         evts = await comp.storage.get_session_events(session_id)
+
+    if as_json:
+        payload = [
+            {
+                "created_at": ev["created_at"],
+                "event_type": ev["event_type"],
+                "content": ev["content"],
+            }
+            for ev in evts
+        ]
+        click.echo(
+            json.dumps(
+                {"session_id": session_id, "events": payload, "count": len(payload)},
+                indent=2,
+            )
+        )
+        return
 
     if not evts:
         click.echo("No events for this session.")

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -1,0 +1,123 @@
+"""Tests for ``mm session list/events --json`` scripting output (#331)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+
+def _mock_components(*, sessions=None, events=None):
+    storage = SimpleNamespace(
+        list_sessions=AsyncMock(return_value=list(sessions or [])),
+        get_session_events=AsyncMock(return_value=list(events or [])),
+    )
+    return SimpleNamespace(storage=storage)
+
+
+def _patched_cli_components(comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestSessionListJson:
+    def test_happy_path(self, runner, monkeypatch):
+        comp = _mock_components(
+            sessions=[
+                {
+                    "id": "sess-1",
+                    "agent_id": "claude",
+                    "started_at": "2026-04-21T12:00:00",
+                    "ended_at": "2026-04-21T13:00:00",
+                },
+                {
+                    "id": "sess-2",
+                    "agent_id": "codex",
+                    "started_at": "2026-04-21T14:00:00",
+                    "ended_at": None,
+                },
+            ]
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["count"] == 2
+        assert [s["id"] for s in data["sessions"]] == ["sess-1", "sess-2"]
+        assert data["sessions"][0]["status"] == "ended"
+        assert data["sessions"][1]["status"] == "active"
+
+    def test_empty(self, runner, monkeypatch):
+        comp = _mock_components(sessions=[])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"sessions": [], "count": 0}
+
+
+class TestSessionEventsJson:
+    def test_happy_path(self, runner, monkeypatch):
+        comp = _mock_components(
+            events=[
+                {
+                    "created_at": "2026-04-21T12:00:00",
+                    "event_type": "tool_call",
+                    "content": "ran tests",
+                },
+            ]
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "events", "sess-1", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["session_id"] == "sess-1"
+        assert data["count"] == 1
+        assert data["events"][0]["event_type"] == "tool_call"
+
+    def test_empty(self, runner, monkeypatch):
+        comp = _mock_components(events=[])
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "events", "sess-empty", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"session_id": "sess-empty", "events": [], "count": 0}
+
+    def test_no_session_returns_error_shape(self, runner, monkeypatch):
+        """With --json and no session_id argument + no active session, emit a
+        parseable error shape on stdout (exit 0) instead of the text-path
+        ClickException. Lets ``mm session events --json | jq`` degrade
+        gracefully when nothing is active."""
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: None)
+
+        result = runner.invoke(cli, ["session", "events", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"error": "no_session"}
+
+    def test_no_session_text_path_unchanged(self, runner, monkeypatch):
+        """Without --json, the no-session path still raises ClickException so
+        existing text callers aren't silently degraded."""
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: None)
+
+        result = runner.invoke(cli, ["session", "events"])
+        assert result.exit_code != 0
+        assert "No session ID provided" in result.output


### PR DESCRIPTION
## Summary

Adds `--json` to `mm session list` and `mm session events`, following the CLI output convention documented in #332 (binary human/machine scenario → `--json` flag).

Shapes:

- `mm session list --json` → `{sessions: [...], count: N}` where each session has `id`, `agent_id`, `started_at`, `ended_at`, `status`.
- `mm session events [SESSION_ID] --json` → `{session_id, events: [...], count: N}`.

### Error path (`session events --json` with no session)

When `session events --json` is invoked without a `SESSION_ID` argument and there's no active session file, emit `{"error": "no_session"}` on stdout with exit 0 instead of the text-path `ClickException`. This mirrors the STM `list --json` missing-config shape and lets `mm session events --json | jq` degrade gracefully instead of getting empty stdin under `2>/dev/null`.

The text path (no `--json`) still raises `ClickException` — a regression test pins that so the two paths can't silently converge.

### `mm activity log` scope split

Originally grouped with this issue, but `activity log` is write-only and silent-by-design for hook callers (no meaningful output exists to add `--json` to). Defining its success output shape is a design decision rather than a parity fix, so it's split out into #335.

Closes #331.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_session_cli.py -v` — 6 passed (new file)
- [x] `uv run ruff check packages/memtomem` + `ruff format --check packages/memtomem` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/session_cmd.py` — clean (advisory)
- [x] Manual: `mm session list --json` → `{"sessions": [], "count": 0}` on empty
- [x] Manual: `mm session events --json` with no active session → `{"error": "no_session"}` + exit 0
- [x] Manual: `mm session events --help` shows `--json  Output as JSON for scripting.`

## Test count note

Plan called for 5 tests (4 + 1). Shipped 6 — added `test_no_session_text_path_unchanged` as a regression guard on the text path so adding `--json` can't silently flip the existing error semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
