### PR TITLE
feat(cli): add `mm version` subcommand for parity with `mms version`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm version` subcommand** — prints `memtomem <version>`, identical output to
+  `mm --version`. Adds parity with `mms version` (memtomem-stm) so users
+  switching between the two CLIs get consistent behavior.
+
 ## [0.1.16] — 2026-04-21
 
 memtomem remains in **alpha**. This release narrows the default `mm web`

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -18,6 +18,14 @@ def cli() -> None:
     """memtomem — markdown-first memory infrastructure for AI agents."""
 
 
+@cli.command()
+def version() -> None:
+    """Show the installed memtomem version."""
+    from importlib.metadata import version as pkg_version
+
+    click.echo(f"memtomem {pkg_version('memtomem')}")
+
+
 # Register subcommands (lazy imports to keep startup fast)
 def _register() -> None:
     from memtomem.cli.agent_cmd import agent

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -50,6 +50,13 @@ class TestCLIGroup:
         assert result.exit_code == 0
         assert result.output.strip().startswith("memtomem ")
 
+    def test_version_subcommand_matches_flag(self, runner: CliRunner) -> None:
+        flag = runner.invoke(cli, ["--version"])
+        sub = runner.invoke(cli, ["version"])
+        assert flag.exit_code == 0
+        assert sub.exit_code == 0
+        assert flag.output.strip() == sub.output.strip()
+
     def test_registered_subcommands(self, runner: CliRunner) -> None:
         """All expected subcommands appear in help output."""
         result = runner.invoke(cli, ["--help"])
@@ -65,6 +72,7 @@ class TestCLIGroup:
             "web",
             "shell",
             "init",
+            "version",
         ):
             assert cmd in result.output, f"'{cmd}' not found in help output"
 


### PR DESCRIPTION
## Summary

- `mm` had only `--version` flag, while sibling `mms` supports both `mms --version` and `mms version` (subcommand kept for backwards compat after flag was added in STM #152).
- Muscle memory mismatch: reaching for `mm version` (after using `mms version`) produced a `Usage: mm [OPTIONS] COMMAND [ARGS]...` error.
- This PR adds a `mm version` subcommand that prints the exact same `memtomem <version>` line as `mm --version`, and a pin test that asserts byte-equality between the two paths so they can't silently drift.

## Implementation

- `packages/memtomem/src/memtomem/cli/__init__.py`: 6-line `@cli.command()` using `importlib.metadata.version("memtomem")`, mirroring the STM pattern in `src/memtomem_stm/cli/proxy.py:422`.
- `packages/memtomem/tests/test_cli.py`:
  - `test_version_subcommand_matches_flag` — invokes both entry points and asserts `.output.strip()` equality.
  - Adds `"version"` to the existing registered-subcommands list.
- `CHANGELOG.md`: one-line `[Unreleased] > Added` entry explaining the parity rationale.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_cli.py -m "not ollama"` — 86 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check` — clean
- [x] Manual: `uv run mm version` and `uv run mm --version` both print `memtomem 0.1.16`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
