### PR TITLE
fix(plugin): filter PostToolUse[Write] indexing by extension and path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,28 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `empty output`, `llm error`) surface in the tool response. See
   [Session Summary](docs/guides/configuration.md#session-summary).
 
+### Changed
+
+- **Plugin `PostToolUse[Write]` hook now filters by extension and
+  path** — the inline `mm index` command in
+  `packages/memtomem-claude-plugin/hooks/hooks.json` was indexing every
+  `Write` regardless of file type or location, which fanned out to
+  `node_modules/`, `dist/`, `__pycache__/`, lock files, binaries, and
+  images in monorepo checkouts (embedding-cost amplifier + search
+  noise). The hook now allowlists canonical source extensions
+  (`md`, `py`, `ts`/`tsx`, `js`/`jsx`, `go`, `rs`, `rb`, `java`, `kt`,
+  `swift`, `c`/`cpp`/`h`/`hpp`, `sh`, `toml`, `yaml`/`yml`, `json`)
+  and blocklists build / cache / VCS paths (`node_modules`, `dist`,
+  `build`, `target`, `.next`, `.nuxt`, `__pycache__`, `.git`,
+  `.venv`/`venv`, `coverage`, `.cache`) inline — `case` statements,
+  no external script. Adjust the patterns in `hooks.json` for
+  project-specific needs. Other hooks (`UserPromptSubmit`,
+  `PostToolUse activity log`, `Stop`) are unchanged. Docs at
+  [`docs/guides/integrations/claude-code.md`](docs/guides/integrations/claude-code.md)
+  Hooks Automation section synced to match. **Documented gap**:
+  rapid consecutive writes still re-index — native
+  `mm index --debounce-window` support is the planned follow-up.
+
 ## [0.1.32] — 2026-04-26
 
 ### Changed (BREAKING)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,9 +60,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   project-specific needs. Other hooks (`UserPromptSubmit`,
   `PostToolUse activity log`, `Stop`) are unchanged. Docs at
   [`docs/guides/integrations/claude-code.md`](docs/guides/integrations/claude-code.md)
-  Hooks Automation section synced to match. **Documented gap**:
-  rapid consecutive writes still re-index — native
-  `mm index --debounce-window` support is the planned follow-up.
+  Hooks Automation section synced to match. A
+  ``test_plugin_hooks_command_matches_docs_snippet`` parity test
+  locks ``hooks.json`` and the docs snippet against silent drift on
+  future edits. Existing installs that copy-pasted the previous
+  snippet into ``~/.claude/settings.json`` continue with the old
+  unfiltered behavior until the user re-pulls the snippet. **Documented
+  gap**: rapid consecutive writes still re-index the same file; native
+  debounce support is tracked separately.
 
 ## [0.1.32] — 2026-04-26
 

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -176,7 +176,7 @@ Add the following to `~/.claude/settings.json`:
       "matcher": "Write",
       "hooks": [{
         "type": "command",
-        "command": "mm index \"${tool_input.file_path}\" 2>>/tmp/mm-hook.log || true",
+        "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in */node_modules/*|*/dist/*|*/build/*|*/target/*|*/.next/*|*/.nuxt/*|*/__pycache__/*|*/.git/*|*/.venv/*|*/venv/*|*/coverage/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
         "timeout": 10000
       }]
     }],
@@ -218,6 +218,8 @@ User submits prompt (>20 chars)
 - **Error logging**: `2>>/tmp/mm-hook.log` preserves errors for debugging. Avoid `2>/dev/null` which hides real failures.
 - **Stop hook = session close**: Use `mm session end --auto` in the Stop hook to close the active session with a structured summary. Don't use a Stop hook to call `mm add` with raw timestamps — those pollute search.
 - **Write only**: `Edit` is excluded from PostToolUse — edited files are already indexed, so re-indexing on every edit is redundant.
+- **Allowlist + blocklist**: `PostToolUse[Write]` only indexes canonical source extensions (`md`, `py`, `ts`/`tsx`, `js`/`jsx`, `go`, `rs`, `rb`, `java`, `kt`, `swift`, `c`/`cpp`/`h`/`hpp`, `sh`, `toml`, `yaml`/`yml`, `json`) and skips build / cache / VCS paths (`node_modules`, `dist`, `build`, `target`, `.next`, `.nuxt`, `__pycache__`, `.git`, `.venv`/`venv`, `coverage`, `.cache`) inline. Adjust the `case` patterns in `hooks.json` for project-specific needs — the filter is a single `case` statement, easy to extend.
+- **Debounce gap**: rapid consecutive writes to the same file (e.g., codegen loops) may re-index it multiple times within a few seconds. The current hook indexes synchronously per Write with no batching. For large monorepos, wrap the `mm index` call in an external script with `flock` + a debounce window, or wait for native `mm index --debounce-window` support.
 - **STM proxy overlap**: If using [memtomem-stm](https://github.com/memtomem/memtomem-stm) (separate package), hooks are redundant — the proxy already handles surfacing and indexing.
 
 ---

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -176,7 +176,7 @@ Add the following to `~/.claude/settings.json`:
       "matcher": "Write",
       "hooks": [{
         "type": "command",
-        "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in */node_modules/*|*/dist/*|*/build/*|*/target/*|*/.next/*|*/.nuxt/*|*/__pycache__/*|*/.git/*|*/.venv/*|*/venv/*|*/coverage/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
+        "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
         "timeout": 10000
       }]
     }],
