### PR TITLE
fix(multi-agent): wire agent_id from mem_session_start to mem_agent_search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `shared-from=...` tag before appending so audit chains do not grow
   unbounded.
 
+- **`mem_session_start` now records `agent_id` so `mem_agent_search`
+  inherits it via session context.** Previously `mem_session_start`
+  only set `current_session_id`, while `mem_agent_search(agent_id=None)`
+  fell back to `current_namespace` — a different axis — so the
+  multi-agent guide's "agent_id is not auto-detected, but inherited via
+  session context" promise silently broke. New `current_agent_id` field
+  on `AppContext`, guarded by a dedicated `_session_lock` (kept distinct
+  from `_config_lock` so config writes can't block session updates and
+  vice versa). `_resolve_agent_namespace` helper documents the priority:
+  explicit `agent_id` arg > `current_agent_id` > `current_namespace`.
+  Calling `mem_session_start` while a session is already active now
+  auto-ends the previous session (warning log + inline notice in the
+  return string) instead of silently overwriting the pointer; the
+  storage row for the auto-ended session is closed with an
+  `auto_ended: true` metadata flag for audit. `mem_session_end` resets
+  both fields.
+
 ## [0.1.27] — 2026-04-24
 
 Hotfix release. Closes the multi-instance bug (#444): running

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -95,6 +95,14 @@ class AppContext:
     webhook_manager: object | None = None
     current_namespace: str | None = None
     current_session_id: str | None = None
+    # Set by ``mem_session_start(agent_id=...)`` and reset by
+    # ``mem_session_end``. ``mem_agent_search(agent_id=None)`` falls back to
+    # this value before falling back to ``current_namespace`` — so an agent
+    # that started a session does not need to repeat its agent_id on every
+    # tool call. Lives on a separate ``_session_lock`` (not ``_config_lock``)
+    # because session state has a different lifetime / mutation cadence than
+    # config — mixing the two locks would entangle their contention paths.
+    current_agent_id: str | None = None
     # Internal state — not part of the public ``__init__`` surface; populated
     # by ``ensure_initialized`` / ``from_components``. The watcher /
     # scheduler / policy_scheduler / health_watchdog handles are populated
@@ -114,6 +122,10 @@ class AppContext:
     _dim_mismatch_announced: bool = False
     _config_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _init_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    # Guards mutations of ``current_session_id`` + ``current_agent_id``.
+    # Kept distinct from ``_config_lock`` so a long-running config write
+    # cannot block a session start, and vice versa.
+    _session_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
     # ── component accessors ───────────────────────────────────────────────
     # These raise ``RuntimeError`` if accessed before ``ensure_initialized``

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -4,10 +4,34 @@ from __future__ import annotations
 
 from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app_initialized
+from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
+
+
+def _resolve_agent_namespace(app: AppContext, agent_id: str | None) -> str | None:
+    """Resolve the namespace ``mem_agent_search`` should query.
+
+    Priority order (each falls back to the next when ``None``):
+
+    1. Explicit ``agent_id`` argument — the caller wants to override the
+       session context for this single call.
+    2. ``app.current_agent_id`` — set by ``mem_session_start(agent_id=...)``;
+       lets agents avoid repeating their identity on every tool call.
+    3. ``app.current_namespace`` — pre-multi-agent legacy fallback. Kept
+       so workflows that pre-date session-driven agent inheritance keep
+       working unchanged.
+
+    Returns ``None`` if no source resolved a namespace, in which case
+    the caller treats the search as un-pinned.
+    """
+
+    if agent_id:
+        return f"{AGENT_NAMESPACE_PREFIX}{agent_id}"
+    if app.current_agent_id:
+        return f"{AGENT_NAMESPACE_PREFIX}{app.current_agent_id}"
+    return app.current_namespace
 
 
 @mcp.tool()
@@ -86,7 +110,7 @@ async def mem_agent_search(
     app = await _get_app_initialized(ctx)
     from memtomem.server.formatters import _format_results
 
-    agent_ns = f"{AGENT_NAMESPACE_PREFIX}{agent_id}" if agent_id else app.current_namespace
+    agent_ns = _resolve_agent_namespace(app, agent_id)
 
     # Build namespace filter
     if include_shared and agent_ns:

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -2,12 +2,48 @@
 
 from __future__ import annotations
 
+import logging
 from uuid import uuid4
 
 from memtomem.server import mcp
-from memtomem.server.context import CtxType, _get_app_initialized
+from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
+
+logger = logging.getLogger(__name__)
+
+
+async def _end_active_session_inline(app: AppContext, reason: str) -> str | None:
+    """End the currently-active session without resetting ``current_*`` state.
+
+    Returns a one-line warning describing what was rolled forward, or
+    ``None`` when no session was active. Caller is responsible for
+    resetting ``current_session_id`` / ``current_agent_id`` afterwards
+    (typically by overwriting them as part of a fresh session start).
+    """
+
+    session_id = app.current_session_id
+    if not session_id:
+        return None
+
+    events = await app.storage.get_session_events(session_id)
+    event_counts: dict[str, int] = {}
+    for e in events:
+        event_counts[e["event_type"]] = event_counts.get(e["event_type"], 0) + 1
+
+    await app.storage.end_session(
+        session_id,
+        f"[auto-ended: {reason}]",
+        {"event_counts": event_counts, "auto_ended": True},
+    )
+    await app.storage.scratch_cleanup(session_id)
+    logger.warning(
+        "mem_session_start auto-ended previous session %s (%s events) — %s",
+        session_id,
+        len(events),
+        reason,
+    )
+    return f"(auto-ended previous session {session_id[:8]}... — {reason})"
 
 
 @mcp.tool()
@@ -21,8 +57,20 @@ async def mem_session_start(
 ) -> str:
     """Start a new episodic memory session.
 
-    Creates a session record and sets it as the current session.
-    All subsequent tool calls will be tracked as session events.
+    Creates a session record and sets it as the current session. All
+    subsequent tool calls will be tracked as session events. The
+    ``agent_id`` is recorded on ``AppContext.current_agent_id`` so that
+    multi-agent tools (``mem_agent_search`` and friends) can resolve the
+    active agent without the caller passing it on every call.
+
+    State transitions:
+
+    * No active session → records the new session, sets
+      ``current_session_id`` and ``current_agent_id``.
+    * Active session present → the previous session is **auto-ended**
+      (with a warning logged and an inline notice in the return string)
+      and the new session takes its place. The previous ``agent_id`` is
+      replaced by the new one — agents do not stack.
 
     Args:
         agent_id: Identifier for the agent starting the session
@@ -33,12 +81,21 @@ async def mem_session_start(
     session_id = str(uuid4())
     effective_ns = namespace or app.current_namespace or "default"
 
-    metadata = {"title": title} if title else {}
-    await app.storage.create_session(session_id, agent_id, effective_ns, metadata=metadata)
-    async with app._config_lock:
+    auto_end_notice: str | None = None
+    async with app._session_lock:
+        if app.current_session_id:
+            auto_end_notice = await _end_active_session_inline(
+                app, reason="superseded by new mem_session_start"
+            )
+
+        metadata = {"title": title} if title else {}
+        await app.storage.create_session(session_id, agent_id, effective_ns, metadata=metadata)
         app.current_session_id = session_id
+        app.current_agent_id = agent_id
 
     lines = [f"Session started: {session_id}"]
+    if auto_end_notice:
+        lines.append(auto_end_notice)
     if title:
         lines.append(f"- Title: {title}")
     lines.append(f"- Agent: {agent_id}")
@@ -55,8 +112,10 @@ async def mem_session_end(
 ) -> str:
     """End the current episodic memory session.
 
-    Closes the session, saves an optional summary, and records
-    event statistics. Working memory bound to this session is cleaned up.
+    Closes the session, saves an optional summary, and records event
+    statistics. Working memory bound to this session is cleaned up.
+    Resets both ``current_session_id`` and ``current_agent_id`` so the
+    next ``mem_agent_search`` falls back to ``current_namespace``.
 
     Args:
         summary: Optional summary of what was accomplished in this session
@@ -79,8 +138,9 @@ async def mem_session_end(
     # Cleanup session-bound working memory
     cleaned = await app.storage.scratch_cleanup(session_id)
 
-    async with app._config_lock:
+    async with app._session_lock:
         app.current_session_id = None
+        app.current_agent_id = None
 
     lines = [
         f"Session ended: {session_id}",

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -19,9 +19,18 @@ imports the constant directly (per ``feedback_pin_test_constant_over_source_scan
 ``shared-from=<source-uuid>`` tag on the copy. Re-sharing must not
 accumulate a chain of inherited ``shared-from=...`` tags — that's the
 dedup invariant unit-tested at the helper seam.
+
+``TestResolveAgentNamespace`` pins the priority order
+``mem_agent_search`` follows when ``agent_id`` is omitted:
+explicit arg > ``current_agent_id`` (set by the active session) >
+``current_namespace`` (legacy fallback). Drift here would break the
+"agent_id inherits via session context" promise documented on the
+multi-agent guide.
 """
 
 from __future__ import annotations
+
+from types import SimpleNamespace
 
 import pytest
 
@@ -33,7 +42,11 @@ from memtomem.constants import (
     default_system_prefixes,
 )
 from memtomem.server.component_factory import close_components, create_components
-from memtomem.server.tools.multi_agent import _SHARED_FROM_TAG_PREFIX, _build_shared_tags
+from memtomem.server.tools.multi_agent import (
+    _SHARED_FROM_TAG_PREFIX,
+    _build_shared_tags,
+    _resolve_agent_namespace,
+)
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
 from helpers import make_chunk
@@ -243,3 +256,43 @@ class TestSharedFromTags:
     def test_handles_empty_source_tags(self):
         out = _build_shared_tags((), "src-uuid")
         assert out == [f"{_SHARED_FROM_TAG_PREFIX}src-uuid"]
+
+
+class TestResolveAgentNamespace:
+    """Priority order for ``_resolve_agent_namespace``:
+
+    1. Explicit ``agent_id`` arg.
+    2. ``app.current_agent_id`` (set by ``mem_session_start``).
+    3. ``app.current_namespace`` (legacy fallback).
+
+    Returns ``None`` when none of the three resolves.
+    """
+
+    def _app(self, current_agent_id: str | None, current_namespace: str | None):
+        return SimpleNamespace(
+            current_agent_id=current_agent_id,
+            current_namespace=current_namespace,
+        )
+
+    def test_explicit_agent_id_wins(self):
+        app = self._app(current_agent_id="planner", current_namespace="archive:old")
+        assert _resolve_agent_namespace(app, "coder") == f"{AGENT_NAMESPACE_PREFIX}coder"
+
+    def test_falls_back_to_current_agent_id(self):
+        app = self._app(current_agent_id="planner", current_namespace="archive:old")
+        assert _resolve_agent_namespace(app, None) == f"{AGENT_NAMESPACE_PREFIX}planner"
+
+    def test_falls_back_to_current_namespace_when_no_session_agent(self):
+        """Legacy fallback for callers that don't use sessions yet."""
+        app = self._app(current_agent_id=None, current_namespace="legacy:project")
+        assert _resolve_agent_namespace(app, None) == "legacy:project"
+
+    def test_returns_none_when_nothing_resolves(self):
+        app = self._app(current_agent_id=None, current_namespace=None)
+        assert _resolve_agent_namespace(app, None) is None
+
+    def test_explicit_arg_overrides_even_when_session_active(self):
+        """Explicit ``agent_id`` is the strongest signal — agents can override
+        their own session context for a one-off cross-agent query."""
+        app = self._app(current_agent_id="planner", current_namespace="legacy:ns")
+        assert _resolve_agent_namespace(app, "coder") == f"{AGENT_NAMESPACE_PREFIX}coder"

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -2,6 +2,22 @@
 
 import pytest
 
+from memtomem.server.context import AppContext
+from memtomem.server.tools.session import mem_session_end, mem_session_start
+
+
+class _StubCtx:
+    """Minimal stand-in for MCP ``Context`` so session tools can be invoked
+    directly. Mirrors the helper in ``test_server_degraded_mode``.
+    """
+
+    def __init__(self, app: AppContext) -> None:
+        class _RC:
+            pass
+
+        self.request_context = _RC()
+        self.request_context.lifespan_context = app
+
 
 class TestSessions:
     @pytest.mark.asyncio
@@ -44,3 +60,91 @@ class TestSessions:
         await storage.create_session("old", "agent", "default")
         sessions = await storage.list_sessions(since="2099-01-01")
         assert len(sessions) == 0
+
+
+class TestSessionAgentInheritance:
+    """``mem_session_start`` records ``agent_id`` on the AppContext so
+    ``mem_agent_search`` can resolve the active agent without the caller
+    repeating the identity on every tool call. Pins the state transitions
+    documented in the multi-agent plan:
+
+    * fresh start → ``current_session_id`` + ``current_agent_id`` set
+    * second start while active → previous session **auto-ended**, new
+      session takes over, ``current_agent_id`` replaced
+    * ``mem_session_end`` → both fields reset to ``None``
+    * ``mem_session_end`` with no active session → no-op
+    """
+
+    @pytest.mark.asyncio
+    async def test_start_sets_current_agent_id(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(agent_id="planner", title="Sprint", ctx=ctx)  # type: ignore[arg-type]
+
+        assert app.current_session_id is not None
+        assert app.current_agent_id == "planner"
+        assert "Session started" in out
+        assert "- Agent: planner" in out
+
+    @pytest.mark.asyncio
+    async def test_second_start_auto_ends_previous(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        first_session = app.current_session_id
+        assert first_session is not None
+
+        out = await mem_session_start(agent_id="coder", ctx=ctx)  # type: ignore[arg-type]
+
+        # New session replaces the old one
+        assert app.current_session_id is not None
+        assert app.current_session_id != first_session
+        assert app.current_agent_id == "coder"
+        # Inline notice surfaces the auto-end so callers are not surprised
+        assert "auto-ended previous session" in out
+        # And the storage row for the old session is closed
+        rows = await app.storage.list_sessions()
+        old_row = next(r for r in rows if r["id"] == first_session)
+        assert old_row["ended_at"] is not None
+        assert "auto-ended" in (old_row.get("summary") or "")
+
+    @pytest.mark.asyncio
+    async def test_end_resets_both_fields(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        assert app.current_agent_id == "planner"
+
+        out = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+        assert "Session ended" in out
+
+    @pytest.mark.asyncio
+    async def test_end_with_no_active_session_is_noop(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        # Ensure no active session
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+
+        out = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+        assert out == "No active session."
+        # State unchanged
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+
+    @pytest.mark.asyncio
+    async def test_session_lock_is_distinct_from_config_lock(self, components):
+        """Session state mutations must use ``_session_lock`` so a config
+        write cannot block them, and vice versa. A simple identity check
+        keeps the two locks from accidentally being aliased.
+        """
+        app = AppContext.from_components(components)
+        assert app._session_lock is not app._config_lock


### PR DESCRIPTION
## Summary

`mem_session_start` only stored `current_session_id` while
`mem_agent_search(agent_id=None)` fell back to `current_namespace` — a
different axis altogether. The [multi-agent guide](https://memtomem.com/ltm/multi-agent/)'s
"agent_id is not auto-detected, but inherited via session context"
promise silently broke: an agent that started a session still had to
repeat its `agent_id` on every search, or got results from
`current_namespace` instead of its own private namespace.

This PR threads `agent_id` through the session lifecycle and gives
multi-agent search a documented resolution priority.

## Changes

- **New `current_agent_id` field on `AppContext`.** Set by
  `mem_session_start(agent_id=...)`, reset by `mem_session_end`.
  Lives behind a new `_session_lock` distinct from `_config_lock` so
  long-running config writes can't block session updates and vice versa.
- **`_resolve_agent_namespace(app, agent_id)` helper** documents the
  priority: explicit `agent_id` arg > `current_agent_id` >
  `current_namespace` (legacy fallback). Top-level so the contract is
  unit-testable without standing up MCP components.
- **`mem_session_start` handles "active session already exists" explicitly.**
  The previous session is auto-ended (warning logged + inline notice
  in the return string) instead of silently overwritten — the storage
  row is closed with an `auto_ended: true` metadata flag for audit. The
  new `agent_id` replaces the old; agents do not stack.
- **`mem_session_end` resets both `current_session_id` and
  `current_agent_id`.** "No active session" branch preserved.

## State transition table

| Trigger | `current_session_id` | `current_agent_id` | DB row state |
|---------|----------------------|--------------------|--------------|
| `mem_session_start("a")`, no active | new uuid | `"a"` | row created |
| `mem_session_start("b")`, active "a" | new uuid | `"b"` | "a" row closed (auto-ended), "b" row created |
| `mem_session_end()`, active | `None` | `None` | row closed |
| `mem_session_end()`, no active | `None` | `None` | unchanged |
| `mem_agent_search(agent_id="x")` | unchanged | unchanged | resolves `agent-runtime:x` |
| `mem_agent_search(agent_id=None)`, session active | unchanged | unchanged | resolves `agent-runtime:<current_agent_id>` |
| `mem_agent_search(agent_id=None)`, no session | unchanged | unchanged | resolves `current_namespace` (legacy) |

## Test plan

- [x] `TestResolveAgentNamespace` (test_multi_agent.py) — 5 cases for
  the priority order: explicit wins, current_agent_id, legacy namespace,
  all-None, override-while-active.
- [x] `TestSessionAgentInheritance` (test_sessions.py) — fresh start
  records agent, second start auto-ends previous, end resets both
  fields, end without active is no-op, the two locks are not aliased.
- [x] `uv run pytest -m "not ollama"` — 2339 passed, 46 deselected.
- [x] `uv run ruff check` + `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
