### PR TITLE
fix(init): step_header renders the actual flow position, not a hardcoded N (#420)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mm init`: step headers show the correct position in every flow —
+  not a hardcoded number correct only for `--advanced`.** Previously every
+  `_step_*` function called `step_header(N, title)` with a hardcoded `N`
+  that matched the step's index in the 10-step advanced sequence. Preset
+  flows re-use the same step functions in shorter sequences, so
+  `_step_memory_dir` advertised `3. Memory Directory` even when it was
+  the first prompt the user saw (`--preset korean`) or the second (default
+  interactive after a preset pick). `wizard.run_steps` now seeds
+  `state["_wizard_position"] = (current_index, total)` before each
+  invocation, and `step_header(state, title)` reads that instead of
+  taking the integer as an argument. Numbers: advanced 1–10 (unchanged),
+  `--preset X` 1–3, default-interactive 1–4 (picker counts as step 1, the
+  silent `_step_provider_dirs_auto` counts as step 3 but prints no header
+  of its own). (#420)
+
 - **`mm init`: "b" (back) at the MCP step now reaches the memory-directory
   prompt instead of stalling on a silent banner.** The wizard's
   `_step_provider_dirs_auto` sits between `_step_memory_dir` and `_step_mcp`

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -278,7 +278,7 @@ def _y_refuse_hint(flag: str, extra: str) -> str:
 
 
 def _step_embedding(state: dict) -> None:
-    step_header(1, "Embedding Provider")
+    step_header(state, "Embedding Provider")
     click.echo("  Choose how to generate embeddings:")
     click.echo("    [1] Quick start — keyword search only, no setup needed (recommended)")
     click.echo("    [2] Local ONNX — dense search, no server needed (pip install memtomem[onnx])")
@@ -440,7 +440,7 @@ def _step_embedding(state: dict) -> None:
 
 
 def _step_reranker(state: dict) -> None:
-    step_header(2, "Reranker (optional)")
+    step_header(state, "Reranker (optional)")
     click.echo("  Cross-encoder reranking sharpens search relevance after BM25+dense fusion.")
     click.echo("  Runs locally via fastembed ONNX — no API key, no server.")
     enabled = nav_confirm("  Enable reranker?", default=False)
@@ -468,7 +468,7 @@ def _step_reranker(state: dict) -> None:
 
 
 def _step_memory_dir(state: dict) -> None:
-    step_header(3, "Memory Directory")
+    step_header(state, "Memory Directory")
     click.echo("  Where are the files you want to index?")
     memory_dir = nav_prompt("  Directory", default="~/memories")
     memory_path = Path(memory_dir).expanduser()
@@ -598,7 +598,7 @@ def _step_provider_dirs(state: dict) -> None:
     to ``default`` for memory_dirs whose basename is non-discriminating
     (``memory`` / ``plans`` / ``memories``).
     """
-    step_header(4, "Provider Memory Folders")
+    step_header(state, "Provider Memory Folders")
     from memtomem.config import _detect_provider_dirs
 
     grouped = _detect_provider_dirs()
@@ -658,7 +658,7 @@ def _step_provider_dirs(state: dict) -> None:
 
 
 def _step_storage(state: dict) -> None:
-    step_header(5, "Storage")
+    step_header(state, "Storage")
     config_dir = Path("~/.memtomem").expanduser()
     db_default = str(config_dir / "memtomem.db")
     state["db_path"] = nav_prompt("  SQLite DB path", default=db_default)
@@ -666,7 +666,7 @@ def _step_storage(state: dict) -> None:
 
 
 def _step_namespace(state: dict) -> None:
-    step_header(6, "Namespace")
+    step_header(state, "Namespace")
     click.echo("  Organize memories into scoped groups (work, personal, project).")
     state["enable_auto_ns"] = nav_confirm(
         "  Auto-assign namespace from folder name? (~/docs → 'docs')", default=False
@@ -676,7 +676,7 @@ def _step_namespace(state: dict) -> None:
 
 
 def _step_search(state: dict) -> None:
-    step_header(7, "Search")
+    step_header(state, "Search")
     state["top_k"] = nav_prompt("  Results per search", type=click.INT, default=10)
     state["decay_enabled"] = nav_confirm(
         "  Enable time-decay? (older memories rank lower)", default=False
@@ -685,7 +685,7 @@ def _step_search(state: dict) -> None:
 
 
 def _step_language(state: dict) -> None:
-    step_header(8, "Language")
+    step_header(state, "Language")
     click.echo("  Search tokenizer:")
     click.echo("    [1] Unicode (default — English and most languages)")
     click.echo("    [2] Korean (kiwipiepy — better Korean word splitting)")
@@ -705,7 +705,7 @@ def _step_language(state: dict) -> None:
 
 
 def _step_settings(state: dict) -> None:
-    step_header(9, "Claude Code Hooks")
+    step_header(state, "Claude Code Hooks")
 
     # Skip entirely if Claude Code is not installed
     claude_dir = Path.home() / ".claude"
@@ -748,7 +748,7 @@ def _step_settings(state: dict) -> None:
 
 
 def _step_mcp(state: dict) -> None:
-    step_header(10, "Connect to AI Editor")
+    step_header(state, "Connect to AI Editor")
     click.echo("  How do you want to connect memtomem?")
     click.echo("    [1] Claude Code (run 'claude mcp add' automatically)")
     click.echo("    [2] Generate .mcp.json here (Claude Code project scope;")

--- a/packages/memtomem/src/memtomem/cli/wizard.py
+++ b/packages/memtomem/src/memtomem/cli/wizard.py
@@ -88,11 +88,20 @@ def run_steps(
     Each step function receives a shared state dict and modifies it.
     Raising StepBack goes to the previous interactive step (skipping any
     ``@silent_step`` in between). WizardCancel aborts.
+
+    Before each invocation, ``state["_wizard_position"] = (i + 1, len(steps))``
+    is seeded so :func:`step_header` (and any other display helper) can render
+    a number reflecting the step's actual position in *this* flow — not a
+    value hardcoded at the step definition. Without the seed the number was
+    only correct for the 10-step ``--advanced`` flow; preset flows showed
+    e.g. ``3. Memory Directory`` when memory-dir was actually the first step
+    the user saw. (#420)
     """
     if state is None:
         state = {}
     i = 0
     while i < len(steps):
+        state["_wizard_position"] = (i + 1, len(steps))
         try:
             steps[i](state)
             i += 1
@@ -116,7 +125,17 @@ def run_steps(
     return state
 
 
-def step_header(number: int, title: str) -> None:
-    """Print a step header with navigation hint."""
-    click.secho(f"{number}. {title}", fg="yellow", bold=True)
+def step_header(state: dict, title: str) -> None:
+    """Print a step header with navigation hint.
+
+    The number is read from ``state["_wizard_position"]`` as seeded by
+    :func:`run_steps`. If the key is absent (standalone / test use), the
+    header is rendered without a number. (#420)
+    """
+    position = state.get("_wizard_position")
+    if position is not None:
+        current, _total = position
+        click.secho(f"{current}. {title}", fg="yellow", bold=True)
+    else:
+        click.secho(title, fg="yellow", bold=True)
     click.echo(click.style("  (b: back, q: quit)", dim=True))

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5259,3 +5259,211 @@ class TestBackNavThroughSilentStep:
         assert "No provider memory folders detected" not in back_pass_window, (
             f"Silent-step banner re-fired on back-pass-through:\n{back_pass_window}"
         )
+
+
+class TestStepHeaderPosition:
+    """(#420) ``step_header`` reads its step number from
+    ``state["_wizard_position"]`` (seeded by ``run_steps``) rather than from a
+    hardcoded integer in each ``_step_*``. That lets the same step function
+    show the correct position in every flow it participates in —
+    ``--advanced`` (1..10), ``--preset X`` (1..3), and default-interactive
+    (1..4 including the picker and the silent provider-dirs step).
+    """
+
+    def test_run_steps_seeds_position_before_each_step(self) -> None:
+        """``run_steps`` must write ``(i + 1, len(steps))`` into state BEFORE
+        invoking each step — step functions read that value during execution,
+        so a post-hoc seed would be too late."""
+        from memtomem.cli.wizard import run_steps
+
+        observed: list[tuple[int, int]] = []
+
+        def step_a(state: dict) -> None:
+            observed.append(state["_wizard_position"])
+
+        def step_b(state: dict) -> None:
+            observed.append(state["_wizard_position"])
+
+        def step_c(state: dict) -> None:
+            observed.append(state["_wizard_position"])
+
+        run_steps([step_a, step_b, step_c])
+
+        assert observed == [(1, 3), (2, 3), (3, 3)]
+
+    def test_position_reseeded_after_back_nav(self) -> None:
+        """After ``StepBack`` + re-enter, the previous step sees its own
+        position again (not the position it had moments before when the user
+        hit 'b'). Pin this so the re-prompt header renders the correct
+        number."""
+        from memtomem.cli.wizard import StepBack, run_steps
+
+        observed: list[tuple[str, tuple[int, int]]] = []
+        call_counts = {"a": 0, "b": 0}
+
+        def step_a(state: dict) -> None:
+            call_counts["a"] += 1
+            observed.append(("a", state["_wizard_position"]))
+
+        def step_b(state: dict) -> None:
+            call_counts["b"] += 1
+            observed.append(("b", state["_wizard_position"]))
+            if call_counts["b"] == 1:
+                raise StepBack()
+
+        run_steps([step_a, step_b])
+
+        # a(1/2) → b(2/2) raises back → a(1/2) → b(2/2) completes.
+        assert observed == [
+            ("a", (1, 2)),
+            ("b", (2, 2)),
+            ("a", (1, 2)),
+            ("b", (2, 2)),
+        ]
+
+    def test_step_header_renders_number_from_state(self) -> None:
+        """With ``_wizard_position`` seeded, ``step_header`` prints
+        ``N. Title`` where N is the 1-based current index."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli.wizard import step_header
+
+        @click.command()
+        def cmd() -> None:
+            state = {"_wizard_position": (2, 4)}
+            step_header(state, "Memory Directory")
+
+        result = CliRunner().invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "2. Memory Directory" in result.output
+
+    def test_step_header_renders_without_number_when_state_unseeded(self) -> None:
+        """Standalone use (no prior ``run_steps``) must not crash — fall
+        back to an unnumbered title. Tests and external callers need this
+        escape hatch."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli.wizard import step_header
+
+        @click.command()
+        def cmd() -> None:
+            step_header({}, "Memory Directory")
+
+        result = CliRunner().invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "Memory Directory" in result.output
+        # No leading "N. " prefix.
+        assert "1. Memory Directory" not in result.output
+        assert "2. Memory Directory" not in result.output
+
+    def test_advanced_flow_shows_numbers_1_through_10(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm init --advanced`` runs 10 interactive steps — step_header
+        must show ``1.`` through ``10.`` respectively. Pre-fix this was
+        correct by coincidence (hardcoded N == actual position); the
+        regression guard pins it to the new seed path."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        # Advanced walks through every step. Inputs chosen to minimize
+        # branching: no-rerank, no provider dirs, skip mcp.
+        # 1. embedding: 1 (quick start / none)
+        # 2. reranker: N (no)
+        # 3. memory_dir: path, y create
+        # 4. provider_dirs: N (skip for all three categories)
+        # 5. storage: accept default (empty line)
+        # 6. namespace: N (no auto-ns), default namespace accept
+        # 7. search: top_k default (empty), decay N
+        # 8. language: 1 (english)
+        # 9. settings hooks: N
+        # 10. mcp: 3 (skip)
+        result = runner.invoke(
+            init,
+            ["--advanced"],
+            input=f"1\nn\n{memory_dir}\ny\nn\nn\nn\n\nn\n\n\n\nn\n1\nn\n3\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        assert "1. Embedding Provider" in out
+        assert "2. Reranker (optional)" in out
+        assert "3. Memory Directory" in out
+        assert "4. Provider Memory Folders" in out
+        assert "5. Storage" in out
+        assert "6. Namespace" in out
+        assert "7. Search" in out
+        assert "8. Language" in out
+        assert "9. Claude Code Hooks" in out
+        assert "10. Connect to AI Editor" in out
+
+    def test_default_preset_flow_renumbers_from_picker(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm init`` (default interactive, preset chosen) runs
+        ``[picker, memory_dir, provider_dirs_auto, mcp]`` — four steps.
+        ``_step_memory_dir`` is position 2/4 here, not 3 (which was the
+        hardcoded value correct only for ``--advanced``). Silent
+        ``_step_provider_dirs_auto`` sits at position 3 but prints no
+        header of its own; mcp is 4."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        # picker: 2 (english) → memory_dir → create → (silent) → mcp skip
+        result = runner.invoke(init, [], input=f"2\n{memory_dir}\ny\n3\n")
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        assert "2. Memory Directory" in out
+        assert "4. Connect to AI Editor" in out
+        # Pre-fix values must NOT appear (they were the bug).
+        assert "3. Memory Directory" not in out
+        assert "10. Connect to AI Editor" not in out
+
+    def test_explicit_preset_flow_renumbers_from_memory_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm init --preset korean`` runs only
+        ``[memory_dir, provider_dirs_auto, mcp]`` — three steps, memory_dir
+        at position 1. Pre-fix this showed ``3. Memory Directory`` which
+        was the bug's most visible symptom."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        result = runner.invoke(init, ["--preset", "korean"], input=f"{memory_dir}\ny\n3\n")
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        assert "1. Memory Directory" in out
+        assert "3. Connect to AI Editor" in out
+        # Old hardcoded values must not leak.
+        assert "3. Memory Directory" not in out
+        assert "10. Connect to AI Editor" not in out


### PR DESCRIPTION
## Summary

Closes #420.

Every `_step_*` function used to call `step_header(N, title)` with an integer
matching the step's index in the 10-step `--advanced` sequence. Preset flows
re-use the same step functions in shorter sequences, so `_step_memory_dir`
advertised `3. Memory Directory` even when it was the first prompt the user
saw (`--preset korean`) or the second (default interactive after a preset
pick). First-time users reading "3" without seeing steps 1 and 2 got a
nagging "did I miss something?" signal.

## Fix

- **`wizard.py`**: `run_steps` now seeds
  `state["_wizard_position"] = (i + 1, len(steps))` before each step
  invocation. `step_header(state, title)` reads the current index from that
  seed rather than taking the integer as an argument. If the key is absent
  (standalone / test use), `step_header` falls back to an unnumbered title.
  The signature change is internal — no external callers use `step_header`.
- **`init_cmd.py`**: 10 call sites migrated from `step_header(N, title)` to
  `step_header(state, title)`.

## Numbers per flow post-fix

| Flow | `step_header` shows | Actually is |
|---|---|---|
| `mm init --advanced` | 1..10 | ✓ (was correct by coincidence) |
| `mm init --preset korean` | 1..3 | ✓ (was 3, 4, 10 — the visible bug) |
| `mm init` (default, preset chosen) | 1..4 | picker=1 (own header), memory_dir=2, silent=3 (no header), mcp=4 |

## Scope notes

- **`_step_preset_picker`** keeps its own custom header (`"Choose setup
  style:"` without a number and only `(q: quit)` since there's no prior
  step). It doesn't use `step_header`, so the picker's look is unchanged.
- **`_step_provider_dirs_auto`** is silent (no header) — its position
  counts (step 3 in default flow) but the user never sees "3." announced.
  Users see numbers 2 and 4 with a banner between them. This matches the
  issue's suggested Direction 1 ("stash `(i + 1, len(steps))`") — changing
  the semantics to "only count interactive steps" would be a separate
  design decision.
- **`(b: back)` hint behavior** is untouched in this PR — that's #422,
  marked good-first-issue for external contributors.

## Test plan

- [x] `TestStepHeaderPosition::test_run_steps_seeds_position_before_each_step`
  — unit: `(i+1, len)` tuple visible to each step *during* its execution.
- [x] `test_position_reseeded_after_back_nav` — unit: re-entry after
  `StepBack` shows the same position number the second time through.
- [x] `test_step_header_renders_number_from_state` — unit: seeded state
  → `"2. Title"` in output.
- [x] `test_step_header_renders_without_number_when_state_unseeded` —
  unit: graceful fallback to unnumbered title.
- [x] `test_advanced_flow_shows_numbers_1_through_10` — CliRunner:
  end-to-end `--advanced` shows 1..10 at each prompt.
- [x] `test_default_preset_flow_renumbers_from_picker` — CliRunner:
  default interactive shows `2. Memory Directory` and
  `4. Connect to AI Editor`, never the pre-fix `3.` / `10.`.
- [x] `test_explicit_preset_flow_renumbers_from_memory_dir` — CliRunner:
  `--preset korean` shows `1. Memory Directory` and `3. Connect to AI Editor`.
- [x] `pytest packages/memtomem/tests -m "not ollama"` → 2229 passed,
  46 deselected.
- [x] `ruff check` + `ruff format --check` + `mypy wizard.py init_cmd.py`
  → clean.

## Related

- #371 / #418 — default-interactive "b" navigation fix. This PR closes
  the step-number half of the follow-up that was explicitly deferred
  from #418's scope.
- #421 — silent-step back-nav fix (same family, different symptom,
  independent PR).
- #422 — `--preset <name>` false-advertises `(b: back)`. Orthogonal to
  the number-display problem; good-first-issue candidate.
