### PR TITLE
feat(web): /memory-dirs/add — flip auto_index default to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`POST /api/memory-dirs/add` indexes the registered directory by
+  default now.** PR #571 introduced opt-in `auto_index` (default
+  `False`) for backward compatibility; the Web UI sent
+  `auto_index=true` while CLI/direct-API callers kept the two-step
+  (register, then `/api/index`). This release flips the default to
+  `True` so omitting the field also indexes — register + index in
+  one call for the common case. Callers that want register-only must
+  now send `auto_index=false` explicitly (JSON `null` is also
+  treated as opt-out, distinct from field omission). Response shape
+  is unchanged, but callers that omit `auto_index` will now receive
+  an `indexed` object (or `indexed: {"error": ...}` on failure)
+  where they previously received `indexed: null` — schema-strict
+  clients should expect a populated value. Watcher invariant and
+  lock boundary are unchanged; indexing failures still surface as
+  `indexed: {"error": ...}` instead of bubbling a 500
+  (registration is preserved).
+
 - **`showConfirm` modal** gained an optional `extraOption: { id, label,
   defaultChecked }` parameter that renders an opt-in checkbox below
   the message. Callers that pass extras receive `{ ok, extras }`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   default now.** PR #571 introduced opt-in `auto_index` (default
   `False`) for backward compatibility; the Web UI sent
   `auto_index=true` while CLI/direct-API callers kept the two-step
