### PR TITLE
fix(init): surface missing [onnx]/[web] extras in wizard summary

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -888,6 +888,81 @@ async def _check_embedding_mismatch(state: dict, *, interactive: bool) -> None:
         await storage.close()
 
 
+# Canonical hint for each extra. Mirrors the form in
+# ``memtomem.cli.web._web_install_hint`` so every user-facing missing-extras
+# message suggests the same install method (uv tool, which matches how the
+# global ``mm`` binary gets on PATH).
+_EXTRA_INSTALL_HINT_PREFIX: str = 'uv tool install --reinstall "memtomem'
+
+
+def _extra_install_hint(extras: list[str]) -> str:
+    """Return the uv-tool install command for one extra (``memtomem[onnx]``)
+    or the combined ``[all]`` extra when two or more are missing.
+
+    Multi-extra case collapses to ``[all]`` instead of bracketed multiples
+    (``memtomem[onnx,web]``) because ``[all]`` is the public, documented extra
+    in ``pyproject.toml``; the user doesn't need to know the sub-bundle."""
+    if len(extras) == 1:
+        return f'{_EXTRA_INSTALL_HINT_PREFIX}[{extras[0]}]"'
+    return f'{_EXTRA_INSTALL_HINT_PREFIX}[all]"'
+
+
+def _collect_missing_extras(state: dict) -> list[str]:
+    """Return ordered list of missing extras the chosen config will need.
+
+    Interpreter-local check via :func:`importlib.util.find_spec` — matches
+    the Python env the current ``mm`` binary runs under. The whole point of
+    this warning is that preset paths (``minimal`` / ``english`` / ``korean``)
+    skip the interactive ``_step_embedding`` that historically surfaced the
+    fastembed gap inline; the user's ``mm init`` → ``mm web`` flow otherwise
+    hits an opaque failure at the third ``Next steps`` command.
+
+    Order: ``onnx`` before ``web`` so the extras appear in the same order
+    the dependent commands fail (``mm index`` → ``mm web``)."""
+    from importlib.util import find_spec
+
+    from memtomem.cli.web import _missing_web_deps
+
+    missing: list[str] = []
+    # [onnx] = fastembed. Both the embedder and the fastembed reranker share
+    # this package — either on its own is enough to require the extra.
+    needs_fastembed = state.get("provider") == "onnx" or (
+        state.get("rerank_enabled") and state.get("rerank_model")
+    )
+    if needs_fastembed and find_spec("fastembed") is None:
+        missing.append("onnx")
+    # [web] = fastapi + uvicorn. Reuse ``_missing_web_deps`` so the check
+    # stays aligned with what ``mm web`` itself errors on.
+    if _missing_web_deps() is not None:
+        missing.append("web")
+    return missing
+
+
+def _emit_missing_extras_warning(missing: list[str]) -> None:
+    """Print an actionable warning about missing extras, or nothing.
+
+    Silent when ``missing`` is empty so the common "already installed" path
+    adds no output noise. When non-empty, names the missing extras, lists
+    which ``Next steps`` commands will fail without them, and prints a single
+    install command (narrow per-extra hint when one missing, ``[all]`` when
+    two+ — matches ``pyproject.toml``'s public extras)."""
+    if not missing:
+        return
+    click.echo()
+    click.secho(
+        f"  [!] Missing extras: {', '.join(missing)}",
+        fg="yellow",
+        bold=True,
+    )
+    if "onnx" in missing and "web" in missing:
+        click.echo("      'mm index' (embeddings) and 'mm web' (UI) will fail until installed.")
+    elif "onnx" in missing:
+        click.echo("      'mm index' will fail to embed until installed.")
+    elif "web" in missing:
+        click.echo("      'mm web' will fail to start until installed.")
+    click.echo(f"      → {_extra_install_hint(missing)}")
+
+
 def _write_config_and_summary(
     state: dict, base_dir: Path | None = None, fresh: bool = False
 ) -> None:
