### PR TITLE
fix(web): gate loadNamespacesTab on dev mode (closes #372)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -172,6 +172,10 @@ function _buildNsCard(ns, defaultNs) {
 }
 
 async function loadNamespacesTab() {
+  // /api/namespaces is mounted only in dev mode (web/app.py _DEV_ONLY_ROUTERS).
+  // Skip the fetch in prod to avoid a guaranteed 404 — the tab keeps its
+  // initial state. Mirrors the gate pattern in loadNamespaceDropdowns above.
+  if (STATE.uiMode !== 'dev') return;
   const list = qs('ns-list');
   list.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
 


### PR DESCRIPTION
## Summary

Follow-up to #385. `loadNamespaceDropdowns` got the dev-mode gate in
#385, but its sibling `loadNamespacesTab` (the Namespaces settings tab
loader) was missed — it still fires an unconditional `api('GET',
'/api/namespaces')` in prod, producing the same 404 #385 fixed for the
filter dropdowns.

Diagnosed by @wahajahmed010 in #372, which proposed a JS-only gate
mirroring `app.js:649-653`. #372's base was stale against #385, so its
`loadNamespaceDropdowns` hunk became a no-op on rebase. Rather than
send the contributor back for a third rebase round on top of the two
`app.py` revert cycles, landing the one-line `loadNamespacesTab` gate
directly and crediting the diagnosis via `Co-authored-by`.

Style matches #385 exactly — comment block + early return before the
loading spinner renders.

Closes #372.

## Test plan

- [ ] Manual smoke — Namespaces tab in prod opens without a 404 in console
- [ ] Dev mode (`STATE.uiMode === 'dev'`) still loads namespaces normally
