### PR TITLE
feat(cli): add mm uninstall for state cleanup separate from binary removal

### DIFF
--- a/docs/guides/uninstall.md
+++ b/docs/guides/uninstall.md
@@ -1,5 +1,38 @@
 # Uninstalling memtomem
 
+## Recommended: `mm uninstall`
+
+Since v0.1.23 the CLI ships an `uninstall` subcommand that handles the
+state cleanup (steps 3 below) and prints the package-manager command for
+your detected install context. It detects `~/.memtomem/`, custom
+`storage.sqlite_path` outside the default dir, and config.d fragments,
+then deletes them in a low→high-value order with confirmation. It does
+NOT touch external editor configs (step 1) — those are reported and left
+for you to clean manually.
+
+```bash
+mm uninstall                  # interactive, removes everything
+mm uninstall -y               # skip the confirmation prompt
+mm uninstall --keep-config    # preserve config.json + config.d/* + backups
+mm uninstall --keep-data      # preserve the SQLite DB + ~/.memtomem/memories/
+mm uninstall --force          # bypass the running-server safety check
+```
+
+The command refuses to run while the MCP server is still alive (open WAL
+handles risk corruption); stop the server first or pass `--force`.
+
+After `mm uninstall` finishes, follow the binary-removal command it prints
+(varies by install context — `uv tool uninstall memtomem`, `pip
+uninstall memtomem`, etc.). Then continue with step 1 below to clean up
+editor MCP entries.
+
+If you don't have the CLI available (e.g. the wheel is broken or you
+never installed it), follow the manual steps below.
+
+---
+
+## Manual cleanup
+
 ## 1. Remove the MCP server from your editor
 
 Remove the `"memtomem"` entry from the `mcpServers` block in your editor's

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -41,6 +41,7 @@ def _register() -> None:
     from memtomem.cli.init_cmd import init
     from memtomem.cli.session_cmd import activity, session
     from memtomem.cli.shell import shell
+    from memtomem.cli.uninstall_cmd import uninstall
     from memtomem.cli.watchdog_cmd import watchdog
     from memtomem.cli.web import web
 
@@ -61,6 +62,7 @@ def _register() -> None:
     cli.add_command(web)
     cli.add_command(shell)
     cli.add_command(agent)
