### PR TITLE
docs: catch up getting-started / PyPI README / reference with v0.1.15 + v0.1.16

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -421,7 +421,7 @@ mm web                     # polished dashboard on http://127.0.0.1:8080
 mm web --dev               # adds opt-in maintainer pages
 ```
 
-The default surface covers search, sources, indexing, tags, timeline, and a Settings tab. Pass `--dev` (or set `MEMTOMEM_WEB__MODE=dev` in your shell profile) to expose maintainer pages like Namespaces, Sessions, Working Memory, and Health Report — see [Configuration → Web UI Mode](configuration.md#web-ui-mode) for details.
+The default surface covers the Home, Search, Sources, Index, Tags, Timeline, and More tabs (the More tab hosts Settings, Dedup, Age-out, Export/Import, and Reset Database). Pass `--dev` (or set `MEMTOMEM_WEB__MODE=dev` in your shell profile) to expose maintainer pages like Namespaces, Sessions, Working Memory, and Health Report — see [Configuration → Web UI Mode](configuration.md#web-ui-mode) for details.
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -414,13 +414,14 @@ See the [memtomem-stm README](https://github.com/memtomem/memtomem-stm#readme) f
 
 ## Optional: Web UI
 
-For a visual dashboard with search, tags, sessions, and health monitoring:
+For a visual dashboard:
 
 ```bash
-mm web                     # opens http://localhost:8080
+mm web                     # polished dashboard on http://127.0.0.1:8080
+mm web --dev               # adds opt-in maintainer pages
 ```
 
-Tabs cover search, sources, indexing, tags, timeline, and a "More" tab with config, namespaces, dedup/decay, export/import, and the harness (sessions, working memory, procedures, health).
+The default surface covers search, sources, indexing, tags, timeline, and a Settings tab. Pass `--dev` (or set `MEMTOMEM_WEB__MODE=dev` in your shell profile) to expose maintainer pages like Namespaces, Sessions, Working Memory, and Health Report — see [Configuration → Web UI Mode](configuration.md#web-ui-mode) for details.
 
 ---
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -908,6 +908,7 @@ mm session list                        # list sessions
 mm session events <id>                 # show events for a session
 mm session wrap -- CMD                 # wrap a command with session lifecycle
 mm activity log                        # log agent activity event
+# Scripting: list/events/log support --json (see CONTRIBUTING.md → CLI output convention)
 
 # Health
 mm watchdog status                     # show latest health check results

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -84,7 +84,7 @@ the editor: `~/.cursor/mcp.json` (Cursor),
 - **🏷️ Namespaces** — scope memories into groups (work / personal / project) with optional auto-derivation from folder names
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
-- **🌐 Web UI** — full-featured SPA dashboard for search, sources, indexing, tags, sessions, health monitoring
+- **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)
 - **🛠️ 74 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
 
 ## Documentation


### PR DESCRIPTION
## Summary

Three public docs still described the pre-0.1.16 full Web UI surface and
omitted the v0.1.15 `--json` scriptability story. This PR catches them up
with the behavior changes already shipped in #342 / #343 / #344 / #345.

## What changed

| File | Before | After |
|------|--------|-------|
| `docs/guides/getting-started.md` (Optional: Web UI) | Listed "More" tab with config / namespaces / dedup / export / harness — the pre-0.1.16 full surface | Names the polished default tabs; documents `mm web --dev` and `MEMTOMEM_WEB__MODE=dev`; anchor link to `configuration.md#web-ui-mode` |
| `packages/memtomem/README.md` (Features bullet, PyPI landing) | "full-featured SPA dashboard for search, sources, indexing, tags, sessions, health monitoring" | "polished SPA dashboard … (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)" |
| `docs/guides/reference.md` (Sessions & activity cheat sheet) | No mention of `--json` variants | Single-line scripting tip under the block pointing to `CONTRIBUTING.md` → **CLI output convention** |

## Not in this PR

- No code behavior change.
- No sync to `memtomem-docs` (private) — these are already-public files, per the one-file-one-place rule.
- Per-command `--json` examples for session / activity CLI (cheat-sheet style is intentionally flag-light; a dedicated scripting doc can come later if users ask).
- Full `docs/guides/` audit — this pass is scoped to v0.1.15 / v0.1.16 drift only.

## Test plan

- [x] `git diff --stat` — 3 files, +6 / -4 lines, text-only
- [x] Cross-referenced wording against `docs/guides/reference.md` Web UI section (lines 856–869) and `docs/guides/configuration.md` § Web UI Mode, already updated in #344
- [x] Confirmed `CONTRIBUTING.md` section name is "CLI output convention" (line 80) before referencing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
