### PR TITLE
fix: namespace defense-in-depth — AppContext setter + architectural guard + message constant

### DIFF
--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -80,6 +80,16 @@ def validate_agent_id(value: object) -> str:
 _NAMESPACE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _MAX_NAMESPACE_LEN: Final[int] = 256
 
+# Single source of truth for the user-facing namespace-rejection prefix.
+# Every error raised by :func:`validate_namespace` starts with this string
+# so log scrapers / alert rules / test assertions can grep for one shape
+# across surfaces. Per-PR-#501 review (Concern: "메시지 형식이 사실상
+# public API 의 일부"): centralising the literal here lets a future tweak
+# stay one change point — sibling tests should import this constant
+# rather than re-typing ``"invalid namespace"`` against the validator's
+# private formatting choices.
+INVALID_NAMESPACE_MESSAGE_PREFIX: Final[str] = "invalid namespace"
+
 
 def validate_namespace(value: object) -> str:
     """Return *value* unchanged if it is a storable namespace string.
@@ -122,32 +132,29 @@ def validate_namespace(value: object) -> str:
     see one shape across surfaces.
     """
 
+    prefix = INVALID_NAMESPACE_MESSAGE_PREFIX
     if not isinstance(value, str):
-        raise InvalidNameError(f"invalid namespace: expected str, got {type(value).__name__}")
+        raise InvalidNameError(f"{prefix}: expected str, got {type(value).__name__}")
     if not value or not value.strip():
-        raise InvalidNameError(f"invalid namespace {value!r}: empty")
+        raise InvalidNameError(f"{prefix} {value!r}: empty")
     if len(value) > _MAX_NAMESPACE_LEN:
         raise InvalidNameError(
-            f"invalid namespace {value!r}: length {len(value)} exceeds {_MAX_NAMESPACE_LEN}"
+            f"{prefix} {value!r}: length {len(value)} exceeds {_MAX_NAMESPACE_LEN}"
         )
 
     segments = value.split(":")
     for seg in segments:
         if not seg:
             raise InvalidNameError(
-                f"invalid namespace {value!r}: empty segment (leading / trailing / consecutive ':')"
+                f"{prefix} {value!r}: empty segment (leading / trailing / consecutive ':')"
             )
         if seg in (".", ".."):
-            raise InvalidNameError(
-                f"invalid namespace {value!r}: segment {seg!r} is a reserved path token"
-            )
+            raise InvalidNameError(f"{prefix} {value!r}: segment {seg!r} is a reserved path token")
         if seg.startswith("-"):
-            raise InvalidNameError(
-                f"invalid namespace {value!r}: segment {seg!r} has a leading dash"
-            )
+            raise InvalidNameError(f"{prefix} {value!r}: segment {seg!r} has a leading dash")
         if not _NAMESPACE_SEGMENT_RE.fullmatch(seg):
             raise InvalidNameError(
-                f"invalid namespace {value!r}: segment {seg!r} must match "
+                f"{prefix} {value!r}: segment {seg!r} must match "
                 f"[A-Za-z0-9._-]+ (no slash / backslash / whitespace / control chars)"
             )
 
@@ -177,7 +184,7 @@ def validate_namespace(value: object) -> str:
             # fragments. ``__cause__`` preserves the agent_id detail for
             # anyone debugging the underlying contract violation.
             raise InvalidNameError(
-                f"invalid namespace {value!r}: {runtime_prefix} segment {segments[1]!r} "
+                f"{prefix} {value!r}: {runtime_prefix} segment {segments[1]!r} "
                 f"failed agent-id contract — {e}"
             ) from e
 

--- a/packages/memtomem/src/memtomem/server/context.py
+++ b/packages/memtomem/src/memtomem/server/context.py
@@ -11,6 +11,7 @@ from mcp.server.fastmcp import Context
 from mcp.server.session import ServerSession
 
 from memtomem.config import Mem2MemConfig
+from memtomem.constants import validate_namespace
 
 if TYPE_CHECKING:
     from memtomem.embedding.base import EmbeddingProvider
@@ -93,7 +94,14 @@ class AppContext:
 
     config: Mem2MemConfig
     webhook_manager: object | None = None
