### PR TITLE
feat(cli): mm agent register/list/share + hidden debug-resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `BaseStore` (`aput` / `aget` / `alist_namespaces`); that surface
   remains a follow-up.
 
+- **`mm agent` CLI: `register`, `list`, `share`, plus hidden `debug-resolve`.**
+  Mirrors the `mem_agent_*` MCP tools so operators don't have to spin up
+  an MCP client for one-off agent setup. `mm agent list [--json]` groups
+  registered agents (`agent-runtime:` namespaces) with the cross-agent
+  `shared` namespace; `mm agent share <chunk-id> [--target ...]`
+  performs the same content copy + `shared-from=<src>` audit tag as the
+  MCP tool. The hidden `mm agent debug-resolve` dumps the namespace
+  filter `mem_agent_search` would resolve given simulated
+  `current_agent_id` / `current_namespace` / `--include-shared` inputs,
+  as JSON — for use in multi-agent integration scripts so they can
+  assert namespace resolution without standing up an MCP client.
+
 - **`mem_import` gains `on_conflict` and `preserve_ids` (bundle schema v2).**
   Bundles now carry per-chunk `chunk_id` + `content_hash` so importers can
   dedup by content across instances. `on_conflict` accepts `"skip"`

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import json as _json
 from typing import TYPE_CHECKING
 
 import click
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
 
 if TYPE_CHECKING:
     from memtomem.storage.sqlite_backend import SqliteBackend
 
 _LEGACY_PREFIX = "agent/"
+# Local alias paired with ``_LEGACY_PREFIX`` so the migration mapping reads
+# as a (old, new) pair. The value derives from ``AGENT_NAMESPACE_PREFIX``;
+# don't redefine the literal here.
 _CURRENT_PREFIX = AGENT_NAMESPACE_PREFIX
 
 
