### PR TITLE
fix(web): calm runtime-only context badges + tighten labels

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -24,10 +24,16 @@ const _ctxStatusLabel = {
   'missing canonical': 'settings.ctx.status_missing_canonical',
 };
 
+// Localized status text for a wire status value. Falls back to the raw
+// status string when no i18n key is mapped — keeps unknown/future statuses
+// visible instead of silently rendering an empty label.
+function _ctxStatusText(status) {
+  return t(_ctxStatusLabel[status] || '', status);
+}
+
 function _ctxBadge(status) {
   const cls = _ctxStatusCls[status] || 'ctx-runtime-badge--missing';
-  const label = t(_ctxStatusLabel[status] || '', status);
-  return `<span class="ctx-runtime-badge ${cls}">${escapeHtml(label)}</span>`;
+  return `<span class="ctx-runtime-badge ${cls}">${escapeHtml(_ctxStatusText(status))}</span>`;
 }
 
 function renderRuntimeBadges(runtimes) {
@@ -35,11 +41,7 @@ function renderRuntimeBadges(runtimes) {
   return '<div class="ctx-runtime-badges">' +
     runtimes.map(r => {
       const short = r.runtime.replace(/_skills|_commands|_agents/g, '');
-      // Route status text through i18n so the UI shows the localized label
-      // (e.g. "Not yet imported") rather than the raw wire string
-      // ("missing canonical"). Falls back to raw status if no key maps.
-      const label = t(_ctxStatusLabel[r.status] || '', r.status);
-      return `<span class="ctx-runtime-badge ${_ctxStatusCls[r.status] || ''}" title="${escapeHtml(r.runtime)}">${escapeHtml(short)}: ${escapeHtml(label)}</span>`;
+      return `<span class="ctx-runtime-badge ${_ctxStatusCls[r.status] || ''}" title="${escapeHtml(r.runtime)}">${escapeHtml(short)}: ${escapeHtml(_ctxStatusText(r.status))}</span>`;
     }).join('') + '</div>';
 }
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -12,7 +12,9 @@ const _ctxStatusCls = {
   'in sync':           'ctx-runtime-badge--sync',
   'out of sync':       'ctx-runtime-badge--warn',
   'missing target':    'ctx-runtime-badge--missing',
-  'missing canonical': 'ctx-runtime-badge--error',
+  // Runtime-only items (canonical absent) are a normal pre-import state, not
+  // an error — the same red treatment as `parse error` over-signaled it.
+  'missing canonical': 'ctx-runtime-badge--pending',
   'parse error':       'ctx-runtime-badge--error',
 };
 const _ctxStatusLabel = {
@@ -33,7 +35,11 @@ function renderRuntimeBadges(runtimes) {
   return '<div class="ctx-runtime-badges">' +
     runtimes.map(r => {
       const short = r.runtime.replace(/_skills|_commands|_agents/g, '');
-      return `<span class="ctx-runtime-badge ${_ctxStatusCls[r.status] || ''}" title="${escapeHtml(r.runtime)}">${escapeHtml(short)}: ${escapeHtml(r.status)}</span>`;
+      // Route status text through i18n so the UI shows the localized label
+      // (e.g. "Not yet imported") rather than the raw wire string
+      // ("missing canonical"). Falls back to raw status if no key maps.
+      const label = t(_ctxStatusLabel[r.status] || '', r.status);
+      return `<span class="ctx-runtime-badge ${_ctxStatusCls[r.status] || ''}" title="${escapeHtml(r.runtime)}">${escapeHtml(short)}: ${escapeHtml(label)}</span>`;
     }).join('') + '</div>';
 }
 

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -216,7 +216,7 @@
   "settings.nav.reset_sub": "Delete all data",
 
   "settings.ctx.overview_title": "Context Gateway",
-  "settings.ctx.detect": "Detect",
+  "settings.ctx.detect": "Refresh",
   "settings.ctx.sync_all": "Sync All",
   "settings.ctx.sync": "Sync",
   "settings.ctx.import": "Import",
@@ -247,7 +247,7 @@
   "settings.ctx.status_in_sync": "In sync",
   "settings.ctx.status_out_of_sync": "Out of sync",
   "settings.ctx.status_missing_target": "Missing",
-  "settings.ctx.status_missing_canonical": "Runtime only",
+  "settings.ctx.status_missing_canonical": "Not yet imported",
   "settings.ctx.dropped_fields": "Dropped",
   "settings.ctx.no_artifacts": "No {type} found",
   "settings.ctx.no_artifacts_hint": "Create one or import from existing runtimes.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -216,7 +216,7 @@
   "settings.nav.reset_sub": "전체 데이터 삭제",
 
   "settings.ctx.overview_title": "컨텍스트 게이트웨이",
-  "settings.ctx.detect": "감지",
+  "settings.ctx.detect": "새로고침",
   "settings.ctx.sync_all": "전체 동기화",
   "settings.ctx.sync": "동기화",
   "settings.ctx.import": "가져오기",
@@ -247,7 +247,7 @@
   "settings.ctx.status_in_sync": "동기화됨",
   "settings.ctx.status_out_of_sync": "불일치",
   "settings.ctx.status_missing_target": "미생성",
-  "settings.ctx.status_missing_canonical": "런타임에만 존재",
+  "settings.ctx.status_missing_canonical": "아직 가져오지 않음",
   "settings.ctx.dropped_fields": "제거됨",
   "settings.ctx.no_artifacts": "{type} 없음",
   "settings.ctx.no_artifacts_hint": "새로 만들거나 기존 런타임에서 가져올 수 있습니다.",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2643,6 +2643,12 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 .ctx-runtime-badge--sync { background: rgba(76, 175, 125, 0.15); color: var(--green); }
 .ctx-runtime-badge--warn { background: rgba(243, 156, 18, 0.15); color: var(--yellow); }
 .ctx-runtime-badge--missing { background: rgba(123, 127, 150, 0.12); color: var(--muted); }
+.ctx-runtime-badge--pending {
+  background: transparent;
+  color: var(--muted);
+  border: 1px solid rgba(123, 127, 150, 0.35);
+  padding: 1px 6px;
+}
 .ctx-runtime-badge--error { background: rgba(224, 90, 90, 0.15); color: var(--danger); }
 
 .ctx-detail { padding: 16px; border: 1px solid var(--border); border-radius: var(--radius); margin-top: 12px; background: var(--surface); }


### PR DESCRIPTION
## Summary

The Settings → Commands/Skills/Agents view renders every runtime-only
artifact with a red `claude: missing canonical` badge (see attached
screenshot scenario). That framed a normal pre-import state — a project
that has `.claude/commands/foo.md` but hasn't created `.memtomem/` yet —
as a hard error and pulled the user toward the wrong primary action
(Sync, which is a no-op when no canonical exists).

This PR is the visual / copy half of a 3-PR cleanup; it intentionally
does not touch action gating or the runtime-only detail panel — those
land in follow-ups so the diff stays small.

- Map `missing canonical` status to a new `--pending` CSS token (muted
  text, transparent background, thin border) instead of `--error` red.
  Reserve red for parse errors / real failures.
- Route `renderRuntimeBadges` status text through i18n so badges read
  "Not yet imported" / "아직 가져오지 않음" instead of the raw wire
  string `missing canonical`. The status → i18n key mapping already
  existed; only this helper was bypassing the lookup.
- Update `settings.ctx.status_missing_canonical` value from
  "Runtime only" → "Not yet imported" so the badge complements the
  card-level `(runtime only)` label rather than duplicating it.
- Rename Detect → Refresh in both locales: the button just calls
  `loadCtxOverview()` (no detection step), so the old label was
  misleading. Button id and event handler unchanged.

Same code path applies to Skills, Commands, Agents — all three
sections inherit the calmer treatment.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py packages/memtomem/tests/test_context_*.py packages/memtomem/tests/test_server_app_context.py -m "not ollama"` (193 passed)
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check`
- [ ] Manual: open Settings → Commands on a project where
      `.memtomem/commands/` is empty but `.claude/commands/` has files.
      Verify (a) badges show "Not yet imported" with muted border instead
      of red, (b) Detect button label reads Refresh / 새로고침.

🤖 Generated with [Claude Code](https://claude.com/claude-code)