### PR TITLE
feat(storage): add chunk_links table + one-shot back-fill from shared-from tags

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -2,14 +2,28 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import sqlite3
+from datetime import datetime, timezone
 
 from memtomem.errors import EmbeddingDimensionMismatchError
 from memtomem.storage.sqlite_meta import MetaManager
 
 logger = logging.getLogger(__name__)
+
+# ``chunk_links.link_type`` values recognised by the back-fill and (in PR-2)
+# the writer. Validation lives in Python so adding a new type is one PR not
+# two — see ``planning/mem-agent-share-chunk-links-rfc.md`` §Storage.
+_VALID_LINK_TYPES: frozenset[str] = frozenset({"shared"})
+
+# Bumping this key (e.g. ``..._v2``) triggers a re-run of the back-fill on
+# the next startup — used if a future release tightens what counts as a
+# share-tag (e.g. namespace prefix on the source UUID).
+_CHUNK_LINKS_BACKFILL_KEY = "chunk_links_backfill_v1"
+
+_SHARED_FROM_TAG_PREFIX = "shared-from="
 
 
 def create_tables(
@@ -335,6 +349,38 @@ def create_tables(
     db.execute("CREATE INDEX IF NOT EXISTS idx_relations_source ON chunk_relations(source_id)")
     db.execute("CREATE INDEX IF NOT EXISTS idx_relations_target ON chunk_relations(target_id)")
 
+    # --- Cross-namespace share lineage ---
+    # Storage-layer FK + cascade replacement for the ``shared-from=<uuid>``
+    # audit tag previously written by ``mem_agent_share``. The tag survived
+    # in markdown, but tag-only provenance does not benefit from an index
+    # and breaks on UUID churn (reindex re-issues chunk ids). See
+    # ``planning/mem-agent-share-chunk-links-rfc.md``.
+    #
+    # ``ON DELETE SET NULL`` on ``source_id`` keeps the destination chunk
+    # alive when the source is deleted (matches existing copy-on-share
+    # durability). ``ON DELETE CASCADE`` on ``target_id`` drops the row
+    # when the destination chunk goes away.
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS chunk_links (
+            source_id TEXT,
+            target_id TEXT NOT NULL,
+            link_type TEXT NOT NULL DEFAULT 'shared',
+            namespace_target TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (target_id, link_type),
+            FOREIGN KEY (source_id) REFERENCES chunks(id) ON DELETE SET NULL,
+            FOREIGN KEY (target_id) REFERENCES chunks(id) ON DELETE CASCADE
+        )
+    """)
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chunk_links_source ON chunk_links(source_id, link_type)"
+    )
+    db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_chunk_links_namespace ON chunk_links(namespace_target)"
+    )
+
+    _backfill_chunk_links(db, meta)
+
     # --- Entity extraction table ---
     db.execute("""
         CREATE TABLE IF NOT EXISTS chunk_entities (
@@ -388,3 +434,64 @@ def create_tables(
     db.commit()
 
     return dimension, dim_mismatch, model_mismatch
+
+
+def _backfill_chunk_links(db: sqlite3.Connection, meta: MetaManager) -> int:
+    """Populate ``chunk_links`` from pre-RFC ``shared-from=<uuid>`` tags.
+
+    ``mem_agent_share`` historically encoded provenance as a
+    ``shared-from=<source-uuid>`` audit tag on the destination chunk's
+    ``tags`` array. This one-shot pass walks those rows once per database
+    and inserts the equivalent ``chunk_links`` row so structured
+    provenance (FK + cascade + index) is available without waiting for
+    a re-share. Idempotent: completion is recorded in ``_memtomem_meta``
+    and re-runs are no-ops.
+
+    Sources whose UUID no longer resolves (already deleted) are stored
+    with ``source_id=NULL`` — same end-state as a post-RFC share whose
+    source was later deleted (``ON DELETE SET NULL``).
+
+    Returns the number of rows inserted on this call (0 once recorded).
+    """
+    if meta.get_meta(_CHUNK_LINKS_BACKFILL_KEY) == "done":
+        return 0
+
+    rows = db.execute(
+        "SELECT id, namespace, tags FROM chunks WHERE tags LIKE ?",
+        (f"%{_SHARED_FROM_TAG_PREFIX}%",),
+    ).fetchall()
+
+    inserted = 0
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    for target_id, namespace, tags_json in rows:
+        try:
+            tags = json.loads(tags_json) if tags_json else []
+        except (ValueError, TypeError):
+            continue
+        if not isinstance(tags, list):
+            continue
+        source_uuid: str | None = None
+        for tag in tags:
+            if not isinstance(tag, str) or not tag.startswith(_SHARED_FROM_TAG_PREFIX):
+                continue
+            value = tag[len(_SHARED_FROM_TAG_PREFIX) :].strip()
+            if value:
+                source_uuid = value
+                break
+        if source_uuid is None:
+            continue
+
+        src_exists = db.execute("SELECT 1 FROM chunks WHERE id = ?", (source_uuid,)).fetchone()
+        source_id_to_store = source_uuid if src_exists else None
+
+        cursor = db.execute(
+            "INSERT OR IGNORE INTO chunk_links "
+            "(source_id, target_id, link_type, namespace_target, created_at) "
+            "VALUES (?, ?, 'shared', ?, ?)",
+            (source_id_to_store, target_id, namespace, now),
+        )
+        if cursor.rowcount > 0:
+            inserted += 1
+
+    meta.set_meta(_CHUNK_LINKS_BACKFILL_KEY, "done")
+    return inserted

--- a/packages/memtomem/tests/test_chunk_links_schema.py
+++ b/packages/memtomem/tests/test_chunk_links_schema.py
@@ -1,0 +1,316 @@
+"""Schema + back-fill tests for the ``chunk_links`` table.
+
+PR-1 of the ``mem_agent_share`` chunk_links series. Covers:
+
+- Table is created by ``create_tables`` with the expected FK / PK / index
+  shape (``planning/mem-agent-share-chunk-links-rfc.md`` §Storage).
+- ``ON DELETE SET NULL`` on ``source_id`` keeps the destination chunk
+  alive when the source is deleted (matches existing copy-on-share
+  durability semantics).
+- ``ON DELETE CASCADE`` on ``target_id`` drops the row.
+- ``PRIMARY KEY (target_id, link_type)`` enforces one link per (target,
+  type) — re-write idempotency lives in ``INSERT OR REPLACE`` (used by
+  PR-2's writer) on top of the same key.
+- Back-fill populates rows from pre-RFC ``shared-from=<uuid>`` audit
+  tags exactly once per database; the second run is a no-op.
+
+The writer / reader Python API ships in PR-2; these tests use raw SQL.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+import sqlite_vec
+
+from memtomem.storage.sqlite_meta import MetaManager
+from memtomem.storage.sqlite_schema import create_tables
+
+
+def _connect() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    db.execute("PRAGMA foreign_keys=ON")
+    return db
+
+
+def _initialize(db: sqlite3.Connection) -> None:
+    """Run ``create_tables`` with a non-meaningful but valid embedding config."""
+    meta = MetaManager(lambda: db)
+    create_tables(
+        db,
+        meta,
+        dimension=0,
+        embedding_provider="none",
+        embedding_model="",
+    )
+
+
+def _insert_chunk(
+    db: sqlite3.Connection,
+    chunk_id: str,
+    *,
+    namespace: str = "default",
+    tags_json: str = "[]",
+) -> None:
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    db.execute(
+        "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
+        "tags, created_at, updated_at) "
+        "VALUES (?, '', '', '', ?, ?, ?, ?)",
+        (chunk_id, namespace, tags_json, now, now),
+    )
+
+
+class TestSchemaShape:
+    def test_table_and_indexes_created(self) -> None:
+        db = _connect()
+        try:
+            _initialize(db)
+            tbl = db.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunk_links'"
+            ).fetchone()
+            assert tbl is not None, "chunk_links table must exist after create_tables"
+
+            indexes = {
+                row[0]
+                for row in db.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='chunk_links'"
+                ).fetchall()
+            }
+            assert "idx_chunk_links_source" in indexes
+            assert "idx_chunk_links_namespace" in indexes
+        finally:
+            db.close()
+
+    def test_create_tables_is_idempotent(self) -> None:
+        """A second ``create_tables`` on the same DB must not error."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _initialize(db)  # must not raise
+        finally:
+            db.close()
+
+
+class TestForeignKeyBehavior:
+    def test_delete_source_sets_link_source_id_to_null(self) -> None:
+        """``mem_agent_share`` durability: deleting the source chunk leaves
+        the destination chunk and the link row, but the link's
+        ``source_id`` becomes NULL."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "src-1")
+            _insert_chunk(db, "tgt-1", namespace="agent-b")
+            db.execute(
+                "INSERT INTO chunk_links "
+                "(source_id, target_id, link_type, namespace_target, created_at) "
+                "VALUES ('src-1', 'tgt-1', 'shared', 'agent-b', '2026-01-01T00:00:00')"
+            )
+            db.commit()
+
+            db.execute("DELETE FROM chunks WHERE id = 'src-1'")
+            db.commit()
+
+            row = db.execute(
+                "SELECT source_id, target_id FROM chunk_links WHERE target_id = 'tgt-1'"
+            ).fetchone()
+            assert row is not None, "link row must survive source delete"
+            assert row[0] is None, "source_id must be NULL after source delete"
+            assert row[1] == "tgt-1"
+
+            # Destination chunk itself untouched.
+            tgt = db.execute("SELECT 1 FROM chunks WHERE id = 'tgt-1'").fetchone()
+            assert tgt is not None
+        finally:
+            db.close()
+
+    def test_delete_target_cascades_link_row(self) -> None:
+        """Destination delete drops the link row (CASCADE)."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "src-2")
+            _insert_chunk(db, "tgt-2", namespace="agent-b")
+            db.execute(
+                "INSERT INTO chunk_links "
+                "(source_id, target_id, link_type, namespace_target, created_at) "
+                "VALUES ('src-2', 'tgt-2', 'shared', 'agent-b', '2026-01-01T00:00:00')"
+            )
+            db.commit()
+
+            db.execute("DELETE FROM chunks WHERE id = 'tgt-2'")
+            db.commit()
+
+            row = db.execute("SELECT 1 FROM chunk_links WHERE target_id = 'tgt-2'").fetchone()
+            assert row is None, "link row must cascade-delete with target"
+        finally:
+            db.close()
+
+    def test_primary_key_uniqueness_per_target_link_type(self) -> None:
+        """A second link with the same (target_id, link_type) must conflict."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "src-a")
+            _insert_chunk(db, "src-b")
+            _insert_chunk(db, "tgt-3")
+            db.execute(
+                "INSERT INTO chunk_links "
+                "(source_id, target_id, link_type, namespace_target, created_at) "
+                "VALUES ('src-a', 'tgt-3', 'shared', 'default', '2026-01-01T00:00:00')"
+            )
+            db.commit()
+
+            with pytest.raises(sqlite3.IntegrityError):
+                db.execute(
+                    "INSERT INTO chunk_links "
+                    "(source_id, target_id, link_type, namespace_target, created_at) "
+                    "VALUES ('src-b', 'tgt-3', 'shared', 'default', '2026-01-01T00:00:01')"
+                )
+        finally:
+            db.close()
+
+
+class TestBackfillFromSharedFromTags:
+    """One-shot back-fill of pre-RFC share copies."""
+
+    def test_backfill_resolves_existing_source(self) -> None:
+        """Source chunk still in DB → link row stores its UUID."""
+        db = _connect()
+        try:
+            # Seed BEFORE create_tables so the back-fill picks them up on
+            # the first run. ``chunks`` table is created up-front by an
+            # initial ``create_tables`` pass; we then insert pre-existing
+            # share copies and clear the back-fill marker so the second
+            # ``create_tables`` re-runs the back-fill against seeded rows.
+            _initialize(db)
+            _insert_chunk(db, "src-keep")
+            _insert_chunk(
+                db,
+                "tgt-keep",
+                namespace="agent-b",
+                tags_json='["pre-rfc", "shared-from=src-keep"]',
+            )
+            db.execute("DELETE FROM _memtomem_meta WHERE key='chunk_links_backfill_v1'")
+            db.commit()
+
+            _initialize(db)  # second pass triggers back-fill
+
+            row = db.execute(
+                "SELECT source_id, link_type, namespace_target "
+                "FROM chunk_links WHERE target_id = 'tgt-keep'"
+            ).fetchone()
+            assert row is not None, "back-fill must populate row for shared-from= tag"
+            assert row[0] == "src-keep"
+            assert row[1] == "shared"
+            assert row[2] == "agent-b"
+        finally:
+            db.close()
+
+    def test_backfill_stores_null_when_source_unresolvable(self) -> None:
+        """Source UUID not in chunks → back-fill writes ``source_id=NULL``."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(
+                db,
+                "tgt-orphan",
+                namespace="agent-b",
+                tags_json='["shared-from=src-deleted-long-ago"]',
+            )
+            db.execute("DELETE FROM _memtomem_meta WHERE key='chunk_links_backfill_v1'")
+            db.commit()
+
+            _initialize(db)
+
+            row = db.execute(
+                "SELECT source_id FROM chunk_links WHERE target_id = 'tgt-orphan'"
+            ).fetchone()
+            assert row is not None
+            assert row[0] is None, "missing source UUID → NULL source_id"
+        finally:
+            db.close()
+
+    def test_backfill_skips_chunks_without_shared_from_tag(self) -> None:
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "tgt-plain", tags_json='["unrelated", "tag"]')
+            db.execute("DELETE FROM _memtomem_meta WHERE key='chunk_links_backfill_v1'")
+            db.commit()
+
+            _initialize(db)
+
+            row = db.execute("SELECT 1 FROM chunk_links WHERE target_id = 'tgt-plain'").fetchone()
+            assert row is None
+        finally:
+            db.close()
+
+    def test_backfill_runs_at_most_once_per_database(self) -> None:
+        """Idempotency marker prevents re-scanning rows added later."""
+        db = _connect()
+        try:
+            _initialize(db)
+            _insert_chunk(db, "src-once")
+            _insert_chunk(
+                db,
+                "tgt-once",
+                tags_json='["shared-from=src-once"]',
+            )
+            db.execute("DELETE FROM _memtomem_meta WHERE key='chunk_links_backfill_v1'")
+            db.commit()
+            _initialize(db)
+
+            # Marker recorded.
+            marker = db.execute(
+                "SELECT value FROM _memtomem_meta WHERE key='chunk_links_backfill_v1'"
+            ).fetchone()
+            assert marker is not None and marker[0] == "done"
+
+            # Add a NEW pre-RFC-shaped chunk after the back-fill ran.
+            _insert_chunk(
+                db,
+                "tgt-late",
+                tags_json='["shared-from=src-once"]',
+            )
+            db.commit()
+            _initialize(db)  # third pass — must not re-scan
+
+            late_row = db.execute(
+                "SELECT 1 FROM chunk_links WHERE target_id = 'tgt-late'"
+            ).fetchone()
+            assert late_row is None, (
+                "marker must short-circuit the back-fill — chunks added after "
+                "the migration go through the (PR-2) writer, not a re-scan."
+            )
+        finally:
+            db.close()
+
+    def test_backfill_handles_corrupt_tags_json(self) -> None:
+        """Malformed ``tags`` JSON must not crash the migration."""
+        db = _connect()
+        try:
+            _initialize(db)
+            # Insert with garbage in the tags column. The LIKE filter still
+            # matches (the substring is present), so the back-fill walks
+            # this row and must skip it gracefully.
+            _insert_chunk(
+                db,
+                "tgt-bad",
+                tags_json="this is not json shared-from=anything",
+            )
+            db.execute("DELETE FROM _memtomem_meta WHERE key='chunk_links_backfill_v1'")
+            db.commit()
+
+            _initialize(db)  # must not raise
+
+            row = db.execute("SELECT 1 FROM chunk_links WHERE target_id = 'tgt-bad'").fetchone()
+            assert row is None
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

PR-1 of the chunk_links series (private RFC
`mem-agent-share-chunk-links-rfc.md`). **Storage-only change — no
public API surface yet, no behavior change for existing callers.** PR-2
wires the writer / reader Python API; PR-3 (optional) exposes a
`mem_share_lineage` MCP tool.

## Why

`mem_agent_share` historically encoded provenance as a
`shared-from=<uuid>` audit tag in the destination chunk's `tags` array.
Tag-based provenance:

- doesn't benefit from an index — fanout queries are
  `tags LIKE '%shared-from=%'`, a full table scan;
- breaks on UUID churn — reindex re-issues chunk ids and the
  `shared-from=<old-uuid>` chain breaks at the gap;
- can't enforce a relationship across delete.

This PR adds the storage substrate so PR-2 can wire structured
provenance without a coordinated big-bang change.

## Schema

`chunk_links` keyed on `(target_id, link_type)` so each destination
chunk has at most one link of each type. Indexes on
`(source_id, link_type)` and `namespace_target` cover fanout / per-NS
queries. FK semantics:

- `ON DELETE SET NULL` on `source_id` — preserves the existing
  copy-on-share durability (a teammate's delete doesn't yank yours).
  The markdown `shared-from=` tag stays in content for human-readable
  provenance after the join becomes NULL.
- `ON DELETE CASCADE` on `target_id` — no dangling pointer when the
  destination chunk is deleted.

`link_type` validation lives in Python (`_VALID_LINK_TYPES`), not a
CHECK constraint, so adding a new value (`consolidated_from`,
`reflected_from`) is one PR, not two.

## Back-fill

One-shot pass on first startup after upgrade:

1. `SELECT id, namespace, tags FROM chunks WHERE tags LIKE '%shared-from=%'`.
2. Parse the source UUID from the tag.
3. Resolve against `chunks.id`; missing source → `source_id=NULL`
   (same end-state as a post-RFC share whose source was later
   deleted).
4. `INSERT OR IGNORE INTO chunk_links (...)`.
5. Record completion in `_memtomem_meta` (`chunk_links_backfill_v1`).

Bumping the version key triggers a re-run if the parser ever needs to
widen.

## Test plan

- [x] `test_chunk_links_schema.py` — 10 cases:
  - schema: table + indexes created, `create_tables` idempotent.
  - FK behavior: `SET NULL` on source delete, `CASCADE` on target
    delete, PK uniqueness conflict.
  - back-fill: existing source resolved, missing source → NULL,
    unrelated tags ignored, marker prevents re-scan of
    post-migration rows, malformed `tags` JSON skipped.
- [x] Full suite: `uv run pytest -m "not ollama"` → 2421 passed
  (was 2411, +10 new cases). No regression.
- [x] `ruff check` + `ruff format --check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)