### PR TITLE
release: v0.1.20 — mm init auto-install + mismatch banner (#362, #364, #365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,30 +5,37 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.20] — 2026-04-22
+
+Phase 2 of the `mm init` install-context UX series (#360 → #361 → this
+release). Phase 1 (v0.1.19) fixed the install-hint text for the
+cwd-vs-runtime mismatch; this release closes the UX loop by actually
+explaining the mismatch and offering to install the missing extras.
+
 ### Changed
 
 - **`mm init` now offers to auto-install missing python extras** — the
-  summary still surfaces the same Phase-1 install-type-aware hint, but
+  summary still surfaces the same Phase 1 install-type-aware hint, but
   first prompts `Install memtomem[all] now?` (defaulting to No — Enter
   skips, preserving the previous hint-only behavior). When the user
-  confirms, the wizard shells out to `uv sync --extra …` (source/project
-  installs) or `uv tool install --reinstall "memtomem[…]"` (tool
-  installs) and prints a single `Installed missing extras: …` line on
-  success. Subprocess failures (missing binary, timeout, non-zero rc)
-  fall back to the hint. Also adds a one-line info banner when the
-  wizard is run from a source/project checkout with a global (non-
-  workspace-venv) interpreter, explaining that `Next steps` assume
-  `uv run mm` — Phase 1 silenced the false warning for this combination
-  but didn't explain why. (#360 Phase 2, #362)
-- **Behavior note for scripted / non-interactive `mm init -y` runs
-  with missing extras**: non-interactive contexts (no TTY on stdin —
-  e.g. `mm init -y </dev/null`, CI jobs, Docker build steps) skip the
-  `Install memtomem[all] now?` prompt entirely and fall back to the
-  Phase-1 hint output; TTY runs show the prompt with a **No** default.
-  The non-TTY gate is required because `click.prompt` raises `Abort!`
-  on stdin EOF rather than returning the default — without it, every
-  scripted pipeline that passed on v0.1.19 would hard-exit in v0.1.20.
-  (#364 follow-up)
+  confirms, the wizard shells out to `uv sync --extra …`
+  (source/project installs) or `uv tool install --reinstall
+  "memtomem[…]"` (tool installs) and prints a single `Installed missing
+  extras: …` line on success. Subprocess failures (missing binary,
+  timeout, non-zero rc) fall back to the hint. Also adds a one-line
+  info banner when the wizard is run from a source/project checkout
+  with a global (non-workspace-venv) interpreter, explaining that
+  `Next steps` assume `uv run mm` — Phase 1 silenced the false warning
+  for this combination but didn't explain why. (#360 Phase 2, #362,
+  #364)
+- **Non-interactive `mm init -y` runs skip the new prompt** —
+  non-TTY contexts (e.g. `mm init -y </dev/null`, CI jobs, Docker
+  build steps) short-circuit the `Install memtomem[all] now?` prompt
+  entirely and fall back to the Phase 1 hint output; TTY runs show
+  the prompt with a **No** default. The non-TTY gate is required
+  because `click.prompt` raises `Abort!` on stdin EOF rather than
+  returning the `default=` — without it, every scripted pipeline that
+  passed on v0.1.19 would hard-exit in v0.1.20. (#365)
 
 ## [0.1.19] — 2026-04-22
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.19"
+version = "0.1.20"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release v0.1.20. Bumps `memtomem` 0.1.19 → 0.1.20 and finalizes the
`[0.1.20]` CHANGELOG section from Unreleased. Ships the full #360
Phase 2 set:

- **#364** (Phase 2): `_install_extras(install_type, extras, *,
  confirm=False, workspace_dir=None)` helper that prompts for the
  heavy extras reinstall (defaulting to No), a cwd-vs-runtime mismatch
  info banner explaining the Phase 1 silence, and an `InstallType`
  Literal with a forward-compatible `"uvx"` branch. Ollama / `claude
  mcp add` left untouched (different argument shapes).
- **#365** (Phase 2 follow-up): `sys.stdin.isatty()` gate on the new
  prompt so scripted / CI contexts (`mm init -y </dev/null`, Docker
  build steps) skip straight to the Phase 1 hint instead of
  hard-exiting on stdin EOF. `click.prompt` raises `Abort!` on EOF
  rather than returning the `default=`, so without this gate every
  scripted pipeline that passed on v0.1.19 would break in v0.1.20.

`uv.lock` updated in sync with the pyproject bump per
`feedback_uv_lock_version_sync.md` — manual edit of the workspace
`[[package]]` entry (both source and reverse deps already reference
`memtomem @ editable = packages/memtomem`, so no dependency
re-resolution needed).

## CHANGELOG (new 0.1.20 section)

```
## [0.1.20] — 2026-04-22

Phase 2 of the `mm init` install-context UX series (#360 → #361 →
this release). Phase 1 (v0.1.19) fixed the install-hint text for the
cwd-vs-runtime mismatch; this release closes the UX loop by actually
explaining the mismatch and offering to install the missing extras.

### Changed
- mm init now offers to auto-install missing python extras … (#360
  Phase 2, #362, #364)
- Non-interactive `mm init -y` runs skip the new prompt … (#365)
```

Full text is in the diff.

## Post-merge steps

1. Tag `v0.1.20` on `main` after this merges.
2. OIDC trusted publisher picks up the tag and pushes
   `memtomem==0.1.20` to PyPI automatically (no manual token).
3. GitHub release notes — lift the `[0.1.20]` CHANGELOG section.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -m "not
  ollama"` → 148 passed (sanity — version bump should not affect
  behavior tests)
- [x] `grep -n "^version" packages/memtomem/pyproject.toml` → `0.1.20`
- [x] `grep -B2 -A1 "^version = \"0.1.20\"$" uv.lock` → workspace
  `[[package]]` entry updated
- [x] `CHANGELOG.md` Unreleased → `[0.1.20] — 2026-04-22`
- [ ] CI green (this PR)
- [ ] Post-merge: `v0.1.20` tag pushed, PyPI publish succeeded.

## Related

- Phase 1 release: #358 (v0.1.18) → #362 (v0.1.19 gh release auto-
  generated by Phase 1 merge)
- Phase 2: #364
- Phase 2 follow-up: #365
- Parent issue: #362 (Phase 2 of #360, will be closed by this
  release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
