### PR TITLE
release: v0.1.21 — Phase 3 install-context refactor + uvx ephemeral detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.21] — 2026-04-22
+
+Phase 3 of the `mm init` install-context series (#360 → v0.1.20 → this
+release). The v0.1.18 axis-mismatch bug exposed two independent axes
+(cwd filesystem vs runtime interpreter) being re-derived at five
+different call sites with no shared contract; this release collapses
+them into a single `RuntimeProfile` struct so the next install-context
+judgment has exactly one place to land. Also adds first-class `uvx`
+detection — pre-Phase-3 the wizard bucketed ephemeral-env invocations
+into the generic "PyPI" label and the ephemeral-install hint branch
+was dead code.
+
 ### Changed
 
 - **`mm init` now classifies `uvx memtomem init` as ephemeral** — when the
@@ -33,6 +45,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   across `mm init` and `mm web` (was split between `find_spec` and
   `__import__`). 20 new tests cover RuntimeProfile fields, the 5-way
   `mm_binary_origin` heuristic, and the project-install path E2E. (#363)
+- **Legacy `state["source_install"] / source_dir / project_install /
+  project_dir` keys dropped from `mm init`** — after the Phase 3
+  `RuntimeProfile` refactor landed, the parallel legacy state keys were
+  intentionally left in place so #367 could ship as a structural-only
+  change. This release removes them: `init()` entry now writes only
+  `state["_profile"]`, and every downstream reader (the MCP server
+  command builder, the missing-extras workspace dir, the "Detected:
+  install" echo paths) reads from `profile.cwd_install_type` /
+  `profile.cwd_install_dir` directly. Test fixtures migrate to a new
+  `_make_test_profile(tmp_path, kind=...)` helper that builds a
+  `RuntimeProfile` without invoking the live `_runtime_profile()`. (#368,
+  #369)
+- **`_get_or_build_profile` back-compat shim removed** — the shim existed
+  to let test fixtures build state directly without populating
+  `_profile`. With the legacy state keys gone (#369) the reconstruction
+  path was dead for production; this release deletes the function
+  entirely (~65 lines) and inlines `state["_profile"]` at the 6 call
+  sites. `_extra_install_hint` and `_collect_missing_extras` now tolerate
+  missing `_profile` via `state.get("_profile")` + `None`-check, treating
+  it as PyPI install — preserves the documented "no state / PyPI default"
+  contract that `_extra_install_hint(extras, state=None)` already
+  advertised. (#370)
 
 ## [0.1.20] — 2026-04-22
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.20"
+version = "0.1.21"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.20"
+version = "0.1.21"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v0.1.20 → v0.1.21 patch release. Promotes the `[Unreleased]` block
covering Phase 3 of the `mm init` install-context series (#360 → v0.1.20
→ this release) into a dated section.

Phase 1 (v0.1.19) fixed the install-hint text for the cwd-vs-runtime
mismatch. Phase 2 (v0.1.20) added auto-install + the one-line mismatch
banner. Phase 3 (this release) collapses the two independent axes (cwd
filesystem vs runtime interpreter) into a single `RuntimeProfile` struct
so a future install-context judgment lands in one place instead of
risking another axis-mismatch class bug. Also adds first-class `uvx`
detection.

## User-visible

- **`Install: uvx (ephemeral)` label + Next-steps hint** — when `mm init`
  is invoked via `uvx memtomem init`, the summary labels the install
  type correctly and points at `uv tool install "memtomem[all]"` for
  repeat use. Pre-Phase-3 the wizard bucketed this into the generic
  "PyPI" label and the existing ephemeral-install hint branch was dead
  code (the call site never routed to it). (#363)

## Internal

- **`RuntimeProfile` dataclass** (#363) — cwd filesystem axis + runtime
  interpreter axis built once at `mm init` entry; every downstream call
  site reads from one struct. Collapses 4 near-identical detector pairs
  into 2 helpers. 20 new tests.
- **Legacy state keys dropped** (#368, #369) — `state["source_install"] /
  source_dir / project_install / project_dir` no longer written; every
  reader goes through `profile.cwd_install_type` / `cwd_install_dir`.
  New `_make_test_profile` test helper.
- **`_get_or_build_profile` shim removed** (#370) — ~65-line
  reconstruction path deleted; 6 call sites inline `state["_profile"]`
  directly. `_extra_install_hint` / `_collect_missing_extras` tolerate
  missing `_profile` as PyPI install.

Net diff from v0.1.20: `init_cmd.py` −116 lines, `test_init_cmd.py`
rewritten to use `_make_test_profile`, `web.py` unified on `find_spec`
(#363).

## Files

- `CHANGELOG.md` — `[Unreleased]` → `[0.1.21] — 2026-04-22`
- `packages/memtomem/pyproject.toml` — `version = "0.1.21"`
- `uv.lock` — workspace `[[package]]` entry synced

## Release flow

After merge:

1. Tag push: `git tag -a v0.1.21 -m "..." && git push origin v0.1.21`
2. Trusted-publisher workflow (OIDC) uploads to PyPI automatically —
   no API token needed.
3. GitHub Release created from the CHANGELOG section.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 2088 passed, 24.6s
- [x] `uv run ruff check` + `format --check` → clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` → clean
- [x] `uv lock` → workspace `memtomem v0.1.20 → v0.1.21` synced
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
