### PR TITLE
feat(context): PR-D C1b — mm wiki {agent,command} override CLI mirror (ADR-0008)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -184,3 +184,89 @@ def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
     ``mm context install`` snapshots pick it up.
     """
     _run_seed_override("skills", name, vendor, force=force, editor=editor)
+
+
+# ── Agent subgroup ──────────────────────────────────────────────────────
+
+
+@wiki.group("agent")
+def agent_group() -> None:
+    """Per-agent operations on the wiki (override seeding, ...)."""
+
+
+@agent_group.command("override")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    required=True,
+    help="Which runtime this override targets.",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing override file in the wiki (creates .bak).",
+)
+@click.option(
+    "--editor",
+    "-e",
+    is_flag=True,
+    help="Open $EDITOR on the seeded file after writing.",
+)
+def agent_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> None:
+    """Seed a wiki override file from the canonical agent content.
+
+    ``mm wiki agent override <name> --vendor <claude|gemini|codex>`` writes
+    ``<wiki>/agents/<name>/overrides/<vendor>.<ext>``. Bytes come from the
+    vendor renderer applied to the canonical ``agent.md`` so the seed
+    matches what the runtime would produce. Fields the vendor format
+    cannot represent (e.g. gemini agents drop ``skills`` / ``isolation``)
+    are surfaced via a stderr warning so the editor knows what the
+    runtime won't see.
+    """
+    _run_seed_override("agents", name, vendor, force=force, editor=editor)
+
+
+# ── Command subgroup ────────────────────────────────────────────────────
+
+
+@wiki.group("command")
+def command_group() -> None:
+    """Per-command operations on the wiki (override seeding, ...)."""
+
+
+@command_group.command("override")
+@click.argument("name")
+@click.option(
+    "--vendor",
+    "-v",
+    type=click.Choice(["claude", "gemini", "codex"]),
+    required=True,
+    help="Which runtime this override targets.",
+)
+@click.option(
+    "--force",
+    "-f",
+    is_flag=True,
+    help="Overwrite existing override file in the wiki (creates .bak).",
+)
+@click.option(
+    "--editor",
+    "-e",
+    is_flag=True,
+    help="Open $EDITOR on the seeded file after writing.",
+)
+def command_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> None:
+    """Seed a wiki override file from the canonical command content.
+
+    ``mm wiki command override <name> --vendor <claude|gemini|codex>`` writes
+    ``<wiki>/commands/<name>/overrides/<vendor>.<ext>``. ``--vendor codex``
+    is a permanent placeholder (no ``codex_commands`` generator); the
+    command surfaces a classified error rather than silently failing.
+    Fields the vendor format cannot represent (e.g. gemini commands drop
+    ``argument-hint`` / ``allowed-tools`` / ``model``) are surfaced via a
+    stderr warning so the editor knows what the runtime won't see.
+    """
+    _run_seed_override("commands", name, vendor, force=force, editor=editor)

--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -5,6 +5,8 @@ See ADR-0008 for the wiki layer's role in the context-gateway pipeline.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import click
 
 from memtomem.context._names import InvalidNameError
@@ -23,6 +25,66 @@ from memtomem.wiki.override import (
 @click.group("wiki")
 def wiki() -> None:
     """Manage the local memtomem wiki (skills/agents/commands library)."""
+
+
+def _run_seed_override(
+    asset_type: Literal["skills", "agents", "commands"],
+    name: str,
+    vendor: str,
+    *,
+    force: bool,
+    editor: bool,
+) -> None:
+    """Shared body for ``mm wiki {skill,agent,command} override``.
+
+    Mirrors the seed → stdout summary → optional stderr warning →
+    optional ``$EDITOR`` flow across all three asset types so the trust-UX
+    is identical: classified ClickException for known errors, no Python
+    traceback leaks, and any vendor-renderer drops surface as a yellow
+    stderr line so the user knows what the runtime won't see in the
+    override.
+    """
+    store = WikiStore.at_default()
+    try:
+        result = seed_override(store, asset_type, name, vendor, force=force)
+    except (
+        WikiNotFoundError,
+        OverrideExistsError,
+        FileNotFoundError,
+        InvalidNameError,
+        NotImplementedError,
+    ) as exc:
+        # 5 sibling classes (verified disjoint: WikiNotFoundError /
+        # OverrideExistsError / NotImplementedError -> RuntimeError;
+        # FileNotFoundError -> OSError; InvalidNameError -> ValueError —
+        # no cross-inheritance, ordering irrelevant). NotImplementedError
+        # carries the ("commands", "codex") placeholder message from
+        # seed_override; surfacing it as ClickException prints a classified
+        # error rather than a Python traceback.
+        raise click.ClickException(str(exc)) from exc
+
+    # ``seed_override`` invariant: target lives under ``store.root``.
+    # No is_relative_to fallback — a violation is a real bug worth
+    # surfacing as ValueError, not a silent path mismatch to mask.
+    rel = result.path.relative_to(store.root)
+    ext = result.path.suffix.lstrip(".")
+    click.secho(f"Seeded {rel}", fg="green")
+    click.echo(str(result.path))
+    click.echo(
+        f"# next: cd {store.root} && "
+        f"git add {asset_type}/{name}/overrides/{vendor}.{ext} && git commit"
+    )
+
+    if result.dropped:
+        click.secho(
+            f"warning: vendor {vendor!r} will not represent these fields: "
+            f"{', '.join(result.dropped)}",
+            fg="yellow",
+            err=True,
+        )
+
+    if editor:
+        click.edit(filename=str(result.path), require_save=False)
 
 
 @wiki.command("init")
@@ -121,24 +183,4 @@ def skill_override_cmd(name: str, vendor: str, force: bool, editor: bool) -> Non
     ``$EDITOR``) and commit it inside the wiki repo so that future
     ``mm context install`` snapshots pick it up.
     """
