### PR TITLE
chore(init): preset-picker review follow-ups — dead write, docstring, coverage

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2184,22 +2184,15 @@ class _AdvancedSelected(Exception):
 def _step_preset_picker(state: dict) -> None:
     """First step of the default interactive path — pick a preset or Advanced.
 
-    Writes ``state["_preset_choice"]`` = one of ``"minimal" | "english" |
-    "korean" | "advanced"``. The Advanced entry raises
-    :class:`_AdvancedSelected` so the caller can dispatch the full
-    10-step wizard; the other three apply the preset inline via
-    :func:`_apply_preset` so the rest of ``run_steps`` can continue with
-    ``_step_memory_dir``, ``_step_provider_dirs_auto``, and ``_step_mcp``
-    against fully populated state.
-
-    Re-entry via ``"b"`` from a later step is safe: :func:`_apply_preset`
-    overwrites the full preset surface, so re-picking a different preset
-    takes effect cleanly.
+    Advanced raises :class:`_AdvancedSelected` so the caller can dispatch
+    the full 10-step wizard. The three preset entries apply the preset
+    inline via :func:`_apply_preset` and set ``state["_preset_choice"]``
+    so the rest of ``run_steps`` can continue with ``_step_memory_dir``,
+    ``_step_provider_dirs_auto``, and ``_step_mcp`` against fully
+    populated state. Re-entry via ``"b"`` is safe — :func:`_apply_preset`
+    overwrites the full preset surface.
     """
-    # First step — no prior step to return to, so only surface 'q: quit'.
-    # 'b' still works (nav_prompt intercepts it before IntRange), but
-    # run_steps treats back-on-step-0 as a no-op, which would confuse
-    # users if advertised.
+    # First step — "b" is a no-op here, so only advertise "q: quit".
     click.secho("  Choose setup style:", fg="yellow", bold=True)
     click.echo(click.style("  (q: quit)", dim=True))
     click.echo()
@@ -2217,7 +2210,6 @@ def _step_preset_picker(state: dict) -> None:
     click.echo()
 
     if choice == advanced_idx:
-        state["_preset_choice"] = "advanced"
         raise _AdvancedSelected()
 
     state["_preset_choice"] = ordered[choice - 1]

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3718,47 +3718,141 @@ class TestPresetWizardBackNav:
         assert "_step_embedding" in advanced
         assert "_step_preset_picker" not in advanced
 
+    @pytest.mark.parametrize(
+        "choice, expected_preset, expected_model, expected_tokenizer",
+        [
+            ("1", "minimal", "", "unicode61"),
+            ("2", "english", "bge-small-en-v1.5", "unicode61"),
+            ("3", "korean", "bge-m3", "kiwipiepy"),
+        ],
+    )
     def test_preset_picker_applies_preset_inline_on_non_advanced(
-        self, monkeypatch: pytest.MonkeyPatch
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        choice: str,
+        expected_preset: str,
+        expected_model: str,
+        expected_tokenizer: str,
     ) -> None:
-        """Unit: picking a non-advanced preset must populate state with the
+        """Unit: picking any non-advanced preset must populate state with that
         preset's fields before ``_step_preset_picker`` returns — that's what
         lets the combined run_steps continue straight into ``_step_memory_dir``
-        without a separate ``_apply_preset`` call."""
+        without a separate ``_apply_preset`` call. Parametrized across all
+        three non-advanced options so a future preset-spec drift on any one
+        breaks loudly and immediately."""
         import click
 
         from memtomem.cli.init_cmd import _step_preset_picker
+
+        captured: dict[str, object] = {}
 
         @click.command()
         def harness() -> None:
             state: dict = {}
             _step_preset_picker(state)
-            # Make the outcome observable via exit code / echo
-            click.echo(f"preset={state.get('_preset_applied')} model={state.get('model')}")
+            captured.update(state)
 
         from click.testing import CliRunner
 
         runner = CliRunner()
-        result = runner.invoke(harness, input="3\n")  # "3" = korean
+        result = runner.invoke(harness, input=f"{choice}\n")
         assert result.exit_code == 0, result.output
