### PR TITLE
feat(wiki): PR-A — wiki scaffold (~/.memtomem-wiki, mm wiki init/list, ADR-0008)

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -1,0 +1,213 @@
+# ADR-0008: Wiki layer for shared canonical artifacts
+
+**Status:** Accepted (PR-A in flight; PR-B/C/D/E sequenced — see PR Breakdown)
+**Date:** 2026-04-30
+**Context:** Context gateway today is a per-project canonical → multi-runtime
+fan-out router (ADR-0001). Users with several projects must re-author the
+same skill/agent/command in each `<project>/.memtomem/`. This ADR introduces
+a global wiki (`~/.memtomem-wiki/`) holding canonical artifacts in a single
+git repository, with `mm context install` snapshotting selected artifacts
+into a project. The wiki adds reuse and (via git remotes) cross-machine
+sync without altering the existing fan-out invariants.
+
+## Background
+
+ADR-0001 fixed the rules for the per-project pipeline (canonical →
+fan-out, on_drop severity, phase independence). It deliberately did not
+address sharing across projects — each `<project>/.memtomem/` was its own
+source of truth, and re-use happened by hand-copying directories or by
+git submodules.
+
+Two recurring user scenarios pushed for a higher layer:
+
+1. *I edit `code-review` skill in project A, want it in project B without
+   diverging.* Today: `cp -R` and remember to keep them in sync.
+2. *I'm setting up a new machine.* Today: there is no portable record of
+   "which artifacts were in which project" — each project's `.memtomem/`
+   is recreated by hand or by re-running `mm context init` against
+   whatever runtime files happened to be present.
+
+The wiki layer addresses both. It is **additive** — projects without a
+wiki continue to work exactly as before.
+
+## Decision
+
+Introduce four new surfaces, each governed by an invariant:
+
+### Invariant 1 — Self-containment of project canonical
+
+`<project>/.memtomem/` MUST work without `~/.memtomem-wiki/` present.
+
+`mm context install` snapshots a wiki artifact as a **directory tree**
+(`shutil.copytree` semantics) into the project — including any
+`overrides/` subdirectory. Fan-out (`generate_all_skills`,
+`generate_all_agents`, `generate_all_commands`) reads only from the
+project tree, never from the wiki. CI machines, archived projects, and
+machines without the wiki all run fan-out unchanged.
+
+### Invariant 2 — Explicit conflict surface for local edits
+
+`mm context update <type> <name>` MUST detect when project canonical was
+modified after install (mtime > `lockfile.installed_at`).
+
+Default behavior: refuse with a clear error. `--force` overwrites and
+leaves a `.bak` copy of each clobbered file. This mirrors ADR-0001's
+on_drop policy of never silently dropping data.
+
+### Invariant 3 — Wiki is optional, project is authoritative
+
+Absence, corruption, or relocation of `~/.memtomem-wiki/` MUST NOT break
+existing commands. Only `mm wiki *` and `mm context {install,update,status}`
+require it; all other commands ignore the wiki entirely. When the wiki is
+absent, the affected commands fail with a precise message
+("`wiki not found at <path>, run \`mm wiki init\`"`) rather than a
+traceback.
+
+A project with `lock.json` but no wiki on disk continues to fan out
+correctly — `lock.json` is metadata, not a runtime dependency.
+
+### Invariant 4 — Override is full-file replacement (v1)
+
+When `<project>/.memtomem/<type>/<name>/overrides/<vendor>.<ext>` exists,
+fan-out MUST byte-copy that file to the runtime directory and skip the
+auto-conversion pipeline for that vendor.
+
+Section-level merge is explicitly **not** in v1. Override semantics are
+"give me exactly this output, do not transform" — diagnosable by reading
+the override file and comparing to the runtime target. Section merge can
+be reconsidered in v2 if a real workflow demands it.
+
+## Architecture
+
+```
+~/.memtomem-wiki/                    ← global wiki (git repo, optional remote)
+├── .git/
+├── skills/<name>/
+│   ├── SKILL.md                     ← canonical (Agent Skills spec)
+│   ├── scripts/, references/, ...   ← spec subdirs
+│   └── overrides/<vendor>.<ext>     ← optional, per Invariant 4
+├── agents/<name>/agent.md
+└── commands/<name>/command.md
+
+         │  mm context install <type> <name>   (copytree + lockfile pin)
+         ▼
+<project>/.memtomem/                 ← project canonical (Invariant 1)
+├── lock.json                        ← { skills: { foo: { wiki_commit, installed_at } } }
+├── skills/<name>/SKILL.md + overrides/...
+├── agents/<name>/...
+└── commands/<name>/...
+
+         │  existing fan-out + override resolution (Invariant 4)
+         ▼
+.claude/, .gemini/, .agents/, .codex/    ← runtime dirs (unchanged from ADR-0001)
+```
+
+## Subcommands
+
+`mm wiki` is nested per asset type so `{edit, override, diff, lint}` form
+a single mental group of "manipulate this artifact":
+
+```
+mm wiki init [--from <git-url>]
+mm wiki list
+
+mm wiki skill   {edit, override, diff, lint} <name> [--vendor <vendor>]
+mm wiki agent   {edit, override, diff, lint} <name> [--vendor <vendor>]
+mm wiki command {edit, override, diff, lint} <name> [--vendor <vendor>]
+
+mm context install <type> <name>
+mm context install --all                # lockfile-driven re-setup
+mm context update  <type> <name> [--all]
+mm context status
+```
+
+`mm context sync --include=skills` (existing, ADR-0001 §3) is unchanged.
+The `mm wiki` group is single-asset; `mm context sync` remains the
+multi-asset bulk verb.
+
+## Lockfile schema
+
+`<project>/.memtomem/lock.json`:
+
+```json
+{
+  "version": 1,
+  "skills":   { "foo": { "wiki_commit": "abc123…", "installed_at": "2026-04-30T…" } },
+  "agents":   { "bar": { … } },
+  "commands": { "baz": { … } }
+}
+```
+
+Reads MUST preserve unknown top-level and per-entry fields (round-trip
+through plain `dict` is sufficient). The `version` field is reserved for
+schema migrations; future fields (`skill_version`, `compat`, `mode`) can
+be added forward-compatibly.
+
+## Vendor format matrix
+
+`OVERRIDE_FORMATS = { (asset_type, vendor): (alias, extension) }` lives
+in `packages/memtomem/src/memtomem/context/_names.py`. v1 covers Claude,
+Gemini, Codex across skills, agents, commands. Cursor and Copilot are
+excluded — their skill/agent/command surfaces are too thin to justify
+override slots. They can be added in v2 if their runtime surface grows.
+
+## PR Breakdown
+
+| PR | Surface | Invariants |
+|----|---------|-----------|
+| **A** | Wiki scaffold: `wiki/store.py`, `mm wiki init [--from]`, `mm wiki list`, this ADR | scaffolding only |
+| **B** | `mm context install`, lockfile schema, `shutil.copytree`, lockfile concurrency | Inv 1 (copytree), Inv 3 (graceful absence) |
+| **C** | Override resolution, `OVERRIDE_FORMATS`, `mm wiki <type> override` (auto-result fork) | Inv 4 |
+| **D** | `mm context {update, install --all, status}`, `mm wiki <type> {diff, lint}`, dirty detection | Inv 2 (refuse-if-dirty + `--force` + `.bak`) |
+| **E** | Web UI (mirrors `web/routes/context_*` patterns post-#488) | — |
+
+## Consequences
+
+- **Project tree gets `lock.json`** when wiki-installed. Manual edits to
+  files under `.memtomem/` after install are detected (Invariant 2);
+  manual edits to projects that never used wiki install continue to
+  work without a lockfile.
+- **`~/.memtomem-wiki/` is a normal git repo.** Backup, sharing, and
+  versioning use git remotes — the same workflow as any private repo.
+  No new sync protocol.
+- **Vendor overrides are opt-in.** Default (no overrides directory)
+  means existing fan-out behavior is unchanged. Override usage is
+  surfaced in `mm context update` log lines (`[override applied:
+  codex]`) so silent application is visible.
+- **`settings.json` is excluded from the wiki.** Settings sync mutates
+  host-scope files (`~/.claude/settings.json`); the wiki avoids that
+  trust boundary entirely. The existing `mm context sync
+  --include=settings` flow (ADR-0001) is unaffected.
+
+## Considered & rejected
+
+- **Reference mode (manifest-only, fetch at build time).** Rejected: it
+  breaks Invariant 1 (project would depend on wiki being reachable) and
+  loses git-checkout reproducibility (`git log .memtomem/` would not
+  show what changed).
+- **Symlink / submodule deploy.** Rejected: macOS/Linux/Windows symlink
+  permission model differs; submodules carry the well-known "forgot to
+  `git submodule update`" failure mode.
+- **Per-skill semver in frontmatter + CHANGELOG.** Rejected: with a
+  single curator (the wiki owner) version metadata becomes paperwork
+  that drifts. Wiki repo git history + lockfile commit pin already
+  captures "which version did this project install."
+- **Section-level override merge.** Rejected for v1; revisit in v2 only
+  if a recurring workflow demands it (Invariant 4 rationale).
+- **Cursor / Copilot override slots.** Deferred — runtime surface too
+  thin in v1.
+- **Settings in wiki.** Rejected — host-scope mutation trust boundary.
+
+## References
+
+- ADR-0001 — context gateway sync policies (this ADR builds on top).
+- ADR-0007 — namespace CRUD prod exposure (dev/prod tier pattern that
+  PR-E reuses for the wiki Web UI surface).
+- `packages/memtomem/src/memtomem/context/skills.py` —
+  `generate_all_skills` (fan-out reused by Invariant 1; modified in
+  PR-C for override branch).
+- `packages/memtomem/src/memtomem/context/_names.py` —
+  `OVERRIDE_FORMATS` lives here (PR-C).
+- `packages/memtomem/src/memtomem/context/projects.py` —
+  `KnownProjectsStore`, `_file_lock` pattern reused in PR-B for
+  lockfile concurrency.

--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -132,11 +132,22 @@ multi-asset bulk verb.
 ```json
 {
   "version": 1,
-  "skills":   { "foo": { "wiki_commit": "abc123…", "installed_at": "2026-04-30T…" } },
-  "agents":   { "bar": { … } },
-  "commands": { "baz": { … } }
+  "skills": {
+    "foo": {
+      "wiki_commit": "abc123def4567890abc123def4567890abc12345",
+      "installed_at": "2026-04-30T12:34:56Z"
+    }
+  },
+  "agents":   { "bar": { "wiki_commit": "…", "installed_at": "…" } },
+  "commands": { "baz": { "wiki_commit": "…", "installed_at": "…" } }
 }
 ```
+
+`wiki_commit` MUST be the **full 40-character SHA**. Display surfaces
+(`mm context status`, `mm wiki list`) may abbreviate to 12 characters
+for readability; the stored value is always full-length to avoid
+abbreviation collisions across projects that share a wiki and to keep
+`git checkout <wiki_commit>` directly usable for forensics.
 
 Reads MUST preserve unknown top-level and per-entry fields (round-trip
 through plain `dict` is sufficient). The `version` field is reserved for

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -47,6 +47,7 @@ def _register() -> None:
     from memtomem.cli.upgrade_cmd import upgrade
     from memtomem.cli.watchdog_cmd import watchdog
     from memtomem.cli.web import web
+    from memtomem.cli.wiki_cmd import wiki
 
     cli.add_command(init)
     cli.add_command(search)
@@ -69,6 +70,7 @@ def _register() -> None:
     cli.add_command(agent)
     cli.add_command(uninstall)
     cli.add_command(upgrade)
+    cli.add_command(wiki)
 
 
 _register()

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -1,7 +1,6 @@
 """``mm wiki`` — manage the local wiki (``~/.memtomem-wiki/``).
 
-PR-A surface: ``init [--from <git-url>]``, ``list``. Edit/override/diff/lint
-verbs ship in PR-C/PR-D. See ADR-0008.
+See ADR-0008 for the wiki layer's role in the context-gateway pipeline.
 """
 
 from __future__ import annotations
@@ -40,7 +39,7 @@ def init_cmd(from_url: str | None) -> None:
             store.init()
             click.secho(f"Initialized wiki at {store.root}", fg="green")
             click.echo("  Layout: skills/, agents/, commands/")
-            click.echo("  Next: `mm wiki skill edit <name>` (PR-C+) or `mm wiki list`.")
+            click.echo("  Run `mm wiki list` or `mm wiki --help` to see what is available.")
     except WikiAlreadyExistsError as exc:
         raise click.ClickException(str(exc)) from exc
     except RuntimeError as exc:

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -1,0 +1,79 @@
+"""``mm wiki`` — manage the local wiki (``~/.memtomem-wiki/``).
+
+PR-A surface: ``init [--from <git-url>]``, ``list``. Edit/override/diff/lint
+verbs ship in PR-C/PR-D. See ADR-0008.
+"""
+
+from __future__ import annotations
+
+import click
+
+from memtomem.wiki import (
+    WIKI_ASSET_TYPES,
+    WikiAlreadyExistsError,
+    WikiNotFoundError,
+    WikiStore,
+)
+
+
+@click.group("wiki")
+def wiki() -> None:
+    """Manage the local memtomem wiki (skills/agents/commands library)."""
+
+
+@wiki.command("init")
+@click.option(
+    "--from",
+    "from_url",
+    metavar="GIT_URL",
+    default=None,
+    help="Clone the wiki from a git URL instead of initializing from scratch.",
+)
+def init_cmd(from_url: str | None) -> None:
+    """Create or clone the wiki at ``~/.memtomem-wiki/``."""
+    store = WikiStore.at_default()
+    try:
+        if from_url:
+            store.init_from_url(from_url)
+            click.secho(f"Cloned wiki from {from_url} → {store.root}", fg="green")
+        else:
+            store.init()
+            click.secho(f"Initialized wiki at {store.root}", fg="green")
+            click.echo("  Layout: skills/, agents/, commands/")
+            click.echo("  Next: `mm wiki skill edit <name>` (PR-C+) or `mm wiki list`.")
+    except WikiAlreadyExistsError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@wiki.command("list")
+@click.option(
+    "--type",
+    "asset_type",
+    type=click.Choice(WIKI_ASSET_TYPES),
+    default=None,
+    help="Restrict output to one asset kind.",
+)
+def list_cmd(asset_type: str | None) -> None:
+    """List skills, agents, and commands in the wiki."""
+    store = WikiStore.at_default()
+    try:
+        assets = store.list_assets(asset_type)
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not assets:
+        scope = asset_type or "any kind"
+        click.echo(f"  (no assets of {scope})")
+        return
+
+    click.secho(f"Wiki: {store.root}", fg="cyan")
+    click.echo(f"  HEAD: {store.current_commit()[:12]}")
+    click.echo("")
+    last_type: str | None = None
+    for asset in assets:
+        if asset.type != last_type:
+            click.secho(f"  {asset.type}/", fg="cyan")
+            last_type = asset.type
+        click.echo(f"    {asset.name}")

--- a/packages/memtomem/src/memtomem/wiki/__init__.py
+++ b/packages/memtomem/src/memtomem/wiki/__init__.py
@@ -1,0 +1,28 @@
+"""memtomem wiki — shared canonical artifact store at ``~/.memtomem-wiki/``.
+
+The wiki is a normal git repository holding skills, agents, and commands
+in vendor-neutral form. ``mm context install`` snapshots wiki artifacts
+into ``<project>/.memtomem/``; ``mm wiki ...`` edits the wiki directly.
+
+See :file:`docs/adr/0008-wiki-layer.md` for invariants.
+"""
+
+from __future__ import annotations
+
+from memtomem.wiki.store import (
+    DEFAULT_WIKI_PATH,
+    WIKI_ASSET_TYPES,
+    WikiAlreadyExistsError,
+    WikiAsset,
+    WikiNotFoundError,
+    WikiStore,
+)
+
+__all__ = [
+    "DEFAULT_WIKI_PATH",
+    "WIKI_ASSET_TYPES",
+    "WikiAlreadyExistsError",
+    "WikiAsset",
+    "WikiNotFoundError",
+    "WikiStore",
+]

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -1,8 +1,9 @@
 """``~/.memtomem-wiki/`` git repository abstraction.
 
-PR-A scope: scratch ``init``, ``init --from <git-url>`` clone, ``list``,
-``current_commit``, ``exists``. Snapshot install / override resolution /
-lockfile / lint live in PR-B/C/D modules. See ADR-0008.
+Provides :class:`WikiStore` with scratch ``init``, ``init --from <git-url>``
+clone, asset listing, and HEAD commit lookup. Snapshot install, override
+resolution, lockfile, and staleness lint live in sibling modules per
+ADR-0008's roadmap.
 """
 
 from __future__ import annotations
@@ -22,10 +23,9 @@ _INITIAL_COMMIT_MESSAGE = "Initialize memtomem wiki"
 
 _README_TEMPLATE = """# memtomem wiki
 
-Local skills/agents/commands library managed by `mm wiki ...`.
+Personal wiki for AI agent skills, agents, and commands.
 
-This is a git repository containing canonical (vendor-neutral) artifacts
-that `mm context install` deploys into projects.
+This is a git repository containing canonical (vendor-neutral) artifacts.
 
 ## Layout
 
@@ -36,16 +36,11 @@ that `mm context install` deploys into projects.
 - `<type>/<name>/overrides/<vendor>.<ext>` — optional vendor-specific
   file; bypasses auto-conversion when present.
 
-## Common operations
+## Available commands
 
-```
-mm wiki init [--from <git-url>]   # create or clone
-mm wiki list                      # show all assets
-mm wiki skill edit <name>         # edit canonical skill
-mm context install skill <name>   # snapshot into current project
-```
-
-See ADR-0008 in the memtomem repo for invariants.
+Run `mm wiki --help` for the current set of subcommands available in your
+installed version. See <https://github.com/memtomem/memtomem> for the
+project README and ADR-0008 (the wiki layer design document).
 """
 
 
@@ -151,7 +146,13 @@ class WikiStore:
         _git(["clone", url, str(self.root)], cwd=self.root.parent)
 
     def current_commit(self) -> str:
-        """Return the wiki HEAD commit SHA (short or full per git config)."""
+        """Return the wiki HEAD commit SHA as the full 40-character hex string.
+
+        Display surfaces (e.g. ``mm wiki list``) may abbreviate when
+        rendering, but the canonical value is always full-length to
+        avoid abbreviation collisions in stored references such as
+        the project lockfile (see ADR-0008).
+        """
         self.require_exists()
         result = _git(["rev-parse", "HEAD"], cwd=self.root)
         return result.stdout.strip()

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -1,0 +1,181 @@
+"""``~/.memtomem-wiki/`` git repository abstraction.
+
+PR-A scope: scratch ``init``, ``init --from <git-url>`` clone, ``list``,
+``current_commit``, ``exists``. Snapshot install / override resolution /
+lockfile / lint live in PR-B/C/D modules. See ADR-0008.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_WIKI_PATH: Path = Path.home() / ".memtomem-wiki"
+"""Default wiki location — overridable via ``MEMTOMEM_WIKI_PATH`` env."""
+
+WIKI_ASSET_TYPES: tuple[str, ...] = ("skills", "agents", "commands")
+"""Asset directory names at the wiki root. Order is significant for listing."""
+
+_INITIAL_COMMIT_MESSAGE = "Initialize memtomem wiki"
+
+_README_TEMPLATE = """# memtomem wiki
+
+Local skills/agents/commands library managed by `mm wiki ...`.
+
+This is a git repository containing canonical (vendor-neutral) artifacts
+that `mm context install` deploys into projects.
+
+## Layout
+
+- `skills/<name>/SKILL.md` — Anthropic Agent Skills spec, byte-identical
+  across Claude Code, Gemini CLI, and Codex CLI.
+- `agents/<name>/agent.md` — sub-agent definition (canonical MD + YAML).
+- `commands/<name>/command.md` — slash command (canonical, `$ARGUMENTS`).
+- `<type>/<name>/overrides/<vendor>.<ext>` — optional vendor-specific
+  file; bypasses auto-conversion when present.
+
+## Common operations
+
+```
+mm wiki init [--from <git-url>]   # create or clone
+mm wiki list                      # show all assets
+mm wiki skill edit <name>         # edit canonical skill
+mm context install skill <name>   # snapshot into current project
+```
+
+See ADR-0008 in the memtomem repo for invariants.
+"""
+
+
+class WikiNotFoundError(RuntimeError):
+    """Raised when a wiki operation runs on a path that is not a wiki."""
+
+
+class WikiAlreadyExistsError(RuntimeError):
+    """Raised when ``init`` or ``init_from_url`` would overwrite existing data."""
+
+
+@dataclass(frozen=True)
+class WikiAsset:
+    """An entry in the wiki — a skill, agent, or command directory."""
+
+    type: str
+    name: str
+    path: Path
+
+
+def _wiki_path_from_env() -> Path:
+    env = os.environ.get("MEMTOMEM_WIKI_PATH")
+    if env:
+        return Path(env).expanduser()
+    return DEFAULT_WIKI_PATH
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``git <args>`` in ``cwd``; raise with stderr on failure."""
+    try:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "").strip()
+        raise RuntimeError(f"git {' '.join(args)} failed: {detail}") from exc
+
+
+@dataclass(frozen=True)
+class WikiStore:
+    """View into a wiki repository at ``root``.
+
+    Construct via :meth:`at_default` (uses ``~/.memtomem-wiki/`` or the
+    ``MEMTOMEM_WIKI_PATH`` env override) or :meth:`at` for an explicit
+    path. The class is frozen — operations that touch disk delegate to
+    git via subprocess.
+    """
+
+    root: Path
+
+    @classmethod
+    def at_default(cls) -> WikiStore:
+        return cls(_wiki_path_from_env())
+
+    @classmethod
+    def at(cls, path: Path | str) -> WikiStore:
+        return cls(Path(path).expanduser())
+
+    def exists(self) -> bool:
+        return (self.root / ".git").is_dir()
+
+    def require_exists(self) -> None:
+        if not self.exists():
+            raise WikiNotFoundError(f"wiki not found at {self.root}, run `mm wiki init`")
+
+    def init(self) -> None:
+        """Initialize a new empty wiki at ``root``."""
+        if self.exists():
+            raise WikiAlreadyExistsError(f"wiki already initialized at {self.root}")
+        if self.root.exists() and any(self.root.iterdir()):
+            raise WikiAlreadyExistsError(
+                f"directory {self.root} is not empty and is not a wiki — refusing to init"
+            )
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        for asset_type in WIKI_ASSET_TYPES:
+            asset_dir = self.root / asset_type
+            asset_dir.mkdir(exist_ok=True)
+            (asset_dir / ".gitkeep").write_text("", encoding="utf-8")
+
+        (self.root / "README.md").write_text(_README_TEMPLATE, encoding="utf-8")
+
+        _git(["init", "-b", "main"], cwd=self.root)
+        _git(["add", "."], cwd=self.root)
+        _git(["commit", "-m", _INITIAL_COMMIT_MESSAGE], cwd=self.root)
+
+    def init_from_url(self, url: str) -> None:
+        """Clone an existing wiki from ``url`` into ``root``."""
+        if self.exists():
+            raise WikiAlreadyExistsError(f"wiki already initialized at {self.root}")
+        if self.root.exists() and any(self.root.iterdir()):
+            raise WikiAlreadyExistsError(f"directory {self.root} is not empty — refusing to clone")
+
+        self.root.parent.mkdir(parents=True, exist_ok=True)
+        # ``git clone`` creates the target directory; if root exists empty,
+        # remove it first so clone owns the layout.
+        if self.root.exists():
+            self.root.rmdir()
+        _git(["clone", url, str(self.root)], cwd=self.root.parent)
+
+    def current_commit(self) -> str:
+        """Return the wiki HEAD commit SHA (short or full per git config)."""
+        self.require_exists()
+        result = _git(["rev-parse", "HEAD"], cwd=self.root)
+        return result.stdout.strip()
+
+    def list_assets(self, asset_type: str | None = None) -> list[WikiAsset]:
+        """Enumerate asset directories under the wiki.
+
+        ``asset_type`` filters to one of :data:`WIKI_ASSET_TYPES`.
+        Hidden entries (``.gitkeep``, ``.git``) are excluded.
+        """
+        self.require_exists()
+
+        if asset_type is not None and asset_type not in WIKI_ASSET_TYPES:
+            raise ValueError(
+                f"unknown asset type {asset_type!r}; expected one of {WIKI_ASSET_TYPES}"
+            )
+
+        types = (asset_type,) if asset_type else WIKI_ASSET_TYPES
+        out: list[WikiAsset] = []
+        for t in types:
+            tdir = self.root / t
+            if not tdir.is_dir():
+                continue
+            for entry in sorted(tdir.iterdir()):
+                if entry.is_dir() and not entry.name.startswith("."):
+                    out.append(WikiAsset(type=t, name=entry.name, path=entry))
+        return out

--- a/packages/memtomem/tests/test_wiki_cmd.py
+++ b/packages/memtomem/tests/test_wiki_cmd.py
@@ -1,0 +1,106 @@
+"""Tests for ``mm wiki`` CLI surface (PR-A: init, list)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki
+
+
+@pytest.fixture
+def isolated_wiki(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the wiki path to tmp + give git an identity."""
+    target = tmp_path / "wiki"
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+    return target
+
+
+class TestInitCmd:
+    def test_init_creates_wiki(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(wiki, ["init"])
+        assert result.exit_code == 0, result.output
+        assert "Initialized wiki" in result.output
+        assert (isolated_wiki / ".git").is_dir()
+        assert (isolated_wiki / "skills").is_dir()
+        assert (isolated_wiki / "agents").is_dir()
+        assert (isolated_wiki / "commands").is_dir()
+
+    def test_init_already_exists(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["init"])
+        assert result.exit_code != 0
+        assert "already initialized" in result.output
+
+    def test_init_from_url_clones(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        source = tmp_path / "source"
+        monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(source))
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+
+        target = tmp_path / "target"
+        monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
+        result = runner.invoke(wiki, ["init", "--from", f"file://{source}"])
+        assert result.exit_code == 0, result.output
+        assert "Cloned wiki" in result.output
+        assert (target / ".git").is_dir()
+        assert (target / "skills").is_dir()
+
+
+class TestListCmd:
+    def test_list_no_wiki(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(wiki, ["list"])
+        assert result.exit_code != 0
+        assert "wiki not found" in result.output
+
+    def test_list_empty_wiki(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["list"])
+        assert result.exit_code == 0
+        assert "no assets" in result.output
+
+    def test_list_shows_assets(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        (isolated_wiki / "skills" / "code-review").mkdir()
+        (isolated_wiki / "skills" / "code-review" / "SKILL.md").write_text("x", encoding="utf-8")
+        (isolated_wiki / "agents" / "reviewer").mkdir()
+
+        result = runner.invoke(wiki, ["list"])
+        assert result.exit_code == 0
+        assert "code-review" in result.output
+        assert "reviewer" in result.output
+        assert "skills/" in result.output
+        assert "agents/" in result.output
+
+    def test_list_filters_by_type(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        (isolated_wiki / "skills" / "alpha").mkdir()
+        (isolated_wiki / "agents" / "beta").mkdir()
+
+        result = runner.invoke(wiki, ["list", "--type", "skills"])
+        assert result.exit_code == 0
+        assert "alpha" in result.output
+        assert "beta" not in result.output
+
+    def test_list_rejects_unknown_type(self, isolated_wiki: Path) -> None:
+        runner = CliRunner()
+        runner.invoke(wiki, ["init"])
+        result = runner.invoke(wiki, ["list", "--type", "widgets"])
+        assert result.exit_code != 0

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -43,7 +43,7 @@ class TestDefaultPath:
     def test_at_default_falls_back_to_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
         store = WikiStore.at_default()
-        assert store.root == DEFAULT_WIKI_PATH
+        assert store.root == Path.home() / ".memtomem-wiki"
 
 
 class TestInitScratch:

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -1,0 +1,204 @@
+"""Tests for wiki/store.py — ``~/.memtomem-wiki/`` git repository abstraction."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from memtomem.wiki.store import (
+    DEFAULT_WIKI_PATH,
+    WIKI_ASSET_TYPES,
+    WikiAlreadyExistsError,
+    WikiNotFoundError,
+    WikiStore,
+)
+
+
+@pytest.fixture
+def wiki_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point WikiStore.at_default() at a tmp dir + give git an identity."""
+    target = tmp_path / "wiki"
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+    return target
+
+
+class TestDefaultPath:
+    def test_default_path_is_home_relative(self) -> None:
+        assert DEFAULT_WIKI_PATH == Path.home() / ".memtomem-wiki"
+
+    def test_at_default_uses_env_override(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "custom-wiki"
+        monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
+        store = WikiStore.at_default()
+        assert store.root == target
+
+    def test_at_default_falls_back_to_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MEMTOMEM_WIKI_PATH", raising=False)
+        store = WikiStore.at_default()
+        assert store.root == DEFAULT_WIKI_PATH
+
+
+class TestInitScratch:
+    def test_init_creates_layout(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        assert not store.exists()
+        store.init()
+        assert store.exists()
+        for asset_type in WIKI_ASSET_TYPES:
+            assert (wiki_root / asset_type).is_dir()
+            assert (wiki_root / asset_type / ".gitkeep").is_file()
+        assert (wiki_root / "README.md").is_file()
+        assert (wiki_root / ".git").is_dir()
+
+    def test_init_makes_initial_commit(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        result = subprocess.run(
+            ["git", "log", "--oneline"],
+            cwd=wiki_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "Initialize memtomem wiki" in result.stdout
+
+    def test_current_commit_after_init(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        sha = store.current_commit()
+        assert len(sha) == 40
+        assert all(c in "0123456789abcdef" for c in sha)
+
+    def test_init_refuses_when_already_a_wiki(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        with pytest.raises(WikiAlreadyExistsError):
+            store.init()
+
+    def test_init_refuses_non_empty_directory(self, wiki_root: Path) -> None:
+        wiki_root.mkdir(parents=True)
+        (wiki_root / "stray.txt").write_text("hello", encoding="utf-8")
+        store = WikiStore.at_default()
+        with pytest.raises(WikiAlreadyExistsError, match="not empty"):
+            store.init()
+
+
+class TestInitFromUrl:
+    def test_clone_from_local_file_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Set up a source wiki at one path…
+        source = tmp_path / "source-wiki"
+        monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(source))
+        monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+        monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+        WikiStore.at_default().init()
+
+        # …clone from it into another path.
+        target = tmp_path / "target-wiki"
+        monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
+        clone = WikiStore.at_default()
+        clone.init_from_url(f"file://{source}")
+
+        assert clone.exists()
+        for asset_type in WIKI_ASSET_TYPES:
+            assert (target / asset_type).is_dir()
+        # HEAD should match the source HEAD.
+        source_head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=source,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        assert clone.current_commit() == source_head
+
+    def test_init_from_url_refuses_existing_wiki(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        with pytest.raises(WikiAlreadyExistsError):
+            store.init_from_url("file:///nonexistent")
+
+    def test_init_from_url_propagates_git_failure(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        with pytest.raises(RuntimeError, match="git clone"):
+            store.init_from_url("file:///definitely/not/a/repo")
+
+
+class TestListAssets:
+    def test_list_empty_after_init(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        assert store.list_assets() == []
+
+    def test_list_finds_assets(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        (wiki_root / "skills" / "code-review").mkdir()
+        (wiki_root / "skills" / "code-review" / "SKILL.md").write_text("x", encoding="utf-8")
+        (wiki_root / "agents" / "reviewer").mkdir()
+        (wiki_root / "commands" / "lint").mkdir()
+
+        assets = store.list_assets()
+        names = [(a.type, a.name) for a in assets]
+        assert ("skills", "code-review") in names
+        assert ("agents", "reviewer") in names
+        assert ("commands", "lint") in names
+        assert len(assets) == 3
+
+    def test_list_filters_by_type(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        (wiki_root / "skills" / "alpha").mkdir()
+        (wiki_root / "agents" / "beta").mkdir()
+
+        skills = store.list_assets("skills")
+        assert [a.name for a in skills] == ["alpha"]
+
+    def test_list_sorts_alphabetically(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        (wiki_root / "skills" / "zeta").mkdir()
+        (wiki_root / "skills" / "alpha").mkdir()
+        names = [a.name for a in store.list_assets("skills")]
+        assert names == ["alpha", "zeta"]
+
+    def test_list_skips_hidden_entries(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        # .gitkeep exists from init; should not appear.
+        (wiki_root / "skills" / ".secret").mkdir()
+        assert store.list_assets("skills") == []
+
+    def test_list_rejects_unknown_type(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        with pytest.raises(ValueError, match="unknown asset type"):
+            store.list_assets("widgets")
+
+    def test_list_requires_existing_wiki(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        with pytest.raises(WikiNotFoundError):
+            store.list_assets()
+
+
+class TestRequireExists:
+    def test_raises_when_absent(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        with pytest.raises(WikiNotFoundError, match="run `mm wiki init`"):
+            store.require_exists()
+
+    def test_silent_when_present(self, wiki_root: Path) -> None:
+        store = WikiStore.at_default()
+        store.init()
+        store.require_exists()  # no exception


### PR DESCRIPTION
## Roadmap

ADR-0008 introduces a 5-PR wiki layer on top of the existing context-gateway router (ADR-0001). **This PR is PR-A** — scaffolding only; the wiki is purely additive at this stage.

| PR | Surface | Status |
|----|---------|--------|
| **A** (this) | Wiki repo + `mm wiki init/list` + ADR-0008 | here |
| B | `mm context install` + lockfile + concurrency | next |
| C | Override resolution + `mm wiki <type> override` | queued |
| D | `mm context update/install --all/status`, dirty detection | queued |
| E | Web UI mirror | queued |

## In scope (PR-A)

- `~/.memtomem-wiki/` directory convention + initial git repo layout
- `WikiStore` — init scratch, init from git URL, list, current_commit, exists
- `mm wiki init [--from <git-url>]` and `mm wiki list [--type skills|agents|commands]`
- ADR-0008 with the four invariants the rest of the layer rests on
- `MEMTOMEM_WIKI_PATH` env override (for tests + advanced users)

## Out of scope (deferred)

- `mm context install/update/status` and lockfile schema → PR-B
- Override resolution and `OVERRIDE_FORMATS` matrix → PR-C
- Dirty-edit detection (`--force`, `.bak`), `--all` UX → PR-D
- Web UI surface (`web/routes/wiki.py`) → PR-E
- Section-level override merge → v2
- Cursor / Copilot override slots → v2 (runtime surface too thin in v1)
- ``settings.json`` in wiki → permanent NO (host-scope mutation trust boundary)

## ADR-0008 invariants

The four rules every later PR upholds:

1. **Self-containment of project canonical** — `<project>/.memtomem/` works without the wiki present (CI machines, archives, machines without the wiki).
2. **Explicit conflict surface** — local edits to project canonical after install must trigger refuse + `--force` + `.bak` (enforced in PR-D).
3. **Wiki is optional, project is authoritative** — wiki absence breaks only `mm wiki *` and `mm context install/update/status`; existing fan-out runs unchanged.
4. **Override is full-file replacement (v1)** — no section-level merge; override files bypass auto-conversion as a byte copy.

## Verification

- 28 unit tests pass (`tests/test_wiki_store.py`, `tests/test_wiki_cmd.py`):
  scratch init / clone init / idempotency refusal / non-empty refusal / asset listing (sort, type filter, hidden exclusion) / `WikiNotFound` graceful surface
- `ruff check` + `ruff format --check` clean across 220 src files
- `mm --help` shows `wiki` in command list; `mm wiki --help`, `mm wiki init --help`, `mm wiki list --help` all resolve

## Test plan

- [x] Unit tests: `uv run pytest packages/memtomem/tests/test_wiki_store.py packages/memtomem/tests/test_wiki_cmd.py -v`
- [x] Lint: `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] CLI smoke: `uv run mm wiki --help`, `uv run mm wiki init --help`, `uv run mm wiki list --help`
- [x] Top-level registration: `uv run mm --help` shows `wiki`

## Follow-up PRs

- [ ] PR-B — snapshot install + lockfile + concurrency (next)
- [ ] PR-C — override resolution
- [ ] PR-D — update / status / dirty detection / `--all`
- [ ] PR-E — Web UI mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)