### PR TITLE
feat(web): introduce prod/dev UI tier plumbing (mechanism only)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import click
 
 
+_WEB_MODE_CHOICES = ("prod", "dev")
+
+
 def _missing_web_deps() -> str | None:
     """Return the name of the first missing web-UI dependency, or None if all
     required packages are importable. Kept private so the wizard can reuse it."""
@@ -29,7 +32,27 @@ def _web_install_hint() -> str:
 @click.option(
     "--timeout", default=30, type=int, help="Timeout for web opening (seconds). Zero is no timeout."
 )
-def web(host: str, port: int, open_browser: bool, timeout: int) -> None:
+@click.option(
+    "--mode",
+    type=click.Choice(_WEB_MODE_CHOICES, case_sensitive=False),
+    default=None,
+    help="UI surface to expose. 'prod' (default) shows the polished page set; "
+    "'dev' adds opt-in maintainer pages. Overrides MEMTOMEM_WEB__MODE.",
+)
+@click.option(
+    "--dev",
+    "dev_flag",
+    is_flag=True,
+    help="Shortcut for --mode dev. Mutually exclusive with --mode.",
+)
+def web(
+    host: str,
+    port: int,
+    open_browser: bool,
+    timeout: int,
+    mode: str | None,
+    dev_flag: bool,
+) -> None:
     """Launch the memtomem Web UI (FastAPI + SPA)."""
     missing = _missing_web_deps()
     if missing is not None:
@@ -45,13 +68,28 @@ def web(host: str, port: int, open_browser: bool, timeout: int) -> None:
         click.echo('  Or, if using pip: pip install "memtomem[web]"')
         raise SystemExit(1)
 
+    if mode is not None and dev_flag:
+        raise click.UsageError("--mode and --dev are mutually exclusive")
+
+    from memtomem.web.app import resolve_web_mode_from_env
+
+    if dev_flag:
+        resolved_mode: str = "dev"
+    elif mode is not None:
+        resolved_mode = mode.lower()
+    else:
+        try:
+            resolved_mode = resolve_web_mode_from_env(strict=True)
+        except ValueError as exc:
+            raise click.BadParameter(str(exc), param_hint="MEMTOMEM_WEB__MODE") from exc
+
     import uvicorn
 
     from memtomem.web.app import _lifespan, create_app
 
     import asyncio
 
-    click.echo(f"Starting memtomem Web UI at http://{host}:{port}")
+    click.echo(f"Starting memtomem Web UI at http://{host}:{port} (mode={resolved_mode})")
 
     async def after_started(server: uvicorn.Server, timeout: float) -> None:
         if not open_browser:
@@ -79,7 +117,11 @@ def web(host: str, port: int, open_browser: bool, timeout: int) -> None:
         webbrowser.open(f"http://{host}:{port}")
 
     async def start_server() -> None:
