### PR TITLE
feat(web): server-bound /api/indexing/active for cross-tab indicator (#582)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -358,6 +358,14 @@ class IndexEngine:
         Drives the cross-tab / post-reload survival of the web UI's header
         indicator (#582 item 4.11). Counter, not boolean — concurrent stream
         + locked runs both keep it on.
+
+        Scope is **broader** than the three web-triggered surfaces #602's
+        ``STATE.indexing`` covered: any caller that enters ``index_path``,
+        ``index_file``, or ``index_path_stream`` is counted, including the
+        file watcher, MCP-tool ``mem_edit`` / ``mem_delete`` paths, and CLI
+        ``mm index``. The result is that the web indicator may flicker
+        briefly on watcher-triggered re-indexes — preferred over silently
+        under-reporting server-side indexing activity to the UI.
         """
         return self._active_runs > 0
 

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -807,10 +807,10 @@ class IndexEngine:
           same loose shape as ``IndexingStats.errors`` so non-stream UI
           handlers reuse verbatim. Empty list when the run had no errors.
 
-        Note: this path runs **outside** ``_index_lock`` (a deliberate
-        carve-out so progress events can interleave with other engine
-        work). The ``_active_runs`` counter is bumped here too so
-        ``GET /api/indexing/active`` covers stream runs uniformly.
+        Note: this path runs **outside** ``_index_lock`` (unlike
+        ``index_path`` / ``index_file``). The ``_active_runs`` counter
+        is bumped here too so ``GET /api/indexing/active`` covers
+        stream runs uniformly.
         """
         self._active_runs += 1
         try:

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -344,6 +344,22 @@ class IndexEngine:
             ]
         )
         self._index_lock = asyncio.Lock()  # prevent concurrent indexing of same files
+        # Observability counter for ``GET /api/indexing/active`` — independent
+        # of ``_index_lock`` because ``index_path_stream`` runs outside the
+        # lock and ``asyncio.Lock.locked()`` is racy. Incremented on entry
+        # and decremented in a ``finally`` block by every public entry point
+        # (``index_path``, ``index_file``, ``index_path_stream``).
+        self._active_runs: int = 0
+
+    @property
+    def is_active(self) -> bool:
+        """True while at least one indexing run is in flight on this engine.
+
+        Drives the cross-tab / post-reload survival of the web UI's header
+        indicator (#582 item 4.11). Counter, not boolean — concurrent stream
+        + locked runs both keep it on.
+        """
+        return self._active_runs > 0
 
     async def index_path(
         self,
@@ -352,8 +368,12 @@ class IndexEngine:
         force: bool = False,
         namespace: str | None = None,
     ) -> IndexingStats:
-        async with self._index_lock:
-            return await self._index_path_inner(path, recursive, force, namespace)
+        self._active_runs += 1
+        try:
+            async with self._index_lock:
+                return await self._index_path_inner(path, recursive, force, namespace)
+        finally:
+            self._active_runs -= 1
 
     async def _index_path_inner(
         self,
@@ -484,10 +504,14 @@ class IndexEngine:
                 duration_ms=0.0,
                 new_chunk_ids=(),
             )
