### PR TITLE
feat(chunking): promote per-entry blockquote tags to ChunkMetadata.tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   test asserts on `metadata.tags` for `shared-from=<src>`. Reindex
   to backfill tags onto memories added by older `mem_add` calls.
 
+  **Note: re-indexed chunks regenerate UUIDs.** Stripping the
+  blockquote header changes `content`, which changes
+  `content_hash = sha256(content)` (`models.py:97`), which the differ
+  treats as a new chunk and assigns a fresh `uuid4()`. After
+  reindex: any external pinning of `chunk_id` (notebooks, scripts,
+  cross-LTM references) will miss, and existing
+  `shared-from=<old-uuid>` audit-tag chains will reference UUIDs
+  that no longer exist. This is a one-time discontinuity the
+  upcoming `chunk_links` table will close permanently.
+
 ### Added
 
 - **LangGraph adapter (`MemtomemStore`) gains multi-agent helpers.** New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **`mem_add(tags=...)` now round-trips through `mem_search(tag_filter=...)`.**
+  The markdown chunker promotes the per-entry blockquote header
+  (``> created: ...`` / ``> tags: [...]`` / legacy lazy-continuation
+  ``tags: [...]``) to first-class `ChunkMetadata.tags`, and strips it
+  from chunk content so it no longer leaks into BM25 / embedding
+  inputs. File-level YAML frontmatter tags compose with per-section
+  blockquote tags via union. Mid-section blockquotes (a quoted
+  paragraph in body prose) are untouched. Multi-agent integration
+  test asserts on `metadata.tags` for `shared-from=<src>`. Reindex
+  to backfill tags onto memories added by older `mem_add` calls.
+
 ### Added
 
 - **LangGraph adapter (`MemtomemStore`) gains multi-agent helpers.** New

--- a/packages/memtomem/src/memtomem/chunking/markdown.py
+++ b/packages/memtomem/src/memtomem/chunking/markdown.py
@@ -187,6 +187,14 @@ class MarkdownChunker:
             if not text:
                 continue
 
+            # Per-entry metadata blockquote (``> created: ...`` / ``> tags:
+            # [...]``) is promoted to ``metadata.tags`` and stripped from
+            # the chunk content so it doesn't leak into BM25/embedding.
+            section_tags, text = self._extract_section_blockquote_tags(text)
+            if not text.strip():
+                continue
+            combined_tags = tuple(sorted(set(fm_tags) | set(section_tags)))
+
             hierarchy = section["hierarchy"]
             est_tokens = len(text) // _TOKEN_CHAR_RATIO
 
@@ -203,7 +211,7 @@ class MarkdownChunker:
                             chunk_type=ChunkType.MARKDOWN_SECTION,
                             start_line=section["start_line"],
                             end_line=section["end_line"],
-                            tags=tuple(fm_tags),
+                            tags=combined_tags,
                             parent_context=parent_ctx,
                             file_context=file_ctx,
                         ),
@@ -223,7 +231,7 @@ class MarkdownChunker:
                                 end_line=sc["end_line"],
                                 overlap_before=sc.get("overlap_before", 0),
                                 overlap_after=sc.get("overlap_after", 0),
-                                tags=tuple(fm_tags),
+                                tags=combined_tags,
                                 parent_context=parent_ctx,
                                 file_context=file_ctx,
                             ),
@@ -233,34 +241,125 @@ class MarkdownChunker:
         return chunks
 
     @staticmethod
