### PR TITLE
refactor(web): drive Sources mode arrow nav from data-mode

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2121,7 +2121,7 @@ document.querySelector('.sources-mode-toggle')?.addEventListener('keydown', (e) 
   e.preventDefault();
   const next = buttons[nextIdx];
   next.focus();
-  setSourcesMode(next.id === 'sources-mode-memory' ? 'memory' : 'general');
+  if (next.dataset.mode) setSourcesMode(next.dataset.mode);
 });
 
 document.querySelectorAll('.sources-sort-btn').forEach(btn => {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -410,8 +410,8 @@
       <button class="tab-help-bar-dismiss" data-help-tab="sources">✕</button>
     </div>
     <div class="sources-mode-toggle" role="tablist" aria-label="Sources view">
-      <button id="sources-mode-memory" class="btn-ghost btn-active" role="tab" aria-selected="true" aria-controls="sources-view-memory" data-i18n="sources.mode.memory">Memory</button>
-      <button id="sources-mode-general" class="btn-ghost" role="tab" aria-selected="false" aria-controls="sources-view-general" data-i18n="sources.mode.general">General sources</button>
+      <button id="sources-mode-memory" class="btn-ghost btn-active" role="tab" aria-selected="true" aria-controls="sources-view-memory" data-mode="memory" data-i18n="sources.mode.memory">Memory</button>
+      <button id="sources-mode-general" class="btn-ghost" role="tab" aria-selected="false" aria-controls="sources-view-general" data-mode="general" data-i18n="sources.mode.general">General sources</button>
     </div>
     <div id="sources-view-memory" class="sources-view" role="tabpanel" aria-labelledby="sources-mode-memory">
       <div id="memory-dirs-panel" class="memory-dirs-panel card"></div>


### PR DESCRIPTION
## Summary

Self-review on #564 flagged the \`.sources-mode-toggle\` keydown handler's hardcoded id check as fragile:

\`\`\`js
setSourcesMode(next.id === 'sources-mode-memory' ? 'memory' : 'general');
\`\`\`

Implicitly assumes exactly two modes and that the non-memory id always means \`'general'\` — adding a third mode would silently route to general.

- Add \`data-mode=\"memory\" | \"general\"\` to the two \`.sources-mode-toggle\` buttons
- Replace the id-based ternary with \`next.dataset.mode\` (truthy-gated)

Same pattern as the existing \`data-tab\` attribute on the main tablist; no behavior change.

## Stack

Stacked on #564 → #563 → main. Once #564 merges, rebase with \`git rebase --onto origin/main feat/tab-keyboard-nav\`.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/test_i18n.py -q\` (12 passed; markup-attribute-only change so parity unaffected)
- [x] \`uv run ruff check packages/memtomem/src\` + \`ruff format --check\`
- [ ] Manual smoke: \`mm web\` → Sources tab, ArrowRight/Left between Memory ↔ General — both modes activate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)