### PR TITLE
feat(search): add temporal-validity filter stage to pipeline (Goal 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,8 @@ for `memtomem` and both resolve to `memtomem.cli:cli`.
   in sync, don't diverge behavior or add flags to only one name.
 - **Search pipeline order is fixed**: query expansion → BM25 + dense (parallel)
   → RRF fusion → cross-encoder rerank (optional) → source/tag filter →
-  time-decay → MMR → access-freq boost → importance boost → context-window
-  expansion. Don't reorder stages in
+  validity filter → time-decay → MMR → access-freq boost → importance boost →
+  context-window expansion. Don't reorder stages in
   `packages/memtomem/src/memtomem/search/pipeline.py` without updating the
   Stage comments in that file.
 - **MCP tools go through the registry.** New tools use `@register` from

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -44,6 +44,38 @@ def _match_source(filter_str: str, source_path: str) -> bool:
     return filter_str in source_path
 
 
+def _apply_validity_filter(results: list[SearchResult], as_of_unix: int) -> list[SearchResult]:
+    """Drop chunks whose temporal-validity window excludes ``as_of_unix``.
+
+    Inclusive on both ends (``valid_from <= as_of <= valid_to``); ``None`` on
+    a bound means unbounded on that side; both ``None`` means always-valid
+    (RFC §Comparison semantics — opt-in default for chunks without a window).
+
+    Order is preserved. The function returns a new list so callers can
+    chain it after source/tag filter without mutating the input.
+
+    Granularity note: when the pipeline falls back to the default
+    ``int(time.time())``, results may be served from the search-result TTL
+    cache for up to ``cache_ttl`` seconds. A chunk whose window expires at
+    midnight can therefore continue to surface for the cache-TTL window
+    after expiry. This is acceptable because the RFC's date-only bounds
+    already operate at 24h granularity; sub-minute drift is invisible at
+    that resolution.
+    """
+    filtered: list[SearchResult] = []
+    for r in results:
+        vfrom = r.chunk.metadata.valid_from_unix
+        vto = r.chunk.metadata.valid_to_unix
+        if vfrom is None and vto is None:
+            filtered.append(r)
+            continue
+        lower = vfrom if vfrom is not None else float("-inf")
+        upper = vto if vto is not None else float("inf")
+        if lower <= as_of_unix <= upper:
+            filtered.append(r)
+    return filtered
+
+
 @dataclass
 class RetrievalStats:
     bm25_candidates: int = 0
@@ -331,6 +363,7 @@ class SearchPipeline:
         namespace: str | list[str] | None = None,
         rrf_weights: list[float] | None = None,
         context_window: int | None = None,
+        as_of_unix: int | None = None,
     ) -> tuple[list[SearchResult], RetrievalStats]:
         top_k = self._config.default_top_k if top_k is None else top_k
         effective_weights = rrf_weights or self._config.rrf_weights
@@ -338,12 +371,18 @@ class SearchPipeline:
         # Check TTL cache for identical queries
         import time
 
+        # ``as_of_unix`` is intentionally excluded from ``cache_key`` and
+        # bypasses the cache entirely when explicit. Default-path (None)
+        # callers fall through to ``int(time.time())`` below and reuse
+        # cached results within ``cache_ttl`` — accepting up-to-TTL
+        # staleness near a date boundary, which the RFC's date-only
+        # bounds already absorb.
         cache_key = self._cache_key(
             query, top_k, source_filter, tag_filter, namespace, context_window
         )
         version_at_start = self._cache_version
         ttl_snapshot = self._cache_ttl
-        if cache_key in self._search_cache:
+        if as_of_unix is None and cache_key in self._search_cache:
             ts, ver, cached_results, cached_stats = self._search_cache[cache_key]
             if ver == self._cache_version and time.time() - ts < ttl_snapshot:
                 return cached_results, cached_stats
@@ -574,6 +613,15 @@ class SearchPipeline:
             required = {t.strip() for t in tag_filter.split(",") if t.strip()}
             fused = [r for r in fused if required & set(r.chunk.metadata.tags)]
 