-    def _extract_frontmatter_tags(content: str) -> list[str]:
+    def _parse_tags_value(value: str, trailing_lines: list[str]) -> list[str]:
+        """Parse a ``tags:`` value across the four shapes we accept.
+
+        - Inline list: ``["a", "b"]`` / ``['a', 'b']`` / ``[a, b]``
+        - Single bare value: ``mytag``
+        - Block list: empty ``value`` followed by ``- item`` lines in
+          ``trailing_lines`` (any leading ``> `` should already have been
+          stripped by the caller).
+
+        Returns ``[]`` when nothing parses.
+        """
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            return [t.strip().strip("'\"") for t in value[1:-1].split(",") if t.strip()]
+        if value:
+            return [value.strip("'\"")]
+        # Block list shape — walk trailing lines until a non-``- `` line.
+        tags: list[str] = []
+        for raw in trailing_lines:
+            ns = raw.strip()
+            if ns.startswith("- "):
+                tags.append(ns[2:].strip().strip("'\""))
+            elif ns and not ns.startswith("#"):
+                break
+        return tags
+
+    @classmethod
+    def _extract_frontmatter_tags(cls, content: str) -> list[str]:
         """Extract tags from YAML frontmatter if present."""
         match = _FRONT_MATTER_RE.match(content)
         if not match:
             return []
-        fm_text = match.group(1)
-        # Parse tags line: "tags: [a, b, c]" or "tags:\n  - a\n  - b"
-        for line in fm_text.splitlines():
+        fm_lines = match.group(1).splitlines()
+        for idx, line in enumerate(fm_lines):
             stripped = line.strip()
             if stripped.startswith("tags:"):
-                value = stripped[5:].strip()
-                if value.startswith("[") and value.endswith("]"):
-                    # Inline list: tags: [project, api, backend]
-                    return [t.strip().strip("'\"") for t in value[1:-1].split(",") if t.strip()]
-                elif value:
-                    # Single value: tags: sometag
-                    return [value.strip("'\"")]
-                else:
-                    # Block list: tags:\n  - a\n  - b
-                    tags = []
-                    for next_line in fm_text.splitlines()[fm_text.splitlines().index(line) + 1 :]:
-                        ns = next_line.strip()
-                        if ns.startswith("- "):
-                            tags.append(ns[2:].strip().strip("'\""))
-                        elif ns and not ns.startswith("#"):
-                            break
-                    return tags
+                return cls._parse_tags_value(stripped[5:], fm_lines[idx + 1 :])
         return []
+
+    @classmethod
+    def _extract_section_blockquote_tags(cls, text: str) -> tuple[list[str], str]:
+        """Detect a section-leading blockquote group, extract ``tags:`` from it.
+
+        ``mem_add`` writes per-entry metadata as a blockquote header
+        (``> created: ...`` plus an optional ``tags:`` line). The chunker
+        promotes that ``tags:`` value into ``ChunkMetadata.tags`` so
+        ``mem_search(tag_filter=...)`` can match. The header itself is
+        stripped from the returned text so it does not leak into BM25 or
+        embedding inputs.
+
+        Section-leading only: the blockquote must be the first non-blank
+        block in *text*. Blockquotes that appear mid-section (a quoted
+        paragraph in body prose) are left untouched, even if they happen
+        to contain a ``tags:`` line.
+
+        Recognises both shapes the writer has emitted:
+        - Canonical: every line starts with ``> `` (post-RFC writer).
+        - Legacy lazy-continuation: a ``> created:`` line followed by a
+          bare ``tags: [...]`` line (CommonMark glues them into one
+          blockquote at render time, and the ``tags`` line carries no
+          ``> `` prefix on disk).
+
+        Returns ``([], text)`` when there is no leading blockquote, or the
+        leading blockquote contains no ``tags:`` key. Returns
+        ``(tags, stripped_text)`` on a hit, with the entire blockquote
+        group plus any immediately-trailing blank lines removed from the
+        returned text.
+        """
+        lines = text.splitlines()
+        # Skip leading blank lines (text is usually .strip()ed already, but
+        # be defensive — _split_section can pass non-stripped chunks).
+        i = 0
+        while i < len(lines) and not lines[i].strip():
+            i += 1
+        if i == len(lines) or not lines[i].lstrip().startswith(">"):
+            return [], text
+
+        # Collect the contiguous blockquote group, including lazy-continuation
+        # lines: a non-blank, non-``>``-prefixed line that immediately follows
+        # a ``>``-prefixed line without an intervening blank line.
+        block_inner: list[str] = []
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.lstrip()
+            if not stripped:
+                break
+            if stripped.startswith(">"):
+                # Strip leading ``>`` and one optional space.
+                inner = stripped[1:]
+                if inner.startswith(" "):
+                    inner = inner[1:]
+                block_inner.append(inner)
+                i += 1
+                continue
+            # Non-blank, non-``>``: lazy continuation only if we already
+            # collected at least one ``>`` line. Otherwise this is body text
+            # that just happens to start the section, not a blockquote.
+            if block_inner:
+                block_inner.append(stripped)
+                i += 1
+                continue
+            break
+
+        # Find a ``tags:`` key inside the block (case-sensitive).
+        tags: list[str] = []
+        for idx, inner in enumerate(block_inner):
+            inner_stripped = inner.strip()
+            if inner_stripped.startswith("tags:"):
+                tags = cls._parse_tags_value(inner_stripped[5:], block_inner[idx + 1 :])
+                break
+
+        if not tags:
+            return [], text
+
+        # Strip the blockquote group plus immediately-trailing blank lines.
+        rest = lines[i:]
+        while rest and not rest[0].strip():
+            rest = rest[1:]
+        return tags, "\n".join(rest)
 
     def _split_section(self, text: str, section: dict) -> list[dict]:
         """Split an oversized section by paragraphs or sentences."""

