### PR TITLE
release: v0.1.23 — mm uninstall CLI for state cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.23] — 2026-04-22
+
+Feature release adding a first-class `mm uninstall` command so users can
+clean up local state (DB, config, fragments) with confirmation and
+install-context awareness, instead of guessing at `rm -rf ~/.memtomem/`.
+
+### Added
+
+- **`mm uninstall` CLI** — categorised inventory + confirmation prompt +
+  per-install-context binary-uninstall hint. Flags: `--keep-config`
+  (preserve `config.json` + `config.d/*` + backups), `--keep-data`
+  (preserve DB + WAL/SHM/journal + `memories/`), `--force` (bypass the
+  running-server safety check), `-y/--yes` (skip confirmation).
+
+  The command solves three concrete problems that `uv tool uninstall`
+  alone can't: (1) it tells you the right binary-removal command for
+  your detected install context (uv-tool / uvx / venv-relative / system
+  / unknown, reusing the existing `RuntimeProfile` from
+  `cli/init_cmd.py`), (2) it refuses to delete while the MCP server is
+  alive (open WAL handle during deletion risks corruption), and (3) it
+  honours custom `storage.sqlite_path` so DBs outside `~/.memtomem/` are
+  included in the cleanup. It falls back to default paths when
+  `config.json` can't be loaded (uninstall is itself a recovery
+  scenario), and detects external editor MCP entries (`~/.claude.json`,
+  `~/.codex/config.toml`, etc.) as inventory-only — those must still be
+  cleaned manually, tracked for a follow-up PR. Deletion runs in
+  low→high value order (pid/session → fragments → backups → config →
+  memories → DB) with per-group success logging, so a mid-flight
+  failure leaves a recoverable trail. (#379)
+
+### Docs
+
+- **`docs/guides/uninstall.md`** — adds a "Recommended: `mm uninstall`"
+  section at the top; the manual `rm -rf` flow remains below as a
+  fallback for environments without the CLI installed. (#379)
+
 ## [0.1.22] — 2026-04-22
 
 Bug-fix release closing the second root-cause path for "no such table:

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.22"
+version = "0.1.23"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.22"
+version = "0.1.23"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v0.1.22 → **v0.1.23** — feature release, 1 PR since last tag.

Adds `mm uninstall` (#379) — an install-context-aware state cleanup command. `uv tool uninstall memtomem` only removes the binary; `~/.memtomem/` survives, so a later reinstall inherits stale state (config, fragments, DB). The documented manual fix is `rm -rf ~/.memtomem/`, but that misses custom `storage.sqlite_path` outside the default dir, ignores a running MCP server (WAL corruption risk), and can't tell you the right binary-uninstall command for your detected install context.

```bash
mm uninstall                  # interactive, removes everything
mm uninstall --keep-config    # preserve config.json + config.d/* + backups
mm uninstall --keep-data      # preserve DB + WAL/SHM/journal + memories/
mm uninstall --force          # bypass the running-server safety check
mm uninstall -y               # skip the confirmation prompt
```

## Release checklist

- [x] `packages/memtomem/pyproject.toml` → `0.1.23`
- [x] `uv.lock` memtomem package version bumped + `uv sync --frozen` verified
- [x] `CHANGELOG.md` new section `[0.1.23] — 2026-04-22` (Added / Docs groups)
- [x] No source changes in this PR — version-bump + CHANGELOG only

## Post-merge steps

1. `git tag v0.1.23 && git push origin v0.1.23` — triggers Trusted Publisher OIDC upload.
2. Approve the `pypi` environment deployment on the Publish workflow run.
3. `gh release create v0.1.23 --notes-file <changelog-excerpt>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
