### PR TITLE
fix(init): distinguish claude mcp add failure modes; dedupe Next steps

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2091,6 +2091,14 @@ def _write_config_and_summary(
             if result.returncode == 0:
                 click.secho("  Claude Code: configured (user scope)", fg="green")
             elif "already exists" in (result.stderr or ""):
+                # Brittle by design: depends on Claude Code's stderr wording
+                # ("MCP server <name> already exists in user config") staying
+                # English-stable. If upstream rephrases or localizes, this
+                # branch silently regresses to the generic-failure path
+                # below — which still writes .mcp.json successfully but
+                # leaves duplicate state. Re-grep claude's source if/when
+                # users report a "claude mcp add failed (...)" with an
+                # already-exists-shaped stderr.
                 click.secho(
                     "  Claude Code: already registered (user scope) — skipped",
                     fg="green",

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2076,12 +2076,29 @@ def _write_config_and_summary(
         claude_cmd.append(server_cmd)
         claude_cmd.extend(server_args)
 
+        # Three failure modes need distinct UX, but the old code collapsed
+        # all of them into "'claude' not found":
+        #   1. FileNotFoundError → claude binary genuinely missing.
+        #   2. returncode != 0 with "already exists" stderr → memtomem MCP
+        #      is already registered in the user's claude config (rerun of
+        #      `mm init`, or manual `claude mcp add` earlier). Treat as
+        #      success and skip the .mcp.json fallback — the existing user
+        #      scope entry already covers Claude Code.
+        #   3. returncode != 0 for any other reason → surface stderr so the
+        #      user can see what actually failed before we fall back.
         try:
             result = _run(claude_cmd, timeout=10)
             if result.returncode == 0:
                 click.secho("  Claude Code: configured (user scope)", fg="green")
+            elif "already exists" in (result.stderr or ""):
+                click.secho(
+                    "  Claude Code: already registered (user scope) — skipped",
+                    fg="green",
+                )
             else:
-                click.echo("  Claude Code: 'claude' not found. Use .mcp.json instead.")
+                stderr_line = (result.stderr or "").strip().splitlines()[0:1]
+                detail = stderr_line[0] if stderr_line else f"exit {result.returncode}"
+                click.echo(f"  Claude Code: claude mcp add failed ({detail}).")
                 _write_mcp_json(server_cmd, server_args, mcp_env)
                 click.echo("  MCP config: wrote ./.mcp.json")
                 _emit_mcp_paste_hints()
@@ -2225,20 +2242,26 @@ def _write_config_and_summary(
     # + unseeded case points at the Web UI Reindex All button because
     # ``mm index`` CLI is single-path only (v0.1.23) — suggesting
     # ``mm index ~/memories`` would miss the 28 provider dirs entirely.
+    # In that branch step 1 already opens `mm web`, so the legacy step 3
+    # ("mm web (browse...)") is folded in as a trailing clause to avoid
+    # printing the same command on two lines (UX cleanup, 2026-04-29).
+    multi_dir_unseeded = (not seeded) and len(seed_paths) > 1
     if seeded:
         click.echo(
             f"    1. {run_prefix}mm index {state['memory_dir']}"
             "  (already seeded — re-run only if you add files)"
         )
-    elif len(seed_paths) > 1:
+    elif multi_dir_unseeded:
         click.echo(
             f"    1. {run_prefix}mm web  "
-            f"(Sources → Reindex All to index {len(seed_paths)} memory_dirs)"
+            f"(Sources → Reindex All to index {len(seed_paths)} memory_dirs, "
+            "then browse & manage your memories)"
         )
     else:
         click.echo(f"    1. {run_prefix}mm index {state['memory_dir']}")
     click.echo(f"    2. {run_prefix}mm search 'your first query'")
-    click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")
+    if not multi_dir_unseeded:
+        click.echo(f"    3. {run_prefix}mm web  (browse & manage your memories)")
     if profile.mm_binary_origin == "uvx":
         # uvx envs are destroyed when the process exits — the next `mm web`
         # invocation starts in a fresh ephemeral env that won't have any

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -2604,6 +2604,14 @@ class TestMcpChoiceOneClaudeAddBranches:
         # user-scope entry covering it.
         assert not (tmp_path / ".mcp.json").exists()
         assert "MCP config: wrote ./.mcp.json" not in out
+        # And paste-hints (Cursor / Windsurf / Claude Desktop / Gemini CLI)
+        # must NOT fire either — the user opted for "auto-register Claude
+        # Code", and the existing user-scope entry already covers it. A
+        # future refactor that hoists _emit_mcp_paste_hints() out of the
+        # generic-failure block would silently spam unrelated paste paths
+        # in this branch; pin against that.
+        assert "~/.cursor/mcp.json" not in out
+        assert "~/.codeium/windsurf/mcp_config.json" not in out
 
     def test_generic_nonzero_surfaces_stderr_and_falls_back(
         self,
@@ -2668,6 +2676,39 @@ class TestMcpChoiceOneClaudeAddBranches:
         out = unstyle(capsys.readouterr().out)
         assert "Claude Code: 'claude' not found" in out
         assert (tmp_path / ".mcp.json").exists()
+
+    def test_timeout_falls_back_to_not_found_branch(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``subprocess.TimeoutExpired`` shares the legacy
+        ``FileNotFoundError`` branch (claude hung past 10s). The current
+        wording reuses "'claude' not found" — not strictly accurate for
+        timeouts but the same .mcp.json fallback is the right recovery,
+        so we just pin the existing behavior. If we ever split these
+        cases, this test wants a distinct message for timeouts.
+        """
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        def _hang(cmd: list[str], timeout: int = 10) -> subprocess.CompletedProcess:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(init_cmd, "_run", _hang)
+
+        init_cmd._write_config_and_summary(self._state(tmp_path), tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Claude Code: 'claude' not found" in out
+        # Same fallback path as FileNotFoundError — write .mcp.json so the
+        # user can still wire Claude Code (or other editors) up manually.
+        assert (tmp_path / ".mcp.json").exists()
+        assert "MCP config: wrote ./.mcp.json" in out
 
 
 class TestClaudeDesktopConfigHint:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -9,6 +9,7 @@ pydantic-settings parses list-typed env vars as JSON arrays.
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 from typing import Literal
@@ -2527,6 +2528,148 @@ class TestMcpPasteHints:
         assert "copy into your editor's config file" in out
 
 
+class TestMcpChoiceOneClaudeAddBranches:
+    """``mcp_choice == 1`` invokes ``claude mcp add`` and must distinguish
+    three failure modes — the old code collapsed all of them into
+    "'claude' not found", which lied to users who had ``claude`` on PATH
+    but already had a ``memtomem`` user-scope entry registered (rerun of
+    ``mm init``).
+    """
+
+    @staticmethod
+    def _state(tmp_path: Path) -> dict:
+        state = _make_init_state(tmp_path)
+        state["mcp_choice"] = 1
+        return state
+
+    def test_returncode_zero_emits_configured(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            init_cmd,
+            "_run",
+            lambda cmd, timeout=10: subprocess.CompletedProcess(cmd, 0, "", ""),
+        )
+
+        init_cmd._write_config_and_summary(self._state(tmp_path), tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Claude Code: configured (user scope)" in out
+        # success path must NOT also write the .mcp.json fallback.
+        assert not (tmp_path / ".mcp.json").exists()
+        assert "MCP config: wrote ./.mcp.json" not in out
+
+    def test_already_exists_stderr_skips_fallback(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Reruns of ``mm init`` (or any case where ``memtomem`` is already
+        in the user-scope claude config) must report success and skip the
+        ``.mcp.json`` fallback — Claude Code is already covered by the
+        existing user-scope entry, so a project-scope file would only add
+        duplicate state for the user to clean up.
+        """
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            init_cmd,
+            "_run",
+            lambda cmd, timeout=10: subprocess.CompletedProcess(
+                cmd, 1, "", "MCP server memtomem already exists in user config\n"
+            ),
+        )
+
+        init_cmd._write_config_and_summary(self._state(tmp_path), tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Claude Code: already registered (user scope) — skipped" in out
+        # Regression: the old wording must not leak back in.
+        assert "'claude' not found" not in out
+        # No fallback file should be written — Claude Code already has the
+        # user-scope entry covering it.
+        assert not (tmp_path / ".mcp.json").exists()
+        assert "MCP config: wrote ./.mcp.json" not in out
+
+    def test_generic_nonzero_surfaces_stderr_and_falls_back(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Any other non-zero return must NOT be reported as "claude not
+        found" — claude clearly ran. Surface the first stderr line so the
+        user can see what actually broke before we fall back to
+        ``.mcp.json``.
+        """
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            init_cmd,
+            "_run",
+            lambda cmd, timeout=10: subprocess.CompletedProcess(
+                cmd, 2, "", "claude: error: scope `user` is locked\n"
+            ),
+        )
+
+        init_cmd._write_config_and_summary(self._state(tmp_path), tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Claude Code: claude mcp add failed" in out
+        assert "scope `user` is locked" in out
+        # Regression: misleading wording must not fire here.
+        assert "'claude' not found" not in out
+        # Generic failure DOES write the fallback — Claude Code is not yet
+        # configured, so user needs the project-scope file to recover.
+        assert (tmp_path / ".mcp.json").exists()
+        assert "MCP config: wrote ./.mcp.json" in out
+
+    def test_filenotfound_keeps_legacy_not_found_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """When the ``claude`` binary is genuinely missing the original
+        message is correct and must stay — this is the only branch where
+        "'claude' not found" reflects reality.
+        """
+        from click import unstyle
+
+        from memtomem.cli import init_cmd
+
+        def _missing(cmd: list[str], timeout: int = 10) -> subprocess.CompletedProcess:
+            raise FileNotFoundError(2, "No such file or directory: 'claude'")
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(init_cmd, "_run", _missing)
+
+        init_cmd._write_config_and_summary(self._state(tmp_path), tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Claude Code: 'claude' not found" in out
+        assert (tmp_path / ".mcp.json").exists()
+
+
 class TestClaudeDesktopConfigHint:
     """The Claude Desktop paste-hint must point at the real Claude Desktop
     config path for the user's OS, not the macOS-only path that used to be
@@ -4935,6 +5078,14 @@ class TestInitialSeedThreshold:
         assert "Reindex All to index 3 memory_dirs" in out
         # Regression: single-dir hint must NOT fire for multi-dir unseeded.
         assert f"mm index {state['memory_dir']}\n" not in out
+        # Step 1 already opens `mm web`, so the legacy step 3 ("3. mm web
+        # (browse...)") is folded into step 1 to avoid printing the same
+        # command on two lines (UX cleanup, 2026-04-29). Pin both halves —
+        # the consolidated wording in step 1, and the absence of a
+        # standalone step-3 line.
+        assert "then browse & manage your memories" in out
+        # The 4-space indented "3. " step-line must be gone in this branch.
+        assert "    3. " not in out
 
     def test_next_steps_single_dir_unseeded_keeps_mm_index_hint(
         self,
@@ -4962,6 +5113,12 @@ class TestInitialSeedThreshold:
         assert f"mm index {state['memory_dir']}" in out
         assert "Reindex All" not in out
         assert "already seeded" not in out
+        # In single-dir (or seeded) branches step 1 is `mm index`, not
+        # `mm web`, so the standalone step-3 `mm web (browse...)` line
+        # must still fire — the consolidation only applies to
+        # multi-dir-unseeded.
+        assert "    3. " in out
+        assert "mm web  (browse & manage your memories)" in out
 
     def test_next_steps_seeded_annotates_mm_index_hint(
         self,


### PR DESCRIPTION
## Summary

- The wizard's Claude Code MCP step (`mcp_choice == 1`) collapsed three distinct failure modes into a single `'claude' not found` message, which misled users who had `claude` on PATH but already had a `memtomem` user-scope entry registered (typical on a re-run of `mm init`):

  ```
  $ claude mcp add memtomem -s user -- ...
  MCP server memtomem already exists in user config
  exit=1
  ```

  Now the three modes route to distinct outcomes:

  | situation | message | `.mcp.json` fallback |
  |---|---|---|
  | `rc=0` | `Claude Code: configured (user scope)` | no |
  | `rc!=0`, stderr contains `already exists` | `Claude Code: already registered (user scope) — skipped` | **no** (existing entry already covers Claude Code; writing a project-scope file would only add duplicate state to clean up) |
  | `rc!=0`, other | `Claude Code: claude mcp add failed (<first stderr line>).` | yes |
  | `FileNotFoundError` | `Claude Code: 'claude' not found. Use .mcp.json instead.` (unchanged) | yes |

- While here, the wizard's `Next steps` printed `mm web` on both line 1 (Sources → Reindex All) and line 3 (browse & manage), in the multi-dir unseeded case — the same command on two lines. Folded the browse clause into step 1 so the duplication is gone. Single-dir and seeded branches keep step 3 because their step 1 is `mm index`, not `mm web`.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_init_cmd.py` (236 passed)
- [x] Full suite `uv run pytest -m "not ollama" packages/memtomem/tests/` (3127 passed)
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` + `ruff format --check` clean
- [x] Manual repro on a real install with `memtomem` already in `claude mcp list -s user`: now reports `Claude Code: already registered (user scope) — skipped` instead of the misleading `'claude' not found`
- [x] New test class `TestMcpChoiceOneClaudeAddBranches` covers all four branches (success / already-exists / other non-zero / FileNotFoundError) and pins the new wording + fallback behavior
- [x] Existing next-steps tests gained step-3 regression guards: present in single-dir / seeded branches, absent in multi-dir-unseeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)