### PR TITLE
fix(init): wizard fallback mentions -y refuse semantic (closes #403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   succeed and silently degrade. `-y` now exits non-zero with an actionable
   error listing the missing extras (and collapses multiple misses into a
   `memtomem[all]` hint when all four are missing). The interactive wizard's
-  warn-and-continue path is unchanged; #403 tracks aligning its wording with
-  the new `-y` refuse semantics. (#396, #402)
+  warn-and-continue path is unchanged; the wizard wording was aligned with
+  the new `-y` refuse semantics in #405 (closes #403). (#396, #402)
 
 ## [0.1.24] — 2026-04-23
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -328,16 +328,37 @@ def _step_embedding(state: dict) -> None:
 
     elif choice == 3:
         provider = "ollama"
-        if not _ollama_available():
+        # Two orthogonal preconditions for Ollama: the runtime binary
+        # (``_ollama_available()`` = ``shutil.which("ollama")``) and the
+        # ``ollama`` Python client (``_have_module("ollama")``). The
+        # ``-y`` extras gate (#402) checks the Python client, not the
+        # binary — so the refuse-hint must fire whenever the Python
+        # client is missing, whether or not the binary is on PATH.
+        have_ollama_binary = _ollama_available()
+        have_ollama_module = _have_module("ollama")
+
+        if not have_ollama_binary:
             click.secho("  Ollama not found.", fg="yellow")
             click.echo("  Install from https://ollama.com, then run 'mm index' to embed.")
             click.echo("  Saving Ollama config now so you're ready after install.")
-            click.echo(_y_refuse_hint("--provider ollama", "ollama"))
+            if not have_ollama_module:
+                click.echo(_y_refuse_hint("--provider ollama", "ollama"))
+                state.setdefault("_extras_warned_inline", set()).add("ollama")
             click.echo()
             # Record intent — config is written, embedding runs when Ollama is available.
             model = "nomic-embed-text"
             dimension = 768
         else:
+            if not have_ollama_module:
+                # Binary is on PATH but the ``-y`` gate additionally
+                # requires the ``ollama`` Python client. Surface the
+                # install hint + refuse note up front so scripted
+                # retries don't surprise the user.
+                click.secho("  ollama Python client not installed.", fg="yellow")
+                click.echo(f"  Install with: {_extra_install_hint(['ollama'], state)}")
+                click.echo(_y_refuse_hint("--provider ollama", "ollama"))
+                click.echo()
+                state.setdefault("_extras_warned_inline", set()).add("ollama")
             if not _ollama_running():
                 click.secho("  Ollama not running. Starting 'ollama serve'...", fg="yellow")
                 click.echo("  Run 'ollama serve' in another terminal if this fails.")

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -247,6 +247,20 @@ def _have_module(name: str) -> bool:
         return False
 
 
+def _y_refuse_hint(flag: str, extra: str) -> str:
+    """Wizard → ``-y`` discoverability bridge (#403).
+
+    Interactive wizard warns-and-saves when an extra is missing; ``mm init -y``
+    refuses with a non-zero exit (#396 / #402). A user who copies a wizard
+    choice into a scripted install gets an unexpected hard failure without
+    this hint. Surface the asymmetry at the wizard warning site.
+    """
+    return (
+        f"  Note: `mm init -y {flag}` refuses without `memtomem[{extra}]`; "
+        f"install first for scripted setups."
+    )
+
+
 # ── Step functions ────────────────────────────────────────────────────
 
 
@@ -284,6 +298,7 @@ def _step_embedding(state: dict) -> None:
             # as already surfaced so ``_collect_missing_extras`` skips it.
             click.echo(f"  Install with: {_extra_install_hint(['onnx'], state)}")
             click.echo("  Saving ONNX config now so you're ready after install.")
+            click.echo(_y_refuse_hint("--provider onnx", "onnx"))
             click.echo()
             state.setdefault("_extras_warned_inline", set()).add("onnx")
 
@@ -317,6 +332,7 @@ def _step_embedding(state: dict) -> None:
             click.secho("  Ollama not found.", fg="yellow")
             click.echo("  Install from https://ollama.com, then run 'mm index' to embed.")
             click.echo("  Saving Ollama config now so you're ready after install.")
+            click.echo(_y_refuse_hint("--provider ollama", "ollama"))
             click.echo()
             # Record intent — config is written, embedding runs when Ollama is available.
             model = "nomic-embed-text"
@@ -637,6 +653,7 @@ def _step_language(state: dict) -> None:
             click.secho("  kiwipiepy is installed.", fg="green")
         except ImportError:
             click.secho("  kiwipiepy not installed. Run: pip install kiwipiepy", fg="yellow")
+            click.echo(_y_refuse_hint("--tokenizer kiwipiepy", "korean"))
     state["tokenizer"] = tokenizer
     click.echo()
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4859,23 +4859,39 @@ class TestYRefuseHintParity:
     def test_wizard_fallback_paths_call_y_refuse_hint(self) -> None:
         """Source-scan pin — each fallback branch must call ``_y_refuse_hint``.
 
-        Fragile by nature (a rename of the helper breaks the scan), but the
-        call pattern is specific enough that false positives are unlikely.
-        Rename → update test in the same PR, same seam.
+        Regex-based so a future reformatter splitting the call across
+        lines doesn't break the scan. The call pattern is specific
+        enough that false positives are unlikely.
         """
         import inspect
+        import re
 
         from memtomem.cli import init_cmd
 
         embedding_src = inspect.getsource(init_cmd._step_embedding)
         language_src = inspect.getsource(init_cmd._step_language)
 
-        assert '_y_refuse_hint("--provider onnx", "onnx")' in embedding_src, (
+        def _count_calls(src: str, flag: str, extra: str) -> int:
+            pattern = (
+                r"_y_refuse_hint\(\s*"
+                + re.escape(f'"{flag}"')
+                + r"\s*,\s*"
+                + re.escape(f'"{extra}"')
+                + r"\s*\)"
+            )
+            return len(re.findall(pattern, src))
+
+        assert _count_calls(embedding_src, "--provider onnx", "onnx") >= 1, (
             "ONNX fallback must surface -y refuse hint (#403)"
         )
-        assert '_y_refuse_hint("--provider ollama", "ollama")' in embedding_src, (
-            "Ollama fallback must surface -y refuse hint (#403)"
+        # Ollama has two orthogonal preconditions (binary + Python client),
+        # so the wizard must hint in both branches — binary-missing and
+        # binary-present-but-module-missing — to cover what ``-y`` refuses
+        # (#405 follow-up to #403).
+        assert _count_calls(embedding_src, "--provider ollama", "ollama") >= 2, (
+            "Ollama fallback must surface -y refuse hint in both "
+            "binary-missing and module-missing branches (#405)"
         )
-        assert '_y_refuse_hint("--tokenizer kiwipiepy", "korean")' in language_src, (
+        assert _count_calls(language_src, "--tokenizer kiwipiepy", "korean") >= 1, (
             "kiwipiepy fallback must surface -y refuse hint (#403)"
         )

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4834,3 +4834,48 @@ class TestNonInteractiveExtrasValidation:
         assert not memory_dir.exists(), (
             "memory_dir must not be created on refused -y runs (gate must precede mkdir)"
         )
+
+
+class TestYRefuseHintParity:
+    """#403 — wizard fallback paths must mention the ``-y`` refuse semantic.
+
+    #402 added a new axis: ``-y`` refuses non-zero while the interactive
+    wizard still warns-and-saves. A user who copies a wizard choice into a
+    scripted install gets an unexpected hard failure unless the wizard
+    warning surfaces the asymmetry. These tests pin:
+    (1) the helper's shape, and
+    (2) that each missing-extra fallback path actually calls it.
+    """
+
+    def test_y_refuse_hint_shape(self) -> None:
+        from memtomem.cli import init_cmd
+
+        hint = init_cmd._y_refuse_hint("--provider onnx", "onnx")
+        assert "mm init -y --provider onnx" in hint
+        assert "memtomem[onnx]" in hint
+        assert "refuses" in hint
+        assert "scripted" in hint
+
+    def test_wizard_fallback_paths_call_y_refuse_hint(self) -> None:
+        """Source-scan pin — each fallback branch must call ``_y_refuse_hint``.
+
+        Fragile by nature (a rename of the helper breaks the scan), but the
+        call pattern is specific enough that false positives are unlikely.
+        Rename → update test in the same PR, same seam.
+        """
+        import inspect
+
+        from memtomem.cli import init_cmd
+
+        embedding_src = inspect.getsource(init_cmd._step_embedding)
+        language_src = inspect.getsource(init_cmd._step_language)
+
+        assert '_y_refuse_hint("--provider onnx", "onnx")' in embedding_src, (
+            "ONNX fallback must surface -y refuse hint (#403)"
+        )
+        assert '_y_refuse_hint("--provider ollama", "ollama")' in embedding_src, (
+            "Ollama fallback must surface -y refuse hint (#403)"
+        )
+        assert '_y_refuse_hint("--tokenizer kiwipiepy", "korean")' in language_src, (
+            "kiwipiepy fallback must surface -y refuse hint (#403)"
+        )


### PR DESCRIPTION
Closes #403 (follow-up to #402 / #396).

## Problem

#402 added a new axis to `mm init` behavior when a required extra is missing:

- **`-y`** — refuses non-zero without writing `config.json`.
- **Interactive wizard** — warns and saves config anyway (unchanged).

A user who picks ONNX / Ollama / kiwipiepy interactively, sees a generic "install then run" warning, and later copies the same choice into a scripted `-y` install gets an unexpected hard failure. The wizard message never hinted at the new refuse behavior.

## Change

Add a small `_y_refuse_hint(flag, extra)` helper and call it from the three interactive fallback paths (ONNX, Ollama, kiwipiepy). The wizard warning now reads:

> fastembed not installed.
>   Install with: ...
>   Saving ONNX config now so you're ready after install.
>   Note: `mm init -y --provider onnx` refuses without `memtomem[onnx]`; install first for scripted setups.

Pin tests:
- `test_y_refuse_hint_shape` — shape of the generated string (helps catch renames / format drift).
- `test_wizard_fallback_paths_call_y_refuse_hint` — each of the three fallback branches calls the helper with the right `(flag, extra)` pair. Source-scan based; fragile by nature but the call pattern is specific enough that false positives are unlikely.

## What this does not fix

- **OpenAI provider in the wizard does not check the `openai` extra at all** — only API-key validation. There is no fallback site to attach the hint, and adding the check is out of scope for a wording PR. This should be a separate issue (or appended to #403's scope if you prefer to keep it on one ticket).
- **Wizard warn-and-save semantic itself is unchanged** — only the warning text gains a line. Changing the wizard to refuse would be a behavior change, not a wording fix.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -k YRefuseHint` passes (2 new tests).
- [x] Full `test_init_cmd.py` suite: 202 passed.
- [x] `ruff check` + `ruff format --check` clean.
