### PR TITLE
feat(web): single Sources panel — drop Memory/General toggle

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -539,11 +539,10 @@ function activateTab(tabName, opts = {}) {
   if (tabName === 'home') { STATE.homeStale = false; loadDashboard(); renderPinnedSection(); }
   if (tabName === 'sources') {
     STATE.sourcesBrowserStale = false;
-    // ``setSourcesMode`` drives the loaders for whichever sub-toggle the
-    // user last left active (memory → memory-dirs panel; general →
-    // ``loadSources()``). Avoids the previous double-fetch pattern that
-    // hit the server even for the view that wasn't visible.
-    setSourcesMode(getSourcesMode());
+    // Single Sources panel: pull memory-dirs status + indexed sources
+    // in one round trip. Vendor grouping is the only classification
+    // axis now, so there's no mode to restore.
+    loadSources();
   }
   if (tabName === 'index') loadStats();
   if (tabName === 'tags') { STATE.tagsTabStale = false; loadTags(); }
@@ -1821,12 +1820,23 @@ function _setDetailMode(mode) {
 })();
 
 // ── B2: Resizable sources sidebar divider ──
+const _SOURCES_WIDTH_LS_KEY = 'memtomem.sources_width';
 (function initSourcesDivider() {
   const divider = qs('sources-divider');
   if (!divider) return;
   const layout = document.querySelector('.sources-layout');
   const sidebar = document.querySelector('.sources-sidebar');
   let startX = 0, startW = 0;
+  let lastW = 0;
+
+  // Restore persisted width on load so the user's preferred sidebar size
+  // sticks across tab switches and reloads.
+  try {
+    const stored = parseInt(localStorage.getItem(_SOURCES_WIDTH_LS_KEY) || '', 10);
+    if (Number.isFinite(stored) && stored >= 200) {
+      layout.style.setProperty('--sources-width', stored + 'px');
+    }
+  } catch (_err) { /* private mode */ }
 
   divider.addEventListener('mousedown', e => {
     e.preventDefault();
@@ -1840,12 +1850,17 @@ function _setDetailMode(mode) {
   function onMove(e) {
     const newW = Math.max(200, Math.min(startW + (e.clientX - startX), window.innerWidth * 0.6));
     layout.style.setProperty('--sources-width', newW + 'px');
+    lastW = newW;
   }
 
   function onUp() {
     divider.classList.remove('dragging');
     document.removeEventListener('mousemove', onMove);
     document.removeEventListener('mouseup', onUp);
+    if (lastW) {
+      try { localStorage.setItem(_SOURCES_WIDTH_LS_KEY, String(Math.round(lastW))); }
+      catch (_err) { /* ignore */ }
+    }
   }
 })();
 
@@ -2056,79 +2071,7 @@ function navigateToSourcesByNs(nsName) {
   activateTab('sources');
 }
 
-qs('refresh-sources-btn').addEventListener('click', () => loadSources('general'));
 qs('sources-filter').addEventListener('input', () => renderSourceTree(_getFilteredSorted()));
-
-// ── Sources sub-toggle: Memory ↔ General ──
-// memory_dirs config lumps two distinct user intents together — agent
-// memory dirs (auto-discovered) vs arbitrary RAG folders. The sub-toggle
-// gives each its own data slice but they now share one ``.sources-layout``
-// (sidebar + chunks-browser) so the view feels coherent: vendor groups
-// only appear when ``mode === 'memory'``, header actions swap between
-// the two modes, and clicking a file opens chunks in the same right pane.
-const SOURCES_MODE_LS_KEY = 'memtomem.sources_mode';
-
-function getSourcesMode() {
-  try {
-    const stored = localStorage.getItem(SOURCES_MODE_LS_KEY);
-    if (stored === 'memory' || stored === 'general') return stored;
-  } catch (_err) { /* private mode */ }
-  return 'memory';
-}
-
-function setSourcesMode(mode) {
-  if (mode !== 'memory' && mode !== 'general') mode = 'memory';
-  STATE.sourcesMode = mode;
-  try { localStorage.setItem(SOURCES_MODE_LS_KEY, mode); } catch (_err) { /* ignore */ }
-
-  const memBtn = qs('sources-mode-memory');
-  const genBtn = qs('sources-mode-general');
-  if (!memBtn || !genBtn) return;
-  if (mode === 'memory') {
-    memBtn.classList.add('btn-active');
-    memBtn.setAttribute('aria-selected', 'true');
-    memBtn.setAttribute('tabindex', '0');
-    genBtn.classList.remove('btn-active');
-    genBtn.setAttribute('aria-selected', 'false');
-    genBtn.setAttribute('tabindex', '-1');
-  } else {
-    genBtn.classList.add('btn-active');
-    genBtn.setAttribute('aria-selected', 'true');
-    genBtn.setAttribute('tabindex', '0');
-    memBtn.classList.remove('btn-active');
-    memBtn.setAttribute('aria-selected', 'false');
-    memBtn.setAttribute('tabindex', '-1');
-  }
-
-  // Header action groups swap with the mode. The add-path inline row
-  // is a Memory-only affordance — closing it on every mode switch keeps
-  // it from surviving as a stuck-open input under General mode.
-  const memActs = qs('sources-actions-memory');
-  const genActs = qs('sources-actions-general');
-  if (memActs) memActs.hidden = mode !== 'memory';
-  if (genActs) genActs.hidden = mode !== 'general';
-  const addRow = qs('memory-add-row');
-  if (addRow) addRow.hidden = true;
-
-  hideBrowser();
-  loadSources(mode);
-}
-
-qs('sources-mode-memory').addEventListener('click', () => setSourcesMode('memory'));
-qs('sources-mode-general').addEventListener('click', () => setSourcesMode('general'));
-
-// Mirror the main tablist's keyboard nav onto the Sources sub-toggle.
-document.querySelector('.sources-mode-toggle')?.addEventListener('keydown', (e) => {
-  if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(e.key)) return;
-  const buttons = Array.from(document.querySelectorAll('.sources-mode-toggle [role="tab"]'));
-  const currentIdx = buttons.indexOf(document.activeElement);
-  const nextIdx = _arrowNavIndex(buttons.length, currentIdx === -1 ? 0 : currentIdx, e.key);
-  if (nextIdx < 0) return;
-  e.preventDefault();
-  const next = buttons[nextIdx];
-  next.focus();
-  if (next.dataset.mode) setSourcesMode(next.dataset.mode);
-});
 
 document.querySelectorAll('.sources-sort-btn').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -2181,34 +2124,26 @@ document.querySelectorAll('.sources-sort-btn').forEach(btn => {
   }
 })();
 
-async function loadSources(mode) {
-  if (mode !== 'memory' && mode !== 'general') mode = STATE.sourcesMode || 'memory';
-  STATE.sourcesMode = mode;
+async function loadSources() {
+  // Single-panel Sources: vendor grouping (사용자 / Claude / Codex) is the
+  // only classification axis. We pull every memory_dir's status and every
+  // indexed source file regardless of backend ``kind`` so user-added dirs
+  // that classify as ``general`` still surface their file rows under their
+  // vendor group.
   const list = qs('sources-list');
   panelLoading(list);
   try {
-    if (mode === 'memory') {
-      // Memory mode joins two endpoints: ``/api/memory-dirs/status`` for
-      // per-directory metadata (vendor / category / counts / timestamps)
-      // and ``/api/sources?kind=memory`` for the file rows under those
-      // directories. ``limit=10000`` matches the route's hard cap.
-      const [statusResp, sourcesResp] = await Promise.all([
-        api('GET', '/api/memory-dirs/status'),
-        api('GET', '/api/sources?kind=memory&limit=10000'),
-      ]);
-      const statusByPath = {};
-      for (const entry of (statusResp && statusResp.dirs) || []) {
-        if (entry && typeof entry.path === 'string') statusByPath[entry.path] = entry;
-      }
-      STATE.memoryStatusByPath = statusByPath;
-      STATE.memoryDirs = (STATE.serverConfig?.indexing?.memory_dirs) || Object.keys(statusByPath);
-      STATE.allSources = (sourcesResp && sourcesResp.sources) || [];
-    } else {
-      // The General view always asks the server for the ``general`` bucket
-      // (orphans tag along server-side so they remain visible).
-      const data = await api('GET', '/api/sources?kind=general');
-      STATE.allSources = data.sources;
+    const [statusResp, sourcesResp] = await Promise.all([
+      api('GET', '/api/memory-dirs/status'),
+      api('GET', '/api/sources?limit=10000'),
+    ]);
+    const statusByPath = {};
+    for (const entry of (statusResp && statusResp.dirs) || []) {
+      if (entry && typeof entry.path === 'string') statusByPath[entry.path] = entry;
     }
+    STATE.memoryStatusByPath = statusByPath;
+    STATE.memoryDirs = (STATE.serverConfig?.indexing?.memory_dirs) || Object.keys(statusByPath);
+    STATE.allSources = (sourcesResp && sourcesResp.sources) || [];
     _renderSourcesNsChip();
     renderSourceTree(_getFilteredSorted());
   } catch (err) {
@@ -2218,131 +2153,32 @@ async function loadSources(mode) {
 
 function renderSourceTree(sources) {
   const list = qs('sources-list');
-  const mode = STATE.sourcesMode || 'memory';
 
-  // C. Summary stats bar
+  // Top summary sums the *indexed* portion of each memory_dir so the
+  // figure matches what the user can actually click into below \u2014 and
+  // avoids inflating the count with unindexed read-only-discovered dirs
+  // whose ``file_count`` reflects disk-only files. Per-dir badges also
+  // surface the ``indexed/files`` split, so this number lines up with
+  // the left side of those badges.
   const statsEl = qs('sources-stats');
-  if (sources.length) {
-    const totalChunks = sources.reduce((sum, s) => sum + (s.chunk_count || 0), 0);
-    const totalSize = sources.reduce((sum, s) => sum + (s.file_size || 0), 0);
-    statsEl.textContent = `${sources.length} files \u00b7 ${totalChunks.toLocaleString()} chunks \u00b7 ${formatBytes(totalSize)}`;
+  const statusByPath = STATE.memoryStatusByPath || {};
+  let indexedFiles = 0;
+  let totalChunks = 0;
+  for (const s of Object.values(statusByPath)) {
+    if (!s || s.exists === false) continue;
+    indexedFiles += s.source_file_count || 0;
+    totalChunks += s.chunk_count || 0;
+  }
+  if (indexedFiles || totalChunks) {
+    statsEl.textContent = `${indexedFiles} files \u00b7 ${totalChunks.toLocaleString()} chunks`;
     statsEl.hidden = false;
   } else {
     statsEl.hidden = true;
   }
 
-  // Memory mode: vendor → memory_dir → file cards. Even with zero
-  // sources the panel still renders so configured-but-empty memory dirs
-  // stay visible (with their reindex/remove actions reachable).
-  if (mode === 'memory') {
-    _renderMemorySourceTree(sources, list);
-    return;
-  }
-
-  if (!sources.length) {
-    list.innerHTML = '<div class="empty-state">' + emptyState('📁', 'No indexed sources', 'Index files from the Index tab') + '</div>';
-    return;
-  }
-  list.innerHTML = '';
-
-  // G. Max chunks for mini bar
-  const maxChunks = Math.max(1, ...sources.map(s => s.chunk_count || 0));
-
-  // Group by parent directory
-  const groups = {};
-  sources.forEach(s => {
-    const parts = s.path.split('/');
-    const dir = parts.slice(0, -1).join('/') || '/';
-    if (!groups[dir]) groups[dir] = [];
-    groups[dir].push(s);
-  });
-
-  Object.entries(groups).forEach(([dir, items]) => {
-    const group = document.createElement('div');
-    group.className = 'source-group';
-
-    // D. Collapsible group header
-    const header = document.createElement('div');
-    header.className = 'source-group-header';
-    header.title = dir;
-    header.innerHTML = `<span class="source-group-chevron">\u25BC</span><span class="source-group-dir">${escapeHtml(shortDir(dir))}</span><span class="source-group-count">${items.length}</span>`;
-    header.setAttribute('aria-expanded', 'true');
-    header.addEventListener('click', () => {
-      group.classList.toggle('collapsed');
-      header.setAttribute('aria-expanded', !group.classList.contains('collapsed'));
-    });
-    group.appendChild(header);
-
-    items.forEach(s => {
-      const filename = s.path.split('/').pop() || s.path;
-      const item = document.createElement('div');
-      item.className = 'source-item';
-      item.title = s.path;
-
-      // A+B. 2-row layout with color dot
-      const size = s.file_size != null ? formatBytes(s.file_size) : '';
-      const age = s.last_indexed_at ? relativeTime(s.last_indexed_at) : '';
-      const barPct = Math.round(((s.chunk_count || 0) / maxChunks) * 100);
-
-      // F. Namespace badges (exclude "default")
-      const nsBadges = (s.namespaces || [])
-        .filter(ns => ns !== 'default')
-        .map(ns => `<span class="badge badge-ns source-ns-badge">${escapeHtml(ns)}</span>`)
-        .join('');
-
-      item.innerHTML = `
-        <div class="source-item-row1">
-          <span class="source-type-dot" style="background:${fileTypeColor(s.path)}"></span>
-          <span class="source-name">${escapeHtml(filename)}</span>
-          ${nsBadges}
-          <button class="source-del-btn remove-btn" data-path="${escapeAttr(s.path)}">✕</button>
-        </div>
-        <div class="source-item-row2">
-          ${s.chunk_count ?? '?'} chunks${size ? ' \u00b7 ' + size : ''}${s.avg_tokens ? ' \u00b7 avg ' + s.avg_tokens + ' tok' : ''}${age ? ' \u00b7 ' + age : ''}
-        </div>
-        <div class="source-chunk-bar">
-          <div class="source-chunk-bar-fill" style="width:${barPct}%"></div>
-        </div>
-      `;
-      item.setAttribute('tabindex', '0');
-      item.addEventListener('click', (e) => {
-        if (e.target.classList.contains('remove-btn')) return;
-        document.querySelectorAll('.source-item').forEach(el => el.classList.remove('active'));
-        item.classList.add('active');
-        browseSource(s.path);
-      });
-      item.addEventListener('keydown', e => {
-        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); item.click(); }
-      });
-      item.querySelector('.remove-btn').addEventListener('click', async (e) => {
-        e.stopPropagation();
-        const ok = await showConfirm({
-          title: t('confirm.source_delete_title'),
-          message: t('confirm.source_delete_msg', { path: s.path }),
-          confirmText: t('common.delete'),
-        });
-        if (!ok) return;
-        try {
-          await api('DELETE', `/api/sources?path=${encodeURIComponent(s.path)}`);
-          showToast(t('toast.source_deleted'), 'success');
-          STATE.allSources = STATE.allSources.filter(x => x.path !== s.path);
-          renderSourceTree(_getFilteredSorted());
-          hideBrowser();
-          STATE.lastResults = STATE.lastResults.filter(r => r.chunk.source_file !== s.path);
-          renderResults(STATE.lastResults);
-          _markDataStale();
-          loadSourceFilter();
-          loadStats();
-        } catch (err) {
-          showToast(t('toast.delete_failed', { error: err.message }), 'error');
-        }
-      });
-      group.appendChild(item);
-    });
-
-    list.appendChild(group);
-  });
+  _renderMemorySourceTree(sources, list);
 }
+
 
 function hideBrowser() {
   hide(qs('chunks-browser-content'));
@@ -2414,34 +2250,79 @@ function _renderMemorySourceTree(sources, list) {
   list.innerHTML = '';
   const maxChunks = Math.max(1, ...sources.map(s => s.chunk_count || 0));
 
+  // "Discovered" = memory dirs that are configured (or auto-detected)
+  // but have no chunks yet — the user hasn't indexed them. We group
+  // these as a collapsed sub-section under their vendor so the indexed
+  // cards stay primary and the candidates read as "ready to index", not
+  // "errors". A dir with ``exists === false`` stays in the main list as
+  // ``.missing`` (a real error).
+  const isDiscovered = (path) => {
+    const st = statusByPath[path];
+    if (!st || st.exists === false) return false;
+    const chunks = st.chunk_count || 0;
+    const files = (typeof st.file_count === 'number') ? st.file_count : 0;
+    return chunks === 0 && files > 0;
+  };
+
+  // For the "user" vendor, the first entry in ``memory_dirs`` config is
+  // the conventional primary memory dir — pin it to the top so the most
+  // common destination doesn't get sorted under a longer alphabetical
+  // sibling.
+  const defaultDir = (STATE.serverConfig?.indexing?.memory_dirs || [])[0];
+  const sortUserDirs = (dirs) => {
+    if (!defaultDir) return dirs;
+    const idx = dirs.indexOf(defaultDir);
+    if (idx <= 0) return dirs;
+    const out = dirs.slice();
+    out.splice(idx, 1);
+    out.unshift(defaultDir);
+    return out;
+  };
+
+  // Build a vendor card whether or not it has any dirs — empty vendors
+  // collapse with a "not found · Add manually" placeholder so users know
+  // the slot exists without it taking up screen space.
   let renderedFiles = 0;
   for (const provider of PROVIDER_ORDER) {
     const bucket = byProvider[provider];
-    if (!bucket.order.length) continue;
 
-    const categories = CATEGORY_ORDER.filter(c => bucket.byCategory[c]);
-    // Drop dirs with no visible files when a filter is active.
-    const visibleCats = filterActive
-      ? categories
+    const categoriesAll = CATEGORY_ORDER.filter(c => bucket.byCategory[c]);
+    const visibleCatsRaw = filterActive
+      ? categoriesAll
           .map(cat => [cat, bucket.byCategory[cat].filter(d => (sourcesByDir[d] || []).length > 0)])
           .filter(([, dirs]) => dirs.length > 0)
-      : categories.map(cat => [cat, bucket.byCategory[cat]]);
-    if (!visibleCats.length) continue;
+      : categoriesAll.map(cat => [cat, bucket.byCategory[cat]]);
+
+    // Partition each category's dirs into indexed (default first for user
+    // provider) and discovered (kind=read-only, rendered as a collapsed
+    // sub-section).
+    const visibleCats = visibleCatsRaw.map(([cat, dirs]) => {
+      const indexed = dirs.filter(d => !isDiscovered(d));
+      const discovered = dirs.filter(d => isDiscovered(d));
+      const indexedSorted = (provider === 'user') ? sortUserDirs(indexed) : indexed;
+      return [cat, indexedSorted, discovered];
+    });
+
+    const isEmptyVendor = !visibleCats.some(([, indexed, discovered]) => indexed.length || discovered.length);
+    if (filterActive && isEmptyVendor) continue;
 
     const totalFiles = visibleCats.reduce(
-      (sum, [, dirs]) => sum + dirs.reduce((s, d) => s + (sourcesByDir[d] || []).length, 0),
+      (sum, [, indexed]) => sum + indexed.reduce((s, d) => s + (sourcesByDir[d] || []).length, 0),
       0,
     );
-    const isSingleLeaf = visibleCats.length === 1;
+    const totalDiscovered = visibleCats.reduce((sum, [, , discovered]) => sum + discovered.length, 0);
+    const visibleIndexedCats = visibleCats.filter(([, indexed]) => indexed.length);
+    const isSingleLeaf = visibleIndexedCats.length === 1 || (visibleIndexedCats.length === 0 && visibleCats.length === 1);
 
     const group = document.createElement('details');
     group.className = 'source-vendor-group';
-    if (!PROVIDER_COLLAPSED.has(provider) || filterActive) group.open = true;
+    if (isEmptyVendor) group.classList.add('source-vendor-empty');
+    if ((!PROVIDER_COLLAPSED.has(provider) || filterActive) && !isEmptyVendor) group.open = true;
     group.dataset.provider = provider;
 
     const summary = document.createElement('summary');
     summary.className = 'source-vendor-summary';
-    const labelKey = isSingleLeaf
+    const labelKey = isSingleLeaf && visibleCats.length
       ? (CATEGORY_LABEL_KEY[visibleCats[0][0]] || PROVIDER_LABEL_KEY[provider] || provider)
       : (PROVIDER_LABEL_KEY[provider] || provider);
     const label = document.createElement('span');
@@ -2456,14 +2337,64 @@ function _renderMemorySourceTree(sources, list) {
 
     group.appendChild(summary);
 
-    if (isSingleLeaf) {
-      for (const dir of visibleCats[0][1]) {
-        group.appendChild(_renderMemoryDirGroup(dir, sourcesByDir[dir] || [], statusByPath[dir], maxChunks));
-      }
+    const renderDir = (dir) => _renderMemoryDirGroup(
+      dir,
+      sourcesByDir[dir] || [],
+      statusByPath[dir],
+      maxChunks,
+      { isDefault: dir === defaultDir },
+    );
+
+    const renderDiscoveredBlock = (dirs) => {
+      if (!dirs.length) return null;
+      const det = document.createElement('details');
+      det.className = 'source-vendor-discovered';
+      const sum = document.createElement('summary');
+      sum.className = 'source-vendor-discovered-summary';
+      const lbl = document.createElement('span');
+      lbl.className = 'source-vendor-discovered-label';
+      lbl.textContent = (typeof t === 'function') ? t('sources.discovered_label') : 'Discovered';
+      sum.appendChild(lbl);
+      const cnt = document.createElement('span');
+      cnt.className = 'source-vendor-count';
+      cnt.textContent = String(dirs.length);
+      sum.appendChild(cnt);
+      det.appendChild(sum);
+      for (const d of dirs) det.appendChild(renderDir(d));
+      return det;
+    };
+
+    if (isEmptyVendor) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'source-vendor-placeholder';
+      const msg = document.createElement('span');
+      msg.className = 'source-vendor-placeholder-msg';
+      const vendorName = (typeof t === 'function') ? t(PROVIDER_LABEL_KEY[provider] || provider) : provider;
+      msg.textContent = (typeof t === 'function')
+        ? t('sources.empty_vendor_placeholder', { vendor: vendorName })
+        : `${vendorName} memory not found`;
+      placeholder.appendChild(msg);
+      const cta = document.createElement('button');
+      cta.type = 'button';
+      cta.className = 'btn-ghost btn-xs source-vendor-add-cta';
+      cta.textContent = (typeof t === 'function') ? t('sources.add_manually_btn') : '+ Add manually';
+      cta.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        const addBtn = qs('memory-add-path-btn');
+        if (addBtn) addBtn.click();
+      });
+      placeholder.appendChild(cta);
+      group.appendChild(placeholder);
+    } else if (isSingleLeaf) {
+      const sole = visibleIndexedCats[0] || visibleCats[0];
+      for (const dir of sole[1]) group.appendChild(renderDir(dir));
+      const disc = renderDiscoveredBlock(sole[2]);
+      if (disc) group.appendChild(disc);
     } else {
       const products = document.createElement('div');
       products.className = 'source-vendor-products';
-      for (const [cat, dirs] of visibleCats) {
+      for (const [cat, indexed, discovered] of visibleCats) {
+        if (!indexed.length && !discovered.length) continue;
         const section = document.createElement('section');
         section.className = 'source-vendor-product';
         section.dataset.category = cat;
@@ -2476,12 +2407,12 @@ function _renderMemorySourceTree(sources, list) {
         productHeader.appendChild(pLabel);
         const pCount = document.createElement('span');
         pCount.className = 'source-vendor-count';
-        pCount.textContent = String(dirs.reduce((sum, d) => sum + (sourcesByDir[d] || []).length, 0));
+        pCount.textContent = String(indexed.reduce((sum, d) => sum + (sourcesByDir[d] || []).length, 0));
         productHeader.appendChild(pCount);
         section.appendChild(productHeader);
-        for (const dir of dirs) {
-          section.appendChild(_renderMemoryDirGroup(dir, sourcesByDir[dir] || [], statusByPath[dir], maxChunks));
-        }
+        for (const dir of indexed) section.appendChild(renderDir(dir));
+        const disc = renderDiscoveredBlock(discovered);
+        if (disc) section.appendChild(disc);
         products.appendChild(section);
       }
       group.appendChild(products);
@@ -2489,6 +2420,7 @@ function _renderMemorySourceTree(sources, list) {
 
     list.appendChild(group);
     renderedFiles += totalFiles;
+    void totalDiscovered;
   }
 
   if (!allDirs.size) {
@@ -2498,56 +2430,60 @@ function _renderMemorySourceTree(sources, list) {
   }
 }
 
-function _renderMemoryDirGroup(dir, items, status, maxChunks) {
-  const group = document.createElement('div');
+function _renderMemoryDirGroup(dir, items, status, maxChunks, opts) {
+  const { isDefault } = opts || {};
+  // ``<details>`` gives us a native chevron + auto-flip on toggle and
+  // matches the vendor group's disclosure shape one level up — keeping a
+  // single mental model for collapse state across the whole tree.
+  const group = document.createElement('details');
   group.className = 'source-group source-group-memory';
   if (status && status.exists === false) group.classList.add('source-group-missing');
+  group.open = true;
+  group.dataset.dir = dir;
 
-  const header = document.createElement('div');
+  const header = document.createElement('summary');
   header.className = 'source-group-header';
   header.title = dir;
-  header.setAttribute('aria-expanded', 'true');
-
-  const chevron = document.createElement('span');
-  chevron.className = 'source-group-chevron';
-  chevron.textContent = '▼';
-  header.appendChild(chevron);
 
   const dirLabel = document.createElement('span');
   dirLabel.className = 'source-group-dir';
-  // Full path goes on the row's ``title`` (set above) so hover still
-  // reveals it; the visible label is collapsed to ``…/parent/leaf`` so
-  // the stats badge + actions stay on screen at the default 340px
-  // sidebar width.
   dirLabel.textContent = (typeof shortDir === 'function') ? shortDir(dir) : dir;
   header.appendChild(dirLabel);
 
-  // Memory mode skips the per-group ``count`` badge that General mode
-  // uses — the stats badge below already carries indexed/files/chunks,
-  // so a separate count would be duplicate noise (and would mismatch
-  // when the sources response is missing rows the status response has).
+  if (isDefault) {
+    const pill = document.createElement('span');
+    pill.className = 'source-group-default-pill';
+    pill.textContent = (typeof t === 'function') ? t('sources.default_pill') : 'default';
+    header.appendChild(pill);
+  }
+
+  // 3-state status:
+  //   - missing  → exists === false (red, "missing")
+  //   - pending  → file_count > 0 && chunk_count === 0 (amber, ready to index)
+  //   - indexed  → otherwise (no color)
   if (status) {
     const statsBadge = document.createElement('span');
     statsBadge.className = 'source-group-stats';
-    if ((status.chunk_count || 0) === 0) statsBadge.classList.add('empty');
-    if (status.exists === false) statsBadge.classList.add('missing');
+    const files = (typeof status.file_count === 'number') ? status.file_count : 0;
+    const indexed = status.source_file_count || 0;
+    const chunks = status.chunk_count || 0;
     if (status.exists === false) {
+      statsBadge.classList.add('missing');
       statsBadge.textContent = (typeof t === 'function')
         ? t('sources.memory_dirs.status_missing') : 'missing';
     } else {
-      const files = (typeof status.file_count === 'number') ? status.file_count : 0;
-      const indexed = status.source_file_count || 0;
-      const chunks = status.chunk_count || 0;
+      if (chunks === 0 && files > 0) statsBadge.classList.add('pending');
       statsBadge.textContent = (typeof t === 'function')
         ? t('sources.memory_dirs.status_group', { files, indexed, chunks })
-        : `${indexed}/${files} files · ${chunks} chunks`;
+        : (indexed + '/' + files + ' files, ' + chunks + ' chunks');
     }
     header.appendChild(statsBadge);
   }
 
   // Hover-revealed actions: open the dir in the OS file manager,
-  // reindex its files, or remove it from memory_dirs config. Each
-  // stops propagation so it doesn't toggle the parent collapse.
+  // index/reindex its files, or remove it from memory_dirs config.
+  // ``preventDefault`` keeps the click from toggling the parent
+  // ``<details>`` (default behavior on summary clicks).
   const actions = document.createElement('div');
   actions.className = 'source-group-actions';
   const tFallback = (key, fb) => (typeof t === 'function' ? t(key) : fb);
@@ -2560,6 +2496,7 @@ function _renderMemoryDirGroup(dir, items, status, maxChunks) {
   if (status && status.exists === false) openBtn.disabled = true;
   openBtn.addEventListener('click', (ev) => {
     ev.stopPropagation();
+    ev.preventDefault();
     if (typeof mdOpenOne === 'function') mdOpenOne(dir, openBtn);
   });
   actions.appendChild(openBtn);
@@ -2575,6 +2512,7 @@ function _renderMemoryDirGroup(dir, items, status, maxChunks) {
   reindexBtn.title = tFallback('sources.memory_dirs.reindex_title', 'Reindex this directory');
   reindexBtn.addEventListener('click', (ev) => {
     ev.stopPropagation();
+    ev.preventDefault();
     if (typeof mdReindexOne === 'function') mdReindexOne(dir, reindexBtn);
   });
   actions.appendChild(reindexBtn);
@@ -2587,20 +2525,12 @@ function _renderMemoryDirGroup(dir, items, status, maxChunks) {
   if ((STATE.memoryDirs || []).length <= 1) removeBtn.disabled = true;
   removeBtn.addEventListener('click', (ev) => {
     ev.stopPropagation();
+    ev.preventDefault();
     if (typeof mdRemove === 'function') mdRemove(dir);
   });
   actions.appendChild(removeBtn);
 
   header.appendChild(actions);
-
-  header.addEventListener('click', (ev) => {
-    // Action buttons / inner spans bubble here too — guard by
-    // checking the closest ``.source-group-actions`` instead of the
-    // literal target.
-    if (ev.target.closest('.source-group-actions')) return;
-    group.classList.toggle('collapsed');
-    header.setAttribute('aria-expanded', !group.classList.contains('collapsed'));
-  });
   group.appendChild(header);
 
   for (const s of items) {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -409,21 +409,14 @@
       <span class="tab-help-bar-text" data-i18n="sources.help">Indexed source files. Click a file to browse chunks. Drag the divider to resize. Sort by name, chunks, size, or recency.</span>
       <button class="tab-help-bar-dismiss" data-help-tab="sources">✕</button>
     </div>
-    <div class="sources-mode-toggle" role="tablist" aria-label="Sources view">
-      <button id="sources-mode-memory" class="btn-ghost btn-active" role="tab" aria-selected="true" aria-controls="sources-view" data-mode="memory" data-i18n="sources.mode.memory">Memory</button>
-      <button id="sources-mode-general" class="btn-ghost" role="tab" aria-selected="false" aria-controls="sources-view" data-mode="general" data-i18n="sources.mode.general">General sources</button>
-    </div>
-    <div id="sources-view" class="sources-view" role="tabpanel" aria-labelledby="sources-mode-memory">
+    <div id="sources-view" class="sources-view" role="region" aria-labelledby="tabbtn-sources">
       <div class="sources-layout">
         <div class="sources-sidebar">
           <div class="sources-header">
-            <h2 data-i18n="sources.title">Sources</h2>
-            <div id="sources-actions-memory" class="sources-actions">
+            <h2 id="sources-heading" data-i18n="sources.title">Sources</h2>
+            <div class="sources-actions">
               <button id="memory-add-path-btn" class="btn-ghost btn-sm" data-i18n="sources.memory_dirs.add_btn">+ Add path</button>
               <button id="memory-reindex-all-btn" class="btn-ghost btn-sm" data-i18n="sources.memory_dirs.reindex_all">Reindex all</button>
-            </div>
-            <div id="sources-actions-general" class="sources-actions" hidden>
-              <button id="refresh-sources-btn" class="btn-ghost" data-i18n="sources.refresh">Refresh</button>
             </div>
           </div>
           <div id="memory-add-row" class="memory-dirs-add" hidden>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -132,7 +132,6 @@
 
   "sources.help": "Indexed source files. Click a file to browse chunks. Drag the divider to resize. Sort by name, chunks, size, or recency.",
   "sources.title": "Sources",
-  "sources.refresh": "Refresh",
   "sources.filter_placeholder": "Type to filter by path… e.g. .md, src/, utils",
   "sources.filter_title": "Filters source list by partial path match",
   "sources.sort_name": "Name",
@@ -141,10 +140,10 @@
   "sources.sort_recent": "Recent",
   "sources.empty_icon": "📄",
   "sources.empty_text": "Select a source to browse its chunks",
-  "sources.mode.memory": "Memory",
-  "sources.mode.general": "General sources",
-  "sources.toast.added_to_other_view": "{path} added to {view}",
-  "sources.toast.switch_view": "Switch",
+  "sources.discovered_label": "Discovered",
+  "sources.empty_vendor_placeholder": "{vendor} memory not found",
+  "sources.add_manually_btn": "+ Add manually",
+  "sources.default_pill": "default",
 
   "index.help": "Index files into memtomem. Type a path to scan, drop files to upload, or write a memory directly. Toggle Force re-index to rebuild existing chunks.",
   "index.title": "Index Files",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -132,7 +132,6 @@
 
   "sources.help": "인덱싱된 소스 파일. 파일을 클릭하여 청크를 탐색. 구분선을 드래그하여 크기 조절. 이름, 청크, 크기, 최근순으로 정렬.",
   "sources.title": "소스",
-  "sources.refresh": "새로고침",
   "sources.filter_placeholder": "경로로 필터… 예: .md, src/, utils",
   "sources.filter_title": "부분 경로 매칭으로 소스 목록 필터",
   "sources.sort_name": "이름",
@@ -141,10 +140,10 @@
   "sources.sort_recent": "최근",
   "sources.empty_icon": "📄",
   "sources.empty_text": "소스를 선택하면 청크를 탐색할 수 있습니다",
-  "sources.mode.memory": "Memory",
-  "sources.mode.general": "일반 소스",
-  "sources.toast.added_to_other_view": "{path} 가 {view} 에 추가됨",
-  "sources.toast.switch_view": "이동",
+  "sources.discovered_label": "발견됨",
+  "sources.empty_vendor_placeholder": "{vendor} 메모리 없음",
+  "sources.add_manually_btn": "+ 수동 추가",
+  "sources.default_pill": "기본",
 
   "index.help": "memtomem 에 파일을 인덱싱합니다. 경로를 입력해 스캔하거나, 파일을 드롭해 업로드하거나, 직접 기억을 작성하세요. 강제 재인덱스로 기존 청크를 다시 생성할 수 있습니다.",
   "index.title": "파일 인덱싱",

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -128,29 +128,10 @@ function _buildMemoryDirsPanel(initialDirs) {
       if (resp && Array.isArray(resp.memory_dirs)) {
         refreshDirs(resp.memory_dirs);
       }
-      // ``kind`` arrives on every successful /memory-dirs/add response
-      // (PR #554). When it falls into the *other* sub-toggle, surface a
-      // one-tap "Switch view" so the user isn't left wondering why the
-      // path they just added isn't visible in the current panel.
-      const addedKind = resp && resp.kind;
-      const currentMode = (typeof getSourcesMode === 'function') ? getSourcesMode() : 'memory';
-      if (addedKind && addedKind !== currentMode) {
-        const otherLabel = t('sources.mode.' + addedKind);
-        showToast(
-          t('sources.toast.added_to_other_view', { path: trimmed, view: otherLabel }),
-          'success',
-          {
-            action: {
-              label: t('sources.toast.switch_view'),
-              onClick: () => {
-                if (typeof setSourcesMode === 'function') setSourcesMode(addedKind);
-              },
-            },
-          },
-        );
-      } else {
-        showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
-      }
+      // PR #554 returns ``kind`` for every add; with the unified single
+      // Sources panel the path always lands in the same view (its vendor
+      // group), so the historic "switch view" toast is no longer needed.
+      showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
     } catch (err) {
       showToast(t('toast.memory_dir.add_failed', { error: _apiErrorText(err) }), 'error');
     }
@@ -163,12 +144,13 @@ function _buildMemoryDirsPanel(initialDirs) {
     if (_memorySourcesByDir !== null) return _memorySourcesByDir;
     if (_memorySourcesPromise) return _memorySourcesPromise;
     _memorySourcesPromise = (async () => {
-      // ``limit=10000`` matches the route's hard cap. The Memory bucket
-      // tops out at one row per indexed file across registered memory
-      // dirs — well under the cap in practice (max observed ≈ a few
-      // hundred). Hitting the cap would be a pathological config and
-      // the user would see truncated drill-ins, not a crash.
-      const data = await api('GET', '/api/sources?kind=memory&limit=10000');
+      // ``limit=10000`` matches the route's hard cap. With the unified
+      // single-panel view we ask for every indexed source (no kind
+      // filter) so user-added dirs that classify as ``general`` still
+      // surface their file rows in their vendor group. Hitting the cap
+      // would be a pathological config and the user would see truncated
+      // drill-ins, not a crash.
+      const data = await api('GET', '/api/sources?limit=10000');
       const byDir = {};
       for (const s of (data && data.sources) || []) {
         const key = s.memory_dir || '';
@@ -282,13 +264,8 @@ function _buildMemoryDirsPanel(initialDirs) {
       li.appendChild(name);
       li.appendChild(meta);
       const activate = () => {
-        // Reuses the General view's chunks browser by switching modes
-        // and selecting the source there. Keeps a single chunks-browser
-        // DOM (no duplicate render path) and gives the user a clear
-        // visual transition into the file detail.
-        if (typeof setSourcesMode === 'function') {
-          setSourcesMode('general');
-        }
+        // Single Sources panel: just open the source in the shared
+        // chunks-browser pane.
         if (typeof browseSource === 'function') {
           browseSource(s.path);
         }
@@ -984,7 +961,7 @@ function renderMemoryDirsPanel() {
     container.appendChild(_buildMemoryDirsPanel(dirs));
     return;
   }
-  if (typeof loadSources === 'function') loadSources('memory');
+  if (typeof loadSources === 'function') loadSources();
 }
 
 // ── Module-level memory-dir actions ───────────────────────────────
@@ -1012,26 +989,8 @@ async function mdAdd(path) {
       }
       STATE.memoryDirs = [...resp.memory_dirs];
     }
-    const addedKind = resp && resp.kind;
-    const currentMode = (typeof getSourcesMode === 'function') ? getSourcesMode() : 'memory';
-    if (addedKind && addedKind !== currentMode) {
-      const otherLabel = t('sources.mode.' + addedKind);
-      showToast(
-        t('sources.toast.added_to_other_view', { path: trimmed, view: otherLabel }),
-        'success',
-        {
-          action: {
-            label: t('sources.toast.switch_view'),
-            onClick: () => {
-              if (typeof setSourcesMode === 'function') setSourcesMode(addedKind);
-            },
-          },
-        },
-      );
-    } else {
-      showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
-    }
-    if (typeof loadSources === 'function') loadSources(currentMode);
+    showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
+    if (typeof loadSources === 'function') loadSources();
   } catch (err) {
     showToast(t('toast.memory_dir.add_failed', { error: _mdApiErrorText(err) }), 'error');
   }
@@ -1072,7 +1031,7 @@ async function mdRemove(path) {
       showToast(t('toast.memory_dir.removed', { path }), 'success');
     }
     if (typeof hideBrowser === 'function') hideBrowser();
-    if (typeof loadSources === 'function') loadSources('memory');
+    if (typeof loadSources === 'function') loadSources();
     if (typeof loadStats === 'function') loadStats();
   } catch (err) {
     showToast(t('toast.memory_dir.remove_failed', { error: _mdApiErrorText(err) }), 'error');
@@ -1111,7 +1070,7 @@ async function mdReindexOne(path, btn) {
     showToast(t('toast.memory_dir.reindex_failed', { error: _mdApiErrorText(err) }), 'error');
   } finally {
     if (btn) btnLoading(btn, false);
-    if (typeof loadSources === 'function') loadSources('memory');
+    if (typeof loadSources === 'function') loadSources();
   }
 }
 
@@ -1134,6 +1093,6 @@ async function mdReindexAll(btn) {
     showToast(t('toast.reindex_failed', { error: _mdApiErrorText(err) }), 'error');
   } finally {
     if (btn) btnLoading(btn, false);
-    if (typeof loadSources === 'function') loadSources('memory');
+    if (typeof loadSources === 'function') loadSources();
   }
 }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -494,7 +494,7 @@ mark {
 /* ── Sources Tab ── */
 #tab-sources { overflow: hidden; }
 .sources-layout { display: flex; height: 100%; }
-.sources-layout .sources-sidebar { width: var(--sources-width, 340px); flex-shrink: 0; }
+.sources-layout .sources-sidebar { width: var(--sources-width, 420px); flex-shrink: 0; }
 .sources-sidebar { border-right: none; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
 .sources-divider {
   width: 4px; cursor: col-resize; background: var(--border);
@@ -516,17 +516,25 @@ mark {
 .sources-ns-chip-clear:hover { color: var(--text); }
 
 /* ── Source tree view (D) ── */
+/* ``.source-group-memory`` is a ``<details>`` element. The summary
+   carries the dir label, status badge, and hover-revealed actions; the
+   native disclosure marker is replaced by a ``::before`` triangle
+   matching the vendor group's style for a consistent flip animation. */
 .source-group { margin-bottom: 10px; }
 .source-group-header {
   display: flex; align-items: center; gap: 6px;
   padding: 4px 8px; margin-bottom: 3px;
   cursor: pointer; user-select: none;
+  list-style: none;
 }
-.source-group-chevron {
-  font-size: 0.6rem; color: var(--muted); transition: transform 0.15s; flex-shrink: 0;
+.source-group-header::-webkit-details-marker { display: none; }
+.source-group-header::before {
+  content: '▸';
+  font-size: 0.62rem; color: var(--muted); width: 10px;
+  transition: transform 0.12s ease;
+  flex-shrink: 0;
 }
-.source-group.collapsed .source-group-chevron { transform: rotate(-90deg); }
-.source-group.collapsed .source-item { display: none; }
+.source-group-memory[open] > .source-group-header::before { transform: rotate(90deg); }
 .source-group-dir { font-family: var(--mono); font-size: 0.7rem; color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
 .source-group-count { font-size: 0.68rem; color: var(--muted); background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1px 6px; flex-shrink: 0; margin-left: 6px; }
 
@@ -586,7 +594,7 @@ mark {
 .sources-sort-btn.active { color: var(--accent); border-color: var(--accent); background: rgba(var(--accent-rgb),0.08); }
 
 /* Chunks browser */
-.chunks-browser { overflow-y: auto; padding: 16px; }
+.chunks-browser { flex: 1; min-width: 0; overflow-y: auto; padding: 16px; }
 .chunks-browser-header { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
 .chunk-card {
   background: var(--surface); border: 1px solid var(--border);
@@ -1258,8 +1266,49 @@ button:active { opacity: 0.7; }
   margin-left: auto; flex-shrink: 0; white-space: nowrap;
   padding: 0 4px;
 }
-.source-group-stats.empty { color: #b91c1c; }
+/* 3-state status (kind label not exposed; color carries the meaning):
+   - default (no class)   indexed, chunks > 0
+   - .pending             file_count > 0 && chunk_count === 0 (ready to index)
+   - .missing             status.exists === false (path resolved but not on disk) */
+.source-group-stats.pending { color: #d97706; }
 .source-group-stats.missing { color: #b91c1c; font-style: italic; }
+/* Default-memory pill: visual cue for the first entry in
+   ``memory_dirs`` config (the conventional primary memory dir). */
+.source-group-default-pill {
+  font-size: 0.62rem; font-weight: 600; letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px; border-radius: 999px;
+  background: rgba(var(--accent-rgb, 59, 130, 246), 0.12);
+  color: var(--accent, #3b82f6);
+  border: 1px solid rgba(var(--accent-rgb, 59, 130, 246), 0.25);
+  margin-left: 4px;
+}
+/* Discovered sub-section: auto-detected memory dirs we haven't indexed
+   yet. Rendered muted + collapsed under their vendor group so they read
+   as "candidates", not the primary content. */
+.source-vendor-discovered {
+  margin-top: 6px;
+  padding: 4px 6px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  opacity: 0.85;
+}
+.source-vendor-discovered-summary {
+  display: flex; align-items: center; gap: 6px;
+  cursor: pointer; user-select: none;
+  font-size: 0.74rem; color: var(--muted);
+  padding: 2px 4px;
+}
+.source-vendor-discovered-label { font-weight: 500; }
+/* Empty vendor: keep the slot visible but quiet so the user knows the
+   track exists without it taking up screen space. */
+.source-vendor-empty > summary { opacity: 0.6; }
+.source-vendor-placeholder {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 12px;
+  font-size: 0.78rem; color: var(--muted);
+}
+.source-vendor-add-cta { font-size: 0.7rem; }
 .source-group-missing > .source-group-header .source-group-dir {
   text-decoration: line-through; color: var(--muted);
 }


### PR DESCRIPTION
## Summary

PR #566 unified the Memory/General sub-toggle layout but kept the toggle itself, leaving two classification axes (mode + vendor) that produced several confusing states. This PR collapses them into a single vendor (사용자 / Claude / Codex) axis.

**Issues fixed (image-13 reference state):**

- A user-added memory_dir whose backend `kind` resolved to `general` (e.g. `…/memtomem-docs/memtomem/planning`) showed its `파일 18/18 · 청크 251` aggregate but **zero file rows** in Memory mode, because `loadSources('memory')` fetched `/api/sources?kind=memory` and general-classified files were filtered out.
- The top stats bar summed `STATE.allSources` (mode-filtered) while per-dir badges summed `/api/memory-dirs/status` (kind-agnostic), so the two figures disagreed.
- Auto-discovered Claude project memory dirs that hadn't been indexed yet rendered as red `파일 0/N · 청크 0` — the same red as a `missing` (path-removed) dir, conflating "ready to index" with "broken state".

## What changed

- `loadSources()` takes no args; fetches `/api/sources?limit=10000` (no kind filter)
- `renderSourceTree` always uses the vendor-grouped renderer; legacy General-flat path removed
- Top stats sum `source_file_count` across status entries (indexed-only, matches the left half of each per-dir badge)
- memory_dir cards are now `<details>` elements (chevron auto-flips, matches vendor group disclosure shape)
- 3-state badge replaces the single `empty` red flag:
  - `indexed` (no color), `pending` (amber, `file_count > 0 && chunk_count === 0`), `missing` (red, `exists === false`)
- New **Discovered** sub-section per vendor — pending dirs collapse into `<details class=\"source-vendor-discovered\">` so indexed cards stay primary and pending ones read as "candidates"
- **Default-memory pill** — first entry in `memory_dirs` config gets a small accent chip and pins to the top of the user vendor group
- **Empty vendor placeholder** — vendors with 0 configured dirs render as a closed `<details>` with a `{vendor} memory not found · [+ Add manually]` CTA that opens the +Add path form
- Sidebar default width 340 → 420px; drag width persists to `localStorage` (`memtomem.sources_width`)
- `.chunks-browser` gets explicit `flex: 1; min-width: 0` so the right pane grows predictably

i18n: removed `sources.mode.memory`, `sources.mode.general`, `sources.refresh`, `sources.toast.added_to_other_view`, `sources.toast.switch_view`. Added `sources.discovered_label`, `sources.empty_vendor_placeholder`, `sources.add_manually_btn`, `sources.default_pill`.

## Out of scope (follow-ups)

- `vendors.json` data-driven vendor config (so new vendors need zero code)
- Add-time intent flag ("Memory" vs "RAG" at +Add time) to override path-pattern classification
- Backend `kind=read-only` semantics (currently no kind emits this; Discovered keys off pending state)

## Test plan

- [x] `uv run ruff check src/` + `ruff format --check src/` clean
- [x] Full pytest pass (`uv run pytest -m \"not ollama\"`, 3236 passed)
- [x] i18n parity test green (`tests/test_i18n.py`)
- [x] Visual smoke (mode 1, real config + DB):
  - Single panel, no Memory/General toggle
  - 사용자 vendor: `memories/` "기본" pill at top, `planning` shows its 18 file rows
  - Claude vendor: indexed dirs first, then collapsed Discovered (26) sub-section
  - Top stats `40 files · 417 chunks` matches per-dir indexed sums
  - Pending badges amber, missing badges red, indexed badges no color
  - `<details>` chevron auto-flips on toggle
- [x] No console errors; network shows `/api/sources?limit=10000` (no kind filter)
- [ ] CI green
- [ ] PR self-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)