### PR TITLE
release: v0.1.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.32] — 2026-04-26
+
 ### Changed (BREAKING)
 
 - **Caller-supplied `namespace=` / `target=` overrides on every

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.31"
+version = "0.1.32"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -818,7 +818,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.31"
+version = "0.1.32"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v0.1.32 ships the caller-supplied namespace validation series (PR #491–#504) plus a sibling internal rename (PR #505). User-facing behavior change — see Migration below.

## Feature PRs in this release

| PR | Surface gated |
|---|---|
| #491 | `validate_agent_id` at session-start (CLI + MCP) |
| #494 (closes #493) | `mem_agent_register` / `mem_agent_search` / `mm agent register` |
| #498 | LangGraph adapter `MemtomemStore.start_agent_session` |
| #499 (closes #496) | caller-supplied `namespace=` overrides on every session-start surface |
| #501 (closes #500) | `mem_ns_*` CRUD tools |
| #503 | defense-in-depth — AppContext setter + architectural guard + INVALID_NAMESPACE_MESSAGE_PREFIX |
| #504 (closes #497) | `mm agent share --target` CLI sibling |

Plus follow-up:
- #505 — internal storage helper rename `validate_namespace -> _is_valid_ns_chars` (disambiguates from constants validator; bidirectional docstring cross-ref)

## Migration

Caller-supplied `namespace=` / `target=` overrides on every public surface (MCP, CLI, Python adapter) now reject malformed shapes via `validate_namespace`. Existing in-tree shapes (`default`, `shared`, `archive:summary`, `claude-memory:*`, `agent-runtime:planner`, `custom:scope`) are unchanged.

**Rejected**: anything containing slashes, whitespace, comma, control chars, leading dash, or more than one colon under the `agent-runtime:` prefix. The bare single-segment `"agent-runtime"` is also rejected (shadows the multi-agent prefix). Anyone holding such a namespace should rename via `mem_ns_rename` before running session-start with the override.

`mem_agent_register` / `mem_agent_search` / `mm agent register` now reject malformed `agent_id` values loudly instead of silently rewriting them. The `MemtomemStore.start_agent_session` exception narrows from `ValueError("agent_id must be a non-empty string")` to `InvalidNameError("invalid agent-id 'X': ...")` — `InvalidNameError` is a `ValueError` subclass so `except ValueError:` callers keep working, but substring-matching the old message text breaks; switch to `"invalid agent-id"`.

See CHANGELOG `[0.1.32]` for the full per-surface contract.

## Release mechanics

- Single bump commit: `pyproject.toml` (0.1.31 → 0.1.32) + `uv.lock` (workspace memtomem entry) + `CHANGELOG.md` (`[0.1.32]` dated header inserted under `[Unreleased]`).
- Behavior-change release → TestPyPI dry-run required per `feedback_prerelease_dry_run.md` before production tag.

## Test plan

- [ ] CI green on this bump branch (lint / typecheck / test / golden-path / notebooks / CLAAssistant)
- [ ] Squash merge after green
- [ ] `test-v0.1.32a1` tag → TestPyPI publish (env approval needed) → fresh-install smoke (`uv pip install --index-url TestPyPI --extra-index-url PyPI memtomem==0.1.32`) — gated by `mm --version` + a one-shot `mm session start --agent-id planner` sanity
- [ ] `v0.1.32` tag → production PyPI (same-sha auto-skip per workflow memo, fall back to manual approve if `pending_deployments` non-empty)
- [ ] `gh release create v0.1.32` with notes cut from CHANGELOG `[0.1.32]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
