### PR TITLE
feat(context)!: codex_agents project-scope default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **`mm context sync` now writes Codex sub-agents to project-scope
+  `.codex/agents/<name>.toml` instead of user-scope
+  `~/.codex/agents/<name>.toml`.** Previously every `mm context sync`
+  wrote into the user's home directory regardless of which project the
+  command ran from, so two projects with same-named canonical agents
+  silently overwrote each other in `~/.codex/agents/`, and any
+  `mm context sync` from a worktree leaked onto the real host home —
+  defeating worktree isolation. The OpenAI Codex CLI [supports both
+  scopes](https://developers.openai.com/codex/subagents) ("standalone
+  TOML files under `~/.codex/agents/` for personal agents or
+  `.codex/agents/` for project-scoped agents"), and project scope is
+  the right default for a per-repo canonical source. This makes
+  `codex_agents` symmetric with `claude_agents` (`.claude/agents/`)
+  and `gemini_agents` (`.gemini/agents/`).
+
+  **Migration:** if you relied on the old user-scope output, copy any
+  agents you want to keep with
+  `cp ~/.codex/agents/*.toml <project>/.codex/agents/`, or restore
+  user-scope behavior on a future `mm context sync` once `--scope=user`
+  ships (tracked separately). Existing `~/.codex/agents/` files are
+  left in place; memtomem just stops writing there.
+
+  `detect_agent_dirs` now also picks up `.codex/agents/<name>.toml`
+  alongside Claude/Gemini, so `mm context detect` and the Web UI
+  Context Gateway list project-scope Codex agents in their inventory.
+
 ### Fixed
 
 - **`mm context` round-trip no longer silently drops `## <Agent>-Specific`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `cp ~/.codex/agents/*.toml <project>/.codex/agents/`, or restore
   user-scope behavior on a future `mm context sync` once `--scope=user`
   ships (tracked separately). Existing `~/.codex/agents/` files are
-  left in place; memtomem just stops writing there.
+  left in place; memtomem just stops writing there. After copying the
+  ones you want to keep, delete the originals (`rm ~/.codex/agents/*.toml`)
+  — Codex CLI still loads them, but memtomem no longer manages them, so
+  any future edits in the canonical source won't reach the user-scope
+  copy and the two will drift silently.
 
   `detect_agent_dirs` now also picks up `.codex/agents/<name>.toml`
   alongside Claude/Gemini, so `mm context detect` and the Web UI

--- a/docs/adr/0001-context-gateway-sync-policies.md
+++ b/docs/adr/0001-context-gateway-sync-policies.md
@@ -18,9 +18,11 @@ traversal order:
 | Skills     | `claude_skills` → `gemini_skills` → `codex_skills` (detector order) |
 | Commands   | `.claude/commands` → `.gemini/commands` |
 
-Codex agents and prompts are user-scope (`~/.codex/`) and are **never**
-imported — they are one-way (canonical → Codex) to avoid cross-project
-leakage.
+Codex agents fan out to project-scope `<project>/.codex/agents/` (symmetric
+with Claude/Gemini); Codex prompts remain user-scope (`~/.codex/prompts/`,
+no project-scope equivalent). Both are **never** imported — fan-out is
+one-way (canonical → Codex) so the canonical entry stays the single source
+of truth.
 
 **Why this order:** Claude Code is the primary authoring surface in most
 memtomem workflows.  Gemini CLI is experimental and Codex is

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -409,7 +409,7 @@ mm context sync                         # update all after editing context.md
 # Also mirror .memtomem/skills/  → .claude/skills/, .gemini/skills/, .agents/skills/
 mm context sync --include=skills
 
-# Also fan out .memtomem/agents/  → .claude/agents/, .gemini/agents/, ~/.codex/agents/
+# Also fan out .memtomem/agents/  → .claude/agents/, .gemini/agents/, .codex/agents/
 # (reports dropped fields per runtime; add --strict to fail on any drop)
 mm context sync --include=agents
 

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -347,7 +347,7 @@ If you also use Gemini CLI or Codex CLI on the same repo, treat `.memtomem/` as 
 # Mirror .memtomem/skills/<name>/SKILL.md to .claude/skills/, .gemini/skills/, .agents/skills/
 mm context sync --include=skills
 
-# Fan out .memtomem/agents/<name>.md to .claude/agents/, .gemini/agents/, ~/.codex/agents/
+# Fan out .memtomem/agents/<name>.md to .claude/agents/, .gemini/agents/, .codex/agents/
 mm context sync --include=agents
 
 # Fan out .memtomem/commands/<name>.md to .claude/commands/*.md, .gemini/commands/*.toml, and ~/.codex/prompts/*.md

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -2,7 +2,7 @@
 
 The canonical ``name:`` frontmatter on agents and commands, and the directory
 name of a canonical skill, are interpolated into a target path such as
-``.claude/agents/<name>.md`` or ``~/.codex/agents/<name>.toml``. Without
+``.claude/agents/<name>.md`` or ``.codex/agents/<name>.toml``. Without
 validation, ``name: ../../etc/passwd`` would escape the target root. The same
 field is also emitted to log lines, so CR/LF injection is a log-injection
 vector.

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -7,7 +7,13 @@ canonical source we fan out to:
 
 * ``.claude/agents/<name>.md`` — Claude Code (project-scope)
 * ``.gemini/agents/<name>.md`` — Gemini CLI (project-scope; experimental in 2026-03)
-* ``~/.codex/agents/<name>.toml`` — OpenAI Codex CLI (**user-scope only**)
+* ``.codex/agents/<name>.toml`` — OpenAI Codex CLI (project-scope)
+
+Codex CLI accepts both ``~/.codex/agents/`` (user-scope) and ``.codex/agents/``
+(project-scope) per the official subagents docs. memtomem fans out to the
+project-scope path so a single repository's `.memtomem/agents/` source tree
+stays contained within the project — no host-home pollution, worktrees isolate
+naturally, and the layout matches Claude / Gemini.
 
 Unlike Phase 1 skills, sub-agents have genuine format divergence:
 
@@ -412,15 +418,10 @@ class GeminiAgentsGenerator:
 @dataclass
 class CodexAgentsGenerator:
     name: str = "codex_agents"
-    # Display-only — Codex is user-scope, so the real path is resolved from
-    # ``Path.home()`` inside ``target_file``. We keep a visible root string for
-    # CLI / MCP output consistency.
-    output_root: str = "~/.codex/agents"
+    output_root: str = ".codex/agents"
 
     def target_file(self, project_root: Path, agent_name: str) -> Path:
-        # project_root is intentionally ignored — Codex stores custom agents
-        # under the user's home directory.
-        return Path.home() / ".codex/agents" / f"{agent_name}.toml"
+        return project_root / self.output_root / f"{agent_name}.toml"
 
     def render(self, agent: SubAgent) -> tuple[str, list[str]]:
         return _subagent_to_codex_toml(agent)
@@ -577,7 +578,7 @@ def extract_agents_to_canonical(
 
 def _runtime_agent_names(gen_name: str, project_root: Path) -> set[str]:
     if gen_name == "codex_agents":
-        runtime_root = Path.home() / ".codex/agents"
+        runtime_root = project_root / ".codex/agents"
         suffix = ".toml"
     elif gen_name == "claude_agents":
         runtime_root = project_root / ".claude/agents"

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -43,12 +43,20 @@ SKILL_DIRS: dict[str, list[str]] = {
     "codex_skills": [".agents/skills"],
 }
 
-# Sub-agent-runtime name → project-scope directories containing ``<name>.md`` sub-agent
-# files. Codex sub-agents are user-scope only (``~/.codex/agents/``) so they are not
-# discoverable via the project root and intentionally omitted here.
+# Sub-agent-runtime name → project-scope directories containing sub-agent files.
+# Claude / Gemini use Markdown (``<name>.md``); Codex uses TOML (``<name>.toml``).
+# ``detect_agent_dirs`` is responsible for matching the right suffix per runtime.
 AGENT_DIRS: dict[str, list[str]] = {
     "claude_agents": [".claude/agents"],
     "gemini_agents": [".gemini/agents"],
+    "codex_agents": [".codex/agents"],
+}
+
+# Per-runtime suffix used by ``detect_agent_dirs`` when scanning ``AGENT_DIRS``.
+AGENT_FILE_SUFFIX: dict[str, str] = {
+    "claude_agents": ".md",
+    "gemini_agents": ".md",
+    "codex_agents": ".toml",
 }
 
 # Custom-command-runtime name → project-scope directories containing command files.
@@ -129,27 +137,31 @@ def detect_skill_dirs(project_root: Path) -> list[DetectedFile]:
 def detect_agent_dirs(project_root: Path) -> list[DetectedFile]:
     """Scan project root for runtime-specific sub-agent files.
 
-    Each discovered ``<name>.md`` file under a registered ``AGENT_DIRS`` entry
-    is reported as a ``DetectedFile`` with ``kind="agent_file"``. Codex
-    sub-agents live in ``~/.codex/agents/`` (user-scope) and are therefore
-    **not** discoverable here — use :func:`memtomem.context.agents.diff_agents`
-    for the Codex side.
+    Each discovered file under a registered ``AGENT_DIRS`` entry is reported as
+    a ``DetectedFile`` with ``kind="agent_file"``. The expected suffix is per
+    runtime (``.md`` for Claude / Gemini, ``.toml`` for Codex) — see
+    ``AGENT_FILE_SUFFIX``.
+
+    Codex CLI also accepts ``~/.codex/agents/`` (user-scope), but memtomem
+    intentionally only fans out to and scans the project-scope path so that
+    a project's canonical agents stay contained within the repository.
     """
     found: list[DetectedFile] = []
 
     for agent, paths in AGENT_DIRS.items():
+        suffix = AGENT_FILE_SUFFIX.get(agent, ".md")
         for rel_path in paths:
             root = project_root / rel_path
             if not root.is_dir():
                 continue
-            for md_file in sorted(root.glob("*.md")):
-                if not md_file.is_file():
+            for agent_file in sorted(root.glob(f"*{suffix}")):
+                if not agent_file.is_file():
                     continue
                 found.append(
                     DetectedFile(
                         agent=agent,
-                        path=md_file,
-                        size=md_file.stat().st_size,
+                        path=agent_file,
+                        size=agent_file.stat().st_size,
                         kind="agent_file",
                     )
                 )

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -59,6 +59,14 @@ AGENT_FILE_SUFFIX: dict[str, str] = {
     "codex_agents": ".toml",
 }
 
+# Lock the two dicts to the same key set so a future runtime added to
+# ``AGENT_DIRS`` without a matching ``AGENT_FILE_SUFFIX`` entry fails loudly at
+# import instead of silently being treated as Markdown by ``detect_agent_dirs``.
+assert AGENT_FILE_SUFFIX.keys() == AGENT_DIRS.keys(), (
+    "AGENT_FILE_SUFFIX and AGENT_DIRS must have identical keys; "
+    f"diff: {AGENT_FILE_SUFFIX.keys() ^ AGENT_DIRS.keys()}"
+)
+
 # Custom-command-runtime name → project-scope directories containing command files.
 # Claude uses ``.md`` files, Gemini uses ``.toml`` — the detector reports both so
 # context/commands.py can reverse-import whichever is present. Codex commands live
@@ -149,7 +157,7 @@ def detect_agent_dirs(project_root: Path) -> list[DetectedFile]:
     found: list[DetectedFile] = []
 
     for agent, paths in AGENT_DIRS.items():
-        suffix = AGENT_FILE_SUFFIX.get(agent, ".md")
+        suffix = AGENT_FILE_SUFFIX[agent]
         for rel_path in paths:
             root = project_root / rel_path
             if not root.is_dir():

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -46,7 +46,14 @@ Help with things.
 
 @pytest.fixture
 def codex_home(tmp_path, monkeypatch):
-    """Redirect HOME so Codex TOML writes don't touch the real ``~/.codex/agents/``."""
+    """Redirect HOME as a defensive guard.
+
+    Codex agents are now project-scope (``<project>/.codex/agents/``), so this
+    fixture's primary job — keeping writes off the real ``~/.codex/agents/`` —
+    is largely moot for the agents pipeline. It's kept on a few tests so that
+    any code path that still calls ``Path.home()`` (e.g. user-scope settings,
+    or a future regression) cannot leak onto the real host home.
+    """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     monkeypatch.setenv("HOME", str(fake_home))
@@ -189,8 +196,10 @@ class TestCodexRendering:
     def test_writes_valid_toml(self, tmp_path, codex_home):
         _make_canonical_agent(tmp_path, "full", SAMPLE_FULL_AGENT)
         generate_all_agents(tmp_path, runtimes=["codex_agents"])
-        toml_path = codex_home / ".codex/agents/code-reviewer.toml"
+        toml_path = tmp_path / ".codex/agents/code-reviewer.toml"
         assert toml_path.is_file()
+        # Defensive: nothing should have leaked into HOME.
+        assert not (codex_home / ".codex/agents/code-reviewer.toml").exists()
         parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert parsed["name"] == "code-reviewer"
         assert "quality" in parsed["description"]
@@ -211,7 +220,7 @@ class TestCodexRendering:
         _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
         result = generate_all_agents(tmp_path, runtimes=["codex_agents"])
         assert result.dropped == []
-        toml_path = codex_home / ".codex/agents/helper.toml"
+        toml_path = tmp_path / ".codex/agents/helper.toml"
         parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert parsed["name"] == "helper"
         assert parsed["description"] == "Generic helper"
@@ -219,7 +228,7 @@ class TestCodexRendering:
     def test_multiline_body_roundtrips_through_tomllib(self, tmp_path, codex_home):
         _make_canonical_agent(tmp_path, "helper", SAMPLE_MINIMAL_AGENT)
         generate_all_agents(tmp_path, runtimes=["codex_agents"])
-        toml_path = codex_home / ".codex/agents/helper.toml"
+        toml_path = tmp_path / ".codex/agents/helper.toml"
         parsed = tomllib.loads(toml_path.read_text(encoding="utf-8"))
         assert "Help with things." in parsed["developer_instructions"]
 
@@ -231,7 +240,9 @@ class TestGenerateAllAgents:
         assert len(result.generated) == 3
         assert (tmp_path / ".claude/agents/helper.md").is_file()
         assert (tmp_path / ".gemini/agents/helper.md").is_file()
-        assert (codex_home / ".codex/agents/helper.toml").is_file()
+        assert (tmp_path / ".codex/agents/helper.toml").is_file()
+        # Defensive: nothing leaked into HOME.
+        assert not (codex_home / ".codex/agents").exists()
 
     def test_no_canonical_no_op(self, tmp_path):
         result = generate_all_agents(tmp_path)
@@ -307,10 +318,12 @@ class TestExtractAgentsToCanonical:
         assert len(result.imported) == 1
         assert "UPDATED" in canonical.read_text(encoding="utf-8")
 
-    def test_ignores_codex_toml(self, tmp_path, codex_home):
+    def test_ignores_codex_toml(self, tmp_path):
         # Even when a Codex TOML exists, extract does not try to import it.
-        (codex_home / ".codex/agents").mkdir(parents=True)
-        (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n', encoding="utf-8")
+        # The TOML format is too lossy to round-trip without reconstructing
+        # fields we dropped on the way out (tools, skills, isolation, etc.).
+        (tmp_path / ".codex/agents").mkdir(parents=True)
+        (tmp_path / ".codex/agents/helper.toml").write_text('name = "helper"\n', encoding="utf-8")
         result = extract_agents_to_canonical(tmp_path)
         assert result.imported == []
 
@@ -390,7 +403,16 @@ class TestDetectAgentDirs:
         found = detect_agent_dirs(tmp_path)
         assert found[0].agent == "gemini_agents"
 
+    def test_detects_codex_project_scope(self, tmp_path):
+        d = tmp_path / ".codex/agents"
+        d.mkdir(parents=True)
+        (d / "helper.toml").write_text('name = "helper"\n', encoding="utf-8")
+        found = detect_agent_dirs(tmp_path)
+        assert any(f.agent == "codex_agents" and f.path.name == "helper.toml" for f in found)
+
     def test_codex_user_scope_not_in_project_detect(self, tmp_path, codex_home):
+        """Codex user-scope (~/.codex/agents/) is intentionally outside the
+        project detect surface — only the project-scope path is scanned."""
         (codex_home / ".codex/agents").mkdir(parents=True)
         (codex_home / ".codex/agents/helper.toml").write_text('name = "helper"\n', encoding="utf-8")
         found = detect_agent_dirs(tmp_path)
@@ -532,7 +554,7 @@ class TestCodexTomlControlChars:
         p.write_text(body)
 
         generate_all_agents(tmp_path, runtimes=["codex_agents"])
-        toml_path = codex_home / ".codex/agents/odd-body.toml"
+        toml_path = tmp_path / ".codex/agents/odd-body.toml"
         parsed = tomllib.loads(toml_path.read_text())
         # Control chars survive the round-trip through tomllib.
         assert "\x00" in parsed["developer_instructions"]
@@ -551,7 +573,7 @@ class TestCodexTomlControlChars:
         p.write_text(body)
 
         generate_all_agents(tmp_path, runtimes=["codex_agents"])
-        toml_path = codex_home / ".codex/agents/triple.toml"
+        toml_path = tmp_path / ".codex/agents/triple.toml"
         parsed = tomllib.loads(toml_path.read_text())
         assert '"""' in parsed["developer_instructions"]
 

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -10,6 +10,7 @@ from memtomem.context.agents import (
     CANONICAL_AGENT_ROOT,
     AgentParseError,
     StrictDropError,
+    _runtime_agent_names,
     _toml_escape_basic_string,
     _toml_escape_multiline_string,
     diff_agents,
@@ -380,6 +381,51 @@ class TestDiffAgents:
         (claude_dir / "runtime-only.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
         rows = diff_agents(tmp_path)
         assert any(status == "missing canonical" for _, _, status in rows)
+
+
+class TestRuntimeAgentNames:
+    """Pin the runtime-name lookup contract directly so a future revert of the
+    Codex project-scope path can't sneak past via the end-to-end fan-out
+    tests alone."""
+
+    def test_codex_reads_project_scope_toml(self, tmp_path, codex_home):
+        rt_dir = tmp_path / ".codex/agents"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / "helper.toml").write_text('name = "helper"\n', encoding="utf-8")
+        (rt_dir / "reviewer.toml").write_text('name = "reviewer"\n', encoding="utf-8")
+        # Markdown with the wrong suffix must be ignored.
+        (rt_dir / "ignored.md").write_text("# wrong suffix\n", encoding="utf-8")
+
+        # User-scope copies must not leak in.
+        (codex_home / ".codex/agents").mkdir(parents=True)
+        (codex_home / ".codex/agents" / "user-scope.toml").write_text(
+            'name = "user-scope"\n', encoding="utf-8"
+        )
+
+        names = _runtime_agent_names("codex_agents", tmp_path)
+        assert names == {"helper", "reviewer"}
+
+    def test_claude_reads_project_scope_md(self, tmp_path):
+        rt_dir = tmp_path / ".claude/agents"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / "alice.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
+        (rt_dir / "wrong-suffix.toml").write_text("# ignored\n", encoding="utf-8")
+
+        assert _runtime_agent_names("claude_agents", tmp_path) == {"alice"}
+
+    def test_gemini_reads_project_scope_md(self, tmp_path):
+        rt_dir = tmp_path / ".gemini/agents"
+        rt_dir.mkdir(parents=True)
+        (rt_dir / "bob.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
+
+        assert _runtime_agent_names("gemini_agents", tmp_path) == {"bob"}
+
+    def test_unknown_runtime_returns_empty(self, tmp_path):
+        assert _runtime_agent_names("nope_agents", tmp_path) == set()
+
+    def test_missing_dir_returns_empty(self, tmp_path):
+        # No `.codex/agents` directory at all.
+        assert _runtime_agent_names("codex_agents", tmp_path) == set()
 
 
 class TestDetectAgentDirs:

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -549,7 +549,8 @@ class TestListAgents:
     async def test_empty(self, client: AsyncClient):
         r = await client.get("/api/context/agents")
         assert r.status_code == 200
-        # May include user-scope Codex agents from ~/.codex/agents/
+        # Filter to canonical entries; runtime-only agents (e.g. orphan files
+        # under .claude/agents) may still appear without a canonical_path.
         canonicals = [a for a in r.json()["agents"] if a["canonical_path"] is not None]
         assert canonicals == []
 


### PR DESCRIPTION
## Summary

`mm context sync` previously fanned out Codex sub-agents to **user-scope** `~/.codex/agents/<name>.toml` regardless of the project the command ran from. This PR switches the default to **project-scope** `<project>/.codex/agents/<name>.toml`, making `codex_agents` symmetric with `claude_agents` and `gemini_agents`.

This is a **BREAKING CHANGE** but pre-1.0 and well-bounded — see the migration note in `CHANGELOG.md`.

## Why

User-scope-by-default had three concrete problems:

1. **Cross-project collision.** Two projects with the same canonical agent name silently overwrote each other in `~/.codex/agents/`.
2. **Worktree leakage.** Running `mm context sync` from a `git worktree` clone wrote real files into the host's home directory, defeating the isolation worktrees are supposed to provide.
3. **Asymmetry.** `claude_agents` and `gemini_agents` already wrote to project-scope. `codex_agents` was the only generator that ignored its `project_root` argument — fragile and confusing.

Upstream support is verified: the [OpenAI Codex CLI subagents docs](https://developers.openai.com/codex/subagents) explicitly say "standalone TOML files under `~/.codex/agents/` for personal agents or `.codex/agents/` for project-scoped agents." Project scope is the right default for a per-repo canonical source; user-scope can come back as an explicit `--scope=user` flag in a future PR.

## What changed

- `CodexAgentsGenerator.target_file()` now uses `project_root / .codex/agents / <name>.toml` (was `Path.home() / .codex/agents / ...`).
- `_runtime_agent_names("codex_agents", ...)` for `diff_agents()` reads the project-scope path.
- `AGENT_DIRS` adds `"codex_agents": [".codex/agents"]`; new `AGENT_FILE_SUFFIX` so `detect_agent_dirs` can match `.toml` alongside `.md`. `mm context detect` and the Web UI Context Gateway now list project-scope Codex agents.
- Module/function docstrings updated; `_names.py` example path corrected.
- 13 test assertions moved from `codex_home / ".codex/agents/..."` → `tmp_path / ".codex/agents/..."`. Two of those gain a defensive `assert not (codex_home / ".codex/agents").exists()` so a regression that called `Path.home()` would be caught. New `test_detects_codex_project_scope` covers the new detect path; the existing `test_codex_user_scope_not_in_project_detect` is kept (still important — user-scope must NOT be auto-detected).

## Migration

Existing `~/.codex/agents/<name>.toml` files are **left untouched** — memtomem just stops writing to that path. If you relied on user-scope output, copy what you want to keep:

```bash
cp ~/.codex/agents/*.toml <project>/.codex/agents/
```

A `--scope=user` flag is on the roadmap for users who genuinely want to keep writing to `~/.codex/agents/` (tracked separately as PR-8 of the context-gateway audit plan).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_agents.py` — 61 passed (was 60; +1 = `test_detects_codex_project_scope`)
- [x] `uv run pytest -m "not ollama"` — 2477 passed (main: 2476; +1 from above)
- [x] `uv run ruff check …` + `ruff format --check …` — clean
- [x] End-to-end repro with `HOME=/tmp/throwaway uv run python -c "generate_all_agents(...)"` — writes only to `<project>/.codex/agents/sample.toml`; `HOME` directory is never created or touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
