### PR TITLE
feat(init): prompt + progress bar for large memory_dirs too

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1291,10 +1291,18 @@ def _collect_seed_scale(memory_dir: Path) -> tuple[int, int]:
 
 
 def _format_size(total_bytes: int) -> str:
-    """Human-readable size — KB below 1024 KB, MB above (integer-only,
-    avoids fractional noise in the wizard's one-line advisory)."""
+    """Human-readable size — ``<1 KB`` for sub-KB totals (15 tiny memo
+    files shouldn't display as "0 KB"), ``N KB`` up to 1024 KB, ``N MB``
+    above. Integer-only beyond the sub-KB floor to avoid fractional noise
+    in the wizard's one-line advisory."""
+    if total_bytes == 0:
+        return "0 bytes"
     kb = total_bytes // 1024
-    return f"{kb // 1024} MB" if kb >= 1024 else f"{kb} KB"
+    if kb == 0:
+        return "<1 KB"
+    if kb >= 1024:
+        return f"{kb // 1024} MB"
+    return f"{kb} KB"
 
 
 def _provider_seed_hint(provider: str) -> str | None:
@@ -1388,10 +1396,34 @@ def _seed_with_progress(memory_dir: Path) -> bool:
         return False
 
     click.echo()
+    total_files = result["total_files"]
+    indexed = result["indexed_chunks"]
+    skipped = result["skipped_chunks"]
+
+    # Defensive: if the stream processed files but landed zero chunks
+    # (neither new nor skipped-as-unchanged), something went wrong
+    # silently — per-file errors are logged but the `complete` event
+    # aggregates to zero counters. Known trigger: provider=none
+    # (NoopEmbedder dim=0) which leaves the ``chunks_vec`` virtual
+    # table uncreated, so ``upsert_chunks`` rolls back every insert
+    # (``feedback_chunks_vec_dim0_legacy.md``). Return False so the
+    # Next-steps step 1 stays unmarked and the user knows to investigate
+    # rather than seeing a false green success.
+    if total_files > 0 and indexed == 0 and skipped == 0:
+        click.secho(
+            f"  Seeded {total_files} file(s) but 0 chunks were indexed — "
+            "check logs for upsert errors.",
+            fg="yellow",
+        )
+        click.secho(
+            "  If you switched embedders recently, try `mm embedding-reset --mode apply-current`.",
+            fg="yellow",
+        )
+        return False
+
     click.secho(
-        f"  Seeded initial index: {result['total_files']} file(s), "
-        f"{result['indexed_chunks']} new chunk(s), "
-        f"{result['skipped_chunks']} unchanged.",
+        f"  Seeded initial index: {total_files} file(s), "
+        f"{indexed} new chunk(s), {skipped} unchanged.",
         fg="green",
     )
     return True

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1290,60 +1290,137 @@ def _collect_seed_scale(memory_dir: Path) -> tuple[int, int]:
     return count, total
 
 
