### PR TITLE
fix(privacy): tighten \A/\Z detector to ignore escaped literals

### DIFF
--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -74,7 +74,36 @@ _INLINE_FLAG_GROUP_RE = re.compile(r"\(\?[imsux]+\)")
 _NAMED_GROUP_RE = re.compile(r"\(\?P<")
 _INLINE_COMMENT_RE = re.compile(r"\(\?#")
 _FLAG_NEGATION_RE = re.compile(r"\(\?[imsux]*-[imsux]+[:)]")
-_PYTHON_ANCHOR_RE = re.compile(r"\\[AZ]")
+
+
+def _has_unescaped_python_anchor(pat: str) -> bool:
+    r"""True iff ``pat`` contains an unescaped ``\A`` or ``\Z`` anchor.
+
+    A run of consecutive backslashes immediately before ``A`` or ``Z`` is
+    "active" (the final ``\`` escapes the next char) iff its length is odd.
+    Even-length runs are all ``\\`` literal-backslash pairs and leave the
+    next char unescaped — so ``r"foo\\Abar"`` (run of 2) is literal text
+    ``foo\Abar`` with no anchor, while ``r"foo\\\Abar"`` (run of 3) is a
+    literal ``\`` followed by the real ``\A`` anchor.
+
+    Character-class context (e.g. ``[\A]``) is intentionally out of scope
+    (issue #594): this helper checks top-level escape state only. Python's
+    ``re`` rejects ``[\A]`` at compile time anyway, and a secret-class
+    regex putting ``\A`` inside ``[…]`` is implausible.
+    """
+    i, n = 0, len(pat)
+    while i < n:
+        if pat[i] != "\\":
+            i += 1
+            continue
+        j = i
+        while j < n and pat[j] == "\\":
+            j += 1
+        if (j - i) % 2 == 1 and j < n and pat[j] in ("A", "Z"):
+            return True
+        i = j
+    return False
+
 
 # Map Python inline flag chars to ``re`` module flags so the translated
 # body can be sanity-compiled. ``x`` (verbose) is intentionally absent —