+        # Stage β': temporal-validity filter (RFC §Pipeline integration).
+        # AND-combined with source/tag filter via sequential application —
+        # a chunk must pass both to survive. Default ``as_of`` is the
+        # current wall-clock; explicit values bypass the result cache so
+        # historical queries don't poison default-path cache slots.
+        effective_as_of = as_of_unix if as_of_unix is not None else int(time.time())
+        if fused:
+            fused = _apply_validity_filter(fused, effective_as_of)
+
         # Stage 4: Time decay (re-score older chunks lower)
         if self._decay_config.enabled and fused:
             from memtomem.search.decay import apply_score_decay
@@ -662,8 +710,12 @@ class SearchPipeline:
         self._bg_tasks.add(t2)
         t2.add_done_callback(self._bg_tasks.discard)
 
-        # Store in TTL cache only if version hasn't changed during search
-        if self._cache_version == version_at_start:
+        # Store in TTL cache only if version hasn't changed during search.
+        # Skip the write when ``as_of_unix`` was explicit so that a
+        # historical-query result never overwrites the default-path slot
+        # (next default caller would otherwise be served a past-snapshot
+        # filtering of the same query).
+        if as_of_unix is None and self._cache_version == version_at_start:
             self._search_cache[cache_key] = (time.time(), version_at_start, fused, stats)
             # Evict old entries (keep max 50)
             if len(self._search_cache) > 50:

--- a/packages/memtomem/tests/test_temporal_validity.py
+++ b/packages/memtomem/tests/test_temporal_validity.py
@@ -442,8 +442,6 @@ class TestValidityFilterPipelineWiring:
         2024–2025 and one valid for 2030 only — only the 2024–2025 chunk
         should survive.
         """
-        import memtomem.search.pipeline as pipeline_mod
-
         in_window = _result_with_window(
             _ts(2024, 1, 1), _ts(2025, 12, 31, 23, 59, 59), marker="now"
         )
@@ -459,8 +457,6 @@ class TestValidityFilterPipelineWiring:
 
         results, _stats = await pipe.search("anything", top_k=5)
         assert [r.chunk.content for r in results] == ["chunk-now"]
-        # Sanity: confirm we didn't accidentally short-circuit the filter.
-        assert pipeline_mod._apply_validity_filter is not None
 
     @pytest.mark.asyncio
     async def test_explicit_as_of_unix_filters_window(self) -> None:
@@ -511,7 +507,13 @@ class TestValidityFilterPipelineWiring:
 
     @pytest.mark.asyncio
     async def test_default_path_caches_filtered_result(self, monkeypatch) -> None:
-        """Two default-path calls — second hits cache (BM25 only invoked once)."""
+        """Two default-path calls — second hits cache (BM25 only invoked once).
+
+        TTL expiry is not exercised here — pinning ``time.time`` to a constant
+        keeps both calls inside the cache window by construction. The
+        meaningful assertion is the reuse path (one storage call across two
+        searches), not the TTL boundary.
+        """
         import time as _time
 
         monkeypatch.setattr(_time, "time", lambda: float(_ts(2025, 6, 15)))

--- a/packages/memtomem/tests/test_temporal_validity.py
+++ b/packages/memtomem/tests/test_temporal_validity.py
@@ -1,17 +1,17 @@
-"""Frontmatter validity-window parsing, schema, and indexer-level threading.
+"""Frontmatter validity-window parsing, schema, indexer threading, and pipeline filter.
 
-Covers Goals 1+2+3 of the temporal-validity RFC: the frontmatter parser
+Covers Goals 1+2+3+4 of the temporal-validity RFC: the frontmatter parser
 (``_parse_validity_bound`` / ``_extract_validity_window``), the
 ``ChunkMetadata.valid_from_unix`` / ``valid_to_unix`` fields, the schema
-migration that adds the two SQLite columns, and the chunker→metadata wiring.
-The pipeline filter, ``mem_search(as_of=...)``, and CLI/Web surfaces are
-covered by later RFC PRs.
+migration that adds the two SQLite columns, the chunker→metadata wiring,
+and the ``_apply_validity_filter`` pipeline stage with its
+``SearchPipeline.search(as_of_unix=...)`` plumbing. The
+``mem_search(as_of=...)`` MCP/CLI/Web surfaces are covered by later RFC PRs.
 
-The search round-trip tests at the end of the file lock in the fix for
-PR #533 review feedback — bm25_search / dense_search must carry the new
-columns through ``_row_to_chunk`` so the upcoming validity_filter stage
-can rely on chunks emerging from the search path with their windows
-intact.
+The search round-trip tests in the middle of the file lock in the fix
+for PR #533 review feedback — bm25_search / dense_search must carry the
+new columns through ``_row_to_chunk`` so the validity_filter stage can
+rely on chunks emerging from the search path with their windows intact.
 """
 
 from __future__ import annotations
