### PR TITLE
feat(web): expose Settings → Namespaces tab in prod (ADR-0007 PR-A+B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ See [MCP Client Setup](docs/guides/mcp-clients.md) for Cursor / Windsurf / Claud
 - **Hybrid search** — BM25 keyword + dense vector + RRF fusion in one query
 - **Semantic chunking** — heading-aware Markdown, AST-based Python, tree-sitter JS/TS, structure-aware JSON/YAML/TOML
 - **Incremental indexing** — chunk-level SHA-256 diff; only changed chunks get re-embedded
-- **Namespaces** — organize memories into scoped groups with auto-derivation from folder names
+- **Namespaces** — organize memories into scoped groups with auto-derivation from folder names; review and label them (colour, description) from Settings → Namespaces in the Web UI
 - **Maintenance** — near-duplicate detection, time-based decay, TTL expiration, auto-tagging
 - **Web UI** — visual dashboard for search, sources, tags, timeline, dedup, and more (`mm web --dev` for the full maintainer surface)
 - **MCP tools** — `mem_do` meta-tool routes all non-core actions in `core` mode for minimal context usage

--- a/docs/adr/0007-namespace-crud-prod-exposure.md
+++ b/docs/adr/0007-namespace-crud-prod-exposure.md
@@ -1,7 +1,8 @@
 # ADR-0007: Namespace CRUD prod exposure model
 
-**Status:** Proposed (deferred pending trigger)
-**Date:** 2026-04-30
+**Status:** Accepted (PR-A + PR-B implemented)
+**Date:** 2026-04-30 (drafted), 2026-04-30 (accepted same day after maintainer
+prod-user feedback fired the trigger — see Decision section).
 **Context:** Issue #586 — Settings → Namespaces tab (NS list, color,
 description, rules editing) is dev-mode only. PR #604 (#582 4.10a) just
 ungated the Search NS filter dropdown for prod. The deeper product
@@ -158,10 +159,17 @@ promote rename via its own ADR with full chunk-migration design.
 
 ## Decision
 
-**Defer.** Leaning toward **A.2 + B.1 + C.1 + D.2 + E.2** when
-implementation is triggered.
+**Accept A.2 + B.1 + C.1 + D.2 + E.2** — PR-A and PR-B implemented in
+the same release window as the ADR draft. Trigger #1 fired same-day:
+maintainer doing the prod transition reported the Settings → Namespaces
+tab missing in prod and confirmed (via question dialog) that this was
+the gap they cared about, not the filter-dropdown surface PR #604
+already covered. One report from the maintainer — who was the prod-user
+voice the ADR was waiting on — is sufficient signal here; the
+"≥ 2 reports" bar in trigger #1 was framed for external feedback,
+which a maintainer-driven trigger short-circuits.
 
-### Why hold instead of implement now
+### Earlier rationale for holding (kept for reference)
 
 - **Single signal.** The issue body is one design audit. Below the
   "twice = pattern" bar; the same threshold ADR-0004 used to defer.
@@ -173,6 +181,9 @@ implementation is triggered.
   indexing detail") may be correct. Deferring lets a user-facing
   signal (issue, support comment, review) fire before we build the
   empty-state CTA and risk teaching a primitive nobody asked for.
+
+The third bullet is what flipped: the maintainer-as-prod-user signal
+fired, removing the deferral's main rationale.
 
 ### Trigger criteria (any one promotes to "Accepted")
 
@@ -191,34 +202,37 @@ implementation is triggered.
    namespaces as the grouping unit. In that case A.2 + B.1 + C.1
    become a prerequisite.
 
-### Implementation outline (when triggered)
+### Implementation outline (PR-A + PR-B shipped; PR-C deferred)
 
-In rough order, all in `packages/memtomem/src/memtomem/`:
+PR-A and PR-B were bundled in one PR since both unblock the same
+"Namespaces tab in prod" trigger. PR-C remains gated by separate
+chunk-id stability work.
 
