### PR TITLE
feat(context): PR-D C1a — activate agents/commands override + render lift (ADR-0008)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_names.py
+++ b/packages/memtomem/src/memtomem/context/_names.py
@@ -49,9 +49,9 @@ _MAX_LEN = 64
 # v1 covers Claude / Gemini / Codex across skills, agents, commands. The
 # ``("commands", "codex")`` row is a placeholder — there is no
 # ``codex_commands`` generator yet (Codex slash prompts are user-scope and
-# upstream-deprecated; PR-C does not activate that surface). The
-# ``_PR_C_ACTIVE_TYPES`` guard in :mod:`memtomem.context.override` keeps
-# all rows except skills inactive in v1.
+# upstream-deprecated). The matrix entry stays for the day Codex commands
+# ship; until then, ``render_seed_bytes`` raises ``NotImplementedError``
+# for ``("commands", "codex")``.
 OVERRIDE_FORMATS: dict[tuple[str, str], tuple[str, str]] = {
     ("skills", "claude"): ("claude", "md"),
     ("skills", "gemini"): ("gemini", "md"),

--- a/packages/memtomem/src/memtomem/context/override.py
+++ b/packages/memtomem/src/memtomem/context/override.py
@@ -20,13 +20,6 @@ from memtomem.context._names import OVERRIDE_FORMATS
 
 __all__ = ["resolve"]
 
-# PR-C ships override resolution for skills only. Agents and commands
-# carry an ``OVERRIDE_FORMATS`` row each so the matrix is shipped whole,
-# but the resolver skips them until a follow-up PR opens the surface
-# (drop this gate to activate). Tests pin the gate explicitly so the
-# enable-day diff is a one-line revert.
-_PR_C_ACTIVE_TYPES = frozenset({"skills"})
-
 
 def resolve(
     project_root: Path,
@@ -38,8 +31,6 @@ def resolve(
 
     Reads ONLY from project tree. ADR-0008 Invariant 1.
     """
-    if asset_type not in _PR_C_ACTIVE_TYPES:
-        return None
     fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
     if fmt is None:
         return None

--- a/packages/memtomem/src/memtomem/wiki/override.py
+++ b/packages/memtomem/src/memtomem/wiki/override.py
@@ -2,11 +2,18 @@
 
 Companion to :mod:`memtomem.context.override` (which is the project-side
 *resolver*). The seed helper here is what ``mm wiki <type> override``
-calls to produce the initial bytes the user then edits. Skills are
-byte-identical across vendors, so the seed is simply the canonical
-``SKILL.md``; agents and commands need vendor-specific renderers and
-land in a follow-up PR alongside the rest of the multi-kind override
-surface.
+calls to produce the initial bytes the user then edits.
+
+- Skills are byte-identical across vendors, so the seed is simply the
+  canonical ``SKILL.md``.
+- Agents and commands feed the canonical through the vendor's renderer
+  in :data:`AGENT_GENERATORS` / :data:`COMMAND_GENERATORS` so the seed
+  bytes match what the vendor's runtime would actually emit. This reuses
+  PR-C's layout-aware ``parse_canonical_agent`` / ``parse_canonical_command``
+  rather than widening the generator API surface.
+- ``("commands", "codex")`` is a permanent placeholder row in
+  :data:`OVERRIDE_FORMATS` (no ``codex_commands`` generator); seeding
+  raises :class:`NotImplementedError` with a diagnostic message.
 """
 
 from __future__ import annotations
@@ -28,22 +35,55 @@ def render_seed_bytes(
     store: WikiStore,
     asset_type: str,
     name: str,
-    _vendor: str,
+    vendor: str,
 ) -> bytes:
     """Return the bytes to seed an override file with.
 
-    Skills (byte-identical fan-out) → seed equals canonical ``SKILL.md``.
-    Agents and commands ride the vendor-specific renderers and are not
-    activated in PR-C; the resolver in :mod:`memtomem.context.override`
-    has a matching gate. ``_vendor`` is reserved for that follow-up
-    (per-vendor renderer dispatch) and intentionally unused for skills.
+    Skills → canonical ``SKILL.md``.
+    Agents / commands → ``parse_canonical_*`` + vendor renderer.
+    ``("commands", "codex")`` → :class:`NotImplementedError`.
     """
-    if asset_type != "skills":
-        raise NotImplementedError(f"override seeding for {asset_type!r} lands in a follow-up PR")
-    src = store.root / "skills" / name / "SKILL.md"
-    if not src.is_file():
-        raise FileNotFoundError(f"wiki has no skills/{name}/SKILL.md to seed from at {src}")
-    return src.read_bytes()
+    if asset_type == "skills":
+        src = store.root / "skills" / name / "SKILL.md"
+        if not src.is_file():
+            raise FileNotFoundError(f"wiki has no skills/{name}/SKILL.md to seed from at {src}")
+        return src.read_bytes()
+
+    canonical = store.root / asset_type / name / f"{asset_type[:-1]}.md"
+    if not canonical.is_file():
+        raise FileNotFoundError(
+            f"wiki has no {asset_type}/{name}/{asset_type[:-1]}.md to seed from at {canonical}"
+        )
+
+    # Function-body imports dodge a wiki ↔ context import cycle:
+    # ``context.install`` already imports ``wiki.store``; widening to
+    # module-top imports here would close the loop.
+    if asset_type == "agents":
+        from memtomem.context.agents import AGENT_GENERATORS, parse_canonical_agent
+
+        gen_key = f"{vendor}_agents"
+        if gen_key not in AGENT_GENERATORS:
+            raise NotImplementedError(
+                f"{vendor!r} agents not yet supported — see OVERRIDE_FORMATS placeholder"
+            )
+        agent = parse_canonical_agent(canonical, layout="dir")
+        text, _dropped = AGENT_GENERATORS[gen_key].render(agent)
+        return text.encode("utf-8")
+    if asset_type == "commands":
+        from memtomem.context.commands import (
+            COMMAND_GENERATORS,
+            parse_canonical_command,
+        )
+
+        gen_key = f"{vendor}_commands"
+        if gen_key not in COMMAND_GENERATORS:
+            raise NotImplementedError(
+                f"{vendor!r} commands not yet supported — see OVERRIDE_FORMATS placeholder"
+            )
+        cmd = parse_canonical_command(canonical, layout="dir")
+        text, _dropped = COMMAND_GENERATORS[gen_key].render(cmd)
+        return text.encode("utf-8")
+    raise ValueError(f"unsupported asset_type for override seeding: {asset_type!r}")
 
 
 def seed_override(

--- a/packages/memtomem/src/memtomem/wiki/override.py
+++ b/packages/memtomem/src/memtomem/wiki/override.py
@@ -42,7 +42,14 @@ def render_seed_bytes(
     Skills → canonical ``SKILL.md``.
     Agents / commands → ``parse_canonical_*`` + vendor renderer.
     ``("commands", "codex")`` → :class:`NotImplementedError`.
+
+    ``name`` is validated here even though :func:`seed_override` (the usual
+    caller) already validates — the function is in ``__all__`` so direct
+    callers should not have to remember to pre-validate. Defense in depth
+    for the ``store.root / asset_type / name / ...`` path joins below.
     """
+    validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+
     if asset_type == "skills":
         src = store.root / "skills" / name / "SKILL.md"
         if not src.is_file():
@@ -55,6 +62,12 @@ def render_seed_bytes(
             f"wiki has no {asset_type}/{name}/{asset_type[:-1]}.md to seed from at {canonical}"
         )
 
+    # ``gen.render()`` returns ``(text, dropped_field_names)`` — fields the
+    # vendor format can't represent (e.g., gemini drops ``tools`` /
+    # ``skills`` / ``model``). C1a silently discards ``_dropped``; C1b CLI
+    # will surface them via stderr WARNING so users editing the override
+    # know which fields the runtime won't see.
+    #
     # Function-body imports dodge a wiki ↔ context import cycle:
     # ``context.install`` already imports ``wiki.store``; widening to
     # module-top imports here would close the loop.

--- a/packages/memtomem/tests/test_context_override.py
+++ b/packages/memtomem/tests/test_context_override.py
@@ -150,25 +150,33 @@ def test_resolve_invariant_1_works_without_wiki(
     assert result == overrides_dir / "gemini.md"
 
 
-def test_resolve_skips_agents_in_pr_c(tmp_path: Path) -> None:
-    """PR-C activates skills only. Agents/commands matrix rows are
-    shipped but the resolver guards them; flip the guard in PR-D to
-    activate. This test pins the gate so the enable-day diff is
-    one-line revertable."""
+def test_resolve_returns_path_for_agents_override(tmp_path: Path) -> None:
+    """Agents override resolution active post-PR-D gate removal.
+
+    Pin-and-invert from ``test_resolve_skips_agents_in_pr_c`` (carry-forward
+    from PR-C #624). PR-D-prep #627 added fan-out application sites; PR-D
+    C1a removes the ``_PR_C_ACTIVE_TYPES`` gate. Series PR archive.
+    """
     overrides_dir = tmp_path / ".memtomem" / "agents" / "bar" / "overrides"
     overrides_dir.mkdir(parents=True)
-    (overrides_dir / "claude.md").write_bytes(b"# would-be agent override\n")
-    assert override.resolve(tmp_path, "agents", "bar", "claude") is None
+    (overrides_dir / "claude.md").write_bytes(b"# agent override\n")
+    assert override.resolve(tmp_path, "agents", "bar", "claude") == overrides_dir / "claude.md"
 
 
-def test_resolve_skips_commands_in_pr_c(tmp_path: Path) -> None:
+def test_resolve_returns_path_for_commands_override(tmp_path: Path) -> None:
+    """Commands override resolution active post-PR-D gate removal.
+
+    Pin-and-invert from ``test_resolve_skips_commands_in_pr_c`` (carry-forward
+    from PR-C #624). PR-D-prep #627 added fan-out application sites; PR-D
+    C1a removes the ``_PR_C_ACTIVE_TYPES`` gate. Series PR archive.
+    """
     overrides_dir = tmp_path / ".memtomem" / "commands" / "baz" / "overrides"
     overrides_dir.mkdir(parents=True)
-    (overrides_dir / "gemini.toml").write_bytes(b"# would-be command override\n")
-    assert override.resolve(tmp_path, "commands", "baz", "gemini") is None
+    (overrides_dir / "gemini.toml").write_bytes(b"# command override\n")
+    assert override.resolve(tmp_path, "commands", "baz", "gemini") == overrides_dir / "gemini.toml"
 
 
-# ── fan-out under PR-C gate: application sites pinned inactive for agents/commands
+# ── fan-out applies overrides for agents/commands (PR-D C1a)
 
 _SAMPLE_AGENT_BODY = """---
 name: bar
@@ -186,12 +194,14 @@ Command body.
 """
 
 
-def test_agents_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> None:
-    """PR-D-prep adds override application to ``generate_all_agents`` as dead
-    code under the PR-C ``_PR_C_ACTIVE_TYPES`` gate. With the gate active,
-    fan-out must produce canonical-rendered output even when an override file
-    is staged in the project tree. PR-D removes the gate; this test inverts
-    on enable day so the behavior diff is one-line revertable.
+def test_agents_fanout_applies_claude_override(tmp_path: Path) -> None:
+    """Agents fan-out applies override (full-file replacement, Invariant 4).
+
+    Pin-and-invert from ``test_agents_fanout_does_not_apply_override_under_gate``
+    (PR-D-prep #627). PR-D C1a removes ``_PR_C_ACTIVE_TYPES`` so the fan-out
+    application site lights up. 3-assertion marker pattern (per
+    ``feedback_pin_invert_symmetric_assertion``): canonical body absent +
+    override marker present + byte-equality.
     """
     canonical_dir = tmp_path / ".memtomem" / "agents"
     canonical_dir.mkdir(parents=True)
@@ -199,48 +209,53 @@ def test_agents_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> Non
 
     overrides_dir = tmp_path / ".memtomem" / "agents" / "bar" / "overrides"
     overrides_dir.mkdir(parents=True)
-    would_be_override = b"# would-be agent override\n"
-    (overrides_dir / "claude.md").write_bytes(would_be_override)
+    override_body = b"# OVERRIDE_MARKER_AGENT\nclaude full replacement body\n"
+    (overrides_dir / "claude.md").write_bytes(override_body)
 
     generate_all_agents(tmp_path, runtimes=["claude_agents"])
 
     runtime_file = tmp_path / ".claude" / "agents" / "bar.md"
     assert runtime_file.is_file()
-    # Positive assertion: canonical body marker must be present so a generator
-    # failure that writes garbage cannot be mistaken for gate-correct behavior.
-    # PR-D inverts: marker disappears (override replaces full body), and the
-    # negative assertion below flips to ``==``.
-    assert b"Body of the agent." in runtime_file.read_bytes(), (
-        "runtime file does not contain canonical body — generator failure?"
+    body = runtime_file.read_bytes()
+    assert b"Body of the agent." not in body, (
+        "canonical body still present despite gate removed — override not applied?"
     )
-    assert runtime_file.read_bytes() != would_be_override, (
-        "override applied despite _PR_C_ACTIVE_TYPES gate active for agents"
+    assert b"OVERRIDE_MARKER_AGENT" in body, (
+        "override marker absent — override file not seeded correctly?"
     )
+    assert body == override_body
 
 
-def test_commands_fanout_does_not_apply_override_under_gate(tmp_path: Path) -> None:
-    """Same pin as the agents counterpart — fan-out application site is dead
-    code while the gate is active."""
+def test_commands_fanout_applies_claude_override(tmp_path: Path) -> None:
+    """Commands fan-out applies override (full-file replacement, Invariant 4).
+
+    Pin-and-invert from ``test_commands_fanout_does_not_apply_override_under_gate``
+    (PR-D-prep #627). PR-D C1a removes ``_PR_C_ACTIVE_TYPES`` so the fan-out
+    application site lights up. 3-assertion marker pattern (per
+    ``feedback_pin_invert_symmetric_assertion``): canonical body absent +
+    override marker present + byte-equality.
+    """
     canonical_dir = tmp_path / ".memtomem" / "commands"
     canonical_dir.mkdir(parents=True)
     (canonical_dir / "baz.md").write_text(_SAMPLE_COMMAND_BODY, encoding="utf-8")
 
     overrides_dir = tmp_path / ".memtomem" / "commands" / "baz" / "overrides"
     overrides_dir.mkdir(parents=True)
-    would_be_override = b"# would-be command override\n"
-    (overrides_dir / "claude.md").write_bytes(would_be_override)
+    override_body = b"# OVERRIDE_MARKER_COMMAND\nclaude full replacement body\n"
+    (overrides_dir / "claude.md").write_bytes(override_body)
 
     generate_all_commands(tmp_path, runtimes=["claude_commands"])
 
     runtime_file = tmp_path / ".claude" / "commands" / "baz.md"
     assert runtime_file.is_file()
-    # Positive assertion mirrors the agents counterpart — see comment there.
-    assert b"Command body." in runtime_file.read_bytes(), (
-        "runtime file does not contain canonical body — generator failure?"
+    body = runtime_file.read_bytes()
+    assert b"Command body." not in body, (
+        "canonical body still present despite gate removed — override not applied?"
     )
-    assert runtime_file.read_bytes() != would_be_override, (
-        "override applied despite _PR_C_ACTIVE_TYPES gate active for commands"
+    assert b"OVERRIDE_MARKER_COMMAND" in body, (
+        "override marker absent — override file not seeded correctly?"
     )
+    assert body == override_body
 
 
 # ── skills fan-out applies overrides correctly ─────────────────────────

--- a/packages/memtomem/tests/test_wiki_override.py
+++ b/packages/memtomem/tests/test_wiki_override.py
@@ -1,0 +1,100 @@
+"""Tests for ``memtomem.wiki.override.render_seed_bytes`` — vendor-aware seed bytes.
+
+PR-D C1a lifts the skills-only ``NotImplementedError`` so agents and commands
+seed via vendor generators (path (b): ``parse_canonical_*`` + generator
+``render``). The codex commands row in :data:`OVERRIDE_FORMATS` is a
+permanent placeholder (no ``codex_commands`` generator); seeding raises
+``NotImplementedError`` with a diagnostic message.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.wiki.override import render_seed_bytes
+from memtomem.wiki.store import WikiStore
+
+# ``wiki_root`` fixture is registered globally via ``conftest.py`` (which
+# re-exports from ``_wiki_fixtures.py``). No per-file import needed.
+
+
+_AGENT_CANONICAL = """---
+name: bar
+description: a test agent
+---
+
+Body of the agent.
+"""
+
+_COMMAND_CANONICAL = """---
+description: a test command
+---
+
+Command body.
+"""
+
+
+def _initialized_wiki() -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def test_render_seed_bytes_for_agents_uses_vendor_generator(wiki_root: Path) -> None:
+    """Agents seed routes through the vendor generator.
+
+    Codex agents emit TOML — pin format identity (TOML keys, no Markdown
+    frontmatter delimiter) so the seed bytes match what ``.codex/agents/``
+    would receive at fan-out time.
+    """
+    store = _initialized_wiki()
+    agent_dir = wiki_root / "agents" / "bar"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text(_AGENT_CANONICAL, encoding="utf-8")
+
+    seed = render_seed_bytes(store, "agents", "bar", "codex")
+
+    text = seed.decode("utf-8")
+    assert "name = " in text, "TOML name key absent — generator did not emit TOML?"
+    assert "Body of the agent." in text
+    assert not text.lstrip().startswith("---"), (
+        "seed starts with Markdown frontmatter — codex generator returned Markdown?"
+    )
+
+
+def test_render_seed_bytes_for_commands_uses_vendor_generator(wiki_root: Path) -> None:
+    """Commands seed routes through the vendor generator.
+
+    Gemini commands emit TOML — pin format identity.
+    """
+    store = _initialized_wiki()
+    cmd_dir = wiki_root / "commands" / "baz"
+    cmd_dir.mkdir(parents=True)
+    (cmd_dir / "command.md").write_text(_COMMAND_CANONICAL, encoding="utf-8")
+
+    seed = render_seed_bytes(store, "commands", "baz", "gemini")
+
+    text = seed.decode("utf-8")
+    assert "prompt = " in text, "TOML prompt key absent — generator did not emit TOML?"
+    assert "Command body." in text
+    assert not text.lstrip().startswith("---"), (
+        "seed starts with Markdown frontmatter — gemini generator returned Markdown?"
+    )
+
+
+def test_render_seed_bytes_codex_commands_raises_not_implemented(
+    wiki_root: Path,
+) -> None:
+    """``("commands", "codex")`` is a permanent placeholder — no
+    ``codex_commands`` generator. Seeding raises ``NotImplementedError`` with
+    a diagnostic message rather than silently failing on a dict KeyError.
+    """
+    store = _initialized_wiki()
+    cmd_dir = wiki_root / "commands" / "baz"
+    cmd_dir.mkdir(parents=True)
+    (cmd_dir / "command.md").write_text(_COMMAND_CANONICAL, encoding="utf-8")
+
+    with pytest.raises(NotImplementedError, match="commands not yet supported"):
+        render_seed_bytes(store, "commands", "baz", "codex")

--- a/packages/memtomem/tests/test_wiki_override.py
+++ b/packages/memtomem/tests/test_wiki_override.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import pytest
 
+from memtomem.context._names import InvalidNameError
 from memtomem.wiki.override import render_seed_bytes
 from memtomem.wiki.store import WikiStore
 
@@ -98,3 +99,22 @@ def test_render_seed_bytes_codex_commands_raises_not_implemented(
 
     with pytest.raises(NotImplementedError, match="commands not yet supported"):
         render_seed_bytes(store, "commands", "baz", "codex")
+
+
+def test_render_seed_bytes_rejects_traversal_name(wiki_root: Path) -> None:
+    """Defense-in-depth: ``render_seed_bytes`` validates ``name`` itself.
+
+    ``seed_override`` (the usual caller) already validates, but
+    ``render_seed_bytes`` is in ``__all__`` so direct callers should not
+    have to remember to pre-validate. A traversal-shaped name in the
+    ``store.root / asset_type / name / ...`` path would otherwise escape
+    the wiki root.
+    """
+    store = _initialized_wiki()
+
+    with pytest.raises(InvalidNameError):
+        render_seed_bytes(store, "agents", "../etc/passwd", "claude")
+    with pytest.raises(InvalidNameError):
+        render_seed_bytes(store, "commands", "../../escape", "claude")
+    with pytest.raises(InvalidNameError):
+        render_seed_bytes(store, "skills", "../../escape", "claude")


### PR DESCRIPTION
## Summary

PR-D C1a in the ADR-0008 wiki layer series. Removes the PR-C gate
(`_PR_C_ACTIVE_TYPES`) and lifts `wiki/override.py:render_seed_bytes`
so agents and commands seed via the vendor generator path that PR-D-prep
(#627) already wired into the fan-out. Skills behavior is unchanged.

PR-D split per the canonical plan (`pr-d-glistening-sketch.md`):
- **C1a (this PR)**: gate flip + render lift + 4 test inverts + 4 new render_seed_bytes tests.
- **C1b (next)**: `mm wiki agent override` / `mm wiki command override` CLI mirror + ~20 mirror tests. Deferred because including it would push C1 past the ~280 LOC target.
- **C2/C3/C4**: `mm context update` / `status` / `install --all` / `migrate` (subsequent PRs).

## What changed

- `context/override.py` — drop `_PR_C_ACTIVE_TYPES` + the gate branch. `resolve()` now returns paths for every row in `OVERRIDE_FORMATS`.
- `context/_names.py` — drop the gate-mention comment; tighten `("commands", "codex")` placeholder rationale to point at the runtime `NotImplementedError` since the gate is gone.
- `wiki/override.py` — `render_seed_bytes` lifts the skills-only `NotImplementedError`. Path **(b) parse + render**: reuses PR-C's layout-aware `parse_canonical_agent` / `parse_canonical_command` + the existing `AGENT_GENERATORS` / `COMMAND_GENERATORS` registry rather than widening the generator API surface with a new `render_from_canonical(Path)` helper. Function-body imports dodge a `wiki ↔ context` cycle (`context.install` already imports `wiki.store`).
- `("commands", "codex")` keeps an explicit `NotImplementedError` since `GENERATOR_VENDOR` has no `codex_commands` entry — preserves the diagnostic UX vs a silent `KeyError`.
- `test_context_override.py` — invert the 4 gate-pin tests:
  - `test_resolve_skips_agents_in_pr_c` → `test_resolve_returns_path_for_agents_override`
  - `test_resolve_skips_commands_in_pr_c` → `test_resolve_returns_path_for_commands_override`
  - `test_agents_fanout_does_not_apply_override_under_gate` → `test_agents_fanout_applies_claude_override` (3-assertion marker pattern)
  - `test_commands_fanout_does_not_apply_override_under_gate` → `test_commands_fanout_applies_claude_override` (same)
  - Each rename keeps the original test name in the docstring for series-PR archive value (PR-C #624 + PR-D-prep #627).
- `test_wiki_override.py` (new, 4 tests) — `render_seed_bytes` for agents/codex (TOML), commands/gemini (TOML), the codex commands `NotImplementedError` placeholder pin, and the traversal-name rejection guard (added in fixup; see below).

## 3-assertion marker pattern (Step 2 of TDD-ish ordering)

PR-D-prep #627 used a 2-assertion symmetric pin (positive marker present + negative `!=`). PR-D extends to 3 assertions:

1. canonical body absent (`b"Body of the agent." not in body`)
2. override marker present (`b"OVERRIDE_MARKER_AGENT" in body`)
3. byte-equality (`body == override_body`)

Catches three failure modes: (1) stale canonical leak, (2) wrong override file picked, (3) byte-level corruption. Extension of `feedback_pin_invert_symmetric_assertion`.

## Known limitations (deferred to C1b)

- `_dropped` fields from vendor renderers are silently discarded.
  Gemini renderer drops `tools` / `skills` / `model`; codex agents drops
  `tools` / `skills` / `isolation` / `kind` / `temperature`. Users editing
  the override file won't realize which fields the vendor runtime can't
  represent until **C1b** surfaces them via stderr WARNING. Inline comment
  in `render_seed_bytes` flags this as the follow-up.

## API change

- `render_seed_bytes` raises `NotImplementedError` with a new message
  format for `("commands", "codex")` (was: skills-only `NotImplementedError`
  pre-PR-D, with message `"override seeding for {asset_type!r} lands in
  a follow-up PR"`). Internal API — no external callers expected.
- `render_seed_bytes` parameter rename `_vendor` → `vendor` (was unused
  for skills-only path; now load-bearing for vendor dispatch). Internal API.
- `render_seed_bytes` now calls `validate_name` on entry (defense-in-depth;
  see fixup below). Idempotent with `seed_override`'s validate.

## Behavior change

- Manually placed `<project>/.memtomem/<type>/<name>/overrides/<vendor>.<ext>`
  files (which had no effect under the PR-C gate) **now activate**. No CLI
  created these for agents/commands before C1b, so unlikely in practice;
  worth flagging since the gate flip is the activation point.

## Fixup commit

`fixup(c1a): defense-in-depth validate_name in render_seed_bytes + follow-up notes`
(0aca0d4). Self-review caught: `render_seed_bytes` is in `__all__` and
constructs `store.root / asset_type / name / ...` paths. A traversal-shaped
`name` from a direct caller (bypassing `seed_override`) would escape the
wiki root. PR-D C1a is the first PR where the agents/commands branch is
live, so this is the right ship to defend at the function boundary.

- `validate_name(name, kind=...)` at function entry. Idempotent with
  `seed_override`'s existing validate.
- New `test_render_seed_bytes_rejects_traversal_name` covers all 3 asset
  types with traversal-shaped names.
- Inline comment about `_dropped` follow-up.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_override.py -v` — 13 pass (4 inverted + 9 unchanged).
- [x] `uv run pytest packages/memtomem/tests/test_wiki_override.py -v` — 4 pass (new file; 3 + traversal guard).
- [x] `uv run pytest packages/memtomem/tests/test_wiki_cmd_override.py -v` — 10 pass (skills CLI surface unchanged).
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama" -q` — 3453 pass, 46 deselected. No regressions.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] Cycle smoke implicit: `test_render_seed_bytes_*` exercise function-body imports at call time; ImportError would surface there.
- [ ] CI green (waiting).

## Out of scope

- C1b (CLI mirror) — separate PR, depends on C1a merge.
- C2 `installed_at` capture move (PR-B contract micro-fixup) — first sub-commit of the C2 PR.
- ADR-0008 status update — final PR in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)