### PR TITLE
fix(wizard): hide 'b: back' on first step where back is a no-op

### DIFF
--- a/packages/memtomem/src/memtomem/cli/wizard.py
+++ b/packages/memtomem/src/memtomem/cli/wizard.py
@@ -187,6 +187,12 @@ def step_header(state: dict, title: str) -> None:
     The number is read from ``state["_wizard_position"]`` as seeded by
     :func:`run_steps`. If the key is absent (standalone / test use), the
     header is rendered without a number. (#420)
+
+    The nav hint is trimmed to ``(q: quit)`` on the first step of a
+    ``run_steps`` call, because ``b`` has nothing to back into there --
+    advertising it as an option is misleading (#422). Any step after the
+    first (including the memory-dir step when it follows a preset
+    picker) still shows the full hint.
     """
     position = state.get("_wizard_position")
     if position is not None:
@@ -194,4 +200,9 @@ def step_header(state: dict, title: str) -> None:
         click.secho(f"{current}. {title}", fg="yellow", bold=True)
     else:
         click.secho(title, fg="yellow", bold=True)
-    click.echo(click.style("  (b: back, q: quit)", dim=True))
+
+    is_first_step = position is not None and position[0] == 1
+    if is_first_step:
+        click.echo(click.style("  (q: quit)", dim=True))
+    else:
+        click.echo(click.style("  (b: back, q: quit)", dim=True))

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6100,6 +6100,47 @@ class TestStepHeaderPosition:
         assert "1. Memory Directory" not in result.output
         assert "2. Memory Directory" not in result.output
 
+    def test_step_header_first_step_omits_back_hint(self) -> None:
+        """(#422) On the first step of a ``run_steps`` call, ``b`` has
+        nothing to return to -- the hint must only advertise ``q: quit``.
+        The preset-flag path (``mm init --preset <name>``) goes straight
+        to ``_step_memory_dir`` as step 0 of a fresh ``run_steps`` list,
+        so the old unconditional ``(b: back, q: quit)`` was misleading."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli.wizard import step_header
+
+        @click.command()
+        def cmd() -> None:
+            state = {"_wizard_position": (1, 3)}
+            step_header(state, "Memory Directory")
+
+        result = CliRunner().invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "1. Memory Directory" in result.output
+        assert "(q: quit)" in result.output
+        assert "b: back" not in result.output
+
+    def test_step_header_later_step_shows_back_hint(self) -> None:
+        """Regression guard: any step after the first (e.g. memory-dir
+        following the interactive preset picker) must still show
+        ``(b: back, q: quit)`` because ``b`` has a real destination."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli.wizard import step_header
+
+        @click.command()
+        def cmd() -> None:
+            state = {"_wizard_position": (2, 4)}
+            step_header(state, "Memory Directory")
+
+        result = CliRunner().invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "2. Memory Directory" in result.output
+        assert "(b: back, q: quit)" in result.output
+
     def test_advanced_flow_shows_numbers_1_through_10(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes #422. On the first step of a `run_steps` call, `b` has nothing to back into, so `step_header` should not advertise `(b: back, q: quit)`.

The preset-flag path (`mm init --preset <name>`) goes straight into `run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)` — no preset picker upstream — so `_step_memory_dir` runs as position 1. The hint promised a return path that wasn't there; this PR trims the hint to `(q: quit)` on position 1 and leaves every later step's `(b: back, q: quit)` unchanged.

## What changed

`step_header` (`packages/memtomem/src/memtomem/cli/wizard.py`) already reads `_wizard_position` for the number prefix. Reuse the same read:

```python
is_first_step = position is not None and position[0] == 1
if is_first_step:
    click.echo(click.style("  (q: quit)", dim=True))
else:
    click.echo(click.style("  (b: back, q: quit)", dim=True))
```

No change to `run_steps`, to `_step_memory_dir`, or to any caller site. The fix lives where the hint is printed, driven by the position state that `run_steps` already seeds.

## Why this approach (of the three the issue suggested)

The issue listed three options:
1. `show_back: bool` kwarg on `_step_memory_dir` / `step_header`.
2. Dedicated `step_header_first(title)` helper.
3. Fix at `run_steps` level using `_wizard_position`.

Option 3 is what landed. Rationale:
- `_wizard_position` is the existing seam — `step_header` already reads it for the step number. No new kwarg, no new helper, no new caller plumbing.
- It fixes the hint correctly for every `run_steps` entry point at once — the preset-flag path here, any future first-step that happens to be a prompt-taking step, and the test path (explicit `_wizard_position=(1, N)`).
- It doesn't overlap with the step-number-display work the issue mentioned as "separately tracked" — that was fixed in #420 and kept; this PR layers cleanly on top.

## Behavior matrix

| Entry point | First step | Position 1 hint | Position 2+ hint |
|---|---|---|---|
| `mm init --preset <name>` | `_step_memory_dir` | `(q: quit)` ← fix | `(b: back, q: quit)` |
| `mm init` (interactive) | `_step_preset_picker` | `(q: quit)` | `(b: back, q: quit)` for memory-dir (#371 path preserved) |
| `mm init --advanced` | `_step_embedding` | `(q: quit)` | `(b: back, q: quit)` for steps 2-10 |
| Standalone / test (no `_wizard_position`) | n/a | `(b: back, q: quit)` (fallback unchanged) | n/a |

## Tests

- `test_step_header_first_step_omits_back_hint` — asserts `(q: quit)` output and absence of `b: back` on position 1.
- `test_step_header_later_step_shows_back_hint` — regression guard on position 2 to keep the default interactive flow (#371) working.
- Full test suite: **2242 passed, 46 skipped**.

## Acceptance

- [x] `mm init --preset <name>` no longer advertises `(b: back)` on the memory-dir step.
- [x] The default interactive path (where `b` DOES work) keeps the full hint.
- [x] Covered by unit tests in `test_init_cmd.py::TestStepHeaderPosition`.

Fixes #422

---

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
