### PR TITLE
docs(install): flip primary install to memtomem[all]

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ flowchart LR
 ### 1. Install
 
 ```bash
-uv tool install memtomem             # or: pipx install memtomem
+uv tool install 'memtomem[all]'       # or: pipx install 'memtomem[all]'
 mm --version                          # verify install
 ```
 
-> If `mm --version` shows an older version than the [latest release](https://github.com/memtomem/memtomem/releases), `uv` is likely serving cached PyPI metadata — re-run with `uv tool install memtomem --refresh`, or clear the cache first: `uv cache clean memtomem`.
+`[all]` bundles the features the sections below describe — ONNX dense embeddings, Korean tokenizer, Ollama / OpenAI providers, code chunker, and the Web UI. For a BM25-only install without those downloads (~40 MB vs ~250 MB), see the [Minimal install](#minimal-install) option below.
+
+> If `mm --version` shows an older version than the [latest release](https://github.com/memtomem/memtomem/releases), `uv` is likely serving cached PyPI metadata — re-run with `uv tool install 'memtomem[all]' --refresh`, or clear the cache first: `uv cache clean memtomem`.
 
 > **`mm: command not found`?** `uv tool install` drops the shim into `~/.local/bin`, which isn't on `$PATH` in fresh shells on macOS/Linux. Run `uv tool update-shell`, then open a new shell and re-run `mm --version`.
 
@@ -91,9 +93,16 @@ like Namespaces, Sessions, Working Memory, and Health Report.
 <details>
 <summary><b>Other install options</b></summary>
 
+<a id="minimal-install"></a>
+**Minimal** (BM25-only, ~40 MB):
+```bash
+uv tool install memtomem             # no extras — dense search, web UI, Korean tokenizer unavailable until you add them
+```
+Opt in later per-feature: `uv tool install --reinstall 'memtomem[onnx,web]'` (see the extras table in [Getting Started](docs/guides/getting-started.md#option-c-from-source-for-development-or-testing)).
+
 **Project-scoped** (per-project isolation):
 ```bash
-uv add memtomem && uv run mm init    # all commands need `uv run` prefix
+uv add 'memtomem[all]' && uv run mm init    # all commands need `uv run` prefix
 ```
 
 **No install** (uvx on demand):

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -52,11 +52,19 @@ No install needed for MCP usage — `uvx` downloads and runs memtomem on demand 
 
 If you also want the CLI (`mm` command):
 ```bash
-uv tool install memtomem    # or: pipx install memtomem
-mm --version                # verify install
+uv tool install 'memtomem[all]'    # or: pipx install 'memtomem[all]'
+mm --version                        # verify install
 ```
 
-> **If `mm --version` shows an older release**: `uv` caches PyPI metadata per package, and a fresh install can resolve to the cached entry for a short window after a new release. Re-run with `uv tool install memtomem --refresh`, or clear the cache first: `uv cache clean memtomem`. Check the [latest release](https://github.com/memtomem/memtomem/releases) for the expected version.
+**`[all]` vs minimal**: `[all]` bundles ONNX dense embeddings, Korean tokenizer, Ollama / OpenAI SDKs, code chunker, and the Web UI (~250 MB total). For a BM25-only install without downloads (~40 MB), skip the extras:
+
+```bash
+uv tool install memtomem            # BM25 only — dense search, Web UI, Korean tokenizer unavailable
+```
+
+You can opt in to individual features later with `uv tool install --reinstall 'memtomem[onnx,web]'` or any combination from the extras table in [Option C](#option-c-from-source-for-development-or-testing).
+
+> **If `mm --version` shows an older release**: `uv` caches PyPI metadata per package, and a fresh install can resolve to the cached entry for a short window after a new release. Re-run with `uv tool install 'memtomem[all]' --refresh`, or clear the cache first: `uv cache clean memtomem`. Check the [latest release](https://github.com/memtomem/memtomem/releases) for the expected version.
 
 > **If you see `mm: command not found`**: `uv tool install` writes the `mm` shim to `~/.local/bin` (macOS/Linux default), but that directory isn't on `$PATH` in a fresh shell profile. Run `uv tool update-shell` once, then open a new shell and re-run `mm --version`. (`uv` prints a one-line hint on first-ever tool install, but it's easy to miss.)
 
@@ -67,7 +75,7 @@ Skip to [Connect to your AI editor](#connect-to-your-ai-editor).
 Add memtomem as a project dependency — version pinned in `pyproject.toml`:
 
 ```bash
-uv add memtomem                 # or: uv add memtomem[all]
+uv add 'memtomem[all]'          # or: uv add memtomem (BM25-only, skip extras)
 ```
 
 All CLI commands need the `uv run` prefix:
@@ -367,7 +375,7 @@ mm index ~/notes                            # re-index
 
 The CLI isn't installed. Install it:
 ```bash
-uv tool install memtomem     # PyPI
+uv tool install 'memtomem[all]'     # PyPI
 # or
 uv pip install -e "packages/memtomem[all]"  # Source
 ```

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -132,7 +132,7 @@ mem_index(path="~/notes", recursive=True)
 
 > **Plugin users**: Hooks are included in the plugin. You only need to install the CLI for them to activate:
 > ```bash
-> uv tool install memtomem   # or: pipx install memtomem
+> uv tool install 'memtomem[all]'   # or: pipx install 'memtomem[all]'
 > ```
 > Skip to [Tool Usage Guidelines](#tool-usage-guidelines-add-to-claudemd) if you're using the plugin.
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -939,7 +939,7 @@ mm web                                 # launch Web UI (prod surface)
 mm web --dev                           # Web UI with opt-in maintainer pages
 ```
 
-Install the CLI: `uv tool install memtomem` (PyPI) or `uv run mm ...` (source).
+Install the CLI: `uv tool install 'memtomem[all]'` (PyPI) or `uv run mm ...` (source).
 All commands support `-h` and `--help`.
 
 ---

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -14,15 +14,17 @@ Markdown-first long-term memory infrastructure for AI agents. Hybrid keyword + s
 ## Quick Start
 
 ```bash
-# 1. Install memtomem (requires Python 3.12+)
-uv tool install memtomem        # or: pipx install memtomem
-mm --version                    # verify — if stale, re-run with --refresh
+# 1. Install memtomem with all features (requires Python 3.12+)
+uv tool install 'memtomem[all]'  # or: pipx install 'memtomem[all]'
+mm --version                     # verify — if stale, re-run with --refresh
 
 # 2. Run the setup (preset picker → memory_dir + MCP)
 mm init    # on PATH after `uv tool install` — no `uv run` needed
 ```
 
-> `uv` caches PyPI metadata. If `mm --version` doesn't match the [latest release](https://github.com/memtomem/memtomem/releases) right after install, re-run with `uv tool install memtomem --refresh` or clear the cache: `uv cache clean memtomem`.
+`[all]` pulls in ONNX dense embeddings, Korean tokenizer, Ollama / OpenAI SDKs, code chunker, and the Web UI. Skip it (`uv tool install memtomem` bare) for a BM25-only install (~40 MB); opt in later with `uv tool install --reinstall 'memtomem[onnx,web]'` or similar.
+
+> `uv` caches PyPI metadata. If `mm --version` doesn't match the [latest release](https://github.com/memtomem/memtomem/releases) right after install, re-run with `uv tool install 'memtomem[all]' --refresh` or clear the cache: `uv cache clean memtomem`.
 
 > **`mm: command not found`?** `uv` installs the shim to `~/.local/bin` — add it to `$PATH` with `uv tool update-shell`, then open a new shell.
 


### PR DESCRIPTION
## Summary

Flip the primary install command across all first-touch docs to `uv tool install 'memtomem[all]'`. Keep the bare `uv tool install memtomem` shape as a secondary "Minimal install" option. Update the cache-lag blockquotes (from #393) to reference the new primary command.

5 files, +33 / −14 lines. Docs-only, no code changes.

Closes #391.

## Why

The `[all]` extra (`memtomem[onnx,ollama,openai,korean,code,web]`) bundles exactly the features the public docs advertise:

- **ONNX dense embeddings** — required by both "Recommended" presets (`English` / `Korean-optimized`) that `mm init` pushes by default
- **Korean tokenizer** (`kiwipiepy`) — advertised as a multilingual selling point
- **Ollama / OpenAI providers** — listed in every embeddings table
- **Code chunker** (`tree-sitter`) — implied by "index markdown + code"
- **Web UI** (`fastapi`) — surfaced in its own README section + `mm web` command

A fresh `uv tool install memtomem` ships none of these. Observed on 2026-04-23 in a clean tool env:

```
fastembed                 MISSING ✗
onnxruntime               MISSING ✗
kiwipiepy                 MISSING ✗
tree_sitter               MISSING ✗
fastapi                   MISSING ✗
ollama                    MISSING ✗
openai                    MISSING ✗
```

Runtime behaviour after picking a feature that needs a missing extra:

- `mm web` → loud error with remediation (`uv tool install --reinstall 'memtomem[web]'`)
- `mm init -y --provider onnx` → wizard accepts, writes `provider=onnx (0d)`; index/search then warn "degraded mode — Run 'mm embedding-reset' to fix"
- `mm init -y --tokenizer kiwipiepy` → wizard accepts; search-time warning "kiwipiepy not installed — falling back to unicode61"

Users aren't silent-degraded at runtime (that framing from the original issue was revised in [this fact-check comment](https://github.com/memtomem/memtomem/issues/391#issuecomment-4300594282)), but **the install command doesn't match what the same README promises**. Users who follow the README literally can end up configuring a preset that never reaches dense search and only learn about it via runtime warnings.

Going with **Option 1** from the issue discussion: the recommended setups already require `[all]`-level extras, so making the primary command deliver that is consistent with the docs' implicit promise. Users who specifically want a ~40 MB lightweight install can take the Minimal option.

## Files changed

| File | Change |
|---|---|
| `README.md` | Primary install → `[all]`; added **Minimal** option inside `<details>` with an explicit anchor; updated cache-lag blockquote; flipped `uv add` inside `<details>` |
| `packages/memtomem/README.md` (PyPI) | Primary install → `[all]`; added one-line tradeoff paragraph; updated cache-lag blockquote |
| `docs/guides/getting-started.md` | Option A primary → `[all]` + inline BM25-only alternative + extras opt-in pointer; Option B `uv add` flipped; updated cache-lag blockquote; "No such command" Troubleshooting entry also flipped |
| `docs/guides/integrations/claude-code.md` | Hooks-automation install hint → `[all]` |
| `docs/guides/reference.md` | CLI-reference footer install line → `[all]` |

Intentional residual `uv tool install memtomem` bare lines (4 total) are all inside the **Minimal install** alternatives, clearly labeled as such.

## Scope — intentionally out

- **Wizard-time validation of extras** (e.g. `mm init -y --provider onnx` refusing when `fastembed` is missing) — separate gap, tracked adjacent to #362.
- **`[all]` packaging composition** — no `pyproject.toml` changes in this PR. If we later split into a lighter "recommended" extra set, the docs can re-point.
- **Absolute URLs vs relative links** — the PyPI README already mixes both (see line 33); kept the same style.

## Test plan

- [x] Verified on a fresh `uv tool install 'memtomem[all]'` in a clean env: `mm --version` prints `0.1.24`, `fastembed`, `kiwipiepy`, `fastapi`, `ollama`, `openai`, `tree_sitter` all import.
- [x] Inline alternative `uv tool install memtomem` verified in a prior run (48 MB, BM25-only default config).
- [x] Anchor `#minimal-install` added via explicit `<a id>` tag (safer than heading-derived slug).
- [x] Cross-reference `#option-c-from-source-for-development-or-testing` matches GitHub's default anchor slug for the existing `### Option C: From source (for development or testing)` heading.
- [x] No lint/test failures expected — docs only.
- [ ] Reviewer: render each page and confirm the Minimal/alternative blocks read well; verify `[all]` shows up unquoted-unbracket-exploded in rendered code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
