### PR TITLE
fix(indexing): stream endpoint namespace + errors parity (#590)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -709,13 +709,18 @@ class IndexEngine:
         path: Path,
         recursive: bool = True,
         force: bool = False,
+        namespace: str | None = None,
     ):
         """Like index_path(), but yields progress dicts as each file is processed.
 
         Yields dicts with ``type`` key:
         - ``"progress"``: emitted after each file with fields
           ``file, files_done, files_total, indexed, skipped``.
-        - ``"complete"``: final summary (same fields as IndexingStats + duration_ms).
+        - ``"complete"``: final summary — ``total_files, total_chunks,
+          indexed_chunks, skipped_chunks, deleted_chunks, duration_ms,
+          errors``. ``errors`` is a list of human-readable strings in the
+          same loose shape as ``IndexingStats.errors`` so non-stream UI
+          handlers reuse verbatim. Empty list when the run had no errors.
         """
         start = time.monotonic()
         path = path.resolve()
@@ -733,28 +738,35 @@ class IndexEngine:
                 "skipped_chunks": 0,
                 "deleted_chunks": 0,
                 "duration_ms": 0.0,
+                "errors": [],
             }
             return
 
         total_files = len(files)
         agg = {"total_chunks": 0, "indexed": 0, "skipped": 0, "deleted": 0}
+        all_errors: list[str] = []
 
         for i, fp in enumerate(files, start=1):
             try:
-                result = await self._index_file(fp, force)
+                result = await self._index_file(fp, force, namespace=namespace)
             except Exception as exc:
                 logger.error("Stream indexing failed for %s: %s", fp, exc)
+                # Path-prefix matches non-stream's ``asyncio.gather(return_exceptions=True)``
+                # branch in ``_index_path_inner`` so consumers see the same error
+                # shape regardless of whether they used the stream or non-stream
+                # endpoint.
                 result = {
                     "total": 0,
                     "indexed": 0,
                     "skipped": 0,
                     "deleted": 0,
-                    "errors": [str(exc)],
+                    "errors": [f"{fp.name}: {exc}"],
                 }
             agg["total_chunks"] += result["total"]
             agg["indexed"] += result["indexed"]
             agg["skipped"] += result["skipped"]
             agg["deleted"] += result["deleted"]
+            all_errors.extend(result.get("errors", []))
             yield {
                 "type": "progress",
                 "file": str(fp),
@@ -773,6 +785,7 @@ class IndexEngine:
             "skipped_chunks": agg["skipped"],
             "deleted_chunks": agg["deleted"],
             "duration_ms": round(duration, 1),
+            "errors": all_errors,
         }
 
     @staticmethod

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -770,6 +770,7 @@ async def index_stream(
     path: str = ".",
     recursive: bool = True,
     force: bool = False,
+    namespace: str | None = None,
     index_engine=Depends(get_index_engine),
     config=Depends(get_config),
 ) -> StreamingResponse:
