### PR TITLE
feat(init): detect embedding mismatch on reinstall path + document clean reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - **`mm version` subcommand** — prints `memtomem <version>`, identical output to
   `mm --version`. Adds parity with `mms version` (memtomem-stm) so users
   switching between the two CLIs get consistent behavior.
+- **`mm init` detects reinstall-path embedding mismatch** — when the new
+  preset's provider / dimension differs from what an existing
+  `~/.memtomem/memtomem.db` has stored (classically a previous
+  `provider=none` install → `chunks_vec` at dim=0 vs a new `onnx/bge-m3`
+  1024d config), the wizard now prints the mismatch and offers to reset
+  the vector index in place. Without this prompt the next MCP server
+  startup would fail with `EmbeddingDimensionMismatchError`. Under
+  non-interactive `-y`, the wizard prints a loud recovery hint
+  (`mm embedding-reset --mode apply-current`) instead of prompting. The
+  chunks table itself is preserved; only the vector index is rebuilt,
+  so a re-index is required afterwards.
+
+### Changed
+
+- **`docs/guides/uninstall.md` documents the reinstall-from-scratch path** —
+  new section explaining that `mm init` only rewrites config/MCP and
+  leaves the DB in place, with a `rm -rf ~/.memtomem && mm init` recipe
+  for users who want a fully blank slate.
 
 ## [0.1.16] — 2026-04-21
 

--- a/docs/guides/uninstall.md
+++ b/docs/guides/uninstall.md
@@ -71,6 +71,29 @@ whose commands reference `memtomem` or `mm`.
 
 ---
 
