### PR TITLE
feat(privacy): block secret-bearing writes at mem_add ingress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,15 @@ for `memtomem` and both resolve to `memtomem.cli:cli`.
   and talks to this LTM server only through the MCP protocol. Don't
   `import memtomem_stm` from `packages/memtomem/src/`, and don't hand-roll an
   in-process STM client — cross-repo coupling is explicitly forbidden.
+- **`memtomem/privacy.py` syncs from STM, asymmetrically.** The redaction
+  patterns in `packages/memtomem/src/memtomem/privacy.py` are copied from
+  `memtomem-stm/proxy/privacy.py:DEFAULT_PATTERNS` (the SHA pin lives in the
+  module docstring). The trust boundary is here, not there — STM-bypass must
+  not be safety-bypass. When STM adds a **secret-class** pattern, sync it
+  here in the same release window and bump the SHA. **PII-class** patterns
+  (email, phone, name, address, etc.) do not auto-sync — they would force
+  `force_unsafe=True` on most legitimate prose ingress; including any new
+  PII-class pattern requires a separate decision pass.
 - **`mm` ≡ `memtomem`.** Both `project.scripts` entries in
   `packages/memtomem/pyproject.toml` resolve to `memtomem.cli:cli` — keep them
   in sync, don't diverge behavior or add flags to only one name.

