### PR TITLE
feat(server): wire trust-UX hints into mem_agent_search structured payload

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -15,6 +15,7 @@ from memtomem.server import mcp
 from memtomem.server.context import AppContext, CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
 from memtomem.server.formatters import OutputFormat, _VALID_OUTPUT_FORMATS
+from memtomem.server.helpers import _announce_dim_mismatch_once
 from memtomem.server.tool_registry import register
 
 logger = logging.getLogger(__name__)
@@ -162,13 +163,29 @@ async def mem_agent_search(
         namespace=ns_filter,
     )
 
+    # Mirror mem_search trust-UX hints so structured payloads from the two
+    # tools have parity in semantic content, not just shape. The archive
+    # hint engages only when no namespace was pinned (the pipeline's
+    # system_namespace_prefixes filter is gated on that) — for
+    # mem_agent_search this means agent_id was None AND no session/legacy
+    # binding resolved.
+    hints: list[str] = []
+    if ns_filter is None and stats.hidden_system_ns > 0:
+        hints.append(
+            f"{stats.hidden_system_ns} result(s) hidden in system namespaces "
+            f'(pass namespace="archive:..." to include them).'
+        )
+    dim_notice = await _announce_dim_mismatch_once(app)
+    if dim_notice:
+        hints.append(dim_notice)
+
     if not results:
         if output_format == "structured":
-            return _format_structured_results([], hints=None)
+            return _format_structured_results([], hints=hints or None)
         return f"No results found for agent '{agent_id or 'current'}'."
 
     if output_format == "structured":
-        return _format_structured_results(results, hints=None)
+        return _format_structured_results(results, hints=hints or None)
     return _format_results(results, verbose=output_format == "verbose")
 
 

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -751,3 +751,87 @@ class TestCaseFOutputFormat:
         )
 
         assert "Error" in out and INVALID_OUTPUT_FORMAT_PREFIX in out
+
+    @pytest.mark.asyncio
+    async def test_structured_surfaces_archive_hint_when_unbound(self, integration_components):
+        """Structured payload must include the archive-filter hint when the
+        caller hits the un-pinned path (no agent_id, no session, no legacy
+        ``current_namespace``). Without this wire-in ``mem_agent_search``
+        would silently drop hints that ``mem_search`` surfaces — breaking
+        semantic parity between the two structured outputs.
+        """
+        import json
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        archived = make_chunk(
+            "archived note about pipelines",
+            namespace="archive:old",
+        )
+        await comp.storage.upsert_chunks([archived])
+
+        # No agent_id, no session, no current_namespace — ns_filter
+        # resolves to None and the pipeline's system_namespace_prefixes
+        # filter engages. Mirrors the un-pinned-search shape that
+        # mem_search exercises in test_trust_ux.
+        out = await mem_agent_search(  # type: ignore[arg-type]
+            query="pipelines",
+            output_format="structured",
+            ctx=ctx,
+        )
+
+        payload = json.loads(out)
+        assert "hints" in payload, "archive hint missing from structured payload"
+        assert any("hidden in system namespaces" in h for h in payload["hints"])
+
+    @pytest.mark.asyncio
+    async def test_structured_surfaces_dim_mismatch_hint_once(self, integration_components):
+        """The dim-mismatch hint must surface on the first structured call
+        and stay quiet on subsequent ones — same one-shot semantics
+        ``mem_search`` uses via ``_announce_dim_mismatch_once``. Pin the
+        AppContext announce flag explicitly and re-issue the search to
+        catch a regression where the gate stops sticking.
+        """
+        import json
+
+        comp, _ = integration_components
+        # Install a dim/model mismatch on the storage backend; the
+        # ``embedding_mismatch`` property derives from these two attrs
+        # (``_install_mismatch`` in test_trust_ux uses the same shape).
+        comp.storage._dim_mismatch = (384, 1024)
+        comp.storage._model_mismatch = ("onnx", "bge-small-en-v1.5", "onnx", "bge-m3")
+
+        app = AppContext.from_components(comp)
+        assert app._dim_mismatch_announced is False  # fresh AppContext default
+        ctx = _StubCtx(app)
+
+        chunk = make_chunk(
+            "alpha probe",
+            namespace=f"{AGENT_NAMESPACE_PREFIX}alpha",
+        )
+        await comp.storage.upsert_chunks([chunk])
+
+        first = await mem_agent_search(  # type: ignore[arg-type]
+            query="probe",
+            agent_id="alpha",
+            output_format="structured",
+            ctx=ctx,
+        )
+        second = await mem_agent_search(  # type: ignore[arg-type]
+            query="probe",
+            agent_id="alpha",
+            output_format="structured",
+            ctx=ctx,
+        )
+
+        first_hints = json.loads(first).get("hints", [])
+        second_hints = json.loads(second).get("hints", [])
+        assert any("embedding-reset" in h for h in first_hints), (
+            "dim-mismatch hint missing from first structured call"
+        )
+        assert not any("embedding-reset" in h for h in second_hints), (
+            "dim-mismatch hint repeated on second call — one-shot gate failed"
+        )
+        assert app._dim_mismatch_announced is True

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -835,3 +835,62 @@ class TestCaseFOutputFormat:
             "dim-mismatch hint repeated on second call — one-shot gate failed"
         )
         assert app._dim_mismatch_announced is True
