### PR TITLE
feat(scheduler): JOB_KINDS registry with 4 whitelisted runners (P2 Phase A.2)

### DIFF
--- a/packages/memtomem/src/memtomem/scheduler/__init__.py
+++ b/packages/memtomem/src/memtomem/scheduler/__init__.py
@@ -1,0 +1,10 @@
+"""Scheduler — JOB_KINDS registry for periodic memory-lifecycle work.
+
+Phase A of the natural-language-cron RFC (P2). The dispatcher lives in
+``server/health_watchdog.py`` (PR-A3); this package only owns the
+typed registry of what *can* be scheduled.
+"""
+
+from memtomem.scheduler.jobs import JOB_KINDS, JobResult, JobRunStatus, JobSpec
+
+__all__ = ["JOB_KINDS", "JobResult", "JobRunStatus", "JobSpec"]

--- a/packages/memtomem/src/memtomem/scheduler/jobs.py
+++ b/packages/memtomem/src/memtomem/scheduler/jobs.py
@@ -24,6 +24,10 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
 
 from pydantic import BaseModel, Field
 
+# expire_chunks lives in the search package; importing at module top is
+# safe — there is no scheduler ↔ search cycle.
+from memtomem.search.decay import expire_chunks
+
 if TYPE_CHECKING:
     from memtomem.server.context import AppContext
 
@@ -75,11 +79,15 @@ class DedupScanParams(BaseModel):
 
 
 async def _run_compaction(app: AppContext) -> JobResult:
-    """Delete orphan chunks (chunks whose source file no longer exists)."""
-    from pathlib import Path
+    """Delete orphan chunks (chunks whose source file no longer exists).
 
+    Loops orphans one-by-one rather than batching: orphan counts are
+    typically small, and ``delete_by_source`` already handles its own
+    invalidation. If this turns into a bottleneck, add a bulk
+    ``delete_by_sources`` to the storage layer (follow-up).
+    """
     sources = await app.storage.get_all_source_files()
-    orphaned: list[Path] = [sf for sf in sources if not sf.exists()]
+    orphaned = [sf for sf in sources if not sf.exists()]
     deleted = 0
     for sf in orphaned:
         deleted += await app.storage.delete_by_source(sf)
@@ -98,8 +106,6 @@ async def _run_importance_decay(
     source_filter: str | None = None,
 ) -> JobResult:
     """Expire (delete) chunks older than ``max_age_days``."""
