### PR TITLE
feat(cli): expose --as-of on mm search + Validity column on mm recall (Goal 6)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/memory.py
+++ b/packages/memtomem/src/memtomem/cli/memory.py
@@ -10,6 +10,25 @@ from pathlib import Path
 import click
 
 
+def _render_validity_window(valid_from_unix: int | None, valid_to_unix: int | None) -> str:
+    """Render a chunk's temporal-validity window as a compact ``[from → to]`` label.
+
+    Per temporal-validity RFC §CLI surfacing. Both bounds are unix-seconds;
+    ``None`` is rendered as ``∞`` (no bound on that side). Date-only display —
+    the original frontmatter shape (``YYYY-MM-DD`` vs ``YYYY-QN``) is not
+    preserved through unix-second storage, so a quarter that ended ``2026-Q1``
+    surfaces as ``2026-03-31``. The user can inspect the source file for the
+    original spelling.
+    """
+
+    def _fmt(unix: int | None) -> str:
+        if unix is None:
+            return "∞"
+        return datetime.fromtimestamp(unix, tz=timezone.utc).strftime("%Y-%m-%d")
+
+    return f"[{_fmt(valid_from_unix)} → {_fmt(valid_to_unix)}]"
+
+
 @click.command()
 @click.argument("content")
 @click.option("--title", "-t", default=None, help="Entry title")
