### PR TITLE
fix(web): Sources tab a11y — finish ARIA tabs + keyboard drill-in

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -410,13 +410,13 @@
       <button class="tab-help-bar-dismiss" data-help-tab="sources">✕</button>
     </div>
     <div class="sources-mode-toggle" role="tablist" aria-label="Sources view">
-      <button id="sources-mode-memory" class="btn-ghost btn-active" role="tab" aria-selected="true" data-i18n="sources.mode.memory">Memory</button>
-      <button id="sources-mode-general" class="btn-ghost" role="tab" aria-selected="false" data-i18n="sources.mode.general">General sources</button>
+      <button id="sources-mode-memory" class="btn-ghost btn-active" role="tab" aria-selected="true" aria-controls="sources-view-memory" data-i18n="sources.mode.memory">Memory</button>
+      <button id="sources-mode-general" class="btn-ghost" role="tab" aria-selected="false" aria-controls="sources-view-general" data-i18n="sources.mode.general">General sources</button>
     </div>
-    <div id="sources-view-memory" class="sources-view">
+    <div id="sources-view-memory" class="sources-view" role="tabpanel" aria-labelledby="sources-mode-memory">
       <div id="memory-dirs-panel" class="memory-dirs-panel card"></div>
     </div>
-    <div id="sources-view-general" class="sources-view" hidden>
+    <div id="sources-view-general" class="sources-view" role="tabpanel" aria-labelledby="sources-mode-general" hidden>
       <div class="sources-layout">
         <div class="sources-sidebar">
           <div class="sources-header">

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -262,6 +262,13 @@ function _buildMemoryDirsPanel(initialDirs) {
       const li = document.createElement('li');
       li.className = 'memory-dirs-file';
       li.title = s.path;
+      // Keyboard-activatable row: ``role="button"`` + ``tabindex=0`` puts
+      // the row in tab order, and the keydown handler accepts Enter and
+      // Space the same way a native ``<button>`` does. Mirrors the
+      // source-tree rows in ``app.js:_renderSourceTree`` so the drill-in
+      // feels consistent with the General view.
+      li.setAttribute('role', 'button');
+      li.setAttribute('tabindex', '0');
       const filename = s.path.split('/').pop() || s.path;
       const name = document.createElement('span');
       name.className = 'memory-dirs-file-name';
@@ -274,7 +281,7 @@ function _buildMemoryDirsPanel(initialDirs) {
       );
       li.appendChild(name);
       li.appendChild(meta);
-      li.addEventListener('click', () => {
+      const activate = () => {
         // Reuses the General view's chunks browser by switching modes
         // and selecting the source there. Keeps a single chunks-browser
         // DOM (no duplicate render path) and gives the user a clear
@@ -284,6 +291,13 @@ function _buildMemoryDirsPanel(initialDirs) {
         }
         if (typeof browseSource === 'function') {
           browseSource(s.path);
+        }
+      };
+      li.addEventListener('click', activate);
+      li.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Enter' || ev.key === ' ') {
+          ev.preventDefault();
+          activate();
         }
       });
       list.appendChild(li);

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -1262,6 +1262,11 @@ button.memory-dirs-path:focus-visible {
   font-size: 0.78rem;
 }
 .memory-dirs-file:hover { background: var(--bg-hover); }
+.memory-dirs-file:focus-visible {
+  outline: 1px dashed var(--accent);
+  outline-offset: 2px;
+  background: var(--bg-hover);
+}
 .memory-dirs-file-name {
   flex: 1 1 auto;
   min-width: 0;


### PR DESCRIPTION
## Summary

Two a11y gaps surfaced during review of #556:

- **ARIA tabs were half-wired.** The sub-toggle declared `role="tab"` + `role="tablist"` but views had no `role="tabpanel"` and buttons had no `aria-controls`. Half-implemented ARIA misleads screen readers — wire the missing pieces both ways (`aria-controls` on each button, `role="tabpanel"` + `aria-labelledby` on each view).
- **Drill-in file rows were mouse-only.** Add `role="button"`, `tabindex="0"`, and a keydown handler that accepts Enter and Space. Mirrors `app.js:_renderSourceTree` so the two views behave consistently. Adds a `:focus-visible` outline so the keyboard target is obvious.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — clean
- [x] `uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_i18n.py` — 12/12 passed
- [x] Manual smoke (Playwright):
  - [x] ARIA attrs present in post-load DOM (`aria-controls`, `role=tabpanel`, `aria-labelledby` both ways)
  - [x] Enter on a focused file row → mode switches to General, chunks browser populates (11 chunks)
  - [x] Space on a focused file row → same activate path (21 chunks for the second file)
  - [x] Zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)