-        web_config = uvicorn.Config(create_app(lifespan=_lifespan), host=host, port=port)
+        web_config = uvicorn.Config(
+            create_app(lifespan=_lifespan, mode=resolved_mode),
+            host=host,
+            port=port,
+        )
         web_server = uvicorn.Server(web_config)
 
         await asyncio.gather(

--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -71,12 +71,14 @@ def web(
     if mode is not None and dev_flag:
         raise click.UsageError("--mode and --dev are mutually exclusive")
 
-    from memtomem.web.app import resolve_web_mode_from_env
+    from memtomem.web.app import WebMode, resolve_web_mode_from_env
 
+    resolved_mode: WebMode
     if dev_flag:
-        resolved_mode: str = "dev"
+        resolved_mode = "dev"
     elif mode is not None:
-        resolved_mode = mode.lower()
+        # click.Choice has already constrained this to the literal set.
+        resolved_mode = mode.lower()  # type: ignore[assignment]
     else:
         try:
             resolved_mode = resolve_web_mode_from_env(strict=True)

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
+from types import ModuleType
+from typing import Literal
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -41,9 +44,79 @@ logger = logging.getLogger(__name__)
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
+WebMode = Literal["prod", "dev"]
+_VALID_WEB_MODES: frozenset[str] = frozenset({"prod", "dev"})
+_WEB_MODE_ENV = "MEMTOMEM_WEB__MODE"
 
-def create_app(lifespan=None) -> FastAPI:
-    """Factory for creating the FastAPI app (testable without lifespan)."""
+# Routers that define the polished surface shipped to `uv tool install` users.
+# `_DEV_ONLY_ROUTERS` is the opt-in extension (PR 2 fills it in — currently
+# empty so this PR is mechanism-only with no user-visible change).
+_PROD_ROUTERS: list[ModuleType] = [
+    search,
+    chunks,
+    sources,
+    system,
+    tags,
+    dedup,
+    decay,
+    export,
+    namespaces,
+    timeline,
+    sessions,
+    scratch,
+    procedures,
+    evaluation,
+    watchdog,
+    settings_sync,
+    context_gateway,
+    context_skills,
+    context_commands,
+    context_agents,
+]
+_DEV_ONLY_ROUTERS: list[ModuleType] = []
+
+
+def resolve_web_mode_from_env(*, strict: bool = False) -> WebMode:
+    """Return the web mode from ``MEMTOMEM_WEB__MODE``.
+
+    With ``strict=True`` an invalid value raises ``ValueError`` (used by the
+    ``mm web`` CLI, which also enforces mutual exclusion with ``--mode`` /
+    ``--dev``). With ``strict=False`` an invalid value falls back to ``prod``
+    with a warning — this path is taken when ``uvicorn`` mounts the
+    module-level app without going through the CLI (e.g. tests, ASGI hosts).
+    """
+    raw = os.environ.get(_WEB_MODE_ENV, "").strip().lower()
+    if not raw:
+        return "prod"
+    if raw in _VALID_WEB_MODES:
+        return raw  # type: ignore[return-value]
+    if strict:
+        raise ValueError(
+            f"Invalid {_WEB_MODE_ENV}={raw!r}; expected one of {sorted(_VALID_WEB_MODES)}"
+        )
+    logger.warning(
+        "Ignoring invalid %s=%r; falling back to 'prod'. Valid values: %s",
+        _WEB_MODE_ENV,
+        raw,
+        sorted(_VALID_WEB_MODES),
+    )
+    return "prod"
+
+
+def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
+    """Factory for creating the FastAPI app (testable without lifespan).
+
+    ``mode`` controls which routers are mounted:
+
+    * ``prod`` (default) — the polished surface only.
+    * ``dev`` — adds the routers in ``_DEV_ONLY_ROUTERS`` for maintainers.
+
+    The SPA reads ``GET /api/system/ui-mode`` on boot and filters tabs /
+    sections accordingly.
+    """
+    if mode not in _VALID_WEB_MODES:
+        raise ValueError(f"Invalid web mode {mode!r}; expected one of {sorted(_VALID_WEB_MODES)}")
+
     app = FastAPI(
         title="memtomem Web UI",
         description="Web UI for memtomem memory infrastructure",
@@ -52,27 +125,13 @@ def create_app(lifespan=None) -> FastAPI:
         docs_url="/api/docs",
         redoc_url="/api/redoc",
     )
+    app.state.web_mode = mode
 
-    app.include_router(search.router, prefix="/api")
-    app.include_router(chunks.router, prefix="/api")
-    app.include_router(sources.router, prefix="/api")
-    app.include_router(system.router, prefix="/api")
-    app.include_router(tags.router, prefix="/api")
-    app.include_router(dedup.router, prefix="/api")
-    app.include_router(decay.router, prefix="/api")
-    app.include_router(export.router, prefix="/api")
-    app.include_router(namespaces.router, prefix="/api")
-    app.include_router(timeline.router, prefix="/api")
-    app.include_router(sessions.router, prefix="/api")
-    app.include_router(scratch.router, prefix="/api")
-    app.include_router(procedures.router, prefix="/api")
-    app.include_router(evaluation.router, prefix="/api")
-    app.include_router(watchdog.router, prefix="/api")
-    app.include_router(settings_sync.router, prefix="/api")
-    app.include_router(context_gateway.router, prefix="/api")
-    app.include_router(context_skills.router, prefix="/api")
-    app.include_router(context_commands.router, prefix="/api")
-    app.include_router(context_agents.router, prefix="/api")
+    for router_mod in _PROD_ROUTERS:
+        app.include_router(router_mod.router, prefix="/api")
+    if mode == "dev":
+        for router_mod in _DEV_ONLY_ROUTERS:
+            app.include_router(router_mod.router, prefix="/api")
 
     @app.exception_handler(ValueError)
     async def value_error_handler(request: Request, exc: ValueError) -> JSONResponse:
@@ -181,13 +240,22 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         await close_components(comp)
 
 
-app = create_app(lifespan=_lifespan)
+def __getattr__(name: str):
+    """Lazy module-level ``app`` construction.
+
+    Only build the default ASGI app when something actually asks for it
+    (``uvicorn memtomem.web.app:app``). Avoids a second ``create_app`` call —
+    and its ``MEMTOMEM_WEB__MODE`` resolution warning — when the CLI imports
+    ``resolve_web_mode_from_env`` or ``create_app`` directly.
+    """
+    if name == "app":
+        return create_app(lifespan=_lifespan, mode=resolve_web_mode_from_env())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def main() -> None:
     """Run the web UI server."""
     import argparse
-    import os
 
     import uvicorn
 

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -8,7 +8,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType
-from typing import Literal
+from typing import Literal, get_args
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -45,7 +45,10 @@ logger = logging.getLogger(__name__)
 _STATIC_DIR = Path(__file__).parent / "static"
 
 WebMode = Literal["prod", "dev"]
-_VALID_WEB_MODES: frozenset[str] = frozenset({"prod", "dev"})
+# Derive the runtime validator from the Literal so adding a future value
+# (e.g. "preview") in one place updates both type-checking and runtime
+# membership tests — see `feedback_literal_drives_frozenset.md`.
+_VALID_WEB_MODES: frozenset[str] = frozenset(get_args(WebMode))
 _WEB_MODE_ENV = "MEMTOMEM_WEB__MODE"
 
 # Routers that define the polished surface shipped to `uv tool install` users.
@@ -240,16 +243,28 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         await close_components(comp)
 
 
+_app_singleton: FastAPI | None = None
+
+
 def __getattr__(name: str):
-    """Lazy module-level ``app`` construction.
+    """Lazy module-level ``app`` construction, memoized.
 
     Only build the default ASGI app when something actually asks for it
     (``uvicorn memtomem.web.app:app``). Avoids a second ``create_app`` call —
     and its ``MEMTOMEM_WEB__MODE`` resolution warning — when the CLI imports
     ``resolve_web_mode_from_env`` or ``create_app`` directly.
+
+    The cached ``_app_singleton`` is critical: ``__getattr__`` runs on every
+    attribute access that isn't already in the module ``__dict__``, so
+    without memoization two ``from memtomem.web.app import app`` call sites
+    would each get a distinct ``FastAPI`` instance with its own routers,
+    state, and lifespan handlers.
     """
+    global _app_singleton
     if name == "app":
-        return create_app(lifespan=_lifespan, mode=resolve_web_mode_from_env())
+        if _app_singleton is None:
+            _app_singleton = create_app(lifespan=_lifespan, mode=resolve_web_mode_from_env())
+        return _app_singleton
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -91,12 +91,19 @@ def _require_localhost(request: Request) -> None:
 router = APIRouter(tags=["system"])
 
 
-@router.get("/system/ui-mode")
+@router.get(
+    "/system/ui-mode",
+    dependencies=[Depends(_require_localhost)],
+)
 async def get_ui_mode(request: Request) -> dict[str, str]:
     """Return the current web UI mode (``prod`` or ``dev``).
 
     The SPA fetches this on boot to decide which tabs and settings sections
     to render. Falls back to ``prod`` if ``app.state.web_mode`` is missing.
+
+    Localhost-guarded for consistency with other ``system`` endpoints — the
+    SPA runs same-origin so this doesn't affect it, but it keeps external
+    scanners from fingerprinting which installs are in dev mode.
     """
     mode = getattr(request.app.state, "web_mode", "prod")
     return {"mode": mode}

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -91,6 +91,17 @@ def _require_localhost(request: Request) -> None:
 router = APIRouter(tags=["system"])
 
 
+@router.get("/system/ui-mode")
+async def get_ui_mode(request: Request) -> dict[str, str]:
+    """Return the current web UI mode (``prod`` or ``dev``).
+
+    The SPA fetches this on boot to decide which tabs and settings sections
+    to render. Falls back to ``prod`` if ``app.state.web_mode`` is missing.
+    """
+    mode = getattr(request.app.state, "web_mode", "prod")
+    return {"mode": mode}
+
+
 @router.get("/health")
 async def health(storage=Depends(get_storage), embedder=Depends(get_embedder)):
     checks: dict[str, str] = {}

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -41,6 +41,10 @@ const STATE = {
   touchStartX: 0,
   touchStartY: 0,
   helpVisible: true,
+  // Default to 'prod' so boot-race or fetch failure leaves the polished
+  // surface in place. Overwritten by the result of ``GET /api/system/ui-mode``
+  // during ``initUiMode()``.
+  uiMode: 'prod',
 };
 
 // ── C3: Theme init ──
@@ -56,7 +60,10 @@ const STATE = {
   document.addEventListener('DOMContentLoaded', async () => {
     const isDark = el.getAttribute('data-theme') !== 'light';
     qs('theme-toggle').textContent = isDark ? '🌙' : '☀️';
+    // Resolve UI mode + fetch locales in parallel. Both gate rendering.
+    const uiModePromise = initUiMode();
     if (typeof I18N !== 'undefined') await I18N.init();
+    await uiModePromise;
     renderRecentChips();
     _initTabHelp();
     // Re-apply i18n when language changes (dynamic JS strings)
@@ -68,12 +75,60 @@ const STATE = {
     // ``t()`` at build time, so they must run after the locale cache is
     // populated to avoid raw-key flashes.
     const hash = location.hash.slice(1);
-    const validTabs = ['home', 'search', 'sources', 'index', 'tags', 'timeline', 'settings'];
-    if (hash && validTabs.includes(hash)) {
+    if (hash && _visibleMainTabs().includes(hash)) {
       activateTab(hash);
     }
   });
 })();
+
+// ---------------------------------------------------------------------------
+// UI mode (prod / dev) — hides opt-in maintainer pages by default.
+// ---------------------------------------------------------------------------
+
+async function initUiMode() {
+  try {
+    const d = await api('GET', '/api/system/ui-mode');
+    STATE.uiMode = d && d.mode === 'dev' ? 'dev' : 'prod';
+  } catch (err) {
+    // Keep the 'prod' default — degrading toward the polished surface is
+    // safer than showing maintainer pages on a boot-time fetch failure.
+    console.warn('[ui-mode]', err);
+    STATE.uiMode = 'prod';
+  }
+  _applyUiModeFilter();
+}
+
+function _applyUiModeFilter() {
+  const isProd = STATE.uiMode !== 'dev';
+  document.body.classList.toggle('dev-mode', !isProd);
+  const banner = qs('dev-mode-banner');
+  if (banner) banner.hidden = isProd;
+  document.querySelectorAll('[data-ui-tier="dev"]').forEach(el => {
+    if (isProd) {
+      el.hidden = true;
+      el.style.display = 'none';
+    } else {
+      el.hidden = false;
+      el.style.display = '';
+    }
+  });
+}
+
+function _visibleMainTabs() {
+  const isProd = STATE.uiMode !== 'dev';
+  return Array.from(document.querySelectorAll('.tab-btn'))
+    .filter(btn => !isProd || btn.dataset.uiTier !== 'dev')
+    .map(btn => btn.dataset.tab)
+    .filter(Boolean);
+}
+
+function _visibleSettingsSections() {
+  const isProd = STATE.uiMode !== 'dev';
+  return Array.from(document.querySelectorAll('.settings-nav-btn'))
+    .filter(btn => !isProd || btn.dataset.uiTier !== 'dev')
+    .map(btn => btn.dataset.section)
+    .filter(Boolean);
+}
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -287,6 +342,19 @@ function showConfirm({ title, message = '', confirmText = t('common.confirm') })
 // ---------------------------------------------------------------------------
 
 function activateTab(tabName) {
+  // In prod mode, hide dev-only tabs by redirecting to the first visible
+  // main tab instead of showing a dev panel the polished surface doesn't
+  // expose.
+  const targetBtn = document.querySelector(`.tab-btn[data-tab="${tabName}"]`);
+  if (targetBtn && targetBtn.dataset.uiTier === 'dev' && STATE.uiMode !== 'dev') {
+    const visible = _visibleMainTabs();
+    showToast(t('toast.dev_only_section'), 'info');
+    if (visible.length && visible[0] !== tabName) {
+      activateTab(visible[0]);
+    }
+    return;
+  }
+
   // Deactivate all main tabs
   document.querySelectorAll('.tab-btn').forEach(b => {
     b.classList.remove('active');
@@ -398,6 +466,18 @@ function ensureActiveGroupExpanded(section) {
 
 function switchSettingsSection(sectionName) {
   sectionName = LEGACY_SECTION_MAP[sectionName] || sectionName;
+  // In prod mode, redirect dev-only sections to the first visible one.
+  const targetBtn = document.querySelector(
+    `.settings-nav-btn[data-section="${sectionName}"]`,
+  );
+  if (targetBtn && targetBtn.dataset.uiTier === 'dev' && STATE.uiMode !== 'dev') {
+    const visible = _visibleSettingsSections();
+    showToast(t('toast.dev_only_section'), 'info');
+    if (visible.length && visible[0] !== sectionName) {
+      switchSettingsSection(visible[0]);
+    }
+    return;
+  }
   STATE.lastSettingsSection = sectionName;
   try { localStorage.setItem(LAST_SECTION_KEY, sectionName); } catch {}
   document.querySelectorAll('.settings-nav-btn').forEach(b => {
@@ -562,10 +642,16 @@ async function checkEmbeddingMismatch() {
 
 async function loadDashboard() {
   try {
+    const devMode = STATE.uiMode === 'dev';
+    // /api/namespaces becomes dev-only in PR 2 — skip the fetch in prod so
+    // the Home dashboard doesn't fire a guaranteed 404.
+    const nsPromise = devMode
+      ? api('GET', '/api/namespaces').catch(() => ({ namespaces: [] }))
+      : Promise.resolve({ namespaces: [] });
     const [stats, sourcesData, nsData, configData, embStatus, timelineData] = await Promise.all([
       api('GET', '/api/stats'),
       api('GET', '/api/sources'),
-      api('GET', '/api/namespaces'),
+      nsPromise,
       api('GET', '/api/config'),
       api('GET', '/api/embedding-status').catch(() => null),
       api('GET', '/api/timeline?days=365&limit=1000').catch(() => ({ chunks: [] })),
@@ -581,12 +667,17 @@ async function loadDashboard() {
     const totalSize = allSources.reduce((sum, s) => sum + (s.file_size || 0), 0);
     qs('home-total-size').textContent = formatBytes(totalSize) || '0 B';
 
-    // Harness stats (sessions + scratch)
+    // Harness stats (sessions + scratch) — dev-only in PR 2 onwards. In
+    // prod we leave the cards at 0 rather than firing guaranteed 404s.
     try {
-      const [sessData, scratchData] = await Promise.all([
-        api('GET', '/api/sessions?limit=1').catch(() => ({ total: 0 })),
-        api('GET', '/api/scratch').catch(() => ({ total: 0 })),
-      ]);
+      let sessData = { total: 0 };
+      let scratchData = { total: 0 };
+      if (devMode) {
+        [sessData, scratchData] = await Promise.all([
+          api('GET', '/api/sessions?limit=1').catch(() => ({ total: 0 })),
+          api('GET', '/api/scratch').catch(() => ({ total: 0 })),
+        ]);
+      }
       qs('home-sessions').textContent = sessData.total;
       qs('home-scratch').textContent = scratchData.total;
     } catch { /* non-critical */ }

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -104,6 +104,10 @@ function _applyUiModeFilter() {
   const banner = qs('dev-mode-banner');
   if (banner) banner.hidden = isProd;
   document.querySelectorAll('[data-ui-tier="dev"]').forEach(el => {
+    // Belt-and-braces: some dev-only targets live inside `display: flex`
+    // parents (the Settings nav column) where `hidden` alone can be
+    // overridden by stylesheet rules. Pairing it with `display: none`
+    // keeps the filter predictable across CSS contexts.
     if (isProd) {
       el.hidden = true;
       el.style.display = 'none';
@@ -642,16 +646,10 @@ async function checkEmbeddingMismatch() {
 
 async function loadDashboard() {
   try {
-    const devMode = STATE.uiMode === 'dev';
-    // /api/namespaces becomes dev-only in PR 2 — skip the fetch in prod so
-    // the Home dashboard doesn't fire a guaranteed 404.
-    const nsPromise = devMode
-      ? api('GET', '/api/namespaces').catch(() => ({ namespaces: [] }))
-      : Promise.resolve({ namespaces: [] });
     const [stats, sourcesData, nsData, configData, embStatus, timelineData] = await Promise.all([
       api('GET', '/api/stats'),
       api('GET', '/api/sources'),
-      nsPromise,
+      api('GET', '/api/namespaces'),
       api('GET', '/api/config'),
       api('GET', '/api/embedding-status').catch(() => null),
       api('GET', '/api/timeline?days=365&limit=1000').catch(() => ({ chunks: [] })),
@@ -667,17 +665,12 @@ async function loadDashboard() {
     const totalSize = allSources.reduce((sum, s) => sum + (s.file_size || 0), 0);
     qs('home-total-size').textContent = formatBytes(totalSize) || '0 B';
 
-    // Harness stats (sessions + scratch) — dev-only in PR 2 onwards. In
-    // prod we leave the cards at 0 rather than firing guaranteed 404s.
+    // Harness stats (sessions + scratch)
     try {
-      let sessData = { total: 0 };
-      let scratchData = { total: 0 };
-      if (devMode) {
-        [sessData, scratchData] = await Promise.all([
-          api('GET', '/api/sessions?limit=1').catch(() => ({ total: 0 })),
-          api('GET', '/api/scratch').catch(() => ({ total: 0 })),
-        ]);
-      }
+      const [sessData, scratchData] = await Promise.all([
+        api('GET', '/api/sessions?limit=1').catch(() => ({ total: 0 })),
+        api('GET', '/api/scratch').catch(() => ({ total: 0 })),
+      ]);
       qs('home-sessions').textContent = sessData.total;
       qs('home-scratch').textContent = scratchData.total;
     } catch { /* non-critical */ }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -35,14 +35,19 @@
     </div>
   </div>
 
+  <div id="dev-mode-banner" class="dev-mode-banner" role="status" hidden>
+    <span class="dev-mode-banner-icon" aria-hidden="true">🛠</span>
+    <span class="dev-mode-banner-msg" data-i18n="banner.dev_mode">Maintainer mode — all pages are visible. Run <code>mm web</code> without <code>--dev</code> for the polished surface.</span>
+  </div>
+
   <nav class="tab-nav" role="tablist" aria-label="Navigation">
-    <button class="tab-btn" data-tab="home" data-i18n="nav.home">Home</button>
-    <button class="tab-btn active" data-tab="search" data-i18n="nav.search">Search</button>
-    <button class="tab-btn" data-tab="sources" data-i18n="nav.sources">Sources</button>
-    <button class="tab-btn" data-tab="index" data-i18n="nav.index">Index</button>
-    <button class="tab-btn" data-tab="tags" data-i18n="nav.tags">Tags</button>
-    <button class="tab-btn" data-tab="timeline" data-i18n="nav.timeline">Timeline</button>
-    <button class="tab-btn" data-tab="settings" data-i18n="nav.more">More</button>
+    <button class="tab-btn" data-ui-tier="prod" data-tab="home" data-i18n="nav.home">Home</button>
+    <button class="tab-btn active" data-ui-tier="prod" data-tab="search" data-i18n="nav.search">Search</button>
+    <button class="tab-btn" data-ui-tier="prod" data-tab="sources" data-i18n="nav.sources">Sources</button>
+    <button class="tab-btn" data-ui-tier="prod" data-tab="index" data-i18n="nav.index">Index</button>
+    <button class="tab-btn" data-ui-tier="prod" data-tab="tags" data-i18n="nav.tags">Tags</button>
+    <button class="tab-btn" data-ui-tier="prod" data-tab="timeline" data-i18n="nav.timeline">Timeline</button>
+    <button class="tab-btn" data-ui-tier="prod" data-tab="settings" data-i18n="nav.more">More</button>
   </nav>
 
   <!-- ===== HOME TAB ===== -->
@@ -536,14 +541,14 @@
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.general">General</span>
         </button>
-        <button class="settings-nav-btn active" data-section="config" data-group="general" role="tab" aria-selected="true">
+        <button class="settings-nav-btn active" data-ui-tier="prod" data-section="config" data-group="general" role="tab" aria-selected="true">
           <span class="nav-icon" aria-hidden="true">⚙</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.config">Config</span>
             <span class="nav-sub" data-i18n="settings.nav.config_sub">Embedding &amp; DB</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🗂</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.namespaces">Namespaces</span>
@@ -555,35 +560,35 @@
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.integrations">Integrations</span>
         </button>
-        <button class="settings-nav-btn" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🔄</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_overview">Artifact Sync</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Skills/Cmd/Agents status</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🧩</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_skills">Skills</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Skill definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⌘</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_commands">Commands</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_commands_sub">Command definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🤖</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_agents">Agents</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_agents_sub">Agent definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">📎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.hooks_sync">Hook Files</span>
@@ -595,28 +600,28 @@
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.runtime">Runtime</span>
         </button>
-        <button class="settings-nav-btn" data-section="harness-sessions" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-sessions" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">▷</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.sessions">Sessions</span>
             <span class="nav-sub" data-i18n="settings.nav.sessions_sub">Episodic history</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="harness-scratch" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-scratch" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">✎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.working_memory">Working Memory</span>
             <span class="nav-sub" data-i18n="settings.nav.working_memory_sub">Scratch KV</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="harness-procedures" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-procedures" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">📜</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.procedures">Procedures</span>
             <span class="nav-sub" data-i18n="settings.nav.procedures_sub">Saved recipes</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="harness-health" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-health" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">💓</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.health">Health Report</span>
@@ -628,21 +633,21 @@
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.data">Data</span>
         </button>
-        <button class="settings-nav-btn" data-section="dedup" data-group="data" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="dedup" data-group="data" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🧹</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.dedup">Deduplicate</span>
             <span class="nav-sub" data-i18n="settings.nav.dedup_sub">Remove near-duplicates</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="decay" data-group="data" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="decay" data-group="data" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⏲</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.decay">Age-out</span>
             <span class="nav-sub" data-i18n="settings.nav.decay_sub">Expire old memories</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-section="export" data-group="data" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="export" data-group="data" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⇅</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.export_import">Export / Import</span>
@@ -654,7 +659,7 @@
           <span class="nav-group-caret" aria-hidden="true">⚠</span>
           <span data-i18n="settings.nav.danger_zone">Danger Zone</span>
         </div>
-        <button class="settings-nav-btn settings-nav-btn--danger" data-section="reset" data-group="danger" role="tab" aria-selected="false">
+        <button class="settings-nav-btn settings-nav-btn--danger" data-ui-tier="prod" data-section="reset" data-group="danger" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⚠</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.reset">Reset Database</span>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -455,6 +455,7 @@
   "toast.config_saved": "Config saved",
   "toast.fts_rebuilt": "FTS index rebuilt ({count} chunks).",
   "toast.diff_shown": "Showing diff: history → current",
+  "toast.dev_only_section": "Unknown section (dev-only)",
   "toast.stream_fallback": "Streaming failed. Try the Index button instead.",
   "toast.watchdog_disabled": "Health watchdog is disabled. Set MEMTOMEM_HEALTH_WATCHDOG__ENABLED=true to enable.",
   "toast.file_filter": "Only .md/.txt/.py/.js/.ts/.json/.yaml files accepted",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -455,6 +455,7 @@
   "toast.config_saved": "설정이 저장되었습니다",
   "toast.fts_rebuilt": "FTS 인덱스가 재구축되었습니다 ({count}개 청크).",
   "toast.diff_shown": "차이점 표시: 기록 → 현재",
+  "toast.dev_only_section": "알 수 없는 섹션 (dev 전용)",
   "toast.stream_fallback": "스트리밍 실패. Index 버튼을 대신 사용하세요.",
   "toast.watchdog_disabled": "상태 워치독이 비활성화되어 있습니다. MEMTOMEM_HEALTH_WATCHDOG__ENABLED=true로 설정하세요.",
   "toast.file_filter": ".md/.txt/.py/.js/.ts/.json/.yaml 파일만 허용됩니다",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -58,6 +58,22 @@ body { background: var(--bg); color: var(--text); font-family: var(--font); heig
 }
 .btn-warning:hover { opacity: 0.85; }
 
+.dev-mode-banner {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 6px 16px;
+  background: color-mix(in srgb, var(--accent, #3498db) 10%, var(--surface));
+  border-bottom: 1px solid color-mix(in srgb, var(--accent, #3498db) 35%, var(--border));
+  flex-shrink: 0;
+  font-size: 0.82rem; color: var(--text);
+}
+.dev-mode-banner code {
+  padding: 1px 5px; border-radius: 3px;
+  background: color-mix(in srgb, var(--accent, #3498db) 18%, transparent);
+  font-size: 0.95em;
+}
+.dev-mode-banner-icon { font-size: 0.95rem; flex-shrink: 0; }
+.dev-mode-banner-msg { flex: 1; min-width: 0; }
+
 header {
   display: flex; align-items: center; gap: 12px;
   padding: 0 16px; height: 52px;

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -201,3 +201,102 @@ def test_web_timeout_without_open_is_silent() -> None:
     assert result.exit_code == 0
     mock_browser.assert_not_called()
     assert "Warning" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# --mode / --dev plumbing (prod/dev tier; see test_web_mode.py for semantics)
+# ---------------------------------------------------------------------------
+
+
+def _patch_web_stack_no_create_app(server_mock: MagicMock):
+    """Like ``_patch_web_stack`` but leaves ``create_app`` unpatched so the
+    caller can install a capture via ``side_effect``."""
+    return [
+        patch("memtomem.cli.web._missing_web_deps", return_value=None),
+        patch("uvicorn.Config", return_value=MagicMock()),
+        patch("uvicorn.Server", return_value=server_mock),
+        patch("memtomem.web.app._lifespan", MagicMock()),
+    ]
+
+
+def _run_web_capturing_mode(
+    args: list[str],
+    monkeypatch: pytest.MonkeyPatch | None = None,
+    env_mode: str | None = None,
+) -> tuple[int, str, str | None]:
+    runner = CliRunner()
+    server_mock = _make_server_mock(started=True)
+    captured: dict[str, str | None] = {"mode": None}
+
+    def _capture(**kwargs) -> MagicMock:
+        captured["mode"] = kwargs.get("mode")
+        return MagicMock()
+
+    if monkeypatch is not None and env_mode is not None:
+        monkeypatch.setenv("MEMTOMEM_WEB__MODE", env_mode)
+    elif monkeypatch is not None:
+        monkeypatch.delenv("MEMTOMEM_WEB__MODE", raising=False)
+
+    with contextlib.ExitStack() as stack:
+        for p in _patch_web_stack_no_create_app(server_mock):
+            stack.enter_context(p)
+        stack.enter_context(patch("memtomem.web.app.create_app", side_effect=_capture))
+        result = runner.invoke(web, args)
+    return result.exit_code, result.output, captured["mode"]
+
+
+def test_web_mode_and_dev_are_mutually_exclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MEMTOMEM_WEB__MODE", raising=False)
+    runner = CliRunner()
+    with patch("memtomem.cli.web._missing_web_deps", return_value=None):
+        result = runner.invoke(web, ["--mode", "prod", "--dev"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
+def test_web_invalid_env_value_rejects_startup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bogus MEMTOMEM_WEB__MODE must fail fast — never silently fall back
+    to prod, which would mask a user typo."""
+    monkeypatch.setenv("MEMTOMEM_WEB__MODE", "preview")
+    runner = CliRunner()
+    with patch("memtomem.cli.web._missing_web_deps", return_value=None):
+        result = runner.invoke(web, [])
+    assert result.exit_code != 0
+    assert "MEMTOMEM_WEB__MODE" in result.output
+    assert "preview" in result.output
+
+
+def test_web_default_mode_is_prod(monkeypatch: pytest.MonkeyPatch) -> None:
+    exit_code, output, mode = _run_web_capturing_mode([], monkeypatch=monkeypatch)
+    assert exit_code == 0, output
+    assert mode == "prod"
+
+
+def test_web_dev_flag_selects_dev_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    exit_code, output, mode = _run_web_capturing_mode(["--dev"], monkeypatch=monkeypatch)
+    assert exit_code == 0, output
+    assert mode == "dev"
+
+
+def test_web_mode_flag_selects_dev_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    exit_code, output, mode = _run_web_capturing_mode(["--mode", "dev"], monkeypatch=monkeypatch)
+    assert exit_code == 0, output
+    assert mode == "dev"
+
+
+def test_web_env_mode_selects_dev_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    exit_code, output, mode = _run_web_capturing_mode([], monkeypatch=monkeypatch, env_mode="dev")
+    assert exit_code == 0, output
+    assert mode == "dev"
+
+
+def test_web_cli_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    exit_code, output, mode = _run_web_capturing_mode(
+        ["--mode", "prod"], monkeypatch=monkeypatch, env_mode="dev"
+    )
+    assert exit_code == 0, output
+    assert mode == "prod"

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -256,6 +256,20 @@ def test_web_mode_and_dev_are_mutually_exclusive(
     assert "mutually exclusive" in result.output
 
 
+def test_web_mode_and_dev_mutex_rejects_same_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mutex is on presence, not value — ``--mode dev --dev`` is still
+    an error. Consistency matters: if users start relying on "same value is
+    fine" we'd have to pick a tie-breaker when they drift apart."""
+    monkeypatch.delenv("MEMTOMEM_WEB__MODE", raising=False)
+    runner = CliRunner()
+    with patch("memtomem.cli.web._missing_web_deps", return_value=None):
+        result = runner.invoke(web, ["--mode", "dev", "--dev"])
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output
+
+
 def test_web_invalid_env_value_rejects_startup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -1,0 +1,176 @@
+"""Tests for the web UI mode mechanism (prod / dev tier).
+
+PR 1 introduces the plumbing — ``create_app(mode=...)``, ``/api/system/ui-mode``,
+and SPA filtering — without moving any page into the dev-only tier yet.
+The route set between prod and dev is therefore identical in this PR; PR 2
+is where the classification change lands and this snapshot will diverge.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memtomem.web.app import (
+    _DEV_ONLY_ROUTERS,
+    _PROD_ROUTERS,
+    _WEB_MODE_ENV,
+    create_app,
+    resolve_web_mode_from_env,
+)
+
+
+# ---------------------------------------------------------------------------
+# Factory + app.state
+# ---------------------------------------------------------------------------
+
+
+def test_create_app_default_mode_is_prod() -> None:
+    app = create_app()
+    assert app.state.web_mode == "prod"
+
+
+def test_create_app_dev_mode_propagates() -> None:
+    app = create_app(mode="dev")
+    assert app.state.web_mode == "dev"
+
+
+def test_create_app_rejects_invalid_mode() -> None:
+    with pytest.raises(ValueError, match="Invalid web mode"):
+        create_app(mode="preview")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Env resolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("prod", "prod"), ("dev", "dev"), ("PROD", "prod"), ("  DEV  ", "dev")],
+)
+def test_resolve_web_mode_accepts_valid(
+    monkeypatch: pytest.MonkeyPatch, raw: str, expected: str
+) -> None:
+    monkeypatch.setenv(_WEB_MODE_ENV, raw)
+    assert resolve_web_mode_from_env() == expected
+
+
+def test_resolve_web_mode_unset_returns_prod(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_WEB_MODE_ENV, raising=False)
+    assert resolve_web_mode_from_env() == "prod"
+
+
+def test_resolve_web_mode_strict_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_WEB_MODE_ENV, "preview")
+    with pytest.raises(ValueError, match="Invalid MEMTOMEM_WEB__MODE"):
+        resolve_web_mode_from_env(strict=True)
+
+
+def test_resolve_web_mode_lenient_falls_back_to_prod(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv(_WEB_MODE_ENV, "preview")
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="memtomem.web.app"):
+        assert resolve_web_mode_from_env(strict=False) == "prod"
+    assert "Ignoring invalid" in caplog.text
+    assert "MEMTOMEM_WEB__MODE" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# /api/system/ui-mode endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["prod", "dev"])
+def test_ui_mode_endpoint_reflects_app_state(mode: str) -> None:
+    app = create_app(mode=mode)  # type: ignore[arg-type]
+    with TestClient(app) as client:
+        resp = client.get("/api/system/ui-mode")
+    assert resp.status_code == 200
+    assert resp.json() == {"mode": mode}
+
+
+# ---------------------------------------------------------------------------
+# Router classification snapshot (drift guard)
+# ---------------------------------------------------------------------------
+
+
+def test_prod_dev_router_lists_are_disjoint() -> None:
+    assert set(_PROD_ROUTERS).isdisjoint(set(_DEV_ONLY_ROUTERS))
+
+
+def test_pr1_leaves_dev_only_routers_empty() -> None:
+    """PR 1 is mechanism-only: no classification changes yet. When PR 2
+    populates ``_DEV_ONLY_ROUTERS`` this test must be updated alongside."""
+    assert _DEV_ONLY_ROUTERS == []
+
+
+def test_route_counts_match_in_pr1_snapshot() -> None:
+    """With classification unchanged, prod and dev mount identical routes."""
+
+    def api_paths(app) -> set[str]:
+        return {
+            getattr(r, "path", "") for r in app.routes if getattr(r, "path", "").startswith("/api/")
+        }
+
+    assert api_paths(create_app(mode="prod")) == api_paths(create_app(mode="dev"))
+
+
+# ---------------------------------------------------------------------------
+# SPA markup / JS source pins
+# ---------------------------------------------------------------------------
+
+_STATIC = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" / "static"
+
+
+def _read_static(name: str) -> str:
+    return (_STATIC / name).read_text(encoding="utf-8")
+
+
+def test_html_main_tabs_all_carry_ui_tier_attr() -> None:
+    html = _read_static("index.html")
+    tab_buttons = re.findall(r'<button[^>]*class="tab-btn[^"]*"[^>]*>', html)
+    assert tab_buttons, "no tab-btn elements found — markup drift"
+    for tag in tab_buttons:
+        assert "data-ui-tier=" in tag, f"tab-btn missing data-ui-tier: {tag[:120]}"
+
+
+def test_html_settings_nav_btns_all_carry_ui_tier_attr() -> None:
+    html = _read_static("index.html")
+    settings_buttons = re.findall(r'<button[^>]*class="settings-nav-btn[^"]*"[^>]*>', html)
+    assert settings_buttons, "no settings-nav-btn elements found — markup drift"
+    for tag in settings_buttons:
+        assert "data-ui-tier=" in tag, f"settings-nav-btn missing data-ui-tier: {tag[:120]}"
+
+
+def test_html_dev_mode_banner_is_present_and_starts_hidden() -> None:
+    html = _read_static("index.html")
+    assert 'id="dev-mode-banner"' in html, "dev-mode banner removed from markup"
+    banner_tag = re.search(r'<div[^>]*id="dev-mode-banner"[^>]*>', html)
+    assert banner_tag is not None
+    assert "hidden" in banner_tag.group(0), (
+        "dev-mode banner must start hidden; JS reveals it in dev mode"
+    )
+
+
+def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
+    """JS grep pin — the test suite has no JS runtime. A source scan catches
+    regressions in the two behaviors we rely on."""
+    js = _read_static("app.js")
+    # STATE.uiMode default must stay 'prod' so fetch failures degrade to the
+    # polished surface rather than exposing dev pages.
+    assert re.search(r"uiMode:\s*'prod'", js), "STATE.uiMode early default changed"
+    # Hash-fallback / settings-section redirect toast — routed through i18n.
+    assert "toast.dev_only_section" in js, "dev-only redirect toast key missing"
+    # And the locale entries themselves are pinned so a rename doesn't go
+    # unnoticed by the i18n completeness check.
+    en = _read_static("locales/en.json")
+    ko = _read_static("locales/ko.json")
+    assert '"toast.dev_only_section"' in en
+    assert '"toast.dev_only_section"' in ko

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -12,7 +12,7 @@ import re
 from pathlib import Path
 
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 
 from memtomem.web.app import (
     _DEV_ONLY_ROUTERS,
@@ -87,13 +87,46 @@ def test_resolve_web_mode_lenient_falls_back_to_prod(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize("mode", ["prod", "dev"])
-def test_ui_mode_endpoint_reflects_app_state(mode: str) -> None:
+async def test_ui_mode_endpoint_reflects_app_state(mode: str) -> None:
+    """Endpoint echoes ``app.state.web_mode``.
+
+    The endpoint is localhost-guarded (for consistency with other system
+    endpoints), so the transport has to spoof the ASGI scope ``client`` as
+    a loopback address — the default ``testclient`` host would get a 403.
+    """
     app = create_app(mode=mode)  # type: ignore[arg-type]
-    with TestClient(app) as client:
-        resp = client.get("/api/system/ui-mode")
+    transport = ASGITransport(app=app, client=("127.0.0.1", 0))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        resp = await c.get("/api/system/ui-mode")
     assert resp.status_code == 200
     assert resp.json() == {"mode": mode}
+
+
+@pytest.mark.asyncio
+async def test_ui_mode_endpoint_rejects_non_localhost() -> None:
+    """External scanners must not be able to fingerprint dev-mode servers."""
+    app = create_app(mode="dev")
+    transport = ASGITransport(app=app, client=("203.0.113.7", 0))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        resp = await c.get("/api/system/ui-mode")
+    assert resp.status_code == 403
+
+
+def test_module_level_app_is_memoized() -> None:
+    """Two imports of ``memtomem.web.app.app`` must return the same
+    ``FastAPI`` instance. ``__getattr__`` fires on every attribute access
+    that isn't already in the module ``__dict__`` — without a singleton
+    cache, every caller would get their own router set + state."""
+    from memtomem.web import app as app_mod
+
+    # Clear any prior cache so the test is deterministic regardless of
+    # import order from the rest of the suite.
+    app_mod._app_singleton = None
+    first = app_mod.app
+    second = app_mod.app
+    assert first is second
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Mechanism-only first step of a planned two-PR split that narrows the default `mm web` surface to the polished page set.
- This PR adds the plumbing (`create_app(mode=...)`, env/CLI resolution, `/api/system/ui-mode`, SPA filter hooks, dev-mode banner markup, i18n-routed toasts) with `_DEV_ONLY_ROUTERS = []` and every tab/settings-section marked `data-ui-tier="prod"` — so the status quo is preserved.
- PR 2 will populate the classification, reintroduce the Home dashboard dev-only fetch gate, and ship docs/CHANGELOG; reviewers can then focus on the line-drawing without re-litigating the mechanism.

## What changes

- `create_app(lifespan, mode="prod"|"dev")` picks between `_PROD_ROUTERS` and an opt-in `_DEV_ONLY_ROUTERS` (empty in this PR). `app.state.web_mode` exposes the resolved mode.
- `resolve_web_mode_from_env()` reads `MEMTOMEM_WEB__MODE`. `strict=True` raises on invalid values (CLI path); `strict=False` warns and falls back to `prod` (module-level ASGI mount path).
- `_VALID_WEB_MODES` is derived from `get_args(WebMode)` so the `Literal` stays the single source of truth.
- Module-level `app` is lazy via `__getattr__`, memoized in a module-level `_app_singleton` so repeated `from memtomem.web.app import app` returns the same `FastAPI` instance (fresh per-call would leak router sets and lifespan handlers).
- `GET /api/system/ui-mode` returns `{"mode": "prod"|"dev"}` for the SPA to read on boot. Localhost-guarded for consistency with other `system` endpoints.
- `mm web --mode {prod,dev}` + `mm web --dev` shortcut. Mutex enforced with a one-line `click.UsageError` check on presence (no extra dep). Invalid `MEMTOMEM_WEB__MODE` raises `click.BadParameter` — fail loud, don't silently fall back (`feedback_silent_policy_enforcement_gap.md`). `resolved_mode` typed as `WebMode`.
- SPA: `STATE.uiMode` defaults to `'prod'` so a boot-race or fetch failure degrades to the polished surface. `initUiMode()` fetches the endpoint, applies `data-ui-tier="dev"` visibility filters (with a belt-and-braces `hidden` + `display:none` for flex-column parents), toggles the `#dev-mode-banner` header strip. Hidden-tab or hidden-settings-section hashes redirect to the first visible entry with a localized toast (`toast.dev_only_section` — en + ko).
- Markup: every `.tab-btn` and `.settings-nav-btn` carries `data-ui-tier="prod"` today; PR 2 only flips the attribute value on the 11 sections being moved.

## OpenAPI note

One new endpoint (`GET /api/system/ui-mode`) appears in the OpenAPI schema. That is the only user-observable difference in this PR — the SPA surface is unchanged.

## Tests

- New `tests/test_web_mode.py` (24 tests): factory mode propagation, env resolver strict/lenient, endpoint round-trip (with the localhost guard spoofed via `ASGITransport(client=("127.0.0.1", 0))`), public-IP 403 negative case, `_app_singleton` memoization regression, `_PROD_ROUTERS` / `_DEV_ONLY_ROUTERS` disjointness, PR 1 snapshot (`prod == dev` route set), HTML attribute drift guards, JS source-scan pins for `STATE.uiMode: 'prod'` default and the i18n toast key (with matching locale entries).
- Extended `tests/test_web_cli.py` (+8 tests): `--mode` / `--dev` / env mode propagation to `create_app`, mutex on `--mode X --dev Y` including same-value, invalid env (`BadParameter`), CLI-beats-env precedence.
- Full suite: 2000 passed, 46 deselected. `ruff check` + `ruff format --check` clean.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama" -q`
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `mm web` (default prod) → `{"mode":"prod"}` on `/api/system/ui-mode`
- [x] `mm web --dev` → `{"mode":"dev"}`; `/api/sessions` reachable
- [x] `mm web --mode prod --dev` → `UsageError: --mode and --dev are mutually exclusive`
- [x] `MEMTOMEM_WEB__MODE=foo mm web` → `BadParameter` (no silent prod fallback)

## Review changes

- ~~Home dashboard dev-only fetch gate~~ reverted — it had `namespaces`/`sessions`/`scratch` return 0 on Home in prod even though those routers are still registered, which contradicted the "status quo preserved" framing. It'll land in PR 2 alongside the router move so the user-visible change is atomic.
- `__getattr__` now memoizes `_app_singleton`. Without the cache, every attribute re-entry built a fresh `FastAPI` instance with its own state — invisible under `uvicorn memtomem.web.app:app` (one resolution), but a footgun for any other caller.
- Added the `_require_localhost` dependency on `/api/system/ui-mode` + tests that satisfy the ASGI `client` scope.
- Same-value mutex test (`--mode dev --dev`) added.
- `_VALID_WEB_MODES = frozenset(get_args(WebMode))` — `Literal` drives the runtime validator.
- `resolved_mode: WebMode` type narrowing in the CLI.
- Belt-and-braces comment on `_applyUiModeFilter` for the `hidden` + `display:none` pair.

## Follow-up (PR 2, separate)

- Populate `_DEV_ONLY_ROUTERS`, flip `data-ui-tier="dev"` on the 11 agreed-upon sections.
- **Reintroduce the Home dashboard dev-only fetch gate** for `/api/namespaces` / `/api/sessions` / `/api/scratch` (deferred from this PR).
- **Update `test_pr1_leaves_dev_only_routers_empty`** — it will naturally fail once PR 2 populates the list.
- Quickstart one-liner + `configuration.md` / `reference.md` rows + CHANGELOG entry + GitHub Release body with a `## Behavior change` callout (11 tabs disappear from the default surface and a matching set of `/api/` paths start returning 404 in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
