### PR TITLE
fix(multi-agent): hide agent-runtime: from default mem_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`agent-runtime:` is now hidden from default `mem_search` (behavior
+  change).** ``search.system_namespace_prefixes`` default extended from
+  ``["archive:"]`` to ``["archive:", "agent-runtime:"]`` so per-agent
+  private chunks (created by ``mem_agent_register`` / ``mem_agent_search``)
+  no longer leak into ``namespace=None`` search results — restoring the
+  isolation guarantee advertised on the multi-agent guide. The hidden
+  count surfaces through the existing ``hidden_system_ns`` hint, and
+  ``mem_agent_search`` is unaffected because it pins ``namespace=``
+  explicitly. To restore the pre-change behaviour, override
+  ``search.system_namespace_prefixes: []`` in ``config.json`` (or drop
+  ``agent-runtime:`` from the list while keeping ``archive:``). New
+  ``memtomem.constants`` module exports ``AGENT_NAMESPACE_PREFIX``,
+  ``SHARED_NAMESPACE``, and ``default_system_prefixes`` so callers
+  derive the literal from a single source.
+
 - **Default import behaviour flipped to `on_conflict="skip"`.** Previously
   every record got a fresh UUID, so re-importing the same bundle doubled
   row counts and merging bundles with overlapping content produced silent

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -7,11 +7,13 @@ from typing import TYPE_CHECKING
 
 import click
 
+from memtomem.constants import AGENT_NAMESPACE_PREFIX
+
 if TYPE_CHECKING:
     from memtomem.storage.sqlite_backend import SqliteBackend
 
 _LEGACY_PREFIX = "agent/"
-_CURRENT_PREFIX = "agent-runtime:"
+_CURRENT_PREFIX = AGENT_NAMESPACE_PREFIX
 
 
 @click.group()

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -10,6 +10,8 @@ from typing import Annotated, Literal, cast, get_args
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from memtomem.constants import default_system_prefixes
+
 
 @dataclass(frozen=True)
 class MergeStrategy:
@@ -82,11 +84,14 @@ class SearchConfig(BaseSettings):
     # *default* search (``namespace=None``) but remain retrievable with an
     # explicit namespace argument. Keeps system-generated buckets
     # (auto_archive targets, auto_consolidate ``archive:summary`` summaries)
