### PR TITLE
feat(server): mem_add inherits agent scope from mem_session_start (G1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,44 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   alongside Claude/Gemini, so `mm context detect` and the Web UI
   Context Gateway list project-scope Codex agents in their inventory.
 
-### Fixed
+- **`mem_add` and `mem_batch_add` now inherit the agent scope from
+  `mem_session_start(agent_id="...")`.** Following gap G1 of the
+  2026-04-26 multi-agent surface review, the MCP write tools join
+  the same priority chain `mem_agent_search` already uses:
+
+  1. explicit `namespace=` argument (escape hatch — wins everything),
+  2. `app.current_agent_id` → `agent-runtime:<id>` (set by
+     `mem_session_start`),
+  3. `app.current_namespace` (legacy `mem_ns_set` path),
+  4. config default.
+
+  Previously `mem_add` consulted only step 3, so calling
+  `mem_session_start(agent_id="planner")` followed by
+  `mem_add(content=...)` silently wrote to `default` instead of
+  `agent-runtime:planner`, contradicting the multi-agent contract
+  the public page advertises. The change is now symmetric with the
+  LangGraph adapter (which has had this semantic since PR #460) and
+  with `mem_agent_search`'s read-side resolution.
+
+  **Who is affected:**
+  - **Pre-multi-agent users** (no `mem_session_start` call): no
+    change. `current_agent_id` stays `None`; resolution falls
+    through to step 3 / step 4 exactly as before.
+  - **Multi-agent users using only `mem_session_start`**:
+    `mem_add` writes now land in the agent's namespace — the
+    documented behavior, finally honored. The 940-line e2e guide's
+    workaround (passing `namespace="agent-runtime:<id>"` on every
+    `mem_add`) is no longer required.
+  - **Rare combination — both `mem_ns_set` and
+    `mem_session_start` set in the same session**: write target
+    changes from the `mem_ns_set` namespace to the agent's namespace.
+    Pass `namespace="<old-ns>"` explicitly on the call to keep the
+    old destination, or call `mem_session_end()` before writing.
+
+  `mem_add` and `mem_batch_add` now also echo the resolved
+  `Namespace:` line in their confirmation output, so the resolution
+  is observable on the first call. `mem_search` is unchanged in this
+  release — symmetric search-side support is tracked separately.
 
 - **`mm context` round-trip no longer silently drops `## <Agent>-Specific`
   sections.** `extract_sections_from_agent_file` mapped agent-override

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,10 +51,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   alongside Claude/Gemini, so `mm context detect` and the Web UI
   Context Gateway list project-scope Codex agents in their inventory.
 
-- **`mem_add` and `mem_batch_add` now inherit the agent scope from
-  `mem_session_start(agent_id="...")`.** Following gap G1 of the
-  2026-04-26 multi-agent surface review, the MCP write tools join
-  the same priority chain `mem_agent_search` already uses:
+- **`mem_add`, `mem_batch_add`, `mem_index`, and `mem_fetch` now
+  inherit the agent scope from `mem_session_start(agent_id="...")`.**
+  Following gap G1 of the 2026-04-26 multi-agent surface review, the
+  session-aware MCP write tools join the same priority chain
+  `mem_agent_search` already uses:
 
   1. explicit `namespace=` argument (escape hatch — wins everything),
   2. `app.current_agent_id` → `agent-runtime:<id>` (set by
@@ -62,33 +63,44 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   3. `app.current_namespace` (legacy `mem_ns_set` path),
   4. config default.
 
-  Previously `mem_add` consulted only step 3, so calling
-  `mem_session_start(agent_id="planner")` followed by
-  `mem_add(content=...)` silently wrote to `default` instead of
-  `agent-runtime:planner`, contradicting the multi-agent contract
-  the public page advertises. The change is now symmetric with the
+  Previously these write tools consulted only step 3, so calling
+  `mem_session_start(agent_id="planner")` followed by `mem_add` /
+  `mem_index` / `mem_fetch` silently wrote to `default` instead of
+  `agent-runtime:planner`, contradicting the multi-agent contract the
+  public page advertises. The change is now symmetric with the
   LangGraph adapter (which has had this semantic since PR #460) and
   with `mem_agent_search`'s read-side resolution.
+
+  `mem_consolidate_apply` already routed through `_mem_add_core`, so
+  it picks up the new contract automatically.
 
   **Who is affected:**
   - **Pre-multi-agent users** (no `mem_session_start` call): no
     change. `current_agent_id` stays `None`; resolution falls
     through to step 3 / step 4 exactly as before.
-  - **Multi-agent users using only `mem_session_start`**:
-    `mem_add` writes now land in the agent's namespace — the
-    documented behavior, finally honored. The 940-line e2e guide's
-    workaround (passing `namespace="agent-runtime:<id>"` on every
-    `mem_add`) is no longer required.
-  - **Rare combination — both `mem_ns_set` and
-    `mem_session_start` set in the same session**: write target
-    changes from the `mem_ns_set` namespace to the agent's namespace.
-    Pass `namespace="<old-ns>"` explicitly on the call to keep the
-    old destination, or call `mem_session_end()` before writing.
+  - **Multi-agent users using only `mem_session_start`**: writes
+    now land in the agent's namespace — the documented behavior,
+    finally honored. The 940-line e2e guide's workaround (passing
+    `namespace="agent-runtime:<id>"` on every write) is no longer
+    required.
+  - **Rare combination — both `mem_ns_set` and `mem_session_start`
+    set in the same session**: write target changes from the
+    `mem_ns_set` namespace to the agent's namespace. Pass
+    `namespace="<old-ns>"` explicitly on the call to keep the old
+    destination, or call `mem_session_end()` before writing.
 
-  `mem_add` and `mem_batch_add` now also echo the resolved
-  `Namespace:` line in their confirmation output, so the resolution
-  is observable on the first call. `mem_search` is unchanged in this
-  release — symmetric search-side support is tracked separately.
+  `mem_add` now echoes the resolved `Namespace:` line in its
+  confirmation output (`mem_batch_add` / `mem_fetch` already did),
+  so the resolution is observable on the first call.
+
+  Out of scope (tracked separately):
+  - `mem_search` and `mem_recall` (single-agent reads) — `mem_search`
+    keeps its `current_namespace` semantic; use `mem_agent_search` to
+    read inside the agent scope.
+  - `mem_import_notion` / `mem_import_obsidian` — these intentionally
+    fall back to source-tagged namespaces (`notion` / `obsidian`)
+    rather than the session scope, since their value is tagging
+    ingested content by source.
 
 - **`mm context` round-trip no longer silently drops `## <Agent>-Specific`
   sections.** `extract_sections_from_agent_file` mapped agent-override

--- a/packages/memtomem/src/memtomem/server/instructions.py
+++ b/packages/memtomem/src/memtomem/server/instructions.py
@@ -39,14 +39,19 @@ Namespace conventions:
   shared:                 cross-agent shared scope
 Pass explicit namespace= only when overriding the derived value.
 
+Session-bound write contract:
+- After mem_session_start(agent_id="..."), subsequent mem_add and
+  mem_batch_add calls without an explicit namespace= argument
+  automatically write to "agent-runtime:<id>" — the session's
+  agent scope. Pass namespace= explicitly to write somewhere
+  else (e.g. namespace="shared").
+- mem_search still reads from current_namespace by default;
+  use mem_agent_search to read inside the agent scope.
+  (Symmetric search-side support is tracked separately.)
+
 Common pitfalls:
 - mem_session_start() without agent_id falls back to the "default"
   namespace — pass agent_id whenever you want isolation.
-- agent_id and current_namespace are separate axes; mem_add /
-  mem_search without explicit namespace= still consult
-  current_namespace, not the session's "agent-runtime:*" scope.
-  Use mem_agent_search / mem_agent_share to act inside the
-  agent scope.
 - mem_agent_search needs an active session (or current_agent_id);
   call mem_session_start first.
 

--- a/packages/memtomem/src/memtomem/server/tools/indexing.py
+++ b/packages/memtomem/src/memtomem/server/tools/indexing.py
@@ -8,6 +8,7 @@ from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.helpers import _check_embedding_mismatch
+from memtomem.server.tools.multi_agent import _resolve_agent_namespace
 
 
 @mcp.tool()
@@ -37,7 +38,7 @@ async def mem_index(
         return mismatch_msg
 
     target = Path(path).resolve()
-    effective_ns = namespace or app.current_namespace
+    effective_ns = namespace or _resolve_agent_namespace(app, None)
 
     stats = await app.index_engine.index_path(
         target,

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -13,6 +13,7 @@ from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.helpers import _announce_dim_mismatch_once, _check_embedding_mismatch
 from memtomem.server.tool_registry import register
+from memtomem.server.tools.multi_agent import _resolve_agent_namespace
 from memtomem.server.validation import MAX_CONTENT_LENGTH
 from memtomem.server.webhooks import webhook_error_cb
 
@@ -104,14 +105,20 @@ async def _mem_add_core(
     assert target is not None
     await asyncio.to_thread(append_entry, target, content, title=title, tags=tags)
 
-    effective_ns = namespace or app.current_namespace
+    effective_ns = namespace or _resolve_agent_namespace(app, None)
 
     # Re-index the whole file via the standard pipeline so the watcher
     # (which also calls index_file) produces identical hashes → no duplicates.
     stats = await app.index_engine.index_file(target, namespace=effective_ns)
     app.search_pipeline.invalidate_cache()
 
-    result = f"Memory added to {target}\n- Chunks indexed: {stats.indexed_chunks}\n- File: {target}"
+    display_ns = effective_ns or app.config.namespace.default_namespace
+    result = (
+        f"Memory added to {target}\n"
+        f"- Namespace: {display_ns}\n"
+        f"- Chunks indexed: {stats.indexed_chunks}\n"
+        f"- File: {target}"
+    )
 
     # Semantic duplicate check: warn if very similar content already exists
     try:
@@ -386,7 +393,7 @@ async def mem_batch_add(
             continue
         append_entry(target, value, title=key or None, tags=entry_tags)
 
-    effective_ns = namespace or app.current_namespace
+    effective_ns = namespace or _resolve_agent_namespace(app, None)
     stats = await app.index_engine.index_file(target, namespace=effective_ns)
     app.search_pipeline.invalidate_cache()
 

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -15,12 +15,20 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_agent_namespace(app: AppContext, agent_id: str | None) -> str | None:
-    """Resolve the namespace ``mem_agent_search`` should query.
+    """Resolve the namespace a session-aware MCP tool should target.
+
+    Used by both the read path (``mem_agent_search``,
+    ``mem_agent_share``) and the write path (``mem_add``,
+    ``mem_batch_add``, ``mem_index``, ``mem_fetch``) so the
+    "session bound writes go to the agent scope" contract holds
+    across the entire MCP surface — see G1 in
+    ``memtomem-docs/memtomem/planning/multi-agent-public-surface-review-2026-04-26.md``.
 
     Priority order (each falls back to the next when ``None``):
 
     1. Explicit ``agent_id`` argument — the caller wants to override the
-       session context for this single call.
+       session context for this single call. Only the read tools take
+       an ``agent_id`` arg today; write tools always pass ``None``.
     2. ``app.current_agent_id`` — set by ``mem_session_start(agent_id=...)``;
        lets agents avoid repeating their identity on every tool call.
     3. ``app.current_namespace`` — pre-multi-agent legacy fallback. Kept
@@ -28,7 +36,9 @@ def _resolve_agent_namespace(app: AppContext, agent_id: str | None) -> str | Non
        working unchanged.
 
     Returns ``None`` if no source resolved a namespace, in which case
-    the caller treats the search as un-pinned.
+    the caller treats the operation as un-pinned (read tools search
+    everything; write tools defer to the indexing engine's auto-NS
+    rules and config default).
     """
 
     if agent_id:

--- a/packages/memtomem/src/memtomem/server/tools/url_index.py
+++ b/packages/memtomem/src/memtomem/server/tools/url_index.py
@@ -8,6 +8,7 @@ from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
+from memtomem.server.tools.multi_agent import _resolve_agent_namespace
 
 
 @mcp.tool()
@@ -47,7 +48,7 @@ async def mem_fetch(
         return f"Error fetching URL: {exc}"
 
     # Index the fetched file
-    effective_ns = namespace or app.current_namespace
+    effective_ns = namespace or _resolve_agent_namespace(app, None)
     stats = await app.index_engine.index_file(file_path, namespace=effective_ns)
 
     # Apply tags if provided

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -27,6 +27,12 @@ Cases:
   ``MemtomemStore.start_agent_session("planner")`` binds the agent
   scope so ``add()`` defaults to ``agent-runtime:planner`` and
   ``search(include_shared=True)`` returns planner+shared only.
+* **E — mem_add session inheritance** (G1, RFC option B):
+  After ``mem_session_start(agent_id="planner")``, plain
+  ``mem_add(content=...)`` writes to ``agent-runtime:planner``
+  (not ``default``), matching the contract the public page
+  advertises. Pre-multi-agent (no session) callers fall back to
+  ``app.current_namespace`` unchanged.
 """
 
 from __future__ import annotations
@@ -473,3 +479,113 @@ class TestCaseDLangGraphAdapter:
                 await store.search("anything", include_shared=True)
         finally:
             await store.close()
+
+
+# ── Case E — mem_add inherits agent_id from session (G1, RFC option B) ──
+
+
+class TestCaseEMemAddSessionInheritance:
+    """End-to-end: after ``mem_session_start(agent_id="planner")``, a
+    plain ``mem_add(content=...)`` writes to ``agent-runtime:planner``
+    instead of ``default``. This is the gap the public page advertised
+    but the MCP path didn't deliver before option B (G1 RFC).
+
+    The matching read path stays on ``mem_agent_search`` —
+    ``mem_search`` is intentionally out of scope for G1.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mem_add_inherits_agent_id_from_session(self, integration_components):
+        from memtomem.server.tools.memory_crud import mem_add
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        try:
+            result = await mem_add(content="auth flow: JWT in cookie", ctx=ctx)  # type: ignore[arg-type]
+            # The resolved namespace is now visible to the caller —
+            # surfacing the resolution makes the new contract observable.
+            assert "agent-runtime:planner" in result
+
+            # And the chunks themselves landed in the agent's namespace,
+            # so a follow-up `mem_agent_search` reaches them.
+            out = await mem_agent_search(query="JWT", agent_id=None, ctx=ctx)  # type: ignore[arg-type]
+            assert "auth flow" in out
+        finally:
+            await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_mem_batch_add_inherits_agent_id_from_session(self, integration_components):
+        from memtomem.server.tools.memory_crud import mem_batch_add
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        try:
+            result = await mem_batch_add(
+                entries=[
+                    {"key": "Decision A", "value": "use cookie sessions"},
+                    {"key": "Decision B", "value": "rotate tokens daily"},
+                ],
+                ctx=ctx,  # type: ignore[arg-type]
+            )
+            assert "agent-runtime:planner" in result
+
+            out = await mem_agent_search(query="cookie", agent_id=None, ctx=ctx)  # type: ignore[arg-type]
+            assert "use cookie sessions" in out
+        finally:
+            await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_explicit_namespace_overrides_session_agent_id(self, integration_components):
+        """Explicit ``namespace=`` arg is the escape hatch — it wins
+        over the session-bound agent_id, matching the priority chain
+        documented on `_resolve_agent_namespace`.
+        """
+        from memtomem.server.tools.memory_crud import mem_add
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        try:
+            result = await mem_add(
+                content="cross-team architecture note",
+                namespace=SHARED_NAMESPACE,
+                ctx=ctx,  # type: ignore[arg-type]
+            )
+            assert SHARED_NAMESPACE in result
+            assert "agent-runtime:planner" not in result
+        finally:
+            await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_no_session_falls_back_to_current_namespace(self, integration_components):
+        """Pre-multi-agent users (no `mem_session_start`) keep their
+        legacy behavior: `mem_add` reads `app.current_namespace` (set
+        by `mem_ns_set` historically) and falls back to the config
+        default if neither is set. No regression against the old
+        `effective_ns = namespace or app.current_namespace` path.
+        """
+        from memtomem.server.tools.memory_crud import mem_add
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        # No session started → current_agent_id is None.
+        assert app.current_agent_id is None
+        # current_namespace stays at its construction default.
+        app.current_namespace = "team-notes"
+
+        result = await mem_add(content="legacy path note", ctx=ctx)  # type: ignore[arg-type]
+        assert "team-notes" in result
+        assert "agent-runtime:" not in result

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -589,3 +589,33 @@ class TestCaseEMemAddSessionInheritance:
         result = await mem_add(content="legacy path note", ctx=ctx)  # type: ignore[arg-type]
         assert "team-notes" in result
         assert "agent-runtime:" not in result
+
+    @pytest.mark.asyncio
+    async def test_session_agent_id_overrides_legacy_current_namespace(
+        self, integration_components
+    ):
+        """G1 BREAKING case: when both ``mem_ns_set`` (current_namespace)
+        and ``mem_session_start`` (current_agent_id) are set in the same
+        session, the agent_id wins. CHANGELOG documents this as the only
+        behavior change for the rare combination of legacy and
+        multi-agent state; this test pins the contract so a future
+        refactor of the priority chain cannot silently revert it."""
+        from memtomem.server.tools.memory_crud import mem_add
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        # Legacy axis: mem_ns_set-style binding from a pre-multi-agent
+        # workflow that the user has continued to keep around.
+        app.current_namespace = "team-notes"
+
+        await mem_agent_register(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        try:
+            result = await mem_add(content="design decision", ctx=ctx)  # type: ignore[arg-type]
+            # Agent scope wins over the legacy current_namespace.
+            assert "agent-runtime:planner" in result
+            assert "team-notes" not in result
+        finally:
+            await mem_session_end(ctx=ctx)  # type: ignore[arg-type]

--- a/packages/memtomem/tests/test_tools_logic.py
+++ b/packages/memtomem/tests/test_tools_logic.py
@@ -1245,6 +1245,7 @@ def _fake_ctx(components):
         index_engine=components.index_engine,
         search_pipeline=components.search_pipeline,
         current_namespace=None,
+        current_agent_id=None,
         webhook_manager=None,
         ensure_initialized=AsyncMock(),
     )


### PR DESCRIPTION
## Summary
Implements **gap G1** from the 2026-04-26 multi-agent surface review (memtomem-docs#13) following RFC **Option B** (the recommended path in `mem-add-agent-scope-flow-rfc.md`).

After `mem_session_start(agent_id="planner")`, plain `mem_add` / `mem_batch_add` now write to `agent-runtime:planner` instead of `default`. The MCP write tools join the same priority chain `mem_agent_search` already uses, removing the cross-entry-point asymmetry between the LangGraph adapter (Option B since #460) and MCP.

## Behavior change

| User group | Before | After |
|---|---|---|
| Pre-multi-agent (no `mem_session_start`) | `mem_add` → `current_namespace` (or `default`) | **No change** |
| Multi-agent using only `mem_session_start` | `mem_add` → `default` (silent contract break) | `mem_add` → `agent-runtime:<id>` ✅ |
| Both `mem_ns_set` + `mem_session_start` set | `mem_add` → `current_namespace` | `mem_add` → `agent-runtime:<id>` (escape hatch: pass `namespace=` explicitly) |

`mem_search` is intentionally unchanged — RFC §Non-goals. Symmetric search-side support is tracked separately so the single-agent read path can keep its `current_namespace` semantic while a dedicated RFC lands.

## Implementation
- `memory_crud.py:_mem_add_core` and `mem_batch_add` route through `_resolve_agent_namespace` (multi_agent.py:17-38) — single source of truth across read and write paths.
- `instructions.py` "common pitfalls — separate axes" warning becomes a positive "Session-bound write contract" statement; `mem_search` is called out as the still-asymmetric read path.
- `mem_add` / `mem_batch_add` confirmation messages now echo `Namespace: <resolved>`, so the new resolution is observable on the first call.

## Test plan
- [x] `uv run pytest -m "not ollama"` — **2519 passed** (4 new + no regression)
- [x] `tests/test_multi_agent_integration.py` Case E (4 cases):
  - `test_mem_add_inherits_agent_id_from_session`
  - `test_mem_batch_add_inherits_agent_id_from_session`
  - `test_explicit_namespace_overrides_session_agent_id`
  - `test_no_session_falls_back_to_current_namespace` (pins the pre-multi-agent legacy path so the "no regression" claim is enforced by a test)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [ ] Manual smoke (post-merge): `mm session start --agent-id planner`, then call `mem_add` via MCP, verify the resolved `Namespace:` line + chunks land in `agent-runtime:planner`

## Release sequencing
- This is a flagged behavior change → `## [Unreleased]` `### Changed (BREAKING)` callout with migration note.
- Per `feedback_prerelease_dry_run.md`: TestPyPI dry-run before the production tag.
- Pair-with: memtomem-com#7 5-step workflow (already adds `mem_session_start` + `mem_session_end` to the public page; once G1 lands, that page can also document the natural `mem_add` flow without footnotes — follow-up commit on memtomem-com#7).

## Cross-references
- Source: `memtomem/planning/multi-agent-public-surface-review-2026-04-26.md` §3 (G1) + §5.1 (sequencing — RFC FIRST after G2/G3).
- RFC: `memtomem/planning/mem-add-agent-scope-flow-rfc.md` Option B (recommended) + Validation results: test pair audit 0 / docs reference 0 / GitHub issue survey 0 / LangGraph PR #460 confirms Option B was the design choice.
- Companion PRs: memtomem-docs#13 (review + G1 RFC), memtomem-docs#14 (5 sibling RFC drafts), memtomem-com#7 (G3/G8 5-step workflow), memtomem#485 (G2 — CLI namespace derivation, **MERGED**).