### PR TITLE
feat(context): PR-B — mm context install skill + lockfile + concurrency

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -19,6 +19,7 @@ from memtomem.context.commands import (
     extract_commands_to_canonical,
     generate_all_commands,
 )
+from memtomem.context._names import InvalidNameError
 from memtomem.context.detector import (
     detect_agent_dirs,
     detect_agent_files,
@@ -26,6 +27,12 @@ from memtomem.context.detector import (
     detect_settings_files,
     detect_skill_dirs,
 )
+from memtomem.context.install import (
+    AlreadyInstalledError,
+    AssetNotFoundError,
+    install_skill,
+)
+from memtomem.context.lockfile import LockfileVersionError
 from memtomem.context.generator import (
     GENERATORS,
     extract_sections_from_agent_file,
@@ -41,6 +48,7 @@ from memtomem.context.skills import (
     extract_skills_to_canonical,
     generate_all_skills,
 )
+from memtomem.wiki.store import WikiNotFoundError
 
 # Phase 1-3 supports skills/agents/commands; Phase D adds settings.
 _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
@@ -636,3 +644,39 @@ def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) ->
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 
     click.secho("Synced.", fg="green")
+
+
+@context.command("install")
+@click.argument("asset_type", type=click.Choice(["skill"]))
+@click.argument("name")
+def install_cmd(asset_type: str, name: str) -> None:
+    """Install a wiki asset into ``<project>/.memtomem/<type>/<name>/``.
+
+    PR-B supports ``skill`` only. Agents and commands land in PR-C
+    alongside override resolution. The wiki at ``~/.memtomem-wiki/`` must
+    be initialized first (``mm wiki init``).
+    """
+    root = _find_project_root()
+    try:
+        if asset_type == "skill":
+            result = install_skill(root, name)
+        else:  # pragma: no cover — guarded by click.Choice
+            raise click.ClickException(f"unknown asset type: {asset_type}")
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except AssetNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except AlreadyInstalledError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except LockfileVersionError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.secho(
+        f"Installed {result.asset_type}/{result.name} (wiki {result.wiki_commit[:12]})",
+        fg="green",
+    )
+    rel_dest = result.dest.relative_to(root) if result.dest.is_relative_to(root) else result.dest
+    click.echo(f"  → {rel_dest}/")
+    click.echo(f"  {result.files_written} file(s) copied")

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -21,13 +21,33 @@ module and covers ``~/.memtomem/config.json`` specifically.
 from __future__ import annotations
 
 import fcntl
+import logging
 import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
-__all__ = ["atomic_write_bytes", "atomic_write_text", "copy_tree_atomic"]
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "COPY_SKIP_NAMES",
+    "atomic_write_bytes",
+    "atomic_write_text",
+    "copy_tree_atomic",
+]
+
+
+COPY_SKIP_NAMES: frozenset[str] = frozenset({".git", ".DS_Store", "__pycache__"})
+"""Entry names :func:`copy_tree_atomic` refuses to mirror.
+
+- ``.git`` — wiki asset trees should never carry a nested git dir, but a
+  stray one would otherwise get copied verbatim into ``<project>/.memtomem/``.
+- ``.DS_Store`` — macOS Finder side-effect; quietly skipped so wikis stay
+  clean even when curated through the GUI.
+- ``__pycache__`` — Python bytecode caches that test/automation runs may
+  drop into a wiki tree; never wanted in a project's canonical surface.
+"""
 
 
 @contextmanager