@@ -137,7 +166,7 @@ def to_js_pattern(pat: str) -> tuple[str, str]:
     while adding a pattern, extend ``to_js_pattern`` rather than
     suppressing the error.
     """
-    if _PYTHON_ANCHOR_RE.search(pat):
+    if _has_unescaped_python_anchor(pat):
         raise ValueError(
             f"Pattern {pat!r} uses Python-only construct: \\A or \\Z anchor "
             "(JS has no equivalent — use ^ / $ with the m flag)"

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -239,10 +239,11 @@ class TestJsPatternTranslation:
             # ``construct`` is a regex (pytest ``match=``); escape backslashes.
             (r"\Afoo", r"\\A or \\Z anchor"),
             (r"foo\Z", r"\\A or \\Z anchor"),
-            # Odd-length backslash run before ``A``: the leading ``\\`` is a
-            # literal-backslash pair, the final ``\`` actively escapes ``A``.
-            # Real anchor — must still raise.
+            # Odd-length backslash run before ``A``/``Z``: the leading ``\\``
+            # is a literal-backslash pair, the final ``\`` actively escapes
+            # the next char. Real anchor — must still raise. Symmetric pair.
             (r"\\\Afoo", r"\\A or \\Z anchor"),
+            (r"foo\\\Z", r"\\A or \\Z anchor"),
             ("foo(?i)bar", "mid-pattern inline flag group"),
             ("(?ix)foo", "verbose mode"),
             ("(?P<n>x)", "named group"),

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -239,6 +239,10 @@ class TestJsPatternTranslation:
             # ``construct`` is a regex (pytest ``match=``); escape backslashes.
             (r"\Afoo", r"\\A or \\Z anchor"),
             (r"foo\Z", r"\\A or \\Z anchor"),
+            # Odd-length backslash run before ``A``: the leading ``\\`` is a
+            # literal-backslash pair, the final ``\`` actively escapes ``A``.
+            # Real anchor — must still raise.
+            (r"\\\Afoo", r"\\A or \\Z anchor"),
             ("foo(?i)bar", "mid-pattern inline flag group"),
             ("(?ix)foo", "verbose mode"),
             ("(?P<n>x)", "named group"),
@@ -249,6 +253,21 @@ class TestJsPatternTranslation:
     def test_hard_rejects_python_only_constructs(self, bad_pattern, construct):
         with pytest.raises(ValueError, match=construct):
             privacy.to_js_pattern(bad_pattern)
+
+    @pytest.mark.parametrize(
+        "pat",
+        [
+            r"foo\\Abar",  # run of 2: literal ``\`` + literal ``A``, no anchor
+            r"foo\\Zbar",  # run of 2: literal ``\`` + literal ``Z``, no anchor
+            r"foo\\\\Abar",  # run of 4: two literal-``\`` pairs + literal ``A``
+        ],
+    )
+    def test_accepts_escaped_anchor_literals(self, pat):
+        # Detector must distinguish ``\A``/``\Z`` (Python anchor) from
+        # ``\\A``/``\\Z`` (escaped backslash + literal char). Issue #594.
+        body, flags = privacy.to_js_pattern(pat)
+        assert body == pat
+        assert flags == ""
 
     def test_emitted_flags_are_jsregexp_compatible(self):
         # Each entry's flags is a (possibly empty) string of distinct


### PR DESCRIPTION
## Summary

- `privacy._PYTHON_ANCHOR_RE` (added in PR #593) does a literal-text scan over the regex source and over-flags escaped occurrences. `r"foo\\Atest"` (literal text `foo\Atest`) would be hard-rejected at module-import time with a misleading "uses Python-only construct: \A or \Z anchor" error.
- Replace the regex detector with a precise backslash-parity walk: only flag when an *odd*-length run of `\` precedes `A`/`Z` (the case where the final `\` is active).
- Latent today — no `DEFAULT_PATTERNS` entry triggers it. Closes #594.

## Why precise, not the lookbehind heuristic from the issue

The issue suggests `(?<!\\)\\[AZ]`. That fixes `r"foo\\Atest"` but introduces a *new* under-flag for `r"\\\Afoo"`:

- Python: `\\\Afoo` → literal-`\` + `\A` anchor + `foo` (real anchor — degenerate match but defined)
- JS:     `\\\Afoo` → identity-escape, matches the literal text `\Afoo`

The lookbehind would pass it through silently and the JS translator would emit a regex whose semantics diverge from Python's. That's exactly the silent miscompile the `to_js_pattern` docstring calls **"worse than a loud failure"** (lines 129–138 / now 158–167). For a privacy/security module documented to fail loud, an under-flag is a regression, not a fix.

The 10-LOC backslash-parity walk gets every case right.

## Why the sibling detectors aren't touched

Issue #594 says `_NAMED_GROUP_RE`, `_INLINE_COMMENT_RE`, and `_FLAG_NEGATION_RE` "have the same shape and the same theoretical over-flag risk." They don't:

- All three detect constructs starting with literal `(?…`. To put `(` literal in a Python regex source you must write `\(` (unescaped `(` always opens a group). So an attempt to embed e.g. `(?P<` as literal source data becomes `\(\?P<` — six chars with interleaved backslashes — and the detector substring match (four consecutive chars `(?P<`) is broken.
- The `\\` escape over-flag is structurally specific to `\A`/`\Z` because the anchor construct is two characters whose first char is `\` itself, so the detector substring `\\[AZ]` collides with the literal-`\` escape sequence.

Tightening the siblings would be defensive churn that doesn't change behavior. (Note: they *do* have a different theoretical over-flag in character classes like `[(?P<]`, equally vanishingly unlikely in a secret-class regex.)

## Tests

- `test_hard_rejects_python_only_constructs` gains `r"\\\Afoo"` (run-of-3 = literal `\` + real anchor) — pins the precise walk's value over the lookbehind heuristic.
- New `test_accepts_escaped_anchor_literals` covers `r"foo\\Abar"`, `r"foo\\Zbar"`, `r"foo\\\\Abar"` — all pass through unchanged.
- Existing `test_translated_pattern_matches_original` (parity over `DEFAULT_PATTERNS`) and `test_sha_locks_serialization_choice` untouched and green — no regression on current 9 patterns.

## Out of scope (per issue)

- Character-class context (`[\A]` etc.). Python's `re` rejects `[\A]` at compile time anyway; helper docstring is explicit about this.
- Changing import-time fail-loud behavior (intentional, documented).
- `(?P<name>…)` → `(?<name>…)` rewrite.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_privacy.py` — 47 passed
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — green
- [x] `uv run python -c "from memtomem import privacy; print(len(privacy.JS_PATTERNS))"` → `9` (sanity import — `JS_PATTERNS_SHA` unchanged so existing parity / hash-lock tests cover the no-regression claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)