### PR TITLE
release: v0.1.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.30] — 2026-04-26
+
 ### Fixed
+
+- **`mm uninstall` no longer reports `pid None` after a contended
+  server start.** The runtime pid file was opened with
+  `open(pid_file, "w")`, which truncates at open *before* the
+  `fcntl.flock(LOCK_EX | LOCK_NB)` probe decides ownership. When a
+  second `memtomem-server` started while the first was still
+  running (multiple Claude Code / Codex / Gemini MCP clients
+  spawning in parallel, or any restart race), the second process
+  zeroed out the live server's pid file, then bailed on the flock
+  probe — leaving `mm uninstall` with no recorded pid to surface.
+  Fixed by switching to `"a+"` (no open-time truncate) and
+  performing `seek(0); truncate(); write(pid)` only after the
+  flock is held. `mm uninstall` now distinguishes a `pid unknown`
+  branch (truncate-race fingerprint or a partial-write startup
+  crash) from `pid None` and points at `lsof <pidfile>` for
+  diagnosis. Latent since the pid lock was introduced; predates
+  the #412 runtime-dir relocation. (PR #476)
 
 - **`mem_agent_share` example in server `instructions=` had wrong
   parameter name.** The recipe shipped in #477 showed

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.29"
+version = "0.1.30"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.29"
+version = "0.1.30"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bumps to v0.1.30. Wraps four feature/fix PRs that landed since v0.1.29:

| PR | Type | Summary |
|---|---|---|
| #475 | Changed | `mem_session_start(agent_id="<id>")` derives session namespace from `agent_id` when `namespace=` is omitted (matches LangGraph adapter semantics) |
| #477 | Added | FastMCP `instructions=` carries the multi-agent workflow recipe so MCP clients auto-inject it without users pasting system prompts |
| #478 | Fixed | `mem_agent_share` example in instructions had `memory_id=` typo; corrected to `chunk_id=` + signature-parity test |
| #476 | Fixed | pid file `open("w")` truncated before flock probe; a second-server start zeroed the live pid file. Switched to `"a+"` + post-flock `seek(0); truncate(); write(pid)`. `mm uninstall` distinguishes `pid unknown` (truncate-race fingerprint) from `pid None` |

## Files (release mechanics)

- `packages/memtomem/pyproject.toml` — `0.1.29` → `0.1.30`
- `uv.lock` — workspace `memtomem` package re-resolved to `0.1.30`
- `CHANGELOG.md` — `[Unreleased]` entries dated as `[0.1.30] — 2026-04-26`; PR #476 entry added to **Fixed** (omitted from #476's own description, surfaced here so the release notes are complete)

## Post-merge plan

1. **TestPyPI dry-run** — behavior changes are non-trivial (#475 namespace semantics, #476 lock acquisition order). Per `feedback_prerelease_dry_run.md`, push `test-v0.1.30a1` first, fresh-install smoke-test multi-agent + uninstall path, then push `v0.1.30`.
2. **Production tag** — `git tag v0.1.30 <merge-commit>` + `git push origin v0.1.30`. `release.yml` triggers via OIDC trusted publisher; `pypi` environment approval via gh API.
3. **Propagation check** — `uvx --refresh --from "memtomem==0.1.30" mm --version`.
4. **GitHub Release** — `gh release create v0.1.30 --notes-file <CHANGELOG slice>`.
5. **Unblock memtomem-docs#10** — install floor 0.1.29 → 0.1.30 follow-up PR (currently Draft, hold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)