### PR TITLE
feat(server): migrate handlers to _get_app_initialized (#399 phase 2)

### DIFF
--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -21,6 +21,7 @@ from memtomem.server.context import (
     AppContext as AppContext,
     CtxType as CtxType,
     _get_app as _get_app,
+    _get_app_initialized as _get_app_initialized,
 )
 from memtomem.server.formatters import (
     _format_compact_result as _format_compact_result,

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -218,3 +218,23 @@ def _get_app(ctx: CtxType) -> AppContext:
     # tool signatures exists only so the param isn't positional-required.
     assert ctx is not None, "MCP framework must inject ctx at call time"
     return ctx.request_context.lifespan_context
+
+
+async def _get_app_initialized(ctx: CtxType) -> AppContext:
+    """Fetch the ``AppContext`` and guarantee its components are populated.
+
+    Handlers that touch storage / embedder / index_engine / search_pipeline
+    must call this (not ``_get_app``) so the DB + embedder are opened on
+    first use rather than at lifespan startup — that's the whole point of
+    #399: an MCP handshake + ``tools/list`` leaves ``~/.memtomem/`` alone.
+
+    Phase 1 kept ``app_lifespan`` calling ``ensure_initialized`` eagerly,
+    so every handler currently sees populated components even via
+    ``_get_app``. Phase 3 drops the eager call — at that point any handler
+    still reaching through ``_get_app`` would hit the
+    ``_require_initialized`` guard on first property read. Migrating every
+    handler now (Phase 2) is what makes the Phase 3 flip safe.
+    """
+    app = _get_app(ctx)
+    await app.ensure_initialized()
+    return app

--- a/packages/memtomem/src/memtomem/server/resources.py
+++ b/packages/memtomem/src/memtomem/server/resources.py
@@ -6,13 +6,13 @@ import json
 from uuid import UUID
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 
 
 @mcp.resource("memtomem://sources")
 async def sources_resource(ctx: CtxType = None) -> str:
     """List all indexed source files with chunk counts."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     rows = await app.storage.get_source_files_with_counts()
     result = []
     for path, count, updated, ns, avg_tok, min_tok, max_tok in rows:
@@ -31,7 +31,7 @@ async def sources_resource(ctx: CtxType = None) -> str:
 @mcp.resource("memtomem://namespaces")
 async def namespaces_resource(ctx: CtxType = None) -> str:
     """List all namespaces and their chunk counts."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     ns_list = await app.storage.list_namespaces()
     result = [{"namespace": ns, "chunks": count} for ns, count in ns_list]
     return json.dumps(result, indent=2)
@@ -40,7 +40,7 @@ async def namespaces_resource(ctx: CtxType = None) -> str:
 @mcp.resource("memtomem://tags")
 async def tags_resource(ctx: CtxType = None) -> str:
     """List all tags and their usage counts."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     tag_counts = await app.storage.get_tag_counts()
     result = [{"tag": tag, "chunks": count} for tag, count in tag_counts]
     return json.dumps(result, indent=2)
@@ -49,7 +49,7 @@ async def tags_resource(ctx: CtxType = None) -> str:
 @mcp.resource("memtomem://stats")
 async def stats_resource(ctx: CtxType = None) -> str:
     """Current index statistics."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     stats = await app.storage.get_stats()
     return json.dumps(stats, indent=2)
 
@@ -57,7 +57,7 @@ async def stats_resource(ctx: CtxType = None) -> str:
 @mcp.resource("memtomem://chunks/{chunk_id}")
 async def chunk_resource(chunk_id: str, ctx: CtxType = None) -> str:
     """Read a specific chunk by UUID."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     chunk = await app.storage.get_chunk(UUID(chunk_id))
     if chunk is None:
         return json.dumps({"error": f"Chunk {chunk_id} not found"})

--- a/packages/memtomem/src/memtomem/server/tools/ask.py
+++ b/packages/memtomem/src/memtomem/server/tools/ask.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.validation import MAX_QUERY_LENGTH
 from memtomem.server.webhooks import webhook_error_cb
@@ -47,7 +47,7 @@ async def mem_ask(
     if not 1 <= top_k <= 20:
         return f"Error: top_k must be between 1 and 20, got {top_k}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     effective_ns = namespace or app.current_namespace
 
     results, stats = await app.search_pipeline.search(

--- a/packages/memtomem/src/memtomem/server/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/server/tools/auto_tag.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -31,7 +31,7 @@ async def mem_auto_tag(
     """
     from memtomem.tools.auto_tag import auto_tag_storage
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     stats = await auto_tag_storage(
         app.storage,
         source_filter=source_filter,

--- a/packages/memtomem/src/memtomem/server/tools/browse.py
+++ b/packages/memtomem/src/memtomem/server/tools/browse.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.formatters import _display_path
 
@@ -31,7 +31,7 @@ async def mem_list(
     """
     from fnmatch import fnmatch
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     rows = await app.storage.get_source_files_with_counts()
 
     if not rows:
@@ -77,7 +77,7 @@ async def mem_read(
     Args:
         chunk_id: The UUID of the chunk (shown in mem_search results)
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         uid = UUID(chunk_id)

--- a/packages/memtomem/src/memtomem/server/tools/conflict.py
+++ b/packages/memtomem/src/memtomem/server/tools/conflict.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -25,7 +25,7 @@ async def mem_conflict_check(
         content: Content to check against existing memories.
         threshold: Minimum similarity score to consider (default 0.75).
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     from memtomem.search.conflict import detect_conflicts
 

--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -39,7 +39,7 @@ async def mem_consolidate(
     if min_group_size < 2:
         return f"Error: min_group_size must be at least 2, got {min_group_size}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     effective_ns = namespace or app.current_namespace
 
     # Group chunks by source file
@@ -162,7 +162,7 @@ async def mem_consolidate_apply(
         link_consolidation_relations,
     )
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     entry = await app.storage.scratch_get("consolidation_groups")
     if not entry:

--- a/packages/memtomem/src/memtomem/server/tools/cross_ref.py
+++ b/packages/memtomem/src/memtomem/server/tools/cross_ref.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -32,7 +32,7 @@ async def mem_link(
     if source_id == target_id:
         return "Error: cannot link a chunk to itself."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         src_uid = UUID(source_id)
@@ -73,7 +73,7 @@ async def mem_unlink(
         source_id: UUID of the first chunk
         target_id: UUID of the second chunk
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         src_uid = UUID(source_id)
@@ -101,7 +101,7 @@ async def mem_related(
     Args:
         chunk_id: UUID of the chunk to find relations for
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         uid = UUID(chunk_id)

--- a/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
+++ b/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from uuid import UUID
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -32,7 +32,7 @@ async def mem_dedup_scan(
     if not 1 <= limit <= 500:
         return f"Error: limit must be between 1 and 500, got {limit}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     if app.dedup_scanner is None:
         return "DedupScanner not initialized."
     candidates = await app.dedup_scanner.scan(threshold=threshold, limit=limit, max_scan=max_scan)
@@ -72,7 +72,7 @@ async def mem_dedup_merge(
         keep_id: UUID of the chunk to keep
         delete_ids: UUIDs of chunks to delete
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     if app.dedup_scanner is None:
         return "DedupScanner not initialized."
     try:
@@ -105,7 +105,7 @@ async def mem_decay_scan(
 
     from memtomem.search.decay import expire_chunks
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     stats = await expire_chunks(
         app.storage, max_age_days=max_age_days, dry_run=True, source_filter=source_filter
     )
@@ -140,7 +140,7 @@ async def mem_decay_expire(
 
     from memtomem.search.decay import expire_chunks
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     stats = await expire_chunks(
         app.storage, max_age_days=max_age_days, dry_run=dry_run, source_filter=source_filter
     )
@@ -169,7 +169,7 @@ async def mem_cleanup_orphans(
     Args:
         dry_run: If True (default), only list orphaned files without deleting.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     source_files = await app.storage.get_all_source_files()
 
     orphaned: list[Path] = []

--- a/packages/memtomem/src/memtomem/server/tools/entity.py
+++ b/packages/memtomem/src/memtomem/server/tools/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -38,7 +38,7 @@ async def mem_entity_scan(
 
     from memtomem.tools.entity_extraction import extract_entities_with_llm
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     storage = app.storage
 
     # Get all source files
@@ -135,7 +135,7 @@ async def mem_entity_search(
     if not 1 <= limit <= 500:
         return f"Error: limit must be between 1 and 500, got {limit}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     results = await app.storage.search_entities(
         entity_type=entity_type,
         value=value,

--- a/packages/memtomem/src/memtomem/server/tools/evaluation.py
+++ b/packages/memtomem/src/memtomem/server/tools/evaluation.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -25,7 +25,7 @@ async def mem_eval(
         since: Only analyze activity after this date (YYYY-MM-DD or ISO)
         namespace: Scope analysis to this namespace
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     report = await app.storage.get_health_report(namespace=namespace)
 
     lines = ["## Memory Health Report\n"]

--- a/packages/memtomem/src/memtomem/server/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/server/tools/export_import.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.server.helpers import _check_embedding_mismatch
@@ -35,7 +35,7 @@ async def mem_export(
 
     from memtomem.tools.export_import import export_chunks
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     since_dt: datetime | None = None
     if since:
@@ -78,7 +78,7 @@ async def mem_import(
     """
     from memtomem.tools.export_import import import_chunks
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     # Block import if embedding config mismatches DB
     mismatch_msg = _check_embedding_mismatch(app)

--- a/packages/memtomem/src/memtomem/server/tools/importance.py
+++ b/packages/memtomem/src/memtomem/server/tools/importance.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -27,7 +27,7 @@ async def mem_importance_scan(
 
     from memtomem.search.importance import compute_importance
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     rows = await app.storage.get_chunk_factors(namespace=namespace)
     now = datetime.now(timezone.utc)
 

--- a/packages/memtomem/src/memtomem/server/tools/importers.py
+++ b/packages/memtomem/src/memtomem/server/tools/importers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -31,7 +31,7 @@ async def mem_import_notion(
     """
     from memtomem.indexing.importers import import_notion
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     export_path = Path(path).expanduser().resolve()
 
     if not export_path.exists():
@@ -105,7 +105,7 @@ async def mem_import_obsidian(
     """
     from memtomem.indexing.importers import import_obsidian
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     vault = Path(vault_path).expanduser().resolve()
 
     if not vault.exists() or not vault.is_dir():

--- a/packages/memtomem/src/memtomem/server/tools/indexing.py
+++ b/packages/memtomem/src/memtomem/server/tools/indexing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.helpers import _check_embedding_mismatch
 
@@ -29,7 +29,7 @@ async def mem_index(
         namespace: Assign all indexed chunks to this namespace
         auto_tag: If True, run keyword-based auto-tagging on newly indexed chunks
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     # Block indexing if embedding config mismatches DB
     mismatch_msg = _check_embedding_mismatch(app)

--- a/packages/memtomem/src/memtomem/server/tools/ingest.py
+++ b/packages/memtomem/src/memtomem/server/tools/ingest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -86,7 +86,7 @@ async def _ingest_claude(resolved: Path, dry_run: bool, ctx: CtxType) -> str:
                 lines.append(f"    {f.name}  tags=[{', '.join(tags)}]")
         return "\n".join(lines)
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     total_indexed = 0
     total_skipped = 0
     total_deleted = 0
@@ -147,7 +147,7 @@ async def _ingest_gemini(resolved: Path, dry_run: bool, ctx: CtxType) -> str:
             lines.append(f"  {f.name}  tags=[{', '.join(tags)}]")
         return "\n".join(lines)
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     summary = await _ingest_files_with_components(
         app,
         files,
@@ -188,7 +188,7 @@ async def _ingest_codex(resolved: Path, dry_run: bool, ctx: CtxType) -> str:
             lines.append(f"  {f.name}  tags=[{', '.join(tags)}]")
         return "\n".join(lines)
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     summary = await _ingest_files_with_components(
         app,
         files,
@@ -227,7 +227,7 @@ async def _ingest_single(
             lines.append(f"  {f.name}  tags=[{', '.join(tags)}]")
         return "\n".join(lines)
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     summary = await ingest_fn(app, files, ns, tag_fn=tag_fn)  # type: ignore[arg-type]
     result = (
         f"Ingested {len(files)} file(s) into '{ns}': "

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.helpers import _announce_dim_mismatch_once, _check_embedding_mismatch
 from memtomem.server.tool_registry import register
@@ -70,7 +70,7 @@ async def _mem_add_core(
 
     from memtomem.tools.memory_writer import append_entry
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     # Block vector-dependent writes when the server is in degraded mode
     # (see issue #349). Without this gate the subsequent ``index_file``
@@ -209,7 +209,7 @@ async def mem_edit(
 
     from memtomem.tools.memory_writer import replace_lines
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     mismatch_msg = _check_embedding_mismatch(app)
     if mismatch_msg:
         return mismatch_msg
@@ -273,7 +273,7 @@ async def mem_delete(
     """
     from memtomem.tools.memory_writer import remove_lines
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if chunk_id:
         try:
@@ -351,7 +351,7 @@ async def mem_batch_add(
 
     from memtomem.tools.memory_writer import append_entry
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     mismatch_msg = _check_embedding_mismatch(app)
     if mismatch_msg:
         return mismatch_msg

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
@@ -39,7 +39,7 @@ async def mem_agent_register(
     agent_id = sanitize_namespace_segment(agent_id)
     if not agent_id:
         return "Error: agent_id must contain at least one allowed character."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     namespace = f"{_AGENT_NAMESPACE_PREFIX}{agent_id}"
 
     await app.storage.set_namespace_meta(namespace, description=description, color=color)
@@ -87,7 +87,7 @@ async def mem_agent_search(
         agent_id = sanitize_namespace_segment(agent_id)
         if not agent_id:
             return "Error: agent_id must contain at least one allowed character."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     from memtomem.server.formatters import _format_results
 
     agent_ns = f"{_AGENT_NAMESPACE_PREFIX}{agent_id}" if agent_id else app.current_namespace
@@ -132,7 +132,7 @@ async def mem_agent_share(
     """
     from uuid import UUID
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         uid = UUID(chunk_id)

--- a/packages/memtomem/src/memtomem/server/tools/namespace.py
+++ b/packages/memtomem/src/memtomem/server/tools/namespace.py
@@ -5,7 +5,7 @@ mem_ns_update.
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -17,7 +17,7 @@ async def mem_ns_list(
     ctx: CtxType = None,
 ) -> str:
     """List all namespaces and their chunk counts."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     ns_list = await app.storage.list_namespaces()
 
     if not ns_list:
@@ -46,7 +46,7 @@ async def mem_ns_delete(
     """
     if not namespace.strip():
         return "Error: namespace must be non-empty."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     deleted = await app.storage.delete_by_namespace(namespace)
     return f"Deleted {deleted} chunks from namespace '{namespace}'"
 
@@ -66,7 +66,7 @@ async def mem_ns_set(
     """
     if not namespace.strip():
         return "Error: namespace must be non-empty."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     async with app._config_lock:
         app.current_namespace = namespace.strip()
     return f"Session namespace set to '{namespace.strip()}'"
@@ -79,7 +79,7 @@ async def mem_ns_get(
     ctx: CtxType = None,
 ) -> str:
     """Get the current session namespace."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     ns = app.current_namespace
     if ns is None:
         return "No session namespace set (using global default)"
@@ -101,7 +101,7 @@ async def mem_ns_rename(
     """
     if not old.strip() or not new.strip():
         return "Error: both old and new namespace names must be non-empty."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     count = await app.storage.rename_namespace(old.strip(), new.strip())
     return f"Renamed namespace '{old.strip()}' -> '{new.strip()}' ({count} chunks updated)"
 
@@ -122,7 +122,7 @@ async def mem_ns_update(
         description: Optional description text
         color: Optional color hex code (e.g. "#6c5ce7")
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     await app.storage.set_namespace_meta(namespace, description=description, color=color)
     return f"Updated metadata for namespace '{namespace}'"
 
@@ -150,7 +150,7 @@ async def mem_ns_assign(
         return "Error: namespace must be non-empty."
     if not source_filter and not old_namespace:
         return "Error: at least one filter (source_filter or old_namespace) is required."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     count = await app.storage.assign_namespace(
         namespace.strip(), source_filter=source_filter, old_namespace=old_namespace
     )

--- a/packages/memtomem/src/memtomem/server/tools/policy.py
+++ b/packages/memtomem/src/memtomem/server/tools/policy.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -107,7 +107,7 @@ async def mem_policy_add(
     except json.JSONDecodeError as exc:
         return f"Error: invalid JSON config: {exc}"
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     existing = await app.storage.policy_get(name)
     if existing:
         return f"Error: policy '{name}' already exists."
@@ -123,7 +123,7 @@ async def mem_policy_list(
     ctx: CtxType = None,
 ) -> str:
     """List all memory lifecycle policies."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     policies = await app.storage.policy_list()
 
     if not policies:
@@ -152,7 +152,7 @@ async def mem_policy_delete(
     Args:
         name: Policy name to delete
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     deleted = await app.storage.policy_delete(name)
     if not deleted:
         return f"Error: policy '{name}' not found."
@@ -175,7 +175,7 @@ async def mem_policy_run(
     """
     from memtomem.tools.policy_engine import run_all_enabled, run_policy
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if name:
         policy = await app.storage.policy_get(name)

--- a/packages/memtomem/src/memtomem/server/tools/procedure.py
+++ b/packages/memtomem/src/memtomem/server/tools/procedure.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -59,7 +59,7 @@ async def mem_procedure_list(
     ctx: CtxType = None,
 ) -> str:
     """List all saved procedures."""
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     # Find all chunks tagged with "procedure"
     results, _ = await app.search_pipeline.search(

--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -6,7 +6,7 @@ import logging
 from typing import Literal
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.formatters import _display_path, _format_recall_structured
 from memtomem.server.helpers import _announce_dim_mismatch_once, _parse_recall_date
@@ -51,7 +51,7 @@ async def mem_recall(
 
     from memtomem.models import NamespaceFilter
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         since_dt = _parse_recall_date(since) if since else None

--- a/packages/memtomem/src/memtomem/server/tools/reflection.py
+++ b/packages/memtomem/src/memtomem/server/tools/reflection.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -35,7 +35,7 @@ async def mem_reflect(
     if not 1 <= limit <= 200:
         return f"Error: limit must be between 1 and 200, got {limit}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     storage = app.storage
 
     lines = ["## Memory Reflection Report\n"]
@@ -143,7 +143,7 @@ async def mem_reflect_save(
 
     # Link related chunks to the new insight
     if related_chunks:
-        app = _get_app(ctx)
+        app = await _get_app_initialized(ctx)
         from uuid import UUID
 
         recent = await app.storage.recall_chunks(limit=1)

--- a/packages/memtomem/src/memtomem/server/tools/scratch.py
+++ b/packages/memtomem/src/memtomem/server/tools/scratch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -31,7 +31,7 @@ async def mem_scratch_set(
 
     if ttl_minutes is not None and ttl_minutes <= 0:
         return f"Error: ttl_minutes must be a positive number, got {ttl_minutes}."
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     expires_at = None
     if ttl_minutes is not None and ttl_minutes > 0:
         expires_at = (datetime.now(timezone.utc) + timedelta(minutes=ttl_minutes)).isoformat(
@@ -62,7 +62,7 @@ async def mem_scratch_get(
     Args:
         key: The key to look up. Omit to list all entries.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if key is None:
         entries = await app.storage.scratch_list(session_id=app.current_session_id)
@@ -110,7 +110,7 @@ async def mem_scratch_promote(
     """
     from memtomem.server.tools.memory_crud import mem_add
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     entry = await app.storage.scratch_get(key)
 
     if entry is None:

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -8,7 +8,7 @@ from typing import Literal
 from uuid import UUID
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.formatters import _display_path, _format_results, _format_structured_results
 from memtomem.server.helpers import _announce_dim_mismatch_once
@@ -65,7 +65,7 @@ async def mem_search(
     if effective_format not in ("compact", "verbose", "structured"):
         return f"Error: invalid output_format '{output_format}'."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     effective_ns = namespace or app.current_namespace
 
     rrf_weights = None
@@ -196,7 +196,7 @@ async def mem_expand(
         window: Number of adjacent chunks before and after (default 2, max 10)
     """
     window = max(0, min(window, MAX_CONTEXT_WINDOW_CHUNKS))
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     try:
         uid = UUID(chunk_id)
@@ -271,7 +271,7 @@ async def mem_increment_access(
     Args:
         chunk_ids: List of chunk UUIDs (strings) to boost
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if not chunk_ids:
         return "No chunk_ids provided."

--- a/packages/memtomem/src/memtomem/server/tools/search_history.py
+++ b/packages/memtomem/src/memtomem/server/tools/search_history.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -25,7 +25,7 @@ async def mem_search_history(
     if not 1 <= limit <= 200:
         return f"Error: limit must be between 1 and 200, got {limit}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     rows = await app.storage.get_query_history(limit=limit, since=since)
     if not rows:
         return "No search history found."
@@ -53,7 +53,7 @@ async def mem_search_suggest(
     if not prefix.strip():
         return "Error: prefix cannot be empty."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     suggestions = await app.storage.suggest_queries(prefix=prefix, limit=limit)
     if not suggestions:
         return f'No suggestions for "{prefix}".'

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from uuid import uuid4
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -29,7 +29,7 @@ async def mem_session_start(
         title: Optional human-readable session title (e.g. "Sprint Planning")
         namespace: Session namespace (default: current session namespace)
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     session_id = str(uuid4())
     effective_ns = namespace or app.current_namespace or "default"
 
@@ -61,7 +61,7 @@ async def mem_session_end(
     Args:
         summary: Optional summary of what was accomplished in this session
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if not app.current_session_id:
         return "No active session."
@@ -112,7 +112,7 @@ async def mem_session_list(
     if not 1 <= limit <= 200:
         return f"Error: limit must be between 1 and 200, got {limit}."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     sessions = await app.storage.list_sessions(agent_id=agent_id, since=since, limit=limit)
 
     if not sessions:

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 
 from memtomem import __version__
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.server.helpers import _set_config_key
@@ -29,7 +29,7 @@ async def mem_stats(
 
     Use this to quickly assess how many memories are indexed before searching.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     data = await app.storage.get_stats()
     total_chunks = data.get("total_chunks", 0)
     total_sources = data.get("total_sources", 0)
@@ -91,7 +91,7 @@ async def mem_status(
     sub-blocks echoing the DB vs runtime provider/model/dimension so the
     user can see what changed without consulting another tool.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     stats = await app.storage.get_stats()
     config = app.config
 
@@ -183,7 +183,7 @@ async def mem_config(
         persist: If True, save the change to ~/.memtomem/config.json so it
                  survives server restarts. Default is runtime-only.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if key and value is not None:
         result = _set_config_key(app.config, key, value)
@@ -294,7 +294,7 @@ async def mem_embedding_reset(
             - "apply_current": Reset DB to current config. DESTRUCTIVE — deletes all vectors, re-index required.
             - "revert_to_stored": Switch runtime embedder to match DB stored values. Non-destructive.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     if mode not in ("status", "apply_current", "revert_to_stored"):
         return f"Invalid mode '{mode}'. Use: status, apply_current, or revert_to_stored."
@@ -351,7 +351,7 @@ async def mem_reset(
         confirm: Must be True to proceed. Prevents accidental data loss.
     """
     if not confirm:
-        app = _get_app(ctx)
+        app = await _get_app_initialized(ctx)
         stats = await app.storage.get_stats()
         total = stats.get("total_chunks", 0)
         return (
@@ -360,7 +360,7 @@ async def mem_reset(
             "Pass confirm=True to proceed."
         )
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     deleted = await app.storage.reset_all()
     summary = ", ".join(f"{t}: {c}" for t, c in deleted.items() if c > 0)
     return f"Database reset complete. Deleted: {summary or 'empty'}. Run mem_index to re-index."

--- a/packages/memtomem/src/memtomem/server/tools/tag_management.py
+++ b/packages/memtomem/src/memtomem/server/tools/tag_management.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -22,7 +22,7 @@ async def mem_tag_list(
 
     Use this to see which tags exist in the index and how many chunks use each tag.
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     tag_counts = await app.storage.get_tag_counts()
 
     if not tag_counts:
@@ -56,7 +56,7 @@ async def mem_tag_rename(
     if old_tag == new_tag:
         return "Error: old_tag and new_tag are the same."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     updated = await app.storage.rename_tag(old_tag.strip(), new_tag.strip())
     return f"Renamed tag '{old_tag}' → '{new_tag}' in {updated} chunks."
 
@@ -78,6 +78,6 @@ async def mem_tag_delete(
     if not tag.strip():
         return "Error: tag must be non-empty."
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     updated = await app.storage.delete_tag(tag.strip())
     return f"Removed tag '{tag}' from {updated} chunks."

--- a/packages/memtomem/src/memtomem/server/tools/temporal.py
+++ b/packages/memtomem/src/memtomem/server/tools/temporal.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.server.helpers import _parse_recall_date
@@ -42,7 +42,7 @@ async def mem_timeline(
 
     from memtomem.tools.temporal import build_timeline, format_timeline
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     # Search for topic
     results, _stats = await app.search_pipeline.search(
@@ -111,7 +111,7 @@ async def mem_activity(
     """
     from memtomem.tools.temporal import ActivityDay, format_activity
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
 
     # Default: last 30 days
     now = datetime.now(timezone.utc)

--- a/packages/memtomem/src/memtomem/server/tools/url_index.py
+++ b/packages/memtomem/src/memtomem/server/tools/url_index.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -35,7 +35,7 @@ async def mem_fetch(
     if not url.startswith(("http://", "https://")):
         return "Error: URL must start with http:// or https://"
 
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     if not app.config.indexing.memory_dirs:
         return "Error: no memory directories configured. Run 'mm init' first."
     memory_dir = Path(app.config.indexing.memory_dirs[0]).expanduser().resolve()

--- a/packages/memtomem/src/memtomem/server/tools/watchdog.py
+++ b/packages/memtomem/src/memtomem/server/tools/watchdog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app
+from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 
@@ -26,7 +26,7 @@ async def mem_watchdog(
         check: Filter by check name (for history command)
         hours: Hours of history to return (default 24)
     """
-    app = _get_app(ctx)
+    app = await _get_app_initialized(ctx)
     watchdog = app.health_watchdog
     if watchdog is None:
         return "Health watchdog is not enabled. Set MEMTOMEM_HEALTH_WATCHDOG__ENABLED=true"

--- a/packages/memtomem/tests/test_context_window.py
+++ b/packages/memtomem/tests/test_context_window.py
@@ -259,7 +259,9 @@ class TestMemExpand:
         ctx = SimpleNamespace()
 
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_expand(chunk_id=str(target.id), window=2, ctx=ctx)
 
         assert "chunk 3/5" in result
@@ -280,7 +282,9 @@ class TestMemExpand:
 
         ctx = SimpleNamespace()
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_expand(chunk_id=str(target.id), window=2, ctx=ctx)
 
         assert "Before" not in result
@@ -295,7 +299,9 @@ class TestMemExpand:
 
         ctx = SimpleNamespace()
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_expand(chunk_id=str(uuid4()), window=2, ctx=ctx)
 
         assert "not found" in result
@@ -325,7 +331,9 @@ class TestMemIncrementAccess:
         app.storage.increment_access = AsyncMock()
 
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_increment_access(chunk_ids=[], ctx=SimpleNamespace())
 
         assert "No chunk_ids" in result
@@ -339,7 +347,9 @@ class TestMemIncrementAccess:
         app.storage.increment_access = AsyncMock()
 
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_increment_access(
                 chunk_ids=["not-a-uuid", "also-bad"],
                 ctx=SimpleNamespace(),
@@ -358,7 +368,9 @@ class TestMemIncrementAccess:
 
         ids = [str(uuid4()), str(uuid4()), str(uuid4())]
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_increment_access(chunk_ids=ids, ctx=SimpleNamespace())
 
         assert "3 chunk(s)" in result
@@ -376,7 +388,9 @@ class TestMemIncrementAccess:
 
         valid_id = str(uuid4())
         with pytest.MonkeyPatch.context() as m:
-            m.setattr("memtomem.server.tools.search._get_app", lambda _: app)
+            m.setattr(
+                "memtomem.server.tools.search._get_app_initialized", AsyncMock(return_value=app)
+            )
             result = await mem_increment_access(
                 chunk_ids=[valid_id, "not-a-uuid"],
                 ctx=SimpleNamespace(),

--- a/packages/memtomem/tests/test_tool_registration.py
+++ b/packages/memtomem/tests/test_tool_registration.py
@@ -67,3 +67,51 @@ def test_all_mcp_tool_modules_imported():
             lines
         )
         raise AssertionError(msg)
+
+
+def _files_importing_bare_get_app() -> list[Path]:
+    """Return handler files that import ``_get_app`` instead of ``_get_app_initialized``.
+
+    Issue #399 requires every MCP tool / resource handler to fetch the
+    app via ``_get_app_initialized`` so the first handler call (not the
+    lifespan handshake) triggers DB + embedder creation. A file still
+    importing bare ``_get_app`` from ``memtomem.server.context`` is a
+    regression — Phase 3 will drop the eager ``ensure_initialized`` call
+    in ``app_lifespan`` and such a handler would then operate on an
+    uninitialised context.
+    """
+    offenders: list[Path] = []
+    candidates: list[Path] = [_SRC / "resources.py", *_TOOLS_DIR.glob("*.py")]
+    for py in candidates:
+        if py.name == "__init__.py":
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            if node.module != "memtomem.server.context":
+                continue
+            for alias in node.names:
+                if alias.name == "_get_app":
+                    offenders.append(py)
+                    break
+    return offenders
+
+
+def test_handlers_use_get_app_initialized():
+    """Tool / resource modules must import ``_get_app_initialized``, not ``_get_app``.
+
+    Guards the Phase 2 handler migration (issue #399): every handler has
+    to await ``ensure_initialized`` before touching storage / embedder /
+    index_engine / search_pipeline. Using ``_get_app`` bypasses that step
+    and will crash on a read once Phase 3 removes the lifespan's eager
+    init.
+    """
+    offenders = _files_importing_bare_get_app()
+    if offenders:
+        rel = sorted(str(p.relative_to(_SRC.parent)) for p in offenders)
+        msg = (
+            "Handler files importing bare ``_get_app`` — migrate to "
+            "``_get_app_initialized`` (issue #399 Phase 2):\n" + "\n".join(f"  {p}" for p in rel)
+        )
+        raise AssertionError(msg)

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -1223,14 +1223,20 @@ class TestAutoConsolidate:
 
 
 def _fake_ctx(components):
-    """Minimal ctx stub that mimics what _get_app() unwraps.
+    """Minimal ctx stub that mimics what _get_app_initialized() unwraps.
 
     The production MCP context is ``ctx.request_context.lifespan_context``.
     We fabricate a SimpleNamespace matching that shape, filled with real
     services from the ``components`` fixture plus the few AppContext fields
     the tools access (``current_namespace``, ``webhook_manager``).
+
+    ``ensure_initialized`` is a no-op AsyncMock: handlers now call
+    ``await _get_app_initialized(ctx)`` which awaits it before reading
+    storage/embedder, so the stub has to be awaitable. The fake is already
+    populated with the real services — nothing to initialize.
     """
     from types import SimpleNamespace
+    from unittest.mock import AsyncMock
 
     app = SimpleNamespace(
         config=components.config,
@@ -1240,6 +1246,7 @@ def _fake_ctx(components):
         search_pipeline=components.search_pipeline,
         current_namespace=None,
         webhook_manager=None,
+        ensure_initialized=AsyncMock(),
     )
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
 

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -484,6 +484,7 @@ def _recall_ctx(components):
     """
     import asyncio
     from types import SimpleNamespace
+    from unittest.mock import AsyncMock
 
     app = SimpleNamespace(
         config=components.config,
@@ -491,6 +492,7 @@ def _recall_ctx(components):
         current_namespace=None,
         _dim_mismatch_announced=False,
         _config_lock=asyncio.Lock(),
+        ensure_initialized=AsyncMock(),
     )
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))
 
@@ -503,6 +505,7 @@ def _search_ctx(components):
     """
     import asyncio
     from types import SimpleNamespace
+    from unittest.mock import AsyncMock
 
     app = SimpleNamespace(
         config=components.config,
@@ -512,5 +515,6 @@ def _search_ctx(components):
         webhook_manager=None,
         _dim_mismatch_announced=False,
         _config_lock=asyncio.Lock(),
+        ensure_initialized=AsyncMock(),
     )
     return SimpleNamespace(request_context=SimpleNamespace(lifespan_context=app))


### PR DESCRIPTION
## Summary

- #399 Phase 2 handler migration: every `@mcp.tool` / `@mcp.resource` handler now fetches the `AppContext` via `await _get_app_initialized(ctx)` instead of the bare `_get_app(ctx)`.
- Unblocks Phase 3 (dropping the eager `ensure_initialized` from `app_lifespan`). Without this migration, a handler still reaching through `_get_app` would hit the `_require_initialized` guard the moment Phase 3 flips — handshake-only MCP sessions still need that flip to actually stop creating `~/.memtomem/memtomem.db`, but handlers have to be ready first.
- Runtime behavior unchanged: Phase 1 kept `app_lifespan` calling `ensure_initialized` eagerly, so every handler still sees populated components. The migration is purely a call-site swap.

## What changed

| File surface | Change |
|---|---|
| `server/context.py` | New `async _get_app_initialized(ctx) -> AppContext` — one-line wrapper that calls `_get_app` and awaits `ensure_initialized` (idempotent via `_init_lock`, so repeated awaits across 100+ handler call sites have no cost after the first). |
| `server/__init__.py` | Re-export the helper. |
| `server/resources.py` | 5 `@mcp.resource` handlers migrated. |
| `server/tools/*.py` (30 files) | 99 handler call sites switched from `app = _get_app(ctx)` to `app = await _get_app_initialized(ctx)`. Import swap + single-line swap per handler, no logic changes. |
| `tests/test_context_window.py` | 7 monkeypatches on `memtomem.server.tools.search._get_app` retargeted to `_get_app_initialized` via `AsyncMock(return_value=app)` (the helper is async; sync `lambda _: app` no longer works). |
| `tests/test_tools_logic.py` + `tests/test_trust_ux.py` | `_fake_ctx` / `_recall_ctx` / `_search_ctx` `SimpleNamespace` stubs gain `ensure_initialized=AsyncMock()` so the `await` inside the helper resolves without touching real storage. |
| `tests/test_tool_registration.py` | New regression guard `test_handlers_use_get_app_initialized` — AST-checks that no file under `server/tools/` or `server/resources.py` imports bare `_get_app`, so new handlers can't silently drift back. |

## Deliberately out of scope

- **#409 — `_revert_to_stored` writes to read-only `AppContext` properties.** Pre-existing latent bug introduced by Phase 1's property conversion (`embedder` / `search_pipeline` / `index_engine`). `mypy packages/memtomem/src/memtomem/server` surfaces it during this PR's lint pass; runtime impact is on `mem_embedding_reset(mode="revert_to_stored")` which has no test coverage. Filed as #409 and explicitly not fixed here — it's an orthogonal write-path bug, not a handler migration.
- **Phase 3 (lifespan slimming).** Removing the eager `ensure_initialized` call from `app_lifespan` + moving watcher/scheduler/watchdog startup into the first-tool-call path is a separate PR. This PR makes that flip safe but doesn't perform it.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — pass
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — pass
- [x] `uv run pytest -m "not ollama"` — **2172 passed** (2171 pre-existing + 1 new guard). No regressions.
- [x] Spot-checked `test_server_app_context.py` (Phase 1 lock-semantics tests) still pass — the helper builds on the same `ensure_initialized` path those tests cover.
- [x] `uv run mypy packages/memtomem/src/memtomem/server` — no new errors introduced by this PR (3 pre-existing read-only-property writes in `status_config._revert_to_stored` tracked in #409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
