### PR TITLE
feat(server): degraded mode on embedding mismatch instead of fail-fast crash (#349)

### DIFF
--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -14,6 +14,7 @@ from memtomem.chunking.restructured_text import ReStructuredTextChunker
 from memtomem.chunking.structured import StructuredChunker
 from memtomem.config import Mem2MemConfig
 from memtomem.embedding.factory import create_embedder
+from memtomem.errors import EmbeddingDimensionMismatchError
 from memtomem.indexing.engine import IndexEngine
 from memtomem.search.pipeline import SearchPipeline
 from memtomem.storage.factory import create_storage
@@ -36,6 +37,11 @@ class Components:
     index_engine: IndexEngine
     search_pipeline: SearchPipeline
     llm: LLMProvider | None = None
+    # Populated when startup detected a ``chunks_vec`` / provider mismatch
+    # (``EmbeddingDimensionMismatchError``) and the server came up in
+    # degraded mode instead of crashing. The dict has the same shape as
+    # ``SqliteBackend.embedding_mismatch``. See issue #349.
+    embedding_broken: dict | None = None
 
 
 async def create_components(config: Mem2MemConfig | None = None) -> Components:
@@ -54,9 +60,43 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
 
     storage = create_storage(config)
     embedder: EmbeddingProvider | None = None
+    embedding_broken: dict | None = None
     try:
         embedder = create_embedder(config.embedding)
         await storage.initialize()
+    except EmbeddingDimensionMismatchError:
+        # Stored DB has ``embedding_dimension=0`` (prior NoopEmbedder / BM25
+        # install) but the runtime config points at a real provider. Instead
+        # of crashing the server — which leaves the user no MCP-level path to
+        # repair — come up in degraded mode: the storage is re-opened with
+        # ``strict_dim_check=False`` (same seam the ``mm embedding-reset``
+        # CLI uses) so the mismatch surfaces as a structured flag and the
+        # recovery tool (``mem_embedding_reset``) stays callable over MCP.
+        # Vector-dependent tools (``mem_add`` / ``mem_index`` / …) are gated
+        # separately via ``_check_embedding_mismatch``. See issue #349.
+        await storage.close()
+        _log.warning(
+            "Embedding dimension mismatch detected at startup — entering "
+            "degraded mode. Non-vector tools (mem_status, mem_stats, "
+            "mem_embedding_reset, mem_list, mem_read) stay available; "
+            "vector-dependent tools (mem_add, mem_index, ...) will return "
+            "an actionable error until `mem_embedding_reset` is run."
+        )
+        storage = SqliteBackend(
+            config.storage,
+            dimension=config.embedding.dimension,
+            embedding_provider=config.embedding.provider,
+            embedding_model=config.embedding.model,
+            strict_dim_check=False,
+        )
+        try:
+            await storage.initialize()
+        except Exception:
+            if embedder is not None:
+                await embedder.close()
+            await storage.close()
+            raise
+        embedding_broken = storage.embedding_mismatch
     except Exception:
         if embedder is not None:
             await embedder.close()
@@ -133,6 +173,7 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         index_engine=index_engine,
         search_pipeline=search_pipeline,
         llm=llm,
+        embedding_broken=embedding_broken,
     )
 
 

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -37,6 +37,14 @@ class AppContext:
     llm_provider: LLMProvider | None = None
     current_namespace: str | None = None
     current_session_id: str | None = None
+    # Populated when the server entered degraded mode at startup because of a
+    # ``chunks_vec`` / provider mismatch. Same shape as
+    # ``SqliteBackend.embedding_mismatch``. Vector-dependent tool handlers
+    # check this flag (via ``_check_embedding_mismatch``) and short-circuit
+    # with an actionable error; recovery tooling
+    # (``mem_embedding_reset``, ``mem_status``, ``mem_stats``) stays
+    # callable. See issue #349.
+    embedding_broken: dict | None = None
     # per-session, scoped to AppContext lifetime. Gate to emit a dim-mismatch
     # hint only once per MCP session so repeated mem_add / mem_search calls
     # do not spam the same notice. Writes go through ``_config_lock``.

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -104,8 +104,13 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     config = Mem2MemConfig()
     comp = await create_components(config)
 
