### PR TITLE
feat(web): runtime-only context detail view (no 404 click)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -242,7 +242,15 @@ function _ctxRenderItemsHtml(items, type, projectRoot, { clickable }) {
   const cardClass = clickable ? 'ctx-card' : 'ctx-card ctx-card--readonly';
   let html = '';
   for (const item of items) {
-    html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}">
+    // ``data-canonical-path`` is read by the click handler to choose between
+    // the canonical detail GET (which 404s for runtime-only items, since the
+    // wire endpoint only resolves canonical paths) and the runtime-only diff
+    // path. Empty string when the item is runtime-only — readers test for
+    // truthiness so the absence/empty distinction is irrelevant.
+    const canonAttr = item.canonical_path
+      ? ` data-canonical-path="${escapeHtml(item.canonical_path)}"`
+      : ' data-canonical-path=""';
+    html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}"${canonAttr}>
       <div class="ctx-card-header">
         <div>
           <div class="ctx-card-name">${escapeHtml(item.name)}</div>
@@ -279,7 +287,15 @@ async function _loadScopeGroupItems(type, scope, container) {
         card.addEventListener('click', () => {
           listEl.querySelectorAll('.ctx-card').forEach(c => c.classList.remove('active'));
           card.classList.add('active');
-          loadCtxDetail(type, card.dataset.name);
+          // Runtime-only items have no canonical file; calling the GET detail
+          // endpoint returns 404. Branch into the diff-backed renderer so the
+          // user sees the actual runtime contents instead of a "not found".
+          if (card.dataset.canonicalPath) {
+            loadCtxDetail(type, card.dataset.name);
+          } else {
+            const detailEl = qs(`ctx-${type}-detail`);
+            _ctxLoadRuntimeOnlyDetail(type, card.dataset.name, detailEl);
+          }
         });
       });
     }