-def _seed_initial_index(memory_dir: Path) -> bool:
-    """Run one-shot :meth:`IndexEngine.index_path` on ``memory_dir``.
+def _format_size(total_bytes: int) -> str:
+    """Human-readable size — KB below 1024 KB, MB above (integer-only,
+    avoids fractional noise in the wizard's one-line advisory)."""
+    kb = total_bytes // 1024
+    return f"{kb // 1024} MB" if kb >= 1024 else f"{kb} KB"
 
-    Returns ``True`` iff the seed completed. On any failure
-    (ClickException from missing config, embedder error, IO) prints a
-    yellow warning + manual-rerun hint and returns ``False`` — the wizard
-    already succeeded at creating the config so we don't want to abort on
-    a seed-only stumble. The only caller is
-    :func:`_maybe_seed_initial_index`, which has already done the
-    threshold + TTY checks."""
+
+def _provider_seed_hint(provider: str) -> str | None:
+    """Per-provider expectation string for the large-case advisory.
+
+    Returns ``None`` for unknown providers so the wizard falls back to a
+    generic "watch the progress bar" message rather than making up a
+    number. The magnitudes below come from rough bge-m3 CPU benchmarking
+    (~1 ms/token) and network-latency-bound cloud calls — precise enough
+    to set expectations, not so precise users will hold us to them."""
+    if provider == "onnx":
+        return "bge-m3 / CPU embedder → may take several minutes"
+    if provider == "ollama":
+        return "Ollama embedder → time varies by model; watch the progress bar"
+    if provider == "openai":
+        return "OpenAI API → mostly network-bound, usually under a minute"
+    if provider == "none":
+        return "BM25-only provider → tokenize-only, usually fast"
+    return None
+
+
+def _seed_with_progress(memory_dir: Path) -> bool:
+    """Run :meth:`IndexEngine.index_path_stream` with a click progress bar.
+
+    Returns ``True`` iff the seed completed. Used by both small-case and
+    large-case branches of :func:`_maybe_seed_initial_index` so the
+    progress surface is consistent.
+
+    Cancellation: a ``KeyboardInterrupt`` inside the async stream escapes
+    through ``asyncio.run`` as a regular ``KeyboardInterrupt`` — caught
+    here to print a yellow resume hint. ``mm index`` is idempotent
+    (content-hash dedup), so the next invocation picks up where the
+    cancelled run left off.
+
+    Failure: any other ``Exception`` (missing config, embedder init
+    error, IO) prints a yellow warning + manual-rerun hint and returns
+    ``False``. The wizard already succeeded at writing config.json so a
+    seed-only failure must not abort the overall flow."""
     import asyncio
 
-    async def _run() -> tuple[int, int, int] | None:
-        try:
-            from memtomem.cli._bootstrap import cli_components
+    bar_state: dict = {"bar": None}
 
-            async with cli_components() as comp:
-                stats = await comp.index_engine.index_path(
-                    memory_dir, recursive=True, force=False, namespace=None
-                )
-                return stats.total_files, stats.indexed_chunks, stats.skipped_chunks
-        except Exception as e:
-            click.secho(f"  Skipped initial seed: {e}", fg="yellow")
-            click.echo(f"  Run manually later:   mm index {memory_dir}")
-            return None
+    def _close_bar() -> None:
+        if bar_state["bar"] is not None:
+            try:
+                bar_state["bar"].__exit__(None, None, None)
+            except Exception:  # pragma: no cover - click bar cleanup
+                pass
+            bar_state["bar"] = None
 
-    result = asyncio.run(_run())
-    if result is None:
+    async def _stream() -> dict | None:
+        from memtomem.cli._bootstrap import cli_components
+
+        final: dict | None = None
+        async with cli_components() as comp:
+            async for evt in comp.index_engine.index_path_stream(
+                memory_dir, recursive=True, force=False
+            ):
+                if evt["type"] == "progress":
+                    if bar_state["bar"] is None:
+                        bar_state["bar"] = click.progressbar(
+                            length=evt["files_total"],
+                            label="  Seeding",
+                            item_show_func=lambda item: (item or "").rsplit("/", 1)[-1][:40],
+                        ).__enter__()
+                    bar_state["bar"].update(1, evt["file"])
+                elif evt["type"] == "complete":
+                    final = evt
+        return final
+
+    try:
+        result = asyncio.run(_stream())
+    except KeyboardInterrupt:
+        _close_bar()
+        click.echo()
+        click.secho(
+            f"  Cancelled. Resume with: mm index {memory_dir}",
+            fg="yellow",
+        )
         return False
-    total, new, skipped = result
+    except Exception as e:
+        _close_bar()
+        click.secho(f"  Skipped initial seed: {e}", fg="yellow")
+        click.echo(f"  Run manually later:   mm index {memory_dir}")
+        return False
+
+    _close_bar()
+    if result is None:
+        # No files discovered by the stream — shouldn't happen given the
+        # callers already ensured file_count > 0, but handle defensively.
+        return False
+
+    click.echo()
     click.secho(
-        f"  Seeded initial index: {total} file(s), {new} new chunk(s), {skipped} unchanged.",
+        f"  Seeded initial index: {result['total_files']} file(s), "
+        f"{result['indexed_chunks']} new chunk(s), "
+        f"{result['skipped_chunks']} unchanged.",
         fg="green",
     )
     return True
 
 
-def _maybe_seed_initial_index(memory_dir: Path) -> bool:
-    """Offer an opt-in one-shot seed of ``memory_dir`` at wizard end.
+def _maybe_seed_initial_index(memory_dir: Path, state: dict) -> bool:
+    """Offer an opt-in seed of ``memory_dir`` at wizard end.
 
-    Policy (tight, so the wizard stays predictable):
+    Policy:
 
     1. Empty dir / non-existent → silent skip. The wizard already printed
        ``Memory: <dir>``; adding "no files found" noise would confuse.
-    2. Either axis over threshold
-       (``_SEED_MAX_FILES`` / ``_SEED_MAX_BYTES``) → cyan hint pointing at
-       ``mm web`` Reindex and ``mm index``, no prompt. Avoids the PR #295
-       failure mode (CPU-heavy embedder blocks wizard for minutes).
-    3. Both axes small but stdin isn't a TTY (CI, piped ``mm init -y``)
-       → silent skip. ``click.confirm`` with no TTY raises ``Abort``, so
-       we gate explicitly (``feedback_click_prompt_needs_isatty_gate.md``).
-    4. Small + TTY → prompt, default No. Enter preserves the legacy
-       "wizard writes config and exits, user runs step 1 manually"
-       behavior; explicit ``y`` runs the seed inline.
+    2. Non-TTY (CI, piped ``mm init -y``) → silent skip. ``click.confirm``
+       with no TTY raises ``Abort``, so we gate explicitly
+       (``feedback_click_prompt_needs_isatty_gate.md``).
+    3. Small (both axes under threshold) → short confirm, default No.
+       Enter preserves the legacy "wizard writes config, user runs step
+       1 manually" behavior; explicit ``y`` runs the seed inline.
+    4. Large (either axis over) → advisory + confirm, default No. Advisory
+       surfaces the file count, total size, and a provider-specific time
+       expectation (``_provider_seed_hint``). ``y`` runs the seed inline
+       with a visible progress bar so minutes-long runs don't look
+       hung; Ctrl-C cancels and is resumable via ``mm index``.
+
+    PR #295 lesson: the *default* for both prompts is No because a user
+    blindly pressing Enter through the wizard should not accidentally
+    trigger a multi-minute CPU embedder job. The visible progress bar
+    (when they opt in) is the mitigation for the "is it hung?" failure
+    mode that killed the earlier startup-scan attempt.
 
     Returns ``True`` iff the seed actually ran (informs whether the
     Next-steps step 1 can be annotated as already-done)."""
@@ -1352,31 +1429,36 @@ def _maybe_seed_initial_index(memory_dir: Path) -> bool:
     file_count, total_bytes = _collect_seed_scale(memory_dir)
     if file_count == 0:
         return False
-    if file_count > _SEED_MAX_FILES or total_bytes > _SEED_MAX_BYTES:
-        kb = total_bytes // 1024
-        click.echo()
-        click.secho(
-            f"  Found {file_count} file(s) ({kb} KB) in {memory_dir}.",
-            fg="cyan",
-        )
-        click.secho(
-            f"  Seed with:  mm index {memory_dir}  (or click 'Reindex' in `mm web`).",
-            fg="cyan",
-        )
-        return False
     if not sys.stdin.isatty():
         return False
+
+    is_small = file_count <= _SEED_MAX_FILES and total_bytes <= _SEED_MAX_BYTES
     click.echo()
-    try:
-        do_seed = click.confirm(
-            f"  Index the {file_count} existing file(s) in {memory_dir} now?",
-            default=False,
+
+    if is_small:
+        prompt = f"  Index the {file_count} existing file(s) in {memory_dir} now?"
+    else:
+        size_str = _format_size(total_bytes)
+        click.secho(
+            f"  Found {file_count} file(s) ({size_str}) in {memory_dir}.",
+            fg="cyan",
         )
+        provider_hint = _provider_seed_hint(state.get("provider", ""))
+        if provider_hint:
+            click.secho(f"  {provider_hint}.", fg="cyan")
+        click.secho(
+            "  Ctrl-C cancels; resume later with `mm index <dir>` (hash-dedup safe).",
+            fg="cyan",
+        )
+        prompt = "  Start seeding now?"
+
+    try:
+        do_seed = click.confirm(prompt, default=False)
     except click.Abort:
         return False
     if not do_seed:
         return False
-    return _seed_initial_index(memory_dir)
+    return _seed_with_progress(memory_dir)
 
 
 def _collect_missing_extras(state: dict) -> list[str]:
@@ -1818,14 +1900,15 @@ def _write_config_and_summary(
             else:
                 _emit_missing_extras_warning(missing, state)
 
-    # Offer to seed the initial index inline when the memory_dir is small
-    # enough (two-axis threshold) and stdin is a TTY. Large-case or
-    # non-TTY paths fall back to the printed `mm index` Next-step. See
-    # _maybe_seed_initial_index for the policy rationale and
-    # `feedback_pullbased_vs_startup_scan.md` for why this is gated
-    # narrowly (PR #295 failed trying to scan on lifespan startup).
+    # Offer to seed the initial index inline. Both small and large cases
+    # now prompt (TTY-only, default No), with a visible progress bar and
+    # Ctrl-C resume hint so long runs don't look hung. Large-case adds a
+    # provider-specific advisory ("bge-m3 CPU → several minutes"). See
+    # _maybe_seed_initial_index for the full policy and
+    # `feedback_pullbased_vs_startup_scan.md` for the PR #295 lesson
+    # that shapes the default-No + progress-bar design.
     memory_dir_path = Path(state["memory_dir"]).expanduser()
-    seeded = _maybe_seed_initial_index(memory_dir_path)
+    seeded = _maybe_seed_initial_index(memory_dir_path, state)
 
     click.echo()
     click.secho("  Next steps:", fg="cyan")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3821,6 +3821,21 @@ class TestInitialSeedThreshold:
 
         assert _collect_seed_scale(tmp_path / "does-not-exist") == (0, 0)
 
+    def test_format_size_boundaries(self) -> None:
+        """Sub-KB totals display as ``<1 KB`` not ``0 KB``. Regression
+        guard: 15 tiny memo files triggered the large-by-count branch
+        and showed "(0 KB)" to the user, who'd reasonably think it was
+        a display bug. Also pin the MB boundary (>= 1024 KB) to catch
+        off-by-one rounding."""
+        from memtomem.cli.init_cmd import _format_size
+
+        assert _format_size(0) == "0 bytes"
+        assert _format_size(500) == "<1 KB"
+        assert _format_size(1024) == "1 KB"
+        assert _format_size(65 * 1024) == "65 KB"
+        assert _format_size(1024 * 1024) == "1 MB"
+        assert _format_size(12 * 1024 * 1024) == "12 MB"
+
     def test_provider_seed_hint_variants(self) -> None:
         """Provider-specific advisory strings. Pins the four known
         providers so a silent change (e.g. dropping ``openai``) fails a
@@ -4060,6 +4075,63 @@ class TestInitialSeedThreshold:
         assert "Skipped initial seed" in out
         assert "embedder unavailable" in out
         assert f"mm index {memory_dir}" in out
+
+    def test_seed_with_progress_zero_chunks_emits_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Stream processes files but lands 0 chunks → yellow warning,
+        return False. Known trigger: provider=none (NoopEmbedder dim=0)
+        leaves ``chunks_vec`` vtable uncreated, ``upsert_chunks`` rolls
+        back every insert. Wizard previously printed green "Seeded N
+        file(s), 0 new chunk(s), 0 unchanged" — misleading success.
+        Regression guard: any future silent per-file failure that
+        aggregates to zero counters should surface as yellow, not green,
+        and skip the Next-steps step-1 annotation."""
+        from contextlib import asynccontextmanager
+
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+
+        class _FakeEngine:
+            async def index_path_stream(self, path, recursive=True, force=False):
+                yield {
+                    "type": "progress",
+                    "file": str(memory_dir / "a.md"),
+                    "files_done": 1,
+                    "files_total": 1,
+                    "indexed": 0,
+                    "skipped": 0,
+                }
+                yield {
+                    "type": "complete",
+                    "total_files": 1,
+                    "total_chunks": 0,
+                    "indexed_chunks": 0,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        assert init_cmd._seed_with_progress(memory_dir) is False
+        out = capsys.readouterr().out
+        assert "0 chunks were indexed" in out
+        assert "embedding-reset" in out
+        # Regression: must NOT print green "Seeded initial index" success line.
+        assert "Seeded initial index" not in out
 
     def test_seed_with_progress_keyboard_interrupt_is_graceful(
         self,

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3780,15 +3780,17 @@ class TestReinstallEmbeddingReconciliation:
 
 
 class TestInitialSeedThreshold:
-    """Opt-in initial-seed prompt at wizard end (PR #374 follow-up).
+    """Opt-in initial-seed prompt at wizard end.
 
-    Policy pins: two-axis (file count AND total bytes) threshold so the
-    wizard doesn't silently block for minutes on CPU-heavy embedders when
-    the user has a large pre-existing memory dir (PR #295 failure mode).
-    Both axes must be under the ceiling to trigger the prompt; either over
-    falls back to a cyan hint pointing at `mm web` Reindex + manual
-    `mm index`. Non-TTY (CI / piped stdin) always skips silently so
-    scripted `mm init -y` pipelines keep passing."""
+    Two-axis threshold (file count AND total bytes) classifies the dir as
+    small vs large; **both** cases prompt (TTY only, default No), but the
+    large case gets a provider-specific advisory first so the user sees
+    an ETA expectation before committing. The seed itself runs via
+    ``index_path_stream`` with a click progress bar so minutes-long
+    embedder runs don't look hung — Ctrl-C cancels and is resumable via
+    ``mm index`` (hash-dedup idempotent). Non-TTY (CI / piped stdin)
+    always skips silently so scripted ``mm init -y`` pipelines keep
+    passing."""
 
     @staticmethod
     def _write_md(dir_: Path, name: str, body: str) -> Path:
@@ -3819,14 +3821,31 @@ class TestInitialSeedThreshold:
 
         assert _collect_seed_scale(tmp_path / "does-not-exist") == (0, 0)
 
-    def test_maybe_seed_large_by_count_emits_hint_no_prompt(
+    def test_provider_seed_hint_variants(self) -> None:
+        """Provider-specific advisory strings. Pins the four known
+        providers so a silent change (e.g. dropping ``openai``) fails a
+        test instead of landing a wrong ETA in production. Unknown
+        providers return None so the caller falls back to a generic
+        progress-bar message rather than fabricating a number."""
+        from memtomem.cli.init_cmd import _provider_seed_hint
+
+        assert "bge-m3" in (_provider_seed_hint("onnx") or "")
+        assert "Ollama" in (_provider_seed_hint("ollama") or "")
+        assert "OpenAI" in (_provider_seed_hint("openai") or "")
+        assert "BM25" in (_provider_seed_hint("none") or "")
+        assert _provider_seed_hint("") is None
+        assert _provider_seed_hint("novel-provider") is None
+
+    def test_maybe_seed_large_by_count_prompts_with_advisory(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """11 small files (>10) → skip + hint. Prompt never fires (ensures
-        a hypothetical click.confirm mock would not be called)."""
+        """11 files (>_SEED_MAX_FILES) → advisory + prompt, default No.
+        Regression guard: pre-#375-followup version skipped large cases
+        silently; now users always get a choice (with a visible progress
+        bar under the hood) so "파일 많을 때 수동만 가능" UX gap is closed."""
         from memtomem.cli import init_cmd
 
         memory_dir = tmp_path / "memories"
@@ -3834,28 +3853,29 @@ class TestInitialSeedThreshold:
         for i in range(11):
             self._write_md(memory_dir, f"m{i}.md", f"memo {i}")
 
-        called = {"confirm": False}
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        confirm_fired = {"yes": False}
+        monkeypatch.setattr(
+            "click.confirm",
+            lambda *a, **kw: confirm_fired.__setitem__("yes", True) or False,
+        )
 
-        def _fail_confirm(*a: object, **kw: object) -> bool:
-            called["confirm"] = True
-            return False
-
-        monkeypatch.setattr("click.confirm", _fail_confirm)
-
-        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
-        assert called["confirm"] is False
+        state = {"provider": "onnx"}
+        assert init_cmd._maybe_seed_initial_index(memory_dir, state) is False
+        assert confirm_fired["yes"] is True  # prompt DID fire this time
         out = capsys.readouterr().out
         assert "11 file(s)" in out
-        assert f"mm index {memory_dir}" in out
+        assert "bge-m3" in out  # provider-specific advisory
+        assert "Ctrl-C" in out
 
-    def test_maybe_seed_large_by_bytes_emits_hint_no_prompt(
+    def test_maybe_seed_large_by_bytes_also_prompts(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """5 files but total > 64KB → skip too. Proves the AND-semantics
-        (count OK alone isn't enough when bytes axis trips)."""
+        """5 files but total > 64 KB → same path (large branch prompts).
+        Exercises the AND-semantics on the bytes axis, not just count."""
         from memtomem.cli import init_cmd
 
         memory_dir = tmp_path / "memories"
@@ -3863,17 +3883,48 @@ class TestInitialSeedThreshold:
         for i in range(5):
             self._write_md(memory_dir, f"big{i}.md", "x" * 20_000)  # 100 KB total
 
-        called = {"confirm": False}
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        confirm_fired = {"yes": False}
         monkeypatch.setattr(
             "click.confirm",
-            lambda *a, **kw: called.__setitem__("confirm", True) or False,
+            lambda *a, **kw: confirm_fired.__setitem__("yes", True) or False,
         )
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
-        assert called["confirm"] is False
+        state = {"provider": "ollama"}
+        assert init_cmd._maybe_seed_initial_index(memory_dir, state) is False
+        assert confirm_fired["yes"] is True
         out = capsys.readouterr().out
         assert "5 file(s)" in out
-        assert "KB)" in out
+        assert "Ollama" in out  # provider advisory reflects state["provider"]
+
+    def test_maybe_seed_large_accept_invokes_seed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Large + Yes → _seed_with_progress fires. Stubs the seeder so
+        the test doesn't need a working embedder; the seeder failure
+        path is exercised separately by
+        test_seed_with_progress_failure_is_graceful."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        for i in range(11):
+            self._write_md(memory_dir, f"m{i}.md", f"memo {i}")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("click.confirm", lambda *a, **kw: True)
+
+        seen: dict[str, Path] = {}
+        monkeypatch.setattr(
+            init_cmd,
+            "_seed_with_progress",
+            lambda p: seen.__setitem__("dir", p) or True,
+        )
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is True
+        assert seen["dir"] == memory_dir
 
     def test_maybe_seed_non_tty_silent_skip(
         self,
@@ -3898,15 +3949,37 @@ class TestInitialSeedThreshold:
             lambda *a, **kw: confirm_fired.__setitem__("yes", True) or True,
         )
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
+        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is False
         assert confirm_fired["yes"] is False
+        assert capsys.readouterr().out == ""
+
+    def test_maybe_seed_large_non_tty_silent_skip(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Large dir + no TTY → silent skip too. Previously large case
+        emitted a cyan hint even without a TTY; now that large-case
+        prompts, consistent skip semantics apply — the Next-steps
+        ``mm index`` line already tells non-interactive users what to
+        run, no need to duplicate."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        for i in range(11):
+            self._write_md(memory_dir, f"m{i}.md", f"memo {i}")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "onnx"}) is False
         assert capsys.readouterr().out == ""
 
     def test_maybe_seed_prompt_decline(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        capsys: pytest.CaptureFixture[str],
     ) -> None:
         """Small + TTY + No → no seed call. Verifies the default-No
         path (Enter-is-Skip) doesn't accidentally seed — the wizard's
@@ -3924,11 +3997,11 @@ class TestInitialSeedThreshold:
         seed_called = {"yes": False}
         monkeypatch.setattr(
             init_cmd,
-            "_seed_initial_index",
+            "_seed_with_progress",
             lambda p: seed_called.__setitem__("yes", True) or True,
         )
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir) is False
+        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is False
         assert seed_called["yes"] is False
 
     def test_maybe_seed_prompt_accept_runs_seed(
@@ -3936,9 +4009,8 @@ class TestInitialSeedThreshold:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Small + TTY + Yes → _seed_initial_index invoked, return value
-        propagates. Seeder itself is stubbed — that path is exercised by
-        test_seed_initial_index_failure_graceful."""
+        """Small + TTY + Yes → _seed_with_progress invoked, return value
+        propagates."""
         from memtomem.cli import init_cmd
 
         memory_dir = tmp_path / "memories"
@@ -3954,26 +4026,26 @@ class TestInitialSeedThreshold:
             seen["dir"] = p
             return True
 
-        monkeypatch.setattr(init_cmd, "_seed_initial_index", _stub_seed)
+        monkeypatch.setattr(init_cmd, "_seed_with_progress", _stub_seed)
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir) is True
+        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is True
         assert seen["dir"] == memory_dir
 
-    def test_seed_initial_index_failure_is_graceful(
+    def test_seed_with_progress_failure_is_graceful(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """If cli_components / index_path raises, return False with a
-        yellow warning + manual-rerun hint. Wizard must not abort —
-        config.json is already written and the seed is best-effort."""
+        """If ``cli_components`` / ``index_path_stream`` raises, return
+        False with a yellow warning + manual-rerun hint. Wizard must not
+        abort — config.json is already written and the seed is
+        best-effort."""
         from memtomem.cli import init_cmd
 
         memory_dir = tmp_path / "memories"
         memory_dir.mkdir()
 
-        # Patch cli_components so the inner async body raises.
         from contextlib import asynccontextmanager
 
         @asynccontextmanager  # type: ignore[misc]
@@ -3983,8 +4055,38 @@ class TestInitialSeedThreshold:
 
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _broken_components)
 
-        assert init_cmd._seed_initial_index(memory_dir) is False
+        assert init_cmd._seed_with_progress(memory_dir) is False
         out = capsys.readouterr().out
         assert "Skipped initial seed" in out
         assert "embedder unavailable" in out
+        assert f"mm index {memory_dir}" in out
+
+    def test_seed_with_progress_keyboard_interrupt_is_graceful(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Ctrl-C during the stream → yellow resume hint, not a traceback.
+        This is the primary mitigation for "seeding looks hung" UX —
+        users must have a visible escape hatch that lands them back in
+        their shell cleanly. ``mm index`` idempotency (content-hash
+        dedup) makes resuming safe."""
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _ctrl_c_components() -> object:  # pragma: no cover - generator
+            raise KeyboardInterrupt
+            yield  # unreachable
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _ctrl_c_components)
+
+        assert init_cmd._seed_with_progress(memory_dir) is False
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
         assert f"mm index {memory_dir}" in out


### PR DESCRIPTION
## Summary

Follow-up to #375. Previously the large-case branch (file count > 10 OR
total bytes > 64 KB) silently skipped the seed prompt and just printed a
`mm web Reindex / mm index` hint. Users with a pre-existing memory dir
(Obsidian vault, synced notes folder, migrated `~/memories`) had no
in-wizard option to kick off the initial index — they had to exit and
re-run `mm index <dir>` separately.

This PR unifies small-case and large-case paths into a **single prompt**
(TTY-only, default No), with a **visible click progress bar** + Ctrl-C
resume hint so minutes-long runs on CPU embedders don't look hung. The
large-case prompt adds a provider-specific advisory so the user knows
roughly what to expect before committing.

## UX flow (large case)

```
  Found 423 file(s) (12 MB) in /Users/x/memories.
  bge-m3 / CPU embedder → may take several minutes.
  Ctrl-C cancels; resume later with `mm index <dir>` (hash-dedup safe).
  Start seeding now? [y/N]: y

  Seeding  [####................]  120/423  notes/day12.md
```

On Ctrl-C:
```
  Cancelled. Resume with: mm index /Users/x/memories
```

## Provider-specific advisories

| `state["provider"]` | Advisory |
|---|---|
| `onnx` (bge-m3 etc) | "may take several minutes" |
| `ollama` | "time varies by model; watch the progress bar" |
| `openai` | "mostly network-bound, usually under a minute" |
| `none` | "BM25-only provider → tokenize-only, usually fast" |
| unknown / absent | (no advisory — falls through to generic Ctrl-C hint) |

## Why default No (both cases)

Blindly pressing Enter through the wizard still shouldn't trigger a
multi-minute embedder job. The visible progress bar (when the user
opts in) is the PR #295 mitigation for the "is it hung?" failure mode
that killed the earlier startup-scan attempt. If the user actively
types `y`, they've implicitly consented to the wait and now they have:

1. Progress visibility (can see it's not stuck)
2. Ctrl-C escape hatch (clean abort, resumable)
3. Provider advisory (know roughly what to expect)

## Changes

- **Replaced** `_seed_initial_index` (one-shot `index_path`) with
  `_seed_with_progress` using `IndexEngine.index_path_stream`. Per-file
  progress dicts feed a `click.progressbar` lazily initialized on the
  first `progress` event (so we know `files_total`). Bar exit is
  handled via a small helper so KeyboardInterrupt / exception paths
  don't leak an open bar into the wizard's subsequent output.
- **`_format_size` + `_provider_seed_hint` helpers**: extracted from
  the large-case branch so the logic is tested in isolation.
- **`_maybe_seed_initial_index` now takes `state`**: needed for the
  provider advisory. Non-TTY skips both branches silently now (large
  case previously emitted a cyan hint even without a TTY — redundant
  with the Next-steps `mm index` line).
- **Cancellation**: `KeyboardInterrupt` during the async stream
  escapes `asyncio.run` as-is and is caught at the sync boundary to
  print a yellow resume hint. `mm index` is content-hash idempotent
  so resuming is safe.

## Tests

12 total in `TestInitialSeedThreshold` (was 8):

- `test_provider_seed_hint_variants` — pins all 4 known providers +
  unknown → `None` fallback.
- `test_maybe_seed_large_by_count_prompts_with_advisory` — was the
  "large skips silently" regression; now asserts prompt fires + advisory
  appears.
- `test_maybe_seed_large_by_bytes_also_prompts` — same for bytes-axis
  trigger.
- `test_maybe_seed_large_accept_invokes_seed` — large + Yes → seeder
  called.
- `test_maybe_seed_large_non_tty_silent_skip` — consistent skip semantic
  with small-case non-TTY.
- `test_seed_with_progress_keyboard_interrupt_is_graceful` — Ctrl-C →
  yellow "Cancelled. Resume with: mm index <dir>", no traceback. Primary
  "escape hatch must land cleanly" pin.
- Plus renames of existing `_seed_initial_index` references to
  `_seed_with_progress`.

## Test plan

- [x] `uv run pytest -m "not ollama"` → 2100 passed (+4 net)
- [x] `uv run ruff check` + `format --check` → clean (288 files)
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` → clean
- [x] Non-TTY large smoke (`mm init -y` + 15 `.md` files + piped stdin)
  → clean Next-steps output, no prompt leak, no "Cancelled" noise.
- [ ] CI green.
- [ ] (Reviewer) TTY smoke: run `mm init --preset english` with 15+
  `.md` files in `~/memories` and press `y` to verify the progress
  bar renders, then Ctrl-C to verify graceful cancel.

## Out of scope

- Background subprocess seeding (Option G from planning) — foreground
  streaming with Ctrl-C escape is simpler, avoids log-file /
  orphan-process / crash-notification infra. Revisit if user feedback
  says "I want wizard to exit while seeding continues".
- Threshold promotion to `config.indexing.seed_max_*` fields —
  module constants are tuned for the 90% case and can grow into
  config surface later if needed.
- `CHANGELOG.md` — user-visible but small; rolls into the next
  release's `[Unreleased]` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