@@ -786,7 +787,7 @@ async def index_stream(
     async def _generate():
         try:
             async for event in index_engine.index_path_stream(
-                resolved, recursive=recursive, force=force
+                resolved, recursive=recursive, force=force, namespace=namespace
             ):
                 yield f"data: {json.dumps(event)}\n\n"
         except Exception as exc:

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -350,6 +350,54 @@ class TestExcludePatterns:
         complete = next(e for e in events if e.get("type") == "complete")
         assert complete["indexed_chunks"] >= 1
 
+    async def test_index_path_stream_namespace_propagates(self, components, memory_dir):
+        """``index_path_stream`` must accept ``namespace`` and apply it to all
+        indexed chunks — same contract as ``index_path``. Issue #590: the
+        streaming endpoint previously dropped this argument silently, so
+        Web UI / CLI / MCP callers that streamed an index ignored the user's
+        namespace selection.
+        """
+        notes = memory_dir / "notes.md"
+        notes.write_text("# Heading\n\nBody to index for namespace check.")
+
+        engine = components.index_engine
+        events = [
+            ev
+            async for ev in engine.index_path_stream(memory_dir, recursive=True, namespace="ns590")
+        ]
+        complete = next(e for e in events if e.get("type") == "complete")
+        assert complete["indexed_chunks"] >= 1
+
+        chunks = await components.storage.list_chunks_by_source(notes)
+        assert chunks, "expected indexed chunks for notes.md"
+        assert all(c.metadata.namespace == "ns590" for c in chunks)
+
+    async def test_index_path_stream_complete_errors_no_silent_drop(self, components, memory_dir):
+        """Per-file ``_index_file`` errors must surface in the ``complete``
+        event's ``errors`` field. Issue #590 regression guard: previously the
+        stream loop summed only chunk counters and silently dropped any
+        ``result["errors"]``, so partial-failure runs (binary file, file too
+        large, embedding failure on a subset) appeared successful.
+
+        Uses a binary file (engine.py:621-628 path) as the cleanest
+        deterministic per-file error trigger — ``_index_file`` returns
+        ``errors=[f"{name}: binary file detected, skipping"]`` without raising.
+        """
+        binary = memory_dir / "blob.md"
+        # NUL byte in the first 8 KiB → ``_index_file`` short-circuits with a
+        # binary-detected error entry rather than chunking + embedding.
+        binary.write_bytes(b"# Title\n\nbody\x00more body\n")
+
+        engine = components.index_engine
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        complete = next(e for e in events if e.get("type") == "complete")
+
+        assert complete["errors"], (
+            "complete.errors must be non-empty when a file fails — silent "
+            "drop is a contract violation (#590)"
+        )
+        assert any("blob.md" in err for err in complete["errors"])
+
 
 # ===========================================================================
 # 2. _resolve_namespace


### PR DESCRIPTION
## Summary

Closes #590.

`IndexEngine.index_path_stream` and `GET /api/index/stream` were missing two contract elements that the non-stream `index_path` / `POST /api/index` pair already had:

1. **`namespace` parameter** — silently dropped. Folder-mode UI / CLI / MCP callers that streamed an index ignored the user's namespace selection.
2. **Error aggregation** — `_index_file` returns `result["errors"]` per file (engine.py:606, 628, 684, 752); the stream loop summed only chunk counters (754-757) and never propagated errors. The `complete` event lacked an `errors` field, so partial-failure runs appeared successful in the UI.

## Changes

- **Engine** (`packages/memtomem/src/memtomem/indexing/engine.py:707-784`):
  - Add `namespace: str | None = None` to `index_path_stream` and forward it to `_index_file(fp, force, namespace=namespace)` (which already accepted the param).
  - Accumulate `result["errors"]` into `all_errors` and emit `errors: list[str]` in the `complete` event — same loose shape as `IndexingStats.errors` so non-stream UI handlers (5-cap "+N more" rendering, error-row toggle) reuse verbatim.
  - Empty-path branch (no files / not-a-path) now emits `errors: []` for shape consistency.
  - Stream-level uncaught-exception branch (line 752) prefixes `f"{fp.name}: {exc}"` so consumers see the same shape regardless of which branch caught the error. Matches non-stream's `asyncio.gather(return_exceptions=True)` branch (line 394).
- **Route** (`packages/memtomem/src/memtomem/web/routes/system.py:768-790`): add `namespace: str | None = None` query param to `GET /api/index/stream`, forward to engine.
- **Tests** (`packages/memtomem/tests/test_indexing_engine.py`):
  - `test_index_path_stream_namespace_propagates` — pass `namespace="ns590"`, verify indexed chunks have `metadata.namespace == "ns590"`.
  - `test_index_path_stream_complete_errors_no_silent_drop` — write a file with a NUL byte (binary-detected branch at engine.py:621-628), assert `complete.errors` is non-empty and mentions the file name. Test name documents intent so future grep finds the regression guard.

## Compatibility

- Adds an optional kwarg + an additive event field. Existing callers (`web/routes/system.py:789` legacy call site already updated; `cli/init_cmd.py:1546` reads only `total_files/indexed_chunks/skipped_chunks` from the complete event and is unaffected) continue to work without change.
- Frontend `runIndexStream` (app.js:3467) doesn't yet read `complete.errors`; that wiring + the namespace URL param land in #582 PR-B (Prev #1 collapse) and PR #6 (4.11 toast). This PR makes those follow-ups possible without silent regressions.

## Out of scope

- Per-file streaming of errors (option ii/iii from the issue's planning discussion). `complete.errors` is sufficient for current UX; revisit if user reports indicate large indexing runs (>100 files) where waiting for `complete` is impractical.
- Normalizing `_index_file`'s mixed path-prefix convention — some branches prefix `f"{file_path.name}: ..."` (file-too-large, binary), others don't (embedding failures at engine.py:684). Separate non-stream bug; this PR preserves the existing loose contract and only path-prefixes the stream-level uncaught-exception branch (line 752) for consistency with the non-stream outer-gather branch.

## Refs

- Issue: #590
- Unblocks: #582 PR-B (Prev #1 — Index tab two-button collapse)
- Informs: #582 PR #6 (4.11 — indexing in-flight visibility, will surface `complete.errors` via toast)

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `uv run pytest packages/memtomem/tests/test_indexing_engine.py -k "test_index_path_stream" -m "not ollama"` — 4/4 pass (2 existing exclude-guard tests + 2 new parity guards)
- [x] `uv run pytest packages/memtomem/tests/test_indexing_engine.py packages/memtomem/tests/test_web_routes.py packages/memtomem/tests/test_web_exclude_guard.py packages/memtomem/tests/test_init_cmd.py -m "not ollama"` — 441/441 pass (combined). Confirms no regression in route handlers, exclude guards, or the `mm init` wizard's seed flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)