-    current_namespace: str | None = None
+    # Backing field for the ``current_namespace`` property below. Kept off
+    # ``__init__`` so callers go through the setter (which validates) and
+    # cannot smuggle a hostile shape via ``AppContext(current_namespace=
+    # "agent-runtime:foo:bar")``. See issue #500 for the transitive bypass
+    # this property closes — direct attribute writes (Python-level bypass
+    # of ``mem_ns_set``) are caught here even if a future tool were added
+    # that mutates app state without re-running ``validate_namespace``.
+    _current_namespace: str | None = field(default=None, init=False, repr=False)
     current_session_id: str | None = None
     # Set by ``mem_session_start(agent_id=...)`` and reset by
     # ``mem_session_end``. ``mem_agent_search(agent_id=None)`` falls back to
@@ -126,6 +134,32 @@ class AppContext:
     # Kept distinct from ``_config_lock`` so a long-running config write
     # cannot block a session start, and vice versa.
     _session_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    # ── current_namespace (validated) ─────────────────────────────────────
+    # Property + setter pair so every write — whether via ``mem_ns_set``,
+    # a future tool we forget to gate, or a bare ``app.current_namespace =
+    # X`` from test code or a Python adapter — runs through
+    # :func:`validate_namespace`. ``mem_session_start``'s priority chain
+    # (priority 3) reads this back as a fallback, so a hostile string here
+    # round-trips into the ``sessions`` row — exactly the bypass issue
+    # #500 was filed to close.
+    #
+    # Defense-in-depth on top of the input gates at every public surface
+    # (``mem_ns_set``, ``mem_session_start(namespace=)``,
+    # ``mem_agent_share(target=)`` …). The forward-shield contract of
+    # :func:`validate_namespace` (constants.py:96-100) still holds: this
+    # property only re-validates **caller-supplied** writes that reach app
+    # state. Internal callers that read the value back never re-validate.
+
+    @property
+    def current_namespace(self) -> str | None:
+        return self._current_namespace
+
+    @current_namespace.setter
+    def current_namespace(self, value: str | None) -> None:
+        if value is not None:
+            validate_namespace(value)
+        self._current_namespace = value
 
     # ── component accessors ───────────────────────────────────────────────
     # These raise ``RuntimeError`` if accessed before ``ensure_initialized``

