### PR TITLE
fix(storage): gate chunks_vec writes on dim=0 BM25-only installs

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -490,10 +490,6 @@ class SqliteBackend(
                         f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(new_rowids))})",
                         new_rowids,
                     )
-                else:
-                    logger.debug(
-                        "bm25-only mode (dimension=0); skipping chunks_vec write in upsert_chunks"
-                    )
 
                 db.executemany(
                     "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?,?,?)",

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -97,6 +97,11 @@ class SqliteBackend(
         self._meta: MetaManager | None = None
         self._ns: NamespaceOps | None = None
         self._in_transaction: bool = False
+        # Invariant: _has_vec_table is True iff sqlite_master contains 'chunks_vec',
+        # which holds iff self._dimension > 0. Maintained by initialize(),
+        # reset_embedding_meta(), and reset_all() — all three must update this
+        # flag in lockstep with the underlying DROP/CREATE.
+        self._has_vec_table: bool = False
 
     async def initialize(self) -> None:
         db_path = Path(self._config.sqlite_path).expanduser()
@@ -140,7 +145,7 @@ class SqliteBackend(
 
         try:
             self._meta = MetaManager(self._get_db)
-            self._ns = NamespaceOps(self._get_db)
+            self._ns = NamespaceOps(self._get_db, lambda: self._has_vec_table)
 
             self._dimension, self._dim_mismatch, self._model_mismatch = create_tables(
                 self._db,
@@ -149,6 +154,12 @@ class SqliteBackend(
                 self._embedding_provider,
                 self._embedding_model,
                 strict_dim_check=self._strict_dim_check,
+            )
+            self._has_vec_table = (
+                self._db.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunks_vec'"
+                ).fetchone()
+                is not None
             )
         except Exception:
             await self.close()
@@ -284,10 +295,14 @@ class SqliteBackend(
             self._embedding_provider = provider
         if model:
             self._embedding_model = model
-        db.execute(f"""
-            CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec
-            USING vec0(embedding float[{self._dimension}])
-        """)
+        if self._dimension > 0:
+            db.execute(f"""
+                CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec
+                USING vec0(embedding float[{self._dimension}])
+            """)
+            self._has_vec_table = True
+        else:
+            self._has_vec_table = False
         db.commit()
         self.clear_embedding_mismatch()
 
@@ -341,10 +356,14 @@ class SqliteBackend(
             # Vector virtual table — drop + recreate is safest for vec0
             db.execute("DROP TABLE IF EXISTS chunks_vec")
             db.execute("DROP TABLE IF EXISTS chunks_vec_info")
-            db.execute(f"""
-                CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec
-                USING vec0(embedding float[{self._dimension}])
-            """)
+            if self._dimension > 0:
+                db.execute(f"""
+                    CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec
+                    USING vec0(embedding float[{self._dimension}])
+                """)
+                self._has_vec_table = True
+            else:
+                self._has_vec_table = False
             deleted["chunks_vec"] = chunk_count
 
             if not self._in_transaction:
@@ -415,7 +434,7 @@ class SqliteBackend(
                     ],
                 )
                 vec_updates = [(c, rowid) for c, rowid in to_update if c.embedding]
-                if vec_updates:
+                if vec_updates and self._has_vec_table:
                     db.executemany(
                         "UPDATE chunks_vec SET embedding=? WHERE rowid=?",
                         [(serialize_f32(c.embedding), rowid) for c, rowid in vec_updates],  # type: ignore[arg-type]
@@ -466,10 +485,15 @@ class SqliteBackend(
                     f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(new_rowids))})",
                     new_rowids,
                 )
-                db.execute(
-                    f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(new_rowids))})",
-                    new_rowids,
-                )
+                if self._has_vec_table:
+                    db.execute(
+                        f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(new_rowids))})",
+                        new_rowids,
+                    )
+                else:
+                    logger.debug(
+                        "bm25-only mode (dimension=0); skipping chunks_vec write in upsert_chunks"
+                    )
 
                 db.executemany(
                     "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?,?,?)",
@@ -488,7 +512,7 @@ class SqliteBackend(
                     for c in to_insert
                     if c.embedding and str(c.id) in new_rowid_map
                 ]
-                if vec_inserts:
+                if vec_inserts and self._has_vec_table:
                     db.executemany(
                         "INSERT INTO chunks_vec(rowid, embedding) VALUES (?,?)",
                         vec_inserts,
@@ -553,9 +577,10 @@ class SqliteBackend(
             db.execute(
                 f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(rowids))})", rowids
             )
