### PR TITLE
feat(init): auto-install missing extras + mismatch banner (#360 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **`mm init` now offers to auto-install missing python extras** — the
+  summary still surfaces the same Phase-1 install-type-aware hint, but
+  first prompts `Install memtomem[all] now?` (defaulting to No — Enter
+  skips, preserving the previous hint-only behavior). When the user
+  confirms, the wizard shells out to `uv sync --extra …` (source/project
+  installs) or `uv tool install --reinstall "memtomem[…]"` (tool
+  installs) and prints a single `Installed missing extras: …` line on
+  success. Subprocess failures (missing binary, timeout, non-zero rc)
+  fall back to the hint. Also adds a one-line info banner when the
+  wizard is run from a source/project checkout with a global (non-
+  workspace-venv) interpreter, explaining that `Next steps` assume
+  `uv run mm` — Phase 1 silenced the false warning for this combination
+  but didn't explain why. (#360 Phase 2, #362)
+- **Behavior note for scripted `mm init -y` runs with missing extras**:
+  the `Install memtomem[all] now?` prompt defaults to No, so an
+  unattended Enter (or TTY-less run) preserves the Phase-1 hint output
+  — no silent install — but scripts that auto-feed the wizard may see
+  one extra prompt line when extras are missing.
+
 ## [0.1.19] — 2026-04-22
 
 First-UX follow-up to 0.1.18. The new missing-extras warning misfired on

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -9,11 +9,14 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Literal
 
 import click
 
 from memtomem.cli.init_presets import PRESETS, _VALID_PRESETS, get_preset
 from memtomem.cli.wizard import nav_confirm, nav_prompt, run_steps, step_header
+
+InstallType = Literal["source", "project", "tool", "uvx"]
 
 
 def _run(cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -995,6 +998,77 @@ def _extra_install_hint(extras: list[str], state: dict | None = None) -> str:
     return f'{_EXTRA_INSTALL_HINT_PREFIX}[{name}]"'
 
 
+def _install_extras(
+    install_type: InstallType,
+    extras: list[str],
+    *,
+    confirm: bool = False,
+    workspace_dir: Path | None = None,
+) -> bool:
+    """Confirm-then-subprocess install for python package extras.
+
+    Scope is intentionally narrow: python package extras only. Ollama model-
+    pull and ``claude mcp add`` have different shapes (no ``install_type ×
+    extras`` axis — a model name vs. a package-extras list) and stay inline
+    at their current call sites. Generalizing this helper into an arbitrary
+    "confirm + subprocess + fallback" runner would bloat it with call-site-
+    specific prompt strings for zero reuse today.
+
+    ``confirm`` is passed as ``default=`` to :func:`nav_confirm`: ``True``
+    means Enter-is-Yes (ollama-style — the user likely wants the heavy
+    model download), ``False`` means Enter-is-No (python-extras-style —
+    the user has already typed through the wizard and a ``[all]`` reinstall
+    is heavy).
+
+    ``workspace_dir`` is REQUIRED when ``install_type`` is ``"source"`` or
+    ``"project"`` (used as ``subprocess.run`` ``cwd=`` for ``uv sync``)
+    and MUST be ``None`` for ``"tool"`` / ``"uvx"``. Callers are expected
+    to branch on the install type before calling.
+
+    Returns ``True`` only when a subprocess actually ran and exited 0. In
+    every other case — empty ``extras``, missing ``workspace_dir`` for
+    source/project, ``uvx`` branch (hint-only, no install semantic),
+    user decline, ``FileNotFoundError``, ``TimeoutExpired``, or non-zero
+    rc — returns ``False`` so the caller falls back to the Phase 1
+    :func:`_emit_missing_extras_warning` hint path."""
+    if not extras:
+        return False
+    name = extras[0] if len(extras) == 1 else "all"
+
+    cwd: str | None
+    if install_type in ("source", "project"):
+        if workspace_dir is None:
+            return False
+        cmd = ["uv", "sync", "--extra", name]
+        cwd = str(workspace_dir)
+    elif install_type == "tool":
+        cmd = ["uv", "tool", "install", "--reinstall", f"memtomem[{name}]"]
+        cwd = None
+    else:  # uvx — ephemeral env; a non-ephemeral install is meaningless
+        click.echo(
+            "  (uvx is ephemeral — re-invoke with "
+            f'`uvx --from "memtomem[{name}]" memtomem ...` instead)'
+        )
+        return False
+
+    prompt = f"  Install memtomem[{name}] now?"
+    if not nav_confirm(prompt, default=confirm):
+        return False
+
+    click.echo(f"  Running: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
 def _collect_missing_extras(state: dict) -> list[str]:
     """Return ordered list of missing extras the chosen config will need.
 
@@ -1039,6 +1113,58 @@ def _collect_missing_extras(state: dict) -> list[str]:
 
     warned = state.get("_extras_warned_inline") or set()
     return [x for x in missing if x not in warned]
+
+
+def _runtime_under_workspace_venv(state: dict) -> bool:
+    """True iff the current ``sys.executable`` is inside ``<workspace>/.venv/``.
+
+    Used by :func:`_emit_cwd_runtime_mismatch_banner` to decide whether the
+    user is running a global ``mm`` from inside a source/project checkout
+    (mismatch) vs. ``uv run mm`` from the workspace venv (aligned).
+
+    Compares raw path strings (no ``.resolve()``) on purpose: ``uv`` creates
+    ``.venv/bin/python3`` as a symlink to its managed interpreter cache
+    (``~/.local/share/uv/python/...``). Resolving the symlink would always
+    land outside the workspace and fire the banner even when the runtime
+    IS the workspace venv. The raw prefix comparison matches how Python
+    itself reports ``sys.executable`` (it reports the symlink path, not
+    the target)."""
+    root = state.get("source_dir") or state.get("project_dir")
+    if not root:
+        return False
+    try:
+        return Path(sys.executable).is_relative_to(Path(root) / ".venv")
+    except (OSError, ValueError):
+        return False
+
+
+def _emit_cwd_runtime_mismatch_banner(state: dict) -> None:
+    """Info banner for ``source/project cwd + non-workspace runtime``.
+
+    Phase 1 (#361) silenced the false missing-extras warning for this
+    combination (the wizard's own interpreter is the tool env but Next-
+    steps uses ``uv run mm`` which probes the workspace venv). Phase 2
+    closes the UX loop by explaining the silence: users otherwise wonder
+    whether the wizard did the right thing or swallowed an error.
+
+    Trigger is orthogonal to extras presence — the mismatch is a property
+    of the axes themselves, not of what's installed. Prints nothing when
+    the runtime interpreter is inside the workspace venv, or when the
+    install type is PyPI / tool (no cwd axis to disagree with)."""
+    if not (state.get("source_install") or state.get("project_install")):
+        return
+    if _runtime_under_workspace_venv(state):
+        return
+    cwd_type = "source" if state.get("source_install") else "project"
+    click.echo()
+    click.secho(
+        f"  i  cwd: {cwd_type} / runtime: uv tool — Next steps assume `uv run mm`.",
+        fg="cyan",
+    )
+    click.secho(
+        "     If you intend to run bare `mm`, install [all] into the tool env.",
+        fg="cyan",
+    )
 
 
 def _emit_missing_extras_warning(missing: list[str], state: dict) -> None:
@@ -1331,6 +1457,15 @@ def _write_config_and_summary(
     # show a single ``run uv sync first`` line instead. Otherwise probe the
     # workspace venv (if present) or in-process and emit the regular
     # warning. Issue #360 Phase 1.
+    #
+    # Before either branch: cwd-vs-runtime mismatch banner (#360 Phase 2).
+    # Source/project cwd + non-workspace runtime → explain why the wizard
+    # stays quiet about the tool-env extras and which invocation shape the
+    # printed Next steps assume.
+    _emit_cwd_runtime_mismatch_banner(state)
+    install_type_lit: InstallType = (
+        "source" if source_install else "project" if project_install else "tool"
+    )
     if _workspace_needs_sync(state):
         click.echo()
         click.secho(
@@ -1338,7 +1473,24 @@ def _write_config_and_summary(
             fg="yellow",
         )
     else:
-        _emit_missing_extras_warning(_collect_missing_extras(state), state)
+        missing = _collect_missing_extras(state)
+        if missing:
+            ws: Path | None
+            if source_install:
+                ws = Path(state["source_dir"])
+            elif project_install:
+                ws = Path(state["project_dir"])
+            else:
+                ws = None
+            installed = _install_extras(install_type_lit, missing, confirm=False, workspace_dir=ws)
+            if installed:
+                click.echo()
+                click.secho(
+                    f"  Installed missing extras: {', '.join(missing)}.",
+                    fg="green",
+                )
+            else:
+                _emit_missing_extras_warning(missing, state)
 
     click.echo()
     click.secho("  Next steps:", fg="cyan")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -367,9 +367,15 @@ class TestMissingExtrasWarning:
         """End-to-end: Korean-preset-style state (provider=onnx) + fastembed
         absent must produce a warning in the printed summary. Regression for
         the preset paths skipping ``_step_embedding``'s inline check.
-        Default state has ``source_install=False`` → PyPI hint preserved."""
+        Default state has ``source_install=False`` → PyPI hint preserved.
+
+        Phase 2 (#362): the summary now routes missing extras through
+        ``_install_extras`` first; with the helper stubbed to ``False``
+        (simulating user decline / subprocess failure / non-TTY) the
+        Phase 1 warning path must still fire."""
         from click import unstyle
 
+        from memtomem.cli import init_cmd
         from memtomem.cli.init_cmd import _write_config_and_summary
 
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -378,6 +384,7 @@ class TestMissingExtrasWarning:
             lambda name: None if name == "fastembed" else object(),
         )
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: False)
 
         state = _make_init_state(tmp_path)
         state["provider"] = "onnx"
@@ -643,6 +650,525 @@ class TestInstallAxesReconcile:
         assert "Workspace .venv not found" not in out
         assert "Next steps:" in out
         assert "uv run mm" in out
+
+    def test_warning_still_fires_when_helper_declines(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Phase 2 regression: when ``_install_extras`` returns ``False``
+        (user declined / subprocess failed / empty contract) the summary
+        must still surface the Phase 1 ``[!] Missing extras:`` warning so
+        the hint path is never silently skipped."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
+        monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Missing extras:" in out
+        assert "Installed missing extras:" not in out
+
+    def test_helper_success_skips_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Phase 2: when ``_install_extras`` returns ``True`` (subprocess
+        ran and exited 0) the summary shows the success line and skips the
+        Phase 1 warning — a hint after a successful install would be
+        noise."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
+        monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = self._make_state_source_with_venv(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Missing extras:" not in out
+        assert "Installed missing extras:" in out
+
+
+class TestInstallExtrasHelper:
+    """Issue #362 Phase 2 — ``_install_extras`` helper unit tests.
+
+    Covers the ``install_type × extras × confirm`` matrix and the failure-
+    fallback contract (helper returns ``False`` on every non-success path
+    so the caller can fall through to :func:`_emit_missing_extras_warning`
+    without losing the Phase 1 hint)."""
+
+    def test_empty_extras_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty ``extras`` list → ``False`` without prompt or subprocess."""
+        from memtomem.cli import init_cmd
+
+        def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("subprocess.run must not be called for empty extras")
+
+        monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
+        assert init_cmd._install_extras("source", [], workspace_dir=Path("/tmp")) is False
+
+    def test_source_confirm_yes_runs_uv_sync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``install_type='source'`` + nav_confirm→True → spawns ``uv sync
+        --extra onnx`` with ``cwd=workspace_dir``; returns ``True`` on rc=0."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        captured: dict = {}
+
+        def _fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["cwd"] = kw.get("cwd")
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
+
+        assert (
+            init_cmd._install_extras("source", ["onnx"], confirm=False, workspace_dir=tmp_path)
+            is True
+        )
+        assert captured["cmd"] == ["uv", "sync", "--extra", "onnx"]
+        assert captured["cwd"] == str(tmp_path)
+
+    def test_project_confirm_yes_runs_uv_sync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``install_type='project'`` behaves identically to ``'source'``."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        captured: dict = {}
+
+        def _fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["cwd"] = kw.get("cwd")
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
+
+        assert (
+            init_cmd._install_extras("project", ["onnx"], confirm=False, workspace_dir=tmp_path)
+            is True
+        )
+        assert captured["cmd"] == ["uv", "sync", "--extra", "onnx"]
+        assert captured["cwd"] == str(tmp_path)
+
+    def test_tool_confirm_yes_runs_uv_tool_reinstall(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``install_type='tool'`` → ``uv tool install --reinstall
+        "memtomem[onnx]"`` with ``cwd=None``."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        captured: dict = {}
+
+        def _fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            captured["cwd"] = kw.get("cwd")
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
+
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is True
+        assert captured["cmd"] == [
+            "uv",
+            "tool",
+            "install",
+            "--reinstall",
+            "memtomem[onnx]",
+        ]
+        assert captured["cwd"] is None
+
+    def test_uvx_branch_hints_and_returns_false(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``install_type='uvx'`` is ephemeral — helper prints a hint
+        about ``uvx --from`` and returns ``False`` without any
+        subprocess call."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("subprocess.run must not be called for uvx")
+
+        monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
+        monkeypatch.setattr(
+            init_cmd, "nav_confirm", lambda *a, **kw: True
+        )  # should not reach nav_confirm either
+
+        assert init_cmd._install_extras("uvx", ["onnx"]) is False
+        out = unstyle(capsys.readouterr().out)
+        assert "uvx is ephemeral" in out
+
+    def test_multi_extras_collapse_to_all(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two or more missing extras → helper collapses to
+        ``memtomem[all]`` / ``--extra all`` (matches ``_extra_install_hint``
+        and keeps ``pyproject.toml``'s public bundle contract)."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        captured: dict = {}
+
+        def _fake_run(cmd, **kw):
+            captured["cmd"] = cmd
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
+
+        assert init_cmd._install_extras("tool", ["onnx", "web"], confirm=False) is True
+        assert captured["cmd"] == [
+            "uv",
+            "tool",
+            "install",
+            "--reinstall",
+            "memtomem[all]",
+        ]
+
+    def test_confirm_declined_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """User presses Enter / N → ``nav_confirm`` → False → helper
+        returns ``False`` and does not spawn a subprocess."""
+        from memtomem.cli import init_cmd
+
+        def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("subprocess.run must not be called when user declines")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: False)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
+
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is False
+
+    def test_filenotfound_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``FileNotFoundError`` (e.g. ``uv`` binary missing) → helper
+        returns ``False`` without crashing."""
+        from memtomem.cli import init_cmd
+
+        def _raise_fnf(*a, **kw):
+            raise FileNotFoundError("uv not found")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _raise_fnf)
+
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is False
+
+    def test_timeout_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``subprocess.TimeoutExpired`` → helper returns ``False``."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        def _raise_timeout(*a, **kw):
+            raise _sp.TimeoutExpired(cmd=a[0] if a else "uv", timeout=600)
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _raise_timeout)
+
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is False
+
+    def test_nonzero_rc_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """subprocess exit code != 0 → helper returns ``False`` so the
+        caller falls back to the Phase 1 hint."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        def _fake_run(cmd, **kw):
+            return _sp.CompletedProcess(cmd, returncode=1, stdout="", stderr="boom")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
+
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is False
+
+    def test_source_without_workspace_dir_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Contract: ``source/project`` install_type requires
+        ``workspace_dir``; passing ``None`` is a caller bug — helper
+        fails safe (returns ``False``) rather than spawning a
+        ``uv sync`` in whatever the current cwd happens to be."""
+        from memtomem.cli import init_cmd
+
+        def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("subprocess.run must not be called without workspace_dir")
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
+
+        assert init_cmd._install_extras("source", ["onnx"], workspace_dir=None) is False
+
+    def test_confirm_kwarg_passed_as_default_to_nav_confirm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """D1 pin: helper's ``confirm`` param is forwarded verbatim to
+        ``nav_confirm``'s ``default`` kwarg — ``True`` = Enter-is-Yes
+        (ollama-style), ``False`` = Enter-is-No (python-extras-style)."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        seen_defaults: list[bool] = []
+
+        def _spy_confirm(prompt, default=False):
+            seen_defaults.append(default)
+            return False  # always decline — we only care about the default
+
+        monkeypatch.setattr(init_cmd, "nav_confirm", _spy_confirm)
+        monkeypatch.setattr(
+            init_cmd.subprocess,
+            "run",
+            lambda *a, **kw: _sp.CompletedProcess([], returncode=0),
+        )
+
+        init_cmd._install_extras("tool", ["onnx"], confirm=True)
+        init_cmd._install_extras("tool", ["onnx"], confirm=False)
+        assert seen_defaults == [True, False]
+
+
+class TestMismatchBanner:
+    """Issue #362 Phase 2 — cwd-vs-runtime mismatch info banner.
+
+    Phase 1 silenced the false ``[!] Missing extras:`` warning for the
+    ``source cwd + global uv-tool mm + workspace .venv has [all]``
+    combination; Phase 2 adds a one-line banner explaining *why* the
+    wizard is quiet. Trigger is orthogonal to extras presence — it
+    fires whenever the cwd axis says source/project but
+    ``sys.executable`` lives outside the workspace ``.venv/``."""
+
+    @staticmethod
+    def _source_state_with_venv(tmp_path: Path) -> dict:
+        state = _make_init_state(tmp_path)
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        (venv_bin / "python").touch()
+        state["source_install"] = True
+        state["source_dir"] = str(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        return state
+
+    def test_banner_fires_source_cwd_tool_runtime(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Source install + ``sys.executable`` outside workspace venv →
+        banner lines present."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastembed", "fastapi", "uvicorn"},
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = self._source_state_with_venv(tmp_path)
+        init_cmd._write_config_and_summary(state, tmp_path)
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd: source / runtime: uv tool" in out
+        assert "bare `mm`" in out
+
+    def test_banner_fires_project_cwd_tool_runtime(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Project install (``uv add memtomem``) + external runtime →
+        banner uses ``cwd: project``."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
+        venv_bin = tmp_path / ".venv" / "bin"
+        venv_bin.mkdir(parents=True, exist_ok=True)
+        (venv_bin / "python").touch()
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastembed", "fastapi", "uvicorn"},
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = _make_init_state(tmp_path)
+        state["project_install"] = True
+        state["project_dir"] = str(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd: project / runtime: uv tool" in out
+
+    def test_banner_silent_when_runtime_under_workspace_venv(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``sys.executable`` points inside ``<workspace>/.venv/`` →
+        runtime matches cwd axis, banner stays silent."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        ws_python = tmp_path / ".venv" / "bin" / "python"
+        monkeypatch.setattr(init_cmd.sys, "executable", str(ws_python))
+        monkeypatch.setattr(
+            init_cmd,
+            "_probe_workspace_extras",
+            lambda py: {"fastembed", "fastapi", "uvicorn"},
+        )
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = self._source_state_with_venv(tmp_path)
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd: source / runtime:" not in out
+
+    def test_banner_silent_for_pypi_install(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Neither source nor project install → no cwd axis to
+        disagree with, banner stays silent regardless of runtime."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = _make_init_state(tmp_path)
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd:" not in out
+        assert "runtime:" not in out
+
+    def test_banner_precedes_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Mismatch + missing extras + helper declines → banner line
+        index in output < ``[!] Missing extras:`` line index (the
+        banner explains the silence *before* the warning)."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
+        monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = self._source_state_with_venv(tmp_path)
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd: source / runtime: uv tool" in out
+        assert "Missing extras:" in out
+        banner_at = out.index("cwd: source / runtime: uv tool")
+        warning_at = out.index("Missing extras:")
+        assert banner_at < warning_at
+
+    def test_banner_and_missing_venv_both_fire(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Source install + ``.venv/`` absent + external runtime → banner
+        (cyan) AND ``Workspace .venv not found`` (yellow) both show."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        # NOTE: no .venv/ created — triggers _workspace_needs_sync branch.
+        state = _make_init_state(tmp_path)
+        state["source_install"] = True
+        state["source_dir"] = str(tmp_path)
+        state["provider"] = "onnx"
+        state["model"] = "bge-m3"
+        state["dimension"] = 1024
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd: source / runtime: uv tool" in out
+        assert "Workspace .venv not found" in out
+
+    def test_banner_still_fires_after_successful_install(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Banner is orthogonal to extras — a successful install does
+        NOT change the fact that cwd and runtime axes disagree. Banner
+        must still print after ``Installed missing extras: …``."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
+        monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
+        monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        state = self._source_state_with_venv(tmp_path)
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "cwd: source / runtime: uv tool" in out
+        assert "Installed missing extras:" in out
+        assert "Missing extras:" not in out
 
 
 class TestPreservedSummary:


### PR DESCRIPTION
## Summary

Phase 2 of #360. Closes two UX gaps left by Phase 1 (#361).

1. **Auto-install consistency.** The wizard already shells out to
   `ollama pull` and `claude mcp add` after confirm, but missing python
   extras stayed echo-only. The summary now routes missing extras
   through a new `_install_extras(install_type, extras, *, confirm=False)`
   helper that prompts (defaulting to **No** to spare unattended `-y`
   runs) and shells out to `uv sync --extra <name>` (source/project) or
   `uv tool install --reinstall "memtomem[<name>]"` (tool). User decline,
   non-zero rc, `FileNotFoundError`, or `TimeoutExpired` falls back to
   the Phase 1 hint — no regression on the silent path.
2. **Mismatch info banner.** Phase 1 suppressed the false
   `[!] Missing extras:` warning when source/project cwd is combined with
   an external tool-env runtime (the classic "repo cwd + global uv-tool
   `mm`" combination) but didn't explain the silence. A one-line cyan
   info banner now fires on that combo — orthogonal to extras presence —
   so the user understands that *Next steps* assume `uv run mm` and which
   tool env they'd need to install into if they want bare `mm`.

Helper scope is intentionally narrow: python package extras only. Ollama
model-pull and `claude mcp add` have different argument shapes
(model-name vs `install_type × extras` list) and stay inline at their
current call sites. The `InstallType` Literal includes `"uvx"` for
forward compatibility; the branch is hint-only today (first-class uvx
detection is Phase 3).

`sys.executable` comparison uses raw paths (no `.resolve()`) on purpose:
`uv` creates `.venv/bin/python3` as a symlink to its managed interpreter
cache (e.g. `~/.local/share/uv/python/cpython-…/bin/python3.13`), and
resolving would always fire the banner even when the runtime IS the
workspace venv. Raw prefix comparison matches how Python itself reports
`sys.executable` in venv-activated contexts.

## Investigation: `uv tool install --upgrade --with <pkg>`

The parent issue asked whether `uv tool install --upgrade --with <pkg>`
could replace `--reinstall "memtomem[…]"` as a lighter install-type
command for the `tool` branch of the helper.

**Status: deferred, `--reinstall` retained as safe default.**

- `uv --version` confirms `--upgrade` and `--with` are both present (we
  tested with 0.8.13), but `uv tool install --help` does not document
  whether `--with <pkg>` persists the extra in `uv-receipt.toml` across
  subsequent `uv tool upgrade memtomem` runs.
- The existing user install on this checkout records
  `requirements = [{ name = "memtomem", extras = ["all"] }]` in
  `~/.local/share/uv/tools/memtomem/uv-receipt.toml` after `--reinstall
  "memtomem[all]"`. Whether `--upgrade --with onnx memtomem` produces an
  equivalent receipt entry (`extras = ["onnx"]` or `["ollama", "onnx"]`?)
  is not visible from docs alone and would require live verification that
  destructively mutates the reviewer's tool install.
- Rolling the swap in without that verification risks shipping a helper
  that "installs" the extra transiently but leaves a subsequent
  `uv tool upgrade memtomem` missing `[onnx]` — worse than the current
  `--reinstall`.

**Recommendation**: keep `--reinstall` now; open a follow-up if/when uv
documents receipt semantics for `--with`. The helper's `tool` branch is
a single line swap (`cmd = ["uv","tool","install","--upgrade","--with",
f"memtomem[{name}]","memtomem"]`) and
`TestInstallExtrasHelper.test_tool_confirm_yes_runs_uv_tool_reinstall`
pins the current command shape so a swap would be deliberate.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` (advisory, clean)
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -m "not ollama"` → 146 passed
- [x] `uv run pytest -m "not ollama"` → 2068 passed (Phase 1 baseline was 2047; Phase 2 adds 21 tests — 12 helper + 7 banner + 2 regression)
- [x] Manual M1 — source cwd + `uv run mm init` (workspace `.venv` has `[all]`): banner **absent**, `Missing extras:` absent, `Next steps: uv run mm …`. Verified under `HOME=/tmp/mm362-m1`.
- [ ] Manual M2 — source cwd + external `mm` (global `uv tool install` shape): banner **present** (`cwd: source / runtime: uv tool`), with or without the workspace `.venv` probe result. Post-merge smoke on a reviewer's system.
- [ ] Manual M3 — PyPI / tool install outside any source repo: banner absent, Phase 1 `uv tool install --reinstall` hint preserved. Post-merge smoke on a reviewer's system.
- [x] Manual M4 — source cwd with workspace `.venv/` absent: banner **present** + cyan `Workspace .venv not found — run \`uv sync --extra all\` first.` line. Covered by `TestMismatchBanner.test_banner_and_missing_venv_both_fire`.

## Test matrix (automated)

New `TestInstallExtrasHelper` (12 cases):

- `test_empty_extras_returns_false`
- `test_source_confirm_yes_runs_uv_sync`
- `test_project_confirm_yes_runs_uv_sync`
- `test_tool_confirm_yes_runs_uv_tool_reinstall`
- `test_uvx_branch_hints_and_returns_false`
- `test_multi_extras_collapse_to_all`
- `test_confirm_declined_returns_false`
- `test_filenotfound_returns_false`
- `test_timeout_returns_false`
- `test_nonzero_rc_returns_false`
- `test_source_without_workspace_dir_returns_false` (contract guard)
- `test_confirm_kwarg_passed_as_default_to_nav_confirm` (D1 pin)

New `TestMismatchBanner` (7 cases):

- `test_banner_fires_source_cwd_tool_runtime`
- `test_banner_fires_project_cwd_tool_runtime`
- `test_banner_silent_when_runtime_under_workspace_venv`
- `test_banner_silent_for_pypi_install`
- `test_banner_precedes_warning`
- `test_banner_and_missing_venv_both_fire`
- `test_banner_still_fires_after_successful_install` (banner × install
  orthogonality — axis mismatch is not resolved by installing extras)

`TestInstallAxesReconcile` extended:

- `test_warning_still_fires_when_helper_declines` (regression guard —
  Phase 1 hint path alive when helper returns `False`)
- `test_helper_success_skips_warning` (success path skips the hint, a
  post-install hint would be noise)

## Defers (Phase 3)

- Collapse `_is_source_install`/`_detect_source_dir` and the project-
  install pair into single helpers returning `(bool, Path | None)`.
- `_runtime_profile()` dataclass — single source of truth for
  `cwd_install_type`, `runtime_interpreter`, `workspace_venv_path`,
  `mm_binary_origin`.
- First-class `uvx` detection (env / `sys.prefix` heuristics). The
  helper's `InstallType` Literal already lists `"uvx"` so Phase 3 only
  wires detection, not the helper.
- Unify `__import__` (web.py) vs `find_spec` (init_cmd.py).
- Project-install end-to-end tests.

## No version bump

Phase 2 is UX-only, no public API change. Ships alongside any other
v0.1.20 changes.

## Behavior note for scripted `mm init -y` runs

Per the CHANGELOG: the new `Install memtomem[all] now?` prompt defaults
to **No**, so an unattended Enter (or TTY-less run) preserves the
Phase 1 hint output — no silent install. Scripts that auto-feed the
wizard may see one extra prompt line when extras are missing.

## Related

- Parent: #360 (closed)
- Phase 1: #361 (merged, v0.1.19)
- Memory lesson (post-merge update, not part of this PR):
  `feedback_install_context_axes.md` — "axis reconcile 로 warning 을
  suppress 할 때는 왜 suppress 했는지 설명하는 one-line info banner 도
  함께 출력."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