@@ -603,6 +619,64 @@ async function _ctxLoadDiff(type, name, detailEl) {
     pane.innerHTML = html;
   } catch (err) {
     pane.innerHTML = `<div class="text-muted">Diff failed: ${escapeHtml(err.message)}</div>`;
+  }
+}
+
+// Render a detail panel for runtime-only items (no canonical file yet). The
+// canonical detail GET 404s for these by design; the diff endpoint already
+// returns ``runtime_content`` for each runtime, so we reuse it as the
+// preview source and surface an "Import all" CTA so the user can pull every
+// runtime-only artifact in one click.
+async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl) {
+  detailEl.hidden = false;
+  _ctxCurrentDetail = { type, name };
+  panelLoading(detailEl);
+
+  try {
+    const res = await fetch(`/api/context/${type}/${encodeURIComponent(name)}/diff`);
+    if (!res.ok) {
+      throw new Error((await res.json().catch(() => ({}))).detail || `Failed to load ${name}`);
+    }
+    const data = await res.json();
+
+    let html = '<div class="ctx-detail">';
+    html += `<div class="ctx-detail-header">
+      <strong>${escapeHtml(name)}</strong>
+      ${_ctxBadge('missing canonical')}
+    </div>`;
+    html += `<div class="text-muted" style="margin:6px 0 12px">${t('settings.ctx.runtime_only_detail_hint', 'Runtime preview — not yet in .memtomem/.')}</div>`;
+
+    if (!data.runtimes || !data.runtimes.length) {
+      html += `<div class="text-muted">${t('settings.ctx.no_artifacts_hint', 'Create one or import from existing runtimes.')}</div>`;
+    } else {
+      for (const rt of data.runtimes) {
+        html += `<div style="margin-bottom:12px">`;
+        html += `<strong>${escapeHtml(rt.runtime)}</strong> ${_ctxBadge(rt.status)}`;
+        if (rt.runtime_content != null) {
+          html += `<pre class="ctx-content-pre" style="margin-top:6px">${escapeHtml(rt.runtime_content)}</pre>`;
+        }
+        html += '</div>';
+      }
+    }
+
+    html += `<div class="ctx-edit-actions" style="margin-top:12px">
+      <button class="btn-primary ctx-runtime-only-import" data-type="${escapeHtml(type)}">
+        ${t('settings.ctx.import_all_includes_this', 'Import all {type} (includes this)').replace('{type}', type)}
+      </button>
+    </div>`;
+
+    html += '</div>';
+    detailEl.innerHTML = html;
+
+    detailEl.querySelector('.ctx-runtime-only-import')?.addEventListener('click', () => {
+      // No single-name import API exists yet, so dispatch a click to the
+      // section-level Import button. When a single-name endpoint lands,
+      // swap this for a direct fetch and refine the CTA copy.
+      const importBtn = document.querySelector(`.ctx-import-btn[data-type="${type}"]`);
+      if (importBtn) importBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+  } catch (err) {
+    detailEl.innerHTML = emptyState('', 'Failed to load detail', err.message);
   }
 }
 

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -261,6 +261,8 @@
   "settings.ctx.runtime_only_banner": "{count} {type} found in {scan_dirs}; none imported yet. Click Import to canonicalize.",
   "settings.ctx.sync_disabled_tooltip": "No canonical {type} to fan out yet. Click Import first.",
   "settings.ctx.sync_all_disabled_tooltip": "No canonical artifacts to fan out yet. Click Import in each section first.",
+  "settings.ctx.runtime_only_detail_hint": "Runtime preview — not yet in .memtomem/.",
+  "settings.ctx.import_all_includes_this": "Import all {type} (includes this)",
   "settings.ctx.runtime_output": "Runtime Output",
   "settings.ctx.canonical_source": "Canonical",
   "settings.ctx.diff_view": "Diff",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -261,6 +261,8 @@
   "settings.ctx.runtime_only_banner": "{scan_dirs} 에서 {type} {count}개를 발견했지만 아직 가져오지 않았습니다. Import 를 눌러 canonical 로 만드세요.",
   "settings.ctx.sync_disabled_tooltip": "아직 fan-out 할 canonical {type} 이 없습니다. Import 를 먼저 누르세요.",
   "settings.ctx.sync_all_disabled_tooltip": "아직 fan-out 할 canonical 아티팩트가 없습니다. 각 섹션에서 Import 를 먼저 누르세요.",
+  "settings.ctx.runtime_only_detail_hint": "런타임 미리보기 — 아직 .memtomem/ 에 없습니다.",
+  "settings.ctx.import_all_includes_this": "모든 {type} 가져오기 (이 항목 포함)",
   "settings.ctx.runtime_output": "런타임 출력",
   "settings.ctx.canonical_source": "Canonical",
   "settings.ctx.diff_view": "비교",


### PR DESCRIPTION
## Summary

- Clicking a runtime-only Skills/Commands/Agents card hit `GET /api/context/{type}/{name}` and 404'd, because the canonical path doesn't exist yet — confusing for an item the list itself just rendered.
- Add `data-canonical-path` to each card's markup; the click handler branches on it. Canonical-backed cards take the existing `loadCtxDetail` path; runtime-only cards fall into a new `_ctxLoadRuntimeOnlyDetail` that reuses `/api/context/{type}/{name}/diff` (already returns `runtime_content`) for a live preview.
- Surfaces an "Import all {type} (includes this)" primary CTA that dispatches a click to the existing section-level Import button — no new endpoint. Swap to a single-name endpoint when one lands.

i18n: two new keys in `en.json` + `ko.json` (`runtime_only_detail_hint`, `import_all_includes_this`); placeholder parity preserved for `{type}`.

Last of three PRs from `image-3-context-calm-ripple` (after #555 calm-the-alarm and #557 import-first).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -q` (parity + placeholder guards)
- [x] `uv run pytest packages/memtomem/tests/test_context*.py -q -m "not ollama"` (165 passed)
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check`
- [ ] Manual smoke: `mm web` → Settings → Commands. Click a runtime-only card; verify the diff-backed preview renders and the "Import all" CTA pulls every runtime-only artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)