### PR TITLE
docs(contrib): document JSON error shape convention (read vs write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   (genuine non-JSON modes like `plain` / `context` / `smart`), with a
   forward-compatibility guidance to prefer `--format` when a command might
   grow additional modes later. (#332)
+- **Documented JSON error shape convention** — `CONTRIBUTING.md` now
+  specifies the `--json` error shape by command kind: read commands
+  (`list`, `get`, `show`, `events`, `status`) emit `{"error": "<reason>"}`
+  since their success payloads self-disambiguate; write commands (`log`,
+  `add`, `set`, `run`) emit `{"ok": false, "reason": "<reason>"}` with an
+  explicit discriminator since write acks have no natural key-based
+  disambiguator. Both shapes exit 0 so `--json` pipelines don't break
+  on handled failures. Anchors the shape choice made in #336 / #337 so
+  future `--json` flags don't re-litigate per-command. (#339)
 
 ## [0.1.14] — 2026-04-21
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,33 @@ plausible a `context` / `digest` / `diff` mode gets added later — choose
 `--format` from the start. Migrating from `--json` flag to `--format` is a
 breaking change for scripts; going the other way isn't necessary.
 
+### JSON error shape
+
+Pick the `--json` error shape by whether the command's success payload
+already disambiguates from an error:
+
+| Command kind | Success shape                       | Error shape                              |
+|--------------|-------------------------------------|------------------------------------------|
+| **Read** (`list`, `get`, `show`, `events`, `status`) | `{"<items>": [...], "count": N}` — the keys self-disambiguate | `{"error": "<reason>"}` |
+| **Write** (`log`, `add`, `set`, `run`) | `{"ok": true, ...}` — explicit flag | `{"ok": false, "reason": "<reason>"}` |
+
+Both shapes keep **exit code 0** under `--json`; the JSON body carries
+the outcome, not the exit code, so `cmd --json | jq` pipelines don't
+break on a handled failure. Unhandled exceptions (programmer errors,
+not expected failure modes) should still surface through Click.
+
+Rationale: read success payloads (`events: [...]`, `sessions: [...]`)
+are naturally disambiguated from `{error: ...}` by presence-of-key, so
+an explicit `ok` flag is redundant noise. Write acks have no such
+natural disambiguator — `{"event_id": ...}` vs `{"error": ...}` forces
+consumers to check by key rather than by a single boolean. An explicit
+`ok` flag is clearer for writes.
+
+The text-path behavior is unchanged by `--json`. No-op / no-session
+cases that are silent under text (hook callers depend on silence)
+should emit the JSON error shape only when `--json` is set, so adding
+the flag never breaks an existing text-path caller.
+
 ## Contributor License Agreement (CLA)
 
 Before we can merge your first pull request, you need to sign the

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -129,8 +129,10 @@ class TestActivityLogJson:
     """``mm activity log --json`` is write-side, so the ack shape uses an
     explicit ``ok`` discriminator (the success payload has no natural
     disambiguator like ``events: [...]``). Error shape intentionally diverges
-    from ``session events --json``'s ``{"error": ...}`` for that reason —
-    see commit / PR body."""
+    from ``session events --json``'s ``{"error": ...}`` — see the "JSON error
+    shape" subsection of ``CONTRIBUTING.md`` for the read/write rule. If you
+    change either this class's shape or ``TestSessionEventsJson``'s, update
+    CONTRIBUTING.md in the same PR or the docs and tests will drift."""
 
     def test_success_emits_ok_ack(self, runner, monkeypatch):
         comp = _mock_components()


### PR DESCRIPTION
## Summary

Adds a `JSON error shape` subsection to `CONTRIBUTING.md`'s existing CLI output convention, anchoring the shape choice made across #336 (read-side) and #337 (write-side) so future contributors don't re-litigate the shape per new `--json` command. Flagged explicitly in the #337 review as "convention sprawl risk."

## The rule

| Command kind | Success shape | Error shape |
|--------------|---------------|-------------|
| **Read** (`list`, `get`, `show`, `events`, `status`) | `{"<items>": [...], "count": N}` — keys self-disambiguate | `{"error": "<reason>"}` |
| **Write** (`log`, `add`, `set`, `run`) | `{"ok": true, ...}` — explicit flag | `{"ok": false, "reason": "<reason>"}` |

Both shapes exit 0 under `--json` so `cmd --json | jq` pipelines don't break on handled failures.

## Why asymmetric

Read success payloads already disambiguate from `{error: ...}` by presence-of-key (`"events" in data`, `"sessions" in data`). An `ok` flag would be redundant noise.

Write acks have no such natural disambiguator — consumers would have to discriminate by the specific keys present (`"event_id" in data` vs `"error" in data`), which gets awkward as ack shapes grow. An explicit `ok` flag is clearer for writes.

## No new tests

Existing `test_session_cli.py::TestSessionEventsJson` and `TestActivityLogJson` already pin the exact shapes the subsection describes — they're fail-if-false tests of the rule. Added a cross-reference comment to the `TestActivityLogJson` docstring so the docs/test link is discoverable from either side. Adding a separate convention-anchor test would be pure redundancy.

## Scope

- **Pure docs + one test-file comment.** No code changes.
- **No retroactive unification** of the two existing shapes. Both are released; changing either breaks downstream scripts. Rules apply forward.
- Intentionally does NOT document success shapes exhaustively (that lives in per-command `--help` + PR-time discussion). This is the *error*-shape rule, which is the one that caused the sprawl risk.

Closes #339.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_session_cli.py -q` — 11 passed (unchanged)
- [x] `uv run ruff check` on touched files — clean
- [x] Manual read-through of the new subsection in rendered GitHub preview (table + paragraphs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