-    # out of day-to-day results while preserving their audit trail.
-    # Set to an empty list to restore the pre-Phase-A.5 behavior where every
-    # namespace is searchable by default.
+    # *and* per-agent private buckets (``agent-runtime:<id>``) out of
+    # day-to-day results while preserving their audit trail. Set to an
+    # empty list to restore the pre-Phase-A.5 behavior where every
+    # namespace is searchable by default. The default list is sourced from
+    # ``memtomem.constants.default_system_prefixes`` so multi_agent and
+    # CLI code can derive the same prefix without re-declaring the literal.
     system_namespace_prefixes: Annotated[list[str], APPEND] = Field(
-        default_factory=lambda: ["archive:"]
+        default_factory=default_system_prefixes
     )
 
     @field_validator("default_top_k", "bm25_candidates", "dense_candidates", "rrf_k")

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -1,0 +1,51 @@
+"""Cross-cutting constants shared by config, search, MCP tools, and CLI.
+
+These names are exported so a single change point updates every call site
+that derives a namespace, builds the default ``system_namespace_prefixes``,
+or refers to the shared multi-agent bucket. Keeping them here prevents the
+parallel-literal drift that ``feedback_drift_close_must_derive`` warns
+against — every importer must derive from these symbols rather than
+re-declaring the string.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Multi-agent buckets. The ``agent-runtime:<agent-id>`` namespace is a
+# *convenience* isolation boundary, not a security boundary — see the
+# multi-agent guide for the threat model.
+AGENT_NAMESPACE_PREFIX: Final[str] = "agent-runtime:"
+SHARED_NAMESPACE: Final[str] = "shared"
+
+# Provider-ingestion buckets created by ``mm ingest claude-memory`` /
+# ``mm ingest gemini-memory`` / ``mm ingest codex-memory``. Re-exported so
+# downstream code can derive ``isinstance``-style checks without restating
+# the literal.
+CLAUDE_MEMORY_NAMESPACE_PREFIX: Final[str] = "claude-memory:"
+GEMINI_MEMORY_NAMESPACE_PREFIX: Final[str] = "gemini-memory:"
+CODEX_MEMORY_NAMESPACE_PREFIX: Final[str] = "codex-memory:"
+
+# Default ``system_namespace_prefixes`` — namespaces matching any of these
+# prefixes are excluded from default ``mem_search`` (``namespace=None``)
+# but stay reachable when an explicit namespace is passed. ``archive:`` is
+# the auto-archive / auto-consolidate bucket (since Phase A.5);
+# ``agent-runtime:`` keeps one agent's private memories from leaking into
+# another agent's default search results. Override with
+# ``search.system_namespace_prefixes: []`` to restore the pre-multi-agent
+# behaviour where every namespace is searchable by default.
+_DEFAULT_SYSTEM_PREFIXES: Final[tuple[str, ...]] = (
+    "archive:",
+    AGENT_NAMESPACE_PREFIX,
+)
+
+
+def default_system_prefixes() -> list[str]:
+    """Return a fresh ``list`` of the default system namespace prefixes.
+
+    Pydantic ``Field(default_factory=...)`` requires a callable that yields
+    a new list on each model instantiation; sharing a single list would
+    leak mutations across instances.
+    """
+
+    return list(_DEFAULT_SYSTEM_PREFIXES)

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -14,17 +14,13 @@ from typing import Final
 
 # Multi-agent buckets. The ``agent-runtime:<agent-id>`` namespace is a
 # *convenience* isolation boundary, not a security boundary — see the
-# multi-agent guide for the threat model.
+# multi-agent guide for the threat model. Provider-ingestion namespace
+# prefixes (``claude-memory:``, ``gemini-memory:``, ``codex-memory:``)
+# stay as locally-defined literals in ``cli/ingest_cmd.py`` for now;
+# promoting them here belongs in the same change that wires them up,
+# not this PR.
 AGENT_NAMESPACE_PREFIX: Final[str] = "agent-runtime:"
 SHARED_NAMESPACE: Final[str] = "shared"
-
-# Provider-ingestion buckets created by ``mm ingest claude-memory`` /
-# ``mm ingest gemini-memory`` / ``mm ingest codex-memory``. Re-exported so
-# downstream code can derive ``isinstance``-style checks without restating
-# the literal.
-CLAUDE_MEMORY_NAMESPACE_PREFIX: Final[str] = "claude-memory:"
-GEMINI_MEMORY_NAMESPACE_PREFIX: Final[str] = "gemini-memory:"
-CODEX_MEMORY_NAMESPACE_PREFIX: Final[str] = "codex-memory:"
 
 # Default ``system_namespace_prefixes`` — namespaces matching any of these
 # prefixes are excluded from default ``mem_search`` (``namespace=None``)

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -9,10 +9,6 @@ from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
-# Re-export for callers that previously imported the local-private symbol.
-# ``AGENT_NAMESPACE_PREFIX`` is the canonical source — see ``constants.py``.
-_AGENT_NAMESPACE_PREFIX = AGENT_NAMESPACE_PREFIX
-
 
 @mcp.tool()
 @tool_handler

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
-# Automatic namespace prefix for the multi-agent tool. Follows the
-# ``{bucket}-{kind}:`` convention used by the ingest pipeline
-# (``claude-memory:``, ``codex-memory:``) — see #318 for the rule.
-_AGENT_NAMESPACE_PREFIX = "agent-runtime:"
+# Re-export for callers that previously imported the local-private symbol.
+# ``AGENT_NAMESPACE_PREFIX`` is the canonical source — see ``constants.py``.
+_AGENT_NAMESPACE_PREFIX = AGENT_NAMESPACE_PREFIX
 
 
 @mcp.tool()
@@ -40,23 +40,23 @@ async def mem_agent_register(
     if not agent_id:
         return "Error: agent_id must contain at least one allowed character."
     app = await _get_app_initialized(ctx)
-    namespace = f"{_AGENT_NAMESPACE_PREFIX}{agent_id}"
+    namespace = f"{AGENT_NAMESPACE_PREFIX}{agent_id}"
 
     await app.storage.set_namespace_meta(namespace, description=description, color=color)
 
-    # Ensure "shared" namespace exists
-    shared_meta = await app.storage.get_namespace_meta("shared")
+    # Ensure shared namespace exists
+    shared_meta = await app.storage.get_namespace_meta(SHARED_NAMESPACE)
     if shared_meta is None:
         await app.storage.set_namespace_meta(
-            "shared", description="Shared knowledge base for all agents"
+            SHARED_NAMESPACE, description="Shared knowledge base for all agents"
         )
 
     return (
         f"Agent registered: {agent_id}\n"
         f"- Namespace: {namespace}\n"
-        f"- Shared namespace: shared\n"
+        f"- Shared namespace: {SHARED_NAMESPACE}\n"
         f"Use namespace='{namespace}' for agent-specific memories,\n"
-        f"or namespace='shared' for cross-agent knowledge."
+        f"or namespace='{SHARED_NAMESPACE}' for cross-agent knowledge."
     )
 
 
@@ -90,11 +90,11 @@ async def mem_agent_search(
     app = await _get_app_initialized(ctx)
     from memtomem.server.formatters import _format_results
 
-    agent_ns = f"{_AGENT_NAMESPACE_PREFIX}{agent_id}" if agent_id else app.current_namespace
+    agent_ns = f"{AGENT_NAMESPACE_PREFIX}{agent_id}" if agent_id else app.current_namespace
 
     # Build namespace filter
     if include_shared and agent_ns:
-        ns_filter = f"{agent_ns},shared"
+        ns_filter = f"{agent_ns},{SHARED_NAMESPACE}"
     elif agent_ns:
         ns_filter = agent_ns
     else:
@@ -118,7 +118,7 @@ async def mem_agent_search(
 @register("multi_agent")
 async def mem_agent_share(
     chunk_id: str,
-    target: str = "shared",
+    target: str = SHARED_NAMESPACE,
     ctx: CtxType = None,
 ) -> str:
     """Share a memory chunk with another agent or the shared namespace.

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -5,13 +5,30 @@ The sanitizer used by ``mem_agent_register`` / ``mem_agent_search`` lives in
 with the ingest pipeline. These tests pin the behavior the multi-agent tool
 relies on (single-segment `agent_id` sanitization so the generated
 ``agent-runtime:{id}`` namespace stays at depth 1).
