### PR TITLE
release: v0.1.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   check, with a 100-row per-call cap so a backlog of orphans drains
   across multiple hook fires instead of stalling boot synchronously;
   `--json` emits one line of `{"session_id": ..., "resumed": bool,
-  "stale_ended": [...]}` for hook parsing. The plugin's `hooks.json`
+  "auto_ended": [...]}` for hook parsing — the list groups both
+  cutoff-based stale cleanup and cross-agent forced-end UUIDs;
+  ``sessions.metadata.reason`` (`stale` or `cross_agent`) carries the
+  per-row distinction. The plugin's `hooks.json`
   ships a SessionStart entry calling `mm session start --idempotent
   --auto-end-stale 24h --agent-id claude-code` and the
   `claude-code.md` Hooks Automation Setup snippet matches byte-for-byte

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.33] — 2026-04-29
+
 ### Added
 
 - **`mm upgrade` CLI** (#443) — wraps `uv tool install --refresh

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.32"
+version = "0.1.33"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/packages/memtomem/src/memtomem/cli/session_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/session_cmd.py
@@ -134,7 +134,7 @@ def session() -> None:
     "--json",
     "as_json",
     is_flag=True,
-    help='Emit one JSON line: {"session_id":..., "resumed":bool, "stale_ended":[...]}',
+    help='Emit one JSON line: {"session_id":..., "resumed":bool, "auto_ended":[...]}',
 )
 def start(
     agent_id: str,
@@ -197,7 +197,14 @@ async def _start(
 ) -> None:
     from memtomem.cli._bootstrap import cli_components
 
-    stale_ended: list[str] = []
+    # JSON exposes a flat ``auto_ended`` list of UUIDs; the per-reason counters
+    # below feed the text-mode breakdown so an interactive operator still sees
+    # whether the cleanup came from cutoff age (stale) or a cross-agent
+    # forced-end. ``sessions.metadata.reason`` carries the same information
+    # row-by-row for JSON consumers that need it (queryable via SQL).
+    auto_ended: list[str] = []
+    n_stale = 0
+    n_cross_agent = 0
     resumed = False
     session_id: str | None = None
     ns = _derive_session_namespace(agent_id, namespace)
@@ -214,7 +221,8 @@ async def _start(
                     f"auto-ended after {stale_label} inactivity",
                     {"auto_ended": True, "reason": "stale"},
                 )
-                stale_ended.append(row["id"])
+                auto_ended.append(row["id"])
+                n_stale += 1
             if len(stale_rows) >= _STALE_CLEANUP_BATCH:
                 logger.warning(
                     "auto-end-stale truncated to %d sessions; rerun the hook "
@@ -241,7 +249,8 @@ async def _start(
                             f"auto-ended on cross-agent resume to {agent_id}",
                             {"auto_ended": True, "reason": "cross_agent"},
                         )
-                        stale_ended.append(current)
+                        auto_ended.append(current)
+                        n_cross_agent += 1
 
         if session_id is None:
             session_id = str(uuid.uuid4())
@@ -255,7 +264,7 @@ async def _start(
                 {
                     "session_id": session_id,
                     "resumed": resumed,
-                    "stale_ended": stale_ended,
+                    "auto_ended": auto_ended,
                 }
             )
         )
@@ -269,8 +278,13 @@ async def _start(
             click.echo(f"  Title: {title}")
     click.echo(f"  Agent: {agent_id}")
     click.echo(f"  Namespace: {ns}")
-    if stale_ended:
-        click.echo(f"  Auto-ended {len(stale_ended)} stale session(s)")
+    if auto_ended:
+        bits = []
+        if n_stale:
+            bits.append(f"{n_stale} stale")
+        if n_cross_agent:
+            bits.append(f"{n_cross_agent} cross-agent")
+        click.echo(f"  Auto-ended {len(auto_ended)} session(s) ({', '.join(bits)})")
 
 
 @session.command()

--- a/packages/memtomem/tests/test_session_cli.py
+++ b/packages/memtomem/tests/test_session_cli.py
@@ -425,7 +425,7 @@ class TestSessionStartIdempotent:
         data = json.loads(result.output)
         assert data["session_id"] == existing_id
         assert data["resumed"] is True
-        assert data["stale_ended"] == []
+        assert data["auto_ended"] == []
         comp.storage.create_session.assert_not_awaited()
         comp.storage.end_session.assert_not_awaited()
 
@@ -442,7 +442,7 @@ class TestSessionStartIdempotent:
         data = json.loads(result.output)
         assert data["resumed"] is False
         assert data["session_id"] != existing_id
-        assert existing_id in data["stale_ended"]
+        assert existing_id in data["auto_ended"]
         comp.storage.end_session.assert_awaited_once()
         comp.storage.create_session.assert_awaited_once()
 
@@ -459,7 +459,7 @@ class TestSessionStartIdempotent:
         data = json.loads(result.output)
         assert data["resumed"] is False
         assert data["session_id"] != ended_id
-        assert data["stale_ended"] == []
+        assert data["auto_ended"] == []
         comp.storage.end_session.assert_not_awaited()
         comp.storage.create_session.assert_awaited_once()
 
@@ -483,7 +483,7 @@ class TestSessionStartIdempotent:
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
         assert data["resumed"] is False
-        assert stale_id in data["stale_ended"]
+        assert stale_id in data["auto_ended"]
         comp.storage.end_session.assert_awaited_once_with(
             stale_id,
             "auto-ended after 24h inactivity",
@@ -504,10 +504,40 @@ class TestSessionStartIdempotent:
         result = runner.invoke(cli, ["session", "start", "--agent-id", "claude-code", "--json"])
         assert result.exit_code == 0, result.output
         data = json.loads(result.output)
-        assert set(data.keys()) == {"session_id", "resumed", "stale_ended"}
+        assert set(data.keys()) == {"session_id", "resumed", "auto_ended"}
         assert isinstance(data["session_id"], str) and data["session_id"]
         assert data["resumed"] is False
-        assert data["stale_ended"] == []
+        assert data["auto_ended"] == []
+
+    def test_text_mode_breakdown_by_reason(self, runner, monkeypatch):
+        """Text mode preserves the stale-vs-cross-agent split that the JSON
+        flat list intentionally drops. Both reasons firing in the same call
+        produces a ``(N stale, M cross-agent)`` suffix; pinning here so a
+        future refactor can't silently regress to a single bare count."""
+        stale_id = "55555555-5555-5555-5555-555555555555"
+        cross_id = "66666666-6666-6666-6666-666666666666"
+        comp = self._comp(
+            current_row=self._row(cross_id, "claude-code"),
+            stale=[self._row(stale_id, "claude-code")],
+        )
+        self._patch(monkeypatch, comp, cross_id)
+
+        result = runner.invoke(
+            cli,
+            [
+                "session",
+                "start",
+                "--agent-id",
+                "codex",
+                "--idempotent",
+                "--auto-end-stale",
+                "24h",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Auto-ended 2 session(s)" in result.output
+        assert "1 stale" in result.output
+        assert "1 cross-agent" in result.output
 
     def test_invalid_duration_raises_bad_parameter(self, runner, monkeypatch):
         """Hook authors mistyping ``--auto-end-stale`` see a useful Click

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.32"
+version = "0.1.33"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v0.1.33 release bundle — behavior-change release. Branch was cut from main on 2026-04-29 ahead of PR #545, which was retargeted into this branch so the JSON-shape rename ships in v0.1.33 (avoiding a pre-released `stale_ended` key on PyPI).

## Bundled PRs (post-v0.1.32)

- **#530** — `mm upgrade` CLI (closes #443)
- **#533, #534, #538, #539, #540** — Temporal validity goal series (RFC `memtomem-docs#22`)
- **#541** — `mm session start` SessionStart hook primitives (RFC `memtomem-docs#24` Phase 1)
- **#542** — Public-surface mentions for temporal validity
- **#543** — Plugin SessionStart hook + Phase 1 review polish (RFC Phase 2)
- **#544** — Untrack experimental openclaw plugin until promoted
- **#545** — `stale_ended` → `auto_ended` JSON key rename + text-mode breakdown polish (RFC `memtomem-docs#24` Item 3)
- Plus pre-release CHANGELOG entries for **#536** (PostToolUse[Write] extension filter) and the auto session summary / `chunk_links` provenance work (RFC P1 Phase B).

## Migration notes

Continues the v0.1.32 namespace / agent_id validation contract — no new BREAKING entries in v0.1.33. Two surface changes worth noting:

- **`mm session start --json`** now emits `auto_ended` (was unreleased `stale_ended` on `main` post-v0.1.32; never tagged into PyPI).
- **Plugin `PostToolUse[Write]` hook** now allowlists source extensions and blocklists build/cache paths; existing pasted snippets in user `~/.claude/settings.json` continue with the old unfiltered behavior until re-pulled.

## Release mechanics

- Single `release` commit `1d97dbb` bumps `pyproject.toml`, `uv.lock`, and inserts the dated `## [0.1.33] — 2026-04-29` CHANGELOG header.
- TestPyPI dry-run required (behavior-change release per `feedback_prerelease_dry_run.md`): `test-v0.1.33a1` tag → `pypi` env approval → fresh-isolated smoke → `v0.1.33` production tag.
- `release.yml` workflow triggers on `v[0-9]*` / `test-v[0-9]*`; OIDC trusted publisher; `pypi` environment requires manual approval.

## Post-merge plan

1. `git checkout main && git pull` to sync the merge commit.
2. `git tag test-v0.1.33a1 <merge-sha> && git push origin test-v0.1.33a1` → approve `pypi` env in browser.
3. Smoke isolated install (PyPI deps + TestPyPI override) per the 2-step recipe.
4. `git tag v0.1.33 <merge-sha> && git push origin v0.1.33` → approve if `pending_deployments` non-empty.
5. `gh release create v0.1.33 --notes-file <changelog-section>`.
6. (No held docs-cutover PRs this round — `memtomem-docs#25` already merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)