### PR TITLE
feat(langgraph): multi-agent helpers on MemtomemStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **LangGraph adapter (`MemtomemStore`) gains multi-agent helpers.** New
+  `start_agent_session(agent_id)` derives the namespace from
+  `agent-runtime:<id>` and binds `_current_agent_id`; subsequent
+  `search()` / `add()` calls inherit the agent scope without the caller
+  passing `namespace=` on every call. `search(include_shared=...)` is a
+  3-state toggle: `None` (auto: include shared if an agent is bound),
+  `True` (force include — raises `ValueError` if no agent is bound,
+  surfacing programming errors instead of degrading to a silent
+  un-pinned search), `False` (private only). `add()` defaults
+  `namespace=None` to the bound agent's private bucket; pass an
+  explicit `namespace="shared"` to publish across agents. Existing
+  `start_session(agent_id, namespace)` is preserved as a low-level
+  escape hatch. The adapter still does not implement LangGraph's
+  `BaseStore` (`aput` / `aget` / `alist_namespaces`); that surface
+  remains a follow-up.
+
 - **`mem_import` gains `on_conflict` and `preserve_ids` (bundle schema v2).**
   Bundles now carry per-chunk `chunk_id` + `content_hash` so importers can
   dedup by content across instances. `on_conflict` accepts `"skip"`

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -14,16 +14,34 @@ Usage::
     async def save_node(state):
         await store.add(state["findings"], tags=["research"])
         return state
+
+Multi-agent usage — bind a session to an agent identity once and let
+``search`` / ``add`` derive the namespace automatically::
+
+    await store.start_agent_session("planner")
+    await store.add("our cache strategy", tags=["arch"])  # → agent-runtime:planner
+    hits = await store.search("cache", include_shared=True)  # → planner + shared
+
+This adapter intentionally does **not** implement LangGraph's
+``BaseStore`` (``aput`` / ``aget`` / ``alist_namespaces``). Adding a
+full ``BaseStore`` with the same multi-agent awareness is tracked as a
+follow-up; for now the multi-agent helpers live on
+``start_agent_session`` and ``search(include_shared=...)`` only.
 """
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 from uuid import UUID, uuid4
 
 if TYPE_CHECKING:
     from memtomem.server.component_factory import Components
+
+
+_AGENT_NAMESPACE_PREFIX = "agent-runtime:"
+_SHARED_NAMESPACE = "shared"
 
 
 class MemtomemStore:
@@ -40,6 +58,8 @@ class MemtomemStore:
         self._components: Components | None = None
         self._config_overrides = config_overrides or {}
         self._current_session_id: str | None = None
+        self._current_agent_id: str | None = None
+        self._session_lock: asyncio.Lock = asyncio.Lock()
 
     async def _ensure_init(self) -> Components:
         """Initialize components on first call; return the cached instance."""
@@ -79,20 +99,42 @@ class MemtomemStore:
         tag_filter: str | None = None,
         bm25_weight: float | None = None,
         dense_weight: float | None = None,
+        include_shared: bool | None = None,
     ) -> list[dict]:
         """Search indexed memories.
 
         Returns list of dicts with keys: id, content, score, source, tags, namespace.
