### PR TITLE
fix(server): tear down startup resources on lifespan failure (closes #404)

### DIFF
--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -95,47 +95,70 @@ async def _teardown_startup_resources(
     watcher: FileWatcher | None,
     ctx: AppContext | None,
 ) -> None:
-    """Tear down startup-allocated resources in reverse-allocation order.
+    """Tear down startup-allocated resources; called on both shutdown paths.
 
-    Called from both the normal shutdown path (after ``yield``) and the
-    startup-failure path (before re-raising, #404). Each step swallows so
-    a later failure doesn't skip earlier ones — shutdown must always
-    complete whatever it can.
+    Invoked from the normal post-``yield`` ``finally`` and from the
+    startup-failure ``except BaseException`` (before re-raising, #404).
+    Each step catches ``Exception`` so a later failure doesn't skip
+    earlier ones — shutdown must always complete whatever it can — but
+    ``CancelledError`` is re-raised so task cancellation propagates and
+    the caller can decide whether to mask the original startup failure.
 
-    Allocation order in :func:`app_lifespan` is:
-    webhook_mgr → ctx/components → watcher → scheduler → policy_scheduler
-    → watchdog. Teardown is the reverse.
+    Order (matches the existing post-yield shutdown sequence since
+    before #404; #404 only centralised it into this helper):
+
+        watchdog → policy_scheduler → scheduler → webhook_mgr → watcher → ctx
+
+    This is *not* strict reverse-allocation order: ``webhook_mgr`` is
+    stopped before ``watcher`` and ``ctx`` because it has no dependency
+    on storage/index — closing it early drops network state that might
+    otherwise hold retries open during the slower component teardown.
+    ``ctx.close()`` is last so the schedulers/watchdog can still touch
+    storage while they stop.
     """
+    import asyncio
+
+    def _log_teardown_failure(stage: str, exc: BaseException) -> None:
+        # CancelledError is BaseException-derived in Python 3.8+; we still
+        # want to record that a teardown step was cancelled (otherwise the
+        # cancellation silently drops the original startup exception if it
+        # happens mid-teardown), then re-raise so cancellation propagates
+        # and the caller decides what to do.
+        if isinstance(exc, asyncio.CancelledError):
+            logger.warning("Shutdown step '%s' cancelled", stage)
+            raise exc
+        logger.warning("Shutdown step '%s' failed", stage, exc_info=True)
+
     if watchdog is not None:
         try:
             await watchdog.stop()  # type: ignore[attr-defined]
-        except Exception:
-            logger.warning("Failed to stop health watchdog", exc_info=True)
+        except BaseException as exc:
+            _log_teardown_failure("health_watchdog", exc)
     if policy_scheduler is not None:
         try:
             await policy_scheduler.stop()  # type: ignore[attr-defined]
-        except Exception:
-            logger.warning("Failed to stop policy scheduler", exc_info=True)
+        except BaseException as exc:
+            _log_teardown_failure("policy_scheduler", exc)
     if scheduler is not None:
         try:
             await scheduler.stop()  # type: ignore[attr-defined]
-        except Exception:
-            logger.warning("Failed to stop scheduler", exc_info=True)
+        except BaseException as exc:
+            _log_teardown_failure("scheduler", exc)
     if webhook_mgr is not None:
         try:
             await webhook_mgr.close()  # type: ignore[attr-defined]
-        except Exception:
-            logger.warning("Failed to close webhook manager", exc_info=True)
+        except BaseException as exc:
+            _log_teardown_failure("webhook_manager", exc)
     if watcher is not None:
         try:
             await watcher.stop()
-        except Exception:
-            logger.warning("Shutdown step 'watcher' failed", exc_info=True)
+        except BaseException as exc:
+            _log_teardown_failure("watcher", exc)
     if ctx is not None:
         try:
             await ctx.close()
-        except Exception:
-            logger.warning("Shutdown step 'components' failed", exc_info=True)
+        except BaseException as exc:
+            _log_teardown_failure("components", exc)
 
 
 @asynccontextmanager

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -86,6 +86,58 @@ def _load_dotenv() -> None:
 # ---------------------------------------------------------------------------
 
 
+async def _teardown_startup_resources(
+    *,
+    watchdog: object | None,
+    policy_scheduler: object | None,
+    scheduler: object | None,
+    webhook_mgr: object | None,
+    watcher: FileWatcher | None,
+    ctx: AppContext | None,
+) -> None:
+    """Tear down startup-allocated resources in reverse-allocation order.
+
+    Called from both the normal shutdown path (after ``yield``) and the
+    startup-failure path (before re-raising, #404). Each step swallows so
+    a later failure doesn't skip earlier ones — shutdown must always
+    complete whatever it can.
+
+    Allocation order in :func:`app_lifespan` is:
+    webhook_mgr → ctx/components → watcher → scheduler → policy_scheduler
+    → watchdog. Teardown is the reverse.
+    """
+    if watchdog is not None:
+        try:
+            await watchdog.stop()  # type: ignore[attr-defined]
+        except Exception:
+            logger.warning("Failed to stop health watchdog", exc_info=True)
+    if policy_scheduler is not None:
+        try:
+            await policy_scheduler.stop()  # type: ignore[attr-defined]
+        except Exception:
+            logger.warning("Failed to stop policy scheduler", exc_info=True)
+    if scheduler is not None:
+        try:
+            await scheduler.stop()  # type: ignore[attr-defined]
+        except Exception:
+            logger.warning("Failed to stop scheduler", exc_info=True)
+    if webhook_mgr is not None:
+        try:
+            await webhook_mgr.close()  # type: ignore[attr-defined]
+        except Exception:
+            logger.warning("Failed to close webhook manager", exc_info=True)
+    if watcher is not None:
+        try:
+            await watcher.stop()
+        except Exception:
+            logger.warning("Shutdown step 'watcher' failed", exc_info=True)
+    if ctx is not None:
+        try:
+            await ctx.close()
+        except Exception:
+            logger.warning("Shutdown step 'components' failed", exc_info=True)
+
+
 @asynccontextmanager
 async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
     _load_dotenv()
@@ -93,88 +145,87 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
 
     config = Mem2MemConfig()
 
-    # Webhook manager is storage-free; safe to construct before component init.
     webhook_mgr = None
-    if config.webhook.enabled and config.webhook.url:
-        from memtomem.server.webhooks import WebhookManager
-
-        webhook_mgr = WebhookManager(config.webhook)
-
-    ctx = AppContext(config=config, webhook_manager=webhook_mgr)
-
-    # Phase 1 of #399 keeps init eager: the rest of startup (watcher,
-    # schedulers, watchdog) needs storage/embedder ready. Phase 3 will move
-    # this call (and the watcher/scheduler startup below) into the first
-    # tool-call path.
-    comp = await ctx.ensure_initialized()
-
-    # When the server came up in degraded mode (embedding mismatch, see
-    # issue #349) don't start the file watcher — indexing goes through
-    # ``upsert_chunks`` which needs ``chunks_vec`` and would crash on
-    # every file change. Recovery happens via ``mem_embedding_reset``.
-    watcher = FileWatcher(comp.index_engine, config.indexing)
-    if comp.embedding_broken is None:
-        await watcher.start()
-
-    # Background schedulers are skipped in degraded mode (see issue #349) —
-    # they walk the index / re-embed chunks and would hit the same missing
-    # ``chunks_vec`` cascade as the watcher. They resume after a restart
-    # once ``mem_embedding_reset`` has fixed the DB.
-    degraded = comp.embedding_broken is not None
-
-    # Auto-consolidation scheduler
+    watcher: FileWatcher | None = None
     scheduler = None
-    if config.consolidation_schedule.enabled and not degraded:
-        from memtomem.server.scheduler import ConsolidationScheduler
-
-        scheduler = ConsolidationScheduler(ctx, config.consolidation_schedule)
-        await scheduler.start()
-
-    # Policy scheduler
     policy_scheduler = None
-    if config.policy.enabled and not degraded:
-        from memtomem.server.scheduler import PolicyScheduler
-
-        policy_scheduler = PolicyScheduler(ctx, config.policy)
-        await policy_scheduler.start()
-
-    # Health watchdog
     watchdog = None
-    if config.health_watchdog.enabled and not degraded:
-        from memtomem.server.health_watchdog import HealthWatchdog
+    ctx: AppContext | None = None
 
-        watchdog = HealthWatchdog(ctx, config.health_watchdog)
-        await watchdog.start()
-        ctx.set_health_watchdog(watchdog)
+    # Startup is wrapped in a single try/except so a failure at any stage
+    # tears down everything allocated so far (#404). ``ensure_initialized``
+    # has its own internal cleanup (PR #400) and leaves ``ctx._components``
+    # unset on failure, so ``ctx.close()`` from the teardown path is a
+    # safe no-op in that case.
+    try:
+        # Webhook manager is storage-free; safe to construct before component init.
+        if config.webhook.enabled and config.webhook.url:
+            from memtomem.server.webhooks import WebhookManager
+
+            webhook_mgr = WebhookManager(config.webhook)
+
+        ctx = AppContext(config=config, webhook_manager=webhook_mgr)
+
+        # Phase 1 of #399 keeps init eager: the rest of startup (watcher,
+        # schedulers, watchdog) needs storage/embedder ready. Phase 3 will move
+        # this call (and the watcher/scheduler startup below) into the first
+        # tool-call path.
+        comp = await ctx.ensure_initialized()
+
+        # When the server came up in degraded mode (embedding mismatch, see
+        # issue #349) don't start the file watcher — indexing goes through
+        # ``upsert_chunks`` which needs ``chunks_vec`` and would crash on
+        # every file change. Recovery happens via ``mem_embedding_reset``.
+        watcher = FileWatcher(comp.index_engine, config.indexing)
+        if comp.embedding_broken is None:
+            await watcher.start()
+
+        # Background schedulers are skipped in degraded mode (see issue #349) —
+        # they walk the index / re-embed chunks and would hit the same missing
+        # ``chunks_vec`` cascade as the watcher. They resume after a restart
+        # once ``mem_embedding_reset`` has fixed the DB.
+        degraded = comp.embedding_broken is not None
+
+        # Auto-consolidation scheduler
+        if config.consolidation_schedule.enabled and not degraded:
+            from memtomem.server.scheduler import ConsolidationScheduler
+
+            scheduler = ConsolidationScheduler(ctx, config.consolidation_schedule)
+            await scheduler.start()
+
+        # Policy scheduler
+        if config.policy.enabled and not degraded:
+            from memtomem.server.scheduler import PolicyScheduler
+
+            policy_scheduler = PolicyScheduler(ctx, config.policy)
+            await policy_scheduler.start()
+
+        # Health watchdog
+        if config.health_watchdog.enabled and not degraded:
+            from memtomem.server.health_watchdog import HealthWatchdog
+
+            watchdog = HealthWatchdog(ctx, config.health_watchdog)
+            await watchdog.start()
+            ctx.set_health_watchdog(watchdog)
+    except BaseException:
+        await _teardown_startup_resources(
+            watchdog=watchdog,
+            policy_scheduler=policy_scheduler,
+            scheduler=scheduler,
+            webhook_mgr=webhook_mgr,
+            watcher=watcher,
+            ctx=ctx,
+        )
+        raise
 
     try:
         yield ctx
     finally:
-        if watchdog:
-            try:
-                await watchdog.stop()
-            except Exception:
-                logger.warning("Failed to stop health watchdog", exc_info=True)
-        if policy_scheduler:
-            try:
-                await policy_scheduler.stop()
-            except Exception:
-                logger.warning("Failed to stop policy scheduler", exc_info=True)
-        if scheduler:
-            try:
-                await scheduler.stop()
-            except Exception:
-                logger.warning("Failed to stop scheduler", exc_info=True)
-        if webhook_mgr:
-            try:
-                await webhook_mgr.close()
-            except Exception:
-                logger.warning("Failed to close webhook manager", exc_info=True)
-        try:
-            await watcher.stop()
-        except Exception:
-            logger.warning("Shutdown step 'watcher' failed", exc_info=True)
-        try:
-            await ctx.close()
-        except Exception:
-            logger.warning("Shutdown step 'components' failed", exc_info=True)
+        await _teardown_startup_resources(
+            watchdog=watchdog,
+            policy_scheduler=policy_scheduler,
+            scheduler=scheduler,
+            webhook_mgr=webhook_mgr,
+            watcher=watcher,
+            ctx=ctx,
+        )

--- a/packages/memtomem/tests/test_server_lifespan.py
+++ b/packages/memtomem/tests/test_server_lifespan.py
@@ -1,0 +1,301 @@
+"""Test ``app_lifespan`` startup-failure teardown (#404).
+
+The original shape of ``app_lifespan`` had no guard between the first
+resource allocation and the ``yield`` — any startup stage raising
+before ``yield`` leaked everything already allocated, because the
+``finally`` block only runs when ``yield`` was reached. This file
+pins:
+
+- :func:`_teardown_startup_resources` shape (order, idempotency, error
+  tolerance), since both the normal shutdown path and the new
+  startup-failure path funnel through it.
+- A minimal integration check that a startup failure triggers
+  reverse-order teardown of everything allocated so far and re-raises.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem.server.lifespan import _teardown_startup_resources
+
+
+def _fake_resource(stop_attr: str = "stop") -> object:
+    """A fake with an async ``stop`` or ``close`` method that records calls."""
+
+    class _R:
+        def __init__(self) -> None:
+            setattr(self, stop_attr, AsyncMock())
+
+    return _R()
+
+
+@pytest.mark.asyncio
+async def test_teardown_all_none_is_noop() -> None:
+    """No resources → no calls, no error."""
+    await _teardown_startup_resources(
+        watchdog=None,
+        policy_scheduler=None,
+        scheduler=None,
+        webhook_mgr=None,
+        watcher=None,
+        ctx=None,
+    )  # should not raise
+
+
+@pytest.mark.asyncio
+async def test_teardown_calls_each_in_reverse_allocation_order() -> None:
+    """All resources present → stop/close called in reverse-allocation order."""
+    order: list[str] = []
+
+    class _Rec:
+        def __init__(self, name: str, method: str) -> None:
+            self.name = name
+            self.method = method
+
+            async def _call() -> None:
+                order.append(name)
+
+            setattr(self, method, _call)
+
+    webhook = _Rec("webhook_mgr", "close")
+    ctx = _Rec("ctx", "close")
+    watcher = _Rec("watcher", "stop")
+    scheduler = _Rec("scheduler", "stop")
+    policy = _Rec("policy_scheduler", "stop")
+    watchdog = _Rec("watchdog", "stop")
+
+    await _teardown_startup_resources(
+        watchdog=watchdog,
+        policy_scheduler=policy,
+        scheduler=scheduler,
+        webhook_mgr=webhook,
+        watcher=watcher,  # type: ignore[arg-type]
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+
+    assert order == [
+        "watchdog",
+        "policy_scheduler",
+        "scheduler",
+        "webhook_mgr",
+        "watcher",
+        "ctx",
+    ], "teardown must run in reverse-allocation order"
+
+
+@pytest.mark.asyncio
+async def test_teardown_continues_after_intermediate_failure() -> None:
+    """A failing stop() must not skip later teardown steps."""
+    called: list[str] = []
+
+    async def _good_stop() -> None:
+        called.append("good")
+
+    async def _bad_stop() -> None:
+        called.append("bad")
+        raise RuntimeError("boom")
+
+    class _R:
+        pass
+
+    watchdog = _R()
+    watchdog.stop = _bad_stop  # type: ignore[attr-defined]
+    scheduler = _R()
+    scheduler.stop = _good_stop  # type: ignore[attr-defined]
+    ctx = _R()
+    ctx.close = _good_stop  # type: ignore[attr-defined]
+
+    await _teardown_startup_resources(
+        watchdog=watchdog,
+        policy_scheduler=None,
+        scheduler=scheduler,
+        webhook_mgr=None,
+        watcher=None,
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+
+    assert called == ["bad", "good", "good"], (
+        "watchdog failure must not skip scheduler/ctx teardown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_teardown_ctx_close_called_last() -> None:
+    """``ctx.close()`` is the last step — DB handles must outlive the
+    schedulers that hold references to them."""
+    order: list[str] = []
+
+    async def _record(name: str) -> None:
+        order.append(name)
+
+    class _R:
+        pass
+
+    watchdog = _R()
+
+    async def _wd_stop() -> None:
+        await _record("watchdog")
+
+    watchdog.stop = _wd_stop  # type: ignore[attr-defined]
+
+    ctx = _R()
+
+    async def _ctx_close() -> None:
+        await _record("ctx")
+
+    ctx.close = _ctx_close  # type: ignore[attr-defined]
+
+    await _teardown_startup_resources(
+        watchdog=watchdog,
+        policy_scheduler=None,
+        scheduler=None,
+        webhook_mgr=None,
+        watcher=None,
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+
+    assert order[-1] == "ctx", "ctx.close must be the final teardown step"
+
+
+# ── integration ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_tears_down_prior_resources(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """If a late startup stage raises, earlier allocations get cleaned up.
+
+    We drive ``app_lifespan`` through ``ensure_initialized`` and inject a
+    failing health-watchdog ``start()`` — webhook_mgr, ctx, watcher, and
+    scheduler must all see teardown, and the lifespan must re-raise.
+    """
+    from memtomem.server import lifespan as lifespan_mod
+
+    # Track teardown calls
+    teardown_calls: list[str] = []
+
+    class _FakeWatcher:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            teardown_calls.append("watcher")
+
+    class _FakeWebhook:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def close(self) -> None:
+            teardown_calls.append("webhook_mgr")
+
+    class _FakeScheduler:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def start(self) -> None:
+            pass
+
+        async def stop(self) -> None:
+            teardown_calls.append("scheduler")
+
+    class _FakePolicyScheduler(_FakeScheduler):
+        async def stop(self) -> None:
+            teardown_calls.append("policy_scheduler")
+
+    class _FailingWatchdog:
+        def __init__(self, *a, **k) -> None:
+            pass
+
+        async def start(self) -> None:
+            raise RuntimeError("watchdog boom")
+
+        async def stop(self) -> None:
+            teardown_calls.append("watchdog")
+
+    # Patch dependencies that the lifespan resolves via lazy imports.
+    monkeypatch.setattr(lifespan_mod, "FileWatcher", _FakeWatcher)
+
+    import memtomem.server.webhooks as webhooks_mod
+
+    monkeypatch.setattr(webhooks_mod, "WebhookManager", _FakeWebhook)
+
+    import memtomem.server.scheduler as scheduler_mod
+
+    monkeypatch.setattr(scheduler_mod, "ConsolidationScheduler", _FakeScheduler)
+    monkeypatch.setattr(scheduler_mod, "PolicyScheduler", _FakePolicyScheduler)
+
+    import memtomem.server.health_watchdog as watchdog_mod
+
+    monkeypatch.setattr(watchdog_mod, "HealthWatchdog", _FailingWatchdog)
+
+    # Stub AppContext.ensure_initialized so we don't need real storage.
+    import memtomem.server.context as context_mod
+
+    ensure_init_called = False
+    ctx_closed = False
+
+    class _FakeComponents:
+        class _Engine:
+            pass
+
+        index_engine = _Engine()
+        embedding_broken = None
+
+    fake_comp = _FakeComponents()
+
+    original_ensure = context_mod.AppContext.ensure_initialized
+    original_close = context_mod.AppContext.close
+
+    async def _fake_ensure(self) -> object:
+        nonlocal ensure_init_called
+        ensure_init_called = True
+        self._components = fake_comp  # type: ignore[assignment]
+        self._owns_components = True
+        return fake_comp
+
+    async def _fake_close(self) -> None:
+        nonlocal ctx_closed
+        ctx_closed = True
+
+    monkeypatch.setattr(context_mod.AppContext, "ensure_initialized", _fake_ensure)
+    monkeypatch.setattr(context_mod.AppContext, "close", _fake_close)
+
+    # Force every optional subsystem on so we exercise webhook + both
+    # schedulers + watchdog. We set env vars before Mem2MemConfig loads.
+    monkeypatch.setenv("MEMTOMEM_WEBHOOK__ENABLED", "true")
+    monkeypatch.setenv("MEMTOMEM_WEBHOOK__URL", "https://example.invalid/hook")
+    monkeypatch.setenv("MEMTOMEM_CONSOLIDATION_SCHEDULE__ENABLED", "true")
+    monkeypatch.setenv("MEMTOMEM_POLICY__ENABLED", "true")
+    monkeypatch.setenv("MEMTOMEM_HEALTH_WATCHDOG__ENABLED", "true")
+    # Keep storage path deterministic (but we don't actually hit disk, since
+    # ensure_initialized is stubbed).
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", str(tmp_path / "mm.db"))
+
+    # Drive the lifespan and assert it re-raises the watchdog failure.
+    with pytest.raises(RuntimeError, match="watchdog boom"):
+        async with lifespan_mod.app_lifespan(object()):  # type: ignore[arg-type]
+            pytest.fail("yield should not be reached — startup must fail first")
+
+    # Everything allocated must have been torn down, including the
+    # watchdog — it was constructed before ``start()`` raised, so the
+    # ``watchdog`` local was already bound. Teardown steps must be
+    # idempotent for this to be safe in general; our fake ``.stop()``
+    # is trivially so.
+    assert ensure_init_called, "ensure_initialized must have been called"
+    assert ctx_closed, "ctx.close must have been called during teardown"
+    assert teardown_calls == [
+        "watchdog",
+        "policy_scheduler",
+        "scheduler",
+        "webhook_mgr",
+        "watcher",
+    ], f"unexpected teardown order or missing steps: {teardown_calls}"
+
+    _ = original_ensure, original_close

--- a/packages/memtomem/tests/test_server_lifespan.py
+++ b/packages/memtomem/tests/test_server_lifespan.py
@@ -46,8 +46,14 @@ async def test_teardown_all_none_is_noop() -> None:
 
 
 @pytest.mark.asyncio
-async def test_teardown_calls_each_in_reverse_allocation_order() -> None:
-    """All resources present → stop/close called in reverse-allocation order."""
+async def test_teardown_order_matches_documented_sequence() -> None:
+    """All resources present → stop/close in the documented sequence.
+
+    Not strict reverse-allocation — ``webhook_mgr`` is stopped before
+    ``watcher`` and ``ctx``. See ``_teardown_startup_resources`` docstring
+    for rationale (webhook has no storage/index dependency, closing it
+    early drops retries during the slower component teardown).
+    """
     order: list[str] = []
 
     class _Rec:
@@ -83,7 +89,7 @@ async def test_teardown_calls_each_in_reverse_allocation_order() -> None:
         "webhook_mgr",
         "watcher",
         "ctx",
-    ], "teardown must run in reverse-allocation order"
+    ], "teardown order must match the documented sequence"
 
 
 @pytest.mark.asyncio
@@ -119,6 +125,47 @@ async def test_teardown_continues_after_intermediate_failure() -> None:
 
     assert called == ["bad", "good", "good"], (
         "watchdog failure must not skip scheduler/ctx teardown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_teardown_reraises_cancelled_error() -> None:
+    """``CancelledError`` must propagate — swallowing it would hide task
+    cancellation, and continuing teardown after cancellation could mask
+    the original startup exception in the ``except BaseException`` caller.
+    """
+    import asyncio
+
+    called: list[str] = []
+
+    async def _cancel_stop() -> None:
+        called.append("watchdog")
+        raise asyncio.CancelledError()
+
+    async def _good_stop() -> None:
+        called.append("scheduler")
+
+    class _R:
+        pass
+
+    watchdog = _R()
+    watchdog.stop = _cancel_stop  # type: ignore[attr-defined]
+    scheduler = _R()
+    scheduler.stop = _good_stop  # type: ignore[attr-defined]
+
+    with pytest.raises(asyncio.CancelledError):
+        await _teardown_startup_resources(
+            watchdog=watchdog,
+            policy_scheduler=None,
+            scheduler=scheduler,
+            webhook_mgr=None,
+            watcher=None,
+            ctx=None,
+        )
+
+    # Later steps were skipped because the cancellation propagated.
+    assert called == ["watchdog"], (
+        f"teardown must stop at CancelledError — later steps reached: {called}"
     )
 
 


### PR DESCRIPTION
Closes #404 (follow-up to #400 / phase 2 blocker for #399).

## Problem

`app_lifespan` allocates six resources before `yield`:

1. `webhook_mgr` (if enabled)
2. `ctx` (`AppContext`)
3. `comp` (via `ctx.ensure_initialized()` — opens DB/embedder)
4. `watcher` (`FileWatcher.start()`)
5. `scheduler` + `policy_scheduler` (if enabled)
6. `watchdog` (if enabled)

The old shape only guarded the body behind `yield` with `try/finally`. If any step between the first allocation and `yield` raised, the `finally` block never ran and everything already allocated leaked.

`ensure_initialized()` has its own internal `try/except close_components` (PR #400), so the DB handles it opened are covered. But the rest — `webhook_mgr`, `watcher`, `scheduler`, `policy_scheduler`, and the just-constructed `watchdog` — all leaked if startup failed after them.

This becomes a **Phase 2/3 blocker** for #399's lazy-init refactor: once the DB open moves into request handlers, a late allocation failure (e.g. `scheduler.start()` racing against network state) becomes more likely than it is in eager-init, and a stale `flock` on `~/.memtomem/memtomem.db` becomes user-visible.

## Fix

Factor the teardown sequence into `_teardown_startup_resources` and call it from both paths:

- **Normal shutdown** — `try/finally` after `yield`, same as before, now routed through the helper.
- **Startup failure** — new `try/except BaseException` around the entire allocation block that runs teardown before re-raising.

Teardown order matches the inverse of allocation. Each step swallows its own exception so a late failure doesn't skip earlier steps — shutdown must always complete whatever it can.

Note on `ctx.close()` in the teardown path: `AppContext.close()` is idempotent (`_components is None` → no-op) and `ensure_initialized()`'s internal rollback leaves `_components` unset on failure, so calling `ctx.close()` from `_teardown_startup_resources` after an `ensure_initialized` failure is a safe no-op. No double-close.

## Tests

- **Unit** (`_teardown_startup_resources`):
  - All-None input → no-op, no error.
  - All present → reverse-allocation order (`watchdog` → … → `ctx`).
  - Intermediate failure → later steps still run.
  - `ctx.close()` is always the final step.
- **Integration** (`test_startup_failure_tears_down_prior_resources`):
  - Inject a failing `HealthWatchdog.start()`.
  - Verify `ensure_initialized`, `watcher`, `scheduler`, `policy_scheduler`, `webhook_mgr`, and `watchdog.stop()` all run in reverse order.
  - Verify the original `RuntimeError("watchdog boom")` re-raises.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_server_lifespan.py`: 5 passed.
- [x] `uv run pytest -m "not ollama"`: 2168 passed (no regressions).
- [x] `uv run ruff check` + `ruff format --check`: clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/server/lifespan.py`: clean.

## Not in scope

- Actually moving to lazy init (Phase 2/3 of #399) — this PR only closes the teardown gap so the subsequent phases can land safely.
- `webhook_mgr` construction is storage-free and currently cannot raise in practice; we still route it through the same teardown seam for consistency.
