### PR TITLE
fix: validate agent_id before agent-runtime namespace concat (CLI + MCP)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import click
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, InvalidNameError, validate_agent_id
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +78,10 @@ def session() -> None:
 @click.option("--namespace", "-n", default=None, help="Namespace for session")
 def start(agent_id: str, title: str | None, namespace: str | None) -> None:
     """Start a new session and save its ID to ~/.memtomem/.current_session."""
+    try:
+        validate_agent_id(agent_id)
+    except InvalidNameError as e:
+        raise click.ClickException(str(e)) from e
     try:
         asyncio.run(_start(agent_id, title, namespace))
     except click.ClickException:
@@ -337,6 +341,11 @@ def wrap(agent_id: str, title: str | None, command: tuple[str, ...]) -> None:
     """
     import subprocess
     import sys
+
+    try:
+        validate_agent_id(agent_id)
+    except InvalidNameError as e:
+        raise click.ClickException(str(e)) from e
 
     # Start session
     session_id = str(uuid.uuid4())

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 from typing import Final
 
+from memtomem.context._names import InvalidNameError as InvalidNameError
+from memtomem.context._names import validate_name
+
 # Multi-agent buckets. The ``agent-runtime:<agent-id>`` namespace is a
 # *convenience* isolation boundary, not a security boundary — see the
 # multi-agent guide for the threat model. Provider-ingestion namespace
@@ -19,8 +22,34 @@ from typing import Final
 # stay as locally-defined literals in ``cli/ingest_cmd.py`` for now;
 # promoting them here belongs in the same change that wires them up,
 # not this PR.
+#
+# ``agent_id`` is interpolated directly into ``AGENT_NAMESPACE_PREFIX``
+# without further escaping, so every entry point that builds an
+# agent-runtime namespace MUST first run ``validate_agent_id`` on the
+# user-provided id. Accepted charset: ``[A-Za-z0-9._-]`` (1–64 chars,
+# no leading dash, not ``"."`` / ``".."``). Rejecting ``:``, ``/``,
+# ``..``, whitespace, and control characters keeps malformed-but-stored
+# values like ``"agent-runtime:foo:bar"`` from round-tripping into
+# storage and search.
 AGENT_NAMESPACE_PREFIX: Final[str] = "agent-runtime:"
 SHARED_NAMESPACE: Final[str] = "shared"
+
+
+def validate_agent_id(value: object) -> str:
+    """Return *value* unchanged if it is a valid agent identifier.
+
+    Used at every boundary that concatenates ``AGENT_NAMESPACE_PREFIX``
+    with a caller-supplied agent id (``mem_session_start``,
+    ``mm session start``, ``mm session wrap``). Raises
+    :class:`InvalidNameError` (a ``ValueError`` subclass, surfaced by
+    ``tool_handler`` as ``"Error: ..."`` on the MCP path and as a
+    ``ClickException`` on the CLI path) when the id contains ``:``,
+    ``/``, ``..``, whitespace, control characters, or anything outside
+    the canonical ``[A-Za-z0-9._-]`` charset documented above.
+    """
+
+    return validate_name(value, kind="agent-id")
+
 
 # Default ``system_namespace_prefixes`` — namespaces matching any of these
 # prefixes are excluded from default ``mem_search`` (``namespace=None``)

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -38,14 +38,25 @@ SHARED_NAMESPACE: Final[str] = "shared"
 def validate_agent_id(value: object) -> str:
     """Return *value* unchanged if it is a valid agent identifier.
 
-    Used at every boundary that concatenates ``AGENT_NAMESPACE_PREFIX``
-    with a caller-supplied agent id (``mem_session_start``,
-    ``mm session start``, ``mm session wrap``). Raises
-    :class:`InvalidNameError` (a ``ValueError`` subclass, surfaced by
-    ``tool_handler`` as ``"Error: ..."`` on the MCP path and as a
-    ``ClickException`` on the CLI path) when the id contains ``:``,
-    ``/``, ``..``, whitespace, control characters, or anything outside
-    the canonical ``[A-Za-z0-9._-]`` charset documented above.
+    Applied at the MCP + CLI session-start surfaces that build an
+    ``agent-runtime:<agent_id>`` namespace from caller input —
+    ``mem_session_start``, ``mm session start``, ``mm session wrap``.
+    Raises :class:`InvalidNameError` (a ``ValueError`` subclass,
+    surfaced by ``tool_handler`` as ``"Error: ..."`` on the MCP path
+    and as a ``ClickException`` on the CLI path) when the id contains
+    ``:``, ``/``, ``..``, whitespace, control characters, or anything
+    outside the canonical ``[A-Za-z0-9._-]`` charset documented above.
+
+    Not yet applied at:
+
+    * the LangGraph adapter
+      (``integrations.langgraph.MemtomemStore.start_agent_session`` and
+      ``MemtomemCheckpointer.namespace_for``), which currently trusts
+      in-process callers — see the issue tracker for the parity
+      follow-up;
+    * the ``mem_agent_register`` / ``mem_agent_search`` tools, which
+      still ``sanitize_namespace_segment`` rather than validate. Same
+      tracker.
     """
 
     return validate_name(value, kind="agent-id")

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, validate_agent_id
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -94,6 +94,7 @@ async def mem_session_start(
         namespace: Session namespace. When omitted and ``agent_id`` is
             non-default, defaults to ``agent-runtime:<agent_id>``.
     """
