### PR TITLE
chore: add GitHub issue forms for bug and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -122,10 +122,8 @@ body:
         - Claude Desktop
         - Cursor
         - Windsurf
-        - Codex CLI
-        - Cline
-        - Aider
         - Gemini CLI
+        - Codex CLI
         - Other
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,6 +21,23 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Surface
+      description: Which part of memtomem is involved? Pick the closest match.
+      options:
+        - CLI (`mm`)
+        - MCP server (tool calls from an agent)
+        - Web UI (`mm web`)
+        - Indexing
+        - Search
+        - STM proxy interaction
+        - Install / setup
+        - Other
+    validations:
+      required: true
+
   - type: textarea
     id: repro
     attributes:
@@ -55,7 +72,7 @@ body:
     attributes:
       label: memtomem version
       description: Output of `mm --version` (or `uv run mm --version` in a dev checkout).
-      placeholder: "0.1.30"
+      placeholder: "0.1.33"
     validations:
       required: true
 
@@ -94,11 +111,30 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: mcp_client
+    attributes:
+      label: MCP client (if applicable)
+      description: Which agent or client was talking to the MCP server? Skip if the bug is CLI- or Web-UI-only.
+      options:
+        - Not applicable (CLI / Web UI only)
+        - Claude Code
+        - Claude Desktop
+        - Cursor
+        - Windsurf
+        - Codex CLI
+        - Cline
+        - Aider
+        - Gemini CLI
+        - Other
+    validations:
+      required: false
+
   - type: textarea
     id: context
     attributes:
       label: Additional context
       description: |
-        Anything else worth knowing — relevant config (`~/.memtomem/config.json`, redacted), the MCP client (Claude Code, Cursor, Codex CLI, etc.), whether STM proxy is involved, recent upgrades, etc.
+        Anything else worth knowing — relevant config (`~/.memtomem/config.json`, redacted), whether STM proxy is involved, recent upgrades, etc.
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,104 @@
+name: Bug report
+description: Report unexpected behavior in memtomem (CLI, MCP server, Web UI, indexing, search, etc.)
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. A few notes before you start:
+
+        - **Have a question or want to discuss an idea?** Please use [Discussions](https://github.com/memtomem/memtomem/discussions) instead.
+        - **Found a security issue?** Please follow [SECURITY.md](https://github.com/memtomem/memtomem/blob/main/SECURITY.md) — do not open a public issue.
+        - **Search first.** A quick check of [open](https://github.com/memtomem/memtomem/issues) and [closed](https://github.com/memtomem/memtomem/issues?q=is%3Aissue+is%3Aclosed) issues often turns up the same bug or a related fix.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences on what went wrong.
+      placeholder: "`mem_search` returns 0 results for a query that should match an indexed file."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps that show the bug. Include the exact commands, tool calls, or UI actions.
+      placeholder: |
+        1. `mm init -y`
+        2. `mm index ~/notes`
+        3. Call `mem_search(query="...")` from Claude Code
+        4. Observe empty result
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: At least one match for the query.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include error messages, stack traces, or relevant log output. Use a code block for long output.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: memtomem version
+      description: Output of `mm --version` (or `uv run mm --version` in a dev checkout).
+      placeholder: "0.1.30"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: Install method
+      options:
+        - uv tool install
+        - pipx
+        - pip
+        - From source (editable / dev)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "3.12.7"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - WSL
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: |
+        Anything else worth knowing — relevant config (`~/.memtomem/config.json`, redacted), the MCP client (Claude Code, Cursor, Codex CLI, etc.), whether STM proxy is involved, recent upgrades, etc.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/memtomem/memtomem/discussions
+    about: Ask questions, share use cases, or propose ideas before filing an issue.
+  - name: Security advisories
+    url: https://github.com/memtomem/memtomem/security/policy
+    about: Report security vulnerabilities privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,46 @@
+name: Feature request
+description: Suggest a new capability, behavior change, or improvement
+title: "[feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Before filing:
+
+        - **Open-ended ideas or questions** belong in [Discussions](https://github.com/memtomem/memtomem/discussions). Issues are for concrete, actionable requests.
+        - **Search first.** A quick scan of [open](https://github.com/memtomem/memtomem/issues) and [closed](https://github.com/memtomem/memtomem/issues?q=is%3Aissue+is%3Aclosed) issues often turns up the same idea or the reason it was declined.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do, and what's blocking or awkward today? Be concrete.
+      placeholder: |
+        I want to share memories across two machines without copying `~/.memtomem/` by hand. Today there's no built-in sync.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like memtomem to do? A rough sketch is fine — don't worry about implementation details unless they're load-bearing for the design.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you tried or thought about, and why they didn't work.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Use cases, related issues, links to similar features in other tools, screenshots, etc.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` (GitHub issue forms).
- Adds `.github/ISSUE_TEMPLATE/config.yml` that disables blank issues and routes questions to Discussions, security reports to `SECURITY.md`.

## Why

The repo had no issue templates, so triage required asking every reporter for version, install method, OS, and reproduction steps by hand. This standardizes intake and unblocks the MCP Registry submission, which expects an established issue intake.

## Notes

- Bug form fields: summary, repro, expected/actual, `mm --version`, install method (uv/pipx/pip/source), Python version, OS, additional context.
- Feature form fields: problem, proposal, alternatives, context.
- Existing labels reused: `bug`, `enhancement`. No new labels introduced.
- `blank_issues_enabled: false` keeps the two forms as the only entry points; questions land in Discussions, security in `SECURITY.md`.

## Test plan

- [ ] After merge, open the new-issue picker on the repo and confirm both forms appear with the contact links.
- [ ] File a throwaway bug-form issue in a fork (or use the rendered preview in the PR's Files tab) to sanity-check field labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)