+    # When the server came up in degraded mode (embedding mismatch, see
+    # issue #349) don't start the file watcher — indexing goes through
+    # ``upsert_chunks`` which needs ``chunks_vec`` and would crash on
+    # every file change. Recovery happens via ``mem_embedding_reset``.
     watcher = FileWatcher(comp.index_engine, config.indexing)
-    await watcher.start()
+    if comp.embedding_broken is None:
+        await watcher.start()
 
     dedup_scanner = DedupScanner(storage=comp.storage, embedder=comp.embedder)
 
@@ -126,11 +131,18 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
         dedup_scanner=dedup_scanner,
         webhook_manager=webhook_mgr,
         llm_provider=comp.llm,
+        embedding_broken=comp.embedding_broken,
     )
+
+    # Background schedulers are skipped in degraded mode (see issue #349) —
+    # they walk the index / re-embed chunks and would hit the same missing
+    # ``chunks_vec`` cascade as the watcher. They resume after a restart
+    # once ``mem_embedding_reset`` has fixed the DB.
+    degraded = comp.embedding_broken is not None
 
     # Auto-consolidation scheduler
     scheduler = None
-    if config.consolidation_schedule.enabled:
+    if config.consolidation_schedule.enabled and not degraded:
         from memtomem.server.scheduler import ConsolidationScheduler
 
         scheduler = ConsolidationScheduler(ctx, config.consolidation_schedule)
@@ -138,7 +150,7 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
 
     # Policy scheduler
     policy_scheduler = None
-    if config.policy.enabled:
+    if config.policy.enabled and not degraded:
         from memtomem.server.scheduler import PolicyScheduler
 
         policy_scheduler = PolicyScheduler(ctx, config.policy)
@@ -146,7 +158,7 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
 
     # Health watchdog
     watchdog = None
-    if config.health_watchdog.enabled:
+    if config.health_watchdog.enabled and not degraded:
         from memtomem.server.health_watchdog import HealthWatchdog
 
         watchdog = HealthWatchdog(ctx, config.health_watchdog)

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app
 from memtomem.server.error_handler import tool_handler
-from memtomem.server.helpers import _announce_dim_mismatch_once
+from memtomem.server.helpers import _announce_dim_mismatch_once, _check_embedding_mismatch
 from memtomem.server.tool_registry import register
 from memtomem.server.validation import MAX_CONTENT_LENGTH
 from memtomem.server.webhooks import webhook_error_cb
