### PR TITLE
release: v0.1.15 — CLI `--json` scriptability + convention lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.15] — 2026-04-21
+
+memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces
+may still shift between 0.1.x releases — external feedback and issue
+reports are especially welcome at
+[github.com/memtomem/memtomem/issues](https://github.com/memtomem/memtomem/issues).
+
+This release focuses on **CLI scriptability**. All read/write session
+commands now expose `--json` output for hook consumers and scripting
+pipelines, `mm --version` answers the obvious first question newcomers
+ask, and the contributor docs lock the `--json` error-shape convention
+(read vs write) so future flags don't re-litigate the shape per command.
+
 ### Added
 
 - **`mm --version` flag** — Click's idiomatic entry point for version output,

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.14"
+version = "0.1.15"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Version bump **0.1.14 → 0.1.15**. Focuses on CLI scriptability — all read/write session commands now expose `--json` output for hook consumers and scripting pipelines, `mm --version` answers the obvious newcomer question, and the contributor docs lock the `--json` error-shape convention so future flags follow the same rule.

No breaking changes. All items accumulated since 0.1.14 are additive.

## Shipped in this release

**Scriptability — `--json` family:**

| PR | Feature |
|----|---------|
| #330 | `mm --version` flag |
| #332 | `mm config show --json` alias of `--format json` |
| #331 | `mm session list --json` → `{sessions: [...], count: N}` |
| #331 | `mm session events --json` → `{session_id, events: [...], count: N}` + `{error: "no_session"}` on no active session |
| #335 | `mm activity log --json` → `{ok: true, session_id, event_type}` / `{ok: false, reason: ...}` |
| #338 | `mm activity log --meta <bad> --json` → `{ok: false, reason: "invalid_meta"}` instead of traceback |

**Convention lock — CONTRIBUTING.md:**

| PR | Doc |
|----|-----|
| #332 | When to use `--json` flag vs `--format [table\|json\|...]` option |
| #339 | JSON error shape by command kind: read `{error: "<reason>"}` vs write `{ok: false, reason: "<reason>"}` |

## Files changed

- `packages/memtomem/pyproject.toml` — `version = "0.1.14"` → `"0.1.15"`
- `uv.lock` — workspace `[[package]]` entry bumped to match
- `CHANGELOG.md` — `[Unreleased]` → `[0.1.15] — 2026-04-21`; empty `[Unreleased]` scaffold preserved

## Release plan (post-merge)

Standard `memtomem` 2-phase per `project_release_workflow.md`:

1. Tag `test-v0.1.15` → TestPyPI (dry-run) → fresh install + `mm --version` smoke
2. Tag `v0.1.15` → production PyPI (OIDC trusted publisher) + GH Release

## Test plan

- [x] `uv run mm --version` → `memtomem 0.1.15` ✓
- [x] `uv run pytest packages/memtomem/tests -q -m "not ollama"` → 1971 passed, 46 deselected
- [x] `uv run ruff check` + `ruff format --check` on `packages/memtomem/{src,tests}` — clean
- [x] `uv lock --check` — lock is consistent with pyproject

🤖 Generated with [Claude Code](https://claude.com/claude-code)
