### PR TITLE
feat(web): Compose privacy warning + client pattern sync (#580)

### DIFF
--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -27,6 +27,8 @@ redaction guard here still applies. STM-bypass is not safety-bypass.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from collections import defaultdict
@@ -53,6 +55,141 @@ DEFAULT_PATTERNS: tuple[str, ...] = (
     r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b",
     r"(?i)(BEGIN\s+(RSA|EC|OPENSSH|DSA|PGP)\s+PRIVATE\s+KEY)",
 )
+
+
+# ---------------------------------------------------------------------------
+# JS-RegExp translation
+# ---------------------------------------------------------------------------
+#
+# The Web UI's compose-mode privacy warning needs to scan textarea content
+# client-side using the same patterns the server enforces. Python's ``re``
+# and JavaScript's ``RegExp`` diverge on inline flag groups: ``(?i)foo``
+# parses in Python but raises ``SyntaxError: Invalid group`` in JS. The
+# translator below lifts a position-0 inline flag group into JS-style
+# global flags and hard-rejects any construct it can't safely translate,
+# so a silent semantic divergence cannot reach the client.
+
+_LEADING_INLINE_FLAGS_RE = re.compile(r"^\(\?([imsux]+)\)")
+_INLINE_FLAG_GROUP_RE = re.compile(r"\(\?[imsux]+\)")
+_NAMED_GROUP_RE = re.compile(r"\(\?P<")
+_INLINE_COMMENT_RE = re.compile(r"\(\?#")
+_FLAG_NEGATION_RE = re.compile(r"\(\?[imsux]*-[imsux]+[:)]")
+_PYTHON_ANCHOR_RE = re.compile(r"\\[AZ]")
+
+# Map Python inline flag chars to ``re`` module flags so the translated
+# body can be sanity-compiled. ``x`` (verbose) is intentionally absent —
+# verbose mode strips whitespace + ``#`` comments and has no JS equivalent,
+# so it's hard-rejected upstream.
+_PY_FLAG_TO_RE = {
+    "i": re.IGNORECASE,
+    "m": re.MULTILINE,
+    "s": re.DOTALL,
+    "u": re.UNICODE,
+}
+
+
+def _flags_str_to_re_flags(flags: str) -> int:
+    out = 0
+    for ch in flags:
+        out |= _PY_FLAG_TO_RE.get(ch, 0)
+    return out
+
+
+def to_js_pattern(pat: str) -> tuple[str, str]:
+    """Translate a Python regex string to a JS-RegExp ``(body, flags)`` pair.
+
+    Translates only what ``DEFAULT_PATTERNS`` actually uses today: a
+    position-0 inline flag group like ``(?i)foo`` or ``(?ims)foo`` is
+    lifted into a flags string and stripped from the body. Everything
+    else passes through unchanged.
+
+    Hard-rejects (raises ``ValueError``) any construct whose JS semantics
+    differ or don't exist:
+
+    - **Mid-pattern inline flag groups** (anywhere except position 0).
+      In Python, ``foo(?i)bar`` makes ``bar`` case-insensitive while
+      ``foo`` stays sensitive — JS has no per-segment flag scope, so a
+      naive lift would silently change semantics.
+    - **Verbose mode** (``(?x)`` or any leading group containing ``x``).
+      Verbose mode strips whitespace + ``#`` comments before matching,
+      which the translator does not do.
+    - **Inline flag negation** like ``(?-i)`` or ``(?i-m:...)`` —
+      same per-segment-scope problem as mid-pattern lifts.
+    - **Named groups** ``(?P<name>...)`` — JS uses ``(?<name>...)`` and
+      a rewrite is not implemented (none of the current 9 patterns use
+      named groups).
+    - **Inline comments** ``(?#comment)`` — no JS equivalent.
+    - **Python-only anchors** ``\\A`` and ``\\Z`` — use ``^`` / ``$``
+      with the ``m`` flag in JS instead.
+
+    Returns ``(body, flags)`` where ``flags`` is a (possibly empty) string
+    of distinct chars from ``imsu``. The caller is responsible for
+    feeding this into ``new RegExp(body, flags)``.
+    """
+    if _PYTHON_ANCHOR_RE.search(pat):
+        raise ValueError(
+            f"Pattern {pat!r} uses Python-only construct: \\A or \\Z anchor "
+            "(JS has no equivalent — use ^ / $ with the m flag)"
+        )
+    if _NAMED_GROUP_RE.search(pat):
+        raise ValueError(
+            f"Pattern {pat!r} uses Python-only construct: named group (?P<...>) "
+            "(JS uses (?<...>); rewrite not implemented)"
+        )
+    if _INLINE_COMMENT_RE.search(pat):
+        raise ValueError(f"Pattern {pat!r} uses Python-only construct: inline comment (?#...)")
+    if _FLAG_NEGATION_RE.search(pat):
+        raise ValueError(
+            f"Pattern {pat!r} uses Python-only construct: inline flag negation "
+            "(JS has no per-segment flag scope)"
+        )
+
+    body = pat
+    flags = ""
+    leading = _LEADING_INLINE_FLAGS_RE.match(pat)
+    if leading:
+        flag_chars = leading.group(1)
+        if "x" in flag_chars:
+            raise ValueError(
+                f"Pattern {pat!r} uses Python-only construct: verbose mode (?x) "
+                "(verbose mode strips whitespace and #-comments — JS has no equivalent)"
+            )
+        flags = "".join(sorted(set(flag_chars)))
+        body = pat[leading.end() :]
+
+    # Anything that still looks like an inline flag group is mid-pattern.
+    # JS ``RegExp`` flags are global to the regex; lifting a mid-pattern
+    # ``(?i)`` to a global flag would change semantics (the unflagged
+    # prefix would also become case-insensitive).
+    if _INLINE_FLAG_GROUP_RE.search(body):
+        raise ValueError(
+            f"Pattern {pat!r} uses Python-only construct: mid-pattern inline flag group "
+            "(JS RegExp has no per-segment flag scope)"
+        )
+
+    # Sanity check: the translated body + lifted flags must still parse
+    # as a valid Python regex. This is the translator's own contract,
+    # not a JS-runtime check.
+    try:
+        re.compile(body, _flags_str_to_re_flags(flags))
+    except re.error as exc:  # pragma: no cover — defensive; current patterns all parse
+        raise ValueError(
+            f"Pattern {pat!r} translation produced invalid regex {body!r}: {exc}"
+        ) from exc
+
+    return body, flags
+
+
+# Pre-computed JS-shape view of ``DEFAULT_PATTERNS`` and a stable hash over
+# it. Both are computed once at import (the pattern tuple is immutable).
+JS_PATTERNS: tuple[dict[str, str], ...] = tuple(
+    {"pattern": body, "flags": flags}
+    for body, flags in (to_js_pattern(p) for p in DEFAULT_PATTERNS)
+)
+JS_PATTERNS_SHA: str = hashlib.sha256(
+    json.dumps(JS_PATTERNS, sort_keys=True, separators=(",", ":")).encode("utf-8")
+).hexdigest()
+
 
 _SCAN_WINDOW = 10_000
 

--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -88,7 +88,7 @@ _PY_FLAG_TO_RE = {
 }
 
 
-def _flags_str_to_re_flags(flags: str) -> int:
+def flags_str_to_re_flags(flags: str) -> int:
     out = 0
     for ch in flags:
         out |= _PY_FLAG_TO_RE.get(ch, 0)
@@ -125,6 +125,17 @@ def to_js_pattern(pat: str) -> tuple[str, str]:
     Returns ``(body, flags)`` where ``flags`` is a (possibly empty) string
     of distinct chars from ``imsu``. The caller is responsible for
     feeding this into ``new RegExp(body, flags)``.
+
+    Note on fail-loud-at-import: ``JS_PATTERNS`` below calls this for
+    every entry in ``DEFAULT_PATTERNS`` at module import. Adding a
+    pattern that this translator can't handle will break
+    ``from memtomem import privacy`` — and therefore ``mm web`` startup,
+    every test that imports privacy, and every MCP ``mem_add`` call.
+    This is **intentional**: a silent client-warning bypass would be
+    worse than a loud failure that forces the contributor to either
+    translate the construct or accept the breakage. If you hit this
+    while adding a pattern, extend ``to_js_pattern`` rather than
+    suppressing the error.
     """
     if _PYTHON_ANCHOR_RE.search(pat):
         raise ValueError(
@@ -171,7 +182,7 @@ def to_js_pattern(pat: str) -> tuple[str, str]:
     # as a valid Python regex. This is the translator's own contract,
     # not a JS-runtime check.
     try:
-        re.compile(body, _flags_str_to_re_flags(flags))
+        re.compile(body, flags_str_to_re_flags(flags))
     except re.error as exc:  # pragma: no cover — defensive; current patterns all parse
         raise ValueError(
             f"Pattern {pat!r} translation produced invalid regex {body!r}: {exc}"

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -49,6 +49,8 @@ from memtomem.web.schemas.config import (
     EmbeddingConfigInfo,
     EmbeddingResetResponse,
     EmbeddingStatusResponse,
+    PrivacyPatternEntry,
+    PrivacyPatternsResponse,
 )
 from memtomem.web.schemas.memory import (
     AddMemoryRequest,
@@ -268,6 +270,28 @@ async def get_builtin_exclude_patterns() -> BuiltinExcludePatternsResponse:
     return BuiltinExcludePatternsResponse(
         secret=list(_BUILTIN_SECRET_PATTERNS),
         noise=list(_BUILTIN_NOISE_PATTERNS),
+    )
+
+
+@router.get("/privacy/patterns", response_model=PrivacyPatternsResponse)
+async def get_privacy_patterns() -> PrivacyPatternsResponse:
+    """Return the LTM secret-class redaction patterns in JS-RegExp shape.
+
+    The Web UI's compose-mode privacy warning fetches this once on load
+    and uses it to scan textarea content client-side. Each entry is a
+    ``{pattern, flags}`` pair already translated to JS-compatible form
+    by ``privacy.to_js_pattern`` — Python inline flag groups like
+    ``(?i)`` are lifted out of the body, since ``new RegExp("(?i)…")``
+    rejects them.
+
+    Read-only metadata; no ``require_configured`` gate (mirrors
+    ``/api/config`` and ``/api/indexing/builtin-exclude-patterns``).
+    """
+    from memtomem import privacy
+
+    return PrivacyPatternsResponse(
+        patterns=[PrivacyPatternEntry(**entry) for entry in privacy.JS_PATTERNS],
+        sha=privacy.JS_PATTERNS_SHA,
     )
 
 

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -49,6 +49,16 @@ class BuiltinExcludePatternsResponse(BaseModel):
     noise: list[str]
 
 
+class PrivacyPatternEntry(BaseModel):
+    pattern: str
+    flags: str
+
+
+class PrivacyPatternsResponse(BaseModel):
+    patterns: list[PrivacyPatternEntry]
+    sha: str
+
+
 class ConfigDecayOut(BaseModel):
     enabled: bool
     half_life_days: float

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3087,6 +3087,14 @@ qs('add-btn').addEventListener('click', async () => {
   // silently: no checkmark, no helper text. A success indicator on a
   // clean input would be peak false security since the regex misses
   // many real secrets.
+  //
+  // Scan-window asymmetry: ``re.test()`` here scans the entire
+  // textarea, while server-side ``privacy.scan()`` caps at the first
+  // 10K chars (``_SCAN_WINDOW`` in privacy.py). Today moot —
+  // ``/api/add`` does not invoke ``privacy.scan`` — but if the
+  // ADR-tracked server gate ever lands, the two would disagree on
+  // very long content. The client is more permissive (covers more);
+  // the server boundary is the source of truth.
   const patterns = STATE.privacyPatterns;
   if (patterns && patterns.some(re => re.test(content))) {
     const ok = await showConfirm({

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -40,6 +40,12 @@ const STATE = {
   tagsSortBy: 'count-desc',
   serverConfig: null,
   serverDefaults: null,
+  // Compiled RegExp objects from /api/privacy/patterns (#580). The
+  // compose-mode Add handler scans textarea content against these and
+  // shows a confirm dialog on a hit. Lazy-init: ``null`` until the
+  // boot-time fetch resolves; on fetch failure stays ``null`` and the
+  // scan is silently skipped (defense-in-depth, not a hard gate).
+  privacyPatterns: null,
   lastRetrievalStats: null,
   groupMode: false,
   cmdPaletteOpen: false,
@@ -70,6 +76,11 @@ const STATE = {
     const uiModePromise = initUiMode();
     if (typeof I18N !== 'undefined') await I18N.init();
     await uiModePromise;
+    // Fire-and-forget: privacy-pattern fetch for the compose warning.
+    // Soft-fails if the endpoint is unavailable (cache stays null,
+    // submit handler skips the scan). Not awaited — Add doesn't gate
+    // on it (#580).
+    loadPrivacyPatterns();
     renderRecentChips();
     _initTabHelp();
     // Re-apply i18n when language changes (dynamic JS strings)
@@ -3042,9 +3053,49 @@ qs('folder-hint-sources-link')?.addEventListener('click', e => {
 // Add Memory
 // ---------------------------------------------------------------------------
 
+// Compile the server's ``/api/privacy/patterns`` payload into JS RegExp
+// objects, cached on STATE.privacyPatterns. Soft-fail on network /
+// translator error: leave the cache null and the submit handler skips
+// the scan rather than break Add on a transient blip. The server's
+// /api/add route does not invoke privacy.scan either, so a strict
+// client gate would not be real security — this is defense-in-depth
+// for accidental paste, not the trust boundary.
+async function loadPrivacyPatterns() {
+  try {
+    const data = await api('GET', '/api/privacy/patterns');
+    const entries = (data && data.patterns) || [];
+    STATE.privacyPatterns = entries
+      .map(({ pattern, flags }) => {
+        try { return new RegExp(pattern, flags); }
+        catch (e) { console.warn('[privacy] skip pattern', pattern, e); return null; }
+      })
+      .filter(Boolean);
+  } catch (err) {
+    console.warn('[privacy] pattern fetch failed; compose warning disabled', err);
+    STATE.privacyPatterns = null;
+  }
+}
+
 qs('add-btn').addEventListener('click', async () => {
   const content = qs('add-content').value.trim();
   if (!content) { setMsg(qs('add-msg'), 'Content is required.', true); return; }
+
+  // Privacy pre-check (#580). On a hit, surface a confirm dialog that
+  // names the *concrete behavior* — "stored as-is in the local
+  // database and exposed to search" — rather than abstract anxiety.
+  // Clean inputs and a missing pattern cache both pass through
+  // silently: no checkmark, no helper text. A success indicator on a
+  // clean input would be peak false security since the regex misses
+  // many real secrets.
+  const patterns = STATE.privacyPatterns;
+  if (patterns && patterns.some(re => re.test(content))) {
+    const ok = await showConfirm({
+      title: t('compose.privacy_warning_title'),
+      message: t('compose.privacy_warning_message'),
+      confirmText: t('compose.privacy_warning_proceed'),
+    });
+    if (!ok) return;
+  }
 
   const title = qs('add-title').value.trim() || null;
   const tagsRaw = qs('add-tags').value.trim();

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -186,6 +186,10 @@
   "index.add_content_placeholder": "Write your memory here…",
   "index.add_btn": "Add",
 
+  "compose.privacy_warning_title": "Possible secret detected",
+  "compose.privacy_warning_message": "What looks like an API key was found. This content will be stored as-is in the local database and exposed to search — proceed anyway?",
+  "compose.privacy_warning_proceed": "Proceed",
+
   "settings.nav.general": "General",
   "settings.nav.integrations": "Integrations",
   "settings.nav.runtime": "Runtime",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -187,7 +187,7 @@
   "index.add_btn": "추가",
 
   "compose.privacy_warning_title": "비밀 정보 가능성",
-  "compose.privacy_warning_message": "API 키로 보이는 내용이 발견됐습니다. 이 내용은 로컬 DB 에 그대로 저장되고 검색에 노출됩니다. 계속할까요?",
+  "compose.privacy_warning_message": "API 키로 보이는 내용이 발견됐습니다. 이 내용은 로컬 DB에 그대로 저장되고 검색에 노출됩니다. 계속할까요?",
   "compose.privacy_warning_proceed": "계속",
 
   "settings.nav.general": "일반",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -186,6 +186,10 @@
   "index.add_content_placeholder": "여기에 기억을 작성하세요…",
   "index.add_btn": "추가",
 
+  "compose.privacy_warning_title": "비밀 정보 가능성",
+  "compose.privacy_warning_message": "API 키로 보이는 내용이 발견됐습니다. 이 내용은 로컬 DB 에 그대로 저장되고 검색에 노출됩니다. 계속할까요?",
+  "compose.privacy_warning_proceed": "계속",
+
   "settings.nav.general": "일반",
   "settings.nav.integrations": "연동",
   "settings.nav.runtime": "런타임",

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -17,7 +17,10 @@ Drift-prevention notes embedded as test pins:
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import re
 
 import pytest
 
@@ -121,3 +124,143 @@ class TestCounter:
         snap = privacy.snapshot()
         assert snap["outcomes"] == {"blocked": 0, "pass": 0, "bypassed": 0}
         assert snap["by_tool"] == {}
+
+
+# ---------------------------------------------------------------------------
+# JS-RegExp translator
+#
+# Background: the Web UI's compose-mode privacy warning needs to scan
+# textarea content client-side using the same patterns the server
+# enforces (#580). Python ``re`` and JS ``RegExp`` diverge on inline
+# flag groups — ``new RegExp("(?i)foo")`` raises in JS — so the server
+# translates patterns before serving them. These tests pin the
+# translator's parity contract (Python re of translated body+flags must
+# match the same fixtures as the original pattern) and lock the
+# hard-reject set so future Python-only constructs can't slip through
+# silently.
+#
+# Fixture-domain assumption: all positive/negative fixtures here are
+# pure-ASCII. Word-boundary semantics (``\b``) align between Python and
+# JS in the ASCII domain. A future pattern that depends on Unicode
+# ``\b`` would need a different parity strategy than direct re vs JS
+# comparison.
+# ---------------------------------------------------------------------------
+
+
+# Per-pattern positive + negative fixtures, paired by index with
+# DEFAULT_PATTERNS. The positives are deliberately drawn from realistic
+# secret shapes; the negatives are similar-looking strings that should
+# NOT match (drift guard against a future translation accidentally
+# broadening the pattern).
+_PATTERN_FIXTURES: tuple[tuple[str, str], ...] = (
+    # 0: api_key/secret_key/access_token (case-insensitive)
+    ("API_KEY: abc123", "api keys are documented separately"),
+    # 1: password/passwd/pwd
+    ("Password = hunter2", "passport renewal next month"),
+    # 2: sk-/ghp_/xox prefix
+    ("token=sk-" + "a" * 30, "Sky color today is blue"),
+    # 3: github_pat_
+    ("github_pat_" + "x" * 30, "github_user joined the org"),
+    # 4: stripe-style sk_live_, pk_test_, whsec_
+    ("sk_live_" + "a" * 25, "sk_live_short"),
+    # 5: npm_
+    ("npm_" + "a" * 30, "npm install foo"),
+    # 6: AWS access key id (AKIA/ASIA)
+    ("AKIAIOSFODNN7EXAMPLE", "AKIA-no-good"),
+    # 7: JWT
+    ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIicm9vdA.SflKxwRJSMeK", "eyJ-not-a-jwt"),
+    # 8: PEM private key header
+    ("-----BEGIN RSA PRIVATE KEY-----", "RSA public key"),
+)
+
+
+class TestJsPatternTranslation:
+    """Parity + hard-reject contract for ``privacy.to_js_pattern``.
+
+    The parity test (§1.5) recovers the issue-580 test-plan item
+    "client-side regex matches a known API-key fixture" without needing
+    a JS runtime: feeding the translated body + lifted flags through
+    Python ``re`` is equivalent to running the original pattern, so a
+    successful Python match guarantees an identical JS match.
+    """
+
+    @pytest.mark.parametrize(
+        "idx,positive,negative",
+        [(i, pos, neg) for i, (pos, neg) in enumerate(_PATTERN_FIXTURES)],
+    )
+    def test_translated_pattern_matches_original(self, idx, positive, negative):
+        original = privacy.DEFAULT_PATTERNS[idx]
+        body, flags = privacy.to_js_pattern(original)
+
+        original_re = re.compile(original)
+        translated_re = re.compile(body, privacy._flags_str_to_re_flags(flags))
+
+        # Positive fixture: same hits, same spans.
+        orig_hits = [m.span() for m in original_re.finditer(positive)]
+        trans_hits = [m.span() for m in translated_re.finditer(positive)]
+        assert orig_hits == trans_hits, (
+            f"Pattern {idx} hit-span parity broke on positive fixture {positive!r}: "
+            f"original={orig_hits} translated={trans_hits}"
+        )
+        assert orig_hits, f"Pattern {idx} positive fixture {positive!r} did not hit"
+
+        # Negative fixture: both reject identically.
+        assert not original_re.search(negative), (
+            f"Pattern {idx} positive-fixture mislabeled — negative {negative!r} actually hits"
+        )
+        assert not translated_re.search(negative)
+
+    def test_module_constants_built_from_default_patterns(self):
+        # JS_PATTERNS is computed once at import. Re-deriving it here
+        # locks the pre-computation to the live translator.
+        derived = tuple(
+            {"pattern": body, "flags": flags}
+            for body, flags in (privacy.to_js_pattern(p) for p in privacy.DEFAULT_PATTERNS)
+        )
+        assert privacy.JS_PATTERNS == derived
+
+    def test_sha_locks_serialization_choice(self):
+        # SHA must match canonical JSON serialization (sort_keys + tight
+        # separators). Computed from the live JS_PATTERNS so adding a
+        # 10th pattern only fails parity tests, not this one — this
+        # test locks the *serialization*, not the pattern set.
+        expected = hashlib.sha256(
+            json.dumps(
+                privacy.JS_PATTERNS,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        assert privacy.JS_PATTERNS_SHA == expected
+
+    @pytest.mark.parametrize(
+        "bad_pattern,construct",
+        [
+            # ``construct`` is a regex (pytest ``match=``); escape backslashes.
+            (r"\Afoo", r"\\A or \\Z anchor"),
+            (r"foo\Z", r"\\A or \\Z anchor"),
+            ("foo(?i)bar", "mid-pattern inline flag group"),
+            ("(?ix)foo", "verbose mode"),
+            ("(?P<n>x)", "named group"),
+            (r"(?#comment)x", r"inline comment \(\?#\.\.\.\)"),
+            ("(?-i:x)", "inline flag negation"),
+        ],
+    )
+    def test_hard_rejects_python_only_constructs(self, bad_pattern, construct):
+        with pytest.raises(ValueError, match=construct):
+            privacy.to_js_pattern(bad_pattern)
+
+    def test_emitted_flags_are_jsregexp_compatible(self):
+        # Each entry's flags is a (possibly empty) string of distinct
+        # chars from the imsu subset (the only Python flags the
+        # translator lifts; x is hard-rejected; g/y are JS-only and the
+        # translator never emits them).
+        allowed = set("imsu")
+        for entry in privacy.JS_PATTERNS:
+            flags = entry["flags"]
+            assert len(flags) == len(set(flags)), (
+                f"Duplicate flag chars in {flags!r} — JS rejects new RegExp(body, 'ii')"
+            )
+            assert set(flags) <= allowed, (
+                f"Translator emitted unexpected flag in {flags!r}; allowed: {sorted(allowed)}"
+            )

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -193,7 +193,7 @@ class TestJsPatternTranslation:
         body, flags = privacy.to_js_pattern(original)
 
         original_re = re.compile(original)
-        translated_re = re.compile(body, privacy._flags_str_to_re_flags(flags))
+        translated_re = re.compile(body, privacy.flags_str_to_re_flags(flags))
 
         # Positive fixture: same hits, same spans.
         orig_hits = [m.span() for m in original_re.finditer(positive)]

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -251,6 +251,40 @@ def test_html_dev_mode_banner_is_present_and_starts_hidden() -> None:
     )
 
 
+def test_app_js_pins_compose_privacy_warning() -> None:
+    """JS-source pin for the compose-mode privacy warning (#580).
+
+    The test suite has no JS runtime, so we grep ``app.js`` for the
+    wiring that the integration test would otherwise verify:
+
+    - the boot-time fetch site exists,
+    - the cache field on STATE is populated from that fetch,
+    - regex objects are constructed from the documented
+      ``{pattern, flags}`` shape (a future refactor that drops the
+      flags arg would silently make ``(?i)``-lifted patterns
+      case-sensitive),
+    - the i18n key the confirm dialog reads is present.
+
+    This pin covers wiring only; behaviour parity (Python ``re`` of
+    translated body+flags == original pattern) is in
+    ``test_privacy.py:TestJsPatternTranslation``.
+    """
+    js = _read_static("app.js")
+    assert "'/api/privacy/patterns'" in js, "privacy patterns fetch site missing"
+    assert "STATE.privacyPatterns" in js, "STATE cache field for privacy patterns missing"
+    assert "compose.privacy_warning_title" in js, "compose privacy i18n key not wired"
+    # Pattern-and-flags constructor — locks the {pattern, flags} shape
+    # so a future refactor that drops the flags argument fails this
+    # pin instead of silently demoting case-insensitive matches.
+    assert "new RegExp(pattern, flags)" in js, (
+        "RegExp constructor must use both pattern and flags from the wire shape"
+    )
+    en = _read_static("locales/en.json")
+    ko = _read_static("locales/ko.json")
+    assert '"compose.privacy_warning_title"' in en
+    assert '"compose.privacy_warning_title"' in ko
+
+
 def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     """JS grep pin — the test suite has no JS runtime. A source scan catches
     regressions in the three behaviors we rely on."""

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -404,6 +404,108 @@ class TestConfig:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/privacy/patterns (issue #580)
+# ---------------------------------------------------------------------------
+
+
+class TestPrivacyPatterns:
+    """The Web UI compose-mode privacy warning fetches LTM secret
+    patterns from this endpoint and runs them client-side against the
+    textarea before submission. The endpoint is read-only metadata —
+    no ``require_configured`` gate, mirroring ``/api/config`` and
+    ``/api/indexing/builtin-exclude-patterns``."""
+
+    async def test_returns_documented_shape(self, client: AsyncClient):
+        from memtomem import privacy
+
+        resp = await client.get("/api/privacy/patterns")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data.keys()) == {"patterns", "sha"}
+
+        assert isinstance(data["sha"], str)
+        assert len(data["sha"]) == 64
+        assert all(c in "0123456789abcdef" for c in data["sha"])
+
+        assert isinstance(data["patterns"], list)
+        assert len(data["patterns"]) == len(privacy.DEFAULT_PATTERNS)
+        # Each entry's flags is a (possibly empty) string of distinct
+        # chars from the JS-compatible subset the translator emits.
+        # ``g`` (global) and ``y`` (sticky) are JS-only — the lifter
+        # never produces them; ``x`` (verbose) is hard-rejected.
+        allowed = set("imsu")
+        for entry in data["patterns"]:
+            assert set(entry.keys()) == {"pattern", "flags"}
+            assert isinstance(entry["pattern"], str) and entry["pattern"]
+            flags = entry["flags"]
+            assert isinstance(flags, str)
+            assert len(flags) == len(set(flags)), (
+                f"duplicate flag char in {flags!r} — JS rejects new RegExp(body, 'ii')"
+            )
+            assert set(flags) <= allowed, (
+                f"unexpected flag in {flags!r}; allowed: {sorted(allowed)}"
+            )
+
+    async def test_patterns_match_translator_over_default_set(self, client: AsyncClient):
+        """Drift guard: the wire patterns must equal what
+        ``to_js_pattern`` produces for the live ``DEFAULT_PATTERNS``.
+        If anyone touches the source tuple without re-deriving the JS
+        view, this fails."""
+        from memtomem import privacy
+
+        resp = await client.get("/api/privacy/patterns")
+        wire = resp.json()["patterns"]
+        derived = [
+            {"pattern": body, "flags": flags}
+            for body, flags in (privacy.to_js_pattern(p) for p in privacy.DEFAULT_PATTERNS)
+        ]
+        assert wire == derived
+
+    async def test_sha_locks_serialization_choice(self, client: AsyncClient):
+        """SHA is computed from the live ``JS_PATTERNS`` using a
+        canonical JSON encoding (sort_keys=True + tight separators).
+        Locks *serialization* only — adding a 10th pattern would fail
+        the parity test above, not this one."""
+        import hashlib
+        import json
+
+        from memtomem import privacy
+
+        resp = await client.get("/api/privacy/patterns")
+        expected = hashlib.sha256(
+            json.dumps(
+                privacy.JS_PATTERNS,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
+        assert resp.json()["sha"] == expected
+
+    async def test_no_require_configured_gate(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Read-only metadata endpoint — must serve patterns even when
+        ``~/.memtomem/config.json`` is absent. Mirrors ``/api/config``
+        (also unguarded). Verified by *restoring* the real gate
+        (the shared ``app`` fixture stubs it to ``lambda: None`` so
+        all unrelated tests don't depend on the developer's real
+        config) and pointing HOME at an empty tmpdir — if the gate
+        had crept onto the route, this would 409."""
+        from memtomem.web.deps import require_configured
+
+        del app.dependency_overrides[require_configured]
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+        resp = await client.get("/api/privacy/patterns")
+        assert resp.status_code == 200, resp.text
+        assert "patterns" in resp.json()
+
+
+# ---------------------------------------------------------------------------
 # GET /api/search
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- New `GET /api/privacy/patterns` endpoint serves LTM secret patterns in JS-RegExp shape (`{pattern, flags}` per entry); compose-mode Add scans the textarea client-side and surfaces a confirm dialog on a hit ("stored as-is in the local database and exposed to search — proceed anyway?")
- `privacy.to_js_pattern()` lifts position-0 inline flag groups (`(?i)foo`) into JS flags and hard-rejects every Python-only construct that would silently change semantics (mid-pattern flag groups, `\A`/`\Z`, `(?P<>)`, `(?#)`, verbose mode, flag negation)
- Soft-fail on fetch failure; clean inputs show no indicator (no false-security checkmark)
- Closes the Compose-mode half of the trust-boundary gap from PR #575 review; folder/upload silent redaction stays in a separate ADR (4.6b)

## Why

PR #575's review surfaced that `privacy.DEFAULT_PATTERNS` is enforced only on the MCP write path — `POST /api/add` (used by all three Web UI Index modes) calls `append_entry` + `index_file` with no `privacy.scan()`. CLAUDE.md's "STM-bypass must not be safety-bypass" treats LTM ingress as the trust boundary; the Web UI silently violated that under an unspoken "Web UI = local user" assumption (remote `mm web`, shared workstation, accidental paste).

This PR delivers defense-in-depth for accidental paste in compose mode. It does **not** change the `/api/add` server gate — that's a real trust-boundary decision separate from this UX fix and tracked in ADR 4.6b.

## Why these design choices (FYI)

- **Translate-and-validate over raw `list[str]`** — 4 of 9 patterns start with `(?i)` which `new RegExp` rejects. A docstring constraint would be fragile to future edits and the JS source-pin can't catch a semantic divergence; translating server-side gives a free Python-side parity test.
- **Mid-pattern `(?i)` is hard-rejected, not silently lifted** — Python's `foo(?i)bar` makes only `bar` case-insensitive; JS has no per-segment flag scope, so a naive lift would change semantics. Reject loudly.
- **Soft-fail on fetch failure** — `/api/add` doesn't invoke `privacy.scan` either, so a strict client gate isn't real security; making Add break on a transient blip is real cost. The client warning is defense-in-depth.
- **No checkmark on clean input** — peak false security; the regex misses many real secrets.
- **Public-named `to_js_pattern` / `JS_PATTERNS` / `JS_PATTERNS_SHA`** — cross-module consumers (route + tests) don't need underscore-poking; matches the existing `scan` / `record` / `snapshot` surface.
- **SHA uses canonical JSON serialization** (sort_keys + tight separators) instead of `"\n".join` — avoids the newline-collision footgun and stays deterministic across processes.

## Test plan

- [x] `uv run pytest -m "not ollama"` — 3285 passed, 0 failed, 46 deselected (ollama)
- [x] `uv run ruff check` + `uv run ruff format --check` — both clean
- [x] `TestJsPatternTranslation` per-pattern parity (Python `re` of translated body+flags vs original) — 9 patterns × {positive, negative} fixtures
- [x] `TestJsPatternTranslation` hard-reject contract — 7 known-bad inputs raise `ValueError`
- [x] `TestPrivacyPatterns` endpoint — shape, parity, SHA serialization lock, no `require_configured` gate
- [x] `test_app_js_pins_compose_privacy_warning` JS source-pin
- [x] `test_i18n.py` parity (en ⇄ ko, placeholders, no-empty)
- [x] **Playwright MCP smoke** — `mm web`, navigate to `#index` → compose → type `AKIAIOSFODNN7EXAMPLE` fixture → confirm modal appears with KO i18n text → Cancel → modal hides, content preserved, no `POST /api/add`
- [x] `STATE.privacyPatterns` populated on page load with 9 compiled `RegExp` objects (verified via `browser_evaluate`)
- [ ] Reviewer i18n pass on KO wording (issue #580 requested one more pass before merge)

## Out of scope (explicit, per issue body)

- Folder/upload silent server-side redaction — real LTM trust-boundary change; ADR 4.6b
- Server-side `privacy.scan()` in `POST /api/add` — same trust-boundary decision; deferred
- Per-pattern severity / classification UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)