### PR TITLE
refactor(server): hoist OutputFormat Literal alias for search/multi_agent parity

### DIFF
--- a/packages/memtomem/src/memtomem/server/formatters.py
+++ b/packages/memtomem/src/memtomem/server/formatters.py
@@ -5,6 +5,20 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path, PurePosixPath
+from typing import Literal, get_args
+
+OutputFormat = Literal["compact", "verbose", "structured"]
+"""Format spec shared by ``mem_search`` and ``mem_agent_search``.
+
+``mem_recall`` uses a 2-format subset (``"compact" | "structured"``) and
+intentionally does not import this alias — its surface lacks a semantic
+equivalent for ``"verbose"``.
+"""
+
+# Membership set derived from OutputFormat so adding a 4th format only
+# requires editing the Literal — call-site validators pick it up via
+# get_args (drift prevention; see feedback_literal_drives_frozenset.md).
+_VALID_OUTPUT_FORMATS: frozenset[str] = frozenset(get_args(OutputFormat))
 
 
 def _display_path(path) -> str:

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from memtomem.constants import (
     AGENT_NAMESPACE_PREFIX,
@@ -14,6 +13,7 @@ from memtomem.constants import (
 from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
+from memtomem.server.formatters import OutputFormat, _VALID_OUTPUT_FORMATS
 from memtomem.server.tool_registry import register
 
 logger = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ async def mem_agent_search(
     agent_id: str | None = None,
     include_shared: bool = True,
     top_k: int = 10,
-    output_format: Literal["compact", "verbose", "structured"] = "compact",
+    output_format: OutputFormat = "compact",
     ctx: CtxType = None,
 ) -> str:
     """Search memories with multi-agent scope awareness.
@@ -140,7 +140,7 @@ async def mem_agent_search(
     """
     if agent_id is not None:
         validate_agent_id(agent_id)
-    if output_format not in ("compact", "verbose", "structured"):
+    if output_format not in _VALID_OUTPUT_FORMATS:
         return f"Error: invalid output_format '{output_format}'."
     app = await _get_app_initialized(ctx)
     from memtomem.server.formatters import _format_results, _format_structured_results

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Literal
 from uuid import UUID
 
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
-from memtomem.server.formatters import _display_path, _format_results, _format_structured_results
+from memtomem.server.formatters import (
+    OutputFormat,
+    _VALID_OUTPUT_FORMATS,
+    _display_path,
+    _format_results,
+    _format_structured_results,
+)
 from memtomem.server.helpers import _announce_dim_mismatch_once
 from memtomem.server.tool_registry import register
 from memtomem.config import MAX_CONTEXT_WINDOW_CHUNKS
@@ -32,7 +37,7 @@ async def mem_search(
     dense_weight: float | None = None,
     context_window: int = 0,
     verbose: bool = False,
-    output_format: Literal["compact", "verbose", "structured"] = "compact",
+    output_format: OutputFormat = "compact",
     ctx: CtxType = None,
 ) -> str:
     """Search across indexed memory files using hybrid BM25 + semantic search.
@@ -62,7 +67,7 @@ async def mem_search(
     effective_format = output_format
     if effective_format == "compact" and verbose:
         effective_format = "verbose"
-    if effective_format not in ("compact", "verbose", "structured"):
+    if effective_format not in _VALID_OUTPUT_FORMATS:
         return f"Error: invalid output_format '{output_format}'."
 
     app = await _get_app_initialized(ctx)


### PR DESCRIPTION
## Summary

Hoist the inline ``Literal["compact", "verbose", "structured"]`` shared by
``mem_search`` and ``mem_agent_search`` into a single ``OutputFormat`` alias
in ``server/formatters.py``. Validators on both call sites switch from
inline tuples to ``_VALID_OUTPUT_FORMATS = frozenset(get_args(OutputFormat))``
so membership stays in sync with the type annotation — adding a 4th format
ever only requires editing the Literal once.

``mem_recall`` intentionally keeps its 2-format inline Literal
(``"compact" | "structured"``) — that surface lacks a semantic equivalent
for ``"verbose"``. The ``OutputFormat`` docstring spells that out at the
source so the asymmetry is documented where future readers will look.

Spirit: ``feedback_literal_drives_frozenset.md`` (drift prevention).
Closes Item 3 of the deferred 2026-04-26 multi-agent rehearsal follow-up
trail (memtomem-docs#17 / memtomem#507 / memtomem#508 successor).

## Test plan
- [x] `uv run pytest -m "not ollama"` (2923 passed, 46 deselected)
- [x] `uv run ruff check` + `ruff format --check` (clean)
- [x] `uv run mypy` on the 3 changed files (no issues)
- [x] Behavioral parity — error string ``invalid output_format`` unchanged;
      existing ``test_multi_agent_integration.py`` invalid-format assertion
      still passes against the new ``_VALID_OUTPUT_FORMATS`` membership set

🤖 Generated with [Claude Code](https://claude.com/claude-code)