### PR TITLE
fix(web): start FileWatcher in mm web lifespan + add startup backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,10 +61,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
     observers — files that landed before `start()` (server was down,
     or the dir was newly added to `memory_dirs`) stayed invisible
     until manual reindex. A one-shot startup backfill task now walks
-    each watched dir via `IndexEngine.index_path(recursive=True)`;
-    content-hash dedup makes already-indexed files no-ops, so the
-    cost is bounded by changed-file count rather than tree size on
-    every restart. Background task — does not block startup.
+    each watched dir via `IndexEngine.index_path(recursive=True)`,
+    gated by the new `indexing.startup_backfill` flag (**default
+    False**). Content-hash dedup makes already-indexed files no-ops,
+    so an enabled backfill costs the changed-file count rather than
+    tree size. Default-off because an unconditional startup walk
+    reintroduces the PR #295 failure mode (silent multi-minute CPU
+    embed job blocking the server on first install) — the `mm init`
+    wizard's opt-in seed is the user-driven path that resolves the
+    same gap with a visible progress bar; users who want backfill on
+    every restart can flip the flag explicitly. `mm index <dir>` and
+    the web UI's per-dir Reindex button cover ad-hoc indexing without
+    flipping the flag.
 
 ## [0.1.33] — 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   the Stop hook chains `mm index --flush` before
   `mm session end --auto`.
 
