### PR TITLE
fix(init): back-nav through silent step reaches previous prompt (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mm init`: "b" (back) at the MCP step now reaches the memory-directory
+  prompt instead of stalling on a silent banner.** The wizard's
+  `_step_provider_dirs_auto` sits between `_step_memory_dir` and `_step_mcp`
+  but only prints a detection banner — no prompt. Pre-fix, "b" at the MCP
+  step decremented the step index onto that silent step, which re-emitted
+  its banner and advanced straight back to `_step_mcp` — so "b" appeared to
+  do nothing until the user hit it twice. `wizard.run_steps` now skips past
+  `@silent_step`-marked functions when handling `StepBack`, so "b" lands on
+  the previous *interactive* step (memory_dir). Banner does not re-fire on
+  the back-pass (it only runs forward, once after each memory_dir
+  confirmation). Unit coverage for the skip mechanism lives in
+  `test_wizard.py`; end-to-end CliRunner regression is in
+  `test_init_cmd.py::TestBackNavThroughSilentStep`. (#421)
+
 - **`mm init`: "b" (back) now works at step 3 in the default interactive
   path.** The preset picker and its follow-up steps (memory dir, provider
   dirs auto-detect, MCP config) used to run in two separate `run_steps`

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -15,7 +15,7 @@ from typing import Literal
 import click
 
 from memtomem.cli.init_presets import PRESETS, _VALID_PRESETS, get_preset
-from memtomem.cli.wizard import nav_confirm, nav_prompt, run_steps, step_header
+from memtomem.cli.wizard import nav_confirm, nav_prompt, run_steps, silent_step, step_header
 
 InstallType = Literal["source", "project", "tool", "uvx"]
 CwdInstallType = Literal["source", "project", "pypi"]
@@ -2249,6 +2249,7 @@ def _apply_preset(state: dict, preset_name: str) -> None:
     state["_preset_applied"] = preset_name
 
 
+@silent_step
 def _step_provider_dirs_auto(state: dict) -> None:
     """Auto-apply detected provider memory folders for preset 2/3.
 
@@ -2256,6 +2257,12 @@ def _step_provider_dirs_auto(state: dict) -> None:
     skips without scanning. When True, scans via ``_detect_provider_dirs``,
     adds every detected category, emits a banner listing what was added (or
     a one-line message when nothing was detected so the skip isn't silent).
+
+    Marked ``@silent_step`` because this function has no ``nav_prompt`` /
+    ``nav_confirm`` call — it only emits banners. ``run_steps`` skips past
+    it during back-navigation so ``b`` at the next step (``_step_mcp``) lands
+    on the previous *interactive* step (``_step_memory_dir``) instead of
+    re-running the banner and falling through to ``_step_mcp`` again. (#421)
     """
     preset_name = state.get("_preset_applied")
     if preset_name is None:

--- a/packages/memtomem/src/memtomem/cli/wizard.py
+++ b/packages/memtomem/src/memtomem/cli/wizard.py
@@ -64,6 +64,21 @@ def nav_confirm(text: str, default: bool = False) -> bool:
         click.echo("  Please answer y or n.")
 
 
+def silent_step(fn: Callable[[dict], None]) -> Callable[[dict], None]:
+    """Mark a step as silent (no user prompt — only side effects like banners).
+
+    Silent steps are skipped during back-navigation so ``b`` lands on the
+    previous *interactive* step instead of re-running the banner and falling
+    straight back to where the user came from.
+    """
+    fn._silent_in_back_nav = True  # type: ignore[attr-defined]
+    return fn
+
+
+def _is_silent(step: Callable[[dict], None]) -> bool:
+    return getattr(step, "_silent_in_back_nav", False)
+
+
 def run_steps(
     steps: Sequence[Callable[[dict], None]],
     state: dict | None = None,
@@ -71,7 +86,8 @@ def run_steps(
     """Run a list of step functions with back/cancel support.
 
     Each step function receives a shared state dict and modifies it.
-    Raising StepBack goes to the previous step, WizardCancel aborts.
+    Raising StepBack goes to the previous interactive step (skipping any
+    ``@silent_step`` in between). WizardCancel aborts.
     """
     if state is None:
         state = {}
@@ -81,8 +97,11 @@ def run_steps(
             steps[i](state)
             i += 1
         except StepBack:
-            if i > 0:
-                i -= 1
+            target = i - 1
+            while target >= 0 and _is_silent(steps[target]):
+                target -= 1
+            if target >= 0:
+                i = target
                 click.echo()
             else:
                 click.echo("  (already at first step)")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5161,3 +5161,101 @@ class TestYRefuseHintParity:
         assert _count_calls(language_src, "--tokenizer kiwipiepy", "korean") >= 1, (
             "kiwipiepy fallback must surface -y refuse hint (#403)"
         )
+
+
+class TestBackNavThroughSilentStep:
+    """(#421) "b" at ``_step_mcp`` must skip past the silent
+    ``_step_provider_dirs_auto`` and land on ``_step_memory_dir`` (the previous
+    interactive step). Previously it landed on the silent step, which re-ran
+    its banner and advanced straight back to ``_step_mcp`` — so "b" appeared
+    to do nothing.
+
+    Unit-level coverage of the skip mechanism lives in ``test_wizard.py``;
+    this class is the CliRunner-level regression that proves the
+    ``@silent_step`` decoration is wired into the real wizard.
+    """
+
+    def test_back_at_mcp_reaches_memory_dir_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After "b" at the mcp step, the next interactive prompt must be
+        ``_step_memory_dir`` (not mcp re-prompting). Pinned by counting the
+        ``Memory Directory`` header occurrences in the captured output —
+        pre-fix this would be 1 (back-nav never escaped the silent step),
+        post-fix it is 2 (original visit + post-back re-entry)."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # CliRunner substitutes sys.stdin; route through init_cmd._isatty seam
+        # so the picker's non-TTY gate doesn't short-circuit (per
+        # feedback_clirunner_isatty_seam.md).
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        # 1) picker: "2" (english, default)
+        # 2) memory_dir: tmp path
+        # 3) "Create it?": y  → path now exists
+        # 4) (silent step runs: "No provider memory folders detected" banner)
+        # 5) mcp: "b"  → expected to skip silent and land on memory_dir
+        # 6) memory_dir: re-enter same path (no create prompt this time —
+        #    the dir was created in step 3)
+        # 7) (silent step runs again — forward direction, expected)
+        # 8) mcp: "3" (skip — don't write to any client config)
+        result = runner.invoke(init, [], input=f"2\n{memory_dir}\ny\nb\n{memory_dir}\n3\n")
+        assert result.exit_code == 0, result.output
+
+        # Memory Directory header must appear twice: initial visit + after
+        # back-nav from mcp. If the silent-skip fix is missing, this is 1.
+        assert result.output.count("Memory Directory") == 2, result.output
+        # MCP header also appears twice: once before "b", once after the
+        # back-and-forward trip. Mostly a sanity check on the flow.
+        assert result.output.count("Connect to AI Editor") == 2, result.output
+
+    def test_silent_step_banner_does_not_refire_on_back_pass(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Between the mcp prompt where "b" is typed and the next memory_dir
+        prompt, the silent step's banner must NOT appear — that's the whole
+        point of the skip. We slice the output at the first mcp prompt and
+        look for banner strings in the window up to the second memory_dir
+        header; any banner text there means the silent step re-ran on the
+        back-pass (pre-fix behavior)."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        result = runner.invoke(init, [], input=f"2\n{memory_dir}\ny\nb\n{memory_dir}\n3\n")
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        # Locate the two "Memory Directory" headers. The window *between*
+        # them is the back-nav transition (mcp "b" → land on memory_dir).
+        first_md = out.find("Memory Directory")
+        second_md = out.find("Memory Directory", first_md + 1)
+        assert first_md != -1 and second_md != -1, out
+
+        # Grab the segment after user's "b" at mcp until the second memory_dir
+        # header. Starting from the first mcp prompt keeps things anchored;
+        # the silent banner must NOT appear in this slice.
+        first_mcp = out.find("Connect to AI Editor")
+        assert first_mcp != -1, out
+        back_pass_window = out[first_mcp:second_md]
+        assert "No provider memory folders detected" not in back_pass_window, (
+            f"Silent-step banner re-fired on back-pass-through:\n{back_pass_window}"
+        )

--- a/packages/memtomem/tests/test_wizard.py
+++ b/packages/memtomem/tests/test_wizard.py
@@ -1,0 +1,200 @@
+"""Unit tests for ``memtomem.cli.wizard`` — ``run_steps``, ``silent_step``,
+back/cancel navigation.
+
+Integration tests for the full ``mm init`` wizard live in ``test_init_cmd.py``;
+this file exercises ``run_steps`` directly with synthetic step functions so
+the navigation mechanics are pinned independent of wiring.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import click
+from click.testing import CliRunner
+
+from memtomem.cli.wizard import StepBack, run_steps, silent_step
+
+
+def _make_step(
+    name: str,
+    log: list[str],
+    raise_back_on_call: int | None = None,
+) -> Callable[[dict], None]:
+    """Build an interactive step. Counts its own invocations in ``log`` and
+    optionally raises ``StepBack`` on the Nth invocation (1-indexed)."""
+    calls = {"n": 0}
+
+    def step(state: dict) -> None:
+        calls["n"] += 1
+        log.append(name)
+        if raise_back_on_call is not None and calls["n"] == raise_back_on_call:
+            raise StepBack()
+
+    step.__name__ = name
+    return step
+
+
+def _make_silent(name: str, log: list[str]) -> Callable[[dict], None]:
+    """Build a silent step — no prompt, only records its invocation."""
+
+    @silent_step
+    def step(state: dict) -> None:
+        log.append(name)
+
+    step.__name__ = name
+    return step
+
+
+class TestSilentStepMarker:
+    """``silent_step`` marks the function in a way ``run_steps`` can detect."""
+
+    def test_decorator_sets_marker_attribute(self) -> None:
+        @silent_step
+        def step(state: dict) -> None:
+            pass
+
+        assert getattr(step, "_silent_in_back_nav", False) is True
+
+    def test_undecorated_step_is_not_silent(self) -> None:
+        def step(state: dict) -> None:
+            pass
+
+        assert getattr(step, "_silent_in_back_nav", False) is False
+
+
+class TestRunStepsBackNav:
+    """Pin the back-navigation skip behavior for silent steps. (#421)"""
+
+    def test_back_through_silent_lands_on_prev_interactive(self) -> None:
+        """``b`` at step 2 (interactive) should skip over silent step 1 and
+        land on interactive step 0 — not re-run the silent banner."""
+        log: list[str] = []
+        step0 = _make_step("s0", log)
+        step1 = _make_silent("silent", log)
+        # step2 raises back on first call, then completes on second.
+        step2 = _make_step("s2", log, raise_back_on_call=1)
+
+        run_steps([step0, step1, step2])
+
+        assert log == [
+            "s0",  # forward
+            "silent",  # forward (banner prints once)
+            "s2",  # forward — raises back
+            "s0",  # back skipped silent, landed on interactive
+            "silent",  # forward again
+            "s2",  # forward completes
+        ]
+
+    def test_back_through_multiple_silent_steps(self) -> None:
+        """Two consecutive silent steps: back-nav skips both."""
+        log: list[str] = []
+        step0 = _make_step("s0", log)
+        silent_a = _make_silent("silent_a", log)
+        silent_b = _make_silent("silent_b", log)
+        step3 = _make_step("s3", log, raise_back_on_call=1)
+
+        run_steps([step0, silent_a, silent_b, step3])
+
+        assert log == [
+            "s0",
+            "silent_a",
+            "silent_b",
+            "s3",
+            "s0",  # back skipped both silents
+            "silent_a",
+            "silent_b",
+            "s3",
+        ]
+
+    def test_back_from_interactive_adjacent_to_interactive_unchanged(self) -> None:
+        """Sanity: when the previous step is already interactive, behavior is
+        the same as before (no silent skipping needed)."""
+        log: list[str] = []
+        step0 = _make_step("s0", log)
+        step1 = _make_step("s1", log, raise_back_on_call=1)
+
+        run_steps([step0, step1])
+
+        assert log == ["s0", "s1", "s0", "s1"]
+
+    def test_back_at_first_step_echoes_message(self) -> None:
+        """``b`` at index 0 with no prior steps keeps the existing
+        ``(already at first step)`` message."""
+        log: list[str] = []
+        step0 = _make_step("s0", log, raise_back_on_call=1)
+
+        runner = CliRunner()
+
+        # Wrap in a click command so CliRunner can capture stdout.
+        @click.command()
+        def cmd() -> None:
+            run_steps([step0])
+
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "(already at first step)" in result.output
+        # Step re-ran after the message.
+        assert log == ["s0", "s0"]
+
+    def test_silent_at_position_zero_prevents_back_to_nowhere(self) -> None:
+        """If only a silent step precedes the current one, treat it as
+        ``(already at first step)`` — there is no interactive step to return
+        to, so the silent banner must NOT re-fire."""
+        log: list[str] = []
+        silent0 = _make_silent("silent", log)
+        step1 = _make_step("s1", log, raise_back_on_call=1)
+
+        runner = CliRunner()
+
+        @click.command()
+        def cmd() -> None:
+            run_steps([silent0, step1])
+
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "(already at first step)" in result.output
+        # Silent step fires once (forward), s1 fires twice (back + forward
+        # complete). Silent banner does NOT re-fire.
+        assert log == ["silent", "s1", "s1"]
+
+
+class TestRunStepsRegressions:
+    """Pin existing behavior that must not regress under the silent-skip fix."""
+
+    def test_forward_only_flow_unchanged(self) -> None:
+        """No back-nav: each step (silent or interactive) runs exactly once."""
+        log: list[str] = []
+        steps = [
+            _make_step("a", log),
+            _make_silent("b", log),
+            _make_step("c", log),
+        ]
+
+        run_steps(steps)
+
+        assert log == ["a", "b", "c"]
+
+    def test_state_mutations_persist_across_back_nav(self) -> None:
+        """State dict shared between steps survives back-nav — this is the
+        whole point of ``run_steps``."""
+        log: list[str] = []
+
+        def step_a(state: dict) -> None:
+            log.append("a")
+            state["a_ran"] = True
+
+        calls_b = {"n": 0}
+
+        def step_b(state: dict) -> None:
+            calls_b["n"] += 1
+            log.append(f"b{calls_b['n']}")
+            if calls_b["n"] == 1:
+                # Confirm state from step_a is visible.
+                assert state.get("a_ran") is True
+                raise StepBack()
+
+        final = run_steps([step_a, step_b])
+
+        assert log == ["a", "b1", "a", "b2"]
+        assert final.get("a_ran") is True


### PR DESCRIPTION
## Summary

Closes #421.

`_step_provider_dirs_auto` sits between `_step_memory_dir` and `_step_mcp`
but only emits a detection banner — it has no user prompt. Pre-fix, "b" at
`_step_mcp` decremented onto this silent step, which re-emitted its banner
and advanced straight back to `_step_mcp`, so "b" appeared to do nothing.
Same "boundary can't be crossed" shape as #371 / #418 but one step further
along the flow.

## Fix

- **`wizard.py`**: new `silent_step` decorator sets a `_silent_in_back_nav`
  attribute on the step function. `run_steps`'s `StepBack` handler now walks
  back past any consecutive silent steps until it reaches an interactive one
  (or echoes `(already at first step)` if none precedes the current
  position). Forward direction is unchanged — silent steps still run their
  banner on the way through.
- **`init_cmd.py`**: decorate `_step_provider_dirs_auto` with `@silent_step`
  and document the skip contract in the docstring. It is the only silent
  step today; the decorator is exposed generically from `wizard.py` so
  future silent steps opt in the same way.

## Acceptance criteria (from #421)

- [x] `b` at `_step_mcp` lands the user back at the previous **prompt**
  (memory-dir), not on a silent step.
- [x] Silent step side effects (banners) don't re-fire on a back-pass-through.
- [x] New test that sequences `CliRunner().invoke(init, input="...")` and
  asserts the memory-dir prompt re-appears in the output.

## Test plan

- [x] `tests/test_wizard.py` (new) — 9 unit tests covering the skip mechanism
  directly: single silent skip, multi-silent skip, forward-only flow,
  back-at-index-0, silent-at-position-zero, state persistence across back-nav.
- [x] `TestBackNavThroughSilentStep` in `test_init_cmd.py` — CliRunner regression
  that pins the real wiring. `Memory Directory` header must appear twice in
  captured output (initial visit + post-back re-entry) and the banner text
  must be absent from the slice between the first mcp prompt and the second
  memory-dir header.
- [x] `pytest packages/memtomem/tests -m "not ollama"` → 2233 passed, 46
  deselected.
- [x] `ruff check` + `ruff format --check` + `mypy init_cmd.py wizard.py` → clean.

## Out of scope (tracked separately)

- **Step-number display drift** (#420) — `step_header` still hardcodes its
  number regardless of the flow. Orthogonal UX polish; next PR.
- **`--preset <name>` false-advertises `(b: back)`** (#422) — memory-dir is
  the only step there, so "b" is legitimately a no-op but the hint lies.
  Cosmetic twin, good-first-issue.
