### PR TITLE
feat(web): move opt-in pages to dev-only tier + docs (behavior change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm web --mode` / `--dev` flags + `MEMTOMEM_WEB__MODE` env var** — select
+  the Web UI surface. `prod` (default) shows the polished page set; `dev`
+  extends it with opt-in maintainer pages (Namespaces, Sessions, Working
+  Memory, Procedures, Health Report, Artifact Sync, Hook Files,
+  Skills/Commands/Agents). `--mode` and `--dev` are mutually exclusive; an
+  invalid env value fails fast instead of silently falling back.
+- **`GET /api/system/ui-mode`** — localhost-guarded endpoint returning the
+  resolved mode so the SPA can filter tabs on boot.
+
+### Changed
+
+- **`mm web` default surface shrunk to the polished page set.** `Home`,
+  `Search`, `Sources`, `Index`, `Tags`, `Timeline`, and Settings (`Config`,
+  `Dedup`, `Age-out`, `Export/Import`, `Reset Database`) are always on. The
+  10 remaining Settings sections are opt-in via `mm web --dev` (or
+  `MEMTOMEM_WEB__MODE=dev`). Their API routes (`/api/namespaces`,
+  `/api/sessions`, `/api/scratch`, `/api/procedures`, `/api/context/*`,
+  `/api/settings-sync`, `/api/watchdog`, `/api/evaluation`) now return
+  **404** in `prod` mode — scripts that rely on them need `dev` mode.
+
 ## [0.1.15] — 2026-04-21
 
 memtomem remains in **alpha**. APIs, defaults, and on-disk config surfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   10 remaining Settings sections are opt-in via `mm web --dev` (or
   `MEMTOMEM_WEB__MODE=dev`). Their API routes (`/api/namespaces`,
   `/api/sessions`, `/api/scratch`, `/api/procedures`, `/api/context/*`,
-  `/api/settings-sync`, `/api/watchdog`, `/api/evaluation`) now return
+  `/api/settings-sync`, `/api/watchdog/*`, `/api/eval/*`) now return
   **404** in `prod` mode — scripts that rely on them need `dev` mode.
 
 ## [0.1.15] — 2026-04-21

--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ See [Embeddings](docs/guides/embeddings.md) for the full model/provider matrix.
 "Remember this insight"      →  mem_add(content="...", tags=["ops"])
 ```
 
+### 4. Web UI (optional)
+
+```bash
+mm web                # polished dashboard on http://127.0.0.1:8080
+mm web --dev          # maintainer surface (adds opt-in pages)
+```
+
+`mm web` shows the polished page set by default. Pass `--dev` (or set
+`MEMTOMEM_WEB__MODE=dev` in your shell profile) to expose maintainer pages
+like Namespaces, Sessions, Working Memory, and Health Report.
+
 <details>
 <summary><b>Other install options</b></summary>
 
@@ -98,7 +109,7 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 - **Incremental indexing** — chunk-level SHA-256 diff; only changed chunks get re-embedded
 - **Namespaces** — organize memories into scoped groups with auto-derivation from folder names
 - **Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
-- **Web UI** — visual dashboard for search, sources, tags, sessions, health monitoring
+- **Web UI** — visual dashboard for search, sources, tags, timeline, dedup, and more (`mm web --dev` for the full maintainer surface)
 - **MCP tools** — `mem_do` meta-tool routes all non-core actions in `core` mode for minimal context usage
 
 ---

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -684,6 +684,16 @@ The `openai` provider works with any OpenAI-compatible endpoint (LM Studio, vLLM
 
 In `core` mode, use `mem_do(action="...", params={...})` to access any of the 65+ non-core actions. Fewer tools means less context usage for AI agents.
 
+## Web UI Mode
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MEMTOMEM_WEB__MODE` | `prod` | Web UI surface: `prod` shows the polished page set; `dev` adds opt-in maintainer pages |
+
+`mm web --mode {prod,dev}` overrides the env. `mm web --dev` is a shortcut for `--mode dev` and is mutually exclusive with `--mode`. An invalid value fails fast rather than silently falling back.
+
+Tab classification changes over time — run `mm web --dev` to see the full surface of your installed version. The API endpoints backing dev-only pages (for example `/api/sessions`, `/api/scratch`, `/api/namespaces`, `/api/context/*`) return 404 in `prod` mode; switch to `dev` mode if you're scripting against them.
+
 ## Querying and Modifying at Runtime
 
 You can also inspect and change settings at runtime via the `mem_config` MCP tool (requires `MEMTOMEM_TOOL_MODE=full`; in `core` or `standard` mode, use `mm config` CLI or the Web UI Settings tab):

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -858,11 +858,15 @@ on promotion prevents the chunk from being immediately re-archived.
 ## Web UI
 
 ```bash
-memtomem-web                  # http://localhost:8080
-memtomem-web --port 3000      # custom port
+mm web                         # http://localhost:8080 (prod surface)
+mm web --port 3000             # custom port
+mm web --dev                   # adds opt-in maintainer pages
+mm web --mode {prod,dev}       # explicit mode (mutually exclusive with --dev)
 ```
 
-The dashboard exposes search, sources, indexing, tags, timeline, and a "More" tab covering config, namespaces, dedup/decay, export/import, and the harness (sessions, working memory, procedures, health).
+`mm web` defaults to the polished page set: Home, Search, Sources, Index, Tags, Timeline, and Settings (Config, Dedup, Age-out, Export/Import, Reset Database). `mm web --dev` — or setting `MEMTOMEM_WEB__MODE=dev` in your shell profile — extends the surface with maintainer pages (Namespaces, Sessions, Working Memory, Procedures, Health Report, Artifact Sync, Hook Files, Skills/Commands/Agents).
+
+Tab classification changes over time — run `mm web --dev` against your installed version to see the complete surface. The API endpoints backing dev-only pages return 404 in `prod` mode; scripts that hit `/api/sessions`, `/api/scratch`, `/api/namespaces`, `/api/context/*`, etc. need `dev` mode.
 
 ---
 
@@ -917,7 +921,8 @@ mm ingest codex-memory --source PATH   # index Codex CLI memory
 
 # Utilities
 mm shell                               # interactive REPL
-mm web                                 # launch Web UI (http://localhost:8080)
+mm web                                 # launch Web UI (prod surface)
+mm web --dev                           # Web UI with opt-in maintainer pages
 ```
 
 Install the CLI: `uv tool install memtomem` (PyPI) or `uv run mm ...` (source).

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -52,8 +52,11 @@ _VALID_WEB_MODES: frozenset[str] = frozenset(get_args(WebMode))
 _WEB_MODE_ENV = "MEMTOMEM_WEB__MODE"
 
 # Routers that define the polished surface shipped to `uv tool install` users.
-# `_DEV_ONLY_ROUTERS` is the opt-in extension (PR 2 fills it in — currently
-# empty so this PR is mechanism-only with no user-visible change).
+# `_DEV_ONLY_ROUTERS` is the opt-in extension mounted only when
+# ``mode == "dev"`` — those pages have rougher UX, narrower audiences, or
+# are still in flux, so they stay hidden by default until they graduate.
+# Edit carefully: these lists are the source of truth; the SPA's
+# ``data-ui-tier`` attributes in ``index.html`` must match.
 _PROD_ROUTERS: list[ModuleType] = [
     search,
     chunks,
@@ -63,8 +66,10 @@ _PROD_ROUTERS: list[ModuleType] = [
     dedup,
     decay,
     export,
-    namespaces,
     timeline,
+]
+_DEV_ONLY_ROUTERS: list[ModuleType] = [
+    namespaces,
     sessions,
     scratch,
     procedures,
@@ -76,7 +81,6 @@ _PROD_ROUTERS: list[ModuleType] = [
     context_commands,
     context_agents,
 ]
-_DEV_ONLY_ROUTERS: list[ModuleType] = []
 
 
 def resolve_web_mode_from_env(*, strict: bool = False) -> WebMode:

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -646,10 +646,16 @@ async function checkEmbeddingMismatch() {
 
 async function loadDashboard() {
   try {
+    // /api/namespaces is dev-only; prod returns 404. Gate the fetch and
+    // let the namespace card render 0 rather than fire a guaranteed miss.
+    const devMode = STATE.uiMode === 'dev';
+    const nsPromise = devMode
+      ? api('GET', '/api/namespaces').catch(() => ({ namespaces: [] }))
+      : Promise.resolve({ namespaces: [] });
     const [stats, sourcesData, nsData, configData, embStatus, timelineData] = await Promise.all([
       api('GET', '/api/stats'),
       api('GET', '/api/sources'),
-      api('GET', '/api/namespaces'),
+      nsPromise,
       api('GET', '/api/config'),
       api('GET', '/api/embedding-status').catch(() => null),
       api('GET', '/api/timeline?days=365&limit=1000').catch(() => ({ chunks: [] })),
@@ -665,12 +671,17 @@ async function loadDashboard() {
     const totalSize = allSources.reduce((sum, s) => sum + (s.file_size || 0), 0);
     qs('home-total-size').textContent = formatBytes(totalSize) || '0 B';
 
-    // Harness stats (sessions + scratch)
+    // Harness stats (sessions + scratch) — dev-only routers. In prod we
+    // render zeroes rather than fire 404s on every Home render.
     try {
-      const [sessData, scratchData] = await Promise.all([
-        api('GET', '/api/sessions?limit=1').catch(() => ({ total: 0 })),
-        api('GET', '/api/scratch').catch(() => ({ total: 0 })),
-      ]);
+      let sessData = { total: 0 };
+      let scratchData = { total: 0 };
+      if (devMode) {
+        [sessData, scratchData] = await Promise.all([
+          api('GET', '/api/sessions?limit=1').catch(() => ({ total: 0 })),
+          api('GET', '/api/scratch').catch(() => ({ total: 0 })),
+        ]);
+      }
       qs('home-sessions').textContent = sessData.total;
       qs('home-scratch').textContent = scratchData.total;
     } catch { /* non-critical */ }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -548,7 +548,7 @@
             <span class="nav-sub" data-i18n="settings.nav.config_sub">Embedding &amp; DB</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🗂</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.namespaces">Namespaces</span>
