### PR TITLE
feat(multi-agent): chunk_links writer + reader API; mem_agent_share records link

### DIFF
--- a/packages/memtomem/src/memtomem/models.py
+++ b/packages/memtomem/src/memtomem/models.py
@@ -138,6 +138,24 @@ class SearchResult:
 
 
 @dataclass(frozen=True, slots=True)
+class ChunkLink:
+    """Structured provenance link between two chunks.
+
+    Mirrors a row of the ``chunk_links`` SQL table (see
+    ``planning/mem-agent-share-chunk-links-rfc.md``). ``source_id`` is
+    ``None`` when the source chunk has been deleted — the FK is
+    ``ON DELETE SET NULL``, so the destination chunk and the link row
+    survive, but the structured pointer back to the source is gone.
+    """
+
+    target_id: UUID
+    link_type: str
+    namespace_target: str
+    created_at: datetime
+    source_id: UUID | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class IndexingStats:
     total_files: int
     total_chunks: int

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -220,12 +220,24 @@ async def mem_agent_share(
     #
     # ``stats.new_chunk_ids`` holds the UUIDs of chunks freshly upserted
     # by this call. ``append_entry`` writes a single section so we
-    # normally see exactly one new chunk; the first entry is the section
-    # head and is the right representative if the chunker ever splits a
-    # big paste into multiple chunks. ``stats`` is ``None`` on the
-    # early-error paths of ``_mem_add_core`` (empty content, oversized,
-    # template failure) — those paths also return an error message so
-    # the copy did not happen and there is nothing to link.
+    # normally see exactly one new chunk and ``[0]`` is the section head
+    # — the right representative for the share copy.
+    #
+    # Edge case the chunker can produce: ``_merge_short_chunks`` may
+    # fold a freshly-appended short entry *into* the previous trailing
+    # chunk of the daily file, in which case ``new_chunk_ids[0]`` is
+    # the re-merged chunk (old+new content) rather than a pure share
+    # copy. Same indexer behavior exposed by re-sharing into multiple
+    # namespaces on the same day; the link writer inherits it.
+    # Mitigating factors: the markdown ``shared-from=`` tag is still on
+    # the content so humans / tag-filter search still find it, and a
+    # future bump of ``_CHUNK_LINKS_BACKFILL_KEY`` (not done in this PR)
+    # would let a migration widen / re-derive links if we ever need to.
+    #
+    # ``stats`` is ``None`` on the early-error paths of ``_mem_add_core``
+    # (empty content, oversized, template failure) — those paths also
+    # return an error message so the copy did not happen and there is
+    # nothing to link.
     if stats is not None and stats.new_chunk_ids:
         try:
             await app.storage.add_chunk_link(

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import logging
+
 from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_agent_namespace(app: AppContext, agent_id: str | None) -> str | None:
@@ -196,14 +200,50 @@ async def mem_agent_share(
 
     inherited_tags = _build_shared_tags(chunk.metadata.tags, chunk_id)
 
-    from memtomem.server.tools.memory_crud import mem_add
+    from memtomem.server.tools.memory_crud import _mem_add_core
 
-    result = await mem_add(
+    result, stats = await _mem_add_core(
         content=chunk.content,
         title=f"Shared: {' > '.join(chunk.metadata.heading_hierarchy) if chunk.metadata.heading_hierarchy else 'memory'}",
         tags=inherited_tags,
+        file=None,
         namespace=target,
+        template=None,
         ctx=ctx,
     )
+
+    # Record the structured link (PR-2 of the chunk_links series). The
+    # markdown ``shared-from=`` audit tag is still written into content
+    # + metadata.tags for humans and for the back-fill of pre-RFC DBs,
+    # but structured queries (fanout / provenance walk / per-NS audit)
+    # use ``chunk_links`` because that's what has a covering index.
+    #
+    # ``stats.new_chunk_ids`` holds the UUIDs of chunks freshly upserted
+    # by this call. ``append_entry`` writes a single section so we
+    # normally see exactly one new chunk; the first entry is the section
+    # head and is the right representative if the chunker ever splits a
+    # big paste into multiple chunks. ``stats`` is ``None`` on the
+    # early-error paths of ``_mem_add_core`` (empty content, oversized,
+    # template failure) — those paths also return an error message so
+    # the copy did not happen and there is nothing to link.
+    if stats is not None and stats.new_chunk_ids:
+        try:
+            await app.storage.add_chunk_link(
+                source_id=uid,
+                target_id=stats.new_chunk_ids[0],
+                link_type="shared",
+                namespace_target=target,
+            )
+        except Exception:
+            # Link recording is best-effort — the copy itself is durable
+            # via the markdown file and ``shared-from=`` tag, so a writer
+            # failure here must not surface to the user or roll the copy
+            # back. Log for diagnostic use.
+            logger.warning("chunk_links writer failed for share copy", exc_info=True)
+    elif stats is not None:
+        logger.warning(
+            "mem_agent_share: no new chunk UUID from mem_add — "
+            "skipping chunk_links writer (content_hash collision?)"
+        )
 
     return f"Shared to namespace '{target}'.\n{result}"

--- a/packages/memtomem/src/memtomem/storage/base.py
+++ b/packages/memtomem/src/memtomem/storage/base.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Protocol, Sequence
 from uuid import UUID
 
-from memtomem.models import Chunk, NamespaceFilter, SearchResult
+from memtomem.models import Chunk, ChunkLink, NamespaceFilter, SearchResult
 
 
 class StorageBackend(Protocol):
@@ -80,6 +80,28 @@ class StorageBackend(Protocol):
     ) -> None: ...
     async def get_related(self, chunk_id: UUID) -> list[tuple[UUID, str]]: ...
     async def delete_relation(self, source_id: UUID, target_id: UUID) -> bool: ...
+
+    # Share lineage (chunk_links)
+    async def add_chunk_link(
+        self,
+        source_id: UUID | None,
+        target_id: UUID,
+        link_type: str,
+        namespace_target: str,
+    ) -> None: ...
+    async def get_chunk_link(
+        self, target_id: UUID, link_type: str = "shared"
+    ) -> ChunkLink | None: ...
+    async def get_chunks_shared_from(
+        self, source_id: UUID, link_type: str | None = None
+    ) -> list[ChunkLink]: ...
+    async def walk_share_chain(
+        self,
+        target_id: UUID,
+        *,
+        link_type: str = "shared",
+        max_depth: int = 100,
+    ) -> list[ChunkLink]: ...
 
     # Sessions (episodic memory)
     async def create_session(

--- a/packages/memtomem/src/memtomem/storage/mixins/__init__.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/__init__.py
@@ -3,6 +3,7 @@
 from memtomem.storage.mixins.sessions import SessionMixin
 from memtomem.storage.mixins.scratch import ScratchMixin
 from memtomem.storage.mixins.relations import RelationMixin
+from memtomem.storage.mixins.share_links import ShareLinkMixin
 from memtomem.storage.mixins.analytics import AnalyticsMixin
 from memtomem.storage.mixins.history import HistoryMixin
 from memtomem.storage.mixins.entities import EntityMixin
@@ -12,6 +13,7 @@ __all__ = [
     "SessionMixin",
     "ScratchMixin",
     "RelationMixin",
+    "ShareLinkMixin",
     "AnalyticsMixin",
     "HistoryMixin",
     "EntityMixin",

--- a/packages/memtomem/src/memtomem/storage/mixins/share_links.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/share_links.py
@@ -1,0 +1,176 @@
+"""Share-lineage storage methods — writer + reader API for ``chunk_links``.
+
+PR-2 of the ``mem_agent_share`` chunk_links series (see
+``planning/mem-agent-share-chunk-links-rfc.md``). The schema and the
+one-shot back-fill ship in ``sqlite_schema.py``; this mixin hangs the
+Python surface off ``SqliteBackend``.
+
+The table is a superset of ``chunk_relations`` and is deliberately kept
+separate — that table is symmetric and used for user-authored cross
+references, consolidation, reflection. A share link is directed
+(source → target) with a denormalised destination namespace so
+"list everything I've shared out" is one index lookup, not a join.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from memtomem.models import ChunkLink
+from memtomem.storage.sqlite_schema import _VALID_LINK_TYPES
+
+
+def _parse_created_at(value: str) -> datetime:
+    """Rehydrate an ISO-8601 timestamp written by the writer / back-fill.
+
+    ``datetime.fromisoformat`` on 3.12 accepts both the ``Z`` and the
+    ``+00:00`` suffix, but back-fill rows are written with
+    ``timespec='seconds'`` and no timezone offset when the source was
+    already a naive string. Treat missing offsets as UTC — every writer
+    in this codebase emits UTC.
+    """
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _row_to_link(row: tuple) -> ChunkLink:
+    source_id, target_id, link_type, namespace_target, created_at = row
+    return ChunkLink(
+        source_id=UUID(source_id) if source_id else None,
+        target_id=UUID(target_id),
+        link_type=link_type,
+        namespace_target=namespace_target,
+        created_at=_parse_created_at(created_at),
+    )
+
+
+class ShareLinkMixin:
+    """Mixin providing ``chunk_links`` writer + reader. Requires ``self._get_db()``."""
+
+    async def add_chunk_link(
+        self,
+        source_id: UUID | None,
+        target_id: UUID,
+        link_type: str,
+        namespace_target: str,
+    ) -> None:
+        """Record a provenance link from ``source_id`` to ``target_id``.
+
+        Idempotent on ``(target_id, link_type)``: re-calling for the same
+        destination overwrites the row (``INSERT OR REPLACE``). Intended
+        to be called by ``mem_agent_share`` after its internal
+        ``mem_add`` succeeds with the newly-minted destination UUID.
+
+        ``source_id=None`` is a legal state (matches the post-delete row
+        shape produced by ``ON DELETE SET NULL`` and the back-fill when
+        the source UUID is unresolvable); callers normally pass the
+        actual source UUID.
+        """
+        if link_type not in _VALID_LINK_TYPES:
+            raise ValueError(
+                f"link_type={link_type!r} not in {sorted(_VALID_LINK_TYPES)!r}. "
+                "Add to _VALID_LINK_TYPES in storage/sqlite_schema.py to extend."
+            )
+        db = self._get_db()
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        db.execute(
+            "INSERT OR REPLACE INTO chunk_links "
+            "(source_id, target_id, link_type, namespace_target, created_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                str(source_id) if source_id is not None else None,
+                str(target_id),
+                link_type,
+                namespace_target,
+                now,
+            ),
+        )
+        db.commit()
+
+    async def get_chunk_link(
+        self,
+        target_id: UUID,
+        link_type: str = "shared",
+    ) -> ChunkLink | None:
+        """Return the link row for a destination chunk, or ``None``.
+
+        Exact lookup on the primary key ``(target_id, link_type)``.
+        """
+        db = self._get_db()
+        row = db.execute(
+            "SELECT source_id, target_id, link_type, namespace_target, created_at "
+            "FROM chunk_links WHERE target_id = ? AND link_type = ?",
+            (str(target_id), link_type),
+        ).fetchone()
+        return _row_to_link(row) if row is not None else None
+
+    async def get_chunks_shared_from(
+        self,
+        source_id: UUID,
+        link_type: str | None = None,
+    ) -> list[ChunkLink]:
+        """Return every destination that was shared *from* ``source_id``.
+
+        Indexed by ``idx_chunk_links_source (source_id, link_type)`` so
+        fanout is ``O(fanout)``, not a table scan. Pass ``link_type``
+        to narrow to a specific type (default: all types).
+        """
+        db = self._get_db()
+        if link_type is None:
+            rows = db.execute(
+                "SELECT source_id, target_id, link_type, namespace_target, created_at "
+                "FROM chunk_links WHERE source_id = ? ORDER BY created_at, target_id",
+                (str(source_id),),
+            ).fetchall()
+        else:
+            rows = db.execute(
+                "SELECT source_id, target_id, link_type, namespace_target, created_at "
+                "FROM chunk_links WHERE source_id = ? AND link_type = ? "
+                "ORDER BY created_at, target_id",
+                (str(source_id), link_type),
+            ).fetchall()
+        return [_row_to_link(r) for r in rows]
+
+    async def walk_share_chain(
+        self,
+        target_id: UUID,
+        *,
+        link_type: str = "shared",
+        max_depth: int = 100,
+    ) -> list[ChunkLink]:
+        """Walk link rows backwards from ``target_id`` toward the root source.
+
+        Returns links in walk order (closest to ``target_id`` first).
+        Stops when:
+
+        * there is no link row for the current target (walk_up complete);
+        * the link row has ``source_id IS NULL`` (source was deleted or
+          back-filled from an unresolvable tag) — the terminal row is
+          still included in the result;
+        * ``max_depth`` is reached — cycle defence for hand-crafted
+          loops (``A→B→A`` from raw SQL) plus bounded worst-case work.
+        """
+        if max_depth <= 0:
+            return []
+        db = self._get_db()
+        chain: list[ChunkLink] = []
+        visited: set[UUID] = set()
+        current: UUID | None = target_id
+        while current is not None and len(chain) < max_depth:
+            if current in visited:
+                break
+            visited.add(current)
+            row = db.execute(
+                "SELECT source_id, target_id, link_type, namespace_target, created_at "
+                "FROM chunk_links WHERE target_id = ? AND link_type = ?",
+                (str(current), link_type),
+            ).fetchone()
+            if row is None:
+                break
+            link = _row_to_link(row)
+            chain.append(link)
+            current = link.source_id
+        return chain

--- a/packages/memtomem/src/memtomem/storage/mixins/share_links.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/share_links.py
@@ -38,8 +38,12 @@ def _parse_created_at(value: str) -> datetime:
 
 def _row_to_link(row: tuple) -> ChunkLink:
     source_id, target_id, link_type, namespace_target, created_at = row
+    # Strict ``is not None``: the schema uses ``TEXT`` which would accept
+    # an empty string, and the writer/back-fill never write one, so a
+    # truthy check would silently collapse a hypothetical empty-string
+    # source into ``None`` and hide the bad write. Surface it instead.
     return ChunkLink(
-        source_id=UUID(source_id) if source_id else None,
+        source_id=UUID(source_id) if source_id is not None else None,
         target_id=UUID(target_id),
         link_type=link_type,
         namespace_target=namespace_target,

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -36,6 +36,7 @@ from memtomem.storage.mixins import (
     RelationMixin,
     ScratchMixin,
     SessionMixin,
+    ShareLinkMixin,
 )
 from memtomem.storage.sqlite_schema import create_tables
 
@@ -66,6 +67,7 @@ class SqliteBackend(
     SessionMixin,
     ScratchMixin,
     RelationMixin,
+    ShareLinkMixin,
     AnalyticsMixin,
     HistoryMixin,
     EntityMixin,

--- a/packages/memtomem/tests/test_chunk_links_reader.py
+++ b/packages/memtomem/tests/test_chunk_links_reader.py
@@ -1,0 +1,279 @@
+"""Reader-API tests for ``chunk_links`` (PR-2 of the chunk_links series).
+
+Covers ``get_chunk_link``, ``get_chunks_shared_from``, and the
+``walk_share_chain`` provenance walker — the three methods the RFC §Reader
+ships. The walker gets its own block for cycle defence and max_depth.
+
+All tests drive ``SqliteBackend`` directly (no MCP layer) and seed the
+``chunks`` table with minimal rows so the FKs line up without running the
+full indexer.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from memtomem.config import StorageConfig
+from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+@pytest.fixture
+async def backend(tmp_path):
+    cfg = StorageConfig(sqlite_path=tmp_path / "reader.db")
+    be = SqliteBackend(
+        config=cfg,
+        dimension=0,
+        embedding_provider="none",
+        embedding_model="",
+    )
+    await be.initialize()
+    yield be
+    await be.close()
+
+
+def _seed_chunk(backend: SqliteBackend, chunk_id: UUID, *, namespace: str = "default") -> None:
+    db = backend._get_db()
+    db.execute(
+        "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
+        "tags, created_at, updated_at) "
+        "VALUES (?, '', '', '', ?, '[]', '2026-01-01T00:00:00', '2026-01-01T00:00:00')",
+        (str(chunk_id), namespace),
+    )
+    db.commit()
+
+
+def _raw_insert_link(
+    backend: SqliteBackend,
+    *,
+    source_id: UUID | None,
+    target_id: UUID,
+    link_type: str = "shared",
+    namespace_target: str = "shared",
+    created_at: str = "2026-01-01T00:00:00",
+) -> None:
+    """Insert a ``chunk_links`` row bypassing the writer.
+
+    Needed for tests that build cycles (A→B→A) or stress worst-case
+    walker input — shapes the writer would reject because the writer is
+    a one-way funnel from ``mem_agent_share``.
+    """
+    db = backend._get_db()
+    db.execute(
+        "INSERT INTO chunk_links "
+        "(source_id, target_id, link_type, namespace_target, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (
+            str(source_id) if source_id is not None else None,
+            str(target_id),
+            link_type,
+            namespace_target,
+            created_at,
+        ),
+    )
+    db.commit()
+
+
+class TestGetChunkLink:
+    @pytest.mark.asyncio
+    async def test_missing_target_returns_none(self, backend):
+        """Unknown target UUID → ``None`` (not an error)."""
+        assert await backend.get_chunk_link(uuid4()) is None
+
+    @pytest.mark.asyncio
+    async def test_link_type_narrows_lookup(self, backend):
+        """The PK is ``(target_id, link_type)`` — same target with different
+        types does not collide. ``get_chunk_link`` defaults to ``'shared'``.
+        """
+        src = uuid4()
+        tgt = uuid4()
+        _seed_chunk(backend, src)
+        _seed_chunk(backend, tgt)
+        _raw_insert_link(
+            backend, source_id=src, target_id=tgt, link_type="shared", namespace_target="shared"
+        )
+        # No shared-type row? Lookup with default returns the one above.
+        link = await backend.get_chunk_link(tgt)
+        assert link is not None
+        assert link.link_type == "shared"
+
+        # An unknown link_type yields None even though a row with another
+        # type exists for the same target.
+        assert await backend.get_chunk_link(tgt, link_type="consolidated_from") is None
+
+
+class TestGetChunksSharedFrom:
+    @pytest.mark.asyncio
+    async def test_empty_fanout_returns_empty_list(self, backend):
+        assert await backend.get_chunks_shared_from(uuid4()) == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_targets_returned_ordered(self, backend):
+        """Sharing one source into N namespaces produces N link rows, all
+        discoverable via the ``source_id`` index."""
+        src = uuid4()
+        tgt_a = uuid4()
+        tgt_b = uuid4()
+        tgt_c = uuid4()
+        _seed_chunk(backend, src)
+        for t in (tgt_a, tgt_b, tgt_c):
+            _seed_chunk(backend, t, namespace="shared")
+
+        # Insert with ascending created_at so we can assert order.
+        _raw_insert_link(
+            backend,
+            source_id=src,
+            target_id=tgt_a,
+            created_at="2026-01-01T00:00:00",
+        )
+        _raw_insert_link(
+            backend,
+            source_id=src,
+            target_id=tgt_b,
+            created_at="2026-01-01T00:00:01",
+        )
+        _raw_insert_link(
+            backend,
+            source_id=src,
+            target_id=tgt_c,
+            created_at="2026-01-01T00:00:02",
+        )
+
+        rows = await backend.get_chunks_shared_from(src)
+        assert [r.target_id for r in rows] == [tgt_a, tgt_b, tgt_c]
+
+    @pytest.mark.asyncio
+    async def test_link_type_filter_narrows_fanout(self, backend):
+        """Passing ``link_type`` restricts the fanout to that type."""
+        src = uuid4()
+        tgt_a = uuid4()
+        _seed_chunk(backend, src)
+        _seed_chunk(backend, tgt_a, namespace="shared")
+
+        _raw_insert_link(backend, source_id=src, target_id=tgt_a, link_type="shared")
+
+        assert await backend.get_chunks_shared_from(src, link_type="shared") != []
+        assert await backend.get_chunks_shared_from(src, link_type="consolidated_from") == []
+
+
+class TestWalkShareChain:
+    """Provenance walker — follows ``target_id → source_id`` back toward the
+    root. Three properties pinned:
+
+    * happy path: ``C → B → A`` with ``A`` as the original.
+    * source-deleted terminal: the last row's ``source_id`` is NULL and
+      the walk stops there (the NULL-terminal row is included).
+    * cycle + max_depth: hand-crafted ``A → B → A`` does not deadloop.
+    """
+
+    @pytest.mark.asyncio
+    async def test_walks_back_to_root(self, backend):
+        a = uuid4()
+        b = uuid4()
+        c = uuid4()
+        for cid in (a, b, c):
+            _seed_chunk(backend, cid)
+
+        # B was shared from A; C was shared from B. Walking from C gives
+        # [C←B, B←A] — two rows, closest first.
+        _raw_insert_link(
+            backend,
+            source_id=a,
+            target_id=b,
+            created_at="2026-01-01T00:00:00",
+        )
+        _raw_insert_link(
+            backend,
+            source_id=b,
+            target_id=c,
+            created_at="2026-01-01T00:00:01",
+        )
+
+        chain = await backend.walk_share_chain(c)
+        assert [link.target_id for link in chain] == [c, b]
+        assert chain[0].source_id == b
+        assert chain[1].source_id == a
+
+    @pytest.mark.asyncio
+    async def test_stops_at_null_source_id(self, backend):
+        """Back-fill + source-delete both produce NULL source rows. The
+        walk must include that terminal row and stop there — the next
+        step has no UUID to follow.
+        """
+        a = uuid4()
+        b = uuid4()
+        c = uuid4()
+        for cid in (a, b, c):
+            _seed_chunk(backend, cid)
+
+        # A was "shared from deleted source" (source_id=NULL). B was shared
+        # from A. C was shared from B.
+        _raw_insert_link(backend, source_id=None, target_id=a)
+        _raw_insert_link(backend, source_id=a, target_id=b)
+        _raw_insert_link(backend, source_id=b, target_id=c)
+
+        chain = await backend.walk_share_chain(c)
+        assert [link.target_id for link in chain] == [c, b, a]
+        assert chain[-1].source_id is None
+
+    @pytest.mark.asyncio
+    async def test_walk_from_unknown_target_is_empty(self, backend):
+        assert await backend.walk_share_chain(uuid4()) == []
+
+    @pytest.mark.asyncio
+    async def test_cycle_defence(self, backend):
+        """Hand-crafted cycle ``A ↔ B``: the walker must not deadloop.
+
+        The writer cannot produce this shape (each ``mem_agent_share``
+        allocates a fresh UUID) but raw SQL can, and the walker is
+        defensive either way.
+        """
+        a = uuid4()
+        b = uuid4()
+        _seed_chunk(backend, a)
+        _seed_chunk(backend, b)
+        _raw_insert_link(backend, source_id=a, target_id=b)
+        _raw_insert_link(backend, source_id=b, target_id=a)
+
+        chain = await backend.walk_share_chain(a, max_depth=100)
+        # Exits via visited set, not max_depth — bounded output.
+        target_ids = [link.target_id for link in chain]
+        # The visited set stops re-entry, so each chunk appears once.
+        assert len(target_ids) == len(set(target_ids))
+        assert len(target_ids) <= 2
+
+    @pytest.mark.asyncio
+    async def test_max_depth_caps_walk_length(self, backend):
+        """Long legitimate chains still respect ``max_depth`` as a guardrail.
+
+        10-deep chain ``c0 ← c1 ← … ← c9`` walked with ``max_depth=3``
+        yields at most 3 rows.
+        """
+        chain_ids = [uuid4() for _ in range(10)]
+        for cid in chain_ids:
+            _seed_chunk(backend, cid)
+
+        # c_i has source_id=c_{i-1} for i>=1 (c0 has source=None).
+        _raw_insert_link(backend, source_id=None, target_id=chain_ids[0])
+        for i in range(1, 10):
+            _raw_insert_link(
+                backend,
+                source_id=chain_ids[i - 1],
+                target_id=chain_ids[i],
+                created_at=f"2026-01-01T00:00:{i:02d}",
+            )
+
+        result = await backend.walk_share_chain(chain_ids[-1], max_depth=3)
+        assert len(result) == 3
+        # Closest first: c9, c8, c7.
+        assert [link.target_id for link in result] == chain_ids[9:6:-1]
+
+    @pytest.mark.asyncio
+    async def test_max_depth_zero_returns_empty(self, backend):
+        """Degenerate input: ``max_depth=0`` yields nothing (no walk started)."""
+        a = uuid4()
+        _seed_chunk(backend, a)
+        _raw_insert_link(backend, source_id=None, target_id=a)
+
+        assert await backend.walk_share_chain(a, max_depth=0) == []

--- a/packages/memtomem/tests/test_chunk_links_writer.py
+++ b/packages/memtomem/tests/test_chunk_links_writer.py
@@ -241,6 +241,80 @@ class TestMemAgentShareWritesLink:
         fanout = await comp.storage.get_chunks_shared_from(source.id)
         assert [link.target_id for link in fanout] == [copy_id]
 
+
+class TestMemAgentShareWriterFailureNonFatal:
+    """Pin the "link writer failure must not roll back the share" contract.
+
+    The link is best-effort: the durable record is the markdown file and
+    the ``shared-from=`` tag, not the ``chunk_links`` row. A failing
+    writer must log and return the normal success string so callers (and
+    users) don't see a confusing error for what is, from their POV, a
+    completed share.
+    """
+
+    @pytest.mark.asyncio
+    async def test_writer_exception_is_swallowed_and_logged(
+        self, integration_components, monkeypatch, caplog
+    ):
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="alpha", ctx=ctx)  # type: ignore[arg-type]
+
+        source = make_chunk(
+            "rollout plan for the next release",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+        )
+        await comp.storage.upsert_chunks([source])
+
+        # Replace add_chunk_link on the storage instance with a stub that
+        # raises. Using monkeypatch.setattr binds to the live instance so
+        # the mem_agent_share code path picks it up at await time.
+        async def _boom(*_args, **_kwargs):
+            raise RuntimeError("simulated chunk_links writer failure")
+
+        monkeypatch.setattr(comp.storage, "add_chunk_link", _boom)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="memtomem.server.tools.multi_agent"):
+            result = await mem_agent_share(  # type: ignore[arg-type]
+                chunk_id=str(source.id), target=SHARED_NAMESPACE, ctx=ctx
+            )
+
+        # Contract 1: caller sees the normal success string, not an
+        # error surfaced by the link writer.
+        assert "Shared to namespace" in result
+        assert "Error" not in result.splitlines()[0]
+
+        # Contract 2: the warning is logged with exc_info so operators
+        # can find the root cause without the share itself failing.
+        assert any("chunk_links writer failed" in rec.message for rec in caplog.records), (
+            f"expected warning log; got: {[r.message for r in caplog.records]}"
+        )
+
+        # Contract 3: the share copy is still indexed (the markdown file
+        # was written before the link attempt; a writer failure must not
+        # undo the copy).
+        hits, _ = await comp.search_pipeline.search(
+            query="rollout plan",
+            top_k=10,
+            namespace=SHARED_NAMESPACE,
+            tag_filter=f"{_SHARED_FROM_TAG_PREFIX}{source.id}",
+        )
+        assert hits, "share copy must still be indexed after writer failure"
+
+        # Contract 4: no chunk_links row exists for the failed copy —
+        # the back-fill on the next schema-version bump can heal this.
+        copy_id = hits[0].chunk.id
+        # Restore a real getter by reaching through the monkeypatch'd
+        # instance — monkeypatch only replaced add_chunk_link, so
+        # get_chunk_link still works.
+        link = await comp.storage.get_chunk_link(copy_id)
+        assert link is None
+
+
 class TestMemAgentShareLinkSurvivesSourceDelete:
     """When the source chunk is deleted, the link row's ``source_id`` goes
     NULL but the destination chunk and the row survive — matches the

--- a/packages/memtomem/tests/test_chunk_links_writer.py
+++ b/packages/memtomem/tests/test_chunk_links_writer.py
@@ -1,0 +1,281 @@
+"""Writer tests for ``chunk_links`` (PR-2 of the chunk_links series).
+
+Covers the ``SqliteBackend.add_chunk_link`` surface (directly) and the
+``mem_agent_share`` integration (end-to-end via the real MCP tool stack,
+mirroring ``test_multi_agent_integration.TestCaseBShareTrail``). The
+separate schema-level tests live in ``test_chunk_links_schema.py``.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from helpers import make_chunk
+from memtomem.config import Mem2MemConfig, StorageConfig
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
+from memtomem.server.component_factory import close_components, create_components
+from memtomem.server.context import AppContext
+from memtomem.server.tools.multi_agent import (
+    _SHARED_FROM_TAG_PREFIX,
+    mem_agent_register,
+    mem_agent_share,
+)
+from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+@pytest.fixture
+async def backend(tmp_path):
+    cfg = StorageConfig(sqlite_path=tmp_path / "links.db")
+    be = SqliteBackend(
+        config=cfg,
+        dimension=0,
+        embedding_provider="none",
+        embedding_model="",
+    )
+    await be.initialize()
+    yield be
+    await be.close()
+
+
+def _seed_chunk(backend: SqliteBackend, chunk_id: UUID, *, namespace: str = "default") -> None:
+    """Insert a minimal ``chunks`` row so FK checks pass without indexing."""
+    db = backend._get_db()
+    db.execute(
+        "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
+        "tags, created_at, updated_at) "
+        "VALUES (?, '', '', '', ?, '[]', '2026-01-01T00:00:00', '2026-01-01T00:00:00')",
+        (str(chunk_id), namespace),
+    )
+    db.commit()
+
+
+class TestAddChunkLinkUnit:
+    """Direct unit tests for the writer — decoupled from ``mem_agent_share``."""
+
+    @pytest.mark.asyncio
+    async def test_insert_round_trip(self, backend):
+        src = uuid4()
+        tgt = uuid4()
+        _seed_chunk(backend, src)
+        _seed_chunk(backend, tgt, namespace="agent-runtime:beta")
+
+        await backend.add_chunk_link(
+            source_id=src,
+            target_id=tgt,
+            link_type="shared",
+            namespace_target="agent-runtime:beta",
+        )
+
+        link = await backend.get_chunk_link(tgt)
+        assert link is not None
+        assert link.source_id == src
+        assert link.target_id == tgt
+        assert link.link_type == "shared"
+        assert link.namespace_target == "agent-runtime:beta"
+
+    @pytest.mark.asyncio
+    async def test_reshare_overwrites_via_insert_or_replace(self, backend):
+        """A second ``add_chunk_link`` on the same (target, link_type) replaces
+        the row — matches the RFC §Writer idempotency contract. (Re-sharing
+        the same source into a destination that was produced by a prior share
+        is unusual but the writer must not raise.)
+        """
+        src_a = uuid4()
+        src_b = uuid4()
+        tgt = uuid4()
+        _seed_chunk(backend, src_a)
+        _seed_chunk(backend, src_b)
+        _seed_chunk(backend, tgt, namespace="shared")
+
+        await backend.add_chunk_link(
+            source_id=src_a,
+            target_id=tgt,
+            link_type="shared",
+            namespace_target="shared",
+        )
+        await backend.add_chunk_link(
+            source_id=src_b,
+            target_id=tgt,
+            link_type="shared",
+            namespace_target="shared",
+        )
+
+        link = await backend.get_chunk_link(tgt)
+        assert link is not None
+        assert link.source_id == src_b, "second write must win via INSERT OR REPLACE"
+
+    @pytest.mark.asyncio
+    async def test_null_source_id_is_accepted(self, backend):
+        """Back-fill and ``ON DELETE SET NULL`` both produce NULL source rows;
+        the writer must accept ``None`` without raising.
+        """
+        tgt = uuid4()
+        _seed_chunk(backend, tgt, namespace="shared")
+
+        await backend.add_chunk_link(
+            source_id=None,
+            target_id=tgt,
+            link_type="shared",
+            namespace_target="shared",
+        )
+
+        link = await backend.get_chunk_link(tgt)
+        assert link is not None
+        assert link.source_id is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_link_type_raises(self, backend):
+        """``_VALID_LINK_TYPES`` is the single source of truth for accepted
+        values (see ``storage/sqlite_schema.py``). Extending the set is one
+        PR; the writer rejecting unknowns keeps typos and accidental drift
+        out of the DB.
+        """
+        with pytest.raises(ValueError, match="link_type="):
+            await backend.add_chunk_link(
+                source_id=uuid4(),
+                target_id=uuid4(),
+                link_type="forked_from",  # reserved future value — not enabled yet
+                namespace_target="shared",
+            )
+
+
+# ── Integration: mem_agent_share records the link ───────────────────────
+
+_MEMTOMEM_ENV_VARS = (
+    "MEMTOMEM_EMBEDDING__PROVIDER",
+    "MEMTOMEM_EMBEDDING__MODEL",
+    "MEMTOMEM_EMBEDDING__DIMENSION",
+    "MEMTOMEM_STORAGE__SQLITE_PATH",
+    "MEMTOMEM_INDEXING__MEMORY_DIRS",
+)
+
+
+def _isolate_memtomem_env(monkeypatch) -> None:
+    for var in _MEMTOMEM_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    import memtomem.config as _cfg
+
+    monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
+
+
+class _StubCtx:
+    def __init__(self, app: AppContext) -> None:
+        class _RC:
+            pass
+
+        self.request_context = _RC()
+        self.request_context.lifespan_context = app
+
+
+@pytest.fixture
+async def integration_components(tmp_path, monkeypatch):
+    db_path = tmp_path / "integration.db"
+    mem_dir = tmp_path / "memories"
+    mem_dir.mkdir()
+
+    _isolate_memtomem_env(monkeypatch)
+
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+    config.embedding.dimension = 1024
+    config.search.enable_dense = False
+
+    comp = await create_components(config)
+    try:
+        yield comp, mem_dir
+    finally:
+        await close_components(comp)
+
+
+class TestMemAgentShareWritesLink:
+    """End-to-end: ``mem_agent_share`` records a ``chunk_links`` row.
+
+    The ``shared-from=<uuid>`` audit tag still goes into
+    ``metadata.tags`` / chunk content (see ``test_multi_agent_integration``
+    ``TestCaseBShareTrail`` — that path is unchanged), but structured
+    provenance now also lives in the indexed table.
+    """
+
+    @pytest.mark.asyncio
+    async def test_share_records_chunk_link(self, integration_components):
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="alpha", ctx=ctx)  # type: ignore[arg-type]
+
+        source = make_chunk(
+            "cache tuning strategy for the query layer",
+            tags=("decision",),
+            namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+        )
+        await comp.storage.upsert_chunks([source])
+
+        await mem_agent_share(  # type: ignore[arg-type]
+            chunk_id=str(source.id), target=SHARED_NAMESPACE, ctx=ctx
+        )
+
+        # Find the share copy via the audit tag — same path the
+        # integration tests already use.
+        results, _ = await comp.search_pipeline.search(
+            query="cache tuning",
+            top_k=10,
+            namespace=SHARED_NAMESPACE,
+            tag_filter=f"{_SHARED_FROM_TAG_PREFIX}{source.id}",
+        )
+        assert results, "share copy must be indexed in the shared namespace"
+        copy_id = results[0].chunk.id
+
+        link = await comp.storage.get_chunk_link(copy_id)
+        assert link is not None, "mem_agent_share must record a chunk_links row"
+        assert link.source_id == source.id
+        assert link.target_id == copy_id
+        assert link.link_type == "shared"
+        assert link.namespace_target == SHARED_NAMESPACE
+
+        # Fanout lookup: the indexed source_id → targets path must
+        # surface the new copy too.
+        fanout = await comp.storage.get_chunks_shared_from(source.id)
+        assert [link.target_id for link in fanout] == [copy_id]
+
+class TestMemAgentShareLinkSurvivesSourceDelete:
+    """When the source chunk is deleted, the link row's ``source_id`` goes
+    NULL but the destination chunk and the row survive — matches the
+    copy-on-share durability contract the RFC §Design calls out.
+    """
+
+    @pytest.mark.asyncio
+    async def test_source_delete_nulls_link_source_id(self, integration_components):
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="alpha", ctx=ctx)  # type: ignore[arg-type]
+
+        source = make_chunk(
+            "transient rollout plan",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+            source="alpha-note.md",
+        )
+        await comp.storage.upsert_chunks([source])
+
+        await mem_agent_share(  # type: ignore[arg-type]
+            chunk_id=str(source.id), target=SHARED_NAMESPACE, ctx=ctx
+        )
+        # Grab the link's target_id so we can re-query after deleting source.
+        fanout = await comp.storage.get_chunks_shared_from(source.id)
+        assert len(fanout) == 1
+        copy_id = fanout[0].target_id
+
+        # Delete the source chunk directly (the markdown-writer path wants
+        # a real source file; for this contract test, SQL delete is the
+        # cleanest way to exercise the FK trigger).
+        await comp.storage.delete_chunks([source.id])
+
+        link = await comp.storage.get_chunk_link(copy_id)
+        assert link is not None, "destination must survive source delete"
+        assert link.source_id is None
+        assert link.target_id == copy_id

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -254,6 +254,17 @@ class TestCaseBShareTrail:
         # shared scope of this query — verify it is filtered out.
         assert source.id not in filter_ids
 
