### PR TITLE
fix(server): collapse Shared: prefix on every re-share so heading doesn't accumulate

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -158,6 +158,35 @@ async def mem_agent_search(
 
 
 _SHARED_FROM_TAG_PREFIX = "shared-from="
+_SHARED_TITLE_PREFIX = "Shared: "
+
+
+def _build_shared_title(heading_hierarchy: tuple[str, ...] | list[str]) -> str:
+    """Return the ``mem_agent_share`` copy's title.
+
+    Strips any leading ``Shared: `` prefixes from each heading entry
+    before re-prepending a single one. Without this, a chain of re-shares
+    would produce ``Shared: Shared: Shared: ...`` because the source
+    chunk's heading already includes the ``Shared: `` prefix from the
+    previous share, and the naive ``f"Shared: {join}"`` doubles up on
+    every hop. Mirrors the audit-tag chain in :func:`_build_shared_tags`
+    which also collapses re-share history (immediate parent only).
+    """
+
+    if not heading_hierarchy:
+        return f"{_SHARED_TITLE_PREFIX}memory"
+
+    cleaned: list[str] = []
+    for heading in heading_hierarchy:
+        # Strip every leading ``Shared: `` so an N-hop chain — even one
+        # that already accumulated to ``Shared: Shared: Cache ...`` under
+        # the pre-fix code — collapses to a single prefix on the next
+        # share.
+        stripped = heading
+        while stripped.startswith(_SHARED_TITLE_PREFIX):
+            stripped = stripped[len(_SHARED_TITLE_PREFIX) :]
+        cleaned.append(stripped)
+    return f"{_SHARED_TITLE_PREFIX}{' > '.join(cleaned)}"
 
 
 def _build_shared_tags(source_tags: tuple[str, ...] | list[str], source_chunk_id: str) -> list[str]:
@@ -232,7 +261,7 @@ async def mem_agent_share(
 
     result, stats = await _mem_add_core(
         content=chunk.content,
-        title=f"Shared: {' > '.join(chunk.metadata.heading_hierarchy) if chunk.metadata.heading_hierarchy else 'memory'}",
+        title=_build_shared_title(chunk.metadata.heading_hierarchy),
         tags=inherited_tags,
         file=None,
         namespace=target,

--- a/packages/memtomem/tests/test_multi_agent.py
+++ b/packages/memtomem/tests/test_multi_agent.py
@@ -49,6 +49,7 @@ from memtomem.server.component_factory import close_components, create_component
 from memtomem.server.tools.multi_agent import (
     _SHARED_FROM_TAG_PREFIX,
     _build_shared_tags,
+    _build_shared_title,
     _resolve_agent_namespace,
 )
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
@@ -260,6 +261,75 @@ class TestSharedFromTags:
     def test_handles_empty_source_tags(self):
         out = _build_shared_tags((), "src-uuid")
         assert out == [f"{_SHARED_FROM_TAG_PREFIX}src-uuid"]
+
+
+class TestBuildSharedTitle:
+    """``_build_shared_title`` is the seam where ``mem_agent_share``
+    composes the copy's heading. The contract mirrors
+    :class:`Test_BuildSharedTags`: every re-share collapses any prior
+    ``Shared: `` prefix and re-applies a single one, so a chain of N
+    shares produces a heading with **exactly one** ``Shared: `` regardless
+    of the chain depth.
+
+    Without the prefix collapse, the source chunk's heading already
+    contains ``Shared: `` from the previous share — a naive
+    ``f"Shared: {join}"`` would compound the prefix on every hop and
+    produce ``Shared: Shared: Shared: ...`` (observed during the
+    2026-04-26 multi-agent test scenario rehearsal).
+    """
+
+    def test_empty_hierarchy_falls_back_to_memory(self):
+        assert _build_shared_title(()) == "Shared: memory"
+        assert _build_shared_title([]) == "Shared: memory"
+
+    def test_single_heading_gets_prefix_once(self):
+        assert (
+            _build_shared_title(("Cache strategy decision",)) == "Shared: Cache strategy decision"
+        )
+
+    def test_multi_level_hierarchy_joined_with_arrow(self):
+        assert (
+            _build_shared_title(("Top level", "Sub heading")) == "Shared: Top level > Sub heading"
+        )
+
+    def test_strips_leading_shared_prefix_to_avoid_doubling(self):
+        # 1-hop: source heading already has "Shared: ..." from the prior
+        # share. Re-share must not double up.
+        assert (
+            _build_shared_title(("Shared: Cache strategy decision",))
+            == "Shared: Cache strategy decision"
+        )
+
+    def test_collapses_n_hop_accumulated_prefix(self):
+        # 3-hop simulation: a chunk that already accumulated
+        # ``Shared: Shared: ...`` under the pre-fix code should be cleaned
+        # back to a single prefix on the next share. Mirrors the
+        # ``_build_shared_tags`` semantics where multiple inherited
+        # ``shared-from=...`` entries are dropped (defensive backfill).
+        assert (
+            _build_shared_title(("Shared: Shared: Cache strategy decision",))
+            == "Shared: Cache strategy decision"
+        )
+        assert (
+            _build_shared_title(("Shared: Shared: Shared: Cache strategy decision",))
+            == "Shared: Cache strategy decision"
+        )
+
+    def test_strips_at_each_hierarchy_level(self):
+        # If the source chunk's heading_hierarchy itself has multiple
+        # entries that each picked up a prefix, every level is cleaned.
+        assert (
+            _build_shared_title(("Shared: Top level", "Shared: Sub heading"))
+            == "Shared: Top level > Sub heading"
+        )
+
+    def test_does_not_strip_non_leading_shared(self):
+        # ``Shared: `` only matters as a leading prefix — substring
+        # matches inside the heading must not be touched.
+        assert (
+            _build_shared_title(("Notes on Shared: behaviour",))
+            == "Shared: Notes on Shared: behaviour"
+        )
 
 
 class TestResolveAgentNamespace:


### PR DESCRIPTION
## Summary

`mem_agent_share` previously composed the copy's title as
`f"Shared: {' > '.join(chunk.metadata.heading_hierarchy)}"`
(`multi_agent.py:235`). When the source chunk itself was already a share
copy, its `heading_hierarchy` included the prepended `Shared: ` prefix
from the previous share — and the f-string doubled the prefix on every
hop:

- 1-hop: `## Cache strategy decision` (planner) → `## Shared: ## Cache strategy decision` (shared)
- 2-hop: → `## Shared: ## Shared: ## Cache strategy decision` (coder)
- 3-hop: → `## Shared: ## Shared: ## Shared: ## ...`

Asymmetric vs the tag audit chain — `_build_shared_tags`
(`multi_agent.py:163-176`) deliberately strips back to immediate parent
only. The heading was the only re-share artefact still accumulating;
read-side noise only, search/match unaffected (heading is title text,
not a join key).

## Fix

Extract a sibling `_build_shared_title` helper that:
- strips **every** leading `Shared: ` from each `heading_hierarchy` entry
  (defensive — an N-hop chain that already accumulated under the pre-fix
  code collapses cleanly on the next share; mirrors how
  `_build_shared_tags` drops multiple inherited `shared-from=` entries
  from `_build_shared_tags`),
- joins with ` > ` (existing format),
- re-applies a single `Shared: ` prefix.

`mem_agent_share` (line 235) now calls `_build_shared_title(chunk.metadata.heading_hierarchy)`.

## Behavior

| Scenario | Before | After |
|---|---|---|
| 1-hop fresh share (no prior `Shared: `) | `Shared: <heading>` | **No change** |
| 2-hop re-share | `Shared: Shared: <heading>` | `Shared: <heading>` ✅ |
| N-hop legacy chain (already accumulated in DB) | `Shared: Shared: ... Shared: <heading>` | `Shared: <heading>` ✅ (defensive backfill) |
| `Notes on Shared: behaviour` (non-leading substring) | preserved | **No change** (only leading prefix stripped) |

Walk semantic unchanged for one-hop sources; only multi-hop chains stop
compounding.

## Test plan

- [x] 7 new `TestBuildSharedTitle` cases — empty hierarchy, single +
      multi-level paths, single-hop strip, N-hop accumulated collapse,
      per-level strip, non-leading `Shared:` substring preservation.
- [x] `uv run pytest packages/memtomem/tests/test_multi_agent.py` —
      green (existing share / multi-agent tests no regression).
- [x] `uv run ruff check` + `ruff format --check` on changed files —
      clean.

## Discovery

Surfaced during the 2026-04-26 multi-agent test scenarios live rehearsal
(memtomem-docs#17 — 3-hop share chain). Cosmetic, out of scope for the
round-trip verification; that doc flagged it as a follow-up issue
candidate. This PR closes that item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)