### PR TITLE
feat(cli): add `--json` ack to `mm activity log`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `{error: "no_session"}` on stdout (exit 0) so scripts can parse the
   failure instead of getting a Click exit-1 + stderr line. Text path is
   unchanged. (#331)
+- **`mm activity log --json`** — scriptable ack output for hook-driven
+  event writes. Success: `{ok: true, session_id, event_type}`. No active
+  session: `{ok: false, reason: "no_active_session"}`. Write failure:
+  `{ok: false, reason: "write_failed"}`. Exit code is always 0 (the
+  silent-by-default hook contract is preserved without the flag). The
+  ok-flag shape intentionally differs from `session events --json`'s
+  `{error: ...}` — write acks have no natural disambiguator, so an
+  explicit `ok` discriminator is clearer for consumers. (#335)
 
 ### Changed
 

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -257,17 +257,33 @@ def activity() -> None:
 )
 @click.option("--content", "-c", required=True, help="Event description")
 @click.option("--meta", default=None, help="JSON metadata")
-def log_event(event_type: str, content: str, meta: str | None) -> None:
-    """Log an activity event to the current session."""
+@click.option("--json", "as_json", is_flag=True, help="Output a JSON ack for scripting.")
+def log_event(event_type: str, content: str, meta: str | None, *, as_json: bool = False) -> None:
+    """Log an activity event to the current session.
+
+    Silent by default so hook callers never fail. ``--json`` emits an ack
+    shape on stdout: ``{"ok": true, ...}`` on success, ``{"ok": false,
+    "reason": ...}`` when there is no active session or the write failed.
+    Exit code is always 0.
+    """
     session_id = _read_current_session()
     if not session_id:
-        # No active session — silently skip (hooks should not fail)
+        # No active session — silently skip (hooks should not fail).
+        # --json callers get a parseable skip ack so pipelines can tell
+        # "no session" apart from "event written".
+        if as_json:
+            click.echo(json.dumps({"ok": False, "reason": "no_active_session"}))
         return
     metadata = json.loads(meta) if meta else None
     try:
         asyncio.run(_log_event(session_id, event_type, content, metadata))
     except Exception:
         logger.warning("Activity hook failed", exc_info=True)
+        if as_json:
+            click.echo(json.dumps({"ok": False, "reason": "write_failed"}))
+        return
+    if as_json:
+        click.echo(json.dumps({"ok": True, "session_id": session_id, "event_type": event_type}))
 
 
 async def _log_event(session_id: str, event_type: str, content: str, metadata: dict | None) -> None:

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -1,4 +1,5 @@
-"""Tests for ``mm session list/events --json`` scripting output (#331)."""
+"""Tests for ``mm session list/events --json`` scripting output (#331) and
+``mm activity log --json`` ack output (#335)."""
 
 from __future__ import annotations
 
@@ -13,10 +14,11 @@ from click.testing import CliRunner
 from memtomem.cli import cli
 
 
-def _mock_components(*, sessions=None, events=None):
+def _mock_components(*, sessions=None, events=None, add_event=None):
     storage = SimpleNamespace(
         list_sessions=AsyncMock(return_value=list(sessions or [])),
         get_session_events=AsyncMock(return_value=list(events or [])),
+        add_session_event=add_event if add_event is not None else AsyncMock(return_value=None),
     )
     return SimpleNamespace(storage=storage)
 
@@ -121,3 +123,74 @@ class TestSessionEventsJson:
         result = runner.invoke(cli, ["session", "events"])
         assert result.exit_code != 0
         assert "No session ID provided" in result.output
+
+
+class TestActivityLogJson:
+    """``mm activity log --json`` is write-side, so the ack shape uses an
+    explicit ``ok`` discriminator (the success payload has no natural
+    disambiguator like ``events: [...]``). Error shape intentionally diverges
+    from ``session events --json``'s ``{"error": ...}`` for that reason —
+    see commit / PR body."""
+
+    def test_success_emits_ok_ack(self, runner, monkeypatch):
+        comp = _mock_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: "sess-1")
+
+        result = runner.invoke(
+            cli, ["activity", "log", "--type", "tool_call", "-c", "ran tests", "--json"]
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"ok": True, "session_id": "sess-1", "event_type": "tool_call"}
+        comp.storage.add_session_event.assert_awaited_once()
+
+    def test_no_active_session_emits_skip_ack(self, runner, monkeypatch):
+        """With --json and no active session, emit a parseable skip ack on
+        stdout (exit 0). Storage must not be touched."""
+        comp = _mock_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: None)
+
+        result = runner.invoke(cli, ["activity", "log", "-c", "x", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"ok": False, "reason": "no_active_session"}
+        comp.storage.add_session_event.assert_not_awaited()
+
+    def test_write_failure_emits_error_ack(self, runner, monkeypatch):
+        """Storage exceptions are swallowed (hooks must not fail) but --json
+        surfaces them as ``{ok: false, reason: write_failed}``."""
+        failing_add = AsyncMock(side_effect=RuntimeError("db is locked"))
+        comp = _mock_components(add_event=failing_add)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: "sess-2")
+        # Silence logger.warning so the traceback doesn't bleed into CliRunner
+        # output and break the JSON parse. Hook-silent contract is already
+        # covered by test_text_path_silent_on_success.
+        monkeypatch.setattr("memtomem.cli.session_cmd.logger.warning", lambda *a, **kw: None)
+
+        result = runner.invoke(cli, ["activity", "log", "-c", "boom", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"ok": False, "reason": "write_failed"}
+
+    def test_text_path_silent_on_success(self, runner, monkeypatch):
+        """Without --json the silent contract is preserved — no stdout, exit 0."""
+        comp = _mock_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: "sess-3")
+
+        result = runner.invoke(cli, ["activity", "log", "-c", "quiet"])
+        assert result.exit_code == 0
+        assert result.output == ""
+        comp.storage.add_session_event.assert_awaited_once()
+
+    def test_text_path_silent_on_no_session(self, runner, monkeypatch):
+        """Without --json, the no-session path is silent — hook callers rely
+        on this contract and must not see stray stdout."""
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: None)
+
+        result = runner.invoke(cli, ["activity", "log", "-c", "quiet"])
+        assert result.exit_code == 0
+        assert result.output == ""


