### PR TITLE
feat(server): persist mem_session_end summary as archive:session:<id> chunk (Phase A)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+from datetime import datetime, timezone
+from pathlib import Path
 from uuid import uuid4
 
 from memtomem.constants import AGENT_NAMESPACE_PREFIX, validate_agent_id, validate_namespace
@@ -147,8 +151,18 @@ async def mem_session_end(
     Resets both ``current_session_id`` and ``current_agent_id`` so the
     next ``mem_agent_search`` falls back to ``current_namespace``.
 
+    When ``summary`` is provided, the text is also promoted to a
+    first-class chunk under ``archive:session:<session_id>`` (Phase A
+    of the episodic-session-summary RFC). The chunk is hidden from
+    default ``mem_search`` via the ``archive:`` system prefix and
+    surfaces only under explicit ``namespace_filter``. Persisting the
+    chunk is best-effort: a failure is logged but does not roll back
+    the session-end DB write.
+
     Args:
-        summary: Optional summary of what was accomplished in this session
+        summary: Optional summary of what was accomplished in this
+            session. When provided, also written as a chunk under
+            ``<memory_dir>/sessions/<YYYY-MM>/<session_id>.md``.
     """
     app = await _get_app_initialized(ctx)
 
@@ -156,6 +170,7 @@ async def mem_session_end(
         return "No active session."
 
     session_id = app.current_session_id
+    agent_id = app.current_agent_id
 
     # Gather session stats
     events = await app.storage.get_session_events(session_id)
@@ -164,6 +179,23 @@ async def mem_session_end(
         event_counts[e["event_type"]] = event_counts.get(e["event_type"], 0) + 1
 
     await app.storage.end_session(session_id, summary, {"event_counts": event_counts})
+
+    summary_chunk_line: str | None = None
+    if summary:
+        try:
+            summary_chunk_line = await _persist_session_summary_chunk(
+                app,
+                session_id=session_id,
+                agent_id=agent_id,
+                summary=summary,
+                event_counts=event_counts,
+            )
+        except Exception:
+            logger.warning(
+                "session_summary_chunk_persist_failed session_id=%s",
+                session_id,
+                exc_info=True,
+            )
 
     # Cleanup session-bound working memory
     cleaned = await app.storage.scratch_cleanup(session_id)
@@ -178,9 +210,94 @@ async def mem_session_end(
     ]
     if summary:
         lines.append(f"- Summary: {summary[:100]}...")
+    if summary_chunk_line:
+        lines.append(summary_chunk_line)
     if cleaned:
         lines.append(f"- Working memory cleaned: {cleaned} entries")
     return "\n".join(lines)
+
+
+async def _persist_session_summary_chunk(
+    app: AppContext,
+    *,
+    session_id: str,
+    agent_id: str | None,
+    summary: str,
+    event_counts: dict[str, int],
+) -> str | None:
+    """Promote a session summary to a first-class chunk.
+
+    Writes the markdown file at
+    ``<memory_dir>/sessions/<YYYY-MM>/<session_id>.md`` and indexes it
+    under ``archive:session:<session_id>``. The ``archive:`` prefix is
+    a default system namespace, so the chunk is hidden from
+    ``mem_search`` unless the caller passes an explicit
+    ``namespace_filter``. Returns a single-line status for the tool
+    response, or ``None`` when no memory directory is configured.
+    """
+    memory_dirs = app.config.indexing.memory_dirs
+    if not memory_dirs:
+        return None
+
+    base = Path(memory_dirs[0]).expanduser().resolve()
+    now = datetime.now(timezone.utc)
+    target = base / "sessions" / now.strftime("%Y-%m") / f"{session_id}.md"
+    namespace = f"archive:session:{session_id}"
+    validate_namespace(namespace)
+
+    agent_label = agent_id or "default"
+    event_total = sum(event_counts.values())
+    content = _format_session_summary(
+        session_id=session_id,
+        agent_id=agent_label,
+        ended_at=now,
+        event_total=event_total,
+        summary=summary,
+    )
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    await asyncio.to_thread(target.write_text, content, "utf-8")
+
+    stats = await app.index_engine.index_file(target, namespace=namespace)
+    app.search_pipeline.invalidate_cache()
+
+    return f"- Summary chunk: {namespace} ({stats.indexed_chunks} chunks)"
+
+
+def _format_session_summary(
+    *,
+    session_id: str,
+    agent_id: str,
+    ended_at: datetime,
+    event_total: int,
+    summary: str,
+) -> str:
+    """Render the session-summary markdown body.
+
+    Layout: YAML frontmatter (session_id / agent_id / ended_at /
+    event_count) → ``## Session summary: <id>`` heading → blockquote
+    tags (``session-summary``, ``agent=<id>``) → summary body. Matches
+    the chunker's expected entry shape (heading + blockquote group +
+    body) so frontmatter and per-section tags both promote cleanly to
+    ``ChunkMetadata.tags``.
+    """
+    iso_ts = ended_at.isoformat(timespec="seconds")
+    tags_json = json.dumps(["session-summary", f"agent={agent_id}"])
+    body = summary.strip()
+    return (
+        f"---\n"
+        f"session_id: {session_id}\n"
+        f"agent_id: {agent_id}\n"
+        f"ended_at: {iso_ts}\n"
+        f"event_count: {event_total}\n"
+        f"---\n"
+        f"\n"
+        f"## Session summary: {session_id}\n"
+        f"\n"
+        f"> tags: {tags_json}\n"
+        f"\n"
+        f"{body}\n"
+    )
 
 
 @mcp.tool()

--- a/packages/memtomem/src/memtomem/server/tools/session.py
+++ b/packages/memtomem/src/memtomem/server/tools/session.py
@@ -170,6 +170,9 @@ async def mem_session_end(
         return "No active session."
 
     session_id = app.current_session_id
+    # Capture before end_session and the lock-guarded reset below; the
+    # archive helper runs after end_session, so any later state
+    # mutation could clobber the tag we want to record.
     agent_id = app.current_agent_id
 
     # Gather session stats
@@ -233,23 +236,30 @@ async def _persist_session_summary_chunk(
     a default system namespace, so the chunk is hidden from
     ``mem_search`` unless the caller passes an explicit
     ``namespace_filter``. Returns a single-line status for the tool
-    response, or ``None`` when no memory directory is configured.
+    response, or ``None`` when no memory directory is configured or
+    when the indexer rejected the file (zero chunks).
     """
     memory_dirs = app.config.indexing.memory_dirs
     if not memory_dirs:
         return None
 
