### PR TITLE
fix: validate user-supplied namespace strings on mem_ns_* CRUD tools (#500)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/namespace.py
+++ b/packages/memtomem/src/memtomem/server/tools/namespace.py
@@ -4,6 +4,7 @@ mem_ns_update.
 
 from __future__ import annotations
 
+from memtomem.constants import validate_namespace
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -44,8 +45,7 @@ async def mem_ns_delete(
     Args:
         namespace: The namespace to delete.
     """
-    if not namespace.strip():
-        return "Error: namespace must be non-empty."
+    validate_namespace(namespace)
     app = await _get_app_initialized(ctx)
     deleted = await app.storage.delete_by_namespace(namespace)
     return f"Deleted {deleted} chunks from namespace '{namespace}'"
@@ -60,16 +60,25 @@ async def mem_ns_set(
 ) -> str:
     """Set the session-default namespace. Subsequent search/add/recall use this unless overridden.
 
+    ``namespace`` is run through :func:`validate_namespace` before the
+    write, mirroring ``mem_session_start(namespace=...)``. Without the
+    gate, an attacker who controls the value reaching ``mem_ns_set`` could
+    write a hostile-shaped string into ``app.current_namespace`` — and a
+    later ``mem_session_start(agent_id="default")`` would land that string
+    in the ``sessions`` row via the ``current_namespace`` fallback,
+    re-opening the bypass issue #496 closed at the explicit
+    ``namespace=`` surface. See issue #500 for the transitive-bypass
+    write-up.
+
     Examples::
         mem_ns_set(namespace="work")
         mem_ns_set(namespace="project:myapp")
     """
-    if not namespace.strip():
-        return "Error: namespace must be non-empty."
+    validate_namespace(namespace)
     app = await _get_app_initialized(ctx)
     async with app._config_lock:
-        app.current_namespace = namespace.strip()
-    return f"Session namespace set to '{namespace.strip()}'"
+        app.current_namespace = namespace
+    return f"Session namespace set to '{namespace}'"
 
 
 @mcp.tool()
@@ -96,14 +105,18 @@ async def mem_ns_rename(
 ) -> str:
     """Rename a namespace (SQL UPDATE, no re-indexing needed).
 
+    Both ``old`` and ``new`` are run through :func:`validate_namespace`
+    so a hostile-shaped string cannot land verbatim in the chunks /
+    namespace_metadata rows via the rename path. See issue #500.
+
     Examples::
         mem_ns_rename(old="project:v1", new="project:v2")
     """
-    if not old.strip() or not new.strip():
-        return "Error: both old and new namespace names must be non-empty."
+    validate_namespace(old)
+    validate_namespace(new)
     app = await _get_app_initialized(ctx)
-    count = await app.storage.rename_namespace(old.strip(), new.strip())
-    return f"Renamed namespace '{old.strip()}' -> '{new.strip()}' ({count} chunks updated)"
+    count = await app.storage.rename_namespace(old, new)
+    return f"Renamed namespace '{old}' -> '{new}' ({count} chunks updated)"
 
 
 @mcp.tool()
@@ -117,11 +130,16 @@ async def mem_ns_update(
 ) -> str:
     """Update namespace metadata (description and/or color).
 
+    ``namespace`` is run through :func:`validate_namespace` so the lookup
+    key cannot carry a hostile shape into the ``namespace_metadata``
+    write. See issue #500.
+
     Args:
         namespace: The namespace to update
         description: Optional description text
         color: Optional color hex code (e.g. "#6c5ce7")
     """
+    validate_namespace(namespace)
     app = await _get_app_initialized(ctx)
     await app.storage.set_namespace_meta(namespace, description=description, color=color)
     return f"Updated metadata for namespace '{namespace}'"
@@ -141,18 +159,23 @@ async def mem_ns_assign(
     Filter chunks by source path and/or current namespace, then move them
     to the target namespace. This is a SQL UPDATE — fast and non-destructive.
 
+    Both ``namespace`` and ``old_namespace`` (when provided) are run
+    through :func:`validate_namespace` so a hostile-shaped target cannot
+    land verbatim in the chunks rows via the assign path. See issue #500.
+
     Args:
         namespace: Target namespace to assign chunks to
         source_filter: Only assign chunks from sources containing this substring
         old_namespace: Only assign chunks currently in this namespace
     """
-    if not namespace.strip():
-        return "Error: namespace must be non-empty."
+    validate_namespace(namespace)
+    if old_namespace is not None:
+        validate_namespace(old_namespace)
     if not source_filter and not old_namespace:
         return "Error: at least one filter (source_filter or old_namespace) is required."
     app = await _get_app_initialized(ctx)
     count = await app.storage.assign_namespace(
-        namespace.strip(), source_filter=source_filter, old_namespace=old_namespace
+        namespace, source_filter=source_filter, old_namespace=old_namespace
     )
     filters = []
     if source_filter:

--- a/packages/memtomem/tests/test_validate_namespace_ns_tools.py
+++ b/packages/memtomem/tests/test_validate_namespace_ns_tools.py
@@ -1,0 +1,333 @@
+"""Tests for ``validate_namespace`` enforcement on the ``mem_ns_*`` CRUD
+tools.
+
+Closes the kin gap issue #500 flagged on PR #499 review (Concern 1):
+even after #496 / #499 gated every caller-supplied ``namespace=`` /
+``target=`` override on session-start and ``mem_agent_share``, the
+``mem_ns_*`` namespace CRUD tools still wrote user-supplied namespace
+strings into either app state or the storage row with no validation.
+
+The transitive bypass that drives this file:
+
+    mem_ns_set(namespace="agent-runtime:foo:bar")     # accepted today
+    mem_session_start(agent_id="default")             # falls through to
+                                                      # current_namespace
+    -> session row lands with the same shape PR #499 closes elsewhere
+
+The contract this file pins:
+
+* ``mem_ns_set`` rejects hostile-shaped ``namespace=`` BEFORE writing
+  ``app.current_namespace`` — so the transitive bypass into
+  ``mem_session_start``'s priority-chain step 3 (``app.current_namespace``
+  fallback) cannot land a malformed session row.
+* ``mem_ns_rename`` / ``mem_ns_assign`` / ``mem_ns_update`` /
+  ``mem_ns_delete`` reject hostile-shaped namespace arguments BEFORE the
+  storage write / lookup.
+* Rejection text matches the rest of the namespace gate (``Error:
+  invalid namespace ...``) so log scrapers see one shape across surfaces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.server.context import AppContext
+from memtomem.server.tools.namespace import (
+    mem_ns_assign,
+    mem_ns_delete,
+    mem_ns_rename,
+    mem_ns_set,
+    mem_ns_update,
+)
+from memtomem.server.tools.session import mem_session_start
+
+from test_validate_namespace import HOSTILE_NAMESPACES, _StubCtx
+
+
+# ---------------------------------------------------------------------------
+# mem_ns_set — the transitive-bypass closer
+# ---------------------------------------------------------------------------
+
+
+class TestMemNsSetValidatesNamespace:
+    """``mem_ns_set`` writes ``app.current_namespace`` directly. Without
+    a gate, a hostile string lands in app state and is later picked up
+    by ``mem_session_start(agent_id="default")`` via the
+    ``current_namespace`` fallback (priority chain step 3) — re-opening
+    the session-row bypass that PR #499 closed at the explicit
+    ``namespace=`` surface.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_set(
+            namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+        assert "'agent-runtime:foo:bar'" in out
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
+    async def test_hostile_namespaces_all_rejected(self, components, namespace):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_set(
+            namespace=namespace,
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    async def test_rejection_does_not_mutate_current_namespace(self, components):
+        """Belt-and-suspenders: even on a rejected call, ``mem_ns_set``
+        must not have touched ``app.current_namespace``. The validator is
+        called before the lock + write, so the value cannot land in app
+        state through any code path on the rejection branch.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+        before = app.current_namespace
+
+        out = await mem_ns_set(
+            namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+        assert app.current_namespace == before
+
+    @pytest.mark.asyncio
+    async def test_explicit_shared_namespace_still_succeeds(self, components):
+        """Sanity: the gate must not regress the documented happy path.
+        ``mem_ns_set(namespace="shared")`` is one of the in-tree shapes
+        ``ACCEPTED_NAMESPACES`` pins on the unit validator.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_set(
+            namespace="shared",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert "Session namespace set to 'shared'" in out
+        assert app.current_namespace == "shared"
+
+
+# ---------------------------------------------------------------------------
+# mem_ns_set → mem_session_start: the transitive bypass regression
+# ---------------------------------------------------------------------------
+
+
+class TestTransitiveBypassClosed:
+    @pytest.mark.asyncio
+    async def test_set_then_session_start_cannot_land_malformed_row(self, components):
+        """Issue #500 canonical regression:
+
+            mem_ns_set(namespace="agent-runtime:foo:bar")     # rejected
+            mem_session_start(agent_id="default")             # falls
+                                                              # through
+            -> sessions.namespace MUST NOT contain the bypass shape
+
+        This pins the *full* attack chain end-to-end: even if a future
+        regression weakens any one of the three checks (the ns-set gate,
+        the ``current_namespace`` write guard, or the session-start
+        fallback), the storage row outcome stays clean.
+        """
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        rejected = await mem_ns_set(
+            namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+        assert rejected.startswith("Error: invalid namespace")
+
+        out = await mem_session_start(
+            agent_id="default",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+        assert "Session started" in out
+
+        rows = await app.storage.list_sessions()
+        assert not any("agent-runtime:foo:bar" in (r.get("namespace") or "") for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# mem_ns_delete
+# ---------------------------------------------------------------------------
+
+
+class TestMemNsDeleteValidatesNamespace:
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_delete(
+            namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
+    async def test_hostile_namespaces_all_rejected(self, components, namespace):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_delete(
+            namespace=namespace,
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+
+# ---------------------------------------------------------------------------
+# mem_ns_rename — both old and new are user-supplied
+# ---------------------------------------------------------------------------
+
+
+class TestMemNsRenameValidatesNamespace:
+    @pytest.mark.asyncio
+    async def test_hostile_old_returns_error(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_rename(
+            old="agent-runtime:foo:bar",
+            new="cleanup",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    async def test_hostile_new_returns_error(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_rename(
+            old="cleanup",
+            new="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("hostile", HOSTILE_NAMESPACES)
+    async def test_hostile_either_side_rejected(self, components, hostile):
+        """Both arms are user-supplied, both arms must be gated."""
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out_old = await mem_ns_rename(
+            old=hostile,
+            new="cleanup",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+        out_new = await mem_ns_rename(
+            old="cleanup",
+            new=hostile,
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out_old.startswith("Error: invalid namespace")
+        assert out_new.startswith("Error: invalid namespace")
+
+
+# ---------------------------------------------------------------------------
+# mem_ns_assign — namespace + old_namespace are both user-supplied
+# ---------------------------------------------------------------------------
+
+
+class TestMemNsAssignValidatesNamespace:
+    @pytest.mark.asyncio
+    async def test_hostile_namespace_returns_error(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_assign(
+            namespace="agent-runtime:foo:bar",
+            source_filter="docs/",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    async def test_hostile_old_namespace_returns_error(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_assign(
+            namespace="cleanup",
+            old_namespace="agent-runtime:foo:bar",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("hostile", HOSTILE_NAMESPACES)
+    async def test_hostile_either_side_rejected(self, components, hostile):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out_target = await mem_ns_assign(
+            namespace=hostile,
+            source_filter="docs/",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+        out_old = await mem_ns_assign(
+            namespace="cleanup",
+            old_namespace=hostile,
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out_target.startswith("Error: invalid namespace")
+        assert out_old.startswith("Error: invalid namespace")
+
+
+# ---------------------------------------------------------------------------
+# mem_ns_update
+# ---------------------------------------------------------------------------
+
+
+class TestMemNsUpdateValidatesNamespace:
+    @pytest.mark.asyncio
+    async def test_agent_runtime_foo_bar_returns_error_string(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_update(
+            namespace="agent-runtime:foo:bar",
+            description="x",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
+    async def test_hostile_namespaces_all_rejected(self, components, namespace):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        out = await mem_ns_update(
+            namespace=namespace,
+            description="x",
+            ctx=ctx,  # type: ignore[arg-type]
+        )
+
+        assert out.startswith("Error: invalid namespace")


### PR DESCRIPTION
## Summary

Closes #500 — the kin gap PR #499 left on the namespace CRUD surface. After #496 / #499 gated every caller-supplied `namespace=` / `target=` override on session-start and `mem_agent_share`, the `mem_ns_*` tools still wrote user-supplied strings into either app state or the storage row with only an `if not strip()` empty-check.

### The transitive bypass this closes

```python
mem_ns_set(namespace="agent-runtime:foo:bar")    # accepted today
mem_session_start(agent_id="default")            # falls through to step 3
# -> effective_ns = app.current_namespace = "agent-runtime:foo:bar"
# -> sessions row lands with the same shape #496 closed elsewhere
```

`mem_session_start`'s priority chain (`server/tools/session.py:101-112`) treats `app.current_namespace` as the step-3 fallback when `agent_id == "default"`. With `mem_ns_set` ungated, an attacker who controls the value reaching it could land a malformed `current_namespace` and have it round-trip into the next session row through the fallback. Same user-visible outcome as the `namespace=` override #499 closes — different door.

### What's gated

`validate_namespace` (the strict gate from #499) is now applied at every public `mem_ns_*` surface that accepts a user-supplied namespace string, before storage / state is touched:

- `mem_ns_set(namespace=)` — closes the transitive bypass.
- `mem_ns_delete(namespace=)` — read-shaped today, pulled under the gate for consistency.
- `mem_ns_rename(old=, new=)` — both arms gated.
- `mem_ns_assign(namespace=, old_namespace=)` — both arms gated.
- `mem_ns_update(namespace=)` — lookup key gated.

The pre-existing `.strip()` calls on caller input go away — the validator's contract is forward-shield-on-input, and silent stripping of whitespace-padded values is exactly the kind of "sanitise and accept" behaviour the namespace gate is closing across surfaces.

### Out of scope (matches #496 / #499)

- **No data migration.** Forward gate only; any malformed namespace rows already in storage are left as-is.
- **No CLI mirror needed.** There is no `mm ns` command surface today (CLI exposes `mm agent register/share/list/migrate` only, not the ns CRUD tools), so the issue's "CLI mirror" clause is vacuous for this set. If `mm ns` lands later, it inherits the gate via the existing pattern in `mm session start --namespace` / `mm agent register`.

## Test plan

- [x] New `tests/test_validate_namespace_ns_tools.py` — per-tool hostile rejection parametrised over the existing `HOSTILE_NAMESPACES` suite, plus the end-to-end transitive-bypass regression: `mem_ns_set("agent-runtime:foo:bar")` → `mem_session_start(agent_id="default")` cannot land an `agent-runtime:foo:bar` session row.
- [x] Existing `tests/test_validate_namespace.py` re-runs cleanly (no overlap; the ns-tool boundary was previously uncovered).
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run pytest -m "not ollama"` — 2850 passed, 46 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)