### PR TITLE
feat(server): Stage-1 session-summary rescue leg (P1 Phase C)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -559,6 +559,19 @@ class SessionSummaryConfig(BaseSettings):
     # sessions otherwise emit one row per chunk; we keep the newest
     # ``max_summary_links`` (chunks arrive newest first, tail dropped).
     max_summary_links: int = 50
+    # Phase C — Stage-1 query-expansion enrichment. After standard
+    # expansion, the pipeline runs a small lookup against
+    # ``archive:session:*`` and, for any summary chunk scoring above
+    # ``expansion_score_threshold``, follows ``chunk_links`` of type
+    # ``summarizes`` back to the source files of the summarized session.
+    # Those files become a "rescue leg" — a parallel BM25+dense retrieval
+    # restricted to those source paths and merged into RRF as a third
+    # input list weighted by ``expansion_rescue_weight``. This brings
+    # past-session chunks into ranking contention without changing the
+    # storage primitive signatures.
+    expansion_lookup_top_k: int = 3
+    expansion_score_threshold: float = 0.3
+    expansion_rescue_weight: float = 0.5
 
     @field_validator("min_chunks")
     @classmethod
@@ -567,11 +580,23 @@ class SessionSummaryConfig(BaseSettings):
             raise ValueError(f"{info.field_name} must be positive, got {v}")
         return v
 
-    @field_validator("max_summary_tokens", "max_input_chars", "max_summary_links")
+    @field_validator(
+        "max_summary_tokens",
+        "max_input_chars",
+        "max_summary_links",
+        "expansion_lookup_top_k",
+    )
     @classmethod
     def positive_int(cls, v: int, info: ValidationInfo) -> int:
         if v <= 0:
             raise ValueError(f"{info.field_name} must be positive, got {v}")
+        return v
+
+    @field_validator("expansion_score_threshold", "expansion_rescue_weight")
+    @classmethod
+    def non_negative_float(cls, v: float, info: ValidationInfo) -> float:
+        if v < 0:
+            raise ValueError(f"{info.field_name} must be non-negative, got {v}")
         return v
 
 

--- a/packages/memtomem/src/memtomem/models.py
+++ b/packages/memtomem/src/memtomem/models.py
@@ -133,8 +133,17 @@ class SearchResult:
     chunk: Chunk
     score: float
     rank: int
-    source: str  # "bm25", "dense", "fused", "reranked"
+    source: str  # "bm25", "dense", "fused", "reranked", "session_rescue"
     context: ContextInfo | None = None
+    # True when this chunk surfaced (at least in part) via the
+    # Stage-1 session-summary rescue leg — i.e. an
+    # ``archive:session:*`` summary above threshold pointed at this
+    # chunk's source file. Preserved by fusion / dedup / decay / MMR /
+    # access / importance via OR semantics: if any leg of fusion (or
+    # any pre-stage candidate) carried the flag, the merged result
+    # carries it too. Surfaced in ``output_format="structured"``
+    # payloads only — irrelevant to compact/verbose text formats.
+    via_session_summary: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/memtomem/src/memtomem/search/fusion.py
+++ b/packages/memtomem/src/memtomem/search/fusion.py
@@ -13,21 +13,38 @@ def reciprocal_rank_fusion(
     k: int = 60,
     top_k: int = 10,
     weights: list[float] | None = None,
+    list_labels: list[str] | None = None,
 ) -> list[SearchResult]:
     """Merge multiple ranked lists using weighted RRF.
 
     score(d) = sum over all lists: weight[i] / (k + rank(d))
 
     When weights is None or all equal, behaves like standard RRF.
+    ``list_labels`` lets the caller name each input list (defaults to
+    ``["bm25", "dense", ...]``). A fused result's ``source`` reports
+    the originating list when the chunk hit only one input, or
+    ``"fused"`` when it hit more than one.
+
+    ``via_session_summary`` propagates with OR semantics: if any input
+    leg carried the flag for a chunk, the merged result keeps it.
     """
     if weights is None:
         weights = [1.0] * len(result_lists)
     elif len(weights) < len(result_lists):
         weights = list(weights) + [1.0] * (len(result_lists) - len(weights))
 
+    if list_labels is None:
+        list_labels = ["bm25", "dense"]
+    if len(list_labels) < len(result_lists):
+        list_labels = list(list_labels) + [
+            f"leg{i}" for i in range(len(list_labels), len(result_lists))
+        ]
+
     scores: dict[UUID, float] = {}
     chunk_map: dict[UUID, Chunk] = {}
     hit_counts: dict[UUID, int] = {}
+    hit_lists: dict[UUID, list[int]] = {}
+    via_summary: dict[UUID, bool] = {}
 
     for list_idx, result_list in enumerate(result_lists):
         w = weights[list_idx]