--- a/packages/memtomem/tests/test_chunking_blockquote_tags.py
+++ b/packages/memtomem/tests/test_chunking_blockquote_tags.py
@@ -1,0 +1,128 @@
+"""Section-leading blockquote ``tags:`` promotion (mem_add per-entry tags).
+
+``mem_add`` writes per-entry metadata as a leading blockquote header
+(``> created: ...`` plus an optional ``tags:`` line). The chunker must
+promote that ``tags:`` value into ``ChunkMetadata.tags`` so
+``mem_search(tag_filter=...)`` matches, and strip the header from chunk
+content so it does not leak into BM25 / embedding inputs. See
+``planning/mem-add-tags-blockquote-promote-rfc.md``.
+"""
+
+from pathlib import Path
+
+from memtomem.chunking.markdown import MarkdownChunker
+
+
+def _chunk(content: str):
+    return MarkdownChunker().chunk_file(Path("/test.md"), content)
+
+
+class TestSectionBlockquoteTags:
+    def test_canonical_explicit_blockquote_form(self):
+        """Post-RFC writer: every line carries ``> ``."""
+        content = (
+            "## Cache strategy\n"
+            "\n"
+            "> created: 2026-04-24T22:12:30+00:00\n"
+            '> tags: ["cache", "shared-from=abc"]\n'
+            "\n"
+            "Use redis with a 5-minute TTL.\n"
+        )
+        chunks = _chunk(content)
+        assert len(chunks) == 1
+        assert set(chunks[0].metadata.tags) == {"cache", "shared-from=abc"}
+        # Header must be stripped from chunk content.
+        assert "tags:" not in chunks[0].content
+        assert "created:" not in chunks[0].content
+        assert "Use redis" in chunks[0].content
+
+    def test_legacy_lazy_continuation_form(self):
+        """Pre-RFC writer: ``tags:`` line has no ``> `` prefix; lazy continuation."""
+        content = (
+            "## Cache strategy\n"
+            "\n"
+            "> created: 2026-04-24T22:12:30+00:00\n"
+            "tags: ['cache', 'shared-from=abc']\n"
+            "\n"
+            "Use redis with a 5-minute TTL.\n"
+        )
+        chunks = _chunk(content)
+        assert len(chunks) == 1
+        assert set(chunks[0].metadata.tags) == {"cache", "shared-from=abc"}
+        assert "tags:" not in chunks[0].content
+        assert "Use redis" in chunks[0].content
+
+    def test_frontmatter_and_blockquote_compose_via_union(self):
+        """File-level frontmatter tags merge with per-section blockquote tags."""
+        content = (
+            "---\n"
+            "tags: [project, api]\n"
+            "---\n"
+            "\n"
+            "## Cache\n"
+            "\n"
+            '> tags: ["cache"]\n'
+            "\n"
+            "Body text.\n"
+            "\n"
+            "## Auth\n"
+            "\n"
+            "Different section, frontmatter only.\n"
+        )
+        chunks = _chunk(content)
+        # Locate by heading: chunker emits a no-heading frontmatter chunk
+        # too, which the indexing engine later merges. We only care about
+        # the per-section chunks here.
+        cache_chunk = next(
+            c
+            for c in chunks
+            if c.metadata.heading_hierarchy and "Cache" in c.metadata.heading_hierarchy[0]
+        )
+        auth_chunk = next(
+            c
+            for c in chunks
+            if c.metadata.heading_hierarchy and "Auth" in c.metadata.heading_hierarchy[0]
+        )
+        # Cache section gets union: frontmatter + blockquote.
+        assert set(cache_chunk.metadata.tags) == {"project", "api", "cache"}
+        # Auth section keeps frontmatter only — section-level tags do not bleed.
+        assert set(auth_chunk.metadata.tags) == {"project", "api"}
+
+    def test_mid_section_blockquote_is_not_promoted(self):
+        """A blockquote that appears after body text is left alone."""
+        content = (
+            "## Notes\n"
+            "\n"
+            "Some body prose first.\n"
+            "\n"
+            "> tags: ['leaked', 'must-not-promote']\n"
+            "\n"
+            "More body after the quoted block.\n"
+        )
+        chunks = _chunk(content)
+        assert len(chunks) == 1
+        # No promotion: section is not blockquote-led.
+        assert chunks[0].metadata.tags == ()
+        # Mid-section blockquote stays in content.
+        assert "tags:" in chunks[0].content
+        assert "leaked" in chunks[0].content
+
+    def test_section_leading_blockquote_without_tags_is_noop(self):
+        """``> created:`` only — no ``tags:`` line — leaves chunk untouched."""
+        content = "## Heading\n\n> created: 2026-04-24T22:12:30+00:00\n\nBody text.\n"
+        chunks = _chunk(content)
+        assert len(chunks) == 1
+        assert chunks[0].metadata.tags == ()
+        # Without a tags hit we leave the blockquote in content as-is —
+        # callers may still want to render the ``created:`` line.
+        assert "created:" in chunks[0].content
+        assert "Body text" in chunks[0].content
+
+    def test_legacy_repr_form_strip_handles_both_quote_styles(self):
+        """Legacy ``repr(list)`` output uses single quotes; canonical uses double."""
+        content_single = "## A\n\n> tags: ['x', 'y']\n\nbody\n"
+        content_double = '## A\n\n> tags: ["x", "y"]\n\nbody\n'
+        chunks_single = _chunk(content_single)
+        chunks_double = _chunk(content_double)
+        assert set(chunks_single[0].metadata.tags) == {"x", "y"}
+        assert set(chunks_double[0].metadata.tags) == {"x", "y"}

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -226,16 +226,16 @@ class TestCaseBShareTrail:
         assert len(shared_chunks) >= 1, "expected at least one shared copy"
         copy = shared_chunks[0]
         assert copy.id != source.id, "share must produce a fresh UUID, not reuse the source"
