### PR TITLE
feat(context): PR-C — wiki override + agent/command install widening (ADR-0008)

### DIFF
--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -1,6 +1,6 @@
 # ADR-0008: Wiki layer for shared canonical artifacts
 
-**Status:** Accepted (PR-A in flight; PR-B/C/D/E sequenced — see PR Breakdown)
+**Status:** Accepted (PR-A merged, PR-B merged, PR-C in flight; PR-D/E sequenced — see PR Breakdown)
 **Date:** 2026-04-30
 **Context:** Context gateway today is a per-project canonical → multi-runtime
 fan-out router (ADR-0001). Users with several projects must re-author the
@@ -168,8 +168,8 @@ override slots. They can be added in v2 if their runtime surface grows.
 |----|---------|-----------|
 | **A** | Wiki scaffold: `wiki/store.py`, `mm wiki init [--from]`, `mm wiki list`, this ADR | scaffolding only |
 | **B** | `mm context install`, lockfile schema, `shutil.copytree`, lockfile concurrency | Inv 1 (copytree), Inv 3 (graceful absence) |
-| **C** | Override resolution, `OVERRIDE_FORMATS`, `mm wiki <type> override` (auto-result fork) | Inv 4 |
-| **D** | `mm context {update, install --all, status}`, `mm wiki <type> {diff, lint}`, dirty detection | Inv 2 (refuse-if-dirty + `--force` + `.bak`) |
+| **C** | Install widening to agents/commands + dir-layout fan-out BC read; `OVERRIDE_FORMATS`, `context/override.py` resolver, skills override hook; `mm wiki skill override` seed CLI. Override resolution active for skills only — agents/commands gated by `_PR_C_ACTIVE_TYPES` until a follow-up PR opens them. | Inv 4 (skills) |
+| **D** | `mm context {update, install --all, status, migrate}`, `mm wiki <type> {diff, lint}`, dirty detection, flip the `_PR_C_ACTIVE_TYPES` gate to activate agents/commands override | Inv 2 (refuse-if-dirty + `--force` + `.bak`) |
 | **E** | Web UI (mirrors `web/routes/context_*` patterns post-#488) | — |
 
 ## Consequences

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -30,6 +30,8 @@ from memtomem.context.detector import (
 from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
+    install_agent,
+    install_command,
     install_skill,
 )
 from memtomem.context.lockfile import LockfileVersionError
@@ -647,19 +649,23 @@ def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) ->
 
 
 @context.command("install")
-@click.argument("asset_type", type=click.Choice(["skill"]))
+@click.argument("asset_type", type=click.Choice(["skill", "agent", "command"]))
 @click.argument("name")
 def install_cmd(asset_type: str, name: str) -> None:
     """Install a wiki asset into ``<project>/.memtomem/<type>/<name>/``.
 
-    PR-B supports ``skill`` only. Agents and commands land in PR-C
-    alongside override resolution. The wiki at ``~/.memtomem-wiki/`` must
-    be initialized first (``mm wiki init``).
+    The wiki at ``~/.memtomem-wiki/`` must be initialized first
+    (``mm wiki init``). Skills, agents, and commands all flow through
+    fan-out after install.
     """
     root = _find_project_root()
     try:
         if asset_type == "skill":
             result = install_skill(root, name)
+        elif asset_type == "agent":
+            result = install_agent(root, name)
+        elif asset_type == "command":
+            result = install_command(root, name)
         else:  # pragma: no cover — guarded by click.Choice
             raise click.ClickException(f"unknown asset type: {asset_type}")
     except WikiNotFoundError as exc:

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -7,11 +7,16 @@ from __future__ import annotations
 
 import click
 
+from memtomem.context._names import InvalidNameError
 from memtomem.wiki import (
     WIKI_ASSET_TYPES,
     WikiAlreadyExistsError,
     WikiNotFoundError,
     WikiStore,
+)
+from memtomem.wiki.override import (
+    OverrideExistsError,
+    seed_override,
 )
 
 
@@ -76,3 +81,64 @@ def list_cmd(asset_type: str | None) -> None:
             click.secho(f"  {asset.type}/", fg="cyan")
             last_type = asset.type
         click.echo(f"    {asset.name}")
+
+
+# ── Skill subgroup ──────────────────────────────────────────────────────
+
+
+@wiki.group("skill")
+def skill_group() -> None:
+    """Per-skill operations on the wiki (override seeding, ...)."""
+
+
+@skill_group.command("override")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    required=True,
+    help="Which runtime this override targets.",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing override file in the wiki (creates .bak).",
+)
+@click.option(
+    "--editor",
+    "-e",
+    is_flag=True,
+    help="Open $EDITOR on the seeded file after writing.",
+)
+def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> None:
+    """Seed a wiki override file from the canonical skill content.
+
+    ``mm wiki skill override <name> --vendor <claude|gemini|codex>`` writes
+    ``<wiki>/skills/<name>/overrides/<vendor>.md`` using the canonical
+    ``SKILL.md`` as the working baseline. Edit the file (``--editor`` opens
+    ``$EDITOR``) and commit it inside the wiki repo so that future
+    ``mm context install`` snapshots pick it up.
+    """
+    store = WikiStore.at_default()
+    try:
+        target = seed_override(store, "skills", name, vendor, force=force)
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except OverrideExistsError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    rel = target.relative_to(store.root) if target.is_relative_to(store.root) else target
+    click.secho(f"Seeded {rel}", fg="green")
+    click.echo(str(target))
+    click.echo(
+        f"# next: cd {store.root} && git add skills/{name}/overrides/{vendor}.md && git commit"
+    )
+
+    if editor:
+        click.edit(filename=str(target), require_save=False)

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -22,10 +22,54 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-__all__ = ["InvalidNameError", "validate_name"]
+__all__ = [
+    "GENERATOR_VENDOR",
+    "InvalidNameError",
+    "OVERRIDE_FORMATS",
+    "validate_name",
+]
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _MAX_LEN = 64
+
+# ADR-0008 PR-C: per-(asset_type, vendor) override file extension. The
+# tuple is ``(alias, extension)``; ``alias`` is reserved for v2 multi-vendor
+# (e.g. cursor sharing claude's surface) and ``extension`` is what
+# ``override.resolve`` joins to ``<vendor>.<ext>``.
+#
+# v1 covers Claude / Gemini / Codex across skills, agents, commands. The
+# ``("commands", "codex")`` row is a placeholder — there is no
+# ``codex_commands`` generator yet (Codex slash prompts are user-scope and
+# upstream-deprecated; PR-C does not activate that surface). The
+# ``_PR_C_ACTIVE_TYPES`` guard in :mod:`memtomem.context.override` keeps
+# all rows except skills inactive in v1.
+OVERRIDE_FORMATS: dict[tuple[str, str], tuple[str, str]] = {
+    ("skills", "claude"): ("claude", "md"),
+    ("skills", "gemini"): ("gemini", "md"),
+    ("skills", "codex"): ("codex", "md"),
+    ("agents", "claude"): ("claude", "md"),
+    ("agents", "gemini"): ("gemini", "md"),
+    ("agents", "codex"): ("codex", "toml"),
+    ("commands", "claude"): ("claude", "md"),
+    ("commands", "gemini"): ("gemini", "toml"),
+    ("commands", "codex"): ("codex", "md"),
+}
+
+# Maps generator name (`gen.name` — e.g. ``"claude_skills"``) to the
+# vendor key shared with :data:`OVERRIDE_FORMATS`. Centralizing here so
+# ``skills.py`` / ``agents.py`` / ``commands.py`` fan-out and PR-D's
+# lint/status all reuse the same source of truth. Naming pattern is
+# ``<vendor>_<asset_type>`` across the codebase.
+GENERATOR_VENDOR: dict[str, str] = {
+    "claude_skills": "claude",
+    "gemini_skills": "gemini",
+    "codex_skills": "codex",
+    "claude_agents": "claude",
+    "gemini_agents": "gemini",
+    "codex_agents": "codex",
+    "claude_commands": "claude",
+    "gemini_commands": "gemini",
+}
 
 
 class InvalidNameError(ValueError):

--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -21,13 +21,22 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Literal
 
 __all__ = [
     "GENERATOR_VENDOR",
     "InvalidNameError",
+    "Layout",
     "OVERRIDE_FORMATS",
     "validate_name",
 ]
+
+# ADR-0008 PR-C: agents/commands canonical may live in either the legacy
+# flat layout (``<name>.md``) or the directory layout
+# (``<name>/agent.md`` / ``<name>/command.md``). Hoisted here so both
+# ``agents.py`` and ``commands.py`` share one type definition rather than
+# cross-importing.
+Layout = Literal["flat", "dir"]
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 _MAX_LEN = 64

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -36,22 +36,30 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from typing import Any, Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._names import InvalidNameError, Layout, validate_name
 
 logger = logging.getLogger(__name__)
 
 CANONICAL_AGENT_ROOT = ".memtomem/agents"
 AGENT_DIR_FILENAME = "agent.md"
 
-# ADR-0008 commits to directory layout (`agents/<name>/agent.md`); the
-# legacy flat layout (`agents/<name>.md`) was the only form before PR-C.
-# Fan-out reads both during the migration window; reverse-sync preserves
-# whichever form already exists so PR-C does not move user files.
-Layout = Literal["flat", "dir"]
+
+def canonical_agent_name(path: Path, layout: Layout) -> str:
+    """Single source of truth for agent path → name dispatch.
+
+    Used by :func:`list_canonical_agents` consumers, the web routes import
+    handler, and any other place that needs the canonical name without
+    re-implementing the layout fallback. The brittle
+    ``path.name == "agent.md"`` heuristic is intentionally avoided —
+    callers must pass the layout tag they got from
+    :func:`list_canonical_agents` or :func:`extract_agents_to_canonical`.
+    """
+    return path.parent.name if layout == "dir" else path.stem
+
 
 # Reuse the same frontmatter regex used by the markdown chunker so canonical
 # agent files parse consistently with the rest of memtomem.
@@ -489,9 +497,16 @@ class AgentSyncResult:
 
 @dataclass
 class ExtractResult:
-    """Result of a reverse (runtime → canonical) import."""
+    """Result of a reverse (runtime → canonical) import.
 
-    imported: list[Path]
+    Each entry in ``imported`` is ``(path, layout)`` so consumers can use
+    :func:`canonical_agent_name` without re-deriving the layout from the
+    path. ``layout`` is whichever form the canonical now lives in on disk
+    (preserving an existing flat file or writing a new dir entry — see
+    :func:`_resolve_agent_extract_target`).
+    """
+
+    imported: list[tuple[Path, Layout]]
     # (item_name, human_reason, reason_code) — see :mod:`memtomem.context._skip_reasons`.
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = field(default_factory=list)
 
