### PR TITLE
style(web): mode toggle uses bottom-border (sub-tab convention) (#582)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -642,15 +642,27 @@ mark {
 .chunk-card-collapsible:has(.chunk-card-content.expanded):hover::after { opacity: 0.9; }
 
 /* ── Index Tab ── */
-/* Mode toggle mirrors ``.sources-mode-toggle`` so the sub-toggle reads as a
-   primary view selector (folder / upload / compose), not a secondary filter. */
+/* Mode toggle reads as a sub-tab strip (folder / upload / compose), subordinate
+   to the main ``.tab-nav`` row above. Active state mirrors ``.sources-vendor-tab``
+   (bottom-border) rather than the global ``.btn-ghost.btn-active`` outline, so
+   the visual hierarchy between main tabs and mode toggle stays distinct. */
 .index-mode-toggle {
   display: flex; gap: 4px;
   padding: 8px 12px;
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
 }
-.index-mode-toggle .btn-ghost { font-size: 0.82rem; padding: 4px 12px; }
+.index-mode-toggle .btn-ghost {
+  background: none; border: none;
+  border-bottom: 2px solid transparent; border-radius: 0;
+  color: var(--muted);
+  font-size: 0.82rem; padding: 4px 12px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.index-mode-toggle .btn-ghost:hover { color: var(--text); }
+.index-mode-toggle .btn-ghost.btn-active {
+  color: var(--accent); border-bottom-color: var(--accent);
+}
 .index-layout { display: flex; flex-direction: column; gap: 20px; padding: 20px 0 20px; overflow-y: auto; }
 /* min-height keeps the panel container stable across mode switches; floor
    chosen so the folder panel's empty-on-first-visit area stays modest while


### PR DESCRIPTION
## Summary

- The Index tab's mode toggle (folder / upload / compose) used the global `.btn-ghost.btn-active` outline (border on all four sides), while the main `.tab-nav` above already uses bottom-border for its active tab. Both rendered as a blue highlight with different decoration, which weakened the parent/child hierarchy between main tabs and sub-tabs.
- Switch the mode toggle's active state to the same bottom-border convention used by `.sources-vendor-tab`. Both rows now read as tabs at different scales — main tabs stay larger/prominent, the mode toggle reads as subordinate.
- Updates the (now-stale) comment that referenced the non-existent `.sources-mode-toggle` selector to point at the live `.sources-vendor-tab` precedent.

## Scope

- One file: `packages/memtomem/src/memtomem/web/static/style.css`.
- Replaces the single `.index-mode-toggle .btn-ghost { font-size: 0.82rem; padding: 4px 12px; }` rule with a fuller block (background/border reset + inactive/hover/active states), plus an updated header comment. +15 / -3 lines.
- No HTML, JS, or i18n changes. The active-state JS toggle (`btn.classList.toggle('btn-active', active)` in `app.js:2983`) keeps working unchanged — only the CSS interpretation of `btn-active` inside `.index-mode-toggle` is rewritten.
- Specificity isolation: `.index-mode-toggle .btn-ghost.btn-active` (0,0,3,0) overrides the global `.btn-ghost.btn-active` (0,0,2,0). Other consumers of `btn-active` (`filter-toggle`, `adv-toggle`, `group-toggle`, `tags-cloud-btn`, `tags-list-btn`, `tags-sort-btn`) are unaffected.

## Refs

- Umbrella: #582 (Prev #4 — Visual hierarchy between main tab nav and mode toggle)
- Second of the eight follow-up PRs from that umbrella (after #588 / Prev #2, merged in `569dca7`).

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] Visual check via Playwright at viewport 1280×800: navigated to Index tab, screenshotted both `파일 업로드` (Upload) active and `폴더 인덱싱` (Folder) active. Active mode reads as a clean bottom-border tab; inactive modes show muted text with no border. Main `.tab-nav` row keeps its existing bottom-border style — hierarchy is now layered (large main tabs → smaller mode toggle, both bottom-border). Confirmed PR #588's centered dropzone still renders correctly under the new mode-toggle row.
- [x] Side-effects: confirmed via grep that no other `.btn-active` consumers (`filter-toggle`, `adv-toggle`, `group-toggle`, `tags-*`) inherit any of the new scoped declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)