### PR TITLE
docs: surface mentions for temporal-validity (post-RFC ship)

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -272,7 +272,7 @@ uses, so the output is identical. Useful as a sanity check between
 
 | Category | Tools |
 |----------|-------|
-| **Search** | `mem_search` (hybrid BM25+Dense+RRF), `mem_recall` (date-range retrieval), `mem_expand` (context-window expansion) |
+| **Search** | `mem_search` (hybrid BM25+Dense+RRF, optional `as_of` for temporal-validity queries), `mem_recall` (date-range retrieval), `mem_expand` (context-window expansion) |
 | **Browse** | `mem_list` (indexed sources), `mem_read` (chunk by UUID) |
 | **CRUD** | `mem_add`, `mem_edit`, `mem_delete`, `mem_batch_add` |
 | **Indexing** | `mem_index` (file/directory indexing, optional `auto_tag`) |

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -201,6 +201,7 @@ Combines keyword matching (exact words) with meaning-based search (similar conce
 | `source_filter` | File path substring (recommended) or glob | `"docs/adr"`, `".yaml"` |
 | `tag_filter` | Comma-separated tags, OR logic | `"redis,cache"` |
 | `namespace` | Scope to namespace | `"work"` |
+| `as_of` | Temporal validity query — only return chunks valid on this date (default = current time). Date-only `YYYY-MM-DD` or quarter `YYYY-QN`. Chunks without `valid_from`/`valid_to` frontmatter are always-valid and unaffected. | `"2024-Q3"` |
 | `bm25_weight` / `dense_weight` | Override RRF weights (default `1.0`) | `2.0` |
 | `context_window` | Expand each result with ±N adjacent chunks (`0` = disabled) | `1` |
 | `output_format` | `"compact"` (default), `"verbose"`, or `"structured"` (JSON with `hints` field) | `"structured"` |
@@ -208,7 +209,10 @@ Combines keyword matching (exact words) with meaning-based search (similar conce
 ```
 mem_search(query="caching strategy", tag_filter="redis,cache", namespace="work")
 mem_search(query="auth", source_filter="docs/adr", top_k=5)
+mem_search(query="deploy pipeline", as_of="2025-Q3")    # historical query
 ```
+
+> **Result count with filters**: `mem_search` returns *up to* `top_k` results. Post-rerank filters (`source_filter`, `tag_filter`, `as_of` validity) reduce the returned count one-for-one when they exclude candidates. Increase `top_k` or `rerank_pool` to widen the pre-filter candidate set; this method does not auto-oversample.
 
 > **source_filter tip**: Use substrings like `"docs/adr"` or `".py"` for filtering. Glob patterns (`*`, `?`) are matched against the **full absolute path** via `fnmatch`, so `"*.py"` won't work as expected — use `".py"` instead.
 
@@ -976,9 +980,10 @@ mm init                                # 9-step interactive wizard (b: back, q: 
 
 # Core (daily use)
 mm search "deployment"                 # hybrid search (keywords + meaning)
+mm search --as-of 2024-Q3 "deploy"     # temporal-validity query (date-only or YYYY-QN)
 mm index ~/notes                       # manual one-shot index (seed pre-existing files)
 mm add "note" --tags "tag1"            # add a memory
-mm recall --since 2026-03-01           # recall by date
+mm recall --since 2026-03-01           # recall by date (Validity column shown when chunks have valid_from/valid_to)
 
 # Configuration
 mm config show                         # view all settings


### PR DESCRIPTION
## Summary

Temporal-validity RFC v1 shipped all 7 goals on `main` (#533/#534/#538/#539/#540), but the implementation PRs deliberately deferred user-facing docs. This adds the **minimum** surface mentions required by `feedback_doc_update_process.md` — new MCP tool param + new CLI flag should ship with same-PR reference docs.

The comprehensive conceptual guide is **not** in this PR. It lives in the private `memtomem-docs` repo and gets promoted to `docs/guides/temporal-validity.md` after one minor version bump (PROMOTION-CRITERIA #1) and a source-of-truth audit. This PR is the in-the-meantime reference touch only.

## Why now (and not in #538/#539/#540)

The feature is opt-in via frontmatter — users do not encounter `as_of` until they explicitly add `valid_from` / `valid_to` to a chunk. So shipping the surface PRs without same-PR docs did not break any user's expectations. But `feedback_doc_update_process.md` says new CLI/MCP surface should be discoverable in `reference.md` / `mcp-clients.md`, so this is the catch-up.

## Scope

- `docs/guides/reference.md`:
  - `mem_search` parameters table → one `as_of` row (format, default, opt-in semantics)
  - `mem_search` examples → one historical-query example
  - Post-rerank shrinkage caveat → verbatim from `server/tools/search.py` docstring (parallels existing `source_filter` / `tag_filter` caveat shape)
  - CLI quick-reference → one `mm search --as-of` line + a `mm recall` Validity-column parenthetical
- `docs/guides/mcp-clients.md`:
  - Tool inventory `mem_search` row → `(... optional as_of for temporal-validity queries)` parenthetical

`README.md` / `packages/memtomem/README.md` Key Features bullets intentionally left untouched — they sit at the "what is memtomem" abstraction level, and a per-parameter mention would be out of scale. Revisit if temporal-validity grows into a positioning differentiator after the v2 supersession layer.

## Source-of-truth verification (per `feedback_docs_as_tests.md`)

| Doc claim | Source |
|---|---|
| `mem_search(as_of=...)` | `packages/memtomem/src/memtomem/server/tools/search.py:38` |
| `mm search --as-of` | `packages/memtomem/src/memtomem/cli/search.py:22` |
| `mm recall` Validity column (conditional) | `packages/memtomem/src/memtomem/cli/memory.py:163-179` |
| Result-count contract wording | matches `server/tools/search.py:65-68` verbatim |
| Format `YYYY-MM-DD` / `YYYY-QN` | `_parse_validity_bound` accepts both shapes |

## Test plan

- [ ] CI green (markdown rendering only — no code paths touched)
- [ ] Render `docs/guides/reference.md` and confirm `as_of` row reads cleanly inside the existing parameter table
- [ ] Render `docs/guides/mcp-clients.md` and confirm the `mem_search` cell does not overflow visually with the added parenthetical
- [ ] Confirm `mm search --as-of 2024-Q3 "deploy"` in the CLI quick-reference matches the actual `--as-of` flag (already verified in source check above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)