### PR TITLE
fix(server): report memtomem package version in MCP handshake (closes #383)

### DIFF
--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -11,6 +11,7 @@ import os
 
 from mcp.server.fastmcp import FastMCP
 
+from memtomem import __version__ as _memtomem_version
 from memtomem.server.component_factory import (
     Components as Components,
     close_components as close_components,
@@ -37,6 +38,10 @@ from memtomem.server.lifespan import app_lifespan
 
 # ── mcp instance — must be created before tool-module imports ──────────
 mcp = FastMCP("memtomem", lifespan=app_lifespan)
+# FastMCP has no `version=` kwarg; set it on the underlying Server so the
+# MCP `initialize` handshake reports our package version instead of the
+# SDK's fallback (see #383).
+mcp._mcp_server.version = _memtomem_version
 
 # ── Register ALL tools (decorators bind to `mcp` on import) ───────────
 from memtomem.server.tools.ask import mem_ask  # noqa: E402, F401

--- a/packages/memtomem/tests/test_tool_registration.py
+++ b/packages/memtomem/tests/test_tool_registration.py
@@ -67,3 +67,22 @@ def test_all_mcp_tool_modules_imported():
             lines
         )
         raise AssertionError(msg)
+
+
+def test_mcp_serverinfo_version_matches_package():
+    """MCP ``initialize`` handshake must report the memtomem package version.
+
+    ``FastMCP`` exposes no ``version=`` kwarg, so the underlying
+    ``Server.version`` is ``None`` by default and the handshake falls back
+    to the ``mcp`` SDK's own version — a foot-gun for anyone monitoring
+    ``serverInfo.version`` (#383).  ``server/__init__.py`` sets it
+    explicitly; this test pins that assignment against refactors.
+    """
+    from memtomem import __version__
+    from memtomem.server import mcp
+
+    opts = mcp._mcp_server.create_initialization_options()
+    assert opts.server_version == __version__, (
+        f"serverInfo.version={opts.server_version!r} but memtomem.__version__={__version__!r} — "
+        "server/__init__.py must set `mcp._mcp_server.version = __version__`"
+    )


### PR DESCRIPTION
## Summary

Closes #383. `FastMCP` has no `version=` kwarg, so the underlying `Server.version` stayed `None` and `serverInfo.version` in the MCP `initialize` handshake fell back to the `mcp` SDK's own version (`1.27.0` at the time of filing) instead of the memtomem package version.

Fix: assign `mcp._mcp_server.version = memtomem.__version__` immediately after `FastMCP(...)` construction in `server/__init__.py`. If FastMCP gains a `version=` kwarg upstream later, this line folds into the constructor call.

Added a regression test in `test_tool_registration.py` that calls `create_initialization_options()` and pins `server_version` to `memtomem.__version__`.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 1764 pass, 0 fail
- [x] `uv run ruff check` on changed files — clean
- [x] `uv run ruff format --check` on changed files — clean
- [x] Manual MCP handshake probe against an editable install verifies `initialize` response now carries `serverInfo.version = "0.1.10"` (this worktree's version) instead of `"1.27.0"`.

## Why the private-attr access

`FastMCP.__init__` in the current `mcp` SDK (1.27.x) has no `version=` kwarg — it only accepts `name=`, `instructions=`, `icons=`, `lifespan=`, and transport settings. The lower-level `Server(name, version=None)` does accept a version, but FastMCP constructs it without forwarding one. Setting `mcp._mcp_server.version` directly is the minimal-invasive workaround; an upstream PR to add `version=` to FastMCP would let us drop the underscore access. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
