### PR TITLE
fix(init): skip auto-install prompt in non-TTY contexts (missed by #364)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   workspace-venv) interpreter, explaining that `Next steps` assume
   `uv run mm` — Phase 1 silenced the false warning for this combination
   but didn't explain why. (#360 Phase 2, #362)
-- **Behavior note for scripted `mm init -y` runs with missing extras**:
-  the `Install memtomem[all] now?` prompt defaults to No, so an
-  unattended Enter (or TTY-less run) preserves the Phase-1 hint output
-  — no silent install — but scripts that auto-feed the wizard may see
-  one extra prompt line when extras are missing.
+- **Behavior note for scripted / non-interactive `mm init -y` runs
+  with missing extras**: non-interactive contexts (no TTY on stdin —
+  e.g. `mm init -y </dev/null`, CI jobs, Docker build steps) skip the
+  `Install memtomem[all] now?` prompt entirely and fall back to the
+  Phase-1 hint output; TTY runs show the prompt with a **No** default.
+  The non-TTY gate is required because `click.prompt` raises `Abort!`
+  on stdin EOF rather than returning the default — without it, every
+  scripted pipeline that passed on v0.1.19 would hard-exit in v0.1.20.
+  (#364 follow-up)
 
 ## [0.1.19] — 2026-04-22
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1025,15 +1025,38 @@ def _install_extras(
     and MUST be ``None`` for ``"tool"`` / ``"uvx"``. Callers are expected
     to branch on the install type before calling.
 
+    Non-interactive contexts (no TTY on stdin — scripted ``mm init -y
+    </dev/null``, CI jobs, Docker build steps) skip the prompt entirely
+    and return ``False`` so the caller falls through to the Phase 1
+    hint. This is the only sensible choice: ``click.prompt`` raises
+    ``Abort!`` on stdin EOF rather than returning the ``default=``, so
+    without this gate the wizard would hard-exit mid-summary on
+    scripted runs. The ``uvx`` hint-only branch fires BEFORE this check
+    so the hint still prints in non-TTY contexts (it's informational,
+    not a prompt).
+
     Returns ``True`` only when a subprocess actually ran and exited 0. In
     every other case — empty ``extras``, missing ``workspace_dir`` for
     source/project, ``uvx`` branch (hint-only, no install semantic),
-    user decline, ``FileNotFoundError``, ``TimeoutExpired``, or non-zero
-    rc — returns ``False`` so the caller falls back to the Phase 1
-    :func:`_emit_missing_extras_warning` hint path."""
+    non-TTY stdin, user decline, ``FileNotFoundError``, ``TimeoutExpired``,
+    or non-zero rc — returns ``False`` so the caller falls back to the
+    Phase 1 :func:`_emit_missing_extras_warning` hint path."""
     if not extras:
         return False
     name = extras[0] if len(extras) == 1 else "all"
+
+    if install_type == "uvx":  # ephemeral env; a non-ephemeral install is meaningless
+        click.echo(
+            "  (uvx is ephemeral — re-invoke with "
+            f'`uvx --from "memtomem[{name}]" memtomem ...` instead)'
+        )
+        return False
+
+    # Non-TTY: skip prompt and defer to Phase 1 hint. Without this,
+    # click.prompt raises Abort! on stdin EOF — a regression for every
+    # scripted `mm init -y` pipeline that worked on v0.1.19.
+    if not sys.stdin.isatty():
+        return False
 
     cwd: str | None
     if install_type in ("source", "project"):
@@ -1041,15 +1064,9 @@ def _install_extras(
             return False
         cmd = ["uv", "sync", "--extra", name]
         cwd = str(workspace_dir)
-    elif install_type == "tool":
+    else:  # install_type == "tool"
         cmd = ["uv", "tool", "install", "--reinstall", f"memtomem[{name}]"]
         cwd = None
-    else:  # uvx — ephemeral env; a non-ephemeral install is meaningless
-        click.echo(
-            "  (uvx is ephemeral — re-invoke with "
-            f'`uvx --from "memtomem[{name}]" memtomem ...` instead)'
-        )
-        return False
 
     prompt = f"  Install memtomem[{name}] now?"
     if not nav_confirm(prompt, default=confirm):

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -742,6 +742,7 @@ class TestInstallExtrasHelper:
             captured["cwd"] = kw.get("cwd")
             return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
 
@@ -767,6 +768,7 @@ class TestInstallExtrasHelper:
             captured["cwd"] = kw.get("cwd")
             return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
 
@@ -791,6 +793,7 @@ class TestInstallExtrasHelper:
             captured["cwd"] = kw.get("cwd")
             return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
 
@@ -842,6 +845,7 @@ class TestInstallExtrasHelper:
             captured["cmd"] = cmd
             return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
 
@@ -862,6 +866,7 @@ class TestInstallExtrasHelper:
         def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
             raise AssertionError("subprocess.run must not be called when user declines")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: False)
         monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
 
@@ -875,6 +880,7 @@ class TestInstallExtrasHelper:
         def _raise_fnf(*a, **kw):
             raise FileNotFoundError("uv not found")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _raise_fnf)
 
@@ -889,6 +895,7 @@ class TestInstallExtrasHelper:
         def _raise_timeout(*a, **kw):
             raise _sp.TimeoutExpired(cmd=a[0] if a else "uv", timeout=600)
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _raise_timeout)
 
@@ -904,6 +911,7 @@ class TestInstallExtrasHelper:
         def _fake_run(cmd, **kw):
             return _sp.CompletedProcess(cmd, returncode=1, stdout="", stderr="boom")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
 
@@ -921,6 +929,7 @@ class TestInstallExtrasHelper:
         def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
             raise AssertionError("subprocess.run must not be called without workspace_dir")
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
         monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
 
@@ -942,6 +951,7 @@ class TestInstallExtrasHelper:
             seen_defaults.append(default)
             return False  # always decline — we only care about the default
 
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
         monkeypatch.setattr(init_cmd, "nav_confirm", _spy_confirm)
         monkeypatch.setattr(
             init_cmd.subprocess,
@@ -952,6 +962,64 @@ class TestInstallExtrasHelper:
         init_cmd._install_extras("tool", ["onnx"], confirm=True)
         init_cmd._install_extras("tool", ["onnx"], confirm=False)
         assert seen_defaults == [True, False]
+
+    def test_non_tty_stdin_skips_prompt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Scripted / non-TTY contexts (``mm init -y </dev/null``, CI jobs,
+        Docker build steps) must not hit the prompt — ``click.prompt``
+        raises ``Abort!`` on stdin EOF rather than returning the
+        ``default=``, which would hard-exit the wizard mid-summary.
+
+        Regression guard for the Phase 2 follow-up: without this gate,
+        every scripted ``mm init`` pipeline that used to pass on v0.1.19
+        would abort in v0.1.20."""
+        from memtomem.cli import init_cmd
+
+        def _no_prompt(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("nav_confirm must not be called in non-TTY context")
+
+        def _no_subprocess(*a, **kw):  # pragma: no cover - must not run
+            raise AssertionError("subprocess.run must not be called in non-TTY context")
+
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: False)
+        monkeypatch.setattr(init_cmd, "nav_confirm", _no_prompt)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _no_subprocess)
+
+        # Every install_type path that would otherwise prompt must short-circuit.
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is False
+        assert (
+            init_cmd._install_extras("source", ["onnx"], confirm=False, workspace_dir=Path("/tmp"))
+            is False
+        )
+        assert (
+            init_cmd._install_extras("project", ["onnx"], confirm=False, workspace_dir=Path("/tmp"))
+            is False
+        )
+
+    def test_tty_stdin_still_prompts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Reverse pin: the non-TTY gate must not accidentally disable the
+        prompt for real interactive runs. With ``isatty=True`` the helper
+        still invokes ``nav_confirm`` and proceeds to subprocess on
+        confirm."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        called = {"confirm": False, "run": False}
+
+        def _spy_confirm(prompt, default=False):
+            called["confirm"] = True
+            return True
+
+        def _fake_run(cmd, **kw):
+            called["run"] = True
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(init_cmd, "nav_confirm", _spy_confirm)
+        monkeypatch.setattr(init_cmd.subprocess, "run", _fake_run)
+
+        assert init_cmd._install_extras("tool", ["onnx"], confirm=False) is True
+        assert called == {"confirm": True, "run": True}
 
 
 class TestMismatchBanner:


### PR DESCRIPTION
## Summary

Follow-up to #364 (Phase 2 of #360). Phase 2 added a `nav_confirm`
prompt in `_install_extras` so the wizard can auto-install missing
python extras. `click.prompt` raises `click.Abort` on stdin EOF rather
than returning the `default=` value, so scripted pipelines that used to
pass on v0.1.19 (`mm init -y </dev/null`, CI jobs, Docker build steps)
would hard-exit with `Aborted!` mid-summary in v0.1.20.

**Fix**: gate the prompt path on `sys.stdin.isatty()` inside
`_install_extras`. Non-TTY contexts short-circuit to `return False` so
the caller falls through to the Phase 1 `_emit_missing_extras_warning`
hint — the same echo-only behavior v0.1.19 shipped. TTY runs are
unchanged (prompt with `default=No` for python extras).

The `uvx` hint-only branch is moved **above** the gate so the
informational `uvx is ephemeral — re-invoke with uvx --from ...`
message still prints in scripted contexts. `source` / `project` / `tool`
branches sit below the gate since they would otherwise reach the
prompt.

## Reproduction (pre-fix)

```sh
# Non-TTY bash shell, Phase 2 `mm` local build:
HOME=/tmp/mm362-m3 mm init --preset korean -y
```

Summary prints up to `MCP config only contains the server command.`,
then:

```
  Install memtomem[all] now? [y/N]: Aborted!
```

`Next steps` never fires. On v0.1.19 the same invocation printed the
missing-extras warning + hint and exited 0.

## Post-fix (same environment)

```
  [!] Missing extras: onnx, web
      'mm index' (embeddings) and 'mm web' (UI) will fail until installed.
      → uv tool install --reinstall "memtomem[all]"

  Next steps:
    1. mm index ~/memories
    2. mm search 'your first query'
    3. mm web  (browse & manage your memories)
```

Same output shape as v0.1.19 — regression closed.

## Why not `try: ... except click.Abort`?

`KeyboardInterrupt` (Ctrl+C) also arrives as `click.Abort`, so an
except-based fallback can't distinguish "user abandoned the wizard"
from "stdin is closed". An explicit `sys.stdin.isatty()` gate is
cheaper and keeps the user-abort semantic intact.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — pass
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — pass
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` — clean (advisory)
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -m "not ollama"` — 148 passed (146 + 2 new)
- [x] `uv run pytest -m "not ollama"` — **2070 passed** (baseline 2068 + 2)
- [x] Manual non-TTY smoke (bash tool): `HOME=/tmp/.. mm init --preset korean -y` → hint path fires, no Abort
- [x] Manual source-cwd non-TTY smoke: banner + `uv run mm` Next steps still correct

## Tests added

- `test_non_tty_stdin_skips_prompt` — pins the gate for `tool`,
  `source`, `project` install types. Asserts `nav_confirm` and
  `subprocess.run` are never called when `sys.stdin.isatty()` returns
  `False`; all three return `False`.
- `test_tty_stdin_still_prompts` — reverse-direction guard. Asserts
  `nav_confirm` IS called and subprocess IS spawned when `isatty` is
  `True`. Protects against an over-eager future refactor accidentally
  gating the prompt out for interactive runs.

## Existing tests updated

The 10 helper tests that monkeypatch `nav_confirm` now also set
`sys.stdin.isatty → True`. `pytest` captures stdin by default (so
`isatty()` returns `False` in the fixture environment), and without
the explicit patch the new gate would short-circuit before the
`nav_confirm` monkeypatch kicks in — the tests would pass but for the
wrong reason. Explicit TTY=True monkeypatch makes the assertion
meaningful.

Autouse fixture was considered and rejected per
`feedback_autouse_stub_collision.md`: stubbing the very axis a new
test (`test_non_tty_stdin_skips_prompt`) needs to override is a
footgun. Per-test opt-in is explicit.

## CHANGELOG update

The Unreleased "Behavior note for scripted `mm init -y`" bullet is
rewritten to match actual behavior: "non-interactive contexts (no TTY)
skip the prompt entirely and fall back to the Phase 1 hint; TTY runs
show the prompt with `default=No`." The previous wording predicted a
`default` fallback that click doesn't actually provide on EOF.

## Why a follow-up PR

Release window for v0.1.20 is still open (Phase 2 hasn't been tagged
yet), and the regression is a clean silent failure mode for scripted
users — lots of blast radius, tiny scope (single gate + two tests +
CHANGELOG edit + 10 existing-test updates). `feedback_green_ci_admin_merge.md`
rule applies: small fix, green CI, no architectural change.

## Related

- Parent: #362
- Phase 2 (this PR is a follow-up to): #364 (merged, same release
  cycle)
- Memory (post-merge): `feedback_click_prompt_needs_isatty_gate.md`
  — general rule that any new `click.prompt`/`click.confirm` on a
  pre-existing non-interactive path needs an `isatty()` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
