### PR TITLE
feat(indexing): parse temporal-validity frontmatter into chunk metadata

### DIFF
--- a/packages/memtomem/src/memtomem/chunking/markdown.py
+++ b/packages/memtomem/src/memtomem/chunking/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from memtomem.models import Chunk, ChunkMetadata, ChunkType
@@ -11,10 +12,60 @@ from memtomem.models import Chunk, ChunkMetadata, ChunkType
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
 _FRONT_MATTER_RE = re.compile(r"^---\n(.*?)\n---\n?", re.DOTALL)
 _WIKILINK_RE = re.compile(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]")
+# Temporal-validity frontmatter formats (RFC: temporal-validity).
+# Date-only ``YYYY-MM-DD`` and quarter ``YYYY-QN`` (N in 1-4). Anything else
+# parses to ``None`` and the bound is treated as unset (no exception raised —
+# the chunker stays liberal so a typo doesn't break indexing).
+_VALIDITY_DATE_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})$")
+_VALIDITY_QUARTER_RE = re.compile(r"^(\d{4})-Q([1-4])$")
 # Code fence opener/closer: up to 3 leading spaces, then ``` or ~~~ (length is
 # the matched run). Language tag after opener is allowed; closer must be the
 # same character and at least as long (CommonMark §4.5).
 _FENCE_OPEN_RE = re.compile(r"^[ ]{0,3}(`{3,}|~{3,})(.*)$")
+
+
+def _parse_validity_bound(value: str, *, upper: bool) -> int | None:
+    """Parse a ``valid_from`` / ``valid_to`` value to a unix-second bound.
+
+    ``upper`` selects which edge of the calendar unit to return:
+    - ``upper=False`` (lower bound): start of day / start of quarter (00:00:00 UTC).
+    - ``upper=True`` (upper bound): end of day / end of quarter (23:59:59 UTC of
+      the unit's last day) — inclusive, per RFC §Frontmatter shape.
+
+    Returns ``None`` for malformed input (e.g. ``2025-13-45``, ``2025-Q5``) so
+    one bad bound does not prevent the other from being used and indexing is
+    not aborted by a single typo.
+    """
+    m = _VALIDITY_DATE_RE.match(value)
+    if m:
+        try:
+            year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
+            start = datetime(year, month, day, 0, 0, 0, tzinfo=timezone.utc)
+        except ValueError:
+            return None
+        if not upper:
+            return int(start.timestamp())
+        end = start + timedelta(days=1) - timedelta(seconds=1)
+        return int(end.timestamp())
+
+    m = _VALIDITY_QUARTER_RE.match(value)
+    if m:
+        year, quarter = int(m.group(1)), int(m.group(2))
+        first_month = (quarter - 1) * 3 + 1  # Q1=1, Q2=4, Q3=7, Q4=10
+        try:
+            q_start = datetime(year, first_month, 1, 0, 0, 0, tzinfo=timezone.utc)
+        except ValueError:
+            return None
+        if not upper:
+            return int(q_start.timestamp())
+        # End of quarter = (start of next quarter) - 1 second.
+        if first_month == 10:
+            next_q_start = datetime(year + 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        else:
+            next_q_start = datetime(year, first_month + 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+        return int((next_q_start - timedelta(seconds=1)).timestamp())
+
+    return None
 
 
 _TOKEN_CHAR_RATIO = 4  # rough chars-per-token estimate (English-oriented)
@@ -169,6 +220,11 @@ class MarkdownChunker:
         # Extract tags from YAML frontmatter
         fm_tags = self._extract_frontmatter_tags(content)
 
+        # Extract validity window from frontmatter (RFC: temporal-validity).
+        # The window is file-level — every chunk produced from this file
+        # carries the same (valid_from_unix, valid_to_unix) pair.
+        valid_from_unix, valid_to_unix = self._extract_validity_window(content)
+
         # Resolve wikilinks: [[target|alias]] → alias, [[target]] → target
         content = _WIKILINK_RE.sub(lambda m: m.group(2) or m.group(1), content)
 
@@ -224,6 +280,8 @@ class MarkdownChunker:
                             tags=combined_tags,
                             parent_context=parent_ctx,
                             file_context=file_ctx,
+                            valid_from_unix=valid_from_unix,
+                            valid_to_unix=valid_to_unix,
                         ),
                     )
                 )