--- a/packages/memtomem/tests/test_validate_namespace_architectural_guard.py
+++ b/packages/memtomem/tests/test_validate_namespace_architectural_guard.py
@@ -1,0 +1,278 @@
+"""Architectural guard for ``validate_namespace`` coverage on
+``server/tools/*.py``.
+
+Closes the regression class the multi-agent namespace-gate series
+(#491 → #494 → #496 → #498 → #499 → #500/#501) kept hitting one PR at
+a time: a public MCP tool gets added or refactored that takes a
+namespace-shaped argument, but the new code path forgets to import /
+call :func:`validate_namespace`. The series itself is the evidence —
+every PR closed one more surface that had been silently ungated.
+
+This file makes the contract **declarative** rather than per-tool:
+
+* :data:`VALIDATED_NS_SURFACES` — every ``(file, function, parameter)``
+  triple where ``validate_namespace`` MUST appear in the function body.
+  A regression that drops the call (refactor, accidental deletion, copy-
+  paste from a deferred surface) trips :func:`test_declared_validated_
+  surfaces_call_validate_namespace`.
+* :data:`DEFERRED_NS_SURFACES` — every triple the project has
+  *explicitly* decided to leave ungated for now (broader UX call deferred
+  in issue #500). Each entry carries the rationale inline so a future
+  reader can look up *why* the deferral is in place rather than wonder
+  whether it's an oversight.
+* :func:`test_no_unclassified_ns_surfaces` — AST-scans
+  ``server/tools/*.py`` for any tool that takes a namespace-shaped
+  parameter. Every match must be classified into either set; an
+  unclassified hit fails the test, forcing the author to make a decision
+  rather than ship a silent gap.
+
+The result: the next time someone adds ``mem_foo(namespace=...)``
+without calling ``validate_namespace``, this test fails at PR time and
+points them at the missing decision — gate it (move to VALIDATED) or
+explicitly defer it (move to DEFERRED with rationale).
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Surface registry
+# ---------------------------------------------------------------------------
+
+# Triples are ``(filename within server/tools, function_name, parameter)``.
+# Multiple parameters on the same function get one triple each.
+
+# Surfaces that MUST call ``validate_namespace`` on the named parameter
+# before any storage / state mutation. These are the public MCP tools
+# whose namespace argument lands in either ``app.current_namespace``,
+# the ``sessions`` row, or chunks/namespace-metadata rows.
+VALIDATED_NS_SURFACES: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        # PR #499 — the original namespace-override gate.
+        ("session.py", "mem_session_start", "namespace"),
+        ("multi_agent.py", "mem_agent_share", "target"),
+        # PR #501 (issue #500) — namespace CRUD gate.
+        ("namespace.py", "mem_ns_set", "namespace"),
+        ("namespace.py", "mem_ns_delete", "namespace"),
+        ("namespace.py", "mem_ns_rename", "old"),
+        ("namespace.py", "mem_ns_rename", "new"),
+        ("namespace.py", "mem_ns_assign", "namespace"),
+        ("namespace.py", "mem_ns_assign", "old_namespace"),
+        ("namespace.py", "mem_ns_update", "namespace"),
+    }
+)
+
+# Surfaces the project has explicitly left ungated as of this writing.
+# Each entry carries its rationale inline; if the deferral changes, move
+# the triple to ``VALIDATED_NS_SURFACES`` and add the validator call to
+# the function body in the same PR.
+#
+# Bulk deferral context — issue #500 "Out of scope":
+#   > ``mem_add`` / ``mem_search`` ``namespace=`` arguments — broader UX
+#   > call covered separately if pursued.
+#
+# That deferral covers the read-filter and per-write-path ``namespace=``
+# arguments below. The forward-shield at session-start /
+# ``mem_agent_share`` / ``mem_ns_*`` already prevents the bypass shape
+# from landing in app state or session rows; gating these would be a UX
+# decision (do we reject ``mem_add(namespace="foo bar")`` loudly, or
+# accept the legacy charset?) and is tracked as future work.
+DEFERRED_NS_SURFACES: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        # Read-filter surfaces — namespace narrows results, never writes.
+        # Hostile shape does not round-trip into storage.
+        ("ask.py", "mem_ask", "namespace"),
+        ("browse.py", "mem_list", "namespace"),
+        ("entity.py", "mem_entity_scan", "namespace"),
+        ("entity.py", "mem_entity_search", "namespace"),
+        ("evaluation.py", "mem_eval", "namespace"),
+        ("export_import.py", "mem_export", "namespace"),
+        ("importance.py", "mem_importance_scan", "namespace"),
+        ("recall.py", "mem_recall", "namespace"),
+        ("reflection.py", "mem_reflect", "namespace"),
+        ("search.py", "mem_search", "namespace"),
+        ("temporal.py", "mem_timeline", "namespace"),
+        ("temporal.py", "mem_activity", "namespace"),
+        # Write-path surfaces — caller-supplied namespace lands in chunks
+        # rows. Deferred per the same issue-#500 "broader UX call" line;
+        # the storage layer's ``_NS_NAME_RE`` (``[\\w\\-.:@ ]{1,255}``)
+        # still rejects the most pathological shapes today, and tightening
+        # it to the strict gate would break legacy-shape rows. Tracked for
+        # follow-up.
+        ("consolidation.py", "mem_consolidate", "namespace"),
+        ("export_import.py", "mem_import", "namespace"),
+        ("importers.py", "mem_import_notion", "namespace"),
+        ("importers.py", "mem_import_obsidian", "namespace"),
+        ("indexing.py", "mem_index", "namespace"),
+        ("memory_crud.py", "_mem_add_core", "namespace"),
+        ("memory_crud.py", "mem_add", "namespace"),
+        ("memory_crud.py", "mem_delete", "namespace"),
+        ("memory_crud.py", "mem_batch_add", "namespace"),
+        ("procedure.py", "mem_procedure_save", "namespace"),
+        ("url_index.py", "mem_fetch", "namespace"),
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+_TOOLS_DIR = pathlib.Path(__file__).resolve().parents[1] / "src" / "memtomem" / "server" / "tools"
+_NS_PARAM_NAMES: frozenset[str] = frozenset({"namespace", "target", "old", "new", "old_namespace"})
+
+
+def _iter_tool_functions() -> list[tuple[str, ast.AsyncFunctionDef | ast.FunctionDef]]:
+    """Return ``(filename, function_node)`` for every function in
+    ``server/tools/*.py``. Includes both private and public functions —
+    private helpers like ``_mem_add_core`` participate in the gate too
+    (they are the shared core ``mem_add`` / ``mem_batch_add`` route
+    through, so deferring or validating must cover them).
+    """
+    out: list[tuple[str, ast.AsyncFunctionDef | ast.FunctionDef]] = []
+    for path in sorted(_TOOLS_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                out.append((path.name, node))
+    return out
+
+
+def _ns_params(node: ast.AsyncFunctionDef | ast.FunctionDef) -> list[str]:
+    """Return parameter names matching ``_NS_PARAM_NAMES``, in declaration
+    order. Both positional-or-keyword and keyword-only args are scanned
+    so a future tool with a kw-only ``namespace`` is still gated.
+    """
+    return [a.arg for a in (*node.args.args, *node.args.kwonlyargs) if a.arg in _NS_PARAM_NAMES]
+
+
+def _calls_validate_namespace_on(node: ast.AsyncFunctionDef | ast.FunctionDef, param: str) -> bool:
+    """Return True iff the function body contains a call shaped like
+    ``validate_namespace(<param>)`` — either as a bare statement or as
+    an expression whose first positional arg is ``Name(id=<param>)``.
+
+    Deliberately structural: an ``if param is not None:
+    validate_namespace(param)`` pattern (used by ``mem_ns_assign`` for
+    the optional ``old_namespace`` arg) still matches, because the test
+    is checking the call exists with the right argument name, not the
+    surrounding control flow.
+    """
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        # Match bare ``validate_namespace(...)`` and aliased imports
+        # (``from memtomem.constants import validate_namespace as vn``)
+        # by checking the attribute / name component only.
+        callee = (
+            func.attr
+            if isinstance(func, ast.Attribute)
+            else func.id
+            if isinstance(func, ast.Name)
+            else None
+        )
+        if callee != "validate_namespace":
+            continue
+        if not sub.args:
+            continue
+        first = sub.args[0]
+        if isinstance(first, ast.Name) and first.id == param:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename, fn_name, param",
+    sorted(VALIDATED_NS_SURFACES),
+)
+def test_declared_validated_surfaces_call_validate_namespace(
+    filename: str, fn_name: str, param: str
+) -> None:
+    """Every entry in :data:`VALIDATED_NS_SURFACES` must call
+    ``validate_namespace(<param>)`` in its body. A failure here means
+    one of the gates dropped the validator call — the regression class
+    this file exists to catch.
+    """
+    matches = [
+        node for fname, node in _iter_tool_functions() if fname == filename and node.name == fn_name
+    ]
+    assert matches, (
+        f"Declared validated surface not found in source: "
+        f"{filename}::{fn_name}. Either the function was renamed / "
+        f"removed, or VALIDATED_NS_SURFACES is stale."
+    )
+    node = matches[0]
+    assert _calls_validate_namespace_on(node, param), (
+        f"{filename}::{fn_name} declares ``{param}`` as a validated "
+        f"namespace surface but the body does not contain "
+        f"``validate_namespace({param})``. If the gate was intentionally "
+        f"removed (e.g. moving to a deeper layer), update "
+        f"VALIDATED_NS_SURFACES; otherwise restore the validator call "
+        f"before any storage / state mutation."
+    )
+
+
+def test_no_unclassified_ns_surfaces() -> None:
+    """Every tool function with a namespace-shaped parameter must be
+    explicitly classified into either VALIDATED or DEFERRED. An
+    unclassified hit fails this test — forcing the author of a new
+    namespace-touching tool to make the validation decision instead of
+    silently shipping it.
+
+    This is the prospective regression catch the
+    ``feedback_drift_close_must_derive`` and ``feedback_stub_gap_check``
+    memos warn about: every literal that lists "the gated surfaces"
+    eventually drifts unless a guard forces re-classification when the
+    code adds new ones.
+    """
+    declared = VALIDATED_NS_SURFACES | DEFERRED_NS_SURFACES
+    found: set[tuple[str, str, str]] = set()
+    for filename, node in _iter_tool_functions():
+        for p in _ns_params(node):
+            found.add((filename, node.name, p))
+
+    unclassified = found - declared
+    stale = declared - found
+
+    msg_parts = []
+    if unclassified:
+        msg_parts.append(
+            "Unclassified namespace surfaces — every tool with a "
+            "``namespace=``/``target=``/``old=``/``new=``/"
+            "``old_namespace=`` parameter must be added to either "
+            "VALIDATED_NS_SURFACES (if it gates the input) or "
+            "DEFERRED_NS_SURFACES (if the project explicitly leaves it "
+            "ungated for now, with rationale):\n  - "
+            + "\n  - ".join(f"{f}::{n}({p})" for f, n, p in sorted(unclassified))
+        )
+    if stale:
+        msg_parts.append(
+            "Stale entries — declared in VALIDATED/DEFERRED but no "
+            "longer present in source. Remove them so the registry "
+            "reflects the live surface:\n  - "
+            + "\n  - ".join(f"{f}::{n}({p})" for f, n, p in sorted(stale))
+        )
+
+    assert not msg_parts, "\n\n".join(msg_parts)
+
+
+def test_validated_and_deferred_are_disjoint() -> None:
+    """A surface cannot be both gated and deferred — sanity check on
+    the registry definition itself.
+    """
+    overlap = VALIDATED_NS_SURFACES & DEFERRED_NS_SURFACES
+    assert not overlap, (
+        f"Surfaces declared in BOTH validated and deferred sets — choose one: {sorted(overlap)}"
+    )

--- a/packages/memtomem/tests/test_validate_namespace_ns_tools.py
+++ b/packages/memtomem/tests/test_validate_namespace_ns_tools.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import pytest
 
+from memtomem.constants import INVALID_NAMESPACE_MESSAGE_PREFIX, InvalidNameError
 from memtomem.server.context import AppContext
 from memtomem.server.tools.namespace import (
     mem_ns_assign,
@@ -42,6 +43,68 @@ from memtomem.server.tools.namespace import (
 from memtomem.server.tools.session import mem_session_start
 
 from test_validate_namespace import HOSTILE_NAMESPACES, _StubCtx
+
+_ERROR_PREFIX = f"Error: {INVALID_NAMESPACE_MESSAGE_PREFIX}"
+
+
+# ---------------------------------------------------------------------------
+# AppContext.current_namespace property — defense-in-depth setter
+# ---------------------------------------------------------------------------
+
+
+class TestAppContextCurrentNamespaceSetter:
+    """The setter on ``AppContext.current_namespace`` re-validates every
+    write to app state, even ones that bypass ``mem_ns_set``. This
+    catches the regression class where a future tool (or test code, or
+    a Python-level adapter) mutates ``app.current_namespace`` directly
+    without remembering to import ``validate_namespace`` — the same
+    "forgot to gate" pattern the multi-agent series (#491 → #500) hit
+    one PR at a time.
+
+    These tests are at the Python attribute level, not the MCP boundary
+    — the ``mem_ns_set`` tests above already pin the boundary contract.
+    """
+
+    def test_assigning_hostile_value_raises(self, components):
+        app = AppContext.from_components(components)
+        with pytest.raises(InvalidNameError, match=INVALID_NAMESPACE_MESSAGE_PREFIX):
+            app.current_namespace = "agent-runtime:foo:bar"
+
+    @pytest.mark.parametrize("hostile", HOSTILE_NAMESPACES)
+    def test_setter_rejects_every_hostile_shape(self, components, hostile):
+        app = AppContext.from_components(components)
+        with pytest.raises(InvalidNameError, match=INVALID_NAMESPACE_MESSAGE_PREFIX):
+            app.current_namespace = hostile
+
+    def test_rejected_assignment_leaves_attribute_unchanged(self, components):
+        app = AppContext.from_components(components)
+        app.current_namespace = "legacy-ns"  # known-good
+        assert app.current_namespace == "legacy-ns"
+
+        with pytest.raises(InvalidNameError):
+            app.current_namespace = "agent-runtime:foo:bar"
+
+        # Backing store is untouched on the rejected path — the bad value
+        # never reaches ``_current_namespace``.
+        assert app.current_namespace == "legacy-ns"
+
+    def test_assigning_none_passes_through(self, components):
+        """``mem_session_end`` writes ``current_session_id = None`` (a
+        sibling field), and a future caller may want to clear the
+        namespace fallback the same way. ``None`` is the documented
+        cleared state and must not trip the validator.
+        """
+        app = AppContext.from_components(components)
+        app.current_namespace = "shared"
+        app.current_namespace = None
+        assert app.current_namespace is None
+
+    def test_assigning_accepted_shape_succeeds(self, components):
+        app = AppContext.from_components(components)
+        app.current_namespace = "shared"
+        assert app.current_namespace == "shared"
+        app.current_namespace = "claude-memory:project-x"
+        assert app.current_namespace == "claude-memory:project-x"
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +131,7 @@ class TestMemNsSetValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
         assert "'agent-runtime:foo:bar'" in out
 
     @pytest.mark.asyncio
@@ -82,7 +145,7 @@ class TestMemNsSetValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     async def test_rejection_does_not_mutate_current_namespace(self, components):
@@ -100,7 +163,7 @@ class TestMemNsSetValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
         assert app.current_namespace == before
 
     @pytest.mark.asyncio
@@ -148,7 +211,7 @@ class TestTransitiveBypassClosed:
             namespace="agent-runtime:foo:bar",
             ctx=ctx,  # type: ignore[arg-type]
         )
-        assert rejected.startswith("Error: invalid namespace")
+        assert rejected.startswith(_ERROR_PREFIX)
 
         out = await mem_session_start(
             agent_id="default",
@@ -176,7 +239,7 @@ class TestMemNsDeleteValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
@@ -189,7 +252,7 @@ class TestMemNsDeleteValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +272,7 @@ class TestMemNsRenameValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     async def test_hostile_new_returns_error(self, components):
@@ -222,7 +285,7 @@ class TestMemNsRenameValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("hostile", HOSTILE_NAMESPACES)
@@ -242,8 +305,8 @@ class TestMemNsRenameValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out_old.startswith("Error: invalid namespace")
-        assert out_new.startswith("Error: invalid namespace")
+        assert out_old.startswith(_ERROR_PREFIX)
+        assert out_new.startswith(_ERROR_PREFIX)
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +326,7 @@ class TestMemNsAssignValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     async def test_hostile_old_namespace_returns_error(self, components):
@@ -276,7 +339,7 @@ class TestMemNsAssignValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("hostile", HOSTILE_NAMESPACES)
@@ -295,8 +358,8 @@ class TestMemNsAssignValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out_target.startswith("Error: invalid namespace")
-        assert out_old.startswith("Error: invalid namespace")
+        assert out_target.startswith(_ERROR_PREFIX)
+        assert out_old.startswith(_ERROR_PREFIX)
 
 
 # ---------------------------------------------------------------------------
@@ -316,7 +379,7 @@ class TestMemNsUpdateValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("namespace", HOSTILE_NAMESPACES)
@@ -330,4 +393,4 @@ class TestMemNsUpdateValidatesNamespace:
             ctx=ctx,  # type: ignore[arg-type]
         )
 
-        assert out.startswith("Error: invalid namespace")
+        assert out.startswith(_ERROR_PREFIX)


### PR DESCRIPTION
**Stacked on top of #501** — set base to that branch. Once #501 merges, this rebases onto `main`.

## Summary

Three targeted reinforcements that close the *regression class* the multi-agent namespace-gate series (#491 → #494 → #496 → #498 → #499 → #500/#501) kept hitting one PR at a time — every PR closed one more public surface that had silently shipped without `validate_namespace`. The series itself is the evidence; this PR makes the next iteration trip a test before review instead of in production.

### A. `AppContext.current_namespace` property setter

Convert the dataclass field to a backing-store + property pair so every write — `mem_ns_set`, a future tool we forget to gate, a Python adapter, or test code doing `app.current_namespace = X` — runs through `validate_namespace` before the value lands in app state.

The bypass this closes is the Python-level direct-mutation path: `mem_ns_set` is gated, but anyone with an `AppContext` reference can also do `app.current_namespace = "agent-runtime:foo:bar"` without going through the tool. `mem_session_start(agent_id="default")`'s priority chain (step 3 fallback, `server/tools/session.py:109-110`) reads `current_namespace` back as the `sessions`-row namespace, so the same #496 / #500 bypass shape round-trips through this back door.

The forward-shield contract from `constants.py:96-100` is preserved: re-validation only happens on caller-supplied writes that reach app state. Internal callers reading the value back never re-validate; internally-derived namespaces (`f"{AGENT_NAMESPACE_PREFIX}{agent_id}"` after `validate_agent_id` succeeded, `"default"`, `SHARED_NAMESPACE`) skip the gate, same as before.

### B. Architectural guard test

`tests/test_validate_namespace_architectural_guard.py` AST-scans `server/tools/*.py` for any function with a `namespace=` / `target=` / `old=` / `new=` / `old_namespace=` parameter and forces every match to be classified:

- **`VALIDATED_NS_SURFACES`** — the 9 `(file, fn, param)` triples PR #499 + #501 gate today. Test asserts each function body actually calls `validate_namespace(<param>)`; a regression that drops the call (refactor, accidental deletion, copy-paste) trips the test.
- **`DEFERRED_NS_SURFACES`** — the 22 triples the project has *explicitly* left ungated for now (issue #500's "broader UX call covered separately if pursued"). Each entry carries inline rationale.

A new tool with a namespace-shaped param that lands in *neither* set fails `test_no_unclassified_ns_surfaces` and forces the author to make the validation decision at PR time — gate it (move to VALIDATED) or explicitly defer (move to DEFERRED with rationale).

### E. Constantize `"invalid namespace"` message prefix

Per #501 review: the test suite's reliance on `out.startswith("Error: invalid namespace")` made the validator's error formatting an *implicit* public API. Centralised as `INVALID_NAMESPACE_MESSAGE_PREFIX` in `constants.py`, referenced from both the validator's f-strings and the test assertions. No behaviour change.

## Out of scope (deliberate)

- **Storage-layer charset alignment** (`sqlite_namespace._NS_NAME_RE`) — tightening would break legacy rows; same forward-only reasoning as #496 / #499 / #500.
- **Final-resolution helper inside `mem_session_start`** — same pattern as the input gate; marginal value over what (A) delivers.
- **Validating `mem_add` / `mem_search` / `mem_recall` `namespace=`** — tracked via `DEFERRED_NS_SURFACES`; UX call belongs in a follow-up.

## Test plan

- [x] New `TestAppContextCurrentNamespaceSetter` class in `test_validate_namespace_ns_tools.py` — pins the property setter contract at the Python attribute level (5 tests + parametrised hostile sweep).
- [x] New `test_validate_namespace_architectural_guard.py` — 11 tests: 9 parametrised + `test_no_unclassified_ns_surfaces` + `test_validated_and_deferred_are_disjoint`.
- [x] Existing assertions in `test_validate_namespace_ns_tools.py` switched to `_ERROR_PREFIX` (sourced from the new constant).
- [x] `uv run ruff check && ruff format --check` — clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/server/context.py packages/memtomem/src/memtomem/constants.py` — clean.
- [x] `uv run pytest -m "not ollama"` — 2887 passed (was 2850 pre-#501; +37 new tests across the three reinforcements).

🤖 Generated with [Claude Code](https://claude.com/claude-code)