### PR TITLE
feat(web): make supported_extensions GUI-editable (#584)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -758,6 +758,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
         "structured_chunk_mode",
         "exclude_patterns",
         "auto_discover",
+        "supported_extensions",
     },
     "embedding": {"batch_size"},
     "decay": {"enabled", "half_life_days"},

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=69" />
+  <link rel="stylesheet" href="/style.css?v=70" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
 </head>
 <body>
@@ -1277,7 +1277,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=75"></script>
-  <script src="/settings-config.js?v=6"></script>
+  <script src="/settings-config.js?v=7"></script>
   <script src="/sources-memory-dirs.js?v=7"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=3"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -593,7 +593,6 @@
   "settings.exclude_patterns.err_syntax": "Invalid pathspec pattern: {pattern}",
   "settings.exclude_patterns.err_save_blocked": "Fix the highlighted exclude patterns before saving",
 
-  "settings.supported_extensions.label": "Extensions",
   "settings.supported_extensions.placeholder": "e.g. .md, .py",
   "settings.supported_extensions.add": "+ Add",
   "settings.supported_extensions.remove": "Remove extension",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -592,6 +592,16 @@
   "settings.exclude_patterns.err_duplicate": "Duplicate pattern: {pattern}",
   "settings.exclude_patterns.err_syntax": "Invalid pathspec pattern: {pattern}",
   "settings.exclude_patterns.err_save_blocked": "Fix the highlighted exclude patterns before saving",
+
+  "settings.supported_extensions.label": "Extensions",
+  "settings.supported_extensions.placeholder": "e.g. .md, .py",
+  "settings.supported_extensions.add": "+ Add",
+  "settings.supported_extensions.remove": "Remove extension",
+  "settings.supported_extensions.err_cap": "Maximum 20 extensions",
+  "settings.supported_extensions.min_required": "At least one extension required",
+  "settings.supported_extensions.reset_confirm": "Reset extensions to default?",
+  "settings.supported_extensions.reindex_hint": "New extensions take effect on next index. Existing directories need a re-index to pick them up.",
+
   "settings.reset.aria_label": "Reset to default",
   "settings.reset.title": "Reset to default (preview; press Save to apply)",
 

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -592,6 +592,16 @@
   "settings.exclude_patterns.err_duplicate": "중복된 패턴: {pattern}",
   "settings.exclude_patterns.err_syntax": "잘못된 pathspec 패턴: {pattern}",
   "settings.exclude_patterns.err_save_blocked": "저장하기 전에 표시된 exclude 패턴 오류를 수정하세요",
+
+  "settings.supported_extensions.label": "확장자",
+  "settings.supported_extensions.placeholder": "예: .md, .py",
+  "settings.supported_extensions.add": "+ 추가",
+  "settings.supported_extensions.remove": "확장자 제거",
+  "settings.supported_extensions.err_cap": "최대 20개까지 추가할 수 있습니다",
+  "settings.supported_extensions.min_required": "최소 1개의 확장자가 필요합니다",
+  "settings.supported_extensions.reset_confirm": "확장자를 기본값으로 되돌리시겠습니까?",
+  "settings.supported_extensions.reindex_hint": "새 확장자는 다음 인덱싱부터 적용됩니다. 기존 디렉터리는 재인덱싱해야 반영됩니다.",
+
   "settings.reset.aria_label": "기본값으로 되돌리기",
   "settings.reset.title": "기본값으로 되돌리기 (미리보기 — Save 를 눌러야 적용됨)",
 

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -593,7 +593,6 @@
   "settings.exclude_patterns.err_syntax": "잘못된 pathspec 패턴: {pattern}",
   "settings.exclude_patterns.err_save_blocked": "저장하기 전에 표시된 exclude 패턴 오류를 수정하세요",
 
-  "settings.supported_extensions.label": "확장자",
   "settings.supported_extensions.placeholder": "예: .md, .py",
   "settings.supported_extensions.add": "+ 추가",
   "settings.supported_extensions.remove": "확장자 제거",

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -30,7 +30,7 @@ const _READONLY_SECTIONS = new Set(['embedding', 'storage']);
 
 // Individual read-only fields within editable sections
 const _READONLY_FIELDS = {
-  indexing: new Set(['supported_extensions']),
+  indexing: new Set([]),
 };
 
 // Fields that use a custom widget which persists each change immediately
