### PR TITLE
fix(stale.yml): align stale-pr-message with the 30+30 config

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,8 +26,8 @@ jobs:
             This PR has had no updates for 30 days. Marking as `stale`.
 
             If you'd like to keep working on it, leave any comment or push
-            a commit — that's enough to clear the label. Otherwise, it'll
-            receive one more nudge in 15 days and close 15 days after that.
+            a commit — that's enough to clear the label. Otherwise it will
+            close 30 days after this notice.
 
             Thanks for the contribution — this is an automated triage
             message, not a judgement on the PR itself.


### PR DESCRIPTION
## Summary

The stale-bot's notification message promises "another nudge in 15 days and close 15 days after that" but the workflow config is:

\`\`\`yaml
days-before-pr-stale: 30
days-before-pr-close: 30
\`\`\`

So the actual behavior is one notification at day 30, then close at day 60 — no intermediate nudge. The message was both wrong on the cadence (15+15 ≠ 30+30) and promised a second notification that never fires.

This patch rewrites the line to "Otherwise it will close 30 days after this notice." — matching what the workflow actually does.

## Why

Caught while writing the SLA section in `CONTRIBUTING.md` (#620). The doc reads the config; the in-workflow prose was the loose end.

## Test plan

- [x] Single-line message text change in `.github/workflows/stale.yml`
- [x] No config change (`days-before-pr-stale` / `days-before-pr-close` untouched)
- [x] Stale workflow next runs `0 6:37 UTC` daily; the next contributor who gets staled will see the corrected message

🤖 Generated with [Claude Code](https://claude.com/claude-code)