### PR TITLE
fix: validate user-supplied namespace= overrides on session entry points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `Error: invalid namespace 'X': ...` instead of the prior silent
   store. Existing in-tree shapes (`default`, `shared`,
   `archive:summary`, `claude-memory:project-x`,
-  `agent-runtime:planner`, `custom:scope`) are unchanged. Closes #496.
+  `agent-runtime:planner`, `custom:scope`) are unchanged. The bare
+  single-segment `"agent-runtime"` (no trailing colon) is also rejected
+  now — it shadows the multi-agent prefix and the strict-arity rule
+  requires exactly one trailing segment after the prefix. Anyone
+  holding such a namespace should rename it via `mem_ns_rename` before
+  running session-start with the override. Closes #496.
 
 - **`mem_agent_register`, `mem_agent_search`, and `mm agent register`
   now reject malformed `agent_id` values loudly instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed (BREAKING)
 
+- **Caller-supplied `namespace=` / `target=` overrides on every
+  session-start entry point and `mem_agent_share` now reject malformed
+  shapes via a new `validate_namespace` gate.** PR #491 / #494 / #498
+  closed the bypass on `agent_id` itself, but each session-start surface
+  also accepted an explicit `namespace=` argument that landed verbatim
+  in storage — a Python / MCP / CLI caller could write
+  `"agent-runtime:foo:bar"` even though `agent_id` was clean (the
+  bypass shape PR #495 review flagged as Concern 3). The new validator
+  now runs at `mem_session_start(namespace=)` (MCP),
+  `mm session start --namespace` (CLI),
+  `MemtomemStore.start_agent_session(namespace=)` and
+  `MemtomemStore.start_session(namespace=)` (Python adapter), and
+  `mem_agent_share(target=)` (MCP). `agent-runtime:<seg>` overrides
+  re-route the trailing segment through `validate_agent_id` so the
+  override path can't widen the contract that the direct `agent_id=`
+  path enforces.
+
+  **Migration:** callers passing structured-but-unsupported namespace
+  shapes (anything containing slashes, whitespace, comma, control
+  characters, leading dash, or more than one colon under the
+  `agent-runtime:` prefix) will now see
+  `Error: invalid namespace 'X': ...` instead of the prior silent
+  store. Existing in-tree shapes (`default`, `shared`,
+  `archive:summary`, `claude-memory:project-x`,
+  `agent-runtime:planner`, `custom:scope`) are unchanged. Closes #496.
+
 - **`mem_agent_register`, `mem_agent_search`, and `mm agent register`
   now reject malformed `agent_id` values loudly instead of silently
   rewriting them.** PR #491 had wired `validate_agent_id` into the

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -10,7 +10,12 @@ from pathlib import Path
 
 import click
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, InvalidNameError, validate_agent_id
+from memtomem.constants import (
+    AGENT_NAMESPACE_PREFIX,
+    InvalidNameError,
+    validate_agent_id,
+    validate_namespace,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +85,8 @@ def start(agent_id: str, title: str | None, namespace: str | None) -> None:
     """Start a new session and save its ID to ~/.memtomem/.current_session."""
     try:
         validate_agent_id(agent_id)
+        if namespace is not None:
+            validate_namespace(namespace)
     except InvalidNameError as e:
         raise click.ClickException(str(e)) from e
     try:

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -167,7 +167,19 @@ def validate_namespace(value: object) -> str:
                 f"requires exactly one trailing segment "
                 f"(``{runtime_prefix}:<agent_id>``); got {len(segments) - 1}"
             )
-        validate_agent_id(segments[1])
+        try:
+            validate_agent_id(segments[1])
+        except InvalidNameError as e:
+            # Wrap so log scrapers grepping ``"invalid namespace"`` catch
+            # this path too — without the wrap, the user passes
+            # ``namespace=agent-runtime:<X>`` but sees ``"invalid agent-id
+            # ..."``, which splits the alerting surface across two
+            # fragments. ``__cause__`` preserves the agent_id detail for
+            # anyone debugging the underlying contract violation.
+            raise InvalidNameError(
+                f"invalid namespace {value!r}: {runtime_prefix} segment {segments[1]!r} "
+                f"failed agent-id contract — {e}"
+            ) from e
 
     return value
 

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -10,6 +10,7 @@ re-declaring the string.
 
 from __future__ import annotations
 
+import re
 from typing import Final
 
 from memtomem.context._names import InvalidNameError as InvalidNameError
@@ -66,6 +67,109 @@ def validate_agent_id(value: object) -> str:
     """
 
     return validate_name(value, kind="agent-id")
+
+
+# Namespace charset for caller-supplied ``namespace=`` / ``target=``
+# overrides on session-start and ``mem_agent_share``. Covers the existing
+# in-tree shapes (``default``, ``shared``, ``archive:summary``,
+# ``claude-memory:project-x``, ``agent-runtime:planner``) without adding
+# anything that would let an untrusted ``agent_id`` smuggle through the
+# override gate. ``,`` is **not** in the charset — comma-joined namespace
+# lists are a search-time filter shape, not a storable namespace value;
+# letting one through would silently widen scope at write time.
+_NAMESPACE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_MAX_NAMESPACE_LEN: Final[int] = 256
+
+
+def validate_namespace(value: object) -> str:
+    """Return *value* unchanged if it is a storable namespace string.
+
+    Applied to every public surface that accepts a user-supplied
+    ``namespace=`` or ``target=`` argument before storage / search ever
+    sees it: ``mem_session_start(namespace=...)`` (MCP),
+    ``mm session start --namespace`` (CLI),
+    ``MemtomemStore.start_session`` /
+    ``MemtomemStore.start_agent_session(namespace=...)`` (Python
+    adapter), and ``mem_agent_share(target=...)`` (MCP).
+
+    Internally-derived namespaces (``f"{AGENT_NAMESPACE_PREFIX}{agent_id}"``
+    after ``validate_agent_id`` succeeded, ``"default"``,
+    ``SHARED_NAMESPACE``) are safe by construction and skip this gate —
+    re-validating them is dead weight and would tie the agent_id charset
+    to the namespace charset for no benefit. The gate is a forward shield
+    on caller input, not a tripwire on internal derivation.
+
+    Accepted shape: one or more ``:``-separated segments where each
+    segment is non-empty, matches ``[A-Za-z0-9._-]+``, and is neither
+    ``"."``, ``".."``, nor a leading-``-``. Total length capped at 256
+    (well above any in-tree namespace today, narrow enough to bound
+    storage rows). When the first segment is the bare ``agent-runtime``
+    prefix, exactly one further segment is required and that segment is
+    re-validated through :func:`validate_agent_id` (which adds the
+    1–64-char cap and the rest of the agent_id contract). This is the
+    bypass issue #496 was filed to close: a Python / MCP / CLI caller
+    could otherwise smuggle ``"agent-runtime:foo:bar"`` into a session
+    row even though ``agent_id`` itself is gated.
+
+    The per-segment length cap is intentionally NOT applied uniformly —
+    only the ``agent-runtime:`` segment inherits agent_id's 64-char cap.
+    Other namespace shapes (``claude-memory:<long-project-id>``) retain
+    the broader 256-char total budget so legitimate long project ids
+    don't trip this gate.
+
+    Raises :class:`InvalidNameError` (a ``ValueError`` subclass) on
+    rejection, mirroring the ``agent_id`` gate's UX so error scrapers
+    see one shape across surfaces.
+    """
+
+    if not isinstance(value, str):
+        raise InvalidNameError(f"invalid namespace: expected str, got {type(value).__name__}")
+    if not value or not value.strip():
+        raise InvalidNameError(f"invalid namespace {value!r}: empty")
+    if len(value) > _MAX_NAMESPACE_LEN:
+        raise InvalidNameError(
+            f"invalid namespace {value!r}: length {len(value)} exceeds {_MAX_NAMESPACE_LEN}"
+        )
+
+    segments = value.split(":")
+    for seg in segments:
+        if not seg:
+            raise InvalidNameError(
+                f"invalid namespace {value!r}: empty segment (leading / trailing / consecutive ':')"
+            )
+        if seg in (".", ".."):
+            raise InvalidNameError(
+                f"invalid namespace {value!r}: segment {seg!r} is a reserved path token"
+            )
+        if seg.startswith("-"):
+            raise InvalidNameError(
+                f"invalid namespace {value!r}: segment {seg!r} has a leading dash"
+            )
+        if not _NAMESPACE_SEGMENT_RE.fullmatch(seg):
+            raise InvalidNameError(
+                f"invalid namespace {value!r}: segment {seg!r} must match "
+                f"[A-Za-z0-9._-]+ (no slash / backslash / whitespace / control chars)"
+            )
+
+    # ``agent-runtime:<agent_id>`` is the one prefix where the second
+    # segment is interpolated *back into* an agent_id-shaped storage row
+    # — the bypass shape #491 / #494 / #498 closed on the agent_id side.
+    # Re-route the segment through ``validate_agent_id`` so the override
+    # path can't widen the contract that the direct ``agent_id=`` path
+    # already enforces. ``agent-runtime:foo:bar`` lands here as 3
+    # segments and trips the strict-arity check before any agent-id
+    # validation — that's the canonical shape this gate exists for.
+    runtime_prefix = AGENT_NAMESPACE_PREFIX.rstrip(":")
+    if segments[0] == runtime_prefix:
+        if len(segments) != 2:
+            raise InvalidNameError(
+                f"invalid namespace {value!r}: ``{runtime_prefix}:`` prefix "
+                f"requires exactly one trailing segment "
+                f"(``{runtime_prefix}:<agent_id>``); got {len(segments) - 1}"
+            )
+        validate_agent_id(segments[1])
+
+    return value
 
 
 # Default ``system_namespace_prefixes`` — namespaces matching any of these

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -36,7 +36,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 from uuid import UUID, uuid4
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE, validate_agent_id
+from memtomem.constants import (
+    AGENT_NAMESPACE_PREFIX,
+    SHARED_NAMESPACE,
+    validate_agent_id,
+    validate_namespace,
+)
 
 if TYPE_CHECKING:
     from memtomem.server.component_factory import Components
@@ -283,8 +288,16 @@ class MemtomemStore:
         derive a namespace from ``agent_id`` should use
         :meth:`start_agent_session` (or call ``validate_agent_id``
         directly) so the gate isn't reintroduced as a regression.
+
+        ``namespace`` *is* run through :func:`validate_namespace` because
+        an explicit override lands verbatim in the session row — without
+        the gate a Python caller could write ``"agent-runtime:foo:bar"``
+        through this entry point even though the equivalent
+        ``start_agent_session`` path now refuses it (issue #496).
         """
         comp = await self._ensure_init()
+        if namespace is not None:
+            validate_namespace(namespace)
         session_id = str(uuid4())
         ns = namespace or "default"
         await comp.storage.create_session(session_id, agent_id, ns)
@@ -316,8 +329,17 @@ class MemtomemStore:
                 This blocks malformed values from concatenating into
                 ``agent-runtime:<agent_id>`` and round-tripping into
                 storage as ``"agent-runtime:foo:bar"``.
+
+                Or ``namespace`` is supplied with a malformed value (see
+                ``memtomem.constants.validate_namespace``). The override is
+                an escape hatch but not a bypass: a Python caller cannot
+                land ``"agent-runtime:foo:bar"`` in the session row even
+                though ``agent_id`` itself was clean (issue #496 — closes
+                the kin gap to the ``agent_id`` work in #486 / #492).
         """
         validate_agent_id(agent_id)
+        if namespace is not None:
+            validate_namespace(namespace)
 
         comp = await self._ensure_init()
         session_id = str(uuid4())

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import logging
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE, validate_agent_id
+from memtomem.constants import (
+    AGENT_NAMESPACE_PREFIX,
+    SHARED_NAMESPACE,
+    validate_agent_id,
+    validate_namespace,
+)
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -196,12 +201,20 @@ async def mem_agent_share(
     only, not a growing audit chain. Use the parent UUID to walk back
     one hop at a time if needed.
 
+    ``target`` is run through :func:`validate_namespace` before any
+    storage write — it is the same caller-supplied bypass shape that
+    issue #496 closes on the session-start surfaces. Without the gate a
+    caller could land a ``"shared:foo:bar"`` or ``"agent-runtime:foo:bar"``
+    chunk_links row even though the equivalent ``mem_session_start`` and
+    ``mem_agent_register`` paths refuse the same shape.
+
     Args:
         chunk_id: UUID of the chunk to copy
         target: Target namespace — ``'shared'`` or ``'agent-runtime:{agent_id}'``
     """
     from uuid import UUID
 
+    validate_namespace(target)
     app = await _get_app_initialized(ctx)
 
     try:

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, validate_agent_id
+from memtomem.constants import AGENT_NAMESPACE_PREFIX, validate_agent_id, validate_namespace
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -78,6 +78,9 @@ async def mem_session_start(
     behave the same):
 
     1. Explicit ``namespace=`` argument (escape hatch — wins everything).
+       Run through :func:`validate_namespace` so a hostile-shaped string
+       like ``"agent-runtime:foo:bar"`` cannot smuggle past the
+       ``agent_id`` gate via the override; see issue #496.
     2. ``agent-runtime:<agent_id>`` when ``agent_id`` is non-default.
        This is the common case for multi-agent workflows.
     3. ``app.current_namespace`` (pre-multi-agent fallback).
@@ -95,6 +98,8 @@ async def mem_session_start(
             non-default, defaults to ``agent-runtime:<agent_id>``.
     """
     validate_agent_id(agent_id)
+    if namespace is not None:
+        validate_namespace(namespace)
     app = await _get_app_initialized(ctx)
     session_id = str(uuid4())
     if namespace:

--- a/packages/memtomem/tests/test_validate_namespace.py
+++ b/packages/memtomem/tests/test_validate_namespace.py
@@ -1,0 +1,489 @@
+"""Tests for ``validate_namespace`` and its enforcement at every public
+surface that accepts a caller-supplied ``namespace=`` / ``target=``
+override on session-start and ``mem_agent_share``.
+
+Closes the bypass issue #496 flagged on PR #495 review (Concern 3): even
+after #491 / #494 / #498 gated every ``agent_id`` concatenation, the
+explicit ``namespace=`` argument on session-start (and ``target=`` on
+``mem_agent_share``) still landed verbatim in storage. A Python / MCP /
+CLI caller could write ``"agent-runtime:foo:bar"`` even though
+``agent_id`` itself was clean.
+
+The contract this file pins:
+
+* Every entry point (LangGraph ``MemtomemStore.start_agent_session`` /
+  ``start_session``, MCP ``mem_session_start`` / ``mem_agent_share``,
+  CLI ``mm session start --namespace``) rejects hostile shapes with an
+  ``InvalidNameError`` (or its public alias) before storage is touched.
+* Storage / search never see ``"agent-runtime:foo:bar"`` from any
+  surface — pinned with a "would-not-have-been-called" assertion.
+* Rejection is loud, mirroring the ``agent_id`` gate's UX (``Error:
+  invalid namespace ...`` on the MCP path, ``ClickException`` on CLI).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.constants import InvalidNameError, validate_namespace
+from memtomem.server.context import AppContext
+from memtomem.server.tools.session import mem_session_start
+
+# Hostile-shaped values that must be rejected at every namespace boundary.
+# Includes the canonical issue-#496 shape (``agent-runtime:foo:bar`` —
+# the agent-runtime: prefix bypass) plus the broader path / control / regex
+# violations a namespace string must never carry into storage.
+HOSTILE_NAMESPACES = [
+    "agent-runtime:foo:bar",  # issue #496 canonical bypass shape
+    "agent-runtime:foo:bar:baz",  # more depth, same bypass
+    "agent-runtime:",  # trailing colon = empty agent segment
+    "agent-runtime:foo bar",  # whitespace inside the agent segment
+    "agent-runtime:..",  # reserved path token in agent segment
+    "agent-runtime:../etc",  # path traversal in agent segment
+    "agent-runtime:-leading-dash",  # leading-dash in agent segment
+    ":foo",  # leading colon = empty first segment
+    "foo:",  # trailing colon = empty trailing segment
+    "foo::bar",  # consecutive colons = empty middle segment
+    "foo bar",  # whitespace
+    "foo/bar",  # slash
+    "foo\\bar",  # windows-style separator
+    "..",  # reserved path token
+    "../etc",  # path traversal
+    "-leading-dash",  # leading dash
+    "foo,bar",  # comma — search-time list shape, not a storable NS
+    "",  # empty
+    "   ",  # all whitespace
+    "foo\x00bar",  # null byte
+    "foo\nbar",  # newline
+    "foo​bar",  # zero-width space — escape sequence so it isn't an invisible source artifact
+]
+
+# Shapes that must continue to round-trip through the validator so the
+# gate doesn't break any existing in-tree namespace.
+ACCEPTED_NAMESPACES = [
+    "default",
+    "shared",
+    "archive:summary",
+    "archive:auto-consolidate",
+    "claude-memory:project-x",
+    "gemini-memory:project-y",
+    "codex-memory:project-z",
+    "agent-runtime:planner",
+    "agent-runtime:claude_code",
+    "custom:scope",
+    "legacy:ns",
+    "a.b.c",
+    "v2.0",
+]
+
+
+# ---------------------------------------------------------------------------
+# validate_namespace (unit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ACCEPTED_NAMESPACES)
+def test_validate_namespace_accepts_in_tree_shapes(value: str) -> None:
+    assert validate_namespace(value) == value
+
+
+@pytest.mark.parametrize("value", HOSTILE_NAMESPACES)
+def test_validate_namespace_rejects_hostile_inputs(value: str) -> None:
+    with pytest.raises(InvalidNameError, match="invalid namespace"):
+        validate_namespace(value)
+
+
+def test_validate_namespace_rejects_non_string() -> None:
+    with pytest.raises(InvalidNameError, match="expected str"):
+        validate_namespace(123)  # type: ignore[arg-type]
+
+
+def test_validate_namespace_rejects_overlong() -> None:
+    # 257 chars — one past the cap. Not in HOSTILE_NAMESPACES because
+    # it's a structural, not character-class, violation.
+    with pytest.raises(InvalidNameError, match="exceeds 256"):
+        validate_namespace("a" * 257)
+
+
+def test_agent_runtime_prefix_routes_through_validate_agent_id() -> None:
+    """Pin the structural rule: ``agent-runtime:<seg>`` is the only
+    prefix where the trailing segment is re-validated through the
+    stricter agent_id gate. Without this, the override path would widen
+    the contract that the direct ``agent_id=`` path enforces — exactly
+    the shape issue #496 was filed to close.
+    """
+
+    # Length cap: validate_namespace allows segments up to 64 chars
+    # (matching agent_id), so 65 is rejected. Pinned via the agent_id
+    # path so a future relaxation of the namespace segment cap doesn't
+    # silently widen the agent_id contract.
+    overlong_id = "a" * 65
+    with pytest.raises(InvalidNameError, match="invalid agent-id"):
+        validate_namespace(f"agent-runtime:{overlong_id}")
+
+
+# ---------------------------------------------------------------------------
+# MCP boundary — mem_session_start(namespace=...)
+# ---------------------------------------------------------------------------
+
+
+class _StubCtx:
+    """Minimal stand-in for MCP ``Context`` so async tools can be invoked
+    directly. Mirrors ``test_validate_agent_id``.
+    """
+
+    def __init__(self, app: AppContext) -> None:
+        class _RC:
+            pass
+
+        self.request_context = _RC()
+        self.request_context.lifespan_context = app
+
+
+class TestMcpSessionStartNamespaceOverride:
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(
+            agent_id="planner",
+            namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+        assert "'agent-runtime:foo:bar'" in out
+
+    @pytest.mark.asyncio
+    async def test_malformed_namespace_never_reaches_storage(self, components):
+        """Regression pin for issue #496: ``store.start_agent_session
+        (agent_id="planner", namespace="agent-runtime:foo:bar")`` cannot
+        land an ``"agent-runtime:foo:bar"`` row even though ``agent_id``
+        itself is clean. Same shape pinned at the MCP boundary.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(
+            agent_id="planner",
+            namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        rows = await app.storage.list_sessions()
+        assert not any("agent-runtime:foo:bar" in (r["namespace"] or "") for r in rows)
+        assert app.current_session_id is None
+        assert app.current_agent_id is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
+    async def test_hostile_namespaces_all_rejected(self, components, namespace):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(
+            agent_id="planner",
+            namespace=namespace,
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    async def test_explicit_shared_namespace_still_succeeds(self, components):
+        """Sanity: the override IS still an escape hatch — a planner-bound
+        session can publish into ``shared`` even though
+        ``agent-runtime:planner`` is the default derivation.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_session_start(
+            agent_id="planner",
+            namespace="shared",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert "Session started" in out
+        assert "Namespace: shared" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI boundary — mm session start --namespace
+# ---------------------------------------------------------------------------
+
+
+def _patched_cli_components(comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def storage_mock():
+    """Mock storage that fails loudly if any session-creating call lands —
+    the validation gate must short-circuit before storage is ever touched
+    on the rejection path.
+    """
+    return SimpleNamespace(
+        create_session=AsyncMock(),
+        end_session=AsyncMock(),
+        get_session_events=AsyncMock(return_value=[]),
+    )
+
+
+class TestCliSessionStartNamespaceOverride:
+    def test_rejects_agent_runtime_foo_bar(self, runner, monkeypatch, storage_mock):
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "start",
+                "--agent-id",
+                "planner",
+                "--namespace",
+                "agent-runtime:foo:bar",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "invalid namespace" in result.output
+        assert "'agent-runtime:foo:bar'" in result.output
+        # Regression pin: storage never received a malformed namespace.
+        storage_mock.create_session.assert_not_called()
+
+    def test_rejects_path_traversal(self, runner, monkeypatch, storage_mock):
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            ["session", "start", "--agent-id", "planner", "--namespace", "../etc"],
+        )
+
+        assert result.exit_code != 0
+        assert "invalid namespace" in result.output
+        storage_mock.create_session.assert_not_called()
+
+    def test_accepts_explicit_shared(self, runner, monkeypatch, storage_mock):
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            ["session", "start", "--agent-id", "planner", "--namespace", "shared"],
+        )
+
+        assert result.exit_code == 0, result.output
+        storage_mock.create_session.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# LangGraph adapter boundary — MemtomemStore.start_agent_session(namespace=)
+# and MemtomemStore.start_session(namespace=)
+# ---------------------------------------------------------------------------
+
+
+def _stub_components():
+    comp = MagicMock()
+    comp.storage.create_session = AsyncMock(return_value=None)
+    return comp
+
+
+class TestLangGraphStartAgentSessionNamespaceOverride:
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_blocked(self):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = _stub_components()
+        store._components = comp
+
+        with pytest.raises(InvalidNameError, match="invalid namespace"):
+            await store.start_agent_session("planner", namespace="agent-runtime:foo:bar")
+
+        comp.storage.create_session.assert_not_awaited()
+        assert store._current_session_id is None
+        assert store._current_agent_id is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
+    async def test_hostile_namespaces_all_rejected(self, namespace):
+        """Pin the contract per-shape so a future regression in any one
+        category (path-traversal, embedded whitespace, comma, etc.)
+        surfaces as a single failing parametrise rather than silently
+        widening through one unguarded shape.
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = _stub_components()
+        store._components = comp
+
+        with pytest.raises(InvalidNameError, match="invalid namespace"):
+            await store.start_agent_session("planner", namespace=namespace)
+
+        comp.storage.create_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_existing_custom_scope_still_succeeds(self):
+        """The pre-#496 ``custom:scope`` override fixture stays valid —
+        the gate must not regress the documented escape-hatch behaviour
+        (see ``test_explicit_namespace_overrides_default`` in
+        ``test_langgraph.py``).
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = _stub_components()
+        store._components = comp
+
+        await store.start_agent_session("planner", namespace="custom:scope")
+
+        args, _ = comp.storage.create_session.call_args
+        assert args[2] == "custom:scope"
+
+
+class TestLangGraphStartSessionNamespaceOverride:
+    """``start_session`` is the low-level escape hatch that does NOT
+    validate ``agent_id`` (it never concatenates it into a namespace).
+    The ``namespace=`` override IS validated though, because the value
+    lands verbatim in the session row — without the gate this method
+    would re-open the bypass that ``start_agent_session`` now closes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_blocked(self):
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = _stub_components()
+        store._components = comp
+
+        with pytest.raises(InvalidNameError, match="invalid namespace"):
+            await store.start_session("default", namespace="agent-runtime:foo:bar")
+
+        comp.storage.create_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_omitted_namespace_unaffected(self):
+        """``namespace=None`` is the documented default-to-"default" path —
+        must not trip the validator.
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        store = MemtomemStore()
+        comp = _stub_components()
+        store._components = comp
+
+        sid = await store.start_session("default")
+
+        assert sid is not None
+        args, _ = comp.storage.create_session.call_args
+        assert args[2] == "default"
+
+
+# ---------------------------------------------------------------------------
+# MCP boundary — mem_agent_share(target=...)
+# ---------------------------------------------------------------------------
+
+
+class TestMemAgentShareTargetOverride:
+    """``mem_agent_share(target=...)`` is the kin gap flagged on PR #494
+    review: an MCP caller could ask to "share" a chunk into
+    ``target="agent-runtime:foo:bar"`` and the new copy would land in a
+    malformed namespace even though the equivalent ``mem_session_start``
+    / ``mem_agent_register`` paths refuse the same shape.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_returns_error_before_copy(self, components):
+        from memtomem.server.tools.multi_agent import mem_agent_share
+
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        # ``chunk_id`` is irrelevant — the namespace gate must run before
+        # the chunk lookup happens, so we don't even need a real chunk to
+        # pin the contract.
+        out = await mem_agent_share(
+            chunk_id="00000000-0000-0000-0000-000000000000",
+            target="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+        assert "'agent-runtime:foo:bar'" in out
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("target", HOSTILE_NAMESPACES)
+    async def test_hostile_targets_all_rejected(self, components, target):
+        from memtomem.server.tools.multi_agent import mem_agent_share
+
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_share(
+            chunk_id="00000000-0000-0000-0000-000000000000",
+            target=target,
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+
+# ---------------------------------------------------------------------------
+# Cross-surface error parity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_and_cli_share_core_namespace_error_text(components, monkeypatch):
+    """The CLI and MCP surfaces must produce the same identifying text
+    for a malformed namespace so users (and log scrapers) see one error
+    shape regardless of how the request entered the system. Mirrors
+    ``test_cli_and_mcp_share_core_error_text`` for the agent_id gate.
+    """
+    app = AppContext.from_components(components)
+    ctx = _StubCtx(app)
+    mcp_out = await mem_session_start(
+        agent_id="planner",
+        namespace="agent-runtime:foo:bar",
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+
+    storage = SimpleNamespace(create_session=AsyncMock())
+    comp = SimpleNamespace(storage=storage)
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+    cli_result = CliRunner().invoke(
+        cli,
+        [
+            "session",
+            "start",
+            "--agent-id",
+            "planner",
+            "--namespace",
+            "agent-runtime:foo:bar",
+        ],
+    )
+
+    core = "invalid namespace 'agent-runtime:foo:bar'"
+    assert core in mcp_out
+    assert core in cli_result.output

--- a/packages/memtomem/tests/test_validate_namespace.py
+++ b/packages/memtomem/tests/test_validate_namespace.py
@@ -117,15 +117,29 @@ def test_agent_runtime_prefix_routes_through_validate_agent_id() -> None:
     stricter agent_id gate. Without this, the override path would widen
     the contract that the direct ``agent_id=`` path enforces — exactly
     the shape issue #496 was filed to close.
+
+    The outer error fragment must say ``"invalid namespace"`` so log
+    scrapers grepping for that string at the namespace boundary catch
+    every rejection path, including the agent_id-derived one. The
+    underlying agent_id contract violation is preserved on
+    ``__cause__`` for anyone debugging the wrapped error.
     """
 
-    # Length cap: validate_namespace allows segments up to 64 chars
-    # (matching agent_id), so 65 is rejected. Pinned via the agent_id
-    # path so a future relaxation of the namespace segment cap doesn't
-    # silently widen the agent_id contract.
+    # Length cap: ``agent-runtime:`` segments inherit agent_id's 64-char
+    # cap (``validate_agent_id``); other namespace shapes get the broader
+    # 256-char total budget. Pinned via the agent_id path so a future
+    # relaxation of the agent_id cap doesn't silently widen the
+    # agent-runtime contract.
     overlong_id = "a" * 65
-    with pytest.raises(InvalidNameError, match="invalid agent-id"):
+    with pytest.raises(InvalidNameError) as excinfo:
         validate_namespace(f"agent-runtime:{overlong_id}")
+
+    # Outer message — what user / log scraper sees.
+    assert "invalid namespace" in str(excinfo.value)
+    assert "agent-runtime" in str(excinfo.value)
+    # __cause__ — preserved agent_id detail.
+    assert isinstance(excinfo.value.__cause__, InvalidNameError)
+    assert "invalid agent-id" in str(excinfo.value.__cause__)
 
 
 # ---------------------------------------------------------------------------
@@ -246,8 +260,49 @@ def storage_mock():
     )
 
 
+# CLI-safe subset of ``HOSTILE_NAMESPACES``: drops the leading-dash
+# variants because Click parses ``--namespace -leading-dash`` as a
+# missing-option-value error before our validator sees the input. The
+# dash-rejection contract is still pinned at the LangGraph / MCP /
+# unit-validator boundaries, so dropping it here is defense-in-depth
+# without losing coverage. ``CliRunner.invoke`` passes the args list
+# straight through (no shell), so control chars / whitespace / null
+# bytes survive untouched.
+CLI_HOSTILE_NAMESPACES = [v for v in HOSTILE_NAMESPACES if not v.startswith("-")]
+
+
 class TestCliSessionStartNamespaceOverride:
-    def test_rejects_agent_runtime_foo_bar(self, runner, monkeypatch, storage_mock):
+    @pytest.mark.parametrize("namespace", CLI_HOSTILE_NAMESPACES)
+    def test_hostile_namespaces_all_rejected(self, runner, monkeypatch, storage_mock, namespace):
+        """Defense-in-depth: every hostile shape pinned at the validator
+        must produce a CLI-side ``ClickException`` before storage is
+        touched. Without the parametrize, a future regression that lets
+        only one shape (say, ``foo,bar``) through the CLI gate while
+        the validator still rejects it would slip past — the CLI is the
+        thinnest layer over the validator and the easiest place for a
+        ``try/except`` swallow to be reintroduced.
+        """
+        comp = SimpleNamespace(storage=storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            ["session", "start", "--agent-id", "planner", "--namespace", namespace],
+        )
+
+        assert result.exit_code != 0
+        assert "invalid namespace" in result.output
+        # Regression pin: storage never received a malformed namespace.
+        storage_mock.create_session.assert_not_called()
+
+    def test_rejects_agent_runtime_foo_bar_with_quoted_value(
+        self, runner, monkeypatch, storage_mock
+    ):
+        """Pin the canonical issue-#496 shape with the exact error
+        fragment a log scraper would grep for. Kept as a separate test
+        from the parametrize so failures here surface the bypass
+        directly rather than under one of N parametrised IDs.
+        """
         comp = SimpleNamespace(storage=storage_mock)
         monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
 
@@ -266,20 +321,6 @@ class TestCliSessionStartNamespaceOverride:
         assert result.exit_code != 0
         assert "invalid namespace" in result.output
         assert "'agent-runtime:foo:bar'" in result.output
-        # Regression pin: storage never received a malformed namespace.
-        storage_mock.create_session.assert_not_called()
-
-    def test_rejects_path_traversal(self, runner, monkeypatch, storage_mock):
-        comp = SimpleNamespace(storage=storage_mock)
-        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
-
-        result = runner.invoke(
-            cli,
-            ["session", "start", "--agent-id", "planner", "--namespace", "../etc"],
-        )
-
-        assert result.exit_code != 0
-        assert "invalid namespace" in result.output
         storage_mock.create_session.assert_not_called()
 
     def test_accepts_explicit_shared(self, runner, monkeypatch, storage_mock):


### PR DESCRIPTION
## Summary

Closes the bypass [#496](https://github.com/memtomem/memtomem/issues/496) flagged on PR #495 review (Concern 3): even after #491 / #494 / #498 gated every `agent_id` concatenation, the explicit `namespace=` argument on session-start (and `target=` on `mem_agent_share`) still landed verbatim in storage. A Python / MCP / CLI caller could write `"agent-runtime:foo:bar"` even though `agent_id` itself was clean.

- Add `validate_namespace` in `constants.py` with structural rules: `:`-separated segments matching `[A-Za-z0-9._-]+` (no leading dash, no `.`/`..`), 256-char total cap, and a strict-arity rule for `agent-runtime:<seg>` overrides that re-routes the trailing segment through `validate_agent_id`.
- Wire it at every entry point that accepts a caller-supplied namespace argument: `mem_session_start(namespace=)` (MCP), `mm session start --namespace` (CLI), `MemtomemStore.start_agent_session(namespace=)` and `MemtomemStore.start_session(namespace=)` (LangGraph), and `mem_agent_share(target=)` (MCP).
- New `test_validate_namespace.py` pins the wiring + the regression contract: `store.start_agent_session(agent_id="planner", namespace="agent-runtime:foo:bar")` cannot land an `agent-runtime:foo:bar` row, same shape pinned at every other surface.

## Why

The kin issue to the `mem_agent_share(target=...)` gap flagged on PR #494 review: same bypass exists on every surface where a user-supplied namespace string is accepted alongside `agent_id`. Single boundary, single charset, single error message — `Error: invalid namespace 'X': ...` mirrors the `agent_id` gate's UX so error scrapers see one shape regardless of how the request entered the system.

The `agent-runtime:` prefix is the one place where the override path could widen the contract that the direct `agent_id=` path enforces. Re-routing the trailing segment through `validate_agent_id` keeps both paths symmetric: a malformed agent id is rejected whether you smuggled it through `agent_id=foo:bar` or `namespace=agent-runtime:foo:bar`. The chained agent_id error is wrapped so the outer fragment still says `"invalid namespace"` for log-scraper consistency (`__cause__` preserves the underlying detail).

## Out of scope

- **`mem_ns_*` CRUD tools — tracked as [#500](https://github.com/memtomem/memtomem/issues/500).** Code review surfaced a transitive bypass via `app.current_namespace`: `mem_ns_set(namespace="agent-runtime:foo:bar")` followed by `mem_session_start(agent_id="default")` falls through priority step 3 (the `app.current_namespace` fallback) and lands the same shape this PR closes elsewhere. `mem_ns_set` / `mem_ns_rename` / `mem_ns_assign` / `mem_ns_update` / `mem_ns_delete` all accept user-supplied namespace strings without validation today; #500 covers all five so the gate is consistent across the namespace-CRUD surface.
- **`mm session wrap --namespace`** — the option doesn't currently exist on the wrap subcommand (only `--agent-id` and `--title`). The agent_id gate from #491 covers the wrap surface; adding the option belongs in the same change that wires it up, not this PR.
- **`mem_add(namespace=...)` / `mem_search(namespace=...)`** — the issue scopes this to session-start surfaces and the kin `mem_agent_share` gap. CRUD-tool namespace validation is a broader UX call.
- **Migrating any namespace rows that may already be malformed in existing storage** — this is a forward gate only.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 2730 passed, 46 deselected (ollama).
- [x] `uv run ruff check` + `ruff format --check` on `src/` and `tests/` — clean.
- [x] `uv run mypy` on the 5 changed source files — clean.
- [x] New `test_validate_namespace.py` (136 tests):
  - 22 hostile-input rejections at the validator
  - 13 in-tree namespaces still accepted
  - MCP boundary: `mem_session_start(namespace="agent-runtime:foo:bar")` returns `"Error: invalid namespace ..."` and storage stays empty
  - CLI boundary: full `CLI_HOSTILE_NAMESPACES` parametrize (defense-in-depth) + canonical issue-#496 shape pinned separately
  - LangGraph boundary: both `start_agent_session` and `start_session` raise `InvalidNameError` and never await `create_session`
  - `mem_agent_share` boundary: rejects before chunk lookup
  - Cross-surface error parity: MCP and CLI emit the same `invalid namespace 'X'` core text
  - `agent-runtime:<oversized>` wraps the agent_id error: outer says `invalid namespace`, `__cause__` preserves the agent_id detail

Closes #496. Follow-up tracked as #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