@@ -21,10 +21,11 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
 import sqlite_vec
 
 from memtomem.chunking.markdown import MarkdownChunker, _parse_validity_bound
-from memtomem.models import Chunk, ChunkMetadata
+from memtomem.models import Chunk, ChunkMetadata, SearchResult
 from memtomem.storage.sqlite_meta import MetaManager
 from memtomem.storage.sqlite_schema import create_tables
 
@@ -297,3 +298,265 @@ class TestSearchRoundTrip:
         assert results
         assert results[0].chunk.metadata.valid_from_unix is None
         assert results[0].chunk.metadata.valid_to_unix is None
+
+
+# ── Goal 4: pipeline-level validity_filter ─────────────────────────────
+
+
+def _result_with_window(vfrom: int | None, vto: int | None, *, marker: str = "x") -> SearchResult:
+    """Build a minimal SearchResult carrying a validity window for filter tests."""
+    chunk = Chunk(
+        content=f"chunk-{marker}",
+        metadata=ChunkMetadata(
+            source_file=Path(f"/tmp/{marker}.md"),
+            valid_from_unix=vfrom,
+            valid_to_unix=vto,
+        ),
+        id=uuid.uuid4(),
+        embedding=[],
+    )
+    return SearchResult(chunk=chunk, score=1.0, rank=1, source="fused")
+
+
+class TestApplyValidityFilter:
+    """Unit tests for the pure ``_apply_validity_filter`` helper.
+
+    Locks the RFC §Design semantics: inclusive both ends, ``None`` =
+    unbounded on that side, ``(None, None)`` = always-valid (opt-in
+    default), order preservation.
+    """
+
+    def _filter(self, results, as_of_unix):
+        from memtomem.search.pipeline import _apply_validity_filter
+
+        return _apply_validity_filter(results, as_of_unix)
+
+    def test_inside_window_passes(self) -> None:
+        r = _result_with_window(_ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59))
+        assert self._filter([r], _ts(2025, 6, 15)) == [r]
+
+    def test_before_window_excluded(self) -> None:
+        r = _result_with_window(_ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59))
+        assert self._filter([r], _ts(2024, 12, 31)) == []
+
+    def test_after_window_excluded(self) -> None:
+        r = _result_with_window(_ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59))
+        assert self._filter([r], _ts(2026, 1, 1)) == []
+
+    def test_boundary_lower_inclusive(self) -> None:
+        """``as_of == valid_from`` is inside (RFC §Comparison semantics)."""
+        vfrom = _ts(2025, 1, 1)
+        r = _result_with_window(vfrom, _ts(2025, 12, 31, 23, 59, 59))
+        assert self._filter([r], vfrom) == [r]
+
+    def test_boundary_upper_inclusive(self) -> None:
+        """``as_of == valid_to`` is inside (RFC §Comparison semantics)."""
+        vto = _ts(2025, 12, 31, 23, 59, 59)
+        r = _result_with_window(_ts(2025, 1, 1), vto)
+        assert self._filter([r], vto) == [r]
+
+    def test_half_bounded_lower_only(self) -> None:
+        """``valid_from`` only — passes for any ``as_of >= valid_from``."""
+        vfrom = _ts(2025, 1, 1)
+        r = _result_with_window(vfrom, None)
+        assert self._filter([r], vfrom) == [r]
+        assert self._filter([r], _ts(2099, 1, 1)) == [r]
+        assert self._filter([r], _ts(2024, 12, 31)) == []
+
+    def test_half_bounded_upper_only(self) -> None:
+        """``valid_to`` only — passes for any ``as_of <= valid_to``."""
+        vto = _ts(2025, 12, 31, 23, 59, 59)
+        r = _result_with_window(None, vto)
+        assert self._filter([r], vto) == [r]
+        assert self._filter([r], _ts(1970, 1, 1)) == [r]
+        assert self._filter([r], _ts(2026, 1, 1)) == []
+
+    def test_always_valid_passes(self) -> None:
+        """``(None, None)`` is the opt-in default — always retained."""
+        r = _result_with_window(None, None)
+        # Both a "now" and a "long-ago" as_of must keep it.
+        assert self._filter([r], _ts(2025, 6, 15)) == [r]
+        assert self._filter([r], _ts(1970, 1, 1)) == [r]
+
+    def test_order_preserved(self) -> None:
+        """Filter must not reorder survivors — downstream stages depend on rank order."""
+        r1 = _result_with_window(_ts(2024, 1, 1), _ts(2026, 1, 1), marker="a")
+        r2 = _result_with_window(None, None, marker="b")
+        r3 = _result_with_window(_ts(2024, 1, 1), _ts(2026, 1, 1), marker="c")
+        out = self._filter([r1, r2, r3], _ts(2025, 6, 15))
+        assert [r.chunk.content for r in out] == ["chunk-a", "chunk-b", "chunk-c"]
+
+    def test_excluded_chunks_removed_in_mixed_input(self) -> None:
+        """Survivors and rejects mixed in one pass; rejects drop, survivors keep order."""
+        keep1 = _result_with_window(_ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59), marker="k1")
+        drop = _result_with_window(_ts(2020, 1, 1), _ts(2020, 12, 31, 23, 59, 59), marker="d")
+        keep2 = _result_with_window(None, None, marker="k2")
+        out = self._filter([keep1, drop, keep2], _ts(2025, 6, 15))
+        assert [r.chunk.content for r in out] == ["chunk-k1", "chunk-k2"]
+
+
+# ── Goal 4: pipeline wiring (as_of_unix plumbing + cache semantics) ────
+
+
+def _make_validity_pipeline(bm25_results):
+    """SearchPipeline wired around AsyncMock storage with controllable BM25 hits.
+
+    Mirrors the fixture pattern in ``tests/test_pipeline.py`` — the
+    pipeline is exercised end-to-end so the filter wiring (call site,
+    cache gating) is verified against the real ``SearchPipeline.search``
+    code path, not a re-implemented stub.
+    """
+    from unittest.mock import AsyncMock
+
+    from memtomem.config import SearchConfig
+    from memtomem.search.pipeline import SearchPipeline
+
+    storage = AsyncMock()
+    storage.bm25_search = AsyncMock(return_value=bm25_results)
+    storage.dense_search = AsyncMock(return_value=[])
+    storage.increment_access = AsyncMock()
+    storage.save_query_history = AsyncMock()
+    storage.get_access_counts = AsyncMock(return_value={})
+    storage.get_embeddings_for_chunks = AsyncMock(return_value={})
+    storage.get_importance_scores = AsyncMock(return_value={})
+    storage.count_chunks_by_ns_prefix = AsyncMock(return_value=0)
+
+    embedder = AsyncMock()
+    embedder.embed_query = AsyncMock(return_value=[0.1] * 8)
+
+    return SearchPipeline(
+        storage=storage,
+        embedder=embedder,
+        config=SearchConfig(enable_bm25=True, enable_dense=False),
+    )
+
+
+class TestValidityFilterPipelineWiring:
+    """Integration tests for ``as_of_unix`` plumbing through ``SearchPipeline.search``."""
+
+    @pytest.mark.asyncio
+    async def test_default_uses_current_time(self, monkeypatch) -> None:
+        """``as_of_unix=None`` falls back to ``int(time.time())`` at call site.
+
+        Pin time to 2025-06-15 via monkeypatch and seed one chunk valid for
+        2024–2025 and one valid for 2030 only — only the 2024–2025 chunk
+        should survive.
+        """
+        import memtomem.search.pipeline as pipeline_mod
+
+        in_window = _result_with_window(
+            _ts(2024, 1, 1), _ts(2025, 12, 31, 23, 59, 59), marker="now"
+        )
+        future = _result_with_window(_ts(2030, 1, 1), _ts(2030, 12, 31, 23, 59, 59), marker="fut")
+
+        pipe = _make_validity_pipeline([in_window, future])
+        # Patch the module-level ``time`` import that ``search()`` uses.
+        # ``search`` calls ``import time; time.time()`` so we patch
+        # ``time.time`` directly inside that module's import cache.
+        import time as _time
+
+        monkeypatch.setattr(_time, "time", lambda: float(_ts(2025, 6, 15)))
+
+        results, _stats = await pipe.search("anything", top_k=5)
+        assert [r.chunk.content for r in results] == ["chunk-now"]
+        # Sanity: confirm we didn't accidentally short-circuit the filter.
+        assert pipeline_mod._apply_validity_filter is not None
+
+    @pytest.mark.asyncio
+    async def test_explicit_as_of_unix_filters_window(self) -> None:
+        """Explicit historical ``as_of_unix`` retains chunks valid at that instant."""
+        in_2024 = _result_with_window(_ts(2024, 1, 1), _ts(2024, 12, 31, 23, 59, 59), marker="2024")
+        in_2025 = _result_with_window(_ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59), marker="2025")
+
+        pipe = _make_validity_pipeline([in_2024, in_2025])
+
+        results, _stats = await pipe.search("anything", top_k=5, as_of_unix=_ts(2024, 6, 15))
+        assert [r.chunk.content for r in results] == ["chunk-2024"]
+
+    @pytest.mark.asyncio
+    async def test_and_with_source_filter(self) -> None:
+        """Validity AND source filter — chunk must pass both to survive."""
+        # Rebuild with explicit source paths so source_filter discriminates them.
+
+        def _make(marker, source, vfrom, vto):
+            chunk = Chunk(
+                content=f"chunk-{marker}",
+                metadata=ChunkMetadata(
+                    source_file=Path(source),
+                    valid_from_unix=vfrom,
+                    valid_to_unix=vto,
+                ),
+                id=uuid.uuid4(),
+                embedding=[],
+            )
+            return SearchResult(chunk=chunk, score=1.0, rank=1, source="fused")
+
+        keeps_both = _make(
+            "ok", "/tmp/keep/policy.md", _ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59)
+        )
+        passes_validity_fails_source = _make(
+            "src-fail", "/tmp/other/policy.md", _ts(2025, 1, 1), _ts(2025, 12, 31, 23, 59, 59)
+        )
+        passes_source_fails_validity = _make(
+            "val-fail", "/tmp/keep/expired.md", _ts(2020, 1, 1), _ts(2020, 12, 31, 23, 59, 59)
+        )
+
+        pipe = _make_validity_pipeline(
+            [keeps_both, passes_validity_fails_source, passes_source_fails_validity]
+        )
+        results, _stats = await pipe.search(
+            "anything", top_k=5, source_filter="/tmp/keep/", as_of_unix=_ts(2025, 6, 15)
+        )
+        assert [r.chunk.content for r in results] == ["chunk-ok"]
+
+    @pytest.mark.asyncio
+    async def test_default_path_caches_filtered_result(self, monkeypatch) -> None:
+        """Two default-path calls — second hits cache (BM25 only invoked once)."""
+        import time as _time
+
+        monkeypatch.setattr(_time, "time", lambda: float(_ts(2025, 6, 15)))
+
+        in_window = _result_with_window(
+            _ts(2024, 1, 1), _ts(2025, 12, 31, 23, 59, 59), marker="cached"
+        )
+        pipe = _make_validity_pipeline([in_window])
+
+        first, _ = await pipe.search("same query", top_k=5)
+        second, _ = await pipe.search("same query", top_k=5)
+
+        assert [r.chunk.content for r in first] == ["chunk-cached"]
+        assert [r.chunk.content for r in second] == ["chunk-cached"]
+        # BM25 storage call invoked exactly once across two searches.
+        assert pipe._storage.bm25_search.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_as_of_bypasses_cache_read_and_write(self) -> None:
+        """Explicit ``as_of_unix`` bypasses both cache read and cache write.
+
+        Read bypass: an explicit call must not be served from a previously
+        cached default-path result.
+        Write bypass: an explicit call must not poison the default-path
+        slot — a subsequent default call still runs the retrieval.
+        """
+        in_window = _result_with_window(
+            _ts(2024, 1, 1), _ts(2025, 12, 31, 23, 59, 59), marker="hot"
+        )
+        pipe = _make_validity_pipeline([in_window])
+
+        # 1) Explicit-only call — must not write to cache.
+        await pipe.search("q", top_k=5, as_of_unix=_ts(2024, 6, 15))
+        assert pipe._search_cache == {}, "explicit as_of must not populate cache"
+
+        # 2) Default call following an explicit call — must still hit storage.
+        before = pipe._storage.bm25_search.await_count
+        await pipe.search("q", top_k=5)
+        assert pipe._storage.bm25_search.await_count == before + 1
+        assert pipe._search_cache, "default-path call must populate cache"
+
+        # 3) Default-path cache populated; an explicit call must bypass read
+        #    (storage hit again, not served from default-path slot).
+        before = pipe._storage.bm25_search.await_count
+        await pipe.search("q", top_k=5, as_of_unix=_ts(2024, 6, 15))
+        assert pipe._storage.bm25_search.await_count == before + 1, (
+            "explicit as_of must bypass cache read"
+        )


