### PR TITLE
fix(server): truncate pid file only after acquiring flock

### DIFF
--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -691,16 +691,13 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
                 # during startup, or a pre-fix concurrent server start that
                 # truncated the file before bailing on the lock probe; see
                 # server/__init__.py for the open(..., "a+") rationale).
-                # Surface the lock path so the user can lsof against it.
-                lookup = (
-                    f"`lsof {server.pid_file}`"
-                    if server.pid_file is not None
-                    else "`ps aux | grep memtomem`"
-                )
+                # ``_probe_pid_file`` only returns alive=True with the
+                # ``pid_file`` field populated, so it is safe to dereference
+                # here without a fallback.
                 click.secho(
                     "Server still running (pid unknown — flock is held by an active "
                     "writer, but the recorded pid is missing). Refusing to delete "
-                    f"state. Find the holder with {lookup}.",
+                    f"state. Find the holder with `lsof {server.pid_file}`.",
                     fg="red",
                 )
             else:

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -685,11 +685,30 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
     if (server.alive or db_lock.locked) and not force:
         click.echo("")
         if server.alive:
-            click.secho(
-                f"Server still running (pid {server.pid}). Refusing to delete state — "
-                "an active server holds the SQLite WAL and deleting it risks corruption.",
-                fg="red",
-            )
+            if server.pid is None:
+                # Empty pid file but flock IS held — a live writer exists,
+                # but the recorded pid was lost (typically a partial write
+                # during startup, or a pre-fix concurrent server start that
+                # truncated the file before bailing on the lock probe; see
+                # server/__init__.py for the open(..., "a+") rationale).
+                # Surface the lock path so the user can lsof against it.
+                lookup = (
+                    f"`lsof {server.pid_file}`"
+                    if server.pid_file is not None
+                    else "`ps aux | grep memtomem`"
+                )
+                click.secho(
+                    "Server still running (pid unknown — flock is held by an active "
+                    "writer, but the recorded pid is missing). Refusing to delete "
+                    f"state. Find the holder with {lookup}.",
+                    fg="red",
+                )
+            else:
+                click.secho(
+                    f"Server still running (pid {server.pid}). Refusing to delete state — "
+                    "an active server holds the SQLite WAL and deleting it risks corruption.",
+                    fg="red",
+                )
             click.secho("  Stop the server first, or pass --force to override.", fg="red")
         else:
             # db_lock.locked only — writer without .server.pid (mm web,

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -301,7 +301,19 @@ def main() -> None:
 
     # Advisory lock — prevents multiple MCP servers from writing concurrently.
     # The lock is held for the lifetime of the process and auto-released on exit.
-    _lock_fp = open(pid_file, "w")  # noqa: SIM115
+    #
+    # Mode is ``a+`` (not ``w``): ``open(..., "w")`` truncates the file at
+    # open time, *before* we know whether ``flock`` will succeed. When a
+    # second server starts while the first is still running, that pre-flock
+    # truncate would zero out the live server's pid file — leaving an
+    # empty file on disk while the original flock holder keeps running.
+    # ``mm uninstall`` then sees ``pid file exists, content empty, flock
+    # held`` and reports ``Server still running (pid None)``, which loses
+    # the diagnostic value of the recorded pid (and broke ``lsof``-driven
+    # debugging). ``a+`` keeps the existing content readable until the lock
+    # decision is made; we ``truncate`` + write the pid only after acquiring
+    # the lock.
+    _lock_fp = open(pid_file, "a+")  # noqa: SIM115
     try:
         fcntl.flock(_lock_fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except OSError:
@@ -317,6 +329,8 @@ def main() -> None:
             pid_file,
         )
     else:
+        _lock_fp.seek(0)
+        _lock_fp.truncate()
         _lock_fp.write(str(os.getpid()))
         _lock_fp.flush()
         atexit.register(lambda: _lock_fp.close())  # LIFO: runs second

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -414,6 +414,71 @@ def test_legacy_lock_sh_allows_multiple_holders(tmp_path: Path) -> None:
         fp2.close()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+def test_contended_server_start_preserves_pid_file_content(tmp_path: Path) -> None:
