### PR TITLE
feat(storage): schedules table + ScheduleMixin (P2 cron Phase A.1)

### DIFF
--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "watchdog>=6.0",
     "click>=8.1",
     "pathspec>=0.12",
+    "croniter>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/memtomem/src/memtomem/storage/mixins/__init__.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/__init__.py
@@ -8,6 +8,7 @@ from memtomem.storage.mixins.analytics import AnalyticsMixin
 from memtomem.storage.mixins.history import HistoryMixin
 from memtomem.storage.mixins.entities import EntityMixin
 from memtomem.storage.mixins.policies import PolicyMixin
+from memtomem.storage.mixins.schedules import ScheduleMixin
 
 __all__ = [
     "SessionMixin",
@@ -18,4 +19,5 @@ __all__ = [
     "HistoryMixin",
     "EntityMixin",
     "PolicyMixin",
+    "ScheduleMixin",
 ]

--- a/packages/memtomem/src/memtomem/storage/mixins/schedules.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/schedules.py
@@ -1,0 +1,165 @@
+"""Schedule storage mixin — CRUD for the ``schedules`` table (P2 Phase A).
+
+Phase A is direct-cron only (no NL parser). Cron expressions are
+interpreted in UTC; ``created_at`` and ``last_run_at`` are stored as
+UTC ISO strings. ``schedule_list_due`` returns at-most-once catch-up
+semantics — if multiple cron slots elapsed since ``last_run_at``, the
+schedule fires exactly once on the next dispatcher tick (no backfill).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+from croniter import croniter
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _parse_iso_utc(value: str) -> datetime:
+    """Parse an ISO timestamp; assume UTC if naive."""
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+class ScheduleMixin:
+    """Mixin providing scheduled-job CRUD. Requires self._get_db()."""
+
+    async def schedule_insert(
+        self,
+        cron_expr: str,
+        job_kind: str,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        """Insert a new schedule and return its id.
+
+        ``cron_expr`` must be a valid 5-field cron expression (validated
+        by callers via ``croniter.is_valid`` before reaching here);
+        ``job_kind`` must be a registered ``JOB_KINDS`` key (validated
+        by callers).
+        """
+        db = self._get_db()
+        sched_id = uuid4().hex[:12]
+        db.execute(
+            "INSERT INTO schedules "
+            "(id, cron_expr, job_kind, params_json, enabled, created_at) "
+            "VALUES (?, ?, ?, ?, 1, ?)",
+            (
+                sched_id,
+                cron_expr,
+                job_kind,
+                json.dumps(params or {}),
+                _utcnow_iso(),
+            ),
+        )
+        db.commit()
+        return sched_id
+
+    async def schedule_get(self, sched_id: str) -> dict | None:
+        db = self._get_db()
+        row = db.execute(
+            "SELECT id, cron_expr, job_kind, params_json, enabled, "
+            "created_at, last_run_at, last_run_status, last_run_error "
+            "FROM schedules WHERE id=?",
+            (sched_id,),
+        ).fetchone()
+        return _row_to_dict(row) if row else None
+
+    async def schedule_list_all(self) -> list[dict]:
+        db = self._get_db()
+        rows = db.execute(
+            "SELECT id, cron_expr, job_kind, params_json, enabled, "
+            "created_at, last_run_at, last_run_status, last_run_error "
+            "FROM schedules ORDER BY created_at"
+        ).fetchall()
+        return [_row_to_dict(r) for r in rows]
+
+    async def schedule_list_due(self, now: datetime | None = None) -> list[dict]:
+        """Return enabled schedules with at least one elapsed cron slot.
+
+        Catch-up semantics: a schedule that missed N slots fires
+        **once** on the next call, not N times. The base for the next
+        slot is ``last_run_at`` if set, else ``created_at``.
+
+        ``now`` defaults to ``datetime.now(timezone.utc)``; tests pass
+        a frozen value.
+        """
+        if now is None:
+            now = datetime.now(timezone.utc)
+        elif now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+
+        db = self._get_db()
+        rows = db.execute(
+            "SELECT id, cron_expr, job_kind, params_json, enabled, "
+            "created_at, last_run_at, last_run_status, last_run_error "
+            "FROM schedules WHERE enabled=1"
+        ).fetchall()
+
+        due: list[dict] = []
+        for r in rows:
+            sched = _row_to_dict(r)
+            base_iso = sched["last_run_at"] or sched["created_at"]
+            base = _parse_iso_utc(base_iso)
+            try:
+                next_fire = croniter(sched["cron_expr"], base).get_next(datetime)
+            except (ValueError, KeyError):
+                # Invalid cron stored — skip rather than crash dispatcher.
+                continue
+            if next_fire.tzinfo is None:
+                next_fire = next_fire.replace(tzinfo=timezone.utc)
+            if next_fire <= now:
+                due.append(sched)
+        return due
+
+    async def schedule_set_enabled(self, sched_id: str, enabled: bool) -> bool:
+        db = self._get_db()
+        cur = db.execute(
+            "UPDATE schedules SET enabled=? WHERE id=?",
+            (1 if enabled else 0, sched_id),
+        )
+        db.commit()
+        return cur.rowcount > 0
+
+    async def schedule_delete(self, sched_id: str) -> bool:
+        db = self._get_db()
+        cur = db.execute("DELETE FROM schedules WHERE id=?", (sched_id,))
+        db.commit()
+        return cur.rowcount > 0
+
+    async def schedule_mark_run(
+        self,
+        sched_id: str,
+        status: str,
+        error: str | None = None,
+        when: datetime | None = None,
+    ) -> None:
+        """Record a run outcome. ``status`` ∈ {'ok','error','timeout'}."""
+        ts = (when or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        db = self._get_db()
+        db.execute(
+            "UPDATE schedules SET last_run_at=?, last_run_status=?, last_run_error=? WHERE id=?",
+            (ts.isoformat(timespec="seconds"), status, error, sched_id),
+        )
+        db.commit()
+
+
+def _row_to_dict(row: tuple) -> dict:
+    return {
+        "id": row[0],
+        "cron_expr": row[1],
+        "job_kind": row[2],
+        "params": json.loads(row[3]) if row[3] else {},
+        "enabled": bool(row[4]),
+        "created_at": row[5],
+        "last_run_at": row[6],
+        "last_run_status": row[7],
+        "last_run_error": row[8],
+    }

--- a/packages/memtomem/src/memtomem/storage/mixins/schedules.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/schedules.py
@@ -10,11 +10,14 @@ schedule fires exactly once on the next dispatcher tick (no backfill).
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
-from croniter import croniter
+from croniter import CroniterBadCronError, CroniterBadDateError, croniter
+
+logger = logging.getLogger(__name__)
 
 
 def _utcnow_iso() -> str:
@@ -110,8 +113,18 @@ class ScheduleMixin:
             base = _parse_iso_utc(base_iso)
             try:
                 next_fire = croniter(sched["cron_expr"], base).get_next(datetime)
-            except (ValueError, KeyError):
+            except (CroniterBadCronError, CroniterBadDateError) as exc:
                 # Invalid cron stored — skip rather than crash dispatcher.
+                # Loud (warning, not debug) per feedback_silent_except_log_level:
+                # this is the most-likely operational footgun (downgrade /
+                # bad migration leaving a phantom row), and silent skips
+                # would be invisible in production.
+                logger.warning(
+                    "schedule %s has invalid cron_expr %r; skipping (%s)",
+                    sched["id"],
+                    sched["cron_expr"],
+                    exc,
+                )
                 continue
             if next_fire.tzinfo is None:
                 next_fire = next_fire.replace(tzinfo=timezone.utc)

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -34,6 +34,7 @@ from memtomem.storage.mixins import (
     HistoryMixin,
     PolicyMixin,
     RelationMixin,
+    ScheduleMixin,
     ScratchMixin,
     SessionMixin,
     ShareLinkMixin,
@@ -72,6 +73,7 @@ class SqliteBackend(
     HistoryMixin,
     EntityMixin,
     PolicyMixin,
+    ScheduleMixin,
 ):
     def __init__(
         self,

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -431,6 +431,25 @@ def create_tables(
         "ON health_snapshots(check_name, created_at)"
     )
 
+    # --- Scheduled lifecycle jobs (P2 Phase A) ---
+    # Phase A interprets ``cron_expr`` in UTC; ``last_run_at`` and
+    # ``created_at`` are UTC ISO strings. ``list_due`` semantics are
+    # at-most-once catch-up — see ``ScheduleMixin.schedule_list_due``.
+    db.execute("""
+        CREATE TABLE IF NOT EXISTS schedules (
+            id              TEXT PRIMARY KEY,
+            cron_expr       TEXT NOT NULL,
+            job_kind        TEXT NOT NULL,
+            params_json     TEXT NOT NULL DEFAULT '{}',
+            enabled         INTEGER NOT NULL DEFAULT 1,
+            created_at      TEXT NOT NULL,
+            last_run_at     TEXT,
+            last_run_status TEXT,
+            last_run_error  TEXT
+        )
+    """)
+    db.execute("CREATE INDEX IF NOT EXISTS idx_schedules_enabled ON schedules(enabled)")
+
     db.commit()
 
     return dimension, dim_mismatch, model_mismatch

--- a/packages/memtomem/tests/test_schedules_store.py
+++ b/packages/memtomem/tests/test_schedules_store.py
@@ -1,0 +1,137 @@
+"""Tests for ScheduleMixin (P2 cron Phase A storage layer)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+class TestScheduleStore:
+    @pytest.mark.asyncio
+    async def test_insert_and_get(self, storage):
+        sid = await storage.schedule_insert("0 3 * * *", "compaction")
+        assert sid
+
+        sched = await storage.schedule_get(sid)
+        assert sched is not None
+        assert sched["cron_expr"] == "0 3 * * *"
+        assert sched["job_kind"] == "compaction"
+        assert sched["enabled"] is True
+        assert sched["params"] == {}
+        assert sched["last_run_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_all_orders_by_created(self, storage):
+        await storage.schedule_insert("0 1 * * *", "importance_decay")
+        await storage.schedule_insert("0 2 * * *", "compaction")
+        rows = await storage.schedule_list_all()
+        assert [r["job_kind"] for r in rows] == ["importance_decay", "compaction"]
+
+    @pytest.mark.asyncio
+    async def test_get_missing_returns_none(self, storage):
+        assert await storage.schedule_get("no-such-id") is None
+
+    @pytest.mark.asyncio
+    async def test_delete(self, storage):
+        sid = await storage.schedule_insert("0 0 * * *", "compaction")
+        assert await storage.schedule_delete(sid) is True
+        assert await storage.schedule_get(sid) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_missing_returns_false(self, storage):
+        assert await storage.schedule_delete("ghost") is False
+
+    @pytest.mark.asyncio
+    async def test_set_enabled_filters_list_due(self, storage):
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+        # Disable before checking due — should be omitted entirely.
+        await storage.schedule_set_enabled(sid, False)
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        due = await storage.schedule_list_due(future)
+        assert due == []
+
+    @pytest.mark.asyncio
+    async def test_mark_run_records_status(self, storage):
+        sid = await storage.schedule_insert("* * * * *", "compaction")
+        await storage.schedule_mark_run(sid, "ok")
+        sched = await storage.schedule_get(sid)
+        assert sched["last_run_status"] == "ok"
+        assert sched["last_run_at"] is not None
+
+        await storage.schedule_mark_run(sid, "error", error="boom")
+        sched = await storage.schedule_get(sid)
+        assert sched["last_run_status"] == "error"
+        assert sched["last_run_error"] == "boom"
+
+    @pytest.mark.asyncio
+    async def test_list_due_returns_only_due(self, storage):
+        # Hourly schedule. Created "now"; due check just before next hour
+        # should be empty, just after should include it.
+        sid = await storage.schedule_insert("0 * * * *", "compaction")
+        sched = await storage.schedule_get(sid)
+        created = datetime.fromisoformat(sched["created_at"])
+
+        # 30s after creation → no slot yet
+        early = created + timedelta(seconds=30)
+        assert await storage.schedule_list_due(early) == []
+
+        # Well past the next top-of-hour → due
+        late = created + timedelta(hours=2)
+        due = await storage.schedule_list_due(late)
+        assert len(due) == 1
+        assert due[0]["id"] == sid
+
+    @pytest.mark.asyncio
+    async def test_list_due_at_most_once_catchup(self, storage):
+        """If 3 cron slots elapsed, schedule fires once — not 3 times."""
+        sid = await storage.schedule_insert("0 * * * *", "compaction")
+        # Simulate 3 hours elapsed: list_due returns the row exactly once
+        # (it's a list, not a multiplied list). The dispatcher then calls
+        # mark_run, which advances last_run_at, so subsequent ticks do
+        # not re-fire for the missed slots.
+        sched = await storage.schedule_get(sid)
+        created = datetime.fromisoformat(sched["created_at"])
+        far_future = created + timedelta(hours=3, minutes=30)
+
+        due_first = await storage.schedule_list_due(far_future)
+        assert len(due_first) == 1
+
+        # Dispatcher would mark_run after firing — emulate that.
+        await storage.schedule_mark_run(sid, "ok", when=far_future)
+
+        # Second pass at the same `now`: last_run_at is now `far_future`,
+        # so the next slot (4h after creation) is in the future relative
+        # to `far_future` — schedule no longer due.
+        due_second = await storage.schedule_list_due(far_future)
+        assert due_second == []
+
+    @pytest.mark.asyncio
+    async def test_list_due_uses_utc(self, storage):
+        """Naive `now` is treated as UTC (Phase A invariant)."""
+        sid = await storage.schedule_insert("0 * * * *", "compaction")
+        sched = await storage.schedule_get(sid)
+        created = datetime.fromisoformat(sched["created_at"])
+        # Strip tz; mixin should re-attach UTC.
+        naive_late = (created + timedelta(hours=2)).replace(tzinfo=None)
+        due = await storage.schedule_list_due(naive_late)
+        assert len(due) == 1 and due[0]["id"] == sid
+
+    @pytest.mark.asyncio
+    async def test_invalid_cron_in_db_skipped_not_raised(self, storage):
+        """A malformed cron row must not crash the dispatcher path."""
+        sid = await storage.schedule_insert("0 * * * *", "compaction")
+        # Corrupt the cron_expr directly to simulate a bad migration.
+        db = storage._get_db()
+        db.execute(
+            "UPDATE schedules SET cron_expr=? WHERE id=?",
+            ("not-a-cron", sid),
+        )
+        db.commit()
+        # Should not raise.
+        due = await storage.schedule_list_due(datetime.now(timezone.utc))
+        assert due == []

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,18 @@ wheels = [
 ]
 
 [[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.6"
 source = { registry = "https://pypi.org/simple" }
@@ -822,6 +834,7 @@ version = "0.1.32"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },
+    { name = "croniter" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pathspec" },
@@ -870,6 +883,7 @@ web = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
+    { name = "croniter", specifier = ">=2.0" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.115" },
     { name = "fastembed", marker = "extra == 'onnx'", specifier = ">=0.8,<0.9" },
     { name = "httpx", specifier = ">=0.28" },
@@ -1504,6 +1518,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1738,6 +1764,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Storage layer for the **P2 natural-language cron** RFC (Hermes
comparison series — P1 episodic summary already shipped via #513/
#514/#517/#518). This is **PR-A1 of 4** in the Phase A stack —
storage only, no MCP/CLI surface, no dispatcher.

- `schedules` table (`CREATE TABLE IF NOT EXISTS`) with
  `cron_expr`, `job_kind`, `params_json`, `enabled`, `created_at`,
  `last_run_at`, `last_run_status`, `last_run_error`.
- `ScheduleMixin` on `SqliteBackend` — `schedule_insert`,
  `schedule_get`, `schedule_list_all`, `schedule_list_due`,
  `schedule_set_enabled`, `schedule_delete`, `schedule_mark_run`.
- `croniter>=2.0` always-on dep (RFC Open-Q-5).

## Phase A invariants pinned here (so PR-A3 can rely on them)

- **Timezone:** all `cron_expr` interpreted in UTC; `created_at` /
  `last_run_at` stored as UTC ISO strings. Per-schedule TZ override
  is deferred to Phase C (RFC Open-Q-1).
- **Catch-up = at-most-once.** If multiple cron slots elapsed
  since `last_run_at`, the schedule fires **exactly once** on the
  next dispatch tick, not N times. Backfill is intentionally out
  of scope.
- **Bad cron in DB ≠ crash.** `list_due()` skips rows whose stored
  `cron_expr` no longer parses (e.g. after a downgrade). Validity
  enforced at register time by PR-A4.

## Phase A stack

- **A1 (this PR)** — storage layer
- A2 — `JOB_KINDS` registry + 4 runners (Pydantic `params_model`)
- A3 — watchdog dispatcher + `SchedulerConfig` + mismatch warning
- A4 — `mm schedule add/list/run-now/delete` + `mem_do` actions + docs

## Test plan

- [x] `tests/test_schedules_store.py` — 11 tests (insert, list,
      list_due frozen-time, **at-most-once catch-up**, UTC interpretation,
      enable/disable, delete, mark_run, invalid-cron-skipped).
- [x] `uv run pytest -m "not ollama"` — 2965 passed, 0 failed.
- [x] `uv run ruff check && ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)