### PR TITLE
fix(server): correct mem_agent_share example in instructions= field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mem_agent_share` example in server `instructions=` had wrong
+  parameter name.** The recipe shipped in #477 showed
+  `mem_agent_share(memory_id=...)` but the real signature is
+  `mem_agent_share(chunk_id=..., target=...)`. Weak LLMs (reproduced
+  on Claude Haiku 4.5) followed the example verbatim, hit a
+  parameter-name rejection, then `mem_do(action="help")`-recovered to
+  the correct args — burning an extra round trip per multi-agent
+  share. Stronger LLMs (Sonnet 4.5+) inferred past the typo. Fixed
+  the example and tightened `tests/test_server_instructions.py` with
+  a signature-parity check: any `tool(arg=...)` form in INSTRUCTIONS
+  is now cross-checked against `inspect.signature(...)`, so future
+  parameter renames force the example to follow.
+
 ### Added
 
 - **MCP `initialize` response now carries server-level `instructions`.**

--- a/packages/memtomem/src/memtomem/server/instructions.py
+++ b/packages/memtomem/src/memtomem/server/instructions.py
@@ -30,7 +30,7 @@ isolation or shared knowledge between agents):
    "agent-runtime:planner" — no explicit namespace= needed.
 3. Search / share inside the agent scope:
      mem_agent_search(query=..., include_shared=True)
-     mem_agent_share(memory_id=...)   # promote to "shared:"
+     mem_agent_share(chunk_id=..., target="shared")   # copy chunk to shared scope
 4. End the session: mem_session_end(summary=...)
 
 Namespace conventions:

--- a/packages/memtomem/tests/test_server_instructions.py
+++ b/packages/memtomem/tests/test_server_instructions.py
@@ -22,17 +22,26 @@ Two layers, mirroring ``test_server_version_reporting.py``:
 
 from __future__ import annotations
 
+import inspect
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 from pathlib import Path
+from typing import Any, Callable
 
 import pytest
 
 from memtomem.server import mcp
 from memtomem.server.instructions import INSTRUCTIONS
+from memtomem.server.tools.multi_agent import (
+    mem_agent_register,
+    mem_agent_search,
+    mem_agent_share,
+)
+from memtomem.server.tools.session import mem_session_end, mem_session_start
 
 REQUIRED_TOKENS: tuple[str, ...] = (
     # Single-agent quickstart — what 90% of users should reach for.
@@ -73,6 +82,46 @@ def test_instructions_mentions_workflow_token(token: str) -> None:
         f"workflow changed, update memtomem/server/instructions.py "
         f"and the REQUIRED_TOKENS tuple in lockstep."
     )
+
+
+# Tools whose ``foo(arg=...)`` example forms appear in INSTRUCTIONS. If a
+# parameter is renamed at the source, the example must move with it or the
+# string lies to the LLM (causes wrong-arg recovery round trips, observed
+# concretely on Haiku 4.5 in the v0.1.30-pre instructions where
+# ``mem_agent_share(memory_id=...)`` was shown but the real signature is
+# ``chunk_id``).
+_DOCUMENTED_TOOLS: tuple[Callable[..., Any], ...] = (
+    mem_agent_register,
+    mem_agent_search,
+    mem_agent_share,
+    mem_session_start,
+    mem_session_end,
+)
+
+
+@pytest.mark.parametrize("fn", _DOCUMENTED_TOOLS, ids=lambda fn: fn.__name__)
+def test_instructions_kwargs_match_signature(fn: Callable[..., Any]) -> None:
+    """Any ``tool_name(arg=...)`` example in INSTRUCTIONS must use a
+    real parameter name from the function's actual signature. The MCP
+    ``ctx`` parameter is excluded since it's framework-injected and
+    never appears in user-facing examples.
+    """
+    sig = inspect.signature(fn)
+    real_params = {p for p in sig.parameters if p != "ctx"}
+    name = fn.__name__
+
+    # Match each ``name(...)`` occurrence and pull out kwarg names.
+    # The pattern stops at the first ``)`` so multi-line examples need
+    # to fit on one line — which all current INSTRUCTIONS examples do.
+    for match in re.finditer(rf"{re.escape(name)}\(([^)]*)\)", INSTRUCTIONS):
+        arglist = match.group(1)
+        for kwarg in re.findall(r"(\w+)\s*=", arglist):
+            assert kwarg in real_params, (
+                f"INSTRUCTIONS shows {name}({kwarg}=...) but the real "
+                f"signature has parameters {sorted(real_params)}. Either "
+                f"fix the example in memtomem/server/instructions.py or "
+                f"rename the parameter on {fn.__module__}.{name}."
+            )
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")


### PR DESCRIPTION
## Summary

The recipe shipped in #477 showed `mem_agent_share(memory_id=...)`
but the real signature is `mem_agent_share(chunk_id=..., target=...)`
(see `packages/memtomem/src/memtomem/server/tools/multi_agent.py:162`).

**Impact, reproduced via 4-spawn A/B**:

- 2 worktrees (`v0.1.29` baseline vs current `main` w/ instructions=)
- 2 prompts (structured "set up multi-agent isolation" vs ambiguous
  "two AI helpers, keep notes private until handed off")
- 2 models (Sonnet 4.5, Haiku 4.5)
- Same `claude -p` harness, `--mcp-config` pointing at each worktree's
  `python -m memtomem.server`

| Setup | Symptom |
|---|---|
| Sonnet × structured | inferred past the typo, used `chunk_id`+`target` directly |
| Sonnet × ambiguous | same — emergent recovery |
| Haiku × ambiguous | **followed the typo verbatim** → arg-name reject → `mem_do(action="help")` → retried with correct args (extra round trip on the critical share path) |

So the bug is silent on stronger models but adds a recovery hop on
weaker ones. Sonnet's robustness is also why the existing pin test
+ E2E test passed: they only check token *presence*, not signature
parity.

## What changes

- **`server/instructions.py:33`** — `memory_id=...` → `chunk_id=..., target="shared"`,
  comment updated to "copy chunk to shared scope" (matches the
  function docstring's clarification that this is a content copy,
  not a reference link).
- **`tests/test_server_instructions.py`** — new `test_instructions_kwargs_match_signature`
  parametrized over the five multi-agent / session functions
  documented in INSTRUCTIONS (`mem_agent_register`, `mem_agent_search`,
  `mem_agent_share`, `mem_session_start`, `mem_session_end`). It uses
  `inspect.signature(...)` to extract real parameter names and
  cross-checks every `name(arg=...)` form found in INSTRUCTIONS via
  regex. The MCP `ctx` parameter is excluded.
- **CHANGELOG** — `[Unreleased] → Fixed` entry.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_server_instructions.py -v` — 17/17 pass (was 12; +5 parametrized signature-parity cases)
- [x] `uv run ruff check` + `ruff format --check` on changed files — clean
- [x] Sanity: temporarily reverted `chunk_id` → `memory_id` in instructions.py; new test fails with `INSTRUCTIONS shows mem_agent_share(memory_id=...) but the real signature has parameters ['chunk_id', 'target']`
- [ ] Full `pytest -m "not ollama"` in CI

## Why now

The bug is unreleased (PR #477 hasn't shipped to PyPI yet — current
`mm --version` is still 0.1.29). Fixing before the v0.1.30 cut
keeps the changelog narrative clean: the `instructions=` feature
ships correct rather than as "added in 0.1.30, fixed in 0.1.30.1".

## Out of scope

- Adding `agent_id="planner"` example for `mem_agent_register` etc. —
  out of scope; the new signature test would catch any future drift
  there.
- Deepening INSTRUCTIONS into a full reference (`USAGE-multi-agent.md`)
  — the A/B data showed weak ROI for general "deepen" beyond fixing
  this factual error; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)