-- **PR-A — Lift the JS dev-gate; expose PATCH in prod tier.**
-  - Remove the `if (STATE.uiMode !== 'dev') return;` early-return at
-    `web/static/settings-namespaces.js:179`. Read-only listing in
-    prod was already half-wired (the dropdown comment at line 60-62
-    already says the read endpoint is prod tier).
-  - Move `PATCH /api/namespaces/{ns}` from `admin_router` to
-    `namespaces_read` (or to a new `namespaces_edit` mid-tier router).
-    `namespaces.py:57` is the registration site. POST/{ns}/rename and
-    DELETE/{ns} stay on `admin_router`.
-  - The frontend already has the form for color/description. Verify
-    it doesn't reach for the dev-only DELETE path on submit.
-- **PR-B — Empty-state CTA + onboarding link.**
-  - When `loadNamespacesTab()` resolves to an empty list in prod, render
-    a first-time tile: "Define your first namespace" with a one-line
-    explanation and a link to the user-guide section on NS rules.
-  - Optional: a "Create" button that POSTs to a new prod-tier
-    `POST /api/namespaces` (currently nonexistent — `admin_router`
-    doesn't have it, NS are auto-created by indexing). If creating an
-    empty NS turns out to be conceptually weird (a NS with no chunks?),
-    leave creation to indexing and have the CTA link to "add a folder
-    that uses your NS rule" instead.
-- **PR-C (gated by separate triggers, not this ADR's) — rename / bulk
-  delete.**
-  - Each is its own ADR with chunk-migration design.
+- **PR-A — Lift the JS dev-gate; expose PATCH in prod tier.** ✓ shipped.
+  - Removed `if (STATE.uiMode !== 'dev') return;` from
+    `web/static/settings-namespaces.js:loadNamespacesTab`.
+  - Flipped `data-ui-tier="dev"` → `"prod"` on the Settings nav button
+    (`web/static/index.html:596`).
+  - Dropped `update_metadata`'s `@admin_router.patch` decorator and
+    re-mounted via `add_api_route` in `web/routes/namespaces_read.py`
+    (same pattern `list_namespaces` already used).
+  - Rename + Delete buttons in `_buildNsCard` are gated to
+    `STATE.uiMode === 'dev'` so they don't render in prod (their
+    backend routes stay on `admin_router` until PR-C lands).
+- **PR-B — Empty-state CTA + onboarding link.** ✓ shipped.
+  - When `loadNamespacesTab()` resolves to an empty list, the panel
+    renders a first-time tile with title, body, and a CTA link to
+    `docs/guides/configuration.md#namespace`. The "Create" button
+    sub-option was rejected: an empty NS without chunks has no clear
+    semantic, and the indexing/rules path already handles creation.
+  - i18n keys: `settings.ns.empty.title`, `settings.ns.empty.body`,
+    `settings.ns.empty.cta` (en + ko).
+- **PR-C (deferred) — rename / bulk delete prod exposure.**
+  - Each is its own ADR with chunk-migration design (depends on
+    ADR-0005 chunk-id stability outcome). Tracking issue should be
+    filed when one of the trigger criteria fires (post-rollout
+    feedback, multi-agent grouping verdict 2026-05-09, or
+    onboarding-flow rules surface).
 
 ## Consequences
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -722,7 +722,7 @@ In `core` mode, use `mem_do(action="...", params={...})` to access any of the 65
 
 `mm web --mode {prod,dev}` overrides the env. `mm web --dev` is a shortcut for `--mode dev` and is mutually exclusive with `--mode`. An invalid value fails fast rather than silently falling back.
 
-Tab classification changes over time — run `mm web --dev` to see the full surface of your installed version. The API endpoints backing dev-only pages (for example `/api/sessions`, `/api/scratch`, `/api/namespaces`) return 404 in `prod` mode; switch to `dev` mode if you're scripting against them.
+Tab classification changes over time — run `mm web --dev` to see the full surface of your installed version. Dev-only API endpoints (for example `/api/sessions`, `/api/scratch`, `POST /api/namespaces/{ns}/rename`, `DELETE /api/namespaces/{ns}`) return 404 in `prod` mode; switch to `dev` mode if you're scripting against them. The namespace list (`GET /api/namespaces`) and cosmetic metadata edit (`PATCH /api/namespaces/{ns}`) are prod-tier and respond in both modes — see ADR-0007.
 
 ## Querying and Modifying at Runtime
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -319,6 +319,18 @@ mm add "Redis LRU→LFU reduced cache misses by 40%" --tags "redis,performance"
 mm recall --since 2026-04-01
 ```
 
+### 5. Organise memories with namespaces
+
+Each chunk lives in a namespace. Indexing creates them automatically — for
+example, ingesting `~/.claude/projects/...` produces `claude-memory:<slug>`
+namespaces — and you can also pass `--namespace work-notes` to `mm index`
+to bucket on demand. Once a namespace exists, open **Settings →
+Namespaces** in the Web UI to attach a colour and a one-line description
+so it's easy to pick out in filters and result chips. Structural ops
+(rename, delete) live in `--dev` mode pending chunk-id stability work
+(see [`docs/guides/configuration.md#namespace`](configuration.md#namespace)
+for rules and ADR-0007 for the rationale).
+
 ---
 
 ## CLI reference

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -964,9 +964,9 @@ mm web --dev                   # adds opt-in maintainer pages
 mm web --mode {prod,dev}       # explicit mode (mutually exclusive with --dev)
 ```
 
-`mm web` defaults to the polished page set: Home, Search, Sources, Index, Tags, Timeline, and Settings (Config, Artifact Sync, Skills/Commands/Agents, Dedup, Age-out, Export/Import, Reset Database). `mm web --dev` — or setting `MEMTOMEM_WEB__MODE=dev` in your shell profile — extends the surface with maintainer pages (Namespaces, Sessions, Working Memory, Procedures, Health Report, Hook Files).
+`mm web` defaults to the polished page set: Home, Search, Sources, Index, Tags, Timeline, and Settings (Config, Namespaces, Artifact Sync, Skills/Commands/Agents, Dedup, Age-out, Export/Import, Reset Database). `mm web --dev` — or setting `MEMTOMEM_WEB__MODE=dev` in your shell profile — extends the surface with maintainer pages (Sessions, Working Memory, Procedures, Health Report, Hook Files) and unlocks structural namespace verbs (rename, delete) that are dev-only by ADR-0007.
 
-Tab classification changes over time — run `mm web --dev` against your installed version to see the complete surface. The API endpoints backing dev-only pages return 404 in `prod` mode; scripts that hit `/api/sessions`, `/api/scratch`, `/api/namespaces`, etc. need `dev` mode.
+Tab classification changes over time — run `mm web --dev` against your installed version to see the complete surface. The API endpoints backing dev-only pages return 404 in `prod` mode; scripts that hit `/api/sessions`, `/api/scratch`, `/api/namespaces/{ns}/rename`, `DELETE /api/namespaces/{ns}`, etc. need `dev` mode. `GET /api/namespaces` (list) and `PATCH /api/namespaces/{ns}` (cosmetic edit — color, description) are prod-tier and respond in both modes.
 
 ---
 

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -90,7 +90,7 @@ the editor: `~/.cursor/mcp.json` (Cursor),
 - **🔍 Hybrid search** — BM25 (FTS5) + dense vectors (sqlite-vec) merged via Reciprocal Rank Fusion. Exact terms via keyword, meaning via semantic, both at once.
 - **📦 Semantic chunking** — heading-aware Markdown, AST-based Python, tree-sitter JS/TS, structure-aware JSON/YAML/TOML
 - **♻️ Incremental indexing** — chunk-level SHA-256 diff means only changed chunks get re-embedded
-- **🏷️ Namespaces** — scope memories into groups (work / personal / project) with optional auto-derivation from folder names
+- **🏷️ Namespaces** — scope memories into groups (work / personal / project) with optional auto-derivation from folder names; label them (colour, description) from Settings → Namespaces in the Web UI
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
 - **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)

--- a/packages/memtomem/src/memtomem/web/routes/namespaces.py
+++ b/packages/memtomem/src/memtomem/web/routes/namespaces.py
@@ -1,4 +1,16 @@
-"""Namespace management endpoints."""
+"""Namespace management endpoints.
+
+Tier split (after ADR-0007):
+
+* ``list_namespaces`` and ``update_metadata`` are tier-mounted in
+  ``namespaces_read`` (prod). They read or cosmetically edit per-namespace
+  metadata (color, description) — both are safe to expose without
+  chunk-migration policy.
+* ``get_namespace``, ``rename_namespace``, and ``delete_namespace`` stay on
+  ``admin_router`` (dev-only). Rename and delete need chunk-id stability
+  design (ADR-0005) before promotion; the per-namespace info GET is
+  redundant with the list endpoint and stays admin-side.
+"""
 
 from __future__ import annotations
 
@@ -54,7 +66,8 @@ async def get_namespace(namespace: str, storage=Depends(get_storage)) -> Namespa
     )
 
 
-@admin_router.patch("/{namespace}", response_model=NamespaceInfoResponse)
+# Registered on the read router in namespaces_read.py (prod tier — cosmetic
+# edit doesn't migrate chunks). Rename and delete stay on admin_router below.
 async def update_metadata(
     namespace: str,
     body: NamespaceMetaRequest,

--- a/packages/memtomem/src/memtomem/web/routes/namespaces_read.py
+++ b/packages/memtomem/src/memtomem/web/routes/namespaces_read.py
@@ -1,18 +1,23 @@
-"""Read-only namespace endpoint mounted in both prod and dev tiers.
+"""Read-side + cosmetic-edit namespace endpoints, mounted in the prod tier.
 
-The admin (CRUD) routes live on ``namespaces.admin_router`` and stay
-dev-only — see ``web/app.py: _DEV_ONLY_ROUTERS``. Splitting the read
-surface lets the Search / Timeline / Export filter dropdowns and the
-Home dashboard's namespace donut populate in prod without exposing
-PATCH/POST/DELETE.
+The structural admin verbs (per-namespace info GET, rename, delete) stay on
+``namespaces.admin_router`` and remain dev-only — see
+``web/app.py: _DEV_ONLY_ROUTERS``. Splitting the surface lets the Search /
+Timeline / Export filter dropdowns and the Settings → Namespaces tab's
+cosmetic edit (color, description) populate in prod without exposing
+chunk-migrating verbs.
+
+PATCH was promoted from admin to prod under ADR-0007 (cosmetic-only edit
+needs no chunk migration). Rename and delete remain admin-only pending
+ADR-0005's chunk-id stability follow-up.
 """
 
 from __future__ import annotations
 
 from fastapi import APIRouter
 
-from memtomem.web.routes.namespaces import list_namespaces
-from memtomem.web.schemas import NamespacesListResponse
+from memtomem.web.routes.namespaces import list_namespaces, update_metadata
+from memtomem.web.schemas import NamespaceInfoResponse, NamespacesListResponse
 
 router = APIRouter(prefix="/namespaces", tags=["namespaces"])
 router.add_api_route(
@@ -20,4 +25,10 @@ router.add_api_route(
     list_namespaces,
     methods=["GET"],
     response_model=NamespacesListResponse,
+)
+router.add_api_route(
+    "/{namespace}",
+    update_metadata,
+    methods=["PATCH"],
+    response_model=NamespaceInfoResponse,
 )

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=71" />
+  <link rel="stylesheet" href="/style.css?v=72" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
 </head>
 <body>
@@ -593,7 +593,7 @@
             <span class="nav-sub" data-i18n="settings.nav.config_sub">Embedding &amp; DB</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="namespaces" data-group="general" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🗂</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.namespaces">Namespaces</span>
@@ -1299,7 +1299,7 @@
   <script src="/settings-config.js?v=7"></script>
   <script src="/sources-memory-dirs.js?v=8"></script>
   <script src="/settings-maintenance.js?v=1"></script>
-  <script src="/settings-namespaces.js?v=4"></script>
+  <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=1"></script>
   <script src="/timeline.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -325,6 +325,9 @@
   "settings.ns.title": "Namespaces",
   "settings.ns.refresh": "Refresh",
   "settings.ns.group_chunks": "{count} chunks",
+  "settings.ns.empty.title": "No namespaces yet",
+  "settings.ns.empty.body": "Index files with a namespace, or define one in your config rules to bucket memories.",
+  "settings.ns.empty.cta": "Learn how namespaces work",
 
   "settings.dedup.desc": "Find near-duplicate chunks by similarity threshold and merge or skip them.",
   "settings.dedup.threshold_label": "Threshold",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -325,6 +325,9 @@
   "settings.ns.title": "네임스페이스",
   "settings.ns.refresh": "새로고침",
   "settings.ns.group_chunks": "{count}개 청크",
+  "settings.ns.empty.title": "아직 네임스페이스가 없습니다",
+  "settings.ns.empty.body": "파일을 인덱싱할 때 네임스페이스를 지정하거나, 설정 규칙에 정의해 기억을 분류하세요.",
+  "settings.ns.empty.cta": "네임스페이스 사용법 알아보기",
 
   "settings.dedup.desc": "유사도 임계값 기반으로 중복 청크를 찾아 병합하거나 건너뜁니다.",
   "settings.dedup.threshold_label": "임계값",

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -140,16 +140,6 @@ function _buildNsCard(ns, defaultNs) {
   editBtn.textContent = 'Edit';
   editBtn.addEventListener('click', () => editNamespaceMeta(ns, card));
 
-  const renameBtn = document.createElement('button');
-  renameBtn.className = 'btn-ghost btn-xs';
-  renameBtn.textContent = 'Rename';
-  renameBtn.addEventListener('click', () => renameNamespace(ns.namespace));
-
-  const delBtn = document.createElement('button');
-  delBtn.className = 'btn-danger btn-xs';
-  delBtn.textContent = 'Delete';
-  delBtn.addEventListener('click', () => deleteNamespace(ns.namespace));
-
   const sourcesBtn = document.createElement('button');
   sourcesBtn.className = 'btn-ghost btn-xs';
   sourcesBtn.textContent = 'Sources';
@@ -158,8 +148,25 @@ function _buildNsCard(ns, defaultNs) {
 
   actions.appendChild(sourcesBtn);
   actions.appendChild(editBtn);
-  actions.appendChild(renameBtn);
-  actions.appendChild(delBtn);
+
+  // Rename + Delete are admin-only verbs (chunk-migration risk; ADR-0007
+  // defers them to a separate ADR with chunk-id stability design). The
+  // backend routes live on admin_router → _DEV_ONLY_ROUTERS, so calling
+  // them in prod would 404. Keep the buttons in dev only.
+  if (STATE.uiMode === 'dev') {
+    const renameBtn = document.createElement('button');
+    renameBtn.className = 'btn-ghost btn-xs';
+    renameBtn.textContent = 'Rename';
+    renameBtn.addEventListener('click', () => renameNamespace(ns.namespace));
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'btn-danger btn-xs';
+    delBtn.textContent = 'Delete';
+    delBtn.addEventListener('click', () => deleteNamespace(ns.namespace));
+
+    actions.appendChild(renameBtn);
+    actions.appendChild(delBtn);
+  }
 
   card.appendChild(dot);
   card.appendChild(name);
@@ -170,13 +177,11 @@ function _buildNsCard(ns, defaultNs) {
 }
 
 async function loadNamespacesTab() {
-  // The Namespaces management *tab* is dev-only (data-ui-tier="dev" on the
-  // settings nav button). The Edit/Rename/Delete buttons rendered below
-  // call PATCH/POST/DELETE /api/namespaces/{name} on the admin_router,
-  // which stays in _DEV_ONLY_ROUTERS. The list endpoint itself is
-  // prod-mounted but the CRUD UX requires the admin surface, so this
-  // early-return keeps the tab from rendering in prod.
-  if (STATE.uiMode !== 'dev') return;
+  // The tab is prod-visible after ADR-0007. The Edit button calls
+  // PATCH /api/namespaces/{name}, mounted on the prod-tier read router
+  // (cosmetic edit doesn't migrate chunks). Rename + Delete buttons are
+  // gated to dev mode in `_buildNsCard` because their backend routes stay
+  // on admin_router until chunk-id stability lands (ADR-0005 follow-up).
   const list = qs('ns-list');
   list.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
 
@@ -184,7 +189,8 @@ async function loadNamespacesTab() {
     const data = await api('GET', '/api/namespaces');
     const namespaces = data.namespaces || [];
     if (!namespaces.length) {
-      list.innerHTML = emptyState('📁', 'No namespaces yet', 'Index files with a namespace to get started');
+      const cta = `<a class="empty-state-cta" href="https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md#namespace" target="_blank" rel="noopener">${escapeHtml(t('settings.ns.empty.cta'))} →</a>`;
+      list.innerHTML = `<div class="empty-state">${emptyState('🗂', t('settings.ns.empty.title'), t('settings.ns.empty.body'))}${cta}</div>`;
       return;
     }
     list.innerHTML = '';

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -1829,6 +1829,8 @@ select:focus-visible {
 .empty-state { flex-direction: column; gap: 6px; }
 .empty-state-icon { font-size: 1.6rem; opacity: 0.5; }
 .empty-state-hint { font-size: 0.78rem; color: var(--muted); opacity: 0.7; }
+.empty-state-cta { font-size: 0.82rem; color: var(--accent); text-decoration: none; margin-top: 4px; }
+.empty-state-cta:hover { text-decoration: underline; }
 
 /* Recent search chips (empty state) */
 .recent-chips {

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -215,14 +215,15 @@ def test_prod_keeps_polished_routes_mounted() -> None:
 
 @pytest.mark.asyncio
 async def test_namespaces_list_is_prod_mounted_but_admin_routes_blocked() -> None:
-    """4.10a (#582): the read endpoint graduates to prod for the Search /
-    Timeline / Export filter dropdowns and the Home dashboard donut, but the
-    admin (CRUD) surface stays dev-only. A future refactor that promotes
-    PATCH/POST/DELETE to prod must fail this gate.
+    """ADR-0007 PR-A: the read endpoint and the cosmetic PATCH (color,
+    description) live on the prod tier; the structural admin surface
+    (GET-by-id, rename, delete) stays dev-only. Cosmetic edit was
+    promoted because it doesn't migrate chunks; rename/delete need
+    chunk-id stability design (ADR-0005 follow-up) before promotion.
 
-    The list endpoint is mounted via ``namespaces_read`` in _PROD_ROUTERS;
-    the admin surface (PATCH/POST/DELETE/GET-by-id) stays on
-    ``namespaces.admin_router`` in _DEV_ONLY_ROUTERS.
+    Backed by ``namespaces_read.router`` in _PROD_ROUTERS (GET list +
+    PATCH metadata) and ``namespaces.admin_router`` in
+    _DEV_ONLY_ROUTERS (GET info + rename + delete).
     """
     prod_app = create_app(mode="prod")
     prod_paths = _api_paths(prod_app)
@@ -230,13 +231,34 @@ async def test_namespaces_list_is_prod_mounted_but_admin_routes_blocked() -> Non
         "GET /api/namespaces must be prod-mounted via namespaces_read"
     )
 
+    # Path-level pin: PATCH /api/namespaces/{namespace} is prod (cosmetic
+    # edit). Rename and delete share the same path template but live on
+    # admin_router, so a path string match alone isn't enough — verify
+    # the methods registered for the path.
+    patch_methods = {
+        m
+        for r in prod_app.routes
+        if getattr(r, "path", "") == "/api/namespaces/{namespace}"
+        for m in getattr(r, "methods", set()) or set()
+    }
+    assert "PATCH" in patch_methods, (
+        "PATCH /api/namespaces/{namespace} must be prod-mounted via namespaces_read"
+    )
+    assert "GET" not in patch_methods, (
+        "GET /api/namespaces/{namespace} (info) must stay dev-only on admin_router"
+    )
+    assert "DELETE" not in patch_methods, (
+        "DELETE /api/namespaces/{namespace} must stay dev-only on admin_router"
+    )
+
     async with AsyncClient(
         transport=ASGITransport(app=prod_app, client=("127.0.0.1", 0)),
         base_url="http://testserver",
     ) as c:
+        # Structural verbs must stay dev-only — these all live on
+        # namespaces.admin_router and 404 cleanly without a storage mock.
         for method, path in (
             ("GET", "/api/namespaces/foo"),
-            ("PATCH", "/api/namespaces/foo"),
             ("POST", "/api/namespaces/foo/rename"),
             ("DELETE", "/api/namespaces/foo"),
         ):
@@ -405,7 +427,11 @@ def test_html_classification_matches_router_lists() -> None:
     # section id != router module). Source of truth: whoever edits the
     # router lists must also update the HTML, and this test enforces it.
     expected_dev = {
-        "namespaces",
+        # ADR-0007 PR-A promoted Settings → Namespaces to prod (cosmetic
+        # CRUD only). Rename and delete buttons inside the panel are
+        # dev-gated in JS (settings-namespaces.js _buildNsCard) because
+        # their backend verbs stay on admin_router; this HTML check tracks
+        # the section visibility, not the per-button gating.
         "hooks-sync",
         "harness-sessions",
         "harness-scratch",

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -963,6 +963,73 @@ class TestNamespaceCRUD:
 
 
 # ---------------------------------------------------------------------------
+# Namespace tier split (ADR-0007 PR-A)
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceProdTier:
+    """In ``prod`` mode the read+cosmetic surface (GET list, PATCH metadata)
+    is mounted; the structural admin surface (per-NS info GET, rename,
+    delete) returns 404. The dev-mode counterparts already pass via
+    ``TestNamespaceCRUD`` — this class pins the asymmetry.
+    """
+
+    @pytest.fixture
+    async def prod_client(self):
+        application = create_app(lifespan=None, mode="prod")
+        storage = AsyncMock()
+        storage.list_namespace_meta = AsyncMock(
+            return_value=[
+                {
+                    "namespace": "default",
+                    "chunk_count": 1,
+                    "description": "",
+                    "color": "",
+                }
+            ]
+        )
+        storage.list_namespaces = AsyncMock(return_value=[("default", 1)])
+        storage.set_namespace_meta = AsyncMock()
+        storage.get_namespace_meta = AsyncMock(
+            return_value={"description": "Updated", "color": "#abcdef"}
+        )
+        application.state.storage = storage
+        application.state.config = FakeConfig()
+        transport = ASGITransport(app=application)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c
+
+    async def test_list_endpoint_open_in_prod(self, prod_client: AsyncClient):
+        resp = await prod_client.get("/api/namespaces")
+        assert resp.status_code == 200
+
+    async def test_patch_metadata_open_in_prod(self, prod_client: AsyncClient):
+        resp = await prod_client.patch(
+            "/api/namespaces/default",
+            json={"description": "Updated", "color": "#abcdef"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["namespace"] == "default"
+        assert data["description"] == "Updated"
+
+    async def test_per_namespace_info_blocked_in_prod(self, prod_client: AsyncClient):
+        resp = await prod_client.get("/api/namespaces/default")
+        assert resp.status_code == 404
+
+    async def test_rename_blocked_in_prod(self, prod_client: AsyncClient):
+        resp = await prod_client.post(
+            "/api/namespaces/default/rename",
+            json={"new_name": "general"},
+        )
+        assert resp.status_code == 404
+
+    async def test_delete_blocked_in_prod(self, prod_client: AsyncClient):
+        resp = await prod_client.delete("/api/namespaces/default")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
 # Scratch workspace CRUD
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Promotes the Settings → Namespaces tab and the cosmetic-edit verb (PATCH description/color) from dev-only to the prod tier, leaving rename and delete admin-only pending chunk-id stability (ADR-0005 follow-up). Adds a first-time empty-state CTA pointing at the configuration guide. Doc fanout per `feedback_default_change_fanout.md`.

ADR-0007 was drafted earlier today (#586/#607) and explicitly deferred this surface pending prod-user feedback. The same-day prod transition immediately surfaced "namespace barely visible in web UI" as the trigger — eleven other namespace surfaces had already landed via PR #604, but the Settings tab itself was hidden, which was the surface I expected for colour/description editing. Status flips to Accepted with the maintainer-driven trigger noted.

## What changed

**Backend tier split**
- `namespaces_read` (prod) gains PATCH alongside the existing GET list — both safe without chunk migration.
- `namespaces.admin_router` (dev-only) keeps GET-by-id, POST rename, DELETE — each will need its own ADR with chunk-id stability design.

**Frontend**
- Settings → Namespaces nav button: `data-ui-tier="dev"` → `"prod"`.
- `loadNamespacesTab()` no longer early-returns on prod.
- Rename + Delete buttons inside `_buildNsCard` are JS-gated to `STATE.uiMode === 'dev'` so they don't render in prod (their backend routes still 404 there).
- Empty-state tile gains a CTA link to `docs/guides/configuration.md#namespace`.
- en/ko locales gain `settings.ns.empty.{title,body,cta}`.