@@ -249,6 +307,8 @@ class MarkdownChunker:
                                 overlap_after=sc.get("overlap_after", 0),
                                 tags=combined_tags,
                                 parent_context=parent_ctx,
+                                valid_from_unix=valid_from_unix,
+                                valid_to_unix=valid_to_unix,
                                 file_context=file_ctx,
                             ),
                         )
@@ -295,6 +355,34 @@ class MarkdownChunker:
             if stripped.startswith("tags:"):
                 return cls._parse_tags_value(stripped[5:], fm_lines[idx + 1 :])
         return []
+
+    @classmethod
+    def _extract_validity_window(cls, content: str) -> tuple[int | None, int | None]:
+        """Extract ``(valid_from_unix, valid_to_unix)`` from YAML frontmatter.
+
+        Each field is independent — either, both, or neither may be present.
+        Missing or malformed values return ``None`` for that side, leaving the
+        bound unset (semantically: that side of the window is unbounded).
+
+        Accepted formats per side: ``YYYY-MM-DD`` (date) or ``YYYY-QN`` with
+        ``N`` in 1–4 (quarter). Lower bound uses the unit's start (00:00:00
+        UTC); upper bound uses the unit's last day end (23:59:59 UTC). See
+        ``_parse_validity_bound`` for the per-format specifics.
+        """
+        match = _FRONT_MATTER_RE.match(content)
+        if not match:
+            return None, None
+        from_value: str | None = None
+        to_value: str | None = None
+        for line in match.group(1).splitlines():
+            stripped = line.strip()
+            if stripped.startswith("valid_from:"):
+                from_value = stripped[len("valid_from:") :].strip().strip("'\"")
+            elif stripped.startswith("valid_to:"):
+                to_value = stripped[len("valid_to:") :].strip().strip("'\"")
+        vfrom = _parse_validity_bound(from_value, upper=False) if from_value else None
+        vto = _parse_validity_bound(to_value, upper=True) if to_value else None
+        return vfrom, vto
 
     @classmethod
     def _extract_section_blockquote_tags(cls, text: str) -> tuple[list[str], str, int]:

--- a/packages/memtomem/src/memtomem/models.py
+++ b/packages/memtomem/src/memtomem/models.py
@@ -34,6 +34,10 @@ class ChunkMetadata:
     overlap_after: int = 0  # chars of overlap with next chunk
     parent_context: str = ""  # parent heading or document title
     file_context: str = ""  # filename + heading outline
