### PR TITLE
feat(web): Sources vendor sub-tabs — single active vendor at a time (#570)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2236,12 +2236,29 @@ function renderSourceTree(sources) {
   // whose ``file_count`` reflects disk-only files. Per-dir badges also
   // surface the ``indexed/files`` split, so this number lines up with
   // the left side of those badges.
+  //
+  // Scope: the sub-tab strip (issue #570) only renders one vendor's
+  // tree at a time, so the stats line is scoped to that vendor too \u2014
+  // a global "47 files \u00b7 442 chunks" sitting above a User-only sidebar
+  // read as ambiguous (was that User's 20 or all three combined?).
+  // The active-vendor scoping makes the number always match what the
+  // user is currently looking at; global totals can be inferred by
+  // summing the three sub-tab badges.
   const statsEl = qs('sources-stats');
   const statusByPath = STATE.memoryStatusByPath || {};
+  const activeVendor = STATE.sourcesActiveVendor
+    || (typeof _readActiveSourcesVendor === 'function' ? _readActiveSourcesVendor() : 'user');
   let indexedFiles = 0;
   let totalChunks = 0;
   for (const s of Object.values(statusByPath)) {
     if (!s || s.exists === false) continue;
+    // Same fallback rule as ``_renderMemorySourceTree``: unknown
+    // providers (forward-compat for a server that adds a vendor before
+    // the client deploys) bucket into ``user``.
+    const rawProvider = s.provider;
+    const provider = (_SOURCES_VENDORS && _SOURCES_VENDORS.includes(rawProvider))
+      ? rawProvider : 'user';
+    if (provider !== activeVendor) continue;
     indexedFiles += s.source_file_count || 0;
     totalChunks += s.chunk_count || 0;
   }

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -27,6 +27,12 @@ const STATE = {
   allSources: [],
   sourcesSortBy: 'name',
   sourcesNsFilter: '',
+  // Active Sources vendor sub-tab (one of ``user`` / ``claude`` /
+  // ``openai``). Lazily populated from localStorage on first render so
+  // the value survives reloads. Keeping it on STATE means re-renders
+  // (filter typing, sort change) read the active vendor without
+  // hitting localStorage on the hot path.
+  sourcesActiveVendor: null,
   dedupScanActive: false,
   dedupAbortCtrl: null,
   lastTagsData: [],
@@ -2124,6 +2130,76 @@ document.querySelectorAll('.sources-sort-btn').forEach(btn => {
   }
 })();
 
+// ── Sources vendor sub-tabs ──
+// Issue #570: only one vendor's tree renders at a time. The tab strip
+// (``#sources-vendor-tabs``) drives ``STATE.sourcesActiveVendor`` which
+// scopes ``_renderMemorySourceTree`` to a single vendor.
+const _SOURCES_VENDORS = ['user', 'claude', 'openai'];
+const _SOURCES_VENDOR_LS = 'memtomem.sources.active_vendor';
+const _SOURCES_VENDOR_DEFAULT = 'user';
+
+function _readActiveSourcesVendor() {
+  try {
+    const v = localStorage.getItem(_SOURCES_VENDOR_LS);
+    if (v && _SOURCES_VENDORS.includes(v)) return v;
+  } catch (_err) { /* localStorage may be unavailable in private modes */ }
+  return _SOURCES_VENDOR_DEFAULT;
+}
+
+function _writeActiveSourcesVendor(vendor) {
+  try { localStorage.setItem(_SOURCES_VENDOR_LS, vendor); }
+  catch (_err) { /* best-effort persistence */ }
+}
+
+// Update tab DOM (active class, aria-selected, roving tabindex) without
+// re-rendering the tree. Called from ``_renderMemorySourceTree`` on the
+// first lazy resolve and from ``_setActiveSourcesVendor`` on user click /
+// arrow nav.
+function _syncSourcesVendorTabs(activeVendor) {
+  document.querySelectorAll('.sources-vendor-tab').forEach(btn => {
+    const isActive = btn.dataset.vendor === activeVendor;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.tabIndex = isActive ? 0 : -1;
+  });
+}
+
+function _setActiveSourcesVendor(vendor) {
+  if (!_SOURCES_VENDORS.includes(vendor)) return;
+  if (STATE.sourcesActiveVendor === vendor) return;
+  STATE.sourcesActiveVendor = vendor;
+  _writeActiveSourcesVendor(vendor);
+  _syncSourcesVendorTabs(vendor);
+  // ``_getFilteredSorted`` already covers the filter + sort axes; the
+  // active vendor is read from STATE inside the render itself.
+  if (typeof renderSourceTree === 'function') renderSourceTree(_getFilteredSorted());
+}
+
+(function _wireSourcesVendorTabs() {
+  const tabs = document.getElementById('sources-vendor-tabs');
+  if (!tabs) return;
+  tabs.addEventListener('click', (ev) => {
+    const btn = ev.target.closest('.sources-vendor-tab');
+    if (!btn || !btn.dataset.vendor) return;
+    _setActiveSourcesVendor(btn.dataset.vendor);
+    btn.focus();
+  });
+  // Auto-activation arrow nav — same model as the main tablist
+  // (``focus + activate``) so a keyboard user toggles vendors by
+  // walking the strip without an extra Enter press.
+  tabs.addEventListener('keydown', (e) => {
+    if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(e.key)) return;
+    const buttons = Array.from(tabs.querySelectorAll('.sources-vendor-tab'));
+    const currentIdx = buttons.indexOf(document.activeElement);
+    const nextIdx = _arrowNavIndex(buttons.length, currentIdx === -1 ? 0 : currentIdx, e.key);
+    if (nextIdx < 0) return;
+    e.preventDefault();
+    const next = buttons[nextIdx];
+    next.focus();
+    if (next.dataset.vendor) _setActiveSourcesVendor(next.dataset.vendor);
+  });
+})();
+
 async function loadSources() {
   // Single-panel Sources: vendor grouping (사용자 / Claude / Codex) is the
   // only classification axis. We pull every memory_dir's status and every
@@ -2279,10 +2355,15 @@ function _renderMemorySourceTree(sources, list) {
     return out;
   };
 
-  // Build a vendor card whether or not it has any dirs — empty vendors
-  // collapse with a "not found · Add manually" placeholder so users know
-  // the slot exists without it taking up screen space.
-  let renderedFiles = 0;
+  // Pass 1: compute per-vendor stats. The sidebar only renders the
+  // active vendor's content (issue #570) but every vendor's count
+  // populates its sub-tab badge so the user can see at a glance which
+  // vendors hold matches before clicking. ``PROVIDER_COLLAPSED`` no
+  // longer drives an outer ``<details>`` collapse — the sub-tab strip
+  // *is* the disclosure now — but the constant stays imported in case
+  // a future view (e.g. an "all vendors" mode) wants it.
+  void PROVIDER_COLLAPSED;
+  const vendorPlans = {};
   for (const provider of PROVIDER_ORDER) {
     const bucket = byProvider[provider];
 
@@ -2293,8 +2374,8 @@ function _renderMemorySourceTree(sources, list) {
           .filter(([, dirs]) => dirs.length > 0)
       : categoriesAll.map(cat => [cat, bucket.byCategory[cat]]);
 
-    // Partition each category's dirs into indexed (default first for user
-    // provider) and discovered (kind=read-only, rendered as a collapsed
+    // Partition each category's dirs into indexed (default first for
+    // user provider) and discovered (read-only, rendered as a collapsed
     // sub-section).
     const visibleCats = visibleCatsRaw.map(([cat, dirs]) => {
       const indexed = dirs.filter(d => !isDiscovered(d));
@@ -2304,128 +2385,139 @@ function _renderMemorySourceTree(sources, list) {
     });
 
     const isEmptyVendor = !visibleCats.some(([, indexed, discovered]) => indexed.length || discovered.length);
-    if (filterActive && isEmptyVendor) continue;
-
     const totalFiles = visibleCats.reduce(
       (sum, [, indexed]) => sum + indexed.reduce((s, d) => s + (sourcesByDir[d] || []).length, 0),
       0,
     );
-    const totalDiscovered = visibleCats.reduce((sum, [, , discovered]) => sum + discovered.length, 0);
     const visibleIndexedCats = visibleCats.filter(([, indexed]) => indexed.length);
-    const isSingleLeaf = visibleIndexedCats.length === 1 || (visibleIndexedCats.length === 0 && visibleCats.length === 1);
+    const isSingleLeaf = visibleIndexedCats.length === 1
+      || (visibleIndexedCats.length === 0 && visibleCats.length === 1);
+    vendorPlans[provider] = { visibleCats, visibleIndexedCats, isEmptyVendor, totalFiles, isSingleLeaf };
 
-    const group = document.createElement('details');
-    group.className = 'source-vendor-group';
-    if (isEmptyVendor) group.classList.add('source-vendor-empty');
-    if ((!PROVIDER_COLLAPSED.has(provider) || filterActive) && !isEmptyVendor) group.open = true;
-    group.dataset.provider = provider;
-
-    const summary = document.createElement('summary');
-    summary.className = 'source-vendor-summary';
-    const labelKey = isSingleLeaf && visibleCats.length
-      ? (CATEGORY_LABEL_KEY[visibleCats[0][0]] || PROVIDER_LABEL_KEY[provider] || provider)
-      : (PROVIDER_LABEL_KEY[provider] || provider);
-    const label = document.createElement('span');
-    label.className = 'source-vendor-label';
-    label.textContent = (typeof t === 'function') ? t(labelKey) : labelKey;
-    summary.appendChild(label);
-
-    const count = document.createElement('span');
-    count.className = 'source-vendor-count';
-    count.textContent = String(totalFiles);
-    summary.appendChild(count);
-
-    group.appendChild(summary);
-
-    const renderDir = (dir) => _renderMemoryDirGroup(
-      dir,
-      sourcesByDir[dir] || [],
-      statusByPath[dir],
-      maxChunks,
-      { isDefault: dir === defaultDir },
-    );
-
-    const renderDiscoveredBlock = (dirs) => {
-      if (!dirs.length) return null;
-      const det = document.createElement('details');
-      det.className = 'source-vendor-discovered';
-      const sum = document.createElement('summary');
-      sum.className = 'source-vendor-discovered-summary';
-      const lbl = document.createElement('span');
-      lbl.className = 'source-vendor-discovered-label';
-      lbl.textContent = (typeof t === 'function') ? t('sources.discovered_label') : 'Discovered';
-      sum.appendChild(lbl);
-      const cnt = document.createElement('span');
-      cnt.className = 'source-vendor-count';
-      cnt.textContent = String(dirs.length);
-      sum.appendChild(cnt);
-      det.appendChild(sum);
-      for (const d of dirs) det.appendChild(renderDir(d));
-      return det;
-    };
-
-    if (isEmptyVendor) {
-      const placeholder = document.createElement('div');
-      placeholder.className = 'source-vendor-placeholder';
-      const msg = document.createElement('span');
-      msg.className = 'source-vendor-placeholder-msg';
-      const vendorName = (typeof t === 'function') ? t(PROVIDER_LABEL_KEY[provider] || provider) : provider;
-      msg.textContent = (typeof t === 'function')
-        ? t('sources.empty_vendor_placeholder', { vendor: vendorName })
-        : `${vendorName} memory not found`;
-      placeholder.appendChild(msg);
-      const cta = document.createElement('button');
-      cta.type = 'button';
-      cta.className = 'btn-ghost btn-xs source-vendor-add-cta';
-      cta.textContent = (typeof t === 'function') ? t('sources.add_manually_btn') : '+ Add manually';
-      cta.addEventListener('click', (ev) => {
-        ev.stopPropagation();
-        const addBtn = qs('memory-add-path-btn');
-        if (addBtn) addBtn.click();
-      });
-      placeholder.appendChild(cta);
-      group.appendChild(placeholder);
-    } else if (isSingleLeaf) {
-      const sole = visibleIndexedCats[0] || visibleCats[0];
-      for (const dir of sole[1]) group.appendChild(renderDir(dir));
-      const disc = renderDiscoveredBlock(sole[2]);
-      if (disc) group.appendChild(disc);
-    } else {
-      const products = document.createElement('div');
-      products.className = 'source-vendor-products';
-      for (const [cat, indexed, discovered] of visibleCats) {
-        if (!indexed.length && !discovered.length) continue;
-        const section = document.createElement('section');
-        section.className = 'source-vendor-product';
-        section.dataset.category = cat;
-        const productHeader = document.createElement('div');
-        productHeader.className = 'source-vendor-product-header';
-        const pLabel = document.createElement('span');
-        pLabel.className = 'source-vendor-product-label';
-        const pKey = CATEGORY_LABEL_KEY[cat] || cat;
-        pLabel.textContent = (typeof t === 'function') ? t(pKey) : pKey;
-        productHeader.appendChild(pLabel);
-        const pCount = document.createElement('span');
-        pCount.className = 'source-vendor-count';
-        pCount.textContent = String(indexed.reduce((sum, d) => sum + (sourcesByDir[d] || []).length, 0));
-        productHeader.appendChild(pCount);
-        section.appendChild(productHeader);
-        for (const dir of indexed) section.appendChild(renderDir(dir));
-        const disc = renderDiscoveredBlock(discovered);
-        if (disc) section.appendChild(disc);
-        products.appendChild(section);
-      }
-      group.appendChild(products);
+    // Update the sub-tab badge + empty class so all three vendor tabs
+    // reflect current state, not just the active one.
+    const countEl = document.querySelector(`[data-vendor-count="${provider}"]`);
+    if (countEl) {
+      countEl.textContent = String(totalFiles);
+      // Hide a "0" badge so the tab label stays uncluttered when the
+      // vendor has no indexed files. The ``sources-vendor-tab-empty``
+      // class still signals empty-via-color, so we don't lose the cue.
+      countEl.hidden = totalFiles === 0;
     }
-
-    list.appendChild(group);
-    renderedFiles += totalFiles;
-    void totalDiscovered;
+    const tabBtn = document.querySelector(`.sources-vendor-tab[data-vendor="${provider}"]`);
+    if (tabBtn) tabBtn.classList.toggle('sources-vendor-tab-empty', isEmptyVendor);
   }
 
+  // Resolve the active vendor. First render after page load reads
+  // localStorage; subsequent renders read STATE so filter/sort/reindex
+  // re-renders don't re-hit storage on the hot path.
+  let activeVendor = STATE.sourcesActiveVendor;
+  if (!activeVendor || !PROVIDER_ORDER.includes(activeVendor)) {
+    activeVendor = _readActiveSourcesVendor();
+    STATE.sourcesActiveVendor = activeVendor;
+    _syncSourcesVendorTabs(activeVendor);
+  }
+
+  // Helpers shared by the active-vendor render branches. Lifted out of
+  // the per-vendor loop because they don't close over the iteration.
+  const renderDir = (dir) => _renderMemoryDirGroup(
+    dir,
+    sourcesByDir[dir] || [],
+    statusByPath[dir],
+    maxChunks,
+    { isDefault: dir === defaultDir },
+  );
+
+  const renderDiscoveredBlock = (dirs) => {
+    if (!dirs.length) return null;
+    const det = document.createElement('details');
+    det.className = 'source-vendor-discovered';
+    const sum = document.createElement('summary');
+    sum.className = 'source-vendor-discovered-summary';
+    const lbl = document.createElement('span');
+    lbl.className = 'source-vendor-discovered-label';
+    lbl.textContent = (typeof t === 'function') ? t('sources.discovered_label') : 'Discovered';
+    sum.appendChild(lbl);
+    const cnt = document.createElement('span');
+    cnt.className = 'source-vendor-count';
+    cnt.textContent = String(dirs.length);
+    sum.appendChild(cnt);
+    det.appendChild(sum);
+    for (const d of dirs) det.appendChild(renderDir(d));
+    return det;
+  };
+
+  // Pass 2: render only the active vendor's content directly into the
+  // sidebar list — the sub-tab strip carries the vendor disclosure, so
+  // no per-vendor ``<details>`` wrapper is needed.
+  list.innerHTML = '';
+  const plan = vendorPlans[activeVendor];
+
+  if (plan.isEmptyVendor) {
+    const placeholder = document.createElement('div');
+    placeholder.className = 'source-vendor-placeholder';
+    const msg = document.createElement('span');
+    msg.className = 'source-vendor-placeholder-msg';
+    const vendorName = (typeof t === 'function')
+      ? t(PROVIDER_LABEL_KEY[activeVendor] || activeVendor)
+      : activeVendor;
+    msg.textContent = (typeof t === 'function')
+      ? t('sources.empty_vendor_placeholder', { vendor: vendorName })
+      : `${vendorName} memory not found`;
+    placeholder.appendChild(msg);
+    const cta = document.createElement('button');
+    cta.type = 'button';
+    cta.className = 'btn-ghost btn-xs source-vendor-add-cta';
+    cta.textContent = (typeof t === 'function') ? t('sources.add_manually_btn') : '+ Add manually';
+    cta.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const addBtn = qs('memory-add-path-btn');
+      if (addBtn) addBtn.click();
+    });
+    placeholder.appendChild(cta);
+    list.appendChild(placeholder);
+  } else if (plan.isSingleLeaf) {
+    const sole = plan.visibleIndexedCats[0] || plan.visibleCats[0];
+    for (const dir of sole[1]) list.appendChild(renderDir(dir));
+    const disc = renderDiscoveredBlock(sole[2]);
+    if (disc) list.appendChild(disc);
+  } else {
+    const products = document.createElement('div');
+    products.className = 'source-vendor-products';
+    for (const [cat, indexed, discovered] of plan.visibleCats) {
+      if (!indexed.length && !discovered.length) continue;
+      const section = document.createElement('section');
+      section.className = 'source-vendor-product';
+      section.dataset.category = cat;
+      const productHeader = document.createElement('div');
+      productHeader.className = 'source-vendor-product-header';
+      const pLabel = document.createElement('span');
+      pLabel.className = 'source-vendor-product-label';
+      const pKey = CATEGORY_LABEL_KEY[cat] || cat;
+      pLabel.textContent = (typeof t === 'function') ? t(pKey) : pKey;
+      productHeader.appendChild(pLabel);
+      const pCount = document.createElement('span');
+      pCount.className = 'source-vendor-count';
+      pCount.textContent = String(indexed.reduce((sum, d) => sum + (sourcesByDir[d] || []).length, 0));
+      productHeader.appendChild(pCount);
+      section.appendChild(productHeader);
+      for (const dir of indexed) section.appendChild(renderDir(dir));
+      const disc = renderDiscoveredBlock(discovered);
+      if (disc) section.appendChild(disc);
+      products.appendChild(section);
+    }
+    list.appendChild(products);
+  }
+
+  // Empty-state fallbacks scoped to the active vendor. If no memory
+  // dirs exist anywhere, show the "Add one with + Add path" hint
+  // regardless of which tab is active. If a filter is active and the
+  // active vendor has no matches but other vendors do, the muted "no
+  // matches" hint sits inside the panel — the populated badge on
+  // sibling tabs tells the user where to look.
   if (!allDirs.size) {
     list.innerHTML = '<div class="empty-state">' + emptyState('📁', 'No memory directories', 'Add one with the + Add path button') + '</div>';
-  } else if (!renderedFiles && filterActive) {
+  } else if (filterActive && !plan.totalFiles && !plan.isEmptyVendor) {
     list.innerHTML = '<div class="empty-state">' + emptyState('🔍', 'No matches for that filter') + '</div>';
   }
 }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -424,6 +424,20 @@
             <button id="memory-add-submit" class="btn-primary btn-sm" data-i18n="sources.memory_dirs.add_submit">Add</button>
             <button id="memory-add-cancel" class="btn-ghost btn-sm" data-i18n="sources.memory_dirs.add_cancel">Cancel</button>
           </div>
+          <div id="sources-vendor-tabs" class="sources-vendor-tabs" role="tablist" aria-label="Sources vendor">
+            <button type="button" class="sources-vendor-tab active" role="tab" data-vendor="user" aria-selected="true" tabindex="0">
+              <span class="sources-vendor-tab-label" data-i18n="sources.memory_dirs.provider.user">User</span>
+              <span class="sources-vendor-tab-count" data-vendor-count="user" hidden>0</span>
+            </button>
+            <button type="button" class="sources-vendor-tab" role="tab" data-vendor="claude" aria-selected="false" tabindex="-1">
+              <span class="sources-vendor-tab-label" data-i18n="sources.memory_dirs.provider.claude">Claude</span>
+              <span class="sources-vendor-tab-count" data-vendor-count="claude" hidden>0</span>
+            </button>
+            <button type="button" class="sources-vendor-tab" role="tab" data-vendor="openai" aria-selected="false" tabindex="-1">
+              <span class="sources-vendor-tab-label" data-i18n="sources.memory_dirs.provider.openai">OpenAI</span>
+              <span class="sources-vendor-tab-count" data-vendor-count="openai" hidden>0</span>
+            </button>
+          </div>
           <div class="sources-filter-row">
             <input id="sources-filter" type="text" data-i18n-placeholder="sources.filter_placeholder" placeholder="Type to filter by path… e.g. .md, src/, utils" autocomplete="off" data-i18n-title="sources.filter_title" title="Filters source list by partial path match" />
             <span id="sources-ns-chip" hidden></span>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -1196,20 +1196,42 @@ button:active { opacity: 0.7; }
 .memory-dirs-sort:hover { color: var(--text); border-color: var(--accent); }
 .memory-dirs-sort:focus { outline: none; border-color: var(--accent); }
 
-/* Sources sub-toggle: Memory ↔ General. Mirrors ``.tags-view-toggle``
-   visually (same .btn-ghost.btn-active reset already styles the active
-   state) but lives at the panel top so it reads as a primary view
-   selector rather than a secondary filter. */
-.sources-mode-toggle {
-  display: flex;
-  gap: 4px;
-  padding: 8px 12px;
+/* Sources vendor sub-tabs: User / Claude / OpenAI selector that scopes
+   the sidebar tree to one vendor at a time. Mirrors ``.tab-nav`` /
+   ``.tab-btn`` visually (underline-on-active) but tighter for the
+   sidebar slot. Empty vendors keep their tab visible so the user knows
+   the slot exists — rendered with reduced opacity so they read as
+   "available but quiet". */
+.sources-vendor-tabs {
+  display: flex; gap: 2px;
   border-bottom: 1px solid var(--border);
+  padding: 0 4px;
   flex-shrink: 0;
 }
-.sources-mode-toggle .btn-ghost {
-  font-size: 0.82rem;
-  padding: 4px 12px;
+.sources-vendor-tab {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted);
+  padding: 8px 10px; font-size: 0.82rem;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.sources-vendor-tab:hover { color: var(--text); }
+.sources-vendor-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.sources-vendor-tab:focus-visible { outline-offset: -2px; }
+.sources-vendor-tab.sources-vendor-tab-empty { opacity: 0.55; }
+.sources-vendor-tab.sources-vendor-tab-empty.active { opacity: 0.85; }
+.sources-vendor-tab-count {
+  font-size: 0.68rem; color: var(--muted); font-family: var(--mono);
+  padding: 1px 6px; border-radius: 10px;
+  background: var(--bg); border: 1px solid var(--border);
+}
+.sources-vendor-tab.active .sources-vendor-tab-count {
+  color: var(--accent);
+  border-color: rgba(var(--accent-rgb, 59, 130, 246), 0.35);
 }
 .sources-view { display: flex; flex-direction: column; flex: 1; min-height: 0; height: 100%; overflow: hidden; }
 


### PR DESCRIPTION
## Summary

Closes #570. Moves vendor selection (User / Claude / OpenAI) into a sub-tab strip at the top of the Sources sidebar so only one vendor's tree renders at a time. The other two vendors keep their tab visible with file-count badges, but their content stays gated behind a single click — which calms the sidebar (no more 20+ User dirs and 27 Claude dirs competing for the same screen) and tightens the sort/filter scope to the active vendor.

- Static ``#sources-vendor-tabs`` (``role="tablist"``) with three buttons; auto-activate ArrowLeft/Right/Home/End nav reuses the main tablist's ``_arrowNavIndex`` helper.
- ``STATE.sourcesActiveVendor`` lazily resolves from ``localStorage["memtomem.sources.active_vendor"]`` on first render, then stays in STATE for the hot path.
- ``_renderMemorySourceTree`` runs in two passes: pass 1 populates all three sub-tab badges (count + ``sources-vendor-tab-empty`` class); pass 2 renders only the active vendor's content directly into ``#sources-list``, dropping the per-vendor ``<details class="source-vendor-group">`` wrapper since the tab itself is the disclosure.

## What stays the same

- Per-product sort dropdown keys (``{provider}:{category}``) and their localStorage prefs.
- ``_renderMemoryDirGroup`` (per-dir card) is untouched.
- Discovered sub-section behavior (collapsed under each product) is preserved within the active vendor.
- Empty-vendor placeholder + "+ Add manually" CTA from PR #568, just scoped to one vendor.

## Test plan

Manual smoke against the real config + DB (``mm web --port 8088``):

- [x] 3 tabs render with correct counts (User: 20, Claude: 27, OpenAI: 0).
- [x] Click each tab → tree re-renders; ``aria-selected`` and roving ``tabindex`` follow.
- [x] Reload restores the last active vendor from localStorage.
- [x] ArrowLeft/Right/Home/End cycle the active tab with focus following.
- [x] Filter "memtomem" updates badges (User: 18, Claude: 8, OpenAI: 0) and toggles ``sources-vendor-tab-empty`` on OpenAI.
- [x] Multi-leaf Claude tab renders product headers ("Claude 프로젝트", "Claude plans") with per-product counts and discovered sub-section.
- [x] Single-leaf User and OpenAI render dir cards directly without an extra disclosure level.
- [x] No console errors; ruff check + format clean; 292 web/i18n Python tests pass.

Refs: #570; follow-up to PR #568.