### PR TITLE
feat(index): mm index --debounce-window + --flush + --status (closes #536 documented gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`mm index --debounce-window` / `--flush` / `--status` flags** (closes
+  PR #536 documented gap). `mm index` now exposes a file-system-backed
+  debounce queue under `~/.memtomem/index_debounce_queue.json`
+  (flock-protected). Three new flags:
+  - `--debounce-window <SECONDS>` records PATH and drains any entries
+    silent at least SECONDS. Designed for `PostToolUse[Write]` hook
+    callers — rapid consecutive writes to the same file restart the
+    window, so a codegen burst indexes the final state once at the end
+    rather than once per Write.
+  - `--flush` synchronously drains every queued entry. **Blocks until
+    each queued file is indexed (or recorded as an error).** Worst-case
+    latency ≈ queue depth × per-file index cost. Plugin's `Stop` hook
+    now chains `mm index --flush` before `mm session end --auto` so the
+    final burst doesn't get left in the queue.
+  - `--status` prints a snapshot of the queue (depth, oldest entry).
+    **Race-prone by design** — concurrent hooks may add or drain
+    entries between the read and any caller action. Use as telemetry
+    only; `--flush` is the only correctness primitive for "drain the
+    queue".
+
+  Indexer errors leave the entry in the queue for retry on the next
+  hook fire. Last-write-wins for `--namespace`/`--force` when the same
+  path is enqueued twice. `MEMTOMEM_INDEX_DEBOUNCE_QUEUE` env var
+  overrides the queue path (test-only).
+
+  **Future-extensibility (RFC-B PreCompact, deferred):** when the
+  PreCompact hook contract lands and a checkpoint handler wants to
+  flush only the files Claude Code reports as in-flight, `--flush`
+  will gain a `--paths <list>` form for selective drain. The current
+  `--flush` (drain all) remains the default; the API in
+  `memtomem.indexing.debounce.drain_all` already accepts an optional
+  `paths=` filter so adding the CLI surface is additive.
+
+  Plugin `hooks.json` and the `claude-code.md` Hooks Automation Setup
+  snippet are updated byte-for-byte (parity test catches drift). The
+  PostToolUse[Write] hook now calls `mm index --debounce-window 5`;
+  the Stop hook chains `mm index --flush` before
+  `mm session end --auto`.
+
 ## [0.1.33] — 2026-04-29
 
 ### Added

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -184,7 +184,7 @@ Add the following to `~/.claude/settings.json`:
       "matcher": "Write",
       "hooks": [{
         "type": "command",
-        "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
+        "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index --debounce-window 5 \"$FP\" 2>>/tmp/mm-hook.log || true",
         "timeout": 10000
       }]
     }],
@@ -192,8 +192,8 @@ Add the following to `~/.claude/settings.json`:
       "matcher": "",
       "hooks": [{
         "type": "command",
-        "command": "mm session end --auto 2>>/tmp/mm-hook.log || true",
-        "timeout": 5000
+        "command": "mm index --flush 2>>/tmp/mm-hook.log; mm session end --auto 2>>/tmp/mm-hook.log || true",
+        "timeout": 10000
       }]
     }]
   }
@@ -206,8 +206,8 @@ Add the following to `~/.claude/settings.json`:
 |------------|---------------|----------------|
 | `SessionStart` | When a Claude Code session starts | `mm session start --idempotent --auto-end-stale 24h` → Resume the active session for `claude-code`, or open a new one and close orphans older than 24h |
 | `UserPromptSubmit` | When a prompt is submitted | `mm search` → Automatically inject relevant memory into context |
-| `PostToolUse` (Write) | After new file creation | `mm index` → Automatically index the new file |
-| `Stop` | When the agent stops | `mm session end --auto` → Close session with structured summary |
+| `PostToolUse` (Write) | After new file creation | `mm index --debounce-window 5` → Record the file in the debounce queue and drain entries silent ≥5s; rapid consecutive writes restart the window so a burst is indexed once at the end |
+| `Stop` | When the agent stops | `mm index --flush; mm session end --auto` → Synchronously flush any pending debounced files, then close the session with a structured summary |
 
 ### Automation Flow
 
@@ -217,9 +217,9 @@ Claude Code starts
   → User submits prompt (>20 chars)
   → UserPromptSubmit hook → mem_search context injection
   → Claude creates new files
-  → PostToolUse hook → mem_index auto-indexing
+  → PostToolUse hook → mm index --debounce-window 5 (record + drain stale)
   → Agent stops
