### PR TITLE
feat(web): single-item context import + CTA swap

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -527,6 +527,7 @@ def generate_all_agents(
 def extract_agents_to_canonical(
     project_root: Path,
     overwrite: bool = False,
+    only_name: str | None = None,
 ) -> ExtractResult:
     """Import existing Claude / Gemini agent files into ``.memtomem/agents/``.
 
@@ -536,6 +537,11 @@ def extract_agents_to_canonical(
 
     Returns an :class:`ExtractResult` with both imported paths and skipped
     items so the caller can warn the user about silent deduplication.
+
+    When ``only_name`` is set, every runtime file with a different stem is
+    silently skipped before any validation/dedupe work. Callers (e.g. the
+    single-item import route) can detect "no such runtime artifact" by
+    inspecting an empty ``imported`` + ``skipped``.
     """
     canonical_root = project_root / CANONICAL_AGENT_ROOT
     imported: list[Path] = []
@@ -551,6 +557,8 @@ def extract_agents_to_canonical(
         runtime_label = runtime_dir.relative_to(project_root).as_posix()
         for md_file in sorted(runtime_dir.glob("*.md")):
             agent_name = md_file.stem
+            if only_name is not None and agent_name != only_name:
+                continue
             try:
                 validate_name(agent_name, kind="agent name")
             except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -356,6 +356,7 @@ def _gemini_toml_to_canonical(toml_path: Path) -> str:
 def extract_commands_to_canonical(
     project_root: Path,
     overwrite: bool = False,
+    only_name: str | None = None,
 ) -> ExtractResult:
     """Import existing Claude/Gemini command files into ``.memtomem/commands/``.
 
@@ -373,6 +374,11 @@ def extract_commands_to_canonical(
     First occurrence wins: Claude runtime first, then Gemini.  Returns an
     :class:`ExtractResult` with both imported paths and skipped items so the
     caller can warn the user about silent deduplication.
+
+    When ``only_name`` is set, every runtime file with a different stem is
+    silently skipped before any validation/dedupe work. Callers (e.g. the
+    single-item import route) can detect "no such runtime artifact" by
+    inspecting an empty ``imported`` + ``skipped``.
     """
     canonical_root = project_root / CANONICAL_COMMAND_ROOT
     imported: list[Path] = []
@@ -384,6 +390,8 @@ def extract_commands_to_canonical(
     if claude_dir.is_dir():
         for md_file in sorted(claude_dir.glob("*.md")):
             cmd_name = md_file.stem
+            if only_name is not None and cmd_name != only_name:
+                continue
             try:
                 validate_name(cmd_name, kind="command name")
             except InvalidNameError as exc:
@@ -411,6 +419,8 @@ def extract_commands_to_canonical(
     if gemini_dir.is_dir():
         for toml_file in sorted(gemini_dir.glob("*.toml")):
             cmd_name = toml_file.stem
+            if only_name is not None and cmd_name != only_name:
+                continue
             try:
                 validate_name(cmd_name, kind="command name")
             except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -229,6 +229,7 @@ def generate_all_skills(
 def extract_skills_to_canonical(
     project_root: Path,
     overwrite: bool = False,
+    only_name: str | None = None,
 ) -> ExtractResult:
     """Import existing runtime skills into ``.memtomem/skills/``.
 
@@ -239,6 +240,11 @@ def extract_skills_to_canonical(
 
     Returns an :class:`ExtractResult` with both imported paths and skipped
     items so the caller can warn the user about silent deduplication.
+
+    When ``only_name`` is set, every runtime entry with a different name is
+    silently skipped before any validation/dedupe work. Callers (e.g. the
+    single-item import route) can detect "no such runtime artifact" by
+    inspecting an empty ``imported`` + ``skipped``.
     """
     # Lazy import to avoid cycles at module import time.
     from memtomem.context.detector import detect_skill_dirs
@@ -250,6 +256,8 @@ def extract_skills_to_canonical(
 
     for detected in detect_skill_dirs(project_root):
         skill_name = detected.path.name
+        if only_name is not None and skill_name != only_name:
+            continue
         runtime_label = detected.agent  # e.g. "claude_skills"
         try:
             validate_name(skill_name, kind="skill name")

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.context._atomic import atomic_write_text
-from memtomem.context._names import validate_name
+from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.agents import (
     AGENT_GENERATORS,
     CANONICAL_AGENT_ROOT,
@@ -412,6 +412,47 @@ async def import_agents(
         "skipped": [
             {"name": name, "reason": reason, "reason_code": code}
             for name, reason, code in result.skipped
+        ],
+        "project_root": str(project_root),
+        "scanned_dirs": _AGENT_SCAN_DIRS,
+    }
+
+
+@router.post("/context/agents/{name}/import")
+async def import_agent(
+    name: str,
+    body: ImportRequest | None = None,
+    project_root: Path = Depends(get_project_root),
+) -> dict:
+    """Import a single runtime agent into ``.memtomem/agents/``.
+
+    Same response shape as the section-level import so the web UI can reuse
+    its rendering. 404 when no runtime file matches the name (the section
+    import would silently report 0 imported, which is the wrong shape of
+    feedback for "you clicked a specific item that doesn't exist").
+    """
+    try:
+        validate_name(name, kind="agent name")
+    except InvalidNameError as exc:
+        raise HTTPException(400, f"Invalid agent name: {exc}")
+    overwrite = body.overwrite if body else False
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = extract_agents_to_canonical(
+                    project_root, overwrite=overwrite, only_name=name
+                )
+    except TimeoutError:
+        raise HTTPException(503, "Agent import timed out — another sync may be in progress")
+    if not result.imported and not result.skipped:
+        raise HTTPException(404, f"No runtime agent named {name!r} to import")
+    return {
+        "imported": [
+            {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}
+            for p in result.imported
+        ],
+        "skipped": [
+            {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped
         ],
         "project_root": str(project_root),
         "scanned_dirs": _AGENT_SCAN_DIRS,

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.context._atomic import atomic_write_text
-from memtomem.context._names import validate_name
+from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
     COMMAND_GENERATORS,
@@ -388,6 +388,47 @@ async def import_commands(
         "skipped": [
             {"name": name, "reason": reason, "reason_code": code}
             for name, reason, code in result.skipped
+        ],
+        "project_root": str(project_root),
+        "scanned_dirs": _COMMAND_SCAN_DIRS,
+    }
+
+
+@router.post("/context/commands/{name}/import")
+async def import_command(
+    name: str,
+    body: ImportRequest | None = None,
+    project_root: Path = Depends(get_project_root),
+) -> dict:
+    """Import a single runtime command into ``.memtomem/commands/``.
+
+    Same response shape as the section-level import so the web UI can reuse
+    its rendering. 404 when no runtime file matches the name (the section
+    import would silently report 0 imported, which is the wrong shape of
+    feedback for "you clicked a specific item that doesn't exist").
+    """
+    try:
+        validate_name(name, kind="command name")
+    except InvalidNameError as exc:
+        raise HTTPException(400, f"Invalid command name: {exc}")
+    overwrite = body.overwrite if body else False
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = extract_commands_to_canonical(
+                    project_root, overwrite=overwrite, only_name=name
+                )
+    except TimeoutError:
+        raise HTTPException(503, "Command import timed out — another sync may be in progress")
+    if not result.imported and not result.skipped:
+        raise HTTPException(404, f"No runtime command named {name!r} to import")
+    return {
+        "imported": [
+            {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}
+            for p in result.imported
+        ],
+        "skipped": [
+            {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped
         ],
         "project_root": str(project_root),
         "scanned_dirs": _COMMAND_SCAN_DIRS,

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -12,7 +12,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from memtomem.context._atomic import atomic_write_text
-from memtomem.context._names import validate_name
+from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.detector import SKILL_DIRS
 from memtomem.context.skills import (
     CANONICAL_SKILL_ROOT,
@@ -367,6 +367,47 @@ async def import_skills(
         "skipped": [
             {"name": name, "reason": reason, "reason_code": code}
             for name, reason, code in result.skipped
+        ],
+        "project_root": str(project_root),
+        "scanned_dirs": _SKILL_SCAN_DIRS,
+    }
+
+
+@router.post("/context/skills/{name}/import")
+async def import_skill(
+    name: str,
+    body: ImportRequest | None = None,
+    project_root: Path = Depends(get_project_root),
+) -> dict:
+    """Import a single runtime skill into ``.memtomem/skills/``.
+
+    Same response shape as the section-level import so the web UI can reuse
+    its rendering. 404 when no runtime directory matches the name (the
+    section import would silently report 0 imported, which is the wrong
+    shape of feedback for "you clicked a specific item that doesn't exist").
+    """
+    try:
+        validate_name(name, kind="skill name")
+    except InvalidNameError as exc:
+        raise HTTPException(400, f"Invalid skill name: {exc}")
+    overwrite = body.overwrite if body else False
+    try:
+        async with asyncio.timeout(60):
+            async with _gateway_lock:
+                result = extract_skills_to_canonical(
+                    project_root, overwrite=overwrite, only_name=name
+                )
+    except TimeoutError:
+        raise HTTPException(503, "Skill import timed out — another sync may be in progress")
+    if not result.imported and not result.skipped:
+        raise HTTPException(404, f"No runtime skill named {name!r} to import")
+    return {
+        "imported": [
+            {"name": p.name, "canonical_path": str(p.relative_to(project_root))}
+            for p in result.imported
+        ],
+        "skipped": [
+            {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped
         ],
         "project_root": str(project_root),
         "scanned_dirs": _SKILL_SCAN_DIRS,

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -659,21 +659,49 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl) {
       }
     }
 
+    // ``type`` is always the plural section name (skills/commands/agents);
+    // strip the trailing ``s`` for the singular CTA copy. Both i18n strings
+    // expose ``{type}`` so the same placeholder works across en/ko.
+    const singular = type.endsWith('s') ? type.slice(0, -1) : type;
     html += `<div class="ctx-edit-actions" style="margin-top:12px">
       <button class="btn-primary ctx-runtime-only-import" data-type="${escapeHtml(type)}">
-        ${t('settings.ctx.import_all_includes_this', 'Import all {type} (includes this)').replace('{type}', type)}
+        ${t('settings.ctx.import_this', 'Import this {type}').replace('{type}', singular)}
       </button>
     </div>`;
 
     html += '</div>';
     detailEl.innerHTML = html;
 
-    detailEl.querySelector('.ctx-runtime-only-import')?.addEventListener('click', () => {
-      // No single-name import API exists yet, so dispatch a click to the
-      // section-level Import button. When a single-name endpoint lands,
-      // swap this for a direct fetch and refine the CTA copy.
-      const importBtn = document.querySelector(`.ctx-import-btn[data-type="${type}"]`);
-      if (importBtn) importBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    detailEl.querySelector('.ctx-runtime-only-import')?.addEventListener('click', async () => {
+      const btn = detailEl.querySelector('.ctx-runtime-only-import');
+      btnLoading(btn, true);
+      try {
+        const r = await fetch(`/api/context/${type}/${encodeURIComponent(name)}/import`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({}));
+          showToast(err.detail || t('toast.request_failed'), 'error');
+          return;
+        }
+        const data = await r.json();
+        if (data.imported && data.imported.length) {
+          showToast(t('settings.ctx.import_success', 'Import completed'));
+        } else if (data.skipped && data.skipped.length) {
+          // ``reason`` is backend English (e.g. "canonical exists"); the user
+          // still needs to know the import didn't run, so we surface it as-is
+          // rather than swallow it. Localizing every backend skip reason
+          // would multiply i18n keys without changing behavior.
+          showToast(data.skipped[0].reason || t('toast.request_failed'), 'warning');
+        }
+        loadCtxList(type);
+      } catch (err) {
+        showToast(t('toast.import_failed', { error: err.message }), 'error');
+      } finally {
+        btnLoading(btn, false);
+      }
     });
   } catch (err) {
     detailEl.innerHTML = emptyState('', 'Failed to load detail', err.message);

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -262,7 +262,7 @@
   "settings.ctx.sync_disabled_tooltip": "No canonical {type} to fan out yet. Click Import first.",
   "settings.ctx.sync_all_disabled_tooltip": "No canonical artifacts to fan out yet. Click Import in each section first.",
   "settings.ctx.runtime_only_detail_hint": "Runtime preview — not yet in .memtomem/.",
-  "settings.ctx.import_all_includes_this": "Import all {type} (includes this)",
+  "settings.ctx.import_this": "Import this {type}",
   "settings.ctx.runtime_output": "Runtime Output",
   "settings.ctx.canonical_source": "Canonical",
   "settings.ctx.diff_view": "Diff",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -262,7 +262,7 @@
   "settings.ctx.sync_disabled_tooltip": "아직 fan-out 할 canonical {type} 이 없습니다. Import 를 먼저 누르세요.",
   "settings.ctx.sync_all_disabled_tooltip": "아직 fan-out 할 canonical 아티팩트가 없습니다. 각 섹션에서 Import 를 먼저 누르세요.",
   "settings.ctx.runtime_only_detail_hint": "런타임 미리보기 — 아직 .memtomem/ 에 없습니다.",
-  "settings.ctx.import_all_includes_this": "모든 {type} 가져오기 (이 항목 포함)",
+  "settings.ctx.import_this": "이 {type} 가져오기",
   "settings.ctx.runtime_output": "런타임 출력",
   "settings.ctx.canonical_source": "Canonical",
   "settings.ctx.diff_view": "비교",

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -348,6 +348,26 @@ class TestExtractAgentsToCanonical:
         reason_by_name = {name: reason for name, reason, _code in result.skipped}
         assert "invalid name" in reason_by_name["-bad"]
 
+    def test_only_name_filters_to_one(self, tmp_path):
+        d = tmp_path / ".claude/agents"
+        d.mkdir(parents=True)
+        (d / "alpha.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
+        (d / "beta.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
+
+        result = extract_agents_to_canonical(tmp_path, only_name="alpha")
+        assert [p.stem for p in result.imported] == ["alpha"]
+        assert result.skipped == []
+        assert not (tmp_path / CANONICAL_AGENT_ROOT / "beta.md").exists()
+
+    def test_only_name_no_match_returns_empty(self, tmp_path):
+        d = tmp_path / ".claude/agents"
+        d.mkdir(parents=True)
+        (d / "alpha.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
+
+        result = extract_agents_to_canonical(tmp_path, only_name="ghost")
+        assert result.imported == []
+        assert result.skipped == []
+
 
 class TestDiffAgents:
     def test_empty_project(self, tmp_path, codex_home):

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -281,6 +281,29 @@ class TestExtractCommandsToCanonical:
         skipped_names = sorted(name for name, _, _ in result.skipped)
         assert "-bad" in skipped_names
 
+    def test_only_name_filters_to_one(self, tmp_path):
+        d = tmp_path / ".claude/commands"
+        d.mkdir(parents=True)
+        (d / "alpha.md").write_text(SAMPLE_MINIMAL_COMMAND)
+        (d / "beta.md").write_text(SAMPLE_MINIMAL_COMMAND)
+
+        result = extract_commands_to_canonical(tmp_path, only_name="alpha")
+        assert [p.stem for p in result.imported] == ["alpha"]
+        assert result.skipped == []
+        # Beta was untouched — neither imported nor a canonical written.
+        assert not (tmp_path / CANONICAL_COMMAND_ROOT / "beta.md").exists()
+
+    def test_only_name_no_match_returns_empty(self, tmp_path):
+        """Caller-distinguishable signal for single-name miss: imported and
+        skipped both empty (route layer turns this into 404)."""
+        d = tmp_path / ".claude/commands"
+        d.mkdir(parents=True)
+        (d / "alpha.md").write_text(SAMPLE_MINIMAL_COMMAND)
+
+        result = extract_commands_to_canonical(tmp_path, only_name="ghost")
+        assert result.imported == []
+        assert result.skipped == []
+
 
 class TestDiffCommands:
     def test_empty_project(self, tmp_path):

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -238,6 +238,26 @@ class TestExtractSkills:
         assert len(result.imported) == 1
         assert (canonical / "SKILL.md").read_text(encoding="utf-8") == "new"
 
+    def test_only_name_filters_to_one(self, tmp_path):
+        for name in ("alpha", "beta"):
+            d = tmp_path / ".claude/skills" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+
+        result = extract_skills_to_canonical(tmp_path, only_name="alpha")
+        assert [p.name for p in result.imported] == ["alpha"]
+        assert result.skipped == []
+        assert not (tmp_path / CANONICAL_SKILL_ROOT / "beta").exists()
+
+    def test_only_name_no_match_returns_empty(self, tmp_path):
+        d = tmp_path / ".claude/skills/alpha"
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+
+        result = extract_skills_to_canonical(tmp_path, only_name="ghost")
+        assert result.imported == []
+        assert result.skipped == []
+
 
 class TestDiffSkills:
     def test_empty_project(self, tmp_path):

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -388,6 +388,32 @@ class TestImportSkills:
         assert "canonical_exists" in skipped_codes
 
 
+class TestImportOneSkill:
+    @pytest.mark.anyio
+    async def test_import_single(self, client: AsyncClient, tmp_path: Path):
+        _make_runtime_skill(tmp_path, ".claude/skills", "alpha", "# A\n")
+        _make_runtime_skill(tmp_path, ".claude/skills", "beta", "# B\n")
+        r = await client.post("/api/context/skills/alpha/import", json={})
+        assert r.status_code == 200
+        data = r.json()
+        assert [i["name"] for i in data["imported"]] == ["alpha"]
+        assert (tmp_path / ".memtomem" / "skills" / "alpha" / SKILL_MANIFEST).is_file()
+        # Beta untouched — single-name import does not fan out.
+        assert not (tmp_path / ".memtomem" / "skills" / "beta").exists()
+
+    @pytest.mark.anyio
+    async def test_404_when_no_runtime_match(self, client: AsyncClient, tmp_path: Path):
+        _make_runtime_skill(tmp_path, ".claude/skills", "alpha", "# A\n")
+        r = await client.post("/api/context/skills/ghost/import", json={})
+        assert r.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_400_on_invalid_name(self, client: AsyncClient):
+        # Leading dash is rejected by validate_name before the FS is touched.
+        r = await client.post("/api/context/skills/-bad/import", json={})
+        assert r.status_code == 400
+
+
 # ---------------------------------------------------------------------------
 # Path traversal guard
 # ---------------------------------------------------------------------------
@@ -565,6 +591,30 @@ class TestImportCommands:
         assert ".gemini/commands" in data["scanned_dirs"]
 
 
+class TestImportOneCommand:
+    @pytest.mark.anyio
+    async def test_import_single(self, client: AsyncClient, tmp_path: Path):
+        _make_runtime_command(tmp_path, ".claude/commands", "alpha", ".md", _CMD_CONTENT)
+        _make_runtime_command(tmp_path, ".claude/commands", "beta", ".md", _CMD_CONTENT)
+        r = await client.post("/api/context/commands/alpha/import", json={})
+        assert r.status_code == 200
+        data = r.json()
+        assert [i["name"] for i in data["imported"]] == ["alpha"]
+        assert (tmp_path / ".memtomem" / "commands" / "alpha.md").is_file()
+        assert not (tmp_path / ".memtomem" / "commands" / "beta.md").exists()
+
+    @pytest.mark.anyio
+    async def test_404_when_no_runtime_match(self, client: AsyncClient, tmp_path: Path):
+        _make_runtime_command(tmp_path, ".claude/commands", "alpha", ".md", _CMD_CONTENT)
+        r = await client.post("/api/context/commands/ghost/import", json={})
+        assert r.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_400_on_invalid_name(self, client: AsyncClient):
+        r = await client.post("/api/context/commands/-bad/import", json={})
+        assert r.status_code == 400
+
+
 # ===========================================================================
 # Agents
 # ===========================================================================
@@ -728,3 +778,27 @@ class TestImportAgents:
         assert ".claude/agents" in data["scanned_dirs"]
         assert ".gemini/agents" in data["scanned_dirs"]
         assert ".codex/agents" in data["scanned_dirs"]
+
+
+class TestImportOneAgent:
+    @pytest.mark.anyio
+    async def test_import_single(self, client: AsyncClient, tmp_path: Path):
+        _make_runtime_agent(tmp_path, ".claude/agents", "alpha")
+        _make_runtime_agent(tmp_path, ".claude/agents", "beta")
+        r = await client.post("/api/context/agents/alpha/import", json={})
+        assert r.status_code == 200
+        data = r.json()
+        assert [i["name"] for i in data["imported"]] == ["alpha"]
+        assert (tmp_path / ".memtomem" / "agents" / "alpha.md").is_file()
+        assert not (tmp_path / ".memtomem" / "agents" / "beta.md").exists()
+
+    @pytest.mark.anyio
+    async def test_404_when_no_runtime_match(self, client: AsyncClient, tmp_path: Path):
+        _make_runtime_agent(tmp_path, ".claude/agents", "alpha")
+        r = await client.post("/api/context/agents/ghost/import", json={})
+        assert r.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_400_on_invalid_name(self, client: AsyncClient):
+        r = await client.post("/api/context/agents/-bad/import", json={})
+        assert r.status_code == 400


### PR DESCRIPTION
## Summary

Closes the loop on PR #559's runtime-only detail view: adds a single-item import endpoint so the "Import" CTA targets one artifact instead of fanning out the entire section.

- `POST /api/context/{type}/{name}/import` for skills, commands, and agents. Same response shape as the section-level import so the web UI reuses its rendering. **404** when no runtime file matches the name; **400** on invalid names (`validate_name` rejection).
- Backend reuses `extract_*_to_canonical` via a new `only_name: str | None` parameter — runtime scan still drives ordering, dedup, and skip semantics; we just filter to one stem before validation/exists checks. Empty `imported + skipped` on a no-match single-name call is the route layer's 404 signal.
- Frontend `_ctxLoadRuntimeOnlyDetail`: swaps the dispatchEvent CTA for a direct `fetch`, refines the copy from "Import all {type} (includes this)" to "Import this {type_singular}". Reuses existing `import_success`/`import_failed` toasts (no new i18n keys; key renamed `import_all_includes_this` → `import_this`).
- Singular `{type}` derived in JS via `type.slice(0, -1)` so en/ko share one `{type}` placeholder.

Out of scope: the local `mm` CLI doesn't gain a single-name flag here — only the web surface. CLI catch-up belongs in a separate PR if/when there's demand.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_{commands,skills,agents}.py packages/memtomem/tests/test_web_routes_context.py packages/memtomem/tests/test_web_routes_context_locks.py packages/memtomem/tests/test_i18n.py -m "not ollama"` (224 passed)
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check`
- [ ] Manual smoke: `mm web` → Settings → Commands. Click a runtime-only card; verify "Import this command" pulls only that artifact (other runtime-only siblings stay untouched). Re-click an imported card; verify the canonical detail view opens (no regression on PR #559's branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)