### PR TITLE
feat(web): KO label on language toggle for KO/EN symmetry

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/i18n.js
+++ b/packages/memtomem/src/memtomem/web/static/i18n.js
@@ -63,7 +63,7 @@ const I18N = (() => {
     applyDOM();
     // Update the toggle button label
     const btn = document.getElementById('lang-toggle');
-    if (btn) btn.textContent = lang === 'ko' ? 'EN' : '한';
+    if (btn) btn.textContent = lang === 'ko' ? 'EN' : 'KO';
   }
 
   /** Initialise: detect language, load locale, apply. */
@@ -76,7 +76,7 @@ const I18N = (() => {
     applyDOM();
     const btn = document.getElementById('lang-toggle');
     if (btn) {
-      btn.textContent = lang === 'ko' ? 'EN' : '한';
+      btn.textContent = lang === 'ko' ? 'EN' : 'KO';
       btn.addEventListener('click', () => {
         setLang(_lang === 'ko' ? 'en' : 'ko');
         // Notify app.js that language changed

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -20,7 +20,7 @@
     </div>
     <div class="header-actions">
       <button id="settings-btn" class="btn-ghost btn-icon" data-i18n-title="header.settings_title" title="Settings">⚙️</button>
-      <button id="lang-toggle" class="btn-ghost btn-icon" title="Switch language">한</button>
+      <button id="lang-toggle" class="btn-ghost btn-icon" title="Switch language">KO</button>
       <button id="theme-toggle" class="btn-ghost btn-icon" data-i18n-title="header.theme_title" title="Toggle theme">🌙</button>
       <button id="help-toggle" data-i18n-title="header.help_title" title="Toggle help hints (h)" aria-pressed="true">?</button>
     </div>


### PR DESCRIPTION
## Summary
- Replace `한` ↔ `EN` header toggle with `KO` ↔ `EN` so both states use symmetric 2-char ISO codes
- Touches `index.html` (default label) and `i18n.js` (label updates in `init` and `setLang`)

## Why
The previous label used the target language's native script (`한` to switch into Korean), a common multilingual-site convention. Both sides as 2-char ISO codes trades that affordance for visual alignment with the other header icons (⚙️/🌙/?). The `title="Switch language"` tooltip still labels the action.

## Test plan
- [ ] Open `mm web` in English mode → header shows `KO`
- [ ] Click → UI switches to Korean, label flips to `EN`
- [ ] Click again → switches back to English, label flips to `KO`
- [ ] Reload preserves selected locale (localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)