### PR TITLE
feat(server): expose as_of on mem_search MCP tool (Goal 5)

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/search.py
+++ b/packages/memtomem/src/memtomem/server/tools/search.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from uuid import UUID
 
+from memtomem.chunking.markdown import _parse_validity_bound
 from memtomem.constants import INVALID_OUTPUT_FORMAT_PREFIX
 from memtomem.server import mcp
 from memtomem.server.context import CtxType, _get_app_initialized
@@ -34,6 +35,7 @@ async def mem_search(
     source_filter: str | None = None,
     tag_filter: str | None = None,
     namespace: str | None = None,
+    as_of: str | None = None,
     bm25_weight: float | None = None,
     dense_weight: float | None = None,
     context_window: int = 0,
@@ -49,6 +51,10 @@ async def mem_search(
         source_filter: Filter by source file path (substring match, or glob pattern with *, ?, [])
         tag_filter: Comma-separated tags — matches chunks containing ANY of the listed tags (OR logic)
         namespace: Namespace scope (single value)
+        as_of: Temporal bound for retroactive search — date-only ``YYYY-MM-DD`` or
+            quarter ``YYYY-QN`` (N in 1-4). Default ``None`` = current time. Chunks
+            whose ``valid_from`` / ``valid_to`` frontmatter excludes this point in
+            time are filtered out (chunks without those keys are always-valid).
         bm25_weight: Override BM25 weight in RRF fusion (default 1.0). Set higher to favor keyword matches.
         dense_weight: Override dense/semantic weight in RRF fusion (default 1.0). Set higher to favor meaning.
         context_window: Expand each result with ±N adjacent chunks (0=disabled). Use for more context.
@@ -56,6 +62,11 @@ async def mem_search(
         output_format: Output format — "compact" (default, human-readable), "verbose" (full
             details with UUID/pipeline stats), or "structured" (JSON for machine parsing).
             When set to non-default, overrides the verbose flag.
+
+    Result count may fall below ``top_k`` when post-rerank filters
+    (``source_filter``, ``tag_filter``, validity windows via ``as_of``) exclude
+    candidates. Increase ``top_k`` or ``rerank_pool`` to widen the pre-filter
+    candidate set; this method does not auto-oversample.
     """
     if not query.strip():
         return "Error: query cannot be empty."
@@ -70,6 +81,15 @@ async def mem_search(
         effective_format = "verbose"
     if effective_format not in _VALID_OUTPUT_FORMATS:
         return f"Error: {INVALID_OUTPUT_FORMAT_PREFIX} '{output_format}'."
+
+    as_of_unix: int | None = None
+    if as_of is not None:
+        as_of_unix = _parse_validity_bound(as_of, upper=False)
+        if as_of_unix is None:
+            return (
+                f"Error: invalid as_of value '{as_of}'. "
+                "Accepted formats: 'YYYY-MM-DD' (date) or 'YYYY-QN' (quarter, N in 1-4)."
+            )
 
     app = await _get_app_initialized(ctx)
     effective_ns = namespace or app.current_namespace
@@ -86,6 +106,7 @@ async def mem_search(
         namespace=effective_ns,
         rrf_weights=rrf_weights,
         context_window=context_window if context_window > 0 else None,
+        as_of_unix=as_of_unix,
     )
 
     # Build trust-UX hints shared across formats: archive filter count and a

--- a/packages/memtomem/tests/test_temporal_validity.py
+++ b/packages/memtomem/tests/test_temporal_validity.py
@@ -1,12 +1,14 @@
-"""Frontmatter validity-window parsing, schema, indexer threading, and pipeline filter.
+"""Frontmatter validity-window parsing, schema, indexer threading, pipeline filter, and MCP surface.
 
-Covers Goals 1+2+3+4 of the temporal-validity RFC: the frontmatter parser
+Covers Goals 1+2+3+4+5 of the temporal-validity RFC: the frontmatter parser
 (``_parse_validity_bound`` / ``_extract_validity_window``), the
 ``ChunkMetadata.valid_from_unix`` / ``valid_to_unix`` fields, the schema
 migration that adds the two SQLite columns, the chunker→metadata wiring,
-and the ``_apply_validity_filter`` pipeline stage with its
-``SearchPipeline.search(as_of_unix=...)`` plumbing. The
-``mem_search(as_of=...)`` MCP/CLI/Web surfaces are covered by later RFC PRs.
+the ``_apply_validity_filter`` pipeline stage with its
+``SearchPipeline.search(as_of_unix=...)`` plumbing, and the
+``mem_search(as_of=...)`` MCP-tool surface that parses caller strings to
+unix-seconds. The CLI ``mm search --as-of`` (Goal 6) and Web UI badge
+(Goal 7) surfaces are covered by later RFC PRs.
 
 The search round-trip tests in the middle of the file lock in the fix
 for PR #533 review feedback — bm25_search / dense_search must carry the
@@ -562,3 +564,116 @@ class TestValidityFilterPipelineWiring:
         assert pipe._storage.bm25_search.await_count == before + 1, (
             "explicit as_of must bypass cache read"
         )
+
+
+# ── Goal 5: mem_search(as_of=...) MCP-tool surface ─────────────────────
+
+
+class TestMemSearchAsOfValidation:
+    """``as_of`` parsing rejects malformed input *before* app initialization.
+
+    Mirrors ``TestSearchValidation`` in ``test_validation_error_messages.py``:
+    the early validation path runs without a real ``ctx``/app, so these tests
+    invoke ``mem_search`` directly. The error message must point the caller at
+    the two accepted formats so they can fix the call without consulting docs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_garbage_string_returns_error_with_format_hint(self) -> None:
+        from memtomem.server.tools.search import mem_search
+
+        result = await mem_search(query="hello", as_of="not-a-date")
+        assert "invalid as_of" in result
+        assert "not-a-date" in result
+        assert "YYYY-MM-DD" in result
+        assert "YYYY-QN" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_calendar_date_rejected(self) -> None:
+        from memtomem.server.tools.search import mem_search
+
+        result = await mem_search(query="hello", as_of="2025-13-01")
+        assert "invalid as_of" in result
+        assert "2025-13-01" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_quarter_rejected(self) -> None:
+        from memtomem.server.tools.search import mem_search
+
+        result = await mem_search(query="hello", as_of="2025-Q5")
+        assert "invalid as_of" in result
+        assert "2025-Q5" in result
+
+
+class TestMemSearchAsOfPlumbing:
+    """Valid ``as_of`` parses to unix-seconds and reaches the pipeline call.
+
+    Stubs ``_get_app_initialized`` so the test exercises only the parse +
+    forward path inside ``mem_search``, mirroring the ``TestMemExpand``
+    pattern in ``test_context_window.py``. Asserts on the kwargs the tool
+    passes to ``app.search_pipeline.search`` — that is the contract Goal 5
+    is establishing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_date_as_of_passes_day_start_unix_to_pipeline(self, monkeypatch) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from memtomem.search.pipeline import RetrievalStats
+        from memtomem.server.tools import search as search_tool
+
+        app = MagicMock()
+        app.current_namespace = None
+        app.search_pipeline.search = AsyncMock(return_value=([], RetrievalStats()))
+        app.webhook_manager = None
+        monkeypatch.setattr(search_tool, "_get_app_initialized", AsyncMock(return_value=app))
+
+        await search_tool.mem_search(query="hi", as_of="2025-08-15", ctx=SimpleNamespace())
+
+        kwargs = app.search_pipeline.search.await_args.kwargs
+        assert kwargs["as_of_unix"] == _ts(2025, 8, 15, 0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_quarter_as_of_passes_quarter_start_unix_to_pipeline(self, monkeypatch) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from memtomem.search.pipeline import RetrievalStats
+        from memtomem.server.tools import search as search_tool
+
+        app = MagicMock()
+        app.current_namespace = None
+        app.search_pipeline.search = AsyncMock(return_value=([], RetrievalStats()))
+        app.webhook_manager = None
+        monkeypatch.setattr(search_tool, "_get_app_initialized", AsyncMock(return_value=app))
+
+        await search_tool.mem_search(query="hi", as_of="2024-Q3", ctx=SimpleNamespace())
+
+        kwargs = app.search_pipeline.search.await_args.kwargs
+        # Q3 lower bound = July 1, 00:00:00 UTC.
+        assert kwargs["as_of_unix"] == _ts(2024, 7, 1, 0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_default_none_passes_none_to_pipeline(self, monkeypatch) -> None:
+        """``as_of=None`` (default) keeps pipeline-level ``int(time.time())``
+        fallback authoritative — the tool must not pre-resolve ``None`` to a
+        timestamp, otherwise the pipeline's cache slot would diverge from the
+        default-path key.
+        """
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+
+        from memtomem.search.pipeline import RetrievalStats
+        from memtomem.server.tools import search as search_tool
+
+        app = MagicMock()
+        app.current_namespace = None
+        app.search_pipeline.search = AsyncMock(return_value=([], RetrievalStats()))
+        app.webhook_manager = None
+        monkeypatch.setattr(search_tool, "_get_app_initialized", AsyncMock(return_value=app))
+
+        await search_tool.mem_search(query="hi", ctx=SimpleNamespace())
+
+        kwargs = app.search_pipeline.search.await_args.kwargs
+        assert kwargs["as_of_unix"] is None


### PR DESCRIPTION
## Summary

- Implements RFC §API change Goal 5: ``mem_search`` accepts an optional ``as_of`` (date-only ``YYYY-MM-DD`` or quarter ``YYYY-QN``), parses to unix-seconds via ``_parse_validity_bound`` (reused from #533), and forwards as ``as_of_unix=...`` to ``SearchPipeline.search`` (#534's plumbing).
- Default ``as_of=None`` is forwarded unchanged so the pipeline-level ``int(time.time())`` fallback (and its default-path cache slot) stays authoritative — pre-resolving in the tool would split the cache key.
- Invalid input returns the existing string-error shape (`"Error: invalid as_of '<value>'..."`) with a hint pointing at both accepted formats. Matches the surrounding mem_search validation pattern (top_k range, query length, output_format) — `tool_handler` is not the right channel for parameter-shape errors.
- Docstring carries the result-count contract verbatim from RFC §API change. This is the user-facing answer to the post-rerank-truncation question that §Open questions resolved as **Option C** (validity_filter inherits source/tag's truncation contract for sibling consistency). B+D mini-RFC is deferred behind a measurable revisit trigger documented in §Open questions.
- 6 new tests in `test_temporal_validity.py` (3 validation, 3 plumbing). Default `as_of=None` test pins the no-pre-resolve invariant explicitly.

## Stack

This is the first of three stacked PRs implementing Goals 5+6+7 of the temporal-validity RFC:

1. **#TBD this PR** — MCP `mem_search(as_of=...)` (base: `main`)
2. #TBD Goal 6 — CLI `mm search --as-of` + `mm recall` Validity column (base: this branch)
3. #TBD Goal 7 — Web UI badge in detail modal + search results (base: Goal 6 branch)

Goals 1–4 already shipped: #533 (frontmatter parser + schema + indexer + storage round-trip), #534 (`_apply_validity_filter` pipeline stage + `SearchPipeline.search(as_of_unix=...)` plumbing).

## Test plan

- [x] ruff check + format on changed files
- [x] `pytest -m "not ollama" packages/memtomem/tests/test_temporal_validity.py` — 48 → 54 (6 new pass)
- [x] Wider regression: temporal_validity + validation_error_messages + trust_ux + context_window 101/101 pass
- [x] search/pipeline/temporal/server_tools wider sweep — 405/405 pass
- [ ] CI green
- [ ] Manual smoke test once merged: `mm search --as-of 2024-Q3 ...` (CLI) — covered by Goal 6 PR; for now MCP-tool equivalent via `mcp__memtomem__mem_search` would exercise the same code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)