@@ -141,12 +160,33 @@ async def _recall(
             click.echo(c.content[:200])
             click.echo()
     else:
-        click.echo(f"{'Source':<40}{'Created':<25}{'Content'}")
-        click.echo("-" * 80)
-        for c in chunks:
-            src = str(c.metadata.source_file)
-            if len(src) > 38:
-                src = "..." + src[-35:]
-            snippet = c.content[:40].replace("\n", " ")
-            click.echo(f"{src:<40}{c.created_at.strftime('%Y-%m-%d %H:%M'):<25}{snippet}")
+        # Validity column appears only when at least one chunk has a
+        # window — keeps the default table compact for the common case
+        # where no chunks opted into temporal-validity frontmatter.
+        # Per temporal-validity RFC §CLI surfacing.
+        show_validity = any(
+            c.metadata.valid_from_unix is not None or c.metadata.valid_to_unix is not None
+            for c in chunks
+        )
+        if show_validity:
+            click.echo(f"{'Source':<40}{'Created':<18}{'Validity':<26}{'Content'}")
+            click.echo("-" * 100)
+            for c in chunks:
+                src = str(c.metadata.source_file)
+                if len(src) > 38:
+                    src = "..." + src[-35:]
+                snippet = c.content[:40].replace("\n", " ")
+                vw = _render_validity_window(c.metadata.valid_from_unix, c.metadata.valid_to_unix)
+                click.echo(
+                    f"{src:<40}{c.created_at.strftime('%Y-%m-%d %H:%M'):<18}{vw:<26}{snippet}"
+                )
+        else:
+            click.echo(f"{'Source':<40}{'Created':<25}{'Content'}")
+            click.echo("-" * 80)
+            for c in chunks:
+                src = str(c.metadata.source_file)
+                if len(src) > 38:
+                    src = "..." + src[-35:]
+                snippet = c.content[:40].replace("\n", " ")
+                click.echo(f"{src:<40}{c.created_at.strftime('%Y-%m-%d %H:%M'):<25}{snippet}")
         click.echo(f"\n{len(chunks)} chunk(s)")

--- a/packages/memtomem/src/memtomem/cli/search.py
+++ b/packages/memtomem/src/memtomem/cli/search.py
@@ -19,6 +19,12 @@ import click
 @click.option("--tag-filter", "-t", default=None, help="Tag filter (comma-separated)")
 @click.option("--namespace", "-n", default=None, help="Namespace filter")
 @click.option(
+    "--as-of",
+    "as_of",
+    default=None,
+    help="Temporal bound (YYYY-MM-DD or YYYY-QN). Default = now.",
+)
+@click.option(
     "--format",
     "fmt",
     type=click.Choice(["table", "json", "plain", "context", "smart"]),
@@ -30,11 +36,12 @@ def search(
     source_filter: str | None,
     tag_filter: str | None,
     namespace: str | None,
+    as_of: str | None,
     fmt: str,
 ) -> None:
     """Search the knowledge base."""
     try:
-        asyncio.run(_search(query, top_k, source_filter, tag_filter, namespace, fmt))
+        asyncio.run(_search(query, top_k, source_filter, tag_filter, namespace, as_of, fmt))
     except click.ClickException:
         raise
     except Exception as e:
@@ -47,9 +54,20 @@ async def _search(
     source_filter: str | None,
     tag_filter: str | None,
     namespace: str | None,
+    as_of: str | None,
     fmt: str,
 ) -> None:
+    from memtomem.chunking.markdown import _parse_validity_bound
     from memtomem.cli._bootstrap import cli_components
+
+    as_of_unix: int | None = None
+    if as_of is not None:
+        as_of_unix = _parse_validity_bound(as_of, upper=False)
+        if as_of_unix is None:
+            raise click.ClickException(
+                f"invalid --as-of value '{as_of}'. "
+                "Accepted formats: 'YYYY-MM-DD' (date) or 'YYYY-QN' (quarter, N in 1-4)."
+            )
 
     async with cli_components() as comp:
         results, stats = await comp.search_pipeline.search(
@@ -58,6 +76,7 @@ async def _search(
             source_filter=source_filter,
             tag_filter=tag_filter,
             namespace=namespace,
+            as_of_unix=as_of_unix,
         )
 
     if fmt == "context":

--- a/packages/memtomem/tests/test_temporal_validity.py
+++ b/packages/memtomem/tests/test_temporal_validity.py
@@ -1,14 +1,16 @@
-"""Frontmatter validity-window parsing, schema, indexer threading, pipeline filter, and MCP surface.
+"""Frontmatter validity-window parsing, schema, indexer threading, pipeline filter, MCP + CLI surfaces.
 
-Covers Goals 1+2+3+4+5 of the temporal-validity RFC: the frontmatter parser
+Covers Goals 1+2+3+4+5+6 of the temporal-validity RFC: the frontmatter parser
 (``_parse_validity_bound`` / ``_extract_validity_window``), the
 ``ChunkMetadata.valid_from_unix`` / ``valid_to_unix`` fields, the schema
 migration that adds the two SQLite columns, the chunker→metadata wiring,
 the ``_apply_validity_filter`` pipeline stage with its
-``SearchPipeline.search(as_of_unix=...)`` plumbing, and the
-``mem_search(as_of=...)`` MCP-tool surface that parses caller strings to
-unix-seconds. The CLI ``mm search --as-of`` (Goal 6) and Web UI badge
-(Goal 7) surfaces are covered by later RFC PRs.
+``SearchPipeline.search(as_of_unix=...)`` plumbing, the
+``mem_search(as_of=...)`` MCP-tool surface, and the CLI surfaces:
+``mm search --as-of <date>`` and the conditional Validity column on
+``mm recall`` (the actual chunks-listing CLI; the RFC's "mm list" name
+was a drift — corrected in the same release window). The Web UI badge
+(Goal 7) is covered by a later RFC PR.
 
 The search round-trip tests in the middle of the file lock in the fix
 for PR #533 review feedback — bm25_search / dense_search must carry the
@@ -677,3 +679,220 @@ class TestMemSearchAsOfPlumbing:
 
         kwargs = app.search_pipeline.search.await_args.kwargs
         assert kwargs["as_of_unix"] is None
+
+
+# ── Goal 6: CLI surface (mm search --as-of, mm recall validity column) ──
+
+
+def _mock_cli_components_for_search(search_return):
+    """Build a mock ``cli_components()`` context manager for ``mm search``.
+
+    ``search_return`` is the ``(results, stats)`` tuple to return from the
+    pipeline call. The returned async-context-manager yields a
+    ``SimpleNamespace`` whose ``search_pipeline.search`` is an AsyncMock —
+    the test asserts on the AsyncMock's ``await_args``.
+    """
+    from contextlib import asynccontextmanager
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    pipeline_mock = AsyncMock(return_value=search_return)
+    comp = SimpleNamespace(
+        search_pipeline=SimpleNamespace(search=pipeline_mock),
+    )
+
+    @asynccontextmanager
+    async def fake_cli_components():
+        yield comp
+
+    return fake_cli_components, pipeline_mock
+
+
+def _mock_cli_components_for_recall(chunks):
+    """Build a mock ``cli_components()`` context manager for ``mm recall``.
+
+    Provides ``comp.storage.recall_chunks`` returning the supplied chunk list
+    and a minimal ``comp.config.search.system_namespace_prefixes`` so the
+    NamespaceFilter parse path does not blow up.
+    """
+    from contextlib import asynccontextmanager
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    storage = SimpleNamespace(recall_chunks=AsyncMock(return_value=list(chunks)))
+    config = SimpleNamespace(search=SimpleNamespace(system_namespace_prefixes=()))
+    comp = SimpleNamespace(storage=storage, config=config)
+
+    @asynccontextmanager
+    async def fake_cli_components():
+        yield comp
+
+    return fake_cli_components
+
+
+def _make_chunk_for_recall(
+    *,
+    valid_from_unix: int | None = None,
+    valid_to_unix: int | None = None,
+    source: str = "/tmp/note.md",
+    content: str = "hello",
+) -> Chunk:
+    """Construct a minimal ``Chunk`` with optional validity metadata.
+
+    Mirrors the ``mm recall`` data shape: ``recall_chunks`` returns
+    ``Chunk`` instances and the table renderer reads ``metadata.source_file``,
+    ``metadata.valid_from_unix`` / ``valid_to_unix``, ``content``,
+    ``created_at``.
+    """
+    return Chunk(
+        id=uuid.uuid4(),
+        content=content,
+        metadata=ChunkMetadata(
+            source_file=Path(source),
+            valid_from_unix=valid_from_unix,
+            valid_to_unix=valid_to_unix,
+        ),
+        created_at=datetime(2026, 4, 29, 12, 0, 0, tzinfo=timezone.utc),
+    )
+
+
+class TestMmSearchAsOfCLI:
+    """``mm search --as-of <date>`` parses + plumbs to the pipeline.
+
+    Mirrors the MCP-tool tests above but on the click surface. Invalid input
+    travels through ``click.ClickException`` (CliRunner returns non-zero
+    exit code with the message in ``result.output``) — the error message
+    must include the offending value AND both accepted formats so a script
+    author hitting this can correct the call without consulting docs.
+    """
+
+    def test_invalid_as_of_returns_nonzero_with_format_hint(self) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        result = CliRunner().invoke(cli, ["search", "--as-of", "not-a-date", "hello"])
+        assert result.exit_code != 0
+        assert "not-a-date" in result.output
+        assert "YYYY-MM-DD" in result.output
+        assert "YYYY-QN" in result.output
+
+    def test_date_as_of_passes_day_start_unix_to_pipeline(self, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+        from memtomem.search.pipeline import RetrievalStats
+
+        fake_components, pipeline_mock = _mock_cli_components_for_search(([], RetrievalStats()))
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+
+        result = CliRunner().invoke(cli, ["search", "--as-of", "2025-08-15", "hello"])
+        assert result.exit_code == 0, result.output
+        kwargs = pipeline_mock.await_args.kwargs
+        assert kwargs["as_of_unix"] == _ts(2025, 8, 15, 0, 0, 0)
+
+    def test_quarter_as_of_passes_quarter_start_unix_to_pipeline(self, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+        from memtomem.search.pipeline import RetrievalStats
+
+        fake_components, pipeline_mock = _mock_cli_components_for_search(([], RetrievalStats()))
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+
+        result = CliRunner().invoke(cli, ["search", "--as-of", "2024-Q3", "hello"])
+        assert result.exit_code == 0, result.output
+        kwargs = pipeline_mock.await_args.kwargs
+        assert kwargs["as_of_unix"] == _ts(2024, 7, 1, 0, 0, 0)
+
+    def test_default_omitted_passes_none_to_pipeline(self, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+        from memtomem.search.pipeline import RetrievalStats
+
+        fake_components, pipeline_mock = _mock_cli_components_for_search(([], RetrievalStats()))
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake_components)
+
+        result = CliRunner().invoke(cli, ["search", "hello"])
+        assert result.exit_code == 0, result.output
+        kwargs = pipeline_mock.await_args.kwargs
+        assert kwargs["as_of_unix"] is None
+
+
+class TestMmRecallValidityColumn:
+    """``mm recall`` table format surfaces a Validity column when at least
+    one chunk in the listing has ``valid_from_unix`` or ``valid_to_unix``.
+
+    Per RFC §CLI surfacing — the column is conditional so the default
+    table stays compact for users who haven't opted into temporal-validity
+    frontmatter.
+    """
+
+    def test_no_chunks_have_validity_column_omitted(self, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        chunks = [
+            _make_chunk_for_recall(content="alpha"),
+            _make_chunk_for_recall(content="beta"),
+        ]
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components",
+            _mock_cli_components_for_recall(chunks),
+        )
+
+        result = CliRunner().invoke(cli, ["recall"])
+        assert result.exit_code == 0, result.output
+        assert "Validity" not in result.output
+        # Default columns are still rendered.
+        assert "Source" in result.output
+        assert "Created" in result.output
+
+    def test_at_least_one_validity_column_shown(self, monkeypatch) -> None:
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        chunks = [
+            _make_chunk_for_recall(content="plain"),
+            _make_chunk_for_recall(
+                content="windowed",
+                valid_from_unix=_ts(2025, 8, 15, 0, 0, 0),
+                valid_to_unix=_ts(2026, 3, 31, 23, 59, 59),
+            ),
+        ]
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components",
+            _mock_cli_components_for_recall(chunks),
+        )
+
+        result = CliRunner().invoke(cli, ["recall"])
+        assert result.exit_code == 0, result.output
+        assert "Validity" in result.output
+        # Windowed chunk renders both bounds.
+        assert "[2025-08-15 → 2026-03-31]" in result.output
+        # Plain chunk rendered with infinity sentinels on both sides.
+        assert "[∞ → ∞]" in result.output
+
+    def test_half_bounded_renders_infinity_sentinel(self, monkeypatch) -> None:
+        """A chunk with only ``valid_from`` shows ``∞`` on the upper side."""
+        from click.testing import CliRunner
+
+        from memtomem.cli import cli
+
+        chunks = [
+            _make_chunk_for_recall(
+                content="lower-only",
+                valid_from_unix=_ts(2025, 8, 15, 0, 0, 0),
+            ),
+        ]
+        monkeypatch.setattr(
+            "memtomem.cli._bootstrap.cli_components",
+            _mock_cli_components_for_recall(chunks),
+        )
+
+        result = CliRunner().invoke(cli, ["recall"])
+        assert result.exit_code == 0, result.output
+        assert "[2025-08-15 → ∞]" in result.output


### PR DESCRIPTION
## Summary

Implements RFC §CLI surfacing — caller-facing temporal-validity surfaces:

1. **`mm search --as-of <date|quarter> <query>`** — same parser as the MCP tool from Goal 5 (#538), invalid input raises `click.ClickException` with both accepted formats and the offending value echoed. Default forwards `as_of_unix=None` so the pipeline-level `time.time()` fallback (and its default-path cache slot) stays authoritative.

2. **`mm recall` Validity column** — appears *only* when at least one chunk in the listing has `valid_from_unix` or `valid_to_unix` set, keeping the default table compact for the common always-valid case. Renders as `[YYYY-MM-DD → YYYY-MM-DD]` with `∞` for unbounded sides; the original frontmatter shape (date vs quarter) is not preserved through unix-second storage, so `2026-Q1` displays as `2026-03-31`.

## RFC drift correction

The RFC said "mm list" but **`mm list` does not exist** (`mm --help` only has `recall`/`search`/`add`/...). The author wrote the name without verifying — `feedback_docs_as_tests.md` exactly captures this class of drift. The Goal 6 implementation uses the actual chunks-listing CLI (`mm recall`, which already supports `--format=[table|json|plain]`); the RFC was corrected in a sister-commit on the private memtomem-docs repo.

Adding a new `mm list` command alongside `mm recall` was rejected — surface bifurcation with no clear distinction (recall = since/until + listing; list = ???) is worse than the name fix.

## Stack

This is the second of three stacked PRs implementing Goals 5+6+7:

1. #538 — Goal 5 MCP `mem_search(as_of=...)` (base: `main`)
2. **this PR** — Goal 6 CLI surfaces (base: #538)
3. #TBD Goal 7 — Web UI badge (base: this branch)

## Test plan

- [x] ruff check + format
- [x] 7 new tests in `test_temporal_validity.py` — `TestMmSearchAsOfCLI` × 4 (invalid format / date / quarter / default), `TestMmRecallValidityColumn` × 3 (no-validity column omitted / at-least-one shows / half-bounded ∞)
- [x] regression: search/recall/temporal/session_cli 251/251 pass
- [ ] CI green
- [ ] Manual smoke (post-merge to feat/temporal-validity-goal-5): `mm search --as-of 2024-Q3 'foo'`, `mm recall` with mixed chunks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
