### PR TITLE
fix(context): confirm before settings sync writes outside the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm context {generate,sync} --include=settings` now confirms before
+  writing settings files outside the project root** (today only
+  `~/.claude/settings.json`); pass `--yes` / `-y` to skip the prompt.
+  The same gate is enforced inside `generate_all_settings`, so callers
+  that bypass the CLI — `mem_context_generate` / `mem_context_sync`
+  (MCP) and `POST /settings-sync` (Web) — also refuse host writes
+  unless they pass `allow_host_writes=true`. Closes one of the
+  2026-04-26 audit P0 items: a stray sync from a worktree no longer
+  silently edits the real home directory regardless of which front-end
+  drove it. Symlink-aware (`Path.resolve()` both sides) so a
+  symlinked `.claude` cannot smuggle a host write past the gate.
+
 ### Changed (BREAKING)
 
 - **`mm context sync` now writes Codex sub-agents to project-scope

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -32,9 +32,9 @@ from memtomem.context.generator import (
 )
 from memtomem.context.parser import CONTEXT_FILENAME, parse_context, sections_to_markdown
 from memtomem.context.settings import (
-    SETTINGS_GENERATORS,
     diff_settings,
     generate_all_settings,
+    host_write_targets,
 )
 from memtomem.context.skills import (
     diff_skills,
@@ -273,35 +273,16 @@ def _print_settings_detect() -> None:
         click.echo(f"    {f.agent:17s}  {f.path}  {status}")
 
 
-def _settings_host_writes_pending(root: Path) -> list[Path]:
-    """Target files that settings sync would write *outside* the project root.
-
-    A target counts as a "host write" when its path is not under ``root`` —
-    e.g. ``~/.claude/settings.json`` for ``ClaudeSettingsGenerator``. Used to
-    gate user-scope mutations behind a confirmation prompt so a stray
-    ``mm context sync --include=settings`` from a worktree does not silently
-    edit the real home directory.
-    """
-    pending: list[Path] = []
-    for gen in SETTINGS_GENERATORS.values():
-        if not gen.is_available():
-            continue
-        if not gen.canonical_source(root).exists():
-            continue
-        target = gen.target_file(root)
-        if not target.is_relative_to(root):
-            pending.append(target)
-    return pending
-
-
 def _confirm_settings_host_writes(root: Path, *, yes: bool) -> bool:
     """Prompt before mutating settings files outside the project root.
 
-    Returns ``True`` when the caller may proceed (no host writes pending,
-    ``--yes`` supplied, or user confirmed at the prompt). Returns ``False``
-    when the user declines, in which case the caller must skip the write.
+    Returns ``True`` when the caller may pass ``allow_host_writes=True``
+    to :func:`generate_all_settings` (no host writes pending, ``--yes``
+    supplied, or user confirmed at the prompt). Returns ``False`` when
+    the user declines, in which case the caller should not invoke
+    settings sync at all.
     """
-    pending = _settings_host_writes_pending(root)
+    pending = host_write_targets(root)
     if not pending:
         return True
     if yes:
@@ -315,8 +296,8 @@ def _confirm_settings_host_writes(root: Path, *, yes: bool) -> bool:
     return click.confirm("Continue?", default=False)
 
 
-def _print_settings_generate(root: Path) -> None:
-    results = generate_all_settings(root)
+def _print_settings_generate(root: Path, *, allow_host_writes: bool) -> None:
+    results = generate_all_settings(root, allow_host_writes=allow_host_writes)
     for name, r in results.items():
         if r.status == "ok":
             click.secho(f"  Settings: {name} → {r.target}", fg="green")
@@ -324,6 +305,10 @@ def _print_settings_generate(root: Path) -> None:
                 click.secho(f"    warning: {w}", fg="yellow")
         elif r.status == "skipped":
             click.secho(f"  skipped {name}: {r.reason}", fg="yellow")
+        elif r.status == "needs_confirmation":
+            # Defense in depth: should not normally reach here because the CLI
+            # caller already gated on ``_confirm_settings_host_writes``.
+            click.secho(f"  needs confirmation {name}: {r.reason}", fg="yellow")
         elif r.status in ("error", "aborted"):
             click.secho(f"  {r.status} {name}: {r.reason}", fg="red")
 
@@ -469,7 +454,7 @@ def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
     "-y",
     "yes",
     is_flag=True,
-    help="Skip confirmation prompts (e.g. settings sync writing under ~/.claude/).",
+    help="Skip confirmation prompts before writing settings files outside this project.",
 )
 def generate_cmd(
     agent: str, include: tuple[str, ...], strict: bool, on_drop: str, yes: bool
@@ -521,7 +506,7 @@ def generate_cmd(
     if "settings" in inc:
         click.echo("")
         if _confirm_settings_host_writes(root, yes=yes):
-            _print_settings_generate(root)
+            _print_settings_generate(root, allow_host_writes=True)
         else:
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 
@@ -597,7 +582,7 @@ def diff_cmd(include: tuple[str, ...]) -> None:
     "-y",
     "yes",
     is_flag=True,
-    help="Skip confirmation prompts (e.g. settings sync writing under ~/.claude/).",
+    help="Skip confirmation prompts before writing settings files outside this project.",
 )
 def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) -> None:
     """Sync context.md to all detected agent files."""
@@ -646,7 +631,7 @@ def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) ->
     if "settings" in inc:
         click.echo("")
         if _confirm_settings_host_writes(root, yes=yes):
-            _print_settings_generate(root)
+            _print_settings_generate(root, allow_host_writes=True)
         else:
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -32,6 +32,7 @@ from memtomem.context.generator import (
 )
 from memtomem.context.parser import CONTEXT_FILENAME, parse_context, sections_to_markdown
 from memtomem.context.settings import (
+    SETTINGS_GENERATORS,
     diff_settings,
     generate_all_settings,
 )
@@ -272,6 +273,48 @@ def _print_settings_detect() -> None:
         click.echo(f"    {f.agent:17s}  {f.path}  {status}")
 
 
+def _settings_host_writes_pending(root: Path) -> list[Path]:
+    """Target files that settings sync would write *outside* the project root.
+
+    A target counts as a "host write" when its path is not under ``root`` —
+    e.g. ``~/.claude/settings.json`` for ``ClaudeSettingsGenerator``. Used to
+    gate user-scope mutations behind a confirmation prompt so a stray
+    ``mm context sync --include=settings`` from a worktree does not silently
+    edit the real home directory.
+    """
+    pending: list[Path] = []
+    for gen in SETTINGS_GENERATORS.values():
+        if not gen.is_available():
+            continue
+        if not gen.canonical_source(root).exists():
+            continue
+        target = gen.target_file(root)
+        if not target.is_relative_to(root):
+            pending.append(target)
+    return pending
+
+
+def _confirm_settings_host_writes(root: Path, *, yes: bool) -> bool:
+    """Prompt before mutating settings files outside the project root.
+
+    Returns ``True`` when the caller may proceed (no host writes pending,
+    ``--yes`` supplied, or user confirmed at the prompt). Returns ``False``
+    when the user declines, in which case the caller must skip the write.
+    """
+    pending = _settings_host_writes_pending(root)
+    if not pending:
+        return True
+    if yes:
+        return True
+    click.secho(
+        "Settings sync will modify the following files outside this project:",
+        fg="yellow",
+    )
+    for p in pending:
+        click.echo(f"  {p}")
+    return click.confirm("Continue?", default=False)
+
+
 def _print_settings_generate(root: Path) -> None:
     results = generate_all_settings(root)
     for name, r in results.items():
@@ -421,7 +464,16 @@ def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
     default="ignore",
     help="Severity when fields are dropped: ignore (default), warn, or error.",
 )
-def generate_cmd(agent: str, include: tuple[str, ...], strict: bool, on_drop: str) -> None:
+@click.option(
+    "--yes",
+    "-y",
+    "yes",
+    is_flag=True,
+    help="Skip confirmation prompts (e.g. settings sync writing under ~/.claude/).",
+)
+def generate_cmd(
+    agent: str, include: tuple[str, ...], strict: bool, on_drop: str, yes: bool
+) -> None:
     """Generate agent files from .memtomem/context.md."""
     inc = _parse_include(include)
     root = _find_project_root()
@@ -468,7 +520,10 @@ def generate_cmd(agent: str, include: tuple[str, ...], strict: bool, on_drop: st
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_generate(root)
+        if _confirm_settings_host_writes(root, yes=yes):
+            _print_settings_generate(root)
+        else:
+            click.secho("  Skipped settings sync (declined).", fg="yellow")
 
     click.secho("Done.", fg="green")
 
@@ -537,7 +592,14 @@ def diff_cmd(include: tuple[str, ...]) -> None:
     default="ignore",
     help="Severity when fields are dropped: ignore (default), warn, or error.",
 )
-def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str) -> None:
+@click.option(
+    "--yes",
+    "-y",
+    "yes",
+    is_flag=True,
+    help="Skip confirmation prompts (e.g. settings sync writing under ~/.claude/).",
+)
+def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) -> None:
     """Sync context.md to all detected agent files."""
     inc = _parse_include(include)
     root = _find_project_root()
@@ -583,6 +645,9 @@ def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str) -> None:
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_generate(root)
+        if _confirm_settings_host_writes(root, yes=yes):
+            _print_settings_generate(root)
+        else:
+            click.secho("  Skipped settings sync (declined).", fg="yellow")
 
     click.secho("Synced.", fg="green")

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -184,6 +184,48 @@ _register(ClaudeSettingsGenerator())
 # ── Helpers ─────────────────────────────────────────────────────────
 
 
+def _is_under_project_root(target: Path, project_root: Path) -> bool:
+    """``True`` when *target* would write under *project_root*.
+
+    Uses ``resolve(strict=False)`` so a symlink at ``<project>/.claude``
+    pointing into ``~/.claude/`` is treated as the host path it actually
+    refers to (review item 4 on PR #484). ``strict=False`` keeps the call
+    cheap when the target does not exist yet.
+    """
+    try:
+        resolved_target = target.resolve(strict=False)
+        resolved_root = project_root.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    return resolved_target.is_relative_to(resolved_root)
+
+
+def host_write_targets(project_root: Path) -> list[Path]:
+    """Target paths a settings sync would write *outside* the project root.
+
+    A target counts as a "host write" when its resolved path is not under
+    the resolved project root — e.g. ``~/.claude/settings.json`` for the
+    ``ClaudeSettingsGenerator``. Used to gate user-scope mutations behind
+    confirmation in every front-end (CLI, MCP, Web): a stray
+    ``mm context sync --include=settings`` from a worktree must not silently
+    edit the real home directory.
+
+    Generators whose runtime is unavailable (``is_available()`` is False) or
+    that have no canonical source are skipped, so the list mirrors what
+    :func:`generate_all_settings` would actually try to write.
+    """
+    pending: list[Path] = []
+    for gen in SETTINGS_GENERATORS.values():
+        if not gen.is_available():
+            continue
+        if not gen.canonical_source(project_root).exists():
+            continue
+        target = gen.target_file(project_root)
+        if not _is_under_project_root(target, project_root):
+            pending.append(target)
+    return pending
+
+
 def _safe_load_json(path: Path) -> dict | object:
     """Load JSON from *path*, returning :data:`_MALFORMED` on parse error."""
     try:
@@ -218,8 +260,21 @@ def _write_json(path: Path, data: dict) -> None:
 
 def generate_all_settings(
     project_root: Path,
+    *,
+    allow_host_writes: bool = False,
 ) -> dict[str, SettingsSyncResult]:
-    """Fan out ``.memtomem/settings.json`` to registered runtimes."""
+    """Fan out ``.memtomem/settings.json`` to registered runtimes.
+
+    ``allow_host_writes`` defaults to ``False`` so any caller — CLI, MCP
+    server, or Web route — that does not first prompt the user is
+    automatically refused for targets that resolve outside *project_root*
+    (e.g. ``~/.claude/settings.json``). Refused generators come back with
+    ``status="needs_confirmation"`` and ``reason`` containing the host
+    path; callers decide how to surface that. Passing
+    ``allow_host_writes=True`` after acknowledgement (CLI ``--yes``,
+    MCP ``allow_host_writes=True``, Web confirmation modal) restores the
+    previous behavior. Project-scope generators are written unconditionally.
+    """
     results: dict[str, SettingsSyncResult] = {}
 
     for name, gen in SETTINGS_GENERATORS.items():
@@ -248,6 +303,16 @@ def generate_all_settings(
         contributions: dict = raw  # type: ignore[assignment]
 
         target_path = gen.target_file(project_root)
+        if not allow_host_writes and not _is_under_project_root(target_path, project_root):
+            results[name] = SettingsSyncResult(
+                status="needs_confirmation",
+                reason=(
+                    f"{target_path} is outside the project root; pass "
+                    f"allow_host_writes=True after confirming with the user."
+                ),
+                target=target_path,
+            )
+            continue
 
         # Step 1: read existing + capture mtime (ns)
         existing_raw, existing_mtime_ns = _read_with_mtime(target_path)
@@ -359,5 +424,6 @@ __all__ = [
     "SettingsSyncResult",
     "diff_settings",
     "generate_all_settings",
+    "host_write_targets",
     "sync_all_settings",
 ]

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -133,6 +133,7 @@ async def mem_context_generate(
     agent: str = "all",
     include: str = "",
     strict: bool = False,
+    allow_host_writes: bool = False,
     ctx: CtxType = None,
 ) -> str:
     """Generate agent configuration files from .memtomem/context.md.
@@ -140,9 +141,15 @@ async def mem_context_generate(
     Args:
         agent: Agent name (claude, cursor, gemini, codex, copilot) or "all".
         include: Comma-separated extra artifact kinds
-            (``skills``, ``agents``, ``commands``).
+            (``skills``, ``agents``, ``commands``, ``settings``).
         strict: Promote dropped-field warnings to errors when converting
             sub-agents or slash commands.
+        allow_host_writes: When ``include="settings"`` writes a settings
+            file outside the project root (today only
+            ``~/.claude/settings.json``), refuse with a
+            ``needs confirmation`` line unless this is ``True``. Re-call
+            with ``allow_host_writes=True`` after surfacing the host
+            paths to the user.
     """
     from memtomem.context.agents import StrictDropError, generate_all_agents
     from memtomem.context.commands import (
@@ -232,7 +239,7 @@ async def mem_context_generate(
     if "settings" in inc:
         from memtomem.context.settings import generate_all_settings
 
-        settings_results = generate_all_settings(root)
+        settings_results = generate_all_settings(root, allow_host_writes=allow_host_writes)
         for sname, sr in settings_results.items():
             if sr.status == "ok":
                 results.append(f"\nSettings: {sname} → {sr.target}")
@@ -240,6 +247,8 @@ async def mem_context_generate(
                     results.append(f"  warning: {w}")
             elif sr.status == "skipped":
                 results.append(f"  skipped {sname}: {sr.reason}")
+            elif sr.status == "needs_confirmation":
+                results.append(f"  needs confirmation {sname}: {sr.reason}")
             elif sr.status in ("error", "aborted"):
                 results.append(f"  {sr.status} {sname}: {sr.reason}")
 
@@ -351,14 +360,22 @@ async def mem_context_diff(
 async def mem_context_sync(
     include: str = "",
     strict: bool = False,
+    allow_host_writes: bool = False,
     ctx: CtxType = None,
 ) -> str:
     """Sync .memtomem/context.md to all detected agent files.
 
-    Pass ``include="skills,agents,commands"`` to also fan out
-    ``.memtomem/skills/``, ``.memtomem/agents/``, and ``.memtomem/commands/``
-    to their runtime targets (Claude Code, Gemini CLI, Codex CLI).
-    ``strict=True`` turns dropped sub-agent / command fields into errors.
+    Pass ``include="skills,agents,commands,settings"`` to also fan out
+    ``.memtomem/skills/``, ``.memtomem/agents/``, ``.memtomem/commands/``,
+    and ``.memtomem/settings.json`` to their runtime targets (Claude Code,
+    Gemini CLI, Codex CLI).  ``strict=True`` turns dropped sub-agent /
+    command fields into errors.
+
+    ``allow_host_writes`` defaults to ``False``: when ``include="settings"``
+    would write to a file outside the project root (today only
+    ``~/.claude/settings.json``), the tool returns a ``needs confirmation``
+    line listing the host path instead of writing. Surface that to the
+    user, then re-call with ``allow_host_writes=True`` to proceed.
     """
     from memtomem.context.agents import StrictDropError, generate_all_agents
     from memtomem.context.commands import (
@@ -455,7 +472,7 @@ async def mem_context_sync(
     if "settings" in inc:
         from memtomem.context.settings import generate_all_settings
 
-        settings_results = generate_all_settings(root)
+        settings_results = generate_all_settings(root, allow_host_writes=allow_host_writes)
         for sname, sr in settings_results.items():
             if sr.status == "ok":
                 if results:
@@ -465,6 +482,10 @@ async def mem_context_sync(
                     results.append(f"  warning: {w}")
             elif sr.status == "skipped":
                 results.append(f"  skipped {sname}: {sr.reason}")
+            elif sr.status == "needs_confirmation":
+                if results:
+                    results.append("")
+                results.append(f"  needs confirmation {sname}: {sr.reason}")
             elif sr.status in ("error", "aborted"):
                 results.append(f"  {sr.status} {sname}: {sr.reason}")
 

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -143,16 +143,37 @@ async def get_settings_sync(
     return _compare_hooks(canonical_path, target_path)
 
 
+class ApplySettingsSyncRequest(BaseModel):
+    """Body for ``POST /settings-sync``.
+
+    ``allow_host_writes`` mirrors :func:`generate_all_settings`. The default
+    (``False``) makes the route refuse writes outside the project root so a
+    UI built on top must surface the host paths and re-post with the flag
+    set to true after the user confirms — the same gate the CLI confirms
+    interactively.
+    """
+
+    allow_host_writes: bool = False
+
+
 @router.post("/settings-sync")
 @router.post("/context/settings/sync")
 async def apply_settings_sync(
+    body: ApplySettingsSyncRequest | None = None,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    """Run the full settings merge (generate_all_settings)."""
+    """Run the full settings merge (generate_all_settings).
+
+    Default ``allow_host_writes=False`` returns ``needs_confirmation`` for
+    any generator whose target lives outside the project root. The UI is
+    expected to display those targets and re-post with
+    ``{"allow_host_writes": true}`` once the user has confirmed.
+    """
+    allow_host_writes = body.allow_host_writes if body else False
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                results = generate_all_settings(project_root)
+                results = generate_all_settings(project_root, allow_host_writes=allow_host_writes)
     except TimeoutError:
         raise HTTPException(503, "Settings sync timed out — another sync may be in progress")
     out: list[dict] = []

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -404,3 +404,125 @@ class TestClaudeSettingsCliInclude:
         result = runner.invoke(context, ["generate", "--include=bogus"])
         assert result.exit_code != 0
         assert "Unknown" in result.output or "bogus" in result.output
+
+
+class TestClaudeSettingsHostWritePrompt:
+    """``mm context {generate,sync} --include=settings`` confirms before
+    mutating files outside the project root (e.g. ``~/.claude/settings.json``).
+    Without confirmation users couldn't tell that running the command from a
+    worktree silently edited their real home directory.
+
+    The default ``claude_home`` fixture places fake $HOME *inside* tmp_path,
+    which would defeat the ``is_relative_to(root)`` check; these tests use a
+    sibling project dir so the project and the fake home don't overlap.
+    """
+
+    def _setup(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        _make_canonical_settings(
+            project,
+            {"hooks": {"PostToolUse": [_rule("Write", "echo test")]}},
+        )
+        return project
+
+    def test_sync_prompts_before_host_write(self, claude_home, tmp_path, monkeypatch):
+        project = self._setup(tmp_path)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        # Decline the prompt → no file written.
+        result = runner.invoke(context, ["sync", "--include=settings"], input="n\n")
+        assert result.exit_code == 0
+        assert "modify the following files outside this project" in result.output
+        assert str(claude_home / ".claude" / "settings.json") in result.output
+        assert "Skipped settings sync (declined)" in result.output
+        assert not (claude_home / ".claude" / "settings.json").exists()
+
+    def test_sync_proceeds_when_user_confirms(self, claude_home, tmp_path, monkeypatch):
+        project = self._setup(tmp_path)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        result = runner.invoke(context, ["sync", "--include=settings"], input="y\n")
+        assert result.exit_code == 0
+        target = claude_home / ".claude" / "settings.json"
+        assert target.is_file()
+        written = json.loads(target.read_text(encoding="utf-8"))
+        assert "PostToolUse" in written["hooks"]
+
+    def test_sync_yes_flag_bypasses_prompt(self, claude_home, tmp_path, monkeypatch):
+        project = self._setup(tmp_path)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        # No stdin input — would block on prompt without --yes.
+        result = runner.invoke(context, ["sync", "--include=settings", "--yes"])
+        assert result.exit_code == 0
+        assert "modify the following files outside this project" not in result.output
+        assert (claude_home / ".claude" / "settings.json").is_file()
+
+    def test_generate_prompts_before_host_write(self, claude_home, tmp_path, monkeypatch):
+        project = self._setup(tmp_path)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        result = runner.invoke(context, ["generate", "--include=settings"], input="n\n")
+        assert result.exit_code == 0
+        assert "modify the following files outside this project" in result.output
+        assert "Skipped settings sync (declined)" in result.output
+        assert not (claude_home / ".claude" / "settings.json").exists()
+
+    def test_generate_yes_flag_bypasses_prompt(self, claude_home, tmp_path, monkeypatch):
+        project = self._setup(tmp_path)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        result = runner.invoke(context, ["generate", "--include=settings", "-y"])
+        assert result.exit_code == 0
+        assert "modify the following files outside this project" not in result.output
+        assert (claude_home / ".claude" / "settings.json").is_file()
+
+    def test_no_prompt_when_canonical_missing(self, claude_home, tmp_path, monkeypatch):
+        """No canonical settings → nothing to write → no prompt, no error."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        monkeypatch.chdir(project)
+
+        from memtomem.context.parser import CONTEXT_FILENAME
+
+        (project / ".memtomem").mkdir(exist_ok=True)
+        (project / CONTEXT_FILENAME).write_text("# Project\n", encoding="utf-8")
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        # No input — would deadlock if a prompt fired.
+        result = runner.invoke(context, ["sync", "--include=settings"])
+        assert result.exit_code == 0
+        assert "modify the following files outside this project" not in result.output
+        assert not (claude_home / ".claude" / "settings.json").exists()
+
+    def test_no_prompt_when_runtime_unavailable(self, claude_home_missing, tmp_path, monkeypatch):
+        """Runtime not installed → generator skips → no prompt."""
+        project = self._setup(tmp_path)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        runner = CliRunner()
+        result = runner.invoke(context, ["sync", "--include=settings"])
+        assert result.exit_code == 0
+        assert "modify the following files outside this project" not in result.output

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -15,6 +15,7 @@ from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
     diff_settings,
     generate_all_settings,
+    host_write_targets,
 )
 
 
@@ -526,3 +527,94 @@ class TestClaudeSettingsHostWritePrompt:
         result = runner.invoke(context, ["sync", "--include=settings"])
         assert result.exit_code == 0
         assert "modify the following files outside this project" not in result.output
+
+
+class TestGenerateAllSettingsHostWriteGate:
+    """``generate_all_settings(allow_host_writes=False)`` — the library-level
+    gate every front-end (CLI, MCP, Web) routes through. Without this gate
+    living inside the I/O boundary the CLI confirm could be bypassed by any
+    caller that imports the function directly (audit P0 review item 1)."""
+
+    def _setup(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        canonical = project / CANONICAL_SETTINGS_FILE
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [_rule("Write", "echo test")]}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        return project
+
+    def test_default_refuses_host_write(self, claude_home, tmp_path):
+        """Default ``allow_host_writes=False`` → status=needs_confirmation,
+        no file written."""
+        project = self._setup(tmp_path)
+        results = generate_all_settings(project)
+        r = results["claude_settings"]
+        assert r.status == "needs_confirmation"
+        target = claude_home / ".claude" / "settings.json"
+        assert str(target) in r.reason
+        assert r.target == target
+        assert not target.exists()
+
+    def test_allow_host_writes_true_proceeds(self, claude_home, tmp_path):
+        """``allow_host_writes=True`` → previous behavior, file written."""
+        project = self._setup(tmp_path)
+        results = generate_all_settings(project, allow_host_writes=True)
+        r = results["claude_settings"]
+        assert r.status == "ok"
+        target = claude_home / ".claude" / "settings.json"
+        assert target.is_file()
+        written = json.loads(target.read_text(encoding="utf-8"))
+        assert "PostToolUse" in written["hooks"]
+
+    def test_diff_unaffected_by_gate(self, claude_home, tmp_path):
+        """``diff_settings`` is read-only — host-write gate must not make it
+        report ``needs_confirmation``."""
+        project = self._setup(tmp_path)
+        results = diff_settings(project)
+        assert results["claude_settings"].status in {"in sync", "out of sync", "missing target"}
+
+    def test_no_runtime_installed_skips_not_needs_confirmation(self, claude_home_missing, tmp_path):
+        project = self._setup(tmp_path)
+        results = generate_all_settings(project)
+        assert results["claude_settings"].status == "skipped"
+
+    def test_no_canonical_skips_not_needs_confirmation(self, claude_home, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        results = generate_all_settings(project)
+        assert results["claude_settings"].status == "skipped"
+
+    def test_host_write_targets_lists_pending_paths(self, claude_home, tmp_path):
+        """``host_write_targets()`` mirrors what ``generate_all_settings``
+        would refuse — used by every front-end to surface the pending
+        paths to the user."""
+        project = self._setup(tmp_path)
+        pending = host_write_targets(project)
+        target = claude_home / ".claude" / "settings.json"
+        assert pending == [target]
+
+    def test_host_write_targets_empty_when_no_canonical(self, claude_home, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        assert host_write_targets(project) == []
+
+    def test_host_write_targets_empty_when_runtime_missing(self, claude_home_missing, tmp_path):
+        project = self._setup(tmp_path)
+        assert host_write_targets(project) == []
+
+    def test_symlink_target_is_treated_as_host_write(self, claude_home, tmp_path):
+        """A symlink whose project-relative path *appears* under the project
+        root must be classified by the resolved location (review item 4):
+        ``Path.resolve()`` follows the symlink, so the gate still trips."""
+        project = self._setup(tmp_path)
+        # Symlink <project>/.claude → claude_home/.claude
+        (claude_home / ".claude").mkdir(exist_ok=True)
+        (project / ".claude").symlink_to(claude_home / ".claude")
+
+        # The generator's target_file still computes Path.home() / .claude /
+        # settings.json (the host path), and that resolves outside ``project``.
+        results = generate_all_settings(project)
+        assert results["claude_settings"].status == "needs_confirmation"

--- a/packages/memtomem/tests/test_server_tools_context_settings_gate.py
+++ b/packages/memtomem/tests/test_server_tools_context_settings_gate.py
@@ -1,0 +1,93 @@
+"""MCP-tool gate threading: ``mem_context_sync`` / ``mem_context_generate``
+forward ``allow_host_writes`` into ``generate_all_settings``.
+
+The full gate semantics are covered in test_context_settings.py; this file
+just pins the wiring so a future revert that forgets to thread the param
+fails CI immediately (review item 1 on PR #484).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem.context.settings import CANONICAL_SETTINGS_FILE
+from memtomem.server.tools.context import mem_context_generate, mem_context_sync
+
+
+@pytest.fixture
+def claude_home(tmp_path, monkeypatch):
+    """Redirect HOME so any Claude write lands in a temp dir."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    (fake_home / ".claude").mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    return fake_home
+
+
+def _setup_project(tmp_path, monkeypatch):
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    canonical = project / CANONICAL_SETTINGS_FILE
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    canonical.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PostToolUse": [
+                        {
+                            "matcher": "Write",
+                            "hooks": [{"type": "command", "command": "echo test"}],
+                        }
+                    ]
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(project)
+    return project
+
+
+@pytest.mark.anyio
+async def test_mem_context_sync_refuses_host_write_by_default(claude_home, tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    out = await mem_context_sync(include="settings")
+    assert "needs confirmation" in out
+    assert "claude_settings" in out
+    target = claude_home / ".claude" / "settings.json"
+    assert not target.exists()
+
+
+@pytest.mark.anyio
+async def test_mem_context_sync_accepts_allow_host_writes(claude_home, tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    out = await mem_context_sync(include="settings", allow_host_writes=True)
+    assert "needs confirmation" not in out
+    target = claude_home / ".claude" / "settings.json"
+    assert target.is_file()
+
+
+@pytest.mark.anyio
+async def test_mem_context_generate_refuses_host_write_by_default(
+    claude_home, tmp_path, monkeypatch
+):
+    _setup_project(tmp_path, monkeypatch)
+    out = await mem_context_generate(include="settings")
+    assert "needs confirmation" in out
+    target = claude_home / ".claude" / "settings.json"
+    assert not target.exists()
+
+
+@pytest.mark.anyio
+async def test_mem_context_generate_accepts_allow_host_writes(claude_home, tmp_path, monkeypatch):
+    _setup_project(tmp_path, monkeypatch)
+    out = await mem_context_generate(include="settings", allow_host_writes=True)
+    assert "needs confirmation" not in out
+    target = claude_home / ".claude" / "settings.json"
+    assert target.is_file()

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -696,6 +696,69 @@ class TestSettingsSync:
         assert resp.status_code == 200
         assert "results" in resp.json()
 
+    async def test_post_refuses_host_write_by_default(
+        self, app, client: AsyncClient, tmp_path, monkeypatch
+    ):
+        """``POST /api/settings-sync`` without a body refuses host writes by
+        default — review item 1 on PR #484. Library-level gate threading."""
+        # Isolate HOME so the test cannot edit the real ~/.claude/settings.json.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+        # Project lives in a sibling dir so the Claude target is a host write.
+        project = tmp_path / "proj"
+        project.mkdir()
+        canonical = project / ".memtomem" / "settings.json"
+        canonical.parent.mkdir(parents=True)
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo")]}}),
+            encoding="utf-8",
+        )
+        app.state.project_root = project
+
+        resp = await client.post(
+            "/api/settings-sync",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        claude = next(r for r in results if r["name"] == "claude_settings")
+        assert claude["status"] == "needs_confirmation"
+        assert "outside the project root" in claude["reason"]
+        assert not (fake_home / ".claude" / "settings.json").exists()
+
+    async def test_post_proceeds_with_allow_host_writes_true(
+        self, app, client: AsyncClient, tmp_path, monkeypatch
+    ):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        (fake_home / ".claude").mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("USERPROFILE", str(fake_home))
+
+        project = tmp_path / "proj"
+        project.mkdir()
+        canonical = project / ".memtomem" / "settings.json"
+        canonical.parent.mkdir(parents=True)
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo")]}}),
+            encoding="utf-8",
+        )
+        app.state.project_root = project
+
+        resp = await client.post(
+            "/api/settings-sync",
+            json={"allow_host_writes": True},
+        )
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        claude = next(r for r in results if r["name"] == "claude_settings")
+        assert claude["status"] == "ok"
+        assert (fake_home / ".claude" / "settings.json").is_file()
+
     async def test_alias_post_context_settings_resolve(self, app, client: AsyncClient, tmp_path):
         """POST /api/context/settings/resolve resolves a hook conflict."""
         canonical_rule = self._rule("Edit", "echo v2")


### PR DESCRIPTION
## Summary

- `mm context {generate,sync} --include=settings` now confirms before
  writing to a settings file that lives outside the project root
  (today only `~/.claude/settings.json`); declining leaves the host
  untouched.
- `--yes` / `-y` skips the prompt for scripted callers.
- Path-based gate (`target.is_relative_to(root)`) so future
  project-scope settings generators won't prompt at all.

## Why

Running `mm context sync --include=settings` from a worktree silently
edited the real `~/.claude/settings.json`. `setup-worktree.sh`
redirects storage and memory dirs but not HOME, so the host
pollution was easy to miss. This is one of the three P0 items called
out in the 2026-04-26 context-gateway audit (alongside the
round-trip data loss already fixed in #482 and the codex_agents
project-scope fix in #483).

## Test plan

- [x] New regression class `TestClaudeSettingsHostWritePrompt` in
      `test_context_settings.py` (7 cases): sync/generate × {decline,
      confirm, `--yes`} + 2 negatives (missing canonical / runtime
      unavailable) that assert no prompt fires.
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 2488
      passed locally.
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/context_cmd.py`
      — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)