### PR TITLE
fix(uninstall): detect active DB writers via BEGIN IMMEDIATE probe

### DIFF
--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -12,9 +12,12 @@ Design notes:
   (uv-tool / uvx / venv-relative / system / unknown) need different
   uninstall commands; we print the right one but never execute, since the
   package manager owns its own permissions and lifecycle.
-* If the MCP server is still running we refuse — deleting an open SQLite
-  file under WAL mode risks corruption. ``--force`` overrides for the
-  rare case the user knows the pid is wrong.
+* If the MCP server is still running (``.server.pid``) OR any other
+  process holds a SQLite write lock on the DB (``mm web``, ``mm
+  watchdog``, ad-hoc connections) we refuse — deleting an open SQLite
+  file under WAL mode risks corruption. ``--force`` overrides. The
+  write-lock probe uses ``BEGIN IMMEDIATE`` to catch writers the pid
+  file doesn't know about (see ``_check_db_lock``).
 * If config.json is corrupted we fall back to defaults rather than
   aborting — uninstall is itself a recovery path, so it cannot depend on
   a valid config.
@@ -24,6 +27,7 @@ from __future__ import annotations
 
 import fcntl
 import shutil
+import sqlite3
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -82,6 +86,20 @@ class _ServerState:
     alive: bool
     pid: int | None
     pid_file: Path | None
+
+
+@dataclass(frozen=True)
+class _DbLockState:
+    """Result of probing the SQLite DB for an active writer.
+
+    ``locked`` is True only when another connection holds a RESERVED /
+    PENDING / EXCLUSIVE lock at probe time — i.e. an active writer.
+    Pure readers (SHARED locks only) are not detected; that's an
+    accepted tradeoff (see ``_check_db_lock``).
+    """
+
+    locked: bool
+    probe_error: str | None
 
 
 @dataclass(frozen=True)
@@ -193,6 +211,79 @@ def _check_server_liveness() -> _ServerState:
         if state.alive:
             return state
     return _ServerState(alive=False, pid=None, pid_file=None)
+
+
+def _check_db_lock(db_path: Path) -> _DbLockState:
+    """Probe whether another connection holds a write lock on ``db_path``.
+
+    Motivation: the ``.server.pid`` check only catches the MCP
+    ``memtomem-server`` entrypoint. ``mm web``, ``mm watchdog``, and any
+    user-run sqlite3 connection are invisible to that scheme, so
+    uninstall could silently proceed while a live writer was holding the
+    WAL (observed in issue #384).
+
+    Mechanism: open a short-timeout connection and attempt
+    ``BEGIN IMMEDIATE`` — that tries to acquire a RESERVED lock and
+    raises ``SQLITE_BUSY`` (``sqlite3.OperationalError`` whose message
+    contains "locked"/"busy") if any other connection holds
+    RESERVED/PENDING/EXCLUSIVE. On success we ``ROLLBACK`` immediately;
+    the probe never modifies data.
+
+    Tradeoff: a process that only reads (SHARED lock) does NOT block
+    ``BEGIN IMMEDIATE`` in WAL mode, so a quiet-at-probe-time reader
+    slips through. That's an accepted tradeoff here — the WAL-corruption
+    path (active writer) is the severe case and is what this probe is
+    meant to guard. Complete reader-detection would need an ``lsof``
+    fallback or an extended pid-file scheme (see issue #384 discussion).
+
+    Error handling: if the probe can't run (file missing, corrupt,
+    permission denied, sqlite unavailable), returns ``locked=False`` with
+    ``probe_error`` set. Uninstall is itself a recovery path and must not
+    be blocked by unrelated DB integrity issues.
+    """
+    if not db_path.exists():
+        return _DbLockState(locked=False, probe_error=None)
+
+    # Header gate: only probe real SQLite files. Opening a corrupt /
+    # non-SQLite file with ``mode=rw`` can still trigger side effects on
+    # sibling ``-wal`` / ``-shm`` files (observed: a fake-content WAL
+    # got unlinked when SQLite tried to verify it). Stay out of that
+    # code path unless the file is actually a SQLite database.
+    try:
+        with db_path.open("rb") as fh:
+            header = fh.read(16)
+    except OSError as exc:
+        return _DbLockState(locked=False, probe_error=f"{type(exc).__name__}: {exc}")
+    if header != b"SQLite format 3\x00":
+        return _DbLockState(locked=False, probe_error="not a SQLite database")
+
+    conn: sqlite3.Connection | None = None
+    try:
+        # mode=rw: don't auto-create if the file vanishes between stat
+        # and connect (paranoia for concurrent deletions).
+        conn = sqlite3.connect(
+            f"file:{db_path}?mode=rw",
+            uri=True,
+            timeout=0.25,
+        )
+        conn.execute("BEGIN IMMEDIATE")
+        conn.rollback()
+        return _DbLockState(locked=False, probe_error=None)
+    except sqlite3.OperationalError as exc:
+        msg = str(exc).lower()
+        if "locked" in msg or "busy" in msg:
+            return _DbLockState(locked=True, probe_error=None)
+        # Other OperationalError (not-a-database, read-only, etc.) — skip
+        # probe, let uninstall proceed.
+        return _DbLockState(locked=False, probe_error=f"{type(exc).__name__}: {exc}")
+    except (sqlite3.Error, OSError) as exc:
+        return _DbLockState(locked=False, probe_error=f"{type(exc).__name__}: {exc}")
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except sqlite3.Error:
+                pass
 
 
 # ---- inventory -----------------------------------------------------------
