### PR TITLE
docs(mcp-clients): note Antigravity's dual MCP config locations

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -202,6 +202,18 @@ Restart Gemini CLI after configuration.
 > Antigravity does not support the `${workspaceFolder}` variable — use absolute paths.
 > Restart the Agent session after changing settings.
 
+> **Two MCP config locations inside Antigravity.** The steps above register
+> memtomem with the **built-in Gemini agent**, which reads
+> `~/.gemini/antigravity/mcp_config.json` (key `mcpServers`). VS Code-side
+> integrations inside Antigravity — the MCP panel, Copilot Chat, Cline,
+> Claude extension, etc. — read a separate file at
+> `~/Library/Application Support/Antigravity/User/mcp.json` (key `servers`,
+> VS Code's standard MCP schema). Antigravity does **not** inherit MCP
+> entries from a sibling VS Code install; each fork keeps its own
+> `Application Support/<AppName>/User/` directory. Register memtomem in
+> whichever file matches the agent you plan to call it from — or both, if
+> you use both.
+
 ---
 
 ## 7. Verifying Your Connection


### PR DESCRIPTION
## Summary
- §6 Antigravity already covers the Gemini agent path (`~/.gemini/antigravity/mcp_config.json`, key `mcpServers`) but doesn't mention that the same window also runs a separate VS Code-side MCP runtime for extensions (Cline, Copilot Chat, Claude, etc.) which reads `~/Library/Application Support/Antigravity/User/mcp.json` (key `servers`).
- Add a callout under §6 so users registering memtomem for an extension know to use the second file, and clarify that Antigravity does **not** inherit MCP entries from a sibling VS Code install (each fork has its own `Application Support/<AppName>/User/`).

## Test plan
- [x] `ruff check docs/` — passes (no Python under docs/)
- [ ] Render the page locally and confirm the new note sits cleanly under §6 without disrupting the existing screenshot/UI flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)