### PR TITLE
fix(web): require_configured gate on mutating index routes (#577)

### DIFF
--- a/packages/memtomem/src/memtomem/web/deps.py
+++ b/packages/memtomem/src/memtomem/web/deps.py
@@ -11,11 +11,12 @@ from memtomem.storage.sqlite_helpers import norm_path
 
 # Mirror of the CLI bootstrap gate at
 # ``packages/memtomem/src/memtomem/cli/_bootstrap.py`` (`_CONFIG_PATH`
-# + the ``"memtomem is not configured"`` ClickException). Keep the
-# message string and the predicate (``~/.memtomem/config.json``
-# existence) byte-identical so the CLI and Web surfaces refuse with
-# the same signal — see issue #577 for the asymmetry that motivated
-# this gate.
+# + the ``"memtomem is not configured"`` ClickException). The error
+# message string is byte-identical; the predicate
+# (``~/.memtomem/config.json`` existence) matches in shape but is
+# recomputed on every call here, while bootstrap pins the path at
+# module load (see ``require_configured`` docstring for the
+# rationale). Issue #577 motivated this gate.
 
 if TYPE_CHECKING:
     from memtomem.config import Mem2MemConfig

--- a/packages/memtomem/src/memtomem/web/deps.py
+++ b/packages/memtomem/src/memtomem/web/deps.py
@@ -9,6 +9,14 @@ from fastapi import HTTPException, Request
 
 from memtomem.storage.sqlite_helpers import norm_path
 
+# Mirror of the CLI bootstrap gate at
+# ``packages/memtomem/src/memtomem/cli/_bootstrap.py`` (`_CONFIG_PATH`
+# + the ``"memtomem is not configured"`` ClickException). Keep the
+# message string and the predicate (``~/.memtomem/config.json``
+# existence) byte-identical so the CLI and Web surfaces refuse with
+# the same signal — see issue #577 for the asymmetry that motivated
+# this gate.
+
 if TYPE_CHECKING:
     from memtomem.config import Mem2MemConfig
     from memtomem.embedding.base import EmbeddingProvider
@@ -43,6 +51,26 @@ def get_dedup_scanner(request: Request):
 
 def get_project_root(request: Request) -> Path:
     return request.app.state.project_root
+
+
+def require_configured() -> None:
+    """Refuse mutating index routes when ``mm init`` has not run.
+
+    Predicate: ``~/.memtomem/config.json`` exists. Path is recomputed
+    on every call so test fixtures that monkeypatch ``HOME`` work
+    naturally (the CLI bootstrap pins the path at module load — that's
+    fine for a single CLI invocation but unhelpful for the long-lived
+    web process and its tests).
+
+    Raises HTTP 409 with the same message the CLI prints, so a
+    direct-API caller, the Web UI's existing toast handler, and the
+    CLI all see the same signal.
+    """
+    if not (Path.home() / ".memtomem" / "config.json").exists():
+        raise HTTPException(
+            status_code=409,
+            detail="memtomem is not configured. Run 'mm init' to set up.",
+        )
 
 
 def require_indexed_source(user_path: str, indexed_sources: Iterable[Path]) -> Path:

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -835,7 +835,7 @@ async def trigger_index(
 _ALLOWED_UPLOAD_EXTS = {".md", ".txt", ".json", ".yaml", ".yml", ".toml"}
 
 
-@router.post("/upload", response_model=UploadResponse)
+@router.post("/upload", response_model=UploadResponse, dependencies=[Depends(require_configured)])
 async def upload_files(
     files: list[UploadFile] = File(...),
     index_engine=Depends(get_index_engine),
@@ -885,7 +885,7 @@ async def upload_files(
     )
 
 
-@router.post("/add", response_model=AddMemoryResponse)
+@router.post("/add", response_model=AddMemoryResponse, dependencies=[Depends(require_configured)])
 async def add_memory(
     req: AddMemoryRequest,
     index_engine=Depends(get_index_engine),

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -30,6 +30,7 @@ from memtomem.web.deps import (
     get_index_engine,
     get_search_pipeline,
     get_storage,
+    require_configured,
 )
 from memtomem.web.routes._locks import _config_lock
 from memtomem.web.schemas.config import (
@@ -386,7 +387,7 @@ async def save_config(
     return {"ok": True, "message": "Config saved to ~/.memtomem/config.json"}
 
 
-@router.post("/memory-dirs/add")
+@router.post("/memory-dirs/add", dependencies=[Depends(require_configured)])
 async def add_memory_dir(
     request: Request,
     storage=Depends(get_storage),
@@ -658,7 +659,7 @@ async def memory_dirs_status(
     return {"dirs": stats}
 
 
-@router.post("/reindex")
+@router.post("/reindex", dependencies=[Depends(require_configured)])
 async def reindex_all(
     force: bool = False,
     config=Depends(get_config),
@@ -764,7 +765,7 @@ async def get_stats(storage=Depends(get_storage)) -> StatsResponse:
     )
 
 
-@router.get("/index/stream")
+@router.get("/index/stream", dependencies=[Depends(require_configured)])
 async def index_stream(
     path: str = ".",
     recursive: bool = True,
@@ -803,7 +804,7 @@ async def index_stream(
     )
 
 
-@router.post("/index", response_model=IndexResponse)
+@router.post("/index", response_model=IndexResponse, dependencies=[Depends(require_configured)])
 async def trigger_index(
     req: IndexRequest = IndexRequest(),
     index_engine=Depends(get_index_engine),

--- a/packages/memtomem/tests/test_web_exclude_guard.py
+++ b/packages/memtomem/tests/test_web_exclude_guard.py
@@ -28,6 +28,15 @@ async def real_stack_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             monkeypatch.delenv(k, raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
 
+    # Mark the tmp HOME as ``mm init``-completed so the
+    # ``require_configured`` gate (issue #577) lets the
+    # ``/api/index/stream`` request through. This fixture simulates
+    # a real running ``mm web`` against a configured user, which is
+    # exactly what an initialized HOME looks like on disk.
+    cfg_marker = tmp_path / ".memtomem"
+    cfg_marker.mkdir(exist_ok=True)
+    (cfg_marker / "config.json").write_text("{}")
+
     cfg = Mem2MemConfig()
     cfg.embedding.provider = "none"
     cfg.storage.sqlite_path = tmp_path / "mm.db"

--- a/packages/memtomem/tests/test_web_exclude_guard.py
+++ b/packages/memtomem/tests/test_web_exclude_guard.py
@@ -29,10 +29,11 @@ async def real_stack_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("HOME", str(tmp_path))
 
     # Mark the tmp HOME as ``mm init``-completed so the
-    # ``require_configured`` gate (issue #577) lets the
-    # ``/api/index/stream`` request through. This fixture simulates
-    # a real running ``mm web`` against a configured user, which is
-    # exactly what an initialized HOME looks like on disk.
+    # ``require_configured`` gate (issue #577) lets
+    # ``/api/index/stream`` through. The marker file exists *only*
+    # to satisfy the gate's existence check; the runtime config is
+    # the ``Mem2MemConfig()`` instance built immediately below and
+    # passed to ``create_components(cfg)``.
     cfg_marker = tmp_path / ".memtomem"
     cfg_marker.mkdir(exist_ok=True)
     (cfg_marker / "config.json").write_text("{}")

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1476,10 +1476,10 @@ class TestRequireConfigured:
         from memtomem.web.deps import require_configured
 
         del app.dependency_overrides[require_configured]
+        # No teardown: ``app`` is function-scoped per pytest's default,
+        # so the next test gets a freshly-built app with the override
+        # already re-installed by the shared ``app`` fixture.
         yield
-        # Re-install for any later tests reusing ``app``; pytest's
-        # function-scoped fixture should rebuild ``app``, but be safe.
-        app.dependency_overrides[require_configured] = lambda: None
 
     async def test_memory_dirs_add_409_when_no_config(
         self,
@@ -1553,3 +1553,38 @@ class TestRequireConfigured:
                 json={"path": str(target), "auto_index": False},
             )
         assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize(
+        "method,path,kwargs",
+        [
+            ("get", "/api/index/stream", {"params": {"path": "/tmp/x"}}),
+            ("post", "/api/reindex", {}),
+            (
+                "post",
+                "/api/upload",
+                {"files": [("files", ("x.md", b"content", "text/markdown"))]},
+            ),
+            ("post", "/api/add", {"json": {"text": "hello", "source": "/tmp/x"}}),
+        ],
+        ids=["index/stream", "reindex", "upload", "add"],
+    )
+    async def test_other_gated_routes_return_409_when_no_config(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        restore_gate,
+        method,
+        path,
+        kwargs,
+    ):
+        """Per-route 409 coverage for the 4 remaining gated routes.
+        ``dependencies=[]`` is per-route, so a regression that drops
+        the dep on ``/reindex`` (say) without dropping it on
+        ``/memory-dirs/add`` would still pass the deep tests above —
+        these parametrized cases lock the perimeter."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        resp = await getattr(client, method)(path, **kwargs)
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -209,6 +209,15 @@ def app():
     application.state.config_signature = _hot_reload.current_signature()
     application.state.last_reload_error = None
 
+    # Override the ``mm init`` gate (issue #577): these tests use
+    # FakeConfig + AsyncMock components, so the real
+    # ``~/.memtomem/config.json`` predicate is irrelevant. Dedicated
+    # require_configured tests live further down and exercise the
+    # gate against a monkeypatched HOME.
+    from memtomem.web.deps import require_configured
+
+    application.dependency_overrides[require_configured] = lambda: None
+
     return application
 
 
@@ -1441,3 +1450,106 @@ class TestRemoveMemoryDirChunkCleanup:
         assert under_target_a in deleted_paths
         assert under_target_b in deleted_paths
         assert under_keep not in deleted_paths
+
+
+# ---------------------------------------------------------------------------
+# require_configured gate (issue #577)
+# ---------------------------------------------------------------------------
+
+
+class TestRequireConfigured:
+    """Mutating index routes refuse with HTTP 409 when ``mm init`` has
+    not run, mirroring the CLI bootstrap gate at
+    ``cli/_bootstrap.py``. Without this gate ``mm web`` accepts
+    ``+ 경로 추가`` clicks against a fresh HOME and returns
+    ``indexed: {total_files: 0, ...}`` silently — confusing dead-end
+    for the user (issue #577).
+
+    These tests *restore* the gate (the shared ``app`` fixture
+    overrides it to ``lambda: None`` so all the unrelated FakeConfig
+    tests don't depend on the developer's real
+    ``~/.memtomem/config.json``) and monkeypatch ``HOME`` to control
+    the predicate."""
+
+    @pytest.fixture
+    def restore_gate(self, app):
+        from memtomem.web.deps import require_configured
+
+        del app.dependency_overrides[require_configured]
+        yield
+        # Re-install for any later tests reusing ``app``; pytest's
+        # function-scoped fixture should rebuild ``app``, but be safe.
+        app.dependency_overrides[require_configured] = lambda: None
+
+    async def test_memory_dirs_add_409_when_no_config(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        restore_gate,
+    ):
+        """Fresh HOME with no ``~/.memtomem/config.json`` → 409 with
+        the same message ``mm index`` prints. ``index_path`` must
+        not be invoked (gate runs *before* indexing, so a regression
+        that moves the gate after ``index_path`` would catch the
+        artifact-only assertion but fail this one)."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        app.state.index_engine.index_path.reset_mock()
+
+        target = tmp_path / "target"
+        target.mkdir()
+        resp = await client.post(
+            "/api/memory-dirs/add",
+            json={"path": str(target)},
+        )
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")
+        assert app.state.index_engine.index_path.call_count == 0
+
+    async def test_index_409_when_no_config(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        restore_gate,
+    ):
+        """``POST /api/index`` is the second path the issue calls out
+        (the manual reindex trigger). Same gate, same message."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        app.state.index_engine.index_path.reset_mock()
+
+        target = tmp_path / "target"
+        target.mkdir()
+        resp = await client.post("/api/index", json={"path": str(target)})
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")
+        assert app.state.index_engine.index_path.call_count == 0
+
+    async def test_memory_dirs_add_passes_when_config_exists(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        restore_gate,
+    ):
+        """Same gate, configured HOME (``~/.memtomem/config.json``
+        exists) → request proceeds normally."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        cfg_dir = tmp_path / ".memtomem"
+        cfg_dir.mkdir()
+        (cfg_dir / "config.json").write_text("{}")
+
+        target = tmp_path / "target"
+        target.mkdir()
+        app.state.config.indexing.memory_dirs = []
+        app.state.index_engine.index_path.reset_mock()
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.post(
+                "/api/memory-dirs/add",
+                json={"path": str(target), "auto_index": False},
+            )
+        assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary

Closes #577. ``mm web`` started cleanly on a fresh ``HOME`` without
a prior ``mm init`` and silently returned ``indexed: {total_files:
0, ...}`` for both ``POST /api/memory-dirs/add`` and
``POST /api/index`` — confusing dead-end. The CLI side gates every
non-``init`` command at ``cli/_bootstrap.py`` with the message
``memtomem is not configured. Run 'mm init' to set up.`` This PR
adds a symmetric FastAPI dependency for the four mutating index
routes.

## Behavior

| Route | Pre-init `mm web` (before) | Pre-init `mm web` (after) | Post-init |
|---|---|---|---|
| `POST /api/memory-dirs/add` | 200 + `indexed: {0 files, 0 chunks}` (silent) | **409 + `Run 'mm init' to set up.'`** | 200 (unchanged) |
| `POST /api/index` | 200 + `total_files: 0` (silent) | **409 + same message** | 200 |
| `GET /api/index/stream` | 200 SSE + zero events | **409** | 200 |
| `POST /api/reindex` | 200 + `total_indexed: 0` | **409** | 200 |

## Routes left ungated on purpose

- Read-only diagnostics: `/api/health`, `/api/config`,
  `/api/stats`, `/api/embedding-status`,
  `/api/memory-dirs/status`. Useful pre-init for "what's wrong?"
- `/api/memory-dirs/open` (file manager) — read intent.
- `/api/memory-dirs/remove` — config mutation but no indexing
  pipeline; could plausibly be useful for cleaning up
  half-initialized state.
- `/api/embed` — already gated to localhost-only; a diagnostic.

If any of these turn out to need the gate too, that's a separate
follow-up.

## Why 409 (not 503 or 400)

409 matches the existing reload-block in `system.py:_check_reload_block`
("Config file invalid on disk: ..."). Both fire when "config is in
a state that refuses this write" — same shape, same status code.
400 would imply request malformation; 503 would imply transient
unavailability. Neither matches the "you need to run a different
command first" semantics here.

## Implementation

- `packages/memtomem/src/memtomem/web/deps.py` — `require_configured()`.
  Recomputes the path on every call so HOME-monkeypatching tests work
  naturally; CLI bootstrap pins it at module load (fine for a single
  CLI invocation, unhelpful here).
- `packages/memtomem/src/memtomem/web/routes/system.py` — adds
  `dependencies=[Depends(require_configured)]` on the 4 routes plus
  the import.

## Tests

- `test_web_routes.py` shared `app` fixture overrides the dep to a
  no-op so the existing 70+ FakeConfig tests don't depend on the
  developer's real `~/.memtomem/config.json` (CI runners would
  otherwise fail). Three new tests in a `TestRequireConfigured`
  class restore the dep, monkeypatch HOME, and verify:
  - 409 + exact message + **`index_path.call_count == 0`**
    (assert-on-processing-not-artifact: a regression that moves the
    gate after `index_path` would fail this assertion specifically)
  - `/api/index` fires the same gate with the same message
  - Once `config.json` exists at the monkeypatched HOME, the
    request proceeds with 200
- `test_web_exclude_guard.py` `real_stack_app` fixture creates a
  ``mm init``-marker (`tmp_path/.memtomem/config.json`) alongside
  the existing HOME monkeypatch — the fixture's intent is "real
  running mm web", so simulating an initialized user is the most
  authentic fix.

## Test plan

- [x] `uv run ruff check src/ tests/` + `ruff format --check src/ tests/` clean
- [x] Full pytest pass (3255 passed, 46 deselected, 0 failed —
      3252 prior + 3 new gate tests)
- [x] Manual smoke against isolated-HOME `mm web`:
  - No `config.json`: `/api/memory-dirs/add` and `/api/index`
    both return 409 with `"memtomem is not configured. Run 'mm
    init' to set up."`
  - After dropping a `config.json` marker: same call returns 200
- [ ] CI green
- [ ] PR self-review

Closes #577. Surfaced during PR #576 (auto_index default flip)
smoke testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)