-        async with self._index_lock:
-            start = time.monotonic()
-            result = await self._index_file(file_path.resolve(), force, namespace=namespace)
-            duration = (time.monotonic() - start) * 1000
+        self._active_runs += 1
+        try:
+            async with self._index_lock:
+                start = time.monotonic()
+                result = await self._index_file(file_path.resolve(), force, namespace=namespace)
+                duration = (time.monotonic() - start) * 1000
+        finally:
+            self._active_runs -= 1
         return IndexingStats(
             total_files=1,
             total_chunks=result["total"],
@@ -782,78 +806,87 @@ class IndexEngine:
           errors``. ``errors`` is a list of human-readable strings in the
           same loose shape as ``IndexingStats.errors`` so non-stream UI
           handlers reuse verbatim. Empty list when the run had no errors.
-        """
-        start = time.monotonic()
-        path = path.resolve()
 
-        if path.is_file():
-            files = [path]
-        elif path.is_dir():
-            files = self._discover_files(path, recursive)
-        else:
+        Note: this path runs **outside** ``_index_lock`` (a deliberate
+        carve-out so progress events can interleave with other engine
+        work). The ``_active_runs`` counter is bumped here too so
+        ``GET /api/indexing/active`` covers stream runs uniformly.
+        """
+        self._active_runs += 1
+        try:
+            start = time.monotonic()
+            path = path.resolve()
+
+            if path.is_file():
+                files = [path]
+            elif path.is_dir():
+                files = self._discover_files(path, recursive)
+            else:
+                yield {
+                    "type": "complete",
+                    "total_files": 0,
+                    "total_chunks": 0,
+                    "indexed_chunks": 0,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 0.0,
+                    "errors": [],
+                    "resolved_namespaces": [],
+                }
+                return
+
+            total_files = len(files)
+            # Pre-compute the namespace echo so the complete event surfaces
+            # what was actually applied — single render across both stream
+            # and non-stream paths (see ``_index_path_inner``).
+            resolved_ns_for_event = self.resolve_namespaces_for(files, namespace)
+            agg = {"total_chunks": 0, "indexed": 0, "skipped": 0, "deleted": 0}
+            all_errors: list[str] = []
+
+            for i, fp in enumerate(files, start=1):
+                try:
+                    result = await self._index_file(fp, force, namespace=namespace)
+                except Exception as exc:
+                    logger.error("Stream indexing failed for %s: %s", fp, exc)
+                    # Path-prefix matches non-stream's ``asyncio.gather(return_exceptions=True)``
+                    # branch in ``_index_path_inner`` so consumers see the same error
+                    # shape regardless of whether they used the stream or non-stream
+                    # endpoint.
+                    result = {
+                        "total": 0,
+                        "indexed": 0,
+                        "skipped": 0,
+                        "deleted": 0,
+                        "errors": [f"{fp.name}: {exc}"],
+                    }
+                agg["total_chunks"] += result["total"]
+                agg["indexed"] += result["indexed"]
+                agg["skipped"] += result["skipped"]
+                agg["deleted"] += result["deleted"]
+                all_errors.extend(result.get("errors", []))
+                yield {
+                    "type": "progress",
+                    "file": str(fp),
+                    "files_done": i,
+                    "files_total": total_files,
+                    "indexed": result["indexed"],
+                    "skipped": result["skipped"],
+                }
+
+            duration = (time.monotonic() - start) * 1000
             yield {
                 "type": "complete",
-                "total_files": 0,
-                "total_chunks": 0,
-                "indexed_chunks": 0,
-                "skipped_chunks": 0,
-                "deleted_chunks": 0,
-                "duration_ms": 0.0,
-                "errors": [],
-                "resolved_namespaces": [],
+                "total_files": total_files,
+                "total_chunks": agg["total_chunks"],
+                "indexed_chunks": agg["indexed"],
+                "skipped_chunks": agg["skipped"],
+                "deleted_chunks": agg["deleted"],
+                "duration_ms": round(duration, 1),
+                "errors": all_errors,
+                "resolved_namespaces": resolved_ns_for_event,
             }
-            return
-
-        total_files = len(files)
-        # Pre-compute the namespace echo so the complete event surfaces
-        # what was actually applied — single render across both stream
-        # and non-stream paths (see ``_index_path_inner``).
-        resolved_ns_for_event = self.resolve_namespaces_for(files, namespace)
-        agg = {"total_chunks": 0, "indexed": 0, "skipped": 0, "deleted": 0}
-        all_errors: list[str] = []
-
-        for i, fp in enumerate(files, start=1):
-            try:
-                result = await self._index_file(fp, force, namespace=namespace)
-            except Exception as exc:
-                logger.error("Stream indexing failed for %s: %s", fp, exc)
-                # Path-prefix matches non-stream's ``asyncio.gather(return_exceptions=True)``
-                # branch in ``_index_path_inner`` so consumers see the same error
-                # shape regardless of whether they used the stream or non-stream
-                # endpoint.
-                result = {
-                    "total": 0,
-                    "indexed": 0,
-                    "skipped": 0,
-                    "deleted": 0,
-                    "errors": [f"{fp.name}: {exc}"],
-                }
-            agg["total_chunks"] += result["total"]
-            agg["indexed"] += result["indexed"]
-            agg["skipped"] += result["skipped"]
-            agg["deleted"] += result["deleted"]
-            all_errors.extend(result.get("errors", []))
-            yield {
-                "type": "progress",
-                "file": str(fp),
-                "files_done": i,
-                "files_total": total_files,
-                "indexed": result["indexed"],
-                "skipped": result["skipped"],
-            }
-
-        duration = (time.monotonic() - start) * 1000
-        yield {
-            "type": "complete",
-            "total_files": total_files,
-            "total_chunks": agg["total_chunks"],
-            "indexed_chunks": agg["indexed"],
-            "skipped_chunks": agg["skipped"],
-            "deleted_chunks": agg["deleted"],
-            "duration_ms": round(duration, 1),
-            "errors": all_errors,
-            "resolved_namespaces": resolved_ns_for_event,
-        }
+        finally:
+            self._active_runs -= 1
 
     @staticmethod
     def _apply_namespace(chunks: list[Chunk], namespace: str) -> list[Chunk]:

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -791,6 +791,23 @@ async def get_stats(storage=Depends(get_storage)) -> StatsResponse:
     )
 
 
