### PR TITLE
release: v0.1.26 — legacy .server.pid teardown hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+## [0.1.26] — 2026-04-24
+
+Hotfix release. Closes the stale-legacy-pid-file race that caused
+`memtomem-server` to intermittently refuse to start after an earlier
+shutdown, producing the misleading "pre-0.1.25 install" error in
+Claude Code / `claude mcp list`. The live-orphan-holder axis of the
+same user symptom (server alive, handshake failed, lock legitimately
+held) is tracked as a separate follow-up (#440).
+
+### Fixed
+
 - **Legacy `.server.pid` teardown: `~/.memtomem/.server.pid` is now
   unlinked on both normal exit and SIGTERM.** Previously the legacy
   path was only `flock`-released by kernel cleanup but the file itself
@@ -19,7 +30,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   with the misleading "pre-0.1.25 install" message.
   `_install_sigterm_handler` is now variadic and tracks both the new
   `$XDG_RUNTIME_DIR` pid file and the legacy one (when held), matching
-  the `atexit` cleanup. (#437)
+  the `atexit` cleanup. (#437, PR #439)
 
 ## [0.1.25] — 2026-04-23
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.25"
+version = "0.1.26"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.25"
+version = "0.1.26"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Hotfix release for the legacy `.server.pid` stale-file race landed in #439 (closes #437).

Single fix — no new features, no API changes. 0.1.25 users hitting the "another memtomem-server holds a lock (likely a pre-0.1.25 install)" error intermittently on Claude Code `Reconnect` / `claude mcp list` get a clean upgrade path.

## Changes in this release

- `bumped packages/memtomem/pyproject.toml: 0.1.25 → 0.1.26`
- `bumped uv.lock workspace entry`
- `CHANGELOG: [Unreleased] → [0.1.26] — 2026-04-24`

Feature commit (already on `main`): #439 — `fix(server): unlink legacy .server.pid on atexit and SIGTERM (closes #437)`.

## Out of scope (follow-up)

- #440: live orphan holder + stderr message UX + child lifecycle on handshake failure. Orthogonal axis of the same user symptom; separate PR.

## Release mechanics

1. Merge this PR.
2. TestPyPI dry-run: `git tag test-v0.1.26a1 <merge-sha> && git push origin test-v0.1.26a1`, approve `pypi` environment, confirm on test.pypi.org.
3. Production: `git tag v0.1.26 <merge-sha> && git push origin v0.1.26`, approve, confirm on pypi.org.
4. `gh release create v0.1.26 --title "v0.1.26" --notes-file ...`.

Per `project_release_workflow.md`: behavior-change releases get a TestPyPI dry-run. This one touches process-teardown semantics on POSIX, covered by the existing `test_server_sigterm.py` suite plus a new legacy-unlink end-to-end case, all green on CI. Dry-run is still recommended to verify the wheel on a fresh `uv tool install` before flipping PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
