### PR TITLE
feat(server): set FastMCP instructions= so MCP clients see multi-agent recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **MCP `initialize` response now carries server-level `instructions`.**
+  The MCP server passes a workflow-recipe string to
+  `FastMCP(instructions=...)`, which clients auto-inject into every
+  LLM session alongside the tool list. The string covers the
+  single-agent quickstart (`mem_add` / `mem_search`), the multi-agent
+  recipe (`mem_agent_register` → `mem_session_start` →
+  `mem_agent_search` / `mem_agent_share` → `mem_session_end`),
+  namespace conventions (`default` / `agent-runtime:<id>` / `shared:`),
+  and common pitfalls (e.g. `mem_add` without `namespace=` consults
+  `current_namespace`, not the session's `agent-runtime:*` scope).
+  Source of truth: `memtomem/server/instructions.py`; pinned by
+  `tests/test_server_instructions.py` so renames or convention drift
+  fail loud. Motivation: tool docstrings alone left LLMs guessing
+  which tool to call when users asked for "agent isolation" — clients
+  were silently falling back to `mem_add` instead of
+  `mem_agent_share`. The instructions field gives the LLM a workflow
+  hint without anyone having to paste a system snippet.
+
 ### Changed
 
 - **`mem_session_start(agent_id="<id>")` now derives the session

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -35,10 +35,16 @@ from memtomem.server.helpers import (
     _parse_recall_date as _parse_recall_date,
     _set_config_key as _set_config_key,
 )
+from memtomem.server.instructions import INSTRUCTIONS as _INSTRUCTIONS
 from memtomem.server.lifespan import app_lifespan
 
 # ── mcp instance — must be created before tool-module imports ──────────
-mcp = FastMCP("memtomem", lifespan=app_lifespan)
+# ``instructions=`` is auto-injected into every MCP client's session as
+# the ``initialize`` response's ``instructions`` field — the only
+# documentation surface most LLMs see before picking a tool. Source of
+# truth lives in ``memtomem/server/instructions.py``; pinned by
+# ``tests/test_server_instructions.py``.
+mcp = FastMCP("memtomem", instructions=_INSTRUCTIONS, lifespan=app_lifespan)
 
 # Pin ``serverInfo.version`` in the MCP ``initialize`` response to the
 # memtomem package version (#383). ``FastMCP.__init__`` has no ``version``

--- a/packages/memtomem/src/memtomem/server/instructions.py
+++ b/packages/memtomem/src/memtomem/server/instructions.py
@@ -1,0 +1,54 @@
+"""Server-level instructions string.
+
+Passed to ``FastMCP(instructions=...)`` and surfaced to every MCP client
+on the ``initialize`` response. This is the only documentation surface
+most LLMs see before deciding which tool to call — keep it tight and
+focused on workflow recognition, not a full reference. Per-tool
+docstrings cover argument-level detail.
+
+When changing this string, also update the pin test
+``tests/test_server_instructions.py`` so that renamed tools or removed
+namespace conventions don't silently drift.
+"""
+
+from __future__ import annotations
+
+INSTRUCTIONS: str = """\
+memtomem — markdown-first long-term memory MCP server.
+
+Default usage (single-agent — the common case):
+- mem_add to record a note, mem_search to find one. That's it.
+- Notes go to the "default" namespace; agent_id and namespace=
+  can be ignored unless you're orchestrating multiple agents.
+
+Multi-agent workflow (only when the user asks for per-agent
+isolation or shared knowledge between agents):
+1. Register each agent once: mem_agent_register(agent_id="planner")
+2. Start a session per agent run:
+     mem_session_start(agent_id="planner")
+   The session record's namespace auto-derives to
+   "agent-runtime:planner" — no explicit namespace= needed.
+3. Search / share inside the agent scope:
+     mem_agent_search(query=..., include_shared=True)
+     mem_agent_share(memory_id=...)   # promote to "shared:"
+4. End the session: mem_session_end(summary=...)
+
+Namespace conventions:
+  default                 single-agent / pre-multi-agent
+  agent-runtime:<id>      per-agent isolated scope
+  shared:                 cross-agent shared scope
+Pass explicit namespace= only when overriding the derived value.
+
+Common pitfalls:
+- mem_session_start() without agent_id falls back to the "default"
+  namespace — pass agent_id whenever you want isolation.
+- agent_id and current_namespace are separate axes; mem_add /
+  mem_search without explicit namespace= still consult
+  current_namespace, not the session's "agent-runtime:*" scope.
+  Use mem_agent_search / mem_agent_share to act inside the
+  agent scope.
+- mem_agent_search needs an active session (or current_agent_id);
+  call mem_session_start first.
+
+When in doubt, default to mem_add / mem_search with no extras.
+"""

--- a/packages/memtomem/tests/test_server_instructions.py
+++ b/packages/memtomem/tests/test_server_instructions.py
@@ -1,0 +1,158 @@
+"""Pin tests for the FastMCP ``instructions=`` field.
+
+The instructions string set in ``memtomem/server/__init__.py`` is
+auto-injected into every MCP client's ``initialize`` response. For most
+LLMs this is the only workflow-level signal they get before deciding
+which memtomem tool to call — drift here means clients silently fall
+back to docstring-only inference and pick the wrong tool (e.g. plain
+``mem_add`` when the user asked for per-agent isolation).
+
+Two layers, mirroring ``test_server_version_reporting.py``:
+
+* A unit test asserts the constant is wired through to
+  ``mcp.instructions`` and mentions every workflow token an LLM has to
+  recognize. If a tool is renamed or a namespace convention changes,
+  both ``server/instructions.py`` and the ``REQUIRED_TOKENS`` tuple
+  below must move in lockstep.
+* An end-to-end test drives the ``initialize`` RPC against a real
+  subprocess and asserts the ``instructions`` field round-trips, so a
+  future FastMCP release that drops the parameter (or strips it during
+  startup) is still caught.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem.server import mcp
+from memtomem.server.instructions import INSTRUCTIONS
+
+REQUIRED_TOKENS: tuple[str, ...] = (
+    # Single-agent quickstart — what 90% of users should reach for.
+    "mem_add",
+    "mem_search",
+    # Multi-agent workflow — the recipe an LLM has to follow in order.
+    "mem_agent_register",
+    "mem_session_start",
+    "mem_agent_search",
+    "mem_agent_share",
+    "mem_session_end",
+    # Namespace conventions — the vocabulary the LLM needs to recognize.
+    "agent-runtime:",
+    "shared:",
+    "default",
+)
+
+
+def test_instructions_is_wired_to_fastmcp() -> None:
+    """The constant from ``server/instructions.py`` reaches
+    ``mcp.instructions`` (and therefore the ``initialize`` response).
+    Without this, MCP clients have nothing but tool docstrings to go on.
+    """
+    assert mcp.instructions == INSTRUCTIONS, (
+        "FastMCP(instructions=...) must be passed the INSTRUCTIONS "
+        "constant verbatim; see memtomem/server/__init__.py"
+    )
+
+
+@pytest.mark.parametrize("token", REQUIRED_TOKENS)
+def test_instructions_mentions_workflow_token(token: str) -> None:
+    """Each token names a tool or convention an LLM must recognize to
+    route a user request correctly. If a tool is renamed, update both
+    ``INSTRUCTIONS`` and ``REQUIRED_TOKENS`` so this pin keeps working.
+    """
+    assert token in INSTRUCTIONS, (
+        f"instructions string lost reference to {token!r}; if the "
+        f"workflow changed, update memtomem/server/instructions.py "
+        f"and the REQUIRED_TOKENS tuple in lockstep."
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+def test_initialize_response_carries_instructions(tmp_path: Path) -> None:
+    """End-to-end: drive the ``initialize`` RPC and assert the
+    ``instructions`` field on the response matches the wired constant.
+
+    Isolates ``HOME`` + ``XDG_RUNTIME_DIR`` under ``tmp_path`` so the
+    server doesn't touch the developer's real state during the probe
+    (mirrors ``test_server_version_reporting.py``).
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
+    os.chmod(xdg, 0o700)
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["XDG_RUNTIME_DIR"] = str(xdg)
+
+    initialize_request = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "test-probe", "version": "0.1"},
+        },
+    }
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "memtomem.server"],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        assert proc.stdin is not None and proc.stdout is not None
+        proc.stdin.write((json.dumps(initialize_request) + "\n").encode())
+        proc.stdin.flush()
+
+        deadline = time.monotonic() + 15
+        response_line: bytes | None = None
+        while time.monotonic() < deadline:
+            line = proc.stdout.readline()
+            if not line:
+                if proc.poll() is not None:
+                    stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+                    pytest.fail(
+                        f"Server exited before responding (rc={proc.returncode}). stderr:\n{stderr}"
+                    )
+                continue
+            response_line = line
+            break
+        if response_line is None:
+            stderr = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+            pytest.fail(f"No initialize response within 15s. stderr:\n{stderr}")
+
+        response = json.loads(response_line)
+        result = response.get("result", {})
+        instructions = result.get("instructions")
+        assert instructions == INSTRUCTIONS, (
+            "initialize response's `instructions` field must round-trip "
+            "the wired constant; if this fails, FastMCP may have dropped "
+            "the parameter or stripped it during startup."
+        )
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        for stream in (proc.stdin, proc.stdout, proc.stderr):
+            if stream is not None:
+                try:
+                    stream.close()
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