@@ -1138,21 +1213,21 @@ def _write_config_and_summary(
     click.echo()
     click.secho("  All settings are stored in ~/.memtomem/config.json.", dim=True)
     click.secho("  MCP config only contains the server command (no env overrides).", dim=True)
+
+    # Warn about missing extras (fastembed for onnx, fastapi/uvicorn for web)
+    # before Next Steps so users don't hit "fastembed required" or "Web UI
+    # requires the [web] extra" after following the printed commands. The
+    # interactive `_step_embedding` covers the onnx case inline, but preset
+    # paths (minimal/english/korean) skip that step entirely — check here so
+    # every path surfaces the gap.
+    _emit_missing_extras_warning(_collect_missing_extras(state))
+
     click.echo()
     click.secho("  Next steps:", fg="cyan")
     run_prefix = "uv run " if source_install or project_install else ""
     click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}")
     click.echo(f"    2. {run_prefix}mm search 'your first query'")
-
-    # Web UI is behind the [web] extra (fastapi + uvicorn). If it isn't
-    # installed, surface a hint here rather than letting `mm web` fail later.
-    from memtomem.cli.web import _missing_web_deps, _web_install_hint
-
-    if not source_install and not project_install and _missing_web_deps() is not None:
-        click.echo("    3. mm web  (requires [web] extra — not included in base install)")
-        click.echo(f"       → {_web_install_hint()}")
-    else:
-        click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")
+    click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")
     click.echo()
 
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -216,6 +216,158 @@ def test_write_config_and_summary_without_base_dir_falls_back_to_home(
     assert (tmp_path / ".memtomem" / "config.json").exists()
 
 
+class TestMissingExtrasWarning:
+    """`_write_config_and_summary` must surface missing-extras before Next Steps.
+
+    Preset paths (minimal/english/korean) skip ``_step_embedding`` which was
+    the only inline fastembed check; without a centralized warning, a Korean
+    preset user with a base (``[all]``-less) install hits
+    ``Embedding failed ... fastembed is required`` silently during index. The
+    summary also needs a ``[web]``-missing warning regardless of install
+    type, since source-install users can still invoke the global ``mm web``
+    binary (uv tool path) whose interpreter may lack ``[web]``.
+    """
+
+    def test_collect_missing_extras_none_when_provider_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """provider=none + all extras present → no warnings."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd, "_missing_web_deps", lambda: None, raising=False)
+        # Importlib.find_spec goes through the real import machinery; keep it
+        # unmocked here so fastembed presence on dev machines is the truth.
+        state = {"provider": "none", "rerank_enabled": False}
+        # onnx bucket only fires when provider=onnx OR rerank; none+none = []
+        assert init_cmd._collect_missing_extras(state) == []
+
+    def test_collect_missing_extras_onnx_when_fastembed_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """provider=onnx + fastembed not importable → ['onnx']."""
+        from memtomem.cli import init_cmd
+
+        def fake_find_spec(name: str) -> object | None:
+            return None if name == "fastembed" else object()
+
+        monkeypatch.setattr("importlib.util.find_spec", fake_find_spec)
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        state = {"provider": "onnx", "rerank_enabled": False}
+        assert init_cmd._collect_missing_extras(state) == ["onnx"]
+
+    def test_collect_missing_extras_onnx_when_rerank_needs_fastembed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reranker enabled shares fastembed with onnx embedding — absent
+        fastembed still yields ['onnx'] even if provider=none."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        state = {
+            "provider": "none",
+            "rerank_enabled": True,
+            "rerank_model": "jinaai/jina-reranker-v2-base-multilingual",
+        }
+        assert init_cmd._collect_missing_extras(state) == ["onnx"]
+
+    def test_collect_missing_extras_web_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """provider=none + fastapi absent → ['web']."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
+        state = {"provider": "none", "rerank_enabled": False}
+        assert init_cmd._collect_missing_extras(state) == ["web"]
+
+    def test_collect_missing_extras_both(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """onnx + web both missing → ['onnx', 'web'] (ordered by failure
+        sequence: index before web)."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
+        state = {"provider": "onnx", "rerank_enabled": False}
+        assert init_cmd._collect_missing_extras(state) == ["onnx", "web"]
+
+    def test_extra_install_hint_single_uses_narrow_extra(self) -> None:
+        """One missing extra → narrow hint (``[onnx]`` / ``[web]``)."""
+        from memtomem.cli.init_cmd import _extra_install_hint
+
+        assert _extra_install_hint(["onnx"]) == 'uv tool install --reinstall "memtomem[onnx]"'
+        assert _extra_install_hint(["web"]) == 'uv tool install --reinstall "memtomem[web]"'
+
+    def test_extra_install_hint_multiple_collapses_to_all(self) -> None:
+        """Two+ missing → collapse to ``[all]`` (single public extra covering
+        both, simpler than ``[onnx,web]`` listing)."""
+        from memtomem.cli.init_cmd import _extra_install_hint
+
+        assert _extra_install_hint(["onnx", "web"]) == (
+            'uv tool install --reinstall "memtomem[all]"'
+        )
+
+    def test_emit_missing_extras_warning_silent_when_empty(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Empty list → no output (common path must not add noise)."""
+        from memtomem.cli.init_cmd import _emit_missing_extras_warning
+
+        _emit_missing_extras_warning([])
+        assert capsys.readouterr().out == ""
+
+    def test_emit_missing_extras_warning_names_extras_and_hint(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Warning lists the extras, which commands will fail, and a single
+        install hint (the fix for users seeing 'fastembed required' silently
+        during index)."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _emit_missing_extras_warning
+
+        _emit_missing_extras_warning(["onnx", "web"])
+        out = unstyle(capsys.readouterr().out)
+        assert "Missing extras: onnx, web" in out
+        assert "mm index" in out
+        assert "mm web" in out
+        assert "memtomem[all]" in out
+
+    def test_summary_surfaces_onnx_warning_on_preset_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """End-to-end: Korean-preset-style state (provider=onnx) + fastembed
+        absent must produce a warning in the printed summary. Regression for
+        the preset paths skipping ``_step_embedding``'s inline check."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        state = _make_init_state(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Missing extras: onnx" in out
+        assert "memtomem[onnx]" in out
+
+
 class TestPreservedSummary:
     """`_write_config_and_summary` flags non-default values that the wizard
     inherited from a previous config but did not ask about this run.


### PR DESCRIPTION
## Summary

- After `mm init` finishes, the wizard's summary now names missing extras and prints a single install hint before "Next steps", so first users don't hit `Error: Web UI requires the [web] extra` or `fastembed is required` after running the printed commands.
- Centralized check via `_collect_missing_extras` + `_emit_missing_extras_warning` runs for every path (preset paths previously skipped `_step_embedding`'s inline fastembed check; source-install users were gated out of the `[web]` hint at `init_cmd.py:1151`).
- Recommends `memtomem[all]` when two extras are missing, narrower `memtomem[onnx]` / `memtomem[web]` when one. Interpreter-local check (via `importlib.util.find_spec`) matches the `mm` binary the wizard was launched from.

Fixes #353. #354 (silent `POST /api/index` success) and #355 (`/api/namespaces` console noise) are tracked separately.

## Example output

Before (Korean preset, base `uv tool install memtomem`):

```
  Next steps:
    1. mm index ~/memories
    2. mm search 'your first query'
    3. mm web  (browse & manage your memories)
```

…then `mm web` errors out and `mm index` logs "fastembed is required" per file.

After:

```
  [!] Missing extras: onnx, web
      'mm index' (embeddings) and 'mm web' (UI) will fail until installed.
      → uv tool install --reinstall "memtomem[all]"

  Next steps:
    1. mm index ~/memories
    2. mm search 'your first query'
    3. mm web  (browse & manage your memories)
```

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run pytest -m "not ollama"` (2035 passed, 0 regression)
- [x] New tests: `TestMissingExtrasWarning` (11 tests covering helper outputs, end-to-end summary emission, and install-hint collapsing to `[all]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
