### PR TITLE
fix(web): show embedding-mismatch banner in degraded mode (#349 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -219,9 +219,15 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.index_engine = comp.index_engine
     app.state.dedup_scanner = DedupScanner(comp.storage, comp.embedder)
 
-    # Sync config to match DB-stored embedding info (prevents mismatch banner)
+    # Sync config to match DB-stored embedding info (prevents mismatch banner).
+    # Skipped when the server entered degraded mode (issue #349) — in the
+    # dim=0 / real-provider case the stored "embedding" is NoopEmbedder
+    # (provider=none, dim=0), so an auto-sync would silently downgrade the
+    # user's configured onnx/bge-m3 to BM25-only and swallow the broken
+    # state instead of surfacing it. The banner + ``/api/embedding-reset``
+    # flow recovers explicitly; soft-syncing would defeat it.
     stored_info = getattr(comp.storage, "stored_embedding_info", None)
-    if stored_info:
+    if stored_info and comp.embedding_broken is None:
         cfg = comp.config.embedding
         if cfg.model != stored_info["model"] or cfg.dimension != stored_info["dimension"]:
             logger.info(

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -1,0 +1,162 @@
+"""Web lifespan auto-sync gating — follow-up to issue #349.
+
+The web lifespan used to overwrite the runtime embedding config whenever the
+DB-stored ``stored_embedding_info`` differed from config, then call
+``storage.clear_embedding_mismatch()`` to suppress the mismatch banner. For
+normal model drift (e.g. user edited ``config.json`` to a different onnx
+model without running ``mm embedding-reset``) that soft-sync was benign.
+
+For the dim=0 degraded-mode case introduced by #349, the stored "embedding"
+is NoopEmbedder (``provider=none``, ``dim=0``) — auto-syncing silently
+downgrades the user's configured onnx/bge-m3 to BM25-only AND swallows the
+banner, so the user never sees the broken state and has no path to recover
+it from the web UI. The gate below keeps the auto-sync only when the server
+came up clean (``embedding_broken is None``) so the recovery banner +
+``POST /api/embedding-reset`` flow stays reachable in degraded mode.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from memtomem.web.app import _lifespan
+
+
+@dataclass
+class _FakeEmbeddingCfg:
+    provider: str = "onnx"
+    model: str = "bge-m3"
+    dimension: int = 1024
+
+
+@dataclass
+class _FakeIndexingCfg:
+    memory_dirs: list = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        self.memory_dirs = self.memory_dirs or []
+
+
+@dataclass
+class _FakeConfig:
+    embedding: _FakeEmbeddingCfg
+    indexing: _FakeIndexingCfg
+
+
+def _make_components(
+    *,
+    embedding_broken: dict[str, Any] | None,
+    stored_info: dict[str, Any],
+    cfg_provider: str = "onnx",
+    cfg_model: str = "bge-m3",
+    cfg_dim: int = 1024,
+) -> MagicMock:
+    """Build a mock ``Components`` for ``_lifespan``.
+
+    ``storage.clear_embedding_mismatch`` and ``storage.stored_embedding_info``
+    are probed by the auto-sync block; the rest is stubbed just enough to
+    keep the context manager from raising before it yields.
+    """
+    storage = MagicMock()
+    storage.stored_embedding_info = stored_info
+    storage.clear_embedding_mismatch = MagicMock()
+
+    comp = MagicMock()
+    comp.config = _FakeConfig(
+        embedding=_FakeEmbeddingCfg(provider=cfg_provider, model=cfg_model, dimension=cfg_dim),
+        indexing=_FakeIndexingCfg(),
+    )
+    comp.storage = storage
+    comp.embedder = MagicMock()
+    comp.search_pipeline = MagicMock()
+    comp.index_engine = MagicMock()
+    comp.embedding_broken = embedding_broken
+    return comp
+
+
+async def _run_lifespan(comp: MagicMock) -> FastAPI:
+    """Enter and exit ``_lifespan`` with a mocked ``create_components``."""
+    app = FastAPI()
+    with (
+        patch("memtomem.server.component_factory.create_components", AsyncMock(return_value=comp)),
+        patch("memtomem.server.component_factory.close_components", AsyncMock()),
+        # The lifespan also instantiates DedupScanner — harmless to stub.
+        patch("memtomem.search.dedup.DedupScanner", MagicMock()),
+    ):
+        async with _lifespan(app):
+            pass
+    return app
+
+
+async def test_auto_sync_skipped_when_degraded():
+    """With ``embedding_broken`` set, the lifespan must NOT overwrite config
+    or clear the mismatch — the banner + reset button flow depends on those
+    signals being left intact. Regression for issue #349 follow-up."""
+    comp = _make_components(
+        embedding_broken={
+            "dimension_mismatch": True,
+            "model_mismatch": True,
+            "stored": {"dimension": 0, "provider": "none", "model": ""},
+            "configured": {"dimension": 1024, "provider": "onnx", "model": "bge-m3"},
+        },
+        stored_info={"dimension": 0, "provider": "none", "model": ""},
+    )
+
+    await _run_lifespan(comp)
+
+    # Config must still reflect what the user configured, not the legacy
+    # NoopEmbedder meta row.
+    assert comp.config.embedding.provider == "onnx"
+    assert comp.config.embedding.model == "bge-m3"
+    assert comp.config.embedding.dimension == 1024
+
+    # The mismatch flag must survive so ``/api/embedding-status`` can surface
+    # it and the UI banner can fire.
+    comp.storage.clear_embedding_mismatch.assert_not_called()
+
+
+async def test_auto_sync_runs_when_not_degraded():
+    """Non-degraded model drift keeps the pre-#349 soft-sync behavior —
+    config follows DB and the mismatch flag is cleared so the banner does
+    not fire for drift that was already reconciled at startup."""
+    comp = _make_components(
+        embedding_broken=None,
+        stored_info={"dimension": 384, "provider": "onnx", "model": "minilm-l12"},
+        cfg_provider="onnx",
+        cfg_model="bge-m3",
+        cfg_dim=1024,
+    )
+
+    await _run_lifespan(comp)
+
+    assert comp.config.embedding.model == "minilm-l12"
+    assert comp.config.embedding.dimension == 384
+    assert comp.config.embedding.provider == "onnx"
+    comp.storage.clear_embedding_mismatch.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "stored_info",
+    [
+        None,
+        {"dimension": 1024, "provider": "onnx", "model": "bge-m3"},  # matches config
+    ],
+)
+async def test_auto_sync_noop_when_no_drift(stored_info):
+    """When there's no stored info OR stored matches config, the sync block
+    is a no-op regardless of ``embedding_broken`` — validates the gate
+    doesn't accidentally enable sync on the non-drift path."""
+    comp = _make_components(
+        embedding_broken=None,
+        stored_info=stored_info,
+    )
+
+    await _run_lifespan(comp)
+
+    assert comp.config.embedding.provider == "onnx"
+    comp.storage.clear_embedding_mismatch.assert_not_called()


### PR DESCRIPTION
Follow-up to #349 / PR #350 (scope explicitly deferred there).

## Problem

PR #350 kept the MCP server up on a dim=0 / real-provider mismatch, but
`mm web` still silently papered over the broken state:

- `packages/memtomem/src/memtomem/web/app.py::_lifespan` auto-synced
  runtime config to whatever `stored_embedding_info` said, then called
  `storage.clear_embedding_mismatch()` to hide the banner.
- For benign drift (e.g. user edited `config.json` to a different onnx
  model) that soft-sync was fine.
- For the dim=0 degraded-mode case the stored meta is
  `provider=none, dim=0` — auto-syncing silently downgrades the user's
  configured onnx/bge-m3 to BM25-only **and** suppresses the banner,
  leaving zero UI path to recover.

Confirmed by smoke — pre-fix `GET /api/embedding-status` against a
seeded dim=0 DB returned `has_mismatch=false` even though the mismatch
was real.

## What changed

One-line gate: skip the auto-sync block when `comp.embedding_broken` is
set.

```python
stored_info = getattr(comp.storage, "stored_embedding_info", None)
if stored_info and comp.embedding_broken is None:
    ...
```

The banner HTML (`#embedding-mismatch-banner`), the reset-button JS
(`checkEmbeddingMismatch` / `emb-reset-btn` in `app.js`), and the i18n
strings (`banner.emb_reset`, `confirm.emb_reset_*` in `locales/en.json`
+ `ko.json`) were already in place — once the mismatch signal stops
being hushed, the existing flow just works.

## Smoke (isolated HOME, seeded dim=0 meta + `config.json` pointing at onnx/bge-m3/1024d)

```
GET  /api/embedding-status
→ has_mismatch=true, dimension_mismatch=true, model_mismatch=true,
  stored     = {dim=0,    provider=none, model=""}
  configured = {dim=1024, provider=onnx, model=bge-m3}

POST /api/embedding-reset
→ {"ok": true, "message": "Embedding metadata reset. All indexed vectors deleted — please re-index."}

GET  /api/embedding-status   (after reset)
→ has_mismatch=false  (chunks_vec recreated at 1024d; meta updated)
```

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — **2025 pass** (prev 2021 + 4 new), 0 regression.
- [x] `uv run ruff check` + `ruff format --check` — clean.
- [x] Manual end-to-end smoke against `mm web` confirms the banner now
      fires on a seeded dim=0 DB and `/api/embedding-reset` clears it.
- [x] New `tests/test_web_lifespan.py`:
  - `test_auto_sync_skipped_when_degraded` — config + mismatch flag preserved when `embedding_broken` is set.
  - `test_auto_sync_runs_when_not_degraded` — regression guard for the benign-drift soft-sync path.
  - `test_auto_sync_noop_when_no_drift` (2 params) — gate doesn't misfire when there's nothing to sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