@@ -714,6 +714,7 @@ const _CONFIG_SELECT_OPTIONS = {
 const _CONFIG_CUSTOM_WIDGETS = {
   'search.rrf_weights': _buildRRFWeightsWidget,
   'indexing.exclude_patterns': _buildExcludePatternsWidget,
+  'indexing.supported_extensions': _buildSupportedExtensionsWidget,
 };
 
 // Cached {secret, noise} from GET /api/indexing/builtin-exclude-patterns.
@@ -946,6 +947,162 @@ function _resetExcludePatterns(comparandVal, listEl, addRow, syncHidden) {
   const patterns = Array.isArray(comparandVal) ? comparandVal : [];
   patterns.forEach(p => addRow(p));
   syncHidden();
+}
+
+// Cap on the number of extensions a user can configure through the GUI.
+// Soft guardrail — backend has no equivalent limit, so CLI/config.json
+// edits are unaffected. Sized so legitimate language sets still fit.
+const _SUPPORTED_EXTENSIONS_CAP = 20;
+
+// ``raw`` -> ``.lower``; lossy on purpose (forgiving auto-normalize).
+// Returns null for empty/whitespace input so the caller can silently skip.
+function _normalizeExtension(raw) {
+  const s = String(raw == null ? '' : raw).trim().toLowerCase();
+  if (!s) return null;
+  return s.startsWith('.') ? s : '.' + s;
+}
+
+function _buildSupportedExtensionsWidget(section, key, val) {
+  const wrap = document.createElement('div');
+  wrap.className = 'supported-ext-widget';
+
+  // chips is the canonical state; always kept sorted + deduped so the UI
+  // matches the post-reload server view (system.py serializes sorted()).
+  let chips = (Array.isArray(val) ? val : [])
+    .map(_normalizeExtension)
+    .filter(Boolean);
+  chips = Array.from(new Set(chips)).sort();
+
+  const hidden = document.createElement('input');
+  hidden.type = 'hidden';
+  hidden.dataset.section = section;
+  hidden.dataset.key = key;
+  hidden.dataset.valType = 'json';
+  const origStr = JSON.stringify(chips);
+  hidden.dataset.original = origStr;
+  hidden.value = origStr;
+
+  const listEl = document.createElement('div');
+  listEl.className = 'supported-ext-chips';
+  wrap.appendChild(listEl);
+
+  const addRow = document.createElement('div');
+  addRow.className = 'supported-ext-add-row';
+  addRow.innerHTML = `
+    <input type="text" class="supported-ext-input"
+           data-i18n-placeholder="settings.supported_extensions.placeholder" />
+    <button type="button" class="btn-ghost btn-sm supported-ext-add-btn">
+      <span data-i18n="settings.supported_extensions.add">+ Add</span>
+    </button>
+  `;
+  wrap.appendChild(addRow);
+
+  const errEl = document.createElement('div');
+  errEl.className = 'supported-ext-err';
+  errEl.setAttribute('role', 'alert');
+  wrap.appendChild(errEl);
+
+  wrap.appendChild(hidden);
+
+  const inputEl = addRow.querySelector('.supported-ext-input');
+
+  function _syncHidden() {
+    hidden.value = JSON.stringify(chips);
+    _markConfigDirty(section);
+  }
+
+  function _showError(msg) {
+    errEl.textContent = msg || '';
+    errEl.classList.toggle('supported-ext-err-visible', Boolean(msg));
+  }
+
+  function _renderChips() {
+    listEl.innerHTML = '';
+    const minReached = chips.length <= 1;
+    chips.forEach(ext => {
+      const chip = document.createElement('span');
+      chip.className = 'supported-ext-chip';
+      const label = document.createElement('span');
+      label.className = 'supported-ext-chip-label';
+      label.textContent = ext;
+      chip.appendChild(label);
+
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'supported-ext-chip-remove';
+      removeBtn.textContent = '×';
+      removeBtn.setAttribute(
+        'aria-label',
+        t('settings.supported_extensions.remove') + ': ' + ext,
+      );
+      if (minReached) {
+        removeBtn.disabled = true;
+        removeBtn.title = t('settings.supported_extensions.min_required');
+      }
+      removeBtn.addEventListener('click', () => {
+        if (chips.length <= 1) return;
+        chips = chips.filter(e => e !== ext);
+        _renderChips();
+        _syncHidden();
+      });
+      chip.appendChild(removeBtn);
+      listEl.appendChild(chip);
+    });
+  }
+
+  function _tryAdd() {
+    const normalized = _normalizeExtension(inputEl.value);
+    if (!normalized) {
+      // Empty/whitespace — silent skip. Keep input clean.
+      inputEl.value = '';
+      inputEl.focus();
+      return;
+    }
+    if (chips.includes(normalized)) {
+      // Forgiving dedup: silent ignore, just clear the input.
+      inputEl.value = '';
+      inputEl.focus();
+      return;
+    }
+    if (chips.length >= _SUPPORTED_EXTENSIONS_CAP) {
+      _showError(t('settings.supported_extensions.err_cap'));
+      return;
+    }
+    chips = [...chips, normalized].sort();
+    _renderChips();
+    _syncHidden();
+    _showError('');
+    inputEl.value = '';
+    inputEl.focus();
+  }
+
+  addRow.querySelector('.supported-ext-add-btn').addEventListener('click', _tryAdd);
+  inputEl.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      _tryAdd();
+    }
+  });
+
+  _renderChips();
+
+  // Reset-to-default hook (↺): server-provided defaults from
+  // STATE.serverDefaults flow through here. Confirm before wiping user list
+  // since defaults may overwrite a curated set; the value still lands in
+  // the hidden input only — user must press Save to persist.
+  hidden._reset = (comparandVal) => {
+    if (!confirm(t('settings.supported_extensions.reset_confirm'))) return;
+    const next = (Array.isArray(comparandVal) ? comparandVal : [])
+      .map(_normalizeExtension)
+      .filter(Boolean);
+    chips = Array.from(new Set(next)).sort();
+    _renderChips();
+    _syncHidden();
+    _showError('');
+  };
+
+  if (typeof I18N !== 'undefined') I18N.applyDOM();
+  return wrap;
 }
 
 function _buildConfigInput(section, key, val) {
@@ -1209,6 +1366,12 @@ async function _saveSection(section) {
       _syncConfigToUI();
       // Check if changed fields need reindex/FTS rebuild
       _showReindexWarning(resp.applied);
+      // Surface the supported_extensions reindex nudge as a toast — the
+      // ``applied`` list already filters to actual changes, so no extra
+      // diff-tracking needed.
+      if (resp.applied.some(c => c.field === 'indexing.supported_extensions')) {
+        showToast(t('settings.supported_extensions.reindex_hint'), 'info');
+      }
     }
 
     if (btn) btn.disabled = true;

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -1037,6 +1037,30 @@ button:active { opacity: 0.7; }
 .exclude-remove-btn { min-width: 28px; padding: 2px 8px; }
 .exclude-add-btn { align-self: flex-start; font-size: 0.78rem; }
 
+.supported-ext-widget { display: flex; flex-direction: column; gap: 8px; }
+.supported-ext-chips { display: flex; flex-wrap: wrap; gap: 6px; min-height: 28px; }
+.supported-ext-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 4px 3px 10px; border: 1px solid var(--border); border-radius: 999px;
+  background: var(--bg); font-family: var(--mono); font-size: 0.82rem;
+}
+.supported-ext-chip-label { color: var(--text); }
+.supported-ext-chip-remove {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 20px; height: 20px; padding: 0; border: 0; border-radius: 50%;
+  background: transparent; color: var(--muted); cursor: pointer;
+  font-size: 1rem; line-height: 1;
+}
+.supported-ext-chip-remove:hover:not(:disabled) { background: var(--border); color: var(--text); }
+.supported-ext-chip-remove:disabled { opacity: 0.3; cursor: default; }
+.supported-ext-add-row {
+  display: grid; grid-template-columns: 1fr auto; gap: 6px; align-items: center;
+}
+.supported-ext-input { font-family: var(--mono); font-size: 0.84rem; }
+.supported-ext-add-btn { font-size: 0.78rem; }
+.supported-ext-err { font-size: 0.72rem; color: #b91c1c; min-height: 0; display: none; }
+.supported-ext-err.supported-ext-err-visible { display: block; }
+
 /* ============================================================
    Sources tab — Memory Dirs panel
    ============================================================ */

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -881,6 +881,31 @@ class TestConfigPatch:
         assert len(data["applied"]) == 0
         assert any("namespace.rules" in r for r in data["rejected"])
 
+    async def test_patch_supported_extensions(self, app, client: AsyncClient):
+        """PATCH /api/config accepts indexing.supported_extensions as list[str].
+
+        Regression guard for the MUTABLE_FIELDS entry added with the chip-input
+        Settings UI (#584): if the entry is dropped, this PATCH falls through to
+        ``read-only`` rejection and the GUI silently fails.
+        """
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.patch(
+                "/api/config",
+                json={"indexing": {"supported_extensions": [".md", ".org", ".rst"]}},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert len(data["applied"]) == 1
+        assert data["applied"][0]["field"] == "indexing.supported_extensions"
+        # Compare as set — runtime ``setattr`` bypasses pydantic re-validation,
+        # so the live container may be a list rather than the declared
+        # ``frozenset[str]``. Both are accepted downstream.
+        assert set(app.state.config.indexing.supported_extensions) == {
+            ".md",
+            ".org",
+            ".rst",
+        }
+
 
 # ---------------------------------------------------------------------------
 # Namespace CRUD


### PR DESCRIPTION
## Summary

Closes #584. Settings → Config 의 `indexing.supported_extensions` 를 chip input UI 로
GUI-editable 하게 노출. 기존엔 `~/.memtomem/config.json` 직접 편집 또는 `mm config set` 만
가능했고, `.org` / `.rst` / `.adoc` 추가 요청이 자주 들어오는 영역.

**Screenshots** (attached as a follow-up comment — `gh` CLI 가 직접 attach 지원 안 함):
- Default 10 chips
- After typing `org` → auto-normalized to `.org`, sorted insertion between `.md` and `.py`

## Design choices (locked in plan review)

- **Pattern reuse**: `_buildExcludePatternsWidget` 의 hidden input + `_saveSection` PATCH lifecycle 그대로. 외관만 chip 으로 변경, 새 endpoint 없음.
- **Auto-normalize on add (forgiving)**:
  - `org` → `.org` (leading-dot 자동 보정)
  - `.ORG` → `.org` (lowercase 자동)
  - empty / whitespace → silent skip
  - 중복 → silent ignore
  - 21번째 시도 → inline error
- **Sorted display always** — backend `system.py:sorted()` 직렬화와 매칭 → save→reload 에서 chip 순서 점프 없음.
- **Min 1 enforced** — 마지막 chip 의 × 버튼 `disabled` + tooltip. Reset-to-default ↺ 가 있어 \"wipe and rebuild\" 워크플로우는 막히지 않음.
- **Soft cap 20** — i18n inline error.
- **Default source = server** — 기존 `/api/config/defaults` (이미 `STATE.serverDefaults` 로 fetch 중) 재사용. 클라이언트 하드코딩 없음 → drift 위험 없음.
- **Reindex hint** — save 성공 후 `applied[]` 에 supported_extensions 가 포함됐으면 info toast 로 표시. 별도 diff snapshot 불필요.
- **i18n en + ko 같은 commit**. Chip 텍스트는 user data 이므로 `data-i18n` 안 붙임 (lang toggle 시 안전).

## Out of scope

- **Backend validator** — 현재 `supported_extensions` 에 leading-dot/lowercase 강제 validator 없음. FE normalize 로 GUI path 보호 충분. CLI path 는 pre-existing 이라 별 PR 분리.
- **Auto-reindex on extension change** — 사용자 수동 트리거.
- **Upload whitelist (`_ALLOWED_UPLOAD_EXTS`) 정렬** — 의도적 분리 유지.

## Files changed

- `packages/memtomem/src/memtomem/config.py` — 1-line 추가: `MUTABLE_FIELDS['indexing']` 에 `supported_extensions`. 없으면 PATCH 가 read-only 거부.
- `packages/memtomem/src/memtomem/web/static/settings-config.js` — `_READONLY_FIELDS` 해제, `_CONFIG_CUSTOM_WIDGETS` 등록, `_buildSupportedExtensionsWidget` 추가, save success path 에 reindex-hint toast 호출.
- `packages/memtomem/src/memtomem/web/static/style.css` — chip widget 스타일 (flex-wrap chip list + add row + inline error).
- `packages/memtomem/src/memtomem/web/static/index.html` — cache-bust `style.css?v=70`, `settings-config.js?v=7`.
- `packages/memtomem/src/memtomem/web/static/locales/{en,ko}.json` — 7개 i18n key 동시 추가 (review 후 orphan `.label` 제거).
- `packages/memtomem/tests/test_web_routes_extended.py` — `test_patch_supported_extensions` 회귀 가드: MUTABLE_FIELDS 엔트리 누락 시 PATCH 가 read-only 거부로 fall-through 하면 fail.

## Test plan

- [x] `uv run pytest -m \"not ollama\"` — 3313 passed
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 12 passed (parity + JS scan guard)
- [x] `uv run ruff check packages/memtomem/src` — All checks passed
- [x] `uv run ruff format --check packages/memtomem/src` — 215 files already formatted
- [x] Manual mode-1 (real config + Playwright): default 10 chips render → add `.org` (sorted insertion) → save → reindex-hint info toast appears → `~/.memtomem/config.json` reflects → reset-to-default ↺ + save 로 정리
- [x] Auto-normalize: `ORG` → `.org`, `   ` 빈값 silent skip, `.MD` (이미 `.md` 있음) silent dedup
- [x] Cap: 21번째 시도 → inline error 표시, chip 추가 안 됨
- [x] Min 1: 모든 × 클릭 시도 → 마지막 chip 의 × 는 disabled, tooltip 한국어로 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)
