### PR TITLE
feat(scheduler): mm schedule CLI + schedule_* mem_do actions (P2 Phase A.4)

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -892,6 +892,48 @@ on promotion prevents the chunk from being immediately re-archived.
 
 ---
 
+## 9. Scheduled jobs — `mm schedule`, `schedule_*`
+
+Phase A of the cron scheduler ships **direct-cron** registration for the
+maintenance jobs the watchdog already runs. Each schedule is a 5-field
+cron expression interpreted in **UTC**, paired with one of the
+whitelisted `JOB_KINDS`:
+
+| `job_kind`                | Effect                                                      |
+|---------------------------|-------------------------------------------------------------|
+| `compaction`              | Delete chunks whose source files no longer exist on disk    |
+| `importance_decay`        | Delete chunks older than `max_age_days` (TTL-based decay)   |
+| `dead_chunk_link_cleanup` | Remove `chunk_links` rows whose source chunk is gone        |
+| `dedup_scan`              | Surface duplicate-chunk candidates (no auto-merge)          |
+
+Schedules are stored in SQLite and dispatched by the same watchdog tick
+loop that powers `mem_watchdog` — set
+`MEMTOMEM_SCHEDULER__ENABLED=true` on top of the watchdog config to
+enable dispatch.
+
+```bash
+mm schedule add --cron "0 3 * * 0" --job compaction
+mm schedule list
+mm schedule run-now <id>           # out-of-band run; same timeout as dispatcher
+mm schedule delete <id>
+```
+
+The same actions are reachable through `mem_do`:
+
+```
+mem_do(action="schedule_register",
+       params={"cron": "0 3 * * 0", "job_kind": "compaction"})
+mem_do(action="schedule_list")
+mem_do(action="schedule_run_now", params={"id": "<id>"})
+mem_do(action="schedule_delete", params={"id": "<id>"})
+```
+
+> Phase A is direct-cron only. Natural-language schedules
+> (`spec="every Sunday 3am"`) and `disable`/`enable` commands arrive in
+> Phase B and Phase C respectively.
+
+---
+
 ## Web UI
 
 ```bash

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -37,6 +37,7 @@ def _register() -> None:
     from memtomem.cli.memory import add, recall
     from memtomem.cli.purge_cmd import purge
     from memtomem.cli.reset_cmd import reset
+    from memtomem.cli.schedule_cmd import schedule
     from memtomem.cli.search import search
     from memtomem.cli.init_cmd import init
     from memtomem.cli.session_cmd import activity, session
@@ -61,6 +62,7 @@ def _register() -> None:
     cli.add_command(activity)
     cli.add_command(status)
     cli.add_command(watchdog)
+    cli.add_command(schedule)
     cli.add_command(web)
     cli.add_command(shell)
     cli.add_command(agent)

--- a/packages/memtomem/src/memtomem/cli/schedule_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/schedule_cmd.py
@@ -1,0 +1,188 @@
+"""CLI: mm schedule — direct-cron registration for scheduled jobs (P2 Phase A).
+
+Mirrors the shape of ``cli/watchdog_cmd.py``. Direct-cron only —
+natural-language ``--spec`` lands in Phase B.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import click
+
+from croniter import croniter
+
+from memtomem.scheduler.jobs import JOB_KINDS
+
+
+@click.group()
+def schedule() -> None:
+    """Scheduled jobs — register, list, run, and delete cron schedules (UTC)."""
+
+
+@schedule.command("add")
+@click.option("--cron", "cron_expr", required=True, help="5-field cron expression (UTC)")
+@click.option(
+    "--job",
+    "job_kind",
+    required=True,
+    type=click.Choice(sorted(JOB_KINDS)),
+    help="Job kind to run",
+)
+@click.option("--params", "params_json", default=None, help="JSON-encoded params dict")
+def schedule_add(cron_expr: str, job_kind: str, params_json: str | None) -> None:
+    """Register a new schedule."""
+    if not croniter.is_valid(cron_expr):
+        raise click.ClickException(f"invalid cron expression: {cron_expr!r}")
+    try:
+        params = json.loads(params_json) if params_json else {}
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"--params must be valid JSON: {exc}") from exc
+    if not isinstance(params, dict):
+        raise click.ClickException("--params must decode to a JSON object")
+
+    spec = JOB_KINDS[job_kind]
+    try:
+        spec.params_model.model_validate(params)
+    except Exception as exc:
+        raise click.ClickException(f"invalid params: {exc}") from exc
+
+    try:
+        sched_id = asyncio.run(_insert(cron_expr, job_kind, params))
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f"Registered {sched_id}  {cron_expr}  {job_kind}")
+
+
+@schedule.command("list")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+def schedule_list(as_json: bool) -> None:
+    """List all registered schedules."""
+    try:
+        rows = asyncio.run(_list_all())
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if as_json:
+        click.echo(json.dumps(rows, indent=2, default=str))
+        return
+
+    if not rows:
+        click.echo("No schedules registered.  Use 'mm schedule add' to create one.")
+        return
+
+    for r in rows:
+        status = r.get("last_run_status") or "—"
+        last = r.get("last_run_at") or "never"
+        enabled = "on" if r["enabled"] else "off"
+        click.echo(
+            f"  {r['id']}  [{enabled}]  {r['cron_expr']:<15}  "
+            f"{r['job_kind']:<24}  last={last} ({status})"
+        )
+
+
+@schedule.command("run-now")
+@click.argument("sched_id")
+def schedule_run_now(sched_id: str) -> None:
+    """Run a scheduled job synchronously (out-of-band)."""
+    try:
+        result = asyncio.run(_run_now(sched_id))
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not result["ok"]:
+        raise click.ClickException(result["reason"])
+    click.echo(f"OK  {sched_id}  {json.dumps(result.get('result', {}))}")
+
+
+@schedule.command("delete")
+@click.argument("sched_id")
+def schedule_delete(sched_id: str) -> None:
+    """Delete a schedule by id."""
+    try:
+        deleted = asyncio.run(_delete(sched_id))
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not deleted:
+        raise click.ClickException(f"schedule {sched_id!r} not found")
+    click.echo(f"Deleted {sched_id}")
+
+
+# ── Async helpers ────────────────────────────────────────────────────
+
+
+async def _insert(cron_expr: str, job_kind: str, params: dict) -> str:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        return await comp.storage.schedule_insert(cron_expr, job_kind, params)
+
+
+async def _list_all() -> list[dict]:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        return await comp.storage.schedule_list_all()
+
+
+async def _delete(sched_id: str) -> bool:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        return await comp.storage.schedule_delete(sched_id)
+
+
+async def _run_now(sched_id: str) -> dict:
+    """Run a schedule synchronously through the same path the dispatcher uses.
+
+    Mirrors ``mem_schedule_run_now`` (validation, ``schedule_mark_run``,
+    timeout) but bypasses the MCP context plumbing — CLI commands run
+    against a bootstrapped ``Components`` directly.
+    """
+    from memtomem.cli._bootstrap import cli_components
+    from memtomem.server.context import AppContext
+
+    async with cli_components() as comp:
+        app = AppContext.from_components(comp)
+        await app.ensure_initialized()
+
+        sched = await app.storage.schedule_get(sched_id)
+        if sched is None:
+            return {"ok": False, "reason": f"schedule {sched_id!r} not found"}
+
+        spec = JOB_KINDS.get(sched["job_kind"])
+        if spec is None:
+            reason = f"unknown job_kind: {sched['job_kind']}"
+            await app.storage.schedule_mark_run(sched_id, "error", error=reason)
+            return {"ok": False, "reason": reason}
+
+        try:
+            validated = spec.params_model.model_validate(sched.get("params") or {})
+        except Exception as exc:
+            reason = f"invalid params: {exc}"
+            await app.storage.schedule_mark_run(sched_id, "error", error=reason)
+            return {"ok": False, "reason": reason}
+
+        timeout = 60.0
+        sched_cfg = getattr(comp.config, "scheduler", None)
+        if sched_cfg is not None:
+            timeout = float(getattr(sched_cfg, "runner_timeout_seconds", timeout))
+
+        try:
+            result = await asyncio.wait_for(
+                spec.runner(app, **validated.model_dump()),
+                timeout=timeout,
+            )
+            await app.storage.schedule_mark_run(sched_id, "ok")
+            return {"ok": True, "reason": "ran", "result": result}
+        except asyncio.TimeoutError:
+            reason = f"exceeded {timeout}s"
+            await app.storage.schedule_mark_run(sched_id, "timeout", error=reason)
+            return {"ok": False, "reason": f"timeout: {reason}"}
+        except Exception as exc:
+            await app.storage.schedule_mark_run(sched_id, "error", error=str(exc))
+            return {"ok": False, "reason": f"runner failed: {exc}"}

--- a/packages/memtomem/src/memtomem/cli/schedule_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/schedule_cmd.py
@@ -48,13 +48,7 @@ def schedule_add(cron_expr: str, job_kind: str, params_json: str | None) -> None
     except Exception as exc:
         raise click.ClickException(f"invalid params: {exc}") from exc
 
-    try:
-        sched_id = asyncio.run(_insert(cron_expr, job_kind, params))
-    except click.ClickException:
-        raise
-    except Exception as exc:
-        raise click.ClickException(str(exc)) from exc
-
+    sched_id = asyncio.run(_insert(cron_expr, job_kind, params))
     click.echo(f"Registered {sched_id}  {cron_expr}  {job_kind}")
 
 
@@ -62,10 +56,7 @@ def schedule_add(cron_expr: str, job_kind: str, params_json: str | None) -> None
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
 def schedule_list(as_json: bool) -> None:
     """List all registered schedules."""
-    try:
-        rows = asyncio.run(_list_all())
-    except Exception as exc:
-        raise click.ClickException(str(exc)) from exc
+    rows = asyncio.run(_list_all())
 
     if as_json:
         click.echo(json.dumps(rows, indent=2, default=str))
@@ -89,11 +80,7 @@ def schedule_list(as_json: bool) -> None:
 @click.argument("sched_id")
 def schedule_run_now(sched_id: str) -> None:
     """Run a scheduled job synchronously (out-of-band)."""
-    try:
-        result = asyncio.run(_run_now(sched_id))
-    except Exception as exc:
-        raise click.ClickException(str(exc)) from exc
-
+    result = asyncio.run(_run_now(sched_id))
     if not result["ok"]:
         raise click.ClickException(result["reason"])
     click.echo(f"OK  {sched_id}  {json.dumps(result.get('result', {}))}")
@@ -103,10 +90,7 @@ def schedule_run_now(sched_id: str) -> None:
 @click.argument("sched_id")
 def schedule_delete(sched_id: str) -> None:
     """Delete a schedule by id."""
-    try:
-        deleted = asyncio.run(_delete(sched_id))
-    except Exception as exc:
-        raise click.ClickException(str(exc)) from exc
+    deleted = asyncio.run(_delete(sched_id))
     if not deleted:
         raise click.ClickException(f"schedule {sched_id!r} not found")
     click.echo(f"Deleted {sched_id}")
@@ -167,10 +151,9 @@ async def _run_now(sched_id: str) -> dict:
             await app.storage.schedule_mark_run(sched_id, "error", error=reason)
             return {"ok": False, "reason": reason}
 
-        timeout = 60.0
-        sched_cfg = getattr(comp.config, "scheduler", None)
-        if sched_cfg is not None:
-            timeout = float(getattr(sched_cfg, "runner_timeout_seconds", timeout))
+        from memtomem.server.tools.schedule import _run_now_timeout
+
+        timeout = _run_now_timeout(app)
 
         try:
             result = await asyncio.wait_for(

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -121,6 +121,12 @@ from memtomem.server.tools.context import (
 )  # noqa: E402, F401
 from memtomem.server.tools.ingest import mem_ingest  # noqa: E402, F401  — no @mcp.tool; import triggers @register("ingest") for mem_do routing
 from memtomem.server.tools.watchdog import mem_watchdog  # noqa: E402, F401
+from memtomem.server.tools.schedule import (  # noqa: E402, F401
+    mem_schedule_delete,
+    mem_schedule_list,
+    mem_schedule_register,
+    mem_schedule_run_now,
+)
 from memtomem.server.tools.meta import mem_do  # noqa: E402, F401
 import memtomem.server.resources  # noqa: E402, F401  — register MCP resources
 
@@ -148,7 +154,15 @@ if _TOOL_MODE != "full":
     if _TOOL_MODE == "standard":
         from memtomem.server.tool_registry import ACTIONS
 
-        _standard_packs = {"crud", "namespace", "tags", "sessions", "scratch", "relations"}
+        _standard_packs = {
+            "crud",
+            "namespace",
+            "tags",
+            "sessions",
+            "scratch",
+            "relations",
+            "schedule",
+        }
         _allowed = _CORE_TOOLS | {
             f"mem_{name}" for name, info in ACTIONS.items() if info.category in _standard_packs
         }

--- a/packages/memtomem/src/memtomem/server/tools/schedule.py
+++ b/packages/memtomem/src/memtomem/server/tools/schedule.py
@@ -28,11 +28,24 @@ from memtomem.server.tool_registry import register
 logger = logging.getLogger(__name__)
 
 
-# Match the dispatcher's per-job timeout default (PR-A3
-# ``SchedulerConfig.runner_timeout_seconds``). ``schedule_run_now`` uses
-# the live config when available and falls back to this when the
-# scheduler block is unset.
-_FALLBACK_RUN_NOW_TIMEOUT_SECONDS = 60.0
+def _run_now_timeout(app) -> float:
+    """Resolve the per-run timeout, mirroring the dispatcher exactly.
+
+    ``schedule_run_now`` and the watchdog dispatcher (PR-A3) must agree
+    on the timeout — otherwise the same schedule fires for 60s under
+    ``mm schedule run-now`` but 300s under auto-dispatch (review
+    feedback PR #522). When the scheduler block is unset (callers
+    constructing ``Mem2MemConfig()`` without overrides), fall back to
+    ``SchedulerConfig().runner_timeout_seconds`` so the default tracks
+    whatever PR-A3 ships.
+    """
+    cfg = getattr(app, "config", None)
+    sched_cfg = getattr(cfg, "scheduler", None) if cfg is not None else None
+    if sched_cfg is not None:
+        return float(sched_cfg.runner_timeout_seconds)
+    from memtomem.config import SchedulerConfig
+
+    return float(SchedulerConfig().runner_timeout_seconds)
 
 
 @mcp.tool()
@@ -111,12 +124,14 @@ async def mem_schedule_run_now(id: str, ctx: CtxType = None) -> str:
         await app.storage.schedule_mark_run(id, "error", error=reason)
         return json.dumps({"ok": False, "reason": reason})
 
-    timeout = _FALLBACK_RUN_NOW_TIMEOUT_SECONDS
-    cfg = getattr(app, "config", None)
-    sched_cfg = getattr(cfg, "scheduler", None) if cfg is not None else None
-    if sched_cfg is not None:
-        timeout = float(getattr(sched_cfg, "runner_timeout_seconds", timeout))
+    timeout = _run_now_timeout(app)
 
+    # Race note: ``run_now`` and the watchdog dispatcher can both fire
+    # the same schedule (different ticks). The current JOB_KINDS are
+    # idempotent maintenance jobs so this is a known, accepted limit
+    # for Phase A; non-idempotent jobs added later (e.g.
+    # ``embedding_rebuild``) need a per-schedule lock here. Tracked for
+    # Phase C alongside disable/enable.
     try:
         result = await asyncio.wait_for(
             spec.runner(app, **validated.model_dump()),

--- a/packages/memtomem/src/memtomem/server/tools/schedule.py
+++ b/packages/memtomem/src/memtomem/server/tools/schedule.py
@@ -1,0 +1,153 @@
+"""Tools: schedule_register, schedule_list, schedule_run_now, schedule_delete.
+
+P2 Phase A user-facing surface for the cron scheduler. Direct-cron only —
+the natural-language ``spec="…"`` field arrives in Phase B. Each tool is
+routed via ``mem_do`` (category="schedule") and also exposed individually
+when ``MEMTOMEM_TOOL_MODE=standard``.
+
+Return shapes follow ``feedback_cli_json_read_vs_write_shape``:
+write actions return ``{ok, reason, ...}`` (always serialized JSON for
+the MCP layer); read actions return either ``{schedules: [...]}`` or
+``{error: ...}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from croniter import croniter
+
+from memtomem.scheduler.jobs import JOB_KINDS
+from memtomem.server import mcp
+from memtomem.server.context import CtxType, _get_app_initialized
+from memtomem.server.error_handler import tool_handler
+from memtomem.server.tool_registry import register
+
+logger = logging.getLogger(__name__)
+
+
+# Match the dispatcher's per-job timeout default (PR-A3
+# ``SchedulerConfig.runner_timeout_seconds``). ``schedule_run_now`` uses
+# the live config when available and falls back to this when the
+# scheduler block is unset.
+_FALLBACK_RUN_NOW_TIMEOUT_SECONDS = 60.0
+
+
+@mcp.tool()
+@tool_handler
+@register("schedule")
+async def mem_schedule_register(
+    cron: str,
+    job_kind: str,
+    params: dict | None = None,
+    ctx: CtxType = None,
+) -> str:
+    """Register a cron-scheduled job (direct-cron mode).
+
+    Args:
+        cron: Five-field cron expression interpreted in UTC (e.g. ``"0 3 * * 0"``).
+        job_kind: One of the registered ``JOB_KINDS`` keys (e.g. ``"compaction"``).
+        params: Optional dict of parameters validated against the job's
+            ``params_model`` before storage.
+    """
+    if not croniter.is_valid(cron):
+        return json.dumps({"ok": False, "reason": f"invalid cron expression: {cron!r}"})
+    spec = JOB_KINDS.get(job_kind)
+    if spec is None:
+        kinds = ", ".join(sorted(JOB_KINDS))
+        return json.dumps(
+            {"ok": False, "reason": f"unknown job_kind {job_kind!r}; available: {kinds}"}
+        )
+    try:
+        spec.params_model.model_validate(params or {})
+    except Exception as exc:
+        return json.dumps({"ok": False, "reason": f"invalid params: {exc}"})
+
+    app = await _get_app_initialized(ctx)
+    sched_id = await app.storage.schedule_insert(cron, job_kind, params or {})
+    return json.dumps({"ok": True, "reason": "registered", "id": sched_id})
+
+
+@mcp.tool()
+@tool_handler
+@register("schedule")
+async def mem_schedule_list(ctx: CtxType = None) -> str:
+    """List all registered schedules with last-run status."""
+    app = await _get_app_initialized(ctx)
+    rows = await app.storage.schedule_list_all()
+    return json.dumps({"schedules": rows})
+
+
+@mcp.tool()
+@tool_handler
+@register("schedule")
+async def mem_schedule_run_now(id: str, ctx: CtxType = None) -> str:
+    """Run a registered schedule synchronously (out-of-band).
+
+    Routes through the same ``JOB_KINDS[...].runner`` path as the
+    dispatcher with the same per-job timeout, and records the outcome
+    via ``schedule_mark_run`` so the next ``schedule_list`` reflects it.
+
+    Args:
+        id: Schedule id returned by ``schedule_register``.
+    """
+    app = await _get_app_initialized(ctx)
+    sched = await app.storage.schedule_get(id)
+    if sched is None:
+        return json.dumps({"ok": False, "reason": f"schedule {id!r} not found"})
+
+    spec = JOB_KINDS.get(sched["job_kind"])
+    if spec is None:
+        reason = f"unknown job_kind: {sched['job_kind']}"
+        await app.storage.schedule_mark_run(id, "error", error=reason)
+        return json.dumps({"ok": False, "reason": reason})
+
+    try:
+        validated = spec.params_model.model_validate(sched.get("params") or {})
+    except Exception as exc:
+        reason = f"invalid params: {exc}"
+        await app.storage.schedule_mark_run(id, "error", error=reason)
+        return json.dumps({"ok": False, "reason": reason})
+
+    timeout = _FALLBACK_RUN_NOW_TIMEOUT_SECONDS
+    cfg = getattr(app, "config", None)
+    sched_cfg = getattr(cfg, "scheduler", None) if cfg is not None else None
+    if sched_cfg is not None:
+        timeout = float(getattr(sched_cfg, "runner_timeout_seconds", timeout))
+
+    try:
+        result = await asyncio.wait_for(
+            spec.runner(app, **validated.model_dump()),
+            timeout=timeout,
+        )
+        await app.storage.schedule_mark_run(id, "ok")
+        return json.dumps({"ok": True, "reason": "ran", "result": result})
+    except asyncio.TimeoutError:
+        reason = f"exceeded {timeout}s"
+        await app.storage.schedule_mark_run(id, "timeout", error=reason)
+        return json.dumps({"ok": False, "reason": f"timeout: {reason}"})
+    except Exception as exc:
+        await app.storage.schedule_mark_run(id, "error", error=str(exc))
+        return json.dumps({"ok": False, "reason": f"runner failed: {exc}"})
+
+
+@mcp.tool()
+@tool_handler
+@register("schedule")
+async def mem_schedule_delete(id: str, ctx: CtxType = None) -> str:
+    """Delete a registered schedule by id.
+
+    Paired with ``schedule_register`` so a bad cron entry can be removed
+    without editing SQLite directly. ``disable``/``enable`` are deferred
+    to Phase C.
+
+    Args:
+        id: Schedule id to delete.
+    """
+    app = await _get_app_initialized(ctx)
+    deleted = await app.storage.schedule_delete(id)
+    if not deleted:
+        return json.dumps({"ok": False, "reason": f"schedule {id!r} not found"})
+    return json.dumps({"ok": True, "reason": "deleted"})

--- a/packages/memtomem/tests/test_meta_tool.py
+++ b/packages/memtomem/tests/test_meta_tool.py
@@ -32,6 +32,7 @@ class TestToolRegistry:
             "advanced",
             "context",
             "search",
+            "schedule",
         }
         assert categories == expected
 
@@ -88,6 +89,24 @@ class TestMemDoRouting:
         """Verify fuzzy matching would find similar actions."""
         similar = [k for k in ACTIONS if "tag" in k]
         assert len(similar) >= 2  # tag_list, tag_rename, tag_delete, auto_tag
+
+
+class TestScheduleActions:
+    """P2 Phase A: schedule_register/list/run_now/delete via mem_do registry."""
+
+    def test_schedule_actions_registered(self):
+        for name in ("schedule_register", "schedule_list", "schedule_run_now", "schedule_delete"):
+            assert name in ACTIONS, f"{name} missing from ACTIONS"
+            assert ACTIONS[name].category == "schedule"
+
+    def test_schedule_register_param_shape(self):
+        info = ACTIONS["schedule_register"]
+        # The plumbing-level contract: callers must provide cron + job_kind
+        # by keyword, params is optional. Pin so Phase B doesn't silently
+        # drop cron= when the spec= field is added.
+        assert "cron" in info.params
+        assert "job_kind" in info.params
+        assert "params" in info.params
 
 
 class TestMemVersion:

--- a/packages/memtomem/tests/test_schedule_cmd.py
+++ b/packages/memtomem/tests/test_schedule_cmd.py
@@ -1,0 +1,145 @@
+"""Tests for ``mm schedule`` CLI (P2 cron Phase A.4)."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+
+def _patched_cli_components(comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    return fake
+
+
+def _mock_components(*, schedules=None, insert_id="abc123", delete_ok=True):
+    rows = list(schedules or [])
+    storage = SimpleNamespace(
+        schedule_insert=AsyncMock(return_value=insert_id),
+        schedule_list_all=AsyncMock(return_value=rows),
+        schedule_delete=AsyncMock(return_value=delete_ok),
+    )
+    return SimpleNamespace(storage=storage, config=SimpleNamespace(scheduler=None))
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+class TestScheduleAdd:
+    def test_happy_path(self, runner, monkeypatch):
+        comp = _mock_components(insert_id="sch-001")
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(
+            cli, ["schedule", "add", "--cron", "0 3 * * 0", "--job", "compaction"]
+        )
+        assert result.exit_code == 0, result.output
+        assert "sch-001" in result.output
+        comp.storage.schedule_insert.assert_awaited_once_with("0 3 * * 0", "compaction", {})
+
+    def test_invalid_cron_rejected(self, runner, monkeypatch):
+        comp = _mock_components()
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(
+            cli, ["schedule", "add", "--cron", "not a cron", "--job", "compaction"]
+        )
+        assert result.exit_code != 0
+        assert "invalid cron" in result.output.lower()
+        comp.storage.schedule_insert.assert_not_awaited()
+
+    def test_unknown_job_rejected(self, runner):
+        # click.Choice rejects pre-bootstrap, so no monkeypatch needed.
+        result = runner.invoke(
+            cli, ["schedule", "add", "--cron", "* * * * *", "--job", "no_such_job"]
+        )
+        assert result.exit_code != 0
+        assert "no_such_job" in result.output or "Invalid value" in result.output
+
+    def test_invalid_params_json_rejected(self, runner, monkeypatch):
+        comp = _mock_components()
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "schedule",
+                "add",
+                "--cron",
+                "* * * * *",
+                "--job",
+                "importance_decay",
+                "--params",
+                "{not-json",
+            ],
+        )
+        assert result.exit_code != 0
+        comp.storage.schedule_insert.assert_not_awaited()
+
+
+class TestScheduleList:
+    def test_empty(self, runner, monkeypatch):
+        comp = _mock_components(schedules=[])
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(cli, ["schedule", "list"])
+        assert result.exit_code == 0
+        assert "No schedules" in result.output
+
+    def test_json_output(self, runner, monkeypatch):
+        rows = [
+            {
+                "id": "s1",
+                "cron_expr": "0 3 * * 0",
+                "job_kind": "compaction",
+                "params": {},
+                "enabled": True,
+                "created_at": "2026-04-28T00:00:00+00:00",
+                "last_run_at": None,
+                "last_run_status": None,
+                "last_run_error": None,
+            }
+        ]
+        comp = _mock_components(schedules=rows)
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(cli, ["schedule", "list", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["id"] == "s1"
+
+
+class TestScheduleDelete:
+    def test_happy_path(self, runner, monkeypatch):
+        comp = _mock_components(delete_ok=True)
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(cli, ["schedule", "delete", "s1"])
+        assert result.exit_code == 0
+        comp.storage.schedule_delete.assert_awaited_once_with("s1")
+
+    def test_not_found(self, runner, monkeypatch):
+        comp = _mock_components(delete_ok=False)
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
+        )
+        result = runner.invoke(cli, ["schedule", "delete", "nope"])
+        assert result.exit_code != 0
+        assert "not found" in result.output.lower()

--- a/packages/memtomem/tests/test_schedule_cmd.py
+++ b/packages/memtomem/tests/test_schedule_cmd.py
@@ -143,3 +143,30 @@ class TestScheduleDelete:
         result = runner.invoke(cli, ["schedule", "delete", "nope"])
         assert result.exit_code != 0
         assert "not found" in result.output.lower()
+
+
+class TestScheduleCliIntegration:
+    """End-to-end CLI ↔ real SQLite storage smoke (per
+    ``feedback_mocked_storage_hides_sql_bugs``)."""
+
+    def test_add_list_delete_roundtrip(self, runner, components, monkeypatch):
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(components)
+        )
+
+        added = runner.invoke(
+            cli, ["schedule", "add", "--cron", "0 3 * * 0", "--job", "compaction"]
+        )
+        assert added.exit_code == 0, added.output
+        sched_id = added.output.strip().split()[1]
+
+        listed = runner.invoke(cli, ["schedule", "list", "--json"])
+        assert listed.exit_code == 0
+        rows = json.loads(listed.output)
+        assert any(r["id"] == sched_id and r["job_kind"] == "compaction" for r in rows)
+
+        deleted = runner.invoke(cli, ["schedule", "delete", sched_id])
+        assert deleted.exit_code == 0
+
+        after = runner.invoke(cli, ["schedule", "list", "--json"])
+        assert all(r["id"] != sched_id for r in json.loads(after.output))

--- a/packages/memtomem/tests/test_schedule_cmd.py
+++ b/packages/memtomem/tests/test_schedule_cmd.py
@@ -39,9 +39,7 @@ def runner() -> CliRunner:
 class TestScheduleAdd:
     def test_happy_path(self, runner, monkeypatch):
         comp = _mock_components(insert_id="sch-001")
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(
             cli, ["schedule", "add", "--cron", "0 3 * * 0", "--job", "compaction"]
         )
@@ -51,9 +49,7 @@ class TestScheduleAdd:
 
     def test_invalid_cron_rejected(self, runner, monkeypatch):
         comp = _mock_components()
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(
             cli, ["schedule", "add", "--cron", "not a cron", "--job", "compaction"]
         )
@@ -71,9 +67,7 @@ class TestScheduleAdd:
 
     def test_invalid_params_json_rejected(self, runner, monkeypatch):
         comp = _mock_components()
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(
             cli,
             [
@@ -94,9 +88,7 @@ class TestScheduleAdd:
 class TestScheduleList:
     def test_empty(self, runner, monkeypatch):
         comp = _mock_components(schedules=[])
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(cli, ["schedule", "list"])
         assert result.exit_code == 0
         assert "No schedules" in result.output
@@ -116,9 +108,7 @@ class TestScheduleList:
             }
         ]
         comp = _mock_components(schedules=rows)
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(cli, ["schedule", "list", "--json"])
         assert result.exit_code == 0
         data = json.loads(result.output)
@@ -128,18 +118,14 @@ class TestScheduleList:
 class TestScheduleDelete:
     def test_happy_path(self, runner, monkeypatch):
         comp = _mock_components(delete_ok=True)
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(cli, ["schedule", "delete", "s1"])
         assert result.exit_code == 0
         comp.storage.schedule_delete.assert_awaited_once_with("s1")
 
     def test_not_found(self, runner, monkeypatch):
         comp = _mock_components(delete_ok=False)
-        monkeypatch.setattr(
-            "memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp)
-        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
         result = runner.invoke(cli, ["schedule", "delete", "nope"])
         assert result.exit_code != 0
         assert "not found" in result.output.lower()


### PR DESCRIPTION
## Summary
Phase A's user-facing surface for the cron scheduler. Direct-cron only — the natural-language `spec="…"` field arrives in Phase B. Closes the P2 Phase A loop after #519 (storage), #520 (JOB_KINDS), #521 (dispatcher).

- `mm schedule add|list|run-now|delete` CLI + matching `mem_do(action="schedule_*")` actions
- `schedule_run_now` reuses the dispatcher's `JOB_KINDS[...].runner` path and `runner_timeout_seconds`, recording outcomes via `schedule_mark_run`
- `schedule_delete` promoted from Phase C so `add` has its inverse without editing SQLite directly
- New `schedule` category added to `_standard_packs`; default `core` mode still routes through `mem_do`
- Docs: new "Scheduled jobs" section in `docs/guides/reference.md` (per `feedback_doc_update_process`)

## Test plan
- [x] `uv run pytest -m "not ollama"` — 2998 passed
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `mm schedule --help` lists `add`/`list`/`run-now`/`delete`
- [ ] Mode-1 smoke (`mm schedule add --cron "*/1 * * * *" --job compaction` → wait one watchdog tick → `mm schedule list` shows `last_run_status=ok`) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)