### PR TITLE
fix(init): reconcile install-type with runtime interpreter (#360 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.19] — 2026-04-22
+
+First-UX follow-up to 0.1.18. The new missing-extras warning misfired on
+the "source repo cwd + global `mm`" combination, sending users into an
+unnecessary tool-env reinstall when their workspace `.venv` already had
+the extras `uv run mm` would use.
+
+### Fixed
+
+- **`mm init` reconciles install-type detection with runtime interpreter**
+  — when source-install or project-install is detected, the missing-extras
+  probe now spawns `<dir>/.venv/bin/python` (the interpreter `uv run mm`
+  will use) instead of running `find_spec` in the wizard's own process,
+  and the install hint branches by install type: workspace installs get
+  `uv sync --extra <name>` / `--extra all`, while PyPI / `uv tool install`
+  paths keep the existing `uv tool install --reinstall "memtomem[…]"`
+  hint. Fresh worktrees without a workspace `.venv` see a single
+  `Workspace .venv not found — run \`uv sync --extra all\` first.` line
+  instead of a noisy warning that probes the wrong interpreter. The
+  interactive `_step_embedding` advanced path also shares the install-type
+  hint and marks the warning as surfaced so the summary doesn't double-
+  print. Subprocess probe failures (timeout / missing binary / bad JSON)
+  fall back to the in-process probe so the wizard never silently swallows
+  a real gap. (#360 Phase 1)
+
 ## [0.1.18] — 2026-04-22
 
 First-UX patch on top of 0.1.17. New users following `mm init` →

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.18"
+version = "0.1.19"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -124,9 +124,13 @@ def _step_embedding(state: dict) -> None:
             _onnx_available = True
         except ImportError:
             click.secho("  fastembed not installed.", fg="yellow")
-            click.echo("  Install with: pip install memtomem[onnx]")
+            # Use the install-type-aware hint so the inline message matches
+            # what the summary would otherwise print, then mark the warning
+            # as already surfaced so ``_collect_missing_extras`` skips it.
+            click.echo(f"  Install with: {_extra_install_hint(['onnx'], state)}")
             click.echo("  Saving ONNX config now so you're ready after install.")
             click.echo()
+            state.setdefault("_extras_warned_inline", set()).add("onnx")
 
         click.echo("  Available models:")
         click.echo("    [1] all-MiniLM-L6-v2 — English, fast, tiny (~22 MB, 384d)")
@@ -888,40 +892,139 @@ async def _check_embedding_mismatch(state: dict, *, interactive: bool) -> None:
         await storage.close()
 
 
-# Canonical hint for each extra. Mirrors the form in
-# ``memtomem.cli.web._web_install_hint`` so every user-facing missing-extras
-# message suggests the same install method (uv tool, which matches how the
-# global ``mm`` binary gets on PATH).
+# Canonical hint prefixes. Branching lives in ``_extra_install_hint``:
+# source/project installs use the workspace ``uv sync`` path so the extras
+# land in the same ``.venv`` that ``uv run mm`` will use; everything else
+# (``uv tool install`` / PyPI) stays on the tool-env reinstall path that the
+# global ``mm`` binary relies on.
 _EXTRA_INSTALL_HINT_PREFIX: str = 'uv tool install --reinstall "memtomem'
+_UV_SYNC_HINT_PREFIX: str = "uv sync --extra "
+
+# Probe snippet for extras presence in a foreign Python. ``find_spec`` is
+# cheaper than ``__import__`` and matches ``_collect_missing_extras``'s
+# historical semantic.
+_PROBE_EXTRAS_CODE: str = (
+    "import json, importlib.util as u; "
+    "print(json.dumps([n for n in ['fastembed','fastapi','uvicorn'] "
+    "if u.find_spec(n) is not None]))"
+)
 
 
-def _extra_install_hint(extras: list[str]) -> str:
-    """Return the uv-tool install command for one extra (``memtomem[onnx]``)
-    or the combined ``[all]`` extra when two or more are missing.
+def _workspace_python(state: dict) -> Path | None:
+    """Return ``<source_dir|project_dir>/.venv/bin/python`` if the workspace
+    venv exists, else ``None``.
+
+    This is the reconcile hook between the cwd-filesystem axis
+    (:func:`_is_source_install`) and the runtime-interpreter axis
+    (``sys.executable``) — the Phase 1 fix for issue #360. When the user
+    runs ``mm init`` from a source/project checkout via a global ``mm``
+    binary (``uv tool install``), the wizard's own interpreter is the tool
+    env (which may lack ``[all]``), but ``Next steps`` prints ``uv run mm``
+    which will use the workspace venv. Probing the workspace venv here
+    avoids warning the user to reinstall the tool env when the workspace
+    already has the extras."""
+    root = state.get("source_dir") or state.get("project_dir")
+    if not root:
+        return None
+    py = Path(root) / ".venv" / "bin" / "python"
+    return py if py.exists() else None
+
+
+def _probe_workspace_extras(py: Path) -> set[str] | None:
+    """Ask a foreign Python which of ``fastembed`` / ``fastapi`` / ``uvicorn``
+    are importable. Returns the importable subset, or ``None`` on subprocess
+    failure (missing binary, timeout, non-zero rc, bad JSON). Callers treat
+    ``None`` as "unknown — fall back to the in-process probe"."""
+    try:
+        result = _run([str(py), "-c", _PROBE_EXTRAS_CODE], timeout=5)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        parsed = json.loads(result.stdout.strip())
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, list):
+        return None
+    return set(parsed)
+
+
+def _inproc_have_extras() -> tuple[bool, bool]:
+    """Return ``(have_fastembed, have_web)`` via in-process ``find_spec`` /
+    :func:`memtomem.cli.web._missing_web_deps`. Used when not a
+    source/project install, or when the workspace-python probe fails."""
+    from importlib.util import find_spec
+
+    from memtomem.cli.web import _missing_web_deps
+
+    return (find_spec("fastembed") is not None, _missing_web_deps() is None)
+
+
+def _workspace_needs_sync(state: dict) -> bool:
+    """True iff source/project install detected but ``<dir>/.venv/`` is
+    absent — a fresh clone / fresh worktree. The summary shows a single
+    ``run uv sync first`` line in this case instead of a noisy missing-
+    extras warning that would have probed the wrong interpreter."""
+    source = state.get("source_install") or state.get("project_install")
+    if not source:
+        return False
+    return _workspace_python(state) is None
+
+
+def _extra_install_hint(extras: list[str], state: dict | None = None) -> str:
+    """Return the install command for one or more missing extras, branched
+    by install type.
+
+    - source / project install → ``uv sync --extra <name>`` (single) or
+      ``uv sync --extra all`` (two+). The workspace ``.venv`` is what
+      ``uv run mm`` will use, so ``uv sync`` is the right install path.
+    - PyPI / ``uv tool install`` (default) → ``uv tool install --reinstall
+      "memtomem[<name>]"`` or ``[all]``. Matches how the global ``mm``
+      binary is installed.
 
     Multi-extra case collapses to ``[all]`` instead of bracketed multiples
-    (``memtomem[onnx,web]``) because ``[all]`` is the public, documented extra
-    in ``pyproject.toml``; the user doesn't need to know the sub-bundle."""
-    if len(extras) == 1:
-        return f'{_EXTRA_INSTALL_HINT_PREFIX}[{extras[0]}]"'
-    return f'{_EXTRA_INSTALL_HINT_PREFIX}[all]"'
+    (``memtomem[onnx,web]``) because ``[all]`` is the public, documented
+    extra in ``pyproject.toml``; the user doesn't need to know the
+    sub-bundle."""
+    state = state or {}
+    is_workspace = state.get("source_install") or state.get("project_install")
+    name = extras[0] if len(extras) == 1 else "all"
+    if is_workspace:
+        return f"{_UV_SYNC_HINT_PREFIX}{name}"
+    return f'{_EXTRA_INSTALL_HINT_PREFIX}[{name}]"'
 
 
 def _collect_missing_extras(state: dict) -> list[str]:
     """Return ordered list of missing extras the chosen config will need.
 
-    Interpreter-local check via :func:`importlib.util.find_spec` — matches
-    the Python env the current ``mm`` binary runs under. The whole point of
-    this warning is that preset paths (``minimal`` / ``english`` / ``korean``)
-    skip the interactive ``_step_embedding`` that historically surfaced the
-    fastembed gap inline; the user's ``mm init`` → ``mm web`` flow otherwise
-    hits an opaque failure at the third ``Next steps`` command.
+    Source/project install: probes the workspace ``.venv/bin/python`` — the
+    interpreter ``uv run mm`` will use — so the warning matches what
+    ``Next steps`` will actually run. If the workspace venv is absent the
+    caller shows a ``run uv sync first`` one-liner instead, so this path
+    only fires when the probe has authoritative state.
+
+    Everything else (PyPI / ``uv tool install``) uses in-process
+    ``find_spec`` as before — it matches the ``mm`` binary the wizard is
+    running under, which is also what the un-prefixed ``mm index`` /
+    ``mm web`` commands will use.
 
     Order: ``onnx`` before ``web`` so the extras appear in the same order
-    the dependent commands fail (``mm index`` → ``mm web``)."""
-    from importlib.util import find_spec
+    the dependent commands fail (``mm index`` → ``mm web``). Entries in
+    ``state['_extras_warned_inline']`` are filtered out so the interactive
+    ``_step_embedding`` path doesn't double-print."""
+    source = state.get("source_install") or state.get("project_install")
+    ws_py = _workspace_python(state) if source else None
 
-    from memtomem.cli.web import _missing_web_deps
+    if source and ws_py is not None:
+        importable = _probe_workspace_extras(ws_py)
+        if importable is not None:
+            have_fastembed = "fastembed" in importable
+            have_web = {"fastapi", "uvicorn"}.issubset(importable)
+        else:
+            have_fastembed, have_web = _inproc_have_extras()
+    else:
+        have_fastembed, have_web = _inproc_have_extras()
 
     missing: list[str] = []
     # [onnx] = fastembed. Both the embedder and the fastembed reranker share
@@ -929,23 +1032,25 @@ def _collect_missing_extras(state: dict) -> list[str]:
     needs_fastembed = state.get("provider") == "onnx" or (
         state.get("rerank_enabled") and state.get("rerank_model")
     )
-    if needs_fastembed and find_spec("fastembed") is None:
+    if needs_fastembed and not have_fastembed:
         missing.append("onnx")
-    # [web] = fastapi + uvicorn. Reuse ``_missing_web_deps`` so the check
-    # stays aligned with what ``mm web`` itself errors on.
-    if _missing_web_deps() is not None:
+    if not have_web:
         missing.append("web")
-    return missing
+
+    warned = state.get("_extras_warned_inline") or set()
+    return [x for x in missing if x not in warned]
 
 
-def _emit_missing_extras_warning(missing: list[str]) -> None:
+def _emit_missing_extras_warning(missing: list[str], state: dict) -> None:
     """Print an actionable warning about missing extras, or nothing.
 
     Silent when ``missing`` is empty so the common "already installed" path
     adds no output noise. When non-empty, names the missing extras, lists
     which ``Next steps`` commands will fail without them, and prints a single
     install command (narrow per-extra hint when one missing, ``[all]`` when
-    two+ — matches ``pyproject.toml``'s public extras)."""
+    two+ — matches ``pyproject.toml``'s public extras). The hint is branched
+    by install type: workspace installs get ``uv sync --extra …``, tool
+    installs get ``uv tool install --reinstall …``."""
     if not missing:
         return
     click.echo()
@@ -960,7 +1065,7 @@ def _emit_missing_extras_warning(missing: list[str]) -> None:
         click.echo("      'mm index' will fail to embed until installed.")
     elif "web" in missing:
         click.echo("      'mm web' will fail to start until installed.")
-    click.echo(f"      → {_extra_install_hint(missing)}")
+    click.echo(f"      → {_extra_install_hint(missing, state)}")
 
 
 def _write_config_and_summary(
@@ -1220,7 +1325,20 @@ def _write_config_and_summary(
     # interactive `_step_embedding` covers the onnx case inline, but preset
     # paths (minimal/english/korean) skip that step entirely — check here so
     # every path surfaces the gap.
-    _emit_missing_extras_warning(_collect_missing_extras(state))
+    #
+    # Source/project install + workspace .venv absent (fresh worktree) →
+    # the missing-extras probe has no authoritative interpreter to query;
+    # show a single ``run uv sync first`` line instead. Otherwise probe the
+    # workspace venv (if present) or in-process and emit the regular
+    # warning. Issue #360 Phase 1.
+    if _workspace_needs_sync(state):
+        click.echo()
+        click.secho(
+            "  Workspace .venv not found — run `uv sync --extra all` first.",
+            fg="yellow",
+        )
+    else:
+        _emit_missing_extras_warning(_collect_missing_extras(state), state)
 
     click.echo()
     click.secho("  Next steps:", fg="cyan")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -296,7 +296,8 @@ class TestMissingExtrasWarning:
         assert init_cmd._collect_missing_extras(state) == ["onnx", "web"]
 
     def test_extra_install_hint_single_uses_narrow_extra(self) -> None:
-        """One missing extra → narrow hint (``[onnx]`` / ``[web]``)."""
+        """One missing extra → narrow hint. Default (no state / PyPI install)
+        keeps the tool-install reinstall path."""
         from memtomem.cli.init_cmd import _extra_install_hint
 
         assert _extra_install_hint(["onnx"]) == 'uv tool install --reinstall "memtomem[onnx]"'
@@ -311,13 +312,33 @@ class TestMissingExtrasWarning:
             'uv tool install --reinstall "memtomem[all]"'
         )
 
+    def test_extra_install_hint_source_install_uses_uv_sync(self) -> None:
+        """Source-install state → ``uv sync --extra <name>`` (single) and
+        ``--extra all`` (multiple). Issue #360 Phase 1: workspace ``.venv``
+        is what ``uv run mm`` uses, so ``uv sync`` is the right install."""
+        from memtomem.cli.init_cmd import _extra_install_hint
+
+        state = {"source_install": True}
+        assert _extra_install_hint(["onnx"], state) == "uv sync --extra onnx"
+        assert _extra_install_hint(["web"], state) == "uv sync --extra web"
+        assert _extra_install_hint(["onnx", "web"], state) == "uv sync --extra all"
+
+    def test_extra_install_hint_project_install_uses_uv_sync(self) -> None:
+        """Project-install (``uv add memtomem`` in a non-source project)
+        also resolves to the workspace ``uv sync`` hint."""
+        from memtomem.cli.init_cmd import _extra_install_hint
+
+        state = {"project_install": True}
+        assert _extra_install_hint(["onnx"], state) == "uv sync --extra onnx"
+        assert _extra_install_hint(["onnx", "web"], state) == "uv sync --extra all"
+
     def test_emit_missing_extras_warning_silent_when_empty(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """Empty list → no output (common path must not add noise)."""
         from memtomem.cli.init_cmd import _emit_missing_extras_warning
 
-        _emit_missing_extras_warning([])
+        _emit_missing_extras_warning([], {})
         assert capsys.readouterr().out == ""
 
     def test_emit_missing_extras_warning_names_extras_and_hint(
@@ -330,7 +351,7 @@ class TestMissingExtrasWarning:
 
         from memtomem.cli.init_cmd import _emit_missing_extras_warning
 
-        _emit_missing_extras_warning(["onnx", "web"])
+        _emit_missing_extras_warning(["onnx", "web"], {})
         out = unstyle(capsys.readouterr().out)
         assert "Missing extras: onnx, web" in out
         assert "mm index" in out
@@ -345,7 +366,8 @@ class TestMissingExtrasWarning:
     ) -> None:
         """End-to-end: Korean-preset-style state (provider=onnx) + fastembed
         absent must produce a warning in the printed summary. Regression for
-        the preset paths skipping ``_step_embedding``'s inline check."""
+        the preset paths skipping ``_step_embedding``'s inline check.
+        Default state has ``source_install=False`` → PyPI hint preserved."""
         from click import unstyle
 
         from memtomem.cli.init_cmd import _write_config_and_summary
@@ -366,6 +388,261 @@ class TestMissingExtrasWarning:
         out = unstyle(capsys.readouterr().out)
         assert "Missing extras: onnx" in out
         assert "memtomem[onnx]" in out
+
+
+class TestInstallAxesReconcile:
+    """Issue #360 Phase 1 — ``mm init`` install-type detection vs runtime
+    interpreter axis reconcile.
+
+    The wizard's cwd-filesystem axis (``_is_source_install`` /
+    ``_is_project_install``) decided ``Next steps: uv run mm …``, but the
+    extras probe ran in the wizard's own Python via ``find_spec``. For
+    "source repo cwd + global ``mm`` (uv tool, no ``[all]``)" + "workspace
+    ``.venv`` HAS ``[all]``", v0.1.18 wrongly hinted at a tool-env reinstall
+    when the workspace was already set up. Phase 1 probes the workspace
+    ``.venv/bin/python`` and branches the install hint by install type."""
+
+    @staticmethod
+    def _make_state_source_with_venv(tmp_path: Path) -> dict:
+        """Build a source-install state whose ``.venv/bin/python`` exists.
+
+        ``_workspace_python`` only checks ``.exists()`` so a touched empty
+        file is enough; the actual subprocess call is monkeypatched."""
+        state = _make_init_state(tmp_path)
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        (venv_bin / "python").touch()
+        state["source_install"] = True
+        state["source_dir"] = str(tmp_path)
+        return state
+
+    def test_source_cwd_workspace_has_all_suppresses_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Acceptance #1: source cwd + global ``mm`` (no extras in tool env)
+        + workspace ``.venv/`` HAS extras → no missing-extras warning. The
+        in-process probe would say "missing" but the workspace probe is
+        authoritative for what ``uv run mm`` will use."""
+        from memtomem.cli import init_cmd
+
+        # In-process probe would report missing — must be ignored.
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
+        # Workspace probe says everything is there.
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastembed", "fastapi", "uvicorn"},
+        )
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        assert init_cmd._collect_missing_extras(state) == []
+
+    def test_source_cwd_workspace_missing_all_suggests_uv_sync_all(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Acceptance #2: workspace ``.venv/`` exists but lacks both extras
+        → ``uv sync --extra all`` hint, not the tool-install reinstall."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        missing = init_cmd._collect_missing_extras(state)
+        assert missing == ["onnx", "web"]
+        assert init_cmd._extra_install_hint(missing, state) == "uv sync --extra all"
+
+    def test_source_cwd_workspace_missing_onnx_only_suggests_uv_sync_onnx(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Workspace has web deps but not fastembed → narrow ``uv sync
+        --extra onnx`` hint."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastapi", "uvicorn"},
+        )
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        missing = init_cmd._collect_missing_extras(state)
+        assert missing == ["onnx"]
+        assert init_cmd._extra_install_hint(missing, state) == "uv sync --extra onnx"
+
+    def test_pypi_install_preserves_uv_tool_reinstall_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Acceptance #3: outside any source/project repo (PyPI / ``uv tool``
+        install) + tool env lacks fastembed → existing tool-install
+        reinstall hint preserved. v0.1.18 regression guard."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        state = {
+            "provider": "onnx",
+            "rerank_enabled": False,
+            "source_install": False,
+            "project_install": False,
+        }
+        missing = init_cmd._collect_missing_extras(state)
+        assert missing == ["onnx"]
+        hint = init_cmd._extra_install_hint(missing, state)
+        assert hint.startswith(init_cmd._EXTRA_INSTALL_HINT_PREFIX)
+        assert hint == 'uv tool install --reinstall "memtomem[onnx]"'
+
+    def test_project_install_workspace_has_all_no_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Project install (``uv add memtomem``) + workspace .venv complete
+        → no warning, same path as source install."""
+        from memtomem.cli import init_cmd
+
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        (venv_bin / "python").touch()
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastembed", "fastapi", "uvicorn"},
+        )
+
+        state = _make_init_state(tmp_path)
+        state["provider"] = "onnx"
+        state["project_install"] = True
+        state["project_dir"] = str(tmp_path)
+        assert init_cmd._collect_missing_extras(state) == []
+
+    def test_missing_venv_shows_sync_one_liner_not_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Source/project install detected but ``.venv/`` is absent (fresh
+        worktree) → summary shows a single ``run uv sync first`` line, NOT
+        the ``[!] Missing extras`` warning. No noisy probe of the wrong
+        interpreter."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        # No .venv created on tmp_path.
+        # In-process probe would say missing — irrelevant, must be skipped.
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = _make_init_state(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        state["source_install"] = True
+        state["source_dir"] = str(tmp_path)
+
+        assert init_cmd._workspace_needs_sync(state) is True
+
+        init_cmd._write_config_and_summary(state, tmp_path)
+        out = unstyle(capsys.readouterr().out)
+        assert "Workspace .venv not found" in out
+        assert "uv sync --extra all" in out
+        assert "Missing extras:" not in out
+
+    def test_subprocess_timeout_falls_back_to_inproc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the workspace-python subprocess fails (``None`` sentinel),
+        fall back to in-process probe so the wizard still surfaces missing
+        extras (better than going silent)."""
+        from memtomem.cli import init_cmd
+
+        # In-process probe says missing.
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        # Subprocess probe fails (timeout / FileNotFoundError simulation).
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: None)
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        assert init_cmd._collect_missing_extras(state) == ["onnx"]
+
+    def test_inline_warned_onnx_dedup_from_summary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Acceptance #4: when ``_step_embedding`` already printed the
+        fastembed warning inline, ``_collect_missing_extras`` filters
+        ``onnx`` out of the summary so the user doesn't see the same hint
+        twice."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        state["_extras_warned_inline"] = {"onnx"}
+        # Probe says fastembed AND web missing; only web should remain.
+        assert init_cmd._collect_missing_extras(state) == ["web"]
+
+    def test_summary_source_install_workspace_has_all_silent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """End-to-end acceptance #1: full ``_write_config_and_summary`` with
+        a source-install state where the workspace probe reports complete
+        extras → summary has no missing-extras warning, and ``Next steps``
+        prints ``uv run mm …`` (workspace is what will run)."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        (venv_bin / "python").touch()
+        # In-process probe would report missing; workspace probe is truth.
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastembed", "fastapi", "uvicorn"},
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = _make_init_state(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        state["source_install"] = True
+        state["source_dir"] = str(tmp_path)
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Missing extras:" not in out
+        assert "Workspace .venv not found" not in out
+        assert "Next steps:" in out
+        assert "uv run mm" in out
 
 
 class TestPreservedSummary:

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Phase 1 of #360. The v0.1.18 missing-extras warning misfired on
"source repo cwd + global `mm` (`uv tool install`)" combinations: the
wizard correctly printed `Next steps: uv run mm …` but ran `find_spec`
in its own (tool-env) Python and hinted at a `uv tool install --reinstall
"memtomem[all]"` even when the workspace `.venv` already had `[all]`.
Reported user (`#360`) followed the hint and did the unnecessary
reinstall.

This PR reconciles the two judgment axes for the warning path only:

- New `_workspace_python(state)` returns `<dir>/.venv/bin/python` when a
  source/project install is detected — the interpreter `uv run mm` will
  use. `_probe_workspace_extras(py)` spawns it with a tiny `find_spec`
  probe; subprocess failure (timeout / missing binary / bad JSON)
  returns `None` so the caller falls back to in-process probing,
  preserving v0.1.18 behavior on every install path that doesn't have
  a workspace.
- `_extra_install_hint` now branches by install type:
  - source / project → `uv sync --extra <name>` (or `--extra all`)
  - PyPI / `uv tool install` → existing `uv tool install --reinstall
    "memtomem[…]"`
- Source/project install detected but `<dir>/.venv/` is absent (fresh
  worktree) → single `Workspace .venv not found — run \`uv sync --extra
  all\` first.` line instead of a noisy warning probing the wrong
  interpreter.
- Interactive `_step_embedding`'s inline fastembed warning uses the
  same install-type-aware hint and marks
  `state["_extras_warned_inline"]` so `_collect_missing_extras` filters
  the same extra out of the summary (no double-print).

`web.py`'s `_missing_web_deps` / `_web_install_hint` stay untouched —
`mm web` itself runs in-process so the in-process probe is correct
there. `__import__`/`find_spec` unification is Phase 3 work.

Bumps memtomem `0.1.18` → `0.1.19`. `uv.lock` updated to match
(`feedback_uv_lock_version_sync.md`).

## Acceptance criteria (from #360 body)

- [x] **#1** — `mm init --preset korean` from source repo cwd + global
      `mm` (no `[all]` in tool env) + workspace `.venv/` HAS `[all]` →
      summary prints NO missing-extras warning.
      Covered by `test_source_cwd_workspace_has_all_suppresses_warning`
      and `test_summary_source_install_workspace_has_all_silent`.
      Manually verified in this checkout (`uv run mm init --preset
      minimal -y`): "Install: source" + `uv run mm` Next steps + no
      warning.
- [x] **#2** — Same setup but `.venv/` has only base install → warning
      hint = `uv sync --extra all`, not `uv tool install --reinstall`.
      Covered by `test_source_cwd_workspace_missing_all_suggests_uv_sync_all`
      and `test_source_cwd_workspace_missing_onnx_only_suggests_uv_sync_onnx`.
- [x] **#3** — `mm init` from outside repo (PyPI / `uv tool install`)
      preserves the existing `uv tool install --reinstall
      "memtomem[all]"` hint when tool env lacks extras (no v0.1.18
      regression). Covered by
      `test_pypi_install_preserves_uv_tool_reinstall_hint` and the
      preexisting `test_extra_install_hint_single_uses_narrow_extra` /
      `test_summary_surfaces_onnx_warning_on_preset_path`.
- [x] **#4** — `_step_embedding`'s inline fastembed warning is not
      double-printed in the summary. Covered by
      `test_inline_warned_onnx_dedup_from_summary`.
- [x] **#5** — Unit-test matrix covering all 5 rows. New
      `TestInstallAxesReconcile` class adds 9 tests; existing
      `TestMissingExtrasSurfacing` class extended with 2 new install-
      type tests + signature-update tests.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py`
- [x] `uv run pytest -m "not ollama"` → 2047 passed, 0 fail
- [x] Manual: `uv run mm init --preset minimal -y` from source cwd →
      "Install: source", `uv run mm` Next steps, no missing-extras
      warning when workspace `.venv` has `[all]`.
- [ ] Post-merge smoke (per `feedback_post_merge_smoke.md`): re-verify
      PyPI-install path on a fresh `uv tool install memtomem` outside
      any source repo to confirm v0.1.18 behavior preserved (test #3
      acceptance).
- [ ] After merge, push `v0.1.19` tag for trusted-publisher PyPI
      release.

## Defers (issue #360 body, layered fix plan)

- **Phase 2** — cwd vs runtime mismatch info banner ("cwd: source /
  runtime: uv tool"); auto-install consistency for python extras
  (extract `_install_extras` helper from the ollama / claude pattern).
- **Phase 3** — collapse the `_is_source_install` / `_detect_source_dir`
  pair into single helpers; introduce `_runtime_profile()` dataclass as
  the single source of truth for run_prefix / hint / warning;
  first-class `uvx` detection; unify `__import__` vs `find_spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
