### PR TITLE
fix: validate `mm agent share --target` overrides (#497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   now runs at `mem_session_start(namespace=)` (MCP),
   `mm session start --namespace` (CLI),
   `MemtomemStore.start_agent_session(namespace=)` and
-  `MemtomemStore.start_session(namespace=)` (Python adapter), and
-  `mem_agent_share(target=)` (MCP). `agent-runtime:<seg>` overrides
-  re-route the trailing segment through `validate_agent_id` so the
-  override path can't widen the contract that the direct `agent_id=`
-  path enforces.
+  `MemtomemStore.start_session(namespace=)` (Python adapter),
+  `mem_agent_share(target=)` (MCP), and `mm agent share --target`
+  (CLI — closes #497, the kin gap PR #499 review flagged on the share
+  surface). `agent-runtime:<seg>` overrides re-route the trailing
+  segment through `validate_agent_id` so the override path can't widen
+  the contract that the direct `agent_id=` path enforces.
 
   **Migration:** callers passing structured-but-unsupported namespace
   shapes (anything containing slashes, whitespace, comma, control
@@ -36,7 +37,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   now — it shadows the multi-agent prefix and the strict-arity rule
   requires exactly one trailing segment after the prefix. Anyone
   holding such a namespace should rename it via `mem_ns_rename` before
-  running session-start with the override. Closes #496.
+  running session-start with the override. Closes #496 and #497.
 
 - **`mem_agent_register`, `mem_agent_search`, and `mm agent register`
   now reject malformed `agent_id` values loudly instead of silently

--- a/packages/memtomem/src/memtomem/cli/agent_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/agent_cmd.py
@@ -13,6 +13,7 @@ from memtomem.constants import (
     SHARED_NAMESPACE,
     InvalidNameError,
     validate_agent_id,
+    validate_namespace,
 )
 
 if TYPE_CHECKING:
@@ -220,7 +221,17 @@ def share(chunk_id: str, target: str) -> None:
     UUID; this command does *not* create a true cross-reference link.
     See the multi-agent guide for the exact semantics and the ongoing
     RFC for true link support.
+
+    ``target`` is run through :func:`validate_namespace` before any
+    storage write — same gate the MCP path closes on issue #496 / PR
+    #499. Hostile shapes like ``agent-runtime:foo:bar`` are rejected
+    loudly so the CLI cannot smuggle a row past the contract that the
+    direct ``agent_id`` and ``mem_agent_share`` MCP surfaces enforce.
     """
+    try:
+        validate_namespace(target)
+    except InvalidNameError as e:
+        raise click.ClickException(str(e)) from e
     asyncio.run(_run_share(chunk_id, target))
 
 

--- a/packages/memtomem/tests/test_validate_namespace.py
+++ b/packages/memtomem/tests/test_validate_namespace.py
@@ -491,6 +491,126 @@ class TestMemAgentShareTargetOverride:
 
 
 # ---------------------------------------------------------------------------
+# CLI boundary — mm agent share --target
+# ---------------------------------------------------------------------------
+
+
+class TestCliAgentShareTargetOverride:
+    """``mm agent share --target`` is the CLI sibling of the MCP gap
+    closed by PR #499 (#496) — issue #497 flagged that the CLI
+    subcommand forwards ``--target`` straight into
+    ``index_engine.index_file(..., namespace=target)`` without
+    validation, so a caller could land an ``agent-runtime:foo:bar`` row
+    even though the equivalent ``mem_agent_share`` MCP / session-start
+    surfaces refuse the same shape. Defense-in-depth tests mirror
+    ``TestCliSessionStartNamespaceOverride`` so a regression on either
+    surface surfaces as a single failing parametrize.
+    """
+
+    @pytest.fixture
+    def share_storage_mock(self):
+        """Mock storage that returns ``None`` for any chunk lookup —
+        on the rejection path we assert ``get_chunk`` was never even
+        called, on the happy path we let the chunk-not-found
+        ``ClickException`` after validation confirm the gate passed.
+        """
+        return SimpleNamespace(get_chunk=AsyncMock(return_value=None))
+
+    @pytest.mark.parametrize("target", CLI_HOSTILE_NAMESPACES)
+    def test_hostile_targets_all_rejected(self, runner, monkeypatch, share_storage_mock, target):
+        comp = SimpleNamespace(storage=share_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            [
+                "agent",
+                "share",
+                "00000000-0000-0000-0000-000000000000",
+                "--target",
+                target,
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "invalid namespace" in result.output
+        # Regression pin: storage never received a malformed namespace.
+        share_storage_mock.get_chunk.assert_not_called()
+
+    def test_rejects_agent_runtime_foo_bar_with_quoted_value(
+        self, runner, monkeypatch, share_storage_mock
+    ):
+        """Canonical issue-#497 shape pinned separately from the
+        parametrize so failures here surface the bypass directly rather
+        than under one of N parametrized IDs.
+        """
+        comp = SimpleNamespace(storage=share_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            [
+                "agent",
+                "share",
+                "00000000-0000-0000-0000-000000000000",
+                "--target",
+                "agent-runtime:foo:bar",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "invalid namespace" in result.output
+        assert "'agent-runtime:foo:bar'" in result.output
+        share_storage_mock.get_chunk.assert_not_called()
+
+    def test_accepts_canonical_agent_runtime(self, runner, monkeypatch, share_storage_mock):
+        """``agent-runtime:planner`` is the dominant non-default share
+        target — must continue to round-trip the validator. We don't
+        assert ``exit_code == 0`` because the chunk-not-found exit comes
+        after validation; asserting on the validator-error fragment
+        keeps the test focused on the gate's contract.
+        """
+        comp = SimpleNamespace(storage=share_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            [
+                "agent",
+                "share",
+                "00000000-0000-0000-0000-000000000000",
+                "--target",
+                "agent-runtime:planner",
+            ],
+        )
+
+        assert "invalid namespace" not in result.output
+        share_storage_mock.get_chunk.assert_awaited_once()
+
+    def test_accepts_default_shared(self, runner, monkeypatch, share_storage_mock):
+        """The ``--target`` default of ``shared`` must round-trip the
+        validator unchanged — the gate's whole point is to reject
+        hostile shapes without touching the documented in-tree ones.
+        """
+        comp = SimpleNamespace(storage=share_storage_mock)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(
+            cli,
+            [
+                "agent",
+                "share",
+                "00000000-0000-0000-0000-000000000000",
+                # ``--target`` omitted on purpose so this also pins the
+                # default value's continued acceptance.
+            ],
+        )
+
+        assert "invalid namespace" not in result.output
+        share_storage_mock.get_chunk.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
 # Cross-surface error parity
 # ---------------------------------------------------------------------------
 
@@ -521,6 +641,43 @@ async def test_mcp_and_cli_share_core_namespace_error_text(components, monkeypat
             "--agent-id",
             "planner",
             "--namespace",
+            "agent-runtime:foo:bar",
+        ],
+    )
+
+    core = "invalid namespace 'agent-runtime:foo:bar'"
+    assert core in mcp_out
+    assert core in cli_result.output
+
+
+@pytest.mark.asyncio
+async def test_mcp_and_cli_agent_share_target_core_error_text(components, monkeypatch):
+    """The ``mem_agent_share(target=...)`` MCP path and the
+    ``mm agent share --target`` CLI path must emit the same
+    identifying namespace-error fragment so the issue-#497 closure is
+    symmetric across surfaces. Sibling of the session-start parity
+    test above.
+    """
+    from memtomem.server.tools.multi_agent import mem_agent_share
+
+    app = AppContext.from_components(components)
+    ctx = _StubCtx(app)
+    mcp_out = await mem_agent_share(
+        chunk_id="00000000-0000-0000-0000-000000000000",
+        target="agent-runtime:foo:bar",
+        ctx=ctx,  # type: ignore[arg-type]
+    )
+
+    storage = SimpleNamespace(get_chunk=AsyncMock(return_value=None))
+    comp = SimpleNamespace(storage=storage)
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+    cli_result = CliRunner().invoke(
+        cli,
+        [
+            "agent",
+            "share",
+            "00000000-0000-0000-0000-000000000000",
+            "--target",
             "agent-runtime:foo:bar",
         ],
     )

--- a/packages/memtomem/tests/test_validate_namespace.py
+++ b/packages/memtomem/tests/test_validate_namespace.py
@@ -513,6 +513,15 @@ class TestCliAgentShareTargetOverride:
         on the rejection path we assert ``get_chunk`` was never even
         called, on the happy path we let the chunk-not-found
         ``ClickException`` after validation confirm the gate passed.
+
+        Load-bearing: the happy-path tests below pin gate-passed by
+        asserting ``get_chunk.assert_awaited_once()``, which assumes
+        ``_run_share`` reaches ``get_chunk`` as its first storage
+        interaction (agent_cmd.py:238). If a future change inserts a
+        pre-storage step (config check, etc.) before ``get_chunk``,
+        those happy-path checks could regress to false-pass on the
+        gate's behavior — extend the mock to cover the new step at
+        that point.
         """
         return SimpleNamespace(get_chunk=AsyncMock(return_value=None))
 


### PR DESCRIPTION
## Summary

Closes the CLI-side kin gap that PR #499 review flagged on the `mem_agent_share(target=)` surface: PR #499 added `validate_namespace` at the MCP entry point but the matching CLI subcommand `mm agent share --target` still forwarded the value straight into `index_engine.index_file(..., namespace=target)` — so a caller could land an `agent-runtime:foo:bar` chunk via the CLI even though every other namespace boundary now refuses the same shape.

- Wire `validate_namespace(target)` at the click handler in `packages/memtomem/src/memtomem/cli/agent_cmd.py`, before `_run_share` runs. Reject path raises `ClickException` so the user sees the same `invalid namespace 'X': ...` fragment the MCP path emits.
- Tests pin the contract via `TestCliAgentShareTargetOverride` (21-shape parametrize over `CLI_HOSTILE_NAMESPACES`, canonical issue-#497 shape pinned separately, `agent-runtime:planner` + default `shared` happy paths) and a sibling `test_mcp_and_cli_agent_share_target_core_error_text` for cross-surface error parity.
- CHANGELOG (Unreleased) namespace-validation BREAKING entry is amended in place — adds `mm agent share --target` to the wired surfaces list and tags `Closes #497`.

## Why

Issue [#497](https://github.com/memtomem/memtomem/issues/497) is the explicit follow-up that PR #494 review left open: the `mem_agent_share` MCP path got the gate in PR #499 but the CLI sibling was missed. Without this PR a caller running `mm agent share --target agent-runtime:foo:bar <uuid>` writes the malformed namespace into storage even though `mm session start --namespace agent-runtime:foo:bar` and `mem_agent_share(target=agent-runtime:foo:bar)` both refuse the same input. Single boundary, single charset, single error message — same defense-in-depth contract every other namespace surface enforces.

## Open question (option a vs b)

Issue #497 left a decision to make on the in-PR description: when `target` is anything outside `'shared'` / `'agent-runtime:<id>'` (i.e. legacy free-form namespaces), do we (a) accept verbatim or (b) reject with a clear error?

**Resolved as option (a)** — `validate_namespace`'s existing structural contract (accept arbitrary `[A-Za-z0-9._-]+` colon-segmented shapes, reject path traversal / whitespace / control chars / comma / leading dash). Mirrors how the MCP `mem_agent_share(target=)` path was wired in PR #499, keeps `custom:scope` / `legacy:ns` / other in-tree non-agent buckets working without forcing the CLI surface to be stricter than the MCP one. The `agent-runtime:` prefix is the only one that gets the strict-arity + agent_id re-route, which is what closes the actual bypass.

## Out of scope

- Whole-namespace validation on `mem_ns_*` CRUD surfaces — already shipped in PR #501.
- Changing `target`'s shape from full namespace string to a bare `agent_id` — explicitly out of scope per #497, removes the documented `'shared'` literal degree of freedom.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 2912 passed, 46 deselected (ollama). +25 new tests in `test_validate_namespace.py` (161 from 136).
- [x] `uv run ruff check` + `ruff format --check` on `packages/memtomem/src` and `packages/memtomem/tests` — clean repo-wide.
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/agent_cmd.py` — pre-existing `_resolve_agent_namespace` SimpleNamespace error in the `debug-resolve` command unchanged (advisory; unrelated to this PR).
- [x] Acceptance criteria from #497:
  - `mem_agent_share(target="agent-runtime:foo:bar", chunk_id=<uuid>)` returns `Error: invalid namespace 'agent-runtime:foo:bar': ...` and does NOT call `_mem_add_core` — already covered by `TestMemAgentShareTargetOverride` (PR #499) ✅
  - `mm agent share --target agent-runtime:foo:bar <uuid>` exits non-zero with `invalid namespace` fragment and does NOT call `index_engine.index_file` (asserted via `share_storage_mock.get_chunk.assert_not_called()` — gate runs before `cli_components` ever fetches a chunk) ✅
  - Regression test pinning `target="shared"` and `target="agent-runtime:planner"` still work end-to-end ✅
  - Cross-surface error parity with `mem_session_start` — pinned via the new `test_mcp_and_cli_agent_share_target_core_error_text` ✅
  - Docstring on `mm agent share` updated to note the validation gate ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)