### PR TITLE
feat(web): graduate context gateway tabs to prod tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **Web UI Context Gateway tabs (Artifact Sync, Skills, Commands,
+  Agents) graduate from `--dev` to the polished prod surface.** The
+  hardening that landed in #482 (round-trip `## *-Specific`
+  preservation), #483 (project-scope `codex_agents` default), and
+  #484 (settings-sync host-write confirm) closed the rough edges that
+  justified hiding these from `mm web` users by default. The four
+  `/api/context/*` routers and matching settings nav buttons now
+  mount in `prod`; dev-only stays dev-only for `Namespaces`,
+  `Sessions`, `Working Memory`, `Procedures`, `Health Report`, and
+  `Hook Files`. Trust boundary unchanged — the loopback + single-user
+  Tier 1 deployment shape from `feedback_tier2_web_gating_deferred.md`
+  is still the only supported one, and these are the first
+  mutator-heavy endpoints to ship in the prod surface, so a future
+  Tier 2 hardening pass starts here.
 - **`mm context {generate,sync} --include=settings` now confirms before
   writing settings files outside the project root** (today only
   `~/.claude/settings.json`); pass `--yes` / `-y` to skip the prompt.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -710,7 +710,7 @@ In `core` mode, use `mem_do(action="...", params={...})` to access any of the 65
 
 `mm web --mode {prod,dev}` overrides the env. `mm web --dev` is a shortcut for `--mode dev` and is mutually exclusive with `--mode`. An invalid value fails fast rather than silently falling back.
 
