### PR TITLE
docs: bump tool count from 74 to 79

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -710,9 +710,9 @@ Requires `MEMTOMEM_LLM__ENABLED=true` and a configured provider. Generated summa
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (~32 incl. `mem_do`), `full` (74) |
+| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (37 incl. `mem_do`), `full` (79) |
 
-In `core` mode, use `mem_do(action="...", params={...})` to access any of the 65+ non-core actions. Fewer tools means less context usage for AI agents.
+In `core` mode, use `mem_do(action="...", params={...})` to access any of the 70+ non-core actions. Fewer tools means less context usage for AI agents.
 
 ## Web UI Mode
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -304,7 +304,7 @@ uses, so the output is identical. Useful as a sanity check between
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 
-> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 74 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
+> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 79 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
 
 ### STM Proxy Tools (optional, separate package)
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -268,7 +268,7 @@ mm status
 uses, so the output is identical. Useful as a sanity check between
 `mm init` and the first editor-side call.
 
-### Available MCP Tools (74)
+### Available MCP Tools (79)
 
 | Category | Tools |
 |----------|-------|

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -63,7 +63,7 @@ sequenceDiagram
 
 ## MCP Tools at a Glance
 
-memtomem provides **74 MCP tools** organized into categories:
+memtomem provides **79 MCP tools** organized into categories:
 
 | Category | Tools | What they do |
 |----------|-------|-------------|
@@ -1133,4 +1133,4 @@ See [`uninstall.md`](uninstall.md) for the five-step removal flow: detach the MC
 - [LLM Providers](llm-providers.md) — Optional LLM features (auto-tag, entity extraction, ask)
 - [MCP Client Setup](mcp-clients.md) — Editor-specific configuration
 - [memtomem-stm](https://github.com/memtomem/memtomem-stm) — Proactive surfacing, compression, caching (separate package)
-- [Full Tool Reference](../../packages/memtomem/README.md) — All 74 tools with parameters
+- [Full Tool Reference](../../packages/memtomem/README.md) — All 79 tools with parameters

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -94,7 +94,7 @@ the editor: `~/.cursor/mcp.json` (Cursor),
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
 - **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)
-- **🛠️ 74 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
+- **🛠️ 79 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
 
 ## Documentation
 


### PR DESCRIPTION
## Summary
Five public-doc files claimed **74 MCP tools** (or implied counts via tool-mode prose) but the live server registers **79** in `full` mode. Verified via `MEMTOMEM_TOOL_MODE=full` runtime introspection of `mcp._tool_manager._tools`.

Numbers updated everywhere they appear:
- `packages/memtomem/README.md` (PyPI page) — features bullet
- `docs/guides/reference.md` — "MCP Tools at a Glance" header + footer link
- `docs/guides/mcp-clients.md` — "Available MCP Tools (NN)" header + tool-mode callout
- `docs/guides/configuration.md` — `MEMTOMEM_TOOL_MODE` env-var row (`~32` → `37`, `74` → `79`) + "65+ non-core actions" → "70+"

Final counts (verified against source):
- **core**: 9 tools (default; routes via `mem_do`)
- **standard**: 37 tools (core 9 + `mem_*` actions in packs `{crud, namespace, tags, sessions, scratch, relations, schedule}`)
- **full**: 79 tools
- **ACTIONS** (mem_do routing table): 72 actions

## Why
PR 1 of the doc-update batch reflecting code changes since v0.1.30. Mechanical, no behavior implications. PyPI page is included so the next release publish picks up the correct count without a separate PR.

## Test plan
- [x] `grep -rnE "\b74\b"` returns no matches in `README.md`, `packages/memtomem/README.md`, `docs/`
- [x] Runtime verification: `MEMTOMEM_TOOL_MODE=full python -c "from memtomem.server import mcp; print(len(mcp._tool_manager._tools))"` → 79
- [x] Standard count: `9 + |{a for a, info in ACTIONS.items() if info.category in {'crud','namespace','tags','sessions','scratch','relations','schedule'}}|` → 37
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)