### PR TITLE
release: v0.1.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.28] — 2026-04-25
+
+Multi-agent share provenance + per-entry tag round-trip release.
+Largest behavior change: the markdown chunker now promotes per-entry
+``> tags:`` blockquotes into ``ChunkMetadata.tags`` and strips the
+header from chunk content, so ``mem_add(tags=...)`` finally
+round-trips through ``mem_search(tag_filter=...)``. This regenerates
+chunk UUIDs on first reindex — a one-time discontinuity; the new
+``chunk_links`` table closes the structural gap for future shares,
+and a one-shot back-fill populates link rows from existing
+``shared-from=<uuid>`` audit tags so older audit chains resolve.
+
+Also flips ``agent-runtime:`` into ``system_namespace_prefixes`` by
+default (restores the isolation guarantee from the multi-agent
+guide), and defaults ``mem_import(on_conflict)`` to ``"skip"`` so
+re-imports become idempotent.
+
 ### Fixed
 
 - **`mem_batch_add` no longer over-applies tags across entries or onto
@@ -67,8 +84,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   reindex: any external pinning of `chunk_id` (notebooks, scripts,
   cross-LTM references) will miss, and existing
   `shared-from=<old-uuid>` audit-tag chains will reference UUIDs
-  that no longer exist. This is a one-time discontinuity the
-  upcoming `chunk_links` table will close permanently.
+  that no longer exist. This is a one-time discontinuity; the new
+  `chunk_links` table (see below) closes the structural gap for
+  future shares, and a one-shot back-fill in this release
+  best-effort recovers pre-existing chains from the
+  `shared-from=` tags.
 
 ### Added
 
@@ -99,6 +119,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `current_agent_id` / `current_namespace` / `--include-shared` inputs,
   as JSON — for use in multi-agent integration scripts so they can
   assert namespace resolution without standing up an MCP client.
+
+- **Structured share lineage via new `chunk_links` table.**
+  `mem_agent_share` now records a source→destination row in
+  `chunk_links` (indexed FK, `ON DELETE SET NULL` on `source_id`,
+  `ON DELETE CASCADE` on `target_id`) alongside the
+  `shared-from=<src>` audit tag it already writes into chunk
+  content. Tag-only provenance was a full-table
+  `LIKE '%shared-from=%'` scan with no index and broke on reindex
+  UUID churn; the structured link is an `O(fanout)` indexed lookup
+  and stays correct across source delete. New `Storage` Python API:
+  `add_chunk_link`, `get_chunk_link`, `get_chunks_shared_from`,
+  `walk_share_chain` (cycle defence + `max_depth`). Public MCP
+  surface is unchanged — `mem_agent_share`'s signature and
+  copy-on-share semantics are identical; the link is a storage
+  invariant. A one-shot back-fill on first 0.1.28 startup scans
+  pre-existing `shared-from=<uuid>` tags and populates link rows
+  so audit chains authored on older versions resolve
+  structurally; unresolvable source UUIDs store `source_id=NULL`.
+  (PR #469, PR #470)
 
 - **`mem_import` gains `on_conflict` and `preserve_ids` (bundle schema v2).**
   Bundles now carry per-chunk `chunk_id` + `content_hash` so importers can

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.27"
+version = "0.1.28"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.27"
+version = "0.1.28"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Cuts v0.1.28 — the first release after v0.1.27 (legacy-flock hotfix, 2026-04-24). Ships the blockquote tag round-trip, the `chunk_links` structured share lineage, and the `agent-runtime:` isolation default that all landed on `main` over the last week.

See `CHANGELOG.md` §`[0.1.28]` for the full notes. Headline behavior changes:

- **Reindex regenerates chunk UUIDs** on first 0.1.28 startup for any `mem_add`-authored memory: the chunker now strips the `> created:` / `> tags:` blockquote header from chunk content before hashing, so `content_hash` shifts and the differ treats the chunks as fresh. External `chunk_id` pins (notebooks, scripts, cross-LTM references) miss after reindex. One-time discontinuity.
- **Schema migration: `chunk_links` table** created + back-filled from existing `shared-from=<uuid>` audit tags on first startup. Rows whose source UUID no longer resolves are stored with `source_id=NULL` (same end-state as a post-release share whose source is later deleted). Idempotent; completion marked in `_memtomem_meta`.
- **`mem_search` (namespace=None) no longer returns `agent-runtime:*` chunks** — `agent-runtime:` is in `system_namespace_prefixes` by default now. Restore pre-0.1.28 behavior by overriding `search.system_namespace_prefixes: []` in `config.json`, or drop just `agent-runtime:` from the list.
- **`mem_import` default flipped to `on_conflict="skip"`** — re-importing the same bundle is idempotent instead of duplicating rows. Callers that relied on duplication must pass `on_conflict="duplicate"` explicitly.

## Release mechanics

- Split 2-PR pattern per `project_release_workflow.md` — this PR carries only `CHANGELOG.md` / `packages/memtomem/pyproject.toml` / `uv.lock` diff, no code changes.
- `uv sync` ran against the bump; `uv.lock`'s `[[package]] memtomem` is now `0.1.28`.
- Behavior-change release → **TestPyPI dry-run required** before production tag. `test-v0.1.28a1` tag → `pypi` environment approval (owner-only) → smoke test → `v0.1.28` tag → approval again → PyPI → GitHub Release.

## Feature PRs included since v0.1.27

Multi-agent surface (2026-04-24): #457, #458, #459, #460, #461, #462.
Blockquote tag round-trip (2026-04-24/25): #463, #464, #465, #466, #468.
chunk_links share lineage (2026-04-25): #469, #470.
Export/import Phase 2 (2026-04-24): #450, #451, #454.
CLI polish (2026-04-24): #455, #456.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run pytest -m "not ollama"` — 2439 passed
- [ ] CI (`lint` / `typecheck` / `test` / `notebooks` / `golden-path` / `CLAAssistant`) green on this PR
- [ ] TestPyPI upload verified at `test.pypi.org/pypi/memtomem/0.1.28/json`
- [ ] PyPI upload verified at `pypi.org/pypi/memtomem/0.1.28/json`
- [ ] GitHub Release notes populated from CHANGELOG extract

🤖 Generated with [Claude Code](https://claude.com/claude-code)
