### PR TITLE
fix(web): gate loadNamespaceDropdowns on dev mode to stop prod 404s

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -116,6 +116,12 @@ function _applyUiModeFilter() {
       el.style.display = '';
     }
   });
+  // Boot-time populate for namespace filter dropdowns. loadNamespaceDropdowns
+  // self-gates on STATE.uiMode, so this is safe to fire in both modes — prod
+  // is a no-op. Replaces a bare module-level call in settings-namespaces.js
+  // that was racing initUiMode (STATE.uiMode still defaulted to 'prod' at
+  // module load, so the bare call never helped dev mode either).
+  if (typeof loadNamespaceDropdowns === 'function') loadNamespaceDropdowns();
 }
 
 function _visibleMainTabs() {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1231,11 +1231,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=2"></script>
-  <script src="/app.js?v=70"></script>
+  <script src="/app.js?v=71"></script>
   <script src="/settings-config.js?v=3"></script>
   <script src="/sources-memory-dirs.js?v=6"></script>
   <script src="/settings-maintenance.js?v=1"></script>
-  <script src="/settings-namespaces.js?v=2"></script>
+  <script src="/settings-namespaces.js?v=3"></script>
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=1"></script>
   <script src="/timeline.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -57,6 +57,11 @@ function _groupNamespaces(namespaces) {
 // ---------------------------------------------------------------------------
 
 async function loadNamespaceDropdowns() {
+  // /api/namespaces is mounted only in dev mode (web/app.py _DEV_ONLY_ROUTERS).
+  // Skip the fetch in prod to avoid a guaranteed 404 — the filter dropdowns
+  // keep their static "All Namespaces" option. Mirrors the gate pattern in
+  // app.js loadDashboard.
+  if (STATE.uiMode !== 'dev') return;
   try {
     const data = await api('GET', '/api/namespaces');
     const namespaces = data.namespaces || [];
@@ -93,8 +98,10 @@ async function loadNamespaceDropdowns() {
   } catch (e) { console.warn('[ns-dropdown]', e); }
 }
 
-// Load on startup and when switching to related tabs
-loadNamespaceDropdowns();
+// Tab-switch triggers (app.js activateTab) and mutation handlers below
+// re-invoke loadNamespaceDropdowns after STATE.uiMode is known. The initial
+// boot-time populate is driven from _applyUiModeFilter once ui-mode has
+// resolved — running here would always race initUiMode and no-op.
 
 // Namespaces tab
 qs('ns-refresh-btn').addEventListener('click', loadNamespacesTab);


### PR DESCRIPTION
## Summary

- `loadNamespaceDropdowns` in `settings-namespaces.js` had no `STATE.uiMode` gate, so every prod session fired `GET /api/namespaces` → 404 at least twice: once from a bare module-level call at script load, once from `activateTab('search'|'timeline')`. The dashboard loader in `app.js` already had the matching gate — this file was the orphan miss.
- Early-return inside `loadNamespaceDropdowns` when not in dev mode. Filter dropdowns in prod keep the static "All Namespaces" option (the `/api/namespaces` route itself remains dev-only by design — see `web/app.py` `_DEV_ONLY_ROUTERS` and `test_web_mode.py::test_dev_only_routes_blocked_in_prod_but_exposed_in_dev`).
- Removed the bare module-level `loadNamespaceDropdowns()` call. It ran before `initUiMode()` resolved, so `STATE.uiMode` was always the default `'prod'` at that moment — the call never helped dev either, it just produced prod log noise.
- Moved the boot-time populate into `_applyUiModeFilter`, which runs after `STATE.uiMode` is known. Combined with the function-level gate: prod → no-op, dev → single deterministic fetch.
- Bumped cache-busters (`app.js v70→71`, `settings-namespaces.js v2→3`).

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — clean
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/test_web_routes_extended.py` — 102 passed
- [x] Manual verification with playwright against `uv run mm web`:
  - **prod** (default): `/api/namespaces` request count = 0 after initial load + timeline tab + search tab (was 2 before).
  - **dev** (`MEMTOMEM_WEB__MODE=dev`): `/api/namespaces` = 1 (200 OK), fired from the `_applyUiModeFilter` boot trigger. Dropdown data still populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