-    store = WikiStore.at_default()
-    try:
-        target = seed_override(store, "skills", name, vendor, force=force)
-    except WikiNotFoundError as exc:
-        raise click.ClickException(str(exc)) from exc
-    except OverrideExistsError as exc:
-        raise click.ClickException(str(exc)) from exc
-    except FileNotFoundError as exc:
-        raise click.ClickException(str(exc)) from exc
-    except InvalidNameError as exc:
-        raise click.ClickException(str(exc)) from exc
-
-    rel = target.relative_to(store.root) if target.is_relative_to(store.root) else target
-    click.secho(f"Seeded {rel}", fg="green")
-    click.echo(str(target))
-    click.echo(
-        f"# next: cd {store.root} && git add skills/{name}/overrides/{vendor}.md && git commit"
-    )
-
-    if editor:
-        click.edit(filename=str(target), require_save=False)
+    _run_seed_override("skills", name, vendor, force=force, editor=editor)

--- a/packages/memtomem/src/memtomem/wiki/override.py
+++ b/packages/memtomem/src/memtomem/wiki/override.py
@@ -5,12 +5,15 @@ Companion to :mod:`memtomem.context.override` (which is the project-side
 calls to produce the initial bytes the user then edits.
 
 - Skills are byte-identical across vendors, so the seed is simply the
-  canonical ``SKILL.md``.
+  canonical ``SKILL.md`` and ``dropped`` is always ``[]``.
 - Agents and commands feed the canonical through the vendor's renderer
   in :data:`AGENT_GENERATORS` / :data:`COMMAND_GENERATORS` so the seed
-  bytes match what the vendor's runtime would actually emit. This reuses
-  PR-C's layout-aware ``parse_canonical_agent`` / ``parse_canonical_command``
-  rather than widening the generator API surface.
+  bytes match what the vendor's runtime would actually emit. The renderer
+  also reports which canonical fields the target format cannot represent;
+  callers (``mm wiki <type> override``) surface those to the user as a
+  stderr warning so the override editor knows what the runtime won't see.
+  This reuses PR-C's layout-aware ``parse_canonical_agent`` /
+  ``parse_canonical_command`` rather than widening the generator API surface.
 - ``("commands", "codex")`` is a permanent placeholder row in
   :data:`OVERRIDE_FORMATS` (no ``codex_commands`` generator); seeding
   raises :class:`NotImplementedError` with a diagnostic message.
@@ -18,17 +21,33 @@ calls to produce the initial bytes the user then edits.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from memtomem.context._atomic import atomic_write_bytes
 from memtomem.context._names import OVERRIDE_FORMATS, validate_name
 from memtomem.wiki.store import WikiStore
 
-__all__ = ["OverrideExistsError", "render_seed_bytes", "seed_override"]
+__all__ = ["OverrideExistsError", "SeedResult", "render_seed_bytes", "seed_override"]
 
 
 class OverrideExistsError(RuntimeError):
     """Raised when an override file already exists and ``force`` was not given."""
+
+
+@dataclass(frozen=True)
+class SeedResult:
+    """Outcome of seeding an override file.
+
+    ``path`` points at the freshly written ``<wiki>/<type>/<name>/overrides/<vendor>.<ext>``.
+    ``dropped`` lists frontmatter / canonical field names the vendor renderer
+    could not represent in its output format — always ``[]`` for skills
+    (byte-copy of canonical), populated for agents / commands depending on
+    vendor (e.g. gemini agents drop ``skills`` / ``isolation``).
+    """
+
+    path: Path
+    dropped: list[str]
 
 
 def render_seed_bytes(
@@ -36,11 +55,12 @@ def render_seed_bytes(
     asset_type: str,
     name: str,
     vendor: str,
-) -> bytes:
-    """Return the bytes to seed an override file with.
+) -> tuple[bytes, list[str]]:
+    """Return ``(seed_bytes, dropped_field_names)``.
 
-    Skills → canonical ``SKILL.md``.
-    Agents / commands → ``parse_canonical_*`` + vendor renderer.
+    Skills → canonical ``SKILL.md`` byte-copy with ``dropped == []``.
+    Agents / commands → ``parse_canonical_*`` + vendor renderer; ``dropped``
+    enumerates canonical fields the vendor format cannot represent.
     ``("commands", "codex")`` → :class:`NotImplementedError`.
 
     ``name`` is validated here even though :func:`seed_override` (the usual
@@ -54,7 +74,7 @@ def render_seed_bytes(
         src = store.root / "skills" / name / "SKILL.md"
         if not src.is_file():
             raise FileNotFoundError(f"wiki has no skills/{name}/SKILL.md to seed from at {src}")
-        return src.read_bytes()
+        return src.read_bytes(), []
 
     canonical = store.root / asset_type / name / f"{asset_type[:-1]}.md"
     if not canonical.is_file():
@@ -63,10 +83,10 @@ def render_seed_bytes(
         )
 
     # ``gen.render()`` returns ``(text, dropped_field_names)`` — fields the
-    # vendor format can't represent (e.g., gemini drops ``tools`` /
-    # ``skills`` / ``model``). C1a silently discards ``_dropped``; C1b CLI
-    # will surface them via stderr WARNING so users editing the override
-    # know which fields the runtime won't see.
+    # vendor format can't represent (e.g., gemini drops ``skills`` /
+    # ``isolation`` for agents, ``argument-hint`` / ``allowed-tools`` /
+    # ``model`` for commands). The dropped list is propagated up so
+    # ``mm wiki <type> override`` can warn the user via stderr.
     #
     # Function-body imports dodge a wiki ↔ context import cycle:
     # ``context.install`` already imports ``wiki.store``; widening to
@@ -80,8 +100,8 @@ def render_seed_bytes(
                 f"{vendor!r} agents not yet supported — see OVERRIDE_FORMATS placeholder"
             )
         agent = parse_canonical_agent(canonical, layout="dir")
-        text, _dropped = AGENT_GENERATORS[gen_key].render(agent)
-        return text.encode("utf-8")
+        text, dropped = AGENT_GENERATORS[gen_key].render(agent)
+        return text.encode("utf-8"), dropped
     if asset_type == "commands":
         from memtomem.context.commands import (
             COMMAND_GENERATORS,
@@ -94,8 +114,8 @@ def render_seed_bytes(
                 f"{vendor!r} commands not yet supported — see OVERRIDE_FORMATS placeholder"
             )
         cmd = parse_canonical_command(canonical, layout="dir")
-        text, _dropped = COMMAND_GENERATORS[gen_key].render(cmd)
-        return text.encode("utf-8")
+        text, dropped = COMMAND_GENERATORS[gen_key].render(cmd)
+        return text.encode("utf-8"), dropped
     raise ValueError(f"unsupported asset_type for override seeding: {asset_type!r}")
 
 
@@ -106,11 +126,13 @@ def seed_override(
     vendor: str,
     *,
     force: bool = False,
-) -> Path:
+) -> SeedResult:
     """Create ``<wiki>/<type>/<name>/overrides/<vendor>.<ext>``.
 
-    Returns the override file path. ``force`` overwrites an existing file
-    after writing a ``.bak`` sibling so the previous content is recoverable.
+    Returns a :class:`SeedResult` (path + list of canonical fields the
+    vendor renderer dropped — empty for skills). ``force`` overwrites an
+    existing file after writing a ``.bak`` sibling so the previous content
+    is recoverable.
 
     All preconditions are checked before any filesystem mutation: a refused
     call (missing wiki / missing canonical / collision without ``force``)
@@ -130,10 +152,10 @@ def seed_override(
         )
     # Pre-flight the seed bytes so missing-canonical does not leave an
     # empty overrides/ directory behind from the mkdir below.
-    seed_bytes = render_seed_bytes(store, asset_type, name, vendor)
+    seed_bytes, dropped = render_seed_bytes(store, asset_type, name, vendor)
     target.parent.mkdir(parents=True, exist_ok=True)
     if target.exists() and force:
         backup = target.with_suffix(target.suffix + ".bak")
         atomic_write_bytes(backup, target.read_bytes())
     atomic_write_bytes(target, seed_bytes)
-    return target
+    return SeedResult(path=target, dropped=dropped)

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -52,6 +52,27 @@ def test_wiki_skill_override_happy_path(wiki_root: Path) -> None:
     assert target.read_bytes() == canonical_bytes
 
 
+def test_wiki_skill_override_no_stderr_warning(wiki_root: Path) -> None:
+    """Helper-collapse safety gate: ``_run_seed_override`` adds a stderr
+    dropped-fields warning, but skills always seed via byte-copy of the
+    canonical (``SeedResult.dropped == []``), so the warning path must
+    stay quiescent for skills. The other skill tests only assert on
+    stdout via ``result.output``, so a silent regression here would not
+    surface elsewhere.
+
+    Click 8.3 keeps ``result.stderr`` separate by default — earlier
+    ``mix_stderr=False`` constructor arg was removed.
+    """
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["skill", "override", "hello", "--vendor", "gemini"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
+
+
 # ── refuse vs force ────────────────────────────────────────────────────
 
 

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -42,9 +42,15 @@ def _seed_agent(
     block — pass e.g. ``"skills:\\n  - foo\\nisolation: workspace\\n"``
     to trigger gemini's drop set (``skills`` / ``isolation``).
     """
+    # Defensive: silent break if a future fixture forgets the trailing
+    # newline — closing ``---`` would merge into the previous line and
+    # YAML parse fails with a cryptic error.
+    fm_extra = frontmatter_extra
+    if fm_extra and not fm_extra.endswith("\n"):
+        fm_extra += "\n"
     agent_dir = wiki_root_path / "agents" / name
     agent_dir.mkdir(parents=True)
-    canonical = f"---\nname: {name}\ndescription: a test agent\n{frontmatter_extra}---\n\n{body}"
+    canonical = f"---\nname: {name}\ndescription: a test agent\n{fm_extra}---\n\n{body}"
     (agent_dir / "agent.md").write_text(canonical, encoding="utf-8")
     _git_commit(wiki_root_path, f"add agent {name}")
 
@@ -63,9 +69,13 @@ def _seed_command(
     to trigger gemini's drop set (``argument-hint`` / ``allowed-tools`` /
     ``model``).
     """
+    # Defensive: see _seed_agent for the silent-break rationale.
+    fm_extra = frontmatter_extra
+    if fm_extra and not fm_extra.endswith("\n"):
+        fm_extra += "\n"
     cmd_dir = wiki_root_path / "commands" / name
     cmd_dir.mkdir(parents=True)
-    canonical = f"---\ndescription: a test command\n{frontmatter_extra}---\n\n{body}"
+    canonical = f"---\ndescription: a test command\n{fm_extra}---\n\n{body}"
     (cmd_dir / "command.md").write_text(canonical, encoding="utf-8")
     _git_commit(wiki_root_path, f"add command {name}")
 

--- a/packages/memtomem/tests/test_wiki_cmd_override.py
+++ b/packages/memtomem/tests/test_wiki_cmd_override.py
@@ -1,8 +1,13 @@
-"""Tests for ``mm wiki skill override`` — wiki-side override seeder (PR-C[3/3]).
+"""Tests for ``mm wiki {skill,agent,command} override`` — wiki-side override seeder.
+
+Skills land in PR-C (#624). Agent / command commands and the dropped-field
+stderr warning land in PR-D C1b (the helper extraction in commit 1 of that
+same PR sets up the shared scaffolding).
 
 The CLI delegates to :mod:`memtomem.wiki.override`. Tests exercise the
 happy path, the refuse-vs-force collision UX, the editor flag, the
-classified errors, and the stdout contract.
+classified errors, the stdout contract, and (for agents / commands) the
+stderr warning when the vendor renderer drops canonical fields.
 """
 
 from __future__ import annotations
@@ -21,9 +26,54 @@ def _seed_skill(wiki_root_path: Path, name: str, body: bytes = b"# canonical\n")
     skill_dir = wiki_root_path / "skills" / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_bytes(body)
+    _git_commit(wiki_root_path, f"add {name}")
+
+
+def _seed_agent(
+    wiki_root_path: Path,
+    name: str,
+    *,
+    frontmatter_extra: str = "",
+    body: str = "Body of the agent.\n",
+) -> None:
+    """Write ``<wiki>/agents/<name>/agent.md`` with a minimal frontmatter.
+
+    ``frontmatter_extra`` is appended verbatim inside the frontmatter
+    block — pass e.g. ``"skills:\\n  - foo\\nisolation: workspace\\n"``
+    to trigger gemini's drop set (``skills`` / ``isolation``).
+    """
+    agent_dir = wiki_root_path / "agents" / name
+    agent_dir.mkdir(parents=True)
+    canonical = f"---\nname: {name}\ndescription: a test agent\n{frontmatter_extra}---\n\n{body}"
+    (agent_dir / "agent.md").write_text(canonical, encoding="utf-8")
+    _git_commit(wiki_root_path, f"add agent {name}")
+
+
+def _seed_command(
+    wiki_root_path: Path,
+    name: str,
+    *,
+    frontmatter_extra: str = "",
+    body: str = "Command body.\n",
+) -> None:
+    """Write ``<wiki>/commands/<name>/command.md`` with a minimal frontmatter.
+
+    ``frontmatter_extra`` is appended verbatim — pass e.g.
+    ``"argument-hint: <arg>\\nallowed-tools: [Read]\\nmodel: claude-3-5\\n"``
+    to trigger gemini's drop set (``argument-hint`` / ``allowed-tools`` /
+    ``model``).
+    """
+    cmd_dir = wiki_root_path / "commands" / name
+    cmd_dir.mkdir(parents=True)
+    canonical = f"---\ndescription: a test command\n{frontmatter_extra}---\n\n{body}"
+    (cmd_dir / "command.md").write_text(canonical, encoding="utf-8")
+    _git_commit(wiki_root_path, f"add command {name}")
+
+
+def _git_commit(wiki_root_path: Path, message: str) -> None:
     subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
     subprocess.run(
-        ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
+        ["git", "-C", str(wiki_root_path), "commit", "-m", message],
         check=True,
         capture_output=True,
     )
@@ -235,3 +285,373 @@ def test_wiki_skill_override_stdout_contract(wiki_root: Path) -> None:
     # Commit hint mentioning git commit.
     assert "git commit" in out
     assert "git add skills/hello/overrides/codex.md" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ── mm wiki agent override ──────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_AGENT_GEMINI_DROPS_FRONTMATTER = "skills:\n  - foo\n  - bar\nisolation: workspace\n"
+"""Frontmatter extra that triggers gemini's agent drop set (skills + isolation)."""
+
+
+def test_wiki_agent_override_happy_path_no_drops(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")  # minimal frontmatter — claude renders without drops
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    target = wiki_root / "agents" / "demo" / "overrides" / "claude.md"
+    assert target.is_file()
+    body = target.read_bytes()
+    # Vendor renderer wrote markdown frontmatter — name is the canonical key.
+    assert b"name: demo" in body
+    assert b"Body of the agent." in body
+    # No drops → no stderr warning.
+    assert result.stderr == ""
+
+
+def test_wiki_agent_override_warns_on_dropped_fields(wiki_root: Path) -> None:
+    """Gemini agents drop ``skills`` + ``isolation``. The CLI must warn
+    on stderr so the user editing the override knows what the runtime
+    won't see."""
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo", frontmatter_extra=_AGENT_GEMINI_DROPS_FRONTMATTER)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "gemini"])
+
+    assert result.exit_code == 0, result.output
+    err = result.stderr
+    assert "warning:" in err
+    assert "'gemini'" in err
+    assert "skills" in err
+    assert "isolation" in err
+    # Stdout retains the seed summary independently of the warning.
+    assert "Seeded agents/demo/overrides/gemini.md" in result.output
+
+
+def test_wiki_agent_override_refuses_existing(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "claude"])
+
+    second = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "claude"])
+
+    assert second.exit_code != 0
+    assert "already exists" in second.output
+
+
+def test_wiki_agent_override_force_writes_bak(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "claude"])
+
+    target = wiki_root / "agents" / "demo" / "overrides" / "claude.md"
+    target.write_bytes(b"# user-edited content\n")
+
+    second = runner.invoke(
+        wiki_group, ["agent", "override", "demo", "--vendor", "claude", "--force"]
+    )
+
+    assert second.exit_code == 0, second.output
+    backup = target.with_suffix(".md.bak")
+    assert backup.is_file()
+    assert backup.read_bytes() == b"# user-edited content\n"
+    # After force, target was rewritten from the canonical seed.
+    assert target.read_bytes() != b"# user-edited content\n"
+
+
+def test_wiki_agent_override_unknown_vendor(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "cursor"])
+
+    assert result.exit_code != 0
+    assert "cursor" in result.output  # click.Choice error references the value
+
+
+def test_wiki_agent_override_missing_agent(wiki_root: Path) -> None:
+    _initialized_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "ghost", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    # FileNotFoundError surfaced as ClickException — no traceback leaks.
+    assert "Traceback" not in result.output
+    assert "ghost" in result.output
+    # Refused call must not leave a half-built overrides/ directory behind.
+    assert not (wiki_root / "agents" / "ghost").exists()
+
+
+def test_wiki_agent_override_missing_wiki(monkeypatch, tmp_path: Path) -> None:
+    """No wiki initialized → classified error, not traceback."""
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_wiki_agent_override_invokes_editor(
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    captured: list[str] = []
+
+    def fake_edit(filename: str | None = None, **_kwargs: object) -> None:
+        if filename is not None:
+            captured.append(filename)
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        wiki_group,
+        ["agent", "override", "demo", "--vendor", "claude", "--editor"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    assert captured[0].endswith("/agents/demo/overrides/claude.md")
+
+
+def test_wiki_agent_override_does_not_invoke_editor_by_default(
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    called = False
+
+    def fake_edit(filename: str | None = None, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert called is False
+
+
+def test_wiki_agent_override_stdout_contract(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_agent(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["agent", "override", "demo", "--vendor", "codex"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Codex agents extension is .toml (not .md) — verifies extension propagated
+    # through OVERRIDE_FORMATS into the helper's stdout summary.
+    assert "Seeded agents/demo/overrides/codex.toml" in out
+    target_path = wiki_root / "agents" / "demo" / "overrides" / "codex.toml"
+    assert str(target_path) in out
+    assert "git commit" in out
+    assert "git add agents/demo/overrides/codex.toml" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ── mm wiki command override ────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────────────────────
+
+
+_COMMAND_GEMINI_DROPS_FRONTMATTER = (
+    "argument-hint: <arg>\nallowed-tools: [Read, Write]\nmodel: claude-3-5-sonnet\n"
+)
+"""Frontmatter extra that triggers gemini's command drop set."""
+
+
+def test_wiki_command_override_happy_path_no_drops(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    target = wiki_root / "commands" / "demo" / "overrides" / "claude.md"
+    assert target.is_file()
+    assert b"Command body." in target.read_bytes()
+    assert result.stderr == ""
+
+
+def test_wiki_command_override_warns_on_dropped_fields(wiki_root: Path) -> None:
+    """Gemini commands drop ``argument-hint`` / ``allowed-tools`` / ``model``."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo", frontmatter_extra=_COMMAND_GEMINI_DROPS_FRONTMATTER)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "gemini"])
+
+    assert result.exit_code == 0, result.output
+    err = result.stderr
+    assert "warning:" in err
+    assert "'gemini'" in err
+    assert "argument-hint" in err
+    assert "allowed-tools" in err
+    assert "model" in err
+    assert "Seeded commands/demo/overrides/gemini.toml" in result.output
+
+
+def test_wiki_command_override_codex_classified_error(wiki_root: Path) -> None:
+    """``("commands", "codex")`` is a permanent placeholder row in
+    ``OVERRIDE_FORMATS`` — no ``codex_commands`` generator. The CLI must
+    surface ``NotImplementedError`` from ``seed_override`` as a classified
+    ClickException, not a traceback."""
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "codex"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "not yet supported" in result.output
+    # Refused call must not leave a half-built overrides/ directory behind.
+    assert not (wiki_root / "commands" / "demo" / "overrides").exists()
+
+
+def test_wiki_command_override_refuses_existing(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "claude"])
+
+    second = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "claude"])
+
+    assert second.exit_code != 0
+    assert "already exists" in second.output
+
+
+def test_wiki_command_override_force_writes_bak(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+    runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "claude"])
+
+    target = wiki_root / "commands" / "demo" / "overrides" / "claude.md"
+    target.write_bytes(b"# user-edited content\n")
+
+    second = runner.invoke(
+        wiki_group, ["command", "override", "demo", "--vendor", "claude", "--force"]
+    )
+
+    assert second.exit_code == 0, second.output
+    backup = target.with_suffix(".md.bak")
+    assert backup.is_file()
+    assert backup.read_bytes() == b"# user-edited content\n"
+    assert target.read_bytes() != b"# user-edited content\n"
+
+
+def test_wiki_command_override_unknown_vendor(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "cursor"])
+
+    assert result.exit_code != 0
+    assert "cursor" in result.output
+
+
+def test_wiki_command_override_missing_command(wiki_root: Path) -> None:
+    _initialized_wiki()
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "ghost", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "ghost" in result.output
+    assert not (wiki_root / "commands" / "ghost").exists()
+
+
+def test_wiki_command_override_missing_wiki(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "claude"])
+
+    assert result.exit_code != 0
+    assert "wiki not found" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_wiki_command_override_invokes_editor(
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    captured: list[str] = []
+
+    def fake_edit(filename: str | None = None, **_kwargs: object) -> None:
+        if filename is not None:
+            captured.append(filename)
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        wiki_group,
+        ["command", "override", "demo", "--vendor", "claude", "--editor"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(captured) == 1
+    assert captured[0].endswith("/commands/demo/overrides/claude.md")
+
+
+def test_wiki_command_override_does_not_invoke_editor_by_default(
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    called = False
+
+    def fake_edit(filename: str | None = None, **_kwargs: object) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("click.edit", fake_edit)
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "claude"])
+
+    assert result.exit_code == 0, result.output
+    assert called is False
+
+
+def test_wiki_command_override_stdout_contract(wiki_root: Path) -> None:
+    _initialized_wiki()
+    _seed_command(wiki_root, "demo")
+    runner = CliRunner()
+
+    result = runner.invoke(wiki_group, ["command", "override", "demo", "--vendor", "gemini"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "Seeded commands/demo/overrides/gemini.toml" in out
+    target_path = wiki_root / "commands" / "demo" / "overrides" / "gemini.toml"
+    assert str(target_path) in out
+    assert "git commit" in out
+    assert "git add commands/demo/overrides/gemini.toml" in out

--- a/packages/memtomem/tests/test_wiki_override.py
+++ b/packages/memtomem/tests/test_wiki_override.py
@@ -55,7 +55,7 @@ def test_render_seed_bytes_for_agents_uses_vendor_generator(wiki_root: Path) -> 
     agent_dir.mkdir(parents=True)
     (agent_dir / "agent.md").write_text(_AGENT_CANONICAL, encoding="utf-8")
 
-    seed = render_seed_bytes(store, "agents", "bar", "codex")
+    seed, dropped = render_seed_bytes(store, "agents", "bar", "codex")
 
     text = seed.decode("utf-8")
     assert "name = " in text, "TOML name key absent — generator did not emit TOML?"
@@ -63,6 +63,8 @@ def test_render_seed_bytes_for_agents_uses_vendor_generator(wiki_root: Path) -> 
     assert not text.lstrip().startswith("---"), (
         "seed starts with Markdown frontmatter — codex generator returned Markdown?"
     )
+    # Minimal canonical (no skills/isolation/temperature/kind) → codex drops nothing.
+    assert dropped == []
 
 
 def test_render_seed_bytes_for_commands_uses_vendor_generator(wiki_root: Path) -> None:
@@ -75,7 +77,7 @@ def test_render_seed_bytes_for_commands_uses_vendor_generator(wiki_root: Path) -
     cmd_dir.mkdir(parents=True)
     (cmd_dir / "command.md").write_text(_COMMAND_CANONICAL, encoding="utf-8")
 
-    seed = render_seed_bytes(store, "commands", "baz", "gemini")
+    seed, dropped = render_seed_bytes(store, "commands", "baz", "gemini")
 
     text = seed.decode("utf-8")
     assert "prompt = " in text, "TOML prompt key absent — generator did not emit TOML?"
@@ -83,6 +85,8 @@ def test_render_seed_bytes_for_commands_uses_vendor_generator(wiki_root: Path) -
     assert not text.lstrip().startswith("---"), (
         "seed starts with Markdown frontmatter — gemini generator returned Markdown?"
     )
+    # Minimal canonical (no argument-hint/allowed-tools/model) → gemini drops nothing.
+    assert dropped == []
 
 
 def test_render_seed_bytes_codex_commands_raises_not_implemented(


### PR DESCRIPTION
## Summary

Closes the CLI gap left by [PR-D C1a (#628)](https://github.com/memtomem/memtomem/pull/628), which lifted `wiki/override.py:render_seed_bytes` for agents / commands but shipped no CLI to drive them. Users now have a symmetric surface across all three asset types:

```
mm wiki skill   override <name> --vendor <claude|gemini|codex>
mm wiki agent   override <name> --vendor <claude|gemini|codex>
mm wiki command override <name> --vendor <claude|gemini|codex>
```

Vendor renderers report which canonical fields they cannot represent (gemini agents drop `skills`/`isolation`; gemini commands drop `argument-hint`/`allowed-tools`/`model`); the new CLI surfaces those via stderr `warning:` so the user editing the override knows what the runtime won't see.

## Series position (ADR-0008 PR-D)

| | Status |
|---|---|
| PR-A wiki scaffold | merged #622 |
| PR-B mm context install + lockfile | merged #625 |
| PR-C wiki override + agent/command install widening | merged #624 |
| PR-D-prep fan-out override application sites | merged #627 |
| PR-D C1a activate agents/commands override + render lift | merged #628 |
| **PR-D C1b CLI mirror + dropped warning (this PR)** | here |
| C2 `mm context update` | next |
| C3 / C4 `status`, `install --all`, `migrate` | sequenced after C2 |

## Why two commits

The plan splits the work along a refactor / new-feature axis so each commit is a working, reviewable unit:

- **`0cc705d` refactor — extract `_run_seed_override` helper for override CLI.** Three call sites are about to share a body, so the YAGNI window for the helper is open _now_. `wiki/override.py` grows a `SeedResult(path, dropped)` dataclass, and `render_seed_bytes` / `seed_override` propagate the renderer's `dropped` list (C1a silently discarded it). `skill_override_cmd` collapses to the helper. The five known errors collapse into one `except (...)` tuple — verified disjoint via inheritance grep (`WikiNotFoundError` / `OverrideExistsError` / `NotImplementedError` → `RuntimeError`; `FileNotFoundError` → `OSError`; `InvalidNameError` → `ValueError`).
- **`e313da5` feat — `mm wiki {agent,command} override` + dropped-fields warning.** Two new `wiki.group` blocks, each with an `override` subcommand that delegates to the helper. The helper now exercises the dropped-fields stderr branch (skills always have `dropped == []`; agents / commands populate it depending on vendor). `("commands", "codex")` keeps its permanent placeholder behaviour — `seed_override` raises `NotImplementedError` and the helper surfaces it as a classified `ClickException` rather than a Python traceback.

## Collapse safety gate

`feedback_pre_collapse_parity_grep` pattern: surviving path's invariants are pinned _before / during_ the N→1 collapse. Skills had ten existing CLI tests (all assert on `result.output`, the combined stream), so a silent regression where the new dropped-fields warning fired for skills would not surface. Commit 1 adds `test_wiki_skill_override_no_stderr_warning`, which uses `result.stderr == ""` (Click 8.3 keeps `result.stderr` separate by default — earlier `mix_stderr=False` constructor arg was removed) to pin the four-axis invariant for skills:

| axis | how it is verified |
|---|---|
| stdout | existing `test_wiki_skill_override_stdout_contract` |
| exit code | existing `test_wiki_skill_override_happy_path` |
| file effect | existing `test_wiki_skill_override_happy_path` (byte-equality) |
| stderr empty | new `test_wiki_skill_override_no_stderr_warning` |

The first three were already pinned before this PR; the fourth is the new collapse-specific gate.

## Test surface

- `test_wiki_override.py` 4 / 4 pass. Two pin tests (`*_for_agents_uses_vendor_generator`, `*_for_commands_uses_vendor_generator`) unpack the new tuple shape and assert `dropped == []` for the minimal canonical fixtures (no vendor-uncovered fields → no drops). The other two are exception-only and unchanged.
- `test_wiki_cmd_override.py` 32 / 32 pass:
  - 10 existing skill tests (PR-C #624) — unchanged behaviour after the helper collapse.
  - 1 new `test_wiki_skill_override_no_stderr_warning` (commit 1 safety gate).
  - 10 agent mirror tests covering happy path / dropped warning / refuse / force / unknown vendor / missing agent / missing wiki / editor / no-editor / stdout contract.
  - 11 command mirror tests covering the same plus `test_wiki_command_override_codex_classified_error` (the permanent placeholder pin).
- Full suite: `uv run pytest packages/memtomem/tests/ -m "not ollama" -q` → **3475 pass, 46 deselected (ollama)**, +22 over C1a's 3453 (1 safety gate + 21 mirror).
- Lint: `ruff check` + `ruff format --check` clean across `packages/memtomem/src` + `packages/memtomem/tests`.

## Manual smoke (mode 2 isolation, `MEMTOMEM_WIKI_PATH` override)

```
=== gemini agent → stderr warning ===
warning: vendor 'gemini' will not represent these fields: skills, isolation
PASS: warning, skills, isolation, stdout summary

=== claude agent → stderr empty ===
PASS: stderr empty, stdout summary

=== codex command → classified error, no traceback ===
exit 1; stderr: Error: 'codex' commands not yet supported — see OVERRIDE_FORMATS placeholder
PASS: non-zero exit, classified message, no traceback

=== gemini command → stderr warning + .toml extension ===
warning: vendor 'gemini' will not represent these fields: argument-hint, allowed-tools, model
PASS: warning, argument-hint, allowed-tools, model, .toml extension
```

## Out of scope (subsequent PRs)

- `mm wiki <type> {edit, diff, lint}` — defined in ADR-0008 §Subcommands but C1b is explicitly override-only.
- `mm context update` / `status` / `install --all` / `migrate` — C2 / C3 / C4.

## Test coverage gap (follow-up)

- Codex agents drop set (`tools` / `skills` / `isolation` / `kind` / `temperature`) is exercised only through the shared helper path, not via a vendor-specific fixture. Gemini agents (`skills` / `isolation`) and gemini commands (`argument-hint` / `allowed-tools` / `model`) cover the warning code path; codex agents share that same path so the marginal regression-detection value is low. Add a codex-specific fixture when generator drop sets change or as part of a vendor-coverage cleanup PR — **not C2 scope**, since C2's dirty detection deals with file mtime, not vendor renderer drops.

## Post-review fixup

- `0a114df fixup(c1b): newline guard in test fixture helpers` — `_seed_agent` / `_seed_command` now normalise `frontmatter_extra` to end with a trailing `\n`. Current call sites already do this; the guard prevents a future fixture from silently producing a malformed YAML frontmatter (closing `---` merging into the previous line). Test-only impact, +12 / -2 lines.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_wiki_cmd_override.py packages/memtomem/tests/test_wiki_override.py -v` — 36 pass.
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama" -q` — 3475 pass.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean.
- [x] Manual mode-2 smoke — 4 / 4 pass.
- [ ] CI green (waiting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
