### PR TITLE
docs(adr): note chunk_links survival as consequence of id preservation in ADR-0005

### DIFF
--- a/docs/adr/0005-force-reindex-metadata-contract.md
+++ b/docs/adr/0005-force-reindex-metadata-contract.md
@@ -179,6 +179,14 @@ In rough order, all in `packages/memtomem/src/memtomem/`:
 - **Importance scoring**: `importance_score` (which factors in
   access_count, tag_count, relation_count) stops resetting on edits.
   See `server/tools/importance.py:51`.
+- **Share lineage**: `chunk_links` rows pointing at content-hash-matched
+  chunks survive force-reindex transitively. The FK is
+  `chunk_links.source_id REFERENCES chunks(id) ON DELETE SET NULL`
+  (`storage/sqlite_schema.py:385`); previously every force pass hard-
+  deleted the chunk row, which fired `SET NULL` on every link pointing
+  at it and silently broke share provenance. With `id` preservation the
+  cascade never fires. This is a consequence of the `id` rule above, not
+  an independent preservation contract.
 - **Performance**: the force path does an extra `SELECT id, content_hash,
   ...` before reconcile. Negligible at typical memtomem scale (a single
   source file's chunks fit in memory; ~10–100 rows per file).


### PR DESCRIPTION
## Summary
Follow-up to #615. PR #615's reference-guide prose claimed force-reindex preserves `chunk_links` rows alongside `id` / `access_count` / `last_accessed_at` / `importance_score`, but ADR-0005's Decision section listed only the four columns. The chunk_links survival is real (CHANGELOG v0.1.33 documents it explicitly) but readers chasing the ADR cite came up short.

This patch adds a Consequences bullet to ADR-0005 making the relationship explicit: chunk_links survival is **transitive** through `id` preservation, not an independent contract.

## Why
- Closes the #615 review note about thin citation.
- The FK is `chunk_links.source_id REFERENCES chunks(id) ON DELETE SET NULL` (`storage/sqlite_schema.py:385`). Before id-preservation, every force pass hard-deleted the chunk row, which silently nulled out `source_id` on every link pointing at it.
- Framing it as a *consequence* of id preservation (not a separate preservation rule) keeps the ADR's Decision section truthful — chunk_links is a separate table, not a column we directly preserve.

## Test plan
- [x] No code changes — ADR text only
- [x] FK behavior verified at `packages/memtomem/src/memtomem/storage/sqlite_schema.py:385`
- [x] CHANGELOG v0.1.33 entry already lists chunk_links survival (CHANGELOG.md:154)

🤖 Generated with [Claude Code](https://claude.com/claude-code)