+    # Validity window from frontmatter (RFC: temporal-validity).
+    # NULL means unbounded on that side; both NULL means always-valid.
+    valid_from_unix: int | None = None
+    valid_to_unix: int | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -721,9 +721,11 @@ class SqliteBackend(
                 if frag:
                     ns_clause = f"AND c.{frag}"
 
-            sql = f"""SELECT c.id, c.content, c.content_hash, c.source_file,
-                          c.heading_hierarchy, c.chunk_type, c.start_line, c.end_line,
-                          c.language, c.tags, c.namespace, c.created_at, c.updated_at, sub.rank
+            # ``c.*`` carries the full chunks-row layout into ``_row_to_chunk``
+            # so all defensive guards (overlap, importance, validity) activate.
+            # Score sits at the trailing position after the chunk columns —
+            # see ``_chunks_table_column_count`` consumer below.
+            sql = f"""SELECT c.*, sub.rank
                    FROM (
                        SELECT rowid, rank
                        FROM chunks_fts
@@ -748,8 +750,8 @@ class SqliteBackend(
 
         return [
             SearchResult(
-                chunk=self._row_to_chunk(row[:13]),
-                score=abs(row[13]),
+                chunk=self._row_to_chunk(row[:-1]),
+                score=abs(row[-1]),
                 rank=rank_idx + 1,
                 source="bm25",
             )
@@ -780,9 +782,7 @@ class SqliteBackend(
 
         try:
             rows = db.execute(
-                f"""SELECT c.id, c.content, c.content_hash, c.source_file,
-                          c.heading_hierarchy, c.chunk_type, c.start_line, c.end_line,
-                          c.language, c.tags, c.namespace, c.created_at, c.updated_at, sub.distance
+                f"""SELECT c.*, sub.distance
                    FROM (
                        SELECT rowid, distance
                        FROM chunks_vec
@@ -805,8 +805,8 @@ class SqliteBackend(
 
         return [
             SearchResult(
-                chunk=self._row_to_chunk(row[:13]),
-                score=1.0 / (1.0 + row[13]),
+                chunk=self._row_to_chunk(row[:-1]),
+                score=1.0 / (1.0 + row[-1]),
                 rank=rank_idx + 1,
                 source="dense",
             )

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -406,7 +406,8 @@ class SqliteBackend(
                 db.executemany(
                     """UPDATE chunks SET content=?, content_hash=?, source_file=?,
                        heading_hierarchy=?, chunk_type=?, start_line=?, end_line=?,
-                       language=?, tags=?, namespace=?, updated_at=?
+                       language=?, tags=?, namespace=?, updated_at=?,
+                       valid_from_unix=?, valid_to_unix=?
                        WHERE id=?""",
                     [
                         (
@@ -421,6 +422,8 @@ class SqliteBackend(
                             json.dumps(list(c.metadata.tags)),
                             c.metadata.namespace,
                             c.updated_at.isoformat(timespec="seconds"),
+                            c.metadata.valid_from_unix,
+                            c.metadata.valid_to_unix,
                             str(c.id),
                         )
                         for c, _ in to_update
@@ -450,8 +453,9 @@ class SqliteBackend(
                        (id, content, content_hash, source_file, heading_hierarchy,
                         chunk_type, start_line, end_line, language, tags,
                         namespace, created_at, updated_at,
-                        overlap_before, overlap_after)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        overlap_before, overlap_after,
+                        valid_from_unix, valid_to_unix)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     [
                         (
                             str(c.id),
@@ -469,6 +473,8 @@ class SqliteBackend(
                             c.updated_at.isoformat(timespec="seconds"),
                             c.metadata.overlap_before,
                             c.metadata.overlap_after,
+                            c.metadata.valid_from_unix,
+                            c.metadata.valid_to_unix,
                         )
                         for c in to_insert
                     ],
@@ -1113,6 +1119,14 @@ class SqliteBackend(
             ob = row[16] or 0
             oa = row[17] or 0
 
+        # Validity-window columns (may not exist in older DBs) — columns 19,20
+        # after importance_score (18). NULL → unbounded on that side.
+        vfrom: int | None = None
+        vto: int | None = None
+        if len(row) >= 21:
+            vfrom = row[19]
+            vto = row[20]
+
         metadata = ChunkMetadata(
             source_file=Path(source_file),
             heading_hierarchy=hh,
@@ -1124,6 +1138,8 @@ class SqliteBackend(
             namespace=namespace,
             overlap_before=ob,
             overlap_after=oa,
+            valid_from_unix=vfrom,
+            valid_to_unix=vto,
         )
 
         # --- timestamps (always timezone-aware) ---

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -112,6 +112,20 @@ def create_tables(
         if "duplicate column" not in str(e).lower():
             raise
 
+    # Idempotent migration: temporal-validity window columns (RFC: temporal-validity).
+    # NULL on either side means "no bound on this side"; both NULL means
+    # always-valid (RFC §Goal 4 — chunks without frontmatter validity fields
+    # stay backward-compatible).
+    for col_sql in (
+        "ALTER TABLE chunks ADD COLUMN valid_from_unix INTEGER",
+        "ALTER TABLE chunks ADD COLUMN valid_to_unix INTEGER",
+    ):
+        try:
+            db.execute(col_sql)
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e).lower():
+                raise
+
     db.execute("""
         CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts
         USING fts5(content, source_file, tokenize='unicode61')

--- a/packages/memtomem/tests/test_temporal_validity.py
+++ b/packages/memtomem/tests/test_temporal_validity.py
@@ -6,17 +6,25 @@ Covers Goals 1+2+3 of the temporal-validity RFC: the frontmatter parser
 migration that adds the two SQLite columns, and the chunker→metadata wiring.
 The pipeline filter, ``mem_search(as_of=...)``, and CLI/Web surfaces are
 covered by later RFC PRs.
+
+The search round-trip tests at the end of the file lock in the fix for
+PR #533 review feedback — bm25_search / dense_search must carry the new
+columns through ``_row_to_chunk`` so the upcoming validity_filter stage
+can rely on chunks emerging from the search path with their windows
+intact.
 """
 
 from __future__ import annotations
 
 import sqlite3
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
 import sqlite_vec
 
 from memtomem.chunking.markdown import MarkdownChunker, _parse_validity_bound
+from memtomem.models import Chunk, ChunkMetadata
 from memtomem.storage.sqlite_meta import MetaManager
 from memtomem.storage.sqlite_schema import create_tables
 
@@ -204,3 +212,88 @@ class TestSchemaMigration:
             _initialize(db)  # must not raise
         finally:
             db.close()
+
+
+def _chunk_with_validity(
+    *,
+    content: str,
+    valid_from_unix: int | None,
+    valid_to_unix: int | None,
+    embedding: list[float] | None = None,
+) -> Chunk:
+    """Build a Chunk that carries an explicit validity window.
+
+    Used by the search round-trip tests below — ``helpers.make_chunk`` does
+    not surface the new fields, and broadening that helper is out of scope
+    for this PR.
+    """
+    return Chunk(
+        content=content,
+        metadata=ChunkMetadata(
+            source_file=Path("/tmp/validity-search.md"),
+            valid_from_unix=valid_from_unix,
+            valid_to_unix=valid_to_unix,
+        ),
+        content_hash=f"hash-{uuid.uuid4().hex[:8]}",
+        embedding=embedding if embedding is not None else [0.1] * 1024,
+    )
+
+
+class TestSearchRoundTrip:
+    """Search results must carry validity columns through ``_row_to_chunk``.
+
+    PR #533 review uncovered that ``bm25_search`` / ``dense_search`` were
+    SELECTing only 13 chunk columns and slicing ``row[:13]`` to
+    ``_row_to_chunk``, so the ``len(row) >= 21`` guard never tripped and
+    every search-derived chunk carried ``valid_from_unix=None`` regardless
+    of what was stored. The fix switches both queries to ``SELECT c.*`` so
+    the full row reaches the deserializer. These tests lock that in.
+    """
+
+    async def test_bm25_search_preserves_validity_window(self, storage) -> None:
+        vfrom = _ts(2025, 8, 15, 0, 0, 0)
+        vto = _ts(2026, 3, 31, 23, 59, 59)
+        chunk = _chunk_with_validity(
+            content="quarterly policy bm25 marker",
+            valid_from_unix=vfrom,
+            valid_to_unix=vto,
+        )
+        await storage.upsert_chunks([chunk])
+
+        results = await storage.bm25_search("quarterly policy bm25 marker", top_k=5)
+        assert results, "BM25 search must return the seeded chunk"
+        assert results[0].chunk.metadata.valid_from_unix == vfrom
+        assert results[0].chunk.metadata.valid_to_unix == vto
+
+    async def test_dense_search_preserves_validity_window(self, storage) -> None:
+        vfrom = _ts(2025, 1, 1, 0, 0, 0)
+        vto = _ts(2025, 12, 31, 23, 59, 59)
+        emb = [0.2 + i * 0.0001 for i in range(1024)]
+        chunk = _chunk_with_validity(
+            content="dense-search validity target",
+            valid_from_unix=vfrom,
+            valid_to_unix=vto,
+            embedding=emb,
+        )
+        await storage.upsert_chunks([chunk])
+
+        results = await storage.dense_search(emb, top_k=5)
+        assert results, "Dense search must return the seeded chunk"
+        assert results[0].chunk.metadata.valid_from_unix == vfrom
+        assert results[0].chunk.metadata.valid_to_unix == vto
+
+    async def test_bm25_search_returns_none_pair_for_unset_chunks(self, storage) -> None:
+        """A chunk written without validity stays unbounded through search —
+        confirms ``SELECT c.*`` did not silently fabricate values for the
+        always-valid (None, None) backward-compat default."""
+        chunk = _chunk_with_validity(
+            content="no-validity bm25 marker",
+            valid_from_unix=None,
+            valid_to_unix=None,
+        )
+        await storage.upsert_chunks([chunk])
+
+        results = await storage.bm25_search("no-validity bm25 marker", top_k=5)
+        assert results
+        assert results[0].chunk.metadata.valid_from_unix is None
+        assert results[0].chunk.metadata.valid_to_unix is None

--- a/packages/memtomem/tests/test_temporal_validity.py
+++ b/packages/memtomem/tests/test_temporal_validity.py
@@ -1,0 +1,206 @@
+"""Frontmatter validity-window parsing, schema, and indexer-level threading.
+
+Covers Goals 1+2+3 of the temporal-validity RFC: the frontmatter parser
+(``_parse_validity_bound`` / ``_extract_validity_window``), the
+``ChunkMetadata.valid_from_unix`` / ``valid_to_unix`` fields, the schema
+migration that adds the two SQLite columns, and the chunker→metadata wiring.
+The pipeline filter, ``mem_search(as_of=...)``, and CLI/Web surfaces are
+covered by later RFC PRs.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import sqlite_vec
+
+from memtomem.chunking.markdown import MarkdownChunker, _parse_validity_bound
+from memtomem.storage.sqlite_meta import MetaManager
+from memtomem.storage.sqlite_schema import create_tables
+
+_extract_validity_window_for_test = MarkdownChunker._extract_validity_window
+
+
+def _ts(year: int, month: int, day: int, hour: int = 0, minute: int = 0, sec: int = 0) -> int:
+    return int(datetime(year, month, day, hour, minute, sec, tzinfo=timezone.utc).timestamp())
+
+
+class TestParseValidityBoundDate:
+    def test_date_lower_bound_is_day_start_utc(self) -> None:
+        assert _parse_validity_bound("2025-08-15", upper=False) == _ts(2025, 8, 15, 0, 0, 0)
+
+    def test_date_upper_bound_is_day_end_utc(self) -> None:
+        assert _parse_validity_bound("2025-08-15", upper=True) == _ts(2025, 8, 15, 23, 59, 59)
+
+    def test_invalid_month_returns_none(self) -> None:
+        assert _parse_validity_bound("2025-13-01", upper=False) is None
+
+    def test_invalid_day_returns_none(self) -> None:
+        assert _parse_validity_bound("2025-02-30", upper=True) is None
+
+    def test_garbage_returns_none(self) -> None:
+        assert _parse_validity_bound("not-a-date", upper=False) is None
+        assert _parse_validity_bound("", upper=True) is None
+
+
+class TestParseValidityBoundQuarter:
+    def test_q1_lower_is_jan_1(self) -> None:
+        assert _parse_validity_bound("2025-Q1", upper=False) == _ts(2025, 1, 1, 0, 0, 0)
+
+    def test_q1_upper_is_mar_31_end_of_day(self) -> None:
+        assert _parse_validity_bound("2025-Q1", upper=True) == _ts(2025, 3, 31, 23, 59, 59)
+
+    def test_q3_lower_is_jul_1(self) -> None:
+        assert _parse_validity_bound("2025-Q3", upper=False) == _ts(2025, 7, 1, 0, 0, 0)
+
+    def test_q4_upper_crosses_year_boundary(self) -> None:
+        """Q4 ends Dec 31 — check the year-rollover branch in the parser."""
+        assert _parse_validity_bound("2025-Q4", upper=True) == _ts(2025, 12, 31, 23, 59, 59)
+
+    def test_invalid_quarter_zero_returns_none(self) -> None:
+        assert _parse_validity_bound("2025-Q0", upper=False) is None
+
+    def test_invalid_quarter_five_returns_none(self) -> None:
+        assert _parse_validity_bound("2025-Q5", upper=True) is None
+
+
+class TestExtractValidityWindow:
+    def test_no_frontmatter_returns_none_pair(self) -> None:
+        vfrom, vto = _extract_validity_window_for_test("# Heading\n\nbody\n")
+        assert vfrom is None and vto is None
+
+    def test_frontmatter_without_validity_keys_returns_none_pair(self) -> None:
+        content = "---\ntags: [a, b]\n---\n\n# H\n"
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom is None and vto is None
+
+    def test_only_valid_from_present(self) -> None:
+        content = "---\nvalid_from: 2025-08-15\n---\n\nbody\n"
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom == _ts(2025, 8, 15, 0, 0, 0)
+        assert vto is None
+
+    def test_only_valid_to_present(self) -> None:
+        content = "---\nvalid_to: 2026-Q1\n---\n\nbody\n"
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom is None
+        assert vto == _ts(2026, 3, 31, 23, 59, 59)
+
+    def test_both_fields_present(self) -> None:
+        content = "---\nvalid_from: 2025-08-15\nvalid_to: 2026-Q1\n---\n\nbody\n"
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom == _ts(2025, 8, 15, 0, 0, 0)
+        assert vto == _ts(2026, 3, 31, 23, 59, 59)
+
+    def test_quoted_values_parse(self) -> None:
+        """YAML allows quoted scalars — strip surrounding quotes before parsing."""
+        content = "---\nvalid_from: '2025-08-15'\nvalid_to: \"2026-Q1\"\n---\n\nbody\n"
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom == _ts(2025, 8, 15, 0, 0, 0)
+        assert vto == _ts(2026, 3, 31, 23, 59, 59)
+
+    def test_malformed_value_drops_only_that_side(self) -> None:
+        """A typo on one side must not poison the other side."""
+        content = "---\nvalid_from: 2025-13-01\nvalid_to: 2026-Q1\n---\n\nbody\n"
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom is None
+        assert vto == _ts(2026, 3, 31, 23, 59, 59)
+
+    def test_other_frontmatter_keys_coexist(self) -> None:
+        content = (
+            "---\n"
+            "tags: [policy]\n"
+            "valid_from: 2025-08-15\n"
+            "valid_to: 2026-Q1\n"
+            "---\n"
+            "\n# Heading\nbody\n"
+        )
+        vfrom, vto = _extract_validity_window_for_test(content)
+        assert vfrom == _ts(2025, 8, 15, 0, 0, 0)
+        assert vto == _ts(2026, 3, 31, 23, 59, 59)
+
+
+class TestChunkerWiring:
+    def test_validity_propagates_to_every_chunk(self) -> None:
+        """File-level validity attaches to every chunk produced from the file."""
+        content = (
+            "---\n"
+            "valid_from: 2025-08-15\n"
+            "valid_to: 2026-Q1\n"
+            "---\n"
+            "\n"
+            "# Section A\n"
+            "alpha body.\n"
+            "\n"
+            "# Section B\n"
+            "beta body.\n"
+        )
+        chunks = MarkdownChunker().chunk_file(Path("/test.md"), content)
+        assert chunks, "chunker must produce at least one chunk"
+        for c in chunks:
+            assert c.metadata.valid_from_unix == _ts(2025, 8, 15, 0, 0, 0)
+            assert c.metadata.valid_to_unix == _ts(2026, 3, 31, 23, 59, 59)
+
+    def test_no_frontmatter_means_both_none(self) -> None:
+        content = "# Heading\n\nbody\n"
+        chunks = MarkdownChunker().chunk_file(Path("/test.md"), content)
+        assert chunks
+        for c in chunks:
+            assert c.metadata.valid_from_unix is None
+            assert c.metadata.valid_to_unix is None
+
+    def test_only_valid_from_propagates_partial_window(self) -> None:
+        content = "---\nvalid_from: 2025-08-15\n---\n\n# H\n\nbody\n"
+        chunks = MarkdownChunker().chunk_file(Path("/test.md"), content)
+        assert chunks
+        for c in chunks:
+            assert c.metadata.valid_from_unix == _ts(2025, 8, 15, 0, 0, 0)
+            assert c.metadata.valid_to_unix is None
+
+
+def _connect_with_vec() -> sqlite3.Connection:
+    db = sqlite3.connect(":memory:")
+    db.enable_load_extension(True)
+    sqlite_vec.load(db)
+    db.enable_load_extension(False)
+    return db
+
+
+def _initialize(db: sqlite3.Connection) -> None:
+    meta = MetaManager(lambda: db)
+    create_tables(
+        db,
+        meta,
+        dimension=0,
+        embedding_provider="none",
+        embedding_model="",
+    )
+
+
+class TestSchemaMigration:
+    def test_columns_added_with_correct_type_and_nullable(self) -> None:
+        db = _connect_with_vec()
+        try:
+            _initialize(db)
+            cols = {row[1]: row for row in db.execute("PRAGMA table_info(chunks)").fetchall()}
+            assert "valid_from_unix" in cols
+            assert "valid_to_unix" in cols
+            # PRAGMA table_info row: (cid, name, type, notnull, dflt_value, pk)
+            assert cols["valid_from_unix"][2].upper() == "INTEGER"
+            assert cols["valid_to_unix"][2].upper() == "INTEGER"
+            assert cols["valid_from_unix"][3] == 0, "must be nullable (notnull=0)"
+            assert cols["valid_to_unix"][3] == 0, "must be nullable (notnull=0)"
+        finally:
+            db.close()
+
+    def test_create_tables_is_idempotent(self) -> None:
+        """Re-running ``create_tables`` on the same DB must not error on the
+        ``ALTER TABLE ADD COLUMN`` for the new validity columns."""
+        db = _connect_with_vec()
+        try:
+            _initialize(db)
+            _initialize(db)  # must not raise
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

- First-cut of the temporal-validity RFC Goals 1+2+3: frontmatter parser, schema migration, and indexer threading.
- Adds `valid_from` / `valid_to` parsing for `YYYY-MM-DD` (date-only) and `YYYY-QN` (quarter) formats; surfaces the parsed window on `ChunkMetadata` and persists it to two new `chunks` columns (`valid_from_unix`, `valid_to_unix`).
- No user-visible behaviour change yet — chunks without frontmatter validity stay always-valid (RFC §Goal 4 backward-compat). The pipeline `validity_filter` stage, `mem_search(as_of=...)`, the `mm search --as-of` CLI flag, and the Web UI badge land in follow-up PRs.

## Design choices worth noting

- **Inclusive-end semantics**: lower bound = unit start (00:00:00 UTC), upper bound = unit's last day end (23:59:59 UTC). Matches the user mental model in the RFC ("from Aug 15" = the whole day Aug 15 onward).
- **Liberal parser**: a malformed value on one side returns `None` for that side without poisoning the other or aborting indexing. A typo in `valid_from` should not block a file from being indexed.
- **`UPDATE` includes the new columns**: same pattern as `tags` (also frontmatter-derived). This means reindex propagates frontmatter validity edits to chunks whose `content_hash` did not change — otherwise an editor changing only the validity window would see no effect on body chunks.

## RFC reference

`memtomem-docs/memtomem/planning/temporal-validity-rfc.md` (commit `297470a` on `memtomem-docs` main). Goals 1+2+3 only.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_temporal_validity.py` — 24 / 24 pass.
- [x] Touched-module regression sweep (`test_chunking`, `test_chunking_blockquote_tags`, `test_chunkers_extended`, `test_storage`, `test_storage_extended`, `test_storage_noop`, `test_sqlite_schema`, `test_chunk_links_schema`, `test_temporal_validity`) — 143 / 143 pass.
- [x] `uv run ruff check` + `uv run ruff format --check` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