--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -1,0 +1,146 @@
+"""Content redaction guard at the LTM trust boundary.
+
+The pattern set is duplicated from memtomem-stm
+``proxy/privacy.py:DEFAULT_PATTERNS`` as of commit ``a98636e``,
+**secrets-only subset**. STM's full pattern set includes patterns whose
+semantic category is PII (e.g., email addresses) rather than secret-class.
+Those are excluded by design here because PII false positives on prose
+ingress would be unworkable; redaction at the LTM ingress is the trust
+boundary where blocking semantics demand a tight false-positive profile.
+
+Sync rule (asymmetric):
+
+- STM additions of secret-class patterns (provider tokens, key formats,
+  PEM-style headers, etc.) require sync into this module + a SHA bump in
+  this docstring.
+- STM additions of PII-class patterns (email, phone, name, address, etc.)
+  do NOT auto-sync. Including any new PII-class pattern here requires a
+  separate decision pass — the false-positive profile in prose ingress is
+  fundamentally different from STM's compression-routing use, and a PII
+  block default would force ``force_unsafe=True`` on most legitimate
+  contact / meeting / conversation notes.
+
+This module is the LTM-side trust boundary. STM's content scanner is a
+routing signal only; if STM is bypassed (direct agent → LTM call), the
+redaction guard here still applies. STM-bypass is not safety-bypass.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from functools import lru_cache
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+# Patterns are secret-class only. See module docstring for sync rule.
+DEFAULT_PATTERNS: tuple[str, ...] = (
+    r"(?i)(api[_-]?key|secret[_-]?key|access[_-]?token)\s*[:=]",
+    r"(?i)(password|passwd|pwd)\s*[:=]",
+    # Provider-prefixed token formats. Anchored by prefix so false positives
+    # on arbitrary high-entropy strings are rare.
+    r"(?i)(sk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36}|xox[bps]-[0-9A-Za-z-]+)",
+    r"github_pat_[A-Za-z0-9_]{20,}",
+    r"(?:(?:sk|pk|rk)_(?:live|test)|whsec)_[A-Za-z0-9]{20,}",
+    r"\bnpm_[A-Za-z0-9]{20,}\b",
+    r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b",
+    # JWT-ish: three base64url segments separated by dots, anchored to the
+    # canonical ``eyJ`` header prefix to limit false positives on arbitrary
+    # dotted identifiers.
+    r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
+    r"(?i)(BEGIN\s+(RSA|EC|OPENSSH|DSA|PGP)\s+PRIVATE\s+KEY)",
+)
+
+_SCAN_WINDOW = 10_000
+
+# Outcome labels recorded for every gated content scan.
+#   blocked  — at least one hit; ``force_unsafe`` not set; write rejected.
+#   pass     — no hits; write proceeded.
+#   bypassed — at least one hit; ``force_unsafe`` was set; write proceeded.
+# The three-label split is the audit surface: "blocked" measures guard
+# value, "bypassed" measures escape-hatch usage.
+_VALID_OUTCOMES: tuple[str, ...] = ("blocked", "pass", "bypassed")
+
+
+@dataclass(frozen=True)
+class RedactionHit:
+    """A single matched span.
+
+    Original matched bytes are intentionally not retained — error messages
+    and audit records must never echo secret content back to the caller.
+    """
+
+    pattern_index: int
+    span: tuple[int, int]
+
+
+@lru_cache(maxsize=1)
+def _compile(patterns: tuple[str, ...]) -> tuple[re.Pattern[str], ...]:
+    compiled: list[re.Pattern[str]] = []
+    for p in patterns:
+        try:
+            compiled.append(re.compile(p))
+        except re.error as exc:
+            logger.warning("Invalid privacy pattern %r: %s", p, exc)
+    return tuple(compiled)
+
+
+def scan(text: str, patterns: tuple[str, ...] | None = None) -> list[RedactionHit]:
+    """Return all redaction hits in the first ``_SCAN_WINDOW`` chars of ``text``.
+
+    The 10 K-char window matches STM's compression-side scanner so the two
+    views of "is this content sensitive" stay aligned at the floor.
+    """
+    effective = patterns if patterns is not None else DEFAULT_PATTERNS
+    if not effective:
+        return []
+    sample = text[:_SCAN_WINDOW]
+    compiled = _compile(tuple(effective))
+    hits: list[RedactionHit] = []
+    for idx, pat in enumerate(compiled):
+        for m in pat.finditer(sample):
+            hits.append(RedactionHit(pattern_index=idx, span=(m.start(), m.end())))
+    return hits
+
+
+_lock = Lock()
+_outcomes: dict[str, int] = {o: 0 for o in _VALID_OUTCOMES}
+_by_tool: dict[str, dict[str, int]] = defaultdict(lambda: {o: 0 for o in _VALID_OUTCOMES})
+
+
+def record(outcome: str, tool: str) -> None:
+    """Increment the outcome counter for ``tool``.
+
+    ``outcome`` must be one of ``_VALID_OUTCOMES``. Unknown values are
+    dropped with a warning so adding a new outcome name without updating
+    the validator surfaces loudly rather than silently.
+    """
+    if outcome not in _VALID_OUTCOMES:
+        logger.warning("privacy.record: unknown outcome %r (tool=%r); skipped", outcome, tool)
+        return
+    with _lock:
+        _outcomes[outcome] += 1
+        _by_tool[tool][outcome] += 1
+
+
+def snapshot() -> dict[str, object]:
+    """Return a deep-copied counter snapshot.
+
+    Safe to mutate or serialise without affecting the live counters.
+    """
+    with _lock:
+        return {
+            "outcomes": dict(_outcomes),
+            "by_tool": {tool: dict(counts) for tool, counts in _by_tool.items()},
+        }
+
+
+def reset_for_tests() -> None:
+    """Zero all counters. Production code does not call this."""
+    with _lock:
+        for o in _VALID_OUTCOMES:
+            _outcomes[o] = 0
+        _by_tool.clear()

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -61,7 +61,13 @@ mcp._mcp_server.version = _memtomem_version
 # ── Register ALL tools (decorators bind to `mcp` on import) ───────────
 from memtomem.server.tools.ask import mem_ask  # noqa: E402, F401
 from memtomem.server.tools.indexing import mem_index  # noqa: E402, F401
-from memtomem.server.tools.memory_crud import mem_add, mem_batch_add, mem_delete, mem_edit  # noqa: E402, F401
+from memtomem.server.tools.memory_crud import (  # noqa: E402, F401
+    mem_add,
+    mem_add_redaction_stats,
+    mem_batch_add,
+    mem_delete,
+    mem_edit,
+)
 from memtomem.server.tools.recall import mem_recall  # noqa: E402, F401
 from memtomem.server.tools.search import mem_search, mem_expand  # noqa: E402, F401
 from memtomem.server.tools.status_config import (

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -52,6 +52,7 @@ async def _mem_add_core(
     namespace: str | None,
     template: str | None,
     ctx: CtxType,
+    force_unsafe: bool = False,
 ) -> tuple[str, "IndexingStats | None"]:
     """Core logic for ``mem_add`` — also usable from internal callers that
     need the ``IndexingStats`` (e.g. ``mem_consolidate_apply`` linking new
@@ -59,13 +60,35 @@ async def _mem_add_core(
 
     Returns:
         Tuple of ``(user_facing_message, stats)``. ``stats`` is ``None``
-        for early error returns (empty content, oversized content, template
-        failure, invalid path) so callers must tolerate ``None``.
+        for early error returns (empty content, oversized content,
+        redaction-guard hit without ``force_unsafe``, template failure,
+        invalid path) so callers must tolerate ``None``.
     """
     if not content.strip():
         return ("Error: content cannot be empty.", None)
     if len(content) > MAX_CONTENT_LENGTH:
         return ("Error: content too large (max 100,000 characters).", None)
+
+    # Trust-boundary redaction guard — see ``memtomem.privacy`` module
+    # docstring for the rationale and the cross-repo sync rule. Runs
+    # before any filesystem write so a flagged write leaves no on-disk
+    # trace to clean up.
+    from memtomem import privacy
+
+    hits = privacy.scan(content)
+    if hits:
+        if force_unsafe:
+            privacy.record("bypassed", "mem_add")
+        else:
+            privacy.record("blocked", "mem_add")
+            return (
+                f"Error: content matches {len(hits)} privacy pattern(s); "
+                "write rejected. Retry with force_unsafe=True to bypass "
+                "(audit-logged).",
+                None,
+            )
+    else:
+        privacy.record("pass", "mem_add")
 
     from datetime import datetime, timezone
 
@@ -161,6 +184,7 @@ async def mem_add(
     file: str | None = None,
     namespace: str | None = None,
     template: str | None = None,
+    force_unsafe: bool = False,
     ctx: CtxType = None,
 ) -> str:
     """Add a new memory entry to a markdown file and immediately index it.
@@ -168,6 +192,13 @@ async def mem_add(
     The entry is appended to the target file (or a new timestamped file is
     created in the first configured memory directory). The file is then
     re-indexed so the entry is immediately searchable.
+
+    Content passes through a trust-boundary redaction guard before any
+    filesystem write. If the content matches a known secret pattern
+    (provider tokens, API keys, PEM headers, etc.) the write is rejected.
+    Set ``force_unsafe=True`` to bypass after manual review; bypass events
+    are recorded with a ``bypassed`` outcome label so guard effectiveness
+    and bypass usage stay observable. See ``mem_add_redaction_stats``.
 
     Args:
         content: The memory content to store
@@ -178,6 +209,10 @@ async def mem_add(
         namespace: Assign indexed chunks to this namespace (default: config default)
         template: Use a built-in template (adr, meeting, debug, decision,
                   procedure). Content can be JSON with field values or plain text.
+        force_unsafe: When True, bypass the redaction guard for this call
+                      even when content matches a secret pattern. Use only
+                      when matches are known false positives (e.g.,
+                      documenting an example credential schema).
 
     Returns a confirmation message. If highly similar memories already exist
     (≥90% match), a duplicate warning is appended to the output.
@@ -189,6 +224,7 @@ async def mem_add(
         file=file,
         namespace=namespace,
         template=template,
+        force_unsafe=force_unsafe,
         ctx=ctx,
     )
     return message
@@ -347,6 +383,7 @@ async def mem_batch_add(
     entries: list[dict],
     namespace: str | None = None,
     file: str | None = None,
+    force_unsafe: bool = False,
     ctx: CtxType = None,
 ) -> str:
     """Add multiple memory entries in one call (KV batch).
@@ -355,13 +392,55 @@ async def mem_batch_add(
     optionally "tags" (list[str]).  All entries are appended to the same file
     and indexed once.
 
+    Each entry's content passes through the same trust-boundary redaction
+    guard as ``mem_add``. If any entry matches a secret pattern, the whole
+    batch is rejected — partial-success on a flagged batch would leak the
+    transactional contract callers rely on. Pass ``force_unsafe=True`` to
+    bypass for the whole batch (each hit item is recorded with a
+    ``bypassed`` outcome label per audit).
+
     Args:
         entries: List of {"key": "title", "value": "content", "tags": [...]}
         namespace: Namespace for all entries (default: config default)
         file: Target .md file.  If omitted, a timestamped file is created.
+        force_unsafe: When True, bypass the redaction guard for any flagged
+                      entries. Bypass events are recorded per item.
     """
     if len(entries) > 500:
         return f"Error: batch too large (max 500 entries, got {len(entries)})."
+
+    # Trust-boundary redaction guard. Pre-scan every entry before any
+    # filesystem write so a flagged batch leaves no on-disk residue
+    # regardless of which entry tripped the pattern. See
+    # ``memtomem.privacy`` for the cross-repo sync rule.
+    from memtomem import privacy
+
+    hit_indices: list[int] = []
+    for idx, entry in enumerate(entries):
+        value = entry.get("value") or entry.get("content", "")
+        if not value:
+            continue
+        if privacy.scan(value):
+            hit_indices.append(idx)
+
+    if hit_indices and not force_unsafe:
+        for _ in hit_indices:
+            privacy.record("blocked", "mem_batch_add")
+        return (
+            f"Error: items at indices {hit_indices} match privacy patterns; "
+            "whole batch rejected. Resubmit with hit items removed, or pass "
+            "force_unsafe=True to bypass (audit-logged)."
+        )
+
+    hit_set = set(hit_indices)
+    for idx, entry in enumerate(entries):
+        value = entry.get("value") or entry.get("content", "")
+        if not value:
+            continue
+        if idx in hit_set:
+            privacy.record("bypassed", "mem_batch_add")
+        else:
+            privacy.record("pass", "mem_batch_add")
 
     from datetime import datetime, timezone
 
@@ -406,3 +485,26 @@ async def mem_batch_add(
     if skipped:
         result += f"\n- Skipped: {skipped} entries (empty content)"
     return result
+
+
+@mcp.tool()
+@tool_handler
+@register("crud")
+async def mem_add_redaction_stats(
+    ctx: CtxType = None,
+) -> str:
+    """Return a JSON snapshot of redaction-guard outcomes since process start.
+
+    Outcome labels:
+        blocked  — write rejected because content matched a privacy pattern.
+        pass     — write proceeded; content matched no patterns.
+        bypassed — write proceeded with ``force_unsafe=True`` despite a match.
+
+    The ``by_tool`` map breaks the same outcomes down by ingress tool
+    (``mem_add``, ``mem_batch_add``).
+    """
+    import json
+
+    from memtomem import privacy
+
+    return json.dumps(privacy.snapshot(), indent=2)

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -79,6 +79,19 @@ async def _mem_add_core(
     if hits:
         if force_unsafe:
             privacy.record("bypassed", "mem_add")
+            # Audit trail for forensic correlation. The matched bytes are
+            # never logged — only the request shape (counters answer "is
+            # bypass happening?"; this line answers "what specifically got
+            # through?"). The full chunk content stays in the on-disk
+            # markdown file the call is about to write.
+            logger.warning(
+                "redaction bypass via force_unsafe=True "
+                "(tool=mem_add, namespace=%r, file=%r, content_chars=%d, hits=%d)",
+                namespace,
+                file,
+                len(content),
+                len(hits),
+            )
         else:
             privacy.record("blocked", "mem_add")
             return (
@@ -199,6 +212,11 @@ async def mem_add(
     Set ``force_unsafe=True`` to bypass after manual review; bypass events
     are recorded with a ``bypassed`` outcome label so guard effectiveness
     and bypass usage stay observable. See ``mem_add_redaction_stats``.
+
+    The redaction scan covers the first 10,000 characters of ``content``;
+    matches beyond that window are not seen by the guard. This is parity
+    with the STM compression-side scanner — split very long content into
+    multiple calls if every region must be inspected.
 
     Args:
         content: The memory content to store
@@ -399,6 +417,10 @@ async def mem_batch_add(
     bypass for the whole batch (each hit item is recorded with a
     ``bypassed`` outcome label per audit).
 
+    The scan covers only the first 10,000 characters of each entry's
+    value; matches beyond that per-entry window are not seen by the
+    guard.
+
     Args:
         entries: List of {"key": "title", "value": "content", "tags": [...]}
         namespace: Namespace for all entries (default: config default)
@@ -439,6 +461,14 @@ async def mem_batch_add(
             continue
         if idx in hit_set:
             privacy.record("bypassed", "mem_batch_add")
+            logger.warning(
+                "redaction bypass via force_unsafe=True "
+                "(tool=mem_batch_add, namespace=%r, file=%r, item_idx=%d, content_chars=%d)",
+                namespace,
+                file,
+                idx,
+                len(value),
+            )
         else:
             privacy.record("pass", "mem_batch_add")
 
@@ -502,6 +532,14 @@ async def mem_add_redaction_stats(
 
     The ``by_tool`` map breaks the same outcomes down by ingress tool
     (``mem_add``, ``mem_batch_add``).
+
+    Counts reflect attempted *write outcomes*, not raw scans. A rejected
+    ``mem_batch_add`` records ``blocked`` once per hit item but does not
+    record ``pass`` for the clean siblings in the same rejected batch
+    (no write occurred for them). Summing
+    ``blocked + pass + bypassed`` therefore equals the count of actual
+    or attempted writes that reached the guard, not the total number
+    of entries inspected.
     """
     import json
 

--- a/packages/memtomem/tests/test_memory_crud_redaction.py
+++ b/packages/memtomem/tests/test_memory_crud_redaction.py
@@ -110,6 +110,38 @@ class TestMemAddRedactionGuard:
         assert after["blocked"] == before["blocked"]
         assert after["bypassed"] == before["bypassed"]
 
+    @pytest.mark.asyncio
+    async def test_clean_content_with_force_unsafe_records_pass_not_bypassed(
+        self, bm25_only_components
+    ):
+        """``force_unsafe=True`` without a hit must still record ``pass``.
+
+        ``bypassed`` is only meaningful when the guard would have blocked;
+        a clean write with the kwarg set is no different from a clean
+        write without it. Pin so the bypass label keeps measuring real
+        escape-hatch usage rather than degrading into "kwarg was passed."
+        """
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "clean_with_force.md"
+
+        before = privacy.snapshot()["outcomes"]
+        await mem_add(  # type: ignore[arg-type]
+            content=_CLEAN_SAMPLE,
+            file=str(target),
+            force_unsafe=True,
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["outcomes"]
+
+        assert after["pass"] == before["pass"] + 1
+        assert after["bypassed"] == before["bypassed"], (
+            "force_unsafe with no hit must not increment bypassed"
+        )
+        assert after["blocked"] == before["blocked"]
+        assert target.exists()
+
 
 class TestMemBatchAddRedactionGuard:
     @pytest.mark.asyncio

--- a/packages/memtomem/tests/test_memory_crud_redaction.py
+++ b/packages/memtomem/tests/test_memory_crud_redaction.py
@@ -1,0 +1,231 @@
+"""Trust-boundary redaction guard at mem_add / mem_batch_add ingress.
+
+Pinned behavior:
+
+- ``mem_add`` blocks content that matches a privacy pattern; counter
+  records ``blocked``; no on-disk write occurs.
+- ``mem_add(force_unsafe=True)`` bypasses the block; counter records
+  ``bypassed``; the file is created.
+- Clean content always passes; counter records ``pass``.
+- ``mem_batch_add`` rejects the whole batch on any hit (transactional);
+  the error message lists the hit indices and no file is created.
+- ``mem_batch_add(force_unsafe=True)`` records ``bypassed`` per hit item
+  and ``pass`` per clean item.
+- ``mem_add_redaction_stats`` surfaces the live counter snapshot.
+
+Counter assertions are paired with each behavior pin so a future change
+that drops the ``record(...)`` calls without touching block / pass logic
+fails the test instead of regressing silently.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem import privacy
+from memtomem.server.context import AppContext
+from memtomem.server.tools.memory_crud import (
+    mem_add,
+    mem_add_redaction_stats,
+    mem_batch_add,
+)
+
+from helpers import StubCtx
+
+# Sample matches pattern #4 (sk-...) — no other ambiguity, single-pattern hit.
+_SECRET_SAMPLE = "Notes on token: sk-" + "a" * 30
+_CLEAN_SAMPLE = "Met with the team about Q2 deploy plans."
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+class TestMemAddRedactionGuard:
+    @pytest.mark.asyncio
+    async def test_blocks_secret_and_records_blocked_outcome(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "block.md"
+
+        before = privacy.snapshot()["outcomes"]["blocked"]
+        result = await mem_add(  # type: ignore[arg-type]
+            content=_SECRET_SAMPLE,
+            file=str(target),
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["outcomes"]["blocked"]
+
+        assert "Error" in result
+        assert "privacy pattern" in result
+        assert "force_unsafe" in result
+        assert after == before + 1, "Block must increment the blocked counter"
+        assert not target.exists(), "Blocked write must not create the file"
+
+    @pytest.mark.asyncio
+    async def test_force_unsafe_passes_and_records_bypassed(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "bypass.md"
+
+        before = privacy.snapshot()["outcomes"]
+        result = await mem_add(  # type: ignore[arg-type]
+            content=_SECRET_SAMPLE,
+            file=str(target),
+            force_unsafe=True,
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["outcomes"]
+
+        assert "Memory added" in result, f"Expected success, got: {result!r}"
+        assert after["bypassed"] == before["bypassed"] + 1
+        assert after["blocked"] == before["blocked"], (
+            "Bypass must not increment the blocked counter"
+        )
+        assert target.exists()
+
+    @pytest.mark.asyncio
+    async def test_clean_content_records_pass(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "clean.md"
+
+        before = privacy.snapshot()["outcomes"]
+        await mem_add(  # type: ignore[arg-type]
+            content=_CLEAN_SAMPLE,
+            file=str(target),
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["outcomes"]
+
+        assert after["pass"] == before["pass"] + 1
+        assert after["blocked"] == before["blocked"]
+        assert after["bypassed"] == before["bypassed"]
+
+
+class TestMemBatchAddRedactionGuard:
+    @pytest.mark.asyncio
+    async def test_full_reject_lists_hit_indices(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "batch_block.md"
+
+        before = privacy.snapshot()["by_tool"].get(
+            "mem_batch_add", {"blocked": 0, "pass": 0, "bypassed": 0}
+        )
+        result = await mem_batch_add(  # type: ignore[arg-type]
+            entries=[
+                {"key": "Clean", "value": _CLEAN_SAMPLE},
+                {"key": "Secret", "value": _SECRET_SAMPLE},
+                {"key": "Also clean", "value": "Another normal note."},
+                {"key": "Also secret", "value": "AKIAIOSFODNN7EXAMPLE"},
+            ],
+            file=str(target),
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["by_tool"]["mem_batch_add"]
+
+        assert "Error" in result
+        assert "[1, 3]" in result, f"Hit indices missing from error: {result!r}"
+        assert "whole batch rejected" in result
+        # Two hit items → two blocked records; clean items get nothing
+        # because no write happened (transactional reject).
+        assert after["blocked"] == before["blocked"] + 2
+        assert after["pass"] == before["pass"], "Pass must not record on rejected batch"
+        assert not target.exists()
+
+    @pytest.mark.asyncio
+    async def test_force_unsafe_records_bypassed_per_hit_and_pass_per_clean(
+        self, bm25_only_components
+    ):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "batch_bypass.md"
+
+        before = privacy.snapshot()["by_tool"].get(
+            "mem_batch_add", {"blocked": 0, "pass": 0, "bypassed": 0}
+        )
+        result = await mem_batch_add(  # type: ignore[arg-type]
+            entries=[
+                {"key": "Clean", "value": _CLEAN_SAMPLE},
+                {"key": "Secret", "value": _SECRET_SAMPLE},
+            ],
+            file=str(target),
+            force_unsafe=True,
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["by_tool"]["mem_batch_add"]
+
+        assert "Batch add complete" in result
+        assert after["bypassed"] == before["bypassed"] + 1
+        assert after["pass"] == before["pass"] + 1
+        assert target.exists()
+
+    @pytest.mark.asyncio
+    async def test_clean_batch_records_pass_per_entry(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+        target = mem_dir / "batch_clean.md"
+
+        before = privacy.snapshot()["by_tool"].get(
+            "mem_batch_add", {"blocked": 0, "pass": 0, "bypassed": 0}
+        )
+        await mem_batch_add(  # type: ignore[arg-type]
+            entries=[
+                {"key": "A", "value": _CLEAN_SAMPLE},
+                {"key": "B", "value": "Another normal note."},
+            ],
+            file=str(target),
+            ctx=ctx,
+        )
+        after = privacy.snapshot()["by_tool"]["mem_batch_add"]
+
+        assert after["pass"] == before["pass"] + 2
+        assert after["blocked"] == before["blocked"]
+
+
+class TestRedactionStatsTool:
+    @pytest.mark.asyncio
+    async def test_snapshot_tool_returns_outcomes_and_by_tool(self, bm25_only_components):
+        comp, mem_dir = bm25_only_components
+        app = AppContext.from_components(comp)
+        ctx = StubCtx(app)
+
+        # Generate one of each outcome via mem_add (covers two tools' worth
+        # of by_tool keys via the batch test below).
+        await mem_add(  # type: ignore[arg-type]
+            content=_CLEAN_SAMPLE,
+            file=str(mem_dir / "stats_pass.md"),
+            ctx=ctx,
+        )
+        await mem_add(  # type: ignore[arg-type]
+            content=_SECRET_SAMPLE,
+            file=str(mem_dir / "stats_block.md"),
+            ctx=ctx,
+        )
+        await mem_add(  # type: ignore[arg-type]
+            content=_SECRET_SAMPLE,
+            file=str(mem_dir / "stats_bypass.md"),
+            force_unsafe=True,
+            ctx=ctx,
+        )
+
+        result = await mem_add_redaction_stats(ctx=ctx)  # type: ignore[arg-type]
+        snap = json.loads(result)
+
+        assert snap["outcomes"]["pass"] >= 1
+        assert snap["outcomes"]["blocked"] >= 1
+        assert snap["outcomes"]["bypassed"] >= 1
+        assert "mem_add" in snap["by_tool"]
+        assert snap["by_tool"]["mem_add"]["blocked"] >= 1

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -1,0 +1,123 @@
+"""Privacy module — pattern surface, scan window, counter behavior.
+
+These tests pin the parent-side trust boundary at the unit level. The
+wire-in tests for ``mem_add`` / ``mem_batch_add`` live in
+``test_memory_crud_redaction.py``.
+
+Drift-prevention notes embedded as test pins:
+
+- ``test_pattern_count_pinned_at_nine`` — the parent set is intentionally
+  the secrets-only subset of STM's ``DEFAULT_PATTERNS`` (10 patterns), with
+  the email/PII pattern excluded by design.
+- ``test_clean_inputs_have_no_hit`` — direct contract pin: well-formed
+  contact-note prose (emails, phone numbers, plain text) must pass
+  through untouched. Future drift toward PII inclusion would break this
+  immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from memtomem import privacy
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+class TestPatternSurface:
+    def test_pattern_count_pinned_at_nine(self):
+        assert len(privacy.DEFAULT_PATTERNS) == 9
+
+    @pytest.mark.parametrize(
+        "clean_input",
+        [
+            "user@example.com",
+            "Email me at jane.doe+work@acme.io about the meeting.",
+            "Call 555-123-4567 for the on-call rotation.",
+            "Met with John today to discuss Q2 plans.",
+            "The IPv4 address 192.168.1.1 is the gateway.",
+            "Note: discussed deploys with team@acme.io and shipping@vendor.co",
+        ],
+    )
+    def test_clean_inputs_have_no_hit(self, clean_input):
+        hits = privacy.scan(clean_input)
+        assert hits == [], f"Expected zero hits for clean input {clean_input!r}; got {hits!r}"
+
+
+class TestScan:
+    @pytest.mark.parametrize(
+        "secret_sample",
+        [
+            "api_key: AKIAIOSFODNN7EXAMPL",
+            "password = hunter2hunter2",
+            "sk-" + "a" * 30,
+            "github_pat_" + "x" * 30,
+            "sk_live_" + "a" * 25,
+            "npm_" + "a" * 30,
+            "AKIAIOSFODNN7EXAMPLE",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIicm9vdA.SflKxwRJSMeK",
+            "-----BEGIN RSA PRIVATE KEY-----",
+        ],
+    )
+    def test_each_secret_pattern_hits(self, secret_sample):
+        hits = privacy.scan(secret_sample)
+        assert hits, f"Expected at least one hit for sample {secret_sample!r}"
+
+    def test_clean_text_returns_empty_list(self):
+        assert privacy.scan("Just a regular note about coffee.") == []
+
+    def test_scan_window_capped_at_10k(self):
+        # Secret beyond the scan window is invisible — parity with STM's
+        # compression-side scanner (10K-char window).
+        hidden = "a" * 10_001 + "AKIAIOSFODNN7EXAMPLE"
+        assert privacy.scan(hidden) == []
+
+    def test_secret_just_within_window_is_seen(self):
+        visible = "a" * 9_900 + " AKIAIOSFODNN7EXAMPLE"
+        assert privacy.scan(visible)
+
+    def test_explicit_empty_pattern_set_returns_no_hit(self):
+        assert privacy.scan("AKIAIOSFODNN7EXAMPLE", patterns=()) == []
+
+
+class TestCounter:
+    def test_record_increments_outcome_and_by_tool(self):
+        privacy.record("blocked", "mem_add")
+        privacy.record("blocked", "mem_add")
+        privacy.record("pass", "mem_add")
+        privacy.record("bypassed", "mem_batch_add")
+
+        snap = privacy.snapshot()
+        assert snap["outcomes"] == {"blocked": 2, "pass": 1, "bypassed": 1}
+        assert snap["by_tool"]["mem_add"] == {"blocked": 2, "pass": 1, "bypassed": 0}
+        assert snap["by_tool"]["mem_batch_add"] == {"blocked": 0, "pass": 0, "bypassed": 1}
+
+    def test_record_unknown_outcome_is_dropped(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="memtomem.privacy"):
+            privacy.record("invalid_outcome", "mem_add")
+        snap = privacy.snapshot()
+        assert all(v == 0 for v in snap["outcomes"].values())
+        assert "unknown outcome" in caplog.text
+
+    def test_snapshot_is_deep_copy_safe(self):
+        privacy.record("pass", "mem_add")
+        snap = privacy.snapshot()
+        snap["outcomes"]["pass"] = 999
+        snap["by_tool"]["mem_add"]["pass"] = 999
+        live = privacy.snapshot()
+        assert live["outcomes"]["pass"] == 1
+        assert live["by_tool"]["mem_add"]["pass"] == 1
+
+    def test_reset_for_tests_clears_state(self):
+        privacy.record("blocked", "mem_add")
+        privacy.reset_for_tests()
+        snap = privacy.snapshot()
+        assert snap["outcomes"] == {"blocked": 0, "pass": 0, "bypassed": 0}
+        assert snap["by_tool"] == {}


### PR DESCRIPTION
## Background

The LTM `mem_add` / `mem_batch_add` tools previously accepted any
content as written. Anything indexed into LTM is reachable later via
search + recall + (when STM is in front) auto-surfacing — so a single
unintended secret write keeps leaking into future agent contexts until
it's manually scrubbed. The cleanup cost on a leaked secret is
asymmetric to the cost of a false-positive block, so this PR shifts
the trust boundary one layer inward: the ingress refuses
secret-pattern matches by default.

The detector lives parent-side, not in the STM proxy, on purpose. The
STM proxy is a convenience / capability layer; an agent that bypasses
STM (direct `mem_add` over MCP) must still hit the same redaction
guard. STM-bypass != safety-bypass.

## What changed

- **New `memtomem.privacy` module.** 9 secret-class regex patterns:
  provider tokens (`sk-…`, `ghp_…`, `xox[bps]-…`, `github_pat_…`,
  `npm_…`, Stripe-style), AWS access keys (`AKIA…`/`ASIA…`), JWT-ish
  triplets, PEM private-key headers, and `(api_key|secret_key|access_token|password|passwd|pwd)` followed by `:` / `=`.
  10K-char scan window matches the STM compression-side scanner so
  the two views of "is this content sensitive" stay aligned at the
  floor.
- **Three-label outcome counter.** `blocked` (rejected), `pass` (no
  hit), `bypassed` (`force_unsafe=True` overrode a hit). Per-tool
  breakdown under `by_tool`. Surfaced through the new
  `mem_add_redaction_stats` MCP tool (registered under `crud`,
  routed via `mem_do` in core mode).
- **`force_unsafe: bool = False` kwarg** on `mem_add`,
  `mem_batch_add`, and `_mem_add_core`. Internal callers
  (`reflection`, `scratch`, `procedure`, `mem_consolidate_apply`,
  multi-agent share) inherit `False` — LLM-driven internal writes
  cannot bypass the guard without a code change.
- **`mem_batch_add` rejects the whole batch on any hit**, listing
  the offending zero-based indices in the error message.
  Partial-success semantics on a flagged batch would break the
  caller's transactional assumption.

## Behavior change

This is a **breaking-by-design** change: previously-accepted content
that matches a secret pattern now returns an error message instead of
being written. Callers can opt back in per-call with
`force_unsafe=True`. Operators tracking false-positive impact can
read the live counter via `mem_add_redaction_stats`.

The pattern set is the **secrets-only subset** of the STM proxy's
content scanner. STM matches an additional email/PII pattern
(`<word>@<word>.<tld>`) that is intentionally excluded here — block
semantics on PII would force `force_unsafe=True` on most legitimate
contact / meeting / conversation notes, defeating the audit value of
the bypass label. STM keeps the email pattern because its
compression-routing use has a benign false-positive mode (fall back
to selective compression).

## Cross-repo sync rule

`CLAUDE.md` gains an asymmetric sync rule:

- STM additions of **secret-class** patterns (provider tokens, key
  formats, etc.) require sync into `memtomem/privacy.py` + a SHA bump
  in the module docstring.
- STM additions of **PII-class** patterns (email, phone, name,
  address, etc.) do not auto-sync; including any new PII-class
  pattern requires a separate decision pass.

Module docstring pins the current STM source SHA (`a98636e`).

## Tests

- `test_privacy.py` — 24 unit tests:
  - Pattern count pin (`len == 9`) — drift signal toward PII drift.
  - Negative contract: clean prose with emails / phone numbers /
    plain text returns zero hits. Catches future PII-style additions
    directly.
  - Per-pattern positive: each of the 9 patterns hits a known sample.
  - Scan-window cap parity with STM.
  - Counter: increment, deep-copy snapshot, unknown-outcome drop +
    warning, reset.
- `test_memory_crud_redaction.py` — 7 wire-in tests on real
  components (`bm25_only_components` fixture):
  - `mem_add` blocks on hit, no file created, `blocked` counter +1.
  - `mem_add(force_unsafe=True)` writes the file, `bypassed` +1,
    `blocked` unchanged.
  - `mem_add` clean → `pass` +1.
  - `mem_batch_add` full reject lists hit indices `[1, 3]`, file not
    created, two hit items recorded as `blocked`.
  - `mem_batch_add(force_unsafe=True)` records `bypassed` per hit
    item and `pass` per clean item.
  - Clean batch records `pass` per entry.
  - `mem_add_redaction_stats` returns expected JSON shape.

Each behavior assertion is paired with a counter-snapshot assertion
so a future change that drops `record(...)` calls without altering
the visible block / pass / bypass logic fails the test instead of
silently regressing.

## Validation

- `uv run pytest packages/memtomem/tests/test_privacy.py packages/memtomem/tests/test_memory_crud_redaction.py` — 31/31 pass.
- Regression sweep on `mem_add` callers
  (`test_batch_add_tag_isolation`, `test_multi_agent_integration`,
  `test_server_degraded_mode`, `test_tools_logic`,
  `test_validation_error_messages`,
  `test_validate_namespace_architectural_guard`) — 145/145 pass.
- Full suite: 3079 passed, 46 deselected (Ollama), 47s.
- `ruff check` + `ruff format --check` clean on touched files.
- `mypy` clean on touched files (advisory).

## Test plan

- [ ] Verify `mem_add(content="api_key: sk-aaaa…")` returns the
      blocking error and does not create the file.
- [ ] Verify `mem_add(content="…", force_unsafe=True)` writes when
      content matches a pattern; check `mem_add_redaction_stats`
      shows a `bypassed` outcome.
- [ ] Verify a `mem_batch_add` with one flagged entry rejects the
      whole batch and reports the hit index.
- [ ] Verify `mem_add_redaction_stats` returns an outcomes +
      by_tool JSON snapshot.
- [ ] Verify routine prose with emails (`team@acme.io`) and phone
      numbers passes without `force_unsafe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)