+
+``TestDefaultIsolation`` pins the multi-agent default search isolation
+behaviour: ``agent-runtime:`` lives in ``system_namespace_prefixes`` by
+default so one agent's private chunks do not leak into another agent's
+``mem_search`` results. Removing the prefix would silently break the
+isolation contract advertised in the multi-agent guide, so the assertion
+imports the constant directly (per ``feedback_pin_test_constant_over_source_scan``).
 """
 
 from __future__ import annotations
 
 import pytest
 
+from memtomem.config import Mem2MemConfig
+from memtomem.constants import (
+    AGENT_NAMESPACE_PREFIX,
+    SHARED_NAMESPACE,
+    _DEFAULT_SYSTEM_PREFIXES,
+    default_system_prefixes,
+)
+from memtomem.server.component_factory import close_components, create_components
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
+
+from helpers import make_chunk
 
 
 class TestSanitizeNamespaceSegment:
@@ -38,3 +55,128 @@ class TestSanitizeNamespaceSegment:
     def test_sanitize_pure_slash_collapses_to_underscore(self):
         """``agent_id="/"`` must not produce ``agent-runtime://`` (double separator)."""
         assert sanitize_namespace_segment("/") == "_"
+
+
+class TestDefaultIsolation:
+    """Default ``system_namespace_prefixes`` hides ``agent-runtime:`` chunks
+    from un-pinned ``mem_search``.
+
+    Removing ``agent-runtime:`` from the default would silently leak one
+    agent's private memories into another agent's day-to-day search
+    results — exactly the isolation guarantee the multi-agent guide
+    advertises. The pin imports the constant directly so a future
+    refactor cannot drift the literal in only one place.
+    """
+
+    def test_constant_includes_agent_runtime_prefix(self):
+        """``_DEFAULT_SYSTEM_PREFIXES`` must include both archive and agent-runtime."""
+        assert "archive:" in _DEFAULT_SYSTEM_PREFIXES
+        assert AGENT_NAMESPACE_PREFIX in _DEFAULT_SYSTEM_PREFIXES
+
+    def test_factory_returns_fresh_list(self):
+        """``default_system_prefixes`` must hand back a fresh list each call.
+
+        Pydantic field defaults that share a list instance leak mutations
+        across model instantiations — a classic gotcha that this test
+        catches at the seam.
+        """
+        first = default_system_prefixes()
+        second = default_system_prefixes()
+        assert first == second
+        assert first is not second
+        first.append("mutate:")
+        assert "mutate:" not in second
+
+    def test_search_config_default_includes_agent_runtime(self):
+        """A freshly built ``Mem2MemConfig`` carries the default in place."""
+        cfg = Mem2MemConfig()
+        prefixes = list(cfg.search.system_namespace_prefixes)
+        assert "archive:" in prefixes
+        assert AGENT_NAMESPACE_PREFIX in prefixes
+
+
+class TestAgentRuntimeIsolationPipeline:
+    """End-to-end pipeline pin: chunk in ``agent-runtime:planner`` is hidden
+    from ``namespace=None`` search (matches the ``archive:*`` flow in
+    ``test_trust_ux``) but reachable when the caller pins the namespace.
+    """
+
+    @pytest.fixture
+    async def isolated_components(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "isolation.db"
+        mem_dir = tmp_path / "memories"
+        mem_dir.mkdir()
+
+        for var in (
+            "MEMTOMEM_EMBEDDING__PROVIDER",
+            "MEMTOMEM_EMBEDDING__MODEL",
+            "MEMTOMEM_EMBEDDING__DIMENSION",
+            "MEMTOMEM_STORAGE__SQLITE_PATH",
+            "MEMTOMEM_INDEXING__MEMORY_DIRS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        config = Mem2MemConfig()
+        config.storage.sqlite_path = db_path
+        config.indexing.memory_dirs = [mem_dir]
+        config.embedding.dimension = 1024
+        config.search.enable_dense = False  # BM25-only — no embedder needed
+
+        import memtomem.config as _cfg
+
+        monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
+
+        comp = await create_components(config)
+        try:
+            yield comp
+        finally:
+            await close_components(comp)
+
+    async def test_default_search_excludes_agent_runtime_chunks(self, isolated_components):
+        """``mem_search`` (namespace=None) must not return another agent's private chunks."""
+        comp = isolated_components
+
+        public = make_chunk("planner discusses architecture", namespace="default")
+        private = make_chunk(
+            "planner private architecture notes",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}planner",
+        )
+        await comp.storage.upsert_chunks([public, private])
+
+        results, stats = await comp.search_pipeline.search("architecture", top_k=10)
+        result_namespaces = {r.chunk.metadata.namespace for r in results}
+
+        assert "default" in result_namespaces
+        assert f"{AGENT_NAMESPACE_PREFIX}planner" not in result_namespaces
+        assert stats.hidden_system_ns >= 1
+
+    async def test_explicit_agent_namespace_returns_chunks(self, isolated_components):
+        """``mem_agent_search`` (which pins ``namespace=``) reaches the same chunks."""
+        comp = isolated_components
+
+        private = make_chunk(
+            "planner private notes",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}planner",
+        )
+        await comp.storage.upsert_chunks([private])
+
+        results, _ = await comp.search_pipeline.search(
+            "planner",
+            top_k=10,
+            namespace=f"{AGENT_NAMESPACE_PREFIX}planner",
+        )
+        assert any(
+            r.chunk.metadata.namespace == f"{AGENT_NAMESPACE_PREFIX}planner" for r in results
+        )
+
+    async def test_shared_namespace_visible_in_default_search(self, isolated_components):
+        """The ``shared`` namespace is *not* a system prefix — cross-agent
+        knowledge stays surfaceable via plain ``mem_search``.
+        """
+        comp = isolated_components
+
+        shared = make_chunk("shared cross-agent knowledge", namespace=SHARED_NAMESPACE)
+        await comp.storage.upsert_chunks([shared])
+
+        results, _ = await comp.search_pipeline.search("knowledge", top_k=10)
+        assert any(r.chunk.metadata.namespace == SHARED_NAMESPACE for r in results)

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -65,7 +65,9 @@ async def trust_components(tmp_path, monkeypatch):
     # non-zero so upsert_chunks works even though dense search itself is off.
     config.embedding.dimension = 1024
     config.search.enable_dense = False  # BM25 only — no embedder required