-            db.execute(
-                f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})", rowids
-            )
+            if self._has_vec_table:
+                db.execute(
+                    f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})", rowids
+                )
             if not self._in_transaction:
                 db.commit()
         except Exception as exc:
@@ -582,9 +607,10 @@ class SqliteBackend(
             db.execute(
                 f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(rowids))})", rowids
             )
-            db.execute(
-                f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})", rowids
-            )
+            if self._has_vec_table:
+                db.execute(
+                    f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})", rowids
+                )
             if not self._in_transaction:
                 db.commit()
         except Exception as exc:
@@ -650,7 +676,7 @@ class SqliteBackend(
 
     async def get_embeddings_for_chunks(self, chunk_ids: list[str]) -> dict[str, list[float]]:
         """Fetch embeddings for a list of chunk IDs. Returns {id: embedding}."""
-        if not chunk_ids:
+        if not chunk_ids or not self._has_vec_table:
             return {}
         db = self._db
         assert db is not None
@@ -730,6 +756,11 @@ class SqliteBackend(
         top_k: int = 20,
         namespace_filter: NamespaceFilter | None = None,
     ) -> list[SearchResult]:
+        # bm25-only mode (dimension=0) — no chunks_vec table to query. Return
+        # early instead of raising OperationalError that the search pipeline
+        # would log as a misleading "Dense search unavailable" warning.
+        if not self._has_vec_table:
+            return []
         db = self._get_read_db()
 
         ns_clause = ""

--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -52,8 +52,17 @@ def _ensure_valid_namespace(name: str) -> None:
 class NamespaceOps:
     """Namespace CRUD operations delegated from SqliteBackend."""
 
-    def __init__(self, get_db: Callable[[], sqlite3.Connection]) -> None:
+    def __init__(
+        self,
+        get_db: Callable[[], sqlite3.Connection],
+        has_vec_table: Callable[[], bool],
+    ) -> None:
         self._get_db = get_db
+        # Live lookup so reset_embedding_meta()'s flag flip is visible here
+        # without re-construction. Required (no default) — sole caller is
+        # SqliteBackend.initialize(); a default would silently regress the
+        # dim=0 guard if a future caller forgets it.
+        self._has_vec_table = has_vec_table
 
     async def list_namespaces(self) -> list[tuple[str, int]]:
         db = self._get_db()
@@ -98,9 +107,11 @@ class NamespaceOps:
             db.execute(
                 f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(rowids))})", rowids
             )
