### PR TITLE
docs(readme): add subtitle under H1 for org-profile first impression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # memtomem
 
+> Markdown-first long-term memory for AI coding agents. Hybrid search over your `.md` files via MCP — your data, your quota, no hooks.
+
 **Official website & docs: [https://memtomem.com](https://memtomem.com)**
 
 [![PyPI](https://img.shields.io/pypi/v/memtomem)](https://pypi.org/project/memtomem/)
@@ -11,8 +13,6 @@
 [![Safety](https://img.shields.io/badge/safety-no%20vulnerabilities-brightgreen)](https://data.safetycli.com/packages/pypi/memtomem)
 
 > 🚧 **Alpha** — APIs, defaults, and on-disk config surfaces may still change between `0.1.x` releases. Feedback and issue reports are especially welcome: [Issues](https://github.com/memtomem/memtomem/issues) · [Discussions](https://github.com/memtomem/memtomem/discussions).
-
-**Give your AI agent a long-term memory.**
 
 memtomem turns your markdown notes, documents, and code into a searchable knowledge base that any AI coding agent can use. Write notes as plain `.md` files — memtomem indexes them and makes them searchable by both keywords and meaning.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # memtomem
 
-> Markdown-first long-term memory for AI coding agents. Hybrid search over your `.md` files via MCP — your data, your quota, no hooks.
+> Markdown-first long-term memory for AI coding agents — your data, your quota, no hooks.
 
 **Official website & docs: [https://memtomem.com](https://memtomem.com)**
 


### PR DESCRIPTION
## Summary

- Adds a one-line blockquote subtitle directly under `# memtomem`.
- Removes the now-redundant `**Give your AI agent a long-term memory.**` tagline 14 lines down (the new subtitle covers the same ground more specifically).

## Why

`memtomem/memtomem` is GitHub's special org-profile repo — its README is the org landing page. The previous structure put the H1 above 7 badges and the alpha banner, so a first-time visitor saw the project name with no immediate context until they scrolled. The new subtitle compresses the positioning (markdown source of truth, MCP-native, local-first, no hook chains) into one line and lands it where the eye lands first.

## Diff preview

Before:
```
# memtomem

**Official website & docs: ...**

[7 badges]

> 🚧 Alpha — ...

**Give your AI agent a long-term memory.**

memtomem turns your markdown notes...
```

After:
```
# memtomem

> Markdown-first long-term memory for AI coding agents. Hybrid search over your `.md` files via MCP — your data, your quota, no hooks.

**Official website & docs: ...**

[7 badges]

> 🚧 Alpha — ...

memtomem turns your markdown notes...
```

## Test plan

- [ ] After merge, view the org profile at <https://github.com/memtomem> and confirm the subtitle renders under the H1 above the badges.
- [ ] View the repo README on github.com directly and confirm the two `>` blockquotes (subtitle and alpha banner) are visually separated by the badge row, not collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)