@@ -218,8 +218,8 @@ User submits prompt (>20 chars)
 - **Error logging**: `2>>/tmp/mm-hook.log` preserves errors for debugging. Avoid `2>/dev/null` which hides real failures.
 - **Stop hook = session close**: Use `mm session end --auto` in the Stop hook to close the active session with a structured summary. Don't use a Stop hook to call `mm add` with raw timestamps — those pollute search.
 - **Write only**: `Edit` is excluded from PostToolUse — edited files are already indexed, so re-indexing on every edit is redundant.
-- **Allowlist + blocklist**: `PostToolUse[Write]` only indexes canonical source extensions (`md`, `py`, `ts`/`tsx`, `js`/`jsx`, `go`, `rs`, `rb`, `java`, `kt`, `swift`, `c`/`cpp`/`h`/`hpp`, `sh`, `toml`, `yaml`/`yml`, `json`) and skips build / cache / VCS paths (`node_modules`, `dist`, `build`, `target`, `.next`, `.nuxt`, `__pycache__`, `.git`, `.venv`/`venv`, `coverage`, `.cache`) inline. Adjust the `case` patterns in `hooks.json` for project-specific needs — the filter is a single `case` statement, easy to extend.
-- **Debounce gap**: rapid consecutive writes to the same file (e.g., codegen loops) may re-index it multiple times within a few seconds. The current hook indexes synchronously per Write with no batching. For large monorepos, wrap the `mm index` call in an external script with `flock` + a debounce window, or wait for native `mm index --debounce-window` support.
+- **Allowlist + blocklist**: `PostToolUse[Write]` only indexes canonical source extensions (`md`, `py`, `ts`/`tsx`, `js`/`jsx`, `go`, `rs`, `rb`, `java`, `kt`, `swift`, `c`/`cpp`/`h`/`hpp`, `sh`, `toml`, `yaml`/`yml`, `json`) and skips build / cache / VCS paths (`node_modules`, `dist`, `build`, `target`, `.next`, `.nuxt`, `__pycache__`, `.git`, `.venv`/`venv`, `coverage`, `.cache`) inline. Patterns include both leading-segment (`node_modules/*`) and any-segment (`*/node_modules/*`) forms for both absolute and relative `tool_input.file_path` values. Extension matching is case-sensitive — `*.MD` / `*.JS` would skip the allowlist; rename or extend the patterns if your repo uses uppercase. Adjust the `case` statements in `hooks.json` for project-specific needs — they are inline, easy to extend.
+- **Debounce gap**: rapid consecutive writes to the same file (e.g., codegen loops) may re-index it multiple times within a few seconds. The current hook indexes synchronously per Write with no batching. For large monorepos, wrap the `mm index` call in an external script with `flock` + a debounce window. Native debounce support is tracked separately.
 - **STM proxy overlap**: If using [memtomem-stm](https://github.com/memtomem/memtomem-stm) (separate package), hooks are redundant — the proxy already handles surfacing and indexing.
 
 ---

--- a/packages/memtomem-claude-plugin/hooks/hooks.json
+++ b/packages/memtomem-claude-plugin/hooks/hooks.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in */node_modules/*|*/dist/*|*/build/*|*/target/*|*/.next/*|*/.nuxt/*|*/__pycache__/*|*/.git/*|*/.venv/*|*/venv/*|*/coverage/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
+            "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
             "timeout": 10000
           }
         ]

--- a/packages/memtomem-claude-plugin/hooks/hooks.json
+++ b/packages/memtomem-claude-plugin/hooks/hooks.json
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "mm index \"${tool_input.file_path}\" 2>>/tmp/mm-hook.log || true",
+            "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in */node_modules/*|*/dist/*|*/build/*|*/target/*|*/.next/*|*/.nuxt/*|*/__pycache__/*|*/.git/*|*/.venv/*|*/venv/*|*/coverage/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
             "timeout": 10000
           }
         ]