-    from memtomem.search.decay import expire_chunks
-
     stats = await expire_chunks(
         app.storage,
         max_age_days=max_age_days,
@@ -123,10 +129,7 @@ async def _run_dead_chunk_link_cleanup(app: AppContext) -> JobResult:
     These rows are no longer useful for provenance walks (PR-A1's
     rescue leg) and accumulate over time.
     """
-    db = app.storage._get_db()
-    cur = db.execute("DELETE FROM chunk_links WHERE source_id IS NULL")
-    deleted = cur.rowcount
-    db.commit()
+    deleted = await app.storage.delete_dangling_chunk_links()
     return {"dead_links_deleted": deleted}
 
 
@@ -143,6 +146,10 @@ async def _run_dedup_scan(
     should run ``mem_dedup_merge`` explicitly after reviewing.
     """
     if app.dedup_scanner is None:
+        # Returning a normal result (not raising) — the dispatcher in
+        # PR-A3 should map this to status="ok" and surface the
+        # ``skipped_reason`` via ``last_run_error``. A missing scanner
+        # is a config state, not a runtime failure.
         return {"candidates": 0, "skipped_reason": "dedup_scanner_not_initialized"}
     candidates = await app.dedup_scanner.scan(threshold=threshold, limit=limit, max_scan=max_scan)
     return {"candidates": len(candidates), "threshold": threshold}

--- a/packages/memtomem/src/memtomem/scheduler/jobs.py
+++ b/packages/memtomem/src/memtomem/scheduler/jobs.py
@@ -1,0 +1,181 @@
+"""Whitelisted job kinds for the cron scheduler (P2 Phase A).
+
+Each ``JobSpec`` declares a stable name, a one-line description (used
+in Phase B's LLM prompt), a Pydantic v2 ``params_model`` for validating
+parameters, and an async ``runner`` that takes ``(app, **params)`` and
+returns a small result dict.
+
+Pydantic was chosen over raw jsonschema because:
+- memtomem already uses pydantic-settings for ``Mem2MemConfig`` so
+  there is no new dependency,
+- ``params_model.model_json_schema()`` gives the LLM-facing schema
+  for free in Phase B,
+- typed kwargs flow naturally into ``runner(**validated.model_dump())``.
+
+The dispatcher (PR-A3) calls ``params_model.model_validate(dict)``
+before invoking the runner — adversarial LLM output cannot reach the
+runner without passing schema validation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Literal
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from memtomem.server.context import AppContext
+
+
+JobRunStatus = Literal["ok", "error", "timeout"]
+"""Status enum for ``ScheduleMixin.schedule_mark_run``."""
+
+JobResult = dict[str, Any]
+"""Runner return shape — small JSON-serializable summary."""
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    """Schema + runner for one schedulable job kind."""
+
+    name: str
+    description: str
+    params_model: type[BaseModel]
+    runner: Callable[..., Awaitable[JobResult]]
+
+
+# ---------------------------------------------------------------------------
+# Param models
+# ---------------------------------------------------------------------------
+
+
+class CompactionParams(BaseModel):
+    """No params — runs cleanup_orphans with dry_run=False."""
+
+
+class ImportanceDecayParams(BaseModel):
+    max_age_days: float = Field(default=90.0, gt=0)
+    source_filter: str | None = None
+
+
+class DeadChunkLinkCleanupParams(BaseModel):
+    """No params — removes chunk_links rows whose source chunk is gone."""
+
+
+class DedupScanParams(BaseModel):
+    threshold: float = Field(default=0.92, ge=0.0, le=1.0)
+    limit: int = Field(default=50, ge=1, le=500)
+    max_scan: int = Field(default=500, ge=1)
+
+
+# ---------------------------------------------------------------------------
+# Runners
+# ---------------------------------------------------------------------------
+
+
+async def _run_compaction(app: AppContext) -> JobResult:
+    """Delete orphan chunks (chunks whose source file no longer exists)."""
+    from pathlib import Path
+
+    sources = await app.storage.get_all_source_files()
+    orphaned: list[Path] = [sf for sf in sources if not sf.exists()]
+    deleted = 0
+    for sf in orphaned:
+        deleted += await app.storage.delete_by_source(sf)
+    if deleted > 0:
+        app.search_pipeline.invalidate_cache()
+    return {
+        "sources_checked": len(sources),
+        "orphan_files": len(orphaned),
+        "chunks_deleted": deleted,
+    }
+
+
+async def _run_importance_decay(
+    app: AppContext,
+    max_age_days: float = 90.0,
+    source_filter: str | None = None,
+) -> JobResult:
+    """Expire (delete) chunks older than ``max_age_days``."""
+    from memtomem.search.decay import expire_chunks
+
+    stats = await expire_chunks(
+        app.storage,
+        max_age_days=max_age_days,
+        dry_run=False,
+        source_filter=source_filter,
+    )
+    if stats.deleted_chunks > 0:
+        app.search_pipeline.invalidate_cache()
+    return {
+        "total_chunks": stats.total_chunks,
+        "expired_chunks": stats.expired_chunks,
+        "deleted_chunks": stats.deleted_chunks,
+    }
+
+
+async def _run_dead_chunk_link_cleanup(app: AppContext) -> JobResult:
+    """Remove ``chunk_links`` rows whose source chunk has been deleted.
+
+    The schema declares ``ON DELETE SET NULL`` for ``source_id``, so a
+    deleted source leaves a dangling row with ``source_id IS NULL``.
+    These rows are no longer useful for provenance walks (PR-A1's
+    rescue leg) and accumulate over time.
+    """
+    db = app.storage._get_db()
+    cur = db.execute("DELETE FROM chunk_links WHERE source_id IS NULL")
+    deleted = cur.rowcount
+    db.commit()
+    return {"dead_links_deleted": deleted}
+
+
+async def _run_dedup_scan(
+    app: AppContext,
+    threshold: float = 0.92,
+    limit: int = 50,
+    max_scan: int = 500,
+) -> JobResult:
+    """Surface duplicate-chunk candidates (no merges — that stays manual).
+
+    Auto-merge is intentionally not part of the scheduled job. A merge
+    can lose tags or namespace metadata in subtle ways; the operator
+    should run ``mem_dedup_merge`` explicitly after reviewing.
+    """
+    if app.dedup_scanner is None:
+        return {"candidates": 0, "skipped_reason": "dedup_scanner_not_initialized"}
+    candidates = await app.dedup_scanner.scan(threshold=threshold, limit=limit, max_scan=max_scan)
+    return {"candidates": len(candidates), "threshold": threshold}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+JOB_KINDS: dict[str, JobSpec] = {
+    "compaction": JobSpec(
+        name="compaction",
+        description=("Delete chunks whose source files no longer exist on disk."),
+        params_model=CompactionParams,
+        runner=_run_compaction,
+    ),
+    "importance_decay": JobSpec(
+        name="importance_decay",
+        description=("Delete chunks older than max_age_days (TTL-based decay)."),
+        params_model=ImportanceDecayParams,
+        runner=_run_importance_decay,
+    ),
+    "dead_chunk_link_cleanup": JobSpec(
+        name="dead_chunk_link_cleanup",
+        description=("Remove chunk_links rows whose source chunk has been deleted."),
+        params_model=DeadChunkLinkCleanupParams,
+        runner=_run_dead_chunk_link_cleanup,
+    ),
+    "dedup_scan": JobSpec(
+        name="dedup_scan",
+        description=("Find duplicate-chunk candidates (no auto-merge; surfaces only)."),
+        params_model=DedupScanParams,
+        runner=_run_dedup_scan,
+    ),
+}

--- a/packages/memtomem/src/memtomem/storage/mixins/share_links.py
+++ b/packages/memtomem/src/memtomem/storage/mixins/share_links.py
@@ -94,6 +94,20 @@ class ShareLinkMixin:
         )
         db.commit()
 
+    async def delete_dangling_chunk_links(self) -> int:
+        """Delete ``chunk_links`` rows whose source chunk has been removed.
+
+        ``source_id`` is declared ``ON DELETE SET NULL``, so deleting the
+        source chunk leaves a dangling row that no longer carries useful
+        provenance. Returns the number of rows deleted. Used by the
+        ``dead_chunk_link_cleanup`` scheduled job (P2 cron Phase A).
+        """
+        db = self._get_db()
+        cur = db.execute("DELETE FROM chunk_links WHERE source_id IS NULL")
+        deleted = cur.rowcount
+        db.commit()
+        return deleted
+
     async def get_chunk_link(
         self,
         target_id: UUID,

--- a/packages/memtomem/tests/test_scheduler_jobs.py
+++ b/packages/memtomem/tests/test_scheduler_jobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from memtomem.scheduler import JOB_KINDS, JobSpec
 from memtomem.server.context import AppContext
@@ -58,7 +59,7 @@ class TestRunners:
     @pytest.mark.asyncio
     async def test_importance_decay_validates_params(self):
         spec = JOB_KINDS["importance_decay"]
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             spec.params_model.model_validate({"max_age_days": -1})
 
     @pytest.mark.asyncio
@@ -77,7 +78,7 @@ class TestRunners:
     @pytest.mark.asyncio
     async def test_dedup_scan_validates_threshold(self):
         spec = JOB_KINDS["dedup_scan"]
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             spec.params_model.model_validate({"threshold": 1.5})
 
 

--- a/packages/memtomem/tests/test_scheduler_jobs.py
+++ b/packages/memtomem/tests/test_scheduler_jobs.py
@@ -1,0 +1,121 @@
+"""Tests for the JOB_KINDS registry (P2 cron Phase A.2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.scheduler import JOB_KINDS, JobSpec
+from memtomem.server.context import AppContext
+
+
+@pytest.fixture
+def app(components):
+    return AppContext.from_components(components)
+
+
+class TestJobRegistryShape:
+    def test_four_kinds_registered(self):
+        assert set(JOB_KINDS.keys()) == {
+            "compaction",
+            "importance_decay",
+            "dead_chunk_link_cleanup",
+            "dedup_scan",
+        }
+
+    @pytest.mark.parametrize("name", list(JOB_KINDS))
+    def test_specs_well_formed(self, name):
+        spec = JOB_KINDS[name]
+        assert isinstance(spec, JobSpec)
+        assert spec.name == name
+        assert spec.description and isinstance(spec.description, str)
+        # The Phase B contract: each params_model must be JSON-schemable.
+        schema = spec.params_model.model_json_schema()
+        assert isinstance(schema, dict)
+        assert schema.get("type") == "object"
+        # Default-construction must succeed (every param has a default).
+        instance = spec.params_model()
+        assert spec.params_model.model_validate(instance.model_dump()) == instance
+
+
+class TestRunners:
+    @pytest.mark.asyncio
+    async def test_compaction_idempotent_on_empty(self, app):
+        spec = JOB_KINDS["compaction"]
+        result = await spec.runner(app, **spec.params_model().model_dump())
+        assert result["chunks_deleted"] == 0
+        assert result["orphan_files"] == 0
+        # Re-run is still a no-op.
+        result2 = await spec.runner(app, **spec.params_model().model_dump())
+        assert result2["chunks_deleted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_importance_decay_zero_on_empty(self, app):
+        spec = JOB_KINDS["importance_decay"]
+        result = await spec.runner(app, **spec.params_model().model_dump())
+        assert result["deleted_chunks"] == 0
+        assert result["expired_chunks"] == 0
+
+    @pytest.mark.asyncio
+    async def test_importance_decay_validates_params(self):
+        spec = JOB_KINDS["importance_decay"]
+        with pytest.raises(Exception):
+            spec.params_model.model_validate({"max_age_days": -1})
+
+    @pytest.mark.asyncio
+    async def test_dead_chunk_link_cleanup_zero_on_empty(self, app):
+        spec = JOB_KINDS["dead_chunk_link_cleanup"]
+        result = await spec.runner(app, **spec.params_model().model_dump())
+        assert result == {"dead_links_deleted": 0}
+
+    @pytest.mark.asyncio
+    async def test_dedup_scan_zero_on_empty(self, app):
+        spec = JOB_KINDS["dedup_scan"]
+        result = await spec.runner(app, **spec.params_model().model_dump())
+        assert "candidates" in result
+        assert result["candidates"] == 0
+
+    @pytest.mark.asyncio
+    async def test_dedup_scan_validates_threshold(self):
+        spec = JOB_KINDS["dedup_scan"]
+        with pytest.raises(Exception):
+            spec.params_model.model_validate({"threshold": 1.5})
+
+
+class TestDeadLinkCleanupSemantics:
+    @pytest.mark.asyncio
+    async def test_removes_only_null_source_rows(self, app):
+        """Only rows with source_id IS NULL should be deleted."""
+        from datetime import datetime, timezone
+
+        db = app.storage._get_db()
+        # Insert a chunk so we have a valid target_id (FK on target).
+        db.execute(
+            "INSERT INTO chunks (id, content, content_hash, source_file, "
+            "created_at, updated_at) "
+            "VALUES (?, '', 'h', 's', ?, ?)",
+            ("chunk-a", "2026-01-01T00:00:00+00:00", "2026-01-01T00:00:00+00:00"),
+        )
+        now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        # Dead row: source NULL
+        db.execute(
+            "INSERT INTO chunk_links (source_id, target_id, link_type, "
+            "namespace_target, created_at) VALUES (NULL, 'chunk-a', 'shared', 'default', ?)",
+            (now,),
+        )
+        # Live row: source present (use chunk-a as both source and target with
+        # link_type='summarizes' to satisfy the (target_id, link_type) PK).
+        db.execute(
+            "INSERT INTO chunk_links (source_id, target_id, link_type, "
+            "namespace_target, created_at) VALUES ('chunk-a', 'chunk-a', "
+            "'summarizes', 'default', ?)",
+            (now,),
+        )
+        db.commit()
+
+        spec = JOB_KINDS["dead_chunk_link_cleanup"]
+        result = await spec.runner(app)
+        assert result["dead_links_deleted"] == 1
+
+        # Live row survives.
+        remaining = db.execute("SELECT link_type FROM chunk_links ORDER BY link_type").fetchall()
+        assert [r[0] for r in remaining] == ["summarizes"]


### PR DESCRIPTION
## Summary

**PR-A2 of 4** in the P2 cron Phase A stack. Builds on #519 (storage
layer). Pure registry — no MCP/CLI surface and no dispatcher yet
(PR-A3 wires this into ``health_watchdog``).

- New ``memtomem/scheduler`` package — ``JobSpec`` dataclass with
  Pydantic v2 ``params_model``, ``runner: (app, **params) -> dict``.
- ``JOB_KINDS`` populated with the 4 Phase A kinds.
- ``JobRunStatus = Literal[\"ok\", \"error\", \"timeout\"]`` exported
  for PR-A3's ``mark_run`` calls (per
  ``feedback_literal_drives_frozenset.md``).

## Why Pydantic over raw jsonschema

- memtomem already depends on ``pydantic-settings`` for ``Mem2MemConfig`` — no new dep.
- Phase B's NL parser gets ``params_model.model_json_schema()`` for
  free as the LLM-facing contract.
- ``model_validate(dict)`` is the security gate: adversarial LLM
  output cannot reach the runner without passing schema validation.

## Phase A kinds (4)

| name | params | what it does |
|---|---|---|
| ``compaction`` | none | delete chunks whose source files no longer exist |
| ``importance_decay`` | ``max_age_days``, ``source_filter`` | TTL expiry over ``chunk.updated_at`` |
| ``dead_chunk_link_cleanup`` | none | remove ``chunk_links`` rows where ``source_id IS NULL`` (schema's ``ON DELETE SET NULL`` leaves these dangling) |
| ``dedup_scan`` | ``threshold``, ``limit``, ``max_scan`` | surface candidates only; auto-merge stays manual |

## Explicitly deferred to Phase B

- ``embedding_rebuild`` — non-trivial reuse path, not blocking Phase A user value.
- ``session_summary_flush`` — depends on P1 Phase B-1 auto-summary semantics.

## Test plan

- [x] ``tests/test_scheduler_jobs.py`` — 12 tests:
  - 4 registry-shape tests (one per kind, parametrized): ``model_json_schema()`` valid, defaults round-trip.
  - 5 runner smoke tests on empty DB: each runner returns the expected dict shape with zero counts.
  - 2 param-validation tests: ``max_age_days=-1`` and ``threshold=1.5`` rejected by Pydantic.
  - 1 semantics test: ``dead_chunk_link_cleanup`` removes only ``source_id IS NULL`` rows; rows with a live source survive.
- [x] ``uv run pytest -m \"not ollama\"`` — 2977 passed.
- [x] ``ruff check`` + ``ruff format --check`` — clean.

## Phase A stack

- A1 SHIPPED (#519 squash 47f30f2)
- **A2 (this PR)**
- A3 — watchdog dispatcher + ``SchedulerConfig``
- A4 — ``mm schedule add/list/run-now/delete`` + ``mem_do`` actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)