### PR TITLE
release: v0.1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.31] — 2026-04-26
+
 ### Added
 
 - **Web UI Context Gateway tabs (Artifact Sync, Skills, Commands,
@@ -116,6 +118,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
     rather than the session scope, since their value is tagging
     ingested content by source.
 
+### Fixed
+
 - **`mm context` round-trip no longer silently drops `## <Agent>-Specific`
   sections.** `extract_sections_from_agent_file` mapped agent-override
   headings (`## Claude-Specific`, `## Cursor-Specific`,
@@ -146,6 +150,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `agent-runtime:<agent-id>` for non-default agents; otherwise
   `default`. `mm session start` also echoes the resolved namespace so
   users can verify before continuing.
+
+- **`mm web` Sync All button no longer toasts "Settings sync failed"
+  in `prod` mode.** Follow-up to the #488 Context Gateway tabs prod
+  graduation. The "Sync All" overview button fanned out to
+  `/api/context/settings/sync` (the settings-hook merge), but that
+  router intentionally stays dev-only; in `prod` the hop returned 404
+  and the whole button toasted failure even though the artifact
+  fanout (skills / commands / agents) succeeded — making the prod
+  surface look broken. The same shape hit the overview's 4th
+  "Settings" card, which deep-linked into the dev-only `hooks-sync`
+  section, so clicking the card landed on a dead tab. Both code
+  paths now self-gate on `STATE.uiMode === 'dev'` (matching the Home
+  dashboard pattern); prod gets a clean 3-card overview and a Sync
+  All that completes silently for the artifacts it actually has a UI
+  for. JS pin tightened to count both gate sites so a future
+  refactor can't silently drop one. (PR #489)
 
 ## [0.1.30] — 2026-04-26
 

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.30"
+version = "0.1.31"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.30"
+version = "0.1.31"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bundles the multi-agent surface fixes (gaps **G1** + **G2** from the
2026-04-26 multi-agent surface review) with the **Web UI Context
Gateway prod-tier graduation** and its follow-up Sync All gate.

| PR | Class | Description |
|---|---|---|
| #487 | **BREAKING** | `mem_add` / `mem_batch_add` / `mem_index` / `mem_fetch` inherit agent scope from `mem_session_start` (G1, RFC Option B). |
| #483 | **BREAKING** | `mm context sync` writes Codex sub-agents to project-scope `.codex/agents/` (was user-scope `~/.codex/`). |
| #488 | Added | Context Gateway tabs (Artifact Sync, Skills, Commands, Agents) graduate from `--dev` to prod surface. |
| #484 | Added | `mm context {generate,sync} --include=settings` confirms before writing settings files outside the project root. |
| #485 | Fixed (G2) | `mm session start` / `mm session wrap` derive `agent-runtime:<id>` namespace from `--agent-id`. |
| #482 | Fixed | `mm context` round-trip no longer drops `## <Agent>-Specific` sections. |
| #489 | Fixed | `mm web` Sync All no longer toasts "Settings sync failed" in prod (`#488` follow-up). |

## Migration notes

**G1 (#487)** changes write-side namespace resolution for callers that already
use `mem_session_start(agent_id="...")`:

- Pre-multi-agent users (no `mem_session_start`): unaffected.
- Multi-agent users using only `mem_session_start`: writes finally land in
  `agent-runtime:<id>` (the documented contract).
- Rare combination — both `mem_ns_set` and `mem_session_start` set in the
  same session: write target shifts from the `mem_ns_set` namespace to the
  agent's namespace. Pass `namespace="<old-ns>"` explicitly to keep the old
  destination, or call `mem_session_end()` before writing.

**Codex agents (#483)**: existing `~/.codex/agents/` files are left in place;
memtomem just stops writing there. To migrate a personal agent into a
project: `cp ~/.codex/agents/<name>.toml <project>/.codex/agents/`. Full
migration steps are in the CHANGELOG entry.

## Release mechanics

- 3-file split-PR (pyproject + uv.lock + CHANGELOG); per
  `project_release_workflow.md`.
- Behavior-change release → **TestPyPI dry-run** before production tag.
- Same-sha `pypi` env approval persistence (per v0.1.30 verification): if
  the dry-run and production tags point at the same merge commit, the
  production deployment skips the manual approval gate.

## Test plan

- [x] `uv run pytest -m "not ollama"` — green pre-merge (verified for each
  bundled PR; no test changes in this release prep commit).
- [x] `uv run ruff check` + `ruff format --check` — clean (no source
  changes).
- [ ] Post-merge: `git tag test-v0.1.31a1 <sha>` → push → `pypi` env
  approve → TestPyPI verify.
- [ ] After dry-run: `git tag v0.1.31 <sha>` → push (same sha → auto-skip
  approval) → PyPI verify → `gh release create v0.1.31`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
