### PR TITLE
feat(embedding): cap ONNX intra-op threads via embedding.threads

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -50,7 +50,14 @@ class EmbeddingConfig(BaseSettings):
     # 0 = use ORT's default (typically all physical CPU cores). Set to a
     # small integer (e.g. 4) to keep seeding from monopolising the machine.
     # Forwarded to ``fastembed.TextEmbedding(threads=...)``; ignored by the
-    # network-bound providers (Ollama, OpenAI).
+    # network-bound providers (Ollama, OpenAI). Bounds ORT's intra-op pool
+    # only — does not affect numpy/scipy thread pools (use OMP_NUM_THREADS
+    # for those).
+    #
+    # Restart-required, intentionally excluded from ``MUTABLE_FIELDS``: the
+    # ``TextEmbedding`` instance is cached on first use, so a runtime change
+    # would not take effect until restart anyway. Same precedent as
+    # ``rerank.provider``/``model``/``api_key`` below.
     threads: int = 0
 
     @field_validator("dimension")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -46,6 +46,12 @@ class EmbeddingConfig(BaseSettings):
     api_key: str = ""
     batch_size: int = 64
     max_concurrent_batches: int = 4
+    # ONNX Runtime intra-op thread cap for the local fastembed provider.
+    # 0 = use ORT's default (typically all physical CPU cores). Set to a
+    # small integer (e.g. 4) to keep seeding from monopolising the machine.
+    # Forwarded to ``fastembed.TextEmbedding(threads=...)``; ignored by the
+    # network-bound providers (Ollama, OpenAI).
+    threads: int = 0
 
     @field_validator("dimension")
     @classmethod
@@ -59,6 +65,13 @@ class EmbeddingConfig(BaseSettings):
     def must_be_positive(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
+        return v
+
+    @field_validator("threads")
+    @classmethod
+    def threads_non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("threads must be non-negative (0 = ORT default)")
         return v
 
 

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -81,8 +81,15 @@ class OnnxEmbedder:
 
         _register_custom_models_if_needed()
         model_id = _resolve_model(self._config.model)
-        logger.info("Loading ONNX embedding model %s …", model_id)
-        self._model = TextEmbedding(model_name=model_id)
+        # threads=0 → leave ORT default (all physical cores); threads>0 caps
+        # the intra-op pool so seeding doesn't saturate the machine.
+        threads = self._config.threads or None
+        logger.info(
+            "Loading ONNX embedding model %s (threads=%s) …",
+            model_id,
+            threads if threads is not None else "ORT default",
+        )
+        self._model = TextEmbedding(model_name=model_id, threads=threads)
         return self._model
 
     @property

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -471,6 +471,42 @@ class TestOnnxEmbedder:
         await embedder.close()
         assert embedder._model is None
 
+    def test_threads_default_is_zero(self):
+        """Default preserves prior behavior — ORT picks all physical cores."""
+        assert _onnx_config().threads == 0
+
+    def test_threads_rejects_negative(self):
+        """Validator catches typos like -1 at config-load time."""
+        with pytest.raises(ValueError, match="non-negative"):
+            EmbeddingConfig(provider="onnx", model="bge-m3", dimension=1024, threads=-1)
+
+    @pytest.mark.anyio
+    async def test_threads_forwarded_to_fastembed(self):
+        """threads=N reaches fastembed.TextEmbedding(threads=N)."""
+        config = _onnx_config(threads=4)
+        embedder = OnnxEmbedder(config)
+        fake_model = _make_fake_embedding_model([[0.1, 0.2, 0.3]])
+        with (
+            patch("memtomem.embedding.onnx._register_custom_models_if_needed"),
+            patch("fastembed.TextEmbedding", return_value=fake_model) as mock_te,
+        ):
+            await embedder.embed_texts(["hi"])
+        mock_te.assert_called_once()
+        assert mock_te.call_args.kwargs["threads"] == 4
+
+    @pytest.mark.anyio
+    async def test_threads_zero_passes_none_to_fastembed(self):
+        """threads=0 → None so fastembed/ORT keeps its default behavior."""
+        config = _onnx_config(threads=0)
+        embedder = OnnxEmbedder(config)
+        fake_model = _make_fake_embedding_model([[0.1, 0.2, 0.3]])
+        with (
+            patch("memtomem.embedding.onnx._register_custom_models_if_needed"),
+            patch("fastembed.TextEmbedding", return_value=fake_model) as mock_te,
+        ):
+            await embedder.embed_texts(["hi"])
+        assert mock_te.call_args.kwargs["threads"] is None
+
 
 # ---------------------------------------------------------------------------
 # 4. create_embedder factory


### PR DESCRIPTION
## Summary
- Add `EmbeddingConfig.threads` (default `0` = ORT default — no behavior change for existing installs).
- Forward to `fastembed.TextEmbedding(threads=...)` so seeding with the local ONNX provider can be capped to N cores instead of saturating the box.
- Startup log now reports the effective thread count so users can confirm the cap took effect.

## Why
A fresh `mm init` + seed on `BAAI/bge-m3` keeps every physical core pinned for the duration of the run, which makes the laptop unusable for other work. There was no knob short of yanking `OMP_NUM_THREADS` (which also drags in numpy/scipy). One opt-in field, no default change.

Set `embedding.threads = 4` in `~/.memtomem/config.json` (or via env `MEMTOMEM_EMBEDDING__THREADS=4`) to cap; leave at `0` for the prior behavior.

## Scope notes
- **Bounds ORT's intra-op pool only** — does not affect numpy/scipy thread pools (use `OMP_NUM_THREADS` for those). Documented inline in the field comment.
- **Restart-required, intentionally excluded from `MUTABLE_FIELDS`/`FIELD_CONSTRAINTS`.** `TextEmbedding` is cached on first embed call, so a runtime mutation through `mm config set` / web UI would not take effect until restart anyway — same precedent as `rerank.provider`/`model`/`api_key` (see config.py:609-611). Inline comment added to prevent the next config-sync audit from flagging it as an oversight.

## Test plan
- [x] `uv run pytest -m "not ollama"` — 2468 passed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] New tests cover: default `0`, validator rejects negative, `threads=4` forwarded as kwarg, `threads=0` forwarded as `None`
- [x] Manual: dev build installed via `uv tool install --reinstall "memtomem[all] @ file:///…/packages/memtomem"`, set `embedding.threads = 4` in `~/.memtomem/config.json`, ran `mm web`, confirmed startup log shows `Loading ONNX embedding model BAAI/bge-m3 (threads=4) …` (onnx.py:87)

## Follow-up
- Doc surface: add `embedding.threads` and `MEMTOMEM_EMBEDDING__THREADS` env var to the config reference in a follow-up PR (per `feedback_doc_update_process` policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)