### PR TITLE
feat(web): kind-classify sources for Memory vs General sub-toggle

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1334,16 +1334,19 @@ def memory_dir_kind(path: str | Path) -> MemoryDirKind:
       is unambiguously memory.
     - A ``"user"``-category dir flips to memory when any path segment is
       ``"memory"`` or ``"memories"`` — covers the common
-      ``~/memories/`` layout. Heuristic, so it intentionally over-includes
-      paths like ``~/Library/Caches/<app>/memory/`` or
-      ``~/projects/foo/memory/``; the cost is showing them in the Memory
-      view instead of General. Future PR can add an explicit
-      ``memory_dirs[i].kind`` override on top.
+      ``~/memories/`` layout. Segment match is case-insensitive so
+      ``/Users/X/Memories`` (which exists on macOS' case-insensitive
+      APFS) classifies the same as ``/Users/X/memories``. Heuristic, so
+      it intentionally over-includes paths like
+      ``~/Library/Caches/<app>/memory/`` or ``~/projects/foo/memory/``;
+      the cost is showing them in the Memory view instead of General.
+      Future PR can add an explicit ``memory_dirs[i].kind`` override on
+      top.
     """
     if categorize_memory_dir(path) != "user":
         return "memory"
     parts = Path(str(path)).parts
-    if any(p in _USER_MEMORY_SEGMENTS for p in parts):
+    if any(p.lower() in _USER_MEMORY_SEGMENTS for p in parts):
         return "memory"
     return "general"
 

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1205,6 +1205,22 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
 ProviderCategory = Literal["user", "claude-memory", "claude-plans", "codex"]
 ProviderName = Literal["user", "claude", "openai"]
 
+# Two-bucket classification on top of ``ProviderCategory`` so the Web UI's
+# Sources page can split entries between agent/user memory and arbitrary
+# RAG-style folders. ``categorize_memory_dir`` already separates known
+# provider layouts from the catch-all ``"user"`` bucket; this further
+# splits ``"user"`` by a path-segment heuristic so a folder named
+# ``~/memories/`` or ``~/Documents/memory/`` lands with the agent memory
+# instead of the general indexed folders. Heuristic — pattern-only, no
+# persisted override.
+MemoryDirKind = Literal["memory", "general"]
+
+# Path segments that, when present anywhere in a ``user``-category dir,
+# flip its kind to ``"memory"``. Frozen so the test fixture and runtime
+# both walk the same set. Edits here are user-visible classification
+# changes — bump the unit-test coverage at the same time.
+_USER_MEMORY_SEGMENTS: frozenset[str] = frozenset({"memory", "memories"})
+
 # Single source of truth for provider-dir classification. Each row ties a
 # category name to the regex that recognises paths in that category. The
 # Web UI's ``/api/memory-dirs/status`` response carries the resulting
@@ -1304,6 +1320,32 @@ def categorize_memory_dir(path: str | Path) -> ProviderCategory:
         if pat.search(s):
             return cat
     return "user"
+
+
+def memory_dir_kind(path: str | Path) -> MemoryDirKind:
+    """Classify a ``memory_dir`` as ``"memory"`` vs ``"general"``.
+
+    Splits the configured dir list into two semantic buckets so the Web
+    UI Sources page can show agent/user memory and arbitrary indexed
+    folders in separate views without persisting a side table. Layered
+    on top of :func:`categorize_memory_dir`:
+
+    - Any non-``"user"`` category (claude-memory, claude-plans, codex…)
+      is unambiguously memory.
+    - A ``"user"``-category dir flips to memory when any path segment is
+      ``"memory"`` or ``"memories"`` — covers the common
+      ``~/memories/`` layout. Heuristic, so it intentionally over-includes
+      paths like ``~/Library/Caches/<app>/memory/`` or
+      ``~/projects/foo/memory/``; the cost is showing them in the Memory
+      view instead of General. Future PR can add an explicit
+      ``memory_dirs[i].kind`` override on top.
+    """
+    if categorize_memory_dir(path) != "user":
+        return "memory"
+    parts = Path(str(path)).parts
+    if any(p in _USER_MEMORY_SEGMENTS for p in parts):
+        return "memory"
+    return "general"
 
 
 def _detect_provider_dirs() -> dict[str, list[Path]]:

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -22,6 +22,7 @@ from memtomem.config import (
     NamespaceConfig,
     NamespacePolicyRule,
     categorize_memory_dir,
+    memory_dir_kind,
     provider_for_category,
 )
 from memtomem.indexing.differ import compute_diff
@@ -118,6 +119,61 @@ def _dir_creation_time_iso(p: Path) -> str | None:
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
+def _norm_dir_prefix(d: str | Path) -> str:
+    """Return the directory path normalized for ``str.startswith`` matching.
+
+    Adds a trailing slash so a configured dir ``/foo`` does not falsely
+    claim files under ``/foo-bar/...``. Always runs through
+    :func:`~memtomem.storage.sqlite_helpers.norm_path` (which resolves
+    symlinks and applies Unicode NFC) so the prefix shape matches the
+    source-side normalisation regardless of whether the dir currently
+    exists on disk — the chunks table holds resolved paths, and a
+    configured-but-missing dir would otherwise compare in raw ``/tmp``
+    form against resolved ``/private/tmp`` source paths on macOS.
+
+    Used by both :func:`memory_dir_stats` (which buckets chunks per
+    configured dir) and :func:`resolve_owning_memory_dir` (which goes
+    the other way — given a source, find the owning dir). Keeping the
+    normalisation in one place ensures the two views stay consistent
+    when the prefix rules evolve.
+    """
+    from memtomem.storage.sqlite_helpers import norm_path
+
+    p = Path(d).expanduser()
+    base = norm_path(p)
+    if not base.endswith("/"):
+        base += "/"
+    return base
+
+
+def resolve_owning_memory_dir(
+    source_path: str | Path,
+    configured_dirs: Iterable[str | Path],
+) -> Path | None:
+    """Return the configured ``memory_dir`` that contains ``source_path``.
+
+    Returns ``None`` for orphan sources — files indexed in the past but
+    whose owning dir is no longer in the configured list (typical after
+    a user removes a dir without purging its chunks). The Web UI surfaces
+    these in the General view so they don't disappear.
+
+    When configured dirs are nested (e.g. ``~/work`` and
+    ``~/work/notes``), the longest-matching prefix wins so the source is
+    attributed to the most specific grouping the user explicitly added.
+    """
+    from memtomem.storage.sqlite_helpers import norm_path
+
+    target = norm_path(Path(source_path).expanduser())
+    best: tuple[int, Path] | None = None
+    for d in configured_dirs:
+        prefix = _norm_dir_prefix(d)
+        if target.startswith(prefix):
+            length = len(prefix)
+            if best is None or length > best[0]:
+                best = (length, Path(d).expanduser())
+    return best[1] if best else None
+
+
 def _count_files_on_disk(p: Path, extensions: frozenset[str]) -> int:
     """Count regular files under ``p`` whose suffix is in ``extensions``.
 