+    validate_agent_id(agent_id)
     app = await _get_app_initialized(ctx)
     session_id = str(uuid4())
     if namespace:

--- a/packages/memtomem/tests/test_validate_agent_id.py
+++ b/packages/memtomem/tests/test_validate_agent_id.py
@@ -1,0 +1,248 @@
+"""Tests for ``validate_agent_id`` and its enforcement at the CLI + MCP
+boundaries that build ``agent-runtime:<agent_id>`` namespaces.
+
+Covers the gate added in #486 — without validation, hostile-shaped values
+like ``"foo:bar"`` or ``"../x"`` round-trip into storage as malformed
+namespace strings (e.g. ``"agent-runtime:foo:bar"``). Both ``mm session
+start`` / ``mm session wrap`` (CLI) and ``mem_session_start`` (MCP) must
+reject the same set with an identical core error message so fixing one
+surface doesn't leave the other open.
+
+Charset coverage for the underlying ``validate_name`` lives in
+``test_context_names.py``; this file pins the **wiring**: that the
+validator is actually called at every entry point that concatenates
+``AGENT_NAMESPACE_PREFIX`` with caller input, and that the storage layer
+never sees a malformed namespace from either surface.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.constants import InvalidNameError, validate_agent_id
+from memtomem.server.context import AppContext
+from memtomem.server.tools.session import mem_session_start
+
+# Hostile-shaped values that must be rejected at every boundary. Each
+# value would otherwise concatenate into a malformed namespace
+# (``agent-runtime:foo:bar``, ``agent-runtime:../etc``, etc.) and
+# round-trip into storage / search.
+HOSTILE_AGENT_IDS = [
+    "foo:bar",  # collides with the namespace separator
+    "../x",  # path traversal
+    "..",  # reserved path token
+    "a/b",  # path separator
+    "a\\b",  # windows-style separator
+    "  spaces  ",  # surrounding whitespace
+    "a b",  # internal whitespace
+    "a​b",  # zero-width space
+    "a\x00b",  # null byte
+    "a\nb",  # newline
+    "-leading-dash",  # collides with click flag parsing
+    "",  # empty
+    "   ",  # all whitespace
+]
+
+
+class _StubCtx:
+    """Minimal stand-in for MCP ``Context`` so async tools can be invoked
+    directly. Mirrors the helper in ``test_sessions``.
+    """
+
+    def __init__(self, app: AppContext) -> None:
+        class _RC:
+            pass
+
+        self.request_context = _RC()
+        self.request_context.lifespan_context = app
+
+
+# ---------------------------------------------------------------------------
+# validate_agent_id (thin wrapper around validate_name)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_agent_id_accepts_canonical_charset() -> None:
+    for value in ("planner", "agent-1", "v2.0", "claude_code", "default"):
+        assert validate_agent_id(value) == value
+
+
+@pytest.mark.parametrize("value", HOSTILE_AGENT_IDS)
+def test_validate_agent_id_rejects_hostile_inputs(value: str) -> None:
+    with pytest.raises(InvalidNameError, match="invalid agent-id"):
+        validate_agent_id(value)
+
+
+# ---------------------------------------------------------------------------
+# MCP boundary — mem_session_start
+# ---------------------------------------------------------------------------
+
+
+class TestMcpBoundary:
+    """``mem_session_start`` must reject malformed agent_ids before any
+    namespace concatenation reaches storage. ``tool_handler`` surfaces the
+    ``InvalidNameError`` (a ``ValueError`` subclass) as ``"Error: ..."``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_colon_in_agent_id_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+        assert out.startswith("Error: invalid agent-id")
+        assert "'foo:bar'" in out
+
+    @pytest.mark.asyncio
+    async def test_malformed_namespace_never_reaches_storage(self, components):
+        """Regression pin: ``agent-runtime:foo:bar`` must not appear in any
+        session row even if validation regresses to a warning.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+        rows = await app.storage.list_sessions()
+        assert not any("agent-runtime:foo:bar" in (r["namespace"] or "") for r in rows)
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("agent_id", HOSTILE_AGENT_IDS)
+    async def test_hostile_agent_ids_all_rejected(self, components, agent_id):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(agent_id=agent_id, ctx=ctx)  # type: ignore[arg-type]
+
+        assert out.startswith("Error: invalid agent-id")
+
+    @pytest.mark.asyncio
+    async def test_valid_agent_id_still_succeeds(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        assert "Session started" in out
+        assert app.current_agent_id == "planner"
+
+
+# ---------------------------------------------------------------------------
+# CLI boundary — mm session start / mm session wrap
+# ---------------------------------------------------------------------------
+
+
+def _patched_cli_components(comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def storage_mock():
+    """Mock storage that fails loudly if any session-creating call lands —
+    the validation gate must short-circuit before storage is ever touched
+    on the rejection path.
+    """
+    return SimpleNamespace(
+        create_session=AsyncMock(),
+        end_session=AsyncMock(),
+        get_session_events=AsyncMock(return_value=[]),
+    )
+
+
+class TestCliBoundary:
+    def test_session_start_rejects_colon(self, runner, monkeypatch, storage_mock):
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "start", "--agent-id", "foo:bar"])
+
+        assert result.exit_code != 0
+        assert "invalid agent-id" in result.output
+        assert "'foo:bar'" in result.output
+        # Regression pin: storage never received a malformed namespace.
+        storage_mock.create_session.assert_not_called()
+
+    def test_session_start_rejects_path_traversal(self, runner, monkeypatch, storage_mock):
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "start", "--agent-id", "../etc"])
+
+        assert result.exit_code != 0
+        assert "invalid agent-id" in result.output
+        storage_mock.create_session.assert_not_called()
+
+    def test_session_wrap_rejects_colon_before_subprocess(self, runner, monkeypatch, storage_mock):
+        """``mm session wrap`` must fail BEFORE the wrapped command runs —
+        otherwise an invalid agent_id leaves a half-set state file plus a
+        rogue child process, and the user only sees a Warning.
+        """
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        # Use ``--`` to hand the rest to the wrapped command. ``echo`` is
+        # benign but if it ever runs, the test would still pass — what we
+        # actually pin is that storage never saw the malformed namespace
+        # AND the exit code is non-zero (Click's ClickException, not the
+        # subprocess's exit code).
+        result = runner.invoke(
+            cli, ["session", "wrap", "--agent-id", "foo:bar", "--", "echo", "hi"]
+        )
+
+        assert result.exit_code != 0
+        assert "invalid agent-id" in result.output
+        storage_mock.create_session.assert_not_called()
+
+    def test_session_start_accepts_valid_agent_id(self, runner, monkeypatch, storage_mock):
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["session", "start", "--agent-id", "planner"])
+
+        assert result.exit_code == 0, result.output
+        storage_mock.create_session.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface error parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cli_and_mcp_share_core_error_text(components, monkeypatch):
+    """The CLI and MCP surfaces must produce the same identifying text
+    so users (and log scrapers) see one error shape regardless of how the
+    request entered the system. Both wrap a common ``InvalidNameError``
+    message; only the framing prefix (``Error:`` from Click vs.
+    ``Error:`` from ``tool_handler``) differs.
+    """
+    app = AppContext.from_components(components)
+    ctx = _StubCtx(app)
+    mcp_out = await mem_session_start(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+    storage = SimpleNamespace(create_session=AsyncMock())
+    comp = SimpleNamespace(storage=storage)
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+    cli_result = CliRunner().invoke(cli, ["session", "start", "--agent-id", "foo:bar"])
+
+    core = "invalid agent-id 'foo:bar'"
+    assert core in mcp_out
+    assert core in cli_result.output

--- a/packages/memtomem/tests/test_validate_agent_id.py
+++ b/packages/memtomem/tests/test_validate_agent_id.py
@@ -41,7 +41,7 @@ HOSTILE_AGENT_IDS = [
     "a\\b",  # windows-style separator
     "  spaces  ",  # surrounding whitespace
     "a b",  # internal whitespace
-    "a​b",  # zero-width space
+    "a\u200bb",  # zero-width space — escape sequence so it isn't an invisible source artifact
     "a\x00b",  # null byte
     "a\nb",  # newline
     "-leading-dash",  # collides with click flag parsing
@@ -195,14 +195,22 @@ class TestCliBoundary:
         otherwise an invalid agent_id leaves a half-set state file plus a
         rogue child process, and the user only sees a Warning.
         """