@@ -621,7 +636,7 @@ def extract_agents_to_canonical(
     PR-C — migration to directory layout is a separate command (PR-D).
     """
     canonical_root = project_root / CANONICAL_AGENT_ROOT
-    imported: list[Path] = []
+    imported: list[tuple[Path, Layout]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # agent_name → first runtime label
 
@@ -651,7 +666,7 @@ def extract_agents_to_canonical(
                 skipped.append((agent_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
                 continue
-            dst, _layout = _resolve_agent_extract_target(canonical_root, agent_name)
+            dst, layout = _resolve_agent_extract_target(canonical_root, agent_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((agent_name, reason, skip_codes.CANONICAL_EXISTS))
@@ -660,7 +675,7 @@ def extract_agents_to_canonical(
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_bytes(dst, md_file.read_bytes())
-            imported.append(dst)
+            imported.append((dst, layout))
             seen[agent_name] = runtime_label
 
     return ExtractResult(imported=imported, skipped=skipped)
@@ -742,6 +757,7 @@ __all__ = [
     "ON_DROP_LEVELS",
     "StrictDropError",
     "SubAgent",
+    "canonical_agent_name",
     "diff_agents",
     "extract_agents_to_canonical",
     "generate_all_agents",

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -36,7 +36,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
@@ -45,6 +45,13 @@ from memtomem.context._names import InvalidNameError, validate_name
 logger = logging.getLogger(__name__)
 
 CANONICAL_AGENT_ROOT = ".memtomem/agents"
+AGENT_DIR_FILENAME = "agent.md"
+
+# ADR-0008 commits to directory layout (`agents/<name>/agent.md`); the
+# legacy flat layout (`agents/<name>.md`) was the only form before PR-C.
+# Fan-out reads both during the migration window; reverse-sync preserves
+# whichever form already exists so PR-C does not move user files.
+Layout = Literal["flat", "dir"]
 
 # Reuse the same frontmatter regex used by the markdown chunker so canonical
 # agent files parse consistently with the rest of memtomem.
@@ -171,8 +178,15 @@ _KNOWN_AGENT_KEYS = frozenset(
 )
 
 
-def parse_canonical_agent(path: Path) -> SubAgent:
-    """Parse a canonical agent file into a :class:`SubAgent`."""
+def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
+    """Parse a canonical agent file into a :class:`SubAgent`.
+
+    ``layout`` selects the default-name fallback when the frontmatter omits
+    ``name``: ``"flat"`` (legacy ``agents/<name>.md``) uses ``path.stem``;
+    ``"dir"`` (ADR-0008 ``agents/<name>/agent.md``) uses
+    ``path.parent.name``. Callers normally get ``layout`` from
+    :func:`list_canonical_agents`.
+    """
     content = path.read_text(encoding="utf-8")
     # Normalize CRLF → LF so ``_FRONT_MATTER_RE`` (which anchors on ``\n``) matches
     # files authored on Windows or by editors that emit CRLF.
@@ -188,7 +202,8 @@ def parse_canonical_agent(path: Path) -> SubAgent:
 
     body = content[m.end() :].lstrip("\n").rstrip() + "\n"
 
-    name = frontmatter.get("name") or path.stem
+    default_name = path.parent.name if layout == "dir" else path.stem
+    name = frontmatter.get("name") or default_name
     try:
         name = validate_name(str(name), kind="agent name")
     except InvalidNameError as exc:
@@ -207,11 +222,39 @@ def parse_canonical_agent(path: Path) -> SubAgent:
     )
 
 
-def list_canonical_agents(project_root: Path) -> list[Path]:
+def list_canonical_agents(project_root: Path) -> list[tuple[Path, Layout]]:
+    """Enumerate canonical agents in both flat and directory layouts.
+
+    Flat layout (legacy): ``agents/<name>.md``. Directory layout (ADR-0008
+    PR-C+): ``agents/<name>/agent.md``. When the same name has both forms,
+    the directory layout wins and a WARNING is logged so the silent flat
+    file is visible. ``mm context migrate`` (PR-D) is the supported way
+    to consolidate.
+    """
     root = project_root / CANONICAL_AGENT_ROOT
     if not root.is_dir():
         return []
-    return sorted(p for p in root.glob("*.md") if p.is_file())
+
+    flat: dict[str, Path] = {p.stem: p for p in sorted(root.glob("*.md")) if p.is_file()}
+    dirs: dict[str, Path] = {}
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir():
+            agent_md = entry / AGENT_DIR_FILENAME
+            if agent_md.is_file():
+                dirs[entry.name] = agent_md
+
+    for name in sorted(set(flat) & set(dirs)):
+        logger.warning(
+            "agents/%s: both flat (%s.md) and dir (%s/agent.md) layouts present; "
+            "using dir. Remove the flat file or run `mm context migrate` (PR-D).",
+            name,
+            name,
+            name,
+        )
+
+    merged_paths = {**flat, **dirs}  # dir overrides flat on collision
+    layouts: dict[str, Layout] = {**dict.fromkeys(flat, "flat"), **dict.fromkeys(dirs, "dir")}
+    return [(merged_paths[k], layouts[k]) for k in sorted(merged_paths)]
 
 
 # ── Renderers ────────────────────────────────────────────────────────
@@ -498,9 +541,9 @@ def generate_all_agents(
         if gen is None:
             skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
             continue
-        for agent_path in canonicals:
+        for agent_path, layout in canonicals:
             try:
-                agent = parse_canonical_agent(agent_path)
+                agent = parse_canonical_agent(agent_path, layout=layout)
             except AgentParseError as exc:
                 skipped.append((agent_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
                 continue
@@ -524,6 +567,36 @@ def generate_all_agents(
 # ── Reverse: runtime → canonical ────────────────────────────────────
 
 
+def _resolve_agent_extract_target(canonical_root: Path, agent_name: str) -> tuple[Path, Layout]:
+    """Decide where reverse-sync writes the canonical for ``agent_name``.
+
+    Truth table (ADR-0008 PR-C):
+      dir+flat both → dir wins, flat is silently divergent → WARN
+      dir only      → dir
+      flat only     → flat (preserve existing layout; PR-C does not migrate)
+      neither       → dir (ADR-0008 layout for new agents)
+    """
+    dir_target = canonical_root / agent_name / AGENT_DIR_FILENAME
+    flat_target = canonical_root / f"{agent_name}.md"
+    has_dir = dir_target.is_file()
+    has_flat = flat_target.is_file()
+    if has_dir and has_flat:
+        logger.warning(
+            "agents/%s: reverse-sync updates dir layout (%s/agent.md); the flat "
+            "file (%s.md) is now silently divergent. Remove it or run "
+            "`mm context migrate` (PR-D).",
+            agent_name,
+            agent_name,
+            agent_name,
+        )
+        return dir_target, "dir"
+    if has_dir:
+        return dir_target, "dir"
+    if has_flat:
+        return flat_target, "flat"
+    return dir_target, "dir"
+
+
 def extract_agents_to_canonical(
     project_root: Path,
     overwrite: bool = False,
@@ -542,6 +615,10 @@ def extract_agents_to_canonical(
     silently skipped before any validation/dedupe work. Callers (e.g. the
     single-item import route) can detect "no such runtime artifact" by
     inspecting an empty ``imported`` + ``skipped``.
+
+    Layout policy: new agents (no existing canonical) land in directory
+    layout per ADR-0008. Existing flat-layout entries are preserved by
+    PR-C — migration to directory layout is a separate command (PR-D).
     """
     canonical_root = project_root / CANONICAL_AGENT_ROOT
     imported: list[Path] = []
@@ -574,13 +651,14 @@ def extract_agents_to_canonical(
                 skipped.append((agent_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
                 continue
-            dst = canonical_root / f"{agent_name}.md"
+            dst, _layout = _resolve_agent_extract_target(canonical_root, agent_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((agent_name, reason, skip_codes.CANONICAL_EXISTS))
                 logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
                 seen[agent_name] = runtime_label
                 continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_bytes(dst, md_file.read_bytes())
             imported.append(dst)
             seen[agent_name] = runtime_label
@@ -616,7 +694,11 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
     ``"parse error"``.
     """
     results: list[tuple[str, str, str]] = []
-    canonical_names = {p.stem for p in list_canonical_agents(project_root)}
+    canonical_index = {
+        path.parent.name if layout == "dir" else path.stem: (path, layout)
+        for path, layout in list_canonical_agents(project_root)
+    }
+    canonical_names = set(canonical_index)
 
     for gen_name, gen in AGENT_GENERATORS.items():
         runtime_names = _runtime_agent_names(gen_name, project_root)
@@ -628,9 +710,9 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
                 results.append((gen_name, name, "missing canonical"))
                 continue
 
-            src = project_root / CANONICAL_AGENT_ROOT / f"{name}.md"
+            src, layout = canonical_index[name]
             try:
-                agent = parse_canonical_agent(src)
+                agent = parse_canonical_agent(src, layout=layout)
             except AgentParseError:
                 results.append((gen_name, name, "parse error"))
                 continue
@@ -646,6 +728,7 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
 
 
 __all__ = [
+    "AGENT_DIR_FILENAME",
     "AGENT_GENERATORS",
     "AgentGenerator",
     "AgentParseError",
@@ -655,6 +738,7 @@ __all__ = [
     "ClaudeAgentsGenerator",
     "CodexAgentsGenerator",
     "GeminiAgentsGenerator",
+    "Layout",
     "ON_DROP_LEVELS",
     "StrictDropError",
     "SubAgent",

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -42,6 +42,7 @@ from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.agents import (
+    Layout,
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
     _toml_scalar,
@@ -50,6 +51,7 @@ from memtomem.context.agents import (
 logger = logging.getLogger(__name__)
 
 CANONICAL_COMMAND_ROOT = ".memtomem/commands"
+COMMAND_DIR_FILENAME = "command.md"
 
 
 # ── Canonical dataclass ──────────────────────────────────────────────
@@ -71,8 +73,16 @@ class CommandParseError(ValueError):
     """Raised when a canonical command file cannot be parsed."""
 
 
-def parse_canonical_command(path: Path) -> SlashCommand:
-    """Parse a canonical command file into a :class:`SlashCommand`."""
+def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashCommand:
+    """Parse a canonical command file into a :class:`SlashCommand`.
+
+    ``layout`` selects the default-name fallback when the frontmatter omits
+    ``name``: ``"flat"`` (legacy ``commands/<name>.md``) uses ``path.stem``;
+    ``"dir"`` (ADR-0008 ``commands/<name>/command.md``) uses
+    ``path.parent.name``.
+    """
+    default_name = path.parent.name if layout == "dir" else path.stem
+
     content = path.read_text(encoding="utf-8")
     # Share agents.py's CRLF normalization — the shared ``_FRONT_MATTER_RE``
     # anchors on ``\n`` only, so a CRLF file would otherwise parse as "no
@@ -84,7 +94,7 @@ def parse_canonical_command(path: Path) -> SlashCommand:
         # as the prompt body with a filename-derived name.
         body = content.lstrip("\n").rstrip() + "\n"
         try:
-            stem = validate_name(path.stem, kind="command name")
+            stem = validate_name(default_name, kind="command name")
         except InvalidNameError as exc:
             raise CommandParseError(f"{exc} (source: {path})") from exc
         return SlashCommand(name=stem, description="", body=body)
@@ -92,7 +102,7 @@ def parse_canonical_command(path: Path) -> SlashCommand:
     frontmatter = _parse_flat_yaml(m.group(1))
     body = content[m.end() :].lstrip("\n").rstrip() + "\n"
 
-    name = str(frontmatter.get("name") or path.stem)
+    name = str(frontmatter.get("name") or default_name)
     try:
         name = validate_name(name, kind="command name")
     except InvalidNameError as exc:
@@ -129,11 +139,39 @@ def parse_canonical_command(path: Path) -> SlashCommand:
     )
 
 
-def list_canonical_commands(project_root: Path) -> list[Path]:
+def list_canonical_commands(project_root: Path) -> list[tuple[Path, Layout]]:
+    """Enumerate canonical commands in both flat and directory layouts.
+
+    Flat layout (legacy): ``commands/<name>.md``. Directory layout (ADR-0008
+    PR-C+): ``commands/<name>/command.md``. When the same name has both
+    forms, the directory layout wins and a WARNING is logged so the silent
+    flat file is visible.
+    """
     root = project_root / CANONICAL_COMMAND_ROOT
     if not root.is_dir():
         return []
-    return sorted(p for p in root.glob("*.md") if p.is_file())
+
+    flat: dict[str, Path] = {p.stem: p for p in sorted(root.glob("*.md")) if p.is_file()}
+    dirs: dict[str, Path] = {}
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir():
+            cmd_md = entry / COMMAND_DIR_FILENAME
+            if cmd_md.is_file():
+                dirs[entry.name] = cmd_md
+
+    for name in sorted(set(flat) & set(dirs)):
+        logger.warning(
+            "commands/%s: both flat (%s.md) and dir (%s/command.md) layouts "
+            "present; using dir. Remove the flat file or run "
+            "`mm context migrate` (PR-D).",
+            name,
+            name,
+            name,
+        )
+
+    merged_paths = {**flat, **dirs}  # dir overrides flat on collision
+    layouts: dict[str, Layout] = {**dict.fromkeys(flat, "flat"), **dict.fromkeys(dirs, "dir")}
+    return [(merged_paths[k], layouts[k]) for k in sorted(merged_paths)]
 
 
 # ── Placeholder rewriting ────────────────────────────────────────────
@@ -312,9 +350,9 @@ def generate_all_commands(
         if gen is None:
             skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
             continue
-        for cmd_path in canonicals:
+        for cmd_path, layout in canonicals:
             try:
-                cmd = parse_canonical_command(cmd_path)
+                cmd = parse_canonical_command(cmd_path, layout=layout)
             except CommandParseError as exc:
                 skipped.append((cmd_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
                 continue
@@ -353,6 +391,34 @@ def _gemini_toml_to_canonical(toml_path: Path) -> str:
     return body
 
 
+def _resolve_command_extract_target(canonical_root: Path, cmd_name: str) -> tuple[Path, Layout]:
+    """Decide where reverse-sync writes the canonical for ``cmd_name``.
+
+    Truth table mirrors :func:`memtomem.context.agents._resolve_agent_extract_target`:
+    dir+flat both → dir wins (silent flat divergence WARNed);
+    dir only → dir; flat only → flat (preserve); neither → dir (ADR layout).
+    """
+    dir_target = canonical_root / cmd_name / COMMAND_DIR_FILENAME
+    flat_target = canonical_root / f"{cmd_name}.md"
+    has_dir = dir_target.is_file()
+    has_flat = flat_target.is_file()
+    if has_dir and has_flat:
+        logger.warning(
+            "commands/%s: reverse-sync updates dir layout (%s/command.md); the "
+            "flat file (%s.md) is now silently divergent. Remove it or run "
+            "`mm context migrate` (PR-D).",
+            cmd_name,
+            cmd_name,
+            cmd_name,
+        )
+        return dir_target, "dir"
+    if has_dir:
+        return dir_target, "dir"
+    if has_flat:
+        return flat_target, "flat"
+    return dir_target, "dir"
+
+
 def extract_commands_to_canonical(
     project_root: Path,
     overwrite: bool = False,
@@ -379,6 +445,10 @@ def extract_commands_to_canonical(
     silently skipped before any validation/dedupe work. Callers (e.g. the
     single-item import route) can detect "no such runtime artifact" by
     inspecting an empty ``imported`` + ``skipped``.
+
+    Layout policy: new commands (no existing canonical) land in directory
+    layout per ADR-0008. Existing flat-layout entries are preserved by
+    PR-C — migration to directory layout is a separate command (PR-D).
     """
     canonical_root = project_root / CANONICAL_COMMAND_ROOT
     imported: list[Path] = []
@@ -403,13 +473,14 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from .claude/commands: %s", cmd_name, reason)
                 continue
-            dst = canonical_root / f"{cmd_name}.md"
+            dst, _layout = _resolve_command_extract_target(canonical_root, cmd_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
                 logger.warning("skip %s from .claude/commands: %s", cmd_name, reason)
                 seen[cmd_name] = ".claude/commands"
                 continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_bytes(dst, md_file.read_bytes())
             imported.append(dst)
             seen[cmd_name] = ".claude/commands"
@@ -432,7 +503,7 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from .gemini/commands: %s", cmd_name, reason)
                 continue
-            dst = canonical_root / f"{cmd_name}.md"
+            dst, _layout = _resolve_command_extract_target(canonical_root, cmd_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
@@ -445,6 +516,7 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, "TOML parse error", skip_codes.TOML_PARSE_ERROR))
                 logger.warning("skip %s from .gemini/commands: TOML parse error", cmd_name)
                 continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(dst, canonical_content)
             imported.append(dst)
             seen[cmd_name] = ".gemini/commands"
@@ -478,8 +550,11 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
     ``"missing canonical"``, or ``"parse error"``.
     """
     results: list[tuple[str, str, str]] = []
-    canonical_root = project_root / CANONICAL_COMMAND_ROOT
-    canonical_names = {p.stem for p in list_canonical_commands(project_root)}
+    canonical_index = {
+        path.parent.name if layout == "dir" else path.stem: (path, layout)
+        for path, layout in list_canonical_commands(project_root)
+    }
+    canonical_names = set(canonical_index)
 
     for gen_name, gen in COMMAND_GENERATORS.items():
         runtime_names = _runtime_command_names(gen_name, project_root)
@@ -492,9 +567,9 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
                 results.append((gen_name, name, "missing canonical"))
                 continue
 
-            src = canonical_root / f"{name}.md"
+            src, layout = canonical_index[name]
             try:
-                cmd = parse_canonical_command(src)
+                cmd = parse_canonical_command(src, layout=layout)
             except CommandParseError:
                 results.append((gen_name, name, "parse error"))
                 continue
@@ -511,6 +586,7 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
 
 __all__ = [
     "CANONICAL_COMMAND_ROOT",
+    "COMMAND_DIR_FILENAME",
     "COMMAND_GENERATORS",
     "ClaudeCommandsGenerator",
     "CommandGenerator",

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -40,9 +40,8 @@ from typing import Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._names import InvalidNameError, Layout, validate_name
 from memtomem.context.agents import (
-    Layout,
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
     _toml_scalar,
@@ -52,6 +51,17 @@ logger = logging.getLogger(__name__)
 
 CANONICAL_COMMAND_ROOT = ".memtomem/commands"
 COMMAND_DIR_FILENAME = "command.md"
+
+
+def canonical_command_name(path: Path, layout: Layout) -> str:
+    """Single source of truth for command path → name dispatch.
+
+    Mirror of :func:`memtomem.context.agents.canonical_agent_name`. Avoids
+    the brittle ``path.name == "command.md"`` heuristic — callers must
+    pass the layout tag from :func:`list_canonical_commands` or
+    :func:`extract_commands_to_canonical`.
+    """
+    return path.parent.name if layout == "dir" else path.stem
 
 
 # ── Canonical dataclass ──────────────────────────────────────────────
@@ -303,9 +313,14 @@ class CommandSyncResult:
 
 @dataclass
 class ExtractResult:
-    """Result of a reverse (runtime → canonical) import."""
+    """Result of a reverse (runtime → canonical) import.
 
-    imported: list[Path]
+    Each entry in ``imported`` is ``(path, layout)`` so consumers can use
+    :func:`canonical_command_name` without re-deriving the layout from
+    the path.
+    """
+
+    imported: list[tuple[Path, Layout]]
     # (item_name, human_reason, reason_code) — see :mod:`memtomem.context._skip_reasons`.
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = field(default_factory=list)
 
@@ -451,7 +466,7 @@ def extract_commands_to_canonical(
     PR-C — migration to directory layout is a separate command (PR-D).
     """
     canonical_root = project_root / CANONICAL_COMMAND_ROOT
-    imported: list[Path] = []
+    imported: list[tuple[Path, Layout]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # cmd_name → first runtime label
 
@@ -473,7 +488,7 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from .claude/commands: %s", cmd_name, reason)
                 continue
-            dst, _layout = _resolve_command_extract_target(canonical_root, cmd_name)
+            dst, layout = _resolve_command_extract_target(canonical_root, cmd_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
@@ -482,7 +497,7 @@ def extract_commands_to_canonical(
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_bytes(dst, md_file.read_bytes())
-            imported.append(dst)
+            imported.append((dst, layout))
             seen[cmd_name] = ".claude/commands"
 
     # Gemini — TOML → canonical Markdown conversion.
@@ -503,7 +518,7 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
                 logger.warning("skip %s from .gemini/commands: %s", cmd_name, reason)
                 continue
-            dst, _layout = _resolve_command_extract_target(canonical_root, cmd_name)
+            dst, layout = _resolve_command_extract_target(canonical_root, cmd_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
@@ -518,7 +533,7 @@ def extract_commands_to_canonical(
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(dst, canonical_content)
-            imported.append(dst)
+            imported.append((dst, layout))
             seen[cmd_name] = ".gemini/commands"
 
     return ExtractResult(imported=imported, skipped=skipped)
@@ -596,6 +611,7 @@ __all__ = [
     "GeminiCommandsGenerator",
     "SlashCommand",
     "StrictDropError",
+    "canonical_command_name",
     "diff_commands",
     "extract_commands_to_canonical",
     "generate_all_commands",

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -1,16 +1,17 @@
 """Install a single wiki asset into ``<project>/.memtomem/<type>/<name>/``.
 
-Implements PR-B of ADR-0008. The wiki at ``~/.memtomem-wiki/`` is the
-source of truth; an "install" is a copytree snapshot pinned to the wiki's
-HEAD commit, recorded in :class:`memtomem.context.lockfile.Lockfile`.
+Implements ADR-0008 PR-B (skills) and PR-C (agents, commands). The wiki at
+``~/.memtomem-wiki/`` is the source of truth; an "install" is a copytree
+snapshot pinned to the wiki's HEAD commit, recorded in
+:class:`memtomem.context.lockfile.Lockfile`.
 
-PR-B exposes only :func:`install_skill`. Skill fan-out works end-to-end
-through the existing :mod:`memtomem.context.skills` generators, so the
-user can install a wiki skill and immediately have it appear under
-``.claude/skills/`` etc. Agent and command install land in PR-C alongside
-override resolution — without override-aware extraction the snapshot
-exists on disk but does not flow through fan-out, which would surprise
-users into thinking install is broken.
+Public wrappers — :func:`install_skill`, :func:`install_agent`,
+:func:`install_command` — all delegate to :func:`_install_asset`. The wiki
+is expected to use directory layout for every kind
+(``agents/<name>/agent.md``, ``commands/<name>/command.md``); fan-out at
+:mod:`memtomem.context.agents` / :mod:`memtomem.context.commands` reads
+both directory and legacy flat layouts during PR-C so the install does
+not strand newly-installed assets in an unread layout.
 
 Install is intentionally non-destructive: if either a lockfile entry OR
 the destination directory already exists, install refuses with a
@@ -35,6 +36,8 @@ __all__ = [
     "AlreadyInstalledError",
     "AssetNotFoundError",
     "InstallResult",
+    "install_agent",
+    "install_command",
     "install_skill",
 ]
 
@@ -49,15 +52,9 @@ class AlreadyInstalledError(RuntimeError):
 
 @dataclass(frozen=True)
 class InstallResult:
-    """Outcome of a successful install. Display-oriented; not persisted.
+    """Outcome of a successful install. Display-oriented; not persisted."""
 
-    ``asset_type`` is ``Literal["skills"]`` in PR-B and widens alongside the
-    public ``install_agent`` / ``install_command`` wrappers that PR-C adds.
-    The private ``_install_asset`` callee keeps a wider parameter type so
-    PR-C is a one-line widening, not a re-architecture.
-    """
-
-    asset_type: Literal["skills"]
+    asset_type: Literal["skills", "agents", "commands"]
     name: str
     wiki_commit: str
     installed_at: str
@@ -79,6 +76,26 @@ def install_skill(
     or the destination directory already exists — see module docstring.
     """
     return _install_asset(project_root, "skills", name, wiki=wiki)
+
+
+def install_agent(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+) -> InstallResult:
+    """Snapshot ``<wiki>/agents/<name>/`` into ``<project>/.memtomem/agents/<name>/``."""
+    return _install_asset(project_root, "agents", name, wiki=wiki)
+
+
+def install_command(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+) -> InstallResult:
+    """Snapshot ``<wiki>/commands/<name>/`` into ``<project>/.memtomem/commands/<name>/``."""
+    return _install_asset(project_root, "commands", name, wiki=wiki)
 
 
 def _install_asset(
@@ -137,11 +154,8 @@ def _install_asset(
         installed_at=installed_at,
     )
 
-    # PR-B contract: only "skills" reaches this construction site (the
-    # public wrapper is install_skill). PR-C widens InstallResult.asset_type
-    # alongside install_agent / install_command wrappers.
     return InstallResult(
-        asset_type=cast('Literal["skills"]', asset_type),
+        asset_type=cast('Literal["skills", "agents", "commands"]', asset_type),
         name=validated,
         wiki_commit=wiki_commit,
         installed_at=installed_at,

--- a/packages/memtomem/src/memtomem/context/override.py
+++ b/packages/memtomem/src/memtomem/context/override.py
@@ -1,0 +1,48 @@
+"""Vendor override resolution — reads project tree only (ADR-0008 Invariant 1).
+
+Fan-out modules call :func:`resolve` per-vendor before writing to the
+runtime target. When the resolver returns a path, the caller MUST
+byte-copy that file to the vendor target and skip auto-conversion for
+that vendor (Invariant 4: full-file replacement).
+
+The resolver intentionally takes only ``project_root`` — never the wiki —
+to enforce Invariant 1: ``mm context install`` already copytreed the
+wiki's ``overrides/`` subdir into the project, so fan-out never needs
+the wiki at sync time. CI machines, archived projects, and machines
+without ``~/.memtomem-wiki/`` all run fan-out unchanged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.context._names import OVERRIDE_FORMATS
+
+__all__ = ["resolve"]
+
+# PR-C ships override resolution for skills only. Agents and commands
+# carry an ``OVERRIDE_FORMATS`` row each so the matrix is shipped whole,
+# but the resolver skips them until a follow-up PR opens the surface
+# (drop this gate to activate). Tests pin the gate explicitly so the
+# enable-day diff is a one-line revert.
+_PR_C_ACTIVE_TYPES = frozenset({"skills"})
+
+
+def resolve(
+    project_root: Path,
+    asset_type: str,
+    name: str,
+    vendor: str,
+) -> Path | None:
+    """Returns project's overrides/<vendor>.<ext> if exists, else None.
+
+    Reads ONLY from project tree. ADR-0008 Invariant 1.
+    """
+    if asset_type not in _PR_C_ACTIVE_TYPES:
+        return None
+    fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
+    if fmt is None:
+        return None
+    _, ext = fmt
+    candidate = project_root / ".memtomem" / asset_type / name / "overrides" / f"{vendor}.{ext}"
+    return candidate if candidate.is_file() else None

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -25,8 +25,9 @@ from pathlib import Path
 from typing import Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context._atomic import copy_tree_atomic
-from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context import override as _override
+from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
 
 logger = logging.getLogger(__name__)
 
@@ -207,6 +208,16 @@ def generate_all_skills(
         for skill_dir in canonicals:
             dst = gen.target_dir(project_root, skill_dir.name)
             copy_skill(skill_dir, dst)
+            # ADR-0008 Invariant 4: per-vendor override replaces SKILL.md only.
+            # Auxiliary files (scripts/, references/) stay from canonical.
+            vendor = GENERATOR_VENDOR.get(target)
+            if vendor is not None:
+                override_path = _override.resolve(project_root, "skills", skill_dir.name, vendor)
+                if override_path is not None:
+                    atomic_write_bytes(
+                        dst / SKILL_MANIFEST,
+                        override_path.read_bytes(),
+                    )
             generated.append((target, dst))
 
     return SkillSyncResult(generated=generated, skipped=skipped)

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -87,8 +87,10 @@ async def list_agents(
         by_name.setdefault(agent_name, []).append({"runtime": runtime, "status": status})
 
     agents: list[dict[str, object]] = []
-    for agent_path in canonicals:
-        name = agent_path.stem
+    canonical_names: set[str] = set()
+    for agent_path, layout in canonicals:
+        name = agent_path.parent.name if layout == "dir" else agent_path.stem
+        canonical_names.add(name)
         agents.append(
             {
                 "name": name,
@@ -97,7 +99,6 @@ async def list_agents(
             }
         )
 
-    canonical_names = {p.stem for p in canonicals}
     for agent_name, runtimes in by_name.items():
         if agent_name not in canonical_names:
             agents.append({"name": agent_name, "canonical_path": None, "runtimes": runtimes})
@@ -406,7 +407,10 @@ async def import_agents(
         raise HTTPException(503, "Agents import timed out — another sync may be in progress")
     return {
         "imported": [
-            {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}
+            {
+                "name": p.parent.name if p.name == "agent.md" else p.stem,
+                "canonical_path": str(p.relative_to(project_root)),
+            }
             for p in result.imported
         ],
         "skipped": [
@@ -448,7 +452,10 @@ async def import_agent(
         raise HTTPException(404, f"No runtime agent named {name!r} to import")
     return {
         "imported": [
-            {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}
+            {
+                "name": p.parent.name if p.name == "agent.md" else p.stem,
+                "canonical_path": str(p.relative_to(project_root)),
+            }
             for p in result.imported
         ],
         "skipped": [

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -17,6 +17,7 @@ from memtomem.context.agents import (
     CANONICAL_AGENT_ROOT,
     AgentParseError,
     SubAgent,
+    canonical_agent_name,
     diff_agents,
     extract_agents_to_canonical,
     generate_all_agents,
@@ -89,7 +90,7 @@ async def list_agents(
     agents: list[dict[str, object]] = []
     canonical_names: set[str] = set()
     for agent_path, layout in canonicals:
-        name = agent_path.parent.name if layout == "dir" else agent_path.stem
+        name = canonical_agent_name(agent_path, layout)
         canonical_names.add(name)
         agents.append(
             {
@@ -408,10 +409,10 @@ async def import_agents(
     return {
         "imported": [
             {
-                "name": p.parent.name if p.name == "agent.md" else p.stem,
+                "name": canonical_agent_name(p, layout),
                 "canonical_path": str(p.relative_to(project_root)),
             }
-            for p in result.imported
+            for p, layout in result.imported
         ],
         "skipped": [
             {"name": name, "reason": reason, "reason_code": code}
@@ -453,10 +454,10 @@ async def import_agent(
     return {
         "imported": [
             {
-                "name": p.parent.name if p.name == "agent.md" else p.stem,
+                "name": canonical_agent_name(p, layout),
                 "canonical_path": str(p.relative_to(project_root)),
             }
-            for p in result.imported
+            for p, layout in result.imported
         ],
         "skipped": [
             {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -16,6 +16,7 @@ from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
     COMMAND_GENERATORS,
     CommandParseError,
+    canonical_command_name,
     diff_commands,
     extract_commands_to_canonical,
     generate_all_commands,
@@ -75,7 +76,7 @@ async def list_commands(
     commands: list[dict[str, object]] = []
     canonical_names: set[str] = set()
     for cmd_path, layout in canonicals:
-        name = cmd_path.parent.name if layout == "dir" else cmd_path.stem
+        name = canonical_command_name(cmd_path, layout)
         canonical_names.add(name)
         commands.append(
             {
@@ -384,10 +385,10 @@ async def import_commands(
     return {
         "imported": [
             {
-                "name": p.parent.name if p.name == "command.md" else p.stem,
+                "name": canonical_command_name(p, layout),
                 "canonical_path": str(p.relative_to(project_root)),
             }
-            for p in result.imported
+            for p, layout in result.imported
         ],
         "skipped": [
             {"name": name, "reason": reason, "reason_code": code}
@@ -429,10 +430,10 @@ async def import_command(
     return {
         "imported": [
             {
-                "name": p.parent.name if p.name == "command.md" else p.stem,
+                "name": canonical_command_name(p, layout),
                 "canonical_path": str(p.relative_to(project_root)),
             }
-            for p in result.imported
+            for p, layout in result.imported
         ],
         "skipped": [
             {"name": n, "reason": reason, "reason_code": code} for n, reason, code in result.skipped

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -73,8 +73,10 @@ async def list_commands(
         by_name.setdefault(cmd_name, []).append({"runtime": runtime, "status": status})
 
     commands: list[dict[str, object]] = []
-    for cmd_path in canonicals:
-        name = cmd_path.stem
+    canonical_names: set[str] = set()
+    for cmd_path, layout in canonicals:
+        name = cmd_path.parent.name if layout == "dir" else cmd_path.stem
+        canonical_names.add(name)
         commands.append(
             {
                 "name": name,
@@ -83,7 +85,6 @@ async def list_commands(
             }
         )
 
-    canonical_names = {p.stem for p in canonicals}
     for cmd_name, runtimes in by_name.items():
         if cmd_name not in canonical_names:
             commands.append({"name": cmd_name, "canonical_path": None, "runtimes": runtimes})
@@ -382,7 +383,10 @@ async def import_commands(
         raise HTTPException(503, "Commands import timed out — another sync may be in progress")
     return {
         "imported": [
-            {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}
+            {
+                "name": p.parent.name if p.name == "command.md" else p.stem,
+                "canonical_path": str(p.relative_to(project_root)),
+            }
             for p in result.imported
         ],
         "skipped": [
@@ -424,7 +428,10 @@ async def import_command(
         raise HTTPException(404, f"No runtime command named {name!r} to import")
     return {
         "imported": [
-            {"name": p.stem, "canonical_path": str(p.relative_to(project_root))}
+            {
+                "name": p.parent.name if p.name == "command.md" else p.stem,
+                "canonical_path": str(p.relative_to(project_root)),
+            }
             for p in result.imported
         ],
         "skipped": [

--- a/packages/memtomem/src/memtomem/wiki/override.py
+++ b/packages/memtomem/src/memtomem/wiki/override.py
@@ -28,23 +28,21 @@ def render_seed_bytes(
     store: WikiStore,
     asset_type: str,
     name: str,
-    vendor: str,
+    _vendor: str,
 ) -> bytes:
     """Return the bytes to seed an override file with.
 
     Skills (byte-identical fan-out) → seed equals canonical ``SKILL.md``.
     Agents and commands ride the vendor-specific renderers and are not
     activated in PR-C; the resolver in :mod:`memtomem.context.override`
-    has a matching gate.
+    has a matching gate. ``_vendor`` is reserved for that follow-up
+    (per-vendor renderer dispatch) and intentionally unused for skills.
     """
     if asset_type != "skills":
         raise NotImplementedError(f"override seeding for {asset_type!r} lands in a follow-up PR")
     src = store.root / "skills" / name / "SKILL.md"
     if not src.is_file():
         raise FileNotFoundError(f"wiki has no skills/{name}/SKILL.md to seed from at {src}")
-    # Vendor parameter is reserved for parity with the agents/commands
-    # surface that will land later — for skills the seed is vendor-agnostic.
-    del vendor
     return src.read_bytes()
 
 
@@ -60,6 +58,10 @@ def seed_override(
 
     Returns the override file path. ``force`` overwrites an existing file
     after writing a ``.bak`` sibling so the previous content is recoverable.
+
+    All preconditions are checked before any filesystem mutation: a refused
+    call (missing wiki / missing canonical / collision without ``force``)
+    must NOT leave a half-built ``overrides/`` directory behind.
     """
     store.require_exists()
     validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
@@ -68,14 +70,17 @@ def seed_override(
         raise ValueError(f"no override format registered for ({asset_type!r}, {vendor!r})")
     _, ext = fmt
     target = store.root / asset_type / name / "overrides" / f"{vendor}.{ext}"
-    target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists() and not force:
         raise OverrideExistsError(
             f"override already exists at {target}; pass --force to overwrite "
             f"(creates a .bak sibling so the previous content is recoverable)"
         )
+    # Pre-flight the seed bytes so missing-canonical does not leave an
+    # empty overrides/ directory behind from the mkdir below.
+    seed_bytes = render_seed_bytes(store, asset_type, name, vendor)
+    target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists() and force:
         backup = target.with_suffix(target.suffix + ".bak")
         atomic_write_bytes(backup, target.read_bytes())
-    atomic_write_bytes(target, render_seed_bytes(store, asset_type, name, vendor))
+    atomic_write_bytes(target, seed_bytes)
     return target

--- a/packages/memtomem/src/memtomem/wiki/override.py
+++ b/packages/memtomem/src/memtomem/wiki/override.py
@@ -1,0 +1,81 @@
+"""Wiki-side override seeding — writes into ``~/.memtomem-wiki/<type>/<name>/overrides/``.
+
+Companion to :mod:`memtomem.context.override` (which is the project-side
+*resolver*). The seed helper here is what ``mm wiki <type> override``
+calls to produce the initial bytes the user then edits. Skills are
+byte-identical across vendors, so the seed is simply the canonical
+``SKILL.md``; agents and commands need vendor-specific renderers and
+land in a follow-up PR alongside the rest of the multi-kind override
+surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.context._atomic import atomic_write_bytes
+from memtomem.context._names import OVERRIDE_FORMATS, validate_name
+from memtomem.wiki.store import WikiStore
+
+__all__ = ["OverrideExistsError", "render_seed_bytes", "seed_override"]
+
+
+class OverrideExistsError(RuntimeError):
+    """Raised when an override file already exists and ``force`` was not given."""
+
+
+def render_seed_bytes(
+    store: WikiStore,
+    asset_type: str,
+    name: str,
+    vendor: str,
+) -> bytes:
+    """Return the bytes to seed an override file with.
+
+    Skills (byte-identical fan-out) → seed equals canonical ``SKILL.md``.
+    Agents and commands ride the vendor-specific renderers and are not
+    activated in PR-C; the resolver in :mod:`memtomem.context.override`
+    has a matching gate.
+    """
+    if asset_type != "skills":
+        raise NotImplementedError(f"override seeding for {asset_type!r} lands in a follow-up PR")
+    src = store.root / "skills" / name / "SKILL.md"
+    if not src.is_file():
+        raise FileNotFoundError(f"wiki has no skills/{name}/SKILL.md to seed from at {src}")
+    # Vendor parameter is reserved for parity with the agents/commands
+    # surface that will land later — for skills the seed is vendor-agnostic.
+    del vendor
+    return src.read_bytes()
+
+
+def seed_override(
+    store: WikiStore,
+    asset_type: str,
+    name: str,
+    vendor: str,
+    *,
+    force: bool = False,
+) -> Path:
+    """Create ``<wiki>/<type>/<name>/overrides/<vendor>.<ext>``.
+
+    Returns the override file path. ``force`` overwrites an existing file
+    after writing a ``.bak`` sibling so the previous content is recoverable.
+    """
+    store.require_exists()
+    validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
+    if fmt is None:
+        raise ValueError(f"no override format registered for ({asset_type!r}, {vendor!r})")
+    _, ext = fmt
+    target = store.root / asset_type / name / "overrides" / f"{vendor}.{ext}"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.exists() and not force:
+        raise OverrideExistsError(
+            f"override already exists at {target}; pass --force to overwrite "
+            f"(creates a .bak sibling so the previous content is recoverable)"
+        )
+    if target.exists() and force:
+        backup = target.with_suffix(target.suffix + ".bak")
+        atomic_write_bytes(backup, target.read_bytes())
+    atomic_write_bytes(target, render_seed_bytes(store, asset_type, name, vendor))
+    return target

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -147,7 +147,7 @@ class TestListCanonicalAgents:
     def test_sorted(self, tmp_path):
         _make_canonical_agent(tmp_path, "zeta", SAMPLE_MINIMAL_AGENT.replace("helper", "zeta"))
         _make_canonical_agent(tmp_path, "alpha", SAMPLE_MINIMAL_AGENT.replace("helper", "alpha"))
-        names = [p.stem for p in list_canonical_agents(tmp_path)]
+        names = [p.stem for p, _layout in list_canonical_agents(tmp_path)]
         assert names == ["alpha", "zeta"]
 
 
@@ -284,7 +284,8 @@ class TestExtractAgentsToCanonical:
         (claude_dir / "helper.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
         result = extract_agents_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        assert (tmp_path / CANONICAL_AGENT_ROOT / "helper.md").is_file()
+        # New agents land in directory layout per ADR-0008.
+        assert (tmp_path / CANONICAL_AGENT_ROOT / "helper" / "agent.md").is_file()
         assert result.skipped == []
 
     def test_dedup_across_runtimes(self, tmp_path):
@@ -341,7 +342,8 @@ class TestExtractAgentsToCanonical:
         result = extract_agents_to_canonical(tmp_path)
 
         # Only "ok" imported; "-bad" skipped with invalid-name reason.
-        imported_names = sorted(p.stem for p in result.imported)
+        # Dir layout: imported paths are <root>/<name>/agent.md.
+        imported_names = sorted(p.parent.name for p in result.imported)
         assert imported_names == ["ok"]
         skipped_names = sorted(name for name, _, _ in result.skipped)
         assert "-bad" in skipped_names
@@ -355,9 +357,10 @@ class TestExtractAgentsToCanonical:
         (d / "beta.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
 
         result = extract_agents_to_canonical(tmp_path, only_name="alpha")
-        assert [p.stem for p in result.imported] == ["alpha"]
+        # Dir layout: imported paths are <root>/<name>/agent.md.
+        assert [p.parent.name for p in result.imported] == ["alpha"]
         assert result.skipped == []
-        assert not (tmp_path / CANONICAL_AGENT_ROOT / "beta.md").exists()
+        assert not (tmp_path / CANONICAL_AGENT_ROOT / "beta" / "agent.md").exists()
 
     def test_only_name_no_match_returns_empty(self, tmp_path):
         d = tmp_path / ".claude/agents"
@@ -532,7 +535,10 @@ class TestRoundtrip:
         shutil.rmtree(tmp_path / CANONICAL_AGENT_ROOT)
         result = extract_agents_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        reparsed = parse_canonical_agent(tmp_path / CANONICAL_AGENT_ROOT / "helper.md")
+        # New canonical lands in dir layout per ADR-0008.
+        reparsed = parse_canonical_agent(
+            tmp_path / CANONICAL_AGENT_ROOT / "helper" / "agent.md", layout="dir"
+        )
         assert reparsed.name == "helper"
         assert "Help with things." in reparsed.body
 

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -13,6 +13,7 @@ from memtomem.context.agents import (
     _runtime_agent_names,
     _toml_escape_basic_string,
     _toml_escape_multiline_string,
+    canonical_agent_name,
     diff_agents,
     extract_agents_to_canonical,
     generate_all_agents,
@@ -342,8 +343,9 @@ class TestExtractAgentsToCanonical:
         result = extract_agents_to_canonical(tmp_path)
 
         # Only "ok" imported; "-bad" skipped with invalid-name reason.
-        # Dir layout: imported paths are <root>/<name>/agent.md.
-        imported_names = sorted(p.parent.name for p in result.imported)
+        # ExtractResult.imported is now (path, layout) tuples; new agents
+        # land in dir layout per ADR-0008.
+        imported_names = sorted(canonical_agent_name(p, layout) for p, layout in result.imported)
         assert imported_names == ["ok"]
         skipped_names = sorted(name for name, _, _ in result.skipped)
         assert "-bad" in skipped_names
@@ -357,8 +359,8 @@ class TestExtractAgentsToCanonical:
         (d / "beta.md").write_text(SAMPLE_MINIMAL_AGENT, encoding="utf-8")
 
         result = extract_agents_to_canonical(tmp_path, only_name="alpha")
-        # Dir layout: imported paths are <root>/<name>/agent.md.
-        assert [p.parent.name for p in result.imported] == ["alpha"]
+        # ExtractResult.imported is (path, layout) tuples.
+        assert [canonical_agent_name(p, layout) for p, layout in result.imported] == ["alpha"]
         assert result.skipped == []
         assert not (tmp_path / CANONICAL_AGENT_ROOT / "beta" / "agent.md").exists()
 

--- a/packages/memtomem/tests/test_context_agents_bc_layout.py
+++ b/packages/memtomem/tests/test_context_agents_bc_layout.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from memtomem.context.agents import (
     CANONICAL_AGENT_ROOT,
+    canonical_agent_name,
     extract_agents_to_canonical,
     list_canonical_agents,
     parse_canonical_agent,
@@ -92,6 +93,23 @@ def test_list_agents_both_layouts_dir_wins(
     assert any(
         "both flat" in rec.message and rec.levelno == logging.WARNING for rec in caplog.records
     )
+
+
+# ── canonical_agent_name helper ────────────────────────────────────────
+
+
+def test_canonical_agent_name_dispatch_on_layout(tmp_path: Path) -> None:
+    """Helper is the single source of truth for path → name. Layout tag
+    drives the dispatch; the brittle ``path.name == "agent.md"`` heuristic
+    is intentionally not used (a literal flat ``agent.md`` file would
+    misclassify under that heuristic)."""
+    flat = tmp_path / CANONICAL_AGENT_ROOT / "foo.md"
+    dir_path = tmp_path / CANONICAL_AGENT_ROOT / "foo" / "agent.md"
+    literal_agent_flat = tmp_path / CANONICAL_AGENT_ROOT / "agent.md"
+    assert canonical_agent_name(flat, "flat") == "foo"
+    assert canonical_agent_name(dir_path, "dir") == "foo"
+    # Literal `agent.md` flat file is NOT misread as dir-form.
+    assert canonical_agent_name(literal_agent_flat, "flat") == "agent"
 
 
 # ── parse_canonical_agent layout dispatch ───────────────────────────────

--- a/packages/memtomem/tests/test_context_agents_bc_layout.py
+++ b/packages/memtomem/tests/test_context_agents_bc_layout.py
@@ -1,0 +1,183 @@
+"""Backward-compatible enumeration / extraction across agent canonical layouts.
+
+ADR-0008 commits to ``agents/<name>/agent.md`` (directory layout) but the
+legacy form ``agents/<name>.md`` (flat) still exists in PR-B users' trees.
+PR-C must enumerate both, parse both, and preserve the existing layout
+during reverse-sync; new agents land in the directory form.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from memtomem.context.agents import (
+    CANONICAL_AGENT_ROOT,
+    extract_agents_to_canonical,
+    list_canonical_agents,
+    parse_canonical_agent,
+)
+
+
+SAMPLE_FRONTMATTER = """---
+name: helper
+description: Generic helper
+---
+
+Help with things.
+"""
+
+
+def _write_flat_agent(project_root: Path, name: str) -> Path:
+    root = project_root / CANONICAL_AGENT_ROOT
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / f"{name}.md"
+    target.write_text(SAMPLE_FRONTMATTER.replace("name: helper", f"name: {name}"))
+    return target
+
+
+def _write_dir_agent(project_root: Path, name: str) -> Path:
+    root = project_root / CANONICAL_AGENT_ROOT / name
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / "agent.md"
+    target.write_text(SAMPLE_FRONTMATTER.replace("name: helper", f"name: {name}"))
+    return target
+
+
+# ── list_canonical_agents enumeration ───────────────────────────────────
+
+
+def test_list_agents_flat_only_unchanged(tmp_path: Path) -> None:
+    _write_flat_agent(tmp_path, "alpha")
+    _write_flat_agent(tmp_path, "beta")
+    result = list_canonical_agents(tmp_path)
+    names = [p.stem for p, _ in result]
+    layouts = [layout for _, layout in result]
+    assert names == ["alpha", "beta"]
+    assert layouts == ["flat", "flat"]
+
+
+def test_list_agents_dir_only_enumerated(tmp_path: Path) -> None:
+    _write_dir_agent(tmp_path, "gamma")
+    _write_dir_agent(tmp_path, "delta")
+    result = list_canonical_agents(tmp_path)
+    names = [p.parent.name for p, _ in result]
+    layouts = [layout for _, layout in result]
+    assert names == ["delta", "gamma"]
+    assert layouts == ["dir", "dir"]
+
+
+def test_list_returns_layout_tag(tmp_path: Path) -> None:
+    _write_flat_agent(tmp_path, "alpha")
+    _write_dir_agent(tmp_path, "beta")
+    result = list_canonical_agents(tmp_path)
+    by_name = {(p.parent.name if layout == "dir" else p.stem): layout for p, layout in result}
+    assert by_name == {"alpha": "flat", "beta": "dir"}
+
+
+def test_list_agents_both_layouts_dir_wins(
+    tmp_path: Path,
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    _write_flat_agent(tmp_path, "shared")
+    _write_dir_agent(tmp_path, "shared")
+    with caplog.at_level(logging.WARNING):
+        result = list_canonical_agents(tmp_path)
+    # Dir wins on collision.
+    assert len(result) == 1
+    path, layout = result[0]
+    assert layout == "dir"
+    assert path.name == "agent.md"
+    # WARN-level log emitted with the conflict shape.
+    assert any(
+        "both flat" in rec.message and rec.levelno == logging.WARNING for rec in caplog.records
+    )
+
+
+# ── parse_canonical_agent layout dispatch ───────────────────────────────
+
+
+def test_parse_dir_layout_uses_parent_name(tmp_path: Path) -> None:
+    """Frontmatter without ``name`` falls back to ``path.parent.name`` for
+    dir layout (avoids the ``path.stem == "agent"`` heuristic)."""
+    target = tmp_path / CANONICAL_AGENT_ROOT / "foo" / "agent.md"
+    target.parent.mkdir(parents=True)
+    # Frontmatter intentionally omits ``name``.
+    target.write_text("---\ndescription: x\n---\n\nbody\n")
+    agent = parse_canonical_agent(target, layout="dir")
+    assert agent.name == "foo"
+
+
+def test_parse_flat_layout_with_filename_agent(tmp_path: Path) -> None:
+    """Heuristic-free guard: a flat file literally named ``agent.md`` must NOT
+    be misclassified as dir form. The layout tag is the source of truth."""
+    target = tmp_path / CANONICAL_AGENT_ROOT / "agent.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("---\ndescription: x\n---\n\nbody\n")
+    agent = parse_canonical_agent(target, layout="flat")
+    assert agent.name == "agent"
+
+
+# ── extract_agents_to_canonical layout policy ───────────────────────────
+
+
+def test_extract_preserves_flat_layout_when_only_flat_exists(
+    tmp_path: Path,
+) -> None:
+    _write_flat_agent(tmp_path, "legacy")
+    runtime = tmp_path / ".claude/agents"
+    runtime.mkdir(parents=True)
+    runtime_md = runtime / "legacy.md"
+    runtime_md.write_text(
+        SAMPLE_FRONTMATTER.replace("name: helper", "name: legacy").replace(
+            "Generic helper", "UPDATED"
+        )
+    )
+    extract_agents_to_canonical(tmp_path, overwrite=True)
+    # Flat preserved; no dir layout created.
+    flat_path = tmp_path / CANONICAL_AGENT_ROOT / "legacy.md"
+    assert flat_path.is_file()
+    assert "UPDATED" in flat_path.read_text()
+    assert not (tmp_path / CANONICAL_AGENT_ROOT / "legacy" / "agent.md").exists()
+
+
+def test_extract_writes_dir_layout_for_new_agent(tmp_path: Path) -> None:
+    runtime = tmp_path / ".claude/agents"
+    runtime.mkdir(parents=True)
+    (runtime / "fresh.md").write_text(SAMPLE_FRONTMATTER.replace("name: helper", "name: fresh"))
+    extract_agents_to_canonical(tmp_path)
+    # New agent → dir layout.
+    assert (tmp_path / CANONICAL_AGENT_ROOT / "fresh" / "agent.md").is_file()
+    assert not (tmp_path / CANONICAL_AGENT_ROOT / "fresh.md").exists()
+
+
+def test_extract_warns_when_both_layouts_present(
+    tmp_path: Path,
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    """Dir+flat coexist → reverse-sync updates dir, flat goes silently
+    divergent. Emit a separate WARNING from the list-time warning so the
+    user sees the silent-divergence shape during sync, not just on list."""
+    _write_flat_agent(tmp_path, "shared")
+    _write_dir_agent(tmp_path, "shared")
+    runtime = tmp_path / ".claude/agents"
+    runtime.mkdir(parents=True)
+    (runtime / "shared.md").write_text(
+        SAMPLE_FRONTMATTER.replace("name: helper", "name: shared").replace(
+            "Generic helper", "FROM RUNTIME"
+        )
+    )
+    with caplog.at_level(logging.WARNING):
+        extract_agents_to_canonical(tmp_path, overwrite=True)
+    # Dir updated.
+    dir_path = tmp_path / CANONICAL_AGENT_ROOT / "shared" / "agent.md"
+    assert "FROM RUNTIME" in dir_path.read_text()
+    # Flat file stays at its old contents (silent divergence).
+    flat_path = tmp_path / CANONICAL_AGENT_ROOT / "shared.md"
+    assert flat_path.is_file()
+    assert "FROM RUNTIME" not in flat_path.read_text()
+    # WARN-level message about silent divergence in extract.
+    assert any(
+        "silently divergent" in rec.message and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -11,6 +11,7 @@ from memtomem.context.commands import (
     CommandParseError,
     CommandSyncResult,
     StrictDropError,
+    canonical_command_name,
     diff_commands,
     extract_commands_to_canonical,
     generate_all_commands,
@@ -281,8 +282,8 @@ class TestExtractCommandsToCanonical:
         (d / "ok.md").write_text(SAMPLE_MINIMAL_COMMAND)
 
         result = extract_commands_to_canonical(tmp_path)
-        # Dir layout: imported paths are <root>/<name>/command.md.
-        imported_names = sorted(p.parent.name for p in result.imported)
+        # ExtractResult.imported is now (path, layout) tuples.
+        imported_names = sorted(canonical_command_name(p, layout) for p, layout in result.imported)
         assert imported_names == ["ok"]
         skipped_names = sorted(name for name, _, _ in result.skipped)
         assert "-bad" in skipped_names
@@ -294,8 +295,8 @@ class TestExtractCommandsToCanonical:
         (d / "beta.md").write_text(SAMPLE_MINIMAL_COMMAND)
 
         result = extract_commands_to_canonical(tmp_path, only_name="alpha")
-        # Dir layout: imported paths are <root>/<name>/command.md.
-        assert [p.parent.name for p in result.imported] == ["alpha"]
+        # ExtractResult.imported is (path, layout) tuples.
+        assert [canonical_command_name(p, layout) for p, layout in result.imported] == ["alpha"]
         assert result.skipped == []
         # Beta was untouched — neither imported nor a canonical written.
         assert not (tmp_path / CANONICAL_COMMAND_ROOT / "beta" / "command.md").exists()

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -104,7 +104,7 @@ class TestListCanonicalCommands:
     def test_sorted(self, tmp_path):
         _make_canonical_command(tmp_path, "zeta", SAMPLE_MINIMAL_COMMAND)
         _make_canonical_command(tmp_path, "alpha", SAMPLE_MINIMAL_COMMAND)
-        names = [p.stem for p in list_canonical_commands(tmp_path)]
+        names = [p.stem for p, _layout in list_canonical_commands(tmp_path)]
         assert names == ["alpha", "zeta"]
 
 
@@ -213,7 +213,8 @@ class TestExtractCommandsToCanonical:
         (d / "review.md").write_text(SAMPLE_FULL_COMMAND, encoding="utf-8")
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        assert (tmp_path / CANONICAL_COMMAND_ROOT / "review.md").is_file()
+        # New commands land in directory layout per ADR-0008.
+        assert (tmp_path / CANONICAL_COMMAND_ROOT / "review" / "command.md").is_file()
         assert result.skipped == []
 
     def test_imports_gemini_toml_with_placeholder_rewrite(self, tmp_path):
@@ -225,7 +226,9 @@ class TestExtractCommandsToCanonical:
         )
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "review.md").read_text(encoding="utf-8")
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "review" / "command.md").read_text(
+            encoding="utf-8"
+        )
         assert "description: Review a file" in canonical
         # {{args}} rewritten back to $ARGUMENTS
         assert "$ARGUMENTS" in canonical
@@ -241,7 +244,9 @@ class TestExtractCommandsToCanonical:
             (d / filename).write_text(content, encoding="utf-8")
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "shared.md").read_text(encoding="utf-8")
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "shared" / "command.md").read_text(
+            encoding="utf-8"
+        )
         assert "Simple prompt" in canonical  # claude version won
         # Gemini copy was skipped.
         assert len(result.skipped) == 1
@@ -276,7 +281,8 @@ class TestExtractCommandsToCanonical:
         (d / "ok.md").write_text(SAMPLE_MINIMAL_COMMAND)
 
         result = extract_commands_to_canonical(tmp_path)
-        imported_names = sorted(p.stem for p in result.imported)
+        # Dir layout: imported paths are <root>/<name>/command.md.
+        imported_names = sorted(p.parent.name for p in result.imported)
         assert imported_names == ["ok"]
         skipped_names = sorted(name for name, _, _ in result.skipped)
         assert "-bad" in skipped_names
@@ -288,10 +294,11 @@ class TestExtractCommandsToCanonical:
         (d / "beta.md").write_text(SAMPLE_MINIMAL_COMMAND)
 
         result = extract_commands_to_canonical(tmp_path, only_name="alpha")
-        assert [p.stem for p in result.imported] == ["alpha"]
+        # Dir layout: imported paths are <root>/<name>/command.md.
+        assert [p.parent.name for p in result.imported] == ["alpha"]
         assert result.skipped == []
         # Beta was untouched — neither imported nor a canonical written.
-        assert not (tmp_path / CANONICAL_COMMAND_ROOT / "beta.md").exists()
+        assert not (tmp_path / CANONICAL_COMMAND_ROOT / "beta" / "command.md").exists()
 
     def test_only_name_no_match_returns_empty(self, tmp_path):
         """Caller-distinguishable signal for single-name miss: imported and
@@ -406,7 +413,10 @@ class TestRoundtrip:
         shutil.rmtree(tmp_path / CANONICAL_COMMAND_ROOT)
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        reparsed = parse_canonical_command(tmp_path / CANONICAL_COMMAND_ROOT / "review.md")
+        # New canonical lands in dir layout per ADR-0008.
+        reparsed = parse_canonical_command(
+            tmp_path / CANONICAL_COMMAND_ROOT / "review" / "command.md", layout="dir"
+        )
         assert reparsed.name == "review"
         assert "$ARGUMENTS" in reparsed.body
 
@@ -418,7 +428,10 @@ class TestRoundtrip:
         shutil.rmtree(tmp_path / CANONICAL_COMMAND_ROOT)
         result = extract_commands_to_canonical(tmp_path)
         assert len(result.imported) == 1
-        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "hi.md").read_text(encoding="utf-8")
+        # New canonical lands in dir layout per ADR-0008.
+        canonical = (tmp_path / CANONICAL_COMMAND_ROOT / "hi" / "command.md").read_text(
+            encoding="utf-8"
+        )
         assert "description: Simple prompt" in canonical
         assert "$ARGUMENTS" in canonical
         assert "{{args}}" not in canonical

--- a/packages/memtomem/tests/test_context_commands_bc_layout.py
+++ b/packages/memtomem/tests/test_context_commands_bc_layout.py
@@ -1,0 +1,149 @@
+"""Backward-compatible enumeration / extraction across command canonical
+layouts. Mirrors :mod:`tests.test_context_agents_bc_layout` for slash
+commands (``commands/<name>/command.md`` directory layout).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from memtomem.context.commands import (
+    CANONICAL_COMMAND_ROOT,
+    extract_commands_to_canonical,
+    list_canonical_commands,
+    parse_canonical_command,
+)
+
+
+SAMPLE_COMMAND = """---
+description: Simple prompt
+---
+
+run $ARGUMENTS
+"""
+
+
+def _write_flat_command(project_root: Path, name: str) -> Path:
+    root = project_root / CANONICAL_COMMAND_ROOT
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / f"{name}.md"
+    target.write_text(SAMPLE_COMMAND)
+    return target
+
+
+def _write_dir_command(project_root: Path, name: str) -> Path:
+    root = project_root / CANONICAL_COMMAND_ROOT / name
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / "command.md"
+    target.write_text(SAMPLE_COMMAND)
+    return target
+
+
+# ── list_canonical_commands enumeration ─────────────────────────────────
+
+
+def test_list_commands_flat_only_unchanged(tmp_path: Path) -> None:
+    _write_flat_command(tmp_path, "alpha")
+    _write_flat_command(tmp_path, "beta")
+    result = list_canonical_commands(tmp_path)
+    names = [p.stem for p, _ in result]
+    layouts = [layout for _, layout in result]
+    assert names == ["alpha", "beta"]
+    assert layouts == ["flat", "flat"]
+
+
+def test_list_commands_dir_only_enumerated(tmp_path: Path) -> None:
+    _write_dir_command(tmp_path, "gamma")
+    _write_dir_command(tmp_path, "delta")
+    result = list_canonical_commands(tmp_path)
+    names = [p.parent.name for p, _ in result]
+    layouts = [layout for _, layout in result]
+    assert names == ["delta", "gamma"]
+    assert layouts == ["dir", "dir"]
+
+
+def test_list_commands_both_layouts_dir_wins(
+    tmp_path: Path,
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    _write_flat_command(tmp_path, "shared")
+    _write_dir_command(tmp_path, "shared")
+    with caplog.at_level(logging.WARNING):
+        result = list_canonical_commands(tmp_path)
+    assert len(result) == 1
+    path, layout = result[0]
+    assert layout == "dir"
+    assert path.name == "command.md"
+    assert any(
+        "both flat" in rec.message and rec.levelno == logging.WARNING for rec in caplog.records
+    )
+
+
+# ── parse_canonical_command layout dispatch ────────────────────────────
+
+
+def test_parse_dir_layout_uses_parent_name(tmp_path: Path) -> None:
+    target = tmp_path / CANONICAL_COMMAND_ROOT / "foo" / "command.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("---\ndescription: x\n---\n\nbody\n")
+    cmd = parse_canonical_command(target, layout="dir")
+    assert cmd.name == "foo"
+
+
+def test_parse_flat_layout_with_filename_command(tmp_path: Path) -> None:
+    """Flat file literally named ``command.md`` must NOT be misclassified
+    as dir form. Layout tag is the source of truth."""
+    target = tmp_path / CANONICAL_COMMAND_ROOT / "command.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("---\ndescription: x\n---\n\nbody\n")
+    cmd = parse_canonical_command(target, layout="flat")
+    assert cmd.name == "command"
+
+
+# ── extract_commands_to_canonical layout policy ────────────────────────
+
+
+def test_extract_preserves_flat_layout_when_only_flat_exists(
+    tmp_path: Path,
+) -> None:
+    _write_flat_command(tmp_path, "legacy")
+    runtime = tmp_path / ".claude/commands"
+    runtime.mkdir(parents=True)
+    (runtime / "legacy.md").write_text(SAMPLE_COMMAND.replace("Simple", "UPDATED"))
+    extract_commands_to_canonical(tmp_path, overwrite=True)
+    flat_path = tmp_path / CANONICAL_COMMAND_ROOT / "legacy.md"
+    assert flat_path.is_file()
+    assert "UPDATED" in flat_path.read_text()
+    assert not (tmp_path / CANONICAL_COMMAND_ROOT / "legacy" / "command.md").exists()
+
+
+def test_extract_writes_dir_layout_for_new_command(tmp_path: Path) -> None:
+    runtime = tmp_path / ".claude/commands"
+    runtime.mkdir(parents=True)
+    (runtime / "fresh.md").write_text(SAMPLE_COMMAND)
+    extract_commands_to_canonical(tmp_path)
+    assert (tmp_path / CANONICAL_COMMAND_ROOT / "fresh" / "command.md").is_file()
+    assert not (tmp_path / CANONICAL_COMMAND_ROOT / "fresh.md").exists()
+
+
+def test_extract_warns_when_both_layouts_present(
+    tmp_path: Path,
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    _write_flat_command(tmp_path, "shared")
+    _write_dir_command(tmp_path, "shared")
+    runtime = tmp_path / ".claude/commands"
+    runtime.mkdir(parents=True)
+    (runtime / "shared.md").write_text(SAMPLE_COMMAND.replace("Simple", "FROM RUNTIME"))
+    with caplog.at_level(logging.WARNING):
+        extract_commands_to_canonical(tmp_path, overwrite=True)
+    dir_path = tmp_path / CANONICAL_COMMAND_ROOT / "shared" / "command.md"
+    assert "FROM RUNTIME" in dir_path.read_text()
+    flat_path = tmp_path / CANONICAL_COMMAND_ROOT / "shared.md"
+    assert flat_path.is_file()
+    assert "FROM RUNTIME" not in flat_path.read_text()
+    assert any(
+        "silently divergent" in rec.message and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    )

--- a/packages/memtomem/tests/test_context_commands_bc_layout.py
+++ b/packages/memtomem/tests/test_context_commands_bc_layout.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
+    canonical_command_name,
     extract_commands_to_canonical,
     list_canonical_commands,
     parse_canonical_command,
@@ -78,6 +79,21 @@ def test_list_commands_both_layouts_dir_wins(
     assert any(
         "both flat" in rec.message and rec.levelno == logging.WARNING for rec in caplog.records
     )
+
+
+# ── canonical_command_name helper ──────────────────────────────────────
+
+
+def test_canonical_command_name_dispatch_on_layout(tmp_path: Path) -> None:
+    """Mirror of agents helper test — same dispatch shape, layout tag
+    drives the dispatch."""
+    flat = tmp_path / CANONICAL_COMMAND_ROOT / "foo.md"
+    dir_path = tmp_path / CANONICAL_COMMAND_ROOT / "foo" / "command.md"
+    literal_command_flat = tmp_path / CANONICAL_COMMAND_ROOT / "command.md"
+    assert canonical_command_name(flat, "flat") == "foo"
+    assert canonical_command_name(dir_path, "dir") == "foo"
+    # Literal `command.md` flat file is NOT misread as dir-form.
+    assert canonical_command_name(literal_command_flat, "flat") == "command"
 
 
 # ── parse_canonical_command layout dispatch ────────────────────────────

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -358,10 +358,10 @@ def test_cli_install_wiki_missing_message(
 
 def test_cli_install_rejects_unknown_type(project_cwd: Path) -> None:
     runner = CliRunner()
-    result = runner.invoke(context_group, ["install", "agent", "foo"])
-    # PR-B: only "skill" is an allowed type; PR-C widens.
+    result = runner.invoke(context_group, ["install", "settings", "foo"])
+    # PR-C: only skill / agent / command are allowed types.
     assert result.exit_code != 0
-    assert "agent" in result.output  # click usage error mentions the bad value
+    assert "settings" in result.output  # click usage error mentions the bad value
 
 
 def test_cli_install_already_installed_classified_message(

--- a/packages/memtomem/tests/test_context_install_widening.py
+++ b/packages/memtomem/tests/test_context_install_widening.py
@@ -1,0 +1,157 @@
+"""Tests for ADR-0008 PR-C: ``mm context install`` widened to agents/commands.
+
+PR-B shipped install_skill end-to-end. PR-C widens the public surface to
+``install_agent`` and ``install_command`` and updates the CLI ``Choice`` so
+that all three kinds flow through the same install pipeline. Wiki layout
+for new agents/commands is the directory form per ADR-0008
+(``agents/<name>/agent.md``, ``commands/<name>/command.md``).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.context.install import (
+    install_agent,
+    install_command,
+    install_skill,
+)
+from memtomem.context.lockfile import Lockfile
+from memtomem.wiki.store import WikiStore
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _initialized_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _git_commit(wiki_root_path: Path, message: str) -> None:
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", message],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _seed_agent(wiki_root_path: Path, name: str, body: bytes) -> None:
+    agent_dir = wiki_root_path / "agents" / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_bytes(body)
+    _git_commit(wiki_root_path, f"add agent {name}")
+
+
+def _seed_command(wiki_root_path: Path, name: str, body: bytes) -> None:
+    cmd_dir = wiki_root_path / "commands" / name
+    cmd_dir.mkdir(parents=True)
+    (cmd_dir / "command.md").write_bytes(body)
+    _git_commit(wiki_root_path, f"add command {name}")
+
+
+@pytest.fixture
+def project_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+# ── install_agent / install_command happy paths ──────────────────────────
+
+
+def test_install_agent_dir_layout(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki()
+    body = b"---\nname: bar\ndescription: test agent\n---\n\nhello body\n"
+    _seed_agent(wiki_root, "bar", body)
+    project = tmp_path
+
+    result = install_agent(project, "bar")
+
+    assert result.asset_type == "agents"
+    assert result.name == "bar"
+    dest = project / ".memtomem" / "agents" / "bar"
+    assert (dest / "agent.md").read_bytes() == body
+    assert result.dest == dest
+
+
+def test_install_command_dir_layout(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki()
+    body = b"---\ndescription: hi\n---\n\nrun $ARGUMENTS\n"
+    _seed_command(wiki_root, "greet", body)
+    project = tmp_path
+
+    result = install_command(project, "greet")
+
+    assert result.asset_type == "commands"
+    assert result.name == "greet"
+    dest = project / ".memtomem" / "commands" / "greet"
+    assert (dest / "command.md").read_bytes() == body
+
+
+def test_install_records_lockfile_section_per_kind(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki()
+    (wiki_root / "skills" / "alpha").mkdir(parents=True)
+    (wiki_root / "skills" / "alpha" / "SKILL.md").write_bytes(b"# alpha\n")
+    _git_commit(wiki_root, "alpha skill")
+    _seed_agent(wiki_root, "bar", b"---\nname: bar\ndescription: x\n---\nbody\n")
+    _seed_command(wiki_root, "baz", b"---\ndescription: y\n---\nrun\n")
+    project = tmp_path
+
+    install_skill(project, "alpha")
+    install_agent(project, "bar")
+    install_command(project, "baz")
+
+    lock_path = project / ".memtomem" / "lock.json"
+    lock_doc = json.loads(lock_path.read_text())
+    assert "alpha" in lock_doc["skills"]
+    assert "bar" in lock_doc["agents"]
+    assert "baz" in lock_doc["commands"]
+    # Lockfile reads also work via the module API.
+    lock = Lockfile.at(project)
+    assert lock.read_entry("skills", "alpha") is not None
+    assert lock.read_entry("agents", "bar") is not None
+    assert lock.read_entry("commands", "baz") is not None
+
+
+# ── CLI dispatch ────────────────────────────────────────────────────────
+
+
+def test_cli_install_agent_success(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "bar", b"---\nname: bar\ndescription: x\n---\nbody\n")
+    runner = CliRunner()
+
+    result = runner.invoke(context_group, ["install", "agent", "bar"])
+
+    assert result.exit_code == 0, result.output
+    assert "agents/bar" in result.output
+    assert (project_cwd / ".memtomem" / "agents" / "bar" / "agent.md").is_file()
+
+
+def test_cli_install_command_success(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "greet", b"---\ndescription: hi\n---\nrun\n")
+    runner = CliRunner()
+
+    result = runner.invoke(context_group, ["install", "command", "greet"])
+
+    assert result.exit_code == 0, result.output
+    assert "commands/greet" in result.output
+    assert (project_cwd / ".memtomem" / "commands" / "greet" / "command.md").is_file()

--- a/packages/memtomem/tests/test_context_override.py
+++ b/packages/memtomem/tests/test_context_override.py
@@ -15,6 +15,7 @@ import hashlib
 import subprocess
 from pathlib import Path
 
+from memtomem.context import override
 from memtomem.context.install import install_skill
 from memtomem.context.skills import SKILL_GENERATORS, generate_all_skills
 from memtomem.wiki.store import WikiStore
@@ -105,3 +106,145 @@ def test_skills_fanout_byte_identical_preserves_aux_files(wiki_root: Path, tmp_p
             assert vendor == canonical, (
                 f"{gen_name} {relpath} diverged from canonical without override"
             )
+
+
+# ── override.resolve unit tests ─────────────────────────────────────────
+
+
+def test_resolve_returns_none_when_no_override(tmp_path: Path) -> None:
+    (tmp_path / ".memtomem" / "skills" / "foo").mkdir(parents=True)
+    assert override.resolve(tmp_path, "skills", "foo", "claude") is None
+
+
+def test_resolve_returns_path_when_override_present(tmp_path: Path) -> None:
+    overrides_dir = tmp_path / ".memtomem" / "skills" / "foo" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# claude override\n")
+    result = override.resolve(tmp_path, "skills", "foo", "claude")
+    assert result == overrides_dir / "claude.md"
+
+
+def test_resolve_unknown_vendor_returns_none(tmp_path: Path) -> None:
+    """Vendors outside ``OVERRIDE_FORMATS`` (cursor, copilot, ...) get
+    None — the matrix is the trust boundary, not a stringly-typed lookup."""
+    overrides_dir = tmp_path / ".memtomem" / "skills" / "foo" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "cursor.md").write_bytes(b"# stray cursor file\n")
+    assert override.resolve(tmp_path, "skills", "foo", "cursor") is None
+
+
+def test_resolve_invariant_1_works_without_wiki(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """ADR-0008 Invariant 1: resolver reads project tree only — no wiki
+    needed at sync time. Make sure no wiki env var is consulted by
+    pointing the wiki at a non-existent path."""
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-such-wiki"))
+    overrides_dir = tmp_path / ".memtomem" / "skills" / "foo" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "gemini.md").write_bytes(b"# gemini override\n")
+    result = override.resolve(tmp_path, "skills", "foo", "gemini")
+    assert result == overrides_dir / "gemini.md"
+
+
+def test_resolve_skips_agents_in_pr_c(tmp_path: Path) -> None:
+    """PR-C activates skills only. Agents/commands matrix rows are
+    shipped but the resolver guards them; flip the guard in PR-D to
+    activate. This test pins the gate so the enable-day diff is
+    one-line revertable."""
+    overrides_dir = tmp_path / ".memtomem" / "agents" / "bar" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# would-be agent override\n")
+    assert override.resolve(tmp_path, "agents", "bar", "claude") is None
+
+
+def test_resolve_skips_commands_in_pr_c(tmp_path: Path) -> None:
+    overrides_dir = tmp_path / ".memtomem" / "commands" / "baz" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "gemini.toml").write_bytes(b"# would-be command override\n")
+    assert override.resolve(tmp_path, "commands", "baz", "gemini") is None
+
+
+# ── skills fan-out applies overrides correctly ─────────────────────────
+
+
+def test_skills_fanout_applies_claude_override_only(wiki_root: Path, tmp_path: Path) -> None:
+    """Stage a claude override; .claude SKILL.md must equal the override
+    bytes while .gemini and .agents/codex SKILL.md keep canonical bytes."""
+    _initialized_wiki()
+    canonical_bytes = b"# hello\nbody from canonical\n"
+    _seed_skill(wiki_root, "hello", {"SKILL.md": canonical_bytes})
+    project = tmp_path
+    install_skill(project, "hello")
+
+    overrides_dir = project / ".memtomem" / "skills" / "hello" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    claude_override = b"# hello\nclaude-only override body\n"
+    (overrides_dir / "claude.md").write_bytes(claude_override)
+
+    generate_all_skills(project)
+
+    claude_path = SKILL_GENERATORS["claude_skills"].target_dir(project, "hello") / "SKILL.md"
+    gemini_path = SKILL_GENERATORS["gemini_skills"].target_dir(project, "hello") / "SKILL.md"
+    codex_path = SKILL_GENERATORS["codex_skills"].target_dir(project, "hello") / "SKILL.md"
+
+    assert claude_path.read_bytes() == claude_override
+    assert gemini_path.read_bytes() == canonical_bytes
+    assert codex_path.read_bytes() == canonical_bytes
+
+
+def test_skills_fanout_applies_all_three_overrides(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello", {"SKILL.md": b"# canonical\n"})
+    project = tmp_path
+    install_skill(project, "hello")
+
+    overrides_dir = project / ".memtomem" / "skills" / "hello" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    claude_bytes = b"# claude\n"
+    gemini_bytes = b"# gemini\n"
+    codex_bytes = b"# codex\n"
+    (overrides_dir / "claude.md").write_bytes(claude_bytes)
+    (overrides_dir / "gemini.md").write_bytes(gemini_bytes)
+    (overrides_dir / "codex.md").write_bytes(codex_bytes)
+
+    generate_all_skills(project)
+
+    assert (
+        SKILL_GENERATORS["claude_skills"].target_dir(project, "hello") / "SKILL.md"
+    ).read_bytes() == claude_bytes
+    assert (
+        SKILL_GENERATORS["gemini_skills"].target_dir(project, "hello") / "SKILL.md"
+    ).read_bytes() == gemini_bytes
+    assert (
+        SKILL_GENERATORS["codex_skills"].target_dir(project, "hello") / "SKILL.md"
+    ).read_bytes() == codex_bytes
+
+
+def test_override_only_touches_skill_md_not_scripts(wiki_root: Path, tmp_path: Path) -> None:
+    """Invariant 4 says ``byte-copy that file`` (singular). Auxiliary
+    files (``scripts/``, ``references/``) MUST stay from canonical even
+    when an override is staged for the SKILL.md."""
+    _initialized_wiki()
+    _seed_skill(
+        wiki_root,
+        "hello",
+        {
+            "SKILL.md": b"# canonical\n",
+            "scripts/run.sh": b"#!/bin/bash\necho canonical\n",
+        },
+    )
+    project = tmp_path
+    install_skill(project, "hello")
+
+    overrides_dir = project / ".memtomem" / "skills" / "hello" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# claude only\n")
+
+    generate_all_skills(project)
+
+    claude_dir = SKILL_GENERATORS["claude_skills"].target_dir(project, "hello")
+    assert (claude_dir / "SKILL.md").read_bytes() == b"# claude only\n"
+    # The script came from canonical and was NOT replaced by any override.
+    assert (claude_dir / "scripts" / "run.sh").read_bytes() == (b"#!/bin/bash\necho canonical\n")

--- a/packages/memtomem/tests/test_context_override.py
+++ b/packages/memtomem/tests/test_context_override.py
@@ -1,0 +1,107 @@
+"""Tests for ``memtomem.context.override`` — vendor override resolution.
+
+Covers ADR-0008 PR-C: Invariant 4 (full-file replacement) plus the
+byte-identical regression guard that PR-C must not break.
+
+The byte-identical regression test is intentionally written FIRST as a
+guard for the PR-B fan-out semantics: with no overrides present, every
+vendor's ``SKILL.md`` MUST equal the canonical byte-for-byte. PR-C only
+ever diverges that equality when a real override file is staged.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+from memtomem.context.install import install_skill
+from memtomem.context.skills import SKILL_GENERATORS, generate_all_skills
+from memtomem.wiki.store import WikiStore
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _seed_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> None:
+    skill_dir = wiki_root_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    for relpath, data in files.items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _initialized_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _sha256(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+# ── byte-identical regression — PR-C MUST NOT break PR-B fan-out ────────
+
+
+def test_skills_fanout_byte_identical_without_override(wiki_root: Path, tmp_path: Path) -> None:
+    """ADR-0008 Invariant 4 regression guard.
+
+    With no overrides present, all three vendor SKILL.md outputs MUST equal
+    canonical byte-for-byte. PR-C must not regress this.
+    """
+    _initialized_wiki()
+    skill_bytes = b"# hello\n\nbody line one\nbody line two\n"
+    _seed_skill(wiki_root, "hello", {"SKILL.md": skill_bytes})
+    project = tmp_path
+
+    install_skill(project, "hello")
+    generate_all_skills(project)
+
+    canonical = project / ".memtomem" / "skills" / "hello" / "SKILL.md"
+    canonical_sha = _sha256(canonical)
+    assert canonical.read_bytes() == skill_bytes
+
+    for gen_name, gen in SKILL_GENERATORS.items():
+        vendor_skill = gen.target_dir(project, "hello") / "SKILL.md"
+        assert vendor_skill.is_file(), f"{gen_name} did not write SKILL.md"
+        assert _sha256(vendor_skill) == canonical_sha, (
+            f"{gen_name} SKILL.md diverged from canonical without any override "
+            f"(canonical={canonical_sha[:12]}, vendor={_sha256(vendor_skill)[:12]})"
+        )
+
+
+def test_skills_fanout_byte_identical_preserves_aux_files(wiki_root: Path, tmp_path: Path) -> None:
+    """Auxiliary files (scripts/, references/) must also fan out byte-identical
+    when no override is in play. Same regression as the SKILL.md case but for
+    the rest of the skill directory tree."""
+    _initialized_wiki()
+    _seed_skill(
+        wiki_root,
+        "hello",
+        {
+            "SKILL.md": b"# hello\n",
+            "scripts/run.sh": b"#!/bin/bash\necho hi\n",
+            "references/notes.md": b"see also: https://example.com\n",
+        },
+    )
+    project = tmp_path
+
+    install_skill(project, "hello")
+    generate_all_skills(project)
+
+    for gen_name, gen in SKILL_GENERATORS.items():
+        vendor_dir = gen.target_dir(project, "hello")
+        for relpath in ["SKILL.md", "scripts/run.sh", "references/notes.md"]:
+            canonical = (project / ".memtomem" / "skills" / "hello" / relpath).read_bytes()
+            vendor = (vendor_dir / relpath).read_bytes()
+            assert vendor == canonical, (
+                f"{gen_name} {relpath} diverged from canonical without override"
+            )

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -600,8 +600,9 @@ class TestImportOneCommand:
         assert r.status_code == 200
         data = r.json()
         assert [i["name"] for i in data["imported"]] == ["alpha"]
-        assert (tmp_path / ".memtomem" / "commands" / "alpha.md").is_file()
-        assert not (tmp_path / ".memtomem" / "commands" / "beta.md").exists()
+        # New canonical lands in dir layout per ADR-0008.
+        assert (tmp_path / ".memtomem" / "commands" / "alpha" / "command.md").is_file()
+        assert not (tmp_path / ".memtomem" / "commands" / "beta" / "command.md").exists()
 
     @pytest.mark.anyio
     async def test_404_when_no_runtime_match(self, client: AsyncClient, tmp_path: Path):
@@ -789,8 +790,9 @@ class TestImportOneAgent:
         assert r.status_code == 200
         data = r.json()
         assert [i["name"] for i in data["imported"]] == ["alpha"]
-        assert (tmp_path / ".memtomem" / "agents" / "alpha.md").is_file()
-        assert not (tmp_path / ".memtomem" / "agents" / "beta.md").exists()
+        # New canonical lands in dir layout per ADR-0008.
+        assert (tmp_path / ".memtomem" / "agents" / "alpha" / "agent.md").is_file()
+        assert not (tmp_path / ".memtomem" / "agents" / "beta" / "agent.md").exists()
 
     @pytest.mark.anyio
     async def test_404_when_no_runtime_match(self, client: AsyncClient, tmp_path: Path):

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -1,0 +1,200 @@
+"""Tests for ``mm wiki skill override`` — wiki-side override seeder (PR-C[3/3]).
+
+The CLI delegates to :mod:`memtomem.wiki.override`. Tests exercise the
+happy path, the refuse-vs-force collision UX, the editor flag, the
+classified errors, and the stdout contract.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.wiki_cmd import wiki as wiki_group
+from memtomem.wiki.store import WikiStore
+
+
+def _seed_skill(wiki_root_path: Path, name: str, body: bytes = b"# canonical\n") -> None:
+    skill_dir = wiki_root_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(body)
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _initialized_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+
+def test_wiki_skill_override_happy_path(wiki_root: Path) -> None:
+    _initialized_wiki()
+    canonical_bytes = b"# hello\nbody body body\n"
+    _seed_skill(wiki_root, "hello", canonical_bytes)
+
+    runner = CliRunner()
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    target = wiki_root / "skills" / "hello" / "overrides" / "claude.md"
+    assert target.is_file()
+    assert target.read_bytes() == canonical_bytes
+
+
+# ── refuse vs force ────────────────────────────────────────────────────
+
+
+def test_wiki_skill_override_refuses_existing(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    second = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    assert second.exit_code != 0
+    assert "already exists" in second.output
+
+
+def test_wiki_skill_override_force_writes_bak(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello", b"# v1\n")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    target = wiki_root / "skills" / "hello" / "overrides" / "claude.md"
+    target.write_bytes(b"# user-edited content\n")
+
+    # Bump canonical so the seed produces different bytes the second time.
+    (wiki_root / "skills" / "hello" / "SKILL.md").write_bytes(b"# v2 canonical\n")
+
+    second = runner.invoke(
+        wiki_group, ["skill", "override", "hello", "--vendor", "claude", "--force"]
+    )
+
+    assert second.exit_code == 0, second.output
+    assert target.read_bytes() == b"# v2 canonical\n"
+    backup = target.with_suffix(".md.bak")
+    assert backup.is_file()
+    assert backup.read_bytes() == b"# user-edited content\n"
+
+
+# ── error surfaces ─────────────────────────────────────────────────────
+
+
+def test_wiki_skill_override_unknown_vendor(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "cursor"])
+
+    assert result.exit_code != 0
+    assert "cursor" in result.output  # click.Choice error references the value
+
+
+def test_wiki_skill_override_missing_skill(wiki_root: Path) -> None:
+    _initialized_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "ghost", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    # FileNotFoundError surfaced as ClickException — no traceback leaks.
+    assert "Traceback" not in result.output
+    assert "ghost" in result.output
+
+
+def test_wiki_skill_override_missing_wiki(monkeypatch, tmp_path: Path) -> None:
+    """No wiki initialized → classified error, not traceback."""
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+    assert "Traceback" not in result.output
+
+
+# ── editor flag ────────────────────────────────────────────────────────
+
+
+def test_wiki_skill_override_invokes_editor(
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    captured: list[str] = []
+
+    def fake_edit(filename: str | None = None, **_kwargs: object) -> None:
+        if filename is not None:
+            captured.append(filename)
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        wiki_group,
+        ["skill", "override", "hello", "--vendor", "claude", "--editor"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    assert captured[0].endswith("/skills/hello/overrides/claude.md")
+
+
+def test_wiki_skill_override_does_not_invoke_editor_by_default(
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    called = False
+
+    def fake_edit(filename: str | None = None, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert called is False
+
+
+# ── stdout contract ────────────────────────────────────────────────────
+
+
+def test_wiki_skill_override_stdout_contract(wiki_root: Path) -> None:
+    """Substring/presence assertions — order-independent so the contract
+    survives small UX polish changes."""
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "codex"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Seeded skills/hello/overrides/codex.md" in out
+    # Bare absolute path on its own line for shell capture.
+    target_path = wiki_root / "skills" / "hello" / "overrides" / "codex.md"
+    assert str(target_path) in out
+    # Commit hint mentioning git commit.
+    assert "git commit" in out
+    assert "git add skills/hello/overrides/codex.md" in out

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -116,6 +116,22 @@ def test_wiki_skill_override_missing_skill(wiki_root: Path) -> None:
     assert "ghost" in result.output
 
 
+def test_wiki_skill_override_does_not_create_overrides_dir_on_missing_skill(
+    wiki_root: Path,
+) -> None:
+    """Refused calls (missing skill / collision) MUST NOT leave a
+    half-built ``skills/<name>/overrides/`` directory behind. Pre-flight
+    the seed bytes BEFORE mkdir so the wiki tree stays clean on refuse."""
+    _initialized_wiki()
+    runner = CliRunner()
+
+    runner.invoke(wiki_group, ["skill", "override", "ghost", "--vendor", "claude"])
+
+    # The skills/ghost/ subtree must not have been created at all —
+    # neither the overrides/ dir nor its parent ghost/ dir.
+    assert not (wiki_root / "skills" / "ghost").exists()
+
+
 def test_wiki_skill_override_missing_wiki(monkeypatch, tmp_path: Path) -> None:
     """No wiki initialized → classified error, not traceback."""
     monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))


### PR DESCRIPTION
## Summary

ADR-0008 PR-C in three commits — install widening, vendor override
resolution for skills, and the wiki-side seed CLI.

* **commit 1** widens `mm context install` to `skill | agent | command`
  and migrates fan-out enumeration to read both legacy flat
  (`agents/<name>.md`) and new directory layout (`agents/<name>/agent.md`,
  `commands/<name>/command.md`) per ADR-0008 — without moving any
  existing user files. New canonicals land in directory layout;
  legacy flat keeps working.
* **commit 2** ships the override resolver (`context/override.py`)
  and the per-vendor hook in `skills.py`. `OVERRIDE_FORMATS` is the
  full 9-cell matrix; the resolver activates only skills in v1 via
  `_PR_C_ACTIVE_TYPES = frozenset({"skills"})`. Auxiliary files
  (`scripts/`, `references/`) stay from canonical when an override is
  staged (Invariant 4 says ``byte-copy that file`` — singular).
* **commit 3** adds `mm wiki skill override <name> --vendor <V>` with
  `--force` (creates a `.bak` sibling) and `--editor`. Stdout prints
  three pieces — human line, bare absolute path for shell capture,
  and a `git add` / `git commit` hint that names the exact paths to
  run in the wiki repo.

A byte-identical regression test (`test_context_override.py`) was
written first as a guard for PR-B fan-out semantics: with no overrides
on disk, every vendor's `SKILL.md` MUST equal canonical byte-for-byte.
The test stays green across all three commits.

## Why directory layout for agents/commands

ADR-0008 commits to `<type>/<name>/overrides/<vendor>.<ext>` — that
requires a directory shape around each canonical file. Before PR-C,
agents/commands canonical was flat (`<name>.md`) with no place for
an `overrides/` subdir without breaking fan-out. PR-B's `install.py`
docstring already called this out:

> Agent and command install land in PR-C alongside override resolution
> — without override-aware extraction the snapshot exists on disk but
> does not flow through fan-out, which would surprise users into
> thinking install is broken.

Closing the gap without a file migration: `list_canonical_*` returns
`list[tuple[Path, Layout]]` and enumerates both layouts; dir wins on
collision (with WARN); `parse_canonical_*` takes `layout=` and uses
`path.parent.name` for dir form (avoids the brittle `path.stem ==
"agent"` heuristic); `extract_*_to_canonical` preserves the existing
layout per name. `mm context migrate` (PR-D) will be the supported
consolidation path for users who want to move flat → dir.

## Test plan

- [x] `test_context_override.py` byte-identical regression — green
- [x] `test_context_install_widening.py` — install_agent/install_command + CLI dispatch
- [x] `test_context_agents_bc_layout.py` + commands twin — flat-only / dir-only / both-present collision warning / parse layout dispatch / extract preserves layout / extract warns on coexist
- [x] `test_context_override.py` resolver unit + skills override apply (per-vendor + all three) + scripts untouched + Invariant 1 no-wiki + agents/commands gate
- [x] `test_wiki_cmd_override.py` — happy path, refuse + force + .bak, unknown vendor, missing skill, missing wiki, editor on/off, stdout contract
- [x] Full regression: `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 3444 passed, 0 failed
- [x] `uv run ruff check && uv run ruff format --check` — clean

## Out of scope (PR-D and later)

- `mm context update` (mtime-based dirty detection, `--force + .bak`)
- `mm wiki <type> {diff, lint, edit}` and the `agent`/`command` subgroups
- Activating override resolution for agents/commands (`_PR_C_ACTIVE_TYPES`
  flip, `wiki/override.py` rendering for non-skills)
- `mm context migrate` to consolidate flat → dir layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)