### PR TITLE
docs(indexing): clarify memory_dirs auto-watch vs mm index manual seed

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -255,9 +255,27 @@ When enabled, search results include surrounding chunks from the same source fil
 
 ## Indexing
 
+### `memory_dirs` — reactive watch vs one-shot seed
+
+`indexing.memory_dirs` is the source-of-truth list for the file watcher
+that `mm server` starts on boot. The watcher is **reactive only** — it
+reindexes files when the filesystem emits modify / create / move events
+for paths under these directories. Pre-existing files on disk at the
+time the watcher starts are **NOT auto-scanned**; you seed them once
+with either
+
+- `mm index <dir>` from the CLI, or
+- the **Reindex** button per memory_dir in `mm web`.
+
+Both paths are idempotent: chunks are content-hashed, so unchanged files
+are skipped on re-runs. This is why the `mm init` wizard's `Next steps`
+prints `mm index {memory_dir}` as step 1 — once seeded, subsequent edits
+flow through the watcher automatically (as long as `mm server` is
+running).
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` (+ provider folders selected in `mm init`) | Directories to index (see below) |
+| `MEMTOMEM_INDEXING__MEMORY_DIRS` | `["~/.memtomem/memories"]` (+ provider folders selected in `mm init`) | Directories watched for reactive re-index (see above) |
 | `MEMTOMEM_INDEXING__SUPPORTED_EXTENSIONS` | `[".md",".json",".yaml",".yml",".toml",".py",".js",".ts",".tsx",".jsx"]` | File types accepted by the indexer and file watcher |
 | `MEMTOMEM_INDEXING__MAX_CHUNK_TOKENS` | `512` | Maximum tokens per chunk |
 | `MEMTOMEM_INDEXING__MIN_CHUNK_TOKENS` | `128` | Merge threshold for short chunks |

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -249,6 +249,11 @@ You should see index statistics (0 chunks if nothing indexed yet).
 
 ### 1. Index your notes
 
+This one-shot command seeds the index with files already on disk. After
+this, the `mm server` file watcher keeps your `memory_dirs` in sync with
+new edits automatically — you only need to run `mm index` again when you
+add a brand-new directory or want a forced rebuild (`--force`).
+
 In your editor:
 ```
 "Index my notes folder"  →  mem_index(path="~/notes")
@@ -259,7 +264,7 @@ Or via CLI:
 mm index ~/notes
 ```
 
-This scans all supported files (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, etc.), splits them into searchable chunks, and creates embeddings.
+This scans all supported files (`.md`, `.json`, `.yaml`, `.py`, `.js`, `.ts`, etc.), splits them into searchable chunks, and creates embeddings. The re-run is idempotent (content-hash dedup), so it's safe to repeat.
 
 ### 2. Search
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -163,9 +163,22 @@ mem_index(path="~/work/docs", namespace="work")
 mem_index(path="~/personal/notes", namespace="personal")
 ```
 
-### Auto-watch
+### Auto-watch vs manual seed
 
-Files in `MEMTOMEM_INDEXING__MEMORY_DIRS` are watched for changes and re-indexed automatically. For files outside watched directories, call `mem_index` manually.
+`MEMTOMEM_INDEXING__MEMORY_DIRS` feeds a file watcher that runs inside
+the `mm server` (MCP) process. The watcher is **reactive only** — it
+reindexes files when the filesystem emits modify / create / move events.
+Two cases it does NOT cover:
+
+- **Pre-existing files on disk** when you first configure a `memory_dir`.
+  Run `mm index <dir>` (or `mem_index(path="<dir>")`) once to seed them;
+  after that, the watcher picks up further edits.
+- **Files outside `memory_dirs`.** Call `mem_index` / `mm index` manually
+  with the path you want indexed ad-hoc.
+
+Both are idempotent — chunks are content-hashed, so unchanged files are
+skipped on re-runs. This is why the `mm init` wizard's `Next steps` lists
+`mm index {memory_dir}` as step 1.
 
 ---
 
@@ -880,7 +893,7 @@ mm init                                # 9-step interactive wizard (b: back, q: 
 
 # Core (daily use)
 mm search "deployment"                 # hybrid search (keywords + meaning)
