### PR TITLE
docs(install): add `mm --version` verify + `--refresh` hint for PyPI cache lag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ flowchart LR
 
 ```bash
 uv tool install memtomem             # or: pipx install memtomem
+mm --version                          # verify install
 ```
+
+> If `mm --version` shows an older version than the [latest release](https://github.com/memtomem/memtomem/releases), `uv` is likely serving cached PyPI metadata — re-run with `uv tool install memtomem --refresh`, or clear the cache first: `uv cache clean memtomem`.
 
 ### 2. Setup
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -53,7 +53,10 @@ No install needed for MCP usage — `uvx` downloads and runs memtomem on demand 
 If you also want the CLI (`mm` command):
 ```bash
 uv tool install memtomem    # or: pipx install memtomem
+mm --version                # verify install
 ```
+
+> **If `mm --version` shows an older release**: `uv` caches PyPI metadata per package, and a fresh install can resolve to the cached entry for a short window after a new release. Re-run with `uv tool install memtomem --refresh`, or clear the cache first: `uv cache clean memtomem`. Check the [latest release](https://github.com/memtomem/memtomem/releases) for the expected version.
 
 Skip to [Connect to your AI editor](#connect-to-your-ai-editor).
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -16,10 +16,13 @@ Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + s
 ```bash
 # 1. Install memtomem (requires Python 3.12+)
 uv tool install memtomem        # or: pipx install memtomem
+mm --version                    # verify — if stale, re-run with --refresh
 
 # 2. Run the setup (preset picker → memory_dir + MCP)
 mm init    # on PATH after `uv tool install` — no `uv run` needed
 ```
+
+> `uv` caches PyPI metadata. If `mm --version` doesn't match the [latest release](https://github.com/memtomem/memtomem/releases) right after install, re-run with `uv tool install memtomem --refresh` or clear the cache: `uv cache clean memtomem`.
 
 The picker offers three presets and an Advanced fallback:
 


### PR DESCRIPTION
## Summary

- Adds `mm --version` as a verify step inside all three first-touch install blocks (repo `README.md`, PyPI `packages/memtomem/README.md`, `docs/guides/getting-started.md`).
- Adds a short blockquote callout pointing to the releases page and showing both remediations (`uv tool install memtomem --refresh` and `uv cache clean memtomem`).
- No code changes. 3 files, 9 lines added.

Closes #390.

## Why

A first-time user running `uv tool install memtomem` right after a new release can get a stale version because `uv` caches PyPI index metadata per package. This was observed after v0.1.22 / v0.1.23 and is documented internally as a recurring pattern. Before this PR, `--refresh` appeared in **0 places** across the public docs surface (repo README + PyPI README + `docs/`), and no doc had a verify step the user could run to notice the problem.

On a fresh test run in this session (cache cleaned beforehand), `uv tool install memtomem` correctly fetched v0.1.24 — so the stale-version path didn't reproduce locally this time, but the issue is time-windowed and hits whoever installs during the stale window.

## Test plan

- [x] `mm --version` is a real subcommand that prints the installed version. Verified in a fresh tool env: `memtomem 0.1.24`.
- [x] `uv tool install memtomem --refresh` is a documented `uv` flag (`uv tool install --help`).
- [x] `uv cache clean memtomem` is a documented `uv` command (`uv cache clean --help` — accepts a package arg).
- [x] Links to `https://github.com/memtomem/memtomem/releases` resolve.
- [x] No lint/test failures expected — docs-only change, no code paths touched.
- [ ] Reviewer: render the three pages and sanity-check the blockquote placement.

## Scope

Out of scope (separate issues):

- `[all]` extras primary-install choice — #391.
- `mm` not on PATH after `uv tool install` — #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
