### PR TITLE
feat(mem_add,mem_edit): canonical writer + mem_edit header preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   files still parse — the chunker's section-leading parser accepts
   both shapes — but a fresh ``mem_add`` no longer relies on
   CommonMark lazy continuation for the metadata block.
-- **`mem_edit` preserves the per-entry header when editing a body.**
+- **`mem_edit` and Web UI chunk edit preserve the per-entry header.**
   New ``replace_chunk_body`` helper keeps the heading line and the
   section-leading ``> created:`` / ``> tags:`` blockquote intact when
-  the caller passes body-only ``new_content``. To override the
-  heading explicitly, prefix ``new_content`` with ``## `` and the call
+  the caller passes body-only ``new_content``. Both ``mem_edit`` and
+  the Web UI ``PATCH /api/chunks/{id}`` route use it. The Web UI
+  editor surfaces ``chunk.content`` (header-stripped by the chunker),
+  so this matters for Save-from-browser. To override the heading
+  explicitly, prefix ``new_content`` with ``## `` and the call
   reverts to a full replacement (preserving the pre-RFC semantic).
 
 - **`mem_add(tags=...)` now round-trips through `mem_search(tag_filter=...)`.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`mem_add(tags=...)` now writes a canonical blockquote header.**
+  ``append_entry`` emits ``> tags: ["a", "b"]`` (explicit ``> `` prefix
+  on every line, JSON / double-quoted list) instead of the legacy
+  lazy-continuation ``tags: ['a', 'b']`` (Python ``repr()``). Old
+  files still parse — the chunker's section-leading parser accepts
+  both shapes — but a fresh ``mem_add`` no longer relies on
+  CommonMark lazy continuation for the metadata block.
+- **`mem_edit` preserves the per-entry header when editing a body.**
+  New ``replace_chunk_body`` helper keeps the heading line and the
+  section-leading ``> created:`` / ``> tags:`` blockquote intact when
+  the caller passes body-only ``new_content``. To override the
+  heading explicitly, prefix ``new_content`` with ``## `` and the call
+  reverts to a full replacement (preserving the pre-RFC semantic).
+
 - **`mem_add(tags=...)` now round-trips through `mem_search(tag_filter=...)`.**
   The markdown chunker promotes the per-entry blockquote header
   (``> created: ...`` / ``> tags: [...]`` / legacy lazy-continuation

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -197,12 +197,16 @@ async def mem_edit(
 ) -> str:
     """Edit an existing memory entry in its source markdown file.
 
-    Replaces the chunk's original line range in the file with new_content,
-    then re-indexes the file so the change is immediately searchable.
+    ``new_content`` is treated as body-only: the heading line and the
+    section-leading ``> created:`` / ``> tags:`` blockquote header are
+    preserved automatically. To override the heading explicitly,
+    prefix ``new_content`` with ``## `` and the call reverts to a
+    full replacement of the chunk's line range.
 
     Args:
         chunk_id: The UUID of the chunk to edit (shown in mem_search results)
-        new_content: The replacement content
+        new_content: The replacement body. Heading + per-entry metadata
+            blockquote are preserved unless the value starts with ``## ``.
     """
     if not new_content.strip():
         return "Error: new_content cannot be empty."

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -207,7 +207,7 @@ async def mem_edit(
     if not new_content.strip():
         return "Error: new_content cannot be empty."
 
-    from memtomem.tools.memory_writer import replace_lines
+    from memtomem.tools.memory_writer import replace_chunk_body
 
     app = await _get_app_initialized(ctx)
     mismatch_msg = _check_embedding_mismatch(app)
@@ -227,8 +227,13 @@ async def mem_edit(
     # Backup for rollback on indexing failure
     original = await asyncio.to_thread(meta.source_file.read_text, encoding="utf-8")
     try:
+        # ``replace_chunk_body`` preserves the heading + section-leading
+        # blockquote header (``> created:`` / ``> tags:``) so that callers
+        # supplying body-only ``new_content`` don't accidentally erase the
+        # metadata. Pass a content prefixed with ``## `` to override the
+        # heading explicitly and bypass preservation.
         await asyncio.to_thread(
-            replace_lines, meta.source_file, meta.start_line, meta.end_line, new_content
+            replace_chunk_body, meta.source_file, meta.start_line, meta.end_line, new_content
         )
         stats = await app.index_engine.index_file(meta.source_file, force=True)
         app.search_pipeline.invalidate_cache()

--- a/packages/memtomem/src/memtomem/tools/memory_writer.py
+++ b/packages/memtomem/src/memtomem/tools/memory_writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -16,22 +17,110 @@ def append_entry(
     title: str | None = None,
     tags: list[str] | None = None,
 ) -> None:
-    """Append a new entry to a markdown file, creating it if needed."""
+    """Append a new entry to a markdown file, creating it if needed.
+
+    The per-entry metadata (``> created: ...`` and optional
+    ``> tags: [...]``) is emitted as a single explicit blockquote group
+    — every line carries a leading ``> `` so we never rely on CommonMark
+    lazy continuation, and the tag list is JSON (double-quoted) so it
+    parses as YAML downstream. The chunker promotes ``> tags:`` into
+    ``ChunkMetadata.tags`` and strips the header from chunk content (see
+    ``memtomem.chunking.markdown.MarkdownChunker``).
+    """
     file_path.parent.mkdir(parents=True, exist_ok=True)
 
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    tag_str = f"\ntags: {tags}" if tags else ""
+    tag_line = f"\n> tags: {json.dumps(list(tags))}" if tags else ""
 
     # Skip heading if content already starts with one (e.g., from a template)
     stripped = content.strip()
     if stripped.startswith("## "):
-        block = f"\n> created: {now}{tag_str}\n\n{stripped}\n"
+        block = f"\n> created: {now}{tag_line}\n\n{stripped}\n"
     else:
         heading = f"## {title}" if title else f"## Entry {now}"
-        block = f"\n{heading}\n\n> created: {now}{tag_str}\n\n{stripped}\n"
+        block = f"\n{heading}\n\n> created: {now}{tag_line}\n\n{stripped}\n"
 
     with open(file_path, "a", encoding="utf-8") as f:
         f.write(block)
+
+
+def _find_body_start_index(chunk_lines: list[str]) -> int:
+    """Return the index in *chunk_lines* where the entry body starts.
+
+    Entry shape (as written by ``append_entry``):
+
+    - Optional heading line (``## ...``)
+    - Zero or more blank lines
+    - Optional section-leading blockquote group (``>``-prefixed lines,
+      with lazy-continuation lines accepted for legacy compatibility)
+    - Zero or more blank lines
+    - Body
+
+    The index returned points to the first body line. A chunk that
+    starts mid-section (an oversized section's non-first sub-chunk) has
+    no heading or blockquote at its first line; the function then
+    returns 0.
+    """
+    i = 0
+    if i < len(chunk_lines) and chunk_lines[i].lstrip().startswith("#"):
+        i += 1
+    while i < len(chunk_lines) and not chunk_lines[i].strip():
+        i += 1
+    if i < len(chunk_lines) and chunk_lines[i].lstrip().startswith(">"):
+        block_started = False
+        while i < len(chunk_lines):
+            stripped = chunk_lines[i].lstrip()
+            if not stripped:
+                break
+            if stripped.startswith(">"):
+                block_started = True
+                i += 1
+                continue
+            if block_started:
+                # Lazy continuation
+                i += 1
+                continue
+            break
+        while i < len(chunk_lines) and not chunk_lines[i].strip():
+            i += 1
+    return i
+
+
+def replace_chunk_body(file_path: Path, start_line: int, end_line: int, new_content: str) -> None:
+    """Replace a chunk's body in *file_path* while preserving its header.
+
+    "Header" means the heading line and any section-leading blockquote
+    group (``> created: ...`` / ``> tags: ...``). The chunker strips the
+    blockquote header from chunk content, so callers of ``mem_edit``
+    typically supply body-only ``new_content`` and would otherwise
+    accidentally erase the metadata header.
+
+    If ``new_content`` itself starts with ``## ``, the call is treated
+    as a full replacement (preserving the pre-RFC ``mem_edit`` semantic
+    where the user supplied the entire entry including heading); no
+    header preservation is applied.
+    """
+    text = file_path.read_text(encoding="utf-8")
+    trailing_newline = text.endswith("\n") or text.endswith("\r\n")
+    lines = text.splitlines()
+    _validate_line_range(start_line, end_line, len(lines))
+
+    stripped_new = new_content.lstrip("\n")
+    if stripped_new.lstrip().startswith("## "):
+        # Full replacement — caller is overriding heading + header explicitly.
+        replacement = new_content.splitlines()
+    else:
+        chunk_lines = lines[start_line - 1 : end_line]
+        body_start = _find_body_start_index(chunk_lines)
+        preserved = chunk_lines[:body_start]
+        new_body_lines = stripped_new.splitlines()
+        replacement = preserved + new_body_lines
+
+    new_lines = lines[: start_line - 1] + replacement + lines[end_line:]
+    result = "\n".join(new_lines)
+    if trailing_newline:
+        result += "\n"
+    file_path.write_text(result, encoding="utf-8")
 
 
 def _validate_line_range(start_line: int, end_line: int, total_lines: int) -> None:

--- a/packages/memtomem/src/memtomem/tools/memory_writer.py
+++ b/packages/memtomem/src/memtomem/tools/memory_writer.py
@@ -106,6 +106,9 @@ def replace_chunk_body(file_path: Path, start_line: int, end_line: int, new_cont
     _validate_line_range(start_line, end_line, len(lines))
 
     stripped_new = new_content.lstrip("\n")
+    # ``append_entry`` always emits H2 for entry headings; other heading
+    # levels in user input are treated as body content rather than a
+    # header override, so only ``## `` triggers full-replacement.
     if stripped_new.lstrip().startswith("## "):
         # Full replacement — caller is overriding heading + header explicitly.
         replacement = new_content.splitlines()

--- a/packages/memtomem/src/memtomem/web/routes/chunks.py
+++ b/packages/memtomem/src/memtomem/web/routes/chunks.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from memtomem.tools.memory_writer import remove_lines, replace_lines
+from memtomem.tools.memory_writer import remove_lines, replace_chunk_body
 from memtomem.web.deps import get_embedder, get_index_engine, get_storage, require_indexed_source
 from memtomem.web.schemas.core import (
     ChunkOut,
@@ -60,7 +60,14 @@ async def edit_chunk(
     if meta.source_file.is_symlink():
         raise HTTPException(status_code=403, detail="Cannot edit chunks from symlinked files.")
     try:
-        replace_lines(meta.source_file, meta.start_line, meta.end_line, body.new_content)
+        # ``replace_chunk_body`` keeps the heading + section-leading
+        # blockquote header (``> created:`` / ``> tags:``) intact when the
+        # caller passes body-only ``new_content``. The Web UI editor
+        # surfaces ``chunk.content`` (already header-stripped by the
+        # chunker), so saving without preservation would silently erase
+        # the metadata header on disk. Prefix ``new_content`` with ``## ``
+        # to override the heading explicitly.
+        replace_chunk_body(meta.source_file, meta.start_line, meta.end_line, body.new_content)
         await index_engine.index_file(meta.source_file, force=True)
     except Exception as exc:
         logger.error("Chunk edit failed for %s: %s", chunk_id, exc, exc_info=True)

--- a/packages/memtomem/tests/test_chunking_blockquote_tags.py
+++ b/packages/memtomem/tests/test_chunking_blockquote_tags.py
@@ -126,3 +126,18 @@ class TestSectionBlockquoteTags:
         chunks_double = _chunk(content_double)
         assert set(chunks_single[0].metadata.tags) == {"x", "y"}
         assert set(chunks_double[0].metadata.tags) == {"x", "y"}
+
+    def test_block_list_shape_in_blockquote(self):
+        """``> tags:`` followed by ``> - a`` / ``> - b`` block-list lines.
+
+        The current writer never emits this shape, but the shared
+        ``_parse_tags_value`` helper supports it via the same code path
+        as YAML frontmatter block lists. Lock it in so reusing the
+        helper doesn't regress.
+        """
+        content = "## Block-list section\n\n> tags:\n> - alpha\n> - beta\n\nBody paragraph.\n"
+        chunks = _chunk(content)
+        assert len(chunks) == 1
+        assert set(chunks[0].metadata.tags) == {"alpha", "beta"}
+        assert "tags:" not in chunks[0].content
+        assert "Body paragraph." in chunks[0].content

--- a/packages/memtomem/tests/test_mem_edit_header_preservation.py
+++ b/packages/memtomem/tests/test_mem_edit_header_preservation.py
@@ -1,0 +1,120 @@
+"""``replace_chunk_body`` preserves heading + per-entry blockquote header.
+
+The chunker strips the section-leading ``> created: ...`` / ``> tags:
+[...]`` blockquote from chunk content (see
+``test_chunking_blockquote_tags.py``). ``mem_edit`` therefore typically
+receives body-only ``new_content`` and must not erase the metadata
+header. ``replace_chunk_body`` is the helper that handles this.
+"""
+
+from pathlib import Path
+
+from memtomem.tools.memory_writer import replace_chunk_body
+
+
+class TestReplaceChunkBody:
+    def test_preserves_canonical_blockquote_header(self, tmp_path: Path):
+        """Canonical ``> tags: [...]`` header survives a body-only edit."""
+        f = tmp_path / "memory.md"
+        f.write_text(
+            "## Cache\n"
+            "\n"
+            "> created: 2026-04-24T22:00:00+00:00\n"
+            '> tags: ["cache", "decision"]\n'
+            "\n"
+            "Old body.\n",
+            encoding="utf-8",
+        )
+        # Chunk range: heading line through final body line.
+        replace_chunk_body(f, start_line=1, end_line=6, new_content="New body.")
+        result = f.read_text(encoding="utf-8")
+        assert "## Cache" in result
+        assert "> created: 2026-04-24T22:00:00+00:00" in result
+        assert '> tags: ["cache", "decision"]' in result
+        assert "New body." in result
+        assert "Old body." not in result
+
+    def test_preserves_legacy_lazy_continuation_header(self, tmp_path: Path):
+        """Pre-RFC ``tags: [...]`` (no ``> `` prefix) is still preserved."""
+        f = tmp_path / "memory.md"
+        f.write_text(
+            "## Note\n\n> created: 2026-04-01T10:00:00+00:00\ntags: ['legacy']\n\nOld body line.\n",
+            encoding="utf-8",
+        )
+        replace_chunk_body(f, start_line=1, end_line=6, new_content="Replaced body.")
+        result = f.read_text(encoding="utf-8")
+        assert "> created: 2026-04-01T10:00:00+00:00" in result
+        assert "tags: ['legacy']" in result
+        assert "Replaced body." in result
+        assert "Old body line." not in result
+
+    def test_no_blockquote_header_keeps_heading_only(self, tmp_path: Path):
+        """User-authored markdown without ``> created:`` keeps the heading."""
+        f = tmp_path / "memory.md"
+        f.write_text(
+            "## Section\n\nOld body content.\n",
+            encoding="utf-8",
+        )
+        replace_chunk_body(f, start_line=1, end_line=3, new_content="New body content.")
+        result = f.read_text(encoding="utf-8")
+        assert "## Section" in result
+        assert "New body content." in result
+        assert "Old body content." not in result
+
+    def test_explicit_heading_in_new_content_full_replace(self, tmp_path: Path):
+        """``new_content`` starting with ``## `` overrides the original heading."""
+        f = tmp_path / "memory.md"
+        f.write_text(
+            '## Old\n\n> created: 2026-04-01T10:00:00+00:00\n> tags: ["x"]\n\nOld body.\n',
+            encoding="utf-8",
+        )
+        # User explicitly supplies a new heading — full replacement, header
+        # preservation does NOT apply.
+        replace_chunk_body(
+            f,
+            start_line=1,
+            end_line=6,
+            new_content="## New\n\nFresh body without metadata.",
+        )
+        result = f.read_text(encoding="utf-8")
+        assert "## New" in result
+        assert "## Old" not in result
+        assert "Fresh body without metadata." in result
+        # Metadata header is gone — that's the user's explicit choice here.
+        assert "> created:" not in result
+        assert "> tags:" not in result
+
+    def test_mid_section_subchunk_no_header_to_preserve(self, tmp_path: Path):
+        """An oversized section's non-first sub-chunk has no header in its range."""
+        f = tmp_path / "memory.md"
+        f.write_text(
+            "## Big section\n"
+            "\n"
+            "> created: 2026-04-01T10:00:00+00:00\n"
+            "\n"
+            "First half of body.\n"
+            "\n"
+            "Second half of body.\n",
+            encoding="utf-8",
+        )
+        # Edit the second sub-chunk only (lines 7..7) — no header at line 7.
+        replace_chunk_body(f, start_line=7, end_line=7, new_content="Replaced second half.")
+        result = f.read_text(encoding="utf-8")
+        # Header preserved (it was outside the edit range).
+        assert "## Big section" in result
+        assert "> created: 2026-04-01T10:00:00+00:00" in result
+        assert "First half of body." in result
+        assert "Replaced second half." in result
+        assert "Second half of body." not in result
+
+    def test_trailing_newline_preserved(self, tmp_path: Path):
+        """Files with a trailing newline retain it; files without don't gain one."""
+        f1 = tmp_path / "with_nl.md"
+        f1.write_text("## H\n\nBody.\n", encoding="utf-8")
+        replace_chunk_body(f1, 1, 3, "New.")
+        assert f1.read_text(encoding="utf-8").endswith("\n")
+
+        f2 = tmp_path / "no_nl.md"
+        f2.write_text("## H\n\nBody.", encoding="utf-8")
+        replace_chunk_body(f2, 1, 3, "New.")
+        assert not f2.read_text(encoding="utf-8").endswith("\n")

--- a/packages/memtomem/tests/test_memory_writer.py
+++ b/packages/memtomem/tests/test_memory_writer.py
@@ -53,7 +53,9 @@ class TestAppendEntry:
         append_entry(target, "content", title="T", tags=["alpha", "beta"])
 
         text = target.read_text(encoding="utf-8")
-        assert "tags: ['alpha', 'beta']" in text
+        # Canonical blockquote form: explicit ``> `` prefix + JSON array.
+        # Detailed pin lives in test_memory_writer_tag_format.py.
+        assert '> tags: ["alpha", "beta"]' in text
 
     def test_no_tags_line_when_tags_omitted(self, tmp_path):
         target = tmp_path / "notes.md"

--- a/packages/memtomem/tests/test_memory_writer_tag_format.py
+++ b/packages/memtomem/tests/test_memory_writer_tag_format.py
@@ -1,0 +1,63 @@
+"""Pin ``append_entry`` output to the canonical blockquote tag format.
+
+A regression that reverts to the legacy lazy-continuation form
+(``tags: [...]`` without ``> `` prefix) or to Python ``repr()``
+(single-quoted) breaks the chunker contract documented in
+``planning/mem-add-tags-blockquote-promote-rfc.md``. This test makes
+either drift fail loudly.
+"""
+
+import json
+from pathlib import Path
+
+from memtomem.tools.memory_writer import append_entry
+
+
+class TestAppendEntryTagFormat:
+    def test_tag_line_uses_explicit_blockquote_prefix(self, tmp_path: Path):
+        """``> tags:`` line carries an explicit ``> `` prefix."""
+        f = tmp_path / "out.md"
+        append_entry(f, "Body text.", title="Heading", tags=["a", "b"])
+        text = f.read_text(encoding="utf-8")
+        # Must contain the canonical line verbatim.
+        assert '> tags: ["a", "b"]' in text
+        # Legacy lazy-continuation form must NOT appear.
+        assert "\ntags: [" not in text
+        assert "\ntags: '" not in text
+
+    def test_tags_serialized_as_json(self, tmp_path: Path):
+        """JSON (double-quoted) form, not Python ``repr()`` (single-quoted)."""
+        f = tmp_path / "out.md"
+        append_entry(f, "Body.", title="H", tags=["cache", "shared-from=abc"])
+        text = f.read_text(encoding="utf-8")
+        assert '> tags: ["cache", "shared-from=abc"]' in text
+        # Python repr would produce single quotes; reject.
+        assert "'cache'" not in text
+
+    def test_tags_round_trip_via_json(self, tmp_path: Path):
+        """The emitted tag list parses cleanly as JSON."""
+        f = tmp_path / "out.md"
+        tags_in = ["alpha", "beta", "shared-from=xyz", "with space"]
+        append_entry(f, "Body.", title="H", tags=tags_in)
+        text = f.read_text(encoding="utf-8")
+        # Locate the tag line and parse the bracketed value.
+        line = next(line for line in text.splitlines() if line.startswith("> tags: "))
+        value = line.split("> tags: ", 1)[1]
+        assert json.loads(value) == tags_in
+
+    def test_no_tag_line_when_tags_empty(self, tmp_path: Path):
+        """Empty / None tags omit the tag line entirely (today's behavior)."""
+        f = tmp_path / "out.md"
+        append_entry(f, "Body.", title="H", tags=None)
+        assert "tags:" not in f.read_text(encoding="utf-8")
+
+        f2 = tmp_path / "out2.md"
+        append_entry(f2, "Body.", title="H", tags=[])
+        assert "tags:" not in f2.read_text(encoding="utf-8")
+
+    def test_created_line_carries_blockquote_prefix(self, tmp_path: Path):
+        """``> created:`` keeps its prefix unchanged (no regression there)."""
+        f = tmp_path / "out.md"
+        append_entry(f, "Body.", title="H", tags=["x"])
+        text = f.read_text(encoding="utf-8")
+        assert "\n> created: " in text

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -237,6 +237,23 @@ class TestCaseBShareTrail:
         assert "decision" in copy.metadata.tags
         assert "cache strategy" in copy.content
 
+        # Forward direction of the round-trip: ``mem_search`` filtered by
+        # the audit tag must surface the share copy. ``tag_filter`` is set
+        # membership against ``metadata.tags`` (search/pipeline.py:365–366),
+        # so this exercises that the write path put the audit tag where
+        # the search path looks for it.
+        filter_results, _ = await comp.search_pipeline.search(
+            query="cache strategy",
+            top_k=10,
+            namespace=SHARED_NAMESPACE,
+            tag_filter=f"{_SHARED_FROM_TAG_PREFIX}{source_uuid}",
+        )
+        filter_ids = {r.chunk.id for r in filter_results}
+        assert copy.id in filter_ids, "tag_filter must return the share copy"
+        # Source lives in alpha's private namespace and is not in the
+        # shared scope of this query — verify it is filtered out.
+        assert source.id not in filter_ids
+
     @pytest.mark.asyncio
     async def test_receiving_agent_sees_shared_copy(self, integration_components):
         comp, _ = integration_components

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -541,6 +541,57 @@ class TestEditChunk:
             )
             assert resp.status_code == 403
 
+    async def test_edit_chunk_preserves_blockquote_header(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        """Body-only PATCH must keep the per-entry ``> created:`` / ``> tags:``
+        blockquote and the heading. The Web UI editor surfaces ``chunk.content``
+        (already header-stripped by the chunker), so without preservation a
+        Save would silently erase metadata on disk.
+        """
+        source = tmp_path / "memory.md"
+        source.write_text(
+            "## Cache strategy\n"
+            "\n"
+            "> created: 2026-04-24T22:00:00+00:00\n"
+            '> tags: ["cache", "decision"]\n'
+            "\n"
+            "Old body line.\n",
+            encoding="utf-8",
+        )
+        chunk = _make_test_chunk(source=str(source))
+        # Chunk range covers the entire entry on disk.
+        chunk = chunk.__class__(
+            content=chunk.content,
+            metadata=chunk.metadata.__class__(
+                source_file=source,
+                heading_hierarchy=("## Cache strategy",),
+                tags=chunk.metadata.tags,
+                namespace=chunk.metadata.namespace,
+                start_line=1,
+                end_line=6,
+            ),
+            id=chunk.id,
+            content_hash=chunk.content_hash,
+            embedding=chunk.embedding,
+            created_at=chunk.created_at,
+            updated_at=chunk.updated_at,
+        )
+        app.state.storage.get_chunk.return_value = chunk
+
+        resp = await client.patch(
+            f"/api/chunks/{CHUNK_ID}",
+            json={"new_content": "Replaced body."},
+        )
+        assert resp.status_code == 200
+
+        on_disk = source.read_text(encoding="utf-8")
+        assert "## Cache strategy" in on_disk
+        assert "> created: 2026-04-24T22:00:00+00:00" in on_disk
+        assert '> tags: ["cache", "decision"]' in on_disk
+        assert "Replaced body." in on_disk
+        assert "Old body line." not in on_disk
+
 
 # ---------------------------------------------------------------------------
 # GET /api/sessions


### PR DESCRIPTION
Follow-up to #463 (chunker reader). Two coupled writer-side changes plus the e2e round-trip the chunker enabled.

## Summary

- **Writer canonical form** — `append_entry` now emits `> tags: ["a", "b"]` (explicit `> ` prefix on every line, JSON-quoted) instead of the lazy-continuation form `tags: ['a', 'b']` (Python `repr()`). Chunker reader (PR #463) already accepts both shapes, so old files still parse.
- **`mem_edit` header preservation** — new `replace_chunk_body` helper keeps the heading + `> created:` / `> tags:` blockquote intact when the caller supplies body-only `new_content`. Prefix `new_content` with `## ` to bypass preservation and revert to full-replacement (pre-RFC semantic).
- **`mem_search(tag_filter=...)` round-trip** — multi-agent e2e now asserts `mem_search(tag_filter=f"shared-from={src}")` returns the share copy. Closes the gap discovered in PR #462.

## Why two writer changes in one PR

The reviewer flagged on #463 that mem_edit's existing `replace_lines` call wasn't a *new* regression but became a much louder footgun once the chunker strips the blockquote from chunk content. Post-PR-A, a caller who reads `chunk.content` and feeds it back through mem_edit would supply body-only and silently erase the metadata header. Fixing that in the same PR as the canonical writer keeps the related contract change coherent.

## What changed

- `packages/memtomem/src/memtomem/tools/memory_writer.py`
  - `append_entry` switches to `> tags: {json.dumps(list(tags))}`.
  - New `_find_body_start_index(chunk_lines)` walks a chunk's line range and returns the index where the body starts, after heading + leading blockquote group (with lazy-continuation tolerance for legacy on-disk files).
  - New `replace_chunk_body(file_path, start_line, end_line, new_content)` preserves heading + leading blockquote unless `new_content` starts with `## ` (full replace).
- `packages/memtomem/src/memtomem/server/tools/memory_crud.py`
  - `mem_edit` calls `replace_chunk_body` instead of `replace_lines`.
- `packages/memtomem/tests/test_memory_writer.py` — existing tag-format pin updated to canonical form.
- New `tests/test_memory_writer_tag_format.py` — 5 cases pinning the canonical output (explicit `> ` prefix, JSON serialization, round-trip via `json.loads`, empty-tag omission, `> created:` prefix preserved).
- New `tests/test_mem_edit_header_preservation.py` — 6 cases (canonical / legacy lazy / no-header / explicit `## ` full-replace / non-first sub-chunk of oversized section / trailing-newline round-trip).
- `tests/test_chunking_blockquote_tags.py` — adds block-list-shape case (`> tags:\n> - a\n> - b`). Writer never emits this, but the shared `_parse_tags_value` helper supports it and we lock that in.
- `tests/test_multi_agent_integration.py` `test_share_copies_chunk_with_audit_tag` — adds forward-direction `tag_filter` round-trip assertion.

## Test plan

- [x] Full suite: `uv run pytest -m "not ollama"` → **2402 passed**, 0 failed (PR-A baseline 2390 + 12 new).
- [x] `uv run ruff check && uv run ruff format --check` (full repo).
- [x] `uv run mypy` on changed source files — clean.

## Out of scope (still tracked)

Three remaining follow-ups noted in #463 review, all in `planning/mem-add-tags-blockquote-promote-rfc.md` §Follow-ups:

- `_split_section` line-number drift after blockquote strip (small follow-up PR; mem_edit / UI only, search unaffected).
- `add_entries_batch` broadcast-tag cleanup (`memory_crud.py:392–401`); orthogonal cleanup PR.
- `chunk_links` table to permanently close the `shared-from=<old-uuid>` audit-chain gap on reindex UUID churn — separate RFC `mem-agent-share-chunk-links-rfc.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)