@@ -37,20 +54,19 @@ def reciprocal_rank_fusion(
             scores[cid] = scores.get(cid, 0.0) + w / (k + rank)
             chunk_map[cid] = result.chunk
             hit_counts[cid] = hit_counts.get(cid, 0) + 1
+            hit_lists.setdefault(cid, []).append(list_idx)
+            if result.via_session_summary:
+                via_summary[cid] = True
 
     top_items = heapq.nlargest(top_k, scores.items(), key=lambda x: x[1])
 
-    # Label by retrieval source: "fused" = appeared in multiple lists
-    list_labels = ["bm25", "dense"]
-
     def _source_label(cid: UUID) -> str:
-        hits = hit_counts.get(cid, 0)
-        if hits >= len(result_lists):
+        if hit_counts.get(cid, 0) >= 2:
             return "fused"
-        for label, result_list in zip(list_labels, result_lists):
-            if any(r.chunk.id == cid for r in result_list):
-                return label
-        return "fused"
+        idxs = hit_lists.get(cid, [])
+        if not idxs:
+            return "fused"
+        return list_labels[idxs[0]]
 
     return [
         SearchResult(
@@ -58,6 +74,7 @@ def reciprocal_rank_fusion(
             score=score,
             rank=i + 1,
             source=_source_label(cid),
+            via_session_summary=via_summary.get(cid, False),
         )
         for i, (cid, score) in enumerate(top_items)
     ]

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -9,6 +9,9 @@ from typing import TYPE_CHECKING
 
 from dataclasses import dataclass
 
+from dataclasses import replace as dataclass_replace
+from uuid import UUID
+
 from memtomem.config import (
     MAX_CONTEXT_WINDOW_CHUNKS,
     AccessConfig,
@@ -17,6 +20,7 @@ from memtomem.config import (
     MMRConfig,
     RerankConfig,
     SearchConfig,
+    SessionSummaryConfig,
 )
 from memtomem.models import ContextInfo, NamespaceFilter, SearchResult
 from memtomem.search.fusion import reciprocal_rank_fusion
@@ -80,6 +84,7 @@ class SearchPipeline:
         importance_config: object | None = None,
         context_window_config: ContextWindowConfig | None = None,
         llm_provider: LLMProvider | None = None,
+        session_summary_config: SessionSummaryConfig | None = None,
     ) -> None:
         self._storage = storage
         self._embedder = embedder
@@ -93,6 +98,7 @@ class SearchPipeline:
         self._importance_config = importance_config
         self._context_window_config = context_window_config
         self._llm_provider = llm_provider
+        self._session_summary_config = session_summary_config
 
         # Search result TTL cache (per-instance) with version counter
         self._search_cache: dict[str, tuple[float, int, list[SearchResult], RetrievalStats]] = {}
@@ -146,6 +152,129 @@ class SearchPipeline:
         if cfg and cfg.enabled:
             return max(0, min(cfg.window_size, MAX_CONTEXT_WINDOW_CHUNKS))
         return 0
+
+    async def _session_summary_boost_sources(self, query: str) -> set[str]:
+        """Stage-1 enrichment lookup against ``archive:session:*``.
+
+        Runs a small BM25 lookup against the session-summary namespace
+        (top-k = ``expansion_lookup_top_k``) and, for each hit above
+        ``expansion_score_threshold``, follows ``chunk_links`` of type
+        ``"summarizes"`` from the summary chunk back to the source
+        chunks it summarized. The set of source files spanned by those
+        chunks becomes the boost-sources list.
+
+        Returns an empty set when the feature is disabled, the lookup
+        fails, no summary scores above threshold, or no surviving
+        ``summarizes`` link points at any source. The caller treats an
+        empty set as "skip the rescue leg".
+        """
+        cfg = self._session_summary_config
+        if cfg is None or cfg.expansion_lookup_top_k <= 0:
+            return set()
+
+        archive_filter = NamespaceFilter(pattern="archive:session:*")
+        try:
+            summary_hits = await self._storage.bm25_search(
+                query, top_k=cfg.expansion_lookup_top_k, namespace_filter=archive_filter
+            )
+        except Exception:
+            logger.debug("session-summary lookup failed; skipping rescue", exc_info=True)
+            return set()
+
+        threshold = cfg.expansion_score_threshold
+        candidate_summaries = [r for r in summary_hits if r.score >= threshold]
+        if not candidate_summaries:
+            return set()
+
+        # For each above-threshold summary, walk chunk_links(summarizes)
+        # to reach the original source chunks, then collect their
+        # source_file paths. Failures on any one summary are logged and
+        # skipped — we never let a single bad summary mute the rescue.
+        target_chunk_ids: list[UUID] = []
+        for r in candidate_summaries:
+            try:
+                links = await self._storage.get_chunks_shared_from(
+                    r.chunk.id, link_type="summarizes"
+                )
+            except Exception:
+                logger.debug(
+                    "get_chunks_shared_from failed for summary %s", r.chunk.id, exc_info=True
+                )
+                continue
+            for link in links:
+                target_chunk_ids.append(link.target_id)
+
+        if not target_chunk_ids:
+            return set()
+
+        try:
+            chunks_map = await self._storage.get_chunks_batch(target_chunk_ids)
+        except Exception:
+            logger.debug("get_chunks_batch failed for rescue targets", exc_info=True)
+            return set()
+
+        return {str(c.metadata.source_file) for c in chunks_map.values()}
+
+    async def _rescue_retrieval(
+        self,
+        query: str,
+        query_embedding: list[float],
+        top_k: int,
+        boost_sources: set[str],
+        use_bm25: bool,
+        use_dense: bool,
+    ) -> list[SearchResult]:
+        """Parallel BM25+dense retrieval restricted to boost_sources.
+
+        Runs unrestricted retrievals and post-filters by source_file
+        membership rather than threading a new parameter through the
+        storage primitives — keeps ``bm25_search`` / ``dense_search``
+        signatures clean. The leg is merged into RRF as a third input
+        list, weighted by ``expansion_rescue_weight``.
+        """
+        if not boost_sources:
+            return []
+        # Cast a slightly wider net so source filtering still leaves a
+        # useful candidate pool. Bounded by existing candidate caps.
+        oversample = max(top_k, self._config.bm25_candidates)
+
+        async def _bm25_leg() -> list[SearchResult]:
+            if not use_bm25:
+                return []
+            try:
+                hits = await self._storage.bm25_search(
+                    query, top_k=oversample, namespace_filter=None
+                )
+            except Exception:
+                logger.debug("rescue bm25 leg failed", exc_info=True)
+                return []
+            return [r for r in hits if str(r.chunk.metadata.source_file) in boost_sources]
+
+        async def _dense_leg() -> list[SearchResult]:
+            if not use_dense or not query_embedding:
+                return []
+            try:
+                hits = await self._storage.dense_search(
+                    query_embedding, top_k=oversample, namespace_filter=None
+                )
+            except Exception:
+                logger.debug("rescue dense leg failed", exc_info=True)
+                return []
+            return [r for r in hits if str(r.chunk.metadata.source_file) in boost_sources]
+
+        bm25_rescue, dense_rescue = await asyncio.gather(_bm25_leg(), _dense_leg())
+
+        # Merge the rescue leg's BM25 + dense candidates into a single
+        # ranked list (keep best rank across the two legs) so we feed
+        # one rescue list into the outer RRF rather than two — this
+        # matches the RFC's "third input list" framing and avoids
+        # over-weighting rescue when it dominates both legs.
+        seen: dict[UUID, SearchResult] = {}
+        for r in bm25_rescue + dense_rescue:
+            existing = seen.get(r.chunk.id)
+            if existing is None or r.score > existing.score:
+                seen[r.chunk.id] = r
+        return sorted(seen.values(), key=lambda r: r.score, reverse=True)[:oversample]
 
     async def _expand_context(self, results: list[SearchResult], window: int) -> list[SearchResult]:
         """Attach ±window adjacent chunks to each result (batch, single DB call)."""
@@ -313,6 +442,39 @@ class SearchPipeline:
             hidden_system_ns=hidden_system_ns,
         )
 
+        # Stage 1 enrichment (RFC P1 Phase C): session-summary rescue.
+        # When an above-threshold past-session summary's chunk_links
+        # point at source files relevant to this query, run a parallel
+        # BM25+dense retrieval restricted to those files and merge the
+        # result as a third RRF input. This brings past-session chunks
+        # into ranking contention without changing the retrieval
+        # primitives' signatures — keeping ``bm25_search`` /
+        # ``dense_search`` archive-agnostic. (Pure post-fusion score
+        # multiplier was rejected: it can only re-rank candidates that
+        # already surfaced organically; "ranking contention" requires
+        # injection.)
+        rescue_results: list[SearchResult] = []
+        rescue_chunk_ids: set[UUID] = set()
+        if (
+            namespace is None
+            and self._session_summary_config is not None
+            and self._session_summary_config.expansion_lookup_top_k > 0
+        ):
+            try:
+                boost_sources = await self._session_summary_boost_sources(query)
+                if boost_sources:
+                    rescue_results = await self._rescue_retrieval(
+                        query,
+                        query_embedding,
+                        top_k=top_k,
+                        boost_sources=boost_sources,
+                        use_bm25=use_bm25,
+                        use_dense=use_dense,
+                    )
+                    rescue_chunk_ids = {r.chunk.id for r in rescue_results}
+            except Exception:
+                logger.debug("session-summary rescue leg failed", exc_info=True)
+
         # Stage 3: fusion (or single-retriever passthrough)
         # When reranking is active, widen the candidate pool so the
         # cross-encoder can rescue items RRF ranked just outside top_k.
@@ -329,17 +491,64 @@ class SearchPipeline:
         else:
             rerank_pool = top_k
 
+        # Mark rescue-leg results so fusion can OR-propagate the flag.
+        if rescue_results:
+            rescue_results = [
+                dataclass_replace(r, via_session_summary=True) for r in rescue_results
+            ]
+
         if use_bm25 and use_dense:
+            fusion_lists = [bm25_results, dense_results]
+            fusion_weights = list(effective_weights)
+            fusion_labels = ["bm25", "dense"]
+            if rescue_results:
+                fusion_lists.append(rescue_results)
+                rescue_w = (
+                    self._session_summary_config.expansion_rescue_weight
+                    if self._session_summary_config is not None
+                    else 0.5
+                )
+                fusion_weights.append(rescue_w)
+                fusion_labels.append("session_rescue")
             fused = reciprocal_rank_fusion(
-                [bm25_results, dense_results],
+                fusion_lists,
                 k=self._config.rrf_k,
                 top_k=rerank_pool,
-                weights=effective_weights,
+                weights=fusion_weights,
+                list_labels=fusion_labels,
             )
         elif use_bm25:
-            fused = bm25_results[:rerank_pool]
+            if rescue_results:
+                rescue_w = (
+                    self._session_summary_config.expansion_rescue_weight
+                    if self._session_summary_config is not None
+                    else 0.5
+                )
+                fused = reciprocal_rank_fusion(
+                    [bm25_results, rescue_results],
+                    k=self._config.rrf_k,
+                    top_k=rerank_pool,
+                    weights=[effective_weights[0], rescue_w],
+                    list_labels=["bm25", "session_rescue"],
+                )
+            else:
+                fused = bm25_results[:rerank_pool]
         elif use_dense:
-            fused = dense_results[:rerank_pool]
+            if rescue_results:
+                rescue_w = (
+                    self._session_summary_config.expansion_rescue_weight
+                    if self._session_summary_config is not None
+                    else 0.5
+                )
+                fused = reciprocal_rank_fusion(
+                    [dense_results, rescue_results],
+                    k=self._config.rrf_k,
+                    top_k=rerank_pool,
+                    weights=[effective_weights[1] if len(effective_weights) > 1 else 1.0, rescue_w],
+                    list_labels=["dense", "session_rescue"],
+                )
+            else:
+                fused = dense_results[:rerank_pool]
         else:
             fused = []
         stats.fused_total = len(fused)
@@ -409,6 +618,21 @@ class SearchPipeline:
         ctx_win = self._resolve_context_window(context_window)
         if ctx_win > 0 and fused:
             fused = await self._expand_context(fused, ctx_win)
+
+        # Re-stamp ``via_session_summary`` for any chunk that came in
+        # via the rescue leg. Downstream stages (decay, MMR, access,
+        # importance, reranker, context expansion) construct fresh
+        # ``SearchResult`` instances with default field values and so
+        # silently drop the flag — restoring here at the boundary keeps
+        # propagation a single-source-of-truth concern of the pipeline
+        # rather than leaking the obligation into every stage.
+        if rescue_chunk_ids:
+            fused = [
+                dataclass_replace(r, via_session_summary=True)
+                if r.chunk.id in rescue_chunk_ids
+                else r
+                for r in fused
+            ]
 
         stats.final_total = len(fused)
 

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -164,6 +164,7 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         importance_config=config.importance,
         context_window_config=config.context_window,
         llm_provider=llm,
+        session_summary_config=config.session_summary,
     )
 
     return Components(

--- a/packages/memtomem/src/memtomem/server/formatters.py
+++ b/packages/memtomem/src/memtomem/server/formatters.py
@@ -131,17 +131,21 @@ def _format_structured_results(results: list, hints: list[str] | None = None) ->
     for r in results:
         meta = r.chunk.metadata
         hierarchy = " > ".join(meta.heading_hierarchy) if meta.heading_hierarchy else ""
-        out.append(
-            {
-                "rank": r.rank,
-                "score": round(r.score, 4),
-                "source": _short_path(meta.source_file),
-                "hierarchy": hierarchy,
-                "namespace": meta.namespace,
-                "chunk_id": str(r.chunk.id),
-                "content": r.chunk.content,
-            }
-        )
+        entry: dict[str, object] = {
+            "rank": r.rank,
+            "score": round(r.score, 4),
+            "source": _short_path(meta.source_file),
+            "hierarchy": hierarchy,
+            "namespace": meta.namespace,
+            "chunk_id": str(r.chunk.id),
+            "content": r.chunk.content,
+        }
+        # RFC P1 Phase C: surface session-summary rescue provenance only
+        # when set, so the common case (organic hit) keeps a stable
+        # narrow shape and consumers can branch on key presence.
+        if getattr(r, "via_session_summary", False):
+            entry["via_session_summary"] = True
+        out.append(entry)
     payload: dict[str, object] = {"results": out}
     if hints:
         payload["hints"] = list(hints)

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -283,6 +283,7 @@ def _revert_to_stored(app: AppContext) -> str:
         access_config=config.access,
         context_window_config=config.context_window,
         llm_provider=app.llm_provider,
+        session_summary_config=config.session_summary,
     )
     comp.index_engine = IndexEngine(
         storage=storage,

--- a/packages/memtomem/tests/test_session_summary_rescue.py
+++ b/packages/memtomem/tests/test_session_summary_rescue.py
@@ -1,0 +1,371 @@
+"""Phase C — Stage-1 session-summary rescue leg tests.
+
+Covers the new path that runs alongside BM25 + dense:
+
+1. ``_session_summary_boost_sources`` lookup + threshold + chunk_links walk
+2. ``_rescue_retrieval`` boost_sources filter
+3. 3-leg RRF preserving ``via_session_summary`` (OR) and labelling
+   rescue-only chunks as ``session_rescue``
+4. End-to-end ``SearchPipeline.search`` surfacing the flag through
+   downstream stages so structured output sees it
+5. Structured formatter emitting the field only when set
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from memtomem.config import SearchConfig, SessionSummaryConfig
+from memtomem.models import Chunk, ChunkLink, ChunkMetadata, SearchResult
+from memtomem.search.fusion import reciprocal_rank_fusion
+from memtomem.search.pipeline import SearchPipeline
+from memtomem.server.formatters import _format_structured_results
+
+
+def _chunk(content: str = "x", source: str = "a.md", namespace: str = "default") -> Chunk:
+    return Chunk(
+        content=content,
+        metadata=ChunkMetadata(
+            source_file=Path(f"/tmp/{source}"),
+            namespace=namespace,
+        ),
+        embedding=[0.1] * 8,
+    )
+
+
+def _sr(chunk: Chunk, score: float, rank: int, source: str = "bm25", *, via=False) -> SearchResult:
+    return SearchResult(
+        chunk=chunk, score=score, rank=rank, source=source, via_session_summary=via
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Fusion preserves via_session_summary (OR) + labels rescue leg
+# ---------------------------------------------------------------------------
+
+
+class TestFusionViaSessionSummaryPropagation:
+    def test_rescue_only_chunk_labelled_session_rescue(self):
+        bm25 = _chunk("only_bm25")
+        rescue = _chunk("only_rescue")
+        fused = reciprocal_rank_fusion(
+            [
+                [_sr(bm25, 1.0, 1, "bm25")],
+                [],
+                [_sr(rescue, 1.0, 1, "session_rescue", via=True)],
+            ],
+            list_labels=["bm25", "dense", "session_rescue"],
+            top_k=5,
+        )
+        labels = {r.chunk.id: r.source for r in fused}
+        assert labels[rescue.id] == "session_rescue"
+        flags = {r.chunk.id: r.via_session_summary for r in fused}
+        assert flags[rescue.id] is True
+        assert flags[bm25.id] is False
+
+    def test_or_propagation_when_chunk_in_multiple_legs(self):
+        """A chunk that hit bm25 *and* the rescue leg keeps the flag."""
+        shared = _chunk("shared")
+        fused = reciprocal_rank_fusion(
+            [
+                [_sr(shared, 1.0, 1, "bm25", via=False)],
+                [],
+                [_sr(shared, 1.0, 1, "session_rescue", via=True)],
+            ],
+            list_labels=["bm25", "dense", "session_rescue"],
+            top_k=5,
+        )
+        result = next(r for r in fused if r.chunk.id == shared.id)
+        assert result.via_session_summary is True
+        # Hit two legs → labelled "fused"
+        assert result.source == "fused"
+
+
+# ---------------------------------------------------------------------------
+# 2. _session_summary_boost_sources helper
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline(
+    storage: AsyncMock,
+    *,
+    session_summary_config: SessionSummaryConfig | None = None,
+) -> SearchPipeline:
+    embedder = AsyncMock()
+    embedder.embed_query = AsyncMock(return_value=[0.1] * 8)
+    return SearchPipeline(
+        storage=storage,
+        embedder=embedder,
+        config=SearchConfig(enable_bm25=True, enable_dense=False),
+        session_summary_config=session_summary_config,
+    )
+
+
+def _async_storage() -> AsyncMock:
+    s = AsyncMock()
+    s.bm25_search = AsyncMock(return_value=[])
+    s.dense_search = AsyncMock(return_value=[])
+    s.increment_access = AsyncMock()
+    s.save_query_history = AsyncMock()
+    s.get_access_counts = AsyncMock(return_value={})
+    s.get_embeddings_for_chunks = AsyncMock(return_value={})
+    s.get_importance_scores = AsyncMock(return_value={})
+    s.count_chunks_by_ns_prefix = AsyncMock(return_value=0)
+    s.get_chunks_shared_from = AsyncMock(return_value=[])
+    s.get_chunks_batch = AsyncMock(return_value={})
+    return s
+
+
+class TestBoostSourcesHelper:
+    @pytest.mark.asyncio
+    async def test_disabled_when_no_config(self):
+        pipeline = _make_pipeline(_async_storage(), session_summary_config=None)
+        assert await pipeline._session_summary_boost_sources("q") == set()
+
+    @pytest.mark.asyncio
+    async def test_disabled_when_top_k_zero(self):
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=1)
+        # zero is rejected by validator, but we can stub directly via private
+        # set; emulate by setting cfg with min positive value and bypass
+        # threshold-only path: instead, prove disabled by an empty hit list.
+        storage = _async_storage()
+        storage.bm25_search = AsyncMock(return_value=[])
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        assert await pipeline._session_summary_boost_sources("q") == set()
+
+    @pytest.mark.asyncio
+    async def test_threshold_filters_low_score_summary(self):
+        cfg = SessionSummaryConfig(
+            expansion_lookup_top_k=3, expansion_score_threshold=0.5
+        )
+        summary_chunk = _chunk("summary", namespace="archive:session:abc")
+        storage = _async_storage()
+        # Below threshold → no rescue
+        storage.bm25_search = AsyncMock(
+            return_value=[_sr(summary_chunk, score=0.1, rank=1, source="bm25")]
+        )
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        assert await pipeline._session_summary_boost_sources("q") == set()
+        storage.get_chunks_shared_from.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_walks_chunk_links_to_source_files(self):
+        cfg = SessionSummaryConfig(
+            expansion_lookup_top_k=3, expansion_score_threshold=0.3
+        )
+        summary_chunk = _chunk("summary", namespace="archive:session:abc")
+        target1 = _chunk("c1", source="src/a.md")
+        target2 = _chunk("c2", source="src/b.md")
+
+        storage = _async_storage()
+        storage.bm25_search = AsyncMock(
+            return_value=[_sr(summary_chunk, score=0.9, rank=1, source="bm25")]
+        )
+        storage.get_chunks_shared_from = AsyncMock(
+            return_value=[
+                ChunkLink(
+                    target_id=target1.id,
+                    link_type="summarizes",
+                    namespace_target="default",
+                    created_at=datetime.now(timezone.utc),
+                    source_id=summary_chunk.id,
+                ),
+                ChunkLink(
+                    target_id=target2.id,
+                    link_type="summarizes",
+                    namespace_target="default",
+                    created_at=datetime.now(timezone.utc),
+                    source_id=summary_chunk.id,
+                ),
+            ]
+        )
+        storage.get_chunks_batch = AsyncMock(
+            return_value={target1.id: target1, target2.id: target2}
+        )
+
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        sources = await pipeline._session_summary_boost_sources("q")
+        assert sources == {"/tmp/src/a.md", "/tmp/src/b.md"}
+        # Walk used the correct link_type
+        call_args = storage.get_chunks_shared_from.await_args
+        assert call_args.kwargs.get("link_type") == "summarizes"
+
+    @pytest.mark.asyncio
+    async def test_no_links_yields_empty(self):
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.3)
+        summary_chunk = _chunk("summary", namespace="archive:session:abc")
+        storage = _async_storage()
+        storage.bm25_search = AsyncMock(
+            return_value=[_sr(summary_chunk, score=0.9, rank=1, source="bm25")]
+        )
+        storage.get_chunks_shared_from = AsyncMock(return_value=[])
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        assert await pipeline._session_summary_boost_sources("q") == set()
+
+
+# ---------------------------------------------------------------------------
+# 3. End-to-end pipeline: rescue chunk surfaces with flag preserved
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineEndToEndRescue:
+    @pytest.mark.asyncio
+    async def test_rescue_chunk_surfaces_with_flag(self):
+        """A chunk absent from organic BM25 must be able to enter the result
+        set via the rescue leg (RFC ``ranking contention``) and carry
+        ``via_session_summary=True`` through the final pipeline output.
+        """
+        cfg = SessionSummaryConfig(
+            expansion_lookup_top_k=3, expansion_score_threshold=0.3
+        )
+        summary_chunk = _chunk("summary body", namespace="archive:session:abc")
+        rescued = _chunk("rescued chunk", source="src/old_session.md")
+        organic = _chunk("organic chunk", source="src/today.md")
+
+        storage = _async_storage()
+
+        async def bm25_dispatch(query: str, top_k: int, namespace_filter=None):
+            # Archive lookup pattern
+            if namespace_filter is not None and getattr(namespace_filter, "pattern", None) == (
+                "archive:session:*"
+            ):
+                return [_sr(summary_chunk, score=0.9, rank=1, source="bm25")]
+            # Organic + rescue (unrestricted) pool — both chunks visible
+            return [
+                _sr(organic, score=1.0, rank=1, source="bm25"),
+                _sr(rescued, score=0.4, rank=2, source="bm25"),
+            ]
+
+        storage.bm25_search = AsyncMock(side_effect=bm25_dispatch)
+        storage.get_chunks_shared_from = AsyncMock(
+            return_value=[
+                ChunkLink(
+                    target_id=rescued.id,
+                    link_type="summarizes",
+                    namespace_target="default",
+                    created_at=datetime.now(timezone.utc),
+                    source_id=summary_chunk.id,
+                )
+            ]
+        )
+        storage.get_chunks_batch = AsyncMock(return_value={rescued.id: rescued})
+
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        results, _stats = await pipeline.search("q", top_k=10)
+
+        ids = {r.chunk.id for r in results}
+        assert rescued.id in ids
+        rescued_result = next(r for r in results if r.chunk.id == rescued.id)
+        assert rescued_result.via_session_summary is True
+        organic_result = next(r for r in results if r.chunk.id == organic.id)
+        assert organic_result.via_session_summary is False
+
+    @pytest.mark.asyncio
+    async def test_no_rescue_when_no_summary_above_threshold(self):
+        """Common case: no past summary above threshold → rescue leg
+        skipped (no extra retrieval round-trip)."""
+        cfg = SessionSummaryConfig(
+            expansion_lookup_top_k=3, expansion_score_threshold=0.5
+        )
+        organic = _chunk("organic chunk")
+
+        storage = _async_storage()
+        bm25_calls: list[object] = []
+
+        def _label(nf) -> str:
+            if nf is None:
+                return "ORGANIC"
+            if getattr(nf, "pattern", None) == "archive:session:*":
+                return "archive:session:*"
+            return "ORGANIC"
+
+        async def bm25_dispatch(query: str, top_k: int, namespace_filter=None):
+            label = _label(namespace_filter)
+            bm25_calls.append(label)
+            if label == "archive:session:*":
+                return []  # no summary → boost_sources stays empty
+            return [_sr(organic, score=1.0, rank=1, source="bm25")]
+
+        storage.bm25_search = AsyncMock(side_effect=bm25_dispatch)
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        results, _ = await pipeline.search("q", top_k=10)
+        assert {r.chunk.id for r in results} == {organic.id}
+        # Exactly two BM25 calls: archive lookup + organic. No third
+        # rescue retrieval call when boost_sources is empty.
+        assert bm25_calls.count("ORGANIC") == 1
+        assert bm25_calls.count("archive:session:*") == 1
+
+    @pytest.mark.asyncio
+    async def test_disabled_when_namespace_pinned(self):
+        """Caller pinning a namespace explicitly opted in to that scope —
+        the rescue leg (which broadens scope back out) must stay quiet."""
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3)
+        organic = _chunk("organic", namespace="agent-runtime:planner")
+
+        storage = _async_storage()
+        archive_lookup_called = False
+
+        async def bm25_dispatch(query, top_k, namespace_filter=None):
+            nonlocal archive_lookup_called
+            if getattr(namespace_filter, "pattern", None) == "archive:session:*":
+                archive_lookup_called = True
+                return []
+            return [_sr(organic, score=1.0, rank=1, source="bm25")]
+
+        storage.bm25_search = AsyncMock(side_effect=bm25_dispatch)
+        pipeline = _make_pipeline(storage, session_summary_config=cfg)
+        await pipeline.search("q", top_k=10, namespace="agent-runtime:planner")
+        assert archive_lookup_called is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Structured formatter emits via_session_summary only when True
+# ---------------------------------------------------------------------------
+
+
+class TestStructuredFormatterFlag:
+    def test_flag_omitted_when_false(self):
+        import json
+
+        sr = _sr(_chunk("a"), 1.0, 1, "bm25", via=False)
+        out = json.loads(_format_structured_results([sr]))
+        assert "via_session_summary" not in out["results"][0]
+
+    def test_flag_emitted_when_true(self):
+        import json
+
+        sr = _sr(_chunk("a"), 1.0, 1, "session_rescue", via=True)
+        out = json.loads(_format_structured_results([sr]))
+        assert out["results"][0]["via_session_summary"] is True
+
+
+# ---------------------------------------------------------------------------
+# 5. Config validators
+# ---------------------------------------------------------------------------
+
+
+class TestSessionSummaryConfigPhaseC:
+    def test_defaults_match_rfc(self):
+        cfg = SessionSummaryConfig()
+        assert cfg.expansion_lookup_top_k == 3
+        assert cfg.expansion_score_threshold == 0.3
+        assert cfg.expansion_rescue_weight == 0.5
+
+    def test_top_k_must_be_positive(self):
+        with pytest.raises(ValueError):
+            SessionSummaryConfig(expansion_lookup_top_k=0)
+
+    def test_threshold_non_negative(self):
+        SessionSummaryConfig(expansion_score_threshold=0.0)  # ok
+        with pytest.raises(ValueError):
+            SessionSummaryConfig(expansion_score_threshold=-0.1)
+
+    def test_rescue_weight_non_negative(self):
+        SessionSummaryConfig(expansion_rescue_weight=0.0)  # ok
+        with pytest.raises(ValueError):
+            SessionSummaryConfig(expansion_rescue_weight=-1.0)

--- a/packages/memtomem/tests/test_session_summary_rescue.py
+++ b/packages/memtomem/tests/test_session_summary_rescue.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock
-from uuid import UUID, uuid4
-
 import pytest
 
 from memtomem.config import SearchConfig, SessionSummaryConfig
@@ -39,9 +37,7 @@ def _chunk(content: str = "x", source: str = "a.md", namespace: str = "default")
 
 
 def _sr(chunk: Chunk, score: float, rank: int, source: str = "bm25", *, via=False) -> SearchResult:
-    return SearchResult(
-        chunk=chunk, score=score, rank=rank, source=source, via_session_summary=via
-    )
+    return SearchResult(chunk=chunk, score=score, rank=rank, source=source, via_session_summary=via)
 
 
 # ---------------------------------------------------------------------------
@@ -140,9 +136,7 @@ class TestBoostSourcesHelper:
 
     @pytest.mark.asyncio
     async def test_threshold_filters_low_score_summary(self):
-        cfg = SessionSummaryConfig(
-            expansion_lookup_top_k=3, expansion_score_threshold=0.5
-        )
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.5)
         summary_chunk = _chunk("summary", namespace="archive:session:abc")
         storage = _async_storage()
         # Below threshold → no rescue
@@ -155,9 +149,7 @@ class TestBoostSourcesHelper:
 
     @pytest.mark.asyncio
     async def test_above_threshold_walks_chunk_links_to_source_files(self):
-        cfg = SessionSummaryConfig(
-            expansion_lookup_top_k=3, expansion_score_threshold=0.3
-        )
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.3)
         summary_chunk = _chunk("summary", namespace="archive:session:abc")
         target1 = _chunk("c1", source="src/a.md")
         target2 = _chunk("c2", source="src/b.md")
@@ -220,9 +212,7 @@ class TestPipelineEndToEndRescue:
         set via the rescue leg (RFC ``ranking contention``) and carry
         ``via_session_summary=True`` through the final pipeline output.
         """
-        cfg = SessionSummaryConfig(
-            expansion_lookup_top_k=3, expansion_score_threshold=0.3
-        )
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.3)
         summary_chunk = _chunk("summary body", namespace="archive:session:abc")
         rescued = _chunk("rescued chunk", source="src/old_session.md")
         organic = _chunk("organic chunk", source="src/today.md")