@@ -552,6 +643,7 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
     state_dir = _DEFAULT_STATE_DIR
 
     server = _check_server_liveness()
+    db_lock = _check_db_lock(db_path)
 
     # Empty-state fast path.
     if not state_dir.exists() and not db_path.exists():
@@ -571,14 +663,29 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
     label, lines = _binary_uninstall_hint(profile)
     _print_binary_hint(label, lines)
 
-    if server.alive and not force:
+    if (server.alive or db_lock.locked) and not force:
         click.echo("")
-        click.secho(
-            f"Server still running (pid {server.pid}). Refusing to delete state — "
-            "an active server holds the SQLite WAL and deleting it risks corruption.",
-            fg="red",
-        )
-        click.secho("  Stop the server first, or pass --force to override.", fg="red")
+        if server.alive:
+            click.secho(
+                f"Server still running (pid {server.pid}). Refusing to delete state — "
+                "an active server holds the SQLite WAL and deleting it risks corruption.",
+                fg="red",
+            )
+            click.secho("  Stop the server first, or pass --force to override.", fg="red")
+        else:
+            # db_lock.locked only — writer without .server.pid (mm web,
+            # mm watchdog, ad-hoc script, ...). Point the user at lsof /
+            # ps so they can find it without another round-trip.
+            click.secho(
+                f"Another process holds a write lock on {db_path}. Refusing to delete "
+                "state — an active writer can corrupt the WAL.",
+                fg="red",
+            )
+            click.secho(
+                f"  Find it with `lsof {db_path}` (or `ps aux | grep memtomem`), "
+                "stop it, or pass --force to override.",
+                fg="red",
+            )
         sys.exit(2)
 
     if will_delete_bytes == 0 and not inv.other_files.paths:

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -12,6 +12,7 @@ import contextlib
 import fcntl
 import json
 import os
+import sqlite3
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -452,6 +453,71 @@ class TestRuntimePidCleanedWithOther:
 
 
 # -------------------------------------------------------------------- 13
+
+
+class TestDbWriterLockRefuses:
+    """Active SQLite writer without a .server.pid (mm web / watchdog / ad-hoc)
+    must also block the uninstall — the gap #384 called out.
+
+    The probe relies on ``BEGIN IMMEDIATE`` raising ``SQLITE_BUSY`` when
+    another connection holds RESERVED-or-above. Holding an open
+    ``BEGIN IMMEDIATE`` transaction in the test process reproduces this
+    cross-process lock contention within a single pytest run.
+    """
+
+    def _make_real_db(self, home: Path) -> tuple[Path, sqlite3.Connection]:
+        state = home / ".memtomem"
+        state.mkdir(parents=True, exist_ok=True)
+        # Keep parity with _seed_state for non-DB files so the inventory
+        # path is exercised end-to-end, but seed a *real* SQLite DB.
+        (state / "config.json").write_text('{"embedding": {"provider": "none"}}', encoding="utf-8")
+        (state / "memories").mkdir(exist_ok=True)
+        db_path = state / "memtomem.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE _probe (id INTEGER)")
+        conn.commit()
+        return db_path, conn
+
+    def test_refuses_when_writer_holds_lock(self, home):
+        db_path, conn = self._make_real_db(home)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            result = CliRunner().invoke(cli, ["uninstall", "-y"])
+            assert result.exit_code == 2, result.output
+            assert "holds a write lock" in result.output
+            assert str(db_path) in result.output
+            assert "lsof" in result.output
+            # "Server still running" path must NOT trigger — no .server.pid here.
+            assert "Server still running" not in result.output
+            # Nothing deleted while the writer is alive.
+            assert db_path.exists()
+        finally:
+            conn.rollback()
+            conn.close()
+
+    def test_force_overrides_db_lock(self, home):
+        db_path, conn = self._make_real_db(home)
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            result = CliRunner().invoke(cli, ["uninstall", "-y", "--force"])
+            assert result.exit_code == 0, result.output
+            # State dir gets wiped — even if the lock-holding connection
+            # still has the inode, the directory entry is gone.
+            assert not db_path.exists()
+        finally:
+            try:
+                conn.rollback()
+            except sqlite3.ProgrammingError:
+                pass  # connection may be invalidated after the file vanished
+            conn.close()
+
+    def test_proceeds_when_db_exists_but_no_writer(self, home):
+        db_path, conn = self._make_real_db(home)
+        conn.close()  # release before probing — no writer held.
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "holds a write lock" not in result.output
+        assert not db_path.exists()
 
 
 class TestPidStaleProceeds:


