### PR TITLE
test(schedules): pin list_due flake to next-slot anchor

### DIFF
--- a/packages/memtomem/tests/test_schedules_store.py
+++ b/packages/memtomem/tests/test_schedules_store.py
@@ -70,14 +70,20 @@ class TestScheduleStore:
 
     @pytest.mark.asyncio
     async def test_list_due_returns_only_due(self, storage):
-        # Hourly schedule. Created "now"; due check just before next hour
-        # should be empty, just after should include it.
+        # Hourly schedule. Due check just before the next top-of-hour after
+        # creation should be empty; well past it should include the row.
         sid = await storage.schedule_insert("0 * * * *", "compaction")
         sched = await storage.schedule_get(sid)
         created = datetime.fromisoformat(sched["created_at"])
 
-        # 30s after creation → no slot yet
-        early = created + timedelta(seconds=30)
+        # Anchor "early" to the next cron slot rather than ``created + 30s``
+        # — the latter flakes for ~50 seconds every hour when ``created``
+        # lands close to a top-of-hour and ``early`` crosses it (CI run
+        # 25113291250 hit this at 13:59:48Z). 1 second before the next
+        # slot is always strictly before it, regardless of where in the
+        # hour creation happened.
+        next_slot = created.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
+        early = next_slot - timedelta(seconds=1)
         assert await storage.schedule_list_due(early) == []
 
         # Well past the next top-of-hour → due


### PR DESCRIPTION
## Summary

`test_list_due_returns_only_due` computed ``early = created + 30s`` and asserted no schedule was due, which breaks for the ~50-second window per hour when ``created_at`` lands within 30s before a top-of-hour: ``early`` then crosses the cron slot and the hourly schedule is genuinely due.

Hit on the post-merge CI run [25113291250](https://github.com/memtomem/memtomem/actions/runs/25113291250) at 13:59:48Z (#556 main run).

Anchor ``early`` to the next cron slot deterministically — 1s before ``created.replace(minute=0, second=0, microsecond=0) + 1h`` is always strictly less than ``croniter("0 * * * *", created).get_next()``, regardless of where in the hour creation lands.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_schedules_store.py` — 11/11 passed locally
- [x] `uv run ruff check && ruff format --check` — clean
- [x] Math: `next_slot = top of next hour after created`, `early = next_slot - 1s` is always strictly < `next_slot`, so `next_fire <= now` is always false (verified against `schedules.py:131`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)