### PR TITLE
feat(web): warn at startup when scheduler.enabled=true

### DIFF
--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -247,6 +247,17 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     for d in comp.config.indexing.memory_dirs:
         Path(d).expanduser().resolve().mkdir(parents=True, exist_ok=True)
 
+    # P2 cron Phase A footgun: ``mm web`` does not run the schedule
+    # dispatcher (HealthWatchdog is wired only in the MCP server lifespan,
+    # see server/context.py). Mirror the warning emitted there so users who
+    # register schedules against a web-only entry get a loud signal at
+    # startup instead of silently null ``last_run_status``.
+    if comp.config.scheduler.enabled:
+        logger.warning(
+            "scheduler.enabled=True but ``mm web`` does not dispatch schedules — "
+            "run ``memtomem-server`` (MCP) for the watchdog tick that fires registered jobs"
+        )
+
     try:
         yield
     finally:

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -43,9 +43,19 @@ class _FakeIndexingCfg:
 
 
 @dataclass
+class _FakeSchedulerCfg:
+    enabled: bool = False
+
+
+@dataclass
 class _FakeConfig:
     embedding: _FakeEmbeddingCfg
     indexing: _FakeIndexingCfg
+    scheduler: _FakeSchedulerCfg = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.scheduler is None:
+            self.scheduler = _FakeSchedulerCfg()
 
 
 def _make_components(
@@ -55,6 +65,7 @@ def _make_components(
     cfg_provider: str = "onnx",
     cfg_model: str = "bge-m3",
     cfg_dim: int = 1024,
+    scheduler_enabled: bool = False,
 ) -> MagicMock:
     """Build a mock ``Components`` for ``_lifespan``.
 
@@ -70,6 +81,7 @@ def _make_components(
     comp.config = _FakeConfig(
         embedding=_FakeEmbeddingCfg(provider=cfg_provider, model=cfg_model, dimension=cfg_dim),
         indexing=_FakeIndexingCfg(),
+        scheduler=_FakeSchedulerCfg(enabled=scheduler_enabled),
     )
     comp.storage = storage
     comp.embedder = MagicMock()
@@ -160,3 +172,41 @@ async def test_auto_sync_noop_when_no_drift(stored_info):
 
     assert comp.config.embedding.provider == "onnx"
     comp.storage.clear_embedding_mismatch.assert_not_called()
+
+
+async def test_scheduler_enabled_warns_in_web_lifespan(caplog):
+    """``mm web`` does not run the schedule dispatcher (HealthWatchdog is
+    wired only in the MCP server lifespan). Mirror the loud warning emitted
+    by ``AppContext.ensure_initialized`` so users registering schedules
+    against a web-only entry get a startup signal instead of silent
+    null ``last_run_status``. Regression for issue #526."""
+    import logging
+
+    comp = _make_components(
+        embedding_broken=None,
+        stored_info=None,
+        scheduler_enabled=True,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="memtomem.web.app"):
+        await _run_lifespan(comp)
+
+    assert any(
+        "scheduler.enabled=True" in r.message and "mm web" in r.message for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+async def test_scheduler_disabled_no_warning(caplog):
+    """No warning when scheduler is off — avoid noise on the default path."""
+    import logging
+
+    comp = _make_components(
+        embedding_broken=None,
+        stored_info=None,
+        scheduler_enabled=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="memtomem.web.app"):
+        await _run_lifespan(comp)
+
+    assert not any("scheduler.enabled" in r.message for r in caplog.records)

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -17,7 +17,7 @@ came up clean (``embedding_broken is None``) so the recovery banner +
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -51,11 +51,7 @@ class _FakeSchedulerCfg:
 class _FakeConfig:
     embedding: _FakeEmbeddingCfg
     indexing: _FakeIndexingCfg
-    scheduler: _FakeSchedulerCfg = None  # type: ignore[assignment]
-
-    def __post_init__(self) -> None:
-        if self.scheduler is None:
-            self.scheduler = _FakeSchedulerCfg()
+    scheduler: _FakeSchedulerCfg = field(default_factory=_FakeSchedulerCfg)
 
 
 def _make_components(


### PR DESCRIPTION
## Summary
- ``mm web`` does not run the schedule dispatcher — HealthWatchdog is wired only in the MCP server lifespan (server/context.py L294-301). Schedules registered against a web-only entry sit idle with null ``last_run_status`` and no surfaced error.
- Mirror the existing ``AppContext.ensure_initialized`` warning at the top of ``web/app.py:_lifespan``: when ``config.scheduler.enabled`` is true, log a warning pointing users at ``memtomem-server`` for the dispatch tick.
- ~5-line behavior addition; no other lifespan changes.

Closes #526.

## Test plan
- [x] ``test_scheduler_enabled_warns_in_web_lifespan`` — caplog asserts the warning fires
- [x] ``test_scheduler_disabled_no_warning`` — default path stays quiet
- [x] ``uv run pytest packages/memtomem/tests/test_web_lifespan.py`` (6 passed)
- [x] ``uv run ruff check`` + ``ruff format --check``

🤖 Generated with [Claude Code](https://claude.com/claude-code)