### PR TITLE
feat(web): add help bar to Index tab

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -458,6 +458,10 @@
 
   <!-- ===== INDEX TAB ===== -->
   <div id="tab-index" class="tab-panel" hidden>
+    <div class="tab-help-bar" id="help-index" role="status" hidden>
+      <span class="tab-help-bar-text" data-i18n="index.help">Index files into memtomem. Type a path to scan, drop files to upload, or write a memory directly. Toggle Force re-index to rebuild existing chunks.</span>
+      <button class="tab-help-bar-dismiss" data-help-tab="index">✕</button>
+    </div>
     <div class="index-layout">
       <div class="index-form card index-primary">
         <h2 data-i18n="index.title">Index Files</h2>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -146,6 +146,7 @@
   "sources.toast.added_to_other_view": "{path} added to {view}",
   "sources.toast.switch_view": "Switch",
 
+  "index.help": "Index files into memtomem. Type a path to scan, drop files to upload, or write a memory directly. Toggle Force re-index to rebuild existing chunks.",
   "index.title": "Index Files",
   "index.path_label": "Path",
   "index.path_placeholder": "e.g. ~/memories or /path/to/notes",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -146,6 +146,7 @@
   "sources.toast.added_to_other_view": "{path} 가 {view} 에 추가됨",
   "sources.toast.switch_view": "이동",
 
+  "index.help": "memtomem 에 파일을 인덱싱합니다. 경로를 입력해 스캔하거나, 파일을 드롭해 업로드하거나, 직접 기억을 작성하세요. 강제 재인덱스로 기존 청크를 다시 생성할 수 있습니다.",
   "index.title": "파일 인덱싱",
   "index.path_label": "경로",
   "index.path_placeholder": "예: ~/memories 또는 /path/to/notes",

--- a/packages/memtomem/src/memtomem/web/static/settings-harness.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-harness.js
@@ -8,7 +8,7 @@
 // Tab Help System (A + C)
 // ---------------------------------------------------------------------------
 
-const _HELP_TABS = ['search', 'sources', 'tags', 'timeline'];
+const _HELP_TABS = ['search', 'sources', 'index', 'tags', 'timeline'];
 const _HELP_STORAGE_KEY = 'm2m-help-dismissed';
 
 function _getHelpDismissed() {


### PR DESCRIPTION
## Summary

The Index tab was the only main tab missing a \`tab-help-bar\` — Search, Sources, Tags, Timeline all carried one. The dismiss + initial-show loop in \`settings-harness.js\` drove off \`_HELP_TABS\`, which also omitted \`'index'\`, so the markup gap and the JS gap had to land together.

- \`index.html:460\` — add the help bar markup at the top of \`#tab-index\`, mirroring the four existing tabs (role=\"status\", localized text, dismiss \"✕\")
- \`settings-harness.js:11\` — append \`'index'\` to \`_HELP_TABS\`
- \`locales/{en,ko}.json\` — new \`index.help\` key. Tone matches \`sources.help\` / \`tags.help\` length: 1 sentence purpose + 2 sentences on the three entry points (path scan / drop / Add Memory) and the Force re-index toggle

Recon-driven (audit of Sources/Index/Search consistency). Out of the three real findings, this is the smallest atomic fix; the larger main-nav ARIA gap (\`role=\"tab\"\`/\`aria-controls\` missing on the seven \`.tab-btn\`) ships in a separate PR.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/test_i18n.py -q\` (parity + placeholder guards: 12 passed)
- [x] \`uv run ruff check packages/memtomem/src\` + \`ruff format --check\`
- [ ] Manual smoke: \`mm web\` → Index tab. Help bar visible on first paint; \"✕\" dismisses and persists across reload; header \"?\" toggle hides/shows alongside the other tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)