**Tests**
- New `TestNamespaceProdTier` pins the prod tier split (list + PATCH open, info GET / rename / delete blocked).
- `test_namespaces_list_is_prod_mounted_but_admin_routes_blocked` updated: asserts PATCH is registered on the prod app and the structural verbs are not.
- `test_html_classification_matches_router_lists` drops `namespaces` from the dev-section expected set.

**Docs (default-change fanout)**
- ADR-0007 status: `Proposed (deferred)` → `Accepted` with trigger note.
- Stale "/api/namespaces returns 404 in prod" claim corrected in `configuration.md` and `reference.md`.
- `getting-started.md` gains a "5. Organise memories with namespaces" step.
- README.md and packages/memtomem/README.md note the colour/description editing surface.

## Out of scope (PR-C, deferred)

Rename and delete prod exposure stay deferred — they each need chunk-migration design (chunk-id stability under string-keyed NS). PR-C will be filed when one of ADR-0007's other trigger criteria fires (post-rollout feedback, multi-agent grouping verdict 2026-05-09, or onboarding-flow rules surface).

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — passed
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — passed (350 files already formatted)
- [x] `uv run mypy packages/memtomem/src/memtomem/web/routes/namespaces.py packages/memtomem/src/memtomem/web/routes/namespaces_read.py` — no issues
- [x] `uv run pytest -m "not ollama"` — 3344 passed
- [ ] Smoke: `uv run mm web` → Settings → Namespaces tab visible in prod, Edit (color/description) works, Rename/Delete hidden
- [ ] Smoke: `uv run mm web --dev` → Rename/Delete reappear and still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)