### PR TITLE
fix(server): mem_embedding_reset revert_to_stored no longer raises on AppContext properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mem_embedding_reset(mode="revert_to_stored")` no longer raises
+  `AttributeError` on the recovery path.** #399 Phase 1 made `embedder`,
+  `search_pipeline`, and `index_engine` read-only `@property`s on
+  `AppContext`, but `_revert_to_stored` kept writing to them directly.
+  Any user hitting the degraded-mode "revert to stored" recovery flow
+  would see `AttributeError: property 'embedder' of 'AppContext' object
+  has no setter` — the exact scenario the tool exists to handle. The
+  writes now mutate `app._components` fields directly (the underlying
+  dataclass is still mutable by design), and a new end-to-end test
+  pins all three runtime slots as swapped, not just `embedder`. (#409)
+
 - **`mm init -y` refuses to write `config.json` when required extras are missing.**
   Previously `-y` accepted `--provider onnx|ollama|openai` and
   `--tokenizer kiwipiepy` without checking whether the corresponding Python

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -250,10 +250,21 @@ def _revert_to_stored(app: AppContext) -> str:
     config.embedding.model = stored["model"]
     config.embedding.dimension = stored["dimension"]
 
+    # ``app.embedder`` / ``app.search_pipeline`` / ``app.index_engine`` are
+    # read-only properties that proxy to ``app._components.<name>`` (#399
+    # Phase 1). Direct assignment would raise ``AttributeError``. The
+    # ``Components`` dataclass is mutable, so we swap fields on the inner
+    # container and the properties pick up the new values automatically.
+    # ``app.storage`` above already dereferenced ``_components``, so the
+    # container is guaranteed non-None by the time we reach here.
+    comp = app._components
+    assert comp is not None, (
+        "_revert_to_stored called before ensure_initialized — "
+        "handler must go through _get_app_initialized"
+    )
     new_embedder = create_embedder(config.embedding)
-    app.embedder = new_embedder
-
-    app.search_pipeline = SearchPipeline(
+    comp.embedder = new_embedder
+    comp.search_pipeline = SearchPipeline(
         storage=storage,
         embedder=new_embedder,
         config=config.search,
@@ -263,7 +274,7 @@ def _revert_to_stored(app: AppContext) -> str:
         context_window_config=config.context_window,
         llm_provider=app.llm_provider,
     )
-    app.index_engine = IndexEngine(
+    comp.index_engine = IndexEngine(
         storage=storage,
         embedder=new_embedder,
         config=config.indexing,

--- a/packages/memtomem/tests/test_server_degraded_mode.py
+++ b/packages/memtomem/tests/test_server_degraded_mode.py
@@ -208,3 +208,45 @@ async def test_mem_embedding_reset_apply_current_repairs_mismatch(degraded_compo
     assert "Embedding mismatch detected" not in message
     assert add_stats is not None
     assert add_stats.indexed_chunks >= 1
+
+
+async def test_mem_embedding_reset_revert_to_stored_swaps_runtime(degraded_components):
+    """Regression for #409: ``revert_to_stored`` mutates ``app._components``
+    fields directly (not the read-only ``AppContext`` properties introduced
+    by #399 Phase 1). Pre-fix this path raised
+    ``AttributeError: property 'embedder' of 'AppContext' object has no setter``
+    the moment it ran, defeating the whole recovery flow.
+
+    The degraded fixture pins stored=none/dim=0, configured=onnx/bge-m3/1024,
+    so reverting downgrades the runtime to a ``NoopEmbedder`` and clears
+    the mismatch. We verify the three runtime slots actually got swapped,
+    not just ``embedder`` — a partial fix that touched only ``embedder``
+    would leave ``search_pipeline`` / ``index_engine`` holding stale
+    references to the configured embedder.
+    """
+    app = _make_app(degraded_components)
+    ctx = _StubCtx(app)
+    pre_embedder = app.embedder
+    pre_search = app.search_pipeline
+    pre_index = app.index_engine
+
+    reset_out = await mem_embedding_reset(mode="revert_to_stored", ctx=ctx)  # type: ignore[arg-type]
+
+    assert "Reverted to stored DB settings" in reset_out
+    assert "none/" in reset_out  # stored provider was "none"
+    assert "0d" in reset_out  # stored dimension was 0
+
+    # All three runtime slots swapped. Identity check is the right assertion:
+    # construction creates a new instance, so the post object is a different
+    # Python object than the pre. Anything narrower (e.g. "dimension == 0")
+    # would silently pass if only ``embedder`` was touched and the pipelines
+    # kept pointing at the old one.
+    assert app.embedder is not pre_embedder
+    assert app.search_pipeline is not pre_search
+    assert app.index_engine is not pre_index
+
+    # Stored-side settings are now reflected in config + live storage view.
+    assert app.config.embedding.provider == "none"
+    assert app.config.embedding.dimension == 0
+    assert app.storage.embedding_mismatch is None
+    assert "DEGRADED" not in await mem_stats(ctx=ctx)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- `_revert_to_stored` in `server/tools/status_config.py` wrote to
  `app.embedder` / `app.search_pipeline` / `app.index_engine` — which
  #399 Phase 1 (7855042) turned into read-only `@property`s on
  `AppContext`. Any user reaching the degraded-mode "revert to stored"
  recovery path saw `AttributeError: property '...' of 'AppContext'
  object has no setter`.
- Fix mutates `app._components` fields directly (the underlying
  `Components` dataclass is still mutable by design), so the three
  properties pick up the new values on next access.
- Adds an end-to-end test that pins **all three** runtime slots as
  swapped — a partial fix that only touched `embedder` would leave
  `search_pipeline` / `index_engine` holding stale references, which
  is exactly what the original buggy surface would have done if `mypy`
  hadn't flagged the writes.

## Why it escaped CI

1. `mypy` is advisory in this repo (per `CLAUDE.md`), so the three
   `[misc]` errors on the writes ("property '...' is read-only") were
   noise the Phase 1 PR reviewer saw but did not block on.
2. Existing `mem_embedding_reset` coverage exercised only
   `mode="apply_current"`. The `revert_to_stored` branch had no
   integration test — the new `test_mem_embedding_reset_revert_to_stored_swaps_runtime`
   closes that gap.

## Followup to consider (not in this PR)

The broader lesson is that advisory `mypy [misc]` / `[call-arg]` /
`[arg-type]` inside `except Exception` (or, here, inside a rarely-hit
recovery path) is a higher-signal than usual flag — this is the second
time the pattern has shown up (see `feedback_mypy_advisory_runtime_bugs.md`
from #114). A short "scan advisory mypy for runtime bugs on recovery /
error paths" pass at release-cut time would catch these without
promoting `mypy` to a blocker. Worth a triage memo rather than a code
change.

## Test plan

- [x] New test `test_mem_embedding_reset_revert_to_stored_swaps_runtime`
      invokes the tool end-to-end on the existing `degraded_components`
      fixture (stored=none/dim=0, configured=onnx/bge-m3/1024) and
      verifies: return message, config mutation, `embedding_mismatch`
      clearing, `DEGRADED` removal from `mem_stats`, **identity
      change on all three runtime slots**.
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 2178
      passed, 0 regressions.
- [x] `uv run ruff check` + `ruff format --check` — clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/server/tools/status_config.py`
      — `Success: no issues found` (the three `[misc]` errors the issue
      cited are gone).

Closes #409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
