### PR TITLE
fix(install): capture installed_at at lockfile upsert (PR-D C2a, ADR-0008)

### DIFF
--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -113,6 +113,11 @@ def _install_asset(
     individual files consistent, so byte content under ``dest`` converges
     even if the workers interleave. Distinct-asset writers serialize
     cleanly on the lockfile sidecar lock and both entries survive.
+
+    ``installed_at`` is captured at the lockfile-upsert boundary (after the
+    copytree completes) so that a subsequent ``mm context update``'s
+    ``mtime > installed_at`` dirty check cannot false-positive on the
+    install's own writes.
     """
     validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     project_root = Path(project_root).expanduser()
@@ -127,7 +132,6 @@ def _install_asset(
         raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}")
 
     wiki_commit = wiki.current_commit()
-    installed_at = utcnow_iso8601_z()
 
     dest = project_root / ".memtomem" / asset_type / validated
     lock = Lockfile.at(project_root)
@@ -147,6 +151,7 @@ def _install_asset(
     dest.parent.mkdir(parents=True, exist_ok=True)
     files_written = copy_tree_atomic(src, dest)
 
+    installed_at = utcnow_iso8601_z()
     lock.upsert_entry(
         asset_type,
         validated,

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -11,6 +11,7 @@ import json
 import multiprocessing as mp
 import shutil
 import subprocess
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -99,6 +100,47 @@ def test_install_records_lockfile_entry(wiki_root: Path, tmp_path: Path) -> None
     assert lock_doc["version"] == LOCKFILE_VERSION
     assert lock_doc["skills"]["foo"]["wiki_commit"] == expected_commit
     assert lock_doc["skills"]["foo"]["installed_at"] == result.installed_at
+
+
+def test_installed_at_after_all_writes(wiki_root: Path, tmp_path: Path) -> None:
+    """``installed_at`` is captured *after* every dest file is written.
+
+    Regression for ADR-0008 PR-D's ``mtime > installed_at`` dirty check.
+    If ``installed_at`` were captured before ``copy_tree_atomic``, a large
+    copytree could leave dest files with mtimes later than ``installed_at``,
+    false-positiving as dirty on the very next ``mm context update``.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_skill(
+        wiki_root,
+        "foo",
+        {
+            "SKILL.md": b"# foo skill\n",
+            "scripts/run.sh": b"#!/bin/bash\necho hi\n",
+            "scripts/helper.py": b"print('helper')\n",
+            "overrides/claude.md": b"claude-only override\n",
+        },
+    )
+    project = tmp_path
+
+    result = install_skill(project, "foo")
+
+    installed_at_epoch = datetime.fromisoformat(result.installed_at).timestamp()
+
+    dest = project / ".memtomem" / "skills" / "foo"
+    file_mtimes = [f.stat().st_mtime for f in dest.rglob("*") if f.is_file()]
+    assert file_mtimes, "expected dest tree to contain files"
+
+    max_mtime = max(file_mtimes)
+    # installed_at MUST be >= max(dest file mtime). Allow 1ms slack to absorb
+    # fs precision differences between the kernel's mtime clock and Python's
+    # datetime.now() — both are wallclock-derived but may round at different
+    # resolutions on some platforms.
+    assert installed_at_epoch + 0.001 >= max_mtime, (
+        f"installed_at ({result.installed_at}, epoch={installed_at_epoch:.6f}) "
+        f"earlier than newest dest file mtime ({max_mtime:.6f}); "
+        f"diff={max_mtime - installed_at_epoch:.6f}s"
+    )
 
 
 def test_install_skips_dotgit_in_source(wiki_root: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- **PR-B fixup** that ships independently of PR-D C2's `mm context update` work.
- `installed_at` was captured **before** `copy_tree_atomic`, leaving freshly installed files with mtimes potentially later than the recorded `installed_at`. ADR-0008 PR-D's `mtime > installed_at` dirty check ([Invariant 2](https://github.com/memtomem/memtomem/blob/main/docs/adr/0008-wiki-layer.md#invariant-2--explicit-conflict-surface-for-local-edits)) would then false-positive on the install's own writes under any non-trivial copytree latency.
- Move capture to the **lockfile-upsert boundary** (after copy completes) so `mtime <= installed_at` holds for fresh installs by construction.

## Why standalone

C2 (`mm context update` + dirty detection) consumes this invariant in its `is_asset_dirty()` classifier. Splitting the fixup into its own PR keeps that change reviewable as a real PR-B bug fix, independent of C2's much larger surface (`update` CLI, `--all` cross-project, `.bak` semantics).

No user-visible behavior change today; the lockfile semantic is tightened so the upcoming dirty check is sound.

## Test plan

- [x] New regression test `test_installed_at_after_all_writes`: install a multi-file skill (4 files across 3 subdirs), walk dest, assert parsed `installed_at >= max(dest mtimes)` within 1ms slack.
- [x] Existing 19 install tests pass unchanged (`packages/memtomem/tests/test_context_install.py`).
- [x] Adjacent suites pass: `test_context_install_widening.py`, `test_lockfile.py`.
- [x] Full CI filter `uv run pytest -m "not ollama"` — 3476 passed, 46 deselected.
- [x] `ruff check` + `ruff format --check` — green.

## Series

Part of [ADR-0008](https://github.com/memtomem/memtomem/blob/main/docs/adr/0008-wiki-layer.md) wiki layer:
- ✓ #622 PR-A — wiki scaffold
- ✓ #623 PR-B — `mm context install` + lockfile + concurrency
- ✓ #624 PR-C — wiki override + agent/command install widening
- ✓ #627 PR-D-prep — fan-out application sites
- ✓ #628 PR-D C1a — gate flip + render lift
- ✓ #629 PR-D C1b — `mm wiki {agent,command} override` CLI mirror
- ➜ **this PR** — installed_at fixup (C2 prereq)
- (next) PR-D C2 — `mm context update` + dirty detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)