### PR TITLE
feat(cli): add `mm status` to mirror the MCP `mem_status` tool (#382)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm status` CLI command — terminal mirror of the MCP `mem_status` tool.**
+  Closes the gap noted in #382: the README and Quick Start told first-time
+  users to "call the `mem_status` tool" to confirm a healthy install, but
+  there was no equivalent CLI command — only `mm config show` (config, not
+  runtime state) and `mm watchdog status` (periodic-check results). Users
+  with no editor open, or running a scripted post-install check, had no
+  one-liner that surfaced "is the DB reachable, what's indexed, is the
+  embedding config in sync." `mm status` is a thin wrapper that builds an
+  `AppContext` from `cli_components` and calls the same `format_status_report`
+  helper now shared by `mem_status`, so the CLI and MCP outputs are
+  identical. (#382)
+
 ### Changed
 
 - **`memtomem-server` pid / flock file moved to `$XDG_RUNTIME_DIR/memtomem/server.pid`.**

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ See [Embeddings](docs/guides/embeddings.md) for the full model/provider matrix.
 "Remember this insight"      →  mem_add(content="...", tags=["ops"])
 ```
 
+> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed.
+
 ### 4. Web UI (optional)
 
 ```bash

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -256,6 +256,11 @@ Call the mem_status tool
 
 You should see index statistics (0 chunks if nothing indexed yet).
 
+Or from a terminal — same output, no editor needed:
+```bash
+mm status
+```
+
 ---
 
 ## First use
@@ -327,6 +332,7 @@ mm recall --since 2026-04  # recall by date
 mm config show             # view settings
 mm config set key value    # change a setting
 mm config unset key        # drop a pinned override (e.g., mmr.enabled)
+mm status                  # show indexing stats + config (terminal mirror of mem_status)
 mm embedding-reset         # check/resolve embedding model mismatch
 mm reset                   # delete all data and reinitialize the DB
 mm context detect          # find agent config files

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -96,12 +96,25 @@ In Claude Code (or run `/memtomem:status` if using the plugin):
 Call the mem_status tool
 ```
 
-Example of a successful response:
+Example of a successful response (Ollama config; first 12 lines of the
+full report — the `Embedding` and `Dimension` rows change with the
+provider picked in the wizard):
+
 ```
-memtomem status:
-  - Storage backend: SQLite
-  - Total chunks: 0 (not yet indexed)
-  - Embedding model: ollama/nomic-embed-text
+memtomem Status
+==============
+Storage:   sqlite
+DB path:   ~/.memtomem/memtomem.db
+Embedding: ollama / nomic-embed-text
+Dimension: 768
+Top-K:     10
+RRF k:     60
+
+Index stats
+-----------
+Total chunks:  0
+Source files:  0
+...
 ```
 
 Or skip the editor and run the same check directly:

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -104,6 +104,15 @@ memtomem status:
   - Embedding model: ollama/nomic-embed-text
 ```
 
+Or skip the editor and run the same check directly:
+
+```bash
+mm status
+```
+
+`mm status` is a CLI mirror of `mem_status` (same output) — handy when
+the editor hasn't reconnected yet, or for scripted health checks.
+
 > **MCP Reconnection**: After changing `.mcp.json`, restart Claude Code or use the `/mcp` command to reconnect.
 
 ---

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -225,6 +225,19 @@ memtomem status:
   - Embedding model: none (BM25 keyword search only)
 ```
 
+### From a terminal — `mm status`
+
+If the editor isn't reachable yet (or you want to verify the install
+without involving any client), run the same check from a terminal:
+
+```bash
+mm status
+```
+
+`mm status` is a thin CLI wrapper over the same code path `mem_status`
+uses, so the output is identical. Useful as a sanity check between
+`mm init` and the first editor-side call.
+
 ### Available MCP Tools (74)
 
 | Category | Tools |

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -216,14 +216,32 @@ Ask the AI:
 Call the mem_status tool to show the current status
 ```
 
-Expected response example (keyword-only default — the embedding line
-changes depending on the provider picked in the wizard):
+Expected response (BM25 default — the `Embedding` and `Dimension`
+lines change depending on the provider picked in the wizard):
+
 ```
-memtomem status:
-  - Storage backend: SQLite
-  - Total chunks: 0 (not yet indexed)
-  - Embedding model: none (BM25 keyword search only)
+memtomem Status
+==============
+Storage:   sqlite
+DB path:   ~/.memtomem/memtomem.db
+Embedding: none /
+Dimension: 0
+Top-K:     10
+RRF k:     60
+
+Index stats
+-----------
+Total chunks:  0
+Source files:  0
+...
 ```
+
+The full report also includes an `Immutable fields` block (provider /
+model / tokenizer / backend echoed back as a "what can't be changed at
+runtime" reminder), and a `Warnings` block with stable schema keys
+(`kind` / `fix` / `doc` / `stored` / `configured`) when an embedding-
+dimension mismatch is detected. Run `mm status` from a terminal to see
+the exact output your install produces.
 
 ### From a terminal — `mm status`
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -48,6 +48,8 @@ Then in your AI editor, ask:
 "Remember this insight"      →  mem_add(content="...", tags=["ops"])
 ```
 
+> Prefer the terminal? `mm status` is a CLI mirror of `mem_status` — same output, no editor needed.
+
 That's it. Your agent now has a long-term memory built from plain markdown files.
 
 For full setup, OpenAI configuration, and troubleshooting, see the [Getting Started guide](https://github.com/memtomem/memtomem/blob/main/docs/guides/getting-started.md).

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -41,6 +41,7 @@ def _register() -> None:
     from memtomem.cli.init_cmd import init
     from memtomem.cli.session_cmd import activity, session
     from memtomem.cli.shell import shell
+    from memtomem.cli.status_cmd import status
     from memtomem.cli.uninstall_cmd import uninstall
     from memtomem.cli.watchdog_cmd import watchdog
     from memtomem.cli.web import web
@@ -58,6 +59,7 @@ def _register() -> None:
     cli.add_command(reset)
     cli.add_command(session)
     cli.add_command(activity)
+    cli.add_command(status)
     cli.add_command(watchdog)
     cli.add_command(web)
     cli.add_command(shell)

--- a/packages/memtomem/src/memtomem/cli/status_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/status_cmd.py
@@ -1,0 +1,36 @@
+"""CLI: mm status — terminal mirror of the MCP ``mem_status`` tool (#382)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+
+@click.command("status")
+def status() -> None:
+    """Show indexing statistics and current configuration summary.
+
+    Mirrors the MCP ``mem_status`` tool — same output, callable from a
+    terminal without an MCP client. Useful as a post-install sanity
+    check that the binary works, the config is readable, and the DB is
+    reachable, without having to run a search.
+    """
+    try:
+        asyncio.run(_status())
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+
+
+async def _status() -> None:
+    from memtomem.cli._bootstrap import cli_components
+    from memtomem.server.context import AppContext
+    from memtomem.server.tools.status_config import format_status_report
+
+    async with cli_components() as comp:
+        ctx = AppContext.from_components(comp)
+        output = await format_status_report(ctx)
+
+    click.echo(output)

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -62,36 +62,13 @@ async def mem_stats(
     return out
 
 
-@mcp.tool()
-@tool_handler
-async def mem_status(
-    ctx: CtxType = None,
-) -> str:
-    """Show indexing statistics and current configuration summary.
+async def format_status_report(app: AppContext) -> str:
+    """Render the status report shared by ``mem_status`` and ``mm status``.
 
-    Reports storage backend, embedding info, chunk/source counts, and
-    warns when orphaned source files are detected (files removed from
-    disk but still indexed — run mem_cleanup_orphans to fix).
-
-    When a configuration drift is detected (e.g. embedding dimension
-    mismatch between the DB and the runtime config) the output carries
-    a ``Warnings`` block whose entries follow this schema — kept stable
-    across versions so external consumers (uptime probes, dashboards)
-    can pattern-match on the keys:
-
-    ``kind``    open enum describing the warning. Current values:
-                ``embedding_dim_mismatch``. Future releases may add
-                ``stale_index``, ``orphan_vectors``, etc. — consumers
-                must tolerate unknown kinds rather than erroring.
-    ``fix``     the canonical CLI command a user should run.
-    ``doc``     a relative-path link into ``docs/guides/`` with the full
-                remediation flow (see ``configuration.md#reset-flow``).
-
-    Embedding-mismatch entries also include ``stored`` and ``configured``
-    sub-blocks echoing the DB vs runtime provider/model/dimension so the
-    user can see what changed without consulting another tool.
+    Kept as a free function so the CLI wrapper (#382) can reuse the exact
+    same formatting without going through MCP — both surface the same
+    text so users learn one output and can recognize it in either place.
     """
-    app = await _get_app_initialized(ctx)
     stats = await app.storage.get_stats()
     config = app.config
 
@@ -163,6 +140,39 @@ async def mem_status(
         lines.append("  doc:        docs/guides/configuration.md#reset-flow")
 
     return "\n".join(lines)
+
+
+@mcp.tool()
+@tool_handler
+async def mem_status(
+    ctx: CtxType = None,
+) -> str:
+    """Show indexing statistics and current configuration summary.
+
+    Reports storage backend, embedding info, chunk/source counts, and
+    warns when orphaned source files are detected (files removed from
+    disk but still indexed — run mem_cleanup_orphans to fix).
+
+    When a configuration drift is detected (e.g. embedding dimension
+    mismatch between the DB and the runtime config) the output carries
+    a ``Warnings`` block whose entries follow this schema — kept stable
+    across versions so external consumers (uptime probes, dashboards)
+    can pattern-match on the keys:
+
+    ``kind``    open enum describing the warning. Current values:
+                ``embedding_dim_mismatch``. Future releases may add
+                ``stale_index``, ``orphan_vectors``, etc. — consumers
+                must tolerate unknown kinds rather than erroring.
+    ``fix``     the canonical CLI command a user should run.
+    ``doc``     a relative-path link into ``docs/guides/`` with the full
+                remediation flow (see ``configuration.md#reset-flow``).
+
+    Embedding-mismatch entries also include ``stored`` and ``configured``
+    sub-blocks echoing the DB vs runtime provider/model/dimension so the
+    user can see what changed without consulting another tool.
+    """
+    app = await _get_app_initialized(ctx)
+    return await format_status_report(app)
 
 
 @mcp.tool()

--- a/packages/memtomem/tests/test_cli_status.py
+++ b/packages/memtomem/tests/test_cli_status.py
@@ -1,0 +1,155 @@
+"""Tests for ``mm status`` — terminal mirror of the MCP ``mem_status`` tool (#382)."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.config import Mem2MemConfig
+
+
+def _mock_components(
+    *,
+    total_chunks: int = 0,
+    total_sources: int = 0,
+    source_files: list[Path] | None = None,
+    stored_embedding_info: dict | None = None,
+    embedding_mismatch: dict | None = None,
+) -> SimpleNamespace:
+    """Build a minimal ``Components``-shaped mock for ``mm status`` tests.
+
+    ``AppContext.from_components`` reads ``config``, ``storage``, and
+    ``embedder`` off the container; ``format_status_report`` reads
+    ``app.storage.get_stats()`` / ``get_all_source_files()`` plus the two
+    optional ``stored_embedding_info`` / ``embedding_mismatch`` attributes.
+    A ``SimpleNamespace`` covers all of that without dragging in the real
+    ``Components`` dataclass (which would require building a SqliteBackend
+    and an embedder).
+    """
+    storage = SimpleNamespace(
+        get_stats=AsyncMock(
+            return_value={"total_chunks": total_chunks, "total_sources": total_sources}
+        ),
+        get_all_source_files=AsyncMock(return_value=list(source_files or [])),
+        stored_embedding_info=stored_embedding_info,
+        embedding_mismatch=embedding_mismatch,
+    )
+    return SimpleNamespace(
+        config=Mem2MemConfig(),
+        storage=storage,
+        embedder=SimpleNamespace(),
+    )
+
+
+def _patched_cli_components(comp: SimpleNamespace):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestStatusRegistration:
+    """``mm status`` is wired into the top-level CLI group."""
+
+    def test_status_in_top_level_help(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "status" in result.output
+
+    def test_status_help_describes_command(self, runner: CliRunner) -> None:
+        result = runner.invoke(cli, ["status", "--help"])
+        assert result.exit_code == 0
+        assert "indexing statistics" in result.output
+        # Cross-reference to mem_status so users learn the symmetry.
+        assert "mem_status" in result.output
+
+
+class TestStatusOutput:
+    """Happy-path rendering matches the MCP ``mem_status`` text shape."""
+
+    def test_basic_output_renders_all_sections(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(total_chunks=42, total_sources=7)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+
+        # Header + stats sections must appear so users recognize the same
+        # report they get from ``mem_status``.
+        assert "memtomem Status" in result.output
+        assert "Index stats" in result.output
+        assert "Total chunks:  42" in result.output
+        assert "Source files:  7" in result.output
+        assert "Immutable fields (set once at init)" in result.output
+
+    def test_orphan_count_appended_when_files_missing(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # 3 indexed sources, only 1 present on disk → 2 orphaned.
+        present = tmp_path / "present.md"
+        present.write_text("hi")
+        missing_a = tmp_path / "missing_a.md"
+        missing_b = tmp_path / "missing_b.md"
+        comp = _mock_components(
+            total_chunks=3,
+            total_sources=3,
+            source_files=[present, missing_a, missing_b],
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "2 orphaned" in result.output
+        assert "mem_cleanup_orphans" in result.output
+
+    def test_embedding_mismatch_warning_block_emitted(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(
+            embedding_mismatch={
+                "stored": {"provider": "ollama", "model": "bge-m3", "dimension": 1024},
+                "configured": {"provider": "ollama", "model": "nomic", "dimension": 768},
+            },
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        # Stable-schema keys monitoring probes / dashboards rely on.
+        assert "Warnings" in result.output
+        assert "kind:       embedding_dim_mismatch" in result.output
+        assert "fix:        uv run mm embedding-reset --mode apply-current" in result.output
+
+
+class TestStatusUnconfigured:
+    """Without a ``~/.memtomem/config.json`` the command should fail loudly,
+    not silently bootstrap a fresh DB. ``cli_components`` raises a
+    ``ClickException`` in that case; the wrapper must let it propagate."""
+
+    def test_missing_config_yields_clickexception(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Point the cached module-level config path at an empty tmp dir so
+        # the existence check fails deterministically.
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap._CONFIG_PATH", tmp_path / "no-such-config.json"
+        )
+
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code != 0
+        assert "not configured" in result.output
+        assert "mm init" in result.output

--- a/packages/memtomem/tests/test_cli_status.py
+++ b/packages/memtomem/tests/test_cli_status.py
@@ -129,10 +129,59 @@ class TestStatusOutput:
 
         result = runner.invoke(cli, ["status"])
         assert result.exit_code == 0, result.output
-        # Stable-schema keys monitoring probes / dashboards rely on.
+        # Pin the full ``Warnings`` block schema, not just `kind` / `fix` —
+        # the ``mem_status`` docstring advertises ``stored`` / ``configured``
+        # / ``doc`` as stable keys monitoring probes pattern-match on, so
+        # silent renames or dropped fields would break uptime dashboards
+        # without any test catching it.
         assert "Warnings" in result.output
         assert "kind:       embedding_dim_mismatch" in result.output
+        assert "stored:     ollama/bge-m3 (1024d)" in result.output
+        assert "configured: ollama/nomic (768d)" in result.output
         assert "fix:        uv run mm embedding-reset --mode apply-current" in result.output
+        assert "doc:        docs/guides/configuration.md#reset-flow" in result.output
+
+
+class TestStatusMcpParity:
+    """``mm status`` and the MCP ``mem_status`` tool must render identical text.
+
+    Both go through ``format_status_report`` today, but a future refactor
+    that wraps ``mem_status``'s response (e.g. JSON envelope, prefix line)
+    or that has the CLI ``.strip()`` the helper output would silently
+    diverge the two surfaces — and the README sells them as equivalent.
+    Cheap pin: invoke each path with the same mock components and compare
+    the rendered string.
+    """
+
+    def test_cli_output_matches_mem_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Sync test on purpose: the CLI spawns its own ``asyncio.run`` inside
+        # the click handler, so an ``async def`` test (asyncio AUTO mode)
+        # would nest event loops and fail with ``cannot be called from a
+        # running event loop``. Drive the MCP side with its own
+        # ``asyncio.run`` call instead.
+        import asyncio
+        from types import SimpleNamespace as NS
+
+        from memtomem.server.context import AppContext
+        from memtomem.server.tools.status_config import mem_status
+
+        comp = _mock_components(total_chunks=11, total_sources=4)
+
+        # MCP path: build a fake ``ctx`` whose ``request_context.lifespan_context``
+        # is the AppContext, then call ``mem_status`` directly. Same plumbing
+        # FastMCP uses at runtime; ``ensure_initialized`` is a no-op for
+        # ``from_components`` contexts (components already populated).
+        mcp_ctx = NS(request_context=NS(lifespan_context=AppContext.from_components(comp)))
+        mcp_text = asyncio.run(mem_status(mcp_ctx))
+
+        # CLI path: same mock components funneled through ``cli_components``.
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        runner = CliRunner()
+        cli_result = runner.invoke(cli, ["status"])
+        assert cli_result.exit_code == 0, cli_result.output
+
+        # ``click.echo`` appends a trailing newline; the MCP wrapper does not.
+        assert cli_result.output.rstrip("\n") == mcp_text
 
 
 class TestStatusUnconfigured:


### PR DESCRIPTION
## Summary

- Adds `mm status` — a CLI mirror of the MCP `mem_status` tool, with byte-identical output.
- Closes #382. Quick Start tells users to "call `mem_status` to confirm a healthy install" — there was no terminal equivalent. Now there is.
- Implementation is a thin wrapper: extract `format_status_report(app)` from `mem_status` into a free helper; both the MCP tool and the CLI command call it.

## Why this shape

The user-facing problem is teachability: the README sells `mem_status` as the verify primitive, but `mm --help` previously offered no `status` / `info` / `inventory` command. Users following the docs verbatim learned a tool name they couldn't run from a terminal. The fix is symmetry — same name pattern (`mem_status` ↔ `mm status`), same output, same code path.

Two implementation choices worth flagging:

1. **Extracted helper, not duplicated formatter.** The status block grew several incremental sections over time (orphan check, immutable fields, embedding-mismatch warning with stable schema keys for monitoring probes). Re-implementing those in the CLI would guarantee drift. Putting `format_status_report(app)` in `server/tools/status_config.py` keeps a single source — `mem_status` shrinks to 3 lines, `mm status` is a 30-line wrapper, both render the exact same string.
2. **CLI uses `cli_components` + `AppContext.from_components`.** Same path `mm watchdog` / `mm session` / `mm purge` already use, so behavior matches the rest of the CLI fleet (refuses with `mm init` hint when `~/.memtomem/config.json` doesn't exist, no background loops since `from_components` doesn't own them).

## What's in the PR

- `packages/memtomem/src/memtomem/server/tools/status_config.py` — extract `format_status_report(app)`; `mem_status` becomes a thin call.
- `packages/memtomem/src/memtomem/cli/status_cmd.py` — new `mm status` command.
- `packages/memtomem/src/memtomem/cli/__init__.py` — register.
- `packages/memtomem/tests/test_cli_status.py` — 6 tests (registration, help, happy-path render, orphan-count, embedding-mismatch warning schema, unconfigured-path `ClickException`).
- Docs (per `feedback_doc_update_process.md` — same PR for new CLI surface):
  - `README.md` + `packages/memtomem/README.md` — Quick Start "Use" block sibling line for `mm status`.
  - `docs/guides/getting-started.md` — Verify connection block adds `mm status`; CLI reference table adds the row.
  - `docs/guides/mcp-clients.md` — "Verifying Your Connection" gets a `From a terminal — mm status` subsection.
  - `docs/guides/integrations/claude-code.md` — Verify Connection adds the same terminal alternative.
- `CHANGELOG.md` — `[Unreleased]` gets an `### Added` entry.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_cli_status.py -v` — 6/6 pass.
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 2210 pass, 0 regressions.
- [x] `uv run ruff check packages/memtomem/src` and `ruff format --check` — clean.
- [x] Manual smoke: `uv run mm status` against a real `~/.memtomem/` config — renders the expected report.
- [x] Manual smoke: `uv run mm status --help` — docstring renders cleanly, cross-references `mem_status`.
- [ ] Reviewer: skim the docs diff for tone consistency across the four touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
