### PR TITLE
feat(cli): add `mm upgrade` for kill-then-reinstall hygiene (#443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `.server.pid` repro that motivated this command). Probes the server
   pid lock, sends `SIGTERM`, escalates to `SIGKILL` after `--grace`
   seconds (default 5), unlinks the stale pid file, then runs the
-  reinstall. `--version X.Y.Z` pins a release; `--dry-run` prints the
-  plan; `--json` emits a structured result. On Windows the kill stage
-  is skipped automatically (POSIX advisory flock + signals are
+  reinstall. **Extras are preserved automatically** by reading the
+  current `uv tool` receipt — a `memtomem[all]` install stays `[all]`
+  across upgrades instead of silently regressing to a BM25-only base;
+  override with `--extras onnx,web` or suppress with `--extras none`.
+  `--version X.Y.Z` pins a release; `--dry-run` prints the plan;
+  `--json` emits a structured result. On Windows the kill stage is
+  skipped automatically (POSIX advisory flock + signals are
   unavailable) and the reinstall runs alone with a warning.
 - **`chunk_links` provenance from session summary → source chunks**
   (RFC P1 Phase B-2). When the auto-summary path runs on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **`mm upgrade` CLI** (#443) — wraps `uv tool install --refresh
+  --reinstall memtomem` with process-level hygiene so an in-memory
+  pre-upgrade `memtomem-server` can't keep running the old code next
+  to the freshly written disk bytes (the v0.1.25 → v0.1.26 stale
+  `.server.pid` repro that motivated this command). Probes the server
+  pid lock, sends `SIGTERM`, escalates to `SIGKILL` after `--grace`
+  seconds (default 5), unlinks the stale pid file, then runs the
+  reinstall. `--version X.Y.Z` pins a release; `--dry-run` prints the
+  plan; `--json` emits a structured result. On Windows the kill stage
+  is skipped automatically (POSIX advisory flock + signals are
+  unavailable) and the reinstall runs alone with a warning.
 - **`chunk_links` provenance from session summary → source chunks**
   (RFC P1 Phase B-2). When the auto-summary path runs on
   `mem_session_end`, the server now writes `link_type="summarizes"`

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -64,6 +64,8 @@ uv tool install memtomem            # BM25 only — dense search, Web UI, Korean
 
 You can opt in to individual features later with `uv tool install --reinstall 'memtomem[onnx,web]'` or any combination from the extras table in [Option C](#option-c-from-source-for-development-or-testing).
 
+> **Upgrading an installed memtomem**: prefer `mm upgrade` over a bare `uv tool install --reinstall memtomem`. The latter only swaps the on-disk bytes, so any `memtomem-server` already running under your MCP client keeps executing the previous version until it exits. `mm upgrade` stops the server first (SIGTERM → SIGKILL after `--grace`), clears the stale pid lock, then runs the reinstall with `--refresh` so a freshly released version isn't masked by uv's cached resolver result. Pass `--version X.Y.Z` to pin or `--dry-run` to preview the plan.
+
 > **If `mm --version` shows an older release**: `uv` caches PyPI metadata per package, and a fresh install can resolve to the cached entry for a short window after a new release. Re-run with `uv tool install 'memtomem[all]' --refresh`, or clear the cache first: `uv cache clean memtomem`. Check the [latest release](https://github.com/memtomem/memtomem/releases) for the expected version.
 
 > **If you see `mm: command not found`**: `uv tool install` writes the `mm` shim to `~/.local/bin` (macOS/Linux default), but that directory isn't on `$PATH` in a fresh shell profile. Run `uv tool update-shell` once, then open a new shell and re-run `mm --version`. (`uv` prints a one-line hint on first-ever tool install, but it's easy to miss.)

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -44,6 +44,7 @@ def _register() -> None:
     from memtomem.cli.shell import shell
     from memtomem.cli.status_cmd import status
     from memtomem.cli.uninstall_cmd import uninstall
+    from memtomem.cli.upgrade_cmd import upgrade
     from memtomem.cli.watchdog_cmd import watchdog
     from memtomem.cli.web import web
 
@@ -67,6 +68,7 @@ def _register() -> None:
     cli.add_command(shell)
     cli.add_command(agent)
     cli.add_command(uninstall)
+    cli.add_command(upgrade)
 
 
 _register()

--- a/packages/memtomem/src/memtomem/cli/_liveness.py
+++ b/packages/memtomem/src/memtomem/cli/_liveness.py
@@ -1,0 +1,85 @@
+"""Server liveness probe shared by ``mm uninstall`` and ``mm upgrade``.
+
+Both commands need to know whether a ``memtomem-server`` process is currently
+holding the pid lock file. The probe uses ``fcntl.flock(LOCK_EX | LOCK_NB)`` —
+if we can acquire it, no live writer is holding the file (it's a stale
+leftover or fresh and unowned). If we cannot, a writer is alive, regardless
+of whether the recorded PID is still valid or has been recycled.
+
+On Windows ``fcntl`` is unavailable; the probe falls back to conservative
+"pid file exists → assume alive" so callers can decide how to treat the
+ambiguity (uninstall: refuse without ``--force``; upgrade: skip kill stage
+and warn).
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from memtomem._runtime_paths import legacy_server_pid_path, server_pid_path
+
+
+@dataclass(frozen=True)
+class ServerState:
+    alive: bool
+    pid: int | None
+    pid_file: Path | None
+
+
+def probe_pid_file(pid_file: Path) -> ServerState:
+    """Probe a single pid file via ``fcntl.flock``.
+
+    ``server/__init__.py:main`` opens this file and holds an exclusive
+    flock for the entire server lifetime. If we can acquire
+    ``LOCK_EX | LOCK_NB`` on it, no live writer is holding it. If we
+    cannot, a writer is alive — regardless of whether the recorded PID
+    is still valid (kernel may have recycled it; see #387).
+
+    On Windows ``fcntl`` is unavailable; falls back to "pid file exists →
+    assume alive". See #448.
+    """
+    if not pid_file.exists():
+        return ServerState(alive=False, pid=None, pid_file=None)
+
+    pid: int | None
+    try:
+        pid_text = pid_file.read_text().strip()
+        pid = int(pid_text)
+    except (OSError, ValueError):
+        pid = None
+
+    if sys.platform == "win32":
+        return ServerState(alive=True, pid=pid, pid_file=pid_file)
+
+    import fcntl
+
+    try:
+        fp = open(pid_file, "rb")
+    except OSError:
+        return ServerState(alive=True, pid=pid, pid_file=pid_file)
+
+    try:
+        try:
+            fcntl.flock(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return ServerState(alive=True, pid=pid, pid_file=pid_file)
+        except OSError:
+            return ServerState(alive=True, pid=pid, pid_file=pid_file)
+        fcntl.flock(fp, fcntl.LOCK_UN)
+        return ServerState(alive=False, pid=pid, pid_file=pid_file)
+    finally:
+        fp.close()
+
+
+def check_server_liveness() -> ServerState:
+    """Probe the server pid file at both new (#412) and legacy locations.
+
+    First live holder wins; if neither is held the state is dead.
+    """
+    for pid_file in (server_pid_path(), legacy_server_pid_path()):
+        state = probe_pid_file(pid_file)
+        if state.alive:
+            return state
+    return ServerState(alive=False, pid=None, pid_file=None)

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -128,8 +128,9 @@ def _load_config_safely() -> tuple[Path, str | None]:
 # ---- server liveness probe -----------------------------------------------
 #
 # Liveness helpers live in ``memtomem.cli._liveness`` so ``mm upgrade`` can
-# share them. They're re-imported above as ``_check_server_liveness`` /
-# ``_probe_pid_file`` / ``_ServerState`` to keep the existing test seams.
+# share them. They're re-imported above as ``_check_server_liveness`` and
+# ``_probe_pid_file`` to keep the existing test seams; the ``ServerState``
+# dataclass is consumed via duck-typing so no alias is needed.
 
 
 def _check_db_lock(db_path: Path) -> _DbLockState:

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -34,13 +34,9 @@ from typing import Iterable
 
 import click
 
-# ``fcntl`` is POSIX-only. A module-level import here crashed every ``mm``
-# command on Windows because ``cli/__init__.py:_register`` imports this
-# module unconditionally. It is now imported lazily inside
-# ``_probe_pid_file`` behind a ``sys.platform`` guard so the rest of the CLI
-# boots on Windows. See #448.
-
-from memtomem._runtime_paths import legacy_server_pid_path, runtime_dir, server_pid_path
+from memtomem._runtime_paths import runtime_dir, server_pid_path
+from memtomem.cli._liveness import check_server_liveness as _check_server_liveness
+from memtomem.cli._liveness import probe_pid_file as _probe_pid_file  # noqa: F401  (test seam)
 from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
 
 _DEFAULT_STATE_DIR = Path.home() / ".memtomem"
@@ -87,13 +83,6 @@ class _Inventory:
 
 
 @dataclass(frozen=True)
-class _ServerState:
-    alive: bool
-    pid: int | None
-    pid_file: Path | None
-
-
-@dataclass(frozen=True)
 class _DbLockState:
     """Result of probing the SQLite DB for an active writer.
 
@@ -137,99 +126,10 @@ def _load_config_safely() -> tuple[Path, str | None]:
 
 
 # ---- server liveness probe -----------------------------------------------
-
-
-def _probe_pid_file(pid_file: Path) -> _ServerState:
-    """Probe a single pid file via ``fcntl.flock``.
-
-    ``server/__init__.py:main`` opens this file and holds an exclusive
-    flock for the entire server lifetime. If we can acquire
-    ``LOCK_EX | LOCK_NB`` on it, no live writer is holding it (the file
-    is a stale leftover, or fresh and unowned). If we cannot, a writer
-    is alive — *regardless* of whether the recorded PID is still valid,
-    has been recycled to an unrelated process, or was never set at all.
-
-    This replaces the previous ``os.kill(pid, 0)`` probe, which was
-    correct for stale-pid cases but produced false positives once the
-    kernel recycled the recorded PID to an unrelated process (issue
-    #387). The PID inside the file is now read for display only.
-
-    On Windows ``fcntl`` is unavailable; the probe falls back to
-    conservative "pid file exists → assume alive" and relies on
-    ``--force`` for override. See #448.
-    """
-    if not pid_file.exists():
-        return _ServerState(alive=False, pid=None, pid_file=None)
-
-    pid: int | None
-    try:
-        pid_text = pid_file.read_text().strip()
-        pid = int(pid_text)
-    except (OSError, ValueError):
-        # Unreadable / non-int — leave pid=None for the message; the lock
-        # probe below still decides alive vs. dead independently.
-        pid = None
-
-    if sys.platform == "win32":
-        # POSIX advisory flock is unavailable on Windows. Fall back to the
-        # same conservative treatment we use when the probe can't acquire
-        # the lock (unsupported filesystem branch below) — pid file exists,
-        # so assume a live writer and let the user pass ``--force`` to
-        # override. #448.
-        return _ServerState(alive=True, pid=pid, pid_file=pid_file)
-
-    import fcntl
-
-    try:
-        # Read-mode is enough; advisory flock works regardless of fd mode.
-        # Probing ``rb`` rather than ``rb+`` avoids any chance of accidental
-        # truncation on an exotic filesystem if we later abort.
-        fp = open(pid_file, "rb")
-    except OSError:
-        # Conservative — couldn't even open the file (permissions, race
-        # with deletion). Treat as alive so the user explicitly --forces.
-        return _ServerState(alive=True, pid=pid, pid_file=pid_file)
-
-    try:
-        try:
-            fcntl.flock(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            # Another process is holding the lock → live writer.
-            return _ServerState(alive=True, pid=pid, pid_file=pid_file)
-        except OSError:
-            # Unsupported filesystem (some NFS configurations, FUSE) or
-            # other unknown error — be conservative.
-            return _ServerState(alive=True, pid=pid, pid_file=pid_file)
-        # Got the lock. Release immediately — we don't want to hold it,
-        # only probe; holding would block a server starting in the gap
-        # between this probe and the eventual unlink.
-        fcntl.flock(fp, fcntl.LOCK_UN)
-        return _ServerState(alive=False, pid=pid, pid_file=pid_file)
-    finally:
-        fp.close()
-
-
-def _check_server_liveness() -> _ServerState:
-    """Probe the server pid file at both the new and legacy locations.
-
-    As of #412 the server writes its pid / lock file under
-    ``$XDG_RUNTIME_DIR/memtomem/server.pid`` (see ``_runtime_paths``).
-    During the transition window we also probe the legacy
-    ``~/.memtomem/.server.pid`` so a mixed-version upgrade (pre-#412
-    server still running, new uninstall CLI) refuses correctly. First
-    live holder wins; if neither is held the state is dead.
-
-    No ``state_dir`` parameter — both probes use canonical absolute
-    paths from :mod:`memtomem._runtime_paths`. When #384 expands the
-    scheme to cover other writers (``mm web``, ``mm watchdog``) the
-    glob will still live inside :func:`_runtime_paths.runtime_dir`,
-    not under the persistent state dir.
-    """
-    for pid_file in (server_pid_path(), legacy_server_pid_path()):
-        state = _probe_pid_file(pid_file)
-        if state.alive:
-            return state
-    return _ServerState(alive=False, pid=None, pid_file=None)
+#
+# Liveness helpers live in ``memtomem.cli._liveness`` so ``mm upgrade`` can
+# share them. They're re-imported above as ``_check_server_liveness`` /
+# ``_probe_pid_file`` / ``_ServerState`` to keep the existing test seams.
 
 
 def _check_db_lock(db_path: Path) -> _DbLockState:

--- a/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
@@ -1,0 +1,280 @@
+"""CLI: ``mm upgrade`` — stop the running server, then reinstall.
+
+``uv tool install --reinstall memtomem`` only replaces the on-disk bytes;
+any ``memtomem-server`` process already imported by an MCP client keeps
+running the old code until it exits. That split-brain is exactly what
+caused the v0.1.25 → v0.1.26 stale ``.server.pid`` repro that motivated
+issue #443. ``mm upgrade`` wraps the reinstall with process-level hygiene:
+
+    probe live server → SIGTERM (escalate to SIGKILL after grace) →
+    unlink stale pid file → ``uv tool install --refresh --reinstall``.
+
+There is no ``--skip-pkill``: the kill-then-reinstall ordering is the
+whole reason this command exists. On Windows the kill stage is skipped
+automatically (POSIX advisory flock + signals are unavailable) and the
+user is told to stop the server manually if they observe a split-brain.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import click
+
+from memtomem.cli._liveness import ServerState, check_server_liveness
+
+
+def _isatty() -> bool:
+    """CliRunner seam (mirrors ``uninstall_cmd._isatty``)."""
+    return sys.stdin.isatty()
+
+
+def _format_path(p: Path) -> str:
+    home = str(Path.home())
+    s = str(p)
+    return s.replace(home, "~", 1) if s.startswith(home) else s
+
+
+def _pid_alive(pid: int) -> bool:
+    """POSIX liveness check via ``os.kill(pid, 0)``.
+
+    Unix-only; callers gate on ``sys.platform != "win32"``.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we don't own it — for our purposes "alive".
+        return True
+    return True
+
+
+def _stop_server(state: ServerState, grace: float) -> tuple[list[int], list[Path]]:
+    """SIGTERM the live server, escalate to SIGKILL after ``grace`` seconds.
+
+    Returns ``(killed_pids, removed_pid_files)``. Caller is responsible
+    for skipping this on Windows / when ``state.alive`` is False.
+    """
+    killed: list[int] = []
+    removed: list[Path] = []
+
+    pid = state.pid
+    if pid is not None:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            killed.append(pid)
+        except ProcessLookupError:
+            # Already gone between probe and kill.
+            pid = None
+        except PermissionError as exc:
+            raise click.ClickException(
+                f"cannot signal pid {pid}: {exc}. Stop the server manually and retry."
+            ) from exc
+
+        # Poll for exit. server's ``_install_sigterm_handler`` (#439)
+        # unlinks its own pid file on a clean SIGTERM, so the file may
+        # vanish before grace expires — that's fine.
+        deadline = time.monotonic() + grace
+        while pid is not None and time.monotonic() < deadline:
+            if not _pid_alive(pid):
+                break
+            time.sleep(0.1)
+        else:
+            if pid is not None and _pid_alive(pid):
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+                # Brief settle so the kernel actually reaps it before we
+                # try to unlink the lock file.
+                time.sleep(0.5)
+
+    # Unconditionally clean stale pid file. Clean SIGTERM teardown usually
+    # removes it itself, but the SIGKILL path leaves it behind, and an
+    # empty/locked file blocks a fresh post-upgrade server.
+    if state.pid_file is not None:
+        try:
+            state.pid_file.unlink(missing_ok=True)
+            removed.append(state.pid_file)
+        except OSError as exc:
+            raise click.ClickException(
+                f"failed to remove stale pid file {state.pid_file}: {exc}"
+            ) from exc
+
+    return killed, removed
+
+
+def _build_install_cmd(version: str | None) -> list[str]:
+    pkg = "memtomem" if not version else f"memtomem=={version}"
+    # ``--refresh`` invalidates uv's cached PyPI index so a freshly
+    # released version isn't masked by the cached resolver result
+    # (memo: feedback_uv_index_cache_lag.md).
+    return ["uv", "tool", "install", "--refresh", "--reinstall", pkg]
+
+
+@click.command("upgrade")
+@click.option(
+    "--version",
+    "version",
+    default=None,
+    metavar="X.Y.Z",
+    help="Pin a specific version. Default: latest on the configured index.",
+)
+@click.option(
+    "--grace",
+    type=click.FloatRange(min=0.0),
+    default=5.0,
+    show_default=True,
+    help="Seconds to wait after SIGTERM before escalating to SIGKILL.",
+)
+@click.option("-y", "--yes", is_flag=True, help="Skip the confirmation prompt.")
+@click.option("--json", "json_out", is_flag=True, help="Emit a structured JSON result.")
+@click.option(
+    "--dry-run", is_flag=True, help="Print the plan and exit without killing or installing."
+)
+def upgrade(
+    version: str | None,
+    grace: float,
+    yes: bool,
+    json_out: bool,
+    dry_run: bool,
+) -> None:
+    """Stop a running memtomem-server, then reinstall via ``uv tool``.
+
+    The canonical ``uv tool install --reinstall memtomem`` only swaps the
+    on-disk bytes; any server already imported by an MCP client keeps
+    running the previous version. ``mm upgrade`` adds the missing
+    process-level hygiene step around it.
+    """
+    is_windows = sys.platform == "win32"
+    state = check_server_liveness()
+    install_cmd = _build_install_cmd(version)
+    pkg_target = install_cmd[-1]
+
+    # ----- plan -----
+    if not json_out:
+        click.echo("memtomem upgrade plan:")
+        if is_windows:
+            click.secho(
+                "  Detected Windows; skipping process termination. "
+                "Stop the server manually before rerunning if you see a "
+                "split-brain after upgrade.",
+                fg="yellow",
+            )
+        elif state.alive:
+            pid_repr = state.pid if state.pid is not None else "?"
+            pid_file_repr = _format_path(state.pid_file) if state.pid_file else "?"
+            click.echo(f"  Stop running server (pid {pid_repr}, lock {pid_file_repr})")
+            click.echo(f"  Wait up to {grace:g}s for graceful exit, then SIGKILL")
+            click.echo(f"  Remove stale {pid_file_repr}")
+        else:
+            click.echo("  No running server detected — reinstall only")
+        click.echo(f"  Reinstall: {' '.join(install_cmd)}")
+
+    if dry_run:
+        if json_out:
+            click.echo(
+                _json.dumps(
+                    {
+                        "ok": True,
+                        "dry_run": True,
+                        "would_kill": [state.pid] if (state.alive and state.pid) else [],
+                        "would_remove": (
+                            [str(state.pid_file)] if (state.alive and state.pid_file) else []
+                        ),
+                        "would_install": install_cmd,
+                        "version": version,
+                    }
+                )
+            )
+        return
+
+    # ----- confirm -----
+    if not yes:
+        if not _isatty():
+            msg = "Refusing to upgrade without confirmation in a non-interactive shell. Pass -y."
+            if json_out:
+                click.echo(_json.dumps({"ok": False, "error": msg}))
+                sys.exit(1)
+            click.secho(msg, fg="red")
+            raise click.Abort()
+        if not click.confirm("\nProceed with upgrade?", default=True):
+            click.echo("Cancelled — nothing was changed.")
+            sys.exit(1)
+
+    # ----- stop -----
+    killed: list[int] = []
+    removed: list[Path] = []
+    if state.alive and not is_windows:
+        try:
+            killed, removed = _stop_server(state, grace=grace)
+        except click.ClickException as exc:
+            if json_out:
+                click.echo(_json.dumps({"ok": False, "error": str(exc)}))
+                sys.exit(1)
+            raise
+
+    # ----- reinstall -----
+    try:
+        result = subprocess.run(install_cmd, capture_output=True, text=True, timeout=600)
+    except FileNotFoundError:
+        msg = "`uv` not found on PATH. Install uv (https://docs.astral.sh/uv/) and retry."
+        if json_out:
+            click.echo(_json.dumps({"ok": False, "error": msg, "killed": killed}))
+            sys.exit(1)
+        click.secho(msg, fg="red")
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        msg = "uv tool install timed out after 600s."
+        if json_out:
+            click.echo(_json.dumps({"ok": False, "error": msg, "killed": killed}))
+            sys.exit(1)
+        click.secho(msg, fg="red")
+        sys.exit(1)
+
+    if result.returncode != 0:
+        if json_out:
+            click.echo(
+                _json.dumps(
+                    {
+                        "ok": False,
+                        "error": f"uv tool install failed (rc={result.returncode})",
+                        "stderr": result.stderr,
+                        "killed": killed,
+                        "removed": [str(p) for p in removed],
+                    }
+                )
+            )
+            sys.exit(1)
+        click.secho(f"\nuv tool install failed (rc={result.returncode}):", fg="red")
+        click.echo(result.stderr.rstrip())
+        sys.exit(1)
+
+    # ----- success -----
+    if json_out:
+        click.echo(
+            _json.dumps(
+                {
+                    "ok": True,
+                    "killed": killed,
+                    "removed": [str(p) for p in removed],
+                    "reinstalled": pkg_target,
+                    "version": version,
+                }
+            )
+        )
+        return
+
+    if killed:
+        click.secho(f"\nStopped pid {killed[0]}.", fg="green")
+    if removed:
+        for path in removed:
+            click.echo(f"Removed {_format_path(path)}.")
+    click.secho(f"Reinstalled {pkg_target}.", fg="green")

--- a/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
@@ -22,6 +22,7 @@ import os
 import signal
 import subprocess
 import sys
+import re
 import time
 import tomllib
 from pathlib import Path
@@ -29,6 +30,21 @@ from pathlib import Path
 import click
 
 from memtomem.cli._liveness import ServerState, check_server_liveness, probe_pid_file
+
+# Bare PEP 440 release identifier — no operators, no whitespace. We pin
+# with ``memtomem==<version>``, so accepting a specifier like ``>=0.1.30``
+# would compose to ``memtomem==>=0.1.30`` and uv would reject it with a
+# less obvious parser error. Pre/post/dev releases (``0.1.30rc1``,
+# ``0.1.30.post1``, ``0.1.30.dev0``, ``0.1.30+local``) stay allowed.
+_VERSION_PATTERN = re.compile(
+    r"^[0-9]+(?:\.[0-9]+)*"  # release segment: 1, 1.2, 1.2.3, ...
+    r"(?:(?:a|b|rc)[0-9]+)?"  # pre-release: a1, b2, rc3
+    r"(?:\.post[0-9]+)?"  # post-release
+    r"(?:\.dev[0-9]+)?"  # dev release
+    r"(?:\+[a-z0-9]+(?:[._-][a-z0-9]+)*)?"  # local version segment
+    r"$",
+    re.IGNORECASE,
+)
 
 
 def _isatty() -> bool:
@@ -163,6 +179,12 @@ def _build_install_cmd(version: str | None, extras: list[str]) -> list[str]:
     if extras:
         pkg = f"memtomem[{','.join(extras)}]"
     if version:
+        if not _VERSION_PATTERN.match(version):
+            raise click.BadParameter(
+                f"{version!r} is not a bare PEP 440 release (e.g. 0.1.30, 0.1.30rc1). "
+                "Pass a literal version, not a specifier like '>=0.1.30'.",
+                param_hint="--version",
+            )
         pkg = f"{pkg}=={version}"
     # ``--refresh`` invalidates uv's cached PyPI index so a freshly
     # released version isn't masked by the cached resolver result

--- a/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/upgrade_cmd.py
@@ -23,11 +23,12 @@ import signal
 import subprocess
 import sys
 import time
+import tomllib
 from pathlib import Path
 
 import click
 
-from memtomem.cli._liveness import ServerState, check_server_liveness
+from memtomem.cli._liveness import ServerState, check_server_liveness, probe_pid_file
 
 
 def _isatty() -> bool:
@@ -86,37 +87,102 @@ def _stop_server(state: ServerState, grace: float) -> tuple[list[int], list[Path
             if not _pid_alive(pid):
                 break
             time.sleep(0.1)
-        else:
-            if pid is not None and _pid_alive(pid):
-                try:
-                    os.kill(pid, signal.SIGKILL)
-                except ProcessLookupError:
-                    pass
-                # Brief settle so the kernel actually reaps it before we
-                # try to unlink the lock file.
-                time.sleep(0.5)
+        if pid is not None and _pid_alive(pid):
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            # Brief settle so the kernel actually reaps it before we
+            # try to unlink the lock file.
+            time.sleep(0.5)
 
-    # Unconditionally clean stale pid file. Clean SIGTERM teardown usually
-    # removes it itself, but the SIGKILL path leaves it behind, and an
-    # empty/locked file blocks a fresh post-upgrade server.
+    # Clean the stale pid file. Clean SIGTERM teardown usually removes it
+    # itself, but the SIGKILL path leaves it behind. Re-probe immediately
+    # before unlink so we don't accidentally delete a fresh lockfile that
+    # an MCP client just respawned at the same path during the SIGKILL
+    # settle window.
     if state.pid_file is not None:
-        try:
-            state.pid_file.unlink(missing_ok=True)
-            removed.append(state.pid_file)
-        except OSError as exc:
-            raise click.ClickException(
-                f"failed to remove stale pid file {state.pid_file}: {exc}"
-            ) from exc
+        recheck = probe_pid_file(state.pid_file)
+        if recheck.alive:
+            click.secho(
+                f"  Skipping pid-file unlink — {state.pid_file} is now held by a "
+                "freshly started writer (likely an auto-restart from your MCP "
+                "client). Leaving it alone.",
+                fg="yellow",
+            )
+        else:
+            try:
+                state.pid_file.unlink(missing_ok=True)
+                removed.append(state.pid_file)
+            except OSError as exc:
+                raise click.ClickException(
+                    f"failed to remove stale pid file {state.pid_file}: {exc}"
+                ) from exc
 
     return killed, removed
 
 
-def _build_install_cmd(version: str | None) -> list[str]:
-    pkg = "memtomem" if not version else f"memtomem=={version}"
+def _detect_installed_extras() -> list[str]:
+    """Best-effort: read uv's tool receipt to preserve extras on reinstall.
+
+    ``uv tool install 'memtomem[all]'`` records the install spec in
+    ``<uv tool dir>/memtomem/uv-receipt.toml`` as
+    ``[tool].requirements = [{ name = "memtomem", extras = ["all"] }]``.
+    Without re-passing the same extras, ``uv tool install --reinstall
+    memtomem`` would silently fall back to the bare BM25-only install,
+    dropping ONNX dense embeddings, the Web UI, etc. (review feedback).
+
+    Returns ``[]`` on any failure (uv unavailable, receipt missing or
+    malformed) — callers fall back to no extras and can override with
+    ``--extras``.
+    """
+    try:
+        result = subprocess.run(["uv", "tool", "dir"], capture_output=True, text=True, timeout=10)
+        if result.returncode != 0:
+            return []
+        tools_dir = Path(result.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+    receipt = tools_dir / "memtomem" / "uv-receipt.toml"
+    if not receipt.exists():
+        return []
+    try:
+        data = tomllib.loads(receipt.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return []
+    for req in data.get("tool", {}).get("requirements", []):
+        if req.get("name") == "memtomem":
+            extras = req.get("extras") or []
+            return [str(e) for e in extras]
+    return []
+
+
+def _build_install_cmd(version: str | None, extras: list[str]) -> list[str]:
+    pkg = "memtomem"
+    if extras:
+        pkg = f"memtomem[{','.join(extras)}]"
+    if version:
+        pkg = f"{pkg}=={version}"
     # ``--refresh`` invalidates uv's cached PyPI index so a freshly
     # released version isn't masked by the cached resolver result
     # (memo: feedback_uv_index_cache_lag.md).
     return ["uv", "tool", "install", "--refresh", "--reinstall", pkg]
+
+
+def _resolve_extras(extras_flag: str | None) -> tuple[list[str], bool]:
+    """Resolve ``--extras`` value to a concrete list + ``auto_detected`` flag.
+
+    ``None`` (flag omitted) → auto-detect from receipt.
+    ``"none"`` / empty → explicit bare install.
+    Anything else → split on ``,`` and strip.
+    """
+    if extras_flag is None:
+        return _detect_installed_extras(), True
+    cleaned = extras_flag.strip().lower()
+    if cleaned in ("", "none"):
+        return [], False
+    return [e.strip() for e in extras_flag.split(",") if e.strip()], False
 
 
 @click.command("upgrade")
@@ -134,6 +200,17 @@ def _build_install_cmd(version: str | None) -> list[str]:
     show_default=True,
     help="Seconds to wait after SIGTERM before escalating to SIGKILL.",
 )
+@click.option(
+    "--extras",
+    "extras_flag",
+    default=None,
+    metavar="LIST",
+    help=(
+        "Extras to install (e.g. 'all' or 'onnx,web'). "
+        "Default: auto-detect from the current uv-tool install so a "
+        "memtomem[all] user keeps [all]. Pass 'none' for a bare install."
+    ),
+)
 @click.option("-y", "--yes", is_flag=True, help="Skip the confirmation prompt.")
 @click.option("--json", "json_out", is_flag=True, help="Emit a structured JSON result.")
 @click.option(
@@ -142,6 +219,7 @@ def _build_install_cmd(version: str | None) -> list[str]:
 def upgrade(
     version: str | None,
     grace: float,
+    extras_flag: str | None,
     yes: bool,
     json_out: bool,
     dry_run: bool,
@@ -155,7 +233,8 @@ def upgrade(
     """
     is_windows = sys.platform == "win32"
     state = check_server_liveness()
-    install_cmd = _build_install_cmd(version)
+    extras, extras_auto = _resolve_extras(extras_flag)
+    install_cmd = _build_install_cmd(version, extras)
     pkg_target = install_cmd[-1]
 
     # ----- plan -----
@@ -176,6 +255,11 @@ def upgrade(
             click.echo(f"  Remove stale {pid_file_repr}")
         else:
             click.echo("  No running server detected — reinstall only")
+        if extras:
+            source = "auto-detected from uv tool receipt" if extras_auto else "from --extras"
+            click.echo(f"  Extras: [{','.join(extras)}] ({source})")
+        elif extras_auto:
+            click.echo("  Extras: none detected (bare install)")
         click.echo(f"  Reinstall: {' '.join(install_cmd)}")
 
     if dry_run:
@@ -190,6 +274,7 @@ def upgrade(
                             [str(state.pid_file)] if (state.alive and state.pid_file) else []
                         ),
                         "would_install": install_cmd,
+                        "extras": extras,
                         "version": version,
                     }
                 )
@@ -206,8 +291,12 @@ def upgrade(
             click.secho(msg, fg="red")
             raise click.Abort()
         if not click.confirm("\nProceed with upgrade?", default=True):
-            click.echo("Cancelled — nothing was changed.")
-            sys.exit(1)
+            # Voluntary cancel → exit 0; keep JSON schema consistent.
+            if json_out:
+                click.echo(_json.dumps({"ok": True, "cancelled": True}))
+            else:
+                click.echo("Cancelled — nothing was changed.")
+            return
 
     # ----- stop -----
     killed: list[int] = []
@@ -266,6 +355,7 @@ def upgrade(
                     "killed": killed,
                     "removed": [str(p) for p in removed],
                     "reinstalled": pkg_target,
+                    "extras": extras,
                     "version": version,
                 }
             )

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -17,6 +17,16 @@ def force_tty(monkeypatch):
     monkeypatch.setattr(upgrade_cmd, "_isatty", lambda: True)
 
 
+@pytest.fixture(autouse=True)
+def _no_extras_by_default(monkeypatch):
+    """Default tests assume the auto-detect probe finds nothing.
+
+    Individual tests opt in to a non-empty receipt by re-patching
+    ``_detect_installed_extras``.
+    """
+    monkeypatch.setattr(upgrade_cmd, "_detect_installed_extras", lambda: [])
+
+
 @pytest.fixture
 def fake_uv(monkeypatch):
     """Capture subprocess.run invocations and return scripted results."""
@@ -181,6 +191,82 @@ def test_non_tty_without_yes_aborts(monkeypatch, fake_uv):
 
     result = CliRunner().invoke(cli, ["upgrade"])
     assert result.exit_code != 0
+    assert calls == []
+
+
+def test_extras_auto_detected_from_receipt(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+    monkeypatch.setattr(upgrade_cmd, "_detect_installed_extras", lambda: ["all"])
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 0, result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem[all]"]]
+    assert "auto-detected" in result.output
+
+
+def test_extras_flag_overrides_detection(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+    monkeypatch.setattr(upgrade_cmd, "_detect_installed_extras", lambda: ["all"])
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--extras", "onnx,web"])
+    assert result.exit_code == 0, result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem[onnx,web]"]]
+
+
+def test_extras_none_suppresses(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+    monkeypatch.setattr(upgrade_cmd, "_detect_installed_extras", lambda: ["all"])
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--extras", "none"])
+    assert result.exit_code == 0, result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem"]]
+
+
+def test_extras_combined_with_version_pin(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+    monkeypatch.setattr(upgrade_cmd, "_detect_installed_extras", lambda: ["all"])
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--version", "0.1.32"])
+    assert result.exit_code == 0, result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem[all]==0.1.32"]]
+
+
+def test_pid_file_unlink_skipped_if_respawned(monkeypatch, tmp_path, fake_uv, force_tty):
+    """SIGKILL path: a fresh server respawns at the same pid file path
+    inside the settle window. We must NOT delete its lockfile."""
+    _calls, _configure = fake_uv
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text("12345")
+    _patch_liveness(monkeypatch, ServerState(alive=True, pid=12345, pid_file=pid_file))
+    monkeypatch.setattr(upgrade_cmd.os, "kill", lambda pid, sig: None)
+    monkeypatch.setattr(upgrade_cmd, "_pid_alive", lambda pid: False)
+
+    # Re-probe at unlink time sees a live writer (the respawn).
+    monkeypatch.setattr(
+        upgrade_cmd,
+        "probe_pid_file",
+        lambda p: ServerState(alive=True, pid=99999, pid_file=p),
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--grace", "0.1"])
+    assert result.exit_code == 0, result.output
+    assert pid_file.exists()
+    assert "freshly started writer" in result.output
+
+
+def test_cancel_exits_zero_and_json_consistent(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    # Decline confirmation by feeding "n" to click.confirm.
+    result = CliRunner().invoke(cli, ["upgrade", "--json"], input="n\n")
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload == {"ok": True, "cancelled": True}
     assert calls == []
 
 

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -258,6 +258,25 @@ def test_pid_file_unlink_skipped_if_respawned(monkeypatch, tmp_path, fake_uv, fo
     assert "freshly started writer" in result.output
 
 
+def test_version_specifier_rejected(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--version", ">=0.1.30"])
+    assert result.exit_code != 0
+    assert "not a bare PEP 440 release" in result.output
+    assert calls == []
+
+
+def test_version_prerelease_accepted(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--version", "0.1.30rc1"])
+    assert result.exit_code == 0, result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem==0.1.30rc1"]]
+
+
 def test_cancel_exits_zero_and_json_consistent(monkeypatch, fake_uv, force_tty):
     calls, _configure = fake_uv
     _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -1,0 +1,198 @@
+"""Tests for ``mm upgrade`` — kill-then-reinstall hygiene wrapper (#443)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.cli import upgrade_cmd
+from memtomem.cli._liveness import ServerState
+
+
+@pytest.fixture
+def force_tty(monkeypatch):
+    monkeypatch.setattr(upgrade_cmd, "_isatty", lambda: True)
+
+
+@pytest.fixture
+def fake_uv(monkeypatch):
+    """Capture subprocess.run invocations and return scripted results."""
+
+    calls: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode: int = 0, stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = ""
+            self.stderr = stderr
+
+    state = {"result": _Result(), "raise_exc": None}
+
+    def fake_run(cmd, capture_output=True, text=True, timeout=None):
+        calls.append(list(cmd))
+        if state["raise_exc"] is not None:
+            raise state["raise_exc"]
+        return state["result"]
+
+    monkeypatch.setattr(upgrade_cmd.subprocess, "run", fake_run)
+
+    def configure(*, returncode: int = 0, stderr: str = "", raise_exc=None):
+        state["result"] = _Result(returncode=returncode, stderr=stderr)
+        state["raise_exc"] = raise_exc
+
+    return calls, configure
+
+
+def _patch_liveness(monkeypatch, state: ServerState) -> None:
+    monkeypatch.setattr(upgrade_cmd, "check_server_liveness", lambda: state)
+
+
+# ---------------------------------------------------------------- tests
+
+
+def test_no_running_server_just_reinstalls(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 0, result.output
+    assert "No running server detected" in result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem"]]
+
+
+def test_running_server_sigterm_path(monkeypatch, tmp_path, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text("12345")
+    _patch_liveness(monkeypatch, ServerState(alive=True, pid=12345, pid_file=pid_file))
+
+    sent: list[tuple[int, int]] = []
+
+    def fake_kill(pid: int, sig: int) -> None:
+        sent.append((pid, sig))
+
+    # _pid_alive() returns False on the first poll → graceful exit path.
+    monkeypatch.setattr(upgrade_cmd.os, "kill", fake_kill)
+    monkeypatch.setattr(upgrade_cmd, "_pid_alive", lambda pid: False)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--grace", "1"])
+    assert result.exit_code == 0, result.output
+    assert sent and sent[0][1] == upgrade_cmd.signal.SIGTERM
+    assert all(s != upgrade_cmd.signal.SIGKILL for _pid, s in sent)
+    assert not pid_file.exists()
+    assert calls  # uv was invoked
+
+
+def test_running_server_escalates_to_sigkill(monkeypatch, tmp_path, fake_uv, force_tty):
+    _calls, _configure = fake_uv
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text("12345")
+    _patch_liveness(monkeypatch, ServerState(alive=True, pid=12345, pid_file=pid_file))
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(upgrade_cmd.os, "kill", lambda pid, sig: sent.append((pid, sig)))
+    # Stays alive forever → grace expires → SIGKILL.
+    monkeypatch.setattr(upgrade_cmd, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(upgrade_cmd.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        upgrade_cmd.time,
+        "monotonic",
+        _make_monotonic([0.0, 0.0, 1.0, 2.0]),  # past deadline immediately
+    )
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--grace", "0.5"])
+    assert result.exit_code == 0, result.output
+    sigs = [s for _pid, s in sent]
+    assert upgrade_cmd.signal.SIGTERM in sigs
+    assert upgrade_cmd.signal.SIGKILL in sigs
+    assert not pid_file.exists()
+
+
+def test_windows_skips_kill(monkeypatch, tmp_path, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    pid_file = tmp_path / "server.pid"
+    pid_file.write_text("12345")
+    _patch_liveness(monkeypatch, ServerState(alive=True, pid=12345, pid_file=pid_file))
+    monkeypatch.setattr(upgrade_cmd.sys, "platform", "win32")
+
+    def boom(*_a, **_k):
+        raise AssertionError("os.kill must not be called on Windows")
+
+    monkeypatch.setattr(upgrade_cmd.os, "kill", boom)
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 0, result.output
+    assert "Detected Windows" in result.output
+    assert calls  # uv still ran
+    # We also leave the pid file alone — Windows users may need it.
+    assert pid_file.exists()
+
+
+def test_version_pin_passes_to_uv(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--version", "0.1.30"])
+    assert result.exit_code == 0, result.output
+    assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem==0.1.30"]]
+
+
+def test_uv_failure_propagates(monkeypatch, fake_uv, force_tty):
+    _calls, configure = fake_uv
+    configure(returncode=1, stderr="resolver: no matching version")
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y"])
+    assert result.exit_code == 1
+    assert "uv tool install failed" in result.output
+    assert "no matching version" in result.output
+
+
+def test_dry_run_does_nothing(monkeypatch, fake_uv, force_tty):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert calls == []
+    assert "Reinstall:" in result.output
+
+
+def test_json_output_shape_success(monkeypatch, fake_uv, force_tty):
+    _calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+
+    result = CliRunner().invoke(cli, ["upgrade", "-y", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output.strip().splitlines()[-1])
+    assert payload["ok"] is True
+    assert payload["reinstalled"] == "memtomem"
+    assert payload["killed"] == []
+    assert payload["removed"] == []
+
+
+def test_non_tty_without_yes_aborts(monkeypatch, fake_uv):
+    calls, _configure = fake_uv
+    _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
+    monkeypatch.setattr(upgrade_cmd, "_isatty", lambda: False)
+
+    result = CliRunner().invoke(cli, ["upgrade"])
+    assert result.exit_code != 0
+    assert calls == []
+
+
+def _make_monotonic(values: list[float]):
+    """Helper: sequential monotonic stamps then sticky last value."""
+    state = {"i": 0}
+
+    def _now() -> float:
+        i = state["i"]
+        if i < len(values):
+            state["i"] += 1
+            return values[i]
+        return values[-1]
+
+    return _now


### PR DESCRIPTION
## Summary

- New `mm upgrade` command: probe live server → SIGTERM (escalate to SIGKILL after `--grace`) → unlink stale pid file → `uv tool install --refresh --reinstall memtomem`. Closes #443.
- Liveness helpers extracted from `uninstall_cmd.py` into a new `cli/_liveness.py` so both commands share one probe; existing uninstall behavior is unchanged (32 tests still pass).
- No `--skip-pkill` opt-out — kill-then-reinstall is the whole reason the command exists. Windows auto-skips the kill stage (no fcntl/signals) and warns.

## Why

`uv tool install --reinstall memtomem` only swaps the on-disk bytes. Any `memtomem-server` already imported by an MCP client (Claude Code keeps the server alive across prompts) keeps running the previous version until it exits, producing a split-brain where pre-upgrade teardown bugs leak alongside the freshly written disk code. That's exactly the v0.1.25 → v0.1.26 stale `.server.pid` repro that motivated issue #443.

## Surface

```
mm upgrade [--version X.Y.Z] [--grace SECONDS] [-y/--yes] [--json] [--dry-run]
```

- `--version` pins a release; default is latest on the configured index.
- `--grace` (default 5s) is the SIGTERM → SIGKILL window.
- `--dry-run` prints the plan without killing or installing.
- `--json` emits `{ok, killed, removed, reinstalled, version}` (or `{ok:false, error,…}`).

## Test plan

- [x] `pytest packages/memtomem/tests/test_upgrade_cmd.py` — 9 new tests (no-running-server / SIGTERM / SIGKILL escalation / Windows-skips-kill / version pin / uv failure / dry-run / json shape / non-TTY-no-yes)
- [x] `pytest packages/memtomem/tests/test_uninstall_cmd.py` — all 32 existing tests still pass after liveness helper extraction
- [x] `pytest packages/memtomem/tests/ -m "not ollama"` — 3010 pass
- [x] `ruff check && ruff format --check` clean repo-wide
- [x] `uv run mm upgrade --help` / `--dry-run` smoke (detects real running server, prints plan)
- [ ] Reviewer: manual end-to-end on a worktree (start `mm web`, run `mm upgrade --dry-run`, then `mm upgrade --yes --grace 3` and verify the pid file is gone and a fresh server spawns clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)