### PR TITLE
docs: surface mm schedule across getting-started / mcp-clients / README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 - **Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
 - **Web UI** — visual dashboard for search, sources, tags, timeline, dedup, and more (`mm web --dev` for the full maintainer surface)
 - **MCP tools** — `mem_do` meta-tool routes all non-core actions in `core` mode for minimal context usage
+- **Scheduled jobs** — `mm schedule add/list/run-now/delete` (or `mem_do(action="schedule_*")`) for cron-driven compaction, dedup, decay, and reflect runs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 - **Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
 - **Web UI** — visual dashboard for search, sources, tags, timeline, dedup, and more (`mm web --dev` for the full maintainer surface)
 - **MCP tools** — `mem_do` meta-tool routes all non-core actions in `core` mode for minimal context usage
-- **Scheduled jobs** — `mm schedule add/list/run-now/delete` (or `mem_do(action="schedule_*")`) for cron-driven compaction, dedup, decay, and reflect runs
+- **Scheduled jobs** — `mm schedule add/list/run-now/delete` (or `mem_do(action="schedule_*")`) for cron-driven compaction, importance decay, dead-link cleanup, and dedup scans
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -489,3 +489,4 @@ rm -rf ~/.memtomem
 - [Embeddings](embeddings.md) — ONNX, Ollama, OpenAI providers
 - [LLM Providers](llm-providers.md) — Ollama, OpenAI, and compatible endpoints
 - [MCP Client Setup](mcp-clients.md) — editor-specific configuration
+- [Scheduled jobs](reference.md#9-scheduled-jobs--mm-schedule-schedule_) — `mm schedule` for cron-driven compaction, dedup, decay, and reflect runs

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -489,4 +489,4 @@ rm -rf ~/.memtomem
 - [Embeddings](embeddings.md) — ONNX, Ollama, OpenAI providers
 - [LLM Providers](llm-providers.md) — Ollama, OpenAI, and compatible endpoints
 - [MCP Client Setup](mcp-clients.md) — editor-specific configuration
-- [Scheduled jobs](reference.md#9-scheduled-jobs--mm-schedule-schedule_) — `mm schedule` for cron-driven compaction, dedup, decay, and reflect runs
+- [Scheduled jobs](reference.md#9-scheduled-jobs--mm-schedule-schedule_) — `mm schedule` for cron-driven compaction, importance decay, dead-link cleanup, and dedup scans

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -276,7 +276,7 @@ uses, so the output is identical. Useful as a sanity check between
 | **Browse** | `mem_list` (indexed sources), `mem_read` (chunk by UUID) |
 | **CRUD** | `mem_add`, `mem_edit`, `mem_delete`, `mem_batch_add` |
 | **Indexing** | `mem_index` (file/directory indexing, optional `auto_tag`) |
-| **Meta** | `mem_do` (routes to all registered actions, supports aliases) |
+| **Meta** | `mem_do` (routes to all registered actions, supports aliases — including `schedule_register`, `schedule_list`, `schedule_run_now`, `schedule_delete` for cron jobs) |
 | **Ask** | `mem_ask` (natural-language Q&A over indexed memories) |
 | **Namespace** | `mem_ns_list`, `mem_ns_set`, `mem_ns_get`, `mem_ns_assign`, `mem_ns_update`, `mem_ns_rename`, `mem_ns_delete` |
 | **Tags** | `mem_tag_list`, `mem_tag_rename`, `mem_tag_delete`, `mem_auto_tag` |


### PR DESCRIPTION
## Summary
- Add `mm schedule` / `schedule_*` mentions to the three discovery-path docs that missed Phase A's reference-doc update (#522, #524).
- README.md gets a Key Features bullet; getting-started.md "Next steps" gets a pointer to §9 of reference.md; mcp-clients.md tool table extends the `mem_do` row with the four `schedule_*` aliases.

Closes #525.

## Test plan
- [ ] Docs render check (markdown links resolve, anchor `#9-scheduled-jobs--mm-schedule-schedule_` lands on the §9 heading)
- [ ] No source/CI changes — pure docs PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)