### PR TITLE
ci: bump stale.yml actions/stale to Node 24 runtime (refs #428)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-pr-stale: 30
           days-before-pr-close: 30


### PR DESCRIPTION
## Summary

Third and final PR for #428 — `actions/stale` @v9 → @v10. This was the
action that emitted the original Node 20 deprecation annotation when
the new stale workflow from #427 first ran on 2026-04-23.

## Input compatibility

v10 release notes (breaking: Node 24 upgrade; enhancement: `sort-by`
option). All inputs this workflow sets are unchanged between v9 and v10:

```
days-before-pr-stale / days-before-pr-close
stale-pr-label / exempt-pr-labels / exempt-draft-pr
exempt-all-pr-milestones
stale-pr-message / close-pr-message
days-before-issue-stale / days-before-issue-close
operations-per-run / ascending / remove-stale-when-updated
```

So no config change is needed — just the pin bump.

## Test plan

- [ ] Post-merge: `gh workflow run stale.yml` to manually trigger, then
      verify the run completes `success` and carries no Node 20
      deprecation annotation.

Closes the ci/release/stale trio for #428. `cla.yml` stays on
`contributor-assistant/github-action@v2.6.1` because upstream is still
Node 20 — separate tracking to follow.

Refs #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
