### PR TITLE
feat(web): localize relativeTime + migrate plural keys to CLDR _other

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -247,16 +247,16 @@ function relativeTime(dateStr) {
   if (!dateStr) return '';
   const diff = Date.now() - new Date(dateStr).getTime();
   const s = Math.floor(diff / 1000);
-  if (s < 60) return 'just now';
+  if (s < 60) return t('time.relative.just_now');
   const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
+  if (m < 60) return t('time.relative.minutes_ago', { m });
   const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
+  if (h < 24) return t('time.relative.hours_ago', { h });
   const d = Math.floor(h / 24);
-  if (d < 30) return `${d}d ago`;
+  if (d < 30) return t('time.relative.days_ago', { d });
   const mo = Math.floor(d / 30);
-  if (mo < 12) return `${mo}mo ago`;
-  return `${Math.floor(mo / 12)}y ago`;
+  if (mo < 12) return t('time.relative.months_ago', { mo });
+  return t('time.relative.years_ago', { y: Math.floor(mo / 12) });
 }
 
 // ── Temporal-validity badge (RFC §Goal 7) ──
@@ -3312,7 +3312,7 @@ async function loadUploadUsage() {
     if (!d.file_count) { hide(el); return; }
     const countKey = d.file_count === 1
       ? 'index.upload_usage_count_one'
-      : 'index.upload_usage_count_many';
+      : 'index.upload_usage_count_other';
     const parts = [
       t(countKey, { count: d.file_count }),
       formatBytes(d.total_bytes),

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1276,9 +1276,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=77"></script>
+  <script src="/app.js?v=78"></script>
   <script src="/settings-config.js?v=7"></script>
-  <script src="/sources-memory-dirs.js?v=7"></script>
+  <script src="/sources-memory-dirs.js?v=8"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=4"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -186,7 +186,7 @@
   "index.upload_btn": "Upload & Index",
   "index.upload_usage_label": "Saved in",
   "index.upload_usage_count_one": "{count} file",
-  "index.upload_usage_count_many": "{count} files",
+  "index.upload_usage_count_other": "{count} files",
   "index.upload_usage_oldest": "oldest {rel}",
   "index.add_heading_label": "Title",
   "index.add_heading_placeholder": "Optional heading",
@@ -484,6 +484,13 @@
   "common.expire": "Expire",
   "common.sync": "Sync",
 
+  "time.relative.just_now": "just now",
+  "time.relative.minutes_ago": "{m}m ago",
+  "time.relative.hours_ago": "{h}h ago",
+  "time.relative.days_ago": "{d}d ago",
+  "time.relative.months_ago": "{mo}mo ago",
+  "time.relative.years_ago": "{y}y ago",
+
   "toast.copied": "Copied!",
   "toast.pinned": "Pinned!",
   "toast.unpinned": "Unpinned",
@@ -606,7 +613,7 @@
 
   "sources.memory_dirs.title": "Memory Dirs",
   "sources.memory_dirs.total_one": "{count} dir",
-  "sources.memory_dirs.total_many": "{count} dirs",
+  "sources.memory_dirs.total_other": "{count} dirs",
   "sources.memory_dirs.category.user": "User",
   "sources.memory_dirs.category.claude_memory": "Claude projects",
   "sources.memory_dirs.category.claude_plans": "Claude plans",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -186,7 +186,7 @@
   "index.upload_btn": "업로드 & 인덱스",
   "index.upload_usage_label": "저장 위치",
   "index.upload_usage_count_one": "{count}개 파일",
-  "index.upload_usage_count_many": "{count}개 파일",
+  "index.upload_usage_count_other": "{count}개 파일",
   "index.upload_usage_oldest": "가장 오래된 {rel}",
   "index.add_heading_label": "제목",
   "index.add_heading_placeholder": "선택적 헤딩",
@@ -484,6 +484,13 @@
   "common.expire": "만료",
   "common.sync": "동기화",
 
+  "time.relative.just_now": "방금",
+  "time.relative.minutes_ago": "{m}분 전",
+  "time.relative.hours_ago": "{h}시간 전",
+  "time.relative.days_ago": "{d}일 전",
+  "time.relative.months_ago": "{mo}개월 전",
+  "time.relative.years_ago": "{y}년 전",
+
   "toast.copied": "복사됨!",
   "toast.pinned": "고정됨!",
   "toast.unpinned": "고정 해제됨",
@@ -606,7 +613,7 @@
 
   "sources.memory_dirs.title": "Memory 디렉터리",
   "sources.memory_dirs.total_one": "{count}개",
-  "sources.memory_dirs.total_many": "{count}개",
+  "sources.memory_dirs.total_other": "{count}개",
   "sources.memory_dirs.category.user": "사용자",
   "sources.memory_dirs.category.claude_memory": "Claude 프로젝트",
   "sources.memory_dirs.category.claude_plans": "Claude plans",

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -447,7 +447,7 @@ function _buildMemoryDirsPanel(initialDirs) {
     const totalCount = document.createElement('span');
     totalCount.className = 'memory-dirs-total';
     totalCount.textContent = t(
-      dirs.length === 1 ? 'sources.memory_dirs.total_one' : 'sources.memory_dirs.total_many',
+      dirs.length === 1 ? 'sources.memory_dirs.total_one' : 'sources.memory_dirs.total_other',
       { count: dirs.length },
     );
     titleGroup.appendChild(totalCount);


### PR DESCRIPTION
## Summary

Two small i18n hygiene fixes bundled because they share the same locale JSON files.

- **#600** — `relativeTime()` returned English-only literals (`just now`, `Nm ago`, …), bleeding English fragments into otherwise-localized KO prose. Route the 6 unit strings through `t()` with new `time.relative.*` keys (12 new keys total across en/ko). Fixes the most-visible offender from PR #599's uploads-usage panel (`저장 위치 ~/.memtomem/uploads/ · 2개 파일 · 30 B · 가장 오래된 1m ago` → `… 1분 전`) and every other call site downstream (timeline, sessions, scratch entries, search detail, sources, home).
- **#601** — Existing plural keys used `_one` / `_many` suffixes, but the CLDR convention is `_one` / `_other`. Rename both pairs (`index.upload_usage_count_*`, `sources.memory_dirs.total_*`) and update the two JS call sites (`app.js`, `sources-memory-dirs.js`).

No plural variants needed for the relative-time keys — the compact form has no plural distinction in either locale.

Cache-bust `app.js` (v77→v78) and `sources-memory-dirs.js` (v7→v8) since their bodies changed; locale JSON uses `cache: 'no-store'` so no versioning needed there.

Closes #600. Closes #601.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -v` — 12 passed (parity tests cover the 6 new keys and the 2 renames automatically)
- [x] `uv run pytest -m "not ollama" -k "i18n or web"` — 417 passed
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [x] `grep -rn '_many\b' packages/memtomem/src/memtomem/web/ packages/memtomem/tests/` — no remaining i18n key matches
- [ ] Manual smoke (mode 1 — real config): `uv run mm web` → toggle EN/KO on Index tab uploads-usage panel and Sources tab Memory Dirs panel; verify no English fragments in KO prose, plural keys still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)