### PR TITLE
fix(init): seed wizard scans memory_dir + provider_dirs union

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1324,18 +1324,27 @@ def _provider_seed_hint(provider: str) -> str | None:
     return None
 
 
-def _seed_with_progress(memory_dir: Path) -> bool:
-    """Run :meth:`IndexEngine.index_path_stream` with a click progress bar.
+def _seed_with_progress(paths: list[Path]) -> bool:
+    """Run :meth:`IndexEngine.index_path_stream` across ``paths`` with a
+    single click progress bar. Used by both small-case and large-case
+    branches of :func:`_maybe_seed_initial_index` so the progress surface
+    is consistent whether we're seeding one primary ``memory_dir`` or the
+    union of ``memory_dir`` + ``provider_dirs`` (issue #360 followup).
 
-    Returns ``True`` iff the seed completed. Used by both small-case and
-    large-case branches of :func:`_maybe_seed_initial_index` so the
-    progress surface is consistent.
+    Paths are streamed serially and their complete-event counters are
+    aggregated into one green summary line. The progress bar length is
+    pre-computed via :func:`_collect_seed_scale` so the percent indicator
+    is stable even when the streamed file list spans multiple roots.
 
     Cancellation: a ``KeyboardInterrupt`` inside the async stream escapes
     through ``asyncio.run`` as a regular ``KeyboardInterrupt`` — caught
     here to print a yellow resume hint. ``mm index`` is idempotent
     (content-hash dedup), so the next invocation picks up where the
-    cancelled run left off.
+    cancelled run left off. Single-path runs point back at ``mm index
+    <dir>`` to preserve the legacy affordance; multi-path runs point at
+    ``mm web`` → Sources → Reindex All, which iterates memory_dirs
+    (``web/routes/system.py`` ``/api/reindex``) — ``mm index`` is
+    single-path only as of v0.1.23.
 
     Failure: any other ``Exception`` (missing config, embedder init
     error, IO) prints a yellow warning + manual-rerun hint and returns
@@ -1343,7 +1352,14 @@ def _seed_with_progress(memory_dir: Path) -> bool:
     seed-only failure must not abort the overall flow."""
     import asyncio
 
+    if not paths:
+        return False
+
     bar_state: dict = {"bar": None}
+    agg = {"total_files": 0, "indexed": 0, "skipped": 0}
+    # Pre-compute so the progress bar length spans all paths, not just
+    # the first one. Stays accurate across serial iteration.
+    expected_total = sum(_collect_seed_scale(p)[0] for p in paths)
 
     def _close_bar() -> None:
         if bar_state["bar"] is not None:
@@ -1353,53 +1369,49 @@ def _seed_with_progress(memory_dir: Path) -> bool:
                 pass
             bar_state["bar"] = None
 
-    async def _stream() -> dict | None:
+    async def _stream() -> None:
         from memtomem.cli._bootstrap import cli_components
 
-        final: dict | None = None
         async with cli_components() as comp:
-            async for evt in comp.index_engine.index_path_stream(
-                memory_dir, recursive=True, force=False
-            ):
-                if evt["type"] == "progress":
-                    if bar_state["bar"] is None:
-                        bar_state["bar"] = click.progressbar(
-                            length=evt["files_total"],
-                            label="  Seeding",
-                            item_show_func=lambda item: (item or "").rsplit("/", 1)[-1][:40],
-                        ).__enter__()
-                    bar_state["bar"].update(1, evt["file"])
-                elif evt["type"] == "complete":
-                    final = evt
-        return final
+            for p in paths:
+                async for evt in comp.index_engine.index_path_stream(
+                    p, recursive=True, force=False
+                ):
+                    if evt["type"] == "progress":
+                        if bar_state["bar"] is None:
+                            bar_state["bar"] = click.progressbar(
+                                length=expected_total,
+                                label="  Seeding",
+                                item_show_func=lambda item: (item or "").rsplit("/", 1)[-1][:40],
+                            ).__enter__()
+                        bar_state["bar"].update(1, evt["file"])
+                    elif evt["type"] == "complete":
+                        agg["total_files"] += evt["total_files"]
+                        agg["indexed"] += evt["indexed_chunks"]
+                        agg["skipped"] += evt["skipped_chunks"]
+
+    resume_hint = f"mm index {paths[0]}" if len(paths) == 1 else "mm web  (Sources → Reindex All)"
 
     try:
-        result = asyncio.run(_stream())
+        asyncio.run(_stream())
     except KeyboardInterrupt:
         _close_bar()
         click.echo()
-        click.secho(
-            f"  Cancelled. Resume with: mm index {memory_dir}",
-            fg="yellow",
-        )
+        click.secho(f"  Cancelled. Resume with: {resume_hint}", fg="yellow")
         return False
     except Exception as e:
         _close_bar()
         click.secho(f"  Skipped initial seed: {e}", fg="yellow")
-        click.echo(f"  Run manually later:   mm index {memory_dir}")
+        click.echo(f"  Run manually later:   {resume_hint}")
         return False
 
     _close_bar()
-    if result is None:
+    if agg["total_files"] == 0:
         # No files discovered by the stream — shouldn't happen given the
         # callers already ensured file_count > 0, but handle defensively.
         return False
 
     click.echo()
-    total_files = result["total_files"]
-    indexed = result["indexed_chunks"]
-    skipped = result["skipped_chunks"]
-
     # Defensive: if the stream processed files but landed zero chunks
     # (neither new nor skipped-as-unchanged), something went wrong
     # silently — per-file errors are logged but the `complete` event
@@ -1409,9 +1421,9 @@ def _seed_with_progress(memory_dir: Path) -> bool:
     # (``feedback_chunks_vec_dim0_legacy.md``). Return False so the
     # Next-steps step 1 stays unmarked and the user knows to investigate
     # rather than seeing a false green success.
-    if total_files > 0 and indexed == 0 and skipped == 0:
+    if agg["indexed"] == 0 and agg["skipped"] == 0:
         click.secho(
-            f"  Seeded {total_files} file(s) but 0 chunks were indexed — "
+            f"  Seeded {agg['total_files']} file(s) but 0 chunks were indexed — "
             "check logs for upsert errors.",
             fg="yellow",
         )
@@ -1422,20 +1434,29 @@ def _seed_with_progress(memory_dir: Path) -> bool:
         return False
 
     click.secho(
-        f"  Seeded initial index: {total_files} file(s), "
-        f"{indexed} new chunk(s), {skipped} unchanged.",
+        f"  Seeded initial index: {agg['total_files']} file(s), "
+        f"{agg['indexed']} new chunk(s), {agg['skipped']} unchanged.",
         fg="green",
     )
     return True
 
 
-def _maybe_seed_initial_index(memory_dir: Path, state: dict) -> bool:
-    """Offer an opt-in seed of ``memory_dir`` at wizard end.
+def _maybe_seed_initial_index(paths: list[Path], state: dict) -> bool:
+    """Offer an opt-in seed of the wizard's memory dirs.
+
+    ``paths`` is the union of ``state["memory_dir"]`` and any
+    ``provider_dirs`` accepted during the wizard, dedup-preserving order
+    (caller in :func:`_write_config_and_summary` mirrors the
+    ``combined_dirs`` construction used to write ``indexing.memory_dirs``).
+    Prior to this, only the primary ``memory_dir`` was scanned, so a fresh
+    install with an empty ``~/memories`` and 28 auto-discovered provider
+    dirs silently skipped the seed — the UX gap this change closes.
 
     Policy:
 
-    1. Empty dir / non-existent → silent skip. The wizard already printed
-       ``Memory: <dir>``; adding "no files found" noise would confuse.
+    1. No existing paths / empty union → silent skip. The wizard already
+       printed ``Memory: <dir>``; adding "no files found" noise would
+       confuse.
     2. Non-TTY (CI, piped ``mm init -y``) → silent skip. ``click.confirm``
        with no TTY raises ``Abort``, so we gate explicitly
        (``feedback_click_prompt_needs_isatty_gate.md``).
@@ -1446,19 +1467,28 @@ def _maybe_seed_initial_index(memory_dir: Path, state: dict) -> bool:
        surfaces the file count, total size, and a provider-specific time
        expectation (``_provider_seed_hint``). ``y`` runs the seed inline
        with a visible progress bar so minutes-long runs don't look
-       hung; Ctrl-C cancels and is resumable via ``mm index``.
+       hung; Ctrl-C cancels and is resumable via ``mm index`` (single
+       path) or the Web UI Reindex All button (multi).
 
     PR #295 lesson: the *default* for both prompts is No because a user
     blindly pressing Enter through the wizard should not accidentally
     trigger a multi-minute CPU embedder job. The visible progress bar
     (when they opt in) is the mitigation for the "is it hung?" failure
-    mode that killed the earlier startup-scan attempt.
+    mode that killed the earlier startup-scan attempt. Note that the
+    wizard seed is confirmation-gated and progress-bar instrumented; it
+    does not re-introduce the silent background scan PR #295 removed.
 
     Returns ``True`` iff the seed actually ran (informs whether the
     Next-steps step 1 can be annotated as already-done)."""
-    if not memory_dir.exists():
+    existing = [p for p in paths if p.exists()]
+    if not existing:
         return False
-    file_count, total_bytes = _collect_seed_scale(memory_dir)
+    file_count = 0
+    total_bytes = 0
+    for p in existing:
+        c, b = _collect_seed_scale(p)
+        file_count += c
+        total_bytes += b
     if file_count == 0:
         return False
     if not sys.stdin.isatty():
@@ -1467,21 +1497,43 @@ def _maybe_seed_initial_index(memory_dir: Path, state: dict) -> bool:
     is_small = file_count <= _SEED_MAX_FILES and total_bytes <= _SEED_MAX_BYTES
     click.echo()
 
+    # Small-case prompt: phrasing adapts to single vs multi so a user with
+    # an empty ~/memories plus a tiny provider dir still sees a coherent
+    # sentence instead of "in /Users/x/memories" for files that live
+    # elsewhere.
     if is_small:
-        prompt = f"  Index the {file_count} existing file(s) in {memory_dir} now?"
+        if len(existing) == 1:
+            prompt = f"  Index the {file_count} existing file(s) in {existing[0]} now?"
+        else:
+            prompt = (
+                f"  Index the {file_count} existing file(s) across {len(existing)} memory dirs now?"
+            )
     else:
         size_str = _format_size(total_bytes)
-        click.secho(
-            f"  Found {file_count} file(s) ({size_str}) in {memory_dir}.",
-            fg="cyan",
-        )
+        if len(existing) == 1:
+            click.secho(
+                f"  Found {file_count} file(s) ({size_str}) in {existing[0]}.",
+                fg="cyan",
+            )
+        else:
+            click.secho(
+                f"  Found {file_count} file(s) ({size_str}) across {len(existing)} memory dirs.",
+                fg="cyan",
+            )
         provider_hint = _provider_seed_hint(state.get("provider", ""))
         if provider_hint:
             click.secho(f"  {provider_hint}.", fg="cyan")
-        click.secho(
-            "  Ctrl-C cancels; resume later with `mm index <dir>` (hash-dedup safe).",
-            fg="cyan",
-        )
+        if len(existing) == 1:
+            click.secho(
+                "  Ctrl-C cancels; resume later with `mm index <dir>` (hash-dedup safe).",
+                fg="cyan",
+            )
+        else:
+            click.secho(
+                "  Ctrl-C cancels; resume later via `mm web` → Sources → Reindex All "
+                "(hash-dedup safe).",
+                fg="cyan",
+            )
         prompt = "  Start seeding now?"
 
     try:
@@ -1490,7 +1542,7 @@ def _maybe_seed_initial_index(memory_dir: Path, state: dict) -> bool:
         return False
     if not do_seed:
         return False
-    return _seed_with_progress(memory_dir)
+    return _seed_with_progress(existing)
 
 
 def _collect_missing_extras(state: dict) -> list[str]:
@@ -1939,8 +1991,24 @@ def _write_config_and_summary(
     # _maybe_seed_initial_index for the full policy and
     # `feedback_pullbased_vs_startup_scan.md` for the PR #295 lesson
     # that shapes the default-No + progress-bar design.
+    #
+    # Seed scope = union of primary memory_dir + provider_dirs, deduped
+    # while preserving order. Mirrors the combined_dirs construction
+    # above so the seed's file-count / bytes advisory matches what the
+    # wizard actually wrote to ``indexing.memory_dirs``. Without this,
+    # a fresh install with empty ``~/memories`` + 28 auto-discovered
+    # provider dirs silently skipped the seed entirely.
     memory_dir_path = Path(state["memory_dir"]).expanduser()
-    seeded = _maybe_seed_initial_index(memory_dir_path, state)
+    provider_paths = [Path(p).expanduser() for p in (state.get("provider_dirs", []) or [])]
+    seed_paths: list[Path] = []
+    seen_seed_keys: set[str] = set()
+    for p in [memory_dir_path, *provider_paths]:
+        key = str(p)
+        if key in seen_seed_keys:
+            continue
+        seen_seed_keys.add(key)
+        seed_paths.append(p)
+    seeded = _maybe_seed_initial_index(seed_paths, state)
 
     click.echo()
     click.secho("  Next steps:", fg="cyan")
@@ -1951,9 +2019,22 @@ def _write_config_and_summary(
     # auto-indexed. `mm index` is idempotent (content-hash dedup) so
     # re-runs are safe. See docs/guides/configuration.md#memory_dirs.
     # When _maybe_seed_initial_index already ran, the hint is annotated
-    # so users don't think they need to run it a second time.
-    seed_suffix = "  (already seeded — re-run only if you add files)" if seeded else ""
-    click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}{seed_suffix}")
+    # so users don't think they need to run it a second time. Multi-dir
+    # + unseeded case points at the Web UI Reindex All button because
+    # ``mm index`` CLI is single-path only (v0.1.23) — suggesting
+    # ``mm index ~/memories`` would miss the 28 provider dirs entirely.
+    if seeded:
+        click.echo(
+            f"    1. {run_prefix}mm index {state['memory_dir']}"
+            "  (already seeded — re-run only if you add files)"
+        )
+    elif len(seed_paths) > 1:
+        click.echo(
+            f"    1. {run_prefix}mm web  "
+            f"(Sources → Reindex All to index {len(seed_paths)} memory_dirs)"
+        )
+    else:
+        click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}")
     click.echo(f"    2. {run_prefix}mm search 'your first query'")
     click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")
     if profile.mm_binary_origin == "uvx":

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3876,7 +3876,7 @@ class TestInitialSeedThreshold:
         )
 
         state = {"provider": "onnx"}
