### PR TITLE
fix(indexing): preserve chunk identity + access stats across force-reindex (#582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **Force-reindex preserves chunk identity and per-chunk personalization
+  (`mem_edit` / `mem_delete` / `mm index --force` / `POST /reindex`).**
+  Pre-fix the force path called `delete_by_source` followed by fresh
+  `upsert_chunks`, generating new UUIDs and resetting `access_count`,
+  `use_count`, `last_accessed_at`, `importance_score` for every chunk
+  in the file — including chunks the caller never touched. Now the
+  force path runs the same hash-aware diff the non-force path uses,
+  preserves IDs for hash-matched chunks, and re-embeds them
+  (the `force=True` semantics) via the existing-row UPDATE clause —
+  which intentionally does not rewrite personalization columns.
+  User-visible: agents that cache chunk IDs across `mem_edit` calls
+  stop seeing silent invalidation; access-frequency boost
+  (`search/access.py`) and importance scoring
+  (`server/tools/importance.py`) no longer drop to 0 when a sibling
+  chunk is edited. Contract recorded in
+  `docs/adr/0005-force-reindex-metadata-contract.md`. (#582 item 4.2)
+
 - **`POST /api/memory-dirs/add` indexes the registered directory by
   default now.** PR #571 introduced opt-in `auto_index` (default
   `False`) for backward compatibility; the Web UI sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   stop seeing silent invalidation; access-frequency boost
   (`search/access.py`) and importance scoring
   (`server/tools/importance.py`) no longer drop to 0 when a sibling
-  chunk is edited. Contract recorded in
+  chunk is edited. `chunk_links` rows pointing at unchanged chunks
+  also survive — pre-fix the blanket `delete_by_source` cascaded via
+  `ON DELETE CASCADE` (target_id) / `ON DELETE SET NULL` (source_id),
+  silently dropping consolidation-summary and provenance edges
+  whenever a sibling chunk was edited. Contract recorded in
   `docs/adr/0005-force-reindex-metadata-contract.md`. (#582 item 4.2)
 
 - **`POST /api/memory-dirs/add` indexes the registered directory by

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -458,15 +458,15 @@ class IndexEngine:
     ) -> IndexingStats:
         """Index a single file. Convenience wrapper for external callers.
 
-        ``force=True`` currently rebuilds storage by deleting all rows for
-        ``source_file`` and re-inserting fresh chunks. Side effect: chunks
-        whose content was unchanged still lose ``access_count`` /
-        ``last_accessed_at`` and are assigned new UUIDs. This is the
-        unintended-coupling contract documented in
-        ``docs/adr/0005-force-reindex-metadata-contract.md``; the planned
-        fix (preserve metadata for hash-matched chunks) ships in a
-        follow-up PR. Callers that go through ``mem_edit`` / ``mem_delete``
-        / CLI ``mm index --force`` / web ``POST /reindex`` hit this path.
+        ``force=True`` re-embeds every chunk in the file but preserves chunk
+        identity (UUID) and per-chunk personalization (``access_count``,
+        ``use_count``, ``last_accessed_at``, ``importance_score``) for
+        chunks whose content hash matches an existing row. New chunks get
+        schema defaults; chunks whose hash vanished from the file are
+        deleted. See ``docs/adr/0005-force-reindex-metadata-contract.md``
+        for the contract and rationale. Callers that go through
+        ``mem_edit`` / ``mem_delete`` / CLI ``mm index --force`` / web
+        ``POST /reindex`` all use this path.
         """
         # Defense-in-depth: the primary guard lives at the top of
         # ``_index_file`` (covers every caller — watcher, stream endpoint,
@@ -701,13 +701,25 @@ class IndexEngine:
             deleted = await self._storage.delete_by_source(file_path)
             return {"total": 0, "indexed": 0, "skipped": 0, "deleted": deleted, "errors": []}
 
-        if force:
-            diff_result = type(
-                "D", (), {"to_upsert": new_chunks, "to_delete": [], "unchanged": []}
-            )()
-        else:
-            existing_hashes = await self._storage.get_chunk_hashes(file_path)
-            diff_result = compute_diff(existing_hashes, new_chunks)
+        # Always run hash-aware diff: ``compute_diff`` reuses existing chunk
+        # IDs for hash-matched chunks (see ``differ.py:compute_diff``). For
+        # ``force=True`` we then promote the matched ``unchanged`` chunks
+        # into ``to_upsert`` so they get re-embedded — but their IDs are
+        # preserved by the diff, and ``upsert_chunks`` UPDATE clause does not
+        # touch ``access_count`` / ``use_count`` / ``last_accessed_at`` /
+        # ``importance_score`` (sqlite_backend.py UPDATE column list). Net
+        # effect: force re-indexes content but keeps per-chunk personalization
+        # and chunk identity. See ``docs/adr/0005-force-reindex-metadata-contract.md``.
+        existing_hashes = await self._storage.get_chunk_hashes(file_path)
+        diff_result = compute_diff(existing_hashes, new_chunks)
+        # Snapshot truly-new chunk IDs before force may merge unchanged in.
+        # ``new_chunk_ids`` in the return shape is documented as "freshly
+        # created chunks" — callers like ``mem_consolidate_apply`` rely on
+        # this distinction.
+        truly_new_chunk_ids = [c.id for c in diff_result.to_upsert]
+        if force and diff_result.unchanged:
+            diff_result.to_upsert.extend(diff_result.unchanged)
+            diff_result.unchanged = []
 
         # Embed BEFORE any deletion — if embedding fails, DB stays untouched.
         # Skip embedding entirely when using the noop provider (BM25-only mode).
@@ -735,9 +747,7 @@ class IndexEngine:
         # Now safe to mutate DB — embedding succeeded.
         # Wrap delete+upsert in a single transaction for atomicity.
         async with self._storage.transaction():
-            if force:
-                await self._storage.delete_by_source(file_path)
-            elif diff_result.to_delete:
+            if diff_result.to_delete:
                 await self._storage.delete_chunks(diff_result.to_delete)
 
             if diff_result.to_upsert:
@@ -747,9 +757,9 @@ class IndexEngine:
             "total": len(new_chunks),
             "indexed": len(diff_result.to_upsert),
             "skipped": len(diff_result.unchanged),
-            "deleted": len(diff_result.to_delete) if not force else 0,
+            "deleted": len(diff_result.to_delete),
             "errors": [],
-            "new_chunk_ids": [c.id for c in diff_result.to_upsert],
+            "new_chunk_ids": truly_new_chunk_ids,
         }
 
     async def index_path_stream(

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -25,7 +25,7 @@ from memtomem.config import (
     memory_dir_kind,
     provider_for_category,
 )
-from memtomem.indexing.differ import compute_diff
+from memtomem.indexing.differ import DiffResult, compute_diff
 from memtomem.models import Chunk, ChunkMetadata, IndexingStats
 
 if TYPE_CHECKING:
@@ -712,14 +712,17 @@ class IndexEngine:
         # and chunk identity. See ``docs/adr/0005-force-reindex-metadata-contract.md``.
         existing_hashes = await self._storage.get_chunk_hashes(file_path)
         diff_result = compute_diff(existing_hashes, new_chunks)
-        # Snapshot truly-new chunk IDs before force may merge unchanged in.
         # ``new_chunk_ids`` in the return shape is documented as "freshly
         # created chunks" — callers like ``mem_consolidate_apply`` rely on
-        # this distinction.
+        # this distinction. Capture before any force-promotion so the
+        # field stays accurate even when force re-embeds unchanged chunks.
         truly_new_chunk_ids = [c.id for c in diff_result.to_upsert]
         if force and diff_result.unchanged:
-            diff_result.to_upsert.extend(diff_result.unchanged)
-            diff_result.unchanged = []
+            diff_result = DiffResult(
+                to_upsert=diff_result.to_upsert + diff_result.unchanged,
+                to_delete=diff_result.to_delete,
+                unchanged=[],
+            )
 
         # Embed BEFORE any deletion — if embedding fails, DB stays untouched.
         # Skip embedding entirely when using the noop provider (BM25-only mode).

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1310,6 +1310,169 @@ class TestIndexFile:
         hashes = await components.storage.get_chunk_hashes(md_path)
         assert len(hashes) > 0  # chunks were stored
 
+    async def test_force_reindex_preserves_chunk_id_for_unchanged(self, components, memory_dir):
+        """force=True must keep the same UUID for chunks whose content_hash is unchanged.
+
+        Regression guard for ADR-0005: pre-fix the force path called
+        ``delete_by_source`` + fresh ``upsert_chunks``, which generated new
+        UUIDs for chunks the caller had no intent to modify.
+        """
+        md_path = memory_dir / "two_chunks.md"
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 12) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 12) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_texts = AsyncMock(
+            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+        )
+        mock_embedder.dimension = 1024
+        components.index_engine._embedder = mock_embedder
+
+        await components.index_engine.index_file(md_path)
+        ids_before = sorted(
+            str(c.id) for c in await components.storage.list_chunks_by_source(md_path)
+        )
+        assert len(ids_before) >= 2
+
+        await components.index_engine.index_file(md_path, force=True)
+        ids_after = sorted(
+            str(c.id) for c in await components.storage.list_chunks_by_source(md_path)
+        )
+
+        assert ids_after == ids_before
+
+    async def test_force_reindex_preserves_access_count(self, components, memory_dir):
+        """force=True must keep ``access_count`` for chunks whose content is unchanged.
+
+        Regression guard for ADR-0005: pre-fix the force path reset access
+        stats to schema defaults because ``delete_by_source`` removed the
+        row before fresh insertion.
+        """
+        md_path = memory_dir / "two_chunks_access.md"
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 12) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 12) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_texts = AsyncMock(
+            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+        )
+        mock_embedder.dimension = 1024
+        components.index_engine._embedder = mock_embedder
+
+        await components.index_engine.index_file(md_path)
+        chunks_before = await components.storage.list_chunks_by_source(md_path)
+        assert len(chunks_before) >= 2
+        # Bump access_count on the second chunk only
+        target_id = chunks_before[1].id
+        await components.storage.increment_access([target_id])
+
+        ac_before = (await components.storage.get_access_counts([target_id]))[str(target_id)]
+        assert ac_before == 1
+
+        await components.index_engine.index_file(md_path, force=True)
+
+        ac_after = (await components.storage.get_access_counts([target_id]))[str(target_id)]
+        assert ac_after == 1, (
+            f"force-reindex should preserve access_count for unchanged chunks, "
+            f"got {ac_after} (pre-fix would be 0)"
+        )
+
+    async def test_force_reindex_updates_line_ranges_for_unchanged_after_body_edit(
+        self, components, memory_dir
+    ):
+        """When a sibling chunk's body shifts line numbers, the unchanged chunk's
+        ``start_line`` / ``end_line`` columns must catch up — even with force=True
+        (which routes hash-matched chunks through the upsert UPDATE path).
+        """
+        md_path = memory_dir / "shift.md"
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 5) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 5) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_texts = AsyncMock(
+            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+        )
+        mock_embedder.dimension = 1024
+        components.index_engine._embedder = mock_embedder
+
+        await components.index_engine.index_file(md_path)
+        chunks_before = sorted(
+            await components.storage.list_chunks_by_source(md_path),
+            key=lambda c: c.metadata.start_line,
+        )
+        assert len(chunks_before) >= 2
+        b_chunk_before = chunks_before[1]
+        b_id = b_chunk_before.id
+        b_start_before = b_chunk_before.metadata.start_line
+
+        # Insert extra lines in section A so B's start_line shifts.
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 15) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 5) + "\n",
+            encoding="utf-8",
+        )
+        await components.index_engine.index_file(md_path, force=True)
+
+        b_chunk_after = await components.storage.get_chunk(b_id)
+        assert b_chunk_after is not None, "B chunk lost identity across force-reindex"
+        assert b_chunk_after.metadata.start_line > b_start_before, (
+            f"B.start_line should reflect the upward shift; "
+            f"before={b_start_before}, after={b_chunk_after.metadata.start_line}"
+        )
+
+    async def test_mem_edit_preserves_sibling_chunk_metadata(self, components, memory_dir):
+        """End-to-end regression: mem_edit on chunk A leaves chunk B's
+        ``access_count`` and ``id`` intact (the spike scenario from ADR-0005).
+
+        Uses the same call pattern as ``server.tools.memory_crud.mem_edit``:
+        mutate the source file, then ``index_file(force=True)``.
+        """
+        md_path = memory_dir / "edit_pair.md"
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 8) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 8) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_texts = AsyncMock(
+            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+        )
+        mock_embedder.dimension = 1024
+        components.index_engine._embedder = mock_embedder
+
+        await components.index_engine.index_file(md_path)
+        chunks = sorted(
+            await components.storage.list_chunks_by_source(md_path),
+            key=lambda c: c.metadata.start_line,
+        )
+        assert len(chunks) >= 2
+        b_id = chunks[1].id
+        await components.storage.increment_access([b_id])
+
+        # Simulate mem_edit's body-only edit on chunk A: rewrite section A,
+        # leave section B byte-identical, then index_file(force=True).
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A. EDITED.\n" * 8) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 8) + "\n",
+            encoding="utf-8",
+        )
+        await components.index_engine.index_file(md_path, force=True)
+
+        b_after = await components.storage.get_chunk(b_id)
+        assert b_after is not None, "Sibling B should keep its UUID across mem_edit"
+        ac = (await components.storage.get_access_counts([b_id]))[str(b_id)]
+        assert ac == 1, f"Sibling B.access_count should be preserved; got {ac}"
+
 
 # ===========================================================================
 # 8. index_path — directory indexing

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1332,17 +1332,19 @@ class TestIndexFile:
         components.index_engine._embedder = mock_embedder
 
         await components.index_engine.index_file(md_path)
