### PR TITLE
docs(readme): move website link from top to Documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 > Markdown-first long-term memory for AI coding agents — your data, your quota, no hooks.
 
-**Official website & docs: [https://memtomem.com](https://memtomem.com)**
-
 [![PyPI](https://img.shields.io/pypi/v/memtomem)](https://pypi.org/project/memtomem/)
 [![Downloads](https://img.shields.io/pypi/dm/memtomem)](https://pypi.org/project/memtomem/)
 [![GitHub stars](https://img.shields.io/github/stars/memtomem/memtomem)](https://github.com/memtomem/memtomem/stargazers)
@@ -143,6 +141,8 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 ---
 
 ## Documentation
+
+Hosted at **[memtomem.com](https://memtomem.com)** — also available as Markdown in this repo:
 
 | Guide | Description |
 |-------|-------------|


### PR DESCRIPTION
## Summary

- Removes the standalone `**Official website & docs: https://memtomem.com**` line directly under the H1 subtitle.
- Adds the website link as a one-line header inside the existing `## Documentation` section: `Hosted at **memtomem.com** — also available as Markdown in this repo:`.

## Why

After #611 added the H1 subtitle (`Markdown-first long-term memory for AI coding agents — your data, your quota, no hooks.`), the website line directly below it was repeating the "this is memtomem" beat without adding information — both lines effectively said "here's the project, here's where to learn more" before the reader reached anything substantive.

Folding the link into the `## Documentation` section co-locates it with the in-repo guide list. Readers who want hosted docs and readers who prefer Markdown both find the right entry from one place, and the top of the README is freed up to lead with the badges + alpha banner + paragraph + diagram sequence.

## Test plan

- [ ] After merge, view the org profile at <https://github.com/memtomem> and confirm the top of the README reads `H1 → subtitle → badges → alpha banner` with no duplicate "Official website" line.
- [ ] Scroll to the Documentation section and confirm the `Hosted at memtomem.com` line renders above the guides table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)