### PR TITLE
fix(web): warn at startup when policy.enabled=true (#528 follow-up)

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -872,6 +872,13 @@ When enabled, the scheduler runs all enabled policies periodically. The
 atomically. Policies can always be run on-demand via `mem_policy_run`
 regardless of this setting.
 
+> **`PolicyScheduler` requires the MCP server, not `mm web`.** Like the
+> cron scheduler in §9, the policy scheduler is wired into the MCP server
+> lifespan only — `mm web` logs a warning at startup if
+> `policy.enabled=true` but does not actually run policies. Run
+> `memtomem-server` (or connect a Claude Code / Claude Desktop MCP
+> session) for periodic dispatch; `mem_policy_run` works regardless.
+
 ### Combining policies
 
 A common pattern is pairing auto_archive with auto_promote:

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -257,6 +257,11 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             "scheduler.enabled=True but ``mm web`` does not dispatch schedules — "
             "run ``memtomem-server`` (MCP) for the watchdog tick that fires registered jobs"
         )
+    if comp.config.policy.enabled:
+        logger.warning(
+            "policy.enabled=True but ``mm web`` does not run the policy scheduler — "
+            "run ``memtomem-server`` (MCP) for the lifespan that starts PolicyScheduler"
+        )
 
     try:
         yield

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -254,12 +254,12 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     # startup instead of silently null ``last_run_status``.
     if comp.config.scheduler.enabled:
         logger.warning(
-            "scheduler.enabled=True but ``mm web`` does not dispatch schedules — "
+            "scheduler.enabled=true but ``mm web`` does not dispatch schedules — "
             "run ``memtomem-server`` (MCP) for the watchdog tick that fires registered jobs"
         )
     if comp.config.policy.enabled:
         logger.warning(
-            "policy.enabled=True but ``mm web`` does not run the policy scheduler — "
+            "policy.enabled=true but ``mm web`` does not run the policy scheduler — "
             "run ``memtomem-server`` (MCP) for the lifespan that starts PolicyScheduler"
         )
 

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -48,10 +48,16 @@ class _FakeSchedulerCfg:
 
 
 @dataclass
+class _FakePolicyCfg:
+    enabled: bool = False
+
+
+@dataclass
 class _FakeConfig:
     embedding: _FakeEmbeddingCfg
     indexing: _FakeIndexingCfg
     scheduler: _FakeSchedulerCfg = field(default_factory=_FakeSchedulerCfg)
+    policy: _FakePolicyCfg = field(default_factory=_FakePolicyCfg)
 
 
 def _make_components(
@@ -62,6 +68,7 @@ def _make_components(
     cfg_model: str = "bge-m3",
     cfg_dim: int = 1024,
     scheduler_enabled: bool = False,
+    policy_enabled: bool = False,
 ) -> MagicMock:
     """Build a mock ``Components`` for ``_lifespan``.
 
@@ -78,6 +85,7 @@ def _make_components(
         embedding=_FakeEmbeddingCfg(provider=cfg_provider, model=cfg_model, dimension=cfg_dim),
         indexing=_FakeIndexingCfg(),
         scheduler=_FakeSchedulerCfg(enabled=scheduler_enabled),
+        policy=_FakePolicyCfg(enabled=policy_enabled),
     )
     comp.storage = storage
     comp.embedder = MagicMock()
@@ -206,3 +214,40 @@ async def test_scheduler_disabled_no_warning(caplog):
         await _run_lifespan(comp)
 
     assert not any("scheduler.enabled" in r.message for r in caplog.records)
+
+
+async def test_policy_enabled_warns_in_web_lifespan(caplog):
+    """``mm web`` does not start ``PolicyScheduler`` (wired only in
+    ``AppContext.ensure_initialized`` on the MCP server lifespan). Mirror the
+    ``scheduler.enabled`` warning so users running ``mm web`` with
+    ``policy.enabled=true`` see a loud signal at startup."""
+    import logging
+
+    comp = _make_components(
+        embedding_broken=None,
+        stored_info=None,
+        policy_enabled=True,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="memtomem.web.app"):
+        await _run_lifespan(comp)
+
+    assert any(
+        "policy.enabled=True" in r.message and "mm web" in r.message for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+async def test_policy_disabled_no_warning(caplog):
+    """No warning when policy is off — avoid noise on the default path."""
+    import logging
+
+    comp = _make_components(
+        embedding_broken=None,
+        stored_info=None,
+        policy_enabled=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="memtomem.web.app"):
+        await _run_lifespan(comp)
+
+    assert not any("policy.enabled" in r.message for r in caplog.records)

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -196,7 +196,7 @@ async def test_scheduler_enabled_warns_in_web_lifespan(caplog):
         await _run_lifespan(comp)
 
     assert any(
-        "scheduler.enabled=True" in r.message and "mm web" in r.message for r in caplog.records
+        "scheduler.enabled=true" in r.message and "mm web" in r.message for r in caplog.records
     ), [r.message for r in caplog.records]
 
 
@@ -233,7 +233,7 @@ async def test_policy_enabled_warns_in_web_lifespan(caplog):
         await _run_lifespan(comp)
 
     assert any(
-        "policy.enabled=True" in r.message and "mm web" in r.message for r in caplog.records
+        "policy.enabled=true" in r.message and "mm web" in r.message for r in caplog.records
     ), [r.message for r in caplog.records]
 
 


### PR DESCRIPTION
## Summary
- Mirror the `scheduler.enabled` startup warning from #528 for `policy.enabled` — `PolicyScheduler` is wired only in `AppContext.ensure_initialized` (MCP server lifespan), so `mm web` + `policy.enabled=true` silently never runs policies.
- Add a callout to `docs/guides/reference.md` §8 matching the §9 cron-scheduler note.
- Tests: two new cases in `test_web_lifespan.py` for the warn/no-warn paths.

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_web_lifespan.py` — 8 passed
- [x] `uv run ruff check` + `ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)