### PR TITLE
fix: validate agent_id at mem_agent_register / search and `mm agent register` (#493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **`mem_agent_register`, `mem_agent_search`, and `mm agent register`
+  now reject malformed `agent_id` values loudly instead of silently
+  rewriting them.** PR #491 had wired `validate_agent_id` into the
+  three session-start surfaces (`mem_session_start` / `mm session
+  start` / `mm session wrap`) so a hostile shape like `"foo:bar"` or
+  `"../x"` raised
+  `Error: invalid agent-id 'foo:bar': must match [A-Za-z0-9._-]+ ...`.
+  The matching multi-agent registration / search surfaces still ran
+  `sanitize_namespace_segment`, so the same input produced two UX
+  outcomes depending on which tool the caller hit first — registering
+  an agent rewrote the id in place under `agent-runtime:foo_bar`,
+  while starting a session for that same id rejected it. The read /
+  write contract is now symmetric: an `agent_id` either works on
+  every surface or fails on every surface, with the same
+  `invalid agent-id 'X'` error fragment regardless of entry point.
+
+  **Migration:** callers passing values that were previously rewritten
+  (anything containing `:`, `/`, `..`, whitespace, or characters
+  outside `[A-Za-z0-9._-]`) will now see a hard error. Those callers
+  were already storing memories under unexpected namespaces — pick a
+  canonical id matching the documented charset and re-register. The
+  LangGraph adapter parity gap remains tracked separately. Closes #493.
+
 ## [0.1.31] — 2026-04-26
 
 ### Added

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING
 
 import click
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
+from memtomem.constants import (
+    AGENT_NAMESPACE_PREFIX,
+    SHARED_NAMESPACE,
+    InvalidNameError,
+    validate_agent_id,
+)
 
 if TYPE_CHECKING:
     from memtomem.storage.sqlite_backend import SqliteBackend
@@ -97,28 +102,30 @@ def register(agent_id: str, description: str | None, color: str | None) -> None:
     Mirrors the ``mem_agent_register`` MCP tool so operators don't have to
     spin up an MCP client for one-off agent setup. Also ensures the
     cross-agent ``shared`` namespace exists.
+
+    ``agent_id`` is validated against the canonical ``[A-Za-z0-9._-]``
+    charset (same gate as ``mm session start``); hostile shapes like
+    ``foo:bar`` or ``../x`` are rejected loudly rather than silently
+    sanitised.
     """
+    try:
+        validate_agent_id(agent_id)
+    except InvalidNameError as e:
+        raise click.ClickException(str(e)) from e
     asyncio.run(_run_register(agent_id, description, color))
 
 
 async def _run_register(agent_id: str, description: str | None, color: str | None) -> None:
     from memtomem.cli._bootstrap import cli_components
-    from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
-    if not agent_id or not agent_id.strip():
-        raise click.ClickException("agent_id must be non-empty.")
-    sanitized = sanitize_namespace_segment(agent_id)
-    if not sanitized:
-        raise click.ClickException("agent_id must contain at least one allowed character.")
-
-    namespace = f"{_CURRENT_PREFIX}{sanitized}"
+    namespace = f"{_CURRENT_PREFIX}{agent_id}"
     async with cli_components() as comp:
         await comp.storage.set_namespace_meta(namespace, description=description, color=color)
         if await comp.storage.get_namespace_meta(SHARED_NAMESPACE) is None:
             await comp.storage.set_namespace_meta(
                 SHARED_NAMESPACE, description="Shared knowledge base for all agents"
             )
-    click.echo(f"Agent registered: {sanitized}")
+    click.echo(f"Agent registered: {agent_id}")
     click.echo(f"- Namespace: {namespace}")
     click.echo(f"- Shared namespace: {SHARED_NAMESPACE}")
 

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -38,25 +38,26 @@ SHARED_NAMESPACE: Final[str] = "shared"
 def validate_agent_id(value: object) -> str:
     """Return *value* unchanged if it is a valid agent identifier.
 
-    Applied at the MCP + CLI session-start surfaces that build an
-    ``agent-runtime:<agent_id>`` namespace from caller input —
-    ``mem_session_start``, ``mm session start``, ``mm session wrap``.
+    Applied at every surface that concatenates ``AGENT_NAMESPACE_PREFIX``
+    with caller input. Session-start: ``mem_session_start`` (MCP),
+    ``mm session start`` / ``mm session wrap`` (CLI),
+    ``integrations.langgraph.MemtomemStore.start_agent_session``
+    (Python adapter). Multi-agent registration / search:
+    ``mem_agent_register`` / ``mem_agent_search`` (MCP), ``mm agent
+    register`` (CLI).
+
     Raises :class:`InvalidNameError` (a ``ValueError`` subclass,
     surfaced by ``tool_handler`` as ``"Error: ..."`` on the MCP path
     and as a ``ClickException`` on the CLI path) when the id contains
     ``:``, ``/``, ``..``, whitespace, control characters, or anything
     outside the canonical ``[A-Za-z0-9._-]`` charset documented above.
 
-    Not yet applied at:
-
-    * the LangGraph adapter
-      (``integrations.langgraph.MemtomemStore.start_agent_session`` and
-      ``MemtomemCheckpointer.namespace_for``), which currently trusts
-      in-process callers — see the issue tracker for the parity
-      follow-up;
-    * the ``mem_agent_register`` / ``mem_agent_search`` tools, which
-      still ``sanitize_namespace_segment`` rather than validate. Same
-      tracker.
+    The read/write contract is symmetric: an id either works on every
+    surface or fails on every surface. Pre-#493 the multi-agent surfaces
+    silently called ``sanitize_namespace_segment`` instead, which let
+    hostile shapes round-trip into storage under a rewritten namespace
+    while ``mem_session_start`` rejected the same shape — see issue
+    tracker history for the breaking-change note.
     """
 
     return validate_name(value, kind="agent-id")

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -38,11 +38,10 @@ SHARED_NAMESPACE: Final[str] = "shared"
 def validate_agent_id(value: object) -> str:
     """Return *value* unchanged if it is a valid agent identifier.
 
-    Applied at every surface that concatenates ``AGENT_NAMESPACE_PREFIX``
-    with caller input. Session-start: ``mem_session_start`` (MCP),
-    ``mm session start`` / ``mm session wrap`` (CLI),
-    ``integrations.langgraph.MemtomemStore.start_agent_session``
-    (Python adapter). Multi-agent registration / search:
+    Applied at every MCP + CLI surface that concatenates
+    ``AGENT_NAMESPACE_PREFIX`` with caller input. Session-start:
+    ``mem_session_start`` (MCP), ``mm session start`` /
+    ``mm session wrap`` (CLI). Multi-agent registration / search:
     ``mem_agent_register`` / ``mem_agent_search`` (MCP), ``mm agent
     register`` (CLI).
 
@@ -52,12 +51,19 @@ def validate_agent_id(value: object) -> str:
     ``:``, ``/``, ``..``, whitespace, control characters, or anything
     outside the canonical ``[A-Za-z0-9._-]`` charset documented above.
 
-    The read/write contract is symmetric: an id either works on every
-    surface or fails on every surface. Pre-#493 the multi-agent surfaces
-    silently called ``sanitize_namespace_segment`` instead, which let
-    hostile shapes round-trip into storage under a rewritten namespace
-    while ``mem_session_start`` rejected the same shape — see issue
-    tracker history for the breaking-change note.
+    The read/write contract is symmetric across the MCP + CLI surfaces
+    listed above: an id either works on every surface or fails on
+    every surface. Pre-#493 the multi-agent surfaces silently called
+    ``sanitize_namespace_segment`` instead, which let hostile shapes
+    round-trip into storage under a rewritten namespace while
+    ``mem_session_start`` rejected the same shape — see the
+    ``Changed (BREAKING)`` entry in ``CHANGELOG.md`` (Unreleased) and
+    issue #493 for the migration note.
+
+    Not yet applied at the LangGraph adapter
+    (``integrations.langgraph.MemtomemStore.start_agent_session`` and
+    the agent-runtime concat sites in ``MemtomemStore``), which still
+    trusts in-process callers — tracked as issue #492.
     """
 
     return validate_name(value, kind="agent-id")

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 import logging
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE, validate_agent_id
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.tool_registry import register
-from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
 logger = logging.getLogger(__name__)
 
@@ -63,16 +62,19 @@ async def mem_agent_register(
     optionally registers metadata. If the agent is already registered,
     updates metadata.
 
+    ``agent_id`` must match the canonical ``[A-Za-z0-9._-]`` charset used
+    everywhere else that builds an ``agent-runtime:`` namespace; hostile
+    shapes like ``"foo:bar"`` or ``"../x"`` are rejected loudly rather
+    than silently sanitised. This keeps the read/write contract symmetric
+    with ``mem_session_start`` so the same id either works on every
+    surface or fails on every surface.
+
     Args:
         agent_id: Unique identifier for the agent
         description: Optional description of the agent's role
         color: Optional color hex code for UI display
     """
-    if not agent_id or not agent_id.strip():
-        return "Error: agent_id must be non-empty."
-    agent_id = sanitize_namespace_segment(agent_id)
-    if not agent_id:
-        return "Error: agent_id must contain at least one allowed character."
+    validate_agent_id(agent_id)
     app = await _get_app_initialized(ctx)
     namespace = f"{AGENT_NAMESPACE_PREFIX}{agent_id}"
 
@@ -109,18 +111,21 @@ async def mem_agent_search(
     Searches the agent's private namespace and optionally the shared
     namespace, merging results by relevance.
 
+    When ``agent_id`` is supplied it must match the canonical
+    ``[A-Za-z0-9._-]`` charset enforced at registration / session start;
+    hostile shapes are rejected loudly so a typoed lookup can't quietly
+    fall back to "search everything". Pass ``None`` to use the active
+    session's agent (set by ``mem_session_start``) or the legacy
+    ``current_namespace`` fallback.
+
     Args:
         query: Search query
         agent_id: Agent ID to search (omit for current agent)
         include_shared: Also search the shared namespace (default True)
         top_k: Maximum results to return
     """
-    if agent_id is not None and not agent_id.strip():
-        return "Error: agent_id must be non-empty if provided."
     if agent_id is not None:
-        agent_id = sanitize_namespace_segment(agent_id)
-        if not agent_id:
-            return "Error: agent_id must contain at least one allowed character."
+        validate_agent_id(agent_id)
     app = await _get_app_initialized(ctx)
     from memtomem.server.formatters import _format_results
 

--- a/packages/memtomem/tests/test_agent_cmd.py
+++ b/packages/memtomem/tests/test_agent_cmd.py
@@ -136,13 +136,17 @@ class TestAgentRegister:
         assert comp.storage.set_namespace_meta.await_args_list[0].args[0] == "agent-runtime:coder"
 
     def test_register_rejects_empty_agent_id(self, monkeypatch):
+        # Whitespace-only ids fail at ``validate_agent_id`` with the
+        # same shared error vocabulary as ``mem_session_start`` and
+        # ``mm session start`` (issue #493 — read/write parity).
         comp = _registry_components()
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
 
         result = CliRunner().invoke(cli, ["agent", "register", "   "])
 
         assert result.exit_code != 0
-        assert "non-empty" in result.output
+        assert "invalid agent-id" in result.output
+        comp.storage.set_namespace_meta.assert_not_called()
 
 
 class TestAgentList:

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -1,10 +1,14 @@
 """Tests for multi-agent namespace helpers (``mem_agent_*``).
 
-The sanitizer used by ``mem_agent_register`` / ``mem_agent_search`` lives in
-``storage/sqlite_namespace.py`` as ``sanitize_namespace_segment`` — shared
-with the ingest pipeline. These tests pin the behavior the multi-agent tool
-relies on (single-segment `agent_id` sanitization so the generated
-``agent-runtime:{id}`` namespace stays at depth 1).
+``TestSanitizeNamespaceSegment`` pins the behavior of the shared
+``sanitize_namespace_segment`` helper in ``storage/sqlite_namespace.py``,
+which the ingest pipeline still uses for permissively rewriting
+namespace segments derived from filesystem / provider state. As of
+issue #493 the multi-agent tools (``mem_agent_register`` /
+``mem_agent_search`` / ``mm agent register``) no longer route through
+this helper — they call ``validate_agent_id`` instead and reject
+hostile shapes loudly. Wiring for that gate is pinned in
+``test_validate_agent_id.py``; the helper itself is exercised here.
 
 ``TestDefaultIsolation`` pins the multi-agent default search isolation
 behaviour: ``agent-runtime:`` lives in ``system_namespace_prefixes`` by

--- a/packages/memtomem/tests/test_validate_agent_id.py
+++ b/packages/memtomem/tests/test_validate_agent_id.py
@@ -27,6 +27,7 @@ from click.testing import CliRunner
 from memtomem.cli import cli
 from memtomem.constants import InvalidNameError, validate_agent_id
 from memtomem.server.context import AppContext
+from memtomem.server.tools.multi_agent import mem_agent_register, mem_agent_search
 from memtomem.server.tools.session import mem_session_start
 
 # Hostile-shaped values that must be rejected at every boundary. Each
@@ -231,6 +232,143 @@ class TestCliBoundary:
 
 
 # ---------------------------------------------------------------------------
+# MCP boundary — mem_agent_register / mem_agent_search (issue #493)
+# ---------------------------------------------------------------------------
+
+
+class TestMcpMultiAgentBoundary:
+    """``mem_agent_register`` and ``mem_agent_search`` must reject the same
+    hostile shapes as ``mem_session_start`` so the read/write contract
+    stays symmetric (issue #493).
+    """
+
+    @pytest.mark.asyncio
+    async def test_register_colon_in_agent_id_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_register(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+        assert out.startswith("Error: invalid agent-id")
+        assert "'foo:bar'" in out
+
+    @pytest.mark.asyncio
+    async def test_register_malformed_namespace_never_reaches_storage(self, components):
+        """Regression pin: ``agent-runtime:foo:bar`` must not appear as a
+        namespace meta row even if validation regresses to a warning.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_agent_register(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+        rows = await app.storage.list_namespace_meta()
+        assert not any("agent-runtime:foo:bar" in (r.get("namespace") or "") for r in rows)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("agent_id", HOSTILE_AGENT_IDS)
+    async def test_register_hostile_agent_ids_all_rejected(self, components, agent_id):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_register(agent_id=agent_id, ctx=ctx)  # type: ignore[arg-type]
+
+        assert out.startswith("Error: invalid agent-id")
+
+    @pytest.mark.asyncio
+    async def test_register_valid_agent_id_still_succeeds(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_register(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        assert "Agent registered: planner" in out
+        assert "agent-runtime:planner" in out
+
+    @pytest.mark.asyncio
+    async def test_search_colon_in_agent_id_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_search(query="hello", agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+        assert out.startswith("Error: invalid agent-id")
+        assert "'foo:bar'" in out
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("agent_id", HOSTILE_AGENT_IDS)
+    async def test_search_hostile_agent_ids_all_rejected(self, components, agent_id):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_search(query="hello", agent_id=agent_id, ctx=ctx)  # type: ignore[arg-type]
+
+        assert out.startswith("Error: invalid agent-id")
+
+    @pytest.mark.asyncio
+    async def test_search_omitted_agent_id_unaffected(self, components):
+        """``agent_id=None`` is the documented "use session / legacy NS"
+        path — must not trip the validator.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_search(query="nothing-here", agent_id=None, ctx=ctx)  # type: ignore[arg-type]
+
+        # Either "No results found" or a real result list — must NOT be a
+        # validation error. The empty-DB fixture yields no hits.
+        assert not out.startswith("Error:")
+
+
+# ---------------------------------------------------------------------------
+# CLI boundary — mm agent register (issue #493)
+# ---------------------------------------------------------------------------
+
+
+class TestCliAgentRegisterBoundary:
+    @pytest.fixture
+    def agent_storage_mock(self):
+        """Mock storage that fails loudly if any namespace-creating call
+        lands on the rejection path.
+        """
+        return SimpleNamespace(
+            set_namespace_meta=AsyncMock(),
+            get_namespace_meta=AsyncMock(return_value=None),
+        )
+
+    def test_register_rejects_colon(self, runner, monkeypatch, agent_storage_mock):
+        comp = SimpleNamespace(storage=agent_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["agent", "register", "foo:bar"])
+
+        assert result.exit_code != 0
+        assert "invalid agent-id" in result.output
+        assert "'foo:bar'" in result.output
+        agent_storage_mock.set_namespace_meta.assert_not_called()
+
+    def test_register_rejects_path_traversal(self, runner, monkeypatch, agent_storage_mock):
+        comp = SimpleNamespace(storage=agent_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["agent", "register", "../etc"])
+
+        assert result.exit_code != 0
+        assert "invalid agent-id" in result.output
+        agent_storage_mock.set_namespace_meta.assert_not_called()
+
+    def test_register_accepts_valid_agent_id(self, runner, monkeypatch, agent_storage_mock):
+        comp = SimpleNamespace(storage=agent_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["agent", "register", "planner"])
+
+        assert result.exit_code == 0, result.output
+        assert "Agent registered: planner" in result.output
+        agent_storage_mock.set_namespace_meta.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
 # Cross-surface error parity
 # ---------------------------------------------------------------------------
 
@@ -255,3 +393,25 @@ async def test_cli_and_mcp_share_core_error_text(components, monkeypatch):
     core = "invalid agent-id 'foo:bar'"
     assert core in mcp_out
     assert core in cli_result.output
+
+
+@pytest.mark.asyncio
+async def test_session_and_multi_agent_surfaces_share_core_error_text(components):
+    """Issue #493 parity pin: ``mem_session_start``, ``mem_agent_register``,
+    and ``mem_agent_search`` all emit the same identifying error fragment
+    for the same hostile id. Without this, a caller that types ``foo:bar``
+    at the registration tool would have seen a sanitised success while
+    the same string at session-start would loudly reject — the asymmetry
+    that issue #493 was filed to close.
+    """
+    app = AppContext.from_components(components)
+    ctx = _StubCtx(app)
+
+    session_out = await mem_session_start(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+    register_out = await mem_agent_register(agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+    search_out = await mem_agent_search(query="x", agent_id="foo:bar", ctx=ctx)  # type: ignore[arg-type]
+
+    core = "invalid agent-id 'foo:bar'"
+    assert core in session_out
+    assert core in register_out
+    assert core in search_out


### PR DESCRIPTION
## Summary

Closes #493.

PR #491 wired `validate_agent_id` into the three session-start surfaces
(`mem_session_start` / `mm session start` / `mm session wrap`) so a
hostile-shaped `agent_id` like `"foo:bar"` or `"../x"` was rejected
loudly. The matching multi-agent registration / search surfaces
(`mem_agent_register`, `mem_agent_search`, `mm agent register`) still
ran `sanitize_namespace_segment`, so the same input produced two UX
outcomes — registering an agent silently rewrote the id to
`agent-runtime:foo_bar`, while `mem_session_start` for that same id
loudly rejected. This PR closes that asymmetry.

The read / write contract is now symmetric across the MCP + CLI
surfaces — an `agent_id` either works on every surface or fails on
every surface, with the same `invalid agent-id 'X'` error fragment
regardless of entry point. `sanitize_namespace_segment` itself stays
as the permissive helper for the ingest pipeline (where filesystem /
provider segments still need rewriting); only the multi-agent
surfaces stop calling it.

## Breaking change

Callers that relied on silent sanitisation will now see a hard error.
Those callers were already storing memories under unexpected
namespaces (e.g. `agent-runtime:foo_bar` from `agent_id="foo:bar"`)
so the change is the forcing function to pick a canonical id matching
`[A-Za-z0-9._-]+`. Flagged in `CHANGELOG.md` under
`[Unreleased] > Changed (BREAKING)`.

## What changed

- `packages/memtomem/src/memtomem/server/tools/multi_agent.py` —
  `mem_agent_register` and `mem_agent_search` call `validate_agent_id`
  (raises `InvalidNameError`, surfaced as `Error: ...` by
  `tool_handler`); drop the now-redundant non-empty / sanitised-empty
  branches; drop the `sanitize_namespace_segment` import.
- `packages/memtomem/src/memtomem/cli/agent_cmd.py` — `mm agent
  register` validates with the session-start `try/except InvalidNameError
  → ClickException` pattern.
- `packages/memtomem/src/memtomem/constants.py` — `validate_agent_id`
  docstring lists every MCP + CLI surface that now validates, points
  at `CHANGELOG.md` Unreleased + #493 for the breaking-change note,
  and keeps the LangGraph adapter under "Not yet applied at" (tracked
  in #492 — out of scope here).
- `CHANGELOG.md` — `Unreleased > Changed (BREAKING)` entry.

## Tests

- `packages/memtomem/tests/test_validate_agent_id.py` adds:
  - `TestMcpMultiAgentBoundary` — parametrised over the existing
    `HOSTILE_AGENT_IDS` corpus (13 shapes); pins error string + that
    `agent-runtime:foo:bar` never reaches `list_namespace_meta`; valid
    ids still succeed; `agent_id=None` for `mem_agent_search` is
    unaffected.
  - `TestCliAgentRegisterBoundary` — `mm agent register foo:bar` /
    `../etc` reject; storage `set_namespace_meta` never called on the
    rejection path; valid id still succeeds.
  - `test_session_and_multi_agent_surfaces_share_core_error_text` —
    cross-surface parity pin: all three boundaries emit
    `invalid agent-id 'foo:bar'`.
- `packages/memtomem/tests/test_agent_cmd.py::test_register_rejects_empty_agent_id`
  retargeted to the new shared error vocabulary (`invalid agent-id`)
  + storage-not-called assertion.
- `packages/memtomem/tests/test_multi_agent.py` docstring corrected —
  the file now exercises the helper itself, not its (former) use by
  the multi-agent tools.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 2589 passed, 46 deselected
- [x] Targeted: `uv run pytest packages/memtomem/tests/test_validate_agent_id.py` — 70 passed

## Out of scope

- LangGraph adapter parity for `MemtomemStore.start_agent_session` and
  the remaining agent-runtime concat sites — tracked in #492 as a
  separate follow-up (review feedback: this PR shouldn't claim
  LangGraph validation it doesn't ship).
- `mem_agent_share(target=...)` validation — `target` is a full
  namespace string (not a bare `agent_id`), so `validate_agent_id`
  doesn't drop in directly. Currently a caller passing
  `target="agent-runtime:foo:bar"` plumbs straight into
  `_mem_add_core(namespace=target)` and stores under exactly the
  hostile namespace this PR closes for register / search. Worth a
  follow-up issue under the same #493 banner — see review thread.
- New "loose vs strict" config knob — adds an axis we don't actually
  need until users ask for it (per #493 acceptance).

## Review fixups (post-#494 review)

- `94e9422` — drop LangGraph claim from `validate_agent_id` docstring.
  The original PR docstring listed
  `integrations.langgraph.MemtomemStore.start_agent_session` under
  "Applied at", but the LangGraph wiring is not in this PR (it lives
  in the stacked-PR work for #492). Until #492 lands this PR shouldn't
  claim coverage it doesn't ship — the LangGraph mention is now under
  "Not yet applied at" with a concrete pointer to #492. The vague
  "see issue tracker history" history pointer is also replaced with
  a concrete `CHANGELOG.md` Unreleased + #493 anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