+
+        ``include_shared`` is the multi-agent semantic toggle. State table:
+
+        ============== ===================== =======================================
+        ``include_shared`` ``_current_agent_id``  Resulting ``namespace`` filter
+        ============== ===================== =======================================
+        ``None`` (auto) set ("planner")        ``"agent-runtime:planner,shared"``
+        ``None`` (auto) unset                  caller's ``namespace=`` (legacy)
+        ``True``        set ("planner")        ``"agent-runtime:planner,shared"``
+        ``True``        unset                  raises ``ValueError``
+        ``False``       set ("planner")        ``"agent-runtime:planner"`` (no shared)
+        ``False``       unset                  caller's ``namespace=``
+        ============== ===================== =======================================
+
+        ``True`` + no agent session is treated as a programming error
+        (the caller asked to include the *shared* slice of an agent's
+        view but never bound an agent) — raised explicitly so the bug
+        surfaces immediately rather than degrading to a silent
+        un-pinned search.
         """
         comp = await self._ensure_init()
         rrf_weights = None
         if bm25_weight is not None or dense_weight is not None:
             rrf_weights = [bm25_weight or 1.0, dense_weight or 1.0]
 
+        effective_namespace = self._resolve_search_namespace(namespace, include_shared)
+
         results, stats = await comp.search_pipeline.search(
             query=query,
             top_k=top_k,
-            namespace=namespace,
+            namespace=effective_namespace,
             source_filter=source_filter,
             tag_filter=tag_filter,
             rrf_weights=rrf_weights,
@@ -110,6 +152,44 @@ class MemtomemStore:
             for r in results
         ]
 
+    def _resolve_search_namespace(
+        self, namespace: str | None, include_shared: bool | None
+    ) -> str | None:
+        """Translate ``include_shared`` + bound agent into a namespace filter.
+
+        Public contract is documented in ``search``'s docstring; this helper
+        only encodes the lookup table so it can be unit-tested without
+        spinning up components.
+        """
+
+        if include_shared is True and self._current_agent_id is None:
+            raise ValueError(
+                "include_shared=True requires an active agent session. "
+                "Call start_agent_session(agent_id) first or set include_shared=False."
+            )
+        if include_shared is False and self._current_agent_id is not None:
+            return f"{_AGENT_NAMESPACE_PREFIX}{self._current_agent_id}"
+        if include_shared in (None, True) and self._current_agent_id is not None:
+            return f"{_AGENT_NAMESPACE_PREFIX}{self._current_agent_id},{_SHARED_NAMESPACE}"
+        # No agent bound and the caller did not force include_shared=True →
+        # fall back to whatever the caller passed (legacy behaviour).
+        return namespace
+
+    def _resolve_add_namespace(self, namespace: str | None) -> str | None:
+        """Default the ``add`` namespace to the bound agent's private bucket.
+
+        If the caller passes an explicit ``namespace`` it wins (escape hatch
+        for "I want to write to ``shared`` while my session is bound to
+        ``planner``"). Otherwise, when an agent session is active, writes
+        land in ``agent-runtime:<id>``.
+        """
+
+        if namespace is not None:
+            return namespace
+        if self._current_agent_id is not None:
+            return f"{_AGENT_NAMESPACE_PREFIX}{self._current_agent_id}"
+        return None
+
     # ── CRUD ──────────────────────────────────────────────────────────────
 
     async def add(
@@ -121,7 +201,13 @@ class MemtomemStore:
         namespace: str | None = None,
         template: str | None = None,
     ) -> dict:
-        """Add a memory entry. Returns dict with file path and chunk count."""
+        """Add a memory entry. Returns dict with file path and chunk count.
+
+        When an agent session is active (``start_agent_session`` was
+        called), ``namespace=None`` defaults to the agent's private
+        ``agent-runtime:<id>`` bucket. Pass an explicit ``namespace=`` to
+        override (e.g. ``"shared"``).
+        """
         comp = await self._ensure_init()
         from datetime import datetime, timezone
         from memtomem.tools.memory_writer import append_entry
@@ -141,8 +227,10 @@ class MemtomemStore:
             date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
             target = base / f"{date_str}.md"
 
+        effective_namespace = self._resolve_add_namespace(namespace)
+
         append_entry(target, content, title=title, tags=tags)
-        stats = await comp.index_engine.index_file(target, namespace=namespace)
+        stats = await comp.index_engine.index_file(target, namespace=effective_namespace)
 
         return {
             "file": str(target),
@@ -172,16 +260,56 @@ class MemtomemStore:
     # ── Sessions (Episodic Memory) ────────────────────────────────────────
 
     async def start_session(self, agent_id: str = "default", namespace: str | None = None) -> str:
-        """Start an episodic memory session. Returns session_id."""
+        """Start an episodic memory session. Returns session_id.
+
+        Low-level escape hatch — for multi-agent scenarios prefer
+        :meth:`start_agent_session`, which derives the namespace from
+        ``agent-runtime:<id>`` and binds ``_current_agent_id`` so
+        :meth:`search` / :meth:`add` can default to the agent scope.
+        """
         comp = await self._ensure_init()
         session_id = str(uuid4())
         ns = namespace or "default"
         await comp.storage.create_session(session_id, agent_id, ns)
-        self._current_session_id = session_id
+        async with self._session_lock:
+            self._current_session_id = session_id
+        return session_id
+
+    async def start_agent_session(
+        self,
+        agent_id: str,
+        *,
+        namespace: str | None = None,
+    ) -> str:
+        """Start a multi-agent-aware episodic memory session.
+
+        Derives the namespace from ``agent-runtime:<agent_id>`` (override
+        with explicit ``namespace=``), records the session in storage, and
+        binds ``_current_agent_id`` so subsequent ``search`` /
+        ``add`` calls inherit the agent scope without the caller passing
+        ``namespace=`` on every call.
+
+        Returns the session id.
+        """
+        if not agent_id:
+            raise ValueError("agent_id must be a non-empty string")
+
+        comp = await self._ensure_init()
+        session_id = str(uuid4())
+        ns = namespace or f"{_AGENT_NAMESPACE_PREFIX}{agent_id}"
+        await comp.storage.create_session(session_id, agent_id, ns)
+        async with self._session_lock:
+            self._current_session_id = session_id
+            self._current_agent_id = agent_id
         return session_id
 
     async def end_session(self, summary: str | None = None) -> dict:
-        """End the current session. Returns session stats."""
+        """End the current session. Returns session stats.
+
+        Resets both ``_current_session_id`` and ``_current_agent_id``,
+        so subsequent ``search(include_shared=True)`` calls without a
+        new ``start_agent_session`` will raise.
+        """
         comp = await self._ensure_init()
         if not self._current_session_id:
             return {"error": "no active session"}
@@ -199,7 +327,9 @@ class MemtomemStore:
         await comp.storage.scratch_cleanup(session_id=self._current_session_id)
 
         sid = self._current_session_id
-        self._current_session_id = None
+        async with self._session_lock:
+            self._current_session_id = None
+            self._current_agent_id = None
         return {"session_id": sid, "events": len(events), "event_counts": event_counts}
 
     async def log_event(

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -29,6 +29,182 @@ class TestMemtomemStoreInit:
         store = MemtomemStore()
         assert store._current_session_id is None
 
+    def test_agent_id_none_initially(self):
+        """``_current_agent_id`` is set by ``start_agent_session`` only —
+        a fresh ``MemtomemStore`` reports no bound agent.
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        assert store._current_agent_id is None
+
+
+class TestResolveSearchNamespace:
+    """``_resolve_search_namespace`` encodes the 6-case ``include_shared``
+    table documented in ``MemtomemStore.search``. Drift here would let the
+    "include the shared slice of an agent's view" promise degrade to a
+    silent un-pinned search — exactly the kind of fallback the multi-agent
+    plan calls out.
+    """
+
+    def _store_with_agent(self, agent_id: str | None):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        store._current_agent_id = agent_id
+        return store
+
+    def test_auto_with_agent_includes_shared(self):
+        store = self._store_with_agent("planner")
+        assert (
+            store._resolve_search_namespace(namespace=None, include_shared=None)
+            == "agent-runtime:planner,shared"
+        )
+
+    def test_auto_without_agent_defers_to_caller_namespace(self):
+        store = self._store_with_agent(None)
+        assert store._resolve_search_namespace(namespace="archive:old", include_shared=None) == (
+            "archive:old"
+        )
+
+    def test_auto_without_agent_and_no_namespace_returns_none(self):
+        store = self._store_with_agent(None)
+        assert store._resolve_search_namespace(namespace=None, include_shared=None) is None
+
+    def test_explicit_true_with_agent_includes_shared(self):
+        store = self._store_with_agent("planner")
+        assert (
+            store._resolve_search_namespace(namespace=None, include_shared=True)
+            == "agent-runtime:planner,shared"
+        )
+
+    def test_explicit_true_without_agent_raises(self):
+        """Surface programming bugs immediately — silent fallback would let
+        a multi-agent caller leak into an un-pinned search.
+        """
+        store = self._store_with_agent(None)
+        with pytest.raises(ValueError, match="active agent session"):
+            store._resolve_search_namespace(namespace=None, include_shared=True)
+
+    def test_explicit_false_with_agent_excludes_shared(self):
+        store = self._store_with_agent("planner")
+        assert (
+            store._resolve_search_namespace(namespace=None, include_shared=False)
+            == "agent-runtime:planner"
+        )
+
+    def test_explicit_false_without_agent_passes_caller_namespace(self):
+        store = self._store_with_agent(None)
+        assert (
+            store._resolve_search_namespace(namespace="legacy:ns", include_shared=False)
+            == "legacy:ns"
+        )
+
+
+class TestResolveAddNamespace:
+    """``_resolve_add_namespace`` defaults to the bound agent's private
+    bucket when the caller omits ``namespace``. An explicit ``namespace=``
+    always wins so an agent can opt-in to writing to ``shared`` mid-session.
+    """
+
+    def _store_with_agent(self, agent_id: str | None):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        store._current_agent_id = agent_id
+        return store
+
+    def test_no_agent_no_namespace_returns_none(self):
+        store = self._store_with_agent(None)
+        assert store._resolve_add_namespace(None) is None
+
+    def test_no_agent_with_namespace_returns_namespace(self):
+        store = self._store_with_agent(None)
+        assert store._resolve_add_namespace("custom:ns") == "custom:ns"
+
+    def test_agent_no_namespace_defaults_to_agent_runtime(self):
+        store = self._store_with_agent("planner")
+        assert store._resolve_add_namespace(None) == "agent-runtime:planner"
+
+    def test_agent_with_explicit_namespace_wins(self):
+        """Explicit ``namespace="shared"`` lets a planner-bound session
+        publish into the shared bucket without re-binding the session.
+        """
+        store = self._store_with_agent("planner")
+        assert store._resolve_add_namespace("shared") == "shared"
+
+
+class TestStartAgentSession:
+    """``start_agent_session`` derives the namespace from the agent id and
+    binds ``_current_agent_id``. Uses an injected ``_components`` mock so
+    tests do not need to spin up storage / embedder.
+    """
+
+    def _stub_components(self):
+        comp = MagicMock()
+        comp.storage.create_session = AsyncMock(return_value=None)
+        return comp
+
+    @pytest.mark.asyncio
+    async def test_binds_agent_id_and_derives_namespace(self):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        store._components = self._stub_components()
+
+        sid = await store.start_agent_session("planner")
+
+        assert sid is not None
+        assert store._current_session_id == sid
+        assert store._current_agent_id == "planner"
+        # storage.create_session was called with the derived agent-runtime: namespace
+        args, _ = store._components.storage.create_session.call_args
+        assert args[1] == "planner"  # agent_id
+        assert args[2] == "agent-runtime:planner"  # namespace
+
+    @pytest.mark.asyncio
+    async def test_explicit_namespace_overrides_default(self):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        store._components = self._stub_components()
+
+        await store.start_agent_session("planner", namespace="custom:scope")
+
+        args, _ = store._components.storage.create_session.call_args
+        assert args[2] == "custom:scope"
+        # Agent binding still happens — caller wanted a custom namespace,
+        # not to skip the multi-agent semantic.
+        assert store._current_agent_id == "planner"
+
+    @pytest.mark.asyncio
+    async def test_empty_agent_id_raises(self):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        store._components = self._stub_components()
+
+        with pytest.raises(ValueError, match="non-empty"):
+            await store.start_agent_session("")
+
+    @pytest.mark.asyncio
+    async def test_end_session_resets_agent_id(self):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = self._stub_components()
+        comp.storage.get_session_events = AsyncMock(return_value=[])
+        comp.storage.end_session = AsyncMock(return_value=None)
+        comp.storage.scratch_cleanup = AsyncMock(return_value=0)
+        store._components = comp
+
+        await store.start_agent_session("planner")
+        assert store._current_agent_id == "planner"
+
+        await store.end_session(summary="done")
+        assert store._current_session_id is None
+        assert store._current_agent_id is None
+
 
 class TestMemtomemStoreIndex:
     """Regression tests for MemtomemStore.index() — ensures it delegates to


### PR DESCRIPTION
## Summary

Before this PR, the LangGraph adapter (`MemtomemStore`) only exposed
raw `namespace=` strings — multi-agent users had to hand-build
`f"agent-runtime:{id}"` on every call, and the [multi-agent guide](https://memtomem.com/ltm/multi-agent/)'s
advertised "LangGraph adapter for multi-agent" was a thin wrapper
around `start_session` that hard-coded `namespace="default"`.

This PR threads a multi-agent semantic through the adapter:

- `start_agent_session(agent_id, *, namespace=None)` — derives the
  namespace from `agent-runtime:<agent_id>` (override available),
  records the session in storage, binds `_current_agent_id`.
- `search(..., include_shared: bool | None = None)` — 3-state toggle
  with a documented 6-case state table.
- `add(..., namespace=None)` — defaults to the bound agent's private
  bucket; explicit `namespace="shared"` wins so the caller can publish
  cross-agent without re-binding.
- `end_session` resets both `_current_session_id` and `_current_agent_id`.
- Legacy `start_session(agent_id, namespace)` preserved as a low-level
  escape hatch.

## `include_shared` semantic table

| `include_shared` | `_current_agent_id` | resolved `namespace` filter |
|------------------|---------------------|------------------------------|
| `None` (auto) | `"planner"` | `"agent-runtime:planner,shared"` |
| `None` (auto) | unset | caller's `namespace=` (legacy) |
| `True` | `"planner"` | `"agent-runtime:planner,shared"` |
| `True` | unset | **`ValueError`** (no silent leak) |
| `False` | `"planner"` | `"agent-runtime:planner"` (no shared) |
| `False` | unset | caller's `namespace=` |

`True` without a bound agent raises explicitly so a missing
`start_agent_session` surfaces immediately rather than degrading to a
silent un-pinned search.

## Out of scope

Implementing LangGraph's `BaseStore` (`aput` / `aget` /
`alist_namespaces`) with the same multi-agent awareness — tracked as a
follow-up RFC. The adapter stays a hand-rolled wrapper; multi-agent
helpers live on `start_agent_session` and `search(include_shared=)`
only.

## Test plan

- [x] `TestResolveSearchNamespace` — 6 cases, one per row of the
  state table above. The `True + unset` case asserts the explicit
  `ValueError` so silent fallback can never sneak in.
- [x] `TestResolveAddNamespace` — 4 cases for the add namespace
  defaulting: no agent / agent + None / agent + explicit override.
- [x] `TestStartAgentSession` — agent binding, derived namespace,
  explicit override, empty-id rejection, `end_session` reset.
- [x] `uv run pytest -m "not ollama"` — 2345 passed, 46 deselected.
- [x] `uv run ruff check` + `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
