### PR TITLE
release: v0.1.24 — preset-aware wizard seed + namespaces dropdown prod gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.24] — 2026-04-23
+
+Bug-fix release closing a first-run UX gap in `mm init --preset <name>`
+and a matching prod-mode log-noise bug in the web UI. Wizard installs
+that auto-discover provider memory folders (Claude Code projects,
+Claude Desktop plans, Codex memories) now actually consider those
+folders in the seed decision, instead of silently skipping the seed
+because the primary `~/memories` happens to be empty.
+
+### Fixed
+
+- **Wizard auto-seed now scans `memory_dir + provider_dirs` union.**
+  `mm init --preset korean` / `--preset english` / `--preset minimal`
+  registers the primary memory dir plus every auto-discovered provider
+  folder into `indexing.memory_dirs`, but the opt-in inline seed only
+  inspected the primary dir. Since the primary is typically the empty
+  `~/memories` on a fresh install, the seed silently returned `False`
+  and the Next-steps hint pointed at `mm index ~/memories` — which
+  indexed zero files and left the 28 provider dirs invisible to search
+  until the user found Sources → Reindex All in the web UI.
+
+  The seed now sums file count and bytes across the union (deduped
+  preserving order, mirrors the `combined_dirs` construction that
+  feeds `indexing.memory_dirs`) and prompts with "across N memory
+  dirs" phrasing when more than one dir is in scope. `_seed_with_progress`
+  streams paths serially with a single progress bar. Multi-path Ctrl-C
+  / failure hints point at `mm web` → Sources → Reindex All instead of
+  a misleading single-path `mm index <dir>` (the `mm index` CLI is
+  single-path only as of v0.1.23). Next-steps step 1 in
+  `_write_config_and_summary` gets the same split — declined seed with
+  multi-dir registration now reads "uv run mm web  (Sources → Reindex
+  All to index N memory_dirs)" instead of `mm index ~/memories`.
+  PR #295 constraints remain intact: every seed action is
+  confirmation-gated (default No), progress-bar instrumented, and
+  Ctrl-C resumable. No silent startup scan is reintroduced. (#388)
+
+- **Web UI: `loadNamespaceDropdowns` gated on dev mode.** `/api/namespaces`
+  is mounted only in `_DEV_ONLY_ROUTERS` by design (test pin in
+  `test_web_mode.py::test_dev_only_routes_blocked_in_prod_but_exposed_in_dev`),
+  and the `loadDashboard` caller already had the matching gate. The
+  dropdown loader in `settings-namespaces.js` was the orphan: every
+  prod session fired a guaranteed 404 at page load (bare module-level
+  call) and another on each switch to the search or timeline tab.
+  Gate is now internal to `loadNamespaceDropdowns` (prod → early
+  return, filter dropdowns keep the static "All Namespaces" option);
+  boot-time populate moves into `_applyUiModeFilter` which runs after
+  `STATE.uiMode` resolves, so dev still gets a single deterministic
+  fetch instead of the previous race-dependent bare call. (#385)
+
 ## [0.1.23] — 2026-04-22
 
 Feature release adding a first-class `mm uninstall` command so users can

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.23"
+version = "0.1.24"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.23"
+version = "0.1.24"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bug-fix release closing a first-run UX gap in `mm init --preset <name>` and a prod-mode log-noise bug in the web UI. Both merged as separate fixes into main (#388, #385); this PR bundles the version bump + CHANGELOG entry.

- **#388 — Wizard auto-seed now scans the union of `memory_dir` + `provider_dirs`.** Preset installs (claude-memory / claude-plans / codex) now count toward the seed decision. Previously the seed only inspected the primary dir — typically the empty `~/memories` on a fresh install — so the 28 auto-discovered provider dirs sat unindexed until the user found Sources → Reindex All. Next-steps step 1 learns the same split: declined seed + multi-dir points at `mm web` → Reindex All instead of the misleading single-path `mm index ~/memories`.
- **#385 — `loadNamespaceDropdowns` gated on dev mode.** `/api/namespaces` is a dev-only route by design; the dropdown loader was the orphan caller firing guaranteed 404s on every prod page load and each switch to search/timeline tab. `loadDashboard` already had the matching gate; this PR brings the dropdown loader in line.

## PR #295 invariant preserved

For #388, every seed action stays confirmation-gated (default No), progress-bar instrumented, and Ctrl-C resumable. No silent startup scan is reintroduced.

## Release plan

- [x] `packages/memtomem/pyproject.toml` 0.1.23 → 0.1.24
- [x] `uv.lock` workspace `[[package]]` version updated (per `feedback_uv_lock_version_sync.md`)
- [x] `CHANGELOG.md` v0.1.24 section
- [x] `uv run ruff check` — clean
- [x] `uv run pytest -m "not ollama"` — 2135 passed / 0 regressions
- [x] `uv run mm --version` reports 0.1.24
- [ ] Merge → push `v0.1.24` tag → OIDC trusted publisher uploads to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