+@router.get("/indexing/active", dependencies=[Depends(require_configured)])
+async def indexing_active(index_engine=Depends(get_index_engine)) -> dict:
+    """Report whether any indexing run is in flight server-side.
+
+    Drives cross-tab / post-reload survival of the header indicator
+    introduced in #602 (umbrella #582 item 4.11). Covers ``index_path``,
+    ``index_file``, and ``index_path_stream`` uniformly — the SSE stream
+    path is not lock-protected, so we cannot rely on
+    ``_index_lock.locked()``.
+
+    Response shape is intentionally minimal (``{"active": bool}``) to
+    match the client's single-boolean ``STATE.indexing`` model. Adding
+    ``started_at`` / ``path`` / progress fields later is purely additive.
+    """
+    return {"active": index_engine.is_active}
+
+
 @router.get("/index/stream", dependencies=[Depends(require_configured)])
 async def index_stream(
     path: str = ".",

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -792,7 +792,7 @@ async def get_stats(storage=Depends(get_storage)) -> StatsResponse:
 
 
 @router.get("/indexing/active", dependencies=[Depends(require_configured)])
-async def indexing_active(index_engine=Depends(get_index_engine)) -> dict:
+async def indexing_active(index_engine=Depends(get_index_engine)) -> JSONResponse:
     """Report whether any indexing run is in flight server-side.
 
     Drives cross-tab / post-reload survival of the header indicator
@@ -804,8 +804,16 @@ async def indexing_active(index_engine=Depends(get_index_engine)) -> dict:
     Response shape is intentionally minimal (``{"active": bool}``) to
     match the client's single-boolean ``STATE.indexing`` model. Adding
     ``started_at`` / ``path`` / progress fields later is purely additive.
+
+    ``Cache-Control: no-store`` mirrors ``/index/stream``: this endpoint
+    is polled every few seconds while a run is in flight, and a cached
+    ``{"active": false}`` from an intermediary would mask the
+    false→true transition the client is waiting for.
     """
-    return {"active": index_engine.is_active}
+    return JSONResponse(
+        {"active": index_engine.is_active},
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @router.get("/index/stream", dependencies=[Depends(require_configured)])

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -91,6 +91,15 @@ const STATE = {
     loadPrivacyPatterns();
     renderRecentChips();
     _initTabHelp();
+    // Server-bound indicator hydration (#582 item 4.11). Restores the
+    // header pill if a run is in flight (page-reload survival, second-
+    // tab visibility) — see ``_indexingHydrateFromServer``.
+    _indexingHydrateFromServer();
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible' && !STATE.indexing) {
+        _indexingHydrateFromServer();
+      }
+    });
     // Re-apply i18n when language changes (dynamic JS strings)
     window.addEventListener('langchange', () => {
       if (typeof I18N !== 'undefined') I18N.applyDOM();
@@ -426,6 +435,53 @@ function _indexingEnd() {
   STATE.indexing = false;
   const indicator = qs('indexing-indicator');
   if (indicator) hide(indicator);
+  if (STATE._indexingPollHandle) {
+    clearTimeout(STATE._indexingPollHandle);
+    STATE._indexingPollHandle = null;
+  }
+}
+
+// ── Server-bound hydration (#582 item 4.11 follow-up to #602) ──
+// PR #602 left the header indicator session-bound: a page reload mid-
+// indexing reset ``STATE.indexing`` to ``false`` even though the server
+// run continued. ``GET /api/indexing/active`` reports server truth so
+// boot + tab-visibility-change can restore the indicator and a bounded
+// poll clears it once the server-side run actually finishes.
+const _INDEXING_POLL_MS = 3000;
+
+async function _indexingHydrateFromServer() {
+  try {
+    const r = await api('GET', '/api/indexing/active');
+    if (r && r.active && !STATE.indexing) {
+      _indexingTryStart();
+      _indexingPollUntilIdle();
+    }
+  } catch (err) {
+    // Soft-fail: server unavailable just leaves the indicator off.
+    console.warn('[indexing-active]', err);
+  }
+}
+
+function _indexingPollUntilIdle() {
+  if (STATE._indexingPollHandle) return; // single-flight
+  const tick = async () => {
+    STATE._indexingPollHandle = null;
+    if (!STATE.indexing) return; // local handler already cleared it
+    try {
+      const r = await api('GET', '/api/indexing/active');
+      if (!r || !r.active) {
+        _indexingEnd();
+        return;
+      }
+    } catch (err) {
+      // Transient fetch failure — keep the indicator visible and retry.
+      console.warn('[indexing-active poll]', err);
+    }
+    if (STATE.indexing) {
+      STATE._indexingPollHandle = setTimeout(tick, _INDEXING_POLL_MS);
+    }
+  };
+  STATE._indexingPollHandle = setTimeout(tick, _INDEXING_POLL_MS);
 }
 function panelLoading(container) {
   container.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -54,6 +54,11 @@ const STATE = {
   // through ``_indexingTryStart`` / ``_indexingEnd``; reading directly
   // is fine.
   indexing: false,
+  // Active ``setTimeout`` handle for ``_indexingPollUntilIdle``. Single-
+  // flight guard so visibilitychange + boot-hydration don't stack
+  // concurrent pollers. Cleared by ``_indexingEnd`` and by the tick
+  // itself before re-arming.
+  _indexingPollHandle: null,
   lastRetrievalStats: null,
   groupMode: false,
   cmdPaletteOpen: false,

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=78"></script>
+  <script src="/app.js?v=79"></script>
   <script src="/settings-config.js?v=7"></script>
   <script src="/sources-memory-dirs.js?v=8"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -497,6 +497,29 @@ class TestActiveRunsCounter:
         finally:
             engine._index_file = orig  # type: ignore[method-assign]
 
+    async def test_decrements_on_stream_aclose(self, components, memory_dir):
+        """Async-generator path relies on ``GeneratorExit`` triggering the
+        ``finally`` block when the consumer aborts mid-stream (the
+        realistic SSE-disconnect case). Locks the contract in so a
+        future refactor that swaps ``try/finally`` for, say, an
+        ``ExitStack`` doesn't silently break cancellation cleanup.
+        """
+        # Two files so the generator suspends between yields rather
+        # than running through to ``complete`` before we can ``aclose``.
+        (memory_dir / "a.md").write_text("# A\n\nfirst")
+        (memory_dir / "b.md").write_text("# B\n\nsecond")
+        engine = components.index_engine
+        assert engine.is_active is False
+
+        gen = engine.index_path_stream(memory_dir, recursive=True)
+        ev = await gen.__anext__()
+        assert ev.get("type") == "progress"
+        assert engine._active_runs == 1
+
+        await gen.aclose()
+        assert engine.is_active is False
+        assert engine._active_runs == 0
+
     async def test_decrements_on_exception(self, components, memory_dir):
         """``finally`` must restore the counter when the inner work raises.
         Otherwise a single failing run would stick ``is_active`` on

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -397,6 +398,126 @@ class TestExcludePatterns:
             "drop is a contract violation (#590)"
         )
         assert any("blob.md" in err for err in complete["errors"])
+
+
+# ===========================================================================
+# 1.b _active_runs / is_active counter
+# ===========================================================================
+
+
+class TestActiveRunsCounter:
+    """Tests for ``IndexEngine.is_active`` / ``_active_runs``.
+
+    The counter feeds ``GET /api/indexing/active`` so the web UI's header
+    indicator (#582 item 4.11) survives page reloads and reaches second
+    tabs. It must cover all three public entry points — including
+    ``index_path_stream``, which runs **outside** ``_index_lock`` and is
+    therefore invisible to ``asyncio.Lock.locked()``.
+    """
+
+    async def test_idle_engine_is_not_active(self, components):
+        assert components.index_engine.is_active is False
+        assert components.index_engine._active_runs == 0
+
+    async def test_active_during_index_path(self, components, memory_dir):
+        """Counter goes 0 → 1 while ``index_path`` is awaiting and back to
+        0 after it returns. Use a gate to make the lifecycle deterministic
+        without timing assumptions.
+        """
+        (memory_dir / "notes.md").write_text("# Keep\n\nContent.")
+        engine = components.index_engine
+        gate = asyncio.Event()
+        orig = engine._index_file
+
+        async def blocked(fp, force=False, namespace=None):
+            await gate.wait()
+            return await orig(fp, force, namespace=namespace)
+
+        engine._index_file = blocked  # type: ignore[method-assign]
+        try:
+            assert engine.is_active is False
+            task = asyncio.create_task(engine.index_path(memory_dir))
+            # A few yields so the task reaches the lock + the patched
+            # ``_index_file`` and parks on ``gate.wait()``.
+            for _ in range(3):
+                await asyncio.sleep(0)
+            assert engine.is_active is True
+            gate.set()
+            await task
+            assert engine.is_active is False
+            assert engine._active_runs == 0
+        finally:
+            engine._index_file = orig  # type: ignore[method-assign]
+
+    async def test_active_during_index_path_stream(self, components, memory_dir):
+        """``index_path_stream`` runs outside ``_index_lock`` — verify the
+        counter still tracks it. This is the critical path: a server-bound
+        active-state endpoint that read ``_index_lock.locked()`` would
+        miss every streaming run.
+        """
+        (memory_dir / "notes.md").write_text("# Keep\n\nContent.")
+        engine = components.index_engine
+        assert engine.is_active is False
+
+        gen = engine.index_path_stream(memory_dir, recursive=True)
+        first = await gen.__anext__()
+        assert first.get("type") in ("progress", "complete")
+        assert engine.is_active is True
+
+        async for _ in gen:
+            pass
+        assert engine.is_active is False
+        assert engine._active_runs == 0
+
+    async def test_active_concurrent_runs(self, components, memory_dir):
+        """Counter, not boolean — two parallel ``index_path`` calls both
+        bump it to 2 even though the lock serializes the inner work
+        (``_active_runs += 1`` is *outside* ``async with self._index_lock``).
+        """
+        (memory_dir / "notes.md").write_text("# Keep\n\nContent.")
+        engine = components.index_engine
+        gate = asyncio.Event()
+        orig = engine._index_file
+
+        async def blocked(fp, force=False, namespace=None):
+            await gate.wait()
+            return await orig(fp, force, namespace=namespace)
+
+        engine._index_file = blocked  # type: ignore[method-assign]
+        try:
+            t1 = asyncio.create_task(engine.index_path(memory_dir))
+            t2 = asyncio.create_task(engine.index_path(memory_dir))
+            for _ in range(5):
+                await asyncio.sleep(0)
+            assert engine._active_runs == 2
+            gate.set()
+            await asyncio.gather(t1, t2)
+            assert engine._active_runs == 0
+            assert engine.is_active is False
+        finally:
+            engine._index_file = orig  # type: ignore[method-assign]
+
+    async def test_decrements_on_exception(self, components, memory_dir):
+        """``finally`` must restore the counter when the inner work raises.
+        Otherwise a single failing run would stick ``is_active`` on
+        ``True`` until process restart.
+        """
+        notes = memory_dir / "notes.md"
+        notes.write_text("# Keep\n\nContent.")
+        engine = components.index_engine
+        orig = engine._index_file
+
+        async def boom(fp, force=False, namespace=None):
+            raise RuntimeError("simulated failure")
+
+        engine._index_file = boom  # type: ignore[method-assign]
+        try:
+            with pytest.raises(RuntimeError):
+                await engine.index_file(notes)
+            assert engine.is_active is False
+            assert engine._active_runs == 0
+        finally:
+            engine._index_file = orig  # type: ignore[method-assign]
 
 
 # ===========================================================================

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1128,6 +1128,15 @@ class TestIndexingActive:
         assert resp.status_code == 200
         assert resp.json() == {"active": True}
 
+    async def test_no_store_cache_header(self, app, client: AsyncClient):
+        """``Cache-Control: no-store`` keeps a polling client from being
+        served a stale ``active=false`` by an intermediary while a run
+        starts up. Mirrors ``/index/stream``'s no-cache hygiene.
+        """
+        app.state.index_engine.is_active = False
+        resp = await client.get("/api/indexing/active")
+        assert resp.headers.get("cache-control") == "no-store"
+
 
 # ---------------------------------------------------------------------------
 # GET /api/embedding-status

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1103,6 +1103,33 @@ class TestIndex:
 
 
 # ---------------------------------------------------------------------------
+# GET /api/indexing/active  (#582 item 4.11 follow-up — server-bound indicator)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexingActive:
+    """Tests for ``GET /api/indexing/active``.
+
+    The endpoint reports ``IndexEngine.is_active`` so the web UI's header
+    indicator (introduced in #602) survives page reloads and reaches
+    second tabs. Response shape is intentionally minimal —
+    ``{"active": bool}`` only — to match the client's single-bool model.
+    """
+
+    async def test_active_idle(self, app, client: AsyncClient):
+        app.state.index_engine.is_active = False
+        resp = await client.get("/api/indexing/active")
+        assert resp.status_code == 200
+        assert resp.json() == {"active": False}
+
+    async def test_active_running(self, app, client: AsyncClient):
+        app.state.index_engine.is_active = True
+        resp = await client.get("/api/indexing/active")
+        assert resp.status_code == 200
+        assert resp.json() == {"active": True}
+
+
+# ---------------------------------------------------------------------------
 # GET /api/embedding-status
 # ---------------------------------------------------------------------------
 
@@ -1815,6 +1842,23 @@ class TestRequireConfigured:
         assert resp.status_code == 409, resp.text
         assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")
         assert app.state.index_engine.index_path.call_count == 0
+
+    async def test_indexing_active_409_when_no_config(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        restore_gate,
+    ):
+        """``GET /api/indexing/active`` shares the same gate as the rest
+        of the indexing surface (``/index``, ``/index/stream``,
+        ``/reindex``) — uniform 409 on a not-yet-configured server.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        resp = await client.get("/api/indexing/active")
+        assert resp.status_code == 409, resp.text
+        assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")
 
     async def test_memory_dirs_add_passes_when_config_exists(
         self,


### PR DESCRIPTION
## Summary

Issue #582 item 4.11 follow-up to #602. PR #602 shipped the client-side
`STATE.indexing` flag and `#indexing-indicator` pill but explicitly carved
out one remaining gap in its **Limitations** section:

> The indicator is session-bound, not server-bound. If the user reloads
> the page mid-indexing, `STATE.indexing` resets to `false` and the
> indicator hides — but the indexing run continues server-side. … Closing
> this gap properly needs a server endpoint like `GET /api/indexing/active`
> that the page queries on load. Tracked as a follow-up in the umbrella;
> out of scope for this PR.

This PR closes that gap. Page reload mid-index, or opening a second
browser tab while a run is in flight, now restores the header pill from
server truth and clears it once the run actually finishes.

## What changed

**Server**
- `IndexEngine` gains `_active_runs: int` + `is_active` read-only
  property. Three public entry points (`index_path`, `index_file`,
  `index_path_stream`) bracket their work with `try/finally` to inc/dec.
- The counter is **separate** from `_index_lock` deliberately:
  `index_path_stream` runs *outside* the lock (so progress events can
  interleave), and `asyncio.Lock.locked()` is documented as racy. A
  counter (not boolean) lets concurrent stream + locked runs both keep
  the flag on.
- New `GET /api/indexing/active` returns `{"active": bool}` — minimal
  shape matching the client's single-bool model. `require_configured`
  gate matches sibling indexing routes.

**Client**
- `_indexingHydrateFromServer()` fires once on `DOMContentLoaded` and
  again on `visibilitychange → visible`. If the server reports active
  and the local flag is off, it calls `_indexingTryStart()` and starts
  polling.
- `_indexingPollUntilIdle()` runs a single-flight 3 s `setTimeout` loop;
  on `active === false` it calls `_indexingEnd()`. `_indexingEnd()` also
  cancels any pending poll handle so the in-tab SSE-complete path closes
  the loop too.
- `index.html`: `app.js?v=78` → `?v=79` (cache-bust).

## Test plan

- [x] `uv run pytest -m "not ollama"` — **3337 passed**, 46 deselected
- [x] New tests:
  - `TestActiveRunsCounter` × 5 — idle, during `index_path`, during
    `index_path_stream` (lock-bypass), two concurrent runs ⇒ counter==2,
    `finally`-decrement on exception
  - `TestIndexingActive` — idle / running
  - `TestRequireConfigured.test_indexing_active_409_when_no_config`
    — gate parity with `/api/index`
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `uv run mypy packages/memtomem/src/memtomem/indexing/engine.py packages/memtomem/src/memtomem/web/routes/system.py` — clean
- [x] `node --check packages/memtomem/src/memtomem/web/static/app.js`
- [ ] Manual verify: reload Index tab mid-run → pill reappears within ~3 s; second tab during the same run shows the pill via visibilitychange

## References

- Umbrella: #582 (item 4.11)
- Predecessor: #602 (client-side flag + indicator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)