-        # ``mem_add`` writes tags into the markdown blockquote header
-        # rather than promoting them to ``ChunkMetadata.tags`` — the
-        # indexer only extracts YAML frontmatter, not the ``> tags:
-        # [...]`` syntax. The audit trail therefore lives in the chunk
-        # *content* (still BM25-searchable). Promoting the blockquote
-        # header to first-class ``metadata.tags`` so ``tag_filter`` can
-        # match ``shared-from=<id>`` is tracked as a follow-up RFC.
-        assert f"{_SHARED_FROM_TAG_PREFIX}{source_uuid}" in copy.content
-        assert "cache" in copy.content
-        assert "decision" in copy.content
+        # The chunker now promotes the per-entry ``> tags: [...]``
+        # blockquote header into ``ChunkMetadata.tags`` and strips it
+        # from chunk content (so it does not leak into BM25 / embedding
+        # inputs). Both the inherited source tags and the
+        # ``shared-from=<src>`` audit tag therefore live in
+        # ``metadata.tags``; the chunk content carries only the body.
+        assert f"{_SHARED_FROM_TAG_PREFIX}{source_uuid}" in copy.metadata.tags
+        assert "cache" in copy.metadata.tags
+        assert "decision" in copy.metadata.tags
+        assert "cache strategy" in copy.content
 
     @pytest.mark.asyncio
     async def test_receiving_agent_sees_shared_copy(self, integration_components):


