### PR TITLE
feat(context): fan-out override application sites (PR-C carry-forward, ADR-0008 PR-D-prep)

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -39,8 +39,9 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._names import InvalidNameError, Layout, validate_name
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 
 logger = logging.getLogger(__name__)
 
@@ -572,6 +573,12 @@ def generate_all_agents(
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
             out_path = gen.target_file(project_root, agent.name)
             atomic_write_text(out_path, content)
+            # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
+            vendor = GENERATOR_VENDOR.get(target)
+            if vendor is not None:
+                override_path = _override.resolve(project_root, "agents", agent.name, vendor)
+                if override_path is not None:
+                    atomic_write_bytes(out_path, override_path.read_bytes())
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, agent.name, dropped_fields))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -574,6 +574,8 @@ def generate_all_agents(
             out_path = gen.target_file(project_root, agent.name)
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
+            # Race: see PR-D' for the unified write path that closes the
+            # canonical→override window. Same pattern as skills.py:213-220.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
                 override_path = _override.resolve(project_root, "agents", agent.name, vendor)

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -39,8 +39,9 @@ from pathlib import Path
 from typing import Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._names import InvalidNameError, Layout, validate_name
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
@@ -381,6 +382,12 @@ def generate_all_commands(
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
             out_path = gen.target_file(project_root, cmd.name)
             atomic_write_text(out_path, content)
+            # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
+            vendor = GENERATOR_VENDOR.get(target)
+            if vendor is not None:
+                override_path = _override.resolve(project_root, "commands", cmd.name, vendor)
+                if override_path is not None:
+                    atomic_write_bytes(out_path, override_path.read_bytes())
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, cmd.name, dropped_fields))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -383,6 +383,8 @@ def generate_all_commands(
             out_path = gen.target_file(project_root, cmd.name)
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
+            # Race: see PR-D' for the unified write path that closes the
+            # canonical→override window. Same pattern as skills.py:213-220.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
                 override_path = _override.resolve(project_root, "commands", cmd.name, vendor)

--- a/packages/memtomem/tests/test_context_override.py
+++ b/packages/memtomem/tests/test_context_override.py
@@ -16,6 +16,8 @@ import subprocess
 from pathlib import Path
 
 from memtomem.context import override
+from memtomem.context.agents import generate_all_agents
+from memtomem.context.commands import generate_all_commands
 from memtomem.context.install import install_skill
 from memtomem.context.skills import SKILL_GENERATORS, generate_all_skills
 from memtomem.wiki.store import WikiStore
@@ -164,6 +166,70 @@ def test_resolve_skips_commands_in_pr_c(tmp_path: Path) -> None:
     overrides_dir.mkdir(parents=True)
     (overrides_dir / "gemini.toml").write_bytes(b"# would-be command override\n")
     assert override.resolve(tmp_path, "commands", "baz", "gemini") is None
+
+
+# ── fan-out under PR-C gate: application sites pinned inactive for agents/commands
+
+_SAMPLE_AGENT_BODY = """---
+name: bar
+description: test agent
+---
+
+Body of the agent.
+"""
+
+_SAMPLE_COMMAND_BODY = """---
+description: test command
+---
+
+Command body.
+"""
+
+
+def test_agents_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> None:
+    """PR-D-prep adds override application to ``generate_all_agents`` as dead
+    code under the PR-C ``_PR_C_ACTIVE_TYPES`` gate. With the gate active,
+    fan-out must produce canonical-rendered output even when an override file
+    is staged in the project tree. PR-D removes the gate; this test inverts
+    on enable day so the behavior diff is one-line revertable.
+    """
+    canonical_dir = tmp_path / ".memtomem" / "agents"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "bar.md").write_text(_SAMPLE_AGENT_BODY, encoding="utf-8")
+
+    overrides_dir = tmp_path / ".memtomem" / "agents" / "bar" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    would_be_override = b"# would-be agent override\n"
+    (overrides_dir / "claude.md").write_bytes(would_be_override)
+
+    generate_all_agents(tmp_path, runtimes=["claude_agents"])
+
+    runtime_file = tmp_path / ".claude" / "agents" / "bar.md"
+    assert runtime_file.is_file()
+    assert runtime_file.read_bytes() != would_be_override, (
+        "override applied despite _PR_C_ACTIVE_TYPES gate active for agents"
+    )
+
+
+def test_commands_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> None:
+    """Same pin as the agents counterpart — fan-out application site is dead
+    code while the gate is active."""
+    canonical_dir = tmp_path / ".memtomem" / "commands"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "baz.md").write_text(_SAMPLE_COMMAND_BODY, encoding="utf-8")
+
+    overrides_dir = tmp_path / ".memtomem" / "commands" / "baz" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    would_be_override = b"# would-be command override\n"
+    (overrides_dir / "claude.md").write_bytes(would_be_override)
+
+    generate_all_commands(tmp_path, runtimes=["claude_commands"])
+
+    runtime_file = tmp_path / ".claude" / "commands" / "baz.md"
+    assert runtime_file.is_file()
+    assert runtime_file.read_bytes() != would_be_override, (
+        "override applied despite _PR_C_ACTIVE_TYPES gate active for commands"
+    )
 
 
 # ── skills fan-out applies overrides correctly ─────────────────────────

