### PR TITLE
ci: bump release.yml actions to Node 24 runtime (refs #428)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
     permissions:
       id-token: write   # required for OIDC token
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - name: Build distribution


### PR DESCRIPTION
## Summary

Second of three PRs for #428 (Node 24 runtime audit). Same bump pattern
as #432 (ci.yml), applied to `release.yml`:

- `actions/checkout` @v4 → @v6 (Node 24 since v5)
- `astral-sh/setup-uv` @v4 → @v7 (Node 24 since v7; v8 skipped — drops
  major-tag publication, out of scope for a runtime-compat bump)

`pypa/gh-action-pypi-publish` stays at `@release/v1` — it's a composite
action (no Node runtime) and the rolling tag picks up upstream updates
automatically.

## Verification caveat

`release.yml` only runs on `v*` / `test-v*` tag pushes, so this PR's CI
cannot exercise the workflow directly. The same pin set is already
validated by #432 (which bumped `ci.yml` identically and ran green
across all jobs), so the action versions themselves are known-good on
`ubuntu-latest`.

## Test plan

- [x] Pins match #432 exactly — same Node 24 versions, same runner
- [ ] Sanity check on the next TestPyPI dry-run (`test-v*` tag push)
      before the next production `v*` tag
- [ ] Post-merge: confirm no deprecation annotation next time
      release.yml runs

Refs #428. Follow-up PR will cover `stale.yml`; `cla.yml` stays (upstream
Node 20, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