@@ -560,35 +560,35 @@
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.integrations">Integrations</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🔄</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_overview">Artifact Sync</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Skills/Cmd/Agents status</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🧩</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_skills">Skills</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Skill definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⌘</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_commands">Commands</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_commands_sub">Command definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🤖</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_agents">Agents</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_agents_sub">Agent definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">📎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.hooks_sync">Hook Files</span>
@@ -600,28 +600,28 @@
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.runtime">Runtime</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-sessions" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-sessions" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">▷</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.sessions">Sessions</span>
             <span class="nav-sub" data-i18n="settings.nav.sessions_sub">Episodic history</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-scratch" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-scratch" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">✎</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.working_memory">Working Memory</span>
             <span class="nav-sub" data-i18n="settings.nav.working_memory_sub">Scratch KV</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-procedures" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-procedures" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">📜</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.procedures">Procedures</span>
             <span class="nav-sub" data-i18n="settings.nav.procedures_sub">Saved recipes</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="harness-health" data-group="runtime" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="harness-health" data-group="runtime" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">💓</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.health">Health Report</span>

--- a/packages/memtomem/tests/test_web_exclude_guard.py
+++ b/packages/memtomem/tests/test_web_exclude_guard.py
@@ -38,7 +38,7 @@ async def real_stack_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     cfg.indexing.exclude_patterns = []
 
     comp = await create_components(cfg)
