### PR TITLE
refactor(init): remove _get_or_build_profile back-compat shim

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -183,7 +183,7 @@ def _runtime_profile() -> RuntimeProfile:
 
     Pure / inputs are ``Path.cwd()`` + ``sys.executable`` + ``sys.prefix``.
     Call once at :func:`init` entry; downstream code reads the cached
-    profile from ``state["_profile"]`` via :func:`_get_or_build_profile`."""
+    profile from ``state["_profile"]`` directly."""
     src_dir = _detect_source_install()
     proj_dir = _detect_project_install() if src_dir is None else None
 
@@ -226,71 +226,6 @@ def _runtime_profile() -> RuntimeProfile:
         mm_binary_origin=mm_binary_origin,
         runtime_matches_workspace=runtime_matches_workspace,
     )
-
-
-def _get_or_build_profile(state: dict) -> RuntimeProfile:
-    """Return ``state["_profile"]`` if present, else build a fresh profile
-    from the legacy ``state["source_install"]`` / ``project_install`` /
-    ``source_dir`` / ``project_dir`` keys.
-
-    Phase 3 cleanup (#368): after this cycle, production writes ``_profile``
-    exclusively — in-tree callers no longer populate the legacy keys, so the
-    reconstruction path below is effectively dead for production. The shim
-    persists for (a) the 2 :class:`TestRuntimeProfile` regression tests that
-    prove the reconstruction path still works and (b) downstream forks that
-    haven't migrated to ``_profile``. Its deletion is tracked in a separate
-    follow-up issue — reopen trigger: 1–2 minor releases (~v0.1.22) with no
-    external signal of legacy-key usage.
-
-    Tests that bypass :func:`init` and construct ``state`` directly never
-    populate ``_profile``; this shim builds one on demand from the legacy
-    booleans they DO set so the migration to RuntimeProfile doesn't require
-    rewriting every existing test fixture. Result is cached back into
-    ``state`` so multi-call paths (banner + warning + summary) all see the
-    same struct."""
-    profile = state.get("_profile")
-    if isinstance(profile, RuntimeProfile):
-        return profile
-
-    cwd_install_type: CwdInstallType
-    cwd_install_dir: Path | None
-    if state.get("source_install"):
-        cwd_install_type = "source"
-        cwd_install_dir = Path(state["source_dir"]) if state.get("source_dir") else None
-    elif state.get("project_install"):
-        cwd_install_type = "project"
-        cwd_install_dir = Path(state["project_dir"]) if state.get("project_dir") else None
-    else:
-        cwd_install_type = "pypi"
-        cwd_install_dir = None
-
-    runtime_interpreter = Path(sys.executable)
-    workspace_venv_path: Path | None = None
-    if cwd_install_dir is not None:
-        candidate = cwd_install_dir / ".venv"
-        workspace_venv_path = candidate if candidate.exists() else None
-
-    runtime_matches_workspace = False
-    if workspace_venv_path is not None:
-        try:
-            runtime_matches_workspace = runtime_interpreter.is_relative_to(workspace_venv_path)
-        except (OSError, ValueError):
-            runtime_matches_workspace = False
-
-    mm_binary_origin = _detect_mm_binary_origin(
-        runtime_interpreter, runtime_matches_workspace=runtime_matches_workspace
-    )
-
-    profile = RuntimeProfile(
-        cwd_install_type=cwd_install_type,
-        cwd_install_dir=cwd_install_dir,
-        runtime_interpreter=runtime_interpreter,
-        workspace_venv_path=workspace_venv_path,
-        mm_binary_origin=mm_binary_origin,
-        runtime_matches_workspace=runtime_matches_workspace,
-    )
-    state["_profile"] = profile
-    return profile
 
 
 def _have_module(name: str) -> bool:
