### PR TITLE
feat(init): wizard offers startup_backfill opt-in + watcher logs walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
     the web UI's per-dir Reindex button cover ad-hoc indexing without
     flipping the flag.
 
+- **`mm init` wizard now offers `indexing.startup_backfill` as an
+  opt-in toggle.** After a successful inline seed the wizard adds a
+  second prompt — "Auto-index new files on every server restart?" —
+  defaulting to No (same default-skip discipline as the seed prompt).
+  Yes writes `indexing.startup_backfill: true` to `config.json`; the
+  unset / declined / non-TTY paths leave the key out and preserve
+  the `IndexingConfig` default. Closes the discoverability gap from
+  the FileWatcher backfill PR — users who actively sync a memory_dir
+  from elsewhere (cloud sync, periodic git pull) no longer need to
+  hand-edit `config.json` to enable it.
+
+- **`FileWatcher` startup backfill now logs progress.** A
+  `Startup backfill: walking N memory_dir(s)...` line at start and a
+  `Startup backfill complete: M new chunks indexed` line at end —
+  without these the only backfill log was a per-dir summary that only
+  fired when something was actually indexed, so opt-in users on slow
+  embedders couldn't tell whether the walk was hung or just busy.
+
 ## [0.1.33] — 2026-04-29
 
 ### Added

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1714,6 +1714,41 @@ def _maybe_seed_initial_index(paths: list[Path], state: dict) -> bool:
     return _seed_with_progress(existing)
 
 
+def _maybe_offer_startup_backfill(state: dict) -> None:
+    """Offer to enable ``indexing.startup_backfill`` after a successful
+    inline seed.
+
+    The wizard's seed only indexes once. Users who keep adding files to
+    a ``memory_dir`` outside the running server (cloud sync, periodic
+    git pull, etc.) would need to re-run ``mm index`` after every
+    restart unless the backfill flag is on. Default No mirrors the
+    seed prompt — same default-skip discipline (PR #295 lesson),
+    visible to the user as an opt-in second confirm rather than a
+    silent toggle.
+
+    Side effect: when the user confirms, sets
+    ``state["startup_backfill"] = True`` so
+    :func:`_write_config_and_summary` emits
+    ``indexing.startup_backfill = true`` to ``config.json``. No-op when
+    not a TTY (CI, ``mm init -y``) so piped runs stay deterministic.
+    """
+    if not sys.stdin.isatty():
+        return
+    click.echo()
+    try:
+        enable = click.confirm(
+            "  Auto-index new files on every server restart? "
+            "(Useful when you sync this dir from elsewhere; off keeps "
+            "fresh starts fast and you can run `mm index` or click "
+            "Reindex manually)",
+            default=False,
+        )
+    except click.Abort:
+        return
+    if enable:
+        state["startup_backfill"] = True
+
+
 def _collect_missing_extras(state: dict) -> list[str]:
     """Return ordered list of missing extras the chosen config will need.
 
@@ -1933,6 +1968,13 @@ def _write_config_and_summary(
         seen.add(key)
         combined_dirs.append(entry)
 
+    indexing_block: dict = {"memory_dirs": combined_dirs, "auto_discover": False}
+    # Only emit ``startup_backfill`` when the user explicitly opted in via
+    # ``_maybe_offer_startup_backfill`` — leaving it unset preserves the
+    # ``False`` default (PR #295 lesson) and keeps ``config.json`` minimal.
+    if state.get("startup_backfill"):
+        indexing_block["startup_backfill"] = True
+
     init_data: dict = {
         "embedding": {
             "provider": state["provider"],
@@ -1940,7 +1982,7 @@ def _write_config_and_summary(
             "dimension": state["dimension"],
         },
         "storage": {"backend": "sqlite", "sqlite_path": state["db_path"]},
-        "indexing": {"memory_dirs": combined_dirs, "auto_discover": False},
+        "indexing": indexing_block,
         "namespace": {
             "enable_auto_ns": state["enable_auto_ns"],
             "default_namespace": state["default_ns"],
@@ -2236,6 +2278,8 @@ def _write_config_and_summary(
         seen_seed_keys.add(key)
         seed_paths.append(p)
     seeded = _maybe_seed_initial_index(seed_paths, state)
+    if seeded:
+        _maybe_offer_startup_backfill(state)
 
     click.echo()
     click.secho("  Next steps:", fg="cyan")

--- a/packages/memtomem/src/memtomem/indexing/watcher.py
+++ b/packages/memtomem/src/memtomem/indexing/watcher.py
@@ -160,10 +160,20 @@ class FileWatcher:
         every restart.
 
         Per-dir errors are logged and don't abort siblings.
+
+        Logs a single ``Startup backfill: walking N memory_dir(s)...``
+        line at the start so opt-in users can tell whether the (potentially
+        slow) walk is running or already finished — without this the only
+        backfill-related logs were per-dir summary lines, and a quiet log
+        looks identical to a hung server (the same UX failure mode that
+        killed the PR #295 silent startup scan).
         """
