### PR TITLE
fix(cli): make uninstall_cmd import-safe on Windows (closes #448)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -25,7 +25,6 @@ Design notes:
 
 from __future__ import annotations
 
-import fcntl
 import shutil
 import sqlite3
 import sys
@@ -34,6 +33,12 @@ from pathlib import Path
 from typing import Iterable
 
 import click
+
+# ``fcntl`` is POSIX-only. A module-level import here crashed every ``mm``
+# command on Windows because ``cli/__init__.py:_register`` imports this
+# module unconditionally. It is now imported lazily inside
+# ``_probe_pid_file`` behind a ``sys.platform`` guard so the rest of the CLI
+# boots on Windows. See #448.
 
 from memtomem._runtime_paths import legacy_server_pid_path, runtime_dir, server_pid_path
 from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
@@ -148,6 +153,10 @@ def _probe_pid_file(pid_file: Path) -> _ServerState:
     correct for stale-pid cases but produced false positives once the
     kernel recycled the recorded PID to an unrelated process (issue
     #387). The PID inside the file is now read for display only.
+
+    On Windows ``fcntl`` is unavailable; the probe falls back to
+    conservative "pid file exists → assume alive" and relies on
+    ``--force`` for override. See #448.
     """
     if not pid_file.exists():
         return _ServerState(alive=False, pid=None, pid_file=None)
@@ -160,6 +169,16 @@ def _probe_pid_file(pid_file: Path) -> _ServerState:
         # Unreadable / non-int — leave pid=None for the message; the lock
         # probe below still decides alive vs. dead independently.
         pid = None
+
+    if sys.platform == "win32":
+        # POSIX advisory flock is unavailable on Windows. Fall back to the
+        # same conservative treatment we use when the probe can't acquire
+        # the lock (unsupported filesystem branch below) — pid file exists,
+        # so assume a live writer and let the user pass ``--force`` to
+        # override. #448.
+        return _ServerState(alive=True, pid=pid, pid_file=pid_file)
+
+    import fcntl
 
     try:
         # Read-mode is enough; advisory flock works regardless of fd mode.

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -578,4 +578,98 @@ class TestConfigFallback:
         assert "fake permission denied" in result.output
         # default DB path used as fallback → DB still gets cleaned up
         assert "Removed:" in result.output
+
+
+class TestWindowsFcntlGuard:
+    """(#448) ``import fcntl`` at module level broke ``cli/__init__.py:_register``
+    on Windows — every ``mm`` subcommand crashed before even parsing argv.
+
+    The fix moves ``fcntl`` to a lazy import inside ``_probe_pid_file``, gated
+    by ``sys.platform != "win32"``. On Windows the probe returns conservative
+    ``alive=True`` when the pid file exists (matching the existing
+    unsupported-filesystem fallback) so ``mm uninstall`` still refuses unless
+    ``--force``.
+    """
+
+    def test_no_module_level_fcntl_import(self):
+        """Source-scan pin: ``fcntl`` must not appear as a top-level import
+        in ``uninstall_cmd.py``. A future refactor that re-hoists the
+        import would silently reintroduce the Windows crash — CI runs on
+        Linux so a runtime test can't catch it.
+        """
+        import inspect
+        import re
+
+        from memtomem.cli import uninstall_cmd
+
+        src = inspect.getsource(uninstall_cmd)
+        # Top-of-file block only — anything nested (``    import fcntl``)
+        # inside a function is fine and in fact the intended layout.
+        top_level = re.findall(r"(?m)^import fcntl\b", src)
+        assert top_level == [], (
+            "uninstall_cmd.py must not import fcntl at module level — "
+            "that crashes `mm` on Windows at CLI registration time (#448)."
+        )
+
+    def test_probe_returns_alive_on_win32_when_pid_file_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """With ``sys.platform`` patched to ``"win32"``, ``_probe_pid_file``
+        must return ``alive=True`` without ever touching ``fcntl``. The pid
+        value is still read (for the user-facing message) but the live/dead
+        decision is conservative."""
+        from memtomem.cli import uninstall_cmd
+
+        pid_file = tmp_path / "server.pid"
+        pid_file.write_text("4242", encoding="utf-8")
+
+        monkeypatch.setattr(uninstall_cmd.sys, "platform", "win32")
+
+        state = uninstall_cmd._probe_pid_file(pid_file)
+
+        assert state.alive is True
+        assert state.pid == 4242
+        assert state.pid_file == pid_file
+
+    def test_probe_returns_dead_on_win32_when_pid_file_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Windows fallback must not invent liveness out of nothing — an
+        absent pid file means the generic ``not pid_file.exists()`` branch
+        fires first and returns ``alive=False``. Guards against a future
+        refactor that hoists the Windows guard above the existence check.
+        """
+        from memtomem.cli import uninstall_cmd
+
+        pid_file = tmp_path / "missing.pid"
+        monkeypatch.setattr(uninstall_cmd.sys, "platform", "win32")
+
+        state = uninstall_cmd._probe_pid_file(pid_file)
+
+        assert state.alive is False
+        assert state.pid is None
+        assert state.pid_file is None
+
+    def test_force_overrides_win32_conservative_liveness(
+        self, home, monkeypatch: pytest.MonkeyPatch
+    ):
+        """End-to-end: under the Windows fallback, ``mm uninstall -y`` refuses
+        (conservative alive=True) but ``--force`` completes cleanup. Matches
+        the documented escape hatch for unsupported-filesystem cases."""
+        from memtomem.cli import uninstall_cmd
+
+        state = _seed_state(home)
+        pid_file = state / ".server.pid"
+        pid_file.write_text("0", encoding="utf-8")
+
+        monkeypatch.setattr(uninstall_cmd.sys, "platform", "win32")
+
+        refused = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert refused.exit_code == 2, refused.output
+        assert "Server still running" in refused.output
+        assert state.exists(), "refused uninstall must not touch state dir"
+
+        forced = CliRunner().invoke(cli, ["uninstall", "-y", "--force"])
+        assert forced.exit_code == 0, forced.output
+        assert not state.exists()
         assert not (state / "memtomem.db").exists()


### PR DESCRIPTION
## Summary

`import fcntl` at the top of `uninstall_cmd.py` broke `mm` on Windows.
`cli/__init__.py:_register` imports the uninstall command unconditionally
at CLI entry, so `ModuleNotFoundError: No module named 'fcntl'` fired
before argv was even parsed — every `mm` subcommand crashed.

Closes #448.

## Fix

Move `import fcntl` inside `_probe_pid_file`, gated by `sys.platform !=
"win32"`. On Windows the probe returns conservative `alive=True` when
the pid file exists, matching the existing unsupported-filesystem
fallback. `--force` remains the documented escape hatch.

```python
if sys.platform == "win32":
    # POSIX advisory flock is unavailable on Windows. Fall back to the
    # same conservative treatment we use when the probe can't acquire
    # the lock (unsupported filesystem branch below) — pid file exists,
    # so assume a live writer and let the user pass ``--force`` to
    # override. #448.
    return _ServerState(alive=True, pid=pid, pid_file=pid_file)

import fcntl
```

## Scope

Narrow — fixes the reported import-time crash so `mm <anything>` works
on Windows. Every non-`uninstall` subcommand is now fully functional on
Windows (path-handling issues like #316 are tracked separately).

`memtomem-server` (the MCP server binary, a separate entry point) still
uses lazy `import fcntl` inside `main` / `_try_hold_legacy_flock` in
`server/__init__.py`. Running the MCP server on Windows was never
supported and is out of scope for this bug. If cross-platform server
locking becomes a goal, @powerzist's `portalocker` suggestion from #448
would be the natural follow-up — happy to review a PR for that
independently.

## Tests

Three new tests in `TestWindowsFcntlGuard`:

- `test_no_module_level_fcntl_import` — source-scan pin: `fcntl` must not
  appear as a top-level `import` in `uninstall_cmd.py`. CI runs on Linux,
  so a runtime test alone wouldn't catch a future re-hoist; this test
  would.
- `test_probe_returns_alive_on_win32_when_pid_file_exists` /
  `test_probe_returns_dead_on_win32_when_pid_file_missing` — unit-level
  coverage of both Windows fallback branches, with `sys.platform`
  monkey-patched to `"win32"`.
- `test_force_overrides_win32_conservative_liveness` — end-to-end:
  `mm uninstall -y` refuses under the Windows fallback (conservative
  alive=True), but `--force` completes cleanup.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check …` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/uninstall_cmd.py` — clean
- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py -q` — 31 passed
- [x] `uv run pytest -m "not ollama" -q` — 2329 passed, no regressions

## Credits

Thanks to @powerzist for the clear repro + traceback + root-cause on
#448 — analysis was spot-on. Landing a minimum fix now to unblock
Windows users immediately; the `portalocker` refactor is a good
follow-up if Windows server support is on the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
