### PR TITLE
fix(storage): mm agent list misses registered-but-empty namespaces

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -186,15 +186,33 @@ class NamespaceOps:
         db.commit()
 
     async def list_namespace_meta(self) -> list[dict]:
+        # Source from BOTH ``namespace_metadata`` (registered namespaces,
+        # possibly with zero chunks) and ``chunks`` (namespaces that hold
+        # data but have no metadata row), unioned. Iterating only one side
+        # would hide the other — registering an agent before adding any
+        # chunks is a legitimate state (``mm agent register <id>`` followed
+        # by ``mm agent list`` should show the agent), and conversely a
+        # legacy chunk in a namespace without a metadata row should not
+        # disappear from the listing.
         db = self._get_db()
         rows = db.execute("""
-            SELECT c.namespace, COUNT(*) as chunk_count,
-                   COALESCE(m.description, '') as description,
-                   COALESCE(m.color, '') as color
-            FROM chunks c
-            LEFT JOIN namespace_metadata m ON c.namespace = m.namespace
-            GROUP BY c.namespace
-            ORDER BY c.namespace
+            SELECT
+                ns.namespace,
+                COALESCE(c.chunk_count, 0) AS chunk_count,
+                COALESCE(m.description, '') AS description,
+                COALESCE(m.color, '') AS color
+            FROM (
+                SELECT namespace FROM namespace_metadata
+                UNION
+                SELECT DISTINCT namespace FROM chunks
+            ) ns
+            LEFT JOIN (
+                SELECT namespace, COUNT(*) AS chunk_count
+                FROM chunks
+                GROUP BY namespace
+            ) c ON c.namespace = ns.namespace
+            LEFT JOIN namespace_metadata m ON m.namespace = ns.namespace
+            ORDER BY ns.namespace
         """).fetchall()
         return [
             {

--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -204,7 +204,7 @@ class NamespaceOps:
             FROM (
                 SELECT namespace FROM namespace_metadata
                 UNION
-                SELECT DISTINCT namespace FROM chunks
+                SELECT namespace FROM chunks
             ) ns
             LEFT JOIN (
                 SELECT namespace, COUNT(*) AS chunk_count

--- a/packages/memtomem/tests/test_server_tools_org.py
+++ b/packages/memtomem/tests/test_server_tools_org.py
@@ -141,6 +141,7 @@ class TestNamespace:
         assert by_ns["empty-meta"]["description"] == "reg only"
         assert by_ns["chunks-only"]["chunk_count"] == 1
         assert by_ns["chunks-only"]["description"] == ""  # no metadata row
+        assert by_ns["chunks-only"]["color"] == ""  # COALESCE fallback symmetry
         assert by_ns["both"]["chunk_count"] == 2
         assert by_ns["both"]["description"] == "reg + chunks"
         assert by_ns["both"]["color"] == "#abc"

--- a/packages/memtomem/tests/test_server_tools_org.py
+++ b/packages/memtomem/tests/test_server_tools_org.py
@@ -91,6 +91,60 @@ class TestNamespace:
         assert meta["description"] == "desc"
         assert meta["color"] == "#fff"
 
+    async def test_list_namespace_meta_includes_registered_empty_namespace(self, storage):
+        """``mm agent register <id>`` followed by ``mm agent list`` must show
+        the agent even before any chunks land in its namespace.
+
+        Regression: ``list_namespace_meta`` previously sourced rows from
+        ``chunks`` only (LEFT JOIN ``namespace_metadata``), so a registered
+        namespace with zero chunks was invisible — the user-visible symptom
+        was that ``mm agent register planner && mm agent list`` printed
+        ``Agents: 0``. Both real-user testing on v0.1.28 and the
+        scenario-1 walkthrough hit this. Existing CLI tests stubbed the
+        storage so the SQL bug was never exercised
+        (``feedback_storage_artifact_false_pass.md``).
+        """
+        await storage.set_namespace_meta("agent-runtime:planner", description="planner")
+        await storage.set_namespace_meta("agent-runtime:coder")  # description default
+
+        meta = await storage.list_namespace_meta()
+        by_ns = {m["namespace"]: m for m in meta}
+
+        assert "agent-runtime:planner" in by_ns
+        assert by_ns["agent-runtime:planner"]["chunk_count"] == 0
+        assert by_ns["agent-runtime:planner"]["description"] == "planner"
+        assert "agent-runtime:coder" in by_ns
+        assert by_ns["agent-runtime:coder"]["chunk_count"] == 0
+
+    async def test_list_namespace_meta_unions_chunks_and_metadata(self, storage):
+        """Namespace appearing in either side of the union must surface.
+
+        Three states the listing must cover, all in one fixture:
+        - **metadata only** — registered but no chunks yet (``empty-meta``)
+        - **chunks only** — legacy / un-registered chunks (``chunks-only``)
+        - **both** — registered AND has chunks (``both``)
+        """
+        await storage.set_namespace_meta("empty-meta", description="reg only")
+        await storage.set_namespace_meta("both", description="reg + chunks", color="#abc")
+        await storage.upsert_chunks(
+            [
+                make_chunk(content="legacy", namespace="chunks-only"),
+                make_chunk(content="b1", namespace="both"),
+                make_chunk(content="b2", namespace="both"),
+            ]
+        )
+
+        meta = await storage.list_namespace_meta()
+        by_ns = {m["namespace"]: m for m in meta}
+
+        assert by_ns["empty-meta"]["chunk_count"] == 0
+        assert by_ns["empty-meta"]["description"] == "reg only"
+        assert by_ns["chunks-only"]["chunk_count"] == 1
+        assert by_ns["chunks-only"]["description"] == ""  # no metadata row
+        assert by_ns["both"]["chunk_count"] == 2
+        assert by_ns["both"]["description"] == "reg + chunks"
+        assert by_ns["both"]["color"] == "#abc"
+
     async def test_namespace_assign_via_upsert(self, storage):
         """Verify chunks in different namespaces are tracked independently."""
         c1 = make_chunk(content="alpha chunk", namespace="ns-a")


### PR DESCRIPTION
## Repro

```
$ mm agent register planner --description "Architecture & roadmap"
Agent registered: planner
- Namespace: agent-runtime:planner
- Shared namespace: shared
$ mm agent register coder
Agent registered: coder
- Namespace: agent-runtime:coder
- Shared namespace: shared
$ mm agent list
Agents: 0

Shared: shared (0 chunk(s)) — Shared knowledge base for all agents
```

Both registers reported success and wrote a `namespace_metadata`
row, but the listing showed zero agents. The user-visible symptom
is "did the register actually take effect?"; the answer is yes,
the listing was just blind to namespaces that had no chunks yet.

The Web UI's `GET /namespaces` route had the same blind spot via
the same storage method — registered-but-empty namespaces never
appeared in the namespaces tab.

## Root cause

`list_namespace_meta` in `sqlite_namespace.py` was

```sql
SELECT c.namespace, COUNT(*), m.description, m.color
FROM chunks c
LEFT JOIN namespace_metadata m ON c.namespace = m.namespace
GROUP BY c.namespace
```

Iterating from the `chunks` side meant a `namespace_metadata` row
with zero matching chunks rows produced zero output rows. Newly-
registered agents have zero chunks until someone writes into their
namespace, so `mm agent register planner && mm agent list` was
guaranteed to lose `planner`.

`shared` continued to show up in `mm agent list` only because the
CLI fetches it separately via `get_namespace_meta(SHARED_NAMESPACE)`
(`agent_cmd.py:168`), which reads `namespace_metadata` directly.
That asymmetry made the bug class non-obvious.

## Fix

Source `list_namespace_meta` from the **union** of
`namespace_metadata.namespace` and `chunks.namespace`, then LEFT
JOIN both sides for chunk count + description/color:

```sql
SELECT
    ns.namespace,
    COALESCE(c.chunk_count, 0),
    COALESCE(m.description, ''),
    COALESCE(m.color, '')
FROM (
    SELECT namespace FROM namespace_metadata
    UNION
    SELECT DISTINCT namespace FROM chunks
) ns
LEFT JOIN (SELECT namespace, COUNT(*) AS chunk_count FROM chunks GROUP BY namespace) c
    ON c.namespace = ns.namespace
LEFT JOIN namespace_metadata m ON m.namespace = ns.namespace
ORDER BY ns.namespace
```

Three states surface correctly now:

| State | Pre-fix | Post-fix |
|-------|---------|----------|
| metadata only (registered, 0 chunks) | invisible (the bug) | listed, `chunk_count=0` |
| chunks only (legacy / un-registered) | listed | listed (unchanged) |
| both | listed | listed (unchanged) |

No caller-side signature change. The same return shape
(`{namespace, chunk_count, description, color}`) is preserved, so
the Web `GET /namespaces` route picks up the fix transparently.

## Why tests didn't catch this

`tests/test_agent_cmd.py` stubs the storage with `AsyncMock`
returning canned `list_namespace_meta` payloads — the SQL bug
never tripped because the SQL never ran. This is the
`feedback_storage_artifact_false_pass.md` pattern in memory:
asserting on processing-stage spies instead of the actual
storage-layer artifact gives a false PASS.

Two regression tests added in
`tests/test_server_tools_org.py::TestNamespace` against the real
SQLite backend:

1. `test_list_namespace_meta_includes_registered_empty_namespace`
   — exact reproducer (`set_namespace_meta` then
   `list_namespace_meta` with no `upsert_chunks` in between).
2. `test_list_namespace_meta_unions_chunks_and_metadata` —
   enumerates all three union states in one fixture so a
   regression on either side fails loudly.

## How it was found

External tester running the v0.1.28 multi-agent test scenarios
walkthrough (`memtomem-docs/memtomem/testing/multi-agent-test-scenarios.md`,
private repo PR #3) caught this at scenario 1 step 1 — exactly the
class of bug the scenarios doc was written to surface. This is a
data point for the doc's value: gate-2-precondition (external e2e
report) effectively delivered a real bug report on first contact.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_server_tools_org.py::TestNamespace -q` — 21 passed (incl. 2 new)
- [x] `uv run pytest packages/memtomem/tests/test_agent_cmd.py packages/memtomem/tests/test_web_routes_extended.py -q` — 72 passed
- [x] `uv run ruff check + format --check` — clean
- [ ] Manual: rerun the repro after merge — `mm agent register planner && mm agent list` should show `Agents: 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)