### PR TITLE
feat(server): lazy app_lifespan + ensure_initialized owns background loops (#399 phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP handshake no longer creates `~/.memtomem/memtomem.db`.** Previously,
+  every MCP client that connected to memtomem (Claude Code's `claude mcp list`,
+  Cursor, Windsurf, Gemini CLI) instantiated the SQLite database on handshake —
+  even before the user ran `mm init`, and even for short-lived health-check
+  spawns. The DB now opens on the first tool call (`mem_search`, `mem_add`,
+  `mem_status`, …) instead of on the lifespan startup, so a client that
+  connects but never calls a tool leaves the storage path alone. Two
+  follow-on behavior changes are accepted as part of the trade-off:
+
+  - The `"Embedding dimension mismatch detected at startup — entering
+    degraded mode"` warning for issue #349 no longer fires on
+    `memtomem-server` boot stderr. It now surfaces inside the first tool
+    call that triggers initialization. Recovery tools
+    (`mem_embedding_reset`, `mem_status`, `mem_stats`, `mem_list`,
+    `mem_read`) remain callable; users learn about the mismatch from
+    the first tool response instead of the boot log.
+  - An idle server (no tool calls) no longer runs background
+    maintenance. Consolidation, policy, and health-watchdog schedulers
+    start on the first tool call rather than the lifespan handshake.
+    A client that connects but never calls a tool will not see
+    scheduler ticks — consistent with "no DB to maintain" but worth
+    flagging for any maintenance schedule that assumed
+    background-without-tool-calls semantics.
+
+  Note: `~/.memtomem/` itself is still created at process start by the
+  `memtomem-server` `.server.pid` advisory-lock acquisition; relocating
+  that to `$XDG_RUNTIME_DIR` is tracked separately in #384/#387.
+  (#399, #411; builds on #400 plumbing and #410 handler migration.)
+
 ### Fixed
 
 - **`mm init -y` refuses to write `config.json` when required extras are missing.**

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -14,11 +15,40 @@ from memtomem.config import Mem2MemConfig
 if TYPE_CHECKING:
     from memtomem.embedding.base import EmbeddingProvider
     from memtomem.indexing.engine import IndexEngine
+    from memtomem.indexing.watcher import FileWatcher
     from memtomem.llm.base import LLMProvider
     from memtomem.search.dedup import DedupScanner
     from memtomem.search.pipeline import SearchPipeline
     from memtomem.server.component_factory import Components
     from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+logger = logging.getLogger(__name__)
+
+
+async def _stop_quietly(resource: object | None, stage: str) -> None:
+    """Stop ``resource`` and log (don't propagate) ordinary failures.
+
+    Used by both :meth:`AppContext.ensure_initialized` failure cleanup and
+    :meth:`AppContext.close` so a single resource going wrong does not
+    skip the rest of the teardown sequence — shutdown must always finish
+    whatever it can. ``CancelledError`` is re-raised so task cancellation
+    propagates and the caller can decide whether to mask the original
+    exception that triggered teardown (matches the lifespan helper from
+    PR #404 / #406).
+    """
+    if resource is None:
+        return
+    stop = getattr(resource, "stop", None) or getattr(resource, "close", None)
+    if stop is None:
+        return
+    try:
+        await stop()
+    except asyncio.CancelledError:
+        logger.warning("Shutdown step '%s' cancelled", stage)
+        raise
+    except Exception:
+        logger.warning("Shutdown step '%s' failed", stage, exc_info=True)
 
 
 def _require_initialized(components: Components | None, attr: str) -> Components:
@@ -47,9 +77,6 @@ class AppContext:
     sessions (``initialize`` + ``tools/list``) don't trigger DB creation
     in ``~/.memtomem/``. See issue #399 for the full design.
 
-    Phase 1 keeps ``app_lifespan`` calling ``ensure_initialized`` eagerly,
-    so behavior is unchanged. Phase 3 will drop the eager call.
-
     ``_owns_components`` distinguishes two construction paths:
 
     * ``ensure_initialized`` — we created the ``Components`` ourselves, so
@@ -69,10 +96,17 @@ class AppContext:
     current_namespace: str | None = None
     current_session_id: str | None = None
     # Internal state — not part of the public ``__init__`` surface; populated
-    # by ``ensure_initialized`` / ``from_components`` / :meth:`set_health_watchdog`.
+    # by ``ensure_initialized`` / ``from_components``. The watcher /
+    # scheduler / policy_scheduler / health_watchdog handles are populated
+    # only via ``ensure_initialized`` (the lifespan path); ``from_components``
+    # leaves them ``None`` because CLI commands that build a context outside
+    # the MCP server don't run background loops.
     _components: Components | None = field(default=None, init=False, repr=False)
     _owns_components: bool = field(default=False, init=False, repr=False)
     _dedup_scanner: DedupScanner | None = field(default=None, init=False, repr=False)
+    _watcher: FileWatcher | None = field(default=None, init=False, repr=False)
+    _scheduler: object | None = field(default=None, init=False, repr=False)
+    _policy_scheduler: object | None = field(default=None, init=False, repr=False)
     _health_watchdog: object | None = field(default=None, init=False, repr=False)
     # per-session, scoped to AppContext lifetime. Gate to emit a dim-mismatch
     # hint only once per MCP session so repeated mem_add / mem_search calls
@@ -83,11 +117,11 @@ class AppContext:
 
     # ── component accessors ───────────────────────────────────────────────
     # These raise ``RuntimeError`` if accessed before ``ensure_initialized``
-    # has populated ``_components``. Tool handlers must call
-    # ``await app.ensure_initialized()`` before reading them (Phase 2). In
-    # Phase 1 the lifespan eagerly inits, so all handlers see populated
-    # state — the runtime check catches programming errors during the
-    # migration without disappearing under ``python -O``.
+    # has populated ``_components``. Tool handlers reach the context via
+    # ``_get_app_initialized`` (which awaits ``ensure_initialized``), so
+    # the guard catches programming errors — a handler accidentally going
+    # through ``_get_app`` and reading a property before init — without
+    # disappearing under ``python -O`` the way ``assert`` would.
 
     @property
     def storage(self) -> SqliteBackend:
@@ -127,15 +161,6 @@ class AppContext:
             return None
         return self._components.embedding_broken
 
-    def set_health_watchdog(self, watchdog: object) -> None:
-        """Stash the health-watchdog instance the lifespan has started.
-
-        Lifespan-owned, not context-owned — :meth:`close` does not stop it.
-        The indirection gives callers a typed seam instead of poking
-        ``ctx._health_watchdog`` across module boundaries.
-        """
-        self._health_watchdog = watchdog
-
     # ── lifecycle ─────────────────────────────────────────────────────────
 
     async def ensure_initialized(self) -> Components:
@@ -148,30 +173,88 @@ class AppContext:
         creation should not poison the context for the rest of the
         session).
 
-        If ``create_components`` succeeds but a post-factory step
-        (currently the ``DedupScanner`` construction) raises, the already-
-        built ``Components`` would otherwise leak its open sqlite handle
-        and embedder session. We explicitly tear it down before
-        re-raising.
+        After component construction this also wires up the request-path
+        background loops the MCP server depends on — file watcher,
+        consolidation/policy schedulers, health watchdog. Phase 3 of #399
+        moved these out of ``app_lifespan`` so handshake-only sessions
+        (``initialize`` + ``tools/list``) leave ``~/.memtomem/`` alone;
+        the trade-off is that an idle server with zero tool calls runs
+        no background maintenance — see the changelog entry for #399.
+
+        Failure cleanup tears down whatever has already started — any
+        background loops that reached ``start()``, then ``close_components``,
+        then resets ``_components`` so a retry sees fresh state. This
+        prevents leaking the sqlite handle, embedder session, or running
+        background tasks just because a later step failed.
         """
         if self._components is not None:
             return self._components
         async with self._init_lock:
             if self._components is not None:
                 return self._components
+            from memtomem.indexing.watcher import FileWatcher
             from memtomem.search.dedup import DedupScanner
             from memtomem.server.component_factory import close_components, create_components
 
             comp = await create_components(self.config)
-            try:
-                self._dedup_scanner = DedupScanner(storage=comp.storage, embedder=comp.embedder)
-            except Exception:
-                # Don't leak the sqlite/embedder handles the factory opened
-                # just because a post-factory step failed.
-                await close_components(comp)
-                raise
+            # Expose storage/embedder via the property accessors *before*
+            # constructing schedulers — they reach into ``ctx.storage`` etc.,
+            # and ``_require_initialized`` would raise without this. The
+            # except-block below rolls the flag back on failure so a retry
+            # isn't blocked by half-built state.
             self._components = comp
             self._owns_components = True
+
+            dedup: DedupScanner | None = None
+            watcher: FileWatcher | None = None
+            scheduler: object | None = None
+            policy_scheduler: object | None = None
+            watchdog: object | None = None
+            try:
+                dedup = DedupScanner(storage=comp.storage, embedder=comp.embedder)
+
+                # Skip background loops in degraded mode (issue #349) — the
+                # watcher/schedulers/watchdog walk the index or re-embed
+                # chunks and would crash on the missing ``chunks_vec`` table.
+                # Recovery happens via ``mem_embedding_reset``.
+                watcher = FileWatcher(comp.index_engine, self.config.indexing)
+                if comp.embedding_broken is None:
+                    await watcher.start()
+
+                degraded = comp.embedding_broken is not None
+
+                if self.config.consolidation_schedule.enabled and not degraded:
+                    from memtomem.server.scheduler import ConsolidationScheduler
+
+                    scheduler = ConsolidationScheduler(self, self.config.consolidation_schedule)
+                    await scheduler.start()
+
+                if self.config.policy.enabled and not degraded:
+                    from memtomem.server.scheduler import PolicyScheduler
+
+                    policy_scheduler = PolicyScheduler(self, self.config.policy)
+                    await policy_scheduler.start()
+
+                if self.config.health_watchdog.enabled and not degraded:
+                    from memtomem.server.health_watchdog import HealthWatchdog
+
+                    watchdog = HealthWatchdog(self, self.config.health_watchdog)
+                    await watchdog.start()
+            except BaseException:
+                await _stop_quietly(watchdog, "health_watchdog")
+                await _stop_quietly(policy_scheduler, "policy_scheduler")
+                await _stop_quietly(scheduler, "scheduler")
+                await _stop_quietly(watcher, "watcher")
+                await close_components(comp)
+                self._components = None
+                self._owns_components = False
+                raise
+
+            self._dedup_scanner = dedup
+            self._watcher = watcher
+            self._scheduler = scheduler
+            self._policy_scheduler = policy_scheduler
+            self._health_watchdog = watchdog
             return comp
 
     @classmethod
@@ -196,18 +279,38 @@ class AppContext:
     async def close(self) -> None:
         """Tear down components if this context owns them.
 
-        Webhook manager and health watchdog are owned by the lifespan, not
-        the context — they are not closed here. Components passed in via
-        :meth:`from_components` are also left alone (the supplier closes
-        them) — the ``_owns_components`` flag distinguishes the two paths.
+        Webhook manager is owned by the lifespan, not the context — it is
+        not closed here. Components passed in via :meth:`from_components`
+        are also left alone (the supplier closes them) — the
+        ``_owns_components`` flag distinguishes the two paths.
+
+        For lifespan-managed contexts this also stops the background
+        loops :meth:`ensure_initialized` started (file watcher, schedulers,
+        health watchdog) in reverse-allocation order so the loops drop
+        their references before the storage / embedder they hold gets
+        closed. Each step is wrapped via :func:`_stop_quietly` so a single
+        failure does not skip the rest of the teardown sequence.
+
+        Contexts built via :meth:`from_components` never started those
+        loops, so the corresponding fields are ``None`` and the stop
+        calls are no-ops.
         """
         from memtomem.server.component_factory import close_components
+
+        await _stop_quietly(self._health_watchdog, "health_watchdog")
+        await _stop_quietly(self._policy_scheduler, "policy_scheduler")
+        await _stop_quietly(self._scheduler, "scheduler")
+        await _stop_quietly(self._watcher, "watcher")
 
         if self._components is not None and self._owns_components:
             await close_components(self._components)
         self._components = None
         self._owns_components = False
         self._dedup_scanner = None
+        self._watcher = None
+        self._scheduler = None
+        self._policy_scheduler = None
+        self._health_watchdog = None
 
 
 CtxType = Context[ServerSession, AppContext] | None
@@ -228,12 +331,10 @@ async def _get_app_initialized(ctx: CtxType) -> AppContext:
     first use rather than at lifespan startup — that's the whole point of
     #399: an MCP handshake + ``tools/list`` leaves ``~/.memtomem/`` alone.
 
-    Phase 1 kept ``app_lifespan`` calling ``ensure_initialized`` eagerly,
-    so every handler currently sees populated components even via
-    ``_get_app``. Phase 3 drops the eager call — at that point any handler
-    still reaching through ``_get_app`` would hit the
-    ``_require_initialized`` guard on first property read. Migrating every
-    handler now (Phase 2) is what makes the Phase 3 flip safe.
+    After Phase 3 ``app_lifespan`` no longer calls ``ensure_initialized``,
+    so any handler still reaching through ``_get_app`` would hit the
+    ``_require_initialized`` guard on first property read. Phase 2 migrated
+    every handler to this helper to make that flip safe.
     """
     app = _get_app(ctx)
     await app.ensure_initialized()

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -12,8 +12,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 
 from memtomem.config import Mem2MemConfig
-from memtomem.indexing.watcher import FileWatcher
-from memtomem.server.context import AppContext
+from memtomem.server.context import AppContext, _stop_quietly
 
 logger = logging.getLogger(__name__)
 
@@ -86,169 +85,50 @@ def _load_dotenv() -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _teardown_startup_resources(
-    *,
-    watchdog: object | None,
-    policy_scheduler: object | None,
-    scheduler: object | None,
-    webhook_mgr: object | None,
-    watcher: FileWatcher | None,
-    ctx: AppContext | None,
-) -> None:
-    """Tear down startup-allocated resources; called on both shutdown paths.
-
-    Invoked from the normal post-``yield`` ``finally`` and from the
-    startup-failure ``except BaseException`` (before re-raising, #404).
-    Each step catches ``Exception`` so a later failure doesn't skip
-    earlier ones — shutdown must always complete whatever it can — but
-    ``CancelledError`` is re-raised so task cancellation propagates and
-    the caller can decide whether to mask the original startup failure.
-
-    Order (matches the existing post-yield shutdown sequence since
-    before #404; #404 only centralised it into this helper):
-
-        watchdog → policy_scheduler → scheduler → webhook_mgr → watcher → ctx
-
-    This is *not* strict reverse-allocation order: ``webhook_mgr`` is
-    stopped before ``watcher`` and ``ctx`` because it has no dependency
-    on storage/index — closing it early drops network state that might
-    otherwise hold retries open during the slower component teardown.
-    ``ctx.close()`` is last so the schedulers/watchdog can still touch
-    storage while they stop.
-    """
-    import asyncio
-
-    def _log_teardown_failure(stage: str, exc: BaseException) -> None:
-        # CancelledError is BaseException-derived in Python 3.8+; we still
-        # want to record that a teardown step was cancelled (otherwise the
-        # cancellation silently drops the original startup exception if it
-        # happens mid-teardown), then re-raise so cancellation propagates
-        # and the caller decides what to do.
-        if isinstance(exc, asyncio.CancelledError):
-            logger.warning("Shutdown step '%s' cancelled", stage)
-            raise exc
-        logger.warning("Shutdown step '%s' failed", stage, exc_info=True)
-
-    if watchdog is not None:
-        try:
-            await watchdog.stop()  # type: ignore[attr-defined]
-        except BaseException as exc:
-            _log_teardown_failure("health_watchdog", exc)
-    if policy_scheduler is not None:
-        try:
-            await policy_scheduler.stop()  # type: ignore[attr-defined]
-        except BaseException as exc:
-            _log_teardown_failure("policy_scheduler", exc)
-    if scheduler is not None:
-        try:
-            await scheduler.stop()  # type: ignore[attr-defined]
-        except BaseException as exc:
-            _log_teardown_failure("scheduler", exc)
-    if webhook_mgr is not None:
-        try:
-            await webhook_mgr.close()  # type: ignore[attr-defined]
-        except BaseException as exc:
-            _log_teardown_failure("webhook_manager", exc)
-    if watcher is not None:
-        try:
-            await watcher.stop()
-        except BaseException as exc:
-            _log_teardown_failure("watcher", exc)
-    if ctx is not None:
-        try:
-            await ctx.close()
-        except BaseException as exc:
-            _log_teardown_failure("components", exc)
-
-
 @asynccontextmanager
 async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
+    """Run the MCP server with lazy component init (Phase 3 of #399).
+
+    Startup is deliberately minimal: load env, set up logging, build the
+    optional webhook manager, allocate the ``AppContext`` itself. None of
+    these touch ``~/.memtomem/`` — that's the whole point of the lazy
+    init. The first tool-call path goes through
+    :meth:`AppContext.ensure_initialized`, which opens storage/embedder
+    and starts the file watcher + schedulers + health watchdog inside
+    the context (which from then on owns their lifetime).
+
+    Shutdown closes the webhook manager first — dropping outstanding
+    network retries before the slower DB teardown, see PR #404 — then
+    ``ctx.close()`` stops anything ``ensure_initialized`` started and
+    finally closes components. Both stop calls go through
+    :func:`_stop_quietly` so a teardown failure on one side does not
+    skip the other, and ``CancelledError`` propagates rather than being
+    silently swallowed (see #406).
+    """
     _load_dotenv()
     _setup_logging()
 
     config = Mem2MemConfig()
 
     webhook_mgr = None
-    watcher: FileWatcher | None = None
-    scheduler = None
-    policy_scheduler = None
-    watchdog = None
     ctx: AppContext | None = None
 
-    # Startup is wrapped in a single try/except so a failure at any stage
-    # tears down everything allocated so far (#404). ``ensure_initialized``
-    # has its own internal cleanup (PR #400) and leaves ``ctx._components``
-    # unset on failure, so ``ctx.close()`` from the teardown path is a
-    # safe no-op in that case.
     try:
-        # Webhook manager is storage-free; safe to construct before component init.
         if config.webhook.enabled and config.webhook.url:
             from memtomem.server.webhooks import WebhookManager
 
             webhook_mgr = WebhookManager(config.webhook)
-
         ctx = AppContext(config=config, webhook_manager=webhook_mgr)
-
-        # Phase 1 of #399 keeps init eager: the rest of startup (watcher,
-        # schedulers, watchdog) needs storage/embedder ready. Phase 3 will move
-        # this call (and the watcher/scheduler startup below) into the first
-        # tool-call path.
-        comp = await ctx.ensure_initialized()
-
-        # When the server came up in degraded mode (embedding mismatch, see
-        # issue #349) don't start the file watcher — indexing goes through
-        # ``upsert_chunks`` which needs ``chunks_vec`` and would crash on
-        # every file change. Recovery happens via ``mem_embedding_reset``.
-        watcher = FileWatcher(comp.index_engine, config.indexing)
-        if comp.embedding_broken is None:
-            await watcher.start()
-
-        # Background schedulers are skipped in degraded mode (see issue #349) —
-        # they walk the index / re-embed chunks and would hit the same missing
-        # ``chunks_vec`` cascade as the watcher. They resume after a restart
-        # once ``mem_embedding_reset`` has fixed the DB.
-        degraded = comp.embedding_broken is not None
-
-        # Auto-consolidation scheduler
-        if config.consolidation_schedule.enabled and not degraded:
-            from memtomem.server.scheduler import ConsolidationScheduler
-
-            scheduler = ConsolidationScheduler(ctx, config.consolidation_schedule)
-            await scheduler.start()
-
-        # Policy scheduler
-        if config.policy.enabled and not degraded:
-            from memtomem.server.scheduler import PolicyScheduler
-
-            policy_scheduler = PolicyScheduler(ctx, config.policy)
-            await policy_scheduler.start()
-
-        # Health watchdog
-        if config.health_watchdog.enabled and not degraded:
-            from memtomem.server.health_watchdog import HealthWatchdog
-
-            watchdog = HealthWatchdog(ctx, config.health_watchdog)
-            await watchdog.start()
-            ctx.set_health_watchdog(watchdog)
     except BaseException:
-        await _teardown_startup_resources(
-            watchdog=watchdog,
-            policy_scheduler=policy_scheduler,
-            scheduler=scheduler,
-            webhook_mgr=webhook_mgr,
-            watcher=watcher,
-            ctx=ctx,
-        )
+        # ``AppContext()`` is allocation-only and never touches storage,
+        # so the webhook is the only thing that could be partially
+        # allocated here. Close it before re-raising so we don't leak
+        # the network state into the failure path.
+        await _stop_quietly(webhook_mgr, "webhook_manager")
         raise
 
     try:
         yield ctx
     finally:
-        await _teardown_startup_resources(
-            watchdog=watchdog,
-            policy_scheduler=policy_scheduler,
-            scheduler=scheduler,
-            webhook_mgr=webhook_mgr,
-            watcher=watcher,
-            ctx=ctx,
-        )
+        await _stop_quietly(webhook_mgr, "webhook_manager")
+        await _stop_quietly(ctx, "app_context")

--- a/packages/memtomem/tests/test_lazy_init_acceptance.py
+++ b/packages/memtomem/tests/test_lazy_init_acceptance.py
@@ -1,0 +1,139 @@
+"""End-to-end acceptance for the Phase 3 lazy-init flip (#399).
+
+Phase 3 moved component construction (and watcher / scheduler /
+watchdog start) out of ``app_lifespan`` and into the first-tool-call
+path. The behaviour we promise the user is:
+
+1. An MCP client connecting and not making any tool call (the
+   ``claude mcp list`` health-check shape) leaves ``~/.memtomem/`` alone.
+2. The first tool call triggers init and the DB appears.
+3. Concurrent first calls share a single init pass — they don't race
+   into duplicate ``create_components`` invocations.
+
+These tests drive the real ``app_lifespan`` against a tmp-isolated
+``HOME`` so the storage path resolves under the test directory rather
+than the user's machine. ``embedding.provider=none`` keeps init fast
+(NoopEmbedder, no model download), and ``indexing.memory_dirs=[]``
+keeps the file watcher from picking up the contributor's actual
+notes via auto-discovery while the test runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from memtomem.server import lifespan as lifespan_mod
+
+
+@pytest.fixture
+def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Redirect storage + auto-discover roots to ``tmp_path``.
+
+    ``HOME`` swap covers the ``~/.memtomem/config.json`` read path
+    (`feedback_config_json_isolation.md`) so we don't pick up real
+    fragments. The explicit ``MEMTOMEM_STORAGE__SQLITE_PATH`` puts the
+    DB at a known location for assertions, and the empty
+    ``MEMTOMEM_INDEXING__MEMORY_DIRS`` keeps the watcher from scanning
+    the developer's actual notes when it starts under default config.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    db_path = tmp_path / "memtomem.db"
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", str(db_path))
+    monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", "[]")
+    monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "none")
+    # Belt-and-braces: keep every optional subsystem off so this test
+    # exercises only the watcher path that lazy-init owns now.
+    monkeypatch.setenv("MEMTOMEM_CONSOLIDATION_SCHEDULE__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_POLICY__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_HEALTH_WATCHDOG__ENABLED", "false")
+    monkeypatch.setenv("MEMTOMEM_WEBHOOK__ENABLED", "false")
+    return {"home": home, "db_path": db_path}
+
+
+@pytest.mark.asyncio
+async def test_handshake_only_leaves_db_absent(isolated_state: dict[str, Path]) -> None:
+    """Lifespan enter → exit without any tool call must not create the DB.
+
+    This is the user-visible regression #399 fixes: previously, every
+    MCP client that connected (Claude Code's ``claude mcp list``,
+    Cursor, Windsurf, Gemini CLI) instantiated ``~/.memtomem/memtomem.db``
+    on handshake even before the user ran ``mm init``. Phase 3 moves
+    the DB open into the first tool-call path, so a handshake-only
+    session leaves the storage path alone.
+    """
+    db_path = isolated_state["db_path"]
+
+    async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+        assert ctx is not None
+        # Components are unset → storage was never opened.
+        assert ctx._components is None
+
+    assert not db_path.exists(), (
+        f"Phase 3 invariant: handshake-only session must leave the DB "
+        f"untouched, but {db_path} exists after lifespan exit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_ensure_initialized_creates_db(isolated_state: dict[str, Path]) -> None:
+    """The first tool-call path (modeled here as a direct
+    ``ctx.ensure_initialized()``) opens storage and creates the DB.
+
+    This is the inverse of the handshake-only invariant — together they
+    pin that the DB lifecycle now follows tool calls, not the lifespan.
+    """
+    db_path = isolated_state["db_path"]
+
+    async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+        assert not db_path.exists(), "DB must not exist before first tool call"
+
+        await ctx.ensure_initialized()
+
+        assert db_path.exists(), f"first ensure_initialized must create the DB at {db_path}"
+        assert ctx._components is not None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_calls_invoke_create_components_once(
+    isolated_state: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two tool handlers arriving simultaneously on a fresh server must
+    share a single ``create_components`` pass — the ``_init_lock``
+    serializes them. A regression where the lock is dropped (or where a
+    handler bypasses ``ensure_initialized``) would let two factories
+    race on the same SQLite file."""
+    from memtomem.server import component_factory
+
+    real_create = component_factory.create_components
+    call_count = 0
+
+    async def counting_create(config: object) -> object:
+        nonlocal call_count
+        call_count += 1
+        # Tiny sleep widens the race window so a missing lock surfaces
+        # reliably across CI runners.
+        await asyncio.sleep(0.01)
+        return await real_create(config)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(component_factory, "create_components", counting_create)
+
+    async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+        results = await asyncio.gather(
+            ctx.ensure_initialized(),
+            ctx.ensure_initialized(),
+            ctx.ensure_initialized(),
+        )
+
+    assert call_count == 1, (
+        f"_init_lock must serialise concurrent first-callers; "
+        f"create_components ran {call_count}× instead of once"
+    )
+    assert results[0] is results[1] is results[2], (
+        "all concurrent callers must observe the same Components instance"
+    )

--- a/packages/memtomem/tests/test_server_app_context.py
+++ b/packages/memtomem/tests/test_server_app_context.py
@@ -1,20 +1,46 @@
-"""Tests for ``AppContext.ensure_initialized`` lock semantics (issue #399, Phase 1).
+"""Tests for ``AppContext.ensure_initialized`` lock semantics + ownership (issue #399).
 
-These cover the property/factory plumbing that lets the lifespan keep eager
-initialization today and lets handlers move to lazy initialization in
-Phase 2/3 without race conditions on first call.
+These cover the property/factory plumbing that lets handlers do lazy
+initialization without race conditions on first call. Phase 3 also moved
+watcher/scheduler/watchdog start into ``ensure_initialized``; the
+``_no_background_loops`` autouse fixture below stubs those classes out
+so unit tests focus on the lock + ownership logic without leaking real
+watchdog threads / asyncio tasks across tests. The end-to-end lazy-init
+behavior (handshake leaves DB absent, first tool call creates it) is
+covered separately in ``tests/test_lazy_init_acceptance.py``.
 """
 
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from memtomem.config import Mem2MemConfig
 from memtomem.server.component_factory import Components
 from memtomem.server.context import AppContext
+
+
+@pytest.fixture(autouse=True)
+def _no_background_loops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub ``FileWatcher`` so ``ensure_initialized`` doesn't spin a real
+    watchdog Observer thread for every unit test in this file.
+
+    All scheduler enabled-flags default to ``False`` (see ``config.py``),
+    so ``ConsolidationScheduler`` / ``PolicyScheduler`` / ``HealthWatchdog``
+    are not even constructed under default config — only ``FileWatcher``
+    needs to be mocked.
+    """
+    from memtomem.indexing import watcher as watcher_mod
+
+    def _make_fake_watcher(*_args: object, **_kwargs: object) -> object:
+        fake = MagicMock()
+        fake.start = AsyncMock()
+        fake.stop = AsyncMock()
+        return fake
+
+    monkeypatch.setattr(watcher_mod, "FileWatcher", _make_fake_watcher)
 
 
 @pytest.fixture
@@ -235,12 +261,116 @@ async def test_close_after_ensure_initialized_closes_components(
     assert ctx._owns_components is False
 
 
-def test_set_health_watchdog_exposes_via_property() -> None:
-    """``ctx.set_health_watchdog(wd)`` is the lifespan seam — reader side
-    is the ``health_watchdog`` property, not ``_health_watchdog`` poking."""
-    ctx = AppContext(config=Mem2MemConfig())
-    sentinel = object()
+# ── Phase 3: background-loop ownership ────────────────────────────────
 
-    ctx.set_health_watchdog(sentinel)
 
-    assert ctx.health_watchdog is sentinel
+@pytest.mark.asyncio
+async def test_ensure_initialized_starts_file_watcher_under_default_config(
+    fake_components: Components,
+) -> None:
+    """Phase 3 moved ``FileWatcher.start`` from ``app_lifespan`` into
+    ``ensure_initialized``. Default config has all schedulers disabled,
+    so the watcher is the only thing that should start."""
+    ctx = AppContext(config=fake_components.config)
+
+    with patch(
+        "memtomem.server.component_factory.create_components",
+        return_value=fake_components,
+    ):
+        await ctx.ensure_initialized()
+
+    assert ctx._watcher is not None, "watcher should be allocated and stashed on ctx"
+    ctx._watcher.start.assert_awaited_once()  # type: ignore[attr-defined]
+    # Schedulers/watchdog stay None because the default config has them disabled.
+    assert ctx._scheduler is None
+    assert ctx._policy_scheduler is None
+    assert ctx._health_watchdog is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_skips_watcher_in_degraded_mode(
+    fake_components: Components,
+) -> None:
+    """When ``embedding_broken`` is set (issue #349 degraded mode), the
+    watcher is constructed but ``start()`` is skipped — same gate as the
+    pre-Phase-3 lifespan code, just relocated into ``ensure_initialized``.
+    This stops the watcher from crashing on the missing ``chunks_vec``
+    table; ``mem_embedding_reset`` recovers the install."""
+    fake_components.embedding_broken = {"reason": "dim_mismatch"}
+    ctx = AppContext(config=fake_components.config)
+
+    with patch(
+        "memtomem.server.component_factory.create_components",
+        return_value=fake_components,
+    ):
+        await ctx.ensure_initialized()
+
+    assert ctx._watcher is not None, "watcher allocated even in degraded mode"
+    ctx._watcher.start.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_close_stops_started_watcher(fake_components: Components) -> None:
+    """Phase 3 moved watcher ownership to ``AppContext``. ``close()`` must
+    therefore stop the watcher it started — otherwise the watchdog
+    Observer thread + asyncio processor task leak past lifespan
+    teardown."""
+    ctx = AppContext(config=fake_components.config)
+
+    with patch(
+        "memtomem.server.component_factory.create_components",
+        return_value=fake_components,
+    ):
+        await ctx.ensure_initialized()
+
+    started_watcher = ctx._watcher
+    assert started_watcher is not None
+
+    with patch("memtomem.server.component_factory.close_components"):
+        await ctx.close()
+
+    started_watcher.stop.assert_awaited_once()  # type: ignore[attr-defined]
+    assert ctx._watcher is None, "ctx must drop its watcher reference after close"
+
+
+@pytest.mark.asyncio
+async def test_ensure_initialized_rolls_back_components_when_watcher_start_fails(
+    fake_components: Components,
+) -> None:
+    """A ``watcher.start()`` failure must close the freshly-built
+    components and reset ``_components`` so the context isn't poisoned —
+    otherwise the sqlite handle the factory just opened leaks and a
+    retry hits a half-initialized state."""
+    from memtomem.indexing import watcher as watcher_mod
+
+    boom_watcher = MagicMock()
+    boom_watcher.start = AsyncMock(side_effect=RuntimeError("watcher boom"))
+    boom_watcher.stop = AsyncMock()
+
+    ctx = AppContext(config=fake_components.config)
+    close_calls: list[Components] = []
+
+    async def fake_close(comp: Components) -> None:
+        close_calls.append(comp)
+
+    with (
+        patch(
+            "memtomem.server.component_factory.create_components",
+            return_value=fake_components,
+        ),
+        patch("memtomem.server.component_factory.close_components", side_effect=fake_close),
+        patch.object(watcher_mod, "FileWatcher", lambda *a, **k: boom_watcher),
+        pytest.raises(RuntimeError, match="watcher boom"),
+    ):
+        await ctx.ensure_initialized()
+
+    # Watcher we constructed got the failed ``start()``; cleanup must
+    # invoke ``stop()`` so the partially-initialized resource does not
+    # leak its Observer thread.
+    boom_watcher.stop.assert_awaited_once()
+    # Components were torn down so the sqlite/embedder handles don't leak.
+    assert close_calls == [fake_components]
+    # And the context is back to a clean slate — a retry can re-init.
+    assert ctx._components is None
+    assert ctx._owns_components is False
+    assert ctx._watcher is None

--- a/packages/memtomem/tests/test_server_lifespan.py
+++ b/packages/memtomem/tests/test_server_lifespan.py
@@ -1,348 +1,219 @@
-"""Test ``app_lifespan`` startup-failure teardown (#404).
+"""Tests for ``app_lifespan`` startup + shutdown semantics (#399 Phase 3).
 
-The original shape of ``app_lifespan`` had no guard between the first
-resource allocation and the ``yield`` — any startup stage raising
-before ``yield`` leaked everything already allocated, because the
-``finally`` block only runs when ``yield`` was reached. This file
-pins:
+Phase 3 slimmed ``app_lifespan`` to:
 
-- :func:`_teardown_startup_resources` shape (order, idempotency, error
-  tolerance), since both the normal shutdown path and the new
-  startup-failure path funnel through it.
-- A minimal integration check that a startup failure triggers
-  reverse-order teardown of everything allocated so far and re-raises.
+* startup = load env, set up logging, allocate webhook manager,
+  allocate ``AppContext`` (no ``ensure_initialized`` call, no DB touch);
+* shutdown = close webhook then ``ctx.close()`` (which itself stops any
+  background loops and closes components ``ensure_initialized`` started).
+
+These tests pin the new shape so a regression — e.g. someone adding a
+``ctx.ensure_initialized()`` back into the startup path — fails loudly.
+The earlier pre-Phase-3 helper ``_teardown_startup_resources`` is gone;
+its order/idempotency invariants now live on ``AppContext.close`` and
+are covered in ``test_server_app_context.py``.
 """
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from memtomem.server.lifespan import _teardown_startup_resources
+from memtomem.server import lifespan as lifespan_mod
 
 
-def _fake_resource(stop_attr: str = "stop") -> object:
-    """A fake with an async ``stop`` or ``close`` method that records calls."""
+# ── helpers ───────────────────────────────────────────────────────────
 
-    class _R:
-        def __init__(self) -> None:
-            setattr(self, stop_attr, AsyncMock())
 
-    return _R()
+class _FakeWebhook:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        self.close = AsyncMock()
 
 
-@pytest.mark.asyncio
-async def test_teardown_all_none_is_noop() -> None:
-    """No resources → no calls, no error."""
-    await _teardown_startup_resources(
-        watchdog=None,
-        policy_scheduler=None,
-        scheduler=None,
-        webhook_mgr=None,
-        watcher=None,
-        ctx=None,
-    )  # should not raise
+def _enable_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMTOMEM_WEBHOOK__ENABLED", "true")
+    monkeypatch.setenv("MEMTOMEM_WEBHOOK__URL", "https://example.invalid/hook")
 
 
-@pytest.mark.asyncio
-async def test_teardown_order_matches_documented_sequence() -> None:
-    """All resources present → stop/close in the documented sequence.
-
-    Not strict reverse-allocation — ``webhook_mgr`` is stopped before
-    ``watcher`` and ``ctx``. See ``_teardown_startup_resources`` docstring
-    for rationale (webhook has no storage/index dependency, closing it
-    early drops retries during the slower component teardown).
-    """
-    order: list[str] = []
-
-    class _Rec:
-        def __init__(self, name: str, method: str) -> None:
-            self.name = name
-            self.method = method
-
-            async def _call() -> None:
-                order.append(name)
-
-            setattr(self, method, _call)
-
-    webhook = _Rec("webhook_mgr", "close")
-    ctx = _Rec("ctx", "close")
-    watcher = _Rec("watcher", "stop")
-    scheduler = _Rec("scheduler", "stop")
-    policy = _Rec("policy_scheduler", "stop")
-    watchdog = _Rec("watchdog", "stop")
-
-    await _teardown_startup_resources(
-        watchdog=watchdog,
-        policy_scheduler=policy,
-        scheduler=scheduler,
-        webhook_mgr=webhook,
-        watcher=watcher,  # type: ignore[arg-type]
-        ctx=ctx,  # type: ignore[arg-type]
-    )
-
-    assert order == [
-        "watchdog",
-        "policy_scheduler",
-        "scheduler",
-        "webhook_mgr",
-        "watcher",
-        "ctx",
-    ], "teardown order must match the documented sequence"
-
-
-@pytest.mark.asyncio
-async def test_teardown_continues_after_intermediate_failure() -> None:
-    """A failing stop() must not skip later teardown steps."""
-    called: list[str] = []
-
-    async def _good_stop() -> None:
-        called.append("good")
-
-    async def _bad_stop() -> None:
-        called.append("bad")
-        raise RuntimeError("boom")
-
-    class _R:
-        pass
-
-    watchdog = _R()
-    watchdog.stop = _bad_stop  # type: ignore[attr-defined]
-    scheduler = _R()
-    scheduler.stop = _good_stop  # type: ignore[attr-defined]
-    ctx = _R()
-    ctx.close = _good_stop  # type: ignore[attr-defined]
-
-    await _teardown_startup_resources(
-        watchdog=watchdog,
-        policy_scheduler=None,
-        scheduler=scheduler,
-        webhook_mgr=None,
-        watcher=None,
-        ctx=ctx,  # type: ignore[arg-type]
-    )
-
-    assert called == ["bad", "good", "good"], (
-        "watchdog failure must not skip scheduler/ctx teardown"
-    )
-
-
-@pytest.mark.asyncio
-async def test_teardown_reraises_cancelled_error() -> None:
-    """``CancelledError`` must propagate — swallowing it would hide task
-    cancellation, and continuing teardown after cancellation could mask
-    the original startup exception in the ``except BaseException`` caller.
-    """
-    import asyncio
-
-    called: list[str] = []
-
-    async def _cancel_stop() -> None:
-        called.append("watchdog")
-        raise asyncio.CancelledError()
-
-    async def _good_stop() -> None:
-        called.append("scheduler")
-
-    class _R:
-        pass
-
-    watchdog = _R()
-    watchdog.stop = _cancel_stop  # type: ignore[attr-defined]
-    scheduler = _R()
-    scheduler.stop = _good_stop  # type: ignore[attr-defined]
-
-    with pytest.raises(asyncio.CancelledError):
-        await _teardown_startup_resources(
-            watchdog=watchdog,
-            policy_scheduler=None,
-            scheduler=scheduler,
-            webhook_mgr=None,
-            watcher=None,
-            ctx=None,
-        )
-
-    # Later steps were skipped because the cancellation propagated.
-    assert called == ["watchdog"], (
-        f"teardown must stop at CancelledError — later steps reached: {called}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_teardown_ctx_close_called_last() -> None:
-    """``ctx.close()`` is the last step — DB handles must outlive the
-    schedulers that hold references to them."""
-    order: list[str] = []
-
-    async def _record(name: str) -> None:
-        order.append(name)
-
-    class _R:
-        pass
-
-    watchdog = _R()
-
-    async def _wd_stop() -> None:
-        await _record("watchdog")
-
-    watchdog.stop = _wd_stop  # type: ignore[attr-defined]
-
-    ctx = _R()
-
-    async def _ctx_close() -> None:
-        await _record("ctx")
-
-    ctx.close = _ctx_close  # type: ignore[attr-defined]
-
-    await _teardown_startup_resources(
-        watchdog=watchdog,
-        policy_scheduler=None,
-        scheduler=None,
-        webhook_mgr=None,
-        watcher=None,
-        ctx=ctx,  # type: ignore[arg-type]
-    )
-
-    assert order[-1] == "ctx", "ctx.close must be the final teardown step"
-
-
-# ── integration ──────────────────────────────────────────────────────
-
-
-@pytest.mark.asyncio
-async def test_startup_failure_tears_down_prior_resources(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
-    """If a late startup stage raises, earlier allocations get cleaned up.
-
-    We drive ``app_lifespan`` through ``ensure_initialized`` and inject a
-    failing health-watchdog ``start()`` — webhook_mgr, ctx, watcher, and
-    scheduler must all see teardown, and the lifespan must re-raise.
-    """
-    from memtomem.server import lifespan as lifespan_mod
-
-    # Track teardown calls
-    teardown_calls: list[str] = []
-
-    class _FakeWatcher:
-        def __init__(self, *a, **k) -> None:
-            pass
-
-        async def start(self) -> None:
-            pass
-
-        async def stop(self) -> None:
-            teardown_calls.append("watcher")
-
-    class _FakeWebhook:
-        def __init__(self, *a, **k) -> None:
-            pass
-
-        async def close(self) -> None:
-            teardown_calls.append("webhook_mgr")
-
-    class _FakeScheduler:
-        def __init__(self, *a, **k) -> None:
-            pass
-
-        async def start(self) -> None:
-            pass
-
-        async def stop(self) -> None:
-            teardown_calls.append("scheduler")
-
-    class _FakePolicyScheduler(_FakeScheduler):
-        async def stop(self) -> None:
-            teardown_calls.append("policy_scheduler")
-
-    class _FailingWatchdog:
-        def __init__(self, *a, **k) -> None:
-            pass
-
-        async def start(self) -> None:
-            raise RuntimeError("watchdog boom")
-
-        async def stop(self) -> None:
-            teardown_calls.append("watchdog")
-
-    # Patch dependencies that the lifespan resolves via lazy imports.
-    monkeypatch.setattr(lifespan_mod, "FileWatcher", _FakeWatcher)
-
+def _stub_webhook_manager(monkeypatch: pytest.MonkeyPatch) -> None:
     import memtomem.server.webhooks as webhooks_mod
 
     monkeypatch.setattr(webhooks_mod, "WebhookManager", _FakeWebhook)
 
-    import memtomem.server.scheduler as scheduler_mod
 
-    monkeypatch.setattr(scheduler_mod, "ConsolidationScheduler", _FakeScheduler)
-    monkeypatch.setattr(scheduler_mod, "PolicyScheduler", _FakePolicyScheduler)
+# ── handshake-only path ──────────────────────────────────────────────
 
-    import memtomem.server.health_watchdog as watchdog_mod
 
-    monkeypatch.setattr(watchdog_mod, "HealthWatchdog", _FailingWatchdog)
+@pytest.mark.asyncio
+async def test_lifespan_yields_context_without_initializing_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point of Phase 3: handshake (lifespan enter → exit
+    without any tool call) must leave ``_components`` ``None`` so the
+    SQLite DB is never opened. A regression where someone adds an
+    ``await ctx.ensure_initialized()`` back into the startup path would
+    flip this assertion."""
+    # Disable webhook so we don't have to mock it for this minimal case.
+    monkeypatch.delenv("MEMTOMEM_WEBHOOK__ENABLED", raising=False)
+    monkeypatch.delenv("MEMTOMEM_WEBHOOK__URL", raising=False)
 
-    # Stub AppContext.ensure_initialized so we don't need real storage.
+    async with lifespan_mod.app_lifespan(MagicMock()) as ctx:
+        assert ctx is not None
+        assert ctx._components is None, "lifespan must not eagerly init components"
+        assert ctx._watcher is None, "lifespan must not eagerly start watcher"
+        assert ctx._scheduler is None
+        assert ctx._policy_scheduler is None
+        assert ctx._health_watchdog is None
+
+
+# ── shutdown ordering ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lifespan_closes_webhook_before_ctx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Webhook closes first so outstanding network retries drop before
+    the (slower) component teardown — same rationale as the pre-Phase-3
+    ``_teardown_startup_resources`` doc."""
+    _enable_webhook(monkeypatch)
+    _stub_webhook_manager(monkeypatch)
+
+    order: list[str] = []
+    captured: dict[str, object] = {}
+
+    async def _record_webhook_close() -> None:
+        order.append("webhook")
+
+    async def _record_ctx_close(self) -> None:  # type: ignore[no-untyped-def]
+        order.append("ctx")
+
+    # Stub WebhookManager.close to record without doing any work.
+    import memtomem.server.webhooks as webhooks_mod
+
+    class _RecordingWebhook:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.close = _record_webhook_close
+            captured["webhook"] = self
+
+    monkeypatch.setattr(webhooks_mod, "WebhookManager", _RecordingWebhook)
+
+    # Stub AppContext.close so we don't have to drag in real components.
     import memtomem.server.context as context_mod
 
-    ensure_init_called = False
+    monkeypatch.setattr(context_mod.AppContext, "close", _record_ctx_close)
+
+    async with lifespan_mod.app_lifespan(MagicMock()):
+        pass
+
+    assert order == ["webhook", "ctx"], (
+        f"webhook must close before ctx (PR #404 rationale); got {order}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_lifespan_continues_teardown_after_webhook_close_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If webhook ``close()`` raises ``Exception``, ``ctx.close()`` must
+    still run — partial shutdown is worse than a logged failure."""
+    _enable_webhook(monkeypatch)
+
     ctx_closed = False
 
-    class _FakeComponents:
-        class _Engine:
-            pass
+    async def _bad_webhook_close() -> None:
+        raise RuntimeError("webhook close boom")
 
-        index_engine = _Engine()
-        embedding_broken = None
-
-    fake_comp = _FakeComponents()
-
-    original_ensure = context_mod.AppContext.ensure_initialized
-    original_close = context_mod.AppContext.close
-
-    async def _fake_ensure(self) -> object:
-        nonlocal ensure_init_called
-        ensure_init_called = True
-        self._components = fake_comp  # type: ignore[assignment]
-        self._owns_components = True
-        return fake_comp
-
-    async def _fake_close(self) -> None:
+    async def _record_ctx_close(self) -> None:  # type: ignore[no-untyped-def]
         nonlocal ctx_closed
         ctx_closed = True
 
-    monkeypatch.setattr(context_mod.AppContext, "ensure_initialized", _fake_ensure)
-    monkeypatch.setattr(context_mod.AppContext, "close", _fake_close)
+    import memtomem.server.webhooks as webhooks_mod
 
-    # Force every optional subsystem on so we exercise webhook + both
-    # schedulers + watchdog. We set env vars before Mem2MemConfig loads.
-    monkeypatch.setenv("MEMTOMEM_WEBHOOK__ENABLED", "true")
-    monkeypatch.setenv("MEMTOMEM_WEBHOOK__URL", "https://example.invalid/hook")
-    monkeypatch.setenv("MEMTOMEM_CONSOLIDATION_SCHEDULE__ENABLED", "true")
-    monkeypatch.setenv("MEMTOMEM_POLICY__ENABLED", "true")
-    monkeypatch.setenv("MEMTOMEM_HEALTH_WATCHDOG__ENABLED", "true")
-    # Keep storage path deterministic (but we don't actually hit disk, since
-    # ensure_initialized is stubbed).
-    monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", str(tmp_path / "mm.db"))
+    class _BadWebhook:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.close = _bad_webhook_close
 
-    # Drive the lifespan and assert it re-raises the watchdog failure.
-    with pytest.raises(RuntimeError, match="watchdog boom"):
-        async with lifespan_mod.app_lifespan(object()):  # type: ignore[arg-type]
-            pytest.fail("yield should not be reached — startup must fail first")
+    monkeypatch.setattr(webhooks_mod, "WebhookManager", _BadWebhook)
 
-    # Everything allocated must have been torn down, including the
-    # watchdog — it was constructed before ``start()`` raised, so the
-    # ``watchdog`` local was already bound. Teardown steps must be
-    # idempotent for this to be safe in general; our fake ``.stop()``
-    # is trivially so.
-    assert ensure_init_called, "ensure_initialized must have been called"
-    assert ctx_closed, "ctx.close must have been called during teardown"
-    assert teardown_calls == [
-        "watchdog",
-        "policy_scheduler",
-        "scheduler",
-        "webhook_mgr",
-        "watcher",
-    ], f"unexpected teardown order or missing steps: {teardown_calls}"
+    import memtomem.server.context as context_mod
 
-    _ = original_ensure, original_close
+    monkeypatch.setattr(context_mod.AppContext, "close", _record_ctx_close)
+
+    async with lifespan_mod.app_lifespan(MagicMock()):
+        pass
+
+    assert ctx_closed, "ctx.close must run even if webhook close raised"
+
+
+@pytest.mark.asyncio
+async def test_lifespan_reraises_cancellation_during_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``CancelledError`` from a teardown step must propagate so task
+    cancellation is observable — masking it would let shutdown look
+    successful when in fact the loop was being torn down out from under
+    us. Mirrors PR #406 / `feedback_cancelled_error_except_gap.md`."""
+    import asyncio
+
+    _enable_webhook(monkeypatch)
+
+    async def _cancel_webhook_close() -> None:
+        raise asyncio.CancelledError()
+
+    import memtomem.server.webhooks as webhooks_mod
+
+    class _CancelWebhook:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.close = _cancel_webhook_close
+
+    monkeypatch.setattr(webhooks_mod, "WebhookManager", _CancelWebhook)
+
+    with pytest.raises(asyncio.CancelledError):
+        async with lifespan_mod.app_lifespan(MagicMock()):
+            pass
+
+
+# ── startup-failure path ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lifespan_cleans_up_webhook_when_appcontext_init_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``AppContext()`` raises (very rare — it's allocation-only —
+    but possible if dataclass field defaults change), the partially-
+    constructed webhook must still be closed before the lifespan
+    re-raises. This covers the startup-failure ``except BaseException``
+    branch in ``app_lifespan``."""
+    _enable_webhook(monkeypatch)
+
+    closed = False
+
+    async def _record_close() -> None:
+        nonlocal closed
+        closed = True
+
+    import memtomem.server.webhooks as webhooks_mod
+
+    class _RecordingWebhook:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.close = _record_close
+
+    monkeypatch.setattr(webhooks_mod, "WebhookManager", _RecordingWebhook)
+
+    # Force AppContext construction to raise. ``lifespan_mod`` already
+    # imported the symbol with ``from .context import AppContext``, so we
+    # patch the *binding inside lifespan_mod* — patching the source module
+    # would leave the lifespan-local reference pointing at the real class.
+    def _boom_init(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("appcontext boom")
+
+    monkeypatch.setattr(lifespan_mod, "AppContext", _boom_init)
+
+    with pytest.raises(RuntimeError, match="appcontext boom"):
+        async with lifespan_mod.app_lifespan(MagicMock()):
+            pytest.fail("yield should not be reached")
+
+    assert closed, "webhook must be closed when AppContext construction fails"


### PR DESCRIPTION
Final phase of #399 — flips the user-visible behaviour the prior two
PRs only set up. Stacks on #400 (Phase 1 plumbing) + #410 (Phase 2
handler migration).

## What changes

`app_lifespan` no longer eagerly calls `ensure_initialized` and no
longer constructs the `FileWatcher` / `ConsolidationScheduler` /
`PolicyScheduler` / `HealthWatchdog` itself. Component construction
**and** the background-loop start move into
`AppContext.ensure_initialized`, which now also owns their lifetime
— `ctx.close()` stops them in reverse-allocation order before tearing
the components down.

Concretely:

- **Lifespan** (≈40 lines smaller): load env → set up logging → build
  optional `WebhookManager` → allocate `AppContext` → `yield`. None of
  these touch `~/.memtomem/`. On shutdown: `webhook.close()` first
  (drops outstanding network state — same rationale as #404), then
  `ctx.close()`.
- **`AppContext.ensure_initialized`**: keeps the `_init_lock` /
  cached-`Components` / failure-rollback semantics from Phase 1, and
  additionally allocates the watcher + (optional) schedulers + (optional)
  watchdog. Same degraded-mode gate as before — `embedding_broken` set
  → watcher constructed but `start()` skipped, schedulers/watchdog not
  even built, so #349 recovery via `mem_embedding_reset` is unchanged.
- **`AppContext.close`**: stops watchdog → policy → consolidation →
  watcher → components, each through a new `_stop_quietly` helper that
  logs+continues on `Exception` and re-raises `CancelledError`
  (preserves PR #404 / #406 invariants).
- **Removed**: `_teardown_startup_resources` (its order/idempotency
  invariants now live on `AppContext.close`) and `set_health_watchdog`
  (lifespan no longer hands a watchdog to ctx — ctx builds it).

## User-facing behaviour change

```bash
rm -rf ~/.memtomem
claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server
claude mcp list                # before #399: ~/.memtomem/memtomem.db appears
                               # after #399 phase 3: directory stays absent
```

The DB is created on the first tool call (`mem_search`, `mem_add`,
`mem_status`, …) instead of on the MCP handshake.

## Accepted regressions (please call out in changelog)

1. **#349 startup-warning visibility moves to first tool call.** The
   `"Embedding dimension mismatch detected at startup — entering
   degraded mode"` warning previously fired on `memtomem-server`
   stderr at boot. With lazy init it fires when
   `ensure_initialized` runs, i.e. on the first tool call. Recovery
   tools (`mem_embedding_reset`, `mem_status`, `mem_stats`,
   `mem_list`, `mem_read`) stay callable; the user just learns about
   the mismatch from the first response rather than the boot stderr.
2. **Background scheduler-on-idle removed.** Previously, an idle
   server (editor opened in evening, no tool calls until morning)
   still ran consolidation / policy / health-watchdog every interval.
   With lazy init those start on the first tool call. An MCP client
   that connects but never calls a tool will not see any scheduler
   ticks — consistent with "no DB to maintain" but worth flagging for
   anyone whose maintenance schedule assumed background-without-tool-calls.

Both are documented in the issue's open-questions section as accepted
trade-offs.

## Acceptance

Mapped from #399's acceptance checklist:

- [x] handshake-only lifespan leaves the DB absent
      (`test_handshake_only_leaves_db_absent`)
- [x] first `ensure_initialized` creates the DB
      (`test_first_ensure_initialized_creates_db`)
- [x] concurrent first-callers share a single
      `create_components` invocation
      (`test_concurrent_first_calls_invoke_create_components_once` +
      pre-existing `test_ensure_initialized_concurrent_calls_invoke_factory_once`)
- [x] watcher/scheduler/watchdog skipped in degraded mode
      (`test_ensure_initialized_skips_watcher_in_degraded_mode` —
      same gate as the pre-Phase-3 code, just relocated)
- [x] `ctx.close()` stops everything
      `ensure_initialized` started
      (`test_close_stops_started_watcher` +
      `test_lifespan_closes_webhook_before_ctx`)
- [x] watcher-start failure rolls back components
      (`test_ensure_initialized_rolls_back_components_when_watcher_start_fails`)
- [ ] Background `.server.pid` + `~/.memtomem/` mkdir at module
      import is still eager — out of scope for this PR (open
      question 1 in #399, ties into #384/#387 `$XDG_RUNTIME_DIR`
      relocation)

## Smoke test

```
$ HOME=/tmp/mm-phase3-smoke MEMTOMEM_INDEXING__MEMORY_DIRS='[]' \
  MEMTOMEM_EMBEDDING__PROVIDER=none uv run python -c "..."
Pre-lifespan: db exists=False
In lifespan (no tool call): db exists=False components=None
-- now calling ensure_initialized --
After ensure_initialized: db exists=True components is not None=True
Post-lifespan: db exists=True
```

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/server/{context,lifespan}.py` — clean (advisory)
- [x] `uv run pytest -m "not ollama"` — 2177 passed, 46 deselected
- [ ] Manual `claude mcp add` + `claude mcp list` against built
      branch in fresh `~/.memtomem` (reviewer: please confirm DB
      stays absent on your machine too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
