### PR TITLE
refactor(server): hoist invalid output_format prefix to constants

### DIFF
--- a/packages/memtomem/src/memtomem/constants.py
+++ b/packages/memtomem/src/memtomem/constants.py
@@ -90,6 +90,14 @@ _MAX_NAMESPACE_LEN: Final[int] = 256
 # private formatting choices.
 INVALID_NAMESPACE_MESSAGE_PREFIX: Final[str] = "invalid namespace"
 
+# Companion to ``INVALID_NAMESPACE_MESSAGE_PREFIX`` for the ``output_format``
+# validator shared by ``mem_search``, ``mem_agent_search``, and
+# ``mem_recall``. The three call sites format slightly different suffixes
+# (``mem_recall`` appends ``Supported: compact, structured.`` because its
+# subset omits ``verbose``) but the rejection prefix is one shape so a
+# single grep / assertion covers all three surfaces.
+INVALID_OUTPUT_FORMAT_PREFIX: Final[str] = "invalid output_format"
+
 
 def validate_namespace(value: object) -> str:
     """Return *value* unchanged if it is a storable namespace string.

--- a/packages/memtomem/src/memtomem/server/tools/multi_agent.py
+++ b/packages/memtomem/src/memtomem/server/tools/multi_agent.py
@@ -6,6 +6,7 @@ import logging
 
 from memtomem.constants import (
     AGENT_NAMESPACE_PREFIX,
+    INVALID_OUTPUT_FORMAT_PREFIX,
     SHARED_NAMESPACE,
     validate_agent_id,
     validate_namespace,
@@ -141,7 +142,7 @@ async def mem_agent_search(
     if agent_id is not None:
         validate_agent_id(agent_id)
     if output_format not in _VALID_OUTPUT_FORMATS:
-        return f"Error: invalid output_format '{output_format}'."
+        return f"Error: {INVALID_OUTPUT_FORMAT_PREFIX} '{output_format}'."
     app = await _get_app_initialized(ctx)
     from memtomem.server.formatters import _format_results, _format_structured_results
 

--- a/packages/memtomem/src/memtomem/server/tools/recall.py
+++ b/packages/memtomem/src/memtomem/server/tools/recall.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
+from memtomem.constants import INVALID_OUTPUT_FORMAT_PREFIX
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -47,7 +48,10 @@ async def mem_recall(
     if not 1 <= limit <= 500:
         return f"Error: limit must be between 1 and 500, got {limit}."
     if output_format not in ("compact", "structured"):
-        return f"Error: invalid output_format '{output_format}'. Supported: compact, structured."
+        return (
+            f"Error: {INVALID_OUTPUT_FORMAT_PREFIX} '{output_format}'. "
+            "Supported: compact, structured."
+        )
 
     from memtomem.models import NamespaceFilter
 

--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from uuid import UUID
 
+from memtomem.constants import INVALID_OUTPUT_FORMAT_PREFIX
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
 from memtomem.server.error_handler import tool_handler
@@ -68,7 +69,7 @@ async def mem_search(
     if effective_format == "compact" and verbose:
         effective_format = "verbose"
     if effective_format not in _VALID_OUTPUT_FORMATS:
-        return f"Error: invalid output_format '{output_format}'."
+        return f"Error: {INVALID_OUTPUT_FORMAT_PREFIX} '{output_format}'."
 
     app = await _get_app_initialized(ctx)
     effective_ns = namespace or app.current_namespace

--- a/packages/memtomem/tests/test_multi_agent_integration.py
+++ b/packages/memtomem/tests/test_multi_agent_integration.py
@@ -42,7 +42,11 @@ from pathlib import Path
 import pytest
 
 from memtomem.config import Mem2MemConfig
-from memtomem.constants import AGENT_NAMESPACE_PREFIX, SHARED_NAMESPACE
+from memtomem.constants import (
+    AGENT_NAMESPACE_PREFIX,
+    INVALID_OUTPUT_FORMAT_PREFIX,
+    SHARED_NAMESPACE,
+)
 from memtomem.server.component_factory import close_components, create_components
 from memtomem.server.context import AppContext
 from memtomem.server.tools.multi_agent import (
@@ -746,4 +750,4 @@ class TestCaseFOutputFormat:
             ctx=ctx,
         )
 
-        assert "Error" in out and "invalid output_format" in out
+        assert "Error" in out and INVALID_OUTPUT_FORMAT_PREFIX in out

--- a/packages/memtomem/tests/test_trust_ux.py
+++ b/packages/memtomem/tests/test_trust_ux.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 from memtomem.config import Mem2MemConfig
+from memtomem.constants import INVALID_OUTPUT_FORMAT_PREFIX
 from memtomem.models import Chunk, ChunkMetadata
 from memtomem.server.component_factory import close_components, create_components
 from memtomem.server.formatters import _format_structured_results
@@ -341,6 +342,7 @@ class TestArchiveHint:
         out = await mem_recall(limit=10, output_format="verbose", ctx=ctx)
 
         assert out.startswith("Error:")
+        assert INVALID_OUTPUT_FORMAT_PREFIX in out
         assert "verbose" in out
         assert "Supported: compact, structured" in out
 


### PR DESCRIPTION
## Summary

- Add `INVALID_OUTPUT_FORMAT_PREFIX = "invalid output_format"` to
  `packages/memtomem/src/memtomem/constants.py`, mirroring
  `INVALID_NAMESPACE_MESSAGE_PREFIX` (constants.py, PR #501).
- Reference it from the three surfaces that share this rejection prefix:
  `mem_search`, `mem_agent_search`, and `mem_recall`.
- Tests import the constant so one rename moves both call sites and
  assertions in lockstep.

## Why

Three call sites format the same `"invalid output_format '..."` literal
against `_VALID_OUTPUT_FORMATS` (or its 2-format subset for
`mem_recall`). Without a shared constant, a future tweak (translation,
suffix change, alert-rule grep) drifts across surfaces and tests
re-type the private formatting choice. Closes Item 5 of the 2026-04-26
multi-agent rehearsal trail (memtomem#506 / memtomem#508 / memtomem#510
siblings); follows the pattern established by
`feedback_pin_test_constant_over_source_scan.md` and
`feedback_assert_msg_names_target_sym.md`.

## Scope note

`mem_recall` is included even though its message appends a different
suffix (`Supported: compact, structured.`, since the recall surface
omits `verbose`) — the rejection *prefix* is the same shape, so a
single grep / assertion now covers all three surfaces.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` (full
      CI filter, 2923 passed).
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
      + `ruff format --check` clean.
- [x] Targeted: `pytest -k invalid_output_format` covers the two
      assertions that now reference the constant
      (`test_multi_agent_integration.py::TestCaseFOutputFormat::test_invalid_output_format_returns_error`
      + `test_trust_ux.py::TestArchiveHint::test_recall_invalid_output_format`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)