+    """Regression: a contended server start must NOT truncate the live
+    server's pid file when the flock probe bails.
+
+    Pre-fix, ``main()`` opened the pid file with ``open(..., "w")`` which
+    truncates *before* ``fcntl.flock`` is checked. So a second server
+    starting while the first held the lock zeroed out the file content
+    even though the first server kept running. The user-visible symptom:
+    ``mm uninstall`` reports ``Server still running (pid None)`` and
+    ``lsof`` loses the recorded process identity, defeating the whole
+    point of writing the pid in the first place.
+
+    Repro: pre-create the pid file with known content and hold
+    ``LOCK_EX`` on it, spawn the server, and assert the recorded pid
+    survived. The fix uses ``open(..., "a+")`` + post-lock truncate so
+    contended starts leave the live file alone.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+    sub = xdg / "memtomem"
+    sub.mkdir()
+    os.chmod(sub, 0o700)
+    pid_file = sub / "server.pid"
+    pid_file.write_text("12345")
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
+
+    import fcntl as _fcntl
+
+    holder = open(pid_file, "a+b")  # noqa: SIM115 — held for test scope
+    try:
+        _fcntl.flock(holder, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        proc = _spawn_server(env)
+        try:
+            # The open + flock + warning log runs synchronously at
+            # startup, well before mcp.run() spins up the asyncio loop.
+            # 1.5s is generous coverage for cold-start interpreter
+            # overhead while still failing fast on the regression.
+            time.sleep(1.5)
+            assert proc.poll() is None, (
+                "server must stay alive when another holder owns the flock; "
+                f"exited rc={proc.returncode}"
+            )
+            assert pid_file.read_text() == "12345", (
+                "contended server start truncated the live pid file — this "
+                "is the open(..., 'w') race the fix replaces with "
+                "open(..., 'a+') + post-lock truncate. Got: "
+                f"{pid_file.read_text()!r}"
+            )
+        finally:
+            _cleanup_proc(proc)
+    finally:
+        try:
+            _fcntl.flock(holder, _fcntl.LOCK_UN)
+        except OSError:
+            pass
+        holder.close()
+
+
 def stat_mode(path: Path) -> int:
     import stat as _stat
 

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -372,6 +372,37 @@ class TestServerAliveRefuses:
         assert result.exit_code == 0, result.output
         assert not state.exists()
 
+    def test_refuses_with_unknown_pid_branch_when_pid_file_empty(self, home):
+        """Empty pid file + flock held = the truncate-race fingerprint.
+
+        When a pre-fix concurrent server start truncated the live
+        server's pid file, the recorded pid is gone but the flock is
+        still held. The user-facing message must distinguish this from
+        the normal case so the user can run ``lsof <pidfile>`` to find
+        the holder — falling back to the generic ``pid None`` was
+        confusing enough to file in this PR.
+        """
+        from memtomem._runtime_paths import ensure_runtime_dir
+
+        _seed_state(home)
+        pid_file = ensure_runtime_dir() / "server.pid"
+        pid_file.write_text("", encoding="utf-8")  # empty content, exists
+
+        with _hold_pid_lock(pid_file):
+            result = CliRunner().invoke(cli, ["uninstall", "-y"])
+
+        assert result.exit_code == 2
+        assert "pid unknown" in result.output, (
+            "empty pid + held flock must surface the 'pid unknown' branch, "
+            f"not the generic 'pid None' message; got: {result.output!r}"
+        )
+        assert "lsof" in result.output, (
+            "empty-pid branch must point at lsof so the user can identify "
+            "the flock holder without another diagnostic round-trip"
+        )
+        # Refusal still protects state — same WAL-corruption invariant.
+        assert (home / ".memtomem" / "memtomem.db").exists()
+
 
 class TestPidRecyclingDoesNotFalsePositive:
     """#387: a recorded PID that happens to point at a live unrelated process


### PR DESCRIPTION
## Summary

`server/__init__.py:main` opened the runtime pid file with `open(pid_file, "w")`, which truncates at open time — *before* the `fcntl.flock(LOCK_EX | LOCK_NB)` probe decides whether this process is the lock holder. When a second `memtomem-server` starts while the first is still running (multiple Claude Code / Codex / Gemini MCP clients spawning in parallel, or any restart race), the second process zeros out the live server's pid file, then bails on the flock probe and falls through. The first server keeps running, but the recorded pid is gone from disk.

The user-visible symptom is `mm uninstall` reporting:

> Server still running (pid None). Refusing to delete state — an active server holds the SQLite WAL and deleting it risks corruption.

The refusal is correct (flock IS held, removing the WAL would risk corruption) — but `pid None` loses the diagnostic value of the recorded process identity. `lsof <pidfile>` and `ps -p <pid>` both stop working as a way to find the holder.

The legacy compatibility helper `_try_hold_legacy_flock` already uses the safe `"a+b"` pattern, so this is just the primary lock acquisition that never got the same treatment. The open-mode race has been latent since the pid lock was introduced (`0597de4`, predates the #412 path relocation).

## Fix

- `server/__init__.py`: open with `"a+"` (no truncate at open), acquire the flock, then `seek(0) + truncate() + write(pid)`. File content is only mutated after the lock decision.
- `cli/uninstall_cmd.py`: when the recorded pid is `None` but the flock IS held (truncate-race fingerprint, plus partial-write crashes during startup), surface a dedicated "pid unknown" branch that points the user at `lsof <pidfile>` instead of the misleading `pid None`.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 2443 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check ...` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/server/__init__.py packages/memtomem/src/memtomem/cli/uninstall_cmd.py` — no issues
- [x] Regression-test parity: stashed the fix and re-ran the two new tests against pre-fix source. Both fail with the exact symptoms (`Got: ''` for the truncated content; `Server still running (pid None)` literal for the user-reported message). Tests pass after restoring the fix.

## Compatibility audit

Verified the fix doesn't conflict with the rationale of any prior PR touching this code path:

| PR | Intent | Conflict with this fix |
|---|---|---|
| #412 (path relocation to `$XDG_RUNTIME_DIR`) | Keep `~/.memtomem/` out of the MCP handshake | None — same target path, no new opens |
| #413 (runtime dir security gates: `lstat` + owner + `0o700`) | Reject hostile pre-existing dirs | None — gates run before `open` |
| #437 / #439 (atexit unlink ordering on legacy pid) | Stale-file cleanup | None — teardown unchanged |
| #444 / #445 (legacy `LOCK_SH` for 0.1.26+ coexistence) | Multiple post-#412 servers can run together | None — different file |

🤖 Generated with [Claude Code](https://claude.com/claude-code)