### PR TITLE
fix(tests): make test_uninstall_cmd import-safe on Windows (#448 follow-up)

### DIFF
--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -9,10 +9,10 @@ loud and immediate (MEDIUM 6 mitigation).
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import json
 import os
 import sqlite3
+import sys
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -28,7 +28,13 @@ def _hold_pid_lock(pid_file: Path) -> Iterator[None]:
 
     Mirrors what ``server/__init__.py:main`` does at runtime so the
     flock-based liveness probe (#387) sees a live writer.
+
+    POSIX-only — ``fcntl`` is imported lazily so the module collects on
+    Windows. Tests that depend on this helper are gated with
+    ``skipif(sys.platform == "win32", ...)``.
     """
+    import fcntl
+
     fp = open(pid_file, "rb+")
     try:
         fcntl.flock(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -322,6 +328,10 @@ class TestRuntimeProfileImportPin:
 # -------------------------------------------------------------------- 12
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock-based liveness probe is POSIX-only (#448 follow-up)",
+)
 class TestServerAliveRefuses:
     def test_refuses_when_server_alive_at_legacy_path(self, home):
         """Pre-#412 servers still write ``~/.memtomem/.server.pid``. The


### PR DESCRIPTION
## Summary

#456 made `cli/uninstall_cmd.py` Windows-safe by moving `fcntl` to a
lazy import, but the **test module** `tests/test_uninstall_cmd.py:12`
still has a module-level `import fcntl`. That breaks pytest collection
on Windows with `ModuleNotFoundError: No module named 'fcntl'` before
any test in the file can run — and the failure cascades to anyone
trying to validate Windows-specific changes locally.

External contributor reported this while iterating on #515 (Windows
Ollama hang fix); they could not run their own added tests because
collection blew up here first.

## Fix

- Move `import fcntl` inside `_hold_pid_lock` (POSIX-only helper).
- Gate `TestServerAliveRefuses` (4 tests, the only ones that use
  `_hold_pid_lock`) with `skipif(sys.platform == "win32", ...)` — the
  flock-based liveness probe is POSIX-only by design.

The remaining 28 tests in the file collect and run unchanged on
Windows.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py` —
      32 passed on macOS (no regression).
- [x] `uv run ruff check && ruff format --check` — clean.
- [ ] Windows verification deferred to the contributor on #515 once
      this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)