+## Reinstalling from scratch
+
+Switching presets (e.g. `Minimal` → `Korean-optimized`) leaves the previous
+SQLite DB in place, because `mm init` only rewrites `~/.memtomem/config.json`
+and the MCP registration. If the new preset uses a different embedding
+provider or dimension, the server startup will refuse to open a DB whose
+stored embedding metadata doesn't match — `mm init` now detects this and
+offers to reset the vector index in place.
+
+To skip the prompt and start from a fully blank slate, delete the data
+directory before re-running the wizard:
+
+```bash
+rm -rf ~/.memtomem
+mm init
+```
+
+This wipes chunks, embeddings, sessions, uploads, and persisted config.
+MCP registrations in each editor are separate — see step 1 above to clean
+those up first if you want them regenerated.
+
+---
+
 ## Next Steps
 
 - [Reference](reference.md) — Complete feature reference

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -792,6 +792,102 @@ def _emit_preserved_block(
     click.echo("  to restore mmr.enabled=false).")
 
 
+def _maybe_offer_embedding_reset(state: dict, *, interactive: bool) -> None:
+    """Reconcile an existing DB's embedding metadata with the new config.
+
+    ``mm init`` rewrites ``~/.memtomem/config.json`` but leaves the SQLite DB
+    untouched. If a previous install wrote ``chunks_vec`` with a different
+    provider / dimension (classically ``provider=none`` → dim=0), the next
+    MCP server startup fails fast with ``EmbeddingDimensionMismatchError``.
+    Detect the mismatch here and offer to reset so users don't see an opaque
+    crash on their first ``mm web`` / MCP launch.
+
+    Interactive: prompt before the destructive reset (default=yes so the
+    wizard's common case flows forward without extra typing). Non-interactive
+    (``-y`` / piped stdin): print a loud warning pointing at the exact
+    recovery command instead of guessing.
+    """
+    import asyncio
+
+    db_path = Path(state["db_path"]).expanduser()
+    if not db_path.exists():
+        return
+
+    try:
+        asyncio.run(_check_embedding_mismatch(state, interactive=interactive))
+    except Exception as exc:
+        click.secho(
+            f"  Warning: could not check DB embedding state ({exc.__class__.__name__}: {exc}). "
+            f"Run 'mm embedding-reset --mode status' to verify manually.",
+            fg="yellow",
+        )
+
+
+async def _check_embedding_mismatch(state: dict, *, interactive: bool) -> None:
+    from memtomem.config import StorageConfig
+    from memtomem.storage.sqlite_backend import SqliteBackend
+
+    storage_cfg = StorageConfig(sqlite_path=Path(state["db_path"]).expanduser())
+    storage = SqliteBackend(
+        storage_cfg,
+        dimension=state["dimension"],
+        embedding_provider=state["provider"],
+        embedding_model=state["model"],
+        strict_dim_check=False,
+    )
+    await storage.initialize()
+    try:
+        mismatch = getattr(storage, "embedding_mismatch", None)
+        if mismatch is None:
+            return
+
+        stored = mismatch["stored"]
+        configured = mismatch["configured"]
+        click.echo()
+        click.secho("  Existing DB detected — embedding mismatch:", fg="yellow", bold=True)
+        click.echo(
+            f"    DB stored:  {stored['provider']}/{stored['model']} ({stored['dimension']}d)"
+        )
+        click.echo(
+            f"    New config: {configured['provider']}/{configured['model']} "
+            f"({configured['dimension']}d)"
+        )
+        click.echo()
+        click.echo("  The MCP server will fail to start until this is resolved.")
+
+        if not interactive:
+            click.secho(
+                "  Run 'mm embedding-reset --mode apply-current' to recreate the "
+                "vector index with the new dimension.",
+                fg="yellow",
+            )
+            return
+
+        click.echo()
+        if click.confirm(
+            "  Reset vector index now? (chunks table preserved, re-index required)",
+            default=True,
+        ):
+            await storage.reset_embedding_meta(
+                dimension=state["dimension"],
+                provider=state["provider"],
+                model=state["model"],
+            )
+            click.secho(
+                f"  Vector index reset to {state['provider']}/{state['model']} "
+                f"({state['dimension']}d). Run 'mm index <path>' to re-embed.",
+                fg="green",
+            )
+        else:
+            click.secho(
+                "  Skipped. Run 'mm embedding-reset --mode apply-current' before "
+                "starting the MCP server.",
+                fg="yellow",
+            )
+    finally:
+        await storage.close()
+
+
 def _write_config_and_summary(
     state: dict, base_dir: Path | None = None, fresh: bool = False
 ) -> None:
@@ -1519,3 +1615,4 @@ def init(
             run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)
 
     _write_config_and_summary(state, fresh=fresh)
+    _maybe_offer_embedding_reset(state, interactive=not non_interactive)

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -2118,3 +2118,179 @@ class TestPresetSelection:
         assert data["embedding"]["model"] == "bge-m3"  # preset applied
         assert data["mmr"]["enabled"] is True  # non-init field survived
         assert data["mmr"]["lambda_param"] == 0.3
+
+
+class TestReinstallEmbeddingReconciliation:
+    """mm init must detect and offer to fix embedding mismatches left by a
+    previous install (e.g. provider=none → onnx switch leaves DB at dim=0)."""
+
+    @staticmethod
+    async def _seed_db(db_path: Path, provider: str, model: str, dimension: int) -> None:
+        """Create a SQLite DB pre-initialised as if a prior install wrote it."""
+        from memtomem.config import StorageConfig
+        from memtomem.storage.sqlite_backend import SqliteBackend
+
+        storage = SqliteBackend(
+            StorageConfig(sqlite_path=db_path),
+            dimension=dimension,
+            embedding_provider=provider,
+            embedding_model=model,
+            strict_dim_check=False,
+        )
+        await storage.initialize()
+        await storage.close()
+
+    def test_fresh_db_is_noop(self, tmp_path: Path) -> None:
+        """No DB at db_path → helper returns silently without prompting."""
+        from memtomem.cli.init_cmd import _maybe_offer_embedding_reset
+
+        state = _make_init_state(tmp_path)
+        state.update({"provider": "onnx", "model": "bge-m3", "dimension": 1024})
+        # db_path points at non-existent file
+        assert not Path(state["db_path"]).exists()
+
+        # Must not raise and must not emit a prompt (interactive=True would
+        # otherwise block on stdin if the helper tried to prompt).
+        _maybe_offer_embedding_reset(state, interactive=True)
+
+    def test_matching_db_is_noop(self, tmp_path: Path) -> None:
+        """DB already on the target provider/dim → no prompt."""
+        import asyncio
+
+        from memtomem.cli.init_cmd import _maybe_offer_embedding_reset
+
+        db_path = tmp_path / "memtomem.db"
+        asyncio.run(self._seed_db(db_path, "onnx", "bge-m3", 1024))
+
+        state = _make_init_state(tmp_path)
+        state.update(
+            {
+                "provider": "onnx",
+                "model": "bge-m3",
+                "dimension": 1024,
+                "db_path": str(db_path),
+            }
+        )
+        _maybe_offer_embedding_reset(state, interactive=True)
+
+    def test_mismatch_non_interactive_warns_without_reset(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Under -y, helper must print a recovery hint and leave DB untouched."""
+        import asyncio
+
+        from memtomem.cli.init_cmd import _maybe_offer_embedding_reset
+
+        db_path = tmp_path / "memtomem.db"
+        asyncio.run(self._seed_db(db_path, "none", "", 0))  # legacy NoopEmbedder
+
+        state = _make_init_state(tmp_path)
+        state.update(
+            {
+                "provider": "onnx",
+                "model": "bge-m3",
+                "dimension": 1024,
+                "db_path": str(db_path),
+            }
+        )
+        _maybe_offer_embedding_reset(state, interactive=False)
+
+        out = capsys.readouterr().out
+        assert "Existing DB detected" in out
+        assert "mm embedding-reset --mode apply-current" in out
+
+        # Stored meta is unchanged — non-interactive path must never reset.
+        from memtomem.config import StorageConfig
+        from memtomem.storage.sqlite_backend import SqliteBackend
+
+        storage = SqliteBackend(
+            StorageConfig(sqlite_path=db_path),
+            dimension=0,
+            embedding_provider="none",
+            embedding_model="",
+            strict_dim_check=False,
+        )
+        asyncio.run(storage.initialize())
+        assert storage.stored_embedding_info["dimension"] == 0
+        asyncio.run(storage.close())
+
+    def test_mismatch_interactive_confirm_resets(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Interactive yes → chunks_vec recreated at new dimension."""
+        import asyncio
+
+        from memtomem.cli.init_cmd import _maybe_offer_embedding_reset
+
+        db_path = tmp_path / "memtomem.db"
+        asyncio.run(self._seed_db(db_path, "none", "", 0))
+
+        state = _make_init_state(tmp_path)
+        state.update(
+            {
+                "provider": "onnx",
+                "model": "bge-m3",
+                "dimension": 1024,
+                "db_path": str(db_path),
+            }
+        )
+
+        import click
+
+        monkeypatch.setattr(click, "confirm", lambda *a, **kw: True)
+        _maybe_offer_embedding_reset(state, interactive=True)
+
+        out = capsys.readouterr().out
+        assert "Vector index reset" in out
+
+        from memtomem.config import StorageConfig
+        from memtomem.storage.sqlite_backend import SqliteBackend
+
+        storage = SqliteBackend(
+            StorageConfig(sqlite_path=db_path),
+            dimension=1024,
+            embedding_provider="onnx",
+            embedding_model="bge-m3",
+            strict_dim_check=False,
+        )
+        asyncio.run(storage.initialize())
+        # After reset, stored meta matches the new config — no mismatch.
+        assert storage.embedding_mismatch is None
+        assert storage.stored_embedding_info["dimension"] == 1024
+        asyncio.run(storage.close())
+
+    def test_mismatch_interactive_decline_skips(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Interactive no → DB untouched, helper points at recovery command."""
+        import asyncio
+
+        from memtomem.cli.init_cmd import _maybe_offer_embedding_reset
+
+        db_path = tmp_path / "memtomem.db"
+        asyncio.run(self._seed_db(db_path, "none", "", 0))
+
+        state = _make_init_state(tmp_path)
+        state.update(
+            {
+                "provider": "onnx",
+                "model": "bge-m3",
+                "dimension": 1024,
+                "db_path": str(db_path),
+            }
+        )
+
+        import click
+
+        monkeypatch.setattr(click, "confirm", lambda *a, **kw: False)
+        _maybe_offer_embedding_reset(state, interactive=True)
+
+        out = capsys.readouterr().out
+        assert "Skipped" in out
+        assert "mm embedding-reset --mode apply-current" in out


### PR DESCRIPTION
## Summary

Re-running `mm init` with a different preset (classic case: `Minimal` → `Korean-optimized`) rewrites `~/.memtomem/config.json` + the MCP registration but **leaves the SQLite DB untouched**. The previous install's `chunks_vec` was created at dim=0 via `NoopEmbedder`; the new config says `onnx/bge-m3` @ 1024d. Result: the wizard appears to succeed, then the next MCP server startup fails with `EmbeddingDimensionMismatchError` and the user has no idea why.

This PR closes the gap at wizard time.

## Changes

**Code** — `packages/memtomem/src/memtomem/cli/init_cmd.py`:

- New helper `_maybe_offer_embedding_reset` runs after `_write_config_and_summary`.
- Compares stored DB embedding (provider / model / dim) against what the wizard just wrote.
- No DB yet, or matching → no-op.
- Mismatch + interactive → `click.confirm` (default=yes) then `reset_embedding_meta(...)` to recreate `chunks_vec` at the new dim. Chunks table is preserved; only the vector index is rebuilt, so a re-index fully restores the working set.
- Mismatch + non-interactive (`-y`) → print a loud yellow hint pointing at `mm embedding-reset --mode apply-current`. Never runs a destructive op without explicit consent.
- DB read errors are caught and downgraded to a yellow warning so the wizard never aborts on a reconciliation check.

**Docs** — `docs/guides/uninstall.md`:

- New "Reinstalling from scratch" section explaining that `mm init` is effectively a config-only reinstall, with a `rm -rf ~/.memtomem && mm init` recipe for users who want a fully blank slate.
- We considered (and rejected) adding an `mm uninstall` CLI — the existing 5-step doc flow is genuinely sufficient for leaving, since `mm init` only auto-registers Claude Code MCP (matching the one-liner removal step already documented). The real gap was the reinstall path, not the uninstall path.

**CHANGELOG** — `[Unreleased] > Added` + `[Unreleased] > Changed`.

## Test plan

New class `TestReinstallEmbeddingReconciliation` in `test_init_cmd.py` — 5 cases:

- `test_fresh_db_is_noop` — no DB at `db_path` → no prompt, no error
- `test_matching_db_is_noop` — DB already on the target provider/dim → no prompt
- `test_mismatch_non_interactive_warns_without_reset` — verifies `-y` path prints hint and leaves stored meta at dim=0
- `test_mismatch_interactive_confirm_resets` — monkeypatches `click.confirm` → True, verifies `embedding_mismatch is None` afterwards
- `test_mismatch_interactive_decline_skips` — monkeypatches → False, verifies "Skipped" + recovery hint

- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py::TestReinstallEmbeddingReconciliation -v` — 5/5 pass
- [x] `uv run pytest packages/memtomem/tests/test_cli.py packages/memtomem/tests/test_init_cmd.py packages/memtomem/tests/test_embedding*.py -m "not ollama"` — 246 pass
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] End-to-end smoke in `HOME=/tmp/mm-reinstall-smoke`:
  1. `mm init -y --preset minimal` → seeds DB at dim=0
  2. `mm init -y --preset korean` → emits `"Existing DB detected — embedding mismatch"` + recovery hint
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