memtomem's MCP server constructed FastMCP without an `instructions=`
argument:

```python
mcp = FastMCP("memtomem", lifespan=app_lifespan)
```

The MCP spec's `initialize` response carries an `instructions` field
that clients auto-inject into every LLM session alongside the tool
list — but memtomem left it empty, so LLMs had only per-tool
docstrings to go on. When users asked for per-agent isolation, clients
were quietly defaulting to plain `mem_add` instead of routing through
`mem_agent_share`. Surfaced while walking the v0.1.28 multi-agent
test scenarios from `memtomem-docs` (same trail that produced #473
and #475).

This PR threads a workflow-recipe string through `instructions=` so
every client gets the same hint, paste-free.

## What the recipe covers

- **Single-agent quickstart** — `mem_add` / `mem_search`, `default`
  namespace. The 90% case stays one line.
- **Multi-agent recipe in order** — `mem_agent_register` →
  `mem_session_start(agent_id=...)` → `mem_agent_search` /
  `mem_agent_share` → `mem_session_end`.
- **Namespace conventions** — `default` / `agent-runtime:<id>` /
  `shared:` with one-line descriptions.
- **Pitfalls** — notably that `mem_add` without `namespace=` consults
  `current_namespace`, not the session's `agent-runtime:*` scope, so
  multi-agent writes must go through `mem_agent_share`. Caught while
  reviewing #475.

Full string lives in `packages/memtomem/src/memtomem/server/instructions.py`
so it's grep-able and reusable.

## Why this PR (vs. docs / per-tool docstring edits)

- **Per-tool docstrings** are seen only when the LLM has *already*
  picked a tool — they don't help with the routing decision.
- **A separate `USAGE.md` snippet** would require every user to paste
  it into `CLAUDE.md` / system prompt manually. The MCP `instructions`
  channel auto-injects.
- **Prior art** — memtomem-stm already uses `instructions=` (visible
  in any session that has both servers connected). FastMCP supports
  the parameter natively; no SDK changes needed.

## Test plan

Pin tests in `packages/memtomem/tests/test_server_instructions.py`
mirror `test_server_version_reporting.py` (#383):

- [x] Unit: `mcp.instructions == INSTRUCTIONS` and every workflow
      token (tool name or namespace prefix) appears in the constant.
      Renames force both halves to move in lockstep.
- [x] E2E: drives the `initialize` JSON-RPC call against a real
      subprocess, parses the response, and asserts the `instructions`
      field round-trips. Catches FastMCP regressions that drop or
      strip the parameter.
- [x] `uv run pytest packages/memtomem/tests/test_server_instructions.py -v`
      — 12 / 12 pass.
- [x] `uv run pytest -m "not ollama"` — 2457 / 2457 pass, 46
      deselected, no regressions.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
      and `ruff format --check` — clean.

## Backward compat

- No tool signatures change; only the server-level `initialize`
  response gains a non-empty `instructions` field.
- Clients that ignore the field (older MCP libraries, custom clients)
  see no behavioral difference.

## Follow-ups (out of scope)

- Optional `memtomem-docs/USAGE-multi-agent.md` longer-form recipe if
  the 50-line `instructions=` proves too thin in practice. The pin
  test makes it safe to deepen the constant in place first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)