--- a/packages/memtomem/tests/test_docs_guards.py
+++ b/packages/memtomem/tests/test_docs_guards.py
@@ -12,10 +12,17 @@ These guards protect invariants that code cannot enforce directly:
   tool group in both ``reference.md`` and ``mcp-clients.md``; both files
   must mark them with the ``\\*`` + ``MEMTOMEM_TOOL_MODE=full`` footnote,
   or users reading one file won't know they are gated.
+- The ``hooks.json`` snippet rendered in ``claude-code.md`` Hooks
+  Automation Setup must declare byte-identical ``command`` strings to
+  the plugin's shipped ``hooks.json`` for every event the snippet
+  covers. Drift between the two sites silently ships an outdated
+  user-facing recipe.
 """
 
 from __future__ import annotations
 
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -23,6 +30,8 @@ import pytest
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _GUIDES = _REPO_ROOT / "docs" / "guides"
 _INTEGRATIONS = _GUIDES / "integrations"
+_PLUGIN_HOOKS_JSON = _REPO_ROOT / "packages" / "memtomem-claude-plugin" / "hooks" / "hooks.json"
+_HOOKS_SNIPPET_ANCHOR = "Add the following to `~/.claude/settings.json`:"
 
 _ASTERISK_TOOLS = ("mem_config", "mem_embedding_reset", "mem_reset")
 _FOOTNOTE_PREFIX = r"\* Requires `MEMTOMEM_TOOL_MODE=full`"
@@ -124,4 +133,92 @@ class TestToolModeFootnoteParity:
             "mcp-clients.md must carry reference.md's tool-mode footnote "
             "line verbatim so the CLI / Web UI alternate-access hint stays "
             "in sync across the two Config-table entry points."
+        )
+
+
+def _extract_hooks_snippet(claude_code_md: str) -> dict:
+    """Extract the ``Add the following to ~/.claude/settings.json`` JSON
+    block from claude-code.md. Returns the parsed dict.
+
+    The Hooks Automation Setup section embeds a fenced ``json`` block that
+    users copy-paste into their Claude Code settings; this helper returns
+    that block as the parsed dict so parity tests can compare commands
+    against the plugin's shipped hooks.json.
+    """
+    anchor_idx = claude_code_md.find(_HOOKS_SNIPPET_ANCHOR)
+    if anchor_idx == -1:
+        pytest.fail(f"claude-code.md lost its hooks-snippet anchor: {_HOOKS_SNIPPET_ANCHOR!r}")
+    fence_re = re.compile(r"```json\n(.*?)\n```", re.DOTALL)
+    match = fence_re.search(claude_code_md, anchor_idx)
+    if match is None:
+        pytest.fail("claude-code.md has the hooks-snippet anchor but no ```json fence after it")
+    return json.loads(match.group(1))
+
+
+def _commands_by_event_matcher(hooks_doc: dict) -> dict[tuple[str, str], str]:
+    """Flatten a hooks.json shape into ``{(event, matcher): command}``.
+
+    Only entries with a single command are included; multi-command entries
+    fail loudly because the parity test isn't designed for them yet.
+    """
+    out: dict[tuple[str, str], str] = {}
+    for event, entries in hooks_doc.get("hooks", {}).items():
+        for entry in entries:
+            matcher = entry.get("matcher", "")
+            commands = entry.get("hooks", [])
+            assert len(commands) == 1, (
+                f"hooks parity helper expected exactly one command per entry, "
+                f"got {len(commands)} at {event}/{matcher!r}"
+            )
+            out[(event, matcher)] = commands[0]["command"]
+    return out
+
+
+class TestPluginHooksDocsParity:
+    """The hooks.json snippet in claude-code.md must declare byte-identical
+    ``command`` strings to the plugin's shipped hooks.json for every
+    (event, matcher) pair the docs cover. The docs intentionally show a
+    subset (the ``activity log`` PostToolUse entry is omitted to keep the
+    copy-paste recipe tight), so we iterate over the docs entries and
+    require each to match the plugin file — not the other way around.
+    """
+
+    @pytest.fixture(scope="class")
+    def plugin_commands(self) -> dict[tuple[str, str], str]:
+        plugin_hooks = json.loads(_PLUGIN_HOOKS_JSON.read_text(encoding="utf-8"))
+        return _commands_by_event_matcher(plugin_hooks)
+
+    @pytest.fixture(scope="class")
+    def docs_commands(self, claude_code: str) -> dict[tuple[str, str], str]:
+        snippet = _extract_hooks_snippet(claude_code)
+        return _commands_by_event_matcher(snippet)
+
+    def test_docs_snippet_is_subset_of_plugin(
+        self,
+        plugin_commands: dict[tuple[str, str], str],
+        docs_commands: dict[tuple[str, str], str],
+    ) -> None:
+        missing = [k for k in docs_commands if k not in plugin_commands]
+        assert not missing, (
+            f"claude-code.md hooks snippet declares (event, matcher) entries "
+            f"that the plugin hooks.json does not ship: {missing}. Either add "
+            f"them to packages/memtomem-claude-plugin/hooks/hooks.json or "
+            f"remove them from the docs."
+        )
+
+    def test_docs_snippet_commands_match_plugin(
+        self,
+        plugin_commands: dict[tuple[str, str], str],
+        docs_commands: dict[tuple[str, str], str],
+    ) -> None:
+        diffs = [
+            (event_matcher, plugin_commands[event_matcher], docs_cmd)
+            for event_matcher, docs_cmd in docs_commands.items()
+            if plugin_commands.get(event_matcher) != docs_cmd
+        ]
+        assert not diffs, (
+            "claude-code.md hooks snippet drifted from the plugin's "
+            "hooks.json. The two sites must declare byte-identical commands "
+            "for every (event, matcher) the docs render. Diffs:\n"
+            + "\n".join(f"  {em}:\n    plugin: {p}\n    docs:   {d}" for em, p, d in diffs)
         )


### PR DESCRIPTION
## Summary

The plugin's `PostToolUse[Write]` hook was indexing every `Write`
unconditionally, which fanned out to `node_modules/`, `dist/`,
`__pycache__/`, lock files, binaries, and images in monorepo
checkouts. Embedding-cost amplifier + search-result noise that scaled
with build-artifact churn instead of source-file churn.

This PR replaces the inline command with an extension allowlist
(`md`, `py`, `ts`/`tsx`, `js`/`jsx`, `go`, `rs`, `rb`, `java`, `kt`,
`swift`, `c`/`cpp`/`h`/`hpp`, `sh`, `toml`, `yaml`/`yml`, `json`)
and a path blocklist (`node_modules`, `dist`, `build`, `target`,
`.next`, `.nuxt`, `__pycache__`, `.git`, `.venv`/`venv`, `coverage`,
`.cache`) expressed as inline `case` statements in
`packages/memtomem-claude-plugin/hooks/hooks.json`. No external
wrapper script — `hooks.json` stays self-contained.

`docs/guides/integrations/claude-code.md` Hooks Automation snippet is
synced verbatim with the plugin file (drift prevention). Caveats
section gains two bullets covering the new allowlist/blocklist
defaults and the remaining debounce gap (rapid consecutive writes
can still re-index the same file; `mm index --debounce-window` is
the planned follow-up).

Other plugin hooks (`UserPromptSubmit`, `PostToolUse activity log`,
`Stop`) are unchanged.

## Why not also add PreCompact / SessionStart hooks?

Both gaps were considered together with this one and intentionally
deferred to separate RFCs because they need new CLI primitives:

- **SessionStart hook** would call `mm session start`, but that
  command is non-idempotent (`session_cmd.py:110` overwrites
  `~/.memtomem/.current_session` with a fresh UUID every call). A
  hook firing on every Claude Code session would orphan the previous
  session whenever `Stop` failed (crash, kill, timeout). Safe
  integration needs `mm session start --idempotent` (or
  `--resume-if-active`) first.
- **PreCompact hook** is most valuable when it can snapshot working
  context, but the existing CLI surface only offers `mm activity log`
  (marker only). A meaningful checkpoint needs both a new
  `mm session checkpoint` CLI and a clear story for what content the
  hook payload can actually capture.

PostToolUse hardening has zero CLI dependency and ships standalone.

## Test plan

- [x] `python -m json.tool packages/memtomem-claude-plugin/hooks/hooks.json` — JSON valid
- [x] `pytest packages/memtomem/tests/test_docs_guards.py packages/memtomem/tests/test_config_overrides.py -x -q` — 37 passed
- [x] `jq` round-trip: `command` field in docs snippet is byte-identical to `hooks.json`
- [ ] Reviewer: visual diff of CHANGELOG `### Changed` entry under `[Unreleased]`
- [ ] Reviewer: confirm allowlist/blocklist patterns make sense for your stack — they are inline `case` statements, easy to extend per-project

## Out of scope (tracked separately)

- RFC: hooks-friendly session CLI primitives (`mm session start --idempotent`, etc.) — prerequisite for SessionStart hook
- RFC: working-context capture for PreCompact (`mm session checkpoint` design + payload story)
- `mm index --debounce-window` CLI option — debounce gap follow-up
- Plugin v0.1.0 → marketplace publish — separate RFC

🤖 Generated with [Claude Code](https://claude.com/claude-code)