### PR TITLE
fix: validate agent_id at LangGraph adapter agent-runtime concat sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   canonical id matching the documented charset and re-register. The
   LangGraph adapter parity gap remains tracked separately. Closes #493.
 
+- **`MemtomemStore.start_agent_session` (LangGraph adapter) now
+  rejects the same hostile `agent_id` shapes via `validate_agent_id`
+  instead of the prior `if not agent_id` empty-only check.** Closes
+  the last in-process surface where a Python caller could land
+  `"agent-runtime:foo:bar"` in storage even though the MCP / CLI
+  surfaces refuse the same shape. The raised exception narrows from
+  the generic `ValueError("agent_id must be a non-empty string")` to
+  `InvalidNameError("invalid agent-id 'X': ...")` — `InvalidNameError`
+  is a `ValueError` subclass, so `except ValueError:` callers keep
+  working, but any code substring-matching the old message text will
+  break and should switch to matching `"invalid agent-id"`. Closes
+  #492.
+
 ## [0.1.31] — 2026-04-26
 
 ### Added

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -38,10 +38,12 @@ SHARED_NAMESPACE: Final[str] = "shared"
 def validate_agent_id(value: object) -> str:
     """Return *value* unchanged if it is a valid agent identifier.
 
-    Applied at every MCP + CLI surface that concatenates
-    ``AGENT_NAMESPACE_PREFIX`` with caller input. Session-start:
-    ``mem_session_start`` (MCP), ``mm session start`` /
-    ``mm session wrap`` (CLI). Multi-agent registration / search:
+    Applied at every MCP + CLI + Python-adapter surface that
+    concatenates ``AGENT_NAMESPACE_PREFIX`` with caller input.
+    Session-start: ``mem_session_start`` (MCP), ``mm session start`` /
+    ``mm session wrap`` (CLI),
+    ``integrations.langgraph.MemtomemStore.start_agent_session``
+    (Python adapter). Multi-agent registration / search:
     ``mem_agent_register`` / ``mem_agent_search`` (MCP), ``mm agent
     register`` (CLI).
 
@@ -51,19 +53,16 @@ def validate_agent_id(value: object) -> str:
     ``:``, ``/``, ``..``, whitespace, control characters, or anything
     outside the canonical ``[A-Za-z0-9._-]`` charset documented above.
 
-    The read/write contract is symmetric across the MCP + CLI surfaces
-    listed above: an id either works on every surface or fails on
-    every surface. Pre-#493 the multi-agent surfaces silently called
+    The read/write contract is symmetric across all surfaces listed
+    above: an id either works on every surface or fails on every
+    surface. Pre-#493 the multi-agent surfaces silently called
     ``sanitize_namespace_segment`` instead, which let hostile shapes
     round-trip into storage under a rewritten namespace while
-    ``mem_session_start`` rejected the same shape — see the
-    ``Changed (BREAKING)`` entry in ``CHANGELOG.md`` (Unreleased) and
-    issue #493 for the migration note.
-
-    Not yet applied at the LangGraph adapter
-    (``integrations.langgraph.MemtomemStore.start_agent_session`` and
-    the agent-runtime concat sites in ``MemtomemStore``), which still
-    trusts in-process callers — tracked as issue #492.
+    ``mem_session_start`` rejected the same shape; pre-#492 the
+    LangGraph adapter applied only an ``if not agent_id`` empty-check
+    and likewise let malformed values through. See the
+    ``Changed (BREAKING)`` entries in ``CHANGELOG.md`` (Unreleased) and
+    issues #492 / #493 for the migration notes.
     """
 
     return validate_name(value, kind="agent-id")

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -36,12 +36,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 from uuid import UUID, uuid4
 
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE, validate_agent_id
+
 if TYPE_CHECKING:
     from memtomem.server.component_factory import Components
-
-
-_AGENT_NAMESPACE_PREFIX = "agent-runtime:"
-_SHARED_NAMESPACE = "shared"
 
 
 class MemtomemStore:
@@ -168,9 +166,9 @@ class MemtomemStore:
                 "Call start_agent_session(agent_id) first or set include_shared=False."
             )
         if include_shared is False and self._current_agent_id is not None:
-            return f"{_AGENT_NAMESPACE_PREFIX}{self._current_agent_id}"
+            return f"{AGENT_NAMESPACE_PREFIX}{self._current_agent_id}"
         if include_shared in (None, True) and self._current_agent_id is not None:
-            return f"{_AGENT_NAMESPACE_PREFIX}{self._current_agent_id},{_SHARED_NAMESPACE}"
+            return f"{AGENT_NAMESPACE_PREFIX}{self._current_agent_id},{SHARED_NAMESPACE}"
         # No agent bound and the caller did not force include_shared=True →
         # fall back to whatever the caller passed (legacy behaviour).
         return namespace
@@ -187,7 +185,7 @@ class MemtomemStore:
         if namespace is not None:
             return namespace
         if self._current_agent_id is not None:
-            return f"{_AGENT_NAMESPACE_PREFIX}{self._current_agent_id}"
+            return f"{AGENT_NAMESPACE_PREFIX}{self._current_agent_id}"
         return None
 
     # ── CRUD ──────────────────────────────────────────────────────────────
@@ -290,13 +288,21 @@ class MemtomemStore:
         ``namespace=`` on every call.
 
         Returns the session id.