@@ -74,3 +78,259 @@ async def _collect_legacy_mapping(storage: SqliteBackend) -> list[tuple[str, str
         suffix = ns[len(_LEGACY_PREFIX) :]
         out.append((ns, f"{_CURRENT_PREFIX}{suffix}"))
     return out
+
+
+# ── register ────────────────────────────────────────────────────────────
+
+
+@agent.command("register")
+@click.argument("agent_id")
+@click.option("--description", default=None, help="Human-readable description of the agent's role.")
+@click.option(
+    "--color",
+    default=None,
+    help="Optional hex color code for UI display (e.g. ``#ff8800``).",
+)
+def register(agent_id: str, description: str | None, color: str | None) -> None:
+    """Register an agent and create its ``agent-runtime:<id>`` namespace.
+
+    Mirrors the ``mem_agent_register`` MCP tool so operators don't have to
+    spin up an MCP client for one-off agent setup. Also ensures the
+    cross-agent ``shared`` namespace exists.
+    """
+    asyncio.run(_run_register(agent_id, description, color))
+
+
+async def _run_register(agent_id: str, description: str | None, color: str | None) -> None:
+    from memtomem.cli._bootstrap import cli_components
+    from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
+
+    if not agent_id or not agent_id.strip():
+        raise click.ClickException("agent_id must be non-empty.")
+    sanitized = sanitize_namespace_segment(agent_id)
+    if not sanitized:
+        raise click.ClickException("agent_id must contain at least one allowed character.")
+
+    namespace = f"{_CURRENT_PREFIX}{sanitized}"
+    async with cli_components() as comp:
+        await comp.storage.set_namespace_meta(namespace, description=description, color=color)
+        if await comp.storage.get_namespace_meta(SHARED_NAMESPACE) is None:
+            await comp.storage.set_namespace_meta(
+                SHARED_NAMESPACE, description="Shared knowledge base for all agents"
+            )
+    click.echo(f"Agent registered: {sanitized}")
+    click.echo(f"- Namespace: {namespace}")
+    click.echo(f"- Shared namespace: {SHARED_NAMESPACE}")
+
+
+# ── list ────────────────────────────────────────────────────────────────
+
+
+@agent.command("list")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON instead of the default table.",
+)
+def list_agents(as_json: bool) -> None:
+    """List registered agents (``agent-runtime:`` namespaces) and ``shared``.
+
+    Default output is a table grouped by ``agents`` and ``shared`` —
+    machine-readable form via ``--json`` for use in scripts.
+    """
+    asyncio.run(_run_list(as_json=as_json))
+
+
+async def _run_list(as_json: bool) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        ns_counts = dict(await comp.storage.list_namespaces())
+        all_meta = await comp.storage.list_namespace_meta()
+
+        agents: list[dict] = []
+        for meta in all_meta:
+            ns = meta.get("namespace", "")
+            if not ns.startswith(_CURRENT_PREFIX):
+                continue
+            agents.append(
+                {
+                    "agent_id": ns[len(_CURRENT_PREFIX) :],
+                    "namespace": ns,
+                    "description": meta.get("description"),
+                    "color": meta.get("color"),
+                    "chunks": ns_counts.get(ns, 0),
+                }
+            )
+
+        shared_meta = await comp.storage.get_namespace_meta(SHARED_NAMESPACE)
+        shared = (
+            {
+                "namespace": SHARED_NAMESPACE,
+                "description": (shared_meta or {}).get("description"),
+                "chunks": ns_counts.get(SHARED_NAMESPACE, 0),
+            }
+            if shared_meta is not None or SHARED_NAMESPACE in ns_counts
+            else None
+        )
+
+    if as_json:
+        click.echo(_json.dumps({"agents": agents, "shared": shared}, indent=2))
+        return
+
+    if not agents and shared is None:
+        click.echo("No agents registered. Use `mm agent register <id>` to create one.")
+        return
+
+    click.echo(f"Agents: {len(agents)}")
+    for a in agents:
+        desc = f" — {a['description']}" if a.get("description") else ""
+        click.echo(f"  {a['agent_id']:<20} ({a['chunks']} chunk(s)) {a['namespace']}{desc}")
+
+    if shared is not None:
+        click.echo("")
+        desc = f" — {shared['description']}" if shared.get("description") else ""
+        click.echo(f"Shared: {shared['namespace']} ({shared['chunks']} chunk(s)){desc}")
+
+
+# ── share ───────────────────────────────────────────────────────────────
+
+
+@agent.command("share")
+@click.argument("chunk_id")
+@click.option(
+    "--target",
+    default=SHARED_NAMESPACE,
+    show_default=True,
+    help=("Target namespace — ``shared`` or ``agent-runtime:<agent_id>``."),
+)
+def share(chunk_id: str, target: str) -> None:
+    """Copy a chunk's content into another namespace.
+
+    Mirrors the ``mem_agent_share`` MCP tool. The new chunk gets a fresh
+    UUID; this command does *not* create a true cross-reference link.
+    See the multi-agent guide for the exact semantics and the ongoing
+    RFC for true link support.
+    """
+    asyncio.run(_run_share(chunk_id, target))
+
+
+async def _run_share(chunk_id: str, target: str) -> None:
+    from uuid import UUID
+
+    from memtomem.cli._bootstrap import cli_components
+
+    try:
+        uid = UUID(chunk_id)
+    except (ValueError, TypeError) as exc:
+        raise click.ClickException(f"invalid chunk ID format: {chunk_id}") from exc
+
+    async with cli_components() as comp:
+        chunk = await comp.storage.get_chunk(uid)
+        if chunk is None:
+            raise click.ClickException(f"Chunk {chunk_id} not found.")
+
+        # Build the copy's tags using the same dedup contract as the MCP
+        # tool — keep them in lock-step via the helper so future tweaks
+        # stay in one place.
+        try:
+            from memtomem.server.tools.multi_agent import _build_shared_tags
+
+            tags = _build_shared_tags(chunk.metadata.tags, chunk_id)
+        except ImportError:
+            # Fallback for branches that pre-date PR-3 — append the bare
+            # audit tag without dedup. The CLI must keep working even
+            # before the helper lands.
+            tags = list(chunk.metadata.tags) + [f"shared-from={chunk_id}"]
+
+        from memtomem.tools.memory_writer import append_entry
+
+        title = (
+            "Shared: " + " > ".join(chunk.metadata.heading_hierarchy)
+            if chunk.metadata.heading_hierarchy
+            else "Shared: memory"
+        )
+
+        if not comp.config.indexing.memory_dirs:
+            raise click.ClickException("No memory directories configured. Run `mm init` first.")
+        from datetime import datetime, timezone
+        from pathlib import Path
+
+        base = Path(comp.config.indexing.memory_dirs[0]).expanduser().resolve()
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        path = base / f"{date_str}.md"
+        append_entry(path, chunk.content, title=title, tags=tags)
+        stats = await comp.index_engine.index_file(path, namespace=target)
+
+    click.echo(f"Shared to namespace '{target}'.")
+    click.echo(f"- File: {path}")
+    click.echo(f"- Indexed chunks: {stats.indexed_chunks}")
+
+
+# ── debug-resolve (hidden) ──────────────────────────────────────────────
+
+
+@agent.command("debug-resolve", hidden=True)
+@click.option("--agent-id", default=None, help="Explicit agent_id (mem_agent_search arg).")
+@click.option(
+    "--current-agent-id",
+    default=None,
+    help="Simulated AppContext.current_agent_id (set by mem_session_start).",
+)
+@click.option(
+    "--current-namespace",
+    default=None,
+    help="Simulated AppContext.current_namespace (legacy fallback).",
+)
+@click.option(
+    "--include-shared/--no-include-shared",
+    default=True,
+    show_default=True,
+    help="Whether mem_agent_search would also search the shared namespace.",
+)
+def debug_resolve(
+    agent_id: str | None,
+    current_agent_id: str | None,
+    current_namespace: str | None,
+    include_shared: bool,
+) -> None:
+    """Dump the namespace ``mem_agent_search`` would resolve, as JSON.
+
+    Hidden e2e helper — does not require a running MCP server. Lets the
+    multi-agent integration scripts assert namespace resolution without
+    spinning up an MCP client.
+    """
+    from types import SimpleNamespace
+
+    from memtomem.server.tools.multi_agent import _resolve_agent_namespace
+
+    fake_app = SimpleNamespace(
+        current_agent_id=current_agent_id,
+        current_namespace=current_namespace,
+    )
+    agent_ns = _resolve_agent_namespace(fake_app, agent_id)
+
+    if include_shared and agent_ns:
+        ns_filter: str | None = f"{agent_ns},{SHARED_NAMESPACE}"
+    elif agent_ns:
+        ns_filter = agent_ns
+    else:
+        ns_filter = None
+
+    click.echo(
+        _json.dumps(
+            {
+                "inputs": {
+                    "agent_id": agent_id,
+                    "current_agent_id": current_agent_id,
+                    "current_namespace": current_namespace,
+                    "include_shared": include_shared,
+                },
+                "agent_namespace": agent_ns,
+                "resolved_namespace_filter": ns_filter,
+            },
+            indent=2,
+        )
+    )

--- a/packages/memtomem/tests/test_agent_cmd.py
+++ b/packages/memtomem/tests/test_agent_cmd.py
@@ -1,7 +1,8 @@
-"""Tests for ``mm agent migrate``."""
+"""Tests for ``mm agent`` (migrate / register / list / share / debug-resolve)."""
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -74,3 +75,187 @@ class TestAgentMigrate:
         assert result.exit_code == 0
         assert "Nothing to migrate" in result.output
         comp.storage.rename_namespace.assert_not_awaited()
+
+
+def _registry_components(
+    namespaces: list[tuple[str, int]] | None = None,
+    namespace_meta: list[dict] | None = None,
+    shared_meta: dict | None = None,
+):
+    """Storage stub for the register/list path.
+
+    ``list_namespaces`` returns ``(namespace, count)`` pairs and
+    ``list_namespace_meta`` returns the agent meta records. ``get_namespace_meta``
+    returns ``shared_meta`` when queried for ``"shared"`` (the only key the
+    list command looks up explicitly), and ``None`` otherwise.
+    """
+    namespaces = namespaces or []
+    namespace_meta = namespace_meta or []
+
+    async def _get_meta(ns: str) -> dict | None:
+        if ns == "shared":
+            return shared_meta
+        return None
+
+    storage = SimpleNamespace(
+        list_namespaces=AsyncMock(return_value=namespaces),
+        list_namespace_meta=AsyncMock(return_value=namespace_meta),
+        get_namespace_meta=AsyncMock(side_effect=_get_meta),
+        set_namespace_meta=AsyncMock(return_value=None),
+    )
+    return SimpleNamespace(storage=storage)
+
+
+class TestAgentRegister:
+    def test_register_creates_namespace_and_shared(self, monkeypatch):
+        comp = _registry_components(shared_meta=None)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(
+            cli, ["agent", "register", "planner", "--description", "the planning agent"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Agent registered: planner" in result.output
+        assert "agent-runtime:planner" in result.output
+        # Both the agent NS and shared NS were upserted (shared was missing)
+        assert comp.storage.set_namespace_meta.await_count == 2
+        first_call = comp.storage.set_namespace_meta.await_args_list[0]
+        assert first_call.args[0] == "agent-runtime:planner"
+        assert first_call.kwargs["description"] == "the planning agent"
+
+    def test_register_skips_shared_when_already_exists(self, monkeypatch):
+        comp = _registry_components(shared_meta={"namespace": "shared"})
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["agent", "register", "coder"])
+
+        assert result.exit_code == 0, result.output
+        # Only the agent NS was upserted; shared was left alone
+        assert comp.storage.set_namespace_meta.await_count == 1
+        assert comp.storage.set_namespace_meta.await_args_list[0].args[0] == "agent-runtime:coder"
+
+    def test_register_rejects_empty_agent_id(self, monkeypatch):
+        comp = _registry_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["agent", "register", "   "])
+
+        assert result.exit_code != 0
+        assert "non-empty" in result.output
+
+
+class TestAgentList:
+    def test_list_table_groups_agents_and_shared(self, monkeypatch):
+        comp = _registry_components(
+            namespaces=[
+                ("agent-runtime:planner", 5),
+                ("agent-runtime:coder", 2),
+                ("shared", 3),
+                ("default", 8),
+            ],
+            namespace_meta=[
+                {
+                    "namespace": "agent-runtime:planner",
+                    "description": "planner role",
+                    "color": None,
+                },
+                {"namespace": "agent-runtime:coder", "description": None, "color": "#abcdef"},
+                {"namespace": "default", "description": None, "color": None},
+            ],
+            shared_meta={"namespace": "shared", "description": "shared knowledge"},
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["agent", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "Agents: 2" in result.output
+        assert "planner" in result.output
+        assert "agent-runtime:planner" in result.output
+        assert "planner role" in result.output
+        assert "coder" in result.output
+        assert "Shared: shared" in result.output
+        assert "shared knowledge" in result.output
+        # Non-agent namespaces are not surfaced in the table
+        assert "default" not in result.output.split("Shared:")[0]
+
+    def test_list_json_machine_readable(self, monkeypatch):
+        comp = _registry_components(
+            namespaces=[("agent-runtime:planner", 7), ("shared", 2)],
+            namespace_meta=[
+                {"namespace": "agent-runtime:planner", "description": None, "color": None},
+            ],
+            shared_meta={"namespace": "shared", "description": None},
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["agent", "list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert {a["agent_id"] for a in payload["agents"]} == {"planner"}
+        assert payload["agents"][0]["chunks"] == 7
+        assert payload["shared"]["chunks"] == 2
+
+    def test_list_empty_state_message(self, monkeypatch):
+        comp = _registry_components()
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = CliRunner().invoke(cli, ["agent", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "No agents registered" in result.output
+
+
+class TestAgentDebugResolve:
+    """``mm agent debug-resolve`` is the hidden e2e helper — JSON-only output
+    so integration scripts can assert resolved namespaces without standing up
+    an MCP client.
+    """
+
+    def test_explicit_agent_id_with_shared(self):
+        result = CliRunner().invoke(cli, ["agent", "debug-resolve", "--agent-id", "planner"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["agent_namespace"] == "agent-runtime:planner"
+        assert payload["resolved_namespace_filter"] == "agent-runtime:planner,shared"
+
+    def test_falls_back_to_current_agent_id(self):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "agent",
+                "debug-resolve",
+                "--current-agent-id",
+                "planner",
+                "--no-include-shared",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["agent_namespace"] == "agent-runtime:planner"
+        assert payload["resolved_namespace_filter"] == "agent-runtime:planner"
+
+    def test_legacy_current_namespace_fallback(self):
+        result = CliRunner().invoke(
+            cli,
+            [
+                "agent",
+                "debug-resolve",
+                "--current-namespace",
+                "legacy:project",
+                "--no-include-shared",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["agent_namespace"] == "legacy:project"
+        assert payload["resolved_namespace_filter"] == "legacy:project"
+
+    def test_no_inputs_returns_null_filter(self):
+        result = CliRunner().invoke(cli, ["agent", "debug-resolve"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["agent_namespace"] is None
+        assert payload["resolved_namespace_filter"] is None


### PR DESCRIPTION
## Summary

Adds operator-facing CLI mirrors of the multi-agent MCP tools so
running multi-agent workflows no longer requires an MCP client. The
hidden `debug-resolve` subcommand dumps the namespace filter
`mem_agent_search` would resolve as JSON, given simulated
`AppContext` state — so multi-agent integration scripts can verify
namespace resolution end-to-end without standing up an MCP server.

**Stacked on top of #459 (PR-2: session→agent_id inheritance)** because
`debug-resolve` reuses the `_resolve_agent_namespace` helper added
there. Merge order: #459 first, then this PR.

## Commands

- `mm agent register <id> [--description ...] [--color ...]` — mirrors
  `mem_agent_register`. Sanitizes the agent_id, creates the
  `agent-runtime:<id>` namespace, ensures the cross-agent `shared`
  namespace exists.
- `mm agent list [--json]` — table by default (agents section + shared
  section); `--json` for scripts. Non-agent namespaces (`default`,
  `claude-memory:*`, etc.) are intentionally not surfaced — the
  command is scoped to the multi-agent surface.
- `mm agent share <chunk-id> [--target ...]` — mirrors `mem_agent_share`.
  Reuses `_build_shared_tags` from #458 (with a fallback for branches
  that pre-date it) so the audit-tag dedup contract stays in lock-step.
- `mm agent debug-resolve [--agent-id ...] [--current-agent-id ...]
  [--current-namespace ...] [--include-shared/--no-include-shared]`
  — hidden, JSON-only. Re-uses `_resolve_agent_namespace` so the CLI
  reports exactly what the MCP tool would compute given the same
  inputs. Designed for use in PR-6's integration scripts and the
  manual e2e in the multi-agent guide.

## Test plan

- [x] 14 cases in `test_agent_cmd.py`:
  - `TestAgentRegister` — creates NS + ensures shared, skips shared
    when it already exists, rejects empty agent_id.
  - `TestAgentList` — table grouping, JSON shape, empty state.
  - `TestAgentDebugResolve` — explicit-id + shared, `current_agent_id`
    fallback, legacy `current_namespace` fallback, all-None → null
    filter.
- [x] CliRunner mocks `cli_components` per
  `feedback_clirunner_isatty_seam` guidance.
- [x] `uv run pytest -m "not ollama"` — 2349 passed, 46 deselected.
- [x] `uv run ruff check` + `ruff format --check` — clean.

The `share` command itself is exercised end-to-end once PR-6 lands
(needs real `index_engine` wiring); the unit-style coverage above
guards the command-construction surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