-            db.execute(
-                f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})", rowids
-            )
+            if self._has_vec_table():
+                db.execute(
+                    f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(rowids))})",
+                    rowids,
+                )
             db.execute("DELETE FROM namespace_metadata WHERE namespace=?", (namespace,))
             db.commit()
         except Exception as exc:

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -83,8 +83,16 @@ class TestFreshNoopIndexSubprocess:
         what real users hit.
         """
         mm_bin = os.path.join(os.path.dirname(sys.executable), "mm")
+        # Fail loudly instead of pytest.skip — any valid test environment
+        # (``uv run pytest`` or ``uv pip install -e``) must provide the
+        # ``mm`` entry point. A silent skip here would turn this subprocess
+        # regression guard into CI false-green if the editable install is
+        # ever dropped.
         if not os.path.exists(mm_bin):
-            pytest.skip(f"mm binary not installed at {mm_bin}")
+            pytest.fail(
+                f"mm binary not found at {mm_bin}. "
+                "Run `uv pip install -e packages/memtomem[all]` before testing."
+            )
 
         home = tmp_path / "home"
         home.mkdir()

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -37,10 +37,26 @@ def _make_memory_dir(home: str) -> str:
 
 class TestFreshNoopIndexInline:
     def test_init_index_search_via_cli_runner(self, tmp_path, monkeypatch):
-        """``CliRunner`` round-trip: init → index → search must all succeed."""
+        """``CliRunner`` round-trip: init → index → search must all succeed.
+
+        Two-layer isolation needed in-process:
+
+        1. ``HOME`` env override — caught by ``Path.home()`` calls that run
+           inside command functions (e.g. ``init_cmd.py`` config writer).
+        2. Patch ``_bootstrap._CONFIG_PATH`` — that module-level constant is
+           bound at import time, so ``monkeypatch.setenv`` alone leaves the
+           ``cli_components`` existence check pointing at the real home.
+           Previously masked locally by a pre-existing real ``~/.memtomem/
+           config.json`` but exposed in CI (no leaked state).
+        """
+        from memtomem.cli import _bootstrap
+
         home = tmp_path / "home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(
+            _bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json"
+        )
 
         mem_dir = _make_memory_dir(str(home))
 

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -54,9 +54,7 @@ class TestFreshNoopIndexInline:
         home = tmp_path / "home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
-        monkeypatch.setattr(
-            _bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json"
-        )
+        monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
 
         mem_dir = _make_memory_dir(str(home))
 

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -1,0 +1,125 @@
+"""End-to-end pins: fresh ``mm init --provider none`` → ``mm index`` → search.
+
+Before the fix, a fresh ``--provider none`` install did not create the
+``chunks_vec`` virtual table (NoopEmbedder dim=0), and every subsequent
+``upsert_chunks`` crashed with ``no such table: chunks_vec``. These tests
+exercise the whole user journey end-to-end so any regression of the
+unconditional write paths is caught immediately.
+
+Two variants are kept intentionally:
+
+* **inline** — ``CliRunner`` invocations share the process, so the fix
+  is observed directly without subprocess overhead.
+* **subprocess** — ``sys.executable -m memtomem`` round-trip covers the
+  process boundary (``HOME`` / ``XDG_CONFIG_HOME`` / CWD plumbing) that
+  in-process tests can't surface.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+
+def _make_memory_dir(home: str) -> str:
+    mem_dir = os.path.join(home, "memories")
+    os.makedirs(mem_dir, exist_ok=True)
+    with open(os.path.join(mem_dir, "test.md"), "w", encoding="utf-8") as f:
+        f.write("# memo\n\nhello world this is a bm25 smoke test\n")
+    return mem_dir
+
+
+class TestFreshNoopIndexInline:
+    def test_init_index_search_via_cli_runner(self, tmp_path, monkeypatch):
+        """``CliRunner`` round-trip: init → index → search must all succeed."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+
+        mem_dir = _make_memory_dir(str(home))
+
+        runner = CliRunner()
+
+        r = runner.invoke(
+            cli,
+            [
+                "init",
+                "-y",
+                "--provider",
+                "none",
+                "--memory-dir",
+                mem_dir,
+                "--mcp",
+                "skip",
+            ],
+        )
+        assert r.exit_code == 0, f"init failed: {r.output}"
+
+        r = runner.invoke(cli, ["index", mem_dir])
+        assert r.exit_code == 0, f"index failed: {r.output}"
+        # Pre-fix: "no such table: chunks_vec". Post-fix: "1 new".
+        assert "no such table" not in r.output
+        assert "1 new" in r.output or "1 file" in r.output
+
+        r = runner.invoke(cli, ["search", "hello"])
+        assert r.exit_code == 0, f"search failed: {r.output}"
+        assert "hello world" in r.output
+
+
+class TestFreshNoopIndexSubprocess:
+    def test_init_index_search_via_subprocess(self, tmp_path):
+        """Out-of-process variant: catches regressions that only manifest
+        across the HOME / XDG boundary (e.g. config.json path resolution).
+
+        Uses the ``mm`` script installed by ``uv pip install -e`` (co-located
+        with ``sys.executable``) rather than ``python -m memtomem`` — the
+        package has no ``__main__`` module, and the installed entry point is
+        what real users hit.
+        """
+        mm_bin = os.path.join(os.path.dirname(sys.executable), "mm")
+        if not os.path.exists(mm_bin):
+            pytest.skip(f"mm binary not installed at {mm_bin}")
+
+        home = tmp_path / "home"
+        home.mkdir()
+        mem_dir = _make_memory_dir(str(home))
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["XDG_CONFIG_HOME"] = str(home / ".config")
+
+        def _run(*args: str) -> subprocess.CompletedProcess:
+            return subprocess.run(
+                [mm_bin, *args],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+
+        r = _run(
+            "init",
+            "-y",
+            "--provider",
+            "none",
+            "--memory-dir",
+            mem_dir,
+            "--mcp",
+            "skip",
+        )
+        assert r.returncode == 0, f"init failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+
+        r = _run("index", mem_dir)
+        assert r.returncode == 0, f"index failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+        assert "no such table" not in (r.stdout + r.stderr)
+        assert "1 new" in r.stdout or "1 file" in r.stdout
+
+        r = _run("search", "hello")
+        assert r.returncode == 0, f"search failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+        assert "hello world" in r.stdout

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4133,6 +4133,62 @@ class TestInitialSeedThreshold:
         # Regression: must NOT print green "Seeded initial index" success line.
         assert "Seeded initial index" not in out
 
+    def test_seed_with_progress_happy_path_suppresses_zero_chunks_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Happy-path pin: when the stream reports ``indexed > 0`` (the
+        expected outcome of fresh ``--provider none`` post-fix), the yellow
+        "0 chunks were indexed" warning must NOT fire. Guards against the
+        warning condition widening over time — if someone later tightens the
+        threshold (e.g. ``indexed < 2``), this test catches it before users
+        see spurious warnings on valid BM25-only installs."""
+        from contextlib import asynccontextmanager
+
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+
+        class _FakeEngine:
+            async def index_path_stream(self, path, recursive=True, force=False):
+                yield {
+                    "type": "progress",
+                    "file": str(memory_dir / "a.md"),
+                    "files_done": 1,
+                    "files_total": 1,
+                    "indexed": 3,
+                    "skipped": 0,
+                }
+                yield {
+                    "type": "complete",
+                    "total_files": 1,
+                    "total_chunks": 3,
+                    "indexed_chunks": 3,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        assert init_cmd._seed_with_progress(memory_dir) is True
+        out = capsys.readouterr().out
+        assert "Seeded initial index" in out
+        assert "3 new chunk(s)" in out
+        # Regression: yellow warning must NOT fire on happy path.
+        assert "0 chunks were indexed" not in out
+        assert "embedding-reset" not in out
+
     def test_seed_with_progress_keyboard_interrupt_is_graceful(
         self,
         tmp_path: Path,

--- a/packages/memtomem/tests/test_storage_noop.py
+++ b/packages/memtomem/tests/test_storage_noop.py
@@ -1,0 +1,137 @@
+"""Tests for SqliteBackend operating in BM25-only mode (dimension=0).
+
+Regression coverage for the bug where fresh ``mm init --provider none``
+created a schema without ``chunks_vec`` (NoopEmbedder dim=0), and every
+subsequent ``upsert_chunks`` / ``delete_*`` crashed with
+``no such table: chunks_vec`` because the writers were unconditional.
+
+The fix gates every chunks_vec touch on ``SqliteBackend._has_vec_table``,
+which is set from a one-time ``sqlite_master`` probe in ``initialize()``
+and updated by ``reset_embedding_meta`` / ``reset_all``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from helpers import make_chunk
+from memtomem.config import StorageConfig
+from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+@pytest.fixture
+async def noop_backend(tmp_path):
+    """A SqliteBackend initialized with ``dimension=0, provider='none'``."""
+    cfg = StorageConfig(sqlite_path=tmp_path / "noop.db")
+    backend = SqliteBackend(
+        config=cfg,
+        dimension=0,
+        embedding_provider="none",
+        embedding_model="",
+    )
+    await backend.initialize()
+    yield backend
+    await backend.close()
+
+
+def _vec_table_exists(backend: SqliteBackend) -> bool:
+    db = backend._get_db()
+    return (
+        db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunks_vec'"
+        ).fetchone()
+        is not None
+    )
+
+
+class TestUpsertNoopMode:
+    @pytest.mark.asyncio
+    async def test_upsert_chunks_noop_embedder_no_vec_table(self, noop_backend):
+        """Fresh dim=0 init: chunks_vec absent, but writes + reads still work."""
+        # Sanity: the schema gate left chunks_vec unbuilt.
+        assert _vec_table_exists(noop_backend) is False
+        assert noop_backend._has_vec_table is False
+
+        chunks = [
+            make_chunk("hello world from python", embedding=[]),
+            make_chunk("another chunk about retrieval", embedding=[]),
+        ]
+        await noop_backend.upsert_chunks(chunks)
+
+        # Read paths
+        for c in chunks:
+            assert (await noop_backend.get_chunk(c.id)) is not None
+
+        # BM25 search still returns the indexed content.
+        results = await noop_backend.bm25_search("hello", top_k=5)
+        assert len(results) >= 1
+        assert any("hello world" in r.chunk.content for r in results)
+
+        # Read-path pin: get_embeddings_for_chunks early-returns {} without
+        # raising OperationalError when chunks_vec is absent.
+        embeddings = await noop_backend.get_embeddings_for_chunks([str(c.id) for c in chunks])
+        assert embeddings == {}
+
+        # Dense search read path: returns [] instead of crashing the pipeline.
+        dense = await noop_backend.dense_search([0.1, 0.2, 0.3], top_k=5)
+        assert dense == []
+
+
+class TestDeleteNoopMode:
+    @pytest.mark.asyncio
+    async def test_delete_paths_noop_mode(self, noop_backend):
+        """delete_chunks / delete_by_source / delete_by_namespace must not crash."""
+        c1 = make_chunk("first", source="a.md", namespace="ns-a", embedding=[])
+        c2 = make_chunk("second", source="b.md", namespace="ns-b", embedding=[])
+        c3 = make_chunk("third", source="b.md", namespace="ns-b", embedding=[])
+        await noop_backend.upsert_chunks([c1, c2, c3])
+
+        # delete by id
+        n = await noop_backend.delete_chunks([c1.id])
+        assert n == 1
+
+        # delete by source (removes c2 and c3)
+        n = await noop_backend.delete_by_source(Path("/tmp/b.md"))
+        assert n == 2
+
+        # delete_by_namespace on empty namespace is a no-op (returns 0)
+        # but should not raise — re-add and exercise the path.
+        c4 = make_chunk("fourth", namespace="ns-c", embedding=[])
+        await noop_backend.upsert_chunks([c4])
+        n = await noop_backend.delete_by_namespace("ns-c")
+        assert n == 1
+
+
+class TestResetFromNoopToReal:
+    @pytest.mark.asyncio
+    async def test_reset_embedding_meta_creates_vec_table_and_preserves_fts(self, noop_backend):
+        """Recovery path: dim=0 → real provider must build chunks_vec, keep FTS,
+        and live-flip the NamespaceOps callable."""
+        # Seed BM25-only data
+        c1 = make_chunk("alpha keyword unique", namespace="reset-ns", embedding=[])
+        c2 = make_chunk("beta keyword unique", namespace="reset-ns", embedding=[])
+        await noop_backend.upsert_chunks([c1, c2])
+        assert noop_backend._has_vec_table is False
+
+        # Reset to a real provider with non-zero dim
+        await noop_backend.reset_embedding_meta(dimension=8, provider="onnx", model="test-model")
+
+        # chunks_vec now exists, flag flipped True
+        assert _vec_table_exists(noop_backend) is True
+        assert noop_backend._has_vec_table is True
+
+        # FTS entries from before the reset still searchable
+        results = await noop_backend.bm25_search("alpha", top_k=5)
+        assert any("alpha keyword unique" in r.chunk.content for r in results)
+
+        # New chunks with real embeddings upsert without error
+        c3 = make_chunk("gamma keyword unique", embedding=[0.1] * 8)
+        await noop_backend.upsert_chunks([c3])
+        assert (await noop_backend.get_chunk(c3.id)) is not None
+
+        # NamespaceOps callable picks up the live flag flip — delete_by_namespace
+        # actually clears chunks_vec rows for the namespace post-reset.
+        deleted = await noop_backend.delete_by_namespace("reset-ns")
+        assert deleted == 2

--- a/packages/memtomem/tests/test_storage_noop.py
+++ b/packages/memtomem/tests/test_storage_noop.py
@@ -96,12 +96,14 @@ class TestDeleteNoopMode:
         n = await noop_backend.delete_by_source(Path("/tmp/b.md"))
         assert n == 2
 
-        # delete_by_namespace on empty namespace is a no-op (returns 0)
-        # but should not raise — re-add and exercise the path.
+        # delete_by_namespace: exercise both populated and empty-namespace paths.
         c4 = make_chunk("fourth", namespace="ns-c", embedding=[])
         await noop_backend.upsert_chunks([c4])
         n = await noop_backend.delete_by_namespace("ns-c")
         assert n == 1
+        # No-op path: namespace with no rows must return 0 without raising.
+        n = await noop_backend.delete_by_namespace("nonexistent-ns")
+        assert n == 0
 
 
 class TestResetFromNoopToReal:


### PR DESCRIPTION
## Summary

Fresh `mm init --provider none` uses NoopEmbedder (dim=0). The schema gate at `sqlite_schema.py:202-206` correctly skips the `chunks_vec` virtual table when dim=0, but the writer never learned about this — `upsert_chunks`, `delete_chunks`, `delete_by_source`, and `delete_by_namespace` all issue unconditional SQL against `chunks_vec`. Every `mm index` call rolled back with `no such table: chunks_vec`, indexed 0 chunks, and left BM25 search empty because the FTS write shared the same rolled-back transaction. PR #376 added a wizard-only yellow warning; bare `mm index` / MCP `mem_index` stayed broken.

This PR gates every chunks_vec touch on `SqliteBackend._has_vec_table`, a cached boolean primed from a one-time `sqlite_master` probe at `initialize()` and refreshed by `reset_embedding_meta` / `reset_all` whenever the underlying DROP/CREATE runs. `NamespaceOps` receives the flag as a **required** live callable (no default) so recovery transitions dim=0 → real provider flip cleanly without reconstruction.

Repro (pre-fix):
```bash
rm -rf /tmp/mm-bug-home && mkdir -p /tmp/mm-bug-home/memories
echo "hello world" > /tmp/mm-bug-home/memories/test.md
HOME=/tmp/mm-bug-home uv run mm init -y --provider none \
  --memory-dir /tmp/mm-bug-home/memories --mcp skip
HOME=/tmp/mm-bug-home uv run mm index /tmp/mm-bug-home/memories
# upsert_chunks failed, transaction rolled back: no such table: chunks_vec
```

Post-fix:
```
Indexed 1 file(s): 1 new, 0 unchanged, 0 deleted (1ms)
```

## Why this approach (Option B, not A or C)

- **A — schema creates a `float[1]` stub vtable at dim=0.** The legacy DB sniff at `sqlite_schema.py:127-143` reads `float[N]` from the existing chunks_vec SQL and caches it as `stored_dimension=1`. On any later provider switch, the fail-fast gate at line 184 fires `EmbeddingDimensionMismatchError` with a misleading remediation hint. Schema would lie about the real state. Rejected.
- **B — gate the writer (this PR).** Schema stays honest. One cached boolean + 7 one-line guards. Existing dim=0 DBs need no migration.
- **C — add a `bm25_only` config flag.** `enable_dense=False` already exists in `search/pipeline.py`. A new flag would duplicate surface and require reading from 3 layers. Rejected.

## Exhaustiveness verification

`rg -n "chunks_vec" packages/memtomem/src packages/memtomem/tests` — the 8 references outside `storage/` are all comments / docstrings / error-message strings (no SQL):

- `errors.py:18,20` — `EmbeddingDimensionMismatchError` docstring
- `server/context.py:41`, `server/lifespan.py:109,139`, `server/component_factory.py:40` — mismatch-handling comments
- `cli/init_cmd.py:958, 1407, 1409` — wizard zero-chunks defense comments
- `server/tools/memory_crud.py:77` — crash-risk comment

Storage layer is the complete write surface. `NamespaceOps` has a single caller at `sqlite_backend.py:148` — internal API, making the required-parameter constructor safe.

## PR-level notes (design decisions preserved from plan)

1. **`chunks_vec_info` explicit DROP** in reset paths is existing defensive behavior. sqlite-vec's `vec0` typically cascades shadow tables (`_chunks`, `_rowids`, `_info`, …) on virtual-table DROP. Left unchanged per "one change per PR"; if truly redundant, a separate cleanup PR can evaluate.
2. **Single-writer invariant** — `SqliteBackend` has no explicit writer lock; serialization relies on a single `self._db` connection. `_has_vec_table` mutation sits on top of this pre-existing assumption and does not alter it.
3. **Atomicity** — `reset_embedding_meta` / `reset_all` DROP+CREATE are not wrapped in an explicit `BEGIN`/`COMMIT` (existing semantics). If CREATE fails after DROP commits, the flag stays at its old value and every chunks_vec write short-circuits safely; next startup re-probes `sqlite_master` and self-heals.

## Test plan

- [x] `test_storage_noop.py` — 3 unit tests:
  - `test_upsert_chunks_noop_embedder_no_vec_table` — fresh dim=0 schema has no chunks_vec, upsert + BM25 search + `get_chunk` + `get_embeddings_for_chunks(...)=={}` + `dense_search(...)=[]`
  - `test_delete_paths_noop_mode` — `delete_chunks` + `delete_by_source` + `delete_by_namespace` all succeed without `OperationalError`
  - `test_reset_embedding_meta_creates_vec_table_and_preserves_fts` — dim=0 → real provider reset: chunks_vec appears, FTS entries survive, `NamespaceOps` callable picks up the live flag flip
- [x] `test_cli_index_noop_e2e.py` — inline (`CliRunner`) + subprocess (`mm` binary via `sys.executable` bindir) variants of `init → index → search`
- [x] `test_init_cmd.py::test_seed_with_progress_happy_path_suppresses_zero_chunks_warning` — happy-path pin that the yellow "0 chunks were indexed" warning does NOT fire when `indexed > 0`
- [x] Manual repro: pre-fix crashes with "no such table", post-fix "1 new"; `mm embedding-reset` recovery confirmed (flag flips True after dim=0→1024)
- [x] Full suite: `uv run pytest -m "not ollama"` → 2108 passed, 0 regressions
- [x] `uv run ruff check` + `uv run ruff format --check` pass
- [x] `uv run mypy` on changed files: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