@@ -88,23 +108,33 @@ def atomic_write_text(
     atomic_write_bytes(path, text.encode(encoding), mode=mode)
 
 
-def copy_tree_atomic(src: Path, dst: Path) -> int:
+def copy_tree_atomic(src: Path, dst: Path, *, mode: int = 0o644) -> int:
     """Recursively mirror *src* → *dst*, each file via :func:`atomic_write_bytes`.
 
-    Returns the number of files written. Skips ``.git`` entries defensively —
-    asset trees under ``~/.memtomem-wiki/<type>/<name>/`` should never carry a
-    nested ``.git`` directory, but a stray one would otherwise be copied into
-    ``<project>/.memtomem/`` verbatim.
+    Returns the number of files written. ``mode`` (default ``0o644``) is the
+    permission bits applied to copied files — ``0o644`` matches the
+    convention for content meant to be read by other tools (e.g. fan-out
+    target runtimes), unlike the ``0o600`` default of ``atomic_write_bytes``
+    which is tuned for state files.
+
+    Entries named in :data:`COPY_SKIP_NAMES` are skipped silently. Symlinks
+    are skipped with a warning — this helper promises a *byte-for-byte tree
+    mirror*, and silently dereferencing a symlink to ``/etc/passwd`` (or any
+    out-of-tree target) would violate that contract. Callers who want to
+    mirror symlinks must do so explicitly.
     """
     dst.mkdir(parents=True, exist_ok=True)
     written = 0
     for entry in src.iterdir():
-        if entry.name == ".git":
+        if entry.name in COPY_SKIP_NAMES:
+            continue
+        if entry.is_symlink():
+            logger.warning("copy_tree_atomic: skipping symlink %s", entry)
             continue
         target = dst / entry.name
         if entry.is_file():
-            atomic_write_bytes(target, entry.read_bytes())
+            atomic_write_bytes(target, entry.read_bytes(), mode=mode)
             written += 1
         elif entry.is_dir():
-            written += copy_tree_atomic(entry, target)
+            written += copy_tree_atomic(entry, target, mode=mode)
     return written

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -20,11 +20,41 @@ module and covers ``~/.memtomem/config.json`` specifically.
 
 from __future__ import annotations
 
+import fcntl
 import os
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
+from typing import Iterator
 
-__all__ = ["atomic_write_bytes", "atomic_write_text"]
+__all__ = ["atomic_write_bytes", "atomic_write_text", "copy_tree_atomic"]
+
+
+@contextmanager
+def _file_lock(lock_path: Path) -> Iterator[None]:
+    """Cross-process exclusive lock on a sidecar lockfile.
+
+    Locking the data file directly does **not** survive ``os.replace`` —
+    the lock is on the inode, and the rename swaps the inode mid-operation
+    so concurrent writers race on stale fds. The fix is to lock a sibling
+    (``feedback_sidecar_lockfile_for_replaced_files.md``, PR #548). The
+    lockfile itself is never renamed, so its inode is stable.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def _lock_path_for(data_path: Path) -> Path:
+    """Sidecar lockfile path for *data_path* (``.{name}.lock`` next to it)."""
+    return data_path.parent / f".{data_path.name}.lock"
 
 
 def atomic_write_bytes(path: Path, data: bytes, mode: int = 0o600) -> None:
@@ -56,3 +86,25 @@ def atomic_write_text(
 ) -> None:
     """Atomically write *text* to *path* with an explicit file mode."""
     atomic_write_bytes(path, text.encode(encoding), mode=mode)
+
+
+def copy_tree_atomic(src: Path, dst: Path) -> int:
+    """Recursively mirror *src* → *dst*, each file via :func:`atomic_write_bytes`.
+
+    Returns the number of files written. Skips ``.git`` entries defensively —
+    asset trees under ``~/.memtomem-wiki/<type>/<name>/`` should never carry a
+    nested ``.git`` directory, but a stray one would otherwise be copied into
+    ``<project>/.memtomem/`` verbatim.
+    """
+    dst.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for entry in src.iterdir():
+        if entry.name == ".git":
+            continue
+        target = dst / entry.name
+        if entry.is_file():
+            atomic_write_bytes(target, entry.read_bytes())
+            written += 1
+        elif entry.is_dir():
+            written += copy_tree_atomic(entry, target)
+    return written

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -1,0 +1,129 @@
+"""Install a single wiki asset into ``<project>/.memtomem/<type>/<name>/``.
+
+Implements PR-B of ADR-0008. The wiki at ``~/.memtomem-wiki/`` is the
+source of truth; an "install" is a copytree snapshot pinned to the wiki's
+HEAD commit, recorded in :class:`memtomem.context.lockfile.Lockfile`.
+
+PR-B exposes only :func:`install_skill`. Skill fan-out works end-to-end
+through the existing :mod:`memtomem.context.skills` generators, so the
+user can install a wiki skill and immediately have it appear under
+``.claude/skills/`` etc. Agent and command install land in PR-C alongside
+override resolution — without override-aware extraction the snapshot
+exists on disk but does not flow through fan-out, which would surprise
+users into thinking install is broken.
+
+Install is intentionally non-destructive: if either a lockfile entry OR
+the destination directory already exists, install refuses with a
+classified error (see step 6 of the install pipeline). This forward-
+protects ADR-0008 Invariant 2 ("manual edits are detected, not silently
+clobbered") without depending on PR-D's mtime/dirty detection. PR-D's
+``mm context update`` is the supported way to refresh an installed asset.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from memtomem.context._atomic import copy_tree_atomic
+from memtomem.context._names import validate_name
+from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.wiki.store import WikiStore
+
+__all__ = [
+    "AlreadyInstalledError",
+    "AssetNotFoundError",
+    "InstallResult",
+    "install_skill",
+]
+
+
+class AssetNotFoundError(RuntimeError):
+    """Raised when the requested asset directory does not exist in the wiki."""
+
+
+class AlreadyInstalledError(RuntimeError):
+    """Raised when install would overwrite an existing lockfile entry or dest."""
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    """Outcome of a successful install. Display-oriented; not persisted."""
+
+    asset_type: str
+    name: str
+    wiki_commit: str
+    installed_at: str
+    dest: Path
+    files_written: int
+
+
+def install_skill(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+) -> InstallResult:
+    """Snapshot ``<wiki>/skills/<name>/`` into ``<project>/.memtomem/skills/<name>/``.
+
+    Pins the wiki HEAD commit at the start of the operation so a concurrent
+    ``git pull`` in the wiki cannot make the recorded ``wiki_commit`` drift
+    from the bytes that were copied. Refuses if either the lockfile entry
+    or the destination directory already exists — see module docstring.
+    """
+    return _install_asset(project_root, "skills", name, wiki=wiki)
+
+
+def _install_asset(
+    project_root: Path | str,
+    asset_type: str,
+    name: str,
+    *,
+    wiki: WikiStore | None,
+) -> InstallResult:
+    validated = validate_name(name, kind=f"{asset_type.rstrip('s')} name")
+    project_root = Path(project_root).expanduser()
+
+    wiki = wiki if wiki is not None else WikiStore.at_default()
+    wiki.require_exists()
+
+    src = wiki.root / asset_type / validated
+    if not src.is_dir():
+        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}")
+
+    wiki_commit = wiki.current_commit()
+    installed_at = utcnow_iso8601_z()
+
+    dest = project_root / ".memtomem" / asset_type / validated
+    lock = Lockfile.at(project_root)
+    existing = lock.read_entry(asset_type, validated)
+    has_lock = existing is not None
+    has_dest = dest.exists()
+    if has_lock or has_dest:
+        raise AlreadyInstalledError(
+            f"{asset_type}/{validated}: "
+            f"lockfile_entry={'yes' if has_lock else 'no'}, "
+            f"dest={'yes' if has_dest else 'no'}; "
+            f"`mm context update` is reserved for PR-D — "
+            f"to reinstall now, remove BOTH .memtomem/{asset_type}/{validated}/ "
+            f"AND the `{asset_type}.{validated}` entry from .memtomem/lock.json"
+        )
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    files_written = copy_tree_atomic(src, dest)
+
+    lock.upsert_entry(
+        asset_type,
+        validated,
+        wiki_commit=wiki_commit,
+        installed_at=installed_at,
+    )
+
+    return InstallResult(
+        asset_type=asset_type,
+        name=validated,
+        wiki_commit=wiki_commit,
+        installed_at=installed_at,
+        dest=dest,
+        files_written=files_written,
+    )

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, cast
 
 from memtomem.context._atomic import copy_tree_atomic
 from memtomem.context._names import validate_name
@@ -48,9 +49,15 @@ class AlreadyInstalledError(RuntimeError):
 
 @dataclass(frozen=True)
 class InstallResult:
-    """Outcome of a successful install. Display-oriented; not persisted."""
+    """Outcome of a successful install. Display-oriented; not persisted.
 
-    asset_type: str
+    ``asset_type`` is ``Literal["skills"]`` in PR-B and widens alongside the
+    public ``install_agent`` / ``install_command`` wrappers that PR-C adds.
+    The private ``_install_asset`` callee keeps a wider parameter type so
+    PR-C is a one-line widening, not a re-architecture.
+    """
+
+    asset_type: Literal["skills"]
     name: str
     wiki_commit: str
     installed_at: str
@@ -81,8 +88,19 @@ def _install_asset(
     *,
     wiki: WikiStore | None,
 ) -> InstallResult:
-    validated = validate_name(name, kind=f"{asset_type.rstrip('s')} name")
+    """Internal: install a single asset of any type.
+
+    Concurrency contract: same-asset races accept last-write-wins on the
+    lockfile entry. Both writers pin the same ``wiki_commit`` (HEAD is read
+    once per call before copy) and per-file ``atomic_write_bytes`` keeps
+    individual files consistent, so byte content under ``dest`` converges
+    even if the workers interleave. Distinct-asset writers serialize
+    cleanly on the lockfile sidecar lock and both entries survive.
+    """
+    validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
+    if not project_root.is_dir():
+        raise FileNotFoundError(f"project root does not exist: {project_root}")
 
     wiki = wiki if wiki is not None else WikiStore.at_default()
     wiki.require_exists()
@@ -119,8 +137,11 @@ def _install_asset(
         installed_at=installed_at,
     )
 
+    # PR-B contract: only "skills" reaches this construction site (the
+    # public wrapper is install_skill). PR-C widens InstallResult.asset_type
+    # alongside install_agent / install_command wrappers.
     return InstallResult(
-        asset_type=asset_type,
+        asset_type=cast('Literal["skills"]', asset_type),
         name=validated,
         wiki_commit=wiki_commit,
         installed_at=installed_at,

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -72,7 +72,7 @@ class Lockfile:
     last-write-wins on the entry.
     """
 
-    def __init__(self, path: Path) -> None:
+    def __init__(self, path: Path | str) -> None:
         self._path = Path(path).expanduser()
 
     @classmethod

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -1,0 +1,173 @@
+"""Project-level wiki install lockfile (``<project>/.memtomem/lock.json``).
+
+Records which wiki commit each installed asset was snapshotted from, so a
+later ``mm context update`` (PR-D) can detect drift between the on-disk
+canonical tree and the wiki source. Schema and invariants are pinned in
+``docs/adr/0008-wiki-layer.md`` (sections "Lockfile schema" and "PR
+breakdown").
+
+The store is dict-based on purpose: ADR-0008 mandates that reads MUST
+preserve unknown top-level and per-entry fields so future schema additions
+(``compat``, ``mode``, ``skill_version``) round-trip through older client
+versions unchanged. A strict dataclass would silently strip those keys.
+
+Concurrency uses the sidecar-lockfile pattern from
+:mod:`memtomem.context._atomic` (``_file_lock`` + ``_lock_path_for``),
+shared with ``KnownProjectsStore``. The lock window is intentionally narrow
+— only the ``load → mutate dict → atomic_write_bytes`` triple — so the slow
+``copy_tree_atomic`` step in :func:`memtomem.context.install.install_skill`
+runs unlocked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_bytes
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "LOCKFILE_NAME",
+    "LOCKFILE_VERSION",
+    "Lockfile",
+    "LockfileVersionError",
+    "utcnow_iso8601_z",
+]
+
+
+LOCKFILE_NAME = "lock.json"
+LOCKFILE_VERSION = 1
+
+
+class LockfileVersionError(RuntimeError):
+    """The lockfile carries a ``version`` this build does not understand.
+
+    Raised by :meth:`Lockfile.load` with ``strict=True`` (the default for
+    write paths). Diagnostic surfaces (e.g. a future ``mm context status``)
+    can pass ``strict=False`` to recover the raw dict for inspection.
+    """
+
+
+def utcnow_iso8601_z() -> str:
+    """``YYYY-MM-DDTHH:MM:SS.ffffffZ``.
+
+    Microsecond precision keeps concurrency tests deterministic — two
+    writers that land in the same second still produce distinct
+    ``installed_at`` values for ordering.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+class Lockfile:
+    """Read / mutate ``<project>/.memtomem/lock.json``.
+
+    Mutations hold an exclusive sidecar lock and write atomically via
+    ``atomic_write_bytes``. Two writers on different ``(asset_type, name)``
+    keys both survive (no key collision). Two writers on the same key are
+    last-write-wins on the entry.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path).expanduser()
+
+    @classmethod
+    def at(cls, project_root: Path | str) -> Lockfile:
+        """Return a :class:`Lockfile` rooted at ``<project_root>/.memtomem/lock.json``."""
+        return cls(Path(project_root).expanduser() / ".memtomem" / LOCKFILE_NAME)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def load(self, *, strict: bool = True) -> dict[str, Any]:
+        """Return the lockfile dict.
+
+        - Missing file → ``{"version": LOCKFILE_VERSION}`` (write-safe default).
+        - Invalid JSON → log warning, return ``{"version": LOCKFILE_VERSION}``.
+        - ``version`` ≠ ``LOCKFILE_VERSION`` and ``strict=True`` → raise
+          :class:`LockfileVersionError` (canonical record; silent reset
+          would clobber a forward-compatible lockfile written by a newer
+          tool).
+        - ``version`` ≠ ``LOCKFILE_VERSION`` and ``strict=False`` → return
+          the raw dict so diagnostic surfaces can render a useful message.
+        """
+        try:
+            raw = self._path.read_bytes()
+        except FileNotFoundError:
+            return {"version": LOCKFILE_VERSION}
+        except OSError as exc:
+            logger.warning("lockfile: read failed at %s: %s", self._path, exc)
+            return {"version": LOCKFILE_VERSION}
+
+        try:
+            doc = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.warning("lockfile: invalid JSON at %s, ignoring file: %s", self._path, exc)
+            return {"version": LOCKFILE_VERSION}
+
+        if not isinstance(doc, dict):
+            logger.warning("lockfile: top-level not an object at %s, ignoring", self._path)
+            return {"version": LOCKFILE_VERSION}
+
+        version = doc.get("version")
+        if version != LOCKFILE_VERSION:
+            if strict:
+                raise LockfileVersionError(
+                    f"lockfile at {self._path} has version {version!r}; "
+                    f"this build supports version {LOCKFILE_VERSION}"
+                )
+            return doc
+
+        return doc
+
+    def read_entry(self, asset_type: str, name: str) -> dict[str, Any] | None:
+        """Return the entry under ``doc[asset_type][name]`` or ``None``."""
+        doc = self.load()
+        section = doc.get(asset_type)
+        if not isinstance(section, dict):
+            return None
+        entry = section.get(name)
+        if not isinstance(entry, dict):
+            return None
+        return entry
+
+    def upsert_entry(
+        self,
+        asset_type: str,
+        name: str,
+        *,
+        wiki_commit: str,
+        installed_at: str,
+    ) -> None:
+        """Insert or replace the ``(asset_type, name)`` entry.
+
+        Holds the sidecar lock for the load + mutate + write triple.
+        Preserves all unknown sibling and per-entry keys verbatim — only
+        the two mandated fields are written, anything else under
+        ``doc[asset_type][name]`` survives.
+        """
+        with _file_lock(_lock_path_for(self._path)):
+            doc = self.load()
+            section = doc.get(asset_type)
+            if not isinstance(section, dict):
+                section = {}
+                doc[asset_type] = section
+
+            existing = section.get(name)
+            if isinstance(existing, dict):
+                merged = dict(existing)
+            else:
+                merged = {}
+            merged["wiki_commit"] = wiki_commit
+            merged["installed_at"] = installed_at
+            section[name] = merged
+
+            atomic_write_bytes(
+                self._path,
+                json.dumps(doc, indent=2, ensure_ascii=False).encode("utf-8"),
+            )

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -15,19 +15,17 @@ contract plus the ``known_projects.json`` POST/DELETE endpoints.
 
 from __future__ import annotations
 
-import fcntl
 import hashlib
 import json
 import logging
 import os
 import sys
-from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterator, Literal
+from typing import Literal
 
-from memtomem.context._atomic import atomic_write_bytes
+from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -97,32 +95,6 @@ class ProjectScope:
 
 
 _KNOWN_PROJECTS_VERSION = 1
-
-
-@contextmanager
-def _file_lock(lock_path: Path) -> Iterator[None]:
-    """Cross-process exclusive lock on a sidecar lockfile.
-
-    Locking the data file directly does **not** survive ``os.replace`` —
-    the lock is on the inode, and the rename swaps the inode mid-operation
-    so concurrent writers race on stale fds. The fix is to lock a sibling
-    (`feedback_sidecar_lockfile_for_replaced_files.md` PR #548). The
-    lockfile itself is never renamed, so its inode is stable.
-    """
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        yield
-    finally:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-        finally:
-            os.close(fd)
-
-
-def _lock_path_for(data_path: Path) -> Path:
-    return data_path.parent / f".{data_path.name}.lock"
 
 
 @dataclass(frozen=True)

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context._atomic import atomic_write_bytes
+from memtomem.context._atomic import copy_tree_atomic
 from memtomem.context._names import InvalidNameError, validate_name
 
 logger = logging.getLogger(__name__)
@@ -155,18 +155,7 @@ def copy_skill(src: Path, dst: Path) -> None:
         shutil.rmtree(dst)
 
     dst.mkdir(parents=True)
-    _copy_tree_atomic(src, dst)
-
-
-def _copy_tree_atomic(src: Path, dst: Path) -> None:
-    """Recursively mirror *src* → *dst*, each file via atomic_write_bytes."""
-    dst.mkdir(parents=True, exist_ok=True)
-    for entry in src.iterdir():
-        target = dst / entry.name
-        if entry.is_file():
-            atomic_write_bytes(target, entry.read_bytes())
-        elif entry.is_dir():
-            _copy_tree_atomic(entry, target)
+    copy_tree_atomic(src, dst)
 
 
 # ── Fan-out: canonical → runtimes ─────────────────────────────────────

--- a/packages/memtomem/tests/_wiki_fixtures.py
+++ b/packages/memtomem/tests/_wiki_fixtures.py
@@ -1,0 +1,37 @@
+"""Shared pytest fixtures for wiki-related tests.
+
+Imported by ``test_wiki_store.py``, ``test_wiki_cmd.py``, and
+``test_context_install.py``. ``conftest.py`` already inserts
+``packages/memtomem/tests/`` onto ``sys.path``, so a plain
+``from _wiki_fixtures import git_identity, wiki_root`` works in every
+test file. Mark such imports with ``# noqa: F401`` — pytest binds the
+fixture into the test module's namespace.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def git_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set ``GIT_AUTHOR_*`` / ``GIT_COMMITTER_*`` so subprocess git commits
+    succeed in tmp dirs that have no inherited ``.gitconfig``."""
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+
+
+@pytest.fixture
+def wiki_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    git_identity: None,
+) -> Path:
+    """Point ``WikiStore.at_default()`` at a tmp dir; bring the git identity along."""
+    target = tmp_path / "wiki"
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
+    return target

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -14,6 +14,12 @@ import pytest
 from memtomem.config import Mem2MemConfig
 from memtomem.server.component_factory import Components, create_components, close_components
 
