### PR TITLE
fix(web): gate Sync All settings hop on uiMode=dev (PR #488 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -74,12 +74,17 @@ async function loadCtxOverview() {
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Failed to load overview');
     const data = await res.json();
 
+    // The settings (hooks-sync) card links into a dev-only section and its
+    // sync endpoint lives on the dev-only ``settings_sync`` router. Skip it
+    // in prod so users don't see a card that navigates nowhere.
     const types = [
       { key: 'skills',   label: t('settings.ctx.skills_title', 'Skills'),   section: 'ctx-skills' },
       { key: 'commands', label: t('settings.ctx.commands_title', 'Commands'), section: 'ctx-commands' },
       { key: 'agents',   label: t('settings.ctx.agents_title', 'Agents'),   section: 'ctx-agents' },
-      { key: 'settings', label: t('settings.hooks.title', 'Settings'),      section: 'hooks-sync' },
     ];
+    if (STATE.uiMode === 'dev') {
+      types.push({ key: 'settings', label: t('settings.hooks.title', 'Settings'), section: 'hooks-sync' });
+    }
 
     let html = '<div class="ctx-overview-grid">';
     for (const typ of types) {
@@ -124,9 +129,14 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
       const resp = await fetch(`/api/context/${typ}/sync`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
       if (!resp.ok) throw new Error(`Sync ${typ} failed`);
     }
-    // Settings hooks sync (additive merge)
-    const settingsResp = await fetch('/api/context/settings/sync', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
-    if (!settingsResp.ok) throw new Error('Settings sync failed');
+    // Settings hooks sync (additive merge) — the ``settings_sync`` router
+    // stays dev-only, so the endpoint returns 404 in prod and the user has
+    // no Settings tab to drive a manual sync from. Skip it here so "Sync
+    // All" doesn't fail with the artifact fanout already complete.
+    if (STATE.uiMode === 'dev') {
+      const settingsResp = await fetch('/api/context/settings/sync', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      if (!settingsResp.ok) throw new Error('Settings sync failed');
+    }
     showToast(t('settings.ctx.sync_success', 'Sync completed'));
     loadCtxOverview();
   } catch (err) {

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -269,9 +269,12 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     # settings_sync router stays dev-only — so the "Sync All" button and
     # the overview's settings card must self-gate, otherwise prod users
     # would see "Settings sync failed" after a successful artifact fanout.
+    # Both gates use the same predicate, so a count assertion catches a
+    # future refactor that drops one gate while leaving the other.
     cg_js = _read_static("context-gateway.js")
-    assert "STATE.uiMode === 'dev'" in cg_js, (
-        "context-gateway.js lost the dev-only gate around settings_sync"
+    assert cg_js.count("STATE.uiMode === 'dev'") >= 2, (
+        "context-gateway.js lost one of the two dev-only gates around "
+        "settings_sync (overview card push + Sync All settings hop)"
     )
     # And the locale entries themselves are pinned so a rename doesn't go
     # unnoticed by the i18n completeness check.

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -265,6 +265,14 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     assert "const devMode = STATE.uiMode === 'dev'" in js, (
         "Home dashboard lost its dev-only fetch gate"
     )
+    # The Context Gateway (Artifact Sync) tab graduated to prod, but the
+    # settings_sync router stays dev-only — so the "Sync All" button and
+    # the overview's settings card must self-gate, otherwise prod users
+    # would see "Settings sync failed" after a successful artifact fanout.
+    cg_js = _read_static("context-gateway.js")
+    assert "STATE.uiMode === 'dev'" in cg_js, (
+        "context-gateway.js lost the dev-only gate around settings_sync"
+    )
     # And the locale entries themselves are pinned so a rename doesn't go
     # unnoticed by the i18n completeness check.
     en = _read_static("locales/en.json")


### PR DESCRIPTION
## Summary

Regression caught during functional testing of #488. The Context Gateway tabs ship in the prod surface now, but two code paths in `context-gateway.js` reach into the still-dev-only `settings_sync` router:

1. **Sync All button** (`context-gateway.js:124`) — after fanning out skills/commands/agents successfully, it `POST`s `/api/context/settings/sync`. That endpoint lives on the dev-only router, so prod returns 404 and the button toasts `"Settings sync failed"` even though the artifact fanout already completed. The user sees a red error after a successful sync.
2. **Overview's 4th card** — labelled "Settings", links into the `hooks-sync` section. `hooks-sync` is hidden in prod (still dev-only by design), so clicking the card navigates to a tab that isn't rendered.

Both paths now self-gate on `STATE.uiMode === 'dev'`, matching the established pattern in `app.js:657-690` for the Home dashboard's namespaces/sessions/scratch fetches. Prod users get a clean 3-card overview (skills/commands/agents) and a Sync All button that completes silently against the artifacts they have a UI for.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check` — clean
- [x] `uv run pytest packages/memtomem/tests/test_web_mode.py` — 31 passed, including new pin
- [x] **Pin test** added: `test_app_js_pins_ui_mode_default_and_toast_copy` now also asserts `context-gateway.js` contains the `STATE.uiMode === 'dev'` gate. Same source-grep style as the existing app.js pins (no JS runtime in CI).
- [x] **End-to-end via Playwright** against isolated `mm web` (HOME override + fixture project under `/tmp`):
  - Prod overview renders 3 cards (skills, commands, agents); no settings card.
  - Sync All in prod: toasts "동기화 완료" / "Sync completed" — no `Settings sync failed` error.
  - Filesystem outcome verified: `.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `.codex/agents/*.toml` (project-scope per #483), `.gemini/agents/`. No HOME pollution.

## Related

- Caught in functional review of #488 — the PR's smoke test verified routes mount, but didn't drive the Sync All workflow that crosses into the dev-only sibling router.
- Memory `feedback_tier2_web_gating_deferred.md` keeps `settings_sync` in `_DEV_ONLY_ROUTERS` intentionally; this fix is the cheap UX patch rather than promoting another router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)