### PR TITLE
server: relocate .server.pid to $XDG_RUNTIME_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`memtomem-server` pid / flock file moved to `$XDG_RUNTIME_DIR/memtomem/server.pid`.**
+  Previously the server wrote `~/.memtomem/.server.pid` at startup, which
+  forced `~/.memtomem/` into existence on every MCP handshake (even for
+  clients that connect but never call a tool). Runtime state now lives
+  on `$XDG_RUNTIME_DIR/memtomem/` when the platform provides it
+  (Linux w/ systemd), or `$TMPDIR/memtomem-$UID/` otherwise (macOS, BSD,
+  Linux without systemd). Combined with #399 Phase 3's lazy DB creation,
+  an idle MCP handshake against a fresh machine now leaves `~/.memtomem/`
+  untouched entirely. `mm uninstall` probes both the new and legacy
+  locations during the transition window, so a mixed-version upgrade
+  (pre-#412 server still running + new uninstall CLI) still refuses
+  correctly. (#412)
+
 - **MCP handshake no longer creates `~/.memtomem/memtomem.db`.** Previously,
   every MCP client that connected to memtomem (Claude Code's `claude mcp list`,
   Cursor, Windsurf, Gemini CLI) instantiated the SQLite database on handshake —
@@ -31,10 +44,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
     flagging for any maintenance schedule that assumed
     background-without-tool-calls semantics.
 
-  Note: `~/.memtomem/` itself is still created at process start by the
-  `memtomem-server` `.server.pid` advisory-lock acquisition; relocating
-  that to `$XDG_RUNTIME_DIR` is tracked separately in #384/#387.
-  (#399, #411; builds on #400 plumbing and #410 handler migration.)
+  Paired with #412 (runtime pid file relocation), an idle MCP handshake
+  now leaves `~/.memtomem/` untouched altogether — the advisory-lock
+  write that forced its creation moved to `$XDG_RUNTIME_DIR`. (#399,
+  #411; builds on #400 plumbing and #410 handler migration.)
 
 ### Fixed
 

--- a/docs/guides/uninstall.md
+++ b/docs/guides/uninstall.md
@@ -84,7 +84,13 @@ This removes:
 | `memories/` | User-created memories from `mem_add` |
 | `uploads/` | Files uploaded via the Web UI |
 | `.current_session` | Active session marker |
-| `.server.pid` | MCP server advisory lock |
+| `.server.pid` | Legacy MCP server advisory lock (pre-#412 installs only) |
+
+The running server's pid/flock file lives **outside** `~/.memtomem/`
+under `$XDG_RUNTIME_DIR/memtomem/server.pid` (Linux w/ systemd) or
+`$TMPDIR/memtomem-$UID/server.pid` (macOS, BSD). It is cleaned by
+`mm uninstall` automatically; a manual cleanup is rarely needed but
+equivalent to `rm -rf "${XDG_RUNTIME_DIR:-/tmp}/memtomem"*`.
 
 ## 4. Clean up project-scoped files (optional)
 

--- a/packages/memtomem/src/memtomem/_runtime_paths.py
+++ b/packages/memtomem/src/memtomem/_runtime_paths.py
@@ -1,0 +1,84 @@
+"""Runtime-state path resolution.
+
+Runtime files (pid files, locks, sockets) belong on ``$XDG_RUNTIME_DIR``
+when the platform provides one — the kernel auto-cleans them at logout,
+no stale artifacts survive a reboot, and they never mingle with the
+user's persistent data under ``~/.memtomem/``.
+
+Resolution order:
+
+1. ``$XDG_RUNTIME_DIR/memtomem`` — Linux + systemd (and any other OS that
+   exports the var). Per-user, ``tmpfs``-backed, kernel-managed lifecycle.
+2. ``{tempfile.gettempdir()}/memtomem-{uid}`` — macOS (where
+   ``gettempdir()`` resolves to a per-user ``/var/folders/.../T/`` already)
+   and Linux without systemd. ``uid`` suffix disambiguates a shared
+   ``/tmp``; ``mode=0o700`` at creation keeps it private to the user.
+
+The directory is created on first access. We never try to ``chmod`` an
+existing directory — if a user ran memtomem as root once and left behind
+a ``root``-owned runtime dir, fixing it silently would be worse than
+letting the open fail loudly.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def runtime_dir() -> Path:
+    """Return the memtomem runtime directory path *without* creating it.
+
+    See module docstring for resolution order. Use :func:`ensure_runtime_dir`
+    when the directory needs to exist (e.g. opening a pid file for write);
+    the plain form is safe to call during read-only introspection such as
+    the uninstall inventory walk, which must not leave behind an empty dir.
+    """
+    xdg = os.environ.get("XDG_RUNTIME_DIR", "")
+    if xdg:
+        base = Path(xdg)
+        if base.is_dir():
+            return base / "memtomem"
+
+    uid = os.geteuid() if hasattr(os, "geteuid") else 0
+    return Path(tempfile.gettempdir()) / f"memtomem-{uid}"
+
+
+def ensure_runtime_dir() -> Path:
+    """Return the runtime directory, creating it with ``mode=0o700`` if missing.
+
+    Never touches permissions on an existing directory; a ``root``-owned
+    leftover from a prior ``sudo`` invocation is surfaced by the caller's
+    ``open()`` rather than silently adjusted here.
+    """
+    target = runtime_dir()
+    target.mkdir(mode=0o700, exist_ok=True)
+    return target
+
+
+def server_pid_path() -> Path:
+    """Return the path to ``memtomem-server``'s pid / flock file.
+
+    Does not create the parent directory — callers that intend to open the
+    path for write should go through :func:`ensure_runtime_dir` first.
+    """
+    return runtime_dir() / "server.pid"
+
+
+_LEGACY_PID_NAME = ".server.pid"
+
+
+def legacy_server_pid_path() -> Path:
+    """Return the pre-relocation pid file path (``~/.memtomem/.server.pid``).
+
+    Kept as a target for backward-compat probes in the uninstall CLI
+    during the transition period. A mixed-version upgrade (old server
+    running, new uninstall) still needs to see the old location to
+    refuse correctly.
+
+    ``Path.home()`` is evaluated every call so tests that monkeypatch
+    ``HOME`` get the isolated path — import-time binding would capture
+    the developer's real home and leak across the fixture.
+    """
+    return Path.home() / ".memtomem" / _LEGACY_PID_NAME

--- a/packages/memtomem/src/memtomem/_runtime_paths.py
+++ b/packages/memtomem/src/memtomem/_runtime_paths.py
@@ -9,22 +9,55 @@ Resolution order:
 
 1. ``$XDG_RUNTIME_DIR/memtomem`` — Linux + systemd (and any other OS that
    exports the var). Per-user, ``tmpfs``-backed, kernel-managed lifecycle.
+   Accepted only if the base is a real directory (not a symlink), owned
+   by the effective uid, and has mode ``0o700`` (no group/world bits).
 2. ``{tempfile.gettempdir()}/memtomem-{uid}`` — macOS (where
    ``gettempdir()`` resolves to a per-user ``/var/folders/.../T/`` already)
    and Linux without systemd. ``uid`` suffix disambiguates a shared
    ``/tmp``; ``mode=0o700`` at creation keeps it private to the user.
 
-The directory is created on first access. We never try to ``chmod`` an
-existing directory — if a user ran memtomem as root once and left behind
-a ``root``-owned runtime dir, fixing it silently would be worse than
-letting the open fail loudly.
+Security posture for the runtime directory itself:
+
+- Never follow a symlink — an attacker on a shared ``/tmp`` could
+  pre-create ``memtomem-{uid}`` as a link into the user's home, and a
+  naive ``mkdir`` would silently no-op through it. ``os.stat`` with
+  ``follow_symlinks=False`` catches this.
+- Refuse any pre-existing directory not owned by the effective uid or
+  not at mode ``0o700``. This trades convenience for a predictable
+  contract: a ``root``-owned leftover from ``sudo mm …`` or a
+  mode-degraded dir raises :class:`PermissionError` with a remediation
+  hint instead of silently writing the pid file into a world-readable
+  directory. The only fix is ``rm -rf`` the runtime dir and retry.
 """
 
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from pathlib import Path
+
+
+def _is_safe_dir(path: Path) -> bool:
+    """Return True iff ``path`` is a regular directory, owner-matches the
+    effective uid, and has no group/world permission bits.
+
+    Used by both the ``$XDG_RUNTIME_DIR`` gate (where we silently fall
+    through to the tempdir form on failure) and the ``ensure`` path
+    (where failure becomes a :class:`PermissionError`). ``lstat``-style
+    semantics — we reject a symlink outright, never its target.
+    """
+    try:
+        st = os.stat(path, follow_symlinks=False)
+    except OSError:
+        return False
+    if not stat.S_ISDIR(st.st_mode):
+        return False
+    if stat.S_IMODE(st.st_mode) & 0o077:
+        return False
+    if hasattr(os, "geteuid") and st.st_uid != os.geteuid():
+        return False
+    return True
 
 
 def runtime_dir() -> Path:
@@ -34,12 +67,16 @@ def runtime_dir() -> Path:
     when the directory needs to exist (e.g. opening a pid file for write);
     the plain form is safe to call during read-only introspection such as
     the uninstall inventory walk, which must not leave behind an empty dir.
+
+    The ``$XDG_RUNTIME_DIR`` branch is gated on :func:`_is_safe_dir` —
+    a misconfigured export (``XDG_RUNTIME_DIR=/tmp``, or a user-created
+    symlink) silently falls through to the tempdir form so we never
+    place the pid file in a world-readable location just because the
+    environment was wrong.
     """
     xdg = os.environ.get("XDG_RUNTIME_DIR", "")
-    if xdg:
-        base = Path(xdg)
-        if base.is_dir():
-            return base / "memtomem"
+    if xdg and _is_safe_dir(Path(xdg)):
+        return Path(xdg) / "memtomem"
 
     uid = os.geteuid() if hasattr(os, "geteuid") else 0
     return Path(tempfile.gettempdir()) / f"memtomem-{uid}"
@@ -48,12 +85,63 @@ def runtime_dir() -> Path:
 def ensure_runtime_dir() -> Path:
     """Return the runtime directory, creating it with ``mode=0o700`` if missing.
 
-    Never touches permissions on an existing directory; a ``root``-owned
-    leftover from a prior ``sudo`` invocation is surfaced by the caller's
-    ``open()`` rather than silently adjusted here.
+    A pre-existing directory is validated: symlink, wrong owner, or any
+    group/world bit set raises :class:`PermissionError` with a
+    ``rm -rf <path>`` hint. We never ``chmod`` an existing directory
+    (silent permission changes would hide the underlying misconfiguration
+    — and bypass any audit a sysadmin might run against the parent).
+
+    On creation we ``chmod`` explicitly to ``0o700`` as a belt-and-suspenders
+    fix for exotic ``umask`` values (e.g. ``umask 0o177`` would clear the
+    owner-execute bit supplied to ``mkdir``, leaving an unusable directory
+    on silent success).
     """
     target = runtime_dir()
-    target.mkdir(mode=0o700, exist_ok=True)
+    try:
+        st = os.stat(target, follow_symlinks=False)
+    except FileNotFoundError:
+        st = None
+    except OSError as exc:
+        raise PermissionError(
+            f"runtime dir {target}: cannot stat ({exc}). Remove it and retry."
+        ) from exc
+
+    if st is not None:
+        if stat.S_ISLNK(st.st_mode):
+            raise PermissionError(
+                f"runtime dir {target} is a symlink; refusing to follow. Remove it: rm -f {target}"
+            )
+        if not stat.S_ISDIR(st.st_mode):
+            raise PermissionError(
+                f"runtime dir {target} exists but is not a directory. Remove it: rm -f {target}"
+            )
+        if hasattr(os, "geteuid") and st.st_uid != os.geteuid():
+            raise PermissionError(
+                f"runtime dir {target} is owned by uid {st.st_uid} "
+                f"(expected {os.geteuid()}). Remove it and retry: rm -rf {target}"
+            )
+        unsafe = stat.S_IMODE(st.st_mode) & 0o077
+        if unsafe:
+            raise PermissionError(
+                f"runtime dir {target} has unsafe permissions "
+                f"0o{stat.S_IMODE(st.st_mode):o} (expected 0o700, "
+                f"group/world bits: 0o{unsafe:o}). "
+                f"Remove it and retry: rm -rf {target}"
+            )
+        return target
+
+    # Missing — create with 0o700, then chmod explicitly to neutralize any
+    # umask that would have masked the mode bits. Both calls are racy if
+    # another process interposes, but the worst case is a
+    # FileExistsError → re-validate via recursion.
+    try:
+        target.mkdir(mode=0o700, exist_ok=False)
+    except FileExistsError:
+        return ensure_runtime_dir()
+    try:
+        os.chmod(target, 0o700)
+    except OSError:
+        pass
     return target
 
 
@@ -72,10 +160,11 @@ _LEGACY_PID_NAME = ".server.pid"
 def legacy_server_pid_path() -> Path:
     """Return the pre-relocation pid file path (``~/.memtomem/.server.pid``).
 
-    Kept as a target for backward-compat probes in the uninstall CLI
-    during the transition period. A mixed-version upgrade (old server
-    running, new uninstall) still needs to see the old location to
-    refuse correctly.
+    Kept as a target for backward-compat probes during the transition
+    period. Both :mod:`memtomem.server` (startup mutual-exclusion against
+    a pre-#412 server still running at the legacy location) and
+    :mod:`memtomem.cli.uninstall_cmd` (mixed-version refusal) consult
+    this path.
 
     ``Path.home()`` is evaluated every call so tests that monkeypatch
     ``HOME`` get the isolated path — import-time binding would capture

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -31,7 +31,7 @@ from typing import Iterable
 
 import click
 
-from memtomem._runtime_paths import legacy_server_pid_path, server_pid_path
+from memtomem._runtime_paths import legacy_server_pid_path, runtime_dir, server_pid_path
 from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
 
 _DEFAULT_STATE_DIR = Path.home() / ".memtomem"
@@ -172,7 +172,7 @@ def _probe_pid_file(pid_file: Path) -> _ServerState:
         fp.close()
 
 
-def _check_server_liveness(_state_dir: Path) -> _ServerState:
+def _check_server_liveness() -> _ServerState:
     """Probe the server pid file at both the new and legacy locations.
 
     As of #412 the server writes its pid / lock file under
@@ -182,9 +182,11 @@ def _check_server_liveness(_state_dir: Path) -> _ServerState:
     server still running, new uninstall CLI) refuses correctly. First
     live holder wins; if neither is held the state is dead.
 
-    ``_state_dir`` is kept as a parameter for call-site symmetry and
-    future use (other DB writers covered by #384 may register pid files
-    the same way), but both probes use canonical absolute paths today.
+    No ``state_dir`` parameter — both probes use canonical absolute
+    paths from :mod:`memtomem._runtime_paths`. When #384 expands the
+    scheme to cover other writers (``mm web``, ``mm watchdog``) the
+    glob will still live inside :func:`_runtime_paths.runtime_dir`,
+    not under the persistent state dir.
     """
     for pid_file in (server_pid_path(), legacy_server_pid_path()):
         state = _probe_pid_file(pid_file)
@@ -518,9 +520,7 @@ def _delete_inventory(inv: _Inventory, *, keep_config: bool, keep_data: bool) ->
     # Prune the runtime subdir (``$XDG_RUNTIME_DIR/memtomem`` or
     # ``$TMPDIR/memtomem-{uid}``) if we emptied it. We don't own the
     # parent (the kernel / OS does), so we only rmdir our own subdir.
-    from memtomem._runtime_paths import runtime_dir as _rd
-
-    rt = _rd()
+    rt = runtime_dir()
     if rt.exists() and rt.is_dir() and not any(rt.iterdir()):
         try:
             rt.rmdir()
@@ -551,7 +551,7 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
     db_path, config_error = _load_config_safely()
     state_dir = _DEFAULT_STATE_DIR
 
-    server = _check_server_liveness(state_dir)
+    server = _check_server_liveness()
 
     # Empty-state fast path.
     if not state_dir.exists() and not db_path.exists():

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -31,6 +31,7 @@ from typing import Iterable
 
 import click
 
+from memtomem._runtime_paths import legacy_server_pid_path, server_pid_path
 from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
 
 _DEFAULT_STATE_DIR = Path.home() / ".memtomem"
@@ -115,8 +116,8 @@ def _load_config_safely() -> tuple[Path, str | None]:
 # ---- server liveness probe -----------------------------------------------
 
 
-def _check_server_liveness(state_dir: Path) -> _ServerState:
-    """Probe ``state_dir/.server.pid`` via ``fcntl.flock``.
+def _probe_pid_file(pid_file: Path) -> _ServerState:
+    """Probe a single pid file via ``fcntl.flock``.
 
     ``server/__init__.py:main`` opens this file and holds an exclusive
     flock for the entire server lifetime. If we can acquire
@@ -130,7 +131,6 @@ def _check_server_liveness(state_dir: Path) -> _ServerState:
     kernel recycled the recorded PID to an unrelated process (issue
     #387). The PID inside the file is now read for display only.
     """
-    pid_file = state_dir / ".server.pid"
     if not pid_file.exists():
         return _ServerState(alive=False, pid=None, pid_file=None)
 
@@ -170,6 +170,27 @@ def _check_server_liveness(state_dir: Path) -> _ServerState:
         return _ServerState(alive=False, pid=pid, pid_file=pid_file)
     finally:
         fp.close()
+
+
+def _check_server_liveness(_state_dir: Path) -> _ServerState:
+    """Probe the server pid file at both the new and legacy locations.
+
+    As of #412 the server writes its pid / lock file under
+    ``$XDG_RUNTIME_DIR/memtomem/server.pid`` (see ``_runtime_paths``).
+    During the transition window we also probe the legacy
+    ``~/.memtomem/.server.pid`` so a mixed-version upgrade (pre-#412
+    server still running, new uninstall CLI) refuses correctly. First
+    live holder wins; if neither is held the state is dead.
+
+    ``_state_dir`` is kept as a parameter for call-site symmetry and
+    future use (other DB writers covered by #384 may register pid files
+    the same way), but both probes use canonical absolute paths today.
+    """
+    for pid_file in (server_pid_path(), legacy_server_pid_path()):
+        state = _probe_pid_file(pid_file)
+        if state.alive:
+            return state
+    return _ServerState(alive=False, pid=None, pid_file=None)
 
 
 # ---- inventory -----------------------------------------------------------
@@ -223,6 +244,13 @@ def _collect_inventory(db_path: Path) -> _Inventory:
         candidate = state_dir / name
         if candidate.exists():
             other.append(candidate)
+    # New-location pid file lives outside state_dir (#412: on
+    # ``$XDG_RUNTIME_DIR/memtomem/`` or a per-user temp subdir). Include
+    # it in the transient "other" group so it's cleaned with the legacy
+    # ``.server.pid`` and the user sees a single row per file.
+    runtime_pid = server_pid_path()
+    if runtime_pid.exists():
+        other.append(runtime_pid)
 
     return _Inventory(
         state_dir=state_dir,
@@ -484,6 +512,18 @@ def _delete_inventory(inv: _Inventory, *, keep_config: bool, keep_data: bool) ->
         try:
             _DEFAULT_STATE_DIR.rmdir()
             completed.append("state dir")
+        except OSError:
+            pass
+
+    # Prune the runtime subdir (``$XDG_RUNTIME_DIR/memtomem`` or
+    # ``$TMPDIR/memtomem-{uid}``) if we emptied it. We don't own the
+    # parent (the kernel / OS does), so we only rmdir our own subdir.
+    from memtomem._runtime_paths import runtime_dir as _rd
+
+    rt = _rd()
+    if rt.exists() and rt.is_dir() and not any(rt.iterdir()):
+        try:
+            rt.rmdir()
         except OSError:
             pass
 

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -167,12 +167,74 @@ def _install_sigterm_handler(pid_file: Path) -> None:
     signal.signal(signal.SIGTERM, _handle)
 
 
+def _try_hold_legacy_flock(legacy_pid: Path) -> object | None:
+    """Acquire a lifetime flock on the pre-#412 pid file, if present.
+
+    During the transition window a user may still have a v0.1.24 or older
+    ``memtomem-server`` running — it holds ``fcntl.flock`` on
+    ``~/.memtomem/.server.pid``. The new server's own flock target lives
+    on ``$XDG_RUNTIME_DIR``, so without this probe two servers could run
+    concurrently against the same SQLite DB and corrupt the WAL (#412
+    review B1).
+
+    Behavior:
+
+    - If ``~/.memtomem/`` does not exist, skip — this is a fresh install
+      with no upgrade history, and touching it would re-pollute the
+      directory that #412 specifically keeps out of handshake.
+    - Otherwise, open the legacy path (``a+b`` creates it if missing; we
+      are inside an already-existing ``~/.memtomem/`` so no new
+      pollution) and try ``LOCK_EX | LOCK_NB``.
+    - Lock held by another process → an old server is alive; print to
+      stderr and ``sys.exit(1)``. Two concurrent writers is strictly
+      worse than one missed MCP handshake.
+    - Lock acquired → return the file handle; caller holds it for the
+      process lifetime so a *future* old server starting after us also
+      hits this lock and bails via its own concurrent-detection path.
+
+    Returns ``None`` on the skip paths (fresh install, open error). The
+    returned fd must stay referenced for the lock to persist.
+    """
+    import fcntl
+    import sys
+
+    legacy_state_dir = Path.home() / ".memtomem"
+    if not legacy_state_dir.is_dir():
+        return None
+
+    try:
+        legacy_fp = open(legacy_pid, "a+b")
+    except OSError:
+        return None
+
+    try:
+        fcntl.flock(legacy_fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError):
+        print(
+            f"error: another memtomem-server holds a lock at {legacy_pid} "
+            f"(likely a pre-0.1.25 install). Stop it before starting a new "
+            f"server; `mm uninstall` will also refuse until it is gone.",
+            file=sys.stderr,
+        )
+        legacy_fp.close()
+        sys.exit(1)
+    return legacy_fp
+
+
 def main() -> None:
     """Run the MCP server."""
     import atexit
     import fcntl
 
-    from memtomem._runtime_paths import ensure_runtime_dir
+    from memtomem._runtime_paths import ensure_runtime_dir, legacy_server_pid_path
+
+    # B1: bidirectional mutual exclusion during the transition window.
+    # Hold the legacy flock for the process lifetime so an old (pre-#412)
+    # server running *now* is detected and a future one starting *after*
+    # us also bails.
+    _legacy_lock_fp = _try_hold_legacy_flock(legacy_server_pid_path())
+    if _legacy_lock_fp is not None:
+        atexit.register(lambda: _legacy_lock_fp.close())
 
     # Runtime files (pid / flock) live on ``$XDG_RUNTIME_DIR/memtomem``
     # when the platform provides one, otherwise a per-user temp subdir.

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -172,9 +172,13 @@ def main() -> None:
     import atexit
     import fcntl
 
-    pid_dir = Path("~/.memtomem").expanduser()
-    pid_dir.mkdir(parents=True, exist_ok=True)
-    pid_file = pid_dir / ".server.pid"
+    from memtomem._runtime_paths import ensure_runtime_dir
+
+    # Runtime files (pid / flock) live on ``$XDG_RUNTIME_DIR/memtomem``
+    # when the platform provides one, otherwise a per-user temp subdir.
+    # This keeps ``~/.memtomem/`` untouched during MCP handshake — it is
+    # created only when persistent storage is first written (#412).
+    pid_file = ensure_runtime_dir() / "server.pid"
 
     # Advisory lock — prevents multiple MCP servers from writing concurrently.
     # The lock is held for the lifetime of the process and auto-released on exit.

--- a/packages/memtomem/tests/test_runtime_paths.py
+++ b/packages/memtomem/tests/test_runtime_paths.py
@@ -3,7 +3,8 @@
 Runtime files (pid, flock) resolve to ``$XDG_RUNTIME_DIR/memtomem`` when
 the platform provides one, and a per-user temp subdir otherwise. The
 resolver is side-effect free — ``runtime_dir()`` must NOT create the
-directory; ``ensure_runtime_dir()`` is the explicit opt-in.
+directory; ``ensure_runtime_dir()`` is the explicit opt-in and enforces
+the security contract (symlink / owner / mode).
 """
 
 from __future__ import annotations
@@ -23,10 +24,22 @@ from memtomem._runtime_paths import (
 )
 
 
+def _make_safe_xdg(tmp_path: Path) -> Path:
+    """Create an ``$XDG_RUNTIME_DIR``-shaped base under ``tmp_path``.
+
+    ``Path.mkdir`` applies umask to the mode, and system umask may strip
+    owner-only bits we wanted. ``chmod`` after the fact neutralizes that
+    so the happy-path tests don't depend on the developer's umask.
+    """
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+    return xdg
+
+
 class TestRuntimeDir:
     def test_uses_xdg_runtime_dir_when_set(self, tmp_path, monkeypatch):
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
 
         assert runtime_dir() == xdg / "memtomem"
@@ -36,8 +49,7 @@ class TestRuntimeDir:
         walks rely on it to probe for ``server.pid`` without leaving an
         empty subdir behind on machines where the runtime path doesn't
         exist yet."""
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
 
         result = runtime_dir()
@@ -51,11 +63,58 @@ class TestRuntimeDir:
         assert result.parent == Path(tempfile.gettempdir())
         assert result.name.startswith("memtomem-")
 
-    def test_falls_back_when_xdg_points_at_nonexistent_dir(self, tmp_path, monkeypatch):
-        """A user who exports ``XDG_RUNTIME_DIR`` but whose shell never
-        materialized it (some remote-ssh configs) must still get a
-        working path, not a mkdir against a non-existent parent."""
+    def test_falls_back_when_xdg_path_is_missing_or_stale(self, tmp_path, monkeypatch):
+        """``XDG_RUNTIME_DIR`` is exported but the target isn't on disk —
+        either it was never materialised (some remote-ssh configs) or it
+        has been reaped after a session ended. Both produce a missing
+        directory at stat time and must fall through to the tempdir form,
+        not mkdir against a non-existent parent."""
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "does-not-exist"))
+
+        result = runtime_dir()
+
+        assert result.parent == Path(tempfile.gettempdir())
+
+    def test_falls_back_when_xdg_is_symlink(self, tmp_path, monkeypatch):
+        """Attacker on a shared host pre-creates ``$XDG_RUNTIME_DIR`` as a
+        symlink into the user's home. ``_is_safe_dir`` must reject it —
+        the whole point of ``follow_symlinks=False`` is to catch this
+        before ``ensure_runtime_dir`` follows the link and writes the
+        pid file somewhere the user didn't expect."""
+        real = _make_safe_xdg(tmp_path)
+        link = tmp_path / "xdg-link"
+        os.symlink(real, link)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(link))
+
+        result = runtime_dir()
+
+        assert result.parent == Path(tempfile.gettempdir()), (
+            "symlinked XDG base must fall through to tempdir, not be followed"
+        )
+
+    def test_falls_back_when_xdg_is_world_readable(self, tmp_path, monkeypatch):
+        """``XDG_RUNTIME_DIR=/tmp`` (world-writable) is the canonical
+        misconfiguration: falling through to the per-user tempdir form
+        still gives owner-only ``memtomem-{uid}``, while using the bad
+        base would place ``server.pid`` in a directory anyone can list."""
+        loose = tmp_path / "loose-xdg"
+        loose.mkdir()
+        os.chmod(loose, 0o755)  # group + world read/execute
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(loose))
+
+        result = runtime_dir()
+
+        assert result.parent == Path(tempfile.gettempdir())
+
+    @pytest.mark.skipif(not hasattr(os, "geteuid"), reason="owner check is POSIX-only")
+    def test_falls_back_when_xdg_owner_mismatch(self, tmp_path, monkeypatch):
+        """Stubbing ``geteuid`` to return a different uid simulates a
+        root-owned ``$XDG_RUNTIME_DIR`` left over from a ``sudo`` run.
+        The owner check must see the mismatch and fall through."""
+        xdg = _make_safe_xdg(tmp_path)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+        real_uid = os.geteuid()
+        monkeypatch.setattr(os, "geteuid", lambda: real_uid + 1)
 
         result = runtime_dir()
 
@@ -64,50 +123,122 @@ class TestRuntimeDir:
 
 class TestEnsureRuntimeDir:
     def test_creates_directory_with_owner_only_mode(self, tmp_path, monkeypatch):
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
 
         d = ensure_runtime_dir()
 
         assert d.exists() and d.is_dir()
-        # mode & 0o777 masks off file-type bits
+        assert stat.S_IMODE(d.stat().st_mode) == 0o700
+
+    def test_explicit_chmod_survives_wild_umask(self, tmp_path, monkeypatch):
+        """``mkdir(mode=0o700)`` is still subject to umask masking. A
+        pathological ``umask 0o177`` would clear the owner-exec bit and
+        silently produce an unusable 0o600 dir. The belt-and-suspenders
+        explicit ``chmod`` neutralizes that."""
+        xdg = _make_safe_xdg(tmp_path)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+        old_umask = os.umask(0o177)
+        try:
+            d = ensure_runtime_dir()
+        finally:
+            os.umask(old_umask)
+
         assert stat.S_IMODE(d.stat().st_mode) == 0o700
 
     def test_idempotent_does_not_fail_on_existing_dir(self, tmp_path, monkeypatch):
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
 
         ensure_runtime_dir()
-        # Second call must not raise FileExistsError.
+        # Second call must not raise FileExistsError, must re-validate,
+        # must return the same path.
         ensure_runtime_dir()
 
-    def test_does_not_chmod_existing_dir(self, tmp_path, monkeypatch):
-        """A pre-existing dir (maybe created by ``root`` via ``sudo``)
-        keeps its own permissions — we never silently downgrade."""
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+    def test_refuses_existing_symlink(self, tmp_path, monkeypatch):
+        """Symlink-at-the-runtime-path attack: attacker symlinks
+        ``$XDG_RUNTIME_DIR/memtomem`` into the user's home. Pre-M1 fix,
+        ``mkdir(exist_ok=True)`` followed the link silently and
+        ``open(server_pid_path(), "w")`` wrote into the target. Now the
+        validator raises before we touch the file."""
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+        target = tmp_path / "real-target"
+        target.mkdir(mode=0o700)
+        os.symlink(target, xdg / "memtomem")
 
+        with pytest.raises(PermissionError, match="symlink"):
+            ensure_runtime_dir()
+
+    def test_refuses_existing_loose_mode(self, tmp_path, monkeypatch):
+        """Regression for M3 in the #412 review: a pre-existing dir at
+        mode 0o755 used to be silently accepted, leaking the pid file
+        into a group/world-readable location. The contract now enforces
+        0o700 and surfaces remediation ``rm -rf`` in the error."""
+        xdg = _make_safe_xdg(tmp_path)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
         (xdg / "memtomem").mkdir(mode=0o755)
+        os.chmod(xdg / "memtomem", 0o755)  # neutralize umask
 
-        d = ensure_runtime_dir()
+        with pytest.raises(PermissionError, match="unsafe permissions"):
+            ensure_runtime_dir()
 
-        assert stat.S_IMODE(d.stat().st_mode) == 0o755
+    @pytest.mark.skipif(not hasattr(os, "geteuid"), reason="owner check is POSIX-only")
+    def test_refuses_existing_wrong_owner(self, tmp_path, monkeypatch):
+        """Stub ``geteuid`` to simulate a ``root``-owned leftover from a
+        prior ``sudo mm …`` run. The validator must raise with a
+        clean-up hint rather than proceed against a dir we don't own.
+
+        We route through the ``TMPDIR`` fallback rather than XDG because
+        ``runtime_dir()`` also consults ``geteuid()`` for the XDG safety
+        gate — a uid-stub applied before resolution would flip the whole
+        path to fallback before ``ensure_runtime_dir`` ever stat'd the
+        memtomem subdir, missing the existing-dir branch we want to
+        cover. Pre-creating the fallback subdir at the stubbed uid's
+        expected name lets us exercise that branch end-to-end.
+        """
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        tmp_tmp = tmp_path / "tmp"
+        tmp_tmp.mkdir()
+        os.chmod(tmp_tmp, 0o700)
+        monkeypatch.setenv("TMPDIR", str(tmp_tmp))
+        tempfile.tempdir = None  # tempfile caches ``gettempdir()`` — invalidate
+
+        real_uid = os.geteuid()
+        stubbed_uid = real_uid + 1
+        # Pre-create the path that ``runtime_dir()`` will return under
+        # the stubbed uid. Owned by us (``st_uid == real_uid``) but the
+        # stubbed ``geteuid()`` returns ``stubbed_uid`` → mismatch.
+        (tmp_tmp / f"memtomem-{stubbed_uid}").mkdir(mode=0o700)
+        monkeypatch.setattr(os, "geteuid", lambda: stubbed_uid)
+
+        try:
+            with pytest.raises(PermissionError, match="owned by uid"):
+                ensure_runtime_dir()
+        finally:
+            tempfile.tempdir = None  # reset cache for subsequent tests
+
+    def test_refuses_non_directory(self, tmp_path, monkeypatch):
+        """A regular file where we expected a directory — unlikely but
+        the validator should refuse rather than try to ``mkdir`` over
+        it (which would ``FileExistsError`` anyway, just less clearly)."""
+        xdg = _make_safe_xdg(tmp_path)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+        (xdg / "memtomem").write_text("accidentally a file")
+
+        with pytest.raises(PermissionError, match="not a directory"):
+            ensure_runtime_dir()
 
 
 class TestServerPidPath:
     def test_resolves_to_runtime_dir_server_pid(self, tmp_path, monkeypatch):
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
 
         assert server_pid_path() == xdg / "memtomem" / "server.pid"
 
     def test_does_not_create_parent(self, tmp_path, monkeypatch):
-        xdg = tmp_path / "xdg"
-        xdg.mkdir()
+        xdg = _make_safe_xdg(tmp_path)
         monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
 
         server_pid_path()

--- a/packages/memtomem/tests/test_runtime_paths.py
+++ b/packages/memtomem/tests/test_runtime_paths.py
@@ -1,0 +1,141 @@
+"""Tests for :mod:`memtomem._runtime_paths` (#412).
+
+Runtime files (pid, flock) resolve to ``$XDG_RUNTIME_DIR/memtomem`` when
+the platform provides one, and a per-user temp subdir otherwise. The
+resolver is side-effect free — ``runtime_dir()`` must NOT create the
+directory; ``ensure_runtime_dir()`` is the explicit opt-in.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from memtomem._runtime_paths import (
+    ensure_runtime_dir,
+    legacy_server_pid_path,
+    runtime_dir,
+    server_pid_path,
+)
+
+
+class TestRuntimeDir:
+    def test_uses_xdg_runtime_dir_when_set(self, tmp_path, monkeypatch):
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        assert runtime_dir() == xdg / "memtomem"
+
+    def test_does_not_create_directory(self, tmp_path, monkeypatch):
+        """Plain ``runtime_dir()`` must be a pure path resolver. Inventory
+        walks rely on it to probe for ``server.pid`` without leaving an
+        empty subdir behind on machines where the runtime path doesn't
+        exist yet."""
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        result = runtime_dir()
+        assert not result.exists(), "runtime_dir() must not mkdir"
+
+    def test_falls_back_to_tempdir_when_xdg_unset(self, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+        result = runtime_dir()
+
+        assert result.parent == Path(tempfile.gettempdir())
+        assert result.name.startswith("memtomem-")
+
+    def test_falls_back_when_xdg_points_at_nonexistent_dir(self, tmp_path, monkeypatch):
+        """A user who exports ``XDG_RUNTIME_DIR`` but whose shell never
+        materialized it (some remote-ssh configs) must still get a
+        working path, not a mkdir against a non-existent parent."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "does-not-exist"))
+
+        result = runtime_dir()
+
+        assert result.parent == Path(tempfile.gettempdir())
+
+
+class TestEnsureRuntimeDir:
+    def test_creates_directory_with_owner_only_mode(self, tmp_path, monkeypatch):
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        d = ensure_runtime_dir()
+
+        assert d.exists() and d.is_dir()
+        # mode & 0o777 masks off file-type bits
+        assert stat.S_IMODE(d.stat().st_mode) == 0o700
+
+    def test_idempotent_does_not_fail_on_existing_dir(self, tmp_path, monkeypatch):
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        ensure_runtime_dir()
+        # Second call must not raise FileExistsError.
+        ensure_runtime_dir()
+
+    def test_does_not_chmod_existing_dir(self, tmp_path, monkeypatch):
+        """A pre-existing dir (maybe created by ``root`` via ``sudo``)
+        keeps its own permissions — we never silently downgrade."""
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        (xdg / "memtomem").mkdir(mode=0o755)
+
+        d = ensure_runtime_dir()
+
+        assert stat.S_IMODE(d.stat().st_mode) == 0o755
+
+
+class TestServerPidPath:
+    def test_resolves_to_runtime_dir_server_pid(self, tmp_path, monkeypatch):
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        assert server_pid_path() == xdg / "memtomem" / "server.pid"
+
+    def test_does_not_create_parent(self, tmp_path, monkeypatch):
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        server_pid_path()
+
+        assert not (xdg / "memtomem").exists(), (
+            "server_pid_path() is a path resolver; use ensure_runtime_dir() "
+            "explicitly when opening the file"
+        )
+
+
+class TestLegacyServerPidPath:
+    def test_evaluates_home_lazily(self, tmp_path, monkeypatch):
+        """Import-time ``Path.home()`` would capture the developer's
+        real home and leak across fixtures; the function must re-read
+        ``$HOME`` every call."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        assert legacy_server_pid_path() == tmp_path / ".memtomem" / ".server.pid"
+
+
+@pytest.mark.skipif(not hasattr(os, "geteuid"), reason="uid fallback only meaningful on POSIX")
+class TestUidFallback:
+    def test_fallback_dir_contains_effective_uid(self, monkeypatch):
+        """On systems without ``$XDG_RUNTIME_DIR``, the dir name
+        includes ``geteuid()`` so a shared ``/tmp`` doesn't silently
+        collide between users."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+        result = runtime_dir()
+
+        assert result.name == f"memtomem-{os.geteuid()}"

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -68,6 +68,48 @@ def test_sigterm_handler_unlinks_pid_file_and_hard_exits(
 # ── integration ──────────────────────────────────────────────────────
 
 
+def _spawn_server(env: dict[str, str]) -> subprocess.Popen:
+    """Start ``memtomem-server`` as a subprocess that keeps its stdin
+    open — without that, the MCP stdio loop sees EOF immediately and
+    exits via the normal path, defeating any SIGTERM / lifecycle check."""
+    return subprocess.Popen(
+        [sys.executable, "-m", "memtomem.server"],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _wait_for_pid_file(proc: subprocess.Popen, pid_file: Path, *, timeout: float = 10.0) -> None:
+    """Poll until ``pid_file`` materialises or fail with the server's stderr."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and not pid_file.exists():
+        if proc.poll() is not None:
+            stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+            pytest.fail(
+                f"Server died before writing pid file (rc={proc.returncode}). stderr:\n{stderr}"
+            )
+        time.sleep(0.1)
+    if not pid_file.exists():
+        stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+        pytest.fail(f"pid file did not appear within {timeout}s. stderr:\n{stderr}")
+
+
+def _cleanup_proc(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.kill()
+        proc.wait(timeout=5)
+    # Python's Popen leaves these open if we don't close explicitly when
+    # the test path bails early; closing here is idempotent.
+    for stream in (proc.stdin, proc.stdout, proc.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+
 @pytest.mark.skipif(
     sys.platform == "win32", reason="SIGTERM semantics differ on Windows; server is POSIX-only"
 )
@@ -79,44 +121,32 @@ def test_sigterm_unlinks_pid_file_end_to_end(tmp_path: Path) -> None:
     point of #387 is the observable behavior on a live process, not the
     handler shape in isolation.
 
-    Isolation: ``HOME`` + ``XDG_RUNTIME_DIR`` both point under
-    ``tmp_path`` so the server writes to
-    ``tmp_path/xdg_runtime/memtomem/server.pid`` (see #412).
+    Also pins the #412 headline claim: with a fresh ``HOME`` (no
+    pre-existing ``~/.memtomem/``), the server handshake must not
+    create the state directory. The pid / flock write now lives on
+    ``$XDG_RUNTIME_DIR/memtomem/server.pid``, so the persistent data
+    root stays untouched until a tool call writes to it.
     """
     home = tmp_path / "home"
     home.mkdir()
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
+    os.chmod(xdg, 0o700)  # _runtime_paths validator requires owner-only
     pid_file = xdg / "memtomem" / "server.pid"
 
     env = os.environ.copy()
     env["HOME"] = str(home)
     env["XDG_RUNTIME_DIR"] = str(xdg)
 
-    # ``stdin=subprocess.PIPE`` (kept open) makes the stdio MCP loop block on
-    # the JSON-RPC read — without this the server sees EOF immediately and
-    # exits cleanly via the normal path, defeating the SIGTERM check.
-    proc = subprocess.Popen(
-        [sys.executable, "-m", "memtomem.server"],
-        env=env,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    proc = _spawn_server(env)
     try:
-        # Wait for the server to register its pid file. 10 s budget covers
-        # cold imports (sqlite_vec, embedder factory, etc.) on slow CI hosts.
-        deadline = time.monotonic() + 10
-        while time.monotonic() < deadline and not pid_file.exists():
-            if proc.poll() is not None:
-                stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
-                pytest.fail(
-                    f"Server died before writing pid file (rc={proc.returncode}). stderr:\n{stderr}"
-                )
-            time.sleep(0.1)
-        if not pid_file.exists():
-            stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
-            pytest.fail(f"pid file did not appear within 10s. stderr:\n{stderr}")
+        _wait_for_pid_file(proc, pid_file)
+
+        # Headline claim for #412: the handshake must leave HOME alone.
+        assert not (home / ".memtomem").exists(), (
+            "~/.memtomem/ must not be created by MCP handshake (#412 goal); "
+            "the server only writes to $XDG_RUNTIME_DIR/memtomem/"
+        )
 
         proc.send_signal(signal.SIGTERM)
         try:
@@ -129,14 +159,99 @@ def test_sigterm_unlinks_pid_file_end_to_end(tmp_path: Path) -> None:
             f"{pid_file.read_text() if pid_file.exists() else '<missing>'}"
         )
     finally:
-        if proc.poll() is None:
-            proc.kill()
-            proc.wait(timeout=5)
-        # Python's Popen leaves these open if we don't close explicitly when
-        # the test path bails early; closing here is idempotent.
-        for stream in (proc.stdin, proc.stdout, proc.stderr):
-            if stream is not None:
-                try:
-                    stream.close()
-                except Exception:
-                    pass
+        _cleanup_proc(proc)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+def test_server_uses_tempdir_fallback_when_xdg_unset(tmp_path: Path) -> None:
+    """With ``$XDG_RUNTIME_DIR`` unset the server must land on the
+    ``{tempfile.gettempdir()}/memtomem-{uid}/`` fallback, not silently
+    refuse to start or write somewhere unexpected.
+
+    Covers the code path that the default sigterm test skips (XDG set).
+    Uses an isolated ``TMPDIR`` under ``tmp_path`` so we don't litter
+    the real ``/var/folders/.../T/`` during the run.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    tmp_tmp = tmp_path / "tmp"
+    tmp_tmp.mkdir()
+    expected_dir = tmp_tmp / f"memtomem-{os.geteuid()}"
+    expected_pid = expected_dir / "server.pid"
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["TMPDIR"] = str(tmp_tmp)
+    env.pop("XDG_RUNTIME_DIR", None)
+
+    proc = _spawn_server(env)
+    try:
+        _wait_for_pid_file(proc, expected_pid)
+        assert stat_mode(expected_dir) == 0o700, (
+            "tempdir fallback must create the subdir at owner-only mode"
+        )
+        assert not (home / ".memtomem").exists()
+    finally:
+        _cleanup_proc(proc)
+        proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+def test_server_refuses_when_legacy_lock_held(tmp_path: Path) -> None:
+    """B1 regression (PR #413 review): a pre-#412 server holding
+    ``~/.memtomem/.server.pid`` must block a post-#412 server from
+    starting, or two writers would race on the same DB.
+
+    We simulate the old server by holding ``fcntl.flock`` on the legacy
+    path from the test process, then spawn the new server and assert it
+    exits non-zero with a message pointing at the legacy pid file.
+    """
+    import fcntl as _fcntl
+
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".memtomem").mkdir()
+    legacy_pid = home / ".memtomem" / ".server.pid"
+    legacy_pid.touch()
+
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
+
+    holder = open(legacy_pid, "a+b")  # noqa: SIM115 — held for test scope
+    try:
+        _fcntl.flock(holder, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        proc = _spawn_server(env)
+        try:
+            try:
+                rc = proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                pytest.fail(
+                    "Server did not exit within 15s despite legacy flock held — "
+                    "_try_hold_legacy_flock probably missing"
+                )
+            stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+            assert rc != 0, (
+                f"server must exit non-zero when legacy flock is held; rc={rc} stderr={stderr!r}"
+            )
+            assert str(legacy_pid) in stderr, (
+                f"error message must point at the legacy pid file; stderr={stderr!r}"
+            )
+        finally:
+            _cleanup_proc(proc)
+    finally:
+        try:
+            _fcntl.flock(holder, _fcntl.LOCK_UN)
+        except OSError:
+            pass
+        holder.close()
+
+
+def stat_mode(path: Path) -> int:
+    import stat as _stat
+
+    return _stat.S_IMODE(path.stat().st_mode)

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -79,16 +79,19 @@ def test_sigterm_unlinks_pid_file_end_to_end(tmp_path: Path) -> None:
     point of #387 is the observable behavior on a live process, not the
     handler shape in isolation.
 
-    Isolation: ``HOME`` points at ``tmp_path`` so the server uses
-    ``tmp_path/.memtomem/`` for the pid file (matches the
-    ``Path("~/.memtomem")`` resolution in ``main()``).
+    Isolation: ``HOME`` + ``XDG_RUNTIME_DIR`` both point under
+    ``tmp_path`` so the server writes to
+    ``tmp_path/xdg_runtime/memtomem/server.pid`` (see #412).
     """
     home = tmp_path / "home"
     home.mkdir()
-    pid_file = home / ".memtomem" / ".server.pid"
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
+    pid_file = xdg / "memtomem" / "server.pid"
 
     env = os.environ.copy()
     env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
 
     # ``stdin=subprocess.PIPE`` (kept open) makes the stdio MCP loop block on
     # the JSON-RPC read — without this the server sees EOF immediately and

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -63,6 +63,7 @@ def home(tmp_path, monkeypatch):
     h.mkdir()
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
+    os.chmod(xdg, 0o700)  # _runtime_paths validator requires owner-only
     monkeypatch.setenv("HOME", str(h))
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
     monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", h / ".memtomem" / "config.json")
@@ -423,6 +424,31 @@ class TestRuntimePidCleanedWithOther:
         assert not pid_file.exists(), "runtime pid file must be deleted"
         # subdir should be gone too — we own it
         assert not runtime_dir().exists(), "empty runtime subdir must be pruned"
+
+    def test_runtime_subdir_preserved_when_unrelated_files_present(self, home):
+        """Pin the empty-check precondition on the ``rmdir`` call so a
+        future condition invert (``not any(iterdir())`` → ``any(...)``)
+        wouldn't silently wipe unrelated files someone else parked in
+        the runtime subdir. ``mm uninstall`` is scoped; other memtomem
+        entry points (or a future #384 expansion) may legitimately
+        register more pid files in the same dir."""
+        from memtomem._runtime_paths import ensure_runtime_dir, runtime_dir
+
+        _seed_state(home)
+        rt = ensure_runtime_dir()
+        # Our own pid file is cleaned, but a sibling registered by
+        # another memtomem tool must survive.
+        (rt / "server.pid").write_text("0", encoding="utf-8")
+        sibling = rt / "someone-elses.pid"
+        sibling.write_text("42", encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+
+        assert result.exit_code == 0, result.output
+        # server.pid must be gone; sibling must remain; subdir must NOT rmdir.
+        assert not (rt / "server.pid").exists()
+        assert sibling.exists(), "unrelated file in runtime subdir must survive"
+        assert runtime_dir().exists(), "runtime subdir must not be pruned when other files remain"
 
 
 # -------------------------------------------------------------------- 13

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -51,13 +51,20 @@ def home(tmp_path, monkeypatch):
     at import time, so ``monkeypatch.setenv("HOME")`` alone leaves it
     pointing at the developer's real home. Patching it directly is
     required for hermetic tests.
+
+    Also isolates ``$XDG_RUNTIME_DIR`` so the new runtime pid file
+    location (#412) lives under ``tmp_path`` rather than the developer's
+    real ``/run/user/{uid}/memtomem/`` or a shared ``/tmp`` subdir.
     """
     from memtomem.cli import _bootstrap
     from memtomem.cli import uninstall_cmd
 
     h = tmp_path / "home"
     h.mkdir()
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
     monkeypatch.setenv("HOME", str(h))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
     monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", h / ".memtomem" / "config.json")
     monkeypatch.setattr(uninstall_cmd, "_DEFAULT_STATE_DIR", h / ".memtomem")
     return h
@@ -314,7 +321,10 @@ class TestRuntimeProfileImportPin:
 
 
 class TestServerAliveRefuses:
-    def test_refuses_when_server_alive(self, home):
+    def test_refuses_when_server_alive_at_legacy_path(self, home):
+        """Pre-#412 servers still write ``~/.memtomem/.server.pid``. The
+        mixed-version upgrade path (old server running, new uninstall)
+        must still refuse — the flock probe checks both locations."""
         state = _seed_state(home)
         pid_file = state / ".server.pid"
         # The PID inside the file is just for the user-facing message now;
@@ -330,6 +340,24 @@ class TestServerAliveRefuses:
         # nothing deleted
         assert (state / "memtomem.db").exists()
         assert (state / "config.json").exists()
+
+    def test_refuses_when_server_alive_at_runtime_path(self, home):
+        """Post-#412 servers hold the flock at
+        ``$XDG_RUNTIME_DIR/memtomem/server.pid``. The probe must see it
+        even though the pid file lives outside ``~/.memtomem/``."""
+        from memtomem._runtime_paths import ensure_runtime_dir
+
+        _seed_state(home)
+        pid_file = ensure_runtime_dir() / "server.pid"
+        pid_file.write_text(str(os.getpid()), encoding="utf-8")
+
+        with _hold_pid_lock(pid_file):
+            result = CliRunner().invoke(cli, ["uninstall", "-y"])
+
+        assert result.exit_code == 2
+        assert "Server still running" in result.output
+        assert str(os.getpid()) in result.output
+        assert (home / ".memtomem" / "memtomem.db").exists()
 
     def test_force_overrides_liveness(self, home):
         state = _seed_state(home)
@@ -359,6 +387,42 @@ class TestPidRecyclingDoesNotFalsePositive:
         assert result.exit_code == 0, result.output
         assert "Server still running" not in result.output
         assert not state.exists()
+
+    def test_runtime_pid_alive_but_no_lock_means_dead(self, home):
+        """Same as above at the new runtime location — a stale
+        ``server.pid`` with a recycled live PID but no flock holder must
+        not refuse the uninstall."""
+        from memtomem._runtime_paths import ensure_runtime_dir
+
+        _seed_state(home)
+        (ensure_runtime_dir() / "server.pid").write_text(str(os.getpid()), encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+
+        assert result.exit_code == 0, result.output
+        assert "Server still running" not in result.output
+        assert not (home / ".memtomem").exists()
+
+
+class TestRuntimePidCleanedWithOther:
+    """The runtime pid file lives outside ``~/.memtomem/`` but is still
+    transient server state — uninstall must clean it up so a reinstall
+    starts fresh. The runtime subdir is rmdir'd if we empty it."""
+
+    def test_runtime_pid_deleted_and_subdir_pruned(self, home):
+        from memtomem._runtime_paths import ensure_runtime_dir, runtime_dir
+
+        _seed_state(home)
+        rt = ensure_runtime_dir()
+        pid_file = rt / "server.pid"
+        pid_file.write_text("0", encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+
+        assert result.exit_code == 0, result.output
+        assert not pid_file.exists(), "runtime pid file must be deleted"
+        # subdir should be gone too — we own it
+        assert not runtime_dir().exists(), "empty runtime subdir must be pruned"
 
 
 # -------------------------------------------------------------------- 13


### PR DESCRIPTION
## Summary

- Relocate `memtomem-server`'s pid / flock file from
  `~/.memtomem/.server.pid` to `$XDG_RUNTIME_DIR/memtomem/server.pid`
  (with per-user `$TMPDIR/memtomem-$UID/` fallback on macOS / BSD /
  non-systemd Linux).
- Combined with #399 Phase 3's lazy DB creation, an idle MCP handshake
  against a fresh machine now leaves `~/.memtomem/` untouched entirely
  — the last write that forced the dir into existence is gone.
- `mm uninstall` probes both the new and legacy locations during the
  transition window so mixed-version upgrades (pre-#412 server still
  running + new CLI) still refuse correctly.

## Details

New helper `memtomem._runtime_paths`:

- `runtime_dir()` — pure path resolver (no mkdir). Checks
  `$XDG_RUNTIME_DIR`; falls back to `tempfile.gettempdir()/memtomem-$UID`.
- `ensure_runtime_dir()` — explicit opt-in that creates the dir with
  `mode=0o700`. Never re-`chmod`s an existing dir (a `root`-owned
  leftover surfaces via the caller's `open()` rather than silently
  adjusted).
- `server_pid_path()` / `legacy_server_pid_path()` — typed handles for
  the two probe targets.

`server/__init__.py:main` now calls `ensure_runtime_dir() / "server.pid"`
instead of `Path("~/.memtomem").expanduser().mkdir(...) / ".server.pid"`.

`cli/uninstall_cmd.py`:

- `_check_server_liveness` walks `(server_pid_path(), legacy_server_pid_path())`
  and returns `alive=True` for the first flock holder.
- The new runtime pid file is included in the "Other" inventory group
  so it is cleaned alongside `.current_session` + legacy `.server.pid`.
- If the cleanup empties the runtime subdir, it is `rmdir`'d (we own
  the subdir; the XDG parent is kernel-managed and never touched).

## Non-goals

- Does not extend the liveness probe to other DB writers (`mm web`,
  `mm watchdog`) — that is #384 and needs per-process lock
  registration of its own. The new runtime dir is the right *place*
  for those future lock files; adding them is a separate PR.
- `.current_session` stays in `~/.memtomem/`. That is persistent
  session state across reboots, not runtime ephemera.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 2191
      passed, 0 regressions.
- [x] New `test_runtime_paths.py` covers XDG set / unset / stale,
      0o700 creation, idempotency, uid suffix on fallback.
- [x] `test_uninstall_cmd.py` now covers refusal at both the new and
      legacy flock locations, PID recycling at both locations, and
      runtime-subdir cleanup.
- [x] `test_server_sigterm.py` integration test spawns a real
      `memtomem-server` with isolated `$HOME` + `$XDG_RUNTIME_DIR` and
      verifies SIGTERM cleanup at the new location.
- [x] `uv run ruff check` + `uv run ruff format --check` — clean.
- [x] `uv run mypy` advisory on the three changed source files — clean.
- [x] Manual smoke: `memtomem-server` writes and cleans up
      `server.pid` at the new location on macOS; `~/.memtomem/` is not
      created.

Closes #412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