--- a/packages/memtomem/tests/test_context_override.py
+++ b/packages/memtomem/tests/test_context_override.py
@@ -206,6 +206,13 @@ def test_agents_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> Non
 
     runtime_file = tmp_path / ".claude" / "agents" / "bar.md"
     assert runtime_file.is_file()
+    # Positive assertion: canonical body marker must be present so a generator
+    # failure that writes garbage cannot be mistaken for gate-correct behavior.
+    # PR-D inverts: marker disappears (override replaces full body), and the
+    # negative assertion below flips to ``==``.
+    assert b"Body of the agent." in runtime_file.read_bytes(), (
+        "runtime file does not contain canonical body — generator failure?"
+    )
     assert runtime_file.read_bytes() != would_be_override, (
         "override applied despite _PR_C_ACTIVE_TYPES gate active for agents"
     )
@@ -227,6 +234,10 @@ def test_commands_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> N
 
     runtime_file = tmp_path / ".claude" / "commands" / "baz.md"
     assert runtime_file.is_file()
+    # Positive assertion mirrors the agents counterpart — see comment there.
+    assert b"Command body." in runtime_file.read_bytes(), (
+        "runtime file does not contain canonical body — generator failure?"
+    )
     assert runtime_file.read_bytes() != would_be_override, (
         "override applied despite _PR_C_ACTIVE_TYPES gate active for commands"
     )


### PR DESCRIPTION
## Summary

PR-C shipped the `OVERRIDE_FORMATS` matrix and the `_PR_C_ACTIVE_TYPES` gate
but deferred the actual override application call sites in
`generate_all_agents` / `generate_all_commands`. Without this prep, simply
removing the gate in PR-D would activate `_override.resolve()` for
agents/commands but produce no observable behavior change — the resolver's
return value would never be applied to the runtime file.

This PR adds the application call sites as **dead code under the PR-C
gate**: `_PR_C_ACTIVE_TYPES = frozenset({"skills"})` keeps `resolve()`
returning `None` for agents/commands, so the new code paths are exercised
only by the new tests. PR-D removes the gate and the application paths
become live.

Mirrors the skills fan-out pattern at `skills.py:213-220` line-by-line.

## Changes

- `context/agents.py`: per-vendor `_override.resolve` + `atomic_write_bytes`
  in `generate_all_agents` after `atomic_write_text(out_path, content)`
- `context/commands.py`: same pattern in `generate_all_commands`
- `tests/test_context_override.py`:
  - `test_agents_fanout_does_not_apply_override_under_gate`
  - `test_commands_fanout_does_not_apply_override_under_gate`

  These pin "fan-out application is inactive while gate is on", complementing
  the existing resolve-level pins (`test_resolve_skips_agents_in_pr_c`,
  `test_resolve_skips_commands_in_pr_c`). PR-D inverts both pairs together.

## Series context

ADR-0008 wiki layer series:
- PR-A (#622), PR-B (#623), PR-C (#624) merged
- **This PR — PR-D-prep** (carry-forward from PR-C)
- PR-D — gate flip + render lift + `mm context {update, status, install --all, migrate}`
- PR-D-late — `mm wiki <type> {diff, edit, lint}`
- PR-E — Web UI

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run pytest packages/memtomem/tests/test_context_override.py -v` — 13 passed (incl. 2 new)
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 3449 passed, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)