### PR TITLE
fix(cli): honor --mcp flag in `mm init --preset` (closes #449)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -748,6 +748,12 @@ def _step_settings(state: dict) -> None:
 
 
 def _step_mcp(state: dict) -> None:
+    # #449: ``--mcp`` pre-sets ``state["mcp_choice"]`` via ``_override_from_flags``
+    # in the ``--preset`` branch. Skip the prompt so the flag isn't silently
+    # discarded. The ``-y`` branch omits this step entirely; the default picker
+    # branch applies overrides *after* ``run_steps`` so the key is absent here.
+    if "mcp_choice" in state:
+        return
     step_header(state, "Connect to AI Editor")
     click.echo("  How do you want to connect memtomem?")
     click.echo("    [1] Claude Code (run 'claude mcp add' automatically)")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5467,3 +5467,141 @@ class TestStepHeaderPosition:
         # Old hardcoded values must not leak.
         assert "3. Memory Directory" not in out
         assert "10. Connect to AI Editor" not in out
+
+
+class TestPresetMcpFlagPreAnswer:
+    """(#449) ``mm init --preset <name> --mcp <mode>`` must honor ``--mcp``
+    without re-prompting.
+
+    Before the fix, ``_override_from_flags`` set ``state["mcp_choice"]`` from
+    the flag in the ``elif preset:`` branch, then ``run_steps`` invoked
+    ``_step_mcp`` which unconditionally overwrote that key with the prompt
+    default. The flag's value was silently discarded — the user had to type
+    the choice again (and was confused when their flag appeared to do
+    nothing). The fix makes ``_step_mcp`` respect a pre-set ``mcp_choice``
+    and return early.
+    """
+
+    def test_preset_with_mcp_skip_does_not_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--preset minimal --mcp skip`` must reach Setup complete without
+        ever rendering the MCP menu. Inputs cover only memory_dir + create-y;
+        if the MCP prompt fires, stdin runs out and CliRunner aborts."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        result = runner.invoke(
+            init,
+            ["--preset", "minimal", "--mcp", "skip"],
+            input=f"{memory_dir}\ny\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        # The menu header must not appear — that's the whole point of the flag.
+        assert "Connect to AI Editor" not in out, (
+            "--mcp pre-answer must skip the MCP prompt entirely"
+        )
+        # And mcp_choice == 3 means no .mcp.json side effect and no
+        # "Claude Code:" / "MCP config:" lines.
+        assert "MCP config:" not in out
+        assert "Claude Code:" not in out
+        assert "Setup complete" in out
+
+    def test_preset_with_mcp_json_writes_mcp_json_without_prompt(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--mcp json`` is mcp_choice=2 which writes ``.mcp.json`` to cwd.
+        The prompt must not fire, but the side effect must still happen."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        result = runner.invoke(
+            init,
+            ["--preset", "minimal", "--mcp", "json"],
+            input=f"{memory_dir}\ny\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        assert "Connect to AI Editor" not in out
+        # Side effect from mcp_choice=2 must still fire.
+        assert "MCP config: wrote ./.mcp.json" in out
+        assert (tmp_path / ".mcp.json").exists()
+
+    def test_preset_without_mcp_flag_still_prompts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Omitting ``--mcp`` keeps the interactive prompt — the flag's
+        absence must NOT regress into a silent skip. Pairs with
+        ``test_explicit_preset_flow_renumbers_from_memory_dir`` (which
+        covers the positional header) by specifically pinning that the menu
+        body is still rendered."""
+        from click.testing import CliRunner
+
+        from memtomem.cli.init_cmd import init
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
+        )
+
+        runner = CliRunner()
+        memory_dir = tmp_path / "memories"
+        # Trailing "3" answers the MCP prompt with "skip".
+        result = runner.invoke(
+            init,
+            ["--preset", "minimal"],
+            input=f"{memory_dir}\ny\n3\n",
+        )
+        assert result.exit_code == 0, result.output
+
+        out = result.output
+        assert "Connect to AI Editor" in out
+        assert "Claude Code (run 'claude mcp add' automatically)" in out
+
+    def test_step_mcp_unit_skips_when_mcp_choice_preset(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Unit-level pin: ``_step_mcp`` with pre-set ``mcp_choice`` must not
+        call ``nav_prompt`` and must leave the key's value intact. Guards
+        against a future refactor that re-introduces an unconditional
+        assignment."""
+        from memtomem.cli.init_cmd import _step_mcp
+
+        def _explode(*a: object, **kw: object) -> int:
+            raise AssertionError("nav_prompt must not be called when mcp_choice is pre-set")
+
+        monkeypatch.setattr("memtomem.cli.init_cmd.nav_prompt", _explode)
+
+        state: dict = {"mcp_choice": 2}
+        _step_mcp(state)
+
+        assert state["mcp_choice"] == 2
+        out = capsys.readouterr().out
+        # No header, no menu lines — the step is a no-op in this branch.
+        assert out == ""


### PR DESCRIPTION
## Summary

`mm init --preset <name> --mcp <mode>` (without `-y`) silently discarded
the `--mcp` flag. Fix `_step_mcp` to return early when `state["mcp_choice"]`
is already set by `_override_from_flags`.

Closes #449.

## Root cause

In the `elif preset:` branch of `init_cmd.init` the ordering is:

1. `_apply_preset(state, preset)`
2. `_override_from_flags(..., mcp_mode=mcp_mode)` — writes
   `state["mcp_choice"]` from `--mcp`.
3. `run_steps([_step_memory_dir, _step_provider_dirs_auto, _step_mcp], state)`
   — `_step_mcp` unconditionally assigns `state["mcp_choice"] = nav_prompt(...)`,
   overwriting the flag's value with the prompt default (or the user's
   re-answer).

The `-y` branch works because it skips `_step_mcp` entirely. The default
picker branch works by coincidence (it calls `_override_from_flags` *after*
`run_steps`, so the flag wins post-prompt — but the user still sees a
redundant prompt).

## Fix

`_step_mcp` now returns early if `"mcp_choice"` is present in `state`. This
matches the author's Option 1 in #449 and mirrors the `-y` semantic of
"pre-answered, no prompt". The default picker branch is unaffected because
its `_override_from_flags` call runs post-`run_steps`, so `mcp_choice` is
absent when `_step_mcp` executes there.

No change to back-navigation: `_step_mcp` is the last step in every flow
it participates in (`advanced_steps`, the preset branch, and the default
picker branch), so nothing follows it to back-navigate from. The
`@silent_step` decorator doesn't apply — the step is sometimes silent,
sometimes not, and that's a per-invocation property of `state`.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check …` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` — clean
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -q` — 223 passed
- [x] `uv run pytest -m "not ollama" -q` — 2325 passed, no regressions

Four new tests in `TestPresetMcpFlagPreAnswer`:

- `test_preset_with_mcp_skip_does_not_prompt` — `--preset minimal --mcp skip`
  reaches "Setup complete" without rendering the MCP menu (stdin only
  covers memory_dir + create-y; a lingering MCP prompt would starve stdin
  and abort).
- `test_preset_with_mcp_json_writes_mcp_json_without_prompt` — `--mcp json`
  (mcp_choice=2) still writes `.mcp.json`; the side effect survives the
  prompt skip.
- `test_preset_without_mcp_flag_still_prompts` — omitting `--mcp` must NOT
  regress into a silent skip; the menu body still renders.
- `test_step_mcp_unit_skips_when_mcp_choice_preset` — unit-level pin:
  `_step_mcp` with pre-set `mcp_choice` never calls `nav_prompt` and leaves
  the value intact. Guards against a future refactor that re-introduces
  the unconditional assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