+        # Structured provenance link (PR-2 of the chunk_links series).
+        # The markdown ``shared-from=`` tag above is preserved for
+        # humans + back-fill; the ``chunk_links`` row is what structured
+        # queries (fanout, provenance walk) use.
+        link = await comp.storage.get_chunk_link(copy.id)
+        assert link is not None, "mem_agent_share must record a chunk_links row"
+        assert link.source_id == source.id
+        assert link.target_id == copy.id
+        assert link.link_type == "shared"
+        assert link.namespace_target == SHARED_NAMESPACE
+
     @pytest.mark.asyncio
     async def test_receiving_agent_sees_shared_copy(self, integration_components):
         comp, _ = integration_components


### PR DESCRIPTION
## Summary

PR-2 of the `chunk_links` series (private RFC `mem-agent-share-chunk-links-rfc.md`). PR-1 (#469) added the `chunk_links` table plus a one-shot back-fill from the legacy `shared-from=<uuid>` audit tags. This PR wires the writer into `mem_agent_share` and exposes the reader Python API so structured provenance (indexed fanout, FK-bounded cascade, O(depth) walk-back) is populated going forward, not just for pre-RFC rows.

- Public MCP surface is unchanged — `mem_agent_share`'s signature, return shape, and copy-on-share semantics are identical. The link is a storage invariant.
- No schema change in this PR (that shipped in #469).
- A `mem_share_lineage` MCP tool that exposes `walk_share_chain` is the optional PR-3 per the RFC and is intentionally out of scope here.

## Why

Before PR-1, provenance was only recoverable via `LIKE '%shared-from=%'` scans over `chunks.tags`. That doesn't benefit from an index, breaks on UUID churn (reindex re-issues chunk ids), and can't be enforced across delete. PR-1 gave us the indexed, FK-bounded table. This PR makes `mem_agent_share` actually write into it so the structure is populated without waiting for a re-share.

## Changes

### Model (`models.py`)

New `ChunkLink` dataclass:

- `target_id: UUID` — non-null, PK component
- `source_id: UUID | None` — null after source delete (`ON DELETE SET NULL`) or back-fill of an unresolvable tag
- `link_type: str` — currently `'shared'`; `_VALID_LINK_TYPES` in `sqlite_schema.py` is the single source of truth
- `namespace_target: str` — denormalized so "list everything shared out" is one index lookup
- `created_at: datetime`

### Storage (`storage/mixins/share_links.py`, new)

`ShareLinkMixin` wired into `SqliteBackend` with four methods:

- `add_chunk_link(source_id, target_id, link_type, namespace_target)` — `INSERT OR REPLACE`, idempotent on `(target_id, link_type)`. Validates `link_type` against `_VALID_LINK_TYPES` in Python (the table has no `CHECK` constraint so adding a type is one PR, not two).
- `get_chunk_link(target_id, link_type='shared')` — exact PK lookup.
- `get_chunks_shared_from(source_id, link_type=None)` — fanout via `idx_chunk_links_source`; optional `link_type` filter.
- `walk_share_chain(target_id, *, link_type='shared', max_depth=100)` — walks `target_id → source_id` backward. Cycle defence via visited set, plus `max_depth` as a worst-case ceiling. Stops (and includes the terminal row) when `source_id IS NULL`; returns `[]` for unknown targets.

Abstract `StorageBackend` protocol in `base.py` gets the four signatures too.

### Writer (`server/tools/multi_agent.py`)

`mem_agent_share` now calls `_mem_add_core` (returns `IndexingStats`) instead of the MCP-wrapped `mem_add` (string only), so it can read `stats.new_chunk_ids[0]` — the freshly-indexed destination chunk — and pass it to `add_chunk_link`.

Writer failure is **best-effort + logged**, not fatal:

- The markdown file still gets the `shared-from=` tag (copy-on-share durability is untouched).
- A link-table error must not surface to the caller or roll back the copy.
- The back-fill migration already handles rows without link records on upgrade, so even a silent writer drop would self-heal on the next version bump.

## Tests (+17 tests; total 2421 → 2438)

- **`test_chunk_links_writer.py`** — `TestAddChunkLinkUnit` pins the writer contract (round-trip, `INSERT OR REPLACE` on re-share, NULL source acceptance, invalid `link_type` rejection). `TestMemAgentShareWritesLink` verifies the end-to-end integration writes a row with the right `(source_id, target_id, namespace_target)` shape. `TestMemAgentShareLinkSurvivesSourceDelete` exercises the `ON DELETE SET NULL` flow through the MCP surface.
- **`test_chunk_links_reader.py`** — `get_chunk_link` (missing target, `link_type` filter); `get_chunks_shared_from` (empty fanout, multi-target ordering, `link_type` narrowing); `walk_share_chain` (happy path, NULL-terminal, unknown target, `A↔B` cycle, `max_depth=3` on a 10-deep chain, `max_depth=0` degenerate).
- **`test_multi_agent_integration.py`** — `test_share_copies_chunk_with_audit_tag` extended to assert both the pre-existing audit-tag behavior *and* the new `chunk_links` row.

One test I did **not** add: a multi-target "share this into two different namespaces" case. Turned out to expose a pre-existing indexer behavior (both shares append to the same daily markdown file and the second `index_file(path, namespace=...)` re-namespaces the first) — orthogonal to PR-2 and not something I want to slip into this series. Noting it here so it's tracked.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run pytest -m "not ollama"` — 2438 passed, 46 deselected
- [x] Targeted pass: `pytest tests/test_chunk_links_{schema,writer,reader}.py tests/test_multi_agent_integration.py tests/test_multi_agent.py tests/test_storage_noop.py` — 64 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