+
+    @pytest.mark.asyncio
+    async def test_archive_hint_byte_identical_to_mem_search(self, integration_components):
+        """Pin: when both tools hit the un-pinned-archive path, the
+        archive-filter hint they emit must be byte-identical so structured
+        consumers parsing ``payload["hints"]`` can dedup by string identity
+        across siblings. Punctuation drift (``"include them"`` vs
+        ``"include them."``) breaks the aggregation contract.
+
+        Scope note — the rule applies to the ``"search results"`` family
+        (``mem_search`` / ``mem_agent_search``). ``mem_recall`` lives in a
+        separate ``"memories recalled"`` family and intentionally uses
+        ``X memory/memories`` rather than ``X result(s)``; that carveout
+        is documented in ``feedback_hint_prose_parity_siblings.md``.
+        """
+        import json
+
+        comp, _ = integration_components
+        app = AppContext.from_components(comp)
+        ctx = _StubCtx(app)
+
+        archived = make_chunk(
+            "archived note about pipelines",
+            namespace="archive:old",
+        )
+        await comp.storage.upsert_chunks([archived])
+
+        search_out = await mem_search(  # type: ignore[arg-type]
+            query="pipelines",
+            output_format="structured",
+            ctx=ctx,
+        )
+        agent_out = await mem_agent_search(  # type: ignore[arg-type]
+            query="pipelines",
+            output_format="structured",
+            ctx=ctx,
+        )
+
+        search_hints = [
+            h
+            for h in (json.loads(search_out).get("hints") or [])
+            if "hidden in system namespaces" in h
+        ]
+        agent_hints = [
+            h
+            for h in (json.loads(agent_out).get("hints") or [])
+            if "hidden in system namespaces" in h
+        ]
+
+        assert search_hints and agent_hints, (
+            "archive hint missing from one of the tools — fixture mis-setup "
+            "or system_namespace_prefixes regression?"
+        )
+        assert search_hints[0] == agent_hints[0], (
+            f"archive hint prose drift between siblings:\n"
+            f"  mem_search:        {search_hints[0]!r}\n"
+            f"  mem_agent_search:  {agent_hints[0]!r}\n"
+            f"See feedback_hint_prose_parity_siblings.md"
+        )


### PR DESCRIPTION
## Summary

``mem_agent_search`` structured output previously always returned
``hints=null``. ``mem_search`` populates two trust-UX hints from the same
pipeline run — archive-filter count (``stats.hidden_system_ns``) when no
namespace was pinned, plus a one-shot dim-mismatch notice via
``_announce_dim_mismatch_once`` — so structured callers of either tool
deserve the same **semantic content**, not just shape parity.

Wires both hints in:

- **Archive hint** fires when ``ns_filter`` is ``None`` — i.e. neither
  ``agent_id``, an active session, nor legacy ``current_namespace``
  resolved a target. Mirrors the gating ``mem_search`` uses on
  ``effective_ns``.
- **Dim-mismatch hint** uses ``_announce_dim_mismatch_once(app)``, which
  carries its own per-process gate. A long-lived MCP session now sees
  the notice exactly once across ``mem_search`` / ``mem_agent_search``
  / ``mem_recall`` combined — adding ``mem_agent_search`` to the
  consumer set does not double-emit the warning.

## Tests

Three new integration tests in ``TestCaseFOutputFormat``:

1. ``test_structured_surfaces_archive_hint_when_unbound`` — index a chunk
   in ``archive:old`` and call ``mem_agent_search`` with no ``agent_id``,
   no session, no ``current_namespace``. The structured payload must
   include the ``hidden in system namespaces`` hint string.
2. ``test_structured_surfaces_dim_mismatch_hint_once`` — install a
   dim/model mismatch on the storage backend (mirroring
   ``test_trust_ux::_install_mismatch``), pre-assert
   ``app._dim_mismatch_announced is False`` on a fresh AppContext, then
   verify the hint fires on call 1 and stays quiet on call 2.
3. ``test_archive_hint_byte_identical_to_mem_search`` — behavioral pin
   that fails on punctuation/wording drift. Calls both ``mem_search``
   and ``mem_agent_search`` on the same un-pinned-archive fixture and
   asserts the archive-filter hint strings are byte-identical, since
   structured consumers parsing ``payload["hints"]`` dedup by string
   identity. ``mem_recall`` is intentionally outside the pin (separate
   "memories recalled" family); the carveout is documented in
   ``feedback_hint_prose_parity_siblings.md`` and in the test docstring.

The pre-assertion on ``_dim_mismatch_announced`` pins the one-shot gate
so a regression in the AppContext default doesn't quietly mask the
test's signal.

## Test plan
- [x] ``uv run pytest packages/memtomem/tests/test_multi_agent_integration.py -k TestCaseFOutputFormat -v`` (7 passed)
- [x] ``uv run pytest -m "not ollama"`` (2926 passed)
- [x] ``uv run ruff check`` + ``ruff format --check`` (clean)
- [x] ``uv run mypy`` (clean on changed file)

## History

Initially stacked on top of #509 (``OutputFormat`` Literal alias).
``#509`` squash-merged as ``e5128652``; this branch was rebased onto
``main`` via ``git rebase --onto origin/main 865f15c5`` (no conflicts;
single hint-wiring commit on top of main).

Closes Item 4 of the 2026-04-26 multi-agent rehearsal follow-up trail
(memtomem-docs#17 / memtomem#507 / memtomem#508 / memtomem#509
predecessors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)