### PR TITLE
docs(mcp-clients): add Codex CLI setup section

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -178,7 +178,42 @@ Restart Gemini CLI after configuration.
 
 ---
 
-## 6. Antigravity
+## 6. Codex CLI
+
+Codex CLI reads MCP servers from `~/.codex/config.toml` under the
+`[mcp_servers.<id>]` section header — TOML, not JSON. Add a section for
+memtomem:
+
+```toml
+[mcp_servers.memtomem]
+command = "uvx"
+args = ["--from", "memtomem", "memtomem-server"]
+
+[mcp_servers.memtomem.env]
+MEMTOMEM_INDEXING__MEMORY_DIRS = '["~/memories"]'
+```
+
+Restart Codex CLI after configuration.
+
+> Codex MCP tools default to **serialized** calls. memtomem is safe to
+> run in parallel — opt in by adding `supports_parallel_tool_calls = true`
+> alongside `command`/`args`. Other server-level knobs documented by
+> Codex (e.g. `enabled`, `enabled_tools`, `disabled_tools`,
+> `startup_timeout_sec`, `tool_timeout_sec`) all work; see the official
+> [Codex config reference](https://developers.openai.com/codex/config-reference)
+> for the full schema.
+
+### Verify Connection
+
+In Codex CLI:
+
+```
+Call mem_status to check the memtomem connection status
+```
+
+---
+
+## 7. Antigravity
 
 1. Click the `...` menu at the top of the Agent panel > **MCP Servers**
 2. Click **Manage MCP Servers** at the top of the MCP Store
@@ -216,7 +251,7 @@ Restart Gemini CLI after configuration.
 
 ---
 
-## 7. Verifying Your Connection
+## 8. Verifying Your Connection
 
 These verification methods work across all clients.
 
@@ -312,7 +347,7 @@ The STM proxy is distributed as a separate package: **[memtomem-stm](https://git
 
 ---
 
-## 8. Environment Variable Overrides
+## 9. Environment Variable Overrides
 
 You can override settings by adding environment variables to the `env` block.
 


### PR DESCRIPTION
## Summary
Codex CLI is a selectable option in the bug-report issue-form **MCP-client** dropdown but `docs/guides/mcp-clients.md` had no corresponding setup section. A user picking "Codex CLI" in the form had no canonical doc to reference.

This PR adds a Section 6 ("Codex CLI") matching the shape of the other five client sections (config snippet → restart note → verification call), and renumbers later sections to keep the sequence contiguous (Antigravity 6→7, Verifying 7→8, Environment Variable Overrides 8→9).

## What changed
- New `## 6. Codex CLI` section with:
  - Path: `~/.codex/config.toml`
  - Schema: `[mcp_servers.<id>]` TOML section with `command`, `args`, `[mcp_servers.<id>.env]` map
  - Note about Codex MCP tools defaulting to serialized calls and the optional `supports_parallel_tool_calls = true` opt-in
  - Pointer to the upstream [Codex config reference](https://developers.openai.com/codex/config-reference) for the full schema (`enabled`, `enabled_tools`/`disabled_tools`, `startup_timeout_sec`, `tool_timeout_sec`, etc.)
  - Verification: `Call mem_status to check the memtomem connection status`

## Why
PR 5 of the doc-update batch reflecting code changes since v0.1.30. memtomem already supports Codex CLI as a `mm context sync` target (`.codex/agents/`) and as a memory-ingestion source (`mm ingest codex-memory`); the missing piece was the MCP server registration walk-through.

## Test plan
- [x] Schema verified against `https://developers.openai.com/codex/config-reference` (`mcp_servers.<id>` keys + TOML map syntax for `env`)
- [x] Renumbering: section 6 added, sections 6–8 became 7–9 — `grep "^## "` shows contiguous 1→9
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)