### PR TITLE
fix(sessions): mem_session_start derives namespace from agent_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **`mem_session_start(agent_id="<id>")` now derives the session
+  namespace from `agent_id` when the caller doesn't pass an
+  explicit `namespace=`.** Previously the session record's
+  namespace fell back to `app.current_namespace` or `"default"`,
+  ignoring the supplied `agent_id` even though the LangGraph
+  adapter `MemtomemStore.start_agent_session` already auto-derived
+  `agent-runtime:<id>`. The MCP tool now matches that semantic.
+  Priority order: explicit `namespace=` > `agent-runtime:<id>`
+  (when `agent_id != "default"`) > `app.current_namespace` >
+  `"default"`. Only the **session record's** namespace field
+  changes; `app.current_namespace` is untouched, so subsequent
+  `mem_add` / `mem_search` without explicit `namespace=` keep the
+  legacy fallback. Backward compat: callers passing explicit
+  `namespace=` are unaffected (priority 1); callers not passing
+  `agent_id` (defaults to `"default"`) are unaffected (priority 3
+  fallback). Caught while walking the multi-agent test scenarios
+  — `mem_session_start(agent_id="planner")` reported
+  `Namespace: default` even though `current_agent_id` was set to
+  `"planner"`, which the tester reasonably expected to flow into
+  the session row.
+
 ## [0.1.29] — 2026-04-25
 
 Hotfix release. `mm agent register <id>` now surfaces in

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
+from memtomem.constants import AGENT_NAMESPACE_PREFIX
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -72,14 +73,37 @@ async def mem_session_start(
       and the new session takes its place. The previous ``agent_id`` is
       replaced by the new one — agents do not stack.
 
+    Namespace derivation priority (matches the LangGraph adapter
+    ``MemtomemStore.start_agent_session`` so MCP and Python entry points
+    behave the same):
+
+    1. Explicit ``namespace=`` argument (escape hatch — wins everything).
+    2. ``agent-runtime:<agent_id>`` when ``agent_id`` is non-default.
+       This is the common case for multi-agent workflows.
+    3. ``app.current_namespace`` (pre-multi-agent fallback).
+    4. ``"default"``.
+
+    Only the **session record's** namespace is derived; ``mem_add`` /
+    ``mem_search`` without explicit ``namespace=`` still consult
+    ``app.current_namespace`` as before. Namespace and agent_id remain
+    separate axes on ``AppContext``.
+
     Args:
         agent_id: Identifier for the agent starting the session
         title: Optional human-readable session title (e.g. "Sprint Planning")
-        namespace: Session namespace (default: current session namespace)
+        namespace: Session namespace. When omitted and ``agent_id`` is
+            non-default, defaults to ``agent-runtime:<agent_id>``.
     """
     app = await _get_app_initialized(ctx)
     session_id = str(uuid4())
-    effective_ns = namespace or app.current_namespace or "default"
+    if namespace:
+        effective_ns = namespace
+    elif agent_id and agent_id != "default":
+        effective_ns = f"{AGENT_NAMESPACE_PREFIX}{agent_id}"
+    elif app.current_namespace:
+        effective_ns = app.current_namespace
+    else:
+        effective_ns = "default"
 
     auto_end_notice: str | None = None
     async with app._session_lock:

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -148,3 +148,73 @@ class TestSessionAgentInheritance:
         """
         app = AppContext.from_components(components)
         assert app._session_lock is not app._config_lock
+
+
+class TestSessionNamespaceDerivation:
+    """``mem_session_start`` derives the session record's namespace from
+    ``agent_id`` when the caller doesn't pass an explicit ``namespace=``.
+    Mirrors the LangGraph adapter's ``MemtomemStore.start_agent_session``
+    so MCP and Python entry points agree.
+
+    Priority: explicit namespace > agent-runtime:<id> when agent_id is
+    non-default > app.current_namespace > "default".
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_id_auto_derives_namespace(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        assert "- Namespace: agent-runtime:planner" in out
+        rows = await app.storage.list_sessions()
+        active = next(r for r in rows if r["id"] == app.current_session_id)
+        assert active["namespace"] == "agent-runtime:planner"
+
+    @pytest.mark.asyncio
+    async def test_explicit_namespace_wins_over_agent_id(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(
+            agent_id="planner", namespace="custom-ns", ctx=ctx
+        )  # type: ignore[arg-type]
+
+        assert "- Namespace: custom-ns" in out
+        rows = await app.storage.list_sessions()
+        active = next(r for r in rows if r["id"] == app.current_session_id)
+        assert active["namespace"] == "custom-ns"
+
+    @pytest.mark.asyncio
+    async def test_default_agent_id_does_not_auto_derive(self, components):
+        """Backward compat: callers that don't pass ``agent_id`` (it
+        defaults to ``"default"``) keep the legacy namespace behavior so
+        pre-multi-agent workflows are unchanged.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(ctx=ctx)  # type: ignore[arg-type]
+
+        assert "- Namespace: default" in out
+        rows = await app.storage.list_sessions()
+        active = next(r for r in rows if r["id"] == app.current_session_id)
+        assert active["namespace"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_agent_id_beats_current_namespace(self, components):
+        """When both ``agent_id`` and ``app.current_namespace`` could
+        supply a value, ``agent_id`` (priority 2) wins over
+        ``current_namespace`` (priority 3).
+        """
+        app = AppContext.from_components(components)
+        app.current_namespace = "legacy-ns"
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        assert "- Namespace: agent-runtime:planner" in out
+        rows = await app.storage.list_sessions()
+        active = next(r for r in rows if r["id"] == app.current_session_id)
+        assert active["namespace"] == "agent-runtime:planner"

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -177,9 +177,7 @@ class TestSessionNamespaceDerivation:
         app = AppContext.from_components(components)
         ctx = _StubCtx(app)
 
-        out = await mem_session_start(
-            agent_id="planner", namespace="custom-ns", ctx=ctx
-        )  # type: ignore[arg-type]
+        out = await mem_session_start(agent_id="planner", namespace="custom-ns", ctx=ctx)  # type: ignore[arg-type]
 
         assert "- Namespace: custom-ns" in out
         rows = await app.storage.list_sessions()


### PR DESCRIPTION
## Summary

`mem_session_start(agent_id="planner")` previously stored the session row with `namespace="default"` because `session.py:82` only consulted explicit `namespace=`, then `app.current_namespace`, then `"default"`. The supplied `agent_id` was set on `AppContext.current_agent_id` for downstream `mem_agent_search` resolution but never flowed into the session row itself. The LangGraph adapter `MemtomemStore.start_agent_session` already auto-derived `agent-runtime:<id>`; the MCP tool now matches.

New priority order:

1. explicit `namespace=` (escape hatch)
2. `agent-runtime:<agent_id>` when `agent_id != "default"`
3. `app.current_namespace` (pre-multi-agent fallback)
4. `"default"`

Only the session record's namespace field is derived — `app.current_namespace` is **not** touched, so `mem_add` / `mem_search` without explicit `namespace=` keep the legacy fallback. The "namespace and agent_id are separate axes on AppContext" invariant is preserved.

## Backward compat

- Callers passing explicit `namespace=` are unaffected (priority 1).
- Callers not passing `agent_id` (defaults to `"default"`) are unaffected (priority 3 fallback).
- Only `agent_id=<non-default>` without `namespace=` sees new behavior, and the new behavior matches what the LangGraph adapter already does.

## Why now

Caught while walking the v0.1.28 multi-agent test scenarios from `memtomem-docs` — the tester ran `mem_session_start(agent_id="planner", title="Multi-agent guide review")` and saw:

```
Session started: 89b2c742-...
- Title: Multi-agent guide review
- Agent: planner
- Namespace: default
```

Reasonable expectation: if `agent_id` is recorded for downstream tools, it should also drive the session's namespace. The MCP/adapter divergence becomes confusing the moment a tester switches between LangGraph code and the raw MCP tool.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_sessions.py -v` — 14 / 14 pass (10 existing + 4 new in `TestSessionNamespaceDerivation`)
- [x] `uv run pytest -m "not ollama"` — 2445 / 2445 pass, 46 deselected, no regressions
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [ ] Manual smoke: `mm session start --agent-id planner` → `mm session list` shows `agent-runtime:planner` namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)