+
+        Raises:
+            InvalidNameError: ``agent_id`` is empty, contains ``:``, ``/``,
+                ``..``, whitespace, control characters, or anything outside
+                ``[A-Za-z0-9._-]`` — the same gate the MCP / CLI session
+                surfaces apply (see ``memtomem.constants.validate_agent_id``).
+                This blocks malformed values from concatenating into
+                ``agent-runtime:<agent_id>`` and round-tripping into
+                storage as ``"agent-runtime:foo:bar"``.
         """
-        if not agent_id:
-            raise ValueError("agent_id must be a non-empty string")
+        validate_agent_id(agent_id)
 
         comp = await self._ensure_init()
         session_id = str(uuid4())
-        ns = namespace or f"{_AGENT_NAMESPACE_PREFIX}{agent_id}"
+        ns = namespace or f"{AGENT_NAMESPACE_PREFIX}{agent_id}"
         await comp.storage.create_session(session_id, agent_id, ns)
         async with self._session_lock:
             self._current_session_id = session_id

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -158,6 +158,11 @@ class MemtomemStore:
         Public contract is documented in ``search``'s docstring; this helper
         only encodes the lookup table so it can be unit-tested without
         spinning up components.
+
+        ``self._current_agent_id`` is concatenated into ``AGENT_NAMESPACE_PREFIX``
+        without re-validation here: ``start_agent_session`` is the sole writer
+        of that field and runs ``validate_agent_id`` before binding, so any
+        value that reaches this point is already gate-checked.
         """
 
         if include_shared is True and self._current_agent_id is None:
@@ -180,6 +185,10 @@ class MemtomemStore:
         for "I want to write to ``shared`` while my session is bound to
         ``planner``"). Otherwise, when an agent session is active, writes
         land in ``agent-runtime:<id>``.
+
+        ``self._current_agent_id`` reaches the concat path pre-validated —
+        ``start_agent_session`` is the only writer and runs ``validate_agent_id``
+        before binding (same invariant as ``_resolve_search_namespace``).
         """
 
         if namespace is not None:

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -179,13 +179,49 @@ class TestStartAgentSession:
 
     @pytest.mark.asyncio
     async def test_empty_agent_id_raises(self):
+        from memtomem.constants import InvalidNameError
         from memtomem.integrations.langgraph import MemtomemStore
 
         store = MemtomemStore()
-        store._components = self._stub_components()
+        comp = self._stub_components()
+        store._components = comp
 
-        with pytest.raises(ValueError, match="non-empty"):
+        with pytest.raises(InvalidNameError, match="invalid agent-id"):
             await store.start_agent_session("")
+        comp.storage.create_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "agent_id",
+        [
+            "foo:bar",  # collides with the namespace separator
+            "../etc",  # path traversal
+            "a/b",  # path separator
+            "a b",  # internal whitespace
+            "-leading-dash",
+        ],
+    )
+    async def test_hostile_agent_id_blocked_before_storage(self, agent_id):
+        """Regression pin (#492 / PR #491 follow-up): the LangGraph adapter
+        must apply the same ``validate_agent_id`` gate as the MCP / CLI
+        surfaces, so a malformed namespace like ``"agent-runtime:foo:bar"``
+        cannot reach storage from the in-process Python entry point.
+        """
+        from memtomem.constants import InvalidNameError
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = self._stub_components()
+        store._components = comp
+
+        with pytest.raises(InvalidNameError, match="invalid agent-id"):
+            await store.start_agent_session(agent_id)
+
+        comp.storage.create_session.assert_not_awaited()
+        # Binding state stays clean — a rejected start_agent_session
+        # must not leave _current_agent_id pointing at the hostile value.
+        assert store._current_session_id is None
+        assert store._current_agent_id is None
 
     @pytest.mark.asyncio
     async def test_end_session_resets_agent_id(self):


### PR DESCRIPTION
## Summary

- Closes the parity gap PR #491 review flagged: the LangGraph adapter's `MemtomemStore.start_agent_session` was the last entry point that built `agent-runtime:<agent_id>` from caller input without running `validate_agent_id`. Apply the gate so a Python caller can no longer land `"agent-runtime:foo:bar"` in storage even though the MCP / CLI surfaces refuse the same shape.
- Replace the local `_AGENT_NAMESPACE_PREFIX = "agent-runtime:"` literal with the `memtomem.constants` import (`AGENT_NAMESPACE_PREFIX`, `SHARED_NAMESPACE`, `validate_agent_id`) so the integration derives from the single source of truth — the redefinition predated the multi-agent shipping work and was kept on the assumption that integrations shouldn't import from MCP-side modules, but `constants.py` is intentionally above the MCP / CLI / integration split exactly so all three can derive from it. `langgraph.py → constants.py → context._names` stays one-way.
- Stacked on PR #494 (#493) so the `validate_agent_id` docstring there ("Applied at every surface that concatenates `AGENT_NAMESPACE_PREFIX` with caller input") becomes accurate the moment both PRs land.

The other concat sites in `langgraph.py` (`_resolve_search_namespace`, `_resolve_add_namespace`) only read `self._current_agent_id`, which is set exclusively by `start_agent_session` — gating that single entry point covers the whole agent-runtime concat path.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_langgraph.py packages/memtomem/tests/test_validate_agent_id.py packages/memtomem/tests/test_multi_agent_integration.py packages/memtomem/tests/test_multi_agent.py packages/memtomem/tests/test_agent_cmd.py -m "not ollama"` — 149 passed
- [x] `uv run ruff check` + `ruff format --check` on the two changed files
- [x] `test_empty_agent_id_raises` updated to expect `InvalidNameError` ("invalid agent-id '': empty") rather than the old "non-empty" `ValueError`
- [x] New `test_hostile_agent_id_blocked_before_storage` parametrises the same hostile shapes pinned at the MCP / CLI boundaries (`foo:bar`, `../etc`, `a/b`, `a b`, `-leading-dash`) and asserts `storage.create_session` is never awaited and `_current_agent_id` stays unset on the rejection path

Closes #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)