### PR TITLE
feat(server): parent-death watchdog self-SIGTERMs on reparent (closes #440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Parent-death watchdog — `memtomem-server` self-SIGTERMs when its
+  MCP client parent process disappears.** Investigation in #440 showed
+  that Claude Code (and likely other MCP stdio clients) sometimes
+  terminate without closing our stdio unix sockets or sending a signal,
+  leaving `memtomem-server` alive as an orphan holding
+  `~/.memtomem/.server.pid`. The next client start then loses the
+  flock race and reports "Failed to connect". The server now polls
+  `os.getppid()` every 10s (configurable via
+  `MEMTOMEM_PARENT_WATCHDOG_INTERVAL`) and self-SIGTERMs when the
+  parent has been reparented — a POSIX-portable, client-agnostic
+  orphan signal. Self-SIGTERM (not `os._exit`) so the #439 sigterm
+  handler still fires and the pid files are unlinked cleanly. Can be
+  disabled with `MEMTOMEM_PARENT_WATCHDOG=off` for supervised /
+  daemonised deployments where reparenting is expected. (#440)
+
 ### Changed
 
 ### Fixed

--- a/packages/memtomem/src/memtomem/server/lifespan.py
+++ b/packages/memtomem/src/memtomem/server/lifespan.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import logging.config
 import os
+import signal
 import sys
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -81,6 +83,78 @@ def _load_dotenv() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Parent-death watchdog (#440)
+# ---------------------------------------------------------------------------
+
+
+def _watchdog_enabled() -> bool:
+    """Gated by ``MEMTOMEM_PARENT_WATCHDOG`` env (default on).
+
+    Accepts ``off`` / ``0`` / ``false`` (case-insensitive) to disable.
+    Kept separate for testability — unit tests can monkey-patch the
+    environment without spawning a real subprocess."""
+    return os.environ.get("MEMTOMEM_PARENT_WATCHDOG", "on").lower() not in (
+        "off",
+        "0",
+        "false",
+    )
+
+
+def _watchdog_interval() -> float:
+    """Poll interval in seconds; ``MEMTOMEM_PARENT_WATCHDOG_INTERVAL`` override.
+
+    Default 10s — small enough that an orphan releases its pid flock
+    within seconds of the client exiting, large enough that idle CPU
+    overhead is negligible."""
+    try:
+        return float(os.environ.get("MEMTOMEM_PARENT_WATCHDOG_INTERVAL", "10"))
+    except ValueError:
+        return 10.0
+
+
+async def _watch_parent(original_ppid: int, poll_seconds: float) -> None:
+    """Exit the server when the MCP client parent process disappears.
+
+    Motivation — issue #440: Claude Code (and possibly other MCP stdio
+    clients) sometimes terminate without closing our stdio unix sockets
+    OR sending a signal, leaving ``memtomem-server`` alive as an orphan
+    holding ``~/.memtomem/.server.pid``. The next client start loses
+    the flock race against the zombie and reports "Failed to connect".
+
+    POSIX gives us a portable defense: when a child's parent exits, the
+    child is reparented (PID 1 on Linux, launchd on macOS). Polling
+    ``os.getppid()`` and exiting on change is:
+
+    - Client-agnostic: no dependency on stdio close, SIGTERM delivery,
+      or a JSON-RPC ``exit`` notification.
+    - False-positive-free: PPID changes only when the parent really
+      exited — POSIX semantics guarantee this.
+    - Works on macOS and Linux without PR_SET_PDEATHSIG (Linux-only).
+
+    Exit mechanism: self-``SIGTERM`` rather than ``os._exit`` so the
+    sigterm handler installed by ``server.main()`` fires, unlinking
+    every pid file we own (issue #437 / PR #439). Going directly to
+    ``os._exit`` would bypass ``atexit`` and re-create the stale-file
+    class of bugs #439 closed.
+    """
+    while True:
+        try:
+            await asyncio.sleep(poll_seconds)
+        except asyncio.CancelledError:
+            return
+        current_ppid = os.getppid()
+        if current_ppid != original_ppid:
+            logger.warning(
+                "Parent process %d exited (reparented to %d). Self-SIGTERM "
+                "to release MCP server state — issue #440.",
+                original_ppid,
+                current_ppid,
+            )
+            os.kill(os.getpid(), signal.SIGTERM)
+            return  # Signal handler will take over; nothing more for us to do.
+
+
+# ---------------------------------------------------------------------------
 # Main lifespan
 # ---------------------------------------------------------------------------
 
@@ -127,8 +201,24 @@ async def app_lifespan(_server: FastMCP) -> AsyncIterator[AppContext]:
         await _stop_quietly(webhook_mgr, "webhook_manager")
         raise
 
+    watchdog_task: asyncio.Task[None] | None = None
+    if _watchdog_enabled():
+        watchdog_task = asyncio.create_task(
+            _watch_parent(os.getppid(), _watchdog_interval()),
+            name="memtomem-parent-watchdog",
+        )
+
     try:
         yield ctx
     finally:
+        if watchdog_task is not None:
+            watchdog_task.cancel()
+            try:
+                await watchdog_task
+            except (asyncio.CancelledError, Exception):
+                # CancelledError is the expected path; any other exception
+                # during watchdog teardown is informational — don't let it
+                # mask the main lifespan cleanup below.
+                pass
         await _stop_quietly(webhook_mgr, "webhook_manager")
         await _stop_quietly(ctx, "app_context")

--- a/packages/memtomem/tests/test_server_parent_watchdog.py
+++ b/packages/memtomem/tests/test_server_parent_watchdog.py
@@ -1,0 +1,234 @@
+"""Parent-death watchdog — issue #440.
+
+When an MCP stdio client (Claude Code observed) exits without closing
+our stdio sockets OR sending SIGTERM, ``memtomem-server`` is left alive
+as an orphan holding ``~/.memtomem/.server.pid``. This watchdog polls
+``os.getppid()`` and self-SIGTERMs when the parent disappears
+(reparenting to PID 1 / launchd), letting the already-installed sigterm
+handler (#439) unlink the pid files and exit cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem.server.lifespan import (
+    _watch_parent,
+    _watchdog_enabled,
+    _watchdog_interval,
+)
+
+
+# ── env gating ───────────────────────────────────────────────────────
+
+
+def test_watchdog_enabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MEMTOMEM_PARENT_WATCHDOG", raising=False)
+    assert _watchdog_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["off", "0", "false", "OFF", "False"])
+def test_watchdog_disabled_by_env(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMTOMEM_PARENT_WATCHDOG", value)
+    assert _watchdog_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["on", "1", "true", "anything-else"])
+def test_watchdog_enabled_for_truthy_values(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMTOMEM_PARENT_WATCHDOG", value)
+    assert _watchdog_enabled() is True
+
+
+def test_watchdog_interval_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MEMTOMEM_PARENT_WATCHDOG_INTERVAL", raising=False)
+    assert _watchdog_interval() == 10.0
+
+
+def test_watchdog_interval_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEMTOMEM_PARENT_WATCHDOG_INTERVAL", "2.5")
+    assert _watchdog_interval() == 2.5
+
+
+def test_watchdog_interval_invalid_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbage values must not crash the server — fall back to the default."""
+    monkeypatch.setenv("MEMTOMEM_PARENT_WATCHDOG_INTERVAL", "not-a-number")
+    assert _watchdog_interval() == 10.0
+
+
+# ── behavior ─────────────────────────────────────────────────────────
+
+
+async def test_watch_parent_noops_when_ppid_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """As long as getppid() equals the original, nothing happens."""
+    monkeypatch.setattr(os, "getppid", lambda: 12345)
+
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+    task = asyncio.create_task(_watch_parent(original_ppid=12345, poll_seconds=0.01))
+    await asyncio.sleep(0.05)  # ~5 polls at 10ms each
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    assert killed == [], "must not send SIGTERM while parent is alive"
+
+
+async def test_watch_parent_self_sigterms_when_ppid_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulated reparent triggers self-SIGTERM.
+
+    The watchdog sends the signal and returns; the sigterm handler
+    (registered separately in ``main()``) takes it from there. We only
+    verify the signal dispatch here — the handler's behavior is pinned
+    by ``test_server_sigterm.py``.
+    """
+    ppids = iter([11111, 11111, 11111, 1])  # three polls stable, then reparented
+    monkeypatch.setattr(os, "getppid", lambda: next(ppids))
+
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(os, "kill", lambda pid, sig: killed.append((pid, sig)))
+
+    await asyncio.wait_for(
+        _watch_parent(original_ppid=11111, poll_seconds=0.01),
+        timeout=2.0,
+    )
+
+    assert len(killed) == 1, f"expected exactly one signal dispatch, got {killed}"
+    pid, sig = killed[0]
+    assert pid == os.getpid()
+    assert sig == signal.SIGTERM
+
+
+async def test_watch_parent_cancellation_returns_cleanly() -> None:
+    """Cancelling the task during the sleep must raise nothing.
+
+    The lifespan cleanup path does ``task.cancel()`` + ``await task``;
+    if the coroutine leaked a CancelledError up through an unshielded
+    `os.kill` we'd see it here.
+    """
+    task = asyncio.create_task(_watch_parent(original_ppid=os.getppid(), poll_seconds=5.0))
+    await asyncio.sleep(0.01)  # let it enter the sleep
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        # The coroutine *should* catch and return, but depending on
+        # asyncio timing the caller may still observe the cancellation.
+        # Either shape is acceptable; the important part is no other
+        # exception leaks out.
+        pass
+
+
+# ── integration ──────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only watchdog")
+def test_server_exits_when_parent_dies(tmp_path: Path) -> None:
+    """End-to-end: a grandparent spawns ``claude``-simulated parent,
+    which spawns memtomem-server. Kill the parent; the server must
+    notice via the watchdog and exit, unlinking its pid file.
+
+    This is the live repro of the #440 orphan scenario: no stdio close,
+    no SIGTERM from the client — the parent just disappears.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+    pid_file = xdg / "memtomem" / "server.pid"
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
+    env["MEMTOMEM_PARENT_WATCHDOG_INTERVAL"] = "0.2"  # speed up the test
+
+    # Parent = a tiny python that spawns the server and then just sleeps
+    # long enough to be killable. We use a shell script via `sh -c` to
+    # keep the parent PID stable and well-known.
+    parent_cmd = [
+        sys.executable,
+        "-c",
+        "import subprocess, sys, time; "
+        "p = subprocess.Popen([sys.executable, '-m', 'memtomem.server'], "
+        "stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE); "
+        "print(p.pid, flush=True); "
+        "time.sleep(60)",
+    ]
+    parent = subprocess.Popen(
+        parent_cmd,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        # First line of parent stdout is the server PID.
+        assert parent.stdout is not None
+        deadline = time.monotonic() + 10.0
+        server_pid_str = None
+        while time.monotonic() < deadline:
+            line = parent.stdout.readline()
+            if line:
+                server_pid_str = line.decode().strip()
+                break
+            time.sleep(0.05)
+        assert server_pid_str is not None, "parent never printed the server pid"
+        server_pid = int(server_pid_str)
+
+        # Wait for the server to finish startup and create its pid file.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not pid_file.exists():
+            time.sleep(0.05)
+        assert pid_file.exists(), "server pid file never appeared"
+
+        # Now kill the parent with SIGKILL — no chance for it to close
+        # the child's stdio or forward a signal. This simulates the
+        # Claude-Code-exits-leaving-orphan scenario.
+        parent.kill()
+        parent.wait(timeout=5)
+
+        # Server should self-SIGTERM within ~watchdog interval + handler time.
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            try:
+                os.kill(server_pid, 0)  # 0 = check existence, don't signal
+            except ProcessLookupError:
+                break
+            time.sleep(0.1)
+        else:
+            # Cleanup before failing.
+            try:
+                os.kill(server_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            pytest.fail(f"server pid {server_pid} did not exit within 5s of parent death")
+
+        assert not pid_file.exists(), (
+            "server pid file must be unlinked on watchdog-triggered exit "
+            "(sigterm handler from #439 should fire)"
+        )
+    finally:
+        if parent.poll() is None:
+            parent.kill()
+            parent.wait(timeout=5)
+        for stream in (parent.stdin, parent.stdout, parent.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

Closes #440. Makes `memtomem-server` self-terminate when its MCP stdio client parent process disappears, instead of lingering as an orphan holding `~/.memtomem/.server.pid`.

Background from the #440 investigation:

- **Server side is clean**: three shutdown tests (stdin EOF / init+EOF / SIGTERM) all show the server exits properly and unlinks its pid file post-#439.
- **Client side doesn't always close stdio**: live `lsof` shows the stdio unix sockets to `claude` stay open across the shutdown path that produces orphans. When the `claude` process disappears without a clean socket close, the server has no client-provided signal to act on.
- **POSIX gives us one anyway**: when a child's parent exits, the child is reparented (`os.getppid()` changes to 1 on Linux, launchd's PID on macOS). Polling that is a portable, client-agnostic orphan signal.

## Approach

10s-interval `asyncio.create_task` watchdog launched in `app_lifespan`. On reparent detection it sends `SIGTERM` to its own PID rather than `os._exit`. This is deliberate: `_install_sigterm_handler` (#439) unlinks every pid file we own. Going around it would re-create the stale-file class of bugs #437/#439 closed.

## Design choices

- **Gating**: `MEMTOMEM_PARENT_WATCHDOG` env (default `on`). Disable with `off` / `0` / `false` for supervised / daemonised deployments where reparenting is expected.
- **Interval**: `MEMTOMEM_PARENT_WATCHDOG_INTERVAL` (default `10`). Invalid values fall back to default, server never crashes on a bad env.
- **Exit path**: `os.kill(os.getpid(), SIGTERM)` → existing sigterm handler → pid files unlinked → `os._exit(0)`. No new teardown code.
- **Task lifecycle**: created/cancelled in the same `app_lifespan` context, cancellation wrapped so main teardown still runs.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_server_parent_watchdog.py -v` — **17 passed**
  - 6× env-gating parametrized
  - 3× interval (default / override / invalid fallback)
  - Coroutine no-ops while parent alive
  - Coroutine self-SIGTERMs when ppid changes (monkey-patched iterator)
  - Cancellation returns cleanly
  - **End-to-end**: grandparent spawns parent+server, `SIGKILL`s parent, asserts server exits within 5s and pid file is unlinked — exercises the full watchdog → self-SIGTERM → #439 handler → pid file unlink chain
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — **2268 passed** (previously 2251; +17)
- [x] `ruff check` / `ruff format --check` / `mypy` on `server/lifespan.py` — clean

## Out of scope (stays on #440 wishlist, not in this PR)

- Stderr message cleanup for the legacy-flock error ("pre-0.1.25 install" phrasing). With this watchdog live, that error should become rare enough that rewording is lower priority.
- Liveness probe on `_try_hold_legacy_flock` failure (dead-pid detection and unlink). Same rationale — orphan rate should drop sharply.

Either follow-up can land in a separate PR if still worth doing after real-world usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