-        assert init_cmd._maybe_seed_initial_index(memory_dir, state) is False
+        assert init_cmd._maybe_seed_initial_index([memory_dir], state) is False
         assert confirm_fired["yes"] is True  # prompt DID fire this time
         out = capsys.readouterr().out
         assert "11 file(s)" in out
@@ -3906,7 +3906,7 @@ class TestInitialSeedThreshold:
         )
 
         state = {"provider": "ollama"}
-        assert init_cmd._maybe_seed_initial_index(memory_dir, state) is False
+        assert init_cmd._maybe_seed_initial_index([memory_dir], state) is False
         assert confirm_fired["yes"] is True
         out = capsys.readouterr().out
         assert "5 file(s)" in out
@@ -3931,15 +3931,15 @@ class TestInitialSeedThreshold:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("click.confirm", lambda *a, **kw: True)
 
-        seen: dict[str, Path] = {}
+        seen: dict[str, list[Path]] = {}
         monkeypatch.setattr(
             init_cmd,
             "_seed_with_progress",
-            lambda p: seen.__setitem__("dir", p) or True,
+            lambda paths: seen.__setitem__("paths", list(paths)) or True,
         )
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is True
-        assert seen["dir"] == memory_dir
+        assert init_cmd._maybe_seed_initial_index([memory_dir], {"provider": "none"}) is True
+        assert seen["paths"] == [memory_dir]
 
     def test_maybe_seed_non_tty_silent_skip(
         self,
@@ -3964,7 +3964,7 @@ class TestInitialSeedThreshold:
             lambda *a, **kw: confirm_fired.__setitem__("yes", True) or True,
         )
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is False
+        assert init_cmd._maybe_seed_initial_index([memory_dir], {"provider": "none"}) is False
         assert confirm_fired["yes"] is False
         assert capsys.readouterr().out == ""
 