-    base = Path(memory_dirs[0]).expanduser().resolve()
-    now = datetime.now(timezone.utc)
-    target = base / "sessions" / now.strftime("%Y-%m") / f"{session_id}.md"
+    # Validate the derived namespace before doing any I/O so an invalid
+    # session_id (defensive — uuid4 is safe in practice) can't leave a
+    # half-written file behind.
     namespace = f"archive:session:{session_id}"
     validate_namespace(namespace)
 
-    agent_label = agent_id or "default"
+    # Primary memory dir: when multiple are configured, summaries land
+    # under the first one. Keeps the location predictable across runs;
+    # users with multi-dir setups can re-home via memory_dirs ordering.
+    base = Path(memory_dirs[0]).expanduser().resolve()
+    now = datetime.now(timezone.utc)
+    target = base / "sessions" / now.strftime("%Y-%m") / f"{session_id}.md"
+
     event_total = sum(event_counts.values())
     content = _format_session_summary(
         session_id=session_id,
-        agent_id=agent_label,
+        agent_id=agent_id,
         ended_at=now,
         event_total=event_total,
         summary=summary,
@@ -261,13 +271,25 @@ async def _persist_session_summary_chunk(
     stats = await app.index_engine.index_file(target, namespace=namespace)
     app.search_pipeline.invalidate_cache()
 
+    if not stats.indexed_chunks:
+        # File written but indexer produced no chunks (empty body, dedup
+        # collision, or a chunker reject). Surface the path so an
+        # operator can investigate; suppress the misleading "0 chunks"
+        # status line in the tool response.
+        logger.warning(
+            "session_summary_chunk_indexed_zero session_id=%s path=%s",
+            session_id,
+            target,
+        )
+        return None
+
     return f"- Summary chunk: {namespace} ({stats.indexed_chunks} chunks)"
 
 
 def _format_session_summary(
     *,
     session_id: str,
-    agent_id: str,
+    agent_id: str | None,
     ended_at: datetime,
     event_total: int,
     summary: str,
@@ -276,18 +298,27 @@ def _format_session_summary(
 
     Layout: YAML frontmatter (session_id / agent_id / ended_at /
     event_count) → ``## Session summary: <id>`` heading → blockquote
-    tags (``session-summary``, ``agent=<id>``) → summary body. Matches
-    the chunker's expected entry shape (heading + blockquote group +
-    body) so frontmatter and per-section tags both promote cleanly to
-    ``ChunkMetadata.tags``.
+    tags (``session-summary`` plus ``agent=<id>`` when an agent owned
+    the session) → summary body. Matches the chunker's expected entry
+    shape (heading + blockquote group + body) so both frontmatter and
+    per-section tags promote cleanly to ``ChunkMetadata.tags``.
+
+    ``agent_id`` is preserved as ``None`` rather than coerced to
+    ``"default"``: collapsing to a literal would mask sessions that
+    truly had no agent owner behind the legitimate ``default`` agent
+    convention.
     """
     iso_ts = ended_at.isoformat(timespec="seconds")
-    tags_json = json.dumps(["session-summary", f"agent={agent_id}"])
+    tag_list = ["session-summary"]
+    if agent_id:
+        tag_list.append(f"agent={agent_id}")
+    tags_json = json.dumps(tag_list)
+    fm_agent = agent_id if agent_id else "null"
     body = summary.strip()
     return (
         f"---\n"
         f"session_id: {session_id}\n"
-        f"agent_id: {agent_id}\n"
+        f"agent_id: {fm_agent}\n"
         f"ended_at: {iso_ts}\n"
         f"event_count: {event_total}\n"
         f"---\n"

--- a/packages/memtomem/tests/test_sessions.py
+++ b/packages/memtomem/tests/test_sessions.py
@@ -1,5 +1,7 @@
 """Tests for episodic memory (sessions)."""
 
+from pathlib import Path
+
 import pytest
 
 from memtomem.server.context import AppContext
@@ -216,3 +218,71 @@ class TestSessionNamespaceDerivation:
         rows = await app.storage.list_sessions()
         active = next(r for r in rows if r["id"] == app.current_session_id)
         assert active["namespace"] == "agent-runtime:planner"
+
+
+class TestSessionSummaryPhaseA:
+    """Phase A of the episodic-session-summary RFC: an explicit
+    ``summary=`` argument to ``mem_session_end`` is promoted to a
+    first-class chunk under ``archive:session:<session_id>``. The
+    chunk is hidden from default ``mem_search`` via the ``archive:``
+    system prefix; LLM auto-summarization is Phase B and not exercised
+    here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_summary_persists_archive_chunk(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        session_id = app.current_session_id
+        assert session_id is not None
+
+        out = await mem_session_end(  # type: ignore[arg-type]
+            summary="explored the auth flow", ctx=ctx
+        )
+
+        assert f"archive:session:{session_id}" in out
+
+        base = Path(app.config.indexing.memory_dirs[0]).expanduser().resolve()
+        files = list((base / "sessions").rglob(f"{session_id}.md"))
+        assert len(files) == 1
+        body = files[0].read_text(encoding="utf-8")
+        assert "explored the auth flow" in body
+        assert "session-summary" in body
+        assert session_id in body
+
+    @pytest.mark.asyncio
+    async def test_no_summary_skips_chunk(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+        session_id = app.current_session_id
+        assert session_id is not None
+
+        out = await mem_session_end(ctx=ctx)  # type: ignore[arg-type]
+        assert "archive:session:" not in out
+
+        base = Path(app.config.indexing.memory_dirs[0]).expanduser().resolve()
+        sessions_dir = base / "sessions"
+        if sessions_dir.exists():
+            files = list(sessions_dir.rglob(f"{session_id}.md"))
+            assert not files
+
+    @pytest.mark.asyncio
+    async def test_summary_chunk_hidden_from_default_search(self, components):
+        app = AppContext.from_components(components)
+        ctx = _StubCtx(app)
+
+        await mem_session_start(agent_id="planner", ctx=ctx)  # type: ignore[arg-type]
+
+        await mem_session_end(  # type: ignore[arg-type]
+            summary="distinctive phrase for archive search filter test",
+            ctx=ctx,
+        )
+
+        results, _ = await app.search_pipeline.search("distinctive phrase", top_k=10)
+        assert all(not (r.chunk.namespace or "").startswith("archive:session:") for r in results), (
+            "archive:session:* chunks must not appear in default mem_search"
+        )


### PR DESCRIPTION
## Summary

Phase A of the episodic-session-summary RFC. When `mem_session_end`
is called with an explicit `summary=` argument, the text is now
promoted to a first-class chunk under `archive:session:<session_id>`
in addition to the existing `sessions.summary` DB write. The
`archive:` prefix is already a default system namespace, so the
chunk is hidden from default `mem_search` and surfaces only under
explicit `namespace_filter`.

RFC: `memtomem-docs/memtomem/planning/episodic-session-summary-rfc.md`
(private repo, memtomem-docs#19).

## In scope

- `_persist_session_summary_chunk` helper — best-effort write +
  standard-path index via `app.index_engine.index_file` (matches
  watcher hashing).
- `_format_session_summary` renders frontmatter + H2 heading +
  blockquote tags + body so the chunker promotes both metadata
  channels to `ChunkMetadata.tags`.
- File layout: `<memory_dir>/sessions/<YYYY-MM>/<session_id>.md`.
- Three tests in `TestSessionSummaryPhaseA`.

## Out of scope (later phases)

- LLM auto-summary when `summary=` is omitted → Phase B.
- Query-expansion enrichment against `archive:session:*` → Phase C.
- New `system_namespace_prefixes` entry — **not needed**; the
  existing `archive:` prefix already covers `archive:session:*`
  (verified at `constants.py:219`).

## Test plan

- [x] `TestSessionSummaryPhaseA::test_summary_persists_archive_chunk`
      — file written + namespace in tool response.
- [x] `TestSessionSummaryPhaseA::test_no_summary_skips_chunk` —
      no archive file when `summary=` omitted.
- [x] `TestSessionSummaryPhaseA::test_summary_chunk_hidden_from_default_search`
      — default `mem_search` excludes `archive:session:*`.
- [x] Full suite green: 2929 passed, 46 deselected (`-m "not ollama"`).
- [x] `ruff check` + `ruff format --check` clean across `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