-  → Stop hook → mm session end --auto
+  → Stop hook → mm index --flush; mm session end --auto
 ```
 
 ### Important Caveats
@@ -231,7 +231,7 @@ Claude Code starts
 - **SessionStart hook = idempotent resume**: `mm session start --idempotent` resumes the active session for the same `--agent-id` instead of creating a new row, so a Claude Code restart inherits the previous session's `mm activity log` writes. `--auto-end-stale 24h` closes any active session older than 24h before the idempotency check — this is how orphans from a crashed previous run get cleaned up. The 24h cutoff also means that resuming Claude Code the morning after deliberately ends the prior day's session and starts fresh; lower the cutoff (e.g. `30m`) if you want shorter resume windows, raise it (e.g. `7d`) if you want sessions to span breaks. The idempotent path is single-process safe but not concurrency-safe — two parallel SessionStart hooks could both create new sessions; Claude Code's hook runner fires them serially per session, which is the supported case.
 - **Write only**: `Edit` is excluded from PostToolUse — edited files are already indexed, so re-indexing on every edit is redundant.
 - **Allowlist + blocklist**: `PostToolUse[Write]` only indexes canonical source extensions (`md`, `py`, `ts`/`tsx`, `js`/`jsx`, `go`, `rs`, `rb`, `java`, `kt`, `swift`, `c`/`cpp`/`h`/`hpp`, `sh`, `toml`, `yaml`/`yml`, `json`) and skips build / cache / VCS paths (`node_modules`, `dist`, `build`, `target`, `.next`, `.nuxt`, `__pycache__`, `.git`, `.venv`/`venv`, `coverage`, `.cache`) inline. Patterns include both leading-segment (`node_modules/*`) and any-segment (`*/node_modules/*`) forms for both absolute and relative `tool_input.file_path` values. Extension matching is case-sensitive — `*.MD` / `*.JS` would skip the allowlist; rename or extend the patterns if your repo uses uppercase. Adjust the `case` statements in `hooks.json` for project-specific needs — they are inline, easy to extend.
-- **Debounce gap**: rapid consecutive writes to the same file (e.g., codegen loops) may re-index it multiple times within a few seconds. The current hook indexes synchronously per Write with no batching. For large monorepos, wrap the `mm index` call in an external script with `flock` + a debounce window. Native debounce support is tracked separately.
+- **Debounce mechanics**: `mm index --debounce-window 5` records the file in `~/.memtomem/index_debounce_queue.json` (flock-protected) and drains entries that have been silent ≥5 seconds. Each Write hook fire restarts the window for that path, so a codegen burst indexes the final state once after the burst ends rather than once per Write. The Stop hook chains `mm index --flush` (synchronous drain — blocks until every queued file is indexed) before `mm session end --auto` to ensure session-end indexing isn't deferred. `mm index --status` prints a snapshot of the queue (depth + oldest entry) for telemetry; it's race-prone and not a correctness primitive — for "is the queue empty?" use `--flush`. RFC-B (PreCompact, deferred — needs Claude Code's PreCompact payload contract) will use a future `mm index --flush --paths <list>` for selective drain at checkpoint time.
 - **STM proxy overlap**: If using [memtomem-stm](https://github.com/memtomem/memtomem-stm) (separate package), hooks are redundant — the proxy already handles surfacing and indexing.
 
 ---

--- a/packages/memtomem-claude-plugin/hooks/hooks.json
+++ b/packages/memtomem-claude-plugin/hooks/hooks.json
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index \"$FP\" 2>>/tmp/mm-hook.log || true",
+            "command": "FP=\"${tool_input.file_path}\"; case \"$FP\" in *.md|*.py|*.ts|*.tsx|*.js|*.jsx|*.go|*.rs|*.rb|*.java|*.kt|*.swift|*.c|*.cpp|*.h|*.hpp|*.sh|*.toml|*.yaml|*.yml|*.json) ;; *) exit 0 ;; esac; case \"$FP\" in node_modules/*|*/node_modules/*|dist/*|*/dist/*|build/*|*/build/*|target/*|*/target/*|.next/*|*/.next/*|.nuxt/*|*/.nuxt/*|__pycache__/*|*/__pycache__/*|.git/*|*/.git/*|.venv/*|*/.venv/*|venv/*|*/venv/*|coverage/*|*/coverage/*|.cache/*|*/.cache/*) exit 0 ;; esac; mm index --debounce-window 5 \"$FP\" 2>>/tmp/mm-hook.log || true",
             "timeout": 10000
           }
         ]
@@ -52,8 +52,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "mm session end --auto 2>>/tmp/mm-hook.log || true",
-            "timeout": 5000
+            "command": "mm index --flush 2>>/tmp/mm-hook.log; mm session end --auto 2>>/tmp/mm-hook.log || true",
+            "timeout": 10000
           }
         ]
       }

--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -3,18 +3,94 @@
 from __future__ import annotations
 
 import asyncio
+import json as _json
 from pathlib import Path
 
 import click
 
 
 @click.command()
-@click.argument("path", default=".")
+@click.argument("path", default=".", required=False)
 @click.option("--recursive/--no-recursive", default=True, help="Recurse into subdirectories")
 @click.option("--force", is_flag=True, help="Force re-index (ignore hashes)")
 @click.option("--namespace", "-n", default=None, help="Target namespace")
-def index(path: str, recursive: bool, force: bool, namespace: str | None) -> None:
-    """Index files at PATH into the knowledge base."""
+@click.option(
+    "--debounce-window",
+    "debounce_window",
+    type=click.FloatRange(min=0.0),
+    default=None,
+    metavar="SECONDS",
+    help=(
+        "Record PATH in the debounce queue and drain entries that have been silent "
+        "at least SECONDS. Designed for hook callers (PostToolUse[Write]); rapid "
+        "consecutive writes restart the window so a burst is indexed once at the end."
+    ),
+)
+@click.option(
+    "--flush",
+    "do_flush",
+    is_flag=True,
+    help=(
+        "Synchronously drain the debounce queue. Blocks until every queued file "
+        "has been indexed (or recorded as an error). Worst-case latency ≈ queue "
+        "depth × per-file index cost."
+    ),
+)
+@click.option(
+    "--status",
+    "do_status",
+    is_flag=True,
+    help=(
+        "Print a snapshot of the debounce queue (depth, oldest entry). Race-prone: "
+        "concurrent hooks may modify the queue between this read and any later "
+        "action; for correctness use --flush, not status-then-flush."
+    ),
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit one JSON line of the result (works with --debounce-window/--flush/--status).",
+)
+def index(
+    path: str,
+    recursive: bool,
+    force: bool,
+    namespace: str | None,
+    debounce_window: float | None,
+    do_flush: bool,
+    do_status: bool,
+    as_json: bool,
+) -> None:
+    """Index files at PATH into the knowledge base.
+
+    The debounce flags (``--debounce-window`` / ``--flush`` / ``--status``)
+    are mutually exclusive with each other; ``--debounce-window`` and the
+    plain index path are also mutually exclusive — pick recording for a
+    later drain or indexing now.
+    """
+    modes = [debounce_window is not None, do_flush, do_status]
+    if sum(modes) > 1:
+        raise click.UsageError("--debounce-window, --flush, and --status are mutually exclusive.")
+
+    if do_status:
+        _print_status(as_json=as_json)
+        return
+
+    if do_flush:
+        _run_flush(as_json=as_json)
+        return
+
+    if debounce_window is not None:
+        _run_debounce(
+            path=path,
+            window_seconds=debounce_window,
+            namespace=namespace,
+            force=force,
+            as_json=as_json,
+        )
+        return
+
     try:
         asyncio.run(_index(path, recursive, force, namespace))
     except click.ClickException:
@@ -43,3 +119,104 @@ async def _index(path: str, recursive: bool, force: bool, namespace: str | None)
     if stats.errors:
         for err in stats.errors:
             click.echo(click.style(f"  ERROR: {err}", fg="red"))
+
+
+def _print_status(*, as_json: bool) -> None:
+    from memtomem.indexing import debounce
+
+    snap = debounce.status_snapshot()
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "depth": snap.depth,
+                    "oldest_first_seen": snap.oldest_first_seen,
+                    "oldest_path": snap.oldest_path,
+                    "queue_path": str(snap.queue_path),
+                }
+            )
+        )
+        return
+    click.echo(f"Debounce queue: {snap.queue_path}")
+    click.echo(f"  Depth: {snap.depth}")
+    if snap.oldest_path is not None:
+        click.echo(f"  Oldest: {snap.oldest_path} (first seen {snap.oldest_first_seen})")
+
+
+def _run_flush(*, as_json: bool) -> None:
+    from memtomem.indexing import debounce
+
+    async def _flush_async() -> debounce.DrainResult:
+        from memtomem.cli._bootstrap import cli_components
+
+        async with cli_components() as comp:
+            return await debounce.drain_all(indexer=_make_indexer(comp))
+
+    result = asyncio.run(_flush_async())
+    _print_drain_result(result, as_json=as_json, label="Flushed")
+
+
+def _run_debounce(
+    *,
+    path: str,
+    window_seconds: float,
+    namespace: str | None,
+    force: bool,
+    as_json: bool,
+) -> None:
+    from memtomem.indexing import debounce
+
+    abs_path = str(Path(path).resolve())
+    debounce.enqueue(abs_path, namespace=namespace, force=force)
+
+    async def _drain_async() -> debounce.DrainResult:
+        from memtomem.cli._bootstrap import cli_components
+
+        async with cli_components() as comp:
+            return await debounce.drain_ready(
+                window_seconds=window_seconds, indexer=_make_indexer(comp)
+            )
+
+    result = asyncio.run(_drain_async())
+    _print_drain_result(
+        result,
+        as_json=as_json,
+        label=f"Debounced (window={window_seconds}s, queued={abs_path})",
+    )
+
+
+def _make_indexer(comp):
+    """Return an awaitable that indexes a single absolute path with the
+    queue entry's namespace/force. Closes over the bootstrapped components
+    so the drain functions don't depend on the CLI bootstrap module."""
+
+    async def _do(path_str: str, namespace: str | None, force: bool) -> None:
+        await comp.index_engine.index_path(
+            Path(path_str),
+            recursive=False,
+            force=force,
+            namespace=namespace,
+        )
+
+    return _do
+
+
+def _print_drain_result(result, *, as_json: bool, label: str) -> None:
+    if as_json:
+        click.echo(
+            _json.dumps(
+                {
+                    "indexed": result.indexed,
+                    "errors": [{"path": p, "message": m} for p, m in result.errors],
+                    "remaining": result.remaining,
+                }
+            )
+        )
+        return
+    click.echo(f"{label}")
+    click.echo(f"  Indexed: {len(result.indexed)}")
+    if result.errors:
+        click.echo(f"  Errors: {len(result.errors)}")
+        for p, m in result.errors:
+            click.echo(click.style(f"    {p}: {m}", fg="red"))
+    click.echo(f"  Remaining in queue: {result.remaining}")

--- a/packages/memtomem/src/memtomem/indexing/debounce.py
+++ b/packages/memtomem/src/memtomem/indexing/debounce.py
@@ -1,0 +1,304 @@
+"""Debounce queue for hook-driven ``mm index`` calls.
+
+Backs ``mm index --debounce-window`` (PR #536 documented gap close) for the
+plugin's ``PostToolUse[Write]`` hook. The hook fires on every ``Write`` tool
+use; without debouncing, codegen loops re-index the same file many times
+within a few seconds. This module persists a per-path queue so a hook firing
+in a burst can record the path cheaply and the *last* hook in the burst, or
+a later flush, drains the entries that have been silent for at least the
+debounce window.
+
+The queue is a single JSON file under ``~/.memtomem/`` guarded by ``flock``.
+Each entry tracks ``first_seen``, ``last_seen``, plus the ``namespace`` and
+``force`` flags that should apply to the eventual indexing call. When the
+same path is enqueued again with different flags, last-write wins (the most
+recent caller's intent).
+
+Synchronization model:
+
+- Every queue mutation (enqueue, drain) takes ``LOCK_EX`` on the queue file.
+  Concurrent ``mm index --debounce-window`` calls serialize cleanly without
+  losing entries.
+- ``--status`` deliberately skips the lock and reads a snapshot. The
+  docstring on :func:`status_snapshot` flags the race so callers don't try
+  to use status as a decision input — the only correct flush primitive is
+  :func:`drain_all`.
+
+Future-extensibility (RFC-B PreCompact, deferred): :func:`drain_all` is
+defined to take an optional ``paths`` filter that's currently always
+``None``. When the PreCompact payload contract lands and a checkpoint
+handler wants to flush only the files Claude Code reports as in-flight,
+``drain_all(paths=[...])`` becomes the entry point — no second ABI change
+needed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import IO, Awaitable, Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_QUEUE_PATH = Path("~/.memtomem/index_debounce_queue.json").expanduser()
+_QUEUE_VERSION = 1
+
+
+@dataclass
+class QueueEntry:
+    """One queued path with its first-seen / last-seen timestamps and the
+    indexing flags that should apply when it eventually drains."""
+
+    first_seen: float
+    last_seen: float
+    namespace: str | None = None
+    force: bool = False
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "QueueEntry":
+        return cls(
+            first_seen=float(d["first_seen"]),
+            last_seen=float(d["last_seen"]),
+            namespace=d.get("namespace"),
+            force=bool(d.get("force", False)),
+        )
+
+
+@dataclass
+class DrainResult:
+    """Summary of a drain pass — what was indexed, what errored, what's left."""
+
+    indexed: list[str] = field(default_factory=list)
+    errors: list[tuple[str, str]] = field(default_factory=list)  # (path, message)
+    remaining: int = 0
+
+
+@dataclass
+class StatusSnapshot:
+    """Race-prone snapshot of the queue for ``mm index --status``.
+
+    Concurrent hook callers may modify the queue between the read and any
+    subsequent caller action. Use this only for telemetry / human-readable
+    inspection, never as the input to a "is the queue empty?" decision —
+    for that, call :func:`drain_all` (which is synchronous and gives a
+    post-drain guarantee).
+    """
+
+    depth: int
+    oldest_first_seen: float | None
+    oldest_path: str | None
+    queue_path: Path
+
+
+def queue_path() -> Path:
+    """Return the queue file path, honoring ``MEMTOMEM_INDEX_DEBOUNCE_QUEUE``
+    if set (test-only override; matches the pattern used by
+    ``stm_feedback_db_path`` in STM)."""
+    override = os.environ.get("MEMTOMEM_INDEX_DEBOUNCE_QUEUE")
+    if override:
+        return Path(override).expanduser()
+    return _DEFAULT_QUEUE_PATH
+
+
+def _load(path: Path) -> dict[str, QueueEntry]:
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("debounce queue %s unreadable (%s); treating as empty", path, e)
+        return {}
+    entries = raw.get("entries", {}) if isinstance(raw, dict) else {}
+    return {p: QueueEntry.from_dict(d) for p, d in entries.items()}
+
+
+def _save(path: Path, entries: dict[str, QueueEntry]) -> None:
+    """Atomic JSON write — same pattern as :func:`memtomem.config._atomic_write_json`,
+    inlined here to avoid a cross-module private import."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": _QUEUE_VERSION,
+        "entries": {p: asdict(e) for p, e in entries.items()},
+    }
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=".debounce.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        os.replace(tmp_path, path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+class _Lock:
+    """``flock(LOCK_EX)`` on a sidecar lockfile next to the queue.
+
+    The lockfile is deliberately *not* the queue file itself. ``_save``
+    replaces the queue via ``os.replace``, which rebinds the path to a
+    fresh inode mid-critical-section. If we locked the queue file, the
+    lock would attach to the now-unlinked old inode while later callers
+    open the new inode and obtain an uncontended lock — concurrent
+    writers would lose entries.
+
+    The sidecar (``.<queue_name>.lock``) is never replaced; every
+    process locks the same inode for the duration of its critical
+    section, so serialization is correct.
+
+    POSIX only; on Windows the lock is a no-op and concurrent callers
+    may interleave (acceptable: hooks fire serially per Claude Code
+    session, the supported case).
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._lock_path = path.parent / f".{path.name}.lock"
+        self._fp: IO[bytes] | None = None
+
+    def __enter__(self) -> "_Lock":
+        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._fp = open(self._lock_path, "a+b")
+        if sys.platform != "win32":
+            import fcntl
+
+            fcntl.flock(self._fp, fcntl.LOCK_EX)
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._fp is None:
+            return
+        if sys.platform != "win32":
+            import fcntl
+
+            fcntl.flock(self._fp, fcntl.LOCK_UN)
+        self._fp.close()
+        self._fp = None
+
+
+def enqueue(
+    path_str: str,
+    *,
+    namespace: str | None = None,
+    force: bool = False,
+    now: float | None = None,
+    queue_file: Path | None = None,
+) -> None:
+    """Record one path's most recent write timestamp. Last-write wins for
+    ``namespace``/``force`` so the most recent caller's intent applies on
+    drain. Idempotent — repeated calls just push ``last_seen`` forward."""
+    qp = queue_file or queue_path()
+    ts = time.time() if now is None else now
+    with _Lock(qp):
+        entries = _load(qp)
+        existing = entries.get(path_str)
+        if existing is None:
+            entries[path_str] = QueueEntry(
+                first_seen=ts, last_seen=ts, namespace=namespace, force=force
+            )
+        else:
+            existing.last_seen = ts
+            existing.namespace = namespace
+            existing.force = force
+        _save(qp, entries)
+
+
+def _ready(entry: QueueEntry, window_seconds: float, now: float) -> bool:
+    return (now - entry.last_seen) >= window_seconds
+
+
+async def drain_ready(
+    *,
+    window_seconds: float,
+    indexer: Callable[[str, str | None, bool], Awaitable[None]],
+    now: float | None = None,
+    queue_file: Path | None = None,
+) -> DrainResult:
+    """Drain entries that have been silent for at least ``window_seconds``.
+
+    Called from ``mm index --debounce-window``. The caller's own enqueue
+    happened just before this; that entry's ``last_seen`` equals ``now``,
+    so it never qualifies on its own call (correct — this hook fired
+    *because* the file was just written, so the window restarts).
+    """
+    qp = queue_file or queue_path()
+    ts = time.time() if now is None else now
+    result = DrainResult()
+    with _Lock(qp):
+        entries = _load(qp)
+        ready_paths = [p for p, e in entries.items() if _ready(e, window_seconds, ts)]
+        for p in ready_paths:
+            entry = entries[p]
+            try:
+                await indexer(p, entry.namespace, entry.force)
+                result.indexed.append(p)
+                del entries[p]
+            except Exception as e:
+                result.errors.append((p, repr(e)))
+                # Keep the entry so the next hook call retries.
+        result.remaining = len(entries)
+        _save(qp, entries)
+    return result
+
+
+async def drain_all(
+    *,
+    indexer: Callable[[str, str | None, bool], Awaitable[None]],
+    paths: Iterable[str] | None = None,
+    queue_file: Path | None = None,
+) -> DrainResult:
+    """Synchronously drain every queued entry (or only ``paths`` when set).
+
+    Blocks until every targeted entry has been indexed (or recorded as an
+    error). Worst-case latency ≈ ``len(targets) × per_file_index_cost``.
+
+    ``paths`` is reserved for RFC-B (PreCompact, deferred): when that
+    contract specifies an in-flight file list at checkpoint time, the
+    handler will pass it here for selective drain. Until then ``paths`` is
+    always ``None`` and every queued entry drains.
+    """
+    qp = queue_file or queue_path()
+    result = DrainResult()
+    selected = set(paths) if paths is not None else None
+    with _Lock(qp):
+        entries = _load(qp)
+        targets = [p for p in entries if (selected is None or p in selected)]
+        for p in targets:
+            entry = entries[p]
+            try:
+                await indexer(p, entry.namespace, entry.force)
+                result.indexed.append(p)
+                del entries[p]
+            except Exception as e:
+                result.errors.append((p, repr(e)))
+        result.remaining = len(entries)
+        _save(qp, entries)
+    return result
+
+
+def status_snapshot(*, queue_file: Path | None = None) -> StatusSnapshot:
+    """Read-only snapshot — no lock, race-prone by design.
+
+    Concurrent hook callers may add or drain entries between this read and
+    whatever the caller does next. Treat the result as telemetry: queue
+    depth and oldest entry give an operator a rough sense of how far behind
+    the debounce queue is, but never use them to decide "is it safe to
+    skip a flush?" — for that, call :func:`drain_all`, which gives a
+    post-drain guarantee.
+    """
+    qp = queue_file or queue_path()
+    entries = _load(qp)
+    if not entries:
+        return StatusSnapshot(depth=0, oldest_first_seen=None, oldest_path=None, queue_path=qp)
+    oldest_path, oldest_entry = min(entries.items(), key=lambda kv: kv[1].first_seen)
+    return StatusSnapshot(
+        depth=len(entries),
+        oldest_first_seen=oldest_entry.first_seen,
+        oldest_path=oldest_path,
+        queue_path=qp,
+    )

--- a/packages/memtomem/tests/test_index_debounce.py
+++ b/packages/memtomem/tests/test_index_debounce.py
@@ -1,0 +1,308 @@
+"""Tests for ``memtomem.indexing.debounce``.
+
+The debounce module is the file-system substrate behind ``mm index
+--debounce-window`` (PR #536 documented gap close). The tests pin three
+contracts:
+
+1. **Enqueue semantics** — last-write-wins for namespace/force, ``last_seen``
+   pushes forward on every call, ``first_seen`` is set once.
+2. **Drain semantics** — ``drain_ready`` indexes only entries that have been
+   silent at least ``window_seconds``; ``drain_all`` indexes everything;
+   indexer errors leave the entry in the queue for retry.
+3. **Concurrency + persistence** — the queue persists across calls, the
+   ``flock`` serializes parallel mutations, and ``status_snapshot`` reads
+   without a lock (race-prone by design).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from memtomem.indexing import debounce
+
+
+@pytest.fixture
+def queue_file(tmp_path: Path) -> Path:
+    return tmp_path / "index_debounce_queue.json"
+
+
+def _read_raw(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class TestEnqueue:
+    def test_first_enqueue_creates_first_seen_and_last_seen(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/file.py", now=100.0, queue_file=queue_file)
+        raw = _read_raw(queue_file)
+        entry = raw["entries"]["/tmp/file.py"]
+        assert entry["first_seen"] == 100.0
+        assert entry["last_seen"] == 100.0
+        assert entry["namespace"] is None
+        assert entry["force"] is False
+
+    def test_repeated_enqueue_updates_last_seen_only(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/file.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/file.py", now=105.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/file.py", now=110.0, queue_file=queue_file)
+        entry = _read_raw(queue_file)["entries"]["/tmp/file.py"]
+        assert entry["first_seen"] == 100.0
+        assert entry["last_seen"] == 110.0
+
+    def test_last_write_wins_for_namespace_and_force(self, queue_file: Path) -> None:
+        """The most recent caller's intent applies on drain — same path
+        enqueued twice with different flags resolves to the second call's
+        values, not the first."""
+        debounce.enqueue(
+            "/tmp/file.py", now=100.0, namespace="foo", force=False, queue_file=queue_file
+        )
+        debounce.enqueue(
+            "/tmp/file.py", now=105.0, namespace="bar", force=True, queue_file=queue_file
+        )
+        entry = _read_raw(queue_file)["entries"]["/tmp/file.py"]
+        assert entry["namespace"] == "bar"
+        assert entry["force"] is True
+
+    def test_distinct_paths_kept_separately(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/a.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/b.py", now=101.0, queue_file=queue_file)
+        entries = _read_raw(queue_file)["entries"]
+        assert set(entries.keys()) == {"/tmp/a.py", "/tmp/b.py"}
+
+
+class TestDrainReady:
+    """``drain_ready`` is what ``mm index --debounce-window`` calls on every
+    hook fire. The contract: index files silent ≥ ``window_seconds``, leave
+    the rest. The caller's own enqueue (which set ``last_seen`` to ``now``)
+    must not qualify on its own call — otherwise the debounce window
+    collapses to zero and we re-index every Write immediately.
+    """
+
+    def test_recently_seen_entry_is_not_drained(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/file.py", now=100.0, queue_file=queue_file)
+        indexed: list[str] = []
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            indexed.append(p)
+
+        # 2s after enqueue, window=5s → not ready.
+        result = asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=102.0, queue_file=queue_file
+            )
+        )
+        assert result.indexed == []
+        assert result.remaining == 1
+
+    def test_silent_entry_drains_after_window(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/file.py", now=100.0, queue_file=queue_file)
+        indexed: list[str] = []
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            indexed.append(p)
+
+        # 6s later, window=5s → ready.
+        result = asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=106.0, queue_file=queue_file
+            )
+        )
+        assert result.indexed == ["/tmp/file.py"]
+        assert result.remaining == 0
+        assert "/tmp/file.py" not in _read_raw(queue_file)["entries"]
+
+    def test_mixed_queue_drains_only_ready(self, queue_file: Path) -> None:
+        """Entry A enqueued 10s ago is ready; entry B enqueued just now is
+        not. Only A is indexed; B remains queued for the next call."""
+        debounce.enqueue("/tmp/old.py", now=90.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/new.py", now=100.0, queue_file=queue_file)
+        indexed: list[str] = []
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            indexed.append(p)
+
+        result = asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=100.5, queue_file=queue_file
+            )
+        )
+        assert result.indexed == ["/tmp/old.py"]
+        assert result.remaining == 1
+        assert list(_read_raw(queue_file)["entries"].keys()) == ["/tmp/new.py"]
+
+    def test_indexer_error_keeps_entry_for_retry(self, queue_file: Path) -> None:
+        """If indexing raises, the entry stays queued so the next hook call
+        retries. Not silently lost."""
+        debounce.enqueue("/tmp/broken.py", now=100.0, queue_file=queue_file)
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            raise RuntimeError("synthetic indexing failure")
+
+        result = asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+            )
+        )
+        assert result.indexed == []
+        assert len(result.errors) == 1
+        assert result.errors[0][0] == "/tmp/broken.py"
+        assert result.remaining == 1
+
+    def test_indexer_receives_namespace_and_force_from_entry(self, queue_file: Path) -> None:
+        debounce.enqueue(
+            "/tmp/file.py",
+            now=100.0,
+            namespace="claude-memory:project-x",
+            force=True,
+            queue_file=queue_file,
+        )
+        captured: dict = {}
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            captured.update(path=p, namespace=ns, force=force)
+
+        asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+            )
+        )
+        assert captured == {
+            "path": "/tmp/file.py",
+            "namespace": "claude-memory:project-x",
+            "force": True,
+        }
+
+
+class TestDrainAll:
+    """``drain_all`` backs ``mm index --flush``. Every queued entry indexes
+    regardless of last-seen age; the call blocks until done. Reserves the
+    ``paths`` filter for RFC-B (PreCompact, deferred) selective payload."""
+
+    def test_drains_every_entry(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/a.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/b.py", now=100.5, queue_file=queue_file)
+        debounce.enqueue("/tmp/c.py", now=101.0, queue_file=queue_file)
+        indexed: list[str] = []
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            indexed.append(p)
+
+        result = asyncio.run(debounce.drain_all(indexer=indexer, queue_file=queue_file))
+        assert sorted(result.indexed) == ["/tmp/a.py", "/tmp/b.py", "/tmp/c.py"]
+        assert result.remaining == 0
+        assert _read_raw(queue_file)["entries"] == {}
+
+    def test_paths_filter_drains_subset_only(self, queue_file: Path) -> None:
+        """Future-extensibility check for RFC-B: passing ``paths=[...]``
+        drains only those, leaves others. Today the CLI never passes
+        ``paths``; this test pins the contract for the deferred handler."""
+        debounce.enqueue("/tmp/a.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/b.py", now=100.0, queue_file=queue_file)
+        indexed: list[str] = []
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            indexed.append(p)
+
+        result = asyncio.run(
+            debounce.drain_all(indexer=indexer, paths=["/tmp/a.py"], queue_file=queue_file)
+        )
+        assert result.indexed == ["/tmp/a.py"]
+        assert result.remaining == 1
+        assert list(_read_raw(queue_file)["entries"].keys()) == ["/tmp/b.py"]
+
+    def test_empty_queue_is_no_op(self, queue_file: Path) -> None:
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            raise AssertionError("indexer must not be called on empty queue")
+
+        result = asyncio.run(debounce.drain_all(indexer=indexer, queue_file=queue_file))
+        assert result.indexed == []
+        assert result.remaining == 0
+
+
+class TestStatusSnapshot:
+    """``status_snapshot`` is read-without-lock. Concurrent enqueues may
+    race the read; the docstring on :func:`status_snapshot` flags this so
+    callers don't try status-then-flush as a correctness pattern. The
+    tests just pin the shape; the race is the *contract*, not a bug to
+    catch."""
+
+    def test_empty_queue_returns_zero_depth(self, queue_file: Path) -> None:
+        snap = debounce.status_snapshot(queue_file=queue_file)
+        assert snap.depth == 0
+        assert snap.oldest_path is None
+        assert snap.oldest_first_seen is None
+
+    def test_oldest_entry_wins_by_first_seen(self, queue_file: Path) -> None:
+        debounce.enqueue("/tmp/recent.py", now=200.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/old.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/middle.py", now=150.0, queue_file=queue_file)
+        snap = debounce.status_snapshot(queue_file=queue_file)
+        assert snap.depth == 3
+        assert snap.oldest_path == "/tmp/old.py"
+        assert snap.oldest_first_seen == 100.0
+
+
+class TestPersistenceAndConcurrency:
+    def test_queue_persists_across_calls(self, queue_file: Path) -> None:
+        """Each ``enqueue`` round-trips through disk; the next call sees the
+        previous state. This is the load-bearing property — without it,
+        the hook caller would always start with an empty queue and the
+        debounce window would never fire."""
+        debounce.enqueue("/tmp/a.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/b.py", now=101.0, queue_file=queue_file)
+        snap = debounce.status_snapshot(queue_file=queue_file)
+        assert snap.depth == 2
+
+    def test_concurrent_enqueue_does_not_lose_entries(self, queue_file: Path) -> None:
+        """Two threads enqueue distinct paths in parallel. The flock guarantees
+        both writes land. Without the lock, the second writer's load+save
+        would clobber the first writer's entry."""
+        threads: list[threading.Thread] = []
+        for i in range(20):
+            t = threading.Thread(
+                target=debounce.enqueue,
+                args=(f"/tmp/file_{i:02d}.py",),
+                kwargs={"now": 100.0 + i, "queue_file": queue_file},
+            )
+            threads.append(t)
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        entries = _read_raw(queue_file)["entries"]
+        assert len(entries) == 20
+
+    def test_partial_drain_writes_remaining_back(self, queue_file: Path) -> None:
+        """Two entries, one indexer-errors. The successful one is gone from
+        disk; the failing one remains so the next hook call retries."""
+        debounce.enqueue("/tmp/good.py", now=100.0, queue_file=queue_file)
+        debounce.enqueue("/tmp/bad.py", now=100.0, queue_file=queue_file)
+
+        async def indexer(p: str, ns: str | None, force: bool) -> None:
+            if p == "/tmp/bad.py":
+                raise RuntimeError("boom")
+
+        asyncio.run(
+            debounce.drain_ready(
+                window_seconds=5.0, indexer=indexer, now=110.0, queue_file=queue_file
+            )
+        )
+        remaining = _read_raw(queue_file)["entries"]
+        assert list(remaining.keys()) == ["/tmp/bad.py"]
+
+
+class TestQueuePathOverride:
+    def test_env_override_changes_queue_path(self, tmp_path: Path, monkeypatch) -> None:
+        custom = tmp_path / "custom_queue.json"
+        monkeypatch.setenv("MEMTOMEM_INDEX_DEBOUNCE_QUEUE", str(custom))
+        assert debounce.queue_path() == custom
+
+    def test_default_path_under_dot_memtomem(self, monkeypatch) -> None:
+        monkeypatch.delenv("MEMTOMEM_INDEX_DEBOUNCE_QUEUE", raising=False)
+        path = debounce.queue_path()
+        assert path.name == "index_debounce_queue.json"
+        assert ".memtomem" in str(path)


### PR DESCRIPTION
## Summary

Closes the documented debounce gap from PR #536. `mm index` gains three flags backed by a file-system-backed debounce queue under `~/.memtomem/index_debounce_queue.json` (sidecar-lockfile-protected):

- **`--debounce-window <SECONDS>`** — record PATH in the queue and drain entries silent ≥ SECONDS. Designed for `PostToolUse[Write]` hook callers; rapid consecutive writes to the same file restart the window so a codegen burst is indexed once at the end.
- **`--flush`** — **synchronously drain every queued entry. Blocks until each file is indexed (or recorded as an error). Worst-case latency ≈ queue depth × per-file index cost.** The plugin's Stop hook now chains `mm index --flush` before `mm session end --auto`.
- **`--status`** — snapshot of the queue (depth, oldest entry). **Race-prone by design** (no lock); concurrent hooks may modify the queue between the read and any caller action. Use as telemetry only — `--flush` is the only correctness primitive for "drain the queue".

The three flags are mutually exclusive with each other and with the plain `mm index <path>` invocation.

## Concurrency model

The queue file is replaced atomically via `os.replace` on every mutation. Locking the queue file directly would disconnect the lock from the file mid-mutation (the OS keeps the locked inode alive after replace, but later openers see a different inode). The lock is therefore on a sidecar `~/.memtomem/.index_debounce_queue.json.lock` — never replaced, so all writers serialize on the same inode. Verified by `test_concurrent_enqueue_does_not_lose_entries` (20 parallel threads, all entries persisted).

Indexer errors keep entries in the queue for retry on the next hook fire — failing files are not silently lost. Last-write-wins for `--namespace`/`--force` when the same path is enqueued twice.

## RFC-B (PreCompact, deferred) — future-extensibility reserved

When the PreCompact hook contract lands and a checkpoint handler wants to flush only the files Claude Code reports as in-flight, `--flush` will gain a `--paths <list>` form. The underlying `debounce.drain_all` already accepts an optional `paths=` filter (`test_paths_filter_drains_subset_only` pins this) so the CLI addition is additive — no second ABI change. CHANGELOG and `claude-code.md` Caveats both call this out so a future RFC-B reviewer doesn't have to rediscover the extension shape.

## Plugin + docs sync

`packages/memtomem-claude-plugin/hooks/hooks.json` and `docs/guides/integrations/claude-code.md` Hooks Automation Setup are updated **byte-for-byte** (`TestPluginHooksDocsParity` from #536 catches drift):

- `PostToolUse[Write]` → `mm index --debounce-window 5 "$FP"`
- `Stop` → `mm index --flush; mm session end --auto` (timeout bumped 5000 → 10000 ms to accommodate flush worst-case latency)
- "Important Caveats" — old "Debounce gap" caveat (pointed at native debounce as future work) replaced with "Debounce mechanics" caveat covering queue file, window-restart semantics, Stop-hook flush chain, `--status` race, and RFC-B extension shape.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_index_debounce.py -m "not ollama"` — **19 new tests pass** (enqueue semantics, drain-ready/drain-all, status snapshot, 20-thread concurrency, partial-drain retry).
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — **3147 pass, 0 fail** (no regressions; `TestPluginHooksDocsParity` enforces docs↔plugin parity).
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy` — all clean (mypy advisory, no new errors).
- [ ] Manual: `mm index --debounce-window 5 /tmp/test.md` queues; second call within 5s updates `last_seen`; third call after 5s drains. `mm index --status` prints queue depth. `mm index --flush` drains synchronously.

## Open questions for review

- [ ] Reviewer: confirm 5-second window default in the plugin recipe is sane for typical codegen burst spacing; lower (1-2s) catches less, higher (10s) delays too much
- [ ] Reviewer: confirm sidecar-lockfile pattern over named-pipe / SQLite-WAL alternatives — the existing codebase uses fcntl.flock for `_liveness.py` so this is consistent
- [ ] Reviewer: confirm Stop-hook timeout bump 5000 → 10000 ms is enough for flush worst-case (a burst of 20 files at ~250ms each = 5s; the bump leaves headroom but isn't unbounded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)