@@ -3988,7 +3988,7 @@ class TestInitialSeedThreshold:
 
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "onnx"}) is False
+        assert init_cmd._maybe_seed_initial_index([memory_dir], {"provider": "onnx"}) is False
         assert capsys.readouterr().out == ""
 
     def test_maybe_seed_prompt_decline(
@@ -4013,10 +4013,10 @@ class TestInitialSeedThreshold:
         monkeypatch.setattr(
             init_cmd,
             "_seed_with_progress",
-            lambda p: seed_called.__setitem__("yes", True) or True,
+            lambda paths: seed_called.__setitem__("yes", True) or True,
         )
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is False
+        assert init_cmd._maybe_seed_initial_index([memory_dir], {"provider": "none"}) is False
         assert seed_called["yes"] is False
 
     def test_maybe_seed_prompt_accept_runs_seed(
@@ -4035,16 +4035,16 @@ class TestInitialSeedThreshold:
         monkeypatch.setattr("sys.stdin.isatty", lambda: True)
         monkeypatch.setattr("click.confirm", lambda *a, **kw: True)
 
-        seen: dict[str, Path] = {}
+        seen: dict[str, list[Path]] = {}
 
-        def _stub_seed(p: Path) -> bool:
-            seen["dir"] = p
+        def _stub_seed(paths: list[Path]) -> bool:
+            seen["paths"] = list(paths)
             return True
 
         monkeypatch.setattr(init_cmd, "_seed_with_progress", _stub_seed)
 
-        assert init_cmd._maybe_seed_initial_index(memory_dir, {"provider": "none"}) is True
-        assert seen["dir"] == memory_dir
+        assert init_cmd._maybe_seed_initial_index([memory_dir], {"provider": "none"}) is True
+        assert seen["paths"] == [memory_dir]
 
     def test_seed_with_progress_failure_is_graceful(
         self,
@@ -4070,7 +4070,7 @@ class TestInitialSeedThreshold:
 
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _broken_components)
 
-        assert init_cmd._seed_with_progress(memory_dir) is False
+        assert init_cmd._seed_with_progress([memory_dir]) is False
         out = capsys.readouterr().out
         assert "Skipped initial seed" in out
         assert "embedder unavailable" in out
@@ -4126,7 +4126,7 @@ class TestInitialSeedThreshold:
 
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
 
-        assert init_cmd._seed_with_progress(memory_dir) is False
+        assert init_cmd._seed_with_progress([memory_dir]) is False
         out = capsys.readouterr().out
         assert "0 chunks were indexed" in out
         assert "embedding-reset" in out
@@ -4181,7 +4181,7 @@ class TestInitialSeedThreshold:
 
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
 
-        assert init_cmd._seed_with_progress(memory_dir) is True
+        assert init_cmd._seed_with_progress([memory_dir]) is True
         out = capsys.readouterr().out
         assert "Seeded initial index" in out
         assert "3 new chunk(s)" in out
@@ -4214,7 +4214,306 @@ class TestInitialSeedThreshold:
 
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _ctrl_c_components)
 
-        assert init_cmd._seed_with_progress(memory_dir) is False
+        assert init_cmd._seed_with_progress([memory_dir]) is False
         out = capsys.readouterr().out
         assert "Cancelled" in out
         assert f"mm index {memory_dir}" in out
+
+    # ------------------------------------------------------------------
+    # Multi-path (primary memory_dir + provider_dirs) — issue #360 f/u
+    # ------------------------------------------------------------------
+
+    def test_maybe_seed_empty_primary_plus_provider_dir_prompts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Primary memory_dir empty + one provider dir with files → prompt
+        STILL fires with aggregated counts. Regression guard for the core
+        UX bug this landed: ``mm init --preset korean`` registers ~28
+        provider dirs but the prior code scanned only the primary dir,
+        which is typically the empty ``~/memories``, so the seed silently
+        skipped every real-world install."""
+        from memtomem.cli import init_cmd
+
+        primary = tmp_path / "memories"
+        primary.mkdir()  # empty
+        provider = tmp_path / "claude-memory"
+        provider.mkdir()
+        for i in range(3):
+            self._write_md(provider, f"m{i}.md", f"memo {i}")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        prompts: list[str] = []
+
+        def _capture(text, *args, **kwargs):
+            prompts.append(text)
+            return False
+
+        monkeypatch.setattr("click.confirm", _capture)
+
+        assert (
+            init_cmd._maybe_seed_initial_index([primary, provider], {"provider": "none"}) is False
+        )
+        # Small-case prompt text passes through click.confirm's first arg —
+        # capsys wouldn't catch it. Aggregated counts: 3 from provider + 0
+        # from empty primary = 3; phrasing is "across 2 memory dirs".
+        assert len(prompts) == 1
+        assert "3 existing file(s)" in prompts[0]
+        assert "across 2 memory dirs" in prompts[0]
+
+    def test_maybe_seed_multi_path_skips_nonexistent(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Non-existent paths are dropped before the scan. Protects against
+        stale provider_dirs entries (user moved a folder between init
+        runs). If the union reduces to zero existing paths, we return
+        False silently — no "no files found" noise."""
+        from memtomem.cli import init_cmd
+
+        existing = tmp_path / "have"
+        existing.mkdir()
+        self._write_md(existing, "a.md", "hi")
+        missing = tmp_path / "gone"  # never created
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("click.confirm", lambda *a, **kw: True)
+
+        passed: dict[str, list[Path]] = {}
+        monkeypatch.setattr(
+            init_cmd,
+            "_seed_with_progress",
+            lambda paths: passed.__setitem__("paths", list(paths)) or True,
+        )
+
+        assert init_cmd._maybe_seed_initial_index([missing, existing], {"provider": "none"}) is True
+        assert passed["paths"] == [existing]
+
+    def test_maybe_seed_large_multi_path_resume_hint_mentions_web(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Large-case advisory for multi-path runs points at the Web UI
+        Reindex All, not ``mm index <dir>``. ``mm index`` is single-path
+        only, so suggesting it for a 28-dir union would leave 27 dirs
+        unindexed. Dev must match ``_seed_with_progress`` resume hint
+        (same cross-affordance)."""
+        from memtomem.cli import init_cmd
+
+        primary = tmp_path / "memories"
+        primary.mkdir()
+        provider = tmp_path / "claude-memory"
+        provider.mkdir()
+        for i in range(12):  # > _SEED_MAX_FILES
+            self._write_md(provider, f"m{i}.md", f"memo {i}")
+
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("click.confirm", lambda *a, **kw: False)
+
+        init_cmd._maybe_seed_initial_index([primary, provider], {"provider": "onnx"})
+        out = capsys.readouterr().out
+        assert "12 file(s)" in out
+        assert "across 2 memory dirs" in out
+        # Multi-path resume hint goes to Web UI, not `mm index <dir>`.
+        assert "Reindex All" in out
+        assert "`mm index <dir>`" not in out
+
+    def test_seed_with_progress_multi_path_aggregates_counters(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Two paths streamed serially → complete counters sum into one
+        green summary line. Pins the aggregation so a future refactor
+        that regresses to "report only the last path's counters" fails
+        instead of silently under-reporting."""
+        from contextlib import asynccontextmanager
+
+        from memtomem.cli import init_cmd
+
+        dir_a = tmp_path / "a"
+        dir_a.mkdir()
+        dir_b = tmp_path / "b"
+        dir_b.mkdir()
+        # _seed_with_progress pre-computes expected_total from
+        # _collect_seed_scale; write one .md each so the scan reports
+        # non-zero and the bar doesn't trip the "no files" fallback.
+        self._write_md(dir_a, "a.md", "hello")
+        self._write_md(dir_b, "b.md", "world")
+
+        path_counts = {
+            str(dir_a): {"total_files": 2, "indexed_chunks": 5, "skipped_chunks": 1},
+            str(dir_b): {"total_files": 3, "indexed_chunks": 7, "skipped_chunks": 2},
+        }
+
+        class _FakeEngine:
+            async def index_path_stream(self, path, recursive=True, force=False):
+                key = str(path)
+                counts = path_counts[key]
+                yield {
+                    "type": "progress",
+                    "file": f"{key}/file.md",
+                    "files_done": 1,
+                    "files_total": 1,
+                    "indexed": counts["indexed_chunks"],
+                    "skipped": counts["skipped_chunks"],
+                }
+                yield {
+                    "type": "complete",
+                    "total_files": counts["total_files"],
+                    "total_chunks": counts["indexed_chunks"],
+                    "indexed_chunks": counts["indexed_chunks"],
+                    "skipped_chunks": counts["skipped_chunks"],
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        assert init_cmd._seed_with_progress([dir_a, dir_b]) is True
+        out = capsys.readouterr().out
+        # 2 + 3 = 5 files, 5 + 7 = 12 new chunks, 1 + 2 = 3 unchanged.
+        assert "5 file(s)" in out
+        assert "12 new chunk(s)" in out
+        assert "3 unchanged" in out
+
+    def test_seed_with_progress_keyboard_interrupt_multi_path_web_hint(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Ctrl-C during multi-path seed → resume hint points at
+        ``mm web``, not ``mm index <dir>``. Single-path hint continues to
+        use ``mm index`` (tested above); this pins the branch."""
+        from contextlib import asynccontextmanager
+
+        from memtomem.cli import init_cmd
+
+        dir_a = tmp_path / "a"
+        dir_a.mkdir()
+        dir_b = tmp_path / "b"
+        dir_b.mkdir()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _ctrl_c_components() -> object:  # pragma: no cover - generator
+            raise KeyboardInterrupt
+            yield  # unreachable
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _ctrl_c_components)
+
+        assert init_cmd._seed_with_progress([dir_a, dir_b]) is False
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+        assert "Reindex All" in out
+        # Regression: must NOT print the single-dir `mm index <dir>` hint.
+        assert f"mm index {dir_a}" not in out
+        assert f"mm index {dir_b}" not in out
+
+    # ------------------------------------------------------------------
+    # Next-steps step 1 hint — seeded / single-dir / multi-dir branches
+    # ------------------------------------------------------------------
+
+    def test_next_steps_multi_dir_unseeded_points_at_web_reindex(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When provider_dirs are present and the seed is declined/skipped,
+        step 1 must point at ``mm web`` → Sources → Reindex All.
+        ``mm index ~/memories`` would only cover the primary dir — leaving
+        the 28 provider dirs unindexed, which is exactly the UX bug this
+        PR fixes."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_maybe_seed_initial_index", lambda paths, state: False)
+
+        state = _make_init_state(tmp_path)
+        state["provider_dirs"] = [
+            str(tmp_path / "claude-memory"),
+            str(tmp_path / "claude-plans"),
+        ]
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
+
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Next steps:" in out
+        # 3 = primary memory_dir + 2 provider_dirs. Dedup would not fire here
+        # because the three paths are distinct.
+        assert "Reindex All to index 3 memory_dirs" in out
+        # Regression: single-dir hint must NOT fire for multi-dir unseeded.
+        assert f"mm index {state['memory_dir']}\n" not in out
+
+    def test_next_steps_single_dir_unseeded_keeps_mm_index_hint(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """No provider_dirs + seed declined → legacy ``mm index <primary>``
+        hint still fires. Guards against the multi-dir branch over-firing
+        and hijacking the single-dir UX."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_maybe_seed_initial_index", lambda paths, state: False)
+
+        state = _make_init_state(tmp_path)
+        state["provider_dirs"] = []
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
+
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert f"mm index {state['memory_dir']}" in out
+        assert "Reindex All" not in out
+        assert "already seeded" not in out
+
+    def test_next_steps_seeded_annotates_mm_index_hint(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the seed ran inline, step 1 keeps ``mm index <primary>`` but
+        annotates "already seeded — re-run only if you add files" so users
+        don't double-index. Pins the annotation wording — changing it
+        silently would regress the UX clarity."""
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_maybe_seed_initial_index", lambda paths, state: True)
+
+        state = _make_init_state(tmp_path)
+        # provider_dirs populated — seeded=True path wins over multi-dir
+        # branch (already-seeded annotation applies to primary regardless).
+        state["provider_dirs"] = [str(tmp_path / "claude-memory")]
+        state["_profile"] = _make_test_profile(tmp_path, kind="source")
+
+        init_cmd._write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert f"mm index {state['memory_dir']}" in out
+        assert "already seeded" in out
+        assert "Reindex All" not in out


### PR DESCRIPTION
## Summary

Closes the UX gap where `mm init --preset korean` (or any preset that auto-discovers provider memory folders) registered ~28 dirs into `indexing.memory_dirs` but the auto-seed prompt silently skipped them.

- Wizard scanned only `state["memory_dir"]` — the primary dir from step 3, typically the freshly-created empty `~/memories`. So the Korean-preset transcript prints "Auto-added 28 provider folder(s)" → zero seed → 28 dirs sit unindexed until the user finds Sources → Reindex All.
- `_maybe_seed_initial_index` now takes `list[Path]` and sums file count + bytes across the **union of memory_dir + provider_dirs** (deduped preserving order — mirrors the `combined_dirs` construction that feeds `indexing.memory_dirs`). Small-case prompt wording and large-case advisory adapt to `across N memory dirs` when the union has >1 entry.
- `_seed_with_progress` streams paths serially with a **single progress bar** whose length is the aggregate file count. Resume hint splits: single-path keeps `mm index <dir>`; multi-path points at `mm web` → Sources → Reindex All, because `mm index` CLI is single-path only as of v0.1.23.
- Next-steps step 1 in `_write_config_and_summary` gets the same split — declined seed + multi-dir → `mm web  (Sources → Reindex All to index N memory_dirs)` instead of the misleading single-path `mm index ~/memories`.

## PR #295 constraints preserved

Every seed action stays confirmation-gated (`default=False`), progress-bar instrumented, and Ctrl-C resumable. No silent background scan is reintroduced — this PR expands the wizard's explicit-opt-in surface, not the startup path.

## Test plan

- [x] `uv run ruff check packages/memtomem` + `uv run ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` — clean
- [x] `uv run pytest -m "not ollama"` — **2135 passed / 0 regressions** (+3 net)
- [x] 8 new tests in `TestInitialSeedThreshold`:
  - 5 multi-path seed: empty-primary + provider-dir prompts, nonexistent paths dropped, large-case resume hint points at Web UI, aggregate counters across paths, Ctrl-C hint differentiation
  - 3 next-steps hint: multi unseeded → `mm web` reindex, single unseeded → `mm index`, seeded → `mm index` with already-seeded annotation
- [x] 15 existing seed tests adapted to the `list[Path]` signature

## Out of scope (not this PR)

- `mm index --all` CLI flag / multi-path arg — separate feature, would clean up the multi-dir resume hint story further
- Wizard startup scan revival — PR #295 rolled this back deliberately; this PR doesn't touch it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
