### PR TITLE
docs: clarify scheduler dispatch needs MCP server (not mm web)

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -911,6 +911,16 @@ loop that powers `mem_watchdog` — set
 `MEMTOMEM_SCHEDULER__ENABLED=true` on top of the watchdog config to
 enable dispatch.
 
+> **Dispatch requires the MCP server, not `mm web`.** The watchdog (and
+> therefore the schedule dispatcher) is wired into the MCP server
+> lifespan only — it is not started by `mm web`. Schedules registered
+> through `mm schedule add` while only `mm web` is running will sit
+> idle (`mm schedule list` shows `last=never (—)`) until an MCP server
+> session
+> (e.g. a connected Claude Code / Claude Desktop client) is also
+> active. Use `mm schedule run-now <id>` for one-off out-of-band
+> execution that does not depend on the watchdog tick.
+
 ```bash
 mm schedule add --cron "0 3 * * 0" --job compaction
 mm schedule list


### PR DESCRIPTION
## Summary
P2 Phase A post-merge smoke (after #522) revealed the §9 \"Scheduled jobs\" section reads as if `mm web` + `MEMTOMEM_SCHEDULER__ENABLED=true` is enough to dispatch schedules. It is not — `HealthWatchdog` (and the dispatcher riding its tick) is only wired into `AppContext.ensure_initialized`, which `mm web._lifespan` does not invoke. A `mm web`-only operator sees no error: `last_run_status` stays null forever.

One-paragraph callout pointing readers at MCP-server activation or `mm schedule run-now <id>` for out-of-band execution.

Considered, not in this PR: a `mm web --with-watchdog` opt-in. Defer until Phase C scope is clearer.

## Test plan
- [x] `uv run ruff format --check docs/` — n/a (md only); CI lint covers
- [x] Smoke locally — `mm web` + scheduler env on, `mm schedule add` → list shows `last=never` indefinitely (the gap this docs fix names)
- [x] `mm schedule run-now <id>` works without watchdog (the workaround the callout points to)

🤖 Generated with [Claude Code](https://claude.com/claude-code)