### PR TITLE
fix(server): unlink legacy .server.pid on atexit and SIGTERM (closes #437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Legacy `.server.pid` teardown: `~/.memtomem/.server.pid` is now
+  unlinked on both normal exit and SIGTERM.** Previously the legacy
+  path was only `flock`-released by kernel cleanup but the file itself
+  survived, so the next server spawn could race against the stale file
+  under parallel MCP health probes (e.g. `claude mcp list`) and abort
+  with the misleading "pre-0.1.25 install" message.
+  `_install_sigterm_handler` is now variadic and tracks both the new
+  `$XDG_RUNTIME_DIR` pid file and the legacy one (when held), matching
+  the `atexit` cleanup. (#437)
+
 ## [0.1.25] — 2026-04-23
 
 Feature + UX release. Adds `mm status` CLI as the terminal mirror of

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -153,14 +153,21 @@ if _TOOL_MODE != "full":
             mcp._tool_manager.remove_tool(name)
 
 
-def _install_sigterm_handler(pid_file: Path) -> None:
-    """Install a SIGTERM handler that unlinks ``pid_file`` and hard-exits.
+def _install_sigterm_handler(*pid_files: Path) -> None:
+    """Install a SIGTERM handler that unlinks each ``pid_file`` and hard-exits.
 
     ``mcp.run()`` runs an asyncio event loop, and asyncio swallows
     ``SystemExit`` raised from a classic ``signal.signal`` handler — the
     integration test in ``test_server_sigterm.py`` is the live repro.
     So we can't rely on ``sys.exit(0)`` + ``atexit``: we unlink
     explicitly and call ``os._exit(0)`` to bypass the event loop.
+
+    Variadic because we track two pid files during the #412 transition
+    window: the new ``$XDG_RUNTIME_DIR/memtomem/server.pid`` AND the
+    legacy ``~/.memtomem/.server.pid`` (when ``_try_hold_legacy_flock``
+    succeeded). Both need the same teardown, or the next server hits
+    the "pre-0.1.25 install" abort branch on a stale legacy file
+    (issue #437).
 
     Only register after the flock succeeds, so we never unlink a pid
     file another primary owns. ``atexit`` still handles the normal
@@ -170,10 +177,11 @@ def _install_sigterm_handler(pid_file: Path) -> None:
     import signal
 
     def _handle(_signum: int, _frame: object) -> None:
-        try:
-            pid_file.unlink(missing_ok=True)
-        except OSError:
-            pass
+        for pid_file in pid_files:
+            try:
+                pid_file.unlink(missing_ok=True)
+            except OSError:
+                pass
         _os._exit(0)
 
     signal.signal(signal.SIGTERM, _handle)
@@ -244,9 +252,16 @@ def main() -> None:
     # Hold the legacy flock for the process lifetime so an old (pre-#412)
     # server running *now* is detected and a future one starting *after*
     # us also bails.
-    _legacy_lock_fp = _try_hold_legacy_flock(legacy_server_pid_path())
+    legacy_pid_file = legacy_server_pid_path()
+    _legacy_lock_fp = _try_hold_legacy_flock(legacy_pid_file)
     if _legacy_lock_fp is not None:
+        # LIFO: unlink must run before close so the file we delete is still
+        # the one we own the flock on. Without unlink the legacy path
+        # outlives the process and the next server's ``_try_hold_legacy_flock``
+        # can race against the stale file, reporting a phantom "pre-0.1.25
+        # install" holder (issue #437).
         atexit.register(lambda: _legacy_lock_fp.close())
+        atexit.register(lambda: legacy_pid_file.unlink(missing_ok=True))
 
     # Runtime files (pid / flock) live on ``$XDG_RUNTIME_DIR/memtomem``
     # when the platform provides one, otherwise a per-user temp subdir.
@@ -276,6 +291,9 @@ def main() -> None:
         _lock_fp.flush()
         atexit.register(lambda: _lock_fp.close())  # LIFO: runs second
         atexit.register(lambda: pid_file.unlink(missing_ok=True))  # LIFO: runs first
-        _install_sigterm_handler(pid_file)
+        sigterm_targets = [pid_file]
+        if _legacy_lock_fp is not None:
+            sigterm_targets.append(legacy_pid_file)
+        _install_sigterm_handler(*sigterm_targets)
 
     mcp.run()

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -65,6 +65,29 @@ def test_sigterm_handler_unlinks_pid_file_and_hard_exits(
     assert exit_calls == [0], "handler must call os._exit(0), not sys.exit or return"
 
 
+def test_sigterm_handler_unlinks_all_pid_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Variadic form: during the #412 transition ``main()`` tracks two pid
+    files (new XDG path + legacy ``~/.memtomem/.server.pid``). Both must
+    be cleaned up on SIGTERM, otherwise the next server start hits the
+    stale-legacy-lock branch (#437)."""
+    xdg_pid = tmp_path / "server.pid"
+    legacy_pid = tmp_path / "legacy.pid"
+    xdg_pid.write_text("12345")
+    legacy_pid.write_text("12345")
+
+    captured: dict[int, object] = {}
+    monkeypatch.setattr(signal, "signal", lambda sig, h: captured.setdefault(sig, h))
+    monkeypatch.setattr(os, "_exit", lambda code: None)
+
+    _install_sigterm_handler(xdg_pid, legacy_pid)
+    captured[signal.SIGTERM](signal.SIGTERM, None)  # type: ignore[operator]
+
+    assert not xdg_pid.exists(), "XDG pid file must be unlinked"
+    assert not legacy_pid.exists(), "legacy pid file must be unlinked (#437)"
+
+
 # ── integration ──────────────────────────────────────────────────────
 
 
@@ -194,6 +217,53 @@ def test_server_uses_tempdir_fallback_when_xdg_unset(tmp_path: Path) -> None:
     finally:
         _cleanup_proc(proc)
         proc.wait(timeout=5)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="SIGTERM semantics differ on Windows; server is POSIX-only"
+)
+def test_sigterm_unlinks_legacy_pid_file_end_to_end(tmp_path: Path) -> None:
+    """Issue #437: when ``~/.memtomem/`` exists but no live server holds
+    the legacy flock, a new server acquires it, runs, and must unlink
+    the legacy pid file on SIGTERM too.
+
+    Without the fix, the legacy file is left behind after every shutdown.
+    The next start opens it, fails ``flock`` intermittently under
+    parallel probes (``claude mcp list`` probing multiple MCP servers),
+    and prints the misleading "pre-0.1.25 install" message.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".memtomem").mkdir()  # triggers _try_hold_legacy_flock's is_dir() gate
+    legacy_pid = home / ".memtomem" / ".server.pid"
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+    xdg_pid = xdg / "memtomem" / "server.pid"
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
+
+    proc = _spawn_server(env)
+    try:
+        _wait_for_pid_file(proc, xdg_pid)
+        assert legacy_pid.exists(), (
+            "server should have created the legacy pid file on acquiring the flock"
+        )
+
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pytest.fail("Server did not exit within 10s of SIGTERM")
+
+        assert not legacy_pid.exists(), (
+            "legacy pid file must be unlinked on SIGTERM (#437); still present leaves "
+            "a stale artifact that the next server spawn misreads as a pre-0.1.25 holder"
+        )
+    finally:
+        _cleanup_proc(proc)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")


### PR DESCRIPTION
## Summary

- `~/.memtomem/.server.pid` now unlinks on both `atexit` (normal stdin-EOF exit) and SIGTERM, matching the teardown the new `$XDG_RUNTIME_DIR/memtomem/server.pid` path already has.
- `_install_sigterm_handler` becomes variadic (`*pid_files: Path`) so `main()` can pass the new and legacy pid files together when `_try_hold_legacy_flock` acquired the legacy lock.

Fixes #437. Root cause investigation and live repro are in the issue comments.

The bug surfaces as `✘ Failed to connect` in Claude Code / `claude mcp list` after any prior `memtomem-server` shutdown, because the legacy file remains on disk and parallel MCP probes race on `open("a+b") + flock(LOCK_EX|LOCK_NB)`, then exit via the "likely a pre-0.1.25 install" branch. `rm ~/.memtomem/.server.pid` was the manual workaround.

## Why variadic instead of two separate calls

Two separate `signal.signal(SIGTERM, ...)` calls would have the second overwrite the first — only the last-registered handler fires. Bundling both paths into one handler is the shape that keeps the invariant ("SIGTERM cleans up every pid file this process owns").

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_server_sigterm.py -v` — 7 passed
  - New: `test_sigterm_handler_unlinks_all_pid_files` (variadic unit)
  - New: `test_sigterm_unlinks_legacy_pid_file_end_to_end` (subprocess + SIGTERM + legacy pid unlink assertion)
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 2251 passed
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `uv run mypy packages/memtomem/src/memtomem/server/__init__.py` — no issues
- [x] Existing `test_server_refuses_when_legacy_lock_held` still passes (unchanged contract: when a *real* holder has the flock, new server must still abort)

## Out of scope

- Softening the "likely a pre-0.1.25 install" error message — orthogonal and can land separately; the stale-file race is the primary user-visible failure mode.
- The separate wizard bug (#436) that also contributed to the original live report (`mm init` producing a workspace-form `.mcp.json` for an empty `uv init` project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