+        import subprocess
+        from unittest.mock import MagicMock
+
         comp = SimpleNamespace(storage=storage_mock)
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
 
-        # Use ``--`` to hand the rest to the wrapped command. ``echo`` is
-        # benign but if it ever runs, the test would still pass — what we
-        # actually pin is that storage never saw the malformed namespace
-        # AND the exit code is non-zero (Click's ClickException, not the
-        # subprocess's exit code).
+        # Pin the contract directly: ``subprocess.run`` is not invoked
+        # on the rejection path. Without this, we'd only be observing
+        # that storage stayed clean — subprocess could still launch and
+        # leave a rogue child plus the half-set state file the docstring
+        # warns about. ``mm session wrap`` does ``import subprocess``
+        # inside the function, so patching the module attribute lands
+        # before the lazy import resolves it.
+        run_mock = MagicMock()
+        monkeypatch.setattr(subprocess, "run", run_mock)
+
         result = runner.invoke(
             cli, ["session", "wrap", "--agent-id", "foo:bar", "--", "echo", "hi"]
         )
@@ -210,6 +218,7 @@ class TestCliBoundary:
         assert result.exit_code != 0
         assert "invalid agent-id" in result.output
         storage_mock.create_session.assert_not_called()
+        run_mock.assert_not_called()
 
     def test_session_start_accepts_valid_agent_id(self, runner, monkeypatch, storage_mock):
         comp = SimpleNamespace(storage=storage_mock)


