### PR TITLE
fix(init): "b" at Memory Directory navigates back to preset picker (#371)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mm init`: "b" (back) now works at step 3 in the default interactive
+  path.** The preset picker and its follow-up steps (memory dir, provider
+  dirs auto-detect, MCP config) used to run in two separate `run_steps`
+  calls, which made `_step_memory_dir` index 0 of the second call — so
+  hitting "b" at the "Memory Directory" prompt showed `(already at first
+  step)` and re-prompted the same step instead of returning to the preset
+  picker. The two calls are now combined into one: `_step_preset_picker`
+  applies the chosen preset inline and raises a new `_AdvancedSelected`
+  exception when the user picks Advanced, which the caller catches to
+  dispatch the full 10-step wizard. "b" from memory-dir decrements back
+  into the picker, and re-picking a different preset overwrites the
+  previously applied state cleanly (via the idempotent `_apply_preset`).
+  The explicit `--preset <name>` flag path is unchanged — there's no
+  picker to return to there. (#371)
+
 - **MCP `serverInfo.version` now reports the memtomem package version.**
   Previously `FastMCP.__init__` left the underlying `Server.version`
   at `None`, so the lowlevel server fell back to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   The explicit `--preset <name>` flag path is unchanged — there's no
   picker to return to there. (#371)
 
+- **`mm init` default-interactive CLI flag precedence is now "flag wins
+  over prompt", matching the documented behavior of
+  `_override_from_flags`.** The default path used to run the override
+  pass before the memory-dir / MCP prompts, so prompts silently
+  clobbered explicit flags: `mm init --memory-dir /x` (no `--preset`,
+  no `-y`) would apply `/x`, then immediately ask for a directory and
+  overwrite with whatever the user typed (usually the default
+  `~/memories`). The override pass now runs after the combined
+  `run_steps` on the preset branch, so flag values win — same rule that
+  already held for `--preset <name>` (path 2) and `-y` (non-interactive).
+  User-visible effect: `mm init --memory-dir /x` now respects `/x`
+  without requiring `--preset`. Advanced (`--advanced`) is unchanged —
+  advanced prompts per-field and has no baseline to override. (#371)
+
 - **MCP `serverInfo.version` now reports the memtomem package version.**
   Previously `FastMCP.__init__` left the underlying `Server.version`
   at `None`, so the lowlevel server fell back to

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2237,6 +2237,13 @@ def _apply_preset(state: dict, preset_name: str) -> None:
     state["model"] = spec.model
     state["dimension"] = spec.dimension
     state["api_key"] = ""
+    # Drop any stale rerank_model before reapplying — otherwise a
+    # re-pick from a rerank-enabled preset to a rerank-disabled one
+    # (#371 "b" navigation) leaves the old rerank_model string in
+    # state. Downstream readers gate on rerank_enabled first so the
+    # stale value is benign today, but the docstring promises a full
+    # preset-surface overwrite — honoring that avoids future surprises.
+    state.pop("rerank_model", None)
     state["rerank_enabled"] = spec.rerank_enabled
     if spec.rerank_enabled and spec.rerank_model is not None:
         state["rerank_model"] = spec.rerank_model

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -27,6 +27,19 @@ def _run(cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
     return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
 
+def _isatty() -> bool:
+    """Module-level indirection for ``sys.stdin.isatty()``.
+
+    Exists so tests can patch the default-interactive TTY gate without
+    fighting CliRunner's substituted ``sys.stdin`` (see
+    ``feedback_clirunner_isatty_seam.md``). Only the picker-path gate at
+    the bottom of :func:`init` routes through this; the other legacy
+    ``sys.stdin.isatty()`` call sites in this module each have their own
+    test paths.
+    """
+    return sys.stdin.isatty()
+
+
 def _ollama_available() -> bool:
     return shutil.which("ollama") is not None
 
@@ -2159,14 +2172,29 @@ def _write_mcp_json(server_cmd: str, server_args: list[str], mcp_env: dict[str, 
 # ── Preset quick-setup helpers ────────────────────────────────────────
 
 
+class _AdvancedSelected(Exception):
+    """Raised by ``_step_preset_picker`` when the user picks Advanced.
+
+    Breaks out of the combined preset ``run_steps`` so the caller can
+    dispatch the full 10-step wizard. See the default-interactive branch
+    in :func:`init`.
+    """
+
+
 def _step_preset_picker(state: dict) -> None:
     """First step of the default interactive path — pick a preset or Advanced.
 
     Writes ``state["_preset_choice"]`` = one of ``"minimal" | "english" |
-    "korean" | "advanced"``. The Advanced entry falls through to the full
-    10-step wizard; the other three bundle embedding/reranker/tokenizer/
-    namespace defaults via ``_apply_preset`` so the user only sees the
-    essential memory-dir and MCP questions afterwards.
+    "korean" | "advanced"``. The Advanced entry raises
+    :class:`_AdvancedSelected` so the caller can dispatch the full
+    10-step wizard; the other three apply the preset inline via
+    :func:`_apply_preset` so the rest of ``run_steps`` can continue with
+    ``_step_memory_dir``, ``_step_provider_dirs_auto``, and ``_step_mcp``
+    against fully populated state.
+
+    Re-entry via ``"b"`` from a later step is safe: :func:`_apply_preset`
+    overwrites the full preset surface, so re-picking a different preset
+    takes effect cleanly.
     """
     # First step — no prior step to return to, so only surface 'q: quit'.
     # 'b' still works (nav_prompt intercepts it before IntRange), but
@@ -2190,8 +2218,10 @@ def _step_preset_picker(state: dict) -> None:
 
     if choice == advanced_idx:
         state["_preset_choice"] = "advanced"
-    else:
-        state["_preset_choice"] = ordered[choice - 1]
+        raise _AdvancedSelected()
+
+    state["_preset_choice"] = ordered[choice - 1]
+    _apply_preset(state, state["_preset_choice"])
 
 
 def _apply_preset(state: dict, preset_name: str) -> None:
@@ -2598,13 +2628,26 @@ def init(
         run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)
     else:
         # Default interactive path: show the preset picker, dispatch on choice.
-        if not sys.stdin.isatty():
+        if not _isatty():
             raise click.UsageError("Non-interactive terminal detected. Pass --preset <name> or -y.")
-        run_steps([_step_preset_picker], state)
-        if state["_preset_choice"] == "advanced":
+        # Combine the picker with its follow-up steps in ONE run_steps call so
+        # "b" at ``_step_memory_dir`` navigates back to the picker (#371). The
+        # previous split ran picker alone in a separate call, which left
+        # memory_dir as step-0 of a second run_steps where "b" was a no-op.
+        # ``_step_preset_picker`` applies the preset inline on a non-advanced
+        # choice, and raises ``_AdvancedSelected`` to break out to the full
+        # 10-step wizard below.
+        try:
+            run_steps(
+                [_step_preset_picker, _step_memory_dir, _step_provider_dirs_auto, _step_mcp],
+                state,
+            )
+        except _AdvancedSelected:
             run_steps(advanced_steps, state)
         else:
-            _apply_preset(state, state["_preset_choice"])
+            # CLI flag overrides apply only to the preset branch — advanced
+            # prompts for every field interactively, so there's no preset
+            # baseline to override there.
             _override_from_flags(
                 state,
                 provider=provider,
@@ -2619,7 +2662,6 @@ def init(
                 api_key=api_key,
                 mcp_mode=mcp_mode,
             )
-            run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)
 
     _write_config_and_summary(state, fresh=fresh)
     _maybe_offer_embedding_reset(state, interactive=not non_interactive)

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3603,6 +3603,173 @@ class TestPresetSelection:
         assert data["mmr"]["lambda_param"] == 0.3
 
 
+class TestPresetWizardBackNav:
+    """(#371) "b" at the memory-dir step must navigate back to the preset
+    picker in the default interactive path. Previously the picker and its
+    follow-up steps lived in separate ``run_steps`` calls, so ``_step_memory_dir``
+    was index 0 of the second call and "b" silently re-prompted instead of
+    going back. The combined-run_steps fix puts the picker at index 0 of one
+    list so ``StepBack`` from memory_dir decrements cleanly into the picker.
+    """
+
+    def test_back_at_memory_dir_returns_to_preset_picker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pick english, hit "b" at memory-dir, re-pick korean. The final
+        config must reflect korean (bge-m3 + kiwipiepy), proving the picker
+        ran a second time AND the re-pick actually overwrote the first
+        preset's state."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # CliRunner swaps sys.stdin mid-invoke so `sys.stdin.isatty` can't be
+        # patched through that boundary; init_cmd exposes the ``_isatty``
+        # seam for exactly this case.
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        # 1) picker: "2" (english, default)
+        # 2) memory_dir: "b"  → back to picker
+        # 3) picker: "3" (korean)
+        # 4) memory_dir: the tmp path
+        # 5) "create it?": y
+        # 6) mcp: "3" (skip)
+        memory_dir = tmp_path / "memories"
+        result = runner.invoke(init, [], input=f"2\nb\n3\n{memory_dir}\ny\n3\n")
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        # Korean re-pick, not the initial English pick.
+        assert data["embedding"]["model"] == "bge-m3"
+        assert data["search"]["tokenizer"] == "kiwipiepy"
+
+    def test_advanced_from_picker_routes_to_full_wizard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Picking ``[4] Advanced`` at the picker raises ``_AdvancedSelected``,
+        which must break out of the combined ``run_steps`` and dispatch the
+        full 10-step wizard. Regression guard against losing the advanced
+        dispatch when refactoring the picker flow."""
+        from click.testing import CliRunner
+
+        import memtomem.cli.init_cmd as init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+
+        recorded: list[list[str]] = []
+        original_run_steps = init_cmd.run_steps
+
+        def tracking_run_steps(steps, state=None):  # type: ignore[no-untyped-def]
+            names = [s.__name__ for s in steps]
+            recorded.append(names)
+            # First call: combined picker + follow-ups — let the real
+            # run_steps execute so the picker can raise _AdvancedSelected.
+            if "_step_preset_picker" in names:
+                return original_run_steps(steps, state)
+            # Second call: advanced_steps — short-circuit with a valid state
+            # so _write_config_and_summary succeeds.
+            if state is None:
+                state = {}
+            state.update(
+                {
+                    "provider": "none",
+                    "model": "",
+                    "dimension": 0,
+                    "api_key": "",
+                    "rerank_enabled": False,
+                    "memory_dir": str(tmp_path / "memories"),
+                    "db_path": str(tmp_path / ".memtomem" / "memtomem.db"),
+                    "enable_auto_ns": False,
+                    "default_ns": "default",
+                    "top_k": 10,
+                    "tokenizer": "unicode61",
+                    "decay_enabled": False,
+                    "mcp_choice": 3,
+                    "settings_hooks": False,
+                    "provider_dirs": [],
+                    "provider_rules": [],
+                }
+            )
+            return state
+
+        monkeypatch.setattr(init_cmd, "run_steps", tracking_run_steps)
+
+        runner = CliRunner()
+        # Pick "4" = advanced. Picker raises _AdvancedSelected → outer catches
+        # → advanced_steps runs (stubbed).
+        result = runner.invoke(init_cmd.init, [], input="4\n")
+        assert result.exit_code == 0, result.output
+
+        assert len(recorded) == 2, f"expected 2 run_steps calls, got {len(recorded)}: {recorded}"
+        combined, advanced = recorded
+        # First call bundles picker with memory_dir and friends in ONE list —
+        # this is the whole point of the fix.
+        assert combined[0] == "_step_preset_picker"
+        assert "_step_memory_dir" in combined
+        # Second call is the 10-step advanced wizard.
+        assert len(advanced) == 10
+        assert "_step_embedding" in advanced
+        assert "_step_preset_picker" not in advanced
+
+    def test_preset_picker_applies_preset_inline_on_non_advanced(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unit: picking a non-advanced preset must populate state with the
+        preset's fields before ``_step_preset_picker`` returns — that's what
+        lets the combined run_steps continue straight into ``_step_memory_dir``
+        without a separate ``_apply_preset`` call."""
+        import click
+
+        from memtomem.cli.init_cmd import _step_preset_picker
+
+        @click.command()
+        def harness() -> None:
+            state: dict = {}
+            _step_preset_picker(state)
+            # Make the outcome observable via exit code / echo
+            click.echo(f"preset={state.get('_preset_applied')} model={state.get('model')}")
+
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(harness, input="3\n")  # "3" = korean
+        assert result.exit_code == 0, result.output
+        assert "preset=korean" in result.output
+        assert "model=bge-m3" in result.output
+
+    def test_preset_picker_advanced_choice_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unit: picking Advanced raises ``_AdvancedSelected`` rather than
+        applying a preset. The exception is what the caller relies on to
+        break out of the combined ``run_steps`` and route to advanced_steps."""
+        import click
+
+        from memtomem.cli.init_cmd import _AdvancedSelected, _step_preset_picker
+
+        @click.command()
+        def harness() -> None:
+            state: dict = {}
+            try:
+                _step_preset_picker(state)
+            except _AdvancedSelected:
+                click.echo(f"raised preset={state.get('_preset_choice')}")
+                return
+            click.echo("did not raise")  # pragma: no cover — guarded by assertion
+
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(harness, input="4\n")  # "4" = advanced
+        assert result.exit_code == 0, result.output
+        assert "raised preset=advanced" in result.output
+
+
 class TestReinstallEmbeddingReconciliation:
     """mm init must detect and offer to fix embedding mismatches left by a
     previous install (e.g. provider=none → onnx switch leaves DB at dim=0)."""


### PR DESCRIPTION
## Summary

Closes #371. Reported by @powerzist.

In the default interactive `mm init` path, typing `b` at step 3 ("Memory Directory") did nothing — the step re-prompted instead of returning to the preset picker. Root cause was platform-independent: the picker and its follow-up steps lived in two separate `run_steps` calls, so `_step_memory_dir` was **index 0** of the second call and `run_steps` took its "already at first step" branch.

## Why this reproduces only in the default path

Three entry shapes exist today:

1. `mm init --advanced` → `run_steps(advanced_steps)` — `_step_memory_dir` is index 2, "b" works.
2. `mm init --preset <name>` → explicit preset, memory_dir is the first interactive step. No picker to return to, so "b" is legitimately a no-op.
3. `mm init` (default) → `run_steps([_step_preset_picker])` **then** `run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp])` — this is the broken shape the reporter hit. Memory_dir is index 0 of the second list.

The issue title says "step 3" because `_step_memory_dir`'s `step_header(3, …)` hard-codes the label — that display is correct for the `--advanced` shape but misleading in the preset shapes. The fix below doesn't touch step numbering; narrower and scope-contained.

## Fix

- Combine the two `run_steps` calls in the default interactive path into one:
  `[_step_preset_picker, _step_memory_dir, _step_provider_dirs_auto, _step_mcp]`.
- `_step_preset_picker` now applies the chosen preset inline via `_apply_preset`. That's idempotent, so re-picking a different preset after "b" overwrites the previously applied state cleanly.
- Advanced choice is no longer encoded as a sentinel in `state["_preset_choice"]` — it raises a new `_AdvancedSelected` exception that the caller catches to dispatch the 10-step wizard. This lets us break out of the combined `run_steps` without smuggling control flow through state.
- CLI flag overrides (`_override_from_flags`) now run after the combined `run_steps` on the preset branch; advanced prompts per-field so there's no preset baseline to override there.
- Added a module-level `_isatty()` seam so the picker's non-TTY gate is patchable from tests without fighting CliRunner's substituted stdin (per `feedback_clirunner_isatty_seam.md`). Only the picker gate routes through this; the two legacy `sys.stdin.isatty()` call sites elsewhere in `init_cmd.py` are untouched and keep their own test paths.

`mm init --preset <name>` (path 2) is explicitly **not** changed — there's no picker to go back to from memory_dir there, and the current "already at first step" behavior is correct for that flow.

## Review follow-ups (9900208)

- **`_apply_preset` now drops any stale `rerank_model`** before reapplying, so re-picking from a rerank-enabled preset (english/korean) to a rerank-disabled one (minimal) after "b" doesn't leave the previous model string in state. Benign today (all downstream readers gate on `rerank_enabled` first) but the docstring promises a full preset-surface overwrite.
- **CHANGELOG: user-visible precedence change documented**. Combining the two `run_steps` also moved `_override_from_flags` from *before* the prompts to *after* them on the default-interactive branch, which means `mm init --memory-dir /x` (no `--preset`, no `-y`) finally respects `/x` — previously the prompt silently clobbered the flag. Same rule that already held for `--preset` / `-y` paths now also holds for the default path.

## Test plan

- [x] `TestPresetWizardBackNav::test_back_at_memory_dir_returns_to_preset_picker` — end-to-end: pick English, hit "b" at memory-dir, re-pick Korean. Final config writes `bge-m3` + `kiwipiepy`, proving the picker re-ran and the new preset fully overwrote the old one.
- [x] `TestPresetWizardBackNav::test_advanced_from_picker_routes_to_full_wizard` — picking `[4] Advanced` still dispatches the 10-step wizard via `_AdvancedSelected`. Guards against losing the advanced dispatch when refactoring the flow.
- [x] `TestPresetWizardBackNav::test_preset_picker_applies_preset_inline_on_non_advanced` — unit test pinning that `_apply_preset` runs inside the picker now.
- [x] `TestPresetWizardBackNav::test_preset_picker_advanced_choice_raises` — unit test pinning the `_AdvancedSelected` exception path.
- [x] `pytest packages/memtomem/tests/test_init_cmd.py` → 206 passed (202 original + 4 new; no existing test regressed).
- [x] `pytest packages/memtomem/tests -m "not ollama"` → 2215 passed.
- [x] `ruff check` + `ruff format --check` + `mypy init_cmd.py` → clean.

## Out of scope (noted, not fixed here)

- **Step-number display drift**: `step_header(3, "Memory Directory")` hard-codes "3" regardless of the flow, so preset paths show "3" even when it's the first interactive step the user sees. That's a UX polish issue orthogonal to "b" navigation — worth a separate cleanup.
- **Back-through-silent-steps**: `_step_provider_dirs_auto` prints a banner but doesn't prompt, so "b" at `_step_mcp` re-runs the banner and re-prompts MCP instead of jumping past the silent step to memory_dir. Also out of scope.
- **Path 2 `--preset X`**: still advertises "(b: back)" on the memory-dir step_header even though "b" is a no-op there (no picker to return to). Cosmetic; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
