### PR TITLE
release: v0.1.16 — `mm web` polished default surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.16] — 2026-04-21
+
+memtomem remains in **alpha**. This release narrows the default `mm web`
+surface to the polished page set so first-time users see a coherent
+dashboard instead of the full maintainer toolbox. The full surface
+remains available via `mm web --dev` (or `MEMTOMEM_WEB__MODE=dev`), and
+every UI-level hide is backed by a matching 404 on the API so
+scripting callers fail loudly rather than against a half-built page.
+
 ### Added
 
 - **`mm web --mode` / `--dev` flags + `MEMTOMEM_WEB__MODE` env var** — select
@@ -12,9 +21,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   extends it with opt-in maintainer pages (Namespaces, Sessions, Working
   Memory, Procedures, Health Report, Artifact Sync, Hook Files,
   Skills/Commands/Agents). `--mode` and `--dev` are mutually exclusive; an
-  invalid env value fails fast instead of silently falling back.
+  invalid env value fails fast instead of silently falling back. (#343, #344)
 - **`GET /api/system/ui-mode`** — localhost-guarded endpoint returning the
-  resolved mode so the SPA can filter tabs on boot.
+  resolved mode so the SPA can filter tabs on boot. (#343)
 
 ### Changed
 
@@ -25,7 +34,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `MEMTOMEM_WEB__MODE=dev`). Their API routes (`/api/namespaces`,
   `/api/sessions`, `/api/scratch`, `/api/procedures`, `/api/context/*`,
   `/api/settings-sync`, `/api/watchdog/*`, `/api/eval/*`) now return
-  **404** in `prod` mode — scripts that rely on them need `dev` mode.
+  **404** in `prod` mode — scripts that rely on them need `dev` mode. (#344)
 
 ## [0.1.15] — 2026-04-21
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.15"
+version = "0.1.16"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Version bump to **0.1.16**, promoting the `[Unreleased]` CHANGELOG block (PRs #343, #344) into a dated section.
- `packages/memtomem/pyproject.toml` + `uv.lock` workspace entry bumped in the same commit (`feedback_uv_lock_version_sync.md`).
- No source changes — every line in `#343` / `#344` is already on `main`.

## What's in 0.1.16 (user-facing)

> **`mm web` default surface is now the polished page set.** First-time users see a coherent dashboard instead of the full maintainer toolbox. Maintainers opt into the full surface via `mm web --dev` (or `MEMTOMEM_WEB__MODE=dev`).
>
> - Always on: Home, Search, Sources, Index, Tags, Timeline; Settings > Config, Dedup, Age-out, Export/Import, Reset Database.
> - Opt-in (dev-only): Settings > Namespaces, Artifact Sync, Skills/Commands/Agents, Hook Files, Sessions, Working Memory, Procedures, Health Report.
> - Matching API routes return **404** in `prod` mode: `/api/namespaces`, `/api/sessions`, `/api/scratch`, `/api/procedures`, `/api/context/*`, `/api/settings-sync`, `/api/watchdog/*`, `/api/eval/*`. Scripts that rely on them need `dev` mode.

## Release path (after merge)

Per `project_release_workflow.md` + `feedback_prerelease_dry_run.md`:

1. Merge this PR (squash).
2. Push `test-v0.1.16` tag → TestPyPI dry-run → `uvx --refresh --from memtomem==0.1.16 mm --version` to confirm the artifact works.
3. Push `v0.1.16` tag → approve `pypi` deployment environment → trusted publisher uploads.
4. Draft GitHub Release body — reproduce the "What's in 0.1.16" block above so scripting users see the 404 migration note in release notes, not just CHANGELOG.

## Test plan

- [x] `uv lock` — editable workspace entry bumps cleanly, no dependency resolution changes.
- [x] `uv run ruff check packages/memtomem/src` — clean.
- [x] `uv run pytest packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/test_web_cli.py -q` — 51 passed.
- [ ] CI on this PR (repeat of recent runs, expected pass).
- [ ] TestPyPI dry-run after tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