### PR DESCRIPTION
## Summary

Adds a `BEGIN IMMEDIATE` probe against the SQLite DB in `mm uninstall` so that any active writer — `mm web`, `mm watchdog`, an ad-hoc script, anything — blocks the uninstall, not just the MCP `memtomem-server` whose pid we track in `.server.pid`. Closes #384.

2 files, +183 / −10.

## Why

The liveness check shipped in #379 / v0.1.23 was `os.kill(pid, 0)` against `~/.memtomem/.server.pid`. That pid file is written by the MCP entrypoint only. Every other process that can hold a live SQLite handle is invisible to that scheme, which is exactly the silent-data-corruption path #384 reproduced: `mm web` was running, `mm uninstall -y` succeeded without `--force`, the DB inode was unlinked while another process was still writing to it.

## Design

**Primary check — `BEGIN IMMEDIATE` with short `busy_timeout`** (direction 3 from #384, per reporter's stated preference):

- Catches any connection that holds RESERVED / PENDING / EXCLUSIVE at probe time.
- Process-agnostic: doesn't care how the writer was launched.
- Zero side effects: `ROLLBACK` immediately on success; no data modified.

**Scoping tradeoff, documented in the function docstring**:

- A process that holds only a SHARED lock (pure reader at probe time) will *not* block `BEGIN IMMEDIATE` in WAL mode. That reader can still end up with the inode after uninstall unlinks the directory entry, leading to UI/DB desync once the user re-installs.
- The severe case — active writer → WAL corruption — is what this PR guards. Full reader detection needs either `lsof` fallback (POSIX-only) or extending the pid-file scheme to every long-lived entrypoint; both are separate follow-ups and worth doing, but out of scope here.

**Header gate** — only probe when the file's first 16 bytes are `SQLite format 3\x00`:

- Discovered while fixing: opening a non-SQLite file with `mode=rw` can trigger sibling-file side effects (an existing test with fake `b"sqlite-fake"` content started losing its fake `-wal` file after my probe ran). Gating on the magic bytes keeps the probe side-effect-free and makes the existing fake-DB tests continue to exercise the probe-skipped path.

**`.server.pid` behavior preserved**: still checked first; if `.server.pid` is valid and alive, the existing "Server still running (pid X)" message wins. The new DB-lock message only fires when there's no live pid file but the DB is actually locked.

**Error handling is permissive**: if the probe can't run (DB missing, corrupt, permission denied, `sqlite3.Error` of any kind), return `locked=False` with `probe_error` set. Uninstall is itself a recovery path and must not be blocked by unrelated integrity issues — same principle as the existing `_load_config_safely` that swallows config parse errors.

## Test plan

- [x] `test_refuses_when_writer_holds_lock` — open a real SQLite DB, `BEGIN IMMEDIATE` in the test process, verify uninstall exits 2 with "holds a write lock" + `lsof` hint, verify DB still exists.
- [x] `test_force_overrides_db_lock` — same setup, `--force`, verify uninstall proceeds and the DB file is unlinked (even though the test's connection still holds the inode on POSIX — that's the documented escape hatch).
- [x] `test_proceeds_when_db_exists_but_no_writer` — valid SQLite DB with no open connection, uninstall proceeds.
- [x] All 22 existing uninstall tests continue to pass.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` advisory clean on the changed file.
- [x] Broader `pytest -k "cli or uninstall"`: 222 passed.

## Out of scope — tracked as follow-ups

- **Reader-only detection** (the desync case). Options in the issue discussion: `lsof` fallback or pid-file expansion. Pick later.
- **#387** — `memtomem-server` leaves stale `.server.pid` on exit. Separate issue, adjacent but not blocking this fix.
- **Behavior when `--force` proceeds with an active writer**: we print the usual summary but don't escalate beyond what `--force` already signals ("you said so"). If we want a post-hoc "the other process is now orphaned at inode N" message, that's a separate UX call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
