### PR TITLE
fix(cli): `mm activity log --meta <bad> --json` emits invalid_meta ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   ok-flag shape intentionally differs from `session events --json`'s
   `{error: ...}` — write acks have no natural disambiguator, so an
   explicit `ok` discriminator is clearer for consumers. (#335)
+- **`mm activity log --json` invalid-meta ack** — malformed `--meta`
+  JSON now emits `{ok: false, reason: "invalid_meta"}` under `--json`
+  (exit 0) so scripts can distinguish bad input from a write failure.
+  Without `--json` the `json.JSONDecodeError` still bubbles to Click
+  (traceback + exit 1) so a hook author mistyping meta sees why. (#338)
 
 ### Changed
 

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -274,7 +274,17 @@ def log_event(event_type: str, content: str, meta: str | None, *, as_json: bool 
         if as_json:
             click.echo(json.dumps({"ok": False, "reason": "no_active_session"}))
         return
-    metadata = json.loads(meta) if meta else None
+    try:
+        metadata = json.loads(meta) if meta else None
+    except json.JSONDecodeError:
+        # Malformed --meta: under --json emit the error ack (exit 0) so
+        # scripts can distinguish "bad input" from "write failed". Under
+        # text path, let Click surface the traceback — a hook author
+        # mistyping meta wants to see why.
+        if as_json:
+            click.echo(json.dumps({"ok": False, "reason": "invalid_meta"}))
+            return
+        raise
     try:
         asyncio.run(_log_event(session_id, event_type, content, metadata))
     except Exception:

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -196,3 +196,31 @@ class TestActivityLogJson:
         result = runner.invoke(cli, ["activity", "log", "-c", "quiet"])
         assert result.exit_code == 0
         assert result.output == ""
+
+    def test_invalid_meta_emits_invalid_meta_ack(self, runner, monkeypatch):
+        """Malformed --meta under --json emits {ok: false, reason:
+        invalid_meta} (exit 0). Storage must not be touched — the parse
+        error happens before the async call."""
+        comp = _mock_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: "sess-1")
+
+        result = runner.invoke(cli, ["activity", "log", "-c", "x", "--meta", "{oops", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == {"ok": False, "reason": "invalid_meta"}
+        comp.storage.add_session_event.assert_not_awaited()
+
+    def test_invalid_meta_text_path_bubbles(self, runner, monkeypatch):
+        """Malformed --meta without --json lets the JSONDecodeError bubble to
+        Click so a hook author mistyping meta sees the traceback.
+        Intentional per issue #338 — the silent-by-default hook contract is
+        about the *write* failure mode, not programmer input errors."""
+        comp = _mock_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        monkeypatch.setattr("memtomem.cli.session_cmd._read_current_session", lambda: "sess-2")
+
+        result = runner.invoke(cli, ["activity", "log", "-c", "x", "--meta", "{oops"])
+        assert result.exit_code != 0
+        assert isinstance(result.exception, json.JSONDecodeError)
+        comp.storage.add_session_event.assert_not_awaited()


### PR DESCRIPTION
## Summary

Follow-up to #337. Before this fix, `mm activity log --meta '{oops' --json` threw a `json.JSONDecodeError` traceback and exit 1 through Click because `json.loads(meta)` sat outside the try/except that wrapped the storage write. `--json` callers reasonably expect all handled failure modes to emit the ack shape.

## Behavior change

| Invocation                                    | Before                                        | After                                                       |
|-----------------------------------------------|-----------------------------------------------|-------------------------------------------------------------|
| `--meta '{oops' --json`                       | traceback + exit 1                            | `{"ok": false, "reason": "invalid_meta"}` + exit 0          |
| `--meta '{oops'` (text)                       | traceback + exit 1                            | **unchanged** — still traceback + exit 1                    |
| `--meta '{"valid": true}' --json`             | `{"ok": true, ...}` + exit 0                  | **unchanged**                                               |

Text-path behavior is deliberately preserved per #338 option 1 — the silent-by-default hook contract applies to *write* failures (DB locked, schema drift, etc.), not programmer input errors. A hook author mistyping meta wants to see the traceback.

## Implementation

Split the parse into its own try block catching `json.JSONDecodeError` narrowly:

```python
try:
    metadata = json.loads(meta) if meta else None
except json.JSONDecodeError:
    if as_json:
        click.echo(json.dumps({"ok": False, "reason": "invalid_meta"}))
        return
    raise
try:
    asyncio.run(_log_event(session_id, event_type, content, metadata))
except Exception:
    ...  # existing write_failed handler
```

Two blocks instead of one nested handler so that if storage ever raises a `JSONDecodeError` internally (today it doesn't — sqlite3 + `json.dumps` don't), the parse-error ack doesn't mask it as `invalid_meta`. Per failure-mode classification discipline.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_session_cli.py -q` — 13 passed (2 new: `test_invalid_meta_emits_invalid_meta_ack`, `test_invalid_meta_text_path_bubbles`)
- [x] `uv run ruff check packages/memtomem/{src,tests}` + `ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/session_cmd.py` — 0 errors

Closes #338.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