-    app = create_app(lifespan=None)
+    app = create_app(lifespan=None, mode="dev")
     app.state.storage = comp.storage
     app.state.embedder = comp.embedder
     app.state.search_pipeline = comp.search_pipeline

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -78,7 +78,7 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture
 def app(home: Path):
-    application = create_app(lifespan=None)
+    application = create_app(lifespan=None, mode="dev")
 
     # Minimal component mocks — hot-reload path doesn't touch storage/embedder
     # in the read-through case, but some write handlers pass them through.
@@ -618,7 +618,7 @@ class TestSignature:
 
 class TestReloadIfStale:
     def test_no_change_returns_false(self, home: Path):
-        app = create_app(lifespan=None)
+        app = create_app(lifespan=None, mode="dev")
         app.state.config = _hot_reload._build_fresh_config()
         app.state.config_signature = _hot_reload.current_signature()
         app.state.last_reload_error = None
@@ -626,7 +626,7 @@ class TestReloadIfStale:
         assert _hot_reload.reload_if_stale(app) is False
 
     def test_change_swaps_config(self, home: Path):
-        app = create_app(lifespan=None)
+        app = create_app(lifespan=None, mode="dev")
         _write_config(home, {"mmr": {"enabled": False}})
         app.state.config = _hot_reload._build_fresh_config()
         app.state.config_signature = _hot_reload.current_signature()
