### PR TITLE
docs: replace side-effectful verify command with `mm --version` (#381)

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -385,9 +385,9 @@ uv pip install -e "packages/memtomem[all]"  # Source
 1. Restart your editor after configuring MCP
 2. Check that `memtomem-server` (not `memtomem`) is in your MCP config
 3. Verify install: `uvx --from memtomem mm --version` should print the memtomem
-   version (`mm` and `memtomem-server` ship from the same package — running
-   `memtomem-server` bare is not a useful check because it expects JSON-RPC
-   on stdin, so a TTY emits noisy `Invalid JSON` errors)
+   version. (`mm` and `memtomem-server` ship from the same package. Running
+   `memtomem-server` bare isn't a useful check — it expects JSON-RPC on stdin,
+   so a TTY emits noisy `Invalid JSON` errors.)
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -384,7 +384,10 @@ uv pip install -e "packages/memtomem[all]"  # Source
 
 1. Restart your editor after configuring MCP
 2. Check that `memtomem-server` (not `memtomem`) is in your MCP config
-3. Verify: `uvx --from memtomem memtomem-server` should start without errors
+3. Verify install: `uvx --from memtomem mm --version` should print the memtomem
+   version (`mm` and `memtomem-server` ship from the same package — running
+   `memtomem-server` bare is not a useful check because it expects JSON-RPC
+   on stdin, so a TTY emits noisy `Invalid JSON` errors)
 
 ---
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -341,7 +341,10 @@ ollama pull bge-m3
 
 1. **Restart your editor** after changing MCP configuration
 2. Check that you used `memtomem-server` (not `memtomem`) in your config
-3. Test the server manually: `uvx --from memtomem memtomem-server` — should start without errors
+3. Verify install: `uvx --from memtomem mm --version` should print the
+   memtomem version (`mm` and `memtomem-server` ship from the same package —
+   running `memtomem-server` bare is not a useful check because it expects
+   JSON-RPC on stdin, so a TTY emits noisy `Invalid JSON` errors)
 
 ### "Connection refused" or timeout
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -342,9 +342,9 @@ ollama pull bge-m3
 1. **Restart your editor** after changing MCP configuration
 2. Check that you used `memtomem-server` (not `memtomem`) in your config
 3. Verify install: `uvx --from memtomem mm --version` should print the
-   memtomem version (`mm` and `memtomem-server` ship from the same package —
-   running `memtomem-server` bare is not a useful check because it expects
-   JSON-RPC on stdin, so a TTY emits noisy `Invalid JSON` errors)
+   memtomem version. (`mm` and `memtomem-server` ship from the same package.
+   Running `memtomem-server` bare isn't a useful check — it expects JSON-RPC
+   on stdin, so a TTY emits noisy `Invalid JSON` errors.)
 
 ### "Connection refused" or timeout
 


### PR DESCRIPTION
## Summary

- Replace the `uvx --from memtomem memtomem-server` "verify install" step in two troubleshooting sections with `uvx --from memtomem mm --version`.
- Side-effect free and terminal-friendly: `mm --version` prints a single version line; `memtomem-server` speaks JSON-RPC on stdin and prints `ERROR ... Invalid JSON: EOF while parsing a value` when a TTY sends it prompt bytes, which is what a first-time user actually sees.
- Closes #381.

## Context

The troubleshooting step "Tools don't appear in my editor" told users to run `uvx --from memtomem memtomem-server` to confirm the install worked, promising it "should start without errors". In practice:

1. **TTY noise.** The server parses stdin expecting JSON-RPC messages. A bare `uvx --from memtomem memtomem-server` in a terminal has the shell and tty-line-discipline write stray bytes (a prompt, `\n`, etc.) to the process's stdin. The server rejects them as invalid JSON and logs `ERROR` lines. Users reading the docs see `ERROR` and reasonably conclude the install is broken, when in fact it's working correctly.
2. **Hidden side effects (historical).** Pre-#411 the server also ran `create_components()` on lifespan startup, which instantiated `~/.memtomem/memtomem.db` before the user ever ran `mm init`. That vector is now fixed by #411 (lazy DB init) + #413 (pid file relocated to `$XDG_RUNTIME_DIR`), but only in the next release; the current PyPI 0.1.24 still has the eager-init behavior, and even the fixed build doesn't address the TTY-noise part of #381.

`uvx --from memtomem mm --version` exercises the same `uvx` → package-resolution path (catching missing package, stale `uv` cache, wrong Python — the actual things the step was meant to diagnose), prints one clean version line, and touches no stdin / pid / DB. It's a strictly better diagnostic.

The parenthetical note preserves the step-2 guidance (config must name `memtomem-server`, not `memtomem`) by calling out that `mm` and `memtomem-server` ship from the same package, so a successful `mm --version` is sufficient evidence that the `memtomem-server` entry point resolves too.

## Test plan

- [x] Grep confirms only two verify-command occurrences (`getting-started.md:387`, `mcp-clients.md:344`); no other docs claim "should start without errors".
- [x] Local `uv run mm --version` prints `memtomem 0.1.24`.
- [x] Render the updated troubleshooting section visually — bullet structure preserved, parenthetical reads cleanly on a narrow viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
