### PR TITLE
fix(init): -y refuses to write config for missing required extras (closes #396)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mm init -y` refuses to write `config.json` when required extras are missing.**
+  Previously `-y` accepted `--provider onnx|ollama|openai` and
+  `--tokenizer kiwipiepy` without checking whether the corresponding Python
+  extras were importable, then wrote the user-specified choice to
+  `config.json`. The mismatch surfaced only at runtime as a stderr warning
+  from `component_factory` (embedder falls back to 0d) or `fts_tokenizer`
+  (kiwipiepy falls back to unicode61) — a scripted install would appear to
+  succeed and silently degrade. `-y` now exits non-zero with an actionable
+  error listing the missing extras (and collapses multiple misses into a
+  `memtomem[all]` hint when all four are missing). The interactive wizard's
+  warn-and-continue path is unchanged; #403 tracks aligning its wording with
+  the new `-y` refuse semantics. (#396, #402)
+
 ## [0.1.24] — 2026-04-23
 
 Bug-fix release closing a first-run UX gap in `mm init --preset <name>`

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1060,7 +1060,8 @@ _UV_SYNC_HINT_PREFIX: str = "uv sync --extra "
 # historical semantic.
 _PROBE_EXTRAS_CODE: str = (
     "import json, importlib.util as u; "
-    "print(json.dumps([n for n in ['fastembed','fastapi','uvicorn'] "
+    "print(json.dumps([n for n in "
+    "['fastembed','fastapi','uvicorn','ollama','openai','kiwipiepy'] "
     "if u.find_spec(n) is not None]))"
 )
 
@@ -1576,24 +1577,57 @@ def _collect_missing_extras(state: dict) -> list[str]:
         if importable is not None:
             have_fastembed = "fastembed" in importable
             have_web = {"fastapi", "uvicorn"}.issubset(importable)
+            have_ollama = "ollama" in importable
+            have_openai = "openai" in importable
+            have_kiwipiepy = "kiwipiepy" in importable
         else:
             have_fastembed, have_web = _inproc_have_extras()
+            have_ollama = _have_module("ollama")
+            have_openai = _have_module("openai")
+            have_kiwipiepy = _have_module("kiwipiepy")
     else:
         have_fastembed, have_web = _inproc_have_extras()
+        have_ollama = _have_module("ollama")
+        have_openai = _have_module("openai")
+        have_kiwipiepy = _have_module("kiwipiepy")
 
     missing: list[str] = []
     # [onnx] = fastembed. Both the embedder and the fastembed reranker share
     # this package — either on its own is enough to require the extra.
-    needs_fastembed = state.get("provider") == "onnx" or (
+    provider = state.get("provider")
+    needs_fastembed = provider == "onnx" or (
         state.get("rerank_enabled") and state.get("rerank_model")
     )
     if needs_fastembed and not have_fastembed:
         missing.append("onnx")
+    # [ollama] / [openai] — provider-specific client libs. `mm init -y
+    # --provider <x>` previously wrote the choice to config without this
+    # check and the failure surfaced only at runtime (#396).
+    if provider == "ollama" and not have_ollama:
+        missing.append("ollama")
+    if provider == "openai" and not have_openai:
+        missing.append("openai")
+    # [korean] = kiwipiepy. The tokenizer falls back to unicode61 at runtime
+    # if kiwipiepy is absent, so missing it is not fatal — but `mm init -y
+    # --tokenizer kiwipiepy` should still be caught up front (#396).
+    if state.get("tokenizer") == "kiwipiepy" and not have_kiwipiepy:
+        missing.append("korean")
     if not have_web:
         missing.append("web")
 
     warned = state.get("_extras_warned_inline") or set()
     return [x for x in missing if x not in warned]
+
+
+# Extras that ``-y`` must refuse to write a config for when absent. ``web``
+# is excluded — scripted runs often use ``--mcp skip`` without any intention
+# to run the web UI, and the runtime fallback (clear ``mm web`` error on
+# missing fastapi) is already loud. Update this set alongside new provider/
+# tokenizer entries in ``_collect_missing_extras`` if they gain a runtime
+# fallback that silently flips the user-visible config.
+_REQUIRED_EXTRAS_FOR_NON_INTERACTIVE: frozenset[str] = frozenset(
+    {"onnx", "ollama", "openai", "korean"}
+)
 
 
 def _emit_cwd_runtime_mismatch_banner(state: dict) -> None:
@@ -2471,6 +2505,24 @@ def init(
             memory_path.mkdir(parents=True, exist_ok=True)
 
         _resolve_provider_dirs_non_interactive(state, effective_preset, include_providers)
+
+        # #396: fail loudly when the requested provider / tokenizer needs an
+        # extra that isn't importable. Previously `-y` silently wrote the
+        # config and the mismatch surfaced only at runtime (e.g. `mm index`
+        # would enter degraded mode for onnx without fastembed). Scripted
+        # workflows prefer a non-zero exit here over a stale config.
+        # Interactive paths keep their warn-and-continue semantics below.
+        missing = _collect_missing_extras(state)
+        required = [x for x in missing if x in _REQUIRED_EXTRAS_FOR_NON_INTERACTIVE]
+        if required:
+            hint = _extra_install_hint(required, state)
+            raise click.ClickException(
+                f"Missing required extras for `mm init -y`: "
+                f"{', '.join(required)}.\n"
+                f"  Install first: {hint}\n"
+                f"  Or drop the flag(s) that require them "
+                f"(e.g. --provider none, --tokenizer unicode61)."
+            )
     elif advanced:
         run_steps(advanced_steps, state)
     elif preset:

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2500,10 +2500,6 @@ def init(
         if "mcp_choice" not in state:
             state["mcp_choice"] = 3  # skip — scripted runs don't touch Claude
 
-        memory_path = Path(state["memory_dir"]).expanduser()
-        if not memory_path.exists():
-            memory_path.mkdir(parents=True, exist_ok=True)
-
         _resolve_provider_dirs_non_interactive(state, effective_preset, include_providers)
 
         # #396: fail loudly when the requested provider / tokenizer needs an
@@ -2512,6 +2508,10 @@ def init(
         # would enter degraded mode for onnx without fastembed). Scripted
         # workflows prefer a non-zero exit here over a stale config.
         # Interactive paths keep their warn-and-continue semantics below.
+        #
+        # Gate runs BEFORE any disk side effect (memory_dir mkdir, config
+        # write) so a refused -y leaves the filesystem untouched. The earlier
+        # mkdir-then-gate ordering left ``~/memories`` behind on rejected runs.
         missing = _collect_missing_extras(state)
         required = [x for x in missing if x in _REQUIRED_EXTRAS_FOR_NON_INTERACTIVE]
         if required:
@@ -2523,6 +2523,10 @@ def init(
                 f"  Or drop the flag(s) that require them "
                 f"(e.g. --provider none, --tokenizer unicode61)."
             )
+
+        memory_path = Path(state["memory_dir"]).expanduser()
+        if not memory_path.exists():
+            memory_path.mkdir(parents=True, exist_ok=True)
     elif advanced:
         run_steps(advanced_steps, state)
     elif preset:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4706,3 +4706,131 @@ class TestNonInteractiveExtrasValidation:
 
         assert result.exit_code == 0, result.output
         assert (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_provider_openai_missing_client_exits_non_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--provider openai`` is shaped the same as ollama/onnx at the
+        extras-gate layer, but ``--api-key`` plumbing sits alongside in
+        ``_override_from_flags``. Exercising the full CLI path proves the
+        two don't accidentally interact — the gate fires before the key
+        handling runs."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "openai" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "init",
+                "-y",
+                "--provider",
+                "openai",
+                "--model",
+                "text-embedding-3-small",
+                "--api-key",
+                "sk-fake-test-key",
+                "--mcp",
+                "skip",
+            ],
+        )
+
+        assert result.exit_code != 0, result.output
+        assert "Missing required extras" in result.output
+        assert "openai" in result.output
+        assert not (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_multi_extra_missing_reports_both(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both ``--provider onnx`` + ``--tokenizer kiwipiepy`` missing at
+        once. The error must name both so the user knows to install both
+        or drop both, not just the first one encountered."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name in ("fastembed", "kiwipiepy") else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "init",
+                "-y",
+                "--provider",
+                "onnx",
+                "--model",
+                "bge-m3",
+                "--tokenizer",
+                "kiwipiepy",
+                "--mcp",
+                "skip",
+            ],
+        )
+
+        assert result.exit_code != 0, result.output
+        assert "Missing required extras" in result.output
+        # Both extras must be named, not just the first one encountered.
+        assert "onnx" in result.output
+        assert "korean" in result.output
+        # Multi-extra hint collapses to [all] per _extra_install_hint policy.
+        assert "memtomem[all]" in result.output
+        assert not (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_refused_leaves_memory_dir_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Gate must run BEFORE ``memory_path.mkdir``. An earlier shape
+        created ``~/memories`` before validating extras, leaving directory
+        debris on refused runs."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        memory_dir = tmp_path / "scratch_memories"
+        # Pre-condition: memory_dir does not exist yet.
+        assert not memory_dir.exists()
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "init",
+                "-y",
+                "--provider",
+                "onnx",
+                "--model",
+                "bge-m3",
+                "--memory-dir",
+                str(memory_dir),
+                "--mcp",
+                "skip",
+            ],
+        )
+
+        assert result.exit_code != 0, result.output
+        # The refused run must not have created the memory dir.
+        assert not memory_dir.exists(), (
+            "memory_dir must not be created on refused -y runs (gate must precede mkdir)"
+        )

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4517,3 +4517,192 @@ class TestInitialSeedThreshold:
         assert f"mm index {state['memory_dir']}" in out
         assert "already seeded" in out
         assert "Reindex All" not in out
+
+
+class TestNonInteractiveExtrasValidation:
+    """Issue #396: ``mm init -y`` must refuse to write a config when the
+    requested ``--provider`` / ``--tokenizer`` needs an extra that is not
+    importable. Previously ``-y`` accepted the flag values as given and
+    the mismatch surfaced only at runtime (embedder falls back to 0d,
+    kiwipiepy falls back to unicode61, etc.). Scripted workflows prefer
+    a non-zero exit here over a silently-stale config."""
+
+    def test_collect_missing_extras_ollama_when_client_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "ollama" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        state = {"provider": "ollama", "rerank_enabled": False}
+        assert init_cmd._collect_missing_extras(state) == ["ollama"]
+
+    def test_collect_missing_extras_openai_when_client_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "openai" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        state = {"provider": "openai", "rerank_enabled": False}
+        assert init_cmd._collect_missing_extras(state) == ["openai"]
+
+    def test_collect_missing_extras_kiwipiepy_when_tokenizer_chose(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "kiwipiepy" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+        state = {"provider": "none", "tokenizer": "kiwipiepy", "rerank_enabled": False}
+        assert init_cmd._collect_missing_extras(state) == ["korean"]
+
+    def test_yes_flag_provider_onnx_missing_fastembed_exits_non_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Force the runtime profile to PyPI so the in-process find_spec probe
+        # is authoritative (no workspace-python subprocess to consider).
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "fastembed" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "init",
+                "-y",
+                "--provider",
+                "onnx",
+                "--model",
+                "bge-small-en-v1.5",
+                "--mcp",
+                "skip",
+            ],
+        )
+
+        assert result.exit_code != 0, result.output
+        assert "Missing required extras" in result.output
+        assert "onnx" in result.output
+        # Hint should be install-type-aware — pypi → uv tool install --reinstall.
+        assert "uv tool install --reinstall" in result.output
+        # Config must not be written.
+        assert not (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_tokenizer_kiwipiepy_missing_exits_non_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "kiwipiepy" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli, ["init", "-y", "--tokenizer", "kiwipiepy", "--mcp", "skip"]
+        )
+
+        assert result.exit_code != 0, result.output
+        assert "Missing required extras" in result.output
+        assert "korean" in result.output
+        assert not (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_provider_ollama_missing_client_exits_non_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name == "ollama" else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli,
+            [
+                "init",
+                "-y",
+                "--provider",
+                "ollama",
+                "--model",
+                "nomic-embed-text",
+                "--mcp",
+                "skip",
+            ],
+        )
+
+        assert result.exit_code != 0, result.output
+        assert "Missing required extras" in result.output
+        assert "ollama" in result.output
+        assert not (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_web_only_missing_still_writes_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """web is deliberately excluded from the required-extras set —
+        scripted runs with ``--mcp skip`` don't plan to run ``mm web``,
+        and the runtime ``mm web`` error is already loud. A config write
+        must proceed in this case."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr(
+            "importlib.util.find_spec",
+            lambda name: None if name in ("fastapi", "uvicorn") else object(),
+        )
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
+
+        result = CliRunner().invoke(cli, ["init", "-y", "--provider", "none", "--mcp", "skip"])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".memtomem" / "config.json").exists()
+
+    def test_yes_flag_all_extras_present_writes_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli, init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
+        monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
+        monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
+
+        result = CliRunner().invoke(
+            cli,
+            ["init", "-y", "--provider", "onnx", "--model", "bge-m3", "--mcp", "skip"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".memtomem" / "config.json").exists()


### PR DESCRIPTION
Closes #396.

## Summary

`mm init -y` previously accepted `--provider onnx|ollama|openai` and `--tokenizer kiwipiepy` without checking whether the corresponding Python extras were importable, then wrote the user-specified choice to `config.json`. The mismatch surfaced only at runtime — as a stderr warning from `component_factory` (embedder falls back to 0d) or `fts_tokenizer` (kiwipiepy falls back to unicode61), not at `mm init` time.

This PR teaches the `-y` path to refuse upfront with an actionable error.

## Changes

- **`_PROBE_EXTRAS_CODE` and `_collect_missing_extras`** grow `ollama` / `openai` / `kiwipiepy` axes so a single check covers all four `--provider` / `--tokenizer` flag values. Both the workspace-python subprocess probe (source/project installs) and the in-process probe (PyPI / `uv tool install`) populate the new axes.
- **`_REQUIRED_EXTRAS_FOR_NON_INTERACTIVE = {onnx, ollama, openai, korean}`** as the gate set for `-y`. `web` is deliberately excluded — scripted runs typically pair `-y` with `--mcp skip` and never invoke `mm web`; the runtime `mm web` error is already loud, and gating `-y` on it would block legitimate scripted setups. The frozenset has a docstring noting how to extend it.
- **`init()` non-interactive branch** runs `_collect_missing_extras` after `_resolve_provider_dirs_non_interactive` and before `_write_config_and_summary`. If any required extras are missing it raises `click.ClickException` carrying the install-type-aware hint from `_extra_install_hint` plus a "drop the flag" alternative. No config file is written.
- **Interactive paths (preset / advanced / default)** keep their existing warn-and-continue semantics — `_write_config_and_summary`'s missing-extras call still runs there, unchanged. No behavior change for users who go through the wizard.

Example error output (`-y --provider onnx` on a fresh `uv tool install memtomem` with no extras):

```
Error: Missing required extras for `mm init -y`: onnx.
  Install first: uv tool install --reinstall "memtomem[onnx]"
  Or drop the flag(s) that require them (e.g. --provider none, --tokenizer unicode61).
```

The hint shape mirrors the install-type axes from #361:

| Install type | Hint |
| -- | -- |
| PyPI / `uv tool install` | `uv tool install --reinstall "memtomem[onnx]"` |
| source / project workspace | `uv sync --extra onnx` |
| uvx | inline note from `_install_extras` (re-invoke pattern) |

## Test plan

- [x] **`TestNonInteractiveExtrasValidation`** (8 new tests):
  - 3 unit tests for the new `_collect_missing_extras` axes (`ollama`, `openai`, `kiwipiepy`).
  - 5 CliRunner end-to-end tests covering the `-y` refuse cases for `--provider onnx`, `--provider ollama`, `--tokenizer kiwipiepy`; the web-only-missing pass-through; and the all-extras-present pass-through. The `--provider openai` shape is identical to `ollama`/`onnx` and exercised by the unit test for `_collect_missing_extras`; the CliRunner integration is omitted to keep this PR focused.
- [x] Existing `TestMissingExtrasWarning` (12 tests) and `TestInstallAxesReconcile` paths pass unchanged — interactive flow and source-install workspace probe semantics are untouched.
- [x] Full suite: `uv run pytest packages/memtomem/tests -m "not ollama"` → 2146 passed.
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check` clean.

## Out of scope (per #396)

- **Auto-install of missing extras in `-y`** — tracked in #362 (Phase 2 of #360). This PR is the precondition validation; #362 is the remediation.
- **Changing `[all]` composition in `pyproject.toml`** — landed in #395.
- **Re-running wizard on config drift** — different axis, different UX question.

## Related

- Issue #396 — closed by this PR.
- #362 — Phase 2 auto-install consistency (open).
- #361 — Phase 1 source of `_collect_missing_extras` and `_extra_install_hint`.
- #395 — `[all]` install flip; surfaced this gap in fresh-install testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
