### PR TITLE
refactor(storage): rename internal validate_namespace -> _is_valid_ns_chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   break and should switch to matching `"invalid agent-id"`. Closes
   #492.
 
+### Internal
+
+- Renamed the legacy storage-layer helper
+  `memtomem.storage.sqlite_namespace.validate_namespace(name) -> bool`
+  to `_is_valid_ns_chars` and removed it from
+  `memtomem.storage.sqlite_backend.__all__`. Disambiguates from the
+  strict caller-input validator
+  `memtomem.constants.validate_namespace(value) -> str` introduced in
+  PR #491–#503, which raises `InvalidNameError`. The two had the same
+  name but different signatures and contracts (charset-only bool vs.
+  shape-aware raises), which made debugging harder when a stack trace
+  pointed at "validate_namespace". The storage helper has no in-tree
+  callers outside its sibling `_ensure_valid_namespace` wrapper, so
+  the rename is internal-only — it was nominally exported via
+  `__all__`, but a repo-wide grep showed zero external imports.
+
 ## [0.1.31] — 2026-04-26
 
 ### Added

--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -127,6 +127,14 @@ def validate_namespace(value: object) -> str:
     the broader 256-char total budget so legitimate long project ids
     don't trip this gate.
 
+    See also :func:`memtomem.storage.sqlite_namespace._is_valid_ns_chars`
+    — the storage-layer charset companion (a broader bool check at the
+    SQLite row write boundary). The two are intentionally separate:
+    the charset gate accepts shapes this gate rejects (``foo:bar:baz``,
+    ``ns@org``, …) because the legacy row contract has always allowed
+    them. This function is the strict public-surface shape gate; that
+    one is the row-write charset gate.
+
     Raises :class:`InvalidNameError` (a ``ValueError`` subclass) on
     rejection, mirroring the ``agent_id`` gate's UX so error scrapers
     see one shape across surfaces.

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -27,7 +27,7 @@ from memtomem.storage.sqlite_helpers import (
     serialize_f32,
 )
 from memtomem.storage.sqlite_meta import MetaManager
-from memtomem.storage.sqlite_namespace import NamespaceOps, validate_namespace
+from memtomem.storage.sqlite_namespace import NamespaceOps
 from memtomem.storage.mixins import (
     AnalyticsMixin,
     EntityMixin,
@@ -42,7 +42,7 @@ from memtomem.storage.sqlite_schema import create_tables
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["SqliteBackend", "validate_namespace"]
+__all__ = ["SqliteBackend"]
 
 
 # Batch size for streaming rebuild_fts — bounds peak memory regardless of

--- a/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_namespace.py
@@ -21,11 +21,21 @@ _NS_NAME_RE = re.compile(r"^[\w\-.:@ ]{1,255}$", re.UNICODE)
 _SEGMENT_SAFE_RE = re.compile(r"[^\w\-.:@ ]")
 
 
-def validate_namespace(name: str) -> bool:
-    """Check whether *name* is a valid namespace identifier.
+def _is_valid_ns_chars(name: str) -> bool:
+    """Check whether *name* satisfies the storage-layer namespace charset.
 
     Valid names contain word characters, hyphens, dots, colons, @, and spaces,
-    with a maximum length of 255.
+    with a maximum length of 255. This is the legacy SQLite-row charset
+    guard — broader than the strict caller-input validator in
+    :func:`memtomem.constants.validate_namespace`, which is what every
+    public surface (``mem_session_start``, ``mem_agent_share``,
+    ``mem_ns_*``, etc.) calls before a value reaches storage. The two are
+    deliberately different shapes; this one trips only on values that
+    would break the SQLite row contract (e.g. control characters), while
+    the constants validator additionally rejects shapes that are storable
+    but semantically suspect (``agent-runtime:foo:bar``, comma-joined
+    namespace lists, …). Kept private to ``sqlite_namespace`` so callers
+    don't accidentally use it as a substitute for the public gate.
     """
     return bool(_NS_NAME_RE.match(name))
 
@@ -42,8 +52,8 @@ def sanitize_namespace_segment(name: str) -> str:
 
 
 def _ensure_valid_namespace(name: str) -> None:
-    """Raise ``StorageError`` if *name* fails :func:`validate_namespace`."""
-    if not validate_namespace(name):
+    """Raise ``StorageError`` if *name* fails :func:`_is_valid_ns_chars`."""
+    if not _is_valid_ns_chars(name):
         raise StorageError(
             f"Invalid namespace: {name!r} (allowed characters: word, -, ., :, @, space; max 255)"
         )


### PR DESCRIPTION
## Summary

- Renames `memtomem.storage.sqlite_namespace.validate_namespace(name) -> bool` to `_is_valid_ns_chars` to disambiguate from the strict caller-input validator `memtomem.constants.validate_namespace(value) -> str` (raises `InvalidNameError`) introduced in PR #491–#503.
- Removes `validate_namespace` from `memtomem.storage.sqlite_backend.__all__` (was nominally public, but a repo-wide grep shows zero external imports).
- Storage-layer call sites already go through the encapsulating `_ensure_valid_namespace` wrapper, so the renamed bool helper stays a single-use private detail of `sqlite_namespace`.

## Why

The two functions had:
- Same name (`validate_namespace`)
- Different signatures (bool vs. raises)
- Different contracts (legacy SQLite charset regex vs. shape-aware caller-input gate with `agent-runtime:` strict-arity)

Stack traces and grep results pointed at `validate_namespace` without telling you which one. That ambiguity gets worse as the strict validator becomes the load-bearing public-surface gate (`mem_session_start`, `mem_agent_share`, `mem_ns_*`, …) — it should own the name.

## Why this side, not the other

| Side | Call sites | Locked-in by | Rename cost |
|---|---|---|---|
| `memtomem.constants.validate_namespace` | 12+ across 6 modules | `test_validate_namespace_architectural_guard.py` AST-matches literal callee name | High — guard + every site, immediately on top of #491–#503 |
| `memtomem.storage.sqlite_namespace.validate_namespace` | 1 internal (`_ensure_valid_namespace`) + 0 external (verified by grep) | nothing | Low — 5-line change, no behavior shift |

## Test plan

- [x] `uv run ruff check packages/memtomem/src/memtomem/storage/...` — clean
- [x] `uv run ruff format --check ...` — already formatted
- [x] `uv run pytest -m "not ollama"` — 2887 passed
- [x] CHANGELOG `### Internal` entry added under `[Unreleased]` documenting rename rationale
- [ ] CI green on remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)