@@ -1145,7 +1080,7 @@ def _workspace_python(state: dict) -> Path | None:
 
     Phase 3 (#363): reads ``workspace_venv_path`` from :class:`RuntimeProfile`
     so the source/project axis lives in one struct."""
-    profile = _get_or_build_profile(state)
+    profile = state["_profile"]
     if profile.workspace_venv_path is None:
         return None
     py = profile.workspace_venv_path / "bin" / "python"
@@ -1193,7 +1128,7 @@ def _workspace_needs_sync(state: dict) -> bool:
     absent — a fresh clone / fresh worktree. The summary shows a single
     ``run uv sync first`` line in this case instead of a noisy missing-
     extras warning that would have probed the wrong interpreter."""
-    profile = _get_or_build_profile(state)
+    profile = state["_profile"]
     if profile.cwd_install_type == "pypi":
         return False
     return _workspace_python(state) is None
@@ -1216,10 +1151,10 @@ def _extra_install_hint(extras: list[str], state: dict | None = None) -> str:
     sub-bundle.
 
     Phase 3 (#363): reads ``cwd_install_type`` from :class:`RuntimeProfile`
-    so the workspace-vs-tool branch lives in one place."""
-    state = state or {}
-    profile = _get_or_build_profile(state)
-    is_workspace = profile.cwd_install_type in ("source", "project")
+    so the workspace-vs-tool branch lives in one place. Treats missing
+    ``_profile`` as PyPI install (matches the ``state=None`` default)."""
+    profile = (state or {}).get("_profile")
+    is_workspace = profile is not None and profile.cwd_install_type in ("source", "project")
     name = extras[0] if len(extras) == 1 else "all"
     if is_workspace:
         return f"{_UV_SYNC_HINT_PREFIX}{name}"
@@ -1333,9 +1268,11 @@ def _collect_missing_extras(state: dict) -> list[str]:
     ``state['_extras_warned_inline']`` are filtered out so the interactive
     ``_step_embedding`` path doesn't double-print.
 
-    Phase 3 (#363): reads ``cwd_install_type`` from :class:`RuntimeProfile`."""
-    profile = _get_or_build_profile(state)
-    source = profile.cwd_install_type in ("source", "project")
+    Phase 3 (#363): reads ``cwd_install_type`` from :class:`RuntimeProfile`.
+    Treats missing ``_profile`` as PyPI install so tests can build minimal
+    state dicts without constructing a full profile."""
+    profile = state.get("_profile")
+    source = profile is not None and profile.cwd_install_type in ("source", "project")
     ws_py = _workspace_python(state) if source else None
 
     if source and ws_py is not None:
@@ -1381,7 +1318,7 @@ def _emit_cwd_runtime_mismatch_banner(state: dict) -> None:
     from :class:`RuntimeProfile`. The legacy ``_runtime_under_workspace_venv``
     helper has been folded into ``RuntimeProfile`` (raw-path comparison
     semantics preserved — see ``feedback_venv_raw_path_check.md``)."""
-    profile = _get_or_build_profile(state)
+    profile = state["_profile"]
     if profile.cwd_install_type == "pypi":
         return
     if profile.runtime_matches_workspace:
@@ -1443,13 +1380,13 @@ def _write_config_and_summary(
     config_dir.mkdir(parents=True, exist_ok=True)
 
     # All install-context branching reads from the single profile struct
-    # built once at init() entry (or lazily reconstructed from legacy state
-    # booleans by the _get_or_build_profile shim when downstream forks build
-    # state directly). #363 Phase 3 collapsed the prior 4 source_install /
-    # project_install / source_dir / project_dir reads into this struct;
-    # #368 dropped the remaining parallel state keys so there is now exactly
-    # one place a future install-context judgment can land.
-    profile = _get_or_build_profile(state)
+    # built once at init() entry. #363 Phase 3 collapsed the prior 4
+    # source_install / project_install / source_dir / project_dir reads
+    # into this struct; #368 dropped the parallel state keys and the
+    # follow-up removed the _get_or_build_profile back-compat shim, so
+    # there is now exactly one place a future install-context judgment
+    # can land.
+    profile = state["_profile"]
     source_install = profile.cwd_install_type == "source"
     project_install = profile.cwd_install_type == "project"
     workspace_dir = str(profile.cwd_install_dir) if profile.cwd_install_dir else None
@@ -2124,10 +2061,10 @@ def init(
 
     # Build the install-context profile once at entry — every downstream
     # decision (run_prefix, missing-extras hint, summary mismatch banner,
-    # MCP server command) reads from this single struct via
-    # _get_or_build_profile. #368 dropped the parallel legacy
-    # source_install/project_install/source_dir/project_dir state keys so
-    # there is exactly one place to land a new install-context judgment.
+    # MCP server command) reads from state["_profile"] directly. #368
+    # dropped the parallel legacy state keys and the follow-up removed
+    # the _get_or_build_profile back-compat shim, so there is exactly one
+    # place to land a new install-context judgment.
     profile = _runtime_profile()
     state: dict = {"_profile": profile}
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1364,46 +1364,6 @@ class TestRuntimeProfile:
         assert profile.workspace_venv_path is None
         assert profile.runtime_matches_workspace is False
 
-    def test_get_or_build_profile_caches_in_state(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Second call returns the same instance (cached on state)."""
-        from memtomem.cli import init_cmd
-
-        monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
-
-        state: dict = {"source_install": False, "project_install": False}
-        first = init_cmd._get_or_build_profile(state)
-        second = init_cmd._get_or_build_profile(state)
-        assert first is second
-        assert state["_profile"] is first
-
-    def test_get_or_build_profile_falls_back_to_legacy_state_keys(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Tests that build state directly (no ``_profile``) get a profile
-        synthesized from ``state["source_install"]`` / ``source_dir``. This
-        is the back-compat shim that lets the dozens of pre-Phase-3 tests
-        continue to work without rewriting fixtures."""
-        from memtomem.cli import init_cmd
-
-        venv_bin = tmp_path / ".venv" / "bin"
-        venv_bin.mkdir(parents=True)
-        (venv_bin / "python").touch()
-        monkeypatch.setattr(init_cmd.sys, "executable", str(venv_bin / "python"))
-
-        state: dict = {
-            "source_install": True,
-            "source_dir": str(tmp_path),
-            "project_install": False,
-            "project_dir": None,
-        }
-        profile = init_cmd._get_or_build_profile(state)
-        assert profile.cwd_install_type == "source"
-        assert profile.cwd_install_dir == tmp_path
-        assert profile.workspace_venv_path == tmp_path / ".venv"
-        assert profile.runtime_matches_workspace is True
-
 
 class TestMmBinaryOriginDetection:
     """Issue #363 Phase 3 — first-class ``mm_binary_origin`` heuristic.


### PR DESCRIPTION
## Summary

Follow-up to #369 (#368 Phase 3 cleanup). Removes the `_get_or_build_profile`
back-compat shim that #369 deliberately kept "for one more cycle" as a
cautious defense for downstream forks.

Rationale for collapsing the cycle now: every symbol involved —
`_get_or_build_profile`, `RuntimeProfile`, and the legacy
`state["source_install"] / source_dir / project_install / project_dir` keys
— is private (`_` prefix) and carries no SemVer guarantee. Requiring a fork
that touched those internals to wait a release before deletion is
over-cautious for private test-helper surface. Collapsing the two-PR
sequence into one follow-up PR avoids leaving dead reconstruction logic
in production for an indefinite grace period.

**Stacked on #369** (base: `refactor/368-drop-legacy-install-state-keys`).
Will rebase `--onto origin/main` after #369 merges (see
`feedback_stacked_pr_rebase_onto.md`).

Refs #368.

## Changes

**`init_cmd.py` (production, -103 lines net)**

- Delete `_get_or_build_profile` function (~65 lines) — the reconstruction
  path was effectively dead for production after #369 since every in-tree
  caller sets `_profile` at `init()` entry.
- Migrate 6 call sites from `profile = _get_or_build_profile(state)` to
  `profile = state["_profile"]`:
  `_write_config_and_summary`, `_collect_missing_extras`,
  `_extra_install_hint`, `_emit_cwd_runtime_mismatch_banner`,
  `_emit_missing_extras_warning`, `_workspace_needs_sync`.
- `_extra_install_hint` and `_collect_missing_extras` now tolerate missing
  `_profile` via `state.get("_profile")` + `None`-check → treated as PyPI
  install. This preserves the documented `"no state / PyPI default"`
  contract that `_extra_install_hint(extras, state=None)` already advertises
  — the KeyError on empty state would have been an artifact of the shim
  era, not the intended API.
- Update 3 docstring/comment references pointing at the now-removed shim.

**`test_init_cmd.py` (tests, -40 lines)**

- Delete `TestRuntimeProfile.test_get_or_build_profile_caches_in_state`
  and `TestRuntimeProfile.test_get_or_build_profile_falls_back_to_legacy_state_keys`
  — both exercised the removed reconstruction path. The remaining
  `TestRuntimeProfile` tests (builder invariants, uvx detection,
  project-install E2E) stay.

## Acceptance

- [x] `_get_or_build_profile` symbol no longer exists in
      `packages/memtomem` (zero grep hits in source, only 2 historical
      references in comments documenting the refactor path).
- [x] Zero production references to `state["source_install"] /
      source_dir / project_install / project_dir`.
- [x] `RuntimeProfile` remains the sole source of truth for install-context
      decisions.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 2088 passed (was 2090; -2 shim tests removed as expected), 24.4s
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` → clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` → 288 files already formatted
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` → clean (advisory)
- [x] Manual smoke — source path shows `Detected: source install` + `Source directory: ...` identically.
- [ ] CI green.

## Out of scope

- Any behavior change to `mm init` output — this is pure cleanup.
- `CHANGELOG.md` — no user-visible surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