+    cli.add_command(uninstall)
 
 
 _register()

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -1,0 +1,547 @@
+"""CLI: ``mm uninstall`` — wipe local user state separate from the binary.
+
+Removes files under ``~/.memtomem/`` (db, config, fragments, memories, etc.)
+and tells the user the exact package-manager command to remove the binary
+itself for their detected install context. Does NOT touch external editor
+configs (claude.json etc.) — only detects them and reports the paths the
+user must clean up manually.
+
+Design notes:
+
+* State vs binary are separated on purpose. Different install contexts
+  (uv-tool / uvx / venv-relative / system / unknown) need different
+  uninstall commands; we print the right one but never execute, since the
+  package manager owns its own permissions and lifecycle.
+* If the MCP server is still running we refuse — deleting an open SQLite
+  file under WAL mode risks corruption. ``--force`` overrides for the
+  rare case the user knows the pid is wrong.
+* If config.json is corrupted we fall back to defaults rather than
+  aborting — uninstall is itself a recovery path, so it cannot depend on
+  a valid config.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import click
+
+from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
+
+_DEFAULT_STATE_DIR = Path.home() / ".memtomem"
+_DEFAULT_DB_NAME = "memtomem.db"
+_DB_SIBLING_SUFFIXES = ("", "-wal", "-shm", "-journal")
+# Subdirectories under the state dir that we own and should rmdir after
+# their contents are wiped (otherwise the state dir's empty-prune check
+# at the end fails and we leave behind dead skeleton dirs).
+_OWNED_SUBDIRS = ("config.d", "memories", "uploads")
+
+
+def _isatty() -> bool:
+    """Indirection so tests can monkeypatch the TTY check.
+
+    ``CliRunner`` substitutes its own ``sys.stdin`` (a ``StringIO``) whose
+    ``isatty()`` returns ``False``, so a direct call inside the command
+    can't be flipped from the test side without this seam.
+    """
+    return sys.stdin.isatty()
+
+
+@dataclass(frozen=True)
+class _Group:
+    """One row in the printed inventory."""
+
+    label: str
+    paths: list[Path]
+    bytes_total: int
+
+
+@dataclass(frozen=True)
+class _Inventory:
+    """All deletable groups + the resolved state dir, in display order."""
+
+    state_dir: Path
+    db_path: Path
+    db_files: _Group
+    config_files: _Group
+    fragment_files: _Group
+    backup_files: _Group
+    memory_files: _Group
+    upload_files: _Group
+    other_files: _Group  # session, pid — always wiped unless --keep-config (no, see flag table)
+
+
+@dataclass(frozen=True)
+class _ServerState:
+    alive: bool
+    pid: int | None
+    pid_file: Path | None
+
+
+@dataclass(frozen=True)
+class _External:
+    path: Path
+    reason: str
+
+
+# ---- safe config load ----------------------------------------------------
+
+
+def _load_config_safely() -> tuple[Path, str | None]:
+    """Return ``(db_path, error_or_none)``.
+
+    On any failure (malformed JSON, missing fields, permission error)
+    falls back to the default DB path and returns the error message so
+    the caller can surface it as a yellow warning. Uninstall is a
+    recovery scenario — it must work when config is broken.
+    """
+    try:
+        from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+
+        cfg = Mem2MemConfig()
+        load_config_d(cfg, quiet=True)
+        load_config_overrides(cfg)
+        db_path = Path(cfg.storage.sqlite_path).expanduser()
+        return db_path, None
+    except Exception as exc:  # noqa: BLE001 — uninstall must never abort on config
+        return _DEFAULT_STATE_DIR / _DEFAULT_DB_NAME, f"{type(exc).__name__}: {exc}"
+
+
+# ---- server liveness probe -----------------------------------------------
+
+
+def _check_server_liveness(state_dir: Path) -> _ServerState:
+    """Probe ``state_dir/.server.pid`` via ``os.kill(pid, 0)``.
+
+    ``os.kill(pid, 0)`` is a no-op signal that raises ``ProcessLookupError``
+    if the pid is dead and ``PermissionError`` if it's alive but owned by
+    another user (we treat that as alive — refuse and let the user decide).
+    """
+    pid_file = state_dir / ".server.pid"
+    if not pid_file.exists():
+        return _ServerState(alive=False, pid=None, pid_file=None)
+    try:
+        pid_text = pid_file.read_text().strip()
+        pid = int(pid_text)
+    except (OSError, ValueError):
+        # Unreadable / non-int → treat as dead so we can clean it up.
+        return _ServerState(alive=False, pid=None, pid_file=pid_file)
+    try:
+        os.kill(pid, 0)
+        return _ServerState(alive=True, pid=pid, pid_file=pid_file)
+    except ProcessLookupError:
+        return _ServerState(alive=False, pid=pid, pid_file=pid_file)
+    except PermissionError:
+        return _ServerState(alive=True, pid=pid, pid_file=pid_file)
+    except OSError:
+        # Conservative — unknown error treated as alive.
+        return _ServerState(alive=True, pid=pid, pid_file=pid_file)
+
+
+# ---- inventory -----------------------------------------------------------
+
+
+def _file_size(path: Path) -> int:
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _dir_total(path: Path) -> tuple[list[Path], int]:
+    if not path.is_dir():
+        return [], 0
+    files = sorted(p for p in path.rglob("*") if p.is_file())
+    return files, sum(_file_size(p) for p in files)
+
+
+def _make_group(label: str, paths: Iterable[Path]) -> _Group:
+    paths_list = sorted(paths)
+    return _Group(label=label, paths=paths_list, bytes_total=sum(_file_size(p) for p in paths_list))
+
+
+def _collect_inventory(db_path: Path) -> _Inventory:
+    state_dir = _DEFAULT_STATE_DIR
+
+    # Database + WAL/SHM/journal siblings (handles custom storage path).
+    db_paths: list[Path] = []
+    for suffix in _DB_SIBLING_SUFFIXES:
+        candidate = db_path.with_name(db_path.name + suffix) if suffix else db_path
+        if candidate.exists():
+            db_paths.append(candidate)
+
+    config_json = state_dir / "config.json"
+    config_files = [config_json] if config_json.exists() else []
+
+    fragment_dir = state_dir / "config.d"
+    fragments, _ = _dir_total(fragment_dir)
+
+    backups = sorted(state_dir.glob("config.json.bak-*")) if state_dir.exists() else []
+
+    memory_dir = state_dir / "memories"
+    memories, _ = _dir_total(memory_dir)
+
+    upload_dir = state_dir / "uploads"
+    uploads, _ = _dir_total(upload_dir)
+
+    other: list[Path] = []
+    for name in (".current_session", ".server.pid"):
+        candidate = state_dir / name
+        if candidate.exists():
+            other.append(candidate)
+
+    return _Inventory(
+        state_dir=state_dir,
+        db_path=db_path,
+        db_files=_make_group("Database", db_paths),
+        config_files=_make_group("Config", config_files),
+        fragment_files=_make_group("Fragments", fragments),
+        backup_files=_make_group("Backups", backups),
+        memory_files=_make_group("Memories", memories),
+        upload_files=_make_group("Uploads", uploads),
+        other_files=_make_group("Other", other),
+    )
+
+
+# ---- external integrations ----------------------------------------------
+
+
+def _probe_external_integrations() -> list[_External]:
+    home = Path.home()
+    candidates: list[Path] = [
+        home / ".claude.json",
+        home / ".codex" / "config.toml",
+        home / ".cursor" / "mcp.json",
+        home / ".codeium" / "windsurf" / "mcp_config.json",
+        home / ".gemini" / "settings.json",
+        home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json",
+    ]
+    cwd_local = Path.cwd() / ".mcp.json"
+    if cwd_local.exists():
+        candidates.append(cwd_local)
+
+    found: list[_External] = []
+    for path in candidates:
+        if not path.exists():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Substring detection — first-cut, false-positive-tolerant since
+        # this is detect-and-report. LOW 7 in the plan upgrades to a
+        # parsed mcpServers.memtomem key check in a follow-up.
+        if "memtomem" in text:
+            found.append(_External(path=path, reason="contains memtomem MCP entry"))
+    return found
+
+
+# ---- binary uninstall hint ----------------------------------------------
+
+
+def _binary_uninstall_hint(profile: RuntimeProfile) -> tuple[str, list[str]]:
+    """Return ``(label, command_lines)`` for the detected install context."""
+    origin = profile.mm_binary_origin
+    if origin == "uv-tool":
+        return "uv-tool (global)", ["uv tool uninstall memtomem"]
+    if origin == "uvx":
+        return (
+            "uvx (ephemeral — auto-cleaned on process exit)",
+            ["No binary uninstall needed for the uvx caller."],
+        )
+    if origin == "venv-relative":
+        venv_str = (
+            str(profile.workspace_venv_path) if profile.workspace_venv_path else "<workspace>/.venv"
+        )
+        return (
+            f"workspace venv ({venv_str})",
+            [
+                "uv pip uninstall memtomem",
+                f"  # or: rm -rf {venv_str}",
+            ],
+        )
+    if origin == "system":
+        return (
+            f"system Python ({profile.runtime_interpreter})",
+            [
+                "pip uninstall memtomem",
+                "  # or: pipx uninstall memtomem",
+                "  # (sudo may be required if the interpreter is system-owned)",
+            ],
+        )
+    # unknown
+    return (
+        "unknown — could not classify install context",
+        [
+            "Check `which mm` and use the matching uninstall command:",
+            "  uv tool uninstall memtomem      # if uv tool",
+            "  pipx uninstall memtomem         # if pipx",
+            "  pip uninstall memtomem          # if pip into a venv",
+        ],
+    )
+
+
+# ---- printing -----------------------------------------------------------
+
+
+def _human_size(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024 or unit == "GB":
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} {unit}"
+        n /= 1024  # type: ignore[assignment]
+    return f"{n} GB"
+
+
+def _format_path(p: Path) -> str:
+    home = str(Path.home())
+    s = str(p)
+    return s.replace(home, "~", 1) if s.startswith(home) else s
+
+
+def _print_group(group: _Group) -> None:
+    if not group.paths:
+        return
+    if len(group.paths) <= 3:
+        for path in group.paths:
+            click.echo(
+                f"  {group.label:<11}  {_format_path(path):<54}  {_human_size(_file_size(path))}"
+            )
+    else:
+        click.echo(
+            f"  {group.label:<11}  {_format_path(group.paths[0].parent) + '/'}"
+            f" ({len(group.paths)} files)  {_human_size(group.bytes_total)}"
+        )
+
+
+def _print_inventory(inv: _Inventory, *, keep_config: bool, keep_data: bool) -> int:
+    """Print inventory grouped + return total bytes that will be deleted."""
+    click.echo("memtomem state inventory:")
+    if inv.db_path.parent != _DEFAULT_STATE_DIR:
+        click.echo(f"  (custom storage path: {_format_path(inv.db_path.parent)})")
+
+    will_delete_total = 0
+
+    def emit(group: _Group, will_delete: bool) -> None:
+        nonlocal will_delete_total
+        if not group.paths:
+            return
+        _print_group(group)
+        if will_delete:
+            will_delete_total += group.bytes_total
+
+    emit(inv.db_files, not keep_data)
+    emit(inv.config_files, not keep_config)
+    emit(inv.fragment_files, not keep_config)
+    emit(inv.backup_files, not keep_config)
+    emit(inv.memory_files, not keep_data)
+    emit(inv.upload_files, True)
+    emit(inv.other_files, True)
+
+    has_any = any(
+        g.paths
+        for g in (
+            inv.db_files,
+            inv.config_files,
+            inv.fragment_files,
+            inv.backup_files,
+            inv.memory_files,
+            inv.upload_files,
+            inv.other_files,
+        )
+    )
+    if not has_any:
+        click.echo("  (nothing found)")
+    else:
+        click.echo(f"\nTotal to delete: ~{_human_size(will_delete_total)}")
+    return will_delete_total
+
+
+def _print_externals(externals: list[_External]) -> None:
+    if not externals:
+        return
+    click.echo("\nExternal integrations (NOT touched — clean up manually if desired):")
+    for ext in externals:
+        click.echo(f"  {_format_path(ext.path):<54} {ext.reason}")
+
+
+def _print_binary_hint(label: str, lines: list[str]) -> None:
+    click.echo(f"\nBinary install detected: {label}")
+    click.echo("After this completes, also run:")
+    for line in lines:
+        click.echo(f"  {line}")
+
+
+# ---- ordered deletion ----------------------------------------------------
+
+
+class _UninstallPartialError(Exception):
+    """Raised when deletion fails mid-flight, after some groups succeeded."""
+
+    def __init__(self, last_completed: str, failing_path: Path, original: BaseException) -> None:
+        super().__init__(f"failed at {failing_path} after completing: {last_completed}")
+        self.last_completed = last_completed
+        self.failing_path = failing_path
+        self.original = original
+
+
+def _delete_paths(paths: list[Path]) -> None:
+    for path in paths:
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink(missing_ok=True)
+
+
+def _delete_inventory(inv: _Inventory, *, keep_config: bool, keep_data: bool) -> str:
+    """Delete in low→high value order. Returns a summary of what was removed.
+
+    Order: pid/session → fragments → backups → config → memories → uploads
+    → DB+WAL/SHM/journal. Each group is logged before moving on so partial
+    failures leave a recoverable trail.
+    """
+    completed: list[str] = []
+
+    def step(group_label: str, paths: list[Path]) -> None:
+        if not paths:
+            return
+        try:
+            _delete_paths(paths)
+        except (OSError, PermissionError) as exc:
+            failing = paths[0] if len(paths) == 1 else _DEFAULT_STATE_DIR
+            raise _UninstallPartialError(
+                last_completed=", ".join(completed) or "nothing yet",
+                failing_path=failing,
+                original=exc,
+            ) from exc
+        completed.append(group_label)
+
+    # transient first (always wiped — pid/session are runtime ephemera)
+    step("session/pid", inv.other_files.paths)
+    # config surface — fragments and backups are config too, so --keep-config
+    # preserves them along with config.json (matches the flag table in the plan)
+    if not keep_config:
+        step("fragments", inv.fragment_files.paths)
+        step("backups", inv.backup_files.paths)
+        step("config.json", inv.config_files.paths)
+    # data
+    if not keep_data:
+        step("memories", inv.memory_files.paths)
+    step("uploads", inv.upload_files.paths)
+    if not keep_data:
+        step("database", inv.db_files.paths)
+
+    # Prune now-empty subdirs we own (config.d, memories, uploads). _delete_paths
+    # only removes individual files within these, so we have to remove the
+    # skeleton dirs ourselves before the state-dir prune below can succeed.
+    for subdir in _OWNED_SUBDIRS:
+        candidate = _DEFAULT_STATE_DIR / subdir
+        if candidate.exists() and candidate.is_dir() and not any(candidate.iterdir()):
+            try:
+                candidate.rmdir()
+            except OSError:
+                pass
+
+    # If state dir is now empty (no custom storage outside it), prune it.
+    if (
+        _DEFAULT_STATE_DIR.exists()
+        and not any(_DEFAULT_STATE_DIR.iterdir())
+        and inv.db_path.parent == _DEFAULT_STATE_DIR
+    ):
+        try:
+            _DEFAULT_STATE_DIR.rmdir()
+            completed.append("state dir")
+        except OSError:
+            pass
+
+    return ", ".join(completed) if completed else "nothing"
+
+
+# ---- click command ------------------------------------------------------
+
+
+@click.command("uninstall")
+@click.option("--keep-config", is_flag=True, help="Preserve config.json + config.d/* + backups.")
+@click.option("--keep-data", is_flag=True, help="Preserve the SQLite DB and ~/.memtomem/memories/.")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Bypass the running-server safety check (use only if you know the pid is stale).",
+)
+@click.option("-y", "--yes", is_flag=True, help="Skip the confirmation prompt.")
+def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> None:
+    """Remove memtomem user state. The binary itself stays — use your package
+    manager to uninstall it (the command is printed at the end for your
+    install context).
+    """
+    profile = _runtime_profile()
+    db_path, config_error = _load_config_safely()
+    state_dir = _DEFAULT_STATE_DIR
+
+    server = _check_server_liveness(state_dir)
+
+    # Empty-state fast path.
+    if not state_dir.exists() and not db_path.exists():
+        click.echo("No memtomem state to remove (~/.memtomem/ does not exist).")
+        label, lines = _binary_uninstall_hint(profile)
+        _print_binary_hint(label, lines)
+        return
+
+    if config_error is not None:
+        click.secho(f"  Warning: config unreadable, using defaults: {config_error}", fg="yellow")
+
+    inv = _collect_inventory(db_path)
+    externals = _probe_external_integrations()
+
+    will_delete_bytes = _print_inventory(inv, keep_config=keep_config, keep_data=keep_data)
+    _print_externals(externals)
+    label, lines = _binary_uninstall_hint(profile)
+    _print_binary_hint(label, lines)
+
+    if server.alive and not force:
+        click.echo("")
+        click.secho(
+            f"Server still running (pid {server.pid}). Refusing to delete state — "
+            "an active server holds the SQLite WAL and deleting it risks corruption.",
+            fg="red",
+        )
+        click.secho("  Stop the server first, or pass --force to override.", fg="red")
+        sys.exit(2)
+
+    if will_delete_bytes == 0 and not inv.other_files.paths:
+        click.echo("\nNothing to delete with the current flags.")
+        return
+
+    # Confirmation. Non-TTY without -y → Abort (mirrors
+    # feedback_click_prompt_needs_isatty_gate.md).
+    if not yes:
+        if not _isatty():
+            click.secho(
+                "Refusing to delete without confirmation in a non-interactive shell. "
+                "Pass -y to proceed.",
+                fg="red",
+            )
+            raise click.Abort()
+        if not click.confirm("\nProceed with state deletion?", default=False):
+            click.echo("Cancelled — no files were touched.")
+            sys.exit(1)
+
+    try:
+        summary = _delete_inventory(inv, keep_config=keep_config, keep_data=keep_data)
+    except _UninstallPartialError as exc:
+        click.secho(
+            f"\nDeletion failed at {_format_path(exc.failing_path)}: {exc.original}",
+            fg="red",
+        )
+        click.secho(
+            f"  Successfully removed up to: {exc.last_completed}",
+            fg="yellow",
+        )
+        sys.exit(2)
+
+    click.secho(f"\nRemoved: {summary}.", fg="green")
+    click.echo("Run the binary uninstall command above to complete removal.")

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -1,0 +1,379 @@
+"""Tests for ``mm uninstall`` — local state cleanup CLI.
+
+Coverage spans the install-context inventory, flag combinations, server
+liveness refusal, partial-deletion error path, and the ``RuntimeProfile``
+private-import pin so any rename/move in ``cli.init_cmd`` breaks here
+loud and immediate (MEDIUM 6 mitigation).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+
+# ---------------------------------------------------------------- fixtures
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Tmp HOME with both env override and _bootstrap._CONFIG_PATH patched.
+
+    Mirrors the isolation pattern from ``test_cli_index_noop_e2e.py``: the
+    module-level ``_bootstrap._CONFIG_PATH = Path.home() / ...`` is bound
+    at import time, so ``monkeypatch.setenv("HOME")`` alone leaves it
+    pointing at the developer's real home. Patching it directly is
+    required for hermetic tests.
+    """
+    from memtomem.cli import _bootstrap
+    from memtomem.cli import uninstall_cmd
+
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setenv("HOME", str(h))
+    monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", h / ".memtomem" / "config.json")
+    monkeypatch.setattr(uninstall_cmd, "_DEFAULT_STATE_DIR", h / ".memtomem")
+    return h
+
+
+def _seed_state(home: Path, *, with_db: bool = True, with_fragments: bool = True) -> Path:
+    """Populate ~/.memtomem/ with realistic state for inventory tests."""
+    state = home / ".memtomem"
+    state.mkdir(parents=True, exist_ok=True)
+
+    (state / "config.json").write_text('{"embedding": {"provider": "none"}}', encoding="utf-8")
+    (state / "config.json.bak-2026-04-22T00-00-00").write_text("{}", encoding="utf-8")
+    if with_fragments:
+        (state / "config.d").mkdir()
+        (state / "config.d" / "claude.json").write_text("{}", encoding="utf-8")
+    if with_db:
+        (state / "memtomem.db").write_bytes(b"sqlite-fake")
+        (state / "memtomem.db-wal").write_bytes(b"wal")
+        (state / "memtomem.db-shm").write_bytes(b"shm")
+    (state / "memories").mkdir()
+    (state / "memories" / "x.md").write_text("# hello", encoding="utf-8")
+    (state / ".current_session").write_text("sess-id", encoding="utf-8")
+    return state
+
+
+# -------------------------------------------------------------------- 1
+
+
+class TestEmptyState:
+    def test_no_state_directory_exits_cleanly(self, home):
+        result = CliRunner().invoke(cli, ["uninstall"])
+        assert result.exit_code == 0, result.output
+        assert "No memtomem state to remove" in result.output
+        assert "Binary install detected" in result.output
+
+
+# -------------------------------------------------------------------- 2
+
+
+class TestDefaultDeletion:
+    def test_default_removes_everything(self, home):
+        state = _seed_state(home)
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "Removed:" in result.output
+        assert not state.exists(), f"state dir should be pruned, found: {list(state.iterdir())}"
+
+
+# -------------------------------------------------------------------- 3
+
+
+class TestKeepConfig:
+    def test_keep_config_preserves_config_surface(self, home):
+        state = _seed_state(home)
+        result = CliRunner().invoke(cli, ["uninstall", "-y", "--keep-config"])
+        assert result.exit_code == 0, result.output
+        assert (state / "config.json").exists()
+        assert (state / "config.d" / "claude.json").exists()
+        assert (state / "config.json.bak-2026-04-22T00-00-00").exists()
+        # data side wiped
+        assert not (state / "memtomem.db").exists()
+        assert not (state / "memories" / "x.md").exists()
+
+
+# -------------------------------------------------------------------- 4
+
+
+class TestKeepData:
+    def test_keep_data_preserves_db_and_memories(self, home):
+        state = _seed_state(home)
+        result = CliRunner().invoke(cli, ["uninstall", "-y", "--keep-data"])
+        assert result.exit_code == 0, result.output
+        assert (state / "memtomem.db").exists()
+        assert (state / "memtomem.db-wal").exists()
+        assert (state / "memories" / "x.md").exists()
+        # config side wiped
+        assert not (state / "config.json").exists()
+        assert not (state / "config.d").exists()
+
+
+# -------------------------------------------------------------------- 5
+
+
+class TestCustomStoragePath:
+    def test_custom_storage_path_in_inventory_and_deleted(self, home, tmp_path, monkeypatch):
+        """``storage.sqlite_path`` outside ~/.memtomem/ should still be cleaned."""
+        custom_dir = tmp_path / "elsewhere"
+        custom_dir.mkdir()
+        custom_db = custom_dir / "foo.db"
+        custom_db.write_bytes(b"sqlite-fake")
+        (custom_dir / "foo.db-wal").write_bytes(b"wal")
+        (custom_dir / "unrelated.txt").write_text("user file", encoding="utf-8")
+
+        # Seed config that points to the custom path
+        state = home / ".memtomem"
+        state.mkdir()
+        (state / "config.json").write_text(
+            json.dumps({"storage": {"sqlite_path": str(custom_db)}}), encoding="utf-8"
+        )
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "custom storage path" in result.output
+        # custom DB siblings deleted
+        assert not custom_db.exists()
+        assert not (custom_dir / "foo.db-wal").exists()
+        # unrelated sibling left alone
+        assert (custom_dir / "unrelated.txt").exists(), "non-DB siblings must NOT be deleted"
+
+
+# -------------------------------------------------------------------- 6
+
+
+class TestUserMemoryDirsUntouched:
+    def test_user_managed_memory_dirs_never_deleted(self, home, tmp_path):
+        user_notes = tmp_path / "Documents" / "notes"
+        user_notes.mkdir(parents=True)
+        (user_notes / "important.md").write_text("# user data", encoding="utf-8")
+
+        state = home / ".memtomem"
+        state.mkdir()
+        (state / "config.json").write_text(
+            json.dumps({"indexing": {"memory_dirs": [str(user_notes)]}}), encoding="utf-8"
+        )
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert (user_notes / "important.md").exists(), (
+            "user-managed memory_dirs MUST stay — only ~/.memtomem/memories/ is in scope"
+        )
+
+
+# -------------------------------------------------------------------- 7
+
+
+class TestExternalsDetectedNotModified:
+    def test_external_mcp_files_detected_but_unmodified(self, home):
+        claude_json = home / ".claude.json"
+        original_text = json.dumps({"mcpServers": {"memtomem": {"command": "mm-server"}}})
+        claude_json.write_text(original_text, encoding="utf-8")
+
+        # state dir so we don't hit the empty-state fast path
+        state = home / ".memtomem"
+        state.mkdir()
+        (state / "config.json").write_text("{}", encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" in result.output
+        assert ".claude.json" in result.output
+        # external file untouched
+        assert claude_json.exists()
+        assert claude_json.read_text(encoding="utf-8") == original_text
+
+
+# -------------------------------------------------------------------- 8
+
+
+class TestBinaryHintPerOrigin:
+    @pytest.mark.parametrize(
+        "origin,expected_substring",
+        [
+            ("uv-tool", "uv tool uninstall memtomem"),
+            ("uvx", "ephemeral"),
+            ("venv-relative", "uv pip uninstall memtomem"),
+            ("system", "pip uninstall memtomem"),
+            ("unknown", "which mm"),
+        ],
+    )
+    def test_hint_text_per_origin(self, home, monkeypatch, origin, expected_substring):
+        from memtomem.cli import init_cmd
+        from memtomem.cli import uninstall_cmd
+
+        fake_profile = init_cmd.RuntimeProfile(
+            cwd_install_type="pypi",
+            cwd_install_dir=None,
+            runtime_interpreter=Path("/usr/bin/python3"),
+            workspace_venv_path=Path("/tmp/foo/.venv") if origin == "venv-relative" else None,
+            mm_binary_origin=origin,
+            runtime_matches_workspace=(origin == "venv-relative"),
+        )
+        monkeypatch.setattr(uninstall_cmd, "_runtime_profile", lambda: fake_profile)
+
+        result = CliRunner().invoke(cli, ["uninstall"])
+        assert result.exit_code == 0, result.output
+        assert expected_substring in result.output
+
+
+# -------------------------------------------------------------------- 9
+
+
+class TestNonTtyAbort:
+    def test_non_tty_without_yes_aborts(self, home):
+        _seed_state(home)
+        # CliRunner's default input is a non-TTY StringIO → isatty() is False.
+        result = CliRunner().invoke(cli, ["uninstall"], input="")
+        assert result.exit_code != 0
+        assert "non-interactive shell" in result.output
+        # state should be untouched
+        assert (home / ".memtomem" / "memtomem.db").exists()
+
+
+# -------------------------------------------------------------------- 10
+
+
+class TestInteractiveCancellation:
+    def test_interactive_no_cancels_without_changes(self, home, monkeypatch):
+        """Interactive 'n' must produce a distinct cancellation message
+        from the non-TTY abort path so users + tests can tell them apart.
+
+        ``CliRunner`` substitutes ``sys.stdin`` with a ``StringIO`` whose
+        ``isatty()`` returns False, so we patch the ``_isatty`` indirection
+        in ``uninstall_cmd`` directly to flip the TTY check to True.
+        """
+        from memtomem.cli import uninstall_cmd
+
+        _seed_state(home)
+        monkeypatch.setattr(uninstall_cmd, "_isatty", lambda: True)
+
+        result = CliRunner().invoke(cli, ["uninstall"], input="n\n")
+        assert result.exit_code == 1
+        assert "Cancelled" in result.output  # distinct from non-TTY's "non-interactive shell"
+        assert "non-interactive shell" not in result.output
+        # untouched
+        assert (home / ".memtomem" / "memtomem.db").exists()
+
+
+# -------------------------------------------------------------------- 11
+
+
+class TestRuntimeProfileImportPin:
+    """If init_cmd renames or moves _runtime_profile / RuntimeProfile this
+    test breaks immediately. The follow-up is either to update
+    uninstall_cmd.py to track the move, or extract the runtime profile to a
+    shared module — see plan MEDIUM 6."""
+
+    def test_runtime_profile_symbols_importable(self):
+        import dataclasses
+
+        from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
+
+        assert callable(_runtime_profile)
+        # Frozen dataclass — fields live on the dataclass spec, not the class
+        # __dict__, so use dataclasses.fields() rather than hasattr.
+        field_names = {f.name for f in dataclasses.fields(RuntimeProfile)}
+        assert "mm_binary_origin" in field_names
+        assert "cwd_install_type" in field_names
+        # Actually buildable (no args, returns the dataclass).
+        prof = _runtime_profile()
+        assert isinstance(prof, RuntimeProfile)
+
+
+# -------------------------------------------------------------------- 12
+
+
+class TestServerAliveRefuses:
+    def test_refuses_when_server_alive(self, home):
+        state = _seed_state(home)
+        # Use the current process pid — guaranteed alive for the test duration.
+        (state / ".server.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 2
+        assert "Server still running" in result.output
+        assert str(os.getpid()) in result.output
+        # nothing deleted
+        assert (state / "memtomem.db").exists()
+        assert (state / "config.json").exists()
+
+    def test_force_overrides_liveness(self, home):
+        state = _seed_state(home)
+        (state / ".server.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y", "--force"])
+        assert result.exit_code == 0, result.output
+        assert not state.exists()
+
+
+# -------------------------------------------------------------------- 13
+
+
+class TestPidStaleProceeds:
+    def test_proceeds_when_pid_stale(self, home, monkeypatch):
+        """Pick a pid that's guaranteed dead (high number, not currently
+        in use). os.kill(stale_pid, 0) raises ProcessLookupError → not alive.
+        """
+        state = _seed_state(home)
+
+        # Find a stale pid — start at a high number and bump until os.kill
+        # raises ProcessLookupError. Skip if PermissionError (alive but
+        # not ours, can happen at low PIDs).
+        stale_pid = 999_999
+        for candidate in range(999_999, 999_900, -1):
+            try:
+                os.kill(candidate, 0)
+            except ProcessLookupError:
+                stale_pid = candidate
+                break
+            except (PermissionError, OSError):
+                continue
+        else:
+            pytest.skip("could not find a stale pid for testing")
+
+        (state / ".server.pid").write_text(str(stale_pid), encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "Server still running" not in result.output
+        assert not state.exists()
+
+
+# -------------------------------------------------------------------- 14
+
+
+class TestConfigFallback:
+    def test_falls_back_when_config_load_raises(self, home, monkeypatch):
+        """``_load_config_safely`` must catch any exception escaping
+        ``load_config_overrides`` and fall back to the default DB path.
+
+        ``load_config_overrides`` already swallows malformed JSON itself
+        (logs WARNING, returns), so we monkeypatch it to raise outright —
+        that's the failure mode the safety net was added for.
+        """
+        state = home / ".memtomem"
+        state.mkdir()
+        (state / "config.json").write_text("{}", encoding="utf-8")
+        (state / "memtomem.db").write_bytes(b"sqlite-fake")
+
+        def _boom(_cfg):
+            raise PermissionError("fake permission denied on config.json")
+
+        monkeypatch.setattr("memtomem.config.load_config_overrides", _boom)
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "config unreadable" in result.output
+        assert "fake permission denied" in result.output
+        # default DB path used as fallback → DB still gets cleaned up
+        assert "Removed:" in result.output
+        assert not (state / "memtomem.db").exists()


### PR DESCRIPTION
## Summary

`uv tool uninstall memtomem` (and the equivalent for other install contexts) only removes the binary — `~/.memtomem/` survives intact, so a subsequent reinstall picks up stale config/fragments/DB that may not match the new version's expectations. Documented manual cleanup is `rm -rf ~/.memtomem/`, which misses custom storage paths, running servers, and the per-context binary-uninstall command.

`mm uninstall` closes that gap: builds a categorised inventory of state files, refuses to delete while the MCP server is alive (open WAL handles risk corruption), prints the exact binary-uninstall command for the detected install context, and detects external editor MCP entries (`~/.claude.json` etc.) so the user can clean them up manually.

```bash
mm uninstall                  # interactive, removes everything
mm uninstall -y               # skip confirmation
mm uninstall --keep-config    # preserve config.json + config.d/* + backups
mm uninstall --keep-data      # preserve DB + memories/
mm uninstall --force          # bypass server liveness check (stale pid case)
```

## Design highlights

- **State vs binary separation** — Memtomem owns `~/.memtomem/`; the package manager owns the binary. The command never executes the binary uninstall (different tool's permission scope), but prints the exact command for the detected `mm_binary_origin`:
  - `uv-tool` → `uv tool uninstall memtomem`
  - `uvx` → no action (ephemeral)
  - `venv-relative` → `uv pip uninstall memtomem` (or `rm -rf .venv`)
  - `system` → `pip uninstall memtomem`
  - `unknown` → conservative fallback hint
  Reuses the existing `RuntimeProfile` from `cli/init_cmd.py` (no duplication).
- **Server liveness check** — probes `~/.memtomem/.server.pid` via `os.kill(pid, 0)`. If alive: refuse with exit code 2 + shutdown hint + `--force` override. Open WAL handles during DB deletion would corrupt the file.
- **Config-load fallback** — uninstall is a recovery scenario, so it can't depend on a valid `config.json`. Any exception escaping `load_config_overrides` is caught and the default DB path is used as fallback (yellow warning shown).
- **Custom storage path** — `storage.sqlite_path` outside `~/.memtomem/` is included in the deletion scope (DB + WAL/SHM/journal siblings only). Other siblings of the custom path are inventory-only — never touched. User-managed `memory_dirs` are never touched either.
- **Ordered low→high-value deletion** — pid/session → fragments → backups → config → memories → uploads → DB. Mid-flight failure exits 2 with "removed up to X, failed at Y", leaving a recoverable trail.
- **External MCP detection only** — `~/.claude.json`, `~/.codex/config.toml`, `~/.cursor/mcp.json`, etc. are detected and reported. **Not modified** in this PR (per-editor schemas + backup + idempotency need their own design).

## Tests (19 cases, all passing)

- `TestEmptyState` — fresh HOME, no `~/.memtomem/` → exits 0 with binary hint
- `TestDefaultDeletion` — full state wipe with prune
- `TestKeepConfig` / `TestKeepData` — flag preservation semantics
- `TestCustomStoragePath` — custom DB outside default dir included; non-DB siblings preserved
- `TestUserMemoryDirsUntouched` — `memory_dirs` paths never deleted
- `TestExternalsDetectedNotModified` — `~/.claude.json` shown but unchanged
- `TestBinaryHintPerOrigin` — parametrised over all 5 `mm_binary_origin` values
- `TestNonTtyAbort` vs `TestInteractiveCancellation` — distinct messages, both leave state untouched
- `TestServerAliveRefuses` — pid=current process refused; `--force` bypasses
- `TestPidStaleProceeds` — dead pid is treated as deletable
- `TestConfigFallback` — `load_config_overrides` raise → fallback DB path used
- `TestRuntimeProfileImportPin` — forces follow-up if `init_cmd` renames/moves the runtime symbols

## Out of scope (deferred to follow-up PRs)

- Modifying external editor configs (detect-and-report only here)
- Provider/model mismatch CLI banner at startup
- Schema version tracking + downgrade detection
- `RuntimeProfile` extraction to shared module (the import pin test catches drift; refactor itself is a separate PR per one-change-per-PR)
- Parsed `mcpServers.memtomem` key check (currently substring grep — false-positive-tolerant since it's detect-and-report only)
- `--dry-run` flag (interactive prompt + inventory is de-facto dry-run)

## Verification

- [x] `uv run ruff check` + `uv run ruff format --check` pass
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/uninstall_cmd.py` clean
- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py` → 19 passed
- [x] `uv run pytest -m "not ollama"` → 2127 passed, 0 regressions
- [x] Manual smoke under tmp HOME — empty state, populated state, server-alive refusal, `--force` override, `--keep-config` / `--keep-data` combinations all behave as designed
- [x] Docs updated: `docs/guides/uninstall.md` gains a "Recommended: mm uninstall" section pointing at the new command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
