### PR TITLE
feat(server): add output_format to mem_agent_search for structured chunk_id capture

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 from memtomem.constants import (
     AGENT_NAMESPACE_PREFIX,
@@ -109,6 +110,7 @@ async def mem_agent_search(
     agent_id: str | None = None,
     include_shared: bool = True,
     top_k: int = 10,
+    output_format: Literal["compact", "verbose", "structured"] = "compact",
     ctx: CtxType = None,
 ) -> str:
     """Search memories with multi-agent scope awareness.
@@ -128,11 +130,20 @@ async def mem_agent_search(
         agent_id: Agent ID to search (omit for current agent)
         include_shared: Also search the shared namespace (default True)
         top_k: Maximum results to return
+        output_format: Output format — ``"compact"`` (default,
+            human-readable), ``"verbose"`` (full details with UUID), or
+            ``"structured"`` (JSON for machine parsing — exposes
+            ``chunk_id`` directly so callers can capture UUIDs without
+            scraping). Mirrors the same option on ``mem_search`` /
+            ``mem_recall`` so callers don't have to switch tools to get
+            structured output.
     """
     if agent_id is not None:
         validate_agent_id(agent_id)
+    if output_format not in ("compact", "verbose", "structured"):
+        return f"Error: invalid output_format '{output_format}'."
     app = await _get_app_initialized(ctx)
-    from memtomem.server.formatters import _format_results
+    from memtomem.server.formatters import _format_results, _format_structured_results
 
     agent_ns = _resolve_agent_namespace(app, agent_id)
 
@@ -151,10 +162,13 @@ async def mem_agent_search(
     )
 
     if not results:
+        if output_format == "structured":
+            return _format_structured_results([], hints=None)
         return f"No results found for agent '{agent_id or 'current'}'."
 
-    output = _format_results(results)
-    return output
+    if output_format == "structured":
+        return _format_structured_results(results, hints=None)
+    return _format_results(results, verbose=output_format == "verbose")
 
 
 _SHARED_FROM_TAG_PREFIX = "shared-from="

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -619,3 +619,131 @@ class TestCaseEMemAddSessionInheritance:
             assert "team-notes" not in result
         finally:
             await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+
+
+# ── Case F — mem_agent_search output_format parity with mem_search ───
+class TestCaseFOutputFormat:
+    """``mem_agent_search`` must accept the same ``output_format`` knob
+    that ``mem_search`` / ``mem_recall`` already expose, so a caller can
+    capture ``chunk_id`` from a multi-agent search without round-tripping
+    through ``mem_search(namespace=...)``.
+
+    Pre-fix the parameter was missing, which forced agents to retry with
+    ``output_format``/``verbose`` kwargs and trip ``InvalidParameter``
+    before falling back. Surfaced during the 2026-04-26 multi-agent test
+    scenario rehearsal (memtomem-docs#17).
+    """
+
+    @pytest.mark.asyncio
+    async def test_structured_output_returns_json_with_chunk_id(self, integration_components):
+        """``output_format="structured"`` returns parseable JSON whose
+        result objects expose the ``chunk_id`` field directly — the
+        contract callers need to capture UUIDs without scraping
+        compact-format text."""
+        import json
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        await comp.storage.upsert_chunks(
+            [
+                make_chunk(
+                    "alpha private structured probe",
+                    namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+                ),
+            ]
+        )
+
+        out = await mem_agent_search(  # type: ignore[arg-type]
+            query="structured probe",
+            agent_id="alpha",
+            output_format="structured",
+            ctx=ctx,
+        )
+
+        # Must parse as JSON and surface chunk_id on each result.
+        payload = json.loads(out)
+        assert "results" in payload
+        assert len(payload["results"]) >= 1
+        assert "chunk_id" in payload["results"][0]
+        # Empty-result branch also returns valid JSON shape for the
+        # structured path (consumers can rely on the schema).
+        empty = await mem_agent_search(  # type: ignore[arg-type]
+            query="no-such-query-zzz",
+            agent_id="alpha",
+            output_format="structured",
+            ctx=ctx,
+        )
+        empty_payload = json.loads(empty)
+        assert empty_payload["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_verbose_output_includes_full_uuid(self, integration_components):
+        """``output_format="verbose"`` puts the full chunk UUID in the
+        rendered text — the human-readable counterpart to ``structured``."""
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        chunk = make_chunk(
+            "alpha verbose probe",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+        )
+        await comp.storage.upsert_chunks([chunk])
+
+        out = await mem_agent_search(  # type: ignore[arg-type]
+            query="verbose probe",
+            agent_id="alpha",
+            output_format="verbose",
+            ctx=ctx,
+        )
+
+        # Verbose format embeds the full UUID alongside score/path.
+        assert str(chunk.id) in out
+
+    @pytest.mark.asyncio
+    async def test_compact_default_unchanged(self, integration_components):
+        """The default ``"compact"`` form keeps the pre-fix behaviour:
+        no UUID in the output, ``Found N results`` header. Pinned so a
+        future change to the default doesn't quietly break callers that
+        relied on the compact shape."""
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        chunk = make_chunk(
+            "alpha compact probe",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+        )
+        await comp.storage.upsert_chunks([chunk])
+
+        out = await mem_agent_search(  # type: ignore[arg-type]
+            query="compact probe",
+            agent_id="alpha",
+            ctx=ctx,
+        )
+
+        assert "Found" in out and "results" in out
+        # Compact form must NOT leak the UUID — that's the contract that
+        # makes ``structured``/``verbose`` opt-in rather than the default.
+        assert str(chunk.id) not in out
+
+    @pytest.mark.asyncio
+    async def test_invalid_output_format_returns_error(self, integration_components):
+        """Out-of-set values short-circuit before any storage read so a
+        typo in the kwarg cannot silently fall back to compact and hide
+        the mistake. Mirrors ``mem_search``'s validation at
+        ``search.py:65-66``."""
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        out = await mem_agent_search(  # type: ignore[arg-type]
+            query="anything",
+            agent_id="alpha",
+            output_format="json",  # type: ignore[arg-type]
+            ctx=ctx,
+        )
+
+        assert "Error" in out and "invalid output_format" in out


### PR DESCRIPTION
## Summary

`mem_agent_search` previously accepted only
`(query, agent_id, include_shared, top_k, ctx)` while its sibling
`mem_search` / `mem_recall` already exposed
`output_format=Literal["compact", "verbose", "structured"]`. The
asymmetry forced any caller that needed `chunk_id` from a multi-agent
search to either scrape the compact-format output or re-route through
`mem_search(namespace=...)`. In practice agents tried
`mem_agent_search(output_format="structured")` first, hit
`InvalidParameter`, retried with `verbose=true`, hit the same, and fell
back to `mem_search` — three calls where one would do.

## Fix

- Add `output_format: Literal["compact", "verbose", "structured"] = "compact"`
  to `mem_agent_search`.
- Branch on the formatter (`_format_results` for compact/verbose,
  `_format_structured_results` for structured) using the exact same
  pattern `mem_search` follows. Per-format **structural shape** is
  identical across the two tools — callers can switch between them
  without re-parsing.
- Validate the value at the entry point: out-of-set strings
  short-circuit to `Error: invalid output_format 'X'.` before any
  storage read (mirrors `mem_search` at `search.py:65-66`).
- Empty-result branch returns `{"results": [], "hints": null}` for the
  structured path so JSON consumers get a consistent shape regardless
  of whether the search hit anything.

## Behavior

| `mem_agent_search` call | Before | After |
|---|---|---|
| `query=...` (no output_format) | compact | **No change** |
| `output_format="structured"` | `InvalidParameter` | JSON with `chunk_id` per result |
| `output_format="verbose"` | `InvalidParameter` | full UUID in rendered text |
| `output_format="json"` (typo) | `InvalidParameter` (wrong reason) | `Error: invalid output_format` (clear) |

Default unchanged → existing callers and tests are unaffected.

## Out of scope (deliberate)

- **`hints` field is present but always `null`** in
  `mem_agent_search`'s structured payload. `mem_search` populates
  `hints` from `stats.hidden_system_ns` (archive-filter count) and
  `_announce_dim_mismatch_once` (embedding-dim mismatch one-shot
  notice); `mem_agent_search` historically didn't surface either, and
  this PR keeps that behaviour to stay focused on the `output_format`
  parity. Structurally the shape matches `mem_search`'s payload
  (consumers parsing `payload["hints"]` won't crash), but
  semantically the hint sources are not yet wired in. Tracked as a
  follow-up.
- **`OutputFormat` type alias** — `Literal["compact", "verbose",
  "structured"]` is now declared inline at two call sites
  (`mem_search` and `mem_agent_search`). A shared `OutputFormat`
  alias would prevent drift if a fourth format lands; deferred to a
  follow-up so this PR stays minimal.

## Test plan

- [x] 4 new `TestCaseFOutputFormat` integration cases — structured JSON
      shape (with chunk_id and empty-result branch), verbose UUID
      embedding, compact default unchanged, invalid-value error.
- [x] `uv run pytest packages/memtomem/tests/test_multi_agent.py
      packages/memtomem/tests/test_multi_agent_integration.py` — 43
      green (no regression in any existing multi-agent test).
- [x] `uv run ruff check` + `ruff format --check` on changed files —
      clean.

## Discovery

Surfaced during the 2026-04-26 multi-agent test scenarios live rehearsal
(memtomem-docs#17) — scenario 3 step 1 prompt asked the agent to
"capture chunk_id" and the agent retried twice on the missing
`output_format` kwarg before falling back. The doc was updated to
recommend capturing chunk_id from the `mem_add` response directly
(workaround), but that's a paper cut for any caller that does want
chunk_id from a search response. This PR closes that asymmetry on the
`output_format` axis; the `hints` axis (see "Out of scope") is a
separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)