### PR TITLE
feat(init): opt-in auto-seed initial index for small memory_dirs

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1064,6 +1064,22 @@ _PROBE_EXTRAS_CODE: str = (
     "if u.find_spec(n) is not None]))"
 )
 
+# Two-axis threshold for the wizard's opt-in initial-index seed. Only when
+# BOTH axes are under the ceiling does the wizard prompt to seed inline;
+# otherwise it falls back to a hint ("use `mm web` Reindex or run
+# `mm index <dir>`"). AND-semantics err on the side of skip — the downside
+# of a missed auto-seed is one extra command the user types; the downside
+# of a mis-sized auto-seed is the PR #295 failure mode (CPU-bound embedder
+# blocks the wizard for minutes on first invocation, user thinks it hung).
+#
+# Baseline 64 KB derives from bge-m3 (1024d ONNX) on CPU: ~1 byte/0.3 tokens
+# × ~1 ms/token ≈ 20 seconds worst case, well under the 30 s wizard attention
+# budget. 10 files / 64 KB also matches a "fresh ~/memories with a few seed
+# memos" shape — the dominant wizard workflow — without catching "moved my
+# Obsidian vault" installs.
+_SEED_MAX_FILES: int = 10
+_SEED_MAX_BYTES: int = 64 * 1024
+
 
 def _workspace_python(state: dict) -> Path | None:
     """Return ``<workspace_venv_path>/bin/python`` if it exists, else ``None``.
@@ -1247,6 +1263,120 @@ def _install_extras(
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
     return result.returncode == 0
+
+
+def _collect_seed_scale(memory_dir: Path) -> tuple[int, int]:
+    """Count ``.md`` files and total bytes under ``memory_dir``, recursive.
+
+    Two-axis decision input for :func:`_maybe_seed_initial_index`. ``.md``
+    only — other supported extensions (``.json``, ``.py``, etc.) exist but
+    the wizard's dominant workflow seeds human-written markdown memos, and
+    the embedder cost tuning lives in that regime. Silent on stat/permission
+    errors: a dir the user can't read is one the seed can't index either,
+    so return (0, 0) and fall through to "skip"."""
+    if not memory_dir.exists():
+        return 0, 0
+    count = 0
+    total = 0
+    try:
+        for f in memory_dir.rglob("*.md"):
+            try:
+                total += f.stat().st_size
+                count += 1
+            except OSError:
+                continue
+    except OSError:
+        return 0, 0
+    return count, total
+
+
+def _seed_initial_index(memory_dir: Path) -> bool:
+    """Run one-shot :meth:`IndexEngine.index_path` on ``memory_dir``.
+
+    Returns ``True`` iff the seed completed. On any failure
+    (ClickException from missing config, embedder error, IO) prints a
+    yellow warning + manual-rerun hint and returns ``False`` — the wizard
+    already succeeded at creating the config so we don't want to abort on
+    a seed-only stumble. The only caller is
+    :func:`_maybe_seed_initial_index`, which has already done the
+    threshold + TTY checks."""
+    import asyncio
+
+    async def _run() -> tuple[int, int, int] | None:
+        try:
+            from memtomem.cli._bootstrap import cli_components
+
+            async with cli_components() as comp:
+                stats = await comp.index_engine.index_path(
+                    memory_dir, recursive=True, force=False, namespace=None
+                )
+                return stats.total_files, stats.indexed_chunks, stats.skipped_chunks
+        except Exception as e:
+            click.secho(f"  Skipped initial seed: {e}", fg="yellow")
+            click.echo(f"  Run manually later:   mm index {memory_dir}")
+            return None
+
+    result = asyncio.run(_run())
+    if result is None:
+        return False
+    total, new, skipped = result
+    click.secho(
+        f"  Seeded initial index: {total} file(s), {new} new chunk(s), {skipped} unchanged.",
+        fg="green",
+    )
+    return True
+
+
+def _maybe_seed_initial_index(memory_dir: Path) -> bool:
+    """Offer an opt-in one-shot seed of ``memory_dir`` at wizard end.
+
+    Policy (tight, so the wizard stays predictable):
+
+    1. Empty dir / non-existent → silent skip. The wizard already printed
+       ``Memory: <dir>``; adding "no files found" noise would confuse.
+    2. Either axis over threshold
+       (``_SEED_MAX_FILES`` / ``_SEED_MAX_BYTES``) → cyan hint pointing at
+       ``mm web`` Reindex and ``mm index``, no prompt. Avoids the PR #295
+       failure mode (CPU-heavy embedder blocks wizard for minutes).
+    3. Both axes small but stdin isn't a TTY (CI, piped ``mm init -y``)
+       → silent skip. ``click.confirm`` with no TTY raises ``Abort``, so
+       we gate explicitly (``feedback_click_prompt_needs_isatty_gate.md``).
+    4. Small + TTY → prompt, default No. Enter preserves the legacy
+       "wizard writes config and exits, user runs step 1 manually"
+       behavior; explicit ``y`` runs the seed inline.
+
+    Returns ``True`` iff the seed actually ran (informs whether the
+    Next-steps step 1 can be annotated as already-done)."""
+    if not memory_dir.exists():
+        return False
+    file_count, total_bytes = _collect_seed_scale(memory_dir)
+    if file_count == 0:
+        return False
+    if file_count > _SEED_MAX_FILES or total_bytes > _SEED_MAX_BYTES:
+        kb = total_bytes // 1024
+        click.echo()
+        click.secho(
+            f"  Found {file_count} file(s) ({kb} KB) in {memory_dir}.",
+            fg="cyan",
+        )
+        click.secho(
+            f"  Seed with:  mm index {memory_dir}  (or click 'Reindex' in `mm web`).",
+            fg="cyan",
+        )
+        return False
+    if not sys.stdin.isatty():
+        return False
+    click.echo()
+    try:
+        do_seed = click.confirm(
+            f"  Index the {file_count} existing file(s) in {memory_dir} now?",
+            default=False,
+        )
+    except click.Abort:
+        return False
+    if not do_seed:
+        return False
+    return _seed_initial_index(memory_dir)
 
 
 def _collect_missing_extras(state: dict) -> list[str]:
@@ -1688,6 +1818,15 @@ def _write_config_and_summary(
             else:
                 _emit_missing_extras_warning(missing, state)
 
+    # Offer to seed the initial index inline when the memory_dir is small
+    # enough (two-axis threshold) and stdin is a TTY. Large-case or
+    # non-TTY paths fall back to the printed `mm index` Next-step. See
+    # _maybe_seed_initial_index for the policy rationale and
+    # `feedback_pullbased_vs_startup_scan.md` for why this is gated
+    # narrowly (PR #295 failed trying to scan on lifespan startup).
+    memory_dir_path = Path(state["memory_dir"]).expanduser()
+    seeded = _maybe_seed_initial_index(memory_dir_path)
+
     click.echo()
     click.secho("  Next steps:", fg="cyan")
     run_prefix = "uv run " if profile.cwd_install_type in ("source", "project") else ""
@@ -1696,7 +1835,10 @@ def _write_config_and_summary(
     # in memory_dirs. After this one-shot, subsequent edits are
     # auto-indexed. `mm index` is idempotent (content-hash dedup) so
     # re-runs are safe. See docs/guides/configuration.md#memory_dirs.
-    click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}")
+    # When _maybe_seed_initial_index already ran, the hint is annotated
+    # so users don't think they need to run it a second time.
+    seed_suffix = "  (already seeded — re-run only if you add files)" if seeded else ""
+    click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}{seed_suffix}")
     click.echo(f"    2. {run_prefix}mm search 'your first query'")
     click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")
     if profile.mm_binary_origin == "uvx":

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3777,3 +3777,214 @@ class TestReinstallEmbeddingReconciliation:
         out = capsys.readouterr().out
         assert "Skipped" in out
         assert "mm embedding-reset --mode apply-current" in out
+
+
+class TestInitialSeedThreshold:
+    """Opt-in initial-seed prompt at wizard end (PR #374 follow-up).
+
+    Policy pins: two-axis (file count AND total bytes) threshold so the
+    wizard doesn't silently block for minutes on CPU-heavy embedders when
+    the user has a large pre-existing memory dir (PR #295 failure mode).
+    Both axes must be under the ceiling to trigger the prompt; either over
+    falls back to a cyan hint pointing at `mm web` Reindex + manual
+    `mm index`. Non-TTY (CI / piped stdin) always skips silently so
+    scripted `mm init -y` pipelines keep passing."""
+
+    @staticmethod
+    def _write_md(dir_: Path, name: str, body: str) -> Path:
+        f = dir_ / name
+        f.write_text(body, encoding="utf-8")
+        return f
+
+    def test_collect_seed_scale_counts_md_only_and_sums_bytes(self, tmp_path: Path) -> None:
+        """`.md` files count toward both axes; `.json` / other extensions
+        don't (threshold is tuned for markdown embedding cost)."""
+        from memtomem.cli.init_cmd import _collect_seed_scale
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        self._write_md(memory_dir, "a.md", "hello world\n")
+        self._write_md(memory_dir, "b.md", "x" * 100)
+        (memory_dir / "ignored.json").write_text('{"k": 1}', encoding="utf-8")
+
+        count, total = _collect_seed_scale(memory_dir)
+        assert count == 2
+        assert total == len("hello world\n") + 100
+
+    def test_collect_seed_scale_missing_dir_returns_zero(self, tmp_path: Path) -> None:
+        """Non-existent memory_dir → (0, 0). The caller uses count==0 to
+        skip silently — avoids the wizard printing "no files found" noise
+        right after it just printed `Memory: <dir>`."""
+        from memtomem.cli.init_cmd import _collect_seed_scale
+
+        assert _collect_seed_scale(tmp_path / "does-not-exist") == (0, 0)
+
+    def test_maybe_seed_large_by_count_emits_hint_no_prompt(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """11 small files (>10) → skip + hint. Prompt never fires (ensures
+        a hypothetical click.confirm mock would not be called)."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        for i in range(11):
+            self._write_md(memory_dir, f"m{i}.md", f"memo {i}")
+
+        called = {"confirm": False}
+
+        def _fail_confirm(*a: object, **kw: object) -> bool:
+            called["confirm"] = True
+            return False
+
+        monkeypatch.setattr("click.confirm", _fail_confirm)
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
+        assert called["confirm"] is False
+        out = capsys.readouterr().out
+        assert "11 file(s)" in out
+        assert f"mm index {memory_dir}" in out
+
+    def test_maybe_seed_large_by_bytes_emits_hint_no_prompt(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """5 files but total > 64KB → skip too. Proves the AND-semantics
+        (count OK alone isn't enough when bytes axis trips)."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        for i in range(5):
+            self._write_md(memory_dir, f"big{i}.md", "x" * 20_000)  # 100 KB total
+
+        called = {"confirm": False}
+        monkeypatch.setattr(
+            "click.confirm",
+            lambda *a, **kw: called.__setitem__("confirm", True) or False,
+        )
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
+        assert called["confirm"] is False
+        out = capsys.readouterr().out
+        assert "5 file(s)" in out
+        assert "KB)" in out
+
+    def test_maybe_seed_non_tty_silent_skip(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Small dir + no TTY → silent skip. Prompt-on-non-TTY would
+        raise click.Abort and break `mm init -y </dev/null` pipelines
+        (`feedback_click_prompt_needs_isatty_gate.md`)."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        self._write_md(memory_dir, "only.md", "short")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        confirm_fired = {"yes": False}
+        monkeypatch.setattr(
+            "click.confirm",
+            lambda *a, **kw: confirm_fired.__setitem__("yes", True) or True,
+        )
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
+        assert confirm_fired["yes"] is False
+        assert capsys.readouterr().out == ""
+
+    def test_maybe_seed_prompt_decline(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Small + TTY + No → no seed call. Verifies the default-No
+        path (Enter-is-Skip) doesn't accidentally seed — the wizard's
+        other prompts mostly use default-Yes, so the contrast is worth
+        pinning."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        self._write_md(memory_dir, "only.md", "short")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("click.confirm", lambda *a, **kw: False)
+
+        seed_called = {"yes": False}
+        monkeypatch.setattr(
+            init_cmd,
+            "_seed_initial_index",
+            lambda p: seed_called.__setitem__("yes", True) or True,
+        )
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
+        assert seed_called["yes"] is False
+
+    def test_maybe_seed_prompt_accept_runs_seed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Small + TTY + Yes → _seed_initial_index invoked, return value
+        propagates. Seeder itself is stubbed — that path is exercised by
+        test_seed_initial_index_failure_graceful."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        self._write_md(memory_dir, "only.md", "short")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("click.confirm", lambda *a, **kw: True)
+
+        seen: dict[str, Path] = {}
+
+        def _stub_seed(p: Path) -> bool:
+            seen["dir"] = p
+            return True
+
+        monkeypatch.setattr(init_cmd, "_seed_initial_index", _stub_seed)
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir) is True
+        assert seen["dir"] == memory_dir
+
+    def test_seed_initial_index_failure_is_graceful(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If cli_components / index_path raises, return False with a
+        yellow warning + manual-rerun hint. Wizard must not abort —
+        config.json is already written and the seed is best-effort."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+
+        # Patch cli_components so the inner async body raises.
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _broken_components() -> object:  # pragma: no cover - generator
+            raise RuntimeError("embedder unavailable")
+            yield  # unreachable
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _broken_components)
+
+        assert init_cmd._seed_initial_index(memory_dir) is False
+        out = capsys.readouterr().out
+        assert "Skipped initial seed" in out
+        assert "embedder unavailable" in out
+        assert f"mm index {memory_dir}" in out


### PR DESCRIPTION
## Summary

Wizard follow-up to #374 (memory_dirs auto-watch vs `mm index` manual
seed). Adds a narrow opt-in prompt at the end of `mm init` that offers
to run the initial `mm index <memory_dir>` inline, gated by a two-axis
threshold so it never triggers the PR #295 failure mode (CPU-heavy
embedder blocks the wizard for minutes on large configs).

**Stacked on #374** (base: `docs/memory-dirs-auto-vs-manual`). Will
rebase `--onto origin/main` after #374 merges
(`feedback_stacked_pr_rebase_onto.md`).

## Threshold rationale

Both axes must be under the ceiling — **AND semantics, intentional**:

- `_SEED_MAX_FILES = 10`
- `_SEED_MAX_BYTES = 64 * 1024`  (64 KB)

AND errs on the side of **skip**: missing an auto-seed costs one extra
user command (they run `mm index` as step 1 manually); mis-sized
auto-seed costs "wizard hang" UX where the user assumes the tool is
broken and kills it. 64 KB ≈ 10-20 s on bge-m3 CPU (1 byte ≈ 0.3 tokens
× ~1 ms/token), well under the wizard attention budget.

## Policy

1. **Empty / non-existent** `memory_dir` → silent skip. No noise after
   the already-printed `Memory: <dir>` summary line.
2. **Either axis over threshold** → cyan hint pointing at `mm web`
   Reindex + `mm index <dir>` manual invocation. No prompt.
3. **Both small, no TTY** (CI / piped `mm init -y`) → silent skip.
   `click.confirm` on non-TTY raises `Abort`, so we gate explicitly via
   `sys.stdin.isatty()` per `feedback_click_prompt_needs_isatty_gate.md`.
4. **Both small + TTY** → `click.confirm` with **default No**. Enter-is-
   Skip preserves the legacy "wizard writes config and exits, user runs
   step 1 manually" behavior; explicit `y` runs the seed inline.

When seed runs successfully, Next-steps step 1 gets annotated with
`(already seeded — re-run only if you add files)` so users don't think
they need to re-run it.

## Implementation

Three new helpers in `packages/memtomem/src/memtomem/cli/init_cmd.py`:

- `_collect_seed_scale(dir) -> (count, bytes)` — recursive `.md` walk
  with silent `OSError` fallback. Markdown-only because that's the
  dominant wizard workflow; other extensions (`.json`, `.py`) are
  already covered by `SUPPORTED_EXTENSIONS` but the threshold is tuned
  for markdown embedding cost.
- `_seed_initial_index(dir) -> bool` — opens `cli_components()` (reads
  the just-written `config.json`), awaits `IndexEngine.index_path`,
  prints a green success line. On any exception prints a yellow warning
  + manual-rerun hint and returns `False` — wizard already succeeded at
  creating the config so seed failure shouldn't abort.
- `_maybe_seed_initial_index(dir) -> bool` — the policy gate above.

Wired into `_write_config_and_summary` right before the Next-steps
block. 8 new tests in `TestInitialSeedThreshold` cover:

- `_collect_seed_scale`: `.md`-only counting + missing-dir → `(0, 0)`
- Large-by-count, large-by-bytes: both skip with hint, prompt never
  fires (confirm mock verifies)
- Non-TTY silent skip
- Prompt decline (default-No path) + prompt accept (seed runs)
- Seed failure graceful (`cli_components` raises → warning, no abort)

## Test plan

- [x] `uv run pytest -m "not ollama"` → 2096 passed (+8 new)
- [x] `uv run ruff check` + `format --check` → clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` → clean
- [x] Non-TTY smoke: `HOME=/tmp/X uv run mm init -y --provider none
  --memory-dir /tmp/X/memories --mcp skip` — legacy Next-steps unchanged,
  no seed prompt.
- [ ] CI green.
- [ ] (Reviewer) TTY smoke: run `mm init --preset english` with 2-3
  `.md` files in `~/memories` and press `y` to verify seed actually
  runs and annotates step 1.

## Out of scope

- Background rate-limited initial scan (Option C in the planning doc) —
  reintroducing startup-scan infra has multiple open risks (PR #295
  error-flood, coalescing with reactive watcher events, state-file
  crash recovery). Deferred until/unless user feedback says the
  threshold cliff is too sharp.
- Threshold promotion to `config.indexing.seed_max_*` config fields —
  exported module constants are enough for now; config surface can
  grow later if users want to tune.
- `CHANGELOG.md` — user-visible but small; will fold into the next
  release's `[Unreleased]` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