+# Re-export wiki fixtures so any test in this directory can request
+# ``git_identity`` / ``wiki_root`` as a parameter without per-file imports.
+# Keeping the definitions in ``_wiki_fixtures.py`` avoids bloating this
+# already-heavy conftest with unrelated git-env plumbing.
+from _wiki_fixtures import git_identity, wiki_root  # noqa: E402, F401
+
 
 def _ollama_available() -> bool:
     """Check if Ollama is reachable at localhost:11434."""

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -1,0 +1,319 @@
+"""Tests for ``memtomem.context.install`` — wiki-asset install pipeline.
+
+Covers ADR-0008 PR-B: Invariant 1 (copytree snapshot), Invariant 3
+(precise wiki-not-found error), and the OR-refusal forward-protection of
+Invariant 2 (refuse-on-conflict instead of silent clobber).
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.context._names import InvalidNameError
+from memtomem.context.install import (
+    AlreadyInstalledError,
+    AssetNotFoundError,
+    install_skill,
+)
+from memtomem.context.lockfile import LOCKFILE_VERSION, Lockfile
+from memtomem.wiki.store import WikiNotFoundError, WikiStore
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> None:
+    """Drop a skill into an initialized wiki and commit."""
+    skill_dir = wiki_root_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    for relpath, data in files.items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _initialized_wiki(wiki_root_path: Path) -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+# ── install_skill: happy paths ───────────────────────────────────────────
+
+
+def test_install_skill_copies_tree(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(
+        wiki_root,
+        "foo",
+        {
+            "SKILL.md": b"# foo skill\n",
+            "scripts/run.sh": b"#!/bin/bash\necho hi\n",
+            "overrides/claude.md": b"claude-only override\n",
+        },
+    )
+    project = tmp_path / "proj"
+
+    result = install_skill(project, "foo")
+
+    assert result.asset_type == "skills"
+    assert result.name == "foo"
+    assert result.files_written == 3
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").read_bytes() == b"# foo skill\n"
+    assert (dest / "scripts" / "run.sh").read_bytes() == b"#!/bin/bash\necho hi\n"
+    assert (dest / "overrides" / "claude.md").read_bytes() == b"claude-only override\n"
+
+
+def test_install_records_lockfile_entry(wiki_root: Path, tmp_path: Path) -> None:
+    store = _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path / "proj"
+
+    result = install_skill(project, "foo")
+
+    expected_commit = store.current_commit()
+    assert result.wiki_commit == expected_commit
+    assert len(result.wiki_commit) == 40
+
+    # ISO8601-Z with microseconds: YYYY-MM-DDTHH:MM:SS.ffffffZ
+    assert result.installed_at.endswith("Z")
+    assert "." in result.installed_at  # microsecond separator
+    assert "T" in result.installed_at
+
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["version"] == LOCKFILE_VERSION
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == expected_commit
+    assert lock_doc["skills"]["foo"]["installed_at"] == result.installed_at
+
+
+def test_install_skips_dotgit_in_source(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(
+        wiki_root,
+        "foo",
+        {
+            "SKILL.md": b"x",
+            ".git/HEAD": b"ref: refs/heads/main\n",  # synthetic — won't really be added by git
+        },
+    )
+    project = tmp_path / "proj"
+
+    install_skill(project, "foo")
+
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").is_file()
+    assert not (dest / ".git").exists()
+
+
+# ── install_skill: failure paths ─────────────────────────────────────────
+
+
+def test_install_wiki_missing_invariant3(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    git_identity: None,  # noqa: ARG001
+) -> None:
+    """Invariant 3: precise message including path and `mm wiki init`."""
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    project = tmp_path / "proj"
+
+    with pytest.raises(WikiNotFoundError) as excinfo:
+        install_skill(project, "foo")
+    assert "wiki not found at" in str(excinfo.value)
+    assert "mm wiki init" in str(excinfo.value)
+
+
+def test_install_asset_missing(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    project = tmp_path / "proj"
+    with pytest.raises(AssetNotFoundError, match="skills/nope"):
+        install_skill(project, "nope")
+
+
+def test_install_refuses_when_lockfile_and_dest_present(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path / "proj"
+
+    install_skill(project, "foo")
+
+    with pytest.raises(AlreadyInstalledError) as excinfo:
+        install_skill(project, "foo")
+    msg = str(excinfo.value)
+    assert "lockfile_entry=yes" in msg
+    assert "dest=yes" in msg
+
+
+def test_install_refuses_when_only_lockfile_present(wiki_root: Path, tmp_path: Path) -> None:
+    """The OR-not-AND case: user wiped dest but left lockfile orphaned."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path / "proj"
+
+    install_skill(project, "foo")
+    shutil.rmtree(project / ".memtomem" / "skills" / "foo")
+
+    with pytest.raises(AlreadyInstalledError) as excinfo:
+        install_skill(project, "foo")
+    msg = str(excinfo.value)
+    assert "lockfile_entry=yes" in msg
+    assert "dest=no" in msg
+
+
+def test_install_refuses_when_only_dest_present(wiki_root: Path, tmp_path: Path) -> None:
+    """Lockfile damaged (or external copy) but dest exists."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path / "proj"
+    pre = project / ".memtomem" / "skills" / "foo"
+    pre.mkdir(parents=True)
+    (pre / "stray.txt").write_text("hand-placed", encoding="utf-8")
+
+    with pytest.raises(AlreadyInstalledError) as excinfo:
+        install_skill(project, "foo")
+    msg = str(excinfo.value)
+    assert "lockfile_entry=no" in msg
+    assert "dest=yes" in msg
+    # Hand-placed file must not be clobbered.
+    assert (pre / "stray.txt").read_text() == "hand-placed"
+
+
+def test_install_invalid_name(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki(wiki_root)
+    project = tmp_path / "proj"
+    with pytest.raises(InvalidNameError):
+        install_skill(project, "../escape")
+
+
+# ── concurrency ──────────────────────────────────────────────────────────
+
+
+def _install_worker(wiki_path_str: str, project_str: str, name: str) -> None:
+    """Subprocess body — one install per worker, distinct skill names."""
+    import os
+
+    os.environ["MEMTOMEM_WIKI_PATH"] = wiki_path_str
+    install_skill(Path(project_str), name)
+
+
+def test_install_two_skills_concurrent(wiki_root: Path, tmp_path: Path) -> None:
+    """Two installers, distinct skill names, share one lockfile."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    _seed_skill(wiki_root, "bar", {"SKILL.md": b"y"})
+    project = tmp_path / "proj"
+
+    ctx = mp.get_context("spawn")
+    p1 = ctx.Process(target=_install_worker, args=(str(wiki_root), str(project), "foo"))
+    p2 = ctx.Process(target=_install_worker, args=(str(wiki_root), str(project), "bar"))
+    p1.start()
+    p2.start()
+    p1.join(timeout=60)
+    p2.join(timeout=60)
+    assert p1.exitcode == 0, "installer 1 crashed"
+    assert p2.exitcode == 0, "installer 2 crashed"
+
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert "foo" in lock_doc["skills"]
+    assert "bar" in lock_doc["skills"]
+    assert (project / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"x"
+    assert (project / ".memtomem" / "skills" / "bar" / "SKILL.md").read_bytes() == b"y"
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def project_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Tmp project root (with a sentinel ``.git``) wired as cwd so
+    ``_find_project_root`` resolves there."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def test_cli_install_success(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "hello", {"SKILL.md": b"# hello\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "skill", "hello"])
+
+    assert result.exit_code == 0, result.output
+    assert "Installed skills/hello" in result.output
+    assert (project_cwd / ".memtomem" / "skills" / "hello" / "SKILL.md").is_file()
+    assert (project_cwd / ".memtomem" / "lock.json").is_file()
+
+
+def test_cli_install_wiki_missing_message(
+    monkeypatch: pytest.MonkeyPatch,
+    project_cwd: Path,
+    tmp_path: Path,
+    git_identity: None,  # noqa: ARG001
+) -> None:
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "skill", "anything"])
+
+    assert result.exit_code != 0
+    assert "wiki not found at" in result.output
+
+
+def test_cli_install_rejects_unknown_type(project_cwd: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["install", "agent", "foo"])
+    # PR-B: only "skill" is an allowed type; PR-C widens.
+    assert result.exit_code != 0
+    assert "agent" in result.output  # click usage error mentions the bad value
+
+
+def test_cli_install_already_installed_classified_message(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "hello", {"SKILL.md": b"# hello\n"})
+
+    runner = CliRunner()
+    runner.invoke(context_group, ["install", "skill", "hello"])
+    result = runner.invoke(context_group, ["install", "skill", "hello"])
+
+    assert result.exit_code != 0
+    assert "lockfile_entry=yes" in result.output
+    assert "dest=yes" in result.output
+
+
+# ── Lockfile assertions about the live install ──────────────────────────
+
+
+def test_lockfile_contains_only_two_keys_per_entry(wiki_root: Path, tmp_path: Path) -> None:
+    """Schema discipline: install writes exactly the two mandated keys."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path / "proj"
+    install_skill(project, "foo")
+
+    lock = Lockfile.at(project)
+    entry = lock.read_entry("skills", "foo")
+    assert entry is not None
+    assert set(entry) == {"wiki_commit", "installed_at"}

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -66,7 +66,7 @@ def test_install_skill_copies_tree(wiki_root: Path, tmp_path: Path) -> None:
             "overrides/claude.md": b"claude-only override\n",
         },
     )
-    project = tmp_path / "proj"
+    project = tmp_path
 
     result = install_skill(project, "foo")
 
@@ -82,7 +82,7 @@ def test_install_skill_copies_tree(wiki_root: Path, tmp_path: Path) -> None:
 def test_install_records_lockfile_entry(wiki_root: Path, tmp_path: Path) -> None:
     store = _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
-    project = tmp_path / "proj"
+    project = tmp_path
 
     result = install_skill(project, "foo")
 
@@ -111,7 +111,7 @@ def test_install_skips_dotgit_in_source(wiki_root: Path, tmp_path: Path) -> None
             ".git/HEAD": b"ref: refs/heads/main\n",  # synthetic — won't really be added by git
         },
     )
-    project = tmp_path / "proj"
+    project = tmp_path
 
     install_skill(project, "foo")
 
@@ -120,7 +120,81 @@ def test_install_skips_dotgit_in_source(wiki_root: Path, tmp_path: Path) -> None
     assert not (dest / ".git").exists()
 
 
+def test_install_skips_dsstore_and_pycache(wiki_root: Path, tmp_path: Path) -> None:
+    """COPY_SKIP_NAMES: macOS Finder + Python bytecode side-effects don't propagate."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(
+        wiki_root,
+        "foo",
+        {
+            "SKILL.md": b"x",
+            ".DS_Store": b"\x00\x00\x00\x00",
+            "__pycache__/foo.cpython-312.pyc": b"\x00\x00",
+        },
+    )
+    project = tmp_path
+
+    install_skill(project, "foo")
+
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").is_file()
+    assert not (dest / ".DS_Store").exists()
+    assert not (dest / "__pycache__").exists()
+
+
+def test_install_skips_symlinks_in_source(
+    wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """copy_tree_atomic refuses to dereference symlinks — would silently
+    leak out-of-tree bytes (e.g., /etc/passwd) into the project otherwise."""
+    _initialized_wiki(wiki_root)
+    skill_dir = wiki_root / "skills" / "foo"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("real", encoding="utf-8")
+    # Dangling symlink — entry.is_symlink() fires regardless of target validity.
+    (skill_dir / "danger.md").symlink_to("/nonexistent/target")
+    subprocess.run(["git", "-C", str(wiki_root), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root), "commit", "-m", "add foo with symlink"],
+        check=True,
+        capture_output=True,
+    )
+    project = tmp_path
+
+    with caplog.at_level("WARNING", logger="memtomem.context._atomic"):
+        install_skill(project, "foo")
+
+    dest = project / ".memtomem" / "skills" / "foo"
+    assert (dest / "SKILL.md").is_file()
+    assert not (dest / "danger.md").exists()
+    assert any("skipping symlink" in r.message for r in caplog.records)
+
+
+def test_install_files_written_with_default_mode(wiki_root: Path, tmp_path: Path) -> None:
+    """Asset content lands at 0o644 (readable by other tools), not at the
+    0o600 atomic_write_bytes default reserved for state files."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    project = tmp_path
+
+    install_skill(project, "foo")
+
+    skill_md = project / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    # Owner-readable + group/other-readable; no write for group/other.
+    assert (skill_md.stat().st_mode & 0o777) == 0o644
+
+
 # ── install_skill: failure paths ─────────────────────────────────────────
+
+
+def test_install_project_root_missing(wiki_root: Path, tmp_path: Path) -> None:
+    """A typo'd project root errors loudly instead of silently creating it."""
+    _initialized_wiki(wiki_root)
+    _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
+    missing = tmp_path / "nonexistent"
+
+    with pytest.raises(FileNotFoundError, match="project root does not exist"):
+        install_skill(missing, "foo")
 
 
 def test_install_wiki_missing_invariant3(
@@ -130,7 +204,7 @@ def test_install_wiki_missing_invariant3(
 ) -> None:
     """Invariant 3: precise message including path and `mm wiki init`."""
     monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
-    project = tmp_path / "proj"
+    project = tmp_path
 
     with pytest.raises(WikiNotFoundError) as excinfo:
         install_skill(project, "foo")
@@ -140,7 +214,7 @@ def test_install_wiki_missing_invariant3(
 
 def test_install_asset_missing(wiki_root: Path, tmp_path: Path) -> None:
     _initialized_wiki(wiki_root)
-    project = tmp_path / "proj"
+    project = tmp_path
     with pytest.raises(AssetNotFoundError, match="skills/nope"):
         install_skill(project, "nope")
 
@@ -148,7 +222,7 @@ def test_install_asset_missing(wiki_root: Path, tmp_path: Path) -> None:
 def test_install_refuses_when_lockfile_and_dest_present(wiki_root: Path, tmp_path: Path) -> None:
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
-    project = tmp_path / "proj"
+    project = tmp_path
 
     install_skill(project, "foo")
 
@@ -163,7 +237,7 @@ def test_install_refuses_when_only_lockfile_present(wiki_root: Path, tmp_path: P
     """The OR-not-AND case: user wiped dest but left lockfile orphaned."""
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
-    project = tmp_path / "proj"
+    project = tmp_path
 
     install_skill(project, "foo")
     shutil.rmtree(project / ".memtomem" / "skills" / "foo")
@@ -179,7 +253,7 @@ def test_install_refuses_when_only_dest_present(wiki_root: Path, tmp_path: Path)
     """Lockfile damaged (or external copy) but dest exists."""
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
-    project = tmp_path / "proj"
+    project = tmp_path
     pre = project / ".memtomem" / "skills" / "foo"
     pre.mkdir(parents=True)
     (pre / "stray.txt").write_text("hand-placed", encoding="utf-8")
@@ -195,7 +269,7 @@ def test_install_refuses_when_only_dest_present(wiki_root: Path, tmp_path: Path)
 
 def test_install_invalid_name(wiki_root: Path, tmp_path: Path) -> None:
     _initialized_wiki(wiki_root)
-    project = tmp_path / "proj"
+    project = tmp_path
     with pytest.raises(InvalidNameError):
         install_skill(project, "../escape")
 
@@ -216,7 +290,7 @@ def test_install_two_skills_concurrent(wiki_root: Path, tmp_path: Path) -> None:
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
     _seed_skill(wiki_root, "bar", {"SKILL.md": b"y"})
-    project = tmp_path / "proj"
+    project = tmp_path
 
     ctx = mp.get_context("spawn")
     p1 = ctx.Process(target=_install_worker, args=(str(wiki_root), str(project), "foo"))
@@ -241,7 +315,10 @@ def test_install_two_skills_concurrent(wiki_root: Path, tmp_path: Path) -> None:
 @pytest.fixture
 def project_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Tmp project root (with a sentinel ``.git``) wired as cwd so
-    ``_find_project_root`` resolves there."""
+    ``_find_project_root`` resolves there. Uses a subdirectory of
+    ``tmp_path`` so ``_find_project_root`` doesn't accidentally walk up
+    into the test runner's ``tmp_path`` parent and find an unrelated
+    ``.git``/``pyproject.toml`` first."""
     project = tmp_path / "proj"
     project.mkdir()
     (project / ".git").mkdir()
@@ -310,7 +387,7 @@ def test_lockfile_contains_only_two_keys_per_entry(wiki_root: Path, tmp_path: Pa
     """Schema discipline: install writes exactly the two mandated keys."""
     _initialized_wiki(wiki_root)
     _seed_skill(wiki_root, "foo", {"SKILL.md": b"x"})
-    project = tmp_path / "proj"
+    project = tmp_path
     install_skill(project, "foo")
 
     lock = Lockfile.at(project)

--- a/packages/memtomem/tests/test_lockfile.py
+++ b/packages/memtomem/tests/test_lockfile.py
@@ -1,0 +1,203 @@
+"""Tests for ``memtomem.context.lockfile`` — project install lockfile.
+
+Covers ADR-0008 lockfile schema invariants: dict round-trip preserves
+unknown fields, sidecar lock survives concurrent writers, recovery posture
+on missing/invalid/unknown-version files.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.lockfile import (
+    LOCKFILE_VERSION,
+    Lockfile,
+    LockfileVersionError,
+)
+
+
+# ── load() recovery posture ──────────────────────────────────────────────
+
+
+def test_load_missing_returns_default_v1(tmp_path: Path) -> None:
+    lock = Lockfile.at(tmp_path)
+    doc = lock.load()
+    assert doc == {"version": LOCKFILE_VERSION}
+
+
+def test_load_invalid_json_recovers_to_default(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    (project / ".memtomem" / "lock.json").write_text("not valid json {{", encoding="utf-8")
+    lock = Lockfile.at(project)
+    assert lock.load() == {"version": LOCKFILE_VERSION}
+
+
+def test_load_top_level_not_object_recovers(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    (project / ".memtomem" / "lock.json").write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+    lock = Lockfile.at(project)
+    assert lock.load() == {"version": LOCKFILE_VERSION}
+
+
+def test_load_unknown_version_raises_when_strict(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    (project / ".memtomem" / "lock.json").write_text(
+        json.dumps({"version": 99, "skills": {"foo": {}}}), encoding="utf-8"
+    )
+    lock = Lockfile.at(project)
+    with pytest.raises(LockfileVersionError, match="version 99"):
+        lock.load()
+
+
+def test_load_unknown_version_returns_dict_when_not_strict(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    payload = {"version": 99, "skills": {"foo": {"compat": "future"}}}
+    (project / ".memtomem" / "lock.json").write_text(json.dumps(payload), encoding="utf-8")
+    lock = Lockfile.at(project)
+    doc = lock.load(strict=False)
+    assert doc == payload
+
+
+# ── upsert / round-trip ──────────────────────────────────────────────────
+
+
+def test_upsert_creates_file_with_entry(tmp_path: Path) -> None:
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills",
+        "foo",
+        wiki_commit="a" * 40,
+        installed_at="2026-04-30T12:34:56.123456Z",
+    )
+    doc = lock.load()
+    assert doc["version"] == LOCKFILE_VERSION
+    assert doc["skills"]["foo"]["wiki_commit"] == "a" * 40
+    assert doc["skills"]["foo"]["installed_at"] == "2026-04-30T12:34:56.123456Z"
+
+
+def test_upsert_preserves_unknown_top_level_fields(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    seed = {
+        "version": LOCKFILE_VERSION,
+        "future_root": "preserved",
+        "skills": {
+            "alpha": {
+                "wiki_commit": "b" * 40,
+                "installed_at": "2026-01-01T00:00:00.000000Z",
+                "compat": "v2",
+            }
+        },
+    }
+    (project / ".memtomem" / "lock.json").write_text(json.dumps(seed), encoding="utf-8")
+
+    lock = Lockfile.at(project)
+    lock.upsert_entry(
+        "skills",
+        "beta",
+        wiki_commit="c" * 40,
+        installed_at="2026-04-30T00:00:00.000000Z",
+    )
+
+    doc = lock.load()
+    assert doc["future_root"] == "preserved"
+    assert doc["skills"]["alpha"]["compat"] == "v2"
+    assert doc["skills"]["alpha"]["wiki_commit"] == "b" * 40
+    assert doc["skills"]["beta"]["wiki_commit"] == "c" * 40
+
+
+def test_upsert_replaces_existing_entry_keeping_extras(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    seed = {
+        "version": LOCKFILE_VERSION,
+        "skills": {
+            "foo": {
+                "wiki_commit": "old" + "0" * 37,
+                "installed_at": "2026-01-01T00:00:00.000000Z",
+                "compat": "v2",
+            }
+        },
+    }
+    (project / ".memtomem" / "lock.json").write_text(json.dumps(seed), encoding="utf-8")
+
+    lock = Lockfile.at(project)
+    lock.upsert_entry(
+        "skills",
+        "foo",
+        wiki_commit="new" + "0" * 37,
+        installed_at="2026-04-30T00:00:00.000000Z",
+    )
+
+    entry = lock.read_entry("skills", "foo")
+    assert entry is not None
+    assert entry["wiki_commit"] == "new" + "0" * 37
+    assert entry["installed_at"] == "2026-04-30T00:00:00.000000Z"
+    assert entry["compat"] == "v2"  # extra preserved through replace
+
+
+def test_read_entry_returns_none_for_missing(tmp_path: Path) -> None:
+    lock = Lockfile.at(tmp_path)
+    assert lock.read_entry("skills", "nonexistent") is None
+
+
+def test_read_entry_returns_none_for_unknown_section(tmp_path: Path) -> None:
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills",
+        "foo",
+        wiki_commit="a" * 40,
+        installed_at="2026-04-30T00:00:00.000000Z",
+    )
+    assert lock.read_entry("agents", "foo") is None
+
+
+# ── concurrency (real OS-level) ──────────────────────────────────────────
+
+
+def _upsert_worker(project_str: str, asset_type: str, name: str) -> None:
+    """Subprocess body — one upsert per worker, distinct (asset_type, name)."""
+    lock = Lockfile.at(Path(project_str))
+    lock.upsert_entry(
+        asset_type,
+        name,
+        wiki_commit=f"{name:0<40}"[:40],
+        installed_at=f"2026-04-30T00:00:0{name[-1]}.000000Z",
+    )
+
+
+def test_concurrent_upserts_keep_file_valid(tmp_path: Path) -> None:
+    """Eight processes upsert distinct keys; all entries must survive
+    (sidecar lock + key-disjoint = no loss). ADR-0008 lockfile invariant."""
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+
+    ctx = mp.get_context("spawn")
+    procs = [
+        ctx.Process(target=_upsert_worker, args=(str(project), "skills", f"skill{i}"))
+        for i in range(8)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+    for i, p in enumerate(procs):
+        assert p.exitcode == 0, f"worker {i} crashed"
+
+    raw = (project / ".memtomem" / "lock.json").read_text()
+    doc = json.loads(raw)
+    assert doc["version"] == LOCKFILE_VERSION
+    skills = doc.get("skills", {})
+    for i in range(8):
+        name = f"skill{i}"
+        assert name in skills, f"missing entry for {name}; got {sorted(skills)}"
+        assert "wiki_commit" in skills[name]
+        assert "installed_at" in skills[name]

--- a/packages/memtomem/tests/test_wiki_cmd.py
+++ b/packages/memtomem/tests/test_wiki_cmd.py
@@ -11,15 +11,9 @@ from memtomem.cli.wiki_cmd import wiki
 
 
 @pytest.fixture
-def isolated_wiki(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Redirect the wiki path to tmp + give git an identity."""
-    target = tmp_path / "wiki"
-    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
-    monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
-    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
-    monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
-    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
-    return target
+def isolated_wiki(wiki_root: Path) -> Path:
+    """Backwards-compat alias for the shared ``wiki_root`` fixture."""
+    return wiki_root
 
 
 class TestInitCmd:
@@ -40,13 +34,14 @@ class TestInitCmd:
         assert result.exit_code != 0
         assert "already initialized" in result.output
 
-    def test_init_from_url_clones(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_from_url_clones(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_identity: None,  # noqa: ARG002
+    ) -> None:
         source = tmp_path / "source"
         monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(source))
-        monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
-        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
-        monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
-        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
 
         runner = CliRunner()
         runner.invoke(wiki, ["init"])

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -16,18 +16,6 @@ from memtomem.wiki.store import (
 )
 
 
-@pytest.fixture
-def wiki_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Point WikiStore.at_default() at a tmp dir + give git an identity."""
-    target = tmp_path / "wiki"
-    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(target))
-    monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
-    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
-    monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
-    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
-    return target
-
-
 class TestDefaultPath:
     def test_default_path_is_home_relative(self) -> None:
         assert DEFAULT_WIKI_PATH == Path.home() / ".memtomem-wiki"
@@ -93,15 +81,14 @@ class TestInitScratch:
 
 class TestInitFromUrl:
     def test_clone_from_local_file_url(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_identity: None,  # noqa: ARG002
     ) -> None:
         # Set up a source wiki at one path…
         source = tmp_path / "source-wiki"
         monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(source))
-        monkeypatch.setenv("GIT_AUTHOR_NAME", "test")
-        monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
-        monkeypatch.setenv("GIT_COMMITTER_NAME", "test")
-        monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
         WikiStore.at_default().init()
 
         # …clone from it into another path.


### PR DESCRIPTION
## Summary

Implements [ADR-0008](docs/adr/0008-wiki-layer.md) PR-B: install a wiki asset into a project tree with a recorded commit pin and concurrency-safe lockfile. Builds on PR-A (#622) which scaffolded `~/.memtomem-wiki/`, `mm wiki init`, and `mm wiki list`.

- **CLI**: `mm context install skill <name>` — copytree snapshot of `~/.memtomem-wiki/skills/<name>/` into `<project>/.memtomem/skills/<name>/`, pinned to the wiki's HEAD commit.
- **Lockfile**: `<project>/.memtomem/lock.json` (version 1) records `wiki_commit` (full 40-char SHA) and microsecond-precision `installed_at`. Reads round-trip through `dict` so unknown forward-compat fields survive untouched (ADR-0008 §Lockfile schema).
- **Concurrency**: lock window covers only the lockfile JSON load→mutate→atomic_write; the slow copytree runs unlocked. The wiki commit is pinned **before** copy so a concurrent `git pull` cannot drift the recorded `wiki_commit` from the bytes that were copied.

## Scope

PR-B is **skill-only** by design. Agents and commands land in PR-C alongside override resolution — without override-aware extraction the canonical snapshot exists on disk but does not flow through fan-out, which would surprise users into thinking install is broken. The `Choice(['skill'])` widens to `Choice(['skill', 'agent', 'command'])` in one line when PR-C lands; the internal `_install_asset(asset_type, …)` already takes the wider parameter.

Out of scope per ADR-0008 PR breakdown:
- PR-C — override resolution, `OVERRIDE_FORMATS`, `mm wiki <type> override`
- PR-D — `mm context update`, `--force`, `.bak`, `mm context status`, `install --all`, mtime/dirty detection
- v2 — `--commit <ref>` flag, directory-level `os.replace` atomic snapshot

## Refusal posture (forward-protects Invariant 2)

`AlreadyInstalledError` fires on **either** existing-lockfile-entry **OR** existing-dest-dir, not AND. Catches the four cases:

| lockfile entry | dest dir | behavior |
|---|---|---|
| no | no | proceed |
| yes | yes | refuse — normal "already installed" |
| **yes** | **no** | **refuse** — user wiped dest, would silently re-pin |
| **no** | **yes** | **refuse** — dest exists outside lockfile, would clobber |

The error message classifies which side is present so the user knows exactly what to remove.

## Refactors carried in this PR

- `copy_tree_atomic` hoisted from `context/skills.py` to `context/_atomic.py` as a public helper with defensive `.git` skip (single-file ripple verified by `git grep`).
- `_file_lock` + `_lock_path_for` hoisted from `context/projects.py` to `context/_atomic.py` so `KnownProjectsStore` and `Lockfile` share the PR-#548 sidecar pattern instead of cross-importing private symbols.
- `git_identity` / `wiki_root` fixtures moved to `tests/_wiki_fixtures.py` and re-exported from `conftest.py` — `test_wiki_store.py`, `test_wiki_cmd.py`, and `test_context_install.py` share one definition.

## Decisions worth flagging for review

| Question | Decision | Rationale |
|---|---|---|
| Lockfile dict vs dataclass | plain `dict[str, Any]` | ADR-0008:152-155 requires unknown-field round-trip |
| `version != 1` handling | `LockfileVersionError` in strict (write) paths; `load(strict=False)` returns raw dict | future `mm context status` (PR-D) needs to render unknown versions diagnostically without forking the loader |
| `source_path` lockfile field | dropped | redundant — derivable from `(asset_type, name)`; ADR schema doesn't include it |
| `installed_at` precision | microseconds | concurrency tests in same second need ordering signal |
| PR-B asset scope | skill-only | agent/command install without PR-C override-aware fan-out is misleading; smaller PR matches single-change-per-PR |

User-facing docs (README, getting-started) for `mm context install` deferred until the wiki series is feature-complete after PR-D — matches how PR-A shipped ADR-only.

## Test plan

- [x] `uv run pytest tests/test_lockfile.py tests/test_context_install.py` — 26 new tests pass
- [x] `uv run pytest tests/test_wiki_store.py tests/test_wiki_cmd.py` — 28 PR-A regression tests still pass after fixture refactor
- [x] `uv run pytest tests/test_context_projects.py tests/test_context_skills.py` — 56 regression tests still pass after `_file_lock` and `copy_tree_atomic` hoists
- [x] `uv run pytest -m "not ollama"` — full suite, only the pre-existing `test_calibrate_portfolio` live-corpus check fails (unrelated; same on origin/main)
- [x] `uv run ruff check` + `uv run ruff format --check` on every changed file — clean
- [x] `uv run mypy` (advisory) on the four new/modified source files — 0 issues
- [x] End-to-end smoke in isolated `HOME=/tmp/...`: `mm wiki init` → seed skill → `mm context install skill hello` (succeeds, lock.json + dest tree correct) → re-run (refuses with classified error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)