### PR TITLE
docs(contributing): add maintainer response SLA + stale-bot triage notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,36 @@ The STM proxy gateway lives in a separate repository: [memtomem/memtomem-stm](ht
 6. Write a clear commit message describing the "why"
 7. Sign the CLA on your first pull request (see below)
 
+## Maintainer response expectations
+
+memtomem is maintained by a small team. We aim for the following
+**best-effort** windows on contributions — these are targets, not legal
+commitments:
+
+| Event | Target |
+|-------|--------|
+| First response on a new issue or PR | within 5 business days |
+| Decision on a PR (merge / changes-requested / close) | within 14 business days of the first response |
+| Security report (see [`SECURITY.md`](SECURITY.md)) | acknowledgement within 2 business days |
+
+If a PR sits without contributor activity for 30 days the [stale
+bot](.github/workflows/stale.yml) marks it `stale`; another 30 days of
+silence closes it. A single comment or push clears the label — closure is
+never a judgement on the change, just queue hygiene. Re-opening is always
+welcome.
+
+Labels that affect triage:
+
+- `do-not-stale`, `pinned`, `release`, `security`, `needs-maintainer-decision`
+  — exempt from the stale sweep.
+- `needs-cla` — CLA Assistant has not yet recorded a signature; merge is
+  blocked until the bot re-checks (see CLA section below).
+- `good-first-issue` — scoped to ≤3 files and no public API changes; check
+  the comments for an existing claim before starting work.
+
+If your PR is time-sensitive (security, regression on `main`, release
+blocker) call it out in the description so we route it ahead of the queue.
+
 ## MCP Tool Error Response Contract
 
 All MCP tool handlers use `@tool_handler` (`server/error_handler.py`) which


### PR DESCRIPTION
## Summary

External contributors currently have no way to know what response cadence to expect or which labels exempt their PR from the stale sweep. This PR documents both, in a new "Maintainer response expectations" section in `CONTRIBUTING.md`.

## What changed

- **Best-effort SLA table**: first response within 5 business days, decision within 14 business days of first response, security ack within 2.
- **Stale-bot lifecycle**: 30 days idle → `stale`, 30 more → close. A single comment or push clears it. Re-opening always welcome.
- **Triage labels documented**: `do-not-stale`, `pinned`, `release`, `security`, `needs-maintainer-decision` exempt from sweep; `needs-cla` blocks merge until CLA Assistant re-checks; `good-first-issue` scoped to ≤3 files.

## Why

Direct from saved feedback `feedback_external_contributor_review.md` — first-PR contributors deserve a welcoming, predictable queue. Today the response cadence is implicit and the exempt-label list lives only in `.github/workflows/stale.yml`, where contributors don't read.

## Prerequisite (already shipped)

`stale.yml` references the labels `release, pinned, do-not-stale, needs-maintainer-decision` in its `exempt-pr-labels` list, but only `security` actually existed in the repo. Created the four missing labels via `gh label create` before this PR — without them the workflow's exempt list was a no-op.

## Test plan

- [x] No code changes — docs only
- [x] Cross-checked SLA windows + 30+30 lifecycle against `.github/workflows/stale.yml:18-19`
- [x] Verified all five exempt labels exist via `gh label list`
- [ ] Follow-up: `stale.yml` line 30 message text says "another 15 days … close 15 days after that" — contradicts the 30+30 config above. Will file a separate one-line PR to align the message text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)