-        ids_before = sorted(
-            str(c.id) for c in await components.storage.list_chunks_by_source(md_path)
-        )
-        assert len(ids_before) >= 2
+        # Bind id to content so an ID swap (assigning A's id to B and vice
+        # versa) fails the test even though the set of ids would still match.
+        binding_before = {
+            c.content: str(c.id) for c in await components.storage.list_chunks_by_source(md_path)
+        }
+        assert len(binding_before) >= 2
 
         await components.index_engine.index_file(md_path, force=True)
-        ids_after = sorted(
-            str(c.id) for c in await components.storage.list_chunks_by_source(md_path)
-        )
+        binding_after = {
+            c.content: str(c.id) for c in await components.storage.list_chunks_by_source(md_path)
+        }
 
-        assert ids_after == ids_before
+        assert binding_after == binding_before
 
     async def test_force_reindex_preserves_access_count(self, components, memory_dir):
         """force=True must keep ``access_count`` for chunks whose content is unchanged.

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -1383,9 +1383,7 @@ class TestIndexFile:
             f"got {ac_after} (pre-fix would be 0)"
         )
 
-    async def test_force_reindex_updates_line_ranges_for_unchanged_after_body_edit(
-        self, components, memory_dir
-    ):
+    async def test_force_reindex_refreshes_line_ranges_for_unchanged(self, components, memory_dir):
         """When a sibling chunk's body shifts line numbers, the unchanged chunk's
         ``start_line`` / ``end_line`` columns must catch up — even with force=True
         (which routes hash-matched chunks through the upsert UPDATE path).
