### PR TITLE
refactor(init): drop legacy install-context state keys (#368)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -233,6 +233,15 @@ def _get_or_build_profile(state: dict) -> RuntimeProfile:
     from the legacy ``state["source_install"]`` / ``project_install`` /
     ``source_dir`` / ``project_dir`` keys.
 
+    Phase 3 cleanup (#368): after this cycle, production writes ``_profile``
+    exclusively — in-tree callers no longer populate the legacy keys, so the
+    reconstruction path below is effectively dead for production. The shim
+    persists for (a) the 2 :class:`TestRuntimeProfile` regression tests that
+    prove the reconstruction path still works and (b) downstream forks that
+    haven't migrated to ``_profile``. Its deletion is tracked in a separate
+    follow-up issue — reopen trigger: 1–2 minor releases (~v0.1.22) with no
+    external signal of legacy-key usage.
+
     Tests that bypass :func:`init` and construct ``state`` directly never
     populate ``_profile``; this shim builds one on demand from the legacy
     booleans they DO set so the migration to RuntimeProfile doesn't require
@@ -1435,18 +1444,15 @@ def _write_config_and_summary(
 
     # All install-context branching reads from the single profile struct
     # built once at init() entry (or lazily reconstructed from legacy state
-    # booleans in tests via _get_or_build_profile). Phase 3 (#363) collapses
-    # the prior 4 source_install/project_install/source_dir/project_dir reads
-    # so a future install-context judgment has exactly one place to land.
+    # booleans by the _get_or_build_profile shim when downstream forks build
+    # state directly). #363 Phase 3 collapsed the prior 4 source_install /
+    # project_install / source_dir / project_dir reads into this struct;
+    # #368 dropped the remaining parallel state keys so there is now exactly
+    # one place a future install-context judgment can land.
     profile = _get_or_build_profile(state)
     source_install = profile.cwd_install_type == "source"
     project_install = profile.cwd_install_type == "project"
-    source_dir = (
-        str(profile.cwd_install_dir) if source_install and profile.cwd_install_dir else None
-    )
-    project_dir = (
-        str(profile.cwd_install_dir) if project_install and profile.cwd_install_dir else None
-    )
+    workspace_dir = str(profile.cwd_install_dir) if profile.cwd_install_dir else None
 
     # Write ~/.memtomem/config.json (read-merge-write to preserve non-init fields)
     click.secho("Writing configuration...", fg="green")
@@ -1606,13 +1612,17 @@ def _write_config_and_summary(
             written = existing  # unreachable in practice; stay safe
         _emit_preserved_block(existing_before, written, wizard_touched_keys)
 
-    # Build MCP server command
-    if source_install and source_dir:
+    # Build MCP server command. source_install and project_install both
+    # resolve to the same `uv run --directory <workspace_dir>` shape — only
+    # the directory differs. The branches are kept separate (not collapsed
+    # into `if workspace_dir:`) so a reader bisecting a bad .mcp.json can
+    # still tell which install-type produced it from the wizard source.
+    if source_install and workspace_dir:
         server_cmd = "uv"
-        server_args = ["run", "--directory", source_dir, "memtomem-server"]
-    elif project_install and project_dir:
+        server_args = ["run", "--directory", workspace_dir, "memtomem-server"]
+    elif project_install and workspace_dir:
         server_cmd = "uv"
-        server_args = ["run", "--directory", project_dir, "memtomem-server"]
+        server_args = ["run", "--directory", workspace_dir, "memtomem-server"]
     else:
         server_cmd = "uvx"
         server_args = ["--from", "memtomem", "memtomem-server"]
@@ -1730,13 +1740,7 @@ def _write_config_and_summary(
     else:
         missing = _collect_missing_extras(state)
         if missing:
-            ws: Path | None
-            if source_install:
-                ws = Path(state["source_dir"])
-            elif project_install:
-                ws = Path(state["project_dir"])
-            else:
-                ws = None
+            ws = profile.cwd_install_dir if (source_install or project_install) else None
             installed = _install_extras(install_type_lit, missing, confirm=False, workspace_dir=ws)
             if installed:
                 click.echo()
@@ -2119,29 +2123,21 @@ def init(
     click.echo()
 
     # Build the install-context profile once at entry — every downstream
-    # decision (run_prefix, missing-extras hint, summary mismatch banner)
-    # reads from this single struct via _get_or_build_profile. Legacy
-    # state.source_install/project_install/source_dir/project_dir are also
-    # populated for backward compatibility with code paths that haven't
-    # been migrated yet (provider rules banner, MCP server command).
+    # decision (run_prefix, missing-extras hint, summary mismatch banner,
+    # MCP server command) reads from this single struct via
+    # _get_or_build_profile. #368 dropped the parallel legacy
+    # source_install/project_install/source_dir/project_dir state keys so
+    # there is exactly one place to land a new install-context judgment.
     profile = _runtime_profile()
-    source_install = profile.cwd_install_type == "source"
-    project_install = profile.cwd_install_type == "project"
-    state: dict = {
-        "_profile": profile,
-        "source_install": source_install,
-        "source_dir": str(profile.cwd_install_dir) if source_install else None,
-        "project_install": project_install,
-        "project_dir": str(profile.cwd_install_dir) if project_install else None,
-    }
+    state: dict = {"_profile": profile}
 
-    if source_install:
+    if profile.cwd_install_type == "source":
         click.secho("  Detected: source install", fg="blue")
-        click.echo(f"  Source directory: {state['source_dir']}")
+        click.echo(f"  Source directory: {profile.cwd_install_dir}")
         click.echo()
-    elif project_install:
+    elif profile.cwd_install_type == "project":
         click.secho("  Detected: project install", fg="blue")
-        click.echo(f"  Project directory: {state['project_dir']}")
+        click.echo(f"  Project directory: {profile.cwd_install_dir}")
         click.echo()
     elif profile.mm_binary_origin == "uvx":
         click.secho("  Detected: uvx (ephemeral) install", fg="blue")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -9,11 +9,13 @@ pydantic-settings parses list-typed env vars as JSON arrays.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
+from typing import Literal
 
 import pytest
 
-from memtomem.cli.init_cmd import _write_mcp_json
+from memtomem.cli.init_cmd import MmBinaryOrigin, RuntimeProfile, _write_mcp_json
 from memtomem.config import Mem2MemConfig
 
 
@@ -48,6 +50,58 @@ def test_write_mcp_json_preserves_valid_env(
     assert data["mcpServers"]["memtomem"]["env"] == env
 
 
+def _make_test_profile(
+    tmp_path: Path | None = None,
+    *,
+    kind: Literal["source", "project", "pypi"] = "pypi",
+    mm_binary_origin: MmBinaryOrigin = "unknown",
+    runtime_matches_workspace: bool | None = None,
+) -> RuntimeProfile:
+    """Build a :class:`RuntimeProfile` for tests without invoking
+    :func:`_runtime_profile`.
+
+    Replaces the pre-#368 pattern of setting
+    ``state["source_install"] = True`` + ``state["source_dir"] = str(tmp_path)``
+    — those legacy keys no longer exist after Phase 3 cleanup so tests that
+    want a non-pypi profile seed ``state["_profile"]`` directly via this
+    helper. Workspace venv detection mirrors :func:`_runtime_profile`:
+    ``<cwd_install_dir>/.venv`` if it exists on disk.
+
+    ``tmp_path`` is only meaningful when ``kind`` is ``"source"`` or
+    ``"project"`` (it becomes ``cwd_install_dir``). For ``kind="pypi"`` it
+    is ignored — callers may pass ``None`` or omit it.
+
+    ``runtime_matches_workspace`` defaults to ``None`` which auto-computes
+    via ``Path(sys.executable).is_relative_to(workspace_venv_path)`` — the
+    same rule :func:`_runtime_profile` uses. Tests that monkeypatch
+    ``sys.executable`` to point inside ``<tmp_path>/.venv`` then get ``True``
+    automatically; explicit ``True``/``False`` force the flag regardless."""
+    cwd_install_dir = tmp_path if kind in ("source", "project") else None
+    venv = (cwd_install_dir / ".venv") if cwd_install_dir else None
+    workspace_venv_path = venv if (venv and venv.exists()) else None
+    runtime_interpreter = Path(sys.executable)
+
+    matches: bool
+    if runtime_matches_workspace is not None:
+        matches = runtime_matches_workspace
+    elif workspace_venv_path is not None:
+        try:
+            matches = runtime_interpreter.is_relative_to(workspace_venv_path)
+        except (OSError, ValueError):
+            matches = False
+    else:
+        matches = False
+
+    return RuntimeProfile(
+        cwd_install_type=kind,
+        cwd_install_dir=cwd_install_dir,
+        runtime_interpreter=runtime_interpreter,
+        workspace_venv_path=workspace_venv_path,
+        mm_binary_origin=mm_binary_origin,
+        runtime_matches_workspace=matches,
+    )
+
+
 def _make_init_state(tmp_path: Path) -> dict:
     """Return a minimal wizard state dict pointing at *tmp_path*."""
     return {
@@ -65,10 +119,12 @@ def _make_init_state(tmp_path: Path) -> dict:
         # Non-config keys required by _write_config_and_summary
         "mcp_choice": 3,  # skip MCP setup
         "settings_hooks": False,
-        "source_install": False,
-        "source_dir": None,
-        "project_install": False,
-        "project_dir": None,
+        # #368: legacy source_install / project_install / source_dir /
+        # project_dir keys have been dropped — seed a default pypi profile
+        # here so production code reads install-context via profile only.
+        # Tests that need source/project classification overwrite
+        # state["_profile"] via _make_test_profile(tmp_path, kind=...).
+        "_profile": _make_test_profile(),  # default: pypi / unknown
     }
 
 
@@ -318,7 +374,7 @@ class TestMissingExtrasWarning:
         is what ``uv run mm`` uses, so ``uv sync`` is the right install."""
         from memtomem.cli.init_cmd import _extra_install_hint
 
-        state = {"source_install": True}
+        state = {"_profile": _make_test_profile(kind="source")}
         assert _extra_install_hint(["onnx"], state) == "uv sync --extra onnx"
         assert _extra_install_hint(["web"], state) == "uv sync --extra web"
         assert _extra_install_hint(["onnx", "web"], state) == "uv sync --extra all"
@@ -328,7 +384,7 @@ class TestMissingExtrasWarning:
         also resolves to the workspace ``uv sync`` hint."""
         from memtomem.cli.init_cmd import _extra_install_hint
 
-        state = {"project_install": True}
+        state = {"_profile": _make_test_profile(kind="project")}
         assert _extra_install_hint(["onnx"], state) == "uv sync --extra onnx"
         assert _extra_install_hint(["onnx", "web"], state) == "uv sync --extra all"
 
@@ -419,8 +475,7 @@ class TestInstallAxesReconcile:
         venv_bin = tmp_path / ".venv" / "bin"
         venv_bin.mkdir(parents=True, exist_ok=True)
         (venv_bin / "python").touch()
-        state["source_install"] = True
-        state["source_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
         return state
 
     def test_source_cwd_workspace_has_all_suppresses_warning(
@@ -500,8 +555,7 @@ class TestInstallAxesReconcile:
         state = {
             "provider": "onnx",
             "rerank_enabled": False,
-            "source_install": False,
-            "project_install": False,
+            "_profile": _make_test_profile(kind="pypi"),
         }
         missing = init_cmd._collect_missing_extras(state)
         assert missing == ["onnx"]
@@ -527,8 +581,7 @@ class TestInstallAxesReconcile:
 
         state = _make_init_state(tmp_path)
         state["provider"] = "onnx"
-        state["project_install"] = True
-        state["project_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="project")
         assert init_cmd._collect_missing_extras(state) == []
 
     def test_missing_venv_shows_sync_one_liner_not_warning(
@@ -558,8 +611,7 @@ class TestInstallAxesReconcile:
         state["provider"] = "onnx"
         state["model"] = "bge-m3"
         state["dimension"] = 1024
-        state["source_install"] = True
-        state["source_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
 
         assert init_cmd._workspace_needs_sync(state) is True
 
@@ -641,8 +693,7 @@ class TestInstallAxesReconcile:
         state["provider"] = "onnx"
         state["model"] = "bge-m3"
         state["dimension"] = 1024
-        state["source_install"] = True
-        state["source_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
         init_cmd._write_config_and_summary(state, tmp_path)
 
         out = unstyle(capsys.readouterr().out)
@@ -1038,8 +1089,7 @@ class TestMismatchBanner:
         venv_bin = tmp_path / ".venv" / "bin"
         venv_bin.mkdir(parents=True, exist_ok=True)
         (venv_bin / "python").touch()
-        state["source_install"] = True
-        state["source_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
         state["provider"] = "onnx"
         state["model"] = "bge-m3"
         state["dimension"] = 1024
@@ -1095,8 +1145,7 @@ class TestMismatchBanner:
         monkeypatch.setenv("HOME", str(tmp_path))
 
         state = _make_init_state(tmp_path)
-        state["project_install"] = True
-        state["project_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="project")
         state["provider"] = "onnx"
         state["model"] = "bge-m3"
         state["dimension"] = 1024
@@ -1201,8 +1250,7 @@ class TestMismatchBanner:
 
         # NOTE: no .venv/ created — triggers _workspace_needs_sync branch.
         state = _make_init_state(tmp_path)
-        state["source_install"] = True
-        state["source_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
         state["provider"] = "onnx"
         state["model"] = "bge-m3"
         state["dimension"] = 1024
@@ -1471,8 +1519,7 @@ class TestProjectInstallE2E:
     def _project_state(tmp_path: Path, *, with_venv: bool) -> dict:
         """Build a project-install state with optional workspace venv."""
         state = _make_init_state(tmp_path)
-        state["project_install"] = True
-        state["project_dir"] = str(tmp_path)
+        state["_profile"] = _make_test_profile(tmp_path, kind="project")
         state["provider"] = "onnx"
         state["model"] = "bge-m3"
         state["dimension"] = 1024
@@ -1630,10 +1677,9 @@ class TestUvxBranching:
         monkeypatch.setenv("HOME", str(tmp_path))
 
         state = _make_init_state(tmp_path)
-        # Drop legacy booleans to force profile-based classification.
-        state["source_install"] = False
-        state["project_install"] = False
-        # State pre-built profile must NOT be present so the live one fires.
+        # Explicit uvx profile — pypi classification + uvx binary origin
+        # drives the "Install: uvx (ephemeral)" label and Next-steps hint.
+        state["_profile"] = _make_test_profile(kind="pypi", mm_binary_origin="uvx")
         init_cmd._write_config_and_summary(state, tmp_path)
 
         out = unstyle(capsys.readouterr().out)


### PR DESCRIPTION
## Summary

Phase 3 cleanup follow-up to #367 — closes #368. Drops the parallel
legacy `state["source_install"] / source_dir / project_install /
project_dir` keys that PR #367 left in place as a structural-safety
measure. `RuntimeProfile` is now the sole source of truth for
install-context decisions; the next contributor adding an install-context
judgment has exactly one place to land it instead of risking another
axis-mismatch class bug (see `feedback_install_context_axes.md`).

No user-visible behavior changes — labels, Next steps, and `Install:`
line render identically before and after.

Closes #368.

## Changes

**`init_cmd.py` (production)**

- **`init()` entry** — `state: dict = {"_profile": profile}`; echo paths
  read `profile.cwd_install_dir` directly. Removed the back-compat comment
  that pointed at "code paths that haven't been migrated yet" — after this
  PR there are none.
- **`_write_config_and_summary`** — `source_dir` / `project_dir` string
  vars collapse into a single `workspace_dir`; missing-extras `ws` var
  reads `profile.cwd_install_dir` as `Path | None` directly. The
  `source_install` / `project_install` `if/elif` branching in the MCP
  `server_cmd` builder stays intact — the two branches produce the
  identical shape (`server_cmd = "uv"` + `server_args = ["run",
  "--directory", <dir>, "memtomem-server"]`) but keeping them separate
  preserves readability for anyone bisecting a `.mcp.json` by install-type.
- **`_get_or_build_profile`** — shim body unchanged by design; docstring
  prepends a paragraph noting that post-#368, production writes
  `_profile` exclusively. The shim persists for (a) the 2
  `TestRuntimeProfile` regression tests that exercise the reconstruction
  path and (b) downstream forks that haven't migrated. Its deletion is
  tracked in a separate follow-up — reopen trigger: 1–2 minor releases
  (~v0.1.22) with no external signal of legacy-key usage.

**`test_init_cmd.py` (tests)**

- New **`_make_test_profile(tmp_path, kind=...)`** helper builds a
  `RuntimeProfile` without calling `_runtime_profile`.
  `runtime_matches_workspace` defaults to `None` and is auto-computed via
  `Path(sys.executable).is_relative_to(workspace_venv_path)` — the same
  rule `_runtime_profile` uses — so tests that monkeypatch
  `sys.executable` to point inside `<tmp_path>/.venv` automatically get
  `True`, matching the pre-#368 shim behavior.
- **`_make_init_state`** drops the 4 legacy keys and seeds a default
  `pypi / unknown` profile. Tests that need `source` / `project`
  classification overwrite `state["_profile"]` via
  `_make_test_profile(tmp_path, kind=...)`.
- Migrated **≈9 direct `state["source_install"]=True + state["source_dir"]=str(tmp_path)`
  mutation pairs** (+ same for project) → single
  `state["_profile"] = _make_test_profile(tmp_path, kind=...)` line.
- Migrated **3 inline dict literals** (2 `{"source_install": True}` /
  `{"project_install": True}` hint tests + 1
  `_collect_missing_extras` kwargs dict) → `{"_profile":
  _make_test_profile(kind=...)}`.
- Migrated the **uvx `Install: uvx (ephemeral)` regression test** to
  seed an explicit `_make_test_profile(kind="pypi",
  mm_binary_origin="uvx")` rather than relying on the pre-#368
  "drop legacy booleans → force live profile" comment pattern.
- **2 shim tests** (`test_get_or_build_profile_caches_in_state`,
  `test_get_or_build_profile_falls_back_to_legacy_state_keys`) stay as-is —
  they build `state` without `_profile` to exercise the shim's
  reconstruction path.

## Acceptance criteria (from #368)

- [x] `state["source_install"] / source_dir / project_install /
      project_dir` removed from `init()` entry — only `state["_profile"]`
      is written.
- [x] All in-tree readers migrated to `profile.cwd_install_type` /
      `profile.cwd_install_dir`.
- [x] `_make_init_state` no longer carries the 4 legacy keys; affected
      tests build a `RuntimeProfile` directly via `_make_test_profile`.
- [x] Grep for `state.get("source_install"|"project_install"|"source_dir"|"project_dir")`
      in `init_cmd.py` — zero hits outside `_get_or_build_profile`. The 4
      remaining hits (lines 257–262) are all inside the shim body, as
      documented.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 2090 passed, 24.5s
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` → clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` → 288 files already formatted
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` → clean (advisory)
- [x] Manual smoke — source / project / pypi paths all render identical
      labels + directory output to pre-#368.
- [ ] CI green on push.

## Out of scope

- Deletion of `_get_or_build_profile` + the 2 shim regression tests —
  separate follow-up issue (reopen trigger: no downstream-fork signal
  after ~v0.1.22).
- Any behavior change to `mm init` output — this is pure refactor /
  drift-prevention.
- `CHANGELOG.md` — no user-visible surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