-        assert "preset=korean" in result.output
-        assert "model=bge-m3" in result.output
+        assert captured.get("_preset_choice") == expected_preset
+        assert captured.get("_preset_applied") == expected_preset
+        assert captured.get("model") == expected_model
+        assert captured.get("tokenizer") == expected_tokenizer
+
+    def test_repeated_back_to_same_preset_is_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: pick korean, "b", re-pick korean, proceed. The
+        idempotent re-apply claim in the picker's docstring must hold for
+        the same-preset case too (not only the different-preset case
+        covered by test_back_at_memory_dir_returns_to_preset_picker).
+        Regression guard: a future _apply_preset that toggles state (e.g.
+        flips a bool) rather than assigning flat keys would fail here."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        memory_dir = tmp_path / "memories"
+        result = CliRunner().invoke(
+            init,
+            [],
+            # 3 (korean) → b → 3 (korean again) → dir → y → 3 (mcp skip)
+            input=f"3\nb\n3\n{memory_dir}\ny\n3\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert data["embedding"]["model"] == "bge-m3"
+        assert data["search"]["tokenizer"] == "kiwipiepy"
+
+    def test_repeated_back_cycle_through_multiple_presets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: pick english → "b" → korean → "b" → minimal, then
+        proceed. Exercises multiple back-cycles; the final preset must
+        fully replace every previous partial application (provider flips
+        onnx → onnx → none, rerank flips True → True → False, etc.). If
+        any field from english/korean leaked past the final minimal pick
+        this assertion would see it."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        memory_dir = tmp_path / "memories"
+        result = CliRunner().invoke(
+            init,
+            [],
+            # 2 (english) → b → 3 (korean) → b → 1 (minimal) → dir → y → 3
+            input=f"2\nb\n3\nb\n1\n{memory_dir}\ny\n3\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        # Final pick was minimal: provider=none + no rerank + unicode61.
+        assert data["embedding"]["provider"] == "none"
+        assert data["embedding"]["model"] == ""
+        assert data["search"]["tokenizer"] == "unicode61"
+        # No stale rerank field leaked through (the #418 follow-up fix).
+        assert "model" not in data.get("rerank", {}), data.get("rerank")
 
     def test_preset_picker_advanced_choice_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Unit: picking Advanced raises ``_AdvancedSelected`` rather than
-        applying a preset. The exception is what the caller relies on to
-        break out of the combined ``run_steps`` and route to advanced_steps."""
+        """Unit: picking Advanced raises ``_AdvancedSelected`` without
+        touching state (no ``_preset_choice`` write, no ``_apply_preset``
+        call). The exception alone is what the caller relies on to break
+        out of the combined ``run_steps`` and route to advanced_steps, so
+        no state-based sentinel is needed."""
         import click
 
         from memtomem.cli.init_cmd import _AdvancedSelected, _step_preset_picker
 
         @click.command()
         def harness() -> None:
-            state: dict = {}
+            state: dict = {"sentinel": "untouched"}
             try:
                 _step_preset_picker(state)
             except _AdvancedSelected:
-                click.echo(f"raised preset={state.get('_preset_choice')}")
+                click.echo(
+                    f"raised preset_choice={state.get('_preset_choice')} "
+                    f"applied={state.get('_preset_applied')} "
+                    f"sentinel={state.get('sentinel')}"
+                )
                 return
             click.echo("did not raise")  # pragma: no cover — guarded by assertion
 
@@ -3767,7 +3861,8 @@ class TestPresetWizardBackNav:
         runner = CliRunner()
         result = runner.invoke(harness, input="4\n")  # "4" = advanced
         assert result.exit_code == 0, result.output
-        assert "raised preset=advanced" in result.output
+        # No dead write, no preset application — just the exception.
+        assert "raised preset_choice=None applied=None sentinel=untouched" in result.output
 
 
 class TestReinstallEmbeddingReconciliation:


### PR DESCRIPTION
## Summary

Addresses the remaining non-blocking nits from the #418 review round — all scoped to the preset picker and its tests.

## Changes

- **m1 — Drop `state["_preset_choice"] = "advanced"` dead write.** Control flow into the advanced branch goes through the `_AdvancedSelected` exception alone; nothing downstream reads the sentinel. Test updated to pin the "state untouched on advanced" contract explicitly (user-supplied sentinel key survives, both `_preset_choice` and `_preset_applied` stay `None`).

- **n3 — Shorten `_step_preset_picker` docstring + first-step comment.** The combined-`run_steps` change in #418 made the multi-paragraph rationale redundant. Comment is now one line: `# First step — "b" is a no-op here, so only advertise "q: quit".`

- **m3 — Parametrize `test_preset_picker_applies_preset_inline_on_non_advanced`** across all three non-advanced presets (`minimal` / `english` / `korean`) with their expected `model` and `tokenizer`. Previously only `korean` was covered, so a preset-spec drift on `minimal` or `english` (including rerank wiring, tokenizer flip) would have slipped through silently.

- **m4 — New `test_repeated_back_to_same_preset_is_idempotent`** — same-preset repick after "b". Regression guard: a future `_apply_preset` that toggled rather than assigned flat keys would fail here (the `pick-back-pick-different` test from #418 doesn't catch the toggle case).

- **m4 — New `test_repeated_back_cycle_through_multiple_presets`** — multi-cycle: english → "b" → korean → "b" → minimal. Final config must be entirely minimal; any field leaked from the earlier picks (provider, rerank, tokenizer) fails the assertions. Also pins that the `rerank_model` stale-field fix from 9900208 holds across more than one back cycle.

## Test plan

- [x] `pytest packages/memtomem/tests/test_init_cmd.py::TestPresetWizardBackNav` → 8 passed (was 4 pre-PR: +2 m4 tests, +2 net from the parametrize — one test became three parametrize cases, minus one replaced).
- [x] `pytest packages/memtomem/tests/test_init_cmd.py` → 210 passed (+4 from this PR; no existing test regressed).
- [x] `pytest packages/memtomem/tests -m "not ollama"` → 2222 passed.
- [x] `ruff check` / `ruff format --check` / `mypy init_cmd.py` → clean.

## Note on n2

The three out-of-scope UX items from the #418 review (step-number display drift, back-through-silent-step, `--preset X` stale "b: back" advertisement) are being filed as separate follow-up issues rather than bundled here — each touches a different part of the wizard surface and deserves its own scoping discussion before a fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
