### PR TITLE
fix(web): handle 404 from /api/namespaces gracefully in production (#355)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -58,7 +58,10 @@ function _groupNamespaces(namespaces) {
 
 async function loadNamespaceDropdowns() {
   try {
-    const data = await api('GET', '/api/namespaces');
+    const devMode = STATE.uiMode === 'dev';
+    const data = devMode
+      ? await api('GET', '/api/namespaces').catch(() => ({ namespaces: [] }))
+      : { namespaces: [] };
     const namespaces = data.namespaces || [];
     const { groups, ungrouped } = _groupNamespaces(namespaces);
     ['ns-filter', 'tl-namespace', 'exp-namespace'].forEach(id => {
@@ -169,7 +172,10 @@ async function loadNamespacesTab() {
   list.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
 
   try {
-    const data = await api('GET', '/api/namespaces');
+    const devMode = STATE.uiMode === 'dev';
+    const data = devMode
+      ? await api('GET', '/api/namespaces').catch(() => ({ namespaces: [] }))
+      : { namespaces: [] };
     const namespaces = data.namespaces || [];
     if (!namespaces.length) {
       list.innerHTML = emptyState('📁', 'No namespaces yet', 'Index files with a namespace to get started');


### PR DESCRIPTION
The /api/namespaces endpoint is intentionally dev-only (still in flux, see RFC #304). In production it returns 404, which was causing console errors in settings-namespaces.js.

**Changes:**
- Revert namespaces router back to _DEV_ONLY_ROUTERS
- Add `.catch(() => ({ namespaces: [] }))` to both /api/namespaces calls
- This mirrors the existing pattern in app.js:649-653

**Disclosure:** This contribution was generated with AI assistance and reviewed before submission.

Closes #355