@@ -71,6 +71,13 @@ async def _mem_add_core(
     from memtomem.tools.memory_writer import append_entry
 
     app = _get_app(ctx)
+
+    # Block vector-dependent writes when the server is in degraded mode
+    # (see issue #349). Without this gate the subsequent ``index_file``
+    # call hits ``upsert_chunks`` and crashes on a missing ``chunks_vec``.
+    mismatch_msg = _check_embedding_mismatch(app)
+    if mismatch_msg:
+        return (mismatch_msg, None)
 
     # Apply template if specified
     if template:
@@ -203,6 +210,9 @@ async def mem_edit(
     from memtomem.tools.memory_writer import replace_lines
 
     app = _get_app(ctx)
+    mismatch_msg = _check_embedding_mismatch(app)
+    if mismatch_msg:
+        return mismatch_msg
 
     try:
         uid = UUID(chunk_id)
@@ -342,6 +352,9 @@ async def mem_batch_add(
     from memtomem.tools.memory_writer import append_entry
 
     app = _get_app(ctx)
+    mismatch_msg = _check_embedding_mismatch(app)
+    if mismatch_msg:
+        return mismatch_msg
     mdirs = app.config.indexing.memory_dirs
 
     if file:

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -35,12 +35,31 @@ async def mem_stats(
     total_sources = data.get("total_sources", 0)
     backend = app.config.storage.backend
 
-    return (
+    out = (
         f"Memory index statistics:\n"
         f"- Total chunks: {total_chunks}\n"
         f"- Total sources: {total_sources}\n"
         f"- Storage backend: {backend}"
     )
+
+    # Surface live degraded-mode state so monitoring probes and the Web UI
+    # can detect it without a second tool call. Reads from
+    # ``storage.embedding_mismatch`` (not the startup-time
+    # ``ctx.embedding_broken`` snapshot) so the line disappears as soon as
+    # ``mem_embedding_reset`` clears the mismatch. See ``mem_status`` for
+    # the full structured warning block.
+    mismatch = getattr(app.storage, "embedding_mismatch", None)
+    if mismatch is not None:
+        stored = mismatch["stored"]
+        cfg = mismatch["configured"]
+        out += (
+            "\n- Embedding: DEGRADED — "
+            f"stored {stored['provider']}/{stored['model']} ({stored['dimension']}d) "
+            f"vs configured {cfg['provider']}/{cfg['model']} ({cfg['dimension']}d). "
+            'Run mem_embedding_reset(mode="apply_current") to repair.'
+        )
+
+    return out
 
 
 @mcp.tool()

--- a/packages/memtomem/tests/test_server_degraded_mode.py
+++ b/packages/memtomem/tests/test_server_degraded_mode.py
@@ -1,0 +1,218 @@
+"""Issue #349: MCP server degraded-mode startup on embedding mismatch.
+
+When a DB has ``embedding_dimension=0`` (legacy NoopEmbedder / BM25-only
+install) and the runtime config points at a real provider, the server used
+to raise ``EmbeddingDimensionMismatchError`` during ``SqliteBackend.initialize``
+and die before the MCP handshake — leaving no in-protocol way to repair it.
+These tests lock in the recovery-friendly behavior:
+
+* ``create_components`` stays up and exposes ``embedding_broken`` state.
+* Vector-dependent writes (``mem_add``, ``mem_batch_add``, ``mem_edit``)
+  return an actionable ``_check_embedding_mismatch`` error instead of
+  crashing on ``upsert_chunks`` with a missing ``chunks_vec``.
+* ``mem_embedding_reset(mode="apply_current")`` is callable from MCP and
+  repairs the mismatch end-to-end (``mem_stats`` drops the DEGRADED line,
+  ``mem_add`` starts working again).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+import sqlite_vec
+
+import memtomem.config as _cfg
+from memtomem.config import Mem2MemConfig
+from memtomem.server.component_factory import close_components, create_components
+from memtomem.server.context import AppContext
+from memtomem.server.tools.memory_crud import _mem_add_core
+from memtomem.server.tools.status_config import mem_embedding_reset, mem_stats
+
+
+class _FakeEmbedder:
+    """Minimal 1024-d embedder so ``create_components`` does not pull a real model.
+
+    The vectors are deterministic but otherwise meaningless — enough to satisfy
+    ``upsert_chunks`` without downloading ONNX weights or talking to Ollama.
+    """
+
+    dimension = 1024
+    model_name = "bge-m3"
+
+    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+        return [[0.0] * 1024 for _ in texts]
+
+    async def embed_query(self, query: str) -> list[float]:
+        return [0.0] * 1024
+
+    async def close(self) -> None:
+        pass
+
+
+def _seed_legacy_dim0_db(db_path: Path) -> None:
+    """Create a DB that reproduces the issue #349 startup trigger.
+
+    Pre-seeds ``_memtomem_meta`` with ``embedding_dimension=0`` so the next
+    ``SqliteBackend.initialize`` with a non-``none`` configured provider trips
+    :class:`~memtomem.errors.EmbeddingDimensionMismatchError` unless
+    ``strict_dim_check=False``.
+    """
+    db = sqlite3.connect(str(db_path))
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    try:
+        db.execute(
+            "CREATE TABLE IF NOT EXISTS _memtomem_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        db.executemany(
+            "INSERT OR REPLACE INTO _memtomem_meta(key, value) VALUES (?, ?)",
+            [
+                ("embedding_dimension", "0"),
+                ("embedding_provider", "none"),
+                ("embedding_model", ""),
+            ],
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+@pytest.fixture
+async def degraded_components(tmp_path, monkeypatch):
+    """``create_components`` against a dim=0 DB with config pointing at onnx/bge-m3.
+
+    Would have raised ``EmbeddingDimensionMismatchError`` pre-#349; now returns
+    ``Components`` with ``embedding_broken`` populated and a relaxed storage.
+    """
+    db_path = tmp_path / "legacy.db"
+    mem_dir = tmp_path / "memories"
+    mem_dir.mkdir()
+    _seed_legacy_dim0_db(db_path)
+
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+    config.embedding.provider = "onnx"
+    config.embedding.model = "bge-m3"
+    config.embedding.dimension = 1024
+
+    monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
+    monkeypatch.setattr(_cfg, "load_config_d", lambda c: None)
+    monkeypatch.setattr(
+        "memtomem.server.component_factory.create_embedder",
+        lambda embedding_config: _FakeEmbedder(),
+    )
+
+    comp = await create_components(config)
+    try:
+        yield comp
+    finally:
+        await close_components(comp)
+
+
+class _StubCtx:
+    """Minimal stand-in for MCP ``Context`` so tools can be called directly in tests."""
+
+    def __init__(self, app: AppContext) -> None:
+        class _RC:
+            pass
+
+        self.request_context = _RC()
+        self.request_context.lifespan_context = app
+
+
+def _make_app(components) -> AppContext:
+    """Build an ``AppContext`` straight from ``Components`` (no lifespan plumbing).
+
+    Skips watcher / scheduler startup — those would try to touch ``chunks_vec``
+    in degraded mode, which is exactly what the lifespan already gates against.
+    """
+    return AppContext(
+        config=components.config,
+        storage=components.storage,
+        embedder=components.embedder,
+        index_engine=components.index_engine,
+        search_pipeline=components.search_pipeline,
+        watcher=None,  # type: ignore[arg-type]
+        embedding_broken=components.embedding_broken,
+    )
+
+
+async def test_create_components_enters_degraded_instead_of_raising(degraded_components):
+    """Pre-#349 this call raised ``EmbeddingDimensionMismatchError``."""
+    comp = degraded_components
+
+    assert comp.embedding_broken is not None, "embedding_broken must be populated"
+    assert comp.embedding_broken["dimension_mismatch"] is True
+    assert comp.embedding_broken["stored"]["dimension"] == 0
+    assert comp.embedding_broken["configured"]["dimension"] == 1024
+    assert comp.embedding_broken["configured"]["provider"] == "onnx"
+
+    # Live view on the storage must agree — degraded mode is authoritative,
+    # not a snapshot, so ``_check_embedding_mismatch`` keeps blocking writes.
+    assert comp.storage.embedding_mismatch is not None
+
+
+async def test_mem_add_blocked_in_degraded_mode(degraded_components):
+    """``mem_add`` must return the actionable mismatch error, not crash."""
+    app = _make_app(degraded_components)
+    ctx = _StubCtx(app)
+
+    message, stats = await _mem_add_core(
+        content="hello from a degraded server",
+        title=None,
+        tags=None,
+        file=None,
+        namespace=None,
+        template=None,
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+    assert stats is None
+    assert "Embedding mismatch detected" in message
+    assert "mm embedding-reset --mode apply-current" in message
+
+
+async def test_mem_stats_surfaces_degraded_line(degraded_components):
+    """Monitoring probes should see the degraded state from mem_stats alone."""
+    app = _make_app(degraded_components)
+    ctx = _StubCtx(app)
+
+    out = await mem_stats(ctx=ctx)  # type: ignore[arg-type]
+    assert "DEGRADED" in out
+    assert "mem_embedding_reset" in out
+
+
+async def test_mem_embedding_reset_apply_current_repairs_mismatch(degraded_components):
+    """End-to-end recovery: ``apply_current`` clears the mismatch and ``mem_add`` works."""
+    app = _make_app(degraded_components)
+    ctx = _StubCtx(app)
+
+    reset_out = await mem_embedding_reset(mode="apply_current", ctx=ctx)  # type: ignore[arg-type]
+    assert "onnx/bge-m3" in reset_out
+    assert "1024d" in reset_out
+
+    # Live storage view: mismatch cleared.
+    assert app.storage.embedding_mismatch is None
+
+    # Degraded line should disappear from ``mem_stats`` now that the DB is in sync.
+    stats_out = await mem_stats(ctx=ctx)  # type: ignore[arg-type]
+    assert "DEGRADED" not in stats_out
+
+    # And ``mem_add`` no longer bounces off the gate (it will actually write
+    # through the index engine because chunks_vec was just recreated at 1024d).
+    message, add_stats = await _mem_add_core(
+        content="post-recovery write sanity check",
+        title=None,
+        tags=None,
+        file=None,
+        namespace=None,
+        template=None,
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+    assert "Embedding mismatch detected" not in message
+    assert add_stats is not None
+    assert add_stats.indexed_chunks >= 1


### PR DESCRIPTION
Closes #349.

## Problem

Pre-this PR the MCP server fail-fast crashed at lifespan startup whenever
`SqliteBackend.initialize` detected a `chunks_vec` dimension / provider
mismatch against `~/.memtomem/config.json` (dim=0 legacy BM25-only DB paired
with a real-provider config). The MCP handshake never completed, so from an
MCP client's perspective the server "just didn't start" — there was no
in-protocol way to run the fix. The user had to drop to a terminal and run
`mm embedding-reset --mode apply-current`.

PR #348 closed the common trigger (re-running `mm init` with a different
preset), but didn't fix the underlying server fragility — mismatches
introduced via manual `config.json` edits, restored backups, or users
declining the wizard prompt would still hang the server.

## What changed

**Option B from the issue** — degraded mode.

### Server-side

- `create_components` catches `EmbeddingDimensionMismatchError`, closes
  the failed storage, re-opens with `strict_dim_check=False` (the same
  recovery seam `mm embedding-reset` uses via `src/memtomem/cli/embedding_cmd.py`)
  and returns `Components.embedding_broken: dict | None` — structured
  mismatch info matching `SqliteBackend.embedding_mismatch`.
- `AppContext.embedding_broken` mirrors this through the lifespan.
- File watcher and the three background schedulers
  (consolidation / policy / health_watchdog) are **not** started in
  degraded mode — they'd hit the same `chunks_vec` cascade the tool
  guards already catch. Restart-after-recovery brings them back.

### Tool gates

- `mem_add`, `mem_batch_add`, `mem_edit` now call `_check_embedding_mismatch`
  before hitting `index_engine.index_file`. They return the actionable
  multi-line error (stored vs configured + fix command) instead of
  crashing on `upsert_chunks`.
- `mem_index` and `mem_import` already had this guard — no change.
- `mem_search` / `mem_recall` keep the existing one-shot hint;
  their `search_pipeline` already falls back to BM25 on `dense_error`.

### Surfaces

- `mem_stats` gains a single DEGRADED line (stored vs configured +
  `mem_embedding_reset` pointer). Reads from `storage.embedding_mismatch`
  (the live source of truth), so the line disappears immediately after
  `mem_embedding_reset(apply_current)` clears the mismatch.
- `mem_status` already had the structured Warnings block — unchanged.
- `mem_embedding_reset` was already mismatch-aware and callable in
  degraded mode — unchanged.

### Explicitly out of scope

- **Web UI banner + one-click reset**: the issue lists this as a
  follow-up PR. Different surface, different review audience.

## Recovery flow (now end-to-end over MCP)

```
mcp_client → mem_stats   # sees "Embedding: DEGRADED — ..."
mcp_client → mem_embedding_reset(mode="apply_current")
           # → "DB reset to onnx/bge-m3 (1024d). All vectors deleted — run mem_index to re-index."
mcp_client → mem_index    # re-build the index
mcp_client → mem_add ...  # works normally
```

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 2021 pass, 0 regression.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` + `ruff format --check` — clean.
- [x] New `tests/test_server_degraded_mode.py` covers:
  - `create_components` against seeded dim=0 + real-provider config no longer raises; `embedding_broken` populated.
  - `mem_add` returns the `Embedding mismatch detected` block instead of crashing.
  - `mem_stats` surfaces the DEGRADED line.
  - End-to-end: `mem_embedding_reset(apply_current)` clears the mismatch, `mem_stats` drops DEGRADED, follow-up `mem_add` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