### PR DESCRIPTION
## Summary

- Add ``validate_agent_id`` in ``constants.py`` (thin wrapper around ``validate_name(value, kind="agent-id")``).
- Wire it into all three entry points that concatenate ``AGENT_NAMESPACE_PREFIX`` with caller input: ``mem_session_start`` (MCP), ``mm session start``, and ``mm session wrap`` (CLI).
- Pin the wiring + the regression contract in ``test_validate_agent_id``: ``"agent-runtime:foo:bar"`` cannot reach storage from either surface.

## Why

PR #485 review (item 2) flagged that ``f"{AGENT_NAMESPACE_PREFIX}{agent_id}"`` does no input validation. Hostile-shaped values (``foo:bar``, ``../x``, ``  spaces``, control chars) round-trip into storage as malformed namespace strings. The CLI mirrored the gap from the MCP path so a single-surface fix would leave the other open.

Single boundary, single charset, single error message: ``[A-Za-z0-9._-]`` (1–64 chars, no leading dash, not ``"."`` / ``".."``). MCP path raises an ``InvalidNameError`` (a ``ValueError`` subclass) which ``tool_handler`` formats as ``"Error: invalid agent-id 'foo:bar': ..."``; CLI path converts the same exception to a ``ClickException`` with the identical core text.

``mm session wrap`` validates **before** the wrapped subprocess runs so an invalid agent_id never leaves a half-set ``.current_session`` file or a rogue child.

## Out of scope

- Renaming or migrating any agent_ids users may have already stored — this is a forward gate only.
- Tightening ``mem_agent_register`` / ``mem_agent_search`` (which still ``sanitize_namespace_segment`` rather than ``validate_*``); the issue scopes this PR to the session-start surfaces, and changing the multi_agent tools' silently-mutating behavior is a separate UX call.

## Test plan

- [x] ``uv run pytest -m "not ollama"`` — 2554 passed, 46 deselected (ollama).
- [x] ``uv run ruff check`` + ``ruff format --check`` on ``src/`` and ``tests/`` — clean.
- [x] New ``test_validate_agent_id``:
  - charset acceptance + 13 hostile-input rejections at the validator
  - MCP boundary: ``mem_session_start(agent_id="foo:bar")`` returns ``"Error: invalid agent-id ..."`` and storage stays empty
  - CLI boundary: ``mm session start --agent-id "foo:bar"`` exits non-zero, storage mock confirms ``create_session`` was never called
  - ``mm session wrap`` rejects before the wrapped command can run
  - cross-surface parity: both surfaces produce the same ``"invalid agent-id 'foo:bar'"`` core text

Closes #486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)