### PR DESCRIPTION
## Summary

- `mem_add(tags=[...])` now round-trips through `mem_search(tag_filter=...)`. Previously `mem_add` wrote tags into a per-entry blockquote header (`> created: ...` / `tags: [...]`) but the chunker only inspected file-level YAML frontmatter, so `ChunkMetadata.tags` stayed empty and `tag_filter` (set membership at `search/pipeline.py:365–366`) silently missed anything added that way.
- Reader-only PR per `planning/mem-add-tags-blockquote-promote-rfc.md`. Writer (`json.dumps` + explicit `> ` prefix) follows in a stacked PR.

## What changed

- New `MarkdownChunker._extract_section_blockquote_tags(text)` parses a section-leading blockquote group, extracts the `tags:` value, and strips the entire blockquote from chunk content so it no longer leaks into BM25 / embedding inputs. Recognizes the canonical `> tags: ["a"]` form (post-RFC writer) AND the legacy lazy-continuation `tags: ['a']` form (current writer).
- Frontmatter and section-leading blockquote tags **compose by union** into `ChunkMetadata.tags`. Mid-section blockquotes (quoted paragraphs in body prose) are left alone — section-leading only.
- The frontmatter parser was refactored to share its value parser via a new `_parse_tags_value(value, trailing_lines)` helper; both call sites now go through it.
- Multi-agent e2e `test_share_copies_chunk_with_audit_tag` previously asserted the `shared-from=<src>` audit tag in `copy.content`. The chunker now strips that header from content; the test asserts on `copy.metadata.tags` instead. Body text stays in `copy.content` unchanged.

## Why this is safe

- Backward compatibility: existing files written by older `mem_add` (Python `repr()`, lazy continuation) parse correctly. Reindex is enough — no on-disk rewrite.
- No-tags case: section-leading blockquote without a `tags:` key (e.g. just `> created:`) leaves the chunk content unchanged.
- Mid-section blockquote false-positive prevented: parser bails out unless the blockquote is the **first non-blank block** of the section.
- Existing files (frontmatter only, no per-entry blockquote): zero behavior change.

## Test plan

- [x] 6 chunker unit tests in `tests/test_chunking_blockquote_tags.py` covering: canonical / lazy continuation / frontmatter+blockquote union / mid-section noop / no-tags noop / single-vs-double-quote parity
- [x] `tests/test_multi_agent_integration.py` `test_share_copies_chunk_with_audit_tag` re-targets `metadata.tags`
- [x] Full suite: `uv run pytest -m "not ollama"` → 2390 passed, 0 failed
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check ...`
- [x] `uv run mypy packages/memtomem/src/memtomem/chunking/markdown.py` — no issues

## Out of scope (follow-ups)

- Writer change (canonical `> tags: ["a"]` JSON form) — stacked PR.
- `chunk_links` table for true `mem_agent_share` provenance — separate RFC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)