-    # Keep the default system prefix but spell it out for readability.
+    # Narrow to ``archive:`` only so the trust-UX fixture stays focused on the
+    # archive-hint path. The runtime default also includes ``agent-runtime:``,
+    # but multi-agent isolation is exercised by ``test_multi_agent`` instead.
     config.search.system_namespace_prefixes = ["archive:"]
 
     import memtomem.config as _cfg


### PR DESCRIPTION
## Summary

`search.system_namespace_prefixes` default was `["archive:"]` only, so
agent A's private chunks (created by `mem_agent_register` /
`mem_agent_search`) leaked into agent B's `mem_search(namespace=None)`
results — directly contradicting the namespace-based isolation
guarantee documented on the [multi-agent guide](https://memtomem.com/ltm/multi-agent/).

This PR extends the default to `["archive:", "agent-runtime:"]` and
consolidates the literal in a new `memtomem.constants` module so config,
MCP tools, and CLI all derive the prefix from one source.

- New `packages/memtomem/src/memtomem/constants.py` exports
  `AGENT_NAMESPACE_PREFIX`, `SHARED_NAMESPACE`, and
  `default_system_prefixes()`. `multi_agent.py`, `agent_cmd.py`, and
  `config.py` derive from these symbols.
- `mem_agent_search` is unaffected — it builds an explicit namespace
  filter (`agent-runtime:<id>,shared`) so it bypasses the system prefix
  exclusion entirely.
- The hidden count surfaces through the existing `hidden_system_ns`
  hint, so users still see "N hidden — pass namespace=… to include
  them" when relevant.

## Behavior change

Callers relying on plain `mem_search` to read `agent-runtime:*` chunks
must now either:

1. Pin `namespace="agent-runtime:<id>"` on the call, **or**
2. Override `search.system_namespace_prefixes: []` in `config.json`
   (or omit `agent-runtime:` while keeping `archive:`), **or**
3. Use `mem_agent_search` (recommended).

Documented under `[Unreleased]` / `Changed` in `CHANGELOG.md`.

## Threat model

`agent-runtime:<id>` is a **convenience** isolation boundary, not a
security boundary. Direct storage access (raw `namespace=`, ingest
`--namespace`, `list_namespaces`, direct SQL) still reaches private
chunks. This PR closes the default-search UX leak only — proper
multi-tenant ACL/auth boundary is tracked as a separate follow-up.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_multi_agent.py -v` —
  16 tests pass (10 sanitize + 3 default-isolation pin + 3 pipeline
  end-to-end).
- [x] `uv run pytest -m "not ollama"` — 2335 passed, 46 deselected,
  no regression in `test_trust_ux`, `test_init_cmd`,
  `test_config_overrides`, `test_agent_cmd`, `test_server_tools_org`.
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check`
  — clean.
- [x] `uv run mypy` on touched files — no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
