### PR TITLE
fix(init): wizard probes openai Python client (closes #407)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -389,6 +389,18 @@ def _step_embedding(state: dict) -> None:
 
     else:
         provider = "openai"
+        # Mirror the Ollama / ONNX / kiwipiepy probe pattern (#405 / #403):
+        # the ``-y`` extras gate (#402) refuses without the ``openai``
+        # Python client, so the wizard must hint before prompting for a
+        # key the user could otherwise spend effort validating.
+        if not _have_module("openai"):
+            click.secho("  openai Python client not installed.", fg="yellow")
+            click.echo(f"  Install with: {_extra_install_hint(['openai'], state)}")
+            click.echo(_y_refuse_hint("--provider openai", "openai"))
+            click.echo("  Saving OpenAI config now so you're ready after install.")
+            click.echo()
+            state.setdefault("_extras_warned_inline", set()).add("openai")
+
         click.echo("  Available models:")
         click.echo("    [1] text-embedding-3-small — balanced (1536d)")
         click.echo("    [2] text-embedding-3-large — highest accuracy (3072d)")

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -396,8 +396,8 @@ def _step_embedding(state: dict) -> None:
         if not _have_module("openai"):
             click.secho("  openai Python client not installed.", fg="yellow")
             click.echo(f"  Install with: {_extra_install_hint(['openai'], state)}")
-            click.echo(_y_refuse_hint("--provider openai", "openai"))
             click.echo("  Saving OpenAI config now so you're ready after install.")
+            click.echo(_y_refuse_hint("--provider openai", "openai"))
             click.echo()
             state.setdefault("_extras_warned_inline", set()).add("openai")
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4892,6 +4892,10 @@ class TestYRefuseHintParity:
             "Ollama fallback must surface -y refuse hint in both "
             "binary-missing and module-missing branches (#405)"
         )
+        assert _count_calls(embedding_src, "--provider openai", "openai") >= 1, (
+            "OpenAI fallback must surface -y refuse hint when the openai "
+            "Python client is missing (#407)"
+        )
         assert _count_calls(language_src, "--tokenizer kiwipiepy", "korean") >= 1, (
             "kiwipiepy fallback must surface -y refuse hint (#403)"
         )


### PR DESCRIPTION
Closes #407 (follow-up to #405 / #403 / #402).

## Problem

Three of the four provider/tokenizer axes in the wizard already probe the Python client before prompting:

- **ONNX**: `import fastembed` → warn + save + `_y_refuse_hint`
- **Ollama**: `_ollama_available()` (binary) + `_have_module("ollama")` (Python) → warn + save + `_y_refuse_hint` (#405)
- **kiwipiepy**: `import kiwipiepy` → warn + `_y_refuse_hint`

The **OpenAI** path didn't — it only validated the API key (`_test_openai_key`, network). Meanwhile `mm init -y --provider openai` refuses upfront if the `openai` Python client is missing (`_collect_missing_extras`). So:

- Wizard + no `openai` package + valid key → silent pass, config saved, runtime falls back or errors later.
- `-y --provider openai` + no `openai` package → refuses upfront.

A user who copied a successful wizard choice into a scripted `-y` install hit the same discoverability gap #405 closed for the other three axes.

## Change

Mirror the Ollama pattern in the OpenAI branch, before the API-key prompt:

```python
if not _have_module("openai"):
    click.secho("  openai Python client not installed.", fg="yellow")
    click.echo(f"  Install with: {_extra_install_hint(['openai'], state)}")
    click.echo(_y_refuse_hint("--provider openai", "openai"))
    click.echo("  Saving OpenAI config now so you're ready after install.")
    state.setdefault("_extras_warned_inline", set()).add("openai")
```

Key validation + save still run after the warning — the user still gets a clean key-check and the warn-and-save semantic is preserved. `_extras_warned_inline` marker prevents the post-wizard summary from duplicating.

Pin test extended with a fourth axis (`_count_calls(embedding_src, "--provider openai", "openai") >= 1`).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -k "YRefuseHint"`: 2 passed.
- [x] Full `test_init_cmd.py`: 202 passed.
- [x] `ruff check` + `ruff format --check`: clean.

## Scope

Four-axis coverage now complete. No behavior change for users who have the `openai` package installed. No change to `-y` semantics.
