### PR TITLE
release: v0.1.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.29] — 2026-04-25
+
+Hotfix release. `mm agent register <id>` now surfaces in
+`mm agent list` immediately, even before any chunks land in the
+agent's namespace. Caught during the first external walkthrough
+of the v0.1.28 multi-agent test scenarios — exactly the gap the
+walkthrough was designed to expose.
+
+### Fixed
+
+- **`mm agent list` no longer hides registered-but-empty agents.**
+  `list_namespace_meta` previously sourced rows from
+  `chunks LEFT JOIN namespace_metadata`, so a namespace with a
+  metadata row but zero chunks was filtered out by `GROUP BY
+  c.namespace`. After `mm agent register planner` the agent
+  stayed invisible until someone wrote into
+  `agent-runtime:planner`. The Web UI's `GET /namespaces`
+  response had the same blind spot through the same storage
+  method. Fixed by sourcing from the union of
+  `namespace_metadata.namespace` and `chunks.namespace`, then
+  joining for chunk count + description/color. Three states now
+  surface correctly: metadata only (registered, 0 chunks),
+  chunks only (legacy / un-registered), and both. Return shape
+  unchanged so callers (CLI, Web route) pick up the fix
+  transparently. (PR #473)
+
+### Docs
+
+- **ADR-0002 graduates to public.** The blockquote-tags
+  reader/writer contract shipped in v0.1.28 is now documented at
+  `docs/adr/0002-mem-add-blockquote-tags.md` with file:line
+  references against the v0.1.28 layout, an inbound link from
+  the `mem_add` section of the reference guide, and a reverse
+  cross-link from the v0.1.28 changelog entry. (PR #472)
+
 ## [0.1.28] — 2026-04-25
 
 Multi-agent share provenance + per-entry tag round-trip release.

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.28"
+version = "0.1.29"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.28"
+version = "0.1.29"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Hotfix patch on top of v0.1.28. Two changes since the last release:

| PR | Type | Headline |
|----|------|----------|
| #472 | Docs | ADR-0002 graduates — blockquote-tags reader/writer contract documented in `docs/adr/` with v0.1.28 file:line refs and an inbound link from the `mem_add` reference. |
| #473 | Fix  | `mm agent list` no longer hides registered-but-empty agents — `list_namespace_meta` now sources from the union of `namespace_metadata` and `chunks` instead of iterating `chunks` only. Web UI `GET /namespaces` picks up the same fix transparently. |

## Why now

PR #473 was caught on the first external walkthrough of the v0.1.28 multi-agent test scenarios (`memtomem-docs/memtomem/testing/multi-agent-test-scenarios.md`). Scenario 1 step 1: `mm agent register planner && mm agent list` printed `Agents: 0`. The walkthrough doc and its promotion-gate-2 precondition worked exactly as intended — first contact, real bug surfaced, regression locked in.

Shipping the fix as a patch so the test scenarios are runnable end-to-end without testers having to apply the fix manually.

## Release mechanics

- Diff: `pyproject.toml` version bump + `uv.lock` workspace pin + `CHANGELOG.md` entry. Three files, single commit. (`project_release_workflow.md` split-PR pattern, `feedback_uv_lock_version_sync.md` lockfile-in-same-commit rule.)
- TestPyPI dry-run **skipped** — docs-only + scoped SQL hotfix, no behavior change in tools / migrations / wizard / CLI flags. Per `project_release_workflow.md` step 6: "Hotfix / docs-only 릴리즈는 TestPyPI 스킵 가능."
- After merge: tag `v0.1.29` from the merge commit, push, approve `pypi` environment in the browser (owner-only), then `gh release create`.

## Test plan

- [ ] CI green on this PR (lint / typecheck / test / notebooks / golden-path / CLAAssistant).
- [ ] `pyproject.toml` and `uv.lock` show `0.1.29` consistently.
- [ ] CHANGELOG entry under `## [0.1.29] — 2026-04-25` summarises both PRs and is reachable from the v0.1.28 entry's "See ADR-0002" link.
- [ ] After merge: `git tag v0.1.29 <merge-sha> && git push origin v0.1.29` → PyPI workflow waits on `pypi` env approval.
- [ ] After upload: `curl -s https://pypi.org/pypi/memtomem/0.1.29/json | jq -r .info.version` → `"0.1.29"`.
- [ ] `gh release create v0.1.29 --title v0.1.29 --notes-file <changelog-extract>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)