### PR TITLE
docs(install): add `uv tool update-shell` hint for post-install PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ mm --version                          # verify install
 
 > If `mm --version` shows an older version than the [latest release](https://github.com/memtomem/memtomem/releases), `uv` is likely serving cached PyPI metadata — re-run with `uv tool install memtomem --refresh`, or clear the cache first: `uv cache clean memtomem`.
 
+> **`mm: command not found`?** `uv tool install` drops the shim into `~/.local/bin`, which isn't on `$PATH` in fresh shells on macOS/Linux. Run `uv tool update-shell`, then open a new shell and re-run `mm --version`.
+
 ### 2. Setup
 
 ```bash

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -58,6 +58,8 @@ mm --version                # verify install
 
 > **If `mm --version` shows an older release**: `uv` caches PyPI metadata per package, and a fresh install can resolve to the cached entry for a short window after a new release. Re-run with `uv tool install memtomem --refresh`, or clear the cache first: `uv cache clean memtomem`. Check the [latest release](https://github.com/memtomem/memtomem/releases) for the expected version.
 
+> **If you see `mm: command not found`**: `uv tool install` writes the `mm` shim to `~/.local/bin` (macOS/Linux default), but that directory isn't on `$PATH` in a fresh shell profile. Run `uv tool update-shell` once, then open a new shell and re-run `mm --version`. (`uv` prints a one-line hint on first-ever tool install, but it's easy to miss.)
+
 Skip to [Connect to your AI editor](#connect-to-your-ai-editor).
 
 ### Option B: Project dependency (per-project isolation)

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -24,6 +24,8 @@ mm init    # on PATH after `uv tool install` — no `uv run` needed
 
 > `uv` caches PyPI metadata. If `mm --version` doesn't match the [latest release](https://github.com/memtomem/memtomem/releases) right after install, re-run with `uv tool install memtomem --refresh` or clear the cache: `uv cache clean memtomem`.
 
+> **`mm: command not found`?** `uv` installs the shim to `~/.local/bin` — add it to `$PATH` with `uv tool update-shell`, then open a new shell.
+
 The picker offers three presets and an Advanced fallback:
 
 | Preset | Embedding | Reranker | Tokenizer |


### PR DESCRIPTION
## Summary

- Adds a second blockquote after the install block (stacked on #393) in all three first-touch docs that surfaces the `mm: command not found` failure text and points at `uv tool update-shell` as the fix.
- No code changes. 3 files, 6 lines added (2 per file).

**Stacked on #393** — base branch is `docs/install-refresh-cache-lag`. Merge #393 first, then retarget or rebase this onto main.

Closes #392.

## Why

`uv tool install` writes the `mm` shim to `~/.local/bin` (macOS/Linux default), but that directory isn't on `$PATH` in a fresh shell profile. `uv` itself prints a one-line "run `uv tool update-shell`" hint on the first-ever tool install, but it's easy to scroll past, and the wizard flow the docs lead into (`mm init` right after install) will fail with `mm: command not found` before the user connects the dots.

Before this PR, a grep across `README.md` + `packages/memtomem/README.md` + `docs/` for `update-shell`, `command not found`, and `not on .+PATH` returned **0 hits**.

The #393 change added `mm --version` as the verify step, which is exactly the command that surfaces `command not found` on a broken PATH — so this blockquote is the natural extension of that verify step for the failure case.

## Reproducibility note

On this author's machine, `which mm` resolves because `~/.local/bin` is already on `$PATH` (prior `uv tool install` history). Reproducing the `command not found` path requires a shell profile without `~/.local/bin`, which is the default on macOS; I've left a live-repro out of scope for this session. Evidence is the docs gap (0 mentions, verified above) and the well-known uv behavior on fresh profiles.

## Test plan

- [x] `uv tool update-shell` is a documented `uv` command (`uv tool update-shell --help`).
- [x] `~/.local/bin` is the default `XDG_BIN_HOME` uv writes to on macOS/Linux.
- [x] The failure text `mm: command not found` is the exact shell error a user would see, so it's searchable / skimmable.
- [x] No lint/test failures expected — docs-only, no code paths touched.
- [ ] Reviewer: render the three pages and check the two blockquotes read well sequentially (cache-lag → PATH).

## Scope

Out of scope (separate issues / PRs):

- PyPI cache lag — #390 / #393 (stacked base).
- `[all]` extras primary-install choice — #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