@@ -1472,6 +1470,48 @@ class TestIndexFile:
         assert b_after is not None, "Sibling B should keep its UUID across mem_edit"
         ac = (await components.storage.get_access_counts([b_id]))[str(b_id)]
         assert ac == 1, f"Sibling B.access_count should be preserved; got {ac}"
+
+    async def test_force_reindex_deletes_vanished_chunks(self, components, memory_dir):
+        """force=True must drop rows whose hash no longer appears in the file.
+
+        Pre-fix this was guaranteed by ``delete_by_source`` (blanket DELETE);
+        post-fix the same end state must hold via ``compute_diff``'s
+        ``to_delete`` set + ``delete_chunks``.
+        """
+        md_path = memory_dir / "vanish.md"
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 8) + "\n"
+            "# Section B\n\n" + ("Body for section B.\n" * 8) + "\n",
+            encoding="utf-8",
+        )
+
+        mock_embedder = AsyncMock()
+        mock_embedder.embed_texts = AsyncMock(
+            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+        )
+        mock_embedder.dimension = 1024
+        components.index_engine._embedder = mock_embedder
+
+        await components.index_engine.index_file(md_path)
+        chunks_before = await components.storage.list_chunks_by_source(md_path)
+        assert len(chunks_before) >= 2
+
+        # Remove Section B from the file entirely.
+        md_path.write_text(
+            "# Section A\n\n" + ("Body for section A.\n" * 8) + "\n",
+            encoding="utf-8",
+        )
+        stats = await components.index_engine.index_file(md_path, force=True)
+
+        chunks_after = await components.storage.list_chunks_by_source(md_path)
+        assert len(chunks_after) == 1, (
+            f"force-reindex should drop vanished chunks; "
+            f"got {len(chunks_after)} rows after section B was removed"
+        )
+        assert stats.deleted_chunks >= 1, (
+            f"IndexingStats.deleted_chunks should report removals under force; "
+            f"got {stats.deleted_chunks}"
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Implements the contract decided in **ADR-0005** (merged via #596). The force-reindex path now preserves chunk identity (UUID) and per-chunk personalization (`access_count`, `use_count`, `last_accessed_at`, `importance_score`) for chunks whose content is unchanged. Affects `mem_edit`, `mem_delete`, CLI `mm index --force`, and web `POST /reindex` — every caller of `index_file(force=True)`.

## What changed

`indexing/engine.py:_index_file` no longer takes a separate "force = delete-everything" branch. Instead:

1. **Always run `compute_diff`** against existing hashes. The diff path already reuses existing chunk IDs for hash-matched chunks (see `differ.py:52`), so chunk identity persists across re-indexing whenever content is unchanged.
2. **For `force=True`**, the matched `unchanged` chunks are promoted into `to_upsert` so they get re-embedded — preserving the "ignore embedding cache" semantics force callers rely on.
3. **`upsert_chunks`' UPDATE clause** (`sqlite_backend.py`) explicitly excludes `access_count` / `use_count` / `last_accessed_at` / `importance_score` from the SET list, so personalization survives the re-write.
4. **`delete_by_source` is no longer called from the force path.** The `to_delete` set from the diff handles chunk removal scoped by hash, which is what the caller actually wants.
5. **`new_chunk_ids` snapshotted before the unchanged → to_upsert promotion**, so the `IndexingStats.new_chunk_ids` field still means "chunks created in this run" (consumers like `mem_consolidate_apply` rely on the distinction).

## Behavior change (user-visible)

CHANGELOG entry under `[Unreleased] / Changed`:

> Pre-fix the force path called `delete_by_source` followed by fresh `upsert_chunks`, generating new UUIDs and resetting `access_count`, `use_count`, `last_accessed_at`, `importance_score` for every chunk in the file — including chunks the caller never touched.

The qualitative win:
- Agents that cache chunk IDs across `mem_edit` calls stop seeing silent invalidation.
- Search ranking's access-frequency boost (`search/access.py:access_boost`) and importance scoring (`server/tools/importance.py`) no longer drop to 0 when a sibling chunk is edited.

External agents that depended on the old reset behavior (unlikely but worth surfacing) have a CHANGELOG marker.

## Regression guards

Four new tests in `test_indexing_engine.py::TestIndexFile`, names chosen to document intent:

- `test_force_reindex_preserves_chunk_id_for_unchanged`
- `test_force_reindex_preserves_access_count`
- `test_force_reindex_updates_line_ranges_for_unchanged_after_body_edit`
- `test_mem_edit_preserves_sibling_chunk_metadata`

The existing force tests (`test_force_reindex_reembeds`, `TestPowerUserFeatures::test_force_reindex`) continue to pass — force still re-embeds, only the metadata-loss side effect is gone.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — passes
- [x] `uv run ruff format --check packages/memtomem/src` — passes
- [x] `uv run pytest -m "not ollama"` — **3303 passed, 46 deselected** (full CI-equivalent suite)
- [x] `uv run mypy packages/memtomem/src/memtomem/indexing/engine.py` — clean
- [x] All 4 new regression tests pass
- [x] Both pre-existing force-related tests still pass
- [ ] CI green

## References

- ADR: `docs/adr/0005-force-reindex-metadata-contract.md` (merged in #596)
- Spike PR: #596
- Umbrella: #582 item 4.2
- Plan: `~/.claude/plans/https-github-com-memtomem-memtomem-issue-structured-anchor.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)