-Tab classification changes over time — run `mm web --dev` to see the full surface of your installed version. The API endpoints backing dev-only pages (for example `/api/sessions`, `/api/scratch`, `/api/namespaces`, `/api/context/*`) return 404 in `prod` mode; switch to `dev` mode if you're scripting against them.
+Tab classification changes over time — run `mm web --dev` to see the full surface of your installed version. The API endpoints backing dev-only pages (for example `/api/sessions`, `/api/scratch`, `/api/namespaces`) return 404 in `prod` mode; switch to `dev` mode if you're scripting against them.
 
 ## Querying and Modifying at Runtime
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -901,9 +901,9 @@ mm web --dev                   # adds opt-in maintainer pages
 mm web --mode {prod,dev}       # explicit mode (mutually exclusive with --dev)
 ```
 
-`mm web` defaults to the polished page set: Home, Search, Sources, Index, Tags, Timeline, and Settings (Config, Dedup, Age-out, Export/Import, Reset Database). `mm web --dev` — or setting `MEMTOMEM_WEB__MODE=dev` in your shell profile — extends the surface with maintainer pages (Namespaces, Sessions, Working Memory, Procedures, Health Report, Artifact Sync, Hook Files, Skills/Commands/Agents).
+`mm web` defaults to the polished page set: Home, Search, Sources, Index, Tags, Timeline, and Settings (Config, Artifact Sync, Skills/Commands/Agents, Dedup, Age-out, Export/Import, Reset Database). `mm web --dev` — or setting `MEMTOMEM_WEB__MODE=dev` in your shell profile — extends the surface with maintainer pages (Namespaces, Sessions, Working Memory, Procedures, Health Report, Hook Files).
 
-Tab classification changes over time — run `mm web --dev` against your installed version to see the complete surface. The API endpoints backing dev-only pages return 404 in `prod` mode; scripts that hit `/api/sessions`, `/api/scratch`, `/api/namespaces`, `/api/context/*`, etc. need `dev` mode.
+Tab classification changes over time — run `mm web --dev` against your installed version to see the complete surface. The API endpoints backing dev-only pages return 404 in `prod` mode; scripts that hit `/api/sessions`, `/api/scratch`, `/api/namespaces`, etc. need `dev` mode.
 
 ---
 

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -67,6 +67,10 @@ _PROD_ROUTERS: list[ModuleType] = [
     decay,
     export,
     timeline,
+    context_gateway,
+    context_skills,
+    context_commands,
+    context_agents,
 ]
 _DEV_ONLY_ROUTERS: list[ModuleType] = [
     namespaces,
@@ -76,10 +80,6 @@ _DEV_ONLY_ROUTERS: list[ModuleType] = [
     evaluation,
     watchdog,
     settings_sync,
-    context_gateway,
-    context_skills,
-    context_commands,
-    context_agents,
 ]
 
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -564,28 +564,28 @@
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.integrations">Integrations</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🔄</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_overview">Artifact Sync</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Skills/Cmd/Agents status</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🧩</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_skills">Skills</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Skill definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⌘</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_commands">Commands</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_commands_sub">Command definitions</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🤖</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_agents">Agents</span>

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -163,7 +163,6 @@ def test_dev_routes_extend_prod_routes() -> None:
         ("/api/scratch", "GET"),
         ("/api/namespaces", "GET"),
         ("/api/procedures", "GET"),
-        ("/api/context/overview", "GET"),
         ("/api/watchdog/status", "GET"),
         ("/api/settings-sync", "GET"),
         ("/api/eval", "GET"),
@@ -200,7 +199,16 @@ async def test_dev_only_routes_blocked_in_prod_but_exposed_in_dev(path: str, met
 def test_prod_keeps_polished_routes_mounted() -> None:
     """Sanity: the dev-only move mustn't brick the polished surface."""
     prod_paths = _api_paths(create_app(mode="prod"))
-    for expected in ("/api/search", "/api/sources", "/api/stats", "/api/config"):
+    for expected in (
+        "/api/search",
+        "/api/sources",
+        "/api/stats",
+        "/api/config",
+        "/api/context/overview",
+        "/api/context/skills",
+        "/api/context/commands",
+        "/api/context/agents",
+    ):
         assert expected in prod_paths, (
             f"{expected} is missing from prod — reclassify or the router list"
         )
@@ -289,10 +297,6 @@ def test_html_classification_matches_router_lists() -> None:
     # router lists must also update the HTML, and this test enforces it.
     expected_dev = {
         "namespaces",
-        "ctx-overview",
-        "ctx-skills",
-        "ctx-commands",
-        "ctx-agents",
         "hooks-sync",
         "harness-sessions",
         "harness-scratch",


### PR DESCRIPTION
## Summary

- Move the four Context Gateway routers (`context_gateway`, `context_skills`, `context_commands`, `context_agents`) from `_DEV_ONLY_ROUTERS` to `_PROD_ROUTERS` in `web/app.py`, and flip the four matching `settings-nav-btn` `data-ui-tier="dev" → "prod"` in `static/index.html`. Net effect: the **Artifact Sync / Skills / Commands / Agents** tabs ship in the polished surface that all `uv tool install` users see, instead of being gated behind `mm web --dev`.
- This is a **UX maturity** decision, not a security one. Per `feedback_tier2_web_gating_deferred.md`, Tier 1 (loopback + single user) is the only supported deployment shape; the mutator endpoints under `/api/context/*` (POST/PATCH/DELETE) keep the same trust origin as before — already exposed prod endpoints like `/api/config` PATCH have the same gating model.
- The dev-only label was earned during early churn. The hardening that landed in #482 (round-trip `## *-Specific` preservation), #483 (project-scope `codex_agents` default), and #484 (settings-sync host-write confirm) closes the last rough edges that justified hiding these tabs from polished-surface users.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check` — clean
- [x] `uv run pytest -m "not ollama"` — 2514 passed
- [x] `test_web_mode` updates:
  - `expected_dev` drops `ctx-overview`, `ctx-skills`, `ctx-commands`, `ctx-agents`
  - dev-only-route parametrize drops `/api/context/overview`
  - `test_prod_keeps_polished_routes_mounted` adds the four `/api/context/*` paths
- [x] Live smoke against `mm web` (prod, isolated `HOME` + state dir):
  - `/api/system/ui-mode` → `{"mode":"prod"}`
  - `/api/context/{overview,skills,commands,agents}` → all 200
  - `/api/{namespaces,settings-sync,sessions,watchdog/status}` → all 404 (dev-only stays gated)
  - SPA renders the four tabs under **연동 / Integrations**, dev-only sections still hidden, Artifact Sync page loads cleanly

## Notes

- No `app.js` changes needed: the Home dashboard `devMode` gate only covers `/api/namespaces`, `/api/sessions`, `/api/scratch` — context endpoints are not fetched from Home.
- `settings_sync` (the user-scope `~/.claude/settings.json` writer) **stays in `_DEV_ONLY_ROUTERS`**. It's behaviorally adjacent but its UX surface (e.g. host-write confirm flow) is still maturing; promoting it is a separate decision.
- See `scripts/context-gateway-review-plan.md` PR-4 for the original audit context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)