### PR TITLE
release: v0.1.27 — legacy flock LOCK_SH hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+### Fixed
+
+## [0.1.27] — 2026-04-24
+
+Hotfix release. Closes the multi-instance bug (#444): running
+`memtomem-server` in one Claude Code session used to block every
+other session from connecting, because the legacy-flock probe took
+`LOCK_EX` and `sys.exit(1)`'d on contention. Multiple sessions across
+different projects can now coexist.
+
+### Changed
+
 - **Legacy flock downgraded to `LOCK_SH`; two 0.1.26+ servers can now
   coexist.** Previously `_try_hold_legacy_flock` took `LOCK_EX` and
   called `sys.exit(1)` on contention, which was intended as a
@@ -19,9 +31,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   exclusive, so pre-0.1.25's `LOCK_EX` still blocks us (and vice
   versa) — cross-version protection is preserved. On contention we
   now log a warning and fall through to the XDG path rather than
-  aborting. (#444)
-
-### Fixed
+  aborting. (#444, PR #445)
 
 ## [0.1.26] — 2026-04-24
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.26"
+version = "0.1.27"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.26"
+version = "0.1.27"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Hotfix release for the multi-instance bug landed in #445 (closes #444).

Single fix, no new features. 0.1.26 users who tried to use `memtomem` in more than one Claude Code session simultaneously (e.g. different projects) hit "Failed to connect" on every session after the first — because `_try_hold_legacy_flock` took `LOCK_EX` and `sys.exit(1)`'d on contention. 0.1.27 swaps that for `LOCK_SH`: two 0.1.26+ servers coexist, pre-0.1.25 cross-version mutex is preserved.

## Changes

- `packages/memtomem/pyproject.toml`: `0.1.26 → 0.1.27`
- `uv.lock` workspace entry
- `CHANGELOG: [Unreleased] → [0.1.27] — 2026-04-24`

Feature commit on `main`: #445.

## Release mechanics

1. Merge this PR.
2. TestPyPI dry-run: `test-v0.1.27a1` tag → approve `pypi` env → verify on test.pypi.org.
3. Production: `v0.1.27` tag → approve → verify on pypi.org.
4. `gh release create v0.1.27`.

Per `project_release_workflow.md`, behavior-change releases get a dry-run. This one touches process-lifecycle semantics on POSIX, covered by the `test_server_sigterm.py` suite including a live two-subprocess coexistence test. Dry-run still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