### PR DESCRIPTION
## Summary

Follow-up to #331. `activity log` was split out of that issue (which shipped in #336 for the read-side commands) because it's write-side and needed a shape decision before implementation. This closes #335 by adopting **option B** from the issue body — silent by default, `--json` emits an ack with an explicit `ok` discriminator.

## Shape

| scenario           | output                                                         |
|--------------------|----------------------------------------------------------------|
| success            | `{"ok": true, "session_id": ..., "event_type": ...}`           |
| no active session  | `{"ok": false, "reason": "no_active_session"}`                 |
| write failure      | `{"ok": false, "reason": "write_failed"}`                      |

Exit code is always 0. The silent-by-default hook contract is preserved when `--json` is not set, so existing hook callers keep working unchanged.

## Shape choice vs `session events --json`

`session events --json` uses `{"error": "no_session"}` (no `ok` field). This PR deliberately does **not** match that shape:

- `session events` is a **read** command. Its success payload (`events: [...], count: N`) is a natural disambiguator from the error shape, so `"error" in data` is a clean check.
- `activity log` is a **write** command. Its success ack has no natural disambiguator beyond the keys themselves, so an explicit `ok` discriminator lets consumers branch on `data["ok"]` instead of presence-of-a-key.

Documented in the test class docstring and CHANGELOG so the asymmetry is a deliberate design choice, not drift.

## Scope

The issue body's example ack included `event_id`, but `storage.add_session_event` currently returns `None` — surfacing the row id would widen the storage protocol across base + mixin + 4 call sites. Out of scope for a CLI flag addition. Callers who need the id can follow up with `mm session events --json`; a focused follow-up issue is the right shape if a concrete caller later needs it in the ack.

Closes #335.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_session_cli.py` — 11 passed (5 new TestActivityLogJson cases)
- [x] Broader regression — 102 passed across `test_session_cli`, `test_sessions`, `test_tool_registration`, `test_cli`
- [x] `uv run ruff check packages/memtomem/{src,tests}` + `ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/session_cmd.py` — 0 errors
- [ ] Manual: `uv run mm activity log -c "test" --json` (no session) → `{"ok": false, "reason": "no_active_session"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