### PR DESCRIPTION
## Summary

Implements RFC §Pipeline integration of the temporal-validity feature.
Goal 1+2+3 (#533) wired the metadata through the indexer; this PR adds
the actual filter stage so chunks with expired / not-yet-active
windows are dropped from search results.

- New `_apply_validity_filter` helper in `search/pipeline.py` —
  inclusive both ends, `None` = unbounded, `(None, None)` = always-valid.
- Wired into `SearchPipeline.search()` at the **β position**: AND-combined with
  source/tag filter, before time-decay. Pipeline order:
  `... → rerank → source/tag filter → validity_filter → time-decay → MMR → ...`
- New `as_of_unix: int | None = None` parameter on the pipeline entry
  point. `None` falls back to `int(time.time())`; explicit values bypass
  cache read AND write.
- CLAUDE.md "Search pipeline order" invariant updated.

## Cache semantics (Option A — explicit bypass, default cached)

| Path | Cache read | Cache write | Rationale |
| --- | --- | --- | --- |
| `as_of_unix=None` (default) | hit allowed | populate slot | up-to-cache_ttl staleness is invisible at RFC's date-only granularity |
| `as_of_unix=<explicit>` | bypassed | bypassed | historical queries must not poison default-path slot |

Granularity note in the helper docstring documents the cache-TTL ↔
date-boundary trade-off so future readers don't rediscover it.

## Scope (atomic PR)

- IN: filter helper + wiring + cache gating + invariant comment + 15 tests.
- OUT: `mem_search(as_of=...)` MCP API, `mm search --as-of` CLI, `mm list`
  validity column (Goal 5+6), Web UI badge (Goal 7) — each separate PR.

## Tests added (15)

`TestApplyValidityFilter` (10) — pure helper unit:
- inside / before / after window
- boundary-lower / boundary-upper inclusive
- half-bounded (`valid_from` only, `valid_to` only)
- always-valid `(None, None)`
- order preserved
- mixed survivor/reject input

`TestValidityFilterPipelineWiring` (5) — `SearchPipeline.search` integration:
- default `as_of_unix=None` uses `time.time()` (monkeypatch fixed instant)
- explicit historical `as_of_unix` filters window correctly
- AND with `source_filter` — chunk must pass both
- default path caches filtered result (`bm25_search` invoked once across two calls)
- explicit `as_of_unix` bypasses cache read AND write

Local sweep: 3063 passed, 46 deselected (ollama). ruff clean. mypy
advisory clean for `pipeline.py`.

## Test plan

- [x] ruff check + format
- [x] pytest -m "not ollama"
- [x] mypy advisory (pipeline.py)
- [ ] CI green
- [ ] Confirm filter does not regress search latency on a real DB
      (manual smoke after merge — Goal 5+6 will add the surface to test it
      end-to-end via `mm search --as-of`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)