### PR TITLE
release: v0.1.25 — mm status CLI + lazy app_lifespan + idle-handshake cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.1.25] — 2026-04-23
+
+Feature + UX release. Adds `mm status` CLI as the terminal mirror of
+`mem_status`. Cuts idle-handshake disk writes: MCP handshake no longer
+creates `~/.memtomem/` — the DB opens on the first tool call, and the
+server pid file moved to `$XDG_RUNTIME_DIR/memtomem/`. Plus several
+`mm init` back-navigation and flag-precedence fixes (#371, #420, #421),
+a `serverInfo.version` pin (#383), a `mem_embedding_reset` recovery-path
+fix (#409), `-y` refuses to write config for missing extras (#396, #402),
+and a docs troubleshooting cleanup (#398).
+
+### Added
+
 - **`mm status` CLI command — terminal mirror of the MCP `mem_status` tool.**
   Closes the gap noted in #382: the README and Quick Start told first-time
   users to "call the `mem_status` tool" to confirm a healthy install, but
@@ -62,6 +79,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   now leaves `~/.memtomem/` untouched altogether — the advisory-lock
   write that forced its creation moved to `$XDG_RUNTIME_DIR`. (#399,
   #411; builds on #400 plumbing and #410 handler migration.)
+
+- **Docs: troubleshooting dropped the misleading `memtomem-server` TTY
+  verify command.** `uvx --from memtomem memtomem-server` launched bare in
+  a terminal paints the terminal with JSON-RPC parse errors on a healthy
+  install (the server expects JSON-RPC on stdin, so TTY noise triggers
+  `ERROR` lines) and silently provisions `~/.memtomem/`. "Tools don't
+  appear in my editor" in `docs/guides/getting-started.md` and
+  `docs/guides/mcp-clients.md` now point at side-effect-free checks
+  instead: `mm --version` (or `uvx --from memtomem mm --version` for
+  uvx-only setups), then a `mem_status` call from inside the editor.
+  A blockquote explains why the old command is not a healthy-install
+  indicator. (#398, closes #381)
 
 ### Fixed
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.24"
+version = "0.1.25"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.24"
+version = "0.1.25"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Feature + UX release bundling the 22 commits merged to `main` since v0.1.24. Feature PRs already landed separately; this PR carries the version bump, `CHANGELOG.md` rename from `[Unreleased]` → `[0.1.25]`, and the matching `uv.lock` workspace-package version sync.

### Highlights

- **`mm status` CLI (#382)** — terminal mirror of the MCP `mem_status` tool, closing the post-install-verification gap the README had asked users to run through an editor.
- **Lazy `app_lifespan` (#399 phases 1–3, #411, #412)** — MCP handshake no longer creates `~/.memtomem/memtomem.db` or `.server.pid`. DB opens on the first tool call, and the pid file lives under `$XDG_RUNTIME_DIR/memtomem/` (or `$TMPDIR/memtomem-$UID/` on macOS). An idle client leaves `~/.memtomem/` untouched. Two accepted trade-offs are documented in CHANGELOG: the degraded-mode embedding-mismatch warning moves from boot stderr to the first tool call, and background schedulers start on first use instead of lifespan handshake.
- **`mm init` back-nav + flag-precedence fixes (#371, #420, #421)** — step headers now report the actual flow position (not a hardcoded number correct only for `--advanced`), "b" through silent steps reaches the previous *interactive* step, preset-picker "b" works, and `--memory-dir` wins over prompts in the default interactive path.
- **MCP `serverInfo.version` pin (#383)** — `initialize` response now reports the memtomem version instead of the MCP SDK version.
- **`mem_embedding_reset(mode="revert_to_stored")` fix (#409)** — recovery path no longer raises `AttributeError` on `AppContext` properties (regression from #399 Phase 1's property introduction).
- **`mm init -y` extras check (#396, #402)** — refuses to write `config.json` when the requested provider/tokenizer extras aren't importable, with an actionable error that collapses to a `memtomem[all]` hint when all four are missing.
- **Troubleshooting docs cleanup (#398, closes #381)** — `docs/guides/getting-started.md` and `docs/guides/mcp-clients.md` drop the misleading `uvx --from memtomem memtomem-server` TTY verify command in favour of side-effect-free `mm --version` + `mem_status` checks.

Plus the usual minor fixes: uninstall DB-writer liveness probe (#397), SIGTERM pid cleanup (#387), wizard openai probe (#407), install-path docs flip to `memtomem[all]` as primary (#395), PyPI-cache-lag `--refresh` hint (#393), `uv tool update-shell` hint (#394).

## Release plan

- [x] `packages/memtomem/pyproject.toml` 0.1.24 → 0.1.25
- [x] `uv.lock` workspace `[[package]]` version updated (manual edit; `uv sync --frozen` confirms the lockfile still validates)
- [x] `CHANGELOG.md` `[Unreleased]` → `[0.1.25] — 2026-04-23`, fresh `[Unreleased]` scaffold restored
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests tools` — clean
- [x] `uv run ruff format --check ...` — 309 files already formatted
- [x] `uv run pytest -m "not ollama"` — 2240 passed, 46 deselected
- [x] `uv run mm --version` reports `memtomem 0.1.25`
- [ ] Merge → push `test-v0.1.25` tag → TestPyPI dry-run → fresh-install verify (empty-HOME `mm status` smoke for the lazy-handshake invariant)
- [ ] Push `v0.1.25` tag → OIDC trusted publisher uploads to PyPI → approve `pypi` environment
- [ ] `gh release create v0.1.25 --latest` with notes sourced from `CHANGELOG.md` `[0.1.25]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