@@ -269,9 +259,7 @@ class TestPipelineEndToEndRescue:
     async def test_no_rescue_when_no_summary_above_threshold(self):
         """Common case: no past summary above threshold → rescue leg
         skipped (no extra retrieval round-trip)."""
-        cfg = SessionSummaryConfig(
-            expansion_lookup_top_k=3, expansion_score_threshold=0.5
-        )
+        cfg = SessionSummaryConfig(expansion_lookup_top_k=3, expansion_score_threshold=0.5)
         organic = _chunk("organic chunk")
 
         storage = _async_storage()


### PR DESCRIPTION
## Summary

Wires Phase C of the episodic-session-summary RFC: when an above-threshold past-session summary's \`chunk_links\` (the rows Phase B-2 wrote with \`link_type="summarizes"\`) point at source files relevant to the current query, run a **parallel BM25+dense retrieval restricted to those files** and merge the result into RRF as a third input list. This brings past-session chunks into ranking contention without changing the storage primitive signatures — \`bm25_search\` / \`dense_search\` stay archive-agnostic.

## Why a rescue leg, not a multiplier or a primitive-level boost

- A **post-fusion score multiplier** only re-ranks candidates that surfaced organically, which fails the RFC §Goals 5 "ranking contention" requirement (a chunk absent from BM25 and dense top-K must be able to enter the result set).
- A **primitive-level boost** (\`boost_sources\` parameter on \`bm25_search\`/\`dense_search\`) forces archive-specific knowledge into a generic retrieval interface that other enrichment paths share.
- The **parallel-retrieval-into-RRF** path gets injection semantics for free and stays cleanly scoped to the pipeline.

The matching RFC text update is in memtomem-docs#21 (stacked on #19); both are designed to land together.

## Implementation

- \`SessionSummaryConfig.expansion_lookup_top_k=3\`, \`expansion_score_threshold=0.3\`, \`expansion_rescue_weight=0.5\` (RFC defaults).
- \`SearchResult.via_session_summary\` tracks rescue provenance. Downstream stages (decay, MMR, access, importance, reranker, context expansion) construct fresh results with default fields and silently drop the flag — the pipeline restamps it at the boundary using a stable \`rescue_chunk_ids\` set rather than threading the obligation into every stage.
- \`SearchPipeline._session_summary_boost_sources\`: archive lookup → threshold → \`chunk_links(summarizes)\` walk → \`get_chunks_batch\` → set of \`source_file\` paths. Failures on any single summary are logged and skipped — never let a bad summary mute the whole rescue.
- \`SearchPipeline._rescue_retrieval\`: parallel BM25+dense with \`namespace_filter=None\`, post-filtered by source_file membership, then collapsed to one ranked list before fusion. Skipped entirely when \`boost_sources\` is empty, so the common case adds **one round-trip total** (the archive lookup), not three.
- \`reciprocal_rank_fusion\` takes optional \`list_labels\` (defaults \`["bm25", "dense", ...]\`) and OR-propagates \`via_session_summary\` across input legs.
- Structured formatter emits \`via_session_summary\` only when \`True\`, so the common-case payload shape stays narrow.
- Rescue leg gated on \`namespace=None\`: callers who pinned a namespace explicitly opted into that scope and the rescue (which broadens scope) stays quiet.

## Threshold default

\`0.3\` ships from the RFC. Raise-to-\`0.5\` trigger documented in the updated RFC: integration-test or dogfooding observation of unrelated past-session source files entering top-K for queries semantically distant from those sessions' summaries.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/ -m "not ollama" -q\` — 2954 passed
- [x] \`uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src\` — clean
- New \`test_session_summary_rescue.py\` (16 tests):
  - 3-leg fusion OR-propagation of \`via_session_summary\` + \`session_rescue\` label
  - Helper: feature-off / threshold-below / above-threshold walk / empty-link no-op
  - End-to-end pipeline: rescue chunk surfaces with flag preserved through downstream stages to the final structured output
  - Common-case round-trip skip when no above-threshold summary
  - \`namespace=\`-pinned caller skips the leg
  - Structured formatter emits the field only when \`True\`
  - Config validators (positive int, non-negative float)

## Mutability

Phase C config fields are restart-required (consistent with Phase A/B \`session_summary\` shape). Runtime mutability via \`mm config set\` / \`PATCH /api/config\` deferred — call out as a follow-up if dogfooding wants to tune \`expansion_score_threshold\` without restarts.