### PR TITLE
fix(context): preserve `## <Agent>-Specific` sections through round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Fixed
+
+- **`mm context` round-trip no longer silently drops `## <Agent>-Specific`
+  sections.** `extract_sections_from_agent_file` mapped agent-override
+  headings (`## Claude-Specific`, `## Cursor-Specific`,
+  `## Gemini-Specific`, `## Codex-Specific`, `## Copilot-Specific`) to
+  their literal heading strings, but the generators look for canonical
+  keys (`Claude`, `Cursor`, …). On `mm context init` (extract-existing)
+  followed by `mm context generate`, the override section was discarded
+  and `mm context diff` showed `[in sync]` because both sides had the
+  same loss — masking the data loss. Added the five aliases to the
+  reverse-extract map so override sections survive the round-trip.
+  Separately, `CopilotGenerator` emitted the override content without
+  any `##` heading, so a second round-trip absorbed it into the
+  preceding section; it now writes `## Copilot-Specific` like the
+  other generators.
+
 ## [0.1.30] — 2026-04-26
 
 ### Fixed

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -216,6 +216,7 @@ class CopilotGenerator:
             lines.append(sections["Commands"])
             lines.append("")
         if "Copilot" in sections:
+            lines.append("## Copilot-Specific\n")
             lines.append(sections["Copilot"])
             lines.append("")
         return "\n".join(lines)
@@ -258,6 +259,13 @@ def extract_sections_from_agent_file(content: str) -> dict[str, str]:
         "coding rules": "Rules",
         "rules": "Rules",
         "style": "Style",
+        # Agent-specific override sections — must round-trip through
+        # generate() which emits "## <Agent>-Specific" headings.
+        "claude-specific": "Claude",
+        "cursor-specific": "Cursor",
+        "gemini-specific": "Gemini",
+        "codex-specific": "Codex",
+        "copilot-specific": "Copilot",
     }
 
     sections: dict[str, str] = {}

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -181,3 +181,45 @@ Some content here.
 """
         sections = extract_sections_from_agent_file(content)
         assert "Custom Section" in sections
+
+
+class TestSpecificSectionRoundTrip:
+    """`## <Agent>-Specific` sections must survive extract → generate.
+
+    Regression: prior to alias addition, `extract_sections_from_agent_file`
+    stored `## Claude-Specific` content under the literal key
+    `Claude-Specific`, but the generator looks for the canonical key
+    `Claude` — so the override section was silently dropped on round-trip.
+    """
+
+    @pytest.mark.parametrize(
+        "agent,heading",
+        [
+            ("claude", "Claude-Specific"),
+            ("cursor", "Cursor-Specific"),
+            ("gemini", "Gemini-Specific"),
+            ("codex", "Codex-Specific"),
+            ("copilot", "Copilot-Specific"),
+        ],
+    )
+    def test_specific_section_roundtrip(self, agent, heading):
+        marker = "this content must survive round-trip"
+        original = f"""# AGENT_FILE
+
+## What is this project?
+
+- Name: foo
+
+## {heading}
+
+{marker}
+"""
+        sections = extract_sections_from_agent_file(original)
+        # Canonical key is the agent name with capital first letter.
+        canonical = heading.split("-", 1)[0]
+        assert canonical in sections
+        assert marker in sections[canonical]
+
+        regenerated = generate_for_agent(agent, sections)
+        assert heading in regenerated
+        assert marker in regenerated


### PR DESCRIPTION
## Summary

`mm context init` → `mm context generate` round-trip silently dropped `## <Agent>-Specific` override sections, and `mm context diff` reported `[in sync]` because both sides had the same loss — masking the data loss. This fixes the round-trip and adds a regression test.

## Root cause

`extract_sections_from_agent_file` maps headings to canonical section keys via the `aliases` dict. The five `## <Agent>-Specific` headings (Claude / Cursor / Gemini / Codex / Copilot) had **no entries** in that dict, so they were stored under their literal heading strings (`Claude-Specific`, …). Each generator then checks for the canonical key (`if "Claude" in sections: …`), which was never populated, so the override section was discarded on regeneration.

`mm context diff` compared the regenerated output against the just-regenerated file (both written by the same code path), so the diff was `[in sync]` even though both sides were missing the override content.

## Fix

1. Add five aliases (`claude-specific` → `Claude`, etc.) to `extract_sections_from_agent_file`'s alias map so each override heading resolves to the canonical key the generators look for.
2. `CopilotGenerator` was additionally asymmetric: it emitted the override content **without any `##` heading**, so a second round-trip extracted it as part of the preceding `## Commands` section. Fixed to write `## Copilot-Specific` like the other four generators.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context.py` — 23 passed (5 new parametrized round-trip cases)
- [x] `uv run pytest -m "not ollama"` — 2481 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check …` — clean
- [x] End-to-end repro: write `CLAUDE.md` containing `## Claude-Specific`, run `extract_sections_from_agent_file` + `generate_for_agent("claude", …)`, confirm content survives. (Before this PR: dropped. After: preserved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
