### PR TITLE
feat(web): /memory-dirs/add — opt-in auto_index for 1-step register + index

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -391,10 +391,22 @@ async def add_memory_dir(
     request: Request,
     storage=Depends(get_storage),
     search_pipeline=Depends(get_search_pipeline),
+    index_engine=Depends(get_index_engine),
 ):
-    """Add a directory to memory_dirs watch list."""
+    """Add a directory to memory_dirs watch list, optionally indexing immediately.
+
+    Body:
+        path (str, required): Absolute or ``~``-relative path.
+        auto_index (bool, default False): Index the dir immediately after
+            registration. Defaults off for backward compatibility — Web UI
+            opts in via ``auto_index=true`` so a single "+ Add path" click
+            covers register + index + watcher activation. CLI / API users
+            keep the historic two-step (register, then ``/api/index``) by
+            omitting the field.
+    """
     body = await request.json()
     dir_path = body.get("path", "").strip()
+    auto_index = bool(body.get("auto_index", False))
     if not dir_path:
         raise HTTPException(status_code=400, detail="path is required")
 
@@ -412,32 +424,53 @@ async def add_memory_dir(
                 config = request.app.state.config
 
                 current = [Path(p).expanduser().resolve() for p in config.indexing.memory_dirs]
-                # ``kind`` of the just-added dir lets the Web UI's
-                # Sources page show a "Switch view" toast when the user
-                # adds a path that lands in the opposite sub-toggle (e.g.
-                # they're on General sources and add ``~/memories``).
+                # ``kind`` is preserved on the response for downstream
+                # consumers (CLI scripts, settings UI). The Web UI's
+                # historic "Switch view" toast was retired in PR #568 when
+                # the Memory/General sub-toggle disappeared, but the
+                # field stays for API stability.
                 kind = memory_dir_kind(resolved)
-                if norm_path(resolved) in {norm_path(p) for p in current}:
-                    return {
-                        "ok": True,
-                        "message": "Already in memory_dirs",
-                        "memory_dirs": [str(p) for p in current],
-                        "kind": kind,
-                    }
+                already_present = norm_path(resolved) in {norm_path(p) for p in current}
 
-                config.indexing.memory_dirs.append(resolved)
-                save_config_overrides(config)
-                _hot_reload.commit_writer_signature(request.app)
-                return {
-                    "ok": True,
-                    "message": f"Added {resolved}",
-                    "memory_dirs": [
-                        str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs
-                    ],
-                    "kind": kind,
-                }
+                if not already_present:
+                    config.indexing.memory_dirs.append(resolved)
+                    save_config_overrides(config)
+                    _hot_reload.commit_writer_signature(request.app)
+
+                memory_dirs_snapshot = [
+                    str(Path(p).expanduser().resolve()) for p in config.indexing.memory_dirs
+                ]
+                message = "Already in memory_dirs" if already_present else f"Added {resolved}"
     except TimeoutError:
         raise HTTPException(503, "memory-dirs/add timed out — another update may be in progress")
+
+    # Index outside the config lock so a slow scan doesn't block other
+    # config writers (the watcher invariant — path inside ``memory_dirs``
+    # — is already satisfied by the register block above, so
+    # ``index_path`` will pass its own validation).
+    indexed: dict[str, object] | None = None
+    if auto_index:
+        try:
+            stats = await index_engine.index_path(resolved, recursive=True, force=False)
+            indexed = {
+                "total_files": stats.total_files,
+                "total_chunks": stats.total_chunks,
+                "indexed_chunks": stats.indexed_chunks,
+                "skipped_chunks": stats.skipped_chunks,
+                "deleted_chunks": stats.deleted_chunks,
+                "duration_ms": stats.duration_ms,
+                "errors": list(stats.errors) if stats.errors else [],
+            }
+        except Exception as err:  # pragma: no cover — surface partial result
+            indexed = {"error": str(err)}
+
+    return {
+        "ok": True,
+        "message": message,
+        "memory_dirs": memory_dirs_snapshot,
+        "kind": kind,
+        "indexed": indexed,
+    }
 
 
 @router.post("/memory-dirs/remove")

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -617,6 +617,7 @@
   "confirm.memory_dir_remove_msg": "Remove {path} from memory_dirs? The directory and its files on disk are not touched.",
   "confirm.memory_dir_delete_chunks_label": "Also delete {count} indexed chunks from this directory",
   "toast.memory_dir.added": "Added {path}",
+  "toast.memory_dir.added_indexed": "Added {path} · {chunks} chunks from {files} files",
   "toast.memory_dir.removed": "Removed {path}",
   "toast.memory_dir.removed_with_chunks": "Removed {path} and {count} chunks",
   "toast.memory_dir.opened": "Opened {path}",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -617,6 +617,7 @@
   "confirm.memory_dir_remove_msg": "{path} 를 memory_dirs 에서 제거할까요? 디스크의 디렉터리와 파일은 그대로 유지됩니다.",
   "confirm.memory_dir_delete_chunks_label": "이 디렉터리에서 인덱싱된 청크 {count} 개도 함께 삭제",
   "toast.memory_dir.added": "{path} 추가됨",
+  "toast.memory_dir.added_indexed": "{path} 추가 · 파일 {files}개에서 청크 {chunks}개 인덱싱",
   "toast.memory_dir.removed": "{path} 제거됨",
   "toast.memory_dir.removed_with_chunks": "{path} 및 청크 {count} 개 삭제됨",
   "toast.memory_dir.opened": "{path} 열기 시도",

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -124,14 +124,30 @@ function _buildMemoryDirsPanel(initialDirs) {
     const trimmed = path.trim();
     if (!trimmed) return;
     try {
-      const resp = await api('POST', '/api/memory-dirs/add', { path: trimmed });
+      // ``auto_index=true`` collapses the historic two-step (register →
+      // manually click Index) into a single click. The server registers,
+      // then runs ``index_path`` outside the config lock so the request
+      // can stream back chunk stats without blocking other config writes.
+      const resp = await api('POST', '/api/memory-dirs/add', {
+        path: trimmed,
+        auto_index: true,
+      });
       if (resp && Array.isArray(resp.memory_dirs)) {
         refreshDirs(resp.memory_dirs);
       }
-      // PR #554 returns ``kind`` for every add; with the unified single
-      // Sources panel the path always lands in the same view (its vendor
-      // group), so the historic "switch view" toast is no longer needed.
-      showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
+      const stats = resp && resp.indexed;
+      if (stats && typeof stats.indexed_chunks === 'number') {
+        showToast(
+          t('toast.memory_dir.added_indexed', {
+            path: trimmed,
+            chunks: stats.indexed_chunks,
+            files: stats.total_files,
+          }),
+          'success',
+        );
+      } else {
+        showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
+      }
     } catch (err) {
       showToast(t('toast.memory_dir.add_failed', { error: _apiErrorText(err) }), 'error');
     }
@@ -982,14 +998,30 @@ async function mdAdd(path) {
   const trimmed = (path || '').trim();
   if (!trimmed) return;
   try {
-    const resp = await api('POST', '/api/memory-dirs/add', { path: trimmed });
+    // ``auto_index=true`` — see ``handleAdd`` above for rationale.
+    const resp = await api('POST', '/api/memory-dirs/add', {
+      path: trimmed,
+      auto_index: true,
+    });
     if (resp && Array.isArray(resp.memory_dirs)) {
       if (STATE.serverConfig?.indexing) {
         STATE.serverConfig.indexing.memory_dirs = [...resp.memory_dirs];
       }
       STATE.memoryDirs = [...resp.memory_dirs];
     }
-    showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
+    const stats = resp && resp.indexed;
+    if (stats && typeof stats.indexed_chunks === 'number') {
+      showToast(
+        t('toast.memory_dir.added_indexed', {
+          path: trimmed,
+          chunks: stats.indexed_chunks,
+          files: stats.total_files,
+        }),
+        'success',
+      );
+    } else {
+      showToast(t('toast.memory_dir.added', { path: trimmed }), 'success');
+    }
     if (typeof loadSources === 'function') loadSources();
   } catch (err) {
     showToast(t('toast.memory_dir.add_failed', { error: _mdApiErrorText(err) }), 'error');

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1079,6 +1079,59 @@ class TestUnicodePaths:
         assert body["kind"] == "memory"
         assert body["message"].startswith("Added ")
 
+    async def test_add_memory_dir_auto_index_triggers_index_path(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """``auto_index=true`` collapses register + index into one call.
+        After a successful add, ``index_path`` runs on the registered dir
+        and the response carries the ``indexed`` stats block. The watcher
+        invariant (path inside ``memory_dirs``) is satisfied because the
+        register block ran first inside the same handler."""
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        app.state.config.indexing.memory_dirs = []
+        # The shared fixture mocks ``index_path`` to return the stub stats
+        # block; reset the call list so we can assert on it.
+        app.state.index_engine.index_path.reset_mock()
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(memory_dir), "auto_index": True},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["message"].startswith("Added ")
+        assert body["indexed"] is not None
+        assert body["indexed"]["indexed_chunks"] == 2
+        assert body["indexed"]["total_files"] == 1
+        # ``index_path`` was called with the resolved path of the dir we
+        # just added — watcher invariant naturally satisfied.
+        called_args, _ = app.state.index_engine.index_path.call_args
+        assert Path(str(called_args[0])).resolve() == memory_dir.resolve()
+
+    async def test_add_memory_dir_default_skips_index(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Backward compatibility: omitting ``auto_index`` keeps the
+        historic register-only behavior. ``indexed`` is null and
+        ``index_path`` is not called. CLI scripts and direct API users
+        that relied on the two-step flow keep working."""
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        app.state.config.indexing.memory_dirs = []
+        app.state.index_engine.index_path.reset_mock()
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(memory_dir)},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["indexed"] is None
+        assert app.state.index_engine.index_path.call_count == 0
+
     async def test_remove_memory_dir_matches_nfd_and_nfc(self, app, client: AsyncClient, tmp_path):
         # Config has the target dir in NFD form plus a second entry (the
         # route refuses to remove the last remaining memory_dir). The user

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1110,9 +1110,7 @@ class TestUnicodePaths:
         called_args, _ = app.state.index_engine.index_path.call_args
         assert Path(str(called_args[0])).resolve() == memory_dir.resolve()
 
-    async def test_add_memory_dir_default_skips_index(
-        self, app, client: AsyncClient, tmp_path
-    ):
+    async def test_add_memory_dir_default_skips_index(self, app, client: AsyncClient, tmp_path):
         """Backward compatibility: omitting ``auto_index`` keeps the
         historic register-only behavior. ``indexed`` is null and
         ``index_path`` is not called. CLI scripts and direct API users


### PR DESCRIPTION
## Summary

Closes part of #569. Sources panel's "+ 경로 추가" registered the path but didn't index it, leaving the user with a hidden 2-step flow (register → manually click [Index]). This PR adds an opt-in `auto_index` parameter to `/api/memory-dirs/add` that collapses both into a single call. Web UI always opts in; CLI/direct-API callers keep the historic 2-step until a future default flip.

## Behavior

| Caller | `auto_index` | Result |
|---|---|---|
| Web UI (`+ 경로 추가`) | `true` (always) | Register + index in one call; toast shows chunk stats |
| CLI / direct API (omit) | `false` (default) | Register only — backward compatible |
| Direct API explicit `auto_index=true` | `true` | Same as Web UI |

The watcher invariant (`/api/index` requires path to be inside `memory_dirs`) is satisfied automatically because the register block runs *before* `index_path()` inside the same handler.

## Why outside the config lock

Indexing runs after `_config_lock` releases — a slow scan on a large dir would otherwise block all other config writers for the lock's 60s timeout. The lock window stays narrow (config write only); indexing has no shared mutable state with other config writes once the path is registered.

## Failure mode

If `index_path()` raises, the response carries `indexed: {"error": "..."}` instead of bubbling a 500. Registration is never lost — the user can retry indexing via the card's [Index] button.

## Default rollout

PR1 (this): `auto_index` parameter added, default `false`. Web UI sends `true` unconditionally. Direct-API callers see no behavior change.

PR2 (1-2 weeks): flip default to `true` after CHANGELOG window.

## Files

- `packages/memtomem/src/memtomem/web/routes/system.py` — handler + `index_engine` dep, response schema
- `packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js` — `handleAdd` + `mdAdd` send `auto_index: true`, toast adapts to `indexed` block
- `packages/memtomem/src/memtomem/web/static/locales/{en,ko}.json` — `toast.memory_dir.added_indexed`
- `packages/memtomem/tests/test_web_routes.py` — 2 new tests covering both branches

## Test plan

- [x] `uv run ruff check src/` + `ruff format --check src/` clean
- [x] Full pytest pass (3250 passed)
- [x] 2 new tests assert: `auto_index=true` invokes `index_path` once, `auto_index` omitted does not
- [x] Backward compat: existing `test_add_memory_dir_returns_kind` etc. still pass without modification
- [ ] Visual: Sources tab `+ 경로 추가` triggers register + index in single click; toast shows `Added {path} · {chunks} chunks from {files} files`
- [ ] CI green
- [ ] PR self-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)