+### Fixed
+
+- **`mm web` now starts a `FileWatcher` and runs a startup backfill.**
+  Two gaps fixed together because they presented as one bug ("files
+  added to a `memory_dir` don't show up in Sources"):
+  - `mm web`'s lifespan previously did not wire `FileWatcher` at all
+    (only the MCP server's `AppContext` did), so `mm web` ran with no
+    fs watcher — files added while the server was up were never
+    auto-picked-up. The lifespan now starts and stops a `FileWatcher`
+    in the same way `server/context.py` does, gated on the same
+    degraded-mode check (skipped when embedding is broken).
+  - `FileWatcher.start()` previously only registered watchdog
+    observers — files that landed before `start()` (server was down,
+    or the dir was newly added to `memory_dirs`) stayed invisible
+    until manual reindex. A one-shot startup backfill task now walks
+    each watched dir via `IndexEngine.index_path(recursive=True)`;
+    content-hash dedup makes already-indexed files no-ops, so the
+    cost is bounded by changed-file count rather than tree size on
+    every restart. Background task — does not block startup.
+
 ## [0.1.33] — 2026-04-29
 
 ### Added

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -190,6 +190,23 @@ class IndexingConfig(BaseSettings):
     # False. Default stays True so existing users without an explicit value
     # still trigger migration on next startup. Will be removed in a future release.
     auto_discover: bool = True
+    # When True, ``FileWatcher.start()`` walks each ``memory_dir`` once at
+    # startup and indexes files the watchdog observer didn't see (the observer
+    # only fires on change events from the moment it's scheduled, so files
+    # that landed before start() — server was down, or the dir was newly
+    # added to ``memory_dirs`` — would otherwise stay invisible).
+    #
+    # Default False (PR #295 lesson): an unconditional startup walk is
+    # silently CPU-bound on first install — a multi-minute embed job blocks
+    # the server while the user thinks it hung, the same failure mode that
+    # killed the earlier startup-scan attempt. The ``mm init`` wizard's
+    # opt-in ``_maybe_seed_initial_index`` is the user-driven path that
+    # resolves the same gap with a visible progress bar and confirm prompt;
+    # users who want the same backfill on every restart can flip this to
+    # True explicitly. ``mm index <dir>`` and the web UI's per-dir Reindex
+    # button cover ad-hoc indexing without flipping this — content-hash
+    # dedup makes both paths idempotent.
+    startup_backfill: bool = False
 
     @field_validator(
         "max_chunk_tokens",

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -106,13 +106,13 @@ async def memory_dir_stats(
 
     Shape: ``[{path, chunk_count, source_file_count, exists, category,
     provider}]`` in the same order as ``memory_dirs``. Drives the web UI's
-    "(N chunks)" / "(not indexed)" badges. The startup backfill in
-    :class:`~memtomem.indexing.watcher.FileWatcher` indexes pre-existing
-    files automatically, so a "(not indexed)" badge typically means either
-    the backfill hasn't completed yet (background task, eventually
-    consistent) or the server is running degraded (broken embedding) —
-    the manual reindex button still works as a forced re-walk in either
-    case. ``category`` is provided by
+    "(N chunks)" / "(not indexed)" badges so users can see which dirs
+    need a manual reindex (the running watcher only reacts to fs events,
+    so files that landed while the server was down stay invisible until
+    a forced re-walk; the opt-in
+    :attr:`~memtomem.config.IndexingConfig.startup_backfill` flag covers
+    the same gap on startup for users who explicitly enable it).
+    ``category`` is provided by
     :func:`~memtomem.config.categorize_memory_dir` and ``provider`` by
     :func:`~memtomem.config.provider_for_category`, so the Web UI can
     build a vendor → product tree without maintaining its own regex or

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -106,14 +106,17 @@ async def memory_dir_stats(
 
     Shape: ``[{path, chunk_count, source_file_count, exists, category,
     provider}]`` in the same order as ``memory_dirs``. Drives the web UI's
-    "(N chunks)" / "(not indexed)" badges so the user can see which dirs
-    still need a manual reindex (the file watcher only reacts to change
-    events, so pre-existing files in a newly added ``memory_dir`` stay
-    invisible until the user clicks the ↻ button). ``category`` is
-    provided by :func:`~memtomem.config.categorize_memory_dir` and
-    ``provider`` by :func:`~memtomem.config.provider_for_category`, so the
-    Web UI can build a vendor → product tree without maintaining its own
-    regex or mapping. RFC #304 Phase 1.
+    "(N chunks)" / "(not indexed)" badges. The startup backfill in
+    :class:`~memtomem.indexing.watcher.FileWatcher` indexes pre-existing
+    files automatically, so a "(not indexed)" badge typically means either
+    the backfill hasn't completed yet (background task, eventually
+    consistent) or the server is running degraded (broken embedding) —
+    the manual reindex button still works as a forced re-walk in either
+    case. ``category`` is provided by
+    :func:`~memtomem.config.categorize_memory_dir` and ``provider`` by
+    :func:`~memtomem.config.provider_for_category`, so the Web UI can
+    build a vendor → product tree without maintaining its own regex or
+    mapping. RFC #304 Phase 1.
 
     Aggregation: one ``get_source_files_with_counts()`` call over the
     whole ``chunks`` table, bucketed in Python by normalised-path prefix

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -66,7 +66,20 @@ class _MarkdownEventHandler(FileSystemEventHandler):
 class FileWatcher:
     """Watches configured directories and triggers re-indexing on file changes.
 
-    Runs as an asyncio task alongside the MCP server.
+    Runs as an asyncio task alongside the MCP server and the web server
+    (``memtomem.web.app``). ``start()`` does two things:
+
+    1. Registers a ``recursive=True`` ``watchdog`` ``Observer`` on each
+       existing ``memory_dir`` so future create/modify/move events trigger
+       a debounced re-index.
+    2. Kicks off a one-shot **startup backfill** that walks each watched
+       dir via ``IndexEngine.index_path(recursive=True)``. The observer
+       only sees events from the moment it starts, so files that landed
+       while the server was down (or before the dir was added to
+       ``memory_dirs``) would otherwise stay invisible. The backfill is
+       idempotent — content-hash dedup inside ``_index_file`` skips
+       already-indexed files — and runs as a background task so a slow
+       walk over many memory_dirs doesn't block startup.
     """
 
     def __init__(
@@ -81,22 +94,37 @@ class FileWatcher:
         self._observer: BaseObserver | None = None
         self._queue: asyncio.Queue[Path] = asyncio.Queue(maxsize=_WATCHER_QUEUE_MAXSIZE)
         self._task: asyncio.Task[None] | None = None
+        self._backfill_task: asyncio.Task[None] | None = None
 
     async def start(self) -> None:
         loop = asyncio.get_running_loop()
         handler = _MarkdownEventHandler(self._queue, loop, self._config.supported_extensions)
         self._observer = Observer()
 
+        watched: list[Path] = []
         for watch_dir in self._config.memory_dirs:
             expanded = Path(watch_dir).expanduser().resolve()
             if expanded.exists():
                 self._observer.schedule(handler, str(expanded), recursive=True)
                 logger.info("Watching %s for changes", expanded)
+                watched.append(expanded)
 
         self._observer.start()
         self._task = asyncio.create_task(self._process_events())
+        if watched:
+            self._backfill_task = asyncio.create_task(self._backfill_existing(watched))
 
     async def stop(self) -> None:
+        if self._backfill_task is not None and not self._backfill_task.done():
+            # Cancel — the backfill walk can take a while on large trees and
+            # we don't want shutdown to block on it.
+            self._backfill_task.cancel()
+            try:
+                await self._backfill_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.warning("Startup backfill task error during stop: %s", exc)
         if self._task is not None:
             # Signal graceful shutdown — flush pending before exit
             try:
@@ -114,6 +142,36 @@ class FileWatcher:
         if self._observer:
             self._observer.stop()
             self._observer.join()
+
+    async def _backfill_existing(self, dirs: list[Path]) -> None:
+        """Index pre-existing files the observer can't see.
+
+        The watchdog observer only fires on change events from the moment
+        it's scheduled, so files that landed while the server was down (or
+        before the dir was added to ``memory_dirs``) are invisible to it.
+        This walks each watched dir once at startup and lets
+        ``IndexEngine.index_path`` decide what's new — already-indexed
+        files are skipped via content-hash dedup, so the cost is bounded
+        by the changed-file count rather than the total tree size on
+        every restart.
+
+        Per-dir errors are logged and don't abort siblings.
+        """
+        for d in dirs:
+            try:
+                stats = await self._engine.index_path(d, recursive=True)
+                if stats.indexed_chunks or stats.deleted_chunks:
+                    logger.info(
+                        "Startup backfill %s: indexed=%d skipped=%d deleted=%d",
+                        d,
+                        stats.indexed_chunks,
+                        stats.skipped_chunks,
+                        stats.deleted_chunks,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("Startup backfill failed for %s: %s", d, exc)
 
     async def _process_events(self) -> None:
         """Consume changed file paths with batch debouncing.

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -71,15 +71,19 @@ class FileWatcher:
 
     1. Registers a ``recursive=True`` ``watchdog`` ``Observer`` on each
        existing ``memory_dir`` so future create/modify/move events trigger
-       a debounced re-index.
-    2. Kicks off a one-shot **startup backfill** that walks each watched
-       dir via ``IndexEngine.index_path(recursive=True)``. The observer
-       only sees events from the moment it starts, so files that landed
-       while the server was down (or before the dir was added to
-       ``memory_dirs``) would otherwise stay invisible. The backfill is
-       idempotent — content-hash dedup inside ``_index_file`` skips
-       already-indexed files — and runs as a background task so a slow
-       walk over many memory_dirs doesn't block startup.
+       a debounced re-index. Always on — this is the ambient behavior
+       that lets the running server pick up edits.
+    2. **Opt-in startup backfill** (gated by
+       ``IndexingConfig.startup_backfill``, default False): when enabled,
+       walks each watched dir via ``IndexEngine.index_path(recursive=True)``
+       to catch files the observer didn't see (server was down when they
+       landed, or the dir was newly added to ``memory_dirs``). Idempotent
+       via content-hash dedup; runs as a background task so a slow walk
+       doesn't block startup. Default False because an unconditional
+       startup walk reintroduces the PR #295 failure mode — a silent
+       multi-minute CPU embed job blocking the server on first install.
+       Users opt in via the ``mm init`` wizard's seed prompt or by
+       editing ``indexing.startup_backfill`` directly.
     """
 
     def __init__(
@@ -111,7 +115,7 @@ class FileWatcher:
 
         self._observer.start()
         self._task = asyncio.create_task(self._process_events())
-        if watched:
+        if watched and self._config.startup_backfill:
             self._backfill_task = asyncio.create_task(self._backfill_existing(watched))
 
     async def stop(self) -> None:

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -205,6 +205,7 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+    from memtomem.indexing.watcher import FileWatcher
     from memtomem.server.component_factory import close_components, create_components
 
     comp = await create_components()
@@ -263,9 +264,28 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
             "run ``memtomem-server`` (MCP) for the lifespan that starts PolicyScheduler"
         )
 
+    # File watcher: monitors memory_dirs for fs-event-driven re-indexing
+    # and runs a one-shot startup backfill so files added while ``mm web``
+    # was down (or before the dir was registered) get indexed without the
+    # user clicking Reindex. Skipped in degraded mode (broken embedding) —
+    # the indexer would crash on the missing chunks_vec table; recovery
+    # via ``mem_embedding_reset``. Mirrors the wiring in
+    # ``server/context.py``; without this ``mm web`` ran with no fs
+    # watcher at all.
+    watcher: FileWatcher | None = None
+    if comp.embedding_broken is None:
+        watcher = FileWatcher(comp.index_engine, comp.config.indexing)
+        await watcher.start()
+        app.state.file_watcher = watcher
+
     try:
         yield
     finally:
+        if watcher is not None:
+            try:
+                await watcher.stop()
+            except Exception as exc:
+                logger.warning("file watcher stop failed: %s", exc)
         await close_components(comp)
 
 

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1322,6 +1322,69 @@ class TestFileWatcher:
         )
         assert watcher._debounce_s == 2.0
 
+    async def test_startup_backfill_indexes_preexisting_files(self, components, memory_dir):
+        """Pre-existing files get indexed via the startup backfill task.
+
+        The watchdog observer only fires on change events from the moment
+        it's scheduled — files that landed before ``start()`` (or while
+        the server was down) would otherwise stay invisible until the
+        user clicked Reindex. This is the regression cover for the
+        "files added to ``memory_dirs`` don't show up in Sources" bug.
+        """
+        from memtomem.indexing.watcher import FileWatcher
+
+        md = memory_dir / "preexisting.md"
+        md.write_text(
+            "# preexisting\n\ncontent that landed before the watcher started\n",
+            encoding="utf-8",
+        )
+
+        watcher = FileWatcher(
+            index_engine=components.index_engine,
+            config=components.config.indexing,
+            debounce_ms=100,
+        )
+        try:
+            await watcher.start()
+            assert watcher._backfill_task is not None
+            await watcher._backfill_task
+        finally:
+            await watcher.stop()
+
+        hashes = await components.storage.get_chunk_hashes(md)
+        assert len(hashes) > 0, "startup backfill should have indexed the pre-existing file"
+
+    async def test_startup_backfill_idempotent_on_unchanged_files(self, components, memory_dir):
+        """Backfill on every startup is bounded by changed-file count.
+
+        Content-hash dedup in ``IndexEngine`` makes already-indexed
+        files no-ops, so a second backfill produces the same chunk
+        count rather than duplicating chunks.
+        """
+        from memtomem.indexing.watcher import FileWatcher
+
+        md = memory_dir / "stable.md"
+        md.write_text("# stable\n\nno changes between runs\n", encoding="utf-8")
+
+        async def _run_one_backfill() -> int:
+            w = FileWatcher(
+                index_engine=components.index_engine,
+                config=components.config.indexing,
+                debounce_ms=100,
+            )
+            try:
+                await w.start()
+                assert w._backfill_task is not None
+                await w._backfill_task
+            finally:
+                await w.stop()
+            return len(await components.storage.get_chunk_hashes(md))
+
+        first = await _run_one_backfill()
+        second = await _run_one_backfill()
+        assert first > 0
+        assert first == second, f"expected backfill idempotent, got {first} -> {second}"
+
 
 # ===========================================================================
 # 11. memory_dir_stats — per-dir index status for the web widget

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1322,14 +1322,38 @@ class TestFileWatcher:
         )
         assert watcher._debounce_s == 2.0
 
-    async def test_startup_backfill_indexes_preexisting_files(self, components, memory_dir):
-        """Pre-existing files get indexed via the startup backfill task.
+    async def test_startup_backfill_default_off_skips_walk(self, components, memory_dir):
+        """``startup_backfill`` defaults to False — guards against the
+        PR #295 silent-CPU-block regression. An unset flag MUST NOT
+        trigger a walk even when memory_dirs contain unindexed files;
+        users opt in explicitly via the wizard or by editing the config.
+        """
+        from memtomem.indexing.watcher import FileWatcher
 
-        The watchdog observer only fires on change events from the moment
-        it's scheduled — files that landed before ``start()`` (or while
-        the server was down) would otherwise stay invisible until the
-        user clicked Reindex. This is the regression cover for the
-        "files added to ``memory_dirs`` don't show up in Sources" bug.
+        (memory_dir / "unindexed.md").write_text("# never indexed\n", encoding="utf-8")
+        assert components.config.indexing.startup_backfill is False, (
+            "default must stay False; a True default reintroduces PR #295"
+        )
+
+        watcher = FileWatcher(
+            index_engine=components.index_engine,
+            config=components.config.indexing,
+            debounce_ms=100,
+        )
+        try:
+            await watcher.start()
+            assert watcher._backfill_task is None
+        finally:
+            await watcher.stop()
+
+    async def test_startup_backfill_indexes_preexisting_files_when_enabled(
+        self, components, memory_dir
+    ):
+        """When the user opts in via ``startup_backfill=True``, pre-
+        existing files get indexed. The watchdog observer only fires on
+        change events from the moment it's scheduled, so without this
+        opt-in path files that landed before ``start()`` stay invisible
+        until manual reindex.
         """
         from memtomem.indexing.watcher import FileWatcher
 
@@ -1338,6 +1362,7 @@ class TestFileWatcher:
             "# preexisting\n\ncontent that landed before the watcher started\n",
             encoding="utf-8",
         )
+        components.config.indexing.startup_backfill = True
 
         watcher = FileWatcher(
             index_engine=components.index_engine,
@@ -1352,19 +1377,20 @@ class TestFileWatcher:
             await watcher.stop()
 
         hashes = await components.storage.get_chunk_hashes(md)
-        assert len(hashes) > 0, "startup backfill should have indexed the pre-existing file"
+        assert len(hashes) > 0, "opt-in backfill should have indexed the pre-existing file"
 
     async def test_startup_backfill_idempotent_on_unchanged_files(self, components, memory_dir):
-        """Backfill on every startup is bounded by changed-file count.
-
-        Content-hash dedup in ``IndexEngine`` makes already-indexed
-        files no-ops, so a second backfill produces the same chunk
-        count rather than duplicating chunks.
+        """Opt-in backfill on every startup is bounded by changed-file
+        count. Content-hash dedup in ``IndexEngine`` makes already-
+        indexed files no-ops, so a second backfill produces the same
+        chunk count rather than duplicating — users who flip the flag
+        don't pay the full embed cost on every restart.
         """
         from memtomem.indexing.watcher import FileWatcher
 
         md = memory_dir / "stable.md"
         md.write_text("# stable\n\nno changes between runs\n", encoding="utf-8")
+        components.config.indexing.startup_backfill = True
 
         async def _run_one_backfill() -> int:
             w = FileWatcher(

--- a/packages/memtomem/tests/test_web_lifespan.py
+++ b/packages/memtomem/tests/test_web_lifespan.py
@@ -96,13 +96,23 @@ def _make_components(
 
 
 async def _run_lifespan(comp: MagicMock) -> FastAPI:
-    """Enter and exit ``_lifespan`` with a mocked ``create_components``."""
+    """Enter and exit ``_lifespan`` with a mocked ``create_components``.
+
+    The FileWatcher patch keeps the lifespan from spinning a real
+    watchdog Observer thread on every test. Tests that need to assert
+    on ``watcher.start`` / ``watcher.stop`` directly patch FileWatcher
+    themselves with a spy — see ``test_lifespan_starts_and_stops_file_watcher``.
+    """
     app = FastAPI()
+    fake_watcher = MagicMock()
+    fake_watcher.start = AsyncMock()
+    fake_watcher.stop = AsyncMock()
     with (
         patch("memtomem.server.component_factory.create_components", AsyncMock(return_value=comp)),
         patch("memtomem.server.component_factory.close_components", AsyncMock()),
         # The lifespan also instantiates DedupScanner — harmless to stub.
         patch("memtomem.search.dedup.DedupScanner", MagicMock()),
+        patch("memtomem.indexing.watcher.FileWatcher", lambda *_a, **_kw: fake_watcher),
     ):
         async with _lifespan(app):
             pass
@@ -251,3 +261,70 @@ async def test_policy_disabled_no_warning(caplog):
         await _run_lifespan(comp)
 
     assert not any("policy.enabled" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# FileWatcher wiring — guards the regression where ``mm web`` ran with no
+# fs watcher at all. Files added to memory_dirs (whether while the server
+# was up, or before the dir was registered) were never auto-picked-up
+# until the user clicked Reindex. The lifespan now wires the same
+# FileWatcher that ``server/context.py`` uses, gated on the same
+# degraded-mode check.
+# ---------------------------------------------------------------------------
+
+
+async def test_lifespan_starts_and_stops_file_watcher():
+    """Watcher started on lifespan entry, stopped on exit, exposed on
+    ``app.state.file_watcher`` so routes / shutdown handlers can find it.
+    """
+    fake_watcher = MagicMock()
+    fake_watcher.start = AsyncMock()
+    fake_watcher.stop = AsyncMock()
+    comp = _make_components(embedding_broken=None, stored_info=None)
+
+    app = FastAPI()
+    with (
+        patch("memtomem.server.component_factory.create_components", AsyncMock(return_value=comp)),
+        patch("memtomem.server.component_factory.close_components", AsyncMock()),
+        patch("memtomem.search.dedup.DedupScanner", MagicMock()),
+        patch("memtomem.indexing.watcher.FileWatcher", lambda *_a, **_kw: fake_watcher),
+    ):
+        async with _lifespan(app):
+            assert fake_watcher.start.await_count == 1
+            assert app.state.file_watcher is fake_watcher
+
+    assert fake_watcher.stop.await_count == 1
+
+
+async def test_lifespan_skips_watcher_in_degraded_mode():
+    """When embedding is broken, the watcher must NOT start — the
+    indexer would crash on the missing ``chunks_vec`` table. Recovery
+    happens via ``mem_embedding_reset``; mirrors the same guard in
+    ``server/context.py``.
+    """
+    fake_watcher = MagicMock()
+    fake_watcher.start = AsyncMock()
+    fake_watcher.stop = AsyncMock()
+    comp = _make_components(
+        embedding_broken={
+            "dimension_mismatch": True,
+            "model_mismatch": True,
+            "stored": {"dimension": 0, "provider": "none", "model": ""},
+            "configured": {"dimension": 1024, "provider": "onnx", "model": "bge-m3"},
+        },
+        stored_info={"dimension": 0, "provider": "none", "model": ""},
+    )
+
+    app = FastAPI()
+    with (
+        patch("memtomem.server.component_factory.create_components", AsyncMock(return_value=comp)),
+        patch("memtomem.server.component_factory.close_components", AsyncMock()),
+        patch("memtomem.search.dedup.DedupScanner", MagicMock()),
+        patch("memtomem.indexing.watcher.FileWatcher", lambda *_a, **_kw: fake_watcher),
+    ):
+        async with _lifespan(app):
+            pass
+
+    assert fake_watcher.start.await_count == 0
+    assert fake_watcher.stop.await_count == 0
+    assert not hasattr(app.state, "file_watcher")


### PR DESCRIPTION
## Summary

- `mm web`'s lifespan now wires a `FileWatcher` (previously only the MCP server's `AppContext` did) — `mm web` ran with no fs watcher at all, so files added to a `memory_dir` while the server was up were never auto-picked-up. **Always-on**, mirrors `server/context.py`, gated on the same degraded-mode check.
- `FileWatcher.start()` gains an **opt-in** startup backfill (`indexing.startup_backfill`, default **False**) that walks each `memory_dir` once and indexes files the observer didn't see (server was down when they landed, or the dir was newly added to `memory_dirs`). Default-off because an unconditional startup walk reintroduces the PR #295 silent-CPU-block failure mode; the `mm init` wizard's existing seed prompt is the user-driven path with a visible progress bar, and users who want backfill on every restart can flip the flag explicitly. `mm index <dir>` and the web UI's per-dir Reindex button cover ad-hoc indexing without flipping the flag — content-hash dedup makes every path idempotent.

Two gaps fixed together because they presented as one bug — "files added to a `memory_dir` don't show up in the Sources tab" — but with different default-on / default-off treatments matching their cost profile.

## Test plan

- [x] `tests/test_indexing_engine.py::TestFileWatcher`:
      - default-off gate guard (no walk when flag unset — PR #295 regression cover)
      - opt-in indexes pre-existing files
      - opt-in idempotency on unchanged files
- [x] `tests/test_web_lifespan.py` — watcher started on entry / stopped on exit; skipped in degraded mode (broken embedding)
- [x] Manual smoke (isolated worktree, port 8081, isolated `.mmstate/`) with `startup_backfill=True`: pre-existing → backfill; running-add → `on_created` watcher
- [x] `ruff check` / `ruff format --check` / `mypy` (advisory) passing on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)