@@ -638,7 +638,7 @@ class TestReloadIfStale:
         assert app.state.config.mmr.enabled is True
 
     def test_broken_disk_keeps_old_config(self, home: Path):
-        app = create_app(lifespan=None)
+        app = create_app(lifespan=None, mode="dev")
         _write_config(home, {"mmr": {"enabled": False}})
         app.state.config = _hot_reload._build_fresh_config()
         app.state.config_signature = _hot_reload.current_signature()

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -1,9 +1,9 @@
 """Tests for the web UI mode mechanism (prod / dev tier).
 
-PR 1 introduces the plumbing — ``create_app(mode=...)``, ``/api/system/ui-mode``,
-and SPA filtering — without moving any page into the dev-only tier yet.
-The route set between prod and dev is therefore identical in this PR; PR 2
-is where the classification change lands and this snapshot will diverge.
+Covers the ``create_app(mode=...)`` factory, the ``MEMTOMEM_WEB__MODE``
+env resolver, the ``/api/system/ui-mode`` endpoint, and the drift guards
+that keep the HTML ``data-ui-tier`` classification in sync with the
+Python ``_PROD_ROUTERS`` / ``_DEV_ONLY_ROUTERS`` lists.
 """
 
 from __future__ import annotations
@@ -138,21 +138,53 @@ def test_prod_dev_router_lists_are_disjoint() -> None:
     assert set(_PROD_ROUTERS).isdisjoint(set(_DEV_ONLY_ROUTERS))
 
 
-def test_pr1_leaves_dev_only_routers_empty() -> None:
-    """PR 1 is mechanism-only: no classification changes yet. When PR 2
-    populates ``_DEV_ONLY_ROUTERS`` this test must be updated alongside."""
-    assert _DEV_ONLY_ROUTERS == []
+def test_dev_only_routers_are_populated() -> None:
+    """Classification landed: dev mode must actually extend the prod set."""
+    assert _DEV_ONLY_ROUTERS, "_DEV_ONLY_ROUTERS is empty — classification missing"
 
 
-def test_route_counts_match_in_pr1_snapshot() -> None:
-    """With classification unchanged, prod and dev mount identical routes."""
+def _api_paths(app) -> set[str]:
+    return {
+        getattr(r, "path", "") for r in app.routes if getattr(r, "path", "").startswith("/api/")
+    }
 
-    def api_paths(app) -> set[str]:
-        return {
-            getattr(r, "path", "") for r in app.routes if getattr(r, "path", "").startswith("/api/")
-        }
 
