### PR TITLE
feat(web): arrow-key nav for main tablist + Sources sub-toggle

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -665,6 +665,37 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
   btn.addEventListener('click', () => activateTab(btn.dataset.tab));
 });
 
+// ── ARIA tabs keyboard navigation ──
+//
+// ArrowRight/Left cycle through the tablist, Home/End jump to either end.
+// "Auto-activation" model — focus and activate together — matches the click
+// behavior so a keyboard user toggles the panel just by walking the tab row,
+// without an extra Enter press. The currently focused element is the anchor;
+// when focus is outside the tablist the move starts at index 0.
+function _arrowNavIndex(length, currentIdx, key) {
+  if (!length) return -1;
+  if (key === 'ArrowRight') return (currentIdx + 1) % length;
+  if (key === 'ArrowLeft') return (currentIdx - 1 + length) % length;
+  if (key === 'Home') return 0;
+  if (key === 'End') return length - 1;
+  return -1;
+}
+
+document.querySelector('.tab-nav')?.addEventListener('keydown', (e) => {
+  if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(e.key)) return;
+  // Filter out dev-only buttons in prod mode so arrow nav matches what the
+  // user actually sees on screen — otherwise focus could land on a hidden tab.
+  const buttons = Array.from(document.querySelectorAll('.tab-nav .tab-btn'))
+    .filter(b => b.dataset.uiTier !== 'dev' || STATE.uiMode === 'dev');
+  const currentIdx = buttons.indexOf(document.activeElement);
+  const nextIdx = _arrowNavIndex(buttons.length, currentIdx === -1 ? 0 : currentIdx, e.key);
+  if (nextIdx < 0) return;
+  e.preventDefault();
+  const next = buttons[nextIdx];
+  next.focus();
+  if (next.dataset.tab) activateTab(next.dataset.tab);
+});
+
 // ── E1: ARIA init ──
 document.querySelectorAll('.tab-btn').forEach(btn => {
   btn.setAttribute('role', 'tab');
@@ -2040,16 +2071,20 @@ function setSourcesMode(mode) {
   if (mode === 'memory') {
     memBtn.classList.add('btn-active');
     memBtn.setAttribute('aria-selected', 'true');
+    memBtn.setAttribute('tabindex', '0');
     genBtn.classList.remove('btn-active');
     genBtn.setAttribute('aria-selected', 'false');
+    genBtn.setAttribute('tabindex', '-1');
     memView.hidden = false;
     genView.hidden = true;
     if (typeof renderMemoryDirsPanel === 'function') renderMemoryDirsPanel();
   } else {
     genBtn.classList.add('btn-active');
     genBtn.setAttribute('aria-selected', 'true');
+    genBtn.setAttribute('tabindex', '0');
     memBtn.classList.remove('btn-active');
     memBtn.setAttribute('aria-selected', 'false');
+    memBtn.setAttribute('tabindex', '-1');
     memView.hidden = true;
     genView.hidden = false;
     loadSources();
@@ -2058,6 +2093,19 @@ function setSourcesMode(mode) {
 
 qs('sources-mode-memory').addEventListener('click', () => setSourcesMode('memory'));
 qs('sources-mode-general').addEventListener('click', () => setSourcesMode('general'));
+
+// Mirror the main tablist's keyboard nav onto the Sources sub-toggle.
+document.querySelector('.sources-mode-toggle')?.addEventListener('keydown', (e) => {
+  if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(e.key)) return;
+  const buttons = Array.from(document.querySelectorAll('.sources-mode-toggle [role="tab"]'));
+  const currentIdx = buttons.indexOf(document.activeElement);
+  const nextIdx = _arrowNavIndex(buttons.length, currentIdx === -1 ? 0 : currentIdx, e.key);
+  if (nextIdx < 0) return;
+  e.preventDefault();
+  const next = buttons[nextIdx];
+  next.focus();
+  setSourcesMode(next.id === 'sources-mode-memory' ? 'memory' : 'general');
+});
 
 document.querySelectorAll('.sources-sort-btn').forEach(btn => {
   btn.addEventListener('click', () => {

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -468,7 +468,14 @@ function showConfirm({
 // Tab navigation
 // ---------------------------------------------------------------------------
 
-function activateTab(tabName) {
+function activateTab(tabName, opts = {}) {
+  // ``fromKeyboard`` flips two behaviors that would otherwise fight the
+  // ARIA tabs arrow-nav contract:
+  //   * panel auto-focus is skipped so focus stays on the tab button (the
+  //     user keeps ArrowRight'ing through siblings)
+  //   * history mutation uses replaceState so cycling N tabs does not push
+  //     N entries the user has to press Back through to escape
+  const fromKeyboard = opts.fromKeyboard === true;
   // In prod mode, hide dev-only tabs by redirecting to the first visible
   // main tab instead of showing a dev panel the polished surface doesn't
   // expose.
@@ -477,7 +484,7 @@ function activateTab(tabName) {
     const visible = _visibleMainTabs();
     showToast(t('toast.dev_only_section'), 'info');
     if (visible.length && visible[0] !== tabName) {
-      activateTab(visible[0]);
+      activateTab(visible[0], opts);
     }
     return;
   }
@@ -508,14 +515,24 @@ function activateTab(tabName) {
   if (panel) {
     panel.hidden = false;
     panel.classList.add('active');
-    // Focus first focusable element in new panel
-    const focusable = panel.querySelector('input:not([hidden]):not([disabled]), button:not([hidden]):not([disabled]), [tabindex="0"]');
-    if (focusable) focusable.focus();
+    // Focus first focusable element in new panel — but only on click /
+    // direct activation. Arrow-nav must keep focus on the tab button so
+    // subsequent ArrowRight presses still cycle the tablist.
+    if (!fromKeyboard) {
+      const focusable = panel.querySelector('input:not([hidden]):not([disabled]), button:not([hidden]):not([disabled]), [tabindex="0"]');
+      if (focusable) focusable.focus();
+    }
   }
 
-  // History API — enable back button and deep linking
+  // History API — enable back button and deep linking. Arrow-nav uses
+  // replaceState so a cycle through siblings produces one history entry
+  // instead of N (otherwise Back becomes unusable).
   if (location.hash !== `#${tabName}`) {
-    history.pushState({ tab: tabName }, '', `#${tabName}`);
+    if (fromKeyboard) {
+      history.replaceState({ tab: tabName }, '', `#${tabName}`);
+    } else {
+      history.pushState({ tab: tabName }, '', `#${tabName}`);
+    }
   }
 
   // Tab-specific loads
@@ -693,7 +710,7 @@ document.querySelector('.tab-nav')?.addEventListener('keydown', (e) => {
   e.preventDefault();
   const next = buttons[nextIdx];
   next.focus();
-  if (next.dataset.tab) activateTab(next.dataset.tab);
+  if (next.dataset.tab) activateTab(next.dataset.tab, { fromKeyboard: true });
 });
 
 // ── E1: ARIA init ──


### PR DESCRIPTION
## Summary

Follow-up to #563 (main tab-nav ARIA) and #560 (Sources sub-toggle ARIA). Both tablists carried `role=tab/tablist` but the ARIA tabs authoring practices' keyboard nav contract — ArrowRight/Left to cycle siblings, Home/End to jump to either end — was unimplemented, leaving keyboard users without an in-tablist navigation primitive.

- Shared `_arrowNavIndex` helper computes the next index given the cycle direction; same call shape from both handlers
- **Main \`.tab-nav\` keydown**: cycles among visible main tabs (filters out \`data-ui-tier="dev"\` buttons in prod mode so focus never lands on a hidden tab), auto-activates so focus moves the panel without a separate Enter press — matches the existing click behavior
- **\`.sources-mode-toggle\` keydown**: same shape over the two Memory/General buttons. \`setSourcesMode\` now toggles \`tabindex\` alongside \`aria-selected\` so the single-tab-stop pattern (one tab in the keyboard order at a time) holds across mode switches

## Stacked on #563

Base = \`feat/main-nav-aria\`. After #563 squash-merges to main, rebase with \`git rebase --onto origin/main feat/main-nav-aria\`. If GitHub auto-closes on base delete, retarget to \`main\` and reopen.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/test_i18n.py -q\` (12 passed; markup-only change so parity is unaffected)
- [x] \`uv run ruff check packages/memtomem/src\` + \`ruff format --check\`
- [ ] Manual smoke: \`mm web\` → focus a main tab button (Tab key reaches the tablist), verify ArrowRight/Left cycle through visible tabs and activate the panel; Home/End jump to the first / last visible tab; same behavior on the Sources Memory/General sub-toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)