+        logger.info("Startup backfill: walking %d memory_dir(s)...", len(dirs))
+        total_indexed = 0
         for d in dirs:
             try:
                 stats = await self._engine.index_path(d, recursive=True)
+                total_indexed += stats.indexed_chunks
                 if stats.indexed_chunks or stats.deleted_chunks:
                     logger.info(
                         "Startup backfill %s: indexed=%d skipped=%d deleted=%d",
@@ -176,6 +186,7 @@ class FileWatcher:
                 raise
             except Exception as exc:
                 logger.error("Startup backfill failed for %s: %s", d, exc)
+        logger.info("Startup backfill complete: %d new chunks indexed", total_indexed)
 
     async def _process_events(self) -> None:
         """Consume changed file paths with batch debouncing.

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1379,6 +1379,38 @@ class TestFileWatcher:
         hashes = await components.storage.get_chunk_hashes(md)
         assert len(hashes) > 0, "opt-in backfill should have indexed the pre-existing file"
 
+    async def test_startup_backfill_logs_walk_progress(self, components, memory_dir, caplog):
+        """Opt-in backfill emits a 'walking N memory_dir(s)' line at
+        start and a 'complete: M new chunks indexed' line at end.
+        Without these the only backfill log was a per-dir summary that
+        only fires when something was actually indexed — quiet logs
+        on a slow embedder look identical to a hung server, exactly
+        the UX failure mode the PR #295 silent startup scan caused.
+        """
+        import logging
+
+        from memtomem.indexing.watcher import FileWatcher
+
+        (memory_dir / "x.md").write_text("# x", encoding="utf-8")
+        components.config.indexing.startup_backfill = True
+
+        watcher = FileWatcher(
+            index_engine=components.index_engine,
+            config=components.config.indexing,
+            debounce_ms=100,
+        )
+        try:
+            with caplog.at_level(logging.INFO, logger="memtomem.indexing.watcher"):
+                await watcher.start()
+                assert watcher._backfill_task is not None
+                await watcher._backfill_task
+        finally:
+            await watcher.stop()
+
+        msgs = [r.message for r in caplog.records]
+        assert any("Startup backfill: walking" in m for m in msgs), msgs
+        assert any("Startup backfill complete" in m for m in msgs), msgs
+
     async def test_startup_backfill_idempotent_on_unchanged_files(self, components, memory_dir):
         """Opt-in backfill on every startup is bounded by changed-file
         count. Content-hash dedup in ``IndexEngine`` makes already-

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -190,6 +190,89 @@ class TestInitConfigMerge:
         assert data["search"]["default_top_k"] == 10
 
 
+class TestStartupBackfillOptIn:
+    """The wizard offers an opt-in toggle for
+    ``indexing.startup_backfill`` after a successful inline seed —
+    flipping the flag on every restart is a separate decision from the
+    one-shot wizard seed (PR #295 lesson, see ``IndexingConfig``).
+    """
+
+    def test_config_omits_flag_when_state_unset(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default path — no opt-in, no key in ``config.json``. Keeps
+        the ``False`` default in ``IndexingConfig`` and avoids polluting
+        the config file with redundant defaults."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".memtomem").mkdir()
+
+        state = _make_init_state(tmp_path)
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert "startup_backfill" not in data["indexing"]
+
+    def test_config_emits_flag_when_state_true(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User opted in via ``_maybe_offer_startup_backfill`` — config
+        must record ``indexing.startup_backfill = true`` so the next
+        ``mm web`` / ``mm server`` startup honours it."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / ".memtomem").mkdir()
+
+        state = _make_init_state(tmp_path)
+        state["startup_backfill"] = True
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
+        assert data["indexing"]["startup_backfill"] is True
+
+    def test_offer_sets_state_when_user_confirms(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Yes at the prompt → ``state["startup_backfill"] = True``."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(init_cmd.click, "confirm", lambda *a, **kw: True)
+
+        state: dict = {}
+        init_cmd._maybe_offer_startup_backfill(state)
+        assert state["startup_backfill"] is True
+
+    def test_offer_unchanged_when_user_declines(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No at the prompt → state unchanged, key not added. Same
+        default-skip discipline as the seed prompt."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: True)
+        monkeypatch.setattr(init_cmd.click, "confirm", lambda *a, **kw: False)
+
+        state: dict = {}
+        init_cmd._maybe_offer_startup_backfill(state)
+        assert "startup_backfill" not in state
+
+    def test_offer_skipped_when_non_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-TTY (CI, piped ``mm init -y``) → silent skip without
+        calling confirm. Mirrors the seed prompt's isatty gate so
+        non-interactive runs stay deterministic."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd.sys.stdin, "isatty", lambda: False)
+
+        def _explode(*_a: object, **_kw: object) -> bool:
+            raise AssertionError("confirm must not be called when stdin is not a TTY")
+
+        monkeypatch.setattr(init_cmd.click, "confirm", _explode)
+
+        state: dict = {}
+        init_cmd._maybe_offer_startup_backfill(state)
+        assert "startup_backfill" not in state
+
+
 class TestRerankerStep:
     """`_step_reranker` writes an optional `rerank` section into config.json."""
 


### PR DESCRIPTION
Follow-up polish from #550 review:

## Summary

1. **`mm init` discoverability for `indexing.startup_backfill`** — wizard now adds a second confirm prompt after a successful inline seed: "Auto-index new files on every server restart?" Default No mirrors the seed prompt's default-skip discipline (PR #295 lesson). Yes writes `indexing.startup_backfill: true` to `config.json`; declined / non-TTY paths leave it out so the `IndexingConfig` default still wins. Closes the discoverability gap from #550 where users who actively sync a `memory_dir` from elsewhere (cloud sync, periodic git pull) had to hand-edit `config.json` to enable backfill.

2. **`FileWatcher` startup-walk logging** — `_backfill_existing` now emits a `Startup backfill: walking N memory_dir(s)...` line at start and a `Startup backfill complete: M new chunks indexed` line at end. Without these, the per-dir summary only fired when files were actually indexed — quiet logs on a slow embedder looked identical to a hung server (the UX failure mode that killed the PR #295 silent startup scan).

## Test plan

- [x] `tests/test_init_cmd.py::TestStartupBackfillOptIn` — 5 tests covering config emit/omit + offer yes/no/non-TTY paths
- [x] `tests/test_indexing_engine.py::TestFileWatcher::test_startup_backfill_logs_walk_progress` — start + complete lines present when opt-in backfill runs
- [x] `ruff check` / `ruff format --check` passing on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)