-  (register, then `/api/index`). This release flips the default to
+  (register, then `/api/index`). PR #576 flips the default to
   `True` so omitting the field also indexes — register + index in
   one call for the common case. Callers that want register-only must
   now send `auto_index=false` explicitly (JSON `null` is also
@@ -149,10 +149,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   is unchanged, but callers that omit `auto_index` will now receive
   an `indexed` object (or `indexed: {"error": ...}` on failure)
   where they previously received `indexed: null` — schema-strict
-  clients should expect a populated value. Watcher invariant and
-  lock boundary are unchanged; indexing failures still surface as
-  `indexed: {"error": ...}` instead of bubbling a 500
-  (registration is preserved).
+  clients should expect a populated value. **Performance note:**
+  `index_path()` runs in the request/response cycle, so direct-API
+  callers indexing large directories will see longer `add` response
+  times than before; pass `auto_index=false` to keep the historic
+  register-only timings. Watcher invariant and lock boundary are
+  unchanged (indexing still runs outside `_config_lock`); indexing
+  failures still surface as `indexed: {"error": ...}` instead of
+  bubbling a 500 (registration is preserved).
 
 - **`showConfirm` modal** gained an optional `extraOption: { id, label,
   defaultChecked }` parameter that renders an opt-in checkbox below

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -397,16 +397,19 @@ async def add_memory_dir(
 
     Body:
         path (str, required): Absolute or ``~``-relative path.
-        auto_index (bool, default False): Index the dir immediately after
-            registration. Defaults off for backward compatibility — Web UI
-            opts in via ``auto_index=true`` so a single "+ Add path" click
-            covers register + index + watcher activation. CLI / API users
-            keep the historic two-step (register, then ``/api/index``) by
-            omitting the field.
+        auto_index (bool, default True): Index the dir immediately after
+            registration so a single call covers register + index +
+            watcher activation. Direct-API callers that want the historic
+            register-only behavior must pass ``auto_index=false``
+            explicitly. JSON ``null`` is treated the same as ``false``
+            (opt-out), distinct from field omission which fires the
+            default. PR1 (#571) shipped this as opt-in
+            (``default=False``); this PR flips the default after one
+            release cycle.
     """
     body = await request.json()
     dir_path = body.get("path", "").strip()
-    auto_index = bool(body.get("auto_index", False))
+    auto_index = bool(body.get("auto_index", True))
     if not dir_path:
         raise HTTPException(status_code=400, detail="path is required")
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -403,9 +403,9 @@ async def add_memory_dir(
             register-only behavior must pass ``auto_index=false``
             explicitly. JSON ``null`` is treated the same as ``false``
             (opt-out), distinct from field omission which fires the
-            default. PR1 (#571) shipped this as opt-in
-            (``default=False``); this PR flips the default after one
-            release cycle.
+            default. PR #571 shipped this as opt-in
+            (``default=False``); PR #576 flipped the default as a
+            follow-up.
     """
     body = await request.json()
     dir_path = body.get("path", "").strip()

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -198,7 +198,14 @@ async def test_memory_dirs_add_reloads_before_write(
     )
 
     second = tmp_path / "second"
-    resp = await client.post("/api/memory-dirs/add", json={"path": str(second)})
+    # ``auto_index=False`` keeps the test focused on the reload-before-write
+    # contract; the default flipped to ``True`` so an omitted flag would also
+    # exercise ``index_path`` against an unconfigured AsyncMock and obscure
+    # this test's actual assertion (external ``mmr`` edit survives).
+    resp = await client.post(
+        "/api/memory-dirs/add",
+        json={"path": str(second), "auto_index": False},
+    )
     assert resp.status_code == 200, resp.text
 
     on_disk = json.loads((home / ".memtomem" / "config.json").read_text())

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1111,11 +1111,11 @@ class TestUnicodePaths:
         assert Path(str(called_args[0])).resolve() == memory_dir.resolve()
 
     async def test_add_memory_dir_default_omitted_indexes(self, app, client: AsyncClient, tmp_path):
-        """**As of this PR, the ``auto_index`` default is ``True``** —
-        omitting the field triggers indexing. Locks the new default
-        semantics: without this test, a future regression flip back to
-        ``False`` would only fail the explicit-false test (which
-        doesn't actually exercise the omit-path default).
+        """**The ``auto_index`` default is ``True``** (flipped in
+        PR #576) — omitting the field triggers indexing. Locks the
+        new default semantics: without this test, a future regression
+        flip back to ``False`` would only fail the explicit-false
+        test (which doesn't actually exercise the omit-path default).
 
         Naming intentionally describes the *input shape* (``omitted``)
         rather than the behavior (``auto_indexes``) so the test name
@@ -1165,8 +1165,9 @@ class TestUnicodePaths:
         incidental** — locks the contract for clients that send all
         fields with ``null`` placeholders. If a future PR wants
         ``null`` to mean 'use default', that's a contract change:
-        update this test, the docstring at ``system.py:`` (the
-        ``add_memory_dir`` handler), and add a CHANGELOG entry."""
+        update this test, the ``add_memory_dir`` handler docstring in
+        ``packages/memtomem/src/memtomem/web/routes/system.py``, and
+        add a CHANGELOG entry."""
         memory_dir = tmp_path / "memories"
         memory_dir.mkdir()
         app.state.config.indexing.memory_dirs = []

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1110,11 +1110,17 @@ class TestUnicodePaths:
         called_args, _ = app.state.index_engine.index_path.call_args
         assert Path(str(called_args[0])).resolve() == memory_dir.resolve()
 
-    async def test_add_memory_dir_default_skips_index(self, app, client: AsyncClient, tmp_path):
-        """Backward compatibility: omitting ``auto_index`` keeps the
-        historic register-only behavior. ``indexed`` is null and
-        ``index_path`` is not called. CLI scripts and direct API users
-        that relied on the two-step flow keep working."""
+    async def test_add_memory_dir_default_omitted_indexes(self, app, client: AsyncClient, tmp_path):
+        """**As of this PR, the ``auto_index`` default is ``True``** —
+        omitting the field triggers indexing. Locks the new default
+        semantics: without this test, a future regression flip back to
+        ``False`` would only fail the explicit-false test (which
+        doesn't actually exercise the omit-path default).
+
+        Naming intentionally describes the *input shape* (``omitted``)
+        rather than the behavior (``auto_indexes``) so the test name
+        doesn't lie if the default ever moves again — only the
+        assertions need updating."""
         memory_dir = tmp_path / "memories"
         memory_dir.mkdir()
         app.state.config.indexing.memory_dirs = []
@@ -1124,6 +1130,52 @@ class TestUnicodePaths:
             resp = await client.post(
                 "/api/memory-dirs/add",
                 json={"path": str(memory_dir)},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["indexed"] is not None
+        assert app.state.index_engine.index_path.call_count == 1
+
+    async def test_add_memory_dir_explicit_false_skips_index(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Opt-out: explicit ``auto_index=false`` preserves
+        register-only behavior for direct-API callers that want the
+        historic two-step (register, then ``/api/index``)."""
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        app.state.config.indexing.memory_dirs = []
+        app.state.index_engine.index_path.reset_mock()
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(memory_dir), "auto_index": False},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["indexed"] is None
+        assert app.state.index_engine.index_path.call_count == 0
+
+    async def test_add_memory_dir_explicit_null_skips_index(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """JSON ``null`` is treated as opt-out (``bool(None) == False``),
+        distinct from field omission. This lock is **intentional, not
+        incidental** — locks the contract for clients that send all
+        fields with ``null`` placeholders. If a future PR wants
+        ``null`` to mean 'use default', that's a contract change:
+        update this test, the docstring at ``system.py:`` (the
+        ``add_memory_dir`` handler), and add a CHANGELOG entry."""
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        app.state.config.indexing.memory_dirs = []
+        app.state.index_engine.index_path.reset_mock()
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(memory_dir), "auto_index": None},
             )
         assert resp.status_code == 200
         body = resp.json()


### PR DESCRIPTION
## Summary

Staged PR2 follow-up to #571. Flips the `/api/memory-dirs/add`
`auto_index` default from `False` to `True` after one release cycle,
so omitting the flag now triggers indexing in addition to
registration. Web UI behavior is bit-identical (it always sent
`auto_index=true` explicitly); the change is observable only to
direct-API callers.

## Behavior

| Caller | `auto_index` | Result |
|---|---|---|
| Web UI (`+ 경로 추가`) | `true` (always — explicit) | Register + index (unchanged from PR #571) |
| Direct API — omit | (default `True`) | **Register + index now** (was register-only before) |
| Direct API — explicit `auto_index: false` | `False` | Register only (opt-out) |
| Direct API — explicit `auto_index: null` | `bool(None) == False` | Register only (opt-out — distinct from omit) |

## Migration

If you relied on the omit-default being register-only, send
`auto_index=false` explicitly to keep the historic two-step
(register, then `/api/index`).

## Why non-BREAKING

Indexing is idempotent and benign, the opt-out exists, and the new
default is what most callers want. PR #483 reserved `(BREAKING)` for
path-scope changes that broke worktree isolation — a stronger
contract change than this one.

## Files

- `packages/memtomem/src/memtomem/web/routes/system.py` — default
  flip + docstring rewrite (new default, opt-out contract,
  null-vs-omit distinction).
- `packages/memtomem/tests/test_web_routes.py` — rename existing
  test, add two new tests covering omit-default and JSON-null shapes.
  Existing `_auto_index_triggers_index_path` (explicit-true)
  unchanged.
- `packages/memtomem/tests/test_web_hot_reload.py` — **incidental
  scope**: `test_memory_dirs_add_reloads_before_write` now sends
  `auto_index: False` explicitly. The test exercises hot-reload
  semantics, not `auto_index` — without the opt-out it routes
  through the AsyncMock fixture's unconfigured `index_path` and
  produces a recursion error during JSON serialization. One-line
  fix required for the default flip to land green.
- `CHANGELOG.md` — prepend `### Changed` entry under `[Unreleased]`
  documenting contract + response-shape note.

## Test plan

- [x] `uv run ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] Full pytest pass (3252 passed, 46 deselected, 0 failed)
- [x] 3 new / renamed tests cover omit-default, explicit-false,
      explicit-null branches
- [x] Existing `test_add_memory_dir_auto_index_triggers_index_path`
      unchanged (explicit-true contract)
- [ ] Manual smoke against real `mm web` (omit / false / null curl
      matrix per plan)
- [ ] CI green
- [ ] PR self-review

Refs: #571 (PR1 of staged flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)