### PR TITLE
ci: bump ci.yml actions to Node 24 runtime (refs #428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - run: uv sync --frozen
@@ -24,8 +24,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - run: uv sync --frozen
@@ -36,8 +36,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - run: uv sync --frozen
@@ -53,12 +53,12 @@ jobs:
     env:
       FASTEMBED_CACHE_PATH: ${{ github.workspace }}/.fastembed-cache
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - name: Cache fastembed model (paraphrase-multilingual-MiniLM-L12-v2, ~220 MB)
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.FASTEMBED_CACHE_PATH }}
           key: ${{ runner.os }}-fastembed-multilingual-minilm-l12
@@ -71,8 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - run: uv sync --frozen
@@ -81,8 +81,8 @@ jobs:
   notebooks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - run: uv sync --frozen


### PR DESCRIPTION
## Summary

First of three PRs for #428 (Node 24 runtime audit). GitHub forces Node
24 on 2026-06-02 and removes Node 20 on 2026-09-16 — every action
pinned to a Node 20 major in the repo needs to land on a Node 24
release before 2026-06-02 to avoid the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`
opt-out.

This PR bumps every action used in `ci.yml`:

- `actions/checkout` @v4 → @v6 (Node 24 since v5; v6 adds a
  creds-persistence refinement)
- `astral-sh/setup-uv` @v4 → @v7 (Node 24 since v7; stopping at v7
  because v8 drops major-tag publication and would require per-release
  pins — out of scope for a runtime-compat bump)
- `actions/cache` @v4 → @v5 (Node 24)

## Breaking-change audit

Release notes for every major crossed:

- **setup-uv v5** (enable-cache default on) and **v6**
  (activate-environment default off) — **no impact** here, we only set
  `version: "latest"` and never `python-version`, so the venv-activation
  switch doesn't apply.
- **setup-uv v7** — removed deprecated `server-url` input, unused here.
- **checkout v5/v6**, **cache v5**, **setup-uv v7** — all require
  Actions runner ≥ v2.327.1, already default on `ubuntu-latest`.

## Test plan

- [x] This PR's CI runs all jobs green under the new pins
- [ ] Post-merge: trigger `workflow_dispatch` on `ci.yml` once to confirm
      no deprecation annotation remains

Refs #428. Follow-up PRs will cover `release.yml` and `stale.yml`;
`cla.yml`'s `contributor-assistant/github-action` stays pinned (upstream
is still on Node 20, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