-    assert api_paths(create_app(mode="prod")) == api_paths(create_app(mode="dev"))
+def test_dev_routes_extend_prod_routes() -> None:
+    prod_paths = _api_paths(create_app(mode="prod"))
+    dev_paths = _api_paths(create_app(mode="dev"))
+    assert prod_paths < dev_paths, "dev mode must strictly extend prod"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path,method",
+    [
+        ("/api/sessions", "GET"),
+        ("/api/scratch", "GET"),
+        ("/api/namespaces", "GET"),
+        ("/api/procedures", "GET"),
+        ("/api/context/overview", "GET"),
+        ("/api/watchdog/status", "GET"),
+    ],
+)
+async def test_dev_only_routes_return_404_in_prod(path: str, method: str) -> None:
+    """Spot-check a few representative dev-only endpoints — prod must not
+    expose them. Route-level filtering is the security boundary; the SPA's
+    ``data-ui-tier`` hiding is purely UX."""
+    app = create_app(mode="prod")
+    transport = ASGITransport(app=app, client=("127.0.0.1", 0))
+    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
+        resp = await c.request(method, path)
+    assert resp.status_code == 404
+
+
+def test_prod_keeps_polished_routes_mounted() -> None:
+    """Sanity: the dev-only move mustn't brick the polished surface."""
+    prod_paths = _api_paths(create_app(mode="prod"))
+    for expected in ("/api/search", "/api/sources", "/api/stats", "/api/config"):
+        assert expected in prod_paths, (
+            f"{expected} is missing from prod — reclassify or the router list"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -194,16 +226,49 @@ def test_html_dev_mode_banner_is_present_and_starts_hidden() -> None:
 
 def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     """JS grep pin — the test suite has no JS runtime. A source scan catches
-    regressions in the two behaviors we rely on."""
+    regressions in the three behaviors we rely on."""
     js = _read_static("app.js")
     # STATE.uiMode default must stay 'prod' so fetch failures degrade to the
     # polished surface rather than exposing dev pages.
     assert re.search(r"uiMode:\s*'prod'", js), "STATE.uiMode early default changed"
     # Hash-fallback / settings-section redirect toast — routed through i18n.
     assert "toast.dev_only_section" in js, "dev-only redirect toast key missing"
+    # Home dashboard must gate dev-only endpoints behind the mode check so
+    # prod users don't see guaranteed 404s on every Home render.
+    assert "const devMode = STATE.uiMode === 'dev'" in js, (
+        "Home dashboard lost its dev-only fetch gate"
+    )
     # And the locale entries themselves are pinned so a rename doesn't go
     # unnoticed by the i18n completeness check.
     en = _read_static("locales/en.json")
     ko = _read_static("locales/ko.json")
     assert '"toast.dev_only_section"' in en
     assert '"toast.dev_only_section"' in ko
+
+
+def test_html_classification_matches_router_lists() -> None:
+    """HTML ``data-ui-tier`` values must agree with the Python router lists
+    — drift between the two would hide/show a tab whose route disagrees,
+    breaking `mm web --dev` discovery or producing phantom prod 404s."""
+    html = _read_static("index.html")
+    dev_sections = set(re.findall(r'data-ui-tier="dev"\s+data-section="([^"]+)"', html))
+    # Expected dev sections derived from _DEV_ONLY_ROUTERS + naming (SPA
+    # section id != router module). Source of truth: whoever edits the
+    # router lists must also update the HTML, and this test enforces it.
+    expected_dev = {
+        "namespaces",
+        "ctx-overview",
+        "ctx-skills",
+        "ctx-commands",
+        "ctx-agents",
+        "hooks-sync",
+        "harness-sessions",
+        "harness-scratch",
+        "harness-procedures",
+        "harness-health",
+    }
+    assert dev_sections == expected_dev, (
+        f"HTML dev-tier sections drifted from expected set. "
+        f"Only in HTML: {dev_sections - expected_dev}. "
+        f"Missing: {expected_dev - dev_sections}."
+    )

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -165,17 +165,36 @@ def test_dev_routes_extend_prod_routes() -> None:
         ("/api/procedures", "GET"),
         ("/api/context/overview", "GET"),
         ("/api/watchdog/status", "GET"),
+        ("/api/settings-sync", "GET"),
+        ("/api/eval", "GET"),
     ],
 )
-async def test_dev_only_routes_return_404_in_prod(path: str, method: str) -> None:
-    """Spot-check a few representative dev-only endpoints — prod must not
-    expose them. Route-level filtering is the security boundary; the SPA's
-    ``data-ui-tier`` hiding is purely UX."""
-    app = create_app(mode="prod")
-    transport = ASGITransport(app=app, client=("127.0.0.1", 0))
-    async with AsyncClient(transport=transport, base_url="http://testserver") as c:
-        resp = await c.request(method, path)
-    assert resp.status_code == 404
+async def test_dev_only_routes_blocked_in_prod_but_exposed_in_dev(path: str, method: str) -> None:
+    """Spot-check a representative dev-only endpoint — prod must not expose
+    it, dev must. Asserting both sides catches the bug where a parametrize
+    entry with a typo (or wrong method) would trivially "pass" in prod
+    because the route doesn't exist in either mode. Route-level filtering
+    is the security boundary; the SPA's ``data-ui-tier`` hiding is UX.
+
+    The prod check uses real HTTP so we know the 404 comes from the
+    catch-all handler, not route-handler failure. The dev check reads the
+    registered ``app.routes`` set directly — this avoids having to wire
+    ``app.state.storage`` etc. for every dev-only router just to prove
+    the path got mounted."""
+    prod_app = create_app(mode="prod")
+    dev_app = create_app(mode="dev")
+
+    dev_paths = {getattr(r, "path", "") for r in dev_app.routes}
+    assert path in dev_paths, f"{method} {path} is missing in dev too — parametrize entry is wrong"
+
+    async with AsyncClient(
+        transport=ASGITransport(app=prod_app, client=("127.0.0.1", 0)),
+        base_url="http://testserver",
+    ) as c:
+        prod_resp = await c.request(method, path)
+    assert prod_resp.status_code == 404, (
+        f"{method} {path} is still reachable in prod: {prod_resp.status_code}"
+    )
 
 
 def test_prod_keeps_polished_routes_mounted() -> None:
@@ -244,6 +263,19 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     ko = _read_static("locales/ko.json")
     assert '"toast.dev_only_section"' in en
     assert '"toast.dev_only_section"' in ko
+
+
+def test_html_main_tabs_all_stay_prod() -> None:
+    """Main top-nav tabs (Home / Search / Sources / Index / Tags / Timeline /
+    Settings) should all be prod today. Flipping a main tab to dev would be
+    a large UX decision — if it ever happens, update this assertion to an
+    explicit expected set so the intent is reviewable."""
+    html = _read_static("index.html")
+    dev_tabs = set(re.findall(r'data-ui-tier="dev"\s+data-tab="([^"]+)"', html))
+    assert dev_tabs == set(), (
+        f"Main tabs should all be prod; found dev: {dev_tabs}. "
+        "If intentional, replace this assertion with an explicit expected set."
+    )
 
 
 def test_html_classification_matches_router_lists() -> None:

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -118,7 +118,7 @@ class FakeConfig:
 @pytest.fixture
 def app():
     """Create an app without lifespan and wire mock state."""
-    application = create_app(lifespan=None)
+    application = create_app(lifespan=None, mode="dev")
 
     # -- storage mock --
     storage = AsyncMock()

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -20,7 +20,7 @@ from memtomem.web.app import create_app
 @pytest.fixture
 def ctx_app(tmp_path: Path):
     """App with project_root pointing to a temp directory."""
-    application = create_app(lifespan=None)
+    application = create_app(lifespan=None, mode="dev")
     application.state.project_root = tmp_path
     # Minimal stubs for deps the app might check
     application.state.storage = AsyncMock()

--- a/packages/memtomem/tests/test_web_routes_context_locks.py
+++ b/packages/memtomem/tests/test_web_routes_context_locks.py
@@ -45,7 +45,7 @@ def gateway_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture
 def app(gateway_home: Path):
-    application = create_app(lifespan=None)
+    application = create_app(lifespan=None, mode="dev")
     application.state.project_root = gateway_home
     application.state.storage = AsyncMock()
     application.state.config = None

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -118,7 +118,7 @@ class FakeConfig:
 @pytest.fixture
 def app():
     """Create an app without lifespan and wire mock state."""
-    application = create_app(lifespan=None)
+    application = create_app(lifespan=None, mode="dev")
 
     # -- storage mock --
     storage = AsyncMock()
@@ -1072,7 +1072,7 @@ class TestNamespaceIntegration:
         comp = await create_components(config)
         _cfg.load_config_overrides = _orig
 
-        application = create_app(lifespan=None)
+        application = create_app(lifespan=None, mode="dev")
         application.state.storage = comp.storage
         application.state.config = config
         application.state.embedder = comp.embedder


### PR DESCRIPTION
## Behavior change

> **This PR narrows the default `mm web` surface.**
>
> - **10 Settings sections disappear from the default view** (Namespaces, Artifact Sync, Skills/Commands/Agents, Hook Files, Sessions, Working Memory, Procedures, Health Report). Main tabs (Home, Search, Sources, Index, Tags, Timeline) and 5 Settings sections (Config, Dedup, Age-out, Export/Import, Reset Database) remain on by default.
> - **Matching API routes return 404 in `prod` mode**: `/api/namespaces`, `/api/sessions`, `/api/scratch`, `/api/procedures`, `/api/context/*`, `/api/settings-sync`, `/api/watchdog/*`, `/api/eval/*`. Scripts that hit these endpoints need to switch to dev mode.
> - **Restoring the full surface** — either `mm web --dev` (per-invocation) or `export MEMTOMEM_WEB__MODE=dev` in your shell profile (persistent).

## Summary

- Second step of the two-PR split (#343 shipped the plumbing). This PR populates `_DEV_ONLY_ROUTERS`, flips `data-ui-tier` on 10 HTML sections, reintroduces the Home dashboard dev-only fetch gate, and ships the user-facing docs/CHANGELOG.

## Classification (final)

| Surface | Tabs / Settings sections |
|---|---|
| **Prod** (default, always on) | Home, Search, Sources, Index, Tags, Timeline; Settings > Config, Dedup, Age-out, Export/Import, Reset Database |
| **Dev-only** (opt-in) | Settings > Namespaces, Artifact Sync, Skills, Commands, Agents, Hook Files, Sessions, Working Memory, Procedures, Health Report |

Router moves (`web/app.py`): `namespaces`, `sessions`, `scratch`, `procedures`, `evaluation`, `watchdog`, `settings_sync`, `context_gateway`, `context_skills`, `context_commands`, `context_agents` → `_DEV_ONLY_ROUTERS`.

## Implementation

- `_PROD_ROUTERS` keeps `search`, `chunks`, `sources`, `system`, `tags`, `dedup`, `decay`, `export`, `timeline` (9 modules, 11 sections — `system` powers Config/Reset, `chunks` backs the Index tab's Add flow).
- 10 `.settings-nav-btn` entries in `index.html` flip to `data-ui-tier="dev"`. The 7 main tabs stay prod.
- `loadDashboard` in `app.js` now gates `/api/namespaces` (+ the follow-up `/api/sessions` and `/api/scratch` fetches) behind `STATE.uiMode === 'dev'`. Prod renders those cards as 0 rather than firing guaranteed 404s on every Home visit.
- Existing `test_web_*` fixtures call `create_app(mode="dev")` so tests that exercise dev-only routes keep working.

## Tests

- `test_web_mode.py`:
  - `test_dev_only_routers_are_populated` replaces PR #343's "empty dev list" guard.
  - `test_dev_routes_extend_prod_routes` — prod is a proper subset of dev.
  - Parametrized `test_dev_only_routes_blocked_in_prod_but_exposed_in_dev` spot-checks 8 representative endpoints (one per dev-only router module). Asserts both prod 404 *and* dev registration so a typo in the list fails loudly instead of trivially passing.
  - `test_prod_keeps_polished_routes_mounted` — safety net against accidentally classifying a prod route dev.
  - `test_html_main_tabs_all_stay_prod` — drift guard for the top nav; forces the intent to be explicit if a main tab ever flips to dev.
  - `test_html_classification_matches_router_lists` — explicit expected `dev_sections` set; any drift between HTML and Python fails with a diff message.
  - JS grep pin for the Home dashboard `devMode` gate.
- Full suite: **2011 passed, 46 deselected.** `ruff check` + `ruff format --check` clean.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama" -q`
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `mm web` (default prod) → `{"mode":"prod"}`; `/api/sessions`, `/api/scratch`, `/api/namespaces`, `/api/context/overview` → 404; `/api/stats` → 200
- [x] `mm web --dev` → `{"mode":"dev"}`; all of the above → 200
- [ ] Visual check in browser: prod shows Home/Search/Sources/Index/Tags/Timeline + 5 Settings sections; dev shows everything + the `#dev-mode-banner` strip

## Docs

- `README.md` — new "4. Web UI (optional)" Quick Start step + features bullet edited.
- `docs/guides/configuration.md` — new `## Web UI Mode` section with `MEMTOMEM_WEB__MODE` and a drift-proof note: "run `mm web --dev` to see the full surface of your installed version."
- `docs/guides/reference.md` — Web UI section + CLI Reference updated with `--mode`/`--dev` and the 404 list.
- `CHANGELOG.md` — Unreleased `Added` + `Changed` with the complete behavior-change detail.

## Follow-up

- GitHub Release body (drafted at tag time, not here): reproduce the Behavior change block above so scripting users see the migration note in release notes, not just CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
