### PR TITLE
fix(multi-agent): admit mem_agent_share is a copy + add shared-from audit tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mem_agent_share` now stamps a `shared-from=<source-uuid>` audit
+  tag on the copy, with chain dedup.** The docstring previously
+  contradicted itself ("Creates a copy" / "cross-reference link instead
+  of copying" / actual implementation: a brand-new chunk via
+  `mem_add`). The new behaviour is a content **copy** with provenance
+  recorded only via the new tag — the function name is preserved for
+  API stability and true cross-reference / link semantics are tracked
+  as a follow-up RFC. Re-sharing strips any inherited
+  `shared-from=...` tag before appending so audit chains do not grow
+  unbounded.
+
 ## [0.1.27] — 2026-04-24
 
 Hotfix release. Closes the multi-instance bug (#444): running

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -109,6 +109,25 @@ async def mem_agent_search(
     return output
 
 
+_SHARED_FROM_TAG_PREFIX = "shared-from="
+
+
+def _build_shared_tags(source_tags: tuple[str, ...] | list[str], source_chunk_id: str) -> list[str]:
+    """Return the tag list to put on a ``mem_agent_share`` copy.
+
+    Strips any inherited ``shared-from=...`` entries (so a chain of
+    re-shares produces ``shared-from=<immediate-parent>`` only, not a
+    growing audit chain) and appends a single ``shared-from=<source>``
+    pointing at the immediate parent. Extracted as a top-level function
+    so the dedup contract can be unit-tested without spinning up MCP
+    components.
+    """
+
+    inherited = [t for t in source_tags if not t.startswith(_SHARED_FROM_TAG_PREFIX)]
+    inherited.append(f"{_SHARED_FROM_TAG_PREFIX}{source_chunk_id}")
+    return inherited
+
+
 @mcp.tool()
 @tool_handler
 @register("multi_agent")
@@ -117,14 +136,26 @@ async def mem_agent_share(
     target: str = SHARED_NAMESPACE,
     ctx: CtxType = None,
 ) -> str:
-    """Share a memory chunk with another agent or the shared namespace.
+    """Copy a memory chunk's content into another namespace.
 
-    Creates a copy of the chunk in the target namespace. The original
-    chunk remains in its source namespace.
+    Despite the name, this performs a content **copy** into ``target``,
+    not a reference link. The new chunk has a fresh UUID; deleting the
+    source does not delete the copy and updating the source does not
+    propagate. Source linkage is recorded only via a
+    ``shared-from=<source-uuid>`` tag on the new chunk so audit tools
+    can trace provenance. The function name is preserved for API
+    stability — true cross-reference / link semantics (no duplication,
+    bidirectional propagation) are tracked as a separate RFC follow-up.
+
+    Tags from the source chunk are carried over verbatim, with one
+    exception: any pre-existing ``shared-from=...`` tag is **dropped**
+    so a chain of re-shares produces ``shared-from=<immediate-parent>``
+    only, not a growing audit chain. Use the parent UUID to walk back
+    one hop at a time if needed.
 
     Args:
-        chunk_id: UUID of the chunk to share
-        target: Target namespace — 'shared' or 'agent-runtime:{agent_id}'
+        chunk_id: UUID of the chunk to copy
+        target: Target namespace — ``'shared'`` or ``'agent-runtime:{agent_id}'``
     """
     from uuid import UUID
 
@@ -139,14 +170,14 @@ async def mem_agent_share(
     if chunk is None:
         return f"Chunk {chunk_id} not found."
 
-    # Create a cross-reference link instead of copying
-    # This avoids data duplication while maintaining the relationship
+    inherited_tags = _build_shared_tags(chunk.metadata.tags, chunk_id)
+
     from memtomem.server.tools.memory_crud import mem_add
 
     result = await mem_add(
         content=chunk.content,
         title=f"Shared: {' > '.join(chunk.metadata.heading_hierarchy) if chunk.metadata.heading_hierarchy else 'memory'}",
-        tags=list(chunk.metadata.tags),
+        tags=inherited_tags,
         namespace=target,
         ctx=ctx,
     )

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -12,6 +12,13 @@ default so one agent's private chunks do not leak into another agent's
 ``mem_search`` results. Removing the prefix would silently break the
 isolation contract advertised in the multi-agent guide, so the assertion
 imports the constant directly (per ``feedback_pin_test_constant_over_source_scan``).
+
+``TestSharedFromTags`` pins the audit-trail contract for
+``mem_agent_share``: the function copies content into a target namespace
+(it is *not* a reference link, despite the name) and stamps a single
+``shared-from=<source-uuid>`` tag on the copy. Re-sharing must not
+accumulate a chain of inherited ``shared-from=...`` tags — that's the
+dedup invariant unit-tested at the helper seam.
 """
 
 from __future__ import annotations
@@ -26,6 +33,7 @@ from memtomem.constants import (
     default_system_prefixes,
 )
 from memtomem.server.component_factory import close_components, create_components
+from memtomem.server.tools.multi_agent import _SHARED_FROM_TAG_PREFIX, _build_shared_tags
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
 from helpers import make_chunk
@@ -180,3 +188,58 @@ class TestAgentRuntimeIsolationPipeline:
 
         results, _ = await comp.search_pipeline.search("knowledge", top_k=10)
         assert any(r.chunk.metadata.namespace == SHARED_NAMESPACE for r in results)
+
+
+class TestSharedFromTags:
+    """``_build_shared_tags`` is the seam where ``mem_agent_share`` decides
+    what tags land on the copy. The contract is:
+
+    * source tags carry over verbatim,
+    * a single ``shared-from=<source-uuid>`` is appended,
+    * any inherited ``shared-from=...`` is dropped before appending so a
+      chain of re-shares does not accumulate an audit chain.
+    """
+
+    def test_appends_shared_from_tag_for_fresh_chunk(self):
+        out = _build_shared_tags(("python", "decision"), "abc-123")
+        assert "python" in out
+        assert "decision" in out
+        assert f"{_SHARED_FROM_TAG_PREFIX}abc-123" in out
+
+    def test_preserves_source_tags_in_order(self):
+        """Carry-over keeps the source's ordering — share-from is appended at the end."""
+        out = _build_shared_tags(["alpha", "beta", "gamma"], "src-uuid")
+        assert out[:3] == ["alpha", "beta", "gamma"]
+        assert out[-1] == f"{_SHARED_FROM_TAG_PREFIX}src-uuid"
+
+    def test_drops_inherited_shared_from_on_reshare(self):
+        """Re-sharing a chunk that was itself shared must not chain the tag.
+
+        Source has ``shared-from=parent-uuid`` from a prior share; sharing
+        it again under a new chunk_id should yield a list with **only**
+        ``shared-from=new-uuid`` — pointing at the immediate parent.
+        """
+        source_tags = ("topic", f"{_SHARED_FROM_TAG_PREFIX}grandparent-uuid")
+        out = _build_shared_tags(source_tags, "new-uuid")
+
+        shared_from = [t for t in out if t.startswith(_SHARED_FROM_TAG_PREFIX)]
+        assert shared_from == [f"{_SHARED_FROM_TAG_PREFIX}new-uuid"]
+        assert "topic" in out
+        # No chain: the grandparent stamp is gone.
+        assert f"{_SHARED_FROM_TAG_PREFIX}grandparent-uuid" not in out
+
+    def test_drops_multiple_inherited_shared_from_tags(self):
+        """Defensive: should the source carry several shared-from tags
+        (e.g. from a buggy older version), drop them all."""
+        source_tags = (
+            "topic",
+            f"{_SHARED_FROM_TAG_PREFIX}gp1-uuid",
+            f"{_SHARED_FROM_TAG_PREFIX}gp2-uuid",
+        )
+        out = _build_shared_tags(source_tags, "new-uuid")
+        shared_from = [t for t in out if t.startswith(_SHARED_FROM_TAG_PREFIX)]
+        assert shared_from == [f"{_SHARED_FROM_TAG_PREFIX}new-uuid"]
+
+    def test_handles_empty_source_tags(self):
+        out = _build_shared_tags((), "src-uuid")
+        assert out == [f"{_SHARED_FROM_TAG_PREFIX}src-uuid"]


### PR DESCRIPTION
## Summary

`mem_agent_share` had three contradictory descriptions of what it does:

* Docstring line 127: "Creates a copy of the chunk in the target namespace"
* Comment line 146-147: "Create a cross-reference link instead of copying"
* Actual implementation: `mem_add(...)` — a brand-new chunk with a fresh
  UUID and no link back to the source.

The third version is the truth. The other two misled callers (and were
amplified on the [multi-agent guide](https://memtomem.com/ltm/multi-agent/))
into expecting reference-link semantics that the storage layer does not
implement.

This PR:

1. **Admits the function is a copy.** Docstring rewritten to spell out
   that the new chunk has a fresh UUID, that delete/update on the source
   does not propagate, and that the name is preserved for API stability
   while true share semantics are tracked in a follow-up RFC.
2. **Adds a `shared-from=<source-uuid>` audit tag** to the copy so
   audit tooling can walk one hop back to the source. Tag uses `=`
   (not `:`) to avoid collisions with namespace-style tag schemes.
3. **Dedups the audit chain on re-share.** If the source already
   carried an inherited `shared-from=...` tag (from a prior share), it
   is dropped before appending the new stamp — so the new chunk holds
   `shared-from=<immediate parent>` only, never a growing chain.

The dedup logic is extracted into a top-level `_build_shared_tags`
helper so the contract is unit-testable without standing up MCP
components.

## Out of scope (follow-up RFC)

True cross-reference linking — no duplication, bidirectional
propagation, storage-level `chunk_links` table — is a separate change
that needs schema migration. Tracked as a follow-up.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_multi_agent.py -v` —
  15 pass (10 existing sanitize + 5 new `TestSharedFromTags`: fresh
  share, source-order preservation, single-parent dedup, multi-stale
  dedup, empty source tags).
- [x] `uv run pytest -m "not ollama"` — 2334 passed, 46 deselected.
- [x] `uv run ruff check` + `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
