### PR TITLE
feat(server): add AppContext.ensure_initialized plumbing (#399 phase 1)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/watchdog_cmd.py
@@ -83,17 +83,9 @@ async def _watchdog_run(as_json: bool) -> None:
     from memtomem.config import HealthWatchdogConfig
     from memtomem.server.context import AppContext
     from memtomem.server.health_watchdog import HealthWatchdog
-    from memtomem.indexing.watcher import FileWatcher
 
     async with cli_components() as comp:
-        ctx = AppContext(
-            config=comp.config,
-            storage=comp.storage,
-            embedder=comp.embedder,
-            index_engine=comp.index_engine,
-            search_pipeline=comp.search_pipeline,
-            watcher=FileWatcher(comp.index_engine, comp.config.indexing),
-        )
+        ctx = AppContext.from_components(comp)
         config = HealthWatchdogConfig(enabled=True)
         wd = HealthWatchdog(ctx, config)
         await wd.start()

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSession
@@ -21,6 +21,22 @@ if TYPE_CHECKING:
     from memtomem.storage.sqlite_backend import SqliteBackend
 
 
+def _require_initialized(components: Components | None, attr: str) -> Components:
+    """Raise ``RuntimeError`` if ``_components`` has not been populated.
+
+    Uses an explicit ``if … raise`` rather than ``assert`` so the check
+    survives ``python -O`` and ``PYTHONOPTIMIZE`` — pre-init access is a
+    programming bug we want to surface with a clear error, not an
+    ``AttributeError`` the optimizer synthesizes after stripping the assert.
+    """
+    if components is None:
+        raise RuntimeError(
+            f"AppContext.{attr} accessed before ensure_initialized() — "
+            "call ``await app.ensure_initialized()`` in the handler first."
+        )
+    return components
+
+
 @dataclass
 class AppContext:
     """Dependency container for MCP request handlers.
@@ -33,6 +49,19 @@ class AppContext:
 
     Phase 1 keeps ``app_lifespan`` calling ``ensure_initialized`` eagerly,
     so behavior is unchanged. Phase 3 will drop the eager call.
+
+    ``_owns_components`` distinguishes two construction paths:
+
+    * ``ensure_initialized`` — we created the ``Components`` ourselves, so
+      :meth:`close` is responsible for tearing them down.
+    * :meth:`from_components` — the caller supplied a ``Components`` they
+      are already managing (``cli_components`` context manager, test
+      fixtures); :meth:`close` must not double-close on their behalf.
+
+    Without this flag the second path would hand the caller a footgun:
+    calling ``ctx.close()`` would invalidate the ``Components`` they are
+    still holding a live reference to, and the caller's own cleanup would
+    then hit already-closed storage / embedder.
     """
 
     config: Mem2MemConfig
@@ -40,9 +69,9 @@ class AppContext:
     current_namespace: str | None = None
     current_session_id: str | None = None
     # Internal state — not part of the public ``__init__`` surface; populated
-    # by ``ensure_initialized`` / ``from_components`` and by the lifespan
-    # (for ``_health_watchdog`` once it has started).
+    # by ``ensure_initialized`` / ``from_components`` / :meth:`set_health_watchdog`.
     _components: Components | None = field(default=None, init=False, repr=False)
+    _owns_components: bool = field(default=False, init=False, repr=False)
     _dedup_scanner: DedupScanner | None = field(default=None, init=False, repr=False)
     _health_watchdog: object | None = field(default=None, init=False, repr=False)
     # per-session, scoped to AppContext lifetime. Gate to emit a dim-mismatch
@@ -53,44 +82,33 @@ class AppContext:
     _init_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     # ── component accessors ───────────────────────────────────────────────
-    # These raise if accessed before ``ensure_initialized`` has populated
-    # ``_components``. Tool handlers must call ``await app.ensure_initialized()``
-    # before reading them (Phase 2). In Phase 1 the lifespan eagerly inits, so
-    # all handlers see populated state — the assertions catch programming
-    # errors during the migration.
+    # These raise ``RuntimeError`` if accessed before ``ensure_initialized``
+    # has populated ``_components``. Tool handlers must call
+    # ``await app.ensure_initialized()`` before reading them (Phase 2). In
+    # Phase 1 the lifespan eagerly inits, so all handlers see populated
+    # state — the runtime check catches programming errors during the
+    # migration without disappearing under ``python -O``.
 
     @property
     def storage(self) -> SqliteBackend:
-        assert self._components is not None, (
-            "AppContext.storage accessed before ensure_initialized()"
-        )
-        return self._components.storage
+        return _require_initialized(self._components, "storage").storage
 
     @property
     def embedder(self) -> EmbeddingProvider:
-        assert self._components is not None, (
-            "AppContext.embedder accessed before ensure_initialized()"
-        )
-        return self._components.embedder
+        return _require_initialized(self._components, "embedder").embedder
 
     @property
     def index_engine(self) -> IndexEngine:
-        assert self._components is not None, (
-            "AppContext.index_engine accessed before ensure_initialized()"
-        )
-        return self._components.index_engine
+        return _require_initialized(self._components, "index_engine").index_engine
 
     @property
     def search_pipeline(self) -> SearchPipeline:
-        assert self._components is not None, (
-            "AppContext.search_pipeline accessed before ensure_initialized()"
-        )
-        return self._components.search_pipeline
+        return _require_initialized(self._components, "search_pipeline").search_pipeline
 
     @property
     def llm_provider(self) -> LLMProvider | None:
         # LLM is optional even after init — return None when absent rather
-        # than asserting, mirroring the old field semantics.
+        # than raising, mirroring the old field semantics.
         return None if self._components is None else self._components.llm
 
     @property
@@ -109,6 +127,15 @@ class AppContext:
             return None
         return self._components.embedding_broken
 
+    def set_health_watchdog(self, watchdog: object) -> None:
+        """Stash the health-watchdog instance the lifespan has started.
+
+        Lifespan-owned, not context-owned — :meth:`close` does not stop it.
+        The indirection gives callers a typed seam instead of poking
+        ``ctx._health_watchdog`` across module boundaries.
+        """
+        self._health_watchdog = watchdog
+
     # ── lifecycle ─────────────────────────────────────────────────────────
 
     async def ensure_initialized(self) -> Components:
@@ -120,6 +147,12 @@ class AppContext:
         so a retry can succeed (transient failures like a race on DB file
         creation should not poison the context for the rest of the
         session).
+
+        If ``create_components`` succeeds but a post-factory step
+        (currently the ``DedupScanner`` construction) raises, the already-
+        built ``Components`` would otherwise leak its open sqlite handle
+        and embedder session. We explicitly tear it down before
+        re-raising.
         """
         if self._components is not None:
             return self._components
@@ -127,38 +160,53 @@ class AppContext:
             if self._components is not None:
                 return self._components
             from memtomem.search.dedup import DedupScanner
-            from memtomem.server.component_factory import create_components
+            from memtomem.server.component_factory import close_components, create_components
 
             comp = await create_components(self.config)
-            self._dedup_scanner = DedupScanner(storage=comp.storage, embedder=comp.embedder)
+            try:
+                self._dedup_scanner = DedupScanner(storage=comp.storage, embedder=comp.embedder)
+            except Exception:
+                # Don't leak the sqlite/embedder handles the factory opened
+                # just because a post-factory step failed.
+                await close_components(comp)
+                raise
             self._components = comp
+            self._owns_components = True
             return comp
 
     @classmethod
-    def from_components(cls, components: Components, **kwargs: Any) -> AppContext:
-        """Build an ``AppContext`` from already-created ``Components``.
+    def from_components(cls, components: Components) -> AppContext:
+        """Build an ``AppContext`` from a caller-owned ``Components``.
 
         Used by CLI commands (``mm watchdog``) and tests that bootstrap
-        components outside of the MCP server lifespan.
+        components outside of the MCP server lifespan. The caller retains
+        ownership — :meth:`close` will *not* tear the components down,
+        since the caller (typically an ``async with cli_components()``
+        block) is already responsible for that and a double-close would
+        hit already-closed handles.
         """
         from memtomem.search.dedup import DedupScanner
 
-        ctx = cls(config=components.config, **kwargs)
+        ctx = cls(config=components.config)
         ctx._components = components
+        ctx._owns_components = False
         ctx._dedup_scanner = DedupScanner(storage=components.storage, embedder=components.embedder)
         return ctx
 
     async def close(self) -> None:
-        """Tear down components if they were initialized.
+        """Tear down components if this context owns them.
 
         Webhook manager and health watchdog are owned by the lifespan, not
-        the context — they are not closed here.
+        the context — they are not closed here. Components passed in via
+        :meth:`from_components` are also left alone (the supplier closes
+        them) — the ``_owns_components`` flag distinguishes the two paths.
         """
         from memtomem.server.component_factory import close_components
 
-        if self._components is not None:
+        if self._components is not None and self._owns_components:
             await close_components(self._components)
-            self._components = None
+        self._components = None
+        self._owns_components = False
         self._dedup_scanner = None
 
 

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -4,52 +4,162 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSession
 
 from memtomem.config import Mem2MemConfig
-from memtomem.indexing.engine import IndexEngine
-from memtomem.indexing.watcher import FileWatcher
-from memtomem.search.dedup import DedupScanner
-from memtomem.search.pipeline import SearchPipeline
-from memtomem.storage.sqlite_backend import SqliteBackend
 
 if TYPE_CHECKING:
     from memtomem.embedding.base import EmbeddingProvider
+    from memtomem.indexing.engine import IndexEngine
     from memtomem.llm.base import LLMProvider
+    from memtomem.search.dedup import DedupScanner
+    from memtomem.search.pipeline import SearchPipeline
+    from memtomem.server.component_factory import Components
+    from memtomem.storage.sqlite_backend import SqliteBackend
 
 
 @dataclass
 class AppContext:
-    """Dependency container holding all initialized services."""
+    """Dependency container for MCP request handlers.
+
+    Heavy components (storage, embedder, index engine, search pipeline) live
+    behind ``_components`` and are exposed as read-only properties. They are
+    populated lazily by :meth:`ensure_initialized` so handshake-only MCP
+    sessions (``initialize`` + ``tools/list``) don't trigger DB creation
+    in ``~/.memtomem/``. See issue #399 for the full design.
+
+    Phase 1 keeps ``app_lifespan`` calling ``ensure_initialized`` eagerly,
+    so behavior is unchanged. Phase 3 will drop the eager call.
+    """
 
     config: Mem2MemConfig
-    storage: SqliteBackend
-    embedder: EmbeddingProvider
-    index_engine: IndexEngine
-    search_pipeline: SearchPipeline
-    watcher: FileWatcher
-    dedup_scanner: DedupScanner | None = None
     webhook_manager: object | None = None
-    health_watchdog: object | None = None
-    llm_provider: LLMProvider | None = None
     current_namespace: str | None = None
     current_session_id: str | None = None
-    # Populated when the server entered degraded mode at startup because of a
-    # ``chunks_vec`` / provider mismatch. Same shape as
-    # ``SqliteBackend.embedding_mismatch``. Vector-dependent tool handlers
-    # check this flag (via ``_check_embedding_mismatch``) and short-circuit
-    # with an actionable error; recovery tooling
-    # (``mem_embedding_reset``, ``mem_status``, ``mem_stats``) stays
-    # callable. See issue #349.
-    embedding_broken: dict | None = None
+    # Internal state — not part of the public ``__init__`` surface; populated
+    # by ``ensure_initialized`` / ``from_components`` and by the lifespan
+    # (for ``_health_watchdog`` once it has started).
+    _components: Components | None = field(default=None, init=False, repr=False)
+    _dedup_scanner: DedupScanner | None = field(default=None, init=False, repr=False)
+    _health_watchdog: object | None = field(default=None, init=False, repr=False)
     # per-session, scoped to AppContext lifetime. Gate to emit a dim-mismatch
     # hint only once per MCP session so repeated mem_add / mem_search calls
     # do not spam the same notice. Writes go through ``_config_lock``.
     _dim_mismatch_announced: bool = False
     _config_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _init_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    # ── component accessors ───────────────────────────────────────────────
+    # These raise if accessed before ``ensure_initialized`` has populated
+    # ``_components``. Tool handlers must call ``await app.ensure_initialized()``
+    # before reading them (Phase 2). In Phase 1 the lifespan eagerly inits, so
+    # all handlers see populated state — the assertions catch programming
+    # errors during the migration.
+
+    @property
+    def storage(self) -> SqliteBackend:
+        assert self._components is not None, (
+            "AppContext.storage accessed before ensure_initialized()"
+        )
+        return self._components.storage
+
+    @property
+    def embedder(self) -> EmbeddingProvider:
+        assert self._components is not None, (
+            "AppContext.embedder accessed before ensure_initialized()"
+        )
+        return self._components.embedder
+
+    @property
+    def index_engine(self) -> IndexEngine:
+        assert self._components is not None, (
+            "AppContext.index_engine accessed before ensure_initialized()"
+        )
+        return self._components.index_engine
+
+    @property
+    def search_pipeline(self) -> SearchPipeline:
+        assert self._components is not None, (
+            "AppContext.search_pipeline accessed before ensure_initialized()"
+        )
+        return self._components.search_pipeline
+
+    @property
+    def llm_provider(self) -> LLMProvider | None:
+        # LLM is optional even after init — return None when absent rather
+        # than asserting, mirroring the old field semantics.
+        return None if self._components is None else self._components.llm
+
+    @property
+    def dedup_scanner(self) -> DedupScanner | None:
+        return self._dedup_scanner
+
+    @property
+    def health_watchdog(self) -> object | None:
+        return self._health_watchdog
+
+    @property
+    def embedding_broken(self) -> dict | None:
+        # Mirrors the old field: None until init has run, then either None
+        # (healthy) or the mismatch-info dict (degraded mode, see #349).
+        if self._components is None:
+            return None
+        return self._components.embedding_broken
+
+    # ── lifecycle ─────────────────────────────────────────────────────────
+
+    async def ensure_initialized(self) -> Components:
+        """Run ``create_components`` once, return it on subsequent calls.
+
+        Concurrent first-callers serialize on ``_init_lock``; the first
+        completes the init, later ones return the cached ``Components``.
+        On failure the lock is released and ``_components`` stays ``None``,
+        so a retry can succeed (transient failures like a race on DB file
+        creation should not poison the context for the rest of the
+        session).
+        """
+        if self._components is not None:
+            return self._components
+        async with self._init_lock:
+            if self._components is not None:
+                return self._components
+            from memtomem.search.dedup import DedupScanner
+            from memtomem.server.component_factory import create_components
+
+            comp = await create_components(self.config)
+            self._dedup_scanner = DedupScanner(storage=comp.storage, embedder=comp.embedder)
+            self._components = comp
+            return comp
+
+    @classmethod
+    def from_components(cls, components: Components, **kwargs: Any) -> AppContext:
+        """Build an ``AppContext`` from already-created ``Components``.
+
+        Used by CLI commands (``mm watchdog``) and tests that bootstrap
+        components outside of the MCP server lifespan.
+        """
+        from memtomem.search.dedup import DedupScanner
+
+        ctx = cls(config=components.config, **kwargs)
+        ctx._components = components
+        ctx._dedup_scanner = DedupScanner(storage=components.storage, embedder=components.embedder)
+        return ctx
+
+    async def close(self) -> None:
+        """Tear down components if they were initialized.
+
+        Webhook manager and health watchdog are owned by the lifespan, not
+        the context — they are not closed here.
+        """
+        from memtomem.server.component_factory import close_components
+
+        if self._components is not None:
+            await close_components(self._components)
+            self._components = None
+        self._dedup_scanner = None
 
 
 CtxType = Context[ServerSession, AppContext] | None

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -13,8 +13,6 @@ from mcp.server.fastmcp import FastMCP
 
 from memtomem.config import Mem2MemConfig
 from memtomem.indexing.watcher import FileWatcher
-from memtomem.search.dedup import DedupScanner
-from memtomem.server.component_factory import Components, close_components, create_components
 from memtomem.server.context import AppContext
 
 logger = logging.getLogger(__name__)
@@ -83,14 +81,6 @@ def _load_dotenv() -> None:
         pass
 
 
-async def _shutdown(watcher: FileWatcher, comp: Components) -> None:
-    for label, coro in [("watcher", watcher.stop()), ("components", close_components(comp))]:
-        try:
-            await coro
-        except Exception:
-            logger.warning("Shutdown step '%s' failed", label, exc_info=True)
-
-
 # ---------------------------------------------------------------------------
 # Main lifespan
 # ---------------------------------------------------------------------------
@@ -102,7 +92,21 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     _setup_logging()
 
     config = Mem2MemConfig()
-    comp = await create_components(config)
+
+    # Webhook manager is storage-free; safe to construct before component init.
+    webhook_mgr = None
+    if config.webhook.enabled and config.webhook.url:
+        from memtomem.server.webhooks import WebhookManager
+
+        webhook_mgr = WebhookManager(config.webhook)
+
+    ctx = AppContext(config=config, webhook_manager=webhook_mgr)
+
+    # Phase 1 of #399 keeps init eager: the rest of startup (watcher,
+    # schedulers, watchdog) needs storage/embedder ready. Phase 3 will move
+    # this call (and the watcher/scheduler startup below) into the first
+    # tool-call path.
+    comp = await ctx.ensure_initialized()
 
     # When the server came up in degraded mode (embedding mismatch, see
     # issue #349) don't start the file watcher — indexing goes through
@@ -111,28 +115,6 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     watcher = FileWatcher(comp.index_engine, config.indexing)
     if comp.embedding_broken is None:
         await watcher.start()
-
-    dedup_scanner = DedupScanner(storage=comp.storage, embedder=comp.embedder)
-
-    # Webhook manager
-    webhook_mgr = None
-    if config.webhook.enabled and config.webhook.url:
-        from memtomem.server.webhooks import WebhookManager
-
-        webhook_mgr = WebhookManager(config.webhook)
-
-    ctx = AppContext(
-        config=config,
-        storage=comp.storage,
-        embedder=comp.embedder,
-        index_engine=comp.index_engine,
-        search_pipeline=comp.search_pipeline,
-        watcher=watcher,
-        dedup_scanner=dedup_scanner,
-        webhook_manager=webhook_mgr,
-        llm_provider=comp.llm,
-        embedding_broken=comp.embedding_broken,
-    )
 
     # Background schedulers are skipped in degraded mode (see issue #349) —
     # they walk the index / re-embed chunks and would hit the same missing
@@ -163,7 +145,7 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
 
         watchdog = HealthWatchdog(ctx, config.health_watchdog)
         await watchdog.start()
-        ctx.health_watchdog = watchdog
+        ctx._health_watchdog = watchdog
 
     try:
         yield ctx
@@ -188,4 +170,11 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
                 await webhook_mgr.close()
             except Exception:
                 logger.warning("Failed to close webhook manager", exc_info=True)
-        await _shutdown(watcher, comp)
+        try:
+            await watcher.stop()
+        except Exception:
+            logger.warning("Shutdown step 'watcher' failed", exc_info=True)
+        try:
+            await ctx.close()
+        except Exception:
+            logger.warning("Shutdown step 'components' failed", exc_info=True)

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -145,7 +145,7 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
 
         watchdog = HealthWatchdog(ctx, config.health_watchdog)
         await watchdog.start()
-        ctx._health_watchdog = watchdog
+        ctx.set_health_watchdog(watchdog)
 
     try:
         yield ctx

--- a/packages/memtomem/tests/test_server_app_context.py
+++ b/packages/memtomem/tests/test_server_app_context.py
@@ -116,8 +116,11 @@ async def test_from_components_skips_factory(fake_components: Components) -> Non
 
 
 def test_storage_access_before_init_raises() -> None:
+    """Uses ``RuntimeError`` not ``AssertionError`` so the check survives
+    ``python -O`` / ``PYTHONOPTIMIZE=1`` — pre-init access is a real
+    programming bug we want to surface even when asserts are stripped."""
     ctx = AppContext(config=Mem2MemConfig())
-    with pytest.raises(AssertionError, match="ensure_initialized"):
+    with pytest.raises(RuntimeError, match="ensure_initialized"):
         _ = ctx.storage
 
 
@@ -141,3 +144,103 @@ def test_dedup_scanner_before_init_returns_none() -> None:
 def test_health_watchdog_before_init_returns_none() -> None:
     ctx = AppContext(config=Mem2MemConfig())
     assert ctx.health_watchdog is None
+
+
+# ── post-factory failure / ownership coverage ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_closes_components_if_post_factory_step_raises(
+    fake_components: Components,
+) -> None:
+    """A failure in DedupScanner construction must not leak the sqlite /
+    embedder handles the factory already opened. ``close_components`` is
+    called before re-raising; the context stays uninitialized so a retry
+    is still possible."""
+    ctx = AppContext(config=fake_components.config)
+    close_calls: list[Components] = []
+
+    async def fake_close(comp: Components) -> None:
+        close_calls.append(comp)
+
+    def exploding_dedup(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("post-factory boom")
+
+    with (
+        patch(
+            "memtomem.server.component_factory.create_components",
+            return_value=fake_components,
+        ),
+        patch("memtomem.server.component_factory.close_components", side_effect=fake_close),
+        patch("memtomem.search.dedup.DedupScanner", side_effect=exploding_dedup),
+    ):
+        with pytest.raises(RuntimeError, match="post-factory boom"):
+            await ctx.ensure_initialized()
+
+    assert close_calls == [fake_components], (
+        "Post-factory failure must trigger close_components so sqlite / embedder "
+        "handles opened by create_components don't leak."
+    )
+    # Context is clean: neither _components nor _dedup_scanner stays populated,
+    # and _owns_components didn't flip on.
+    assert ctx._components is None
+    assert ctx.dedup_scanner is None
+    assert ctx._owns_components is False
+
+
+@pytest.mark.asyncio
+async def test_close_after_from_components_does_not_touch_caller_owned(
+    fake_components: Components,
+) -> None:
+    """from_components → close must not invoke close_components: the
+    caller (cli_components / test fixture) retains ownership and will
+    close the supplied Components themselves. Calling close_components
+    here would leave the caller with already-torn-down handles."""
+    ctx = AppContext.from_components(fake_components)
+
+    with patch("memtomem.server.component_factory.close_components") as mock_close:
+        await ctx.close()
+
+    mock_close.assert_not_called()
+    # Context still drops its view of the components so accidental
+    # post-close access fails loudly — the caller owns the lifecycle,
+    # but the context stops handing out its storage/embedder.
+    assert ctx._components is None
+    assert ctx._owns_components is False
+    assert ctx.dedup_scanner is None
+
+
+@pytest.mark.asyncio
+async def test_close_after_ensure_initialized_closes_components(
+    fake_components: Components,
+) -> None:
+    """ensure_initialized → close must tear the Components down — we
+    built them, so it's our job to close them. Mirrors the from_components
+    test above in inverse."""
+    ctx = AppContext(config=fake_components.config)
+
+    with patch(
+        "memtomem.server.component_factory.create_components",
+        return_value=fake_components,
+    ):
+        await ctx.ensure_initialized()
+
+    assert ctx._owns_components is True
+
+    with patch("memtomem.server.component_factory.close_components") as mock_close:
+        await ctx.close()
+
+    mock_close.assert_called_once_with(fake_components)
+    assert ctx._components is None
+    assert ctx._owns_components is False
+
+
+def test_set_health_watchdog_exposes_via_property() -> None:
+    """``ctx.set_health_watchdog(wd)`` is the lifespan seam — reader side
+    is the ``health_watchdog`` property, not ``_health_watchdog`` poking."""
+    ctx = AppContext(config=Mem2MemConfig())
+    sentinel = object()
+
+    ctx.set_health_watchdog(sentinel)
+
+    assert ctx.health_watchdog is sentinel

--- a/packages/memtomem/tests/test_server_app_context.py
+++ b/packages/memtomem/tests/test_server_app_context.py
@@ -1,0 +1,143 @@
+"""Tests for ``AppContext.ensure_initialized`` lock semantics (issue #399, Phase 1).
+
+These cover the property/factory plumbing that lets the lifespan keep eager
+initialization today and lets handlers move to lazy initialization in
+Phase 2/3 without race conditions on first call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from memtomem.config import Mem2MemConfig
+from memtomem.server.component_factory import Components
+from memtomem.server.context import AppContext
+
+
+@pytest.fixture
+def fake_components() -> Components:
+    """A bare ``Components`` stand-in for the parts ``ensure_initialized`` reads.
+
+    Storage / embedder are sentinel objects — ``ensure_initialized`` only
+    constructs the ``DedupScanner`` over them, and the dedup-scanner itself
+    just stores the references; nothing calls into them in these tests.
+    """
+    return Components(
+        config=Mem2MemConfig(),
+        storage=object(),  # type: ignore[arg-type]
+        embedder=object(),  # type: ignore[arg-type]
+        index_engine=object(),  # type: ignore[arg-type]
+        search_pipeline=object(),  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_concurrent_calls_invoke_factory_once(
+    fake_components: Components,
+) -> None:
+    """Three coroutines hitting a fresh context simultaneously result in one init."""
+    ctx = AppContext(config=fake_components.config)
+    call_count = 0
+
+    async def slow_create(_config: Mem2MemConfig) -> Components:
+        nonlocal call_count
+        call_count += 1
+        await asyncio.sleep(0.01)
+        return fake_components
+
+    with patch("memtomem.server.component_factory.create_components", side_effect=slow_create):
+        results = await asyncio.gather(
+            ctx.ensure_initialized(),
+            ctx.ensure_initialized(),
+            ctx.ensure_initialized(),
+        )
+
+    assert call_count == 1
+    assert results[0] is results[1] is results[2] is fake_components
+    assert ctx._components is fake_components
+    assert ctx.dedup_scanner is not None
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_idempotent(fake_components: Components) -> None:
+    """Subsequent calls return the cached components without re-invoking the factory."""
+    ctx = AppContext(config=fake_components.config)
+
+    with patch(
+        "memtomem.server.component_factory.create_components",
+        return_value=fake_components,
+    ) as mock_create:
+        first = await ctx.ensure_initialized()
+        second = await ctx.ensure_initialized()
+
+    assert mock_create.call_count == 1
+    assert first is second is fake_components
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_failure_releases_lock_for_retry(
+    fake_components: Components,
+) -> None:
+    """A transient failure leaves the context retryable rather than poisoned."""
+    ctx = AppContext(config=fake_components.config)
+    attempt = 0
+
+    async def flaky_create(_config: Mem2MemConfig) -> Components:
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            raise RuntimeError("transient init failure")
+        return fake_components
+
+    with patch("memtomem.server.component_factory.create_components", side_effect=flaky_create):
+        with pytest.raises(RuntimeError, match="transient init failure"):
+            await ctx.ensure_initialized()
+        # Lock released, retry succeeds.
+        comp = await ctx.ensure_initialized()
+
+    assert comp is fake_components
+    assert attempt == 2
+
+
+@pytest.mark.asyncio
+async def test_from_components_skips_factory(fake_components: Components) -> None:
+    """``ensure_initialized`` returns the pre-supplied components without calling the factory."""
+    ctx = AppContext.from_components(fake_components)
+
+    with patch("memtomem.server.component_factory.create_components") as mock_create:
+        comp = await ctx.ensure_initialized()
+
+    mock_create.assert_not_called()
+    assert comp is fake_components
+    assert ctx.dedup_scanner is not None
+
+
+def test_storage_access_before_init_raises() -> None:
+    ctx = AppContext(config=Mem2MemConfig())
+    with pytest.raises(AssertionError, match="ensure_initialized"):
+        _ = ctx.storage
+
+
+def test_embedding_broken_before_init_returns_none() -> None:
+    """Mirrors the old field default — None until init runs."""
+    ctx = AppContext(config=Mem2MemConfig())
+    assert ctx.embedding_broken is None
+
+
+def test_llm_provider_before_init_returns_none() -> None:
+    """Optional even after init — None when components absent matches old field."""
+    ctx = AppContext(config=Mem2MemConfig())
+    assert ctx.llm_provider is None
+
+
+def test_dedup_scanner_before_init_returns_none() -> None:
+    ctx = AppContext(config=Mem2MemConfig())
+    assert ctx.dedup_scanner is None
+
+
+def test_health_watchdog_before_init_returns_none() -> None:
+    ctx = AppContext(config=Mem2MemConfig())
+    assert ctx.health_watchdog is None

--- a/packages/memtomem/tests/test_server_degraded_mode.py
+++ b/packages/memtomem/tests/test_server_degraded_mode.py
@@ -131,15 +131,7 @@ def _make_app(components) -> AppContext:
     Skips watcher / scheduler startup — those would try to touch ``chunks_vec``
     in degraded mode, which is exactly what the lifespan already gates against.
     """
-    return AppContext(
-        config=components.config,
-        storage=components.storage,
-        embedder=components.embedder,
-        index_engine=components.index_engine,
-        search_pipeline=components.search_pipeline,
-        watcher=None,  # type: ignore[arg-type]
-        embedding_broken=components.embedding_broken,
-    )
+    return AppContext.from_components(components)
 
 
 async def test_create_components_enters_degraded_instead_of_raising(degraded_components):


### PR DESCRIPTION
Phase 1 of #399 — `AppContext` plumbing for the upcoming lazy DB-init refactor.

## Summary

- Move `storage` / `embedder` / `index_engine` / `search_pipeline` / `embedding_broken` / `llm_provider` from direct `AppContext` fields to read-only properties backed by an internal `_components` slot.
- Add `async ensure_initialized()` with `_init_lock` for concurrent-first-call serialization.
- Add `AppContext.from_components(...)` classmethod for CLI / test bootstraps that already have a `Components` (e.g. `mm watchdog`, degraded-mode test fixture).
- Add `async close()` for symmetric teardown.
- Drop the `watcher` field from `AppContext` — handler usage was zero; the lifespan keeps a local var.
- `dedup_scanner` is now derived from `Components.storage` + `.embedder` inside `ensure_initialized` / `from_components` rather than passed in by the lifespan.

`app_lifespan` still calls `await ctx.ensure_initialized()` eagerly, so behavior is unchanged. Phase 2 (handler migration) and Phase 3 (drop the eager call → DB stays absent until first tool call) are stacked PRs.

## Why split it

#399 traces the `~/.memtomem/memtomem.db` side-effect on bare MCP handshake to `app_lifespan` calling `create_components` before yielding. The fix needs three things to land safely:

1. A way for handlers to demand-init storage without races (this PR).
2. Every handler updated to do that demand-init (Phase 2 — ~33 files).
3. The lifespan dropping its eager init so the new path is actually taken (Phase 3).

Splitting it keeps reviewers focused on the lock semantics + property migration here, rather than reading 30+ mechanical handler diffs at the same time.

## Test plan

- [x] New `test_server_app_context.py` (9 tests): concurrent-first-call → single factory invocation, idempotent re-call, failure releases lock for retry, `from_components` short-circuits the factory, pre-init `storage` access raises, pre-init `embedding_broken` / `llm_provider` / `dedup_scanner` / `health_watchdog` return `None` (mirrors the old field defaults).
- [x] `test_server_degraded_mode.py` (4 tests): fixture switched to `AppContext.from_components`.
- [x] Adjacent suites (`test_health_watchdog`, `test_trust_ux`, `test_tools_logic`, `test_server_helpers`) — 209 tests pass unchanged; they go through mock `AppContext` surrogates.
- [x] Full suite: `uv run pytest packages/memtomem/tests -m "not ollama"` → 2144 passed.
- [x] `uv run ruff check packages/memtomem/src` + `uv run ruff format --check` clean.

## Related

- Issue #399 — full design and acceptance criteria (this PR satisfies the "Phase 1 — Plumbing" item in the staging section).
- Phase 2 PR (upcoming): handler migration to `_get_app_initialized` / inline `await app.ensure_initialized()`.
- Phase 3 PR (upcoming): drop eager `ensure_initialized` from `app_lifespan` + move watcher / scheduler / watchdog start into `ensure_initialized`. That's where the user-visible behavior change (DB stays absent on bare handshake) actually lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