@@ -143,8 +199,8 @@ async def memory_dir_stats(
     """Return per-dir index status for each configured ``memory_dir``.
 
     Shape: ``[{path, chunk_count, source_file_count, file_count, exists,
-    category, provider, created_at, last_indexed}]`` in the same order
-    as ``memory_dirs``. Drives the web UI's "(N chunks)" / "(not
+    category, provider, kind, created_at, last_indexed}]`` in the same
+    order as ``memory_dirs``. Drives the web UI's "(N chunks)" / "(not
     indexed)" badges so users can see which dirs need a manual reindex
     (the running watcher only reacts to fs events, so files that landed
     while the server was down stay invisible until a forced re-walk;
@@ -172,7 +228,10 @@ async def memory_dir_stats(
 
     Aggregation: one ``get_source_files_with_counts()`` call over the
     whole ``chunks`` table, bucketed in Python by normalised-path prefix
-    — avoids N LIKE queries for large dir lists.
+    — avoids N LIKE queries for large dir lists. ``kind`` is provided
+    by :func:`~memtomem.config.memory_dir_kind` so the Web UI can split
+    the Sources page into Memory and General views from the same
+    response shape.
     """
     from memtomem.storage.sqlite_helpers import norm_path
 
@@ -200,9 +259,7 @@ async def memory_dir_stats(
     for d, file_count in zip(dir_list, file_counts):
         dir_path = Path(d).expanduser()
         exists = dir_path.exists()
-        prefix = norm_path(dir_path) if exists else str(dir_path)
-        if not prefix.endswith("/"):
-            prefix = prefix + "/"
+        prefix = _norm_dir_prefix(d)
 
         chunk_count = 0
         source_file_count = 0
@@ -235,6 +292,7 @@ async def memory_dir_stats(
                 "exists": exists,
                 "category": category,
                 "provider": provider_for_category(category),
+                "kind": memory_dir_kind(d),
                 "created_at": _dir_creation_time_iso(dir_path) if exists else None,
                 "last_indexed": max_last_updated,
             }

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -119,7 +119,7 @@ def _dir_creation_time_iso(p: Path) -> str | None:
     return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
 
 
-def _norm_dir_prefix(d: str | Path) -> str:
+def norm_dir_prefix(d: str | Path) -> str:
     """Return the directory path normalized for ``str.startswith`` matching.
 
     Adds a trailing slash so a configured dir ``/foo`` does not falsely
@@ -166,7 +166,7 @@ def resolve_owning_memory_dir(
     target = norm_path(Path(source_path).expanduser())
     best: tuple[int, Path] | None = None
     for d in configured_dirs:
-        prefix = _norm_dir_prefix(d)
+        prefix = norm_dir_prefix(d)
         if target.startswith(prefix):
             length = len(prefix)
             if best is None or length > best[0]:
@@ -259,7 +259,7 @@ async def memory_dir_stats(
     for d, file_count in zip(dir_list, file_counts):
         dir_path = Path(d).expanduser()
         exists = dir_path.exists()
-        prefix = _norm_dir_prefix(d)
+        prefix = norm_dir_prefix(d)
 
         chunk_count = 0
         source_file_count = 0

--- a/packages/memtomem/src/memtomem/web/routes/sources.py
+++ b/packages/memtomem/src/memtomem/web/routes/sources.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from memtomem.config import memory_dir_kind
-from memtomem.indexing.engine import resolve_owning_memory_dir
+from memtomem.config import MemoryDirKind, memory_dir_kind
+from memtomem.indexing.engine import norm_dir_prefix
+from memtomem.storage.sqlite_helpers import norm_path
 from memtomem.web.deps import get_config, get_storage, require_indexed_source
 from memtomem.web.schemas.core import DeleteResponse
 from memtomem.web.schemas.sources import ChunkSizeBucket, SourceOut, SourcesResponse
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/sources", tags=["sources"])
 async def list_sources(
     limit: int = Query(100, ge=1, le=10000),
     offset: int = Query(0, ge=0),
-    kind: Literal["memory", "general"] | None = Query(
+    kind: MemoryDirKind | None = Query(
         None,
         description=(
             "Filter to one bucket of the Sources page sub-toggle. "
@@ -35,7 +35,23 @@ async def list_sources(
     config=Depends(get_config),
 ) -> SourcesResponse:
     rows = await storage.get_source_files_with_counts()
-    configured_dirs = list(config.indexing.memory_dirs)
+
+    # Pre-compute (prefix, dir_path, kind) once per request so the
+    # per-source classification stays O(D × startswith) instead of
+    # O(D × Path.resolve()). For ~30 dirs × ~300 sources that drops
+    # ~9000 syscalls / NFC normalisations off the hot path of
+    # ``GET /api/sources``. Sorted by prefix length descending so the
+    # first match in the inner loop is the longest-prefix-wins one —
+    # matches :func:`resolve_owning_memory_dir`'s tie-break rule for
+    # nested configured dirs without repeating the comparison logic.
+    indexed_dirs: list[tuple[str, Path, MemoryDirKind]] = sorted(
+        (
+            (norm_dir_prefix(d), Path(d).expanduser(), memory_dir_kind(d))
+            for d in config.indexing.memory_dirs
+        ),
+        key=lambda t: -len(t[0]),
+    )
+
     all_sources: list[SourceOut] = []
     for p, cnt, last_indexed_iso, ns_csv, avg_tok, min_tok, max_tok in sorted(rows):
         last_indexed_at: datetime | None = None
@@ -55,10 +71,18 @@ async def list_sources(
 
         namespaces = ns_csv.split(",") if ns_csv else ["default"]
 
-        owning_dir = resolve_owning_memory_dir(p, configured_dirs)
-        source_kind: Literal["memory", "general"] | None
+        target = norm_path(p)
+        match = next(
+            (
+                (dir_path, dir_kind)
+                for prefix, dir_path, dir_kind in indexed_dirs
+                if target.startswith(prefix)
+            ),
+            None,
+        )
+        source_kind: MemoryDirKind | None
         memory_dir_str: str | None
-        if owning_dir is None:
+        if match is None:
             # Orphan: indexed source whose configured dir was removed
             # after indexing. Show in General view rather than hiding so
             # users can still find and prune the chunks; ``kind=None``
@@ -67,7 +91,7 @@ async def list_sources(
             source_kind = None
             memory_dir_str = None
         else:
-            source_kind = memory_dir_kind(owning_dir)
+            owning_dir, source_kind = match
             memory_dir_str = str(owning_dir)
 
         if kind is not None:

--- a/packages/memtomem/src/memtomem/web/routes/sources.py
+++ b/packages/memtomem/src/memtomem/web/routes/sources.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from memtomem.web.deps import get_storage, require_indexed_source
+from memtomem.config import memory_dir_kind
+from memtomem.indexing.engine import resolve_owning_memory_dir
+from memtomem.web.deps import get_config, get_storage, require_indexed_source
 from memtomem.web.schemas.core import DeleteResponse
 from memtomem.web.schemas.sources import ChunkSizeBucket, SourceOut, SourcesResponse
 
@@ -18,9 +21,21 @@ router = APIRouter(prefix="/sources", tags=["sources"])
 async def list_sources(
     limit: int = Query(100, ge=1, le=10000),
     offset: int = Query(0, ge=0),
+    kind: Literal["memory", "general"] | None = Query(
+        None,
+        description=(
+            "Filter to one bucket of the Sources page sub-toggle. "
+            "``memory`` keeps only sources under a configured memory_dir "
+            "whose kind is ``memory``; ``general`` keeps the rest, "
+            "including orphan sources whose owning dir is no longer "
+            "registered (so they don't disappear from the UI)."
+        ),
+    ),
     storage=Depends(get_storage),
+    config=Depends(get_config),
 ) -> SourcesResponse:
     rows = await storage.get_source_files_with_counts()
+    configured_dirs = list(config.indexing.memory_dirs)
     all_sources: list[SourceOut] = []
     for p, cnt, last_indexed_iso, ns_csv, avg_tok, min_tok, max_tok in sorted(rows):
         last_indexed_at: datetime | None = None
@@ -40,6 +55,32 @@ async def list_sources(
 
         namespaces = ns_csv.split(",") if ns_csv else ["default"]
 
+        owning_dir = resolve_owning_memory_dir(p, configured_dirs)
+        source_kind: Literal["memory", "general"] | None
+        memory_dir_str: str | None
+        if owning_dir is None:
+            # Orphan: indexed source whose configured dir was removed
+            # after indexing. Show in General view rather than hiding so
+            # users can still find and prune the chunks; ``kind=None``
+            # signals that the categorisation is unknowable, not that
+            # the source is "general" by intent.
+            source_kind = None
+            memory_dir_str = None
+        else:
+            source_kind = memory_dir_kind(owning_dir)
+            memory_dir_str = str(owning_dir)
+
+        if kind is not None:
+            # Orphans (kind=None) ride along with ``general`` so they
+            # remain reachable from the Sources page; filtering to
+            # ``memory`` excludes them. This is the only place orphans
+            # need special handling — every other call site can treat
+            # ``kind`` as the authoritative bucket.
+            if kind == "memory" and source_kind != "memory":
+                continue
+            if kind == "general" and source_kind == "memory":
+                continue
+
         all_sources.append(
             SourceOut(
                 path=str(p),
@@ -50,6 +91,8 @@ async def list_sources(
                 avg_tokens=avg_tok,
                 min_tokens=min_tok,
                 max_tokens=max_tok,
+                memory_dir=memory_dir_str,
+                kind=source_kind,
             )
         )
     total = len(all_sources)

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -18,6 +18,7 @@ from memtomem.config import (
     MUTABLE_FIELDS,
     build_comparand,
     coerce_and_validate,
+    memory_dir_kind,
     save_config_overrides,
 )
 from memtomem.storage.sqlite_helpers import norm_path
@@ -411,11 +412,17 @@ async def add_memory_dir(
                 config = request.app.state.config
 
                 current = [Path(p).expanduser().resolve() for p in config.indexing.memory_dirs]
+                # ``kind`` of the just-added dir lets the Web UI's
+                # Sources page show a "Switch view" toast when the user
+                # adds a path that lands in the opposite sub-toggle (e.g.
+                # they're on General sources and add ``~/memories``).
+                kind = memory_dir_kind(resolved)
                 if norm_path(resolved) in {norm_path(p) for p in current}:
                     return {
                         "ok": True,
                         "message": "Already in memory_dirs",
                         "memory_dirs": [str(p) for p in current],
+                        "kind": kind,
                     }
 
                 config.indexing.memory_dirs.append(resolved)
@@ -427,6 +434,7 @@ async def add_memory_dir(
                     "memory_dirs": [
                         str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs
                     ],
+                    "kind": kind,
                 }
     except TimeoutError:
         raise HTTPException(503, "memory-dirs/add timed out — another update may be in progress")

--- a/packages/memtomem/src/memtomem/web/schemas/sources.py
+++ b/packages/memtomem/src/memtomem/web/schemas/sources.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -18,6 +19,16 @@ class SourceOut(BaseModel):
     avg_tokens: int = 0
     min_tokens: int = 0
     max_tokens: int = 0
+    # The configured ``memory_dir`` that contains this source, expanded
+    # to an absolute path. ``None`` for orphan sources whose owning dir
+    # was unregistered after indexing — they still appear in the General
+    # view so users can prune or re-register them.
+    memory_dir: str | None = None
+    # ``"memory"`` for agent / user-memory dirs (auto-classified by path
+    # pattern) and ``"general"`` for arbitrary indexed folders. ``None``
+    # for orphans (no owning dir to classify). Drives the Sources page's
+    # Memory / General sub-toggle.
+    kind: Literal["memory", "general"] | None = None
 
 
 class SourcesResponse(BaseModel):

--- a/packages/memtomem/src/memtomem/web/schemas/sources.py
+++ b/packages/memtomem/src/memtomem/web/schemas/sources.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel
 
+from memtomem.config import MemoryDirKind
 from memtomem.web.schemas.core import ChunkOut
 
 
@@ -28,7 +28,7 @@ class SourceOut(BaseModel):
     # pattern) and ``"general"`` for arbitrary indexed folders. ``None``
     # for orphans (no owning dir to classify). Drives the Sources page's
     # Memory / General sub-toggle.
-    kind: Literal["memory", "general"] | None = None
+    kind: MemoryDirKind | None = None
 
 
 class SourcesResponse(BaseModel):

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1550,6 +1550,33 @@ class TestMemoryDirStats:
         # Belt-and-suspenders: no entry should be missing ``provider``.
         assert all("provider" in r for r in result)
 
+    async def test_kind_field_splits_memory_vs_general(self, tmp_path):
+        """``kind`` is the single source of truth for the Web UI's
+        Memory / General sub-toggle on the Sources page. Provider
+        layouts and user-memory folders are ``"memory"``; arbitrary
+        user-added RAG folders are ``"general"``. Without this field
+        the frontend would have to re-derive the heuristic on its own
+        and drift from the server."""
+        from memtomem.indexing.engine import memory_dir_stats
+
+        notes = tmp_path / "work" / "docs"
+        memories = tmp_path / "memories"
+        codex = tmp_path / ".codex" / "memories"
+        claude_mem = tmp_path / ".claude" / "projects" / "demo" / "memory"
+        for d in (notes, memories, codex, claude_mem):
+            d.mkdir(parents=True)
+
+        storage = _FakeStorageForStats([])
+        result = await memory_dir_stats(storage, [notes, memories, codex, claude_mem])
+        by_path = {r["path"]: r["kind"] for r in result}
+        assert by_path[str(notes)] == "general"
+        assert by_path[str(memories)] == "memory"
+        assert by_path[str(codex)] == "memory"
+        assert by_path[str(claude_mem)] == "memory"
+        # Defensive: every row must carry ``kind`` so the Web UI never
+        # has to guess.
+        assert all("kind" in r for r in result)
+
     async def test_dir_with_indexed_files_is_aggregated(self, tmp_path):
         from memtomem.indexing.engine import memory_dir_stats
 
@@ -1740,3 +1767,84 @@ class TestMemoryDirStats:
         result = await memory_dir_stats(storage, [gone], supported_extensions=frozenset({".md"}))
         assert result[0]["exists"] is False
         assert result[0]["file_count"] == 0
+
+
+# ===========================================================================
+# 12. resolve_owning_memory_dir — source → owning dir lookup
+# ===========================================================================
+
+
+class TestResolveOwningMemoryDir:
+    """Inverse of :func:`memory_dir_stats`'s bucketing: given a single
+    indexed source path, find which configured memory_dir owns it.
+    Drives the Web UI's per-source ``memory_dir`` / ``kind`` fields on
+    ``GET /api/sources``."""
+
+    def test_source_under_single_dir(self, tmp_path):
+        from memtomem.indexing.engine import resolve_owning_memory_dir
+
+        d = tmp_path / "notes"
+        d.mkdir()
+        f = d / "a.md"
+        f.write_text("#")
+        owner = resolve_owning_memory_dir(f, [d])
+        assert owner == d
+
+    def test_orphan_returns_none(self, tmp_path):
+        """A source that isn't under any configured dir is orphan —
+        typical after the user removes a dir without purging chunks.
+        ``None`` lets the route surface them in the General view rather
+        than dropping them silently."""
+        from memtomem.indexing.engine import resolve_owning_memory_dir
+
+        d = tmp_path / "registered"
+        d.mkdir()
+        elsewhere = tmp_path / "unregistered" / "stray.md"
+        elsewhere.parent.mkdir()
+        elsewhere.write_text("#")
+        assert resolve_owning_memory_dir(elsewhere, [d]) is None
+
+    def test_longest_prefix_wins_for_nested_dirs(self, tmp_path):
+        """When a parent dir and one of its children are both registered
+        (uncommon but legal — e.g. broad RAG corpus + curated subset),
+        the deeper match wins so the source is attributed to the more
+        specific group the user explicitly opted into."""
+        from memtomem.indexing.engine import resolve_owning_memory_dir
+
+        parent = tmp_path / "corpus"
+        child = parent / "curated"
+        child.mkdir(parents=True)
+        f = child / "doc.md"
+        f.write_text("#")
+
+        assert resolve_owning_memory_dir(f, [parent, child]) == child
+        # Order in the configured list must not change the answer.
+        assert resolve_owning_memory_dir(f, [child, parent]) == child
+
+    def test_sibling_with_shared_prefix_does_not_match(self, tmp_path):
+        """``/foo`` must not claim files under ``/foo-bar/...`` — the
+        trailing-slash normalisation in :func:`_norm_dir_prefix` is what
+        prevents this. Pin the behaviour."""
+        from memtomem.indexing.engine import resolve_owning_memory_dir
+
+        foo = tmp_path / "foo"
+        foo_bar = tmp_path / "foo-bar"
+        foo.mkdir()
+        foo_bar.mkdir()
+        sibling_file = foo_bar / "x.md"
+        sibling_file.write_text("#")
+        assert resolve_owning_memory_dir(sibling_file, [foo]) is None
+
+    def test_tilde_input_is_expanded(self, tmp_path, monkeypatch):
+        """The route hands ``config.indexing.memory_dirs`` through
+        verbatim (entries may be ``~/...`` form). The helper must
+        expand both sides before comparing, otherwise tilde-prefixed
+        configured dirs would never match concrete source paths."""
+        from memtomem.indexing.engine import resolve_owning_memory_dir
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "memories").mkdir()
+        f = tmp_path / "memories" / "note.md"
+        f.write_text("#")
+        owner = resolve_owning_memory_dir(f, ["~/memories"])
+        assert owner == (tmp_path / "memories")

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1823,7 +1823,7 @@ class TestResolveOwningMemoryDir:
 
     def test_sibling_with_shared_prefix_does_not_match(self, tmp_path):
         """``/foo`` must not claim files under ``/foo-bar/...`` — the
-        trailing-slash normalisation in :func:`_norm_dir_prefix` is what
+        trailing-slash normalisation in :func:`norm_dir_prefix` is what
         prevents this. Pin the behaviour."""
         from memtomem.indexing.engine import resolve_owning_memory_dir
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3061,6 +3061,18 @@ class TestMemoryDirKind:
         assert memory_dir_kind("/Users/alice/memories") == "memory"
         assert memory_dir_kind("/Users/alice/Documents/memory") == "memory"
 
+    def test_segment_match_is_case_insensitive(self) -> None:
+        """macOS' default APFS is case-insensitive, so the same folder
+        surfaces as ``Memories`` or ``memories`` depending on how the
+        user typed it. Both must classify as memory — otherwise the
+        Sources view would partition the same folder differently
+        across machines."""
+        from memtomem.config import memory_dir_kind
+
+        assert memory_dir_kind("/Users/alice/Memories") == "memory"
+        assert memory_dir_kind("/Users/alice/MEMORIES") == "memory"
+        assert memory_dir_kind("/Users/alice/Documents/Memory") == "memory"
+
     def test_user_dir_without_memory_segment_is_general(self) -> None:
         from memtomem.config import memory_dir_kind
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3041,6 +3041,66 @@ class TestCategorizeMemoryDir:
         assert PROVIDER_DIR_CATEGORIES == tuple(cat for cat, _ in _PROVIDER_CATEGORY_PATTERNS)
 
 
+class TestMemoryDirKind:
+    """Two-bucket classifier (``memory`` vs ``general``) layered on top
+    of :func:`categorize_memory_dir`. Drives the Web UI Sources page
+    sub-toggle so users can see agent/user memory separately from
+    arbitrary indexed RAG folders."""
+
+    def test_known_provider_layouts_are_memory(self) -> None:
+        from memtomem.config import memory_dir_kind
+
+        assert memory_dir_kind("/home/alice/.claude/projects/p/memory") == "memory"
+        assert memory_dir_kind("/home/alice/.claude/plans") == "memory"
+        assert memory_dir_kind("/home/alice/.codex/memories") == "memory"
+
+    def test_user_dir_with_memory_segment_is_memory(self) -> None:
+        from memtomem.config import memory_dir_kind
+
+        # Common layout — user curates a top-level memory folder.
+        assert memory_dir_kind("/Users/alice/memories") == "memory"
+        assert memory_dir_kind("/Users/alice/Documents/memory") == "memory"
+
+    def test_user_dir_without_memory_segment_is_general(self) -> None:
+        from memtomem.config import memory_dir_kind
+
+        # The common case — arbitrary RAG-style folder added by the user.
+        assert memory_dir_kind("/Users/alice/work/docs") == "general"
+        assert memory_dir_kind("/Users/alice/projects/notes") == "general"
+        assert memory_dir_kind("/srv/shared/planning") == "general"
+
+    def test_compound_word_segment_does_not_match(self) -> None:
+        """The heuristic compares whole path segments, not substrings —
+        ``memory-game`` is not the segment ``memory`` and stays general.
+        Documents the heuristic boundary so future tweaks don't regress."""
+        from memtomem.config import memory_dir_kind
+
+        assert memory_dir_kind("/code/memory-game") == "general"
+        assert memory_dir_kind("/code/in-memory-cache") == "general"
+        assert memory_dir_kind("/code/memorial") == "general"
+
+    def test_heuristic_is_aggressive_for_segment_matches(self) -> None:
+        """Documented limitation: any path with an exact ``memory`` /
+        ``memories`` segment lands in the Memory bucket, even when the
+        intent is clearly not agent memory. A future PR can add an
+        explicit per-dir override; until then these classify as memory."""
+        from memtomem.config import memory_dir_kind
+
+        # App cache happens to use a ``memory`` segment.
+        assert memory_dir_kind("/Users/alice/Library/Caches/some-app/memory") == "memory"
+        # Code repo with a folder happening to be named ``memory``.
+        assert memory_dir_kind("/Users/alice/projects/foo/memory") == "memory"
+        # Photo archive named ``memories`` — not a RAG corpus, but the
+        # heuristic can't tell.
+        assert memory_dir_kind("/Users/alice/Documents/memories/photos") == "memory"
+
+    def test_pathlib_input(self) -> None:
+        from memtomem.config import memory_dir_kind
+
+        assert memory_dir_kind(Path("/u/.codex/memories")) == "memory"
+        assert memory_dir_kind(Path("/u/work/notes")) == "general"
+
+
 class TestDetectProviderDirsRoundtrip:
     """Drift guard: every path ``_detect_provider_dirs`` returns must
     classify back to the same category via ``categorize_memory_dir``.

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1057,6 +1057,28 @@ class TestUnicodePaths:
             assert body["kind"] == "memory"
             assert body["message"].startswith("Added ")
 
+    async def test_add_memory_dir_returns_kind_when_config_empty(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Pin the empty-config first-add path: a fresh install has
+        ``memory_dirs=[]``, so the dedupe branch never fires and the
+        kind must come back from the add branch alone. Otherwise the
+        UI's "Switch view" toast would lose its trigger on the very
+        first dir a new user registers."""
+        app.state.config.indexing.memory_dirs = []
+        target = tmp_path / "memories"
+        target.mkdir()
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(target)},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["kind"] == "memory"
+        assert body["message"].startswith("Added ")
+
     async def test_remove_memory_dir_matches_nfd_and_nfc(self, app, client: AsyncClient, tmp_path):
         # Config has the target dir in NFD form plus a second entry (the
         # route refuses to remove the last remaining memory_dir). The user

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -442,6 +442,10 @@ class TestSources:
         src = data["sources"][0]
         assert src["chunk_count"] == 5
         assert "path" in src
+        # ``kind`` / ``memory_dir`` are always present so the Web UI's
+        # Sources-mode toggle can partition without re-deriving anything.
+        assert "kind" in src
+        assert "memory_dir" in src
 
     async def test_list_sources_pagination(self, client: AsyncClient):
         resp = await client.get("/api/sources", params={"limit": 1, "offset": 0})
@@ -449,6 +453,72 @@ class TestSources:
         data = resp.json()
         assert data["limit"] == 1
         assert data["offset"] == 0
+
+    async def test_orphan_source_kind_is_null(self, app, client: AsyncClient):
+        """Indexed sources whose owning dir is no longer in
+        ``memory_dirs`` are orphans — they must surface with
+        ``kind=null`` / ``memory_dir=null`` so the Web UI can show them
+        in the General view rather than dropping them entirely. This
+        is the most error-prone path because the natural code shape is
+        to filter them out."""
+        # Default fixture: source ``/tmp/test.md`` is NOT under any
+        # configured memory_dir (only ``/tmp/memories`` is registered).
+        resp = await client.get("/api/sources")
+        assert resp.status_code == 200
+        src = resp.json()["sources"][0]
+        assert src["kind"] is None
+        assert src["memory_dir"] is None
+
+    async def test_kind_memory_filter_excludes_orphans(self, app, client: AsyncClient):
+        """``?kind=memory`` is the strict filter — orphans (``kind=null``)
+        are excluded so the Memory view only shows sources the user
+        explicitly registered as memory. Pin the asymmetry against the
+        General filter."""
+        resp = await client.get("/api/sources", params={"kind": "memory"})
+        assert resp.status_code == 200
+        # Default fixture's lone source is orphan → empty under
+        # ``kind=memory``.
+        assert resp.json()["total"] == 0
+
+    async def test_kind_general_filter_includes_orphans(self, app, client: AsyncClient):
+        """``?kind=general`` is the catch-all that surfaces orphans.
+        Without this contract, users who removed a memory_dir without
+        purging chunks would lose the ability to find them in the UI
+        until the underlying files were re-registered or deleted."""
+        resp = await client.get("/api/sources", params={"kind": "general"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["sources"][0]["kind"] is None
+
+    async def test_kind_set_when_source_under_memory_dir(self, app, client: AsyncClient):
+        """Sources whose owning dir is registered carry a concrete
+        ``kind``. Use a path under the existing ``/tmp/memories`` dir
+        (which classifies as ``memory`` thanks to the ``memories``
+        segment) so the kind/memory_dir wiring is end-to-end exercised."""
+        app.state.storage.get_source_files_with_counts.return_value = [
+            (
+                Path("/tmp/memories/note.md"),
+                3,
+                "2026-04-29T10:00:00",
+                "default",
+                100,
+                50,
+                200,
+            )
+        ]
+        resp = await client.get("/api/sources")
+        assert resp.status_code == 200
+        src = resp.json()["sources"][0]
+        assert src["kind"] == "memory"
+        assert src["memory_dir"] == str(Path("/tmp/memories"))
+
+        # Same source must round-trip through the kind=memory filter and
+        # be excluded by kind=general.
+        resp_mem = await client.get("/api/sources", params={"kind": "memory"})
+        assert resp_mem.json()["total"] == 1
+        resp_gen = await client.get("/api/sources", params={"kind": "general"})
+        assert resp_gen.json()["total"] == 0
 
 
 # ---------------------------------------------------------------------------
@@ -952,6 +1022,40 @@ class TestUnicodePaths:
         assert resp.status_code == 200, resp.text
         assert resp.json()["message"] == "Already in memory_dirs"
         assert len(app.state.config.indexing.memory_dirs) == 1
+
+    async def test_add_memory_dir_returns_kind(self, app, client: AsyncClient, tmp_path):
+        """The add response carries ``kind`` for the resolved dir so the
+        Web UI can show "Added to {kind} view — Switch?" toast when the
+        user adds a path that lands in the opposite Sources sub-toggle.
+        Cover both branches: newly added + already-in dedupe."""
+        general_dir = tmp_path / "work" / "docs"
+        general_dir.mkdir(parents=True)
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        app.state.config.indexing.memory_dirs = [general_dir]
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            # ``general_dir`` is already in ``memory_dirs`` → exercise
+            # the dedupe branch and confirm ``kind`` rides on it.
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(general_dir)},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["message"] == "Already in memory_dirs"
+            assert body["kind"] == "general"
+
+            # Newly added dir with a ``memories`` segment → exercise the
+            # add branch and confirm ``kind=memory``.
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(memory_dir)},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["kind"] == "memory"
+            assert body["message"].startswith("Added ")
 
     async def test_remove_memory_dir_matches_nfd_and_nfc(self, app, client: AsyncClient, tmp_path):
         # Config has the target dir in NFD form plus a second entry (the


### PR DESCRIPTION
## Summary

Today the `#sources` page stacks two panels — Memory Dirs (top) and Sources (bottom) — that show the same indexed dataset two ways, with no signal to tell agent/user memory apart from arbitrary indexed RAG folders. Splitting them into a Memory / General sub-toggle is a frontend change, but the frontend needs a per-source classification first. This PR is the backend contract; the UI wiring lands in a follow-up.

- `memory_dir_kind(path)` layered on `categorize_memory_dir`: known provider layouts (claude-memory, claude-plans, codex) and any user dir with a `memory`/`memories` segment classify as `memory`; everything else is `general`. Heuristic, intentionally — explicit per-dir override is left for a follow-up so the config schema stays unchanged.
- `resolve_owning_memory_dir(source, dirs)` extracted into `indexing/engine` and reused from `memory_dir_stats` (no duplicated prefix-match logic in two call sites). Always normalises both sides through `norm_path` so a configured-but-missing `/tmp/foo` matches resolved `/private/tmp/foo` sources on macOS.
- `GET /api/sources` now returns `memory_dir` + `kind` per source and accepts `?kind=memory|general`. Orphan sources (their owning dir was unregistered without purging chunks) ride `kind=general` so they remain reachable instead of disappearing — this is the easiest contract to get wrong, so it has a dedicated test.
- `POST /api/memory-dirs/add` echoes `kind` on both dedupe and add branches, enabling a "Switch view" toast when the user adds a dir that lands in the opposite sub-toggle.
- `memory_dir_stats` rows carry `kind` so the UI's Memory Dirs panel can group consistently with the new sources contract.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 3231 passed, 46 deselected
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run mypy` (advisory) on all modified files — clean
- [x] New tests pin: `memory_dir_kind` heuristic edge cases (compound words don't match, `Library/Caches/.../memory/` does), `resolve_owning_memory_dir` longest-prefix + sibling-prefix safety + tilde expansion, `/api/sources` orphan kind=null, `?kind=memory|general` filter asymmetry, `/api/memory-dirs/add` kind in both response branches.

## Notes

- Frontend (sub-toggle UI, drill-in, Add-path toast, i18n) lands in a follow-up PR — this PR's API additions are inert until then.
- The `memory_dir_kind` heuristic is aggressive on segment matches (e.g. `~/Library/Caches/<app>/memory/` classifies as memory). Tests document the behaviour; an explicit per-dir `kind` override on `memory_dirs` config can come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)