### PR TITLE
test(docs-guards): derive tool-mode footnote from reference.md

### DIFF
--- a/packages/memtomem/tests/test_docs_guards.py
+++ b/packages/memtomem/tests/test_docs_guards.py
@@ -24,12 +24,8 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _GUIDES = _REPO_ROOT / "docs" / "guides"
 _INTEGRATIONS = _GUIDES / "integrations"
 
-_TOOL_MODE_FOOTNOTE = (
-    r"\* Requires `MEMTOMEM_TOOL_MODE=full`. "
-    r"In `core` or `standard` mode, "
-    r"use `mm config` (CLI) or the Web UI Settings tab instead."
-)
 _ASTERISK_TOOLS = ("mem_config", "mem_embedding_reset", "mem_reset")
+_FOOTNOTE_PREFIX = r"\* Requires `MEMTOMEM_TOOL_MODE=full`"
 
 
 def _read(path: Path) -> str:
@@ -60,6 +56,24 @@ def mcp_clients() -> str:
 @pytest.fixture(scope="module")
 def reference() -> str:
     return _read(_GUIDES / "reference.md")
+
+
+@pytest.fixture(scope="module")
+def canonical_footnote(reference: str) -> str:
+    """The tool-mode footnote line, extracted from reference.md.
+
+    reference.md is the canonical source; other docs (mcp-clients.md)
+    must carry this line verbatim. Extracting it here keeps parity
+    failures scoped to "target file drifted" — if reference.md itself
+    loses the footnote, this fixture fails and parity tests never run,
+    so a reference-side regression can't be mistaken for a target-side one.
+    """
+    for line in reference.splitlines():
+        if line.startswith(_FOOTNOTE_PREFIX):
+            return line
+    pytest.fail(
+        f"reference.md lost its tool-mode footnote line (no line starts with {_FOOTNOTE_PREFIX!r})"
+    )
 
 
 class TestIntegrationsMmStatus:
@@ -103,12 +117,11 @@ class TestToolModeFootnoteParity:
                 f"(parity with reference.md so users see the tool-mode gate)."
             )
 
-    def test_reference_carries_footnote(self, reference: str) -> None:
-        assert _TOOL_MODE_FOOTNOTE in reference
-
-    def test_mcp_clients_carries_footnote(self, mcp_clients: str) -> None:
-        assert _TOOL_MODE_FOOTNOTE in mcp_clients, (
-            "mcp-clients.md must carry the same `\\*` footnote as "
-            "reference.md so the CLI / Web UI alternate-access hint is "
-            "visible in both entry points."
+    def test_mcp_clients_matches_reference_footnote(
+        self, canonical_footnote: str, mcp_clients: str
+    ) -> None:
+        assert canonical_footnote in mcp_clients, (
+            "mcp-clients.md must carry reference.md's tool-mode footnote "
+            "line verbatim so the CLI / Web UI alternate-access hint stays "
+            "in sync across the two Config-table entry points."
         )


### PR DESCRIPTION
## Summary

Follow-up to code-review item #1 on #429: `test_docs_guards.py`'s
`_TOOL_MODE_FOOTNOTE` was a hardcoded string duplicated in the test —
any wording tweak to `reference.md` would fail the parity check even
when parity itself was preserved.

Now `reference.md` is the canonical source:

- New `canonical_footnote` fixture extracts the footnote line (the first
  line starting with `\* Requires `MEMTOMEM_TOOL_MODE=full``) from
  `reference.md` at test time.
- If `reference.md` loses the footnote, the fixture calls `pytest.fail`
  with a scoped message — so parity-test failures stay limited to
  "target file drifted" instead of conflating it with "canonical gone".
- `test_mcp_clients_matches_reference_footnote` asserts the canonical
  line appears verbatim in `mcp-clients.md`. That's the whole parity
  check now.
- The old `test_reference_carries_footnote` is now redundant (the
  fixture returning a line is itself the smoke check) and was removed.

Net: 10 tests → 9 tests + 1 fixture.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_docs_guards.py -v` — 9/9 pass
- [x] `uv run ruff check` + `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