-mm index ~/notes                       # index directory
+mm index ~/notes                       # manual one-shot index (seed pre-existing files)
 mm add "note" --tags "tag1"            # add a memory
 mm recall --since 2026-03-01           # recall by date
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1691,6 +1691,11 @@ def _write_config_and_summary(
     click.echo()
     click.secho("  Next steps:", fg="cyan")
     run_prefix = "uv run " if profile.cwd_install_type in ("source", "project") else ""
+    # Step 1 seeds the initial index: the FileWatcher (started by
+    # `mm server`) is reactive-only and won't scan pre-existing files
+    # in memory_dirs. After this one-shot, subsequent edits are
+    # auto-indexed. `mm index` is idempotent (content-hash dedup) so
+    # re-runs are safe. See docs/guides/configuration.md#memory_dirs.
     click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}")
     click.echo(f"    2. {run_prefix}mm search 'your first query'")
     click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")


### PR DESCRIPTION
## Summary

Clarify the memory_dirs auto-watch vs `mm index` manual-seed split that
the docs + code comments previously conflated into a vague "directories
to index" phrasing.

### Why this matters

The project owner asked directly whether `mm init`'s `Next steps` step 1
(`mm index {memory_dir}`) was an oversight — after all, `memory_dirs` is
"automatically indexed" in conversations. Re-deriving the actual behavior
from the code:

- **Reactive watch** — `FileWatcher` started by `mm server` on MCP boot.
  Triggers re-index only on fs events (modify / create / move). Does NOT
  scan pre-existing files at startup. Intentional per #295 (startup-scan-
  in-lifespan anti-pattern; pull-based UI badges preferred; see
  `feedback_pullbased_vs_startup_scan.md`).
- **One-shot seed** — `mm index <dir>` (or web UI Reindex button) for
  pre-existing files. Idempotent via content-hash dedup.

So the wizard's step 1 is correct and necessary, but the docs never
spell it out. This PR makes that explicit in the three user-facing
doc files plus the wizard's source code (for future contributors).

This is PR 1 of 2. PR 2 will add an opt-in small-case auto-seed in the
wizard itself, gated by a two-axis `file_count <= 10 AND total_bytes
<= 64 KB` threshold — so wizard users with a fresh `~/memories` skip
the manual step, and users with 2000-file configs fall back to `mm web`
Reindex (avoiding the PR #295 UI-freeze failure mode).

## Changes

- **`docs/guides/configuration.md`** — new `memory_dirs` preamble
  before the Indexing table explicitly names both paths (reactive watch
  vs seed), points at `mm index` and Web UI Reindex, and explains the
  hash-dedup idempotency. Table row updated from "Directories to index"
  → "Directories watched for reactive re-index".
- **`docs/guides/getting-started.md`** — `First use / Index your notes`
  gets a lead paragraph noting this is a one-shot seed; afterwards the
  watcher keeps things in sync. Idempotency called out so users aren't
  afraid to re-run.
- **`docs/guides/reference.md`** — `Auto-watch` subsection rewritten to
  `Auto-watch vs manual seed`, spelling out the two cases the watcher
  does NOT cover (pre-existing files + out-of-`memory_dirs` paths) and
  why `mm init` makes `mm index` step 1. CLI reference comment next to
  `mm index ~/notes` clarifies "manual one-shot (seed pre-existing
  files)".
- **`init_cmd.py`** — 5-line rationale comment above the Next-steps
  block explaining why step 1 is `mm index`. User-facing output
  unchanged.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_init_cmd.py -q` → 166 passed
- [x] `uv run ruff check packages/memtomem/src` → clean
- [x] `uv run ruff format --check packages/memtomem/src` → clean
- [ ] CI green.

## Out of scope

- Behavior change in the wizard (opt-in seed) — stacked PR 2.
- Adding a background rate-limited initial scan to the watcher — PR #295
  lesson steers this away; `mm web` Reindex + future PR 2 threshold
  covers the common cases.
- `CHANGELOG.md` — docs-only, no user-visible surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
