### PR TITLE
fix(cli)!: rename mm session start --json key stale_ended → auto_ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   check, with a 100-row per-call cap so a backlog of orphans drains
   across multiple hook fires instead of stalling boot synchronously;
   `--json` emits one line of `{"session_id": ..., "resumed": bool,
-  "stale_ended": [...]}` for hook parsing. The plugin's `hooks.json`
+  "auto_ended": [...]}` for hook parsing — the list groups both
+  cutoff-based stale cleanup and cross-agent forced-end UUIDs;
+  ``sessions.metadata.reason`` (`stale` or `cross_agent`) carries the
+  per-row distinction. The plugin's `hooks.json`
   ships a SessionStart entry calling `mm session start --idempotent
   --auto-end-stale 24h --agent-id claude-code` and the
   `claude-code.md` Hooks Automation Setup snippet matches byte-for-byte

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -134,7 +134,7 @@ def session() -> None:
     "--json",
     "as_json",
     is_flag=True,
-    help='Emit one JSON line: {"session_id":..., "resumed":bool, "stale_ended":[...]}',
+    help='Emit one JSON line: {"session_id":..., "resumed":bool, "auto_ended":[...]}',
 )
 def start(
     agent_id: str,
@@ -197,7 +197,7 @@ async def _start(
 ) -> None:
     from memtomem.cli._bootstrap import cli_components
 
-    stale_ended: list[str] = []
+    auto_ended: list[str] = []
     resumed = False
     session_id: str | None = None
     ns = _derive_session_namespace(agent_id, namespace)
@@ -214,7 +214,7 @@ async def _start(
                     f"auto-ended after {stale_label} inactivity",
                     {"auto_ended": True, "reason": "stale"},
                 )
-                stale_ended.append(row["id"])
+                auto_ended.append(row["id"])
             if len(stale_rows) >= _STALE_CLEANUP_BATCH:
                 logger.warning(
                     "auto-end-stale truncated to %d sessions; rerun the hook "
@@ -241,7 +241,7 @@ async def _start(
                             f"auto-ended on cross-agent resume to {agent_id}",
                             {"auto_ended": True, "reason": "cross_agent"},
                         )
-                        stale_ended.append(current)
+                        auto_ended.append(current)
 
         if session_id is None:
             session_id = str(uuid.uuid4())
@@ -255,7 +255,7 @@ async def _start(
                 {
                     "session_id": session_id,
                     "resumed": resumed,
-                    "stale_ended": stale_ended,
+                    "auto_ended": auto_ended,
                 }
             )
         )
@@ -269,8 +269,8 @@ async def _start(
             click.echo(f"  Title: {title}")
     click.echo(f"  Agent: {agent_id}")
     click.echo(f"  Namespace: {ns}")
-    if stale_ended:
-        click.echo(f"  Auto-ended {len(stale_ended)} stale session(s)")
+    if auto_ended:
+        click.echo(f"  Auto-ended {len(auto_ended)} session(s)")
 
 
 @session.command()

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -197,7 +197,14 @@ async def _start(
 ) -> None:
     from memtomem.cli._bootstrap import cli_components
 
+    # JSON exposes a flat ``auto_ended`` list of UUIDs; the per-reason counters
+    # below feed the text-mode breakdown so an interactive operator still sees
+    # whether the cleanup came from cutoff age (stale) or a cross-agent
+    # forced-end. ``sessions.metadata.reason`` carries the same information
+    # row-by-row for JSON consumers that need it (queryable via SQL).
     auto_ended: list[str] = []
+    n_stale = 0
+    n_cross_agent = 0
     resumed = False
     session_id: str | None = None
     ns = _derive_session_namespace(agent_id, namespace)
@@ -215,6 +222,7 @@ async def _start(
                     {"auto_ended": True, "reason": "stale"},
                 )
                 auto_ended.append(row["id"])
+                n_stale += 1
             if len(stale_rows) >= _STALE_CLEANUP_BATCH:
                 logger.warning(
                     "auto-end-stale truncated to %d sessions; rerun the hook "
@@ -242,6 +250,7 @@ async def _start(
                             {"auto_ended": True, "reason": "cross_agent"},
                         )
                         auto_ended.append(current)
+                        n_cross_agent += 1
 
         if session_id is None:
             session_id = str(uuid.uuid4())
@@ -270,7 +279,12 @@ async def _start(
     click.echo(f"  Agent: {agent_id}")
     click.echo(f"  Namespace: {ns}")
     if auto_ended:
-        click.echo(f"  Auto-ended {len(auto_ended)} session(s)")
+        bits = []
+        if n_stale:
+            bits.append(f"{n_stale} stale")
+        if n_cross_agent:
+            bits.append(f"{n_cross_agent} cross-agent")
+        click.echo(f"  Auto-ended {len(auto_ended)} session(s) ({', '.join(bits)})")
 
 
 @session.command()

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -425,7 +425,7 @@ class TestSessionStartIdempotent:
         data = json.loads(result.output)
         assert data["session_id"] == existing_id
         assert data["resumed"] is True
-        assert data["stale_ended"] == []
+        assert data["auto_ended"] == []
         comp.storage.create_session.assert_not_awaited()
         comp.storage.end_session.assert_not_awaited()
 
@@ -442,7 +442,7 @@ class TestSessionStartIdempotent:
         data = json.loads(result.output)
         assert data["resumed"] is False
         assert data["session_id"] != existing_id
-        assert existing_id in data["stale_ended"]
+        assert existing_id in data["auto_ended"]
         comp.storage.end_session.assert_awaited_once()
         comp.storage.create_session.assert_awaited_once()
 
@@ -459,7 +459,7 @@ class TestSessionStartIdempotent:
         data = json.loads(result.output)
         assert data["resumed"] is False
         assert data["session_id"] != ended_id
-        assert data["stale_ended"] == []
+        assert data["auto_ended"] == []
         comp.storage.end_session.assert_not_awaited()
         comp.storage.create_session.assert_awaited_once()
 
@@ -483,7 +483,7 @@ class TestSessionStartIdempotent:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert data["resumed"] is False
-        assert stale_id in data["stale_ended"]
+        assert stale_id in data["auto_ended"]
         comp.storage.end_session.assert_awaited_once_with(
             stale_id,
             "auto-ended after 24h inactivity",
@@ -504,10 +504,10 @@ class TestSessionStartIdempotent:
         result = runner.invoke(cli, ["session", "start", "--agent-id", "claude-code", "--json"])
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
-        assert set(data.keys()) == {"session_id", "resumed", "stale_ended"}
+        assert set(data.keys()) == {"session_id", "resumed", "auto_ended"}
         assert isinstance(data["session_id"], str) and data["session_id"]
         assert data["resumed"] is False
-        assert data["stale_ended"] == []
+        assert data["auto_ended"] == []
 
     def test_invalid_duration_raises_bad_parameter(self, runner, monkeypatch):
         """Hook authors mistyping ``--auto-end-stale`` see a useful Click

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -509,6 +509,36 @@ class TestSessionStartIdempotent:
         assert data["resumed"] is False
         assert data["auto_ended"] == []
 
+    def test_text_mode_breakdown_by_reason(self, runner, monkeypatch):
+        """Text mode preserves the stale-vs-cross-agent split that the JSON
+        flat list intentionally drops. Both reasons firing in the same call
+        produces a ``(N stale, M cross-agent)`` suffix; pinning here so a
+        future refactor can't silently regress to a single bare count."""
+        stale_id = "55555555-5555-5555-5555-555555555555"
+        cross_id = "66666666-6666-6666-6666-666666666666"
+        comp = self._comp(
+            current_row=self._row(cross_id, "claude-code"),
+            stale=[self._row(stale_id, "claude-code")],
+        )
+        self._patch(monkeypatch, comp, cross_id)
+
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "start",
+                "--agent-id",
+                "codex",
+                "--idempotent",
+                "--auto-end-stale",
+                "24h",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Auto-ended 2 session(s)" in result.output
+        assert "1 stale" in result.output
+        assert "1 cross-agent" in result.output
+
     def test_invalid_duration_raises_bad_parameter(self, runner, monkeypatch):
         """Hook authors mistyping ``--auto-end-stale`` see a useful Click
         error instead of a stack trace. Pinned because the parser is


### PR DESCRIPTION
## Summary

- Rename `mm session start --json` output key `stale_ended` → `auto_ended` so the CLI surface matches the DB metadata's existing `auto_ended` flag and stops calling cross-agent forced-ends "stale".
- The list groups two reason classes — cutoff-based stale cleanup (`--auto-end-stale`) and cross-agent forced-end inside `--idempotent`. Per-row distinction stays on `sessions.metadata.reason` (`stale` or `cross_agent`).
- Text mode preserves the per-reason split that JSON intentionally drops: `Auto-ended N session(s) (X stale, Y cross-agent)`. Pinned by a new `test_text_mode_breakdown_by_reason`.

## Why this is safe to land as-is — base retargeted to `release/v0.1.33`

The `stale_ended` shape only appeared on `main` after v0.1.32 (PR #543, b8a5673, 2026-04-29) and was never tagged into a published PyPI release. **Base retargeted from `main` to `release/v0.1.33`** so the rename ships as part of the v0.1.33 cut — `stale_ended` therefore never reaches PyPI and there is no published API to break. Plugin's own `hooks.json` calls the CLI in text mode, not `--json`, so the rename has zero impact on the shipped Claude Code SessionStart recipe.

## Followup tracker

RFC `memtomem-docs#24` listed two open questions deferred to "telemetry-then-decide":

- **Item 3 (this PR)** — JSON / DB key vocabulary alignment. Decided semantically: rename now, costs are bounded.
- **Item 2 (still deferred)** — JSON entry shape (flat list vs split arrays vs `[{id, reason}]`). Needs a distribution measurement on `sessions.metadata.reason` after a few weeks of hook usage to know whether cross-agent ends are common enough to justify schema enrichment. The reason field is already persisted on every auto-end (`session_cmd.py:215, 245`), so no extra telemetry plumbing is required when the data window is up.

## Review polish addressed

- **Text-mode information loss** (called out in review): the rename initially dropped the "stale" hint from the human-mode print line. Polish commit `b511dcf` adds per-reason counters at the two append sites and renders `(N stale, M cross-agent)` whenever either fired. JSON shape unchanged.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_session_cli.py -m "not ollama"` — 27 passed (26 prior + new breakdown test).
- [x] `uv run pytest packages/memtomem/tests -m "not ollama" -k "session or hook"` — all pass.
- [x] `uv run ruff check` and `uv run ruff format --check` clean.
- [ ] Manual: `mm session start --idempotent --auto-end-stale 24h --agent-id claude-code --json` returns `auto_ended` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)