### PR TITLE
PR-D C2 main: mm context update + --all + dirty classifier (ADR-0008)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -860,9 +860,11 @@ def _run_update_all(
             wiki=wiki,
             projects=project_roots,
         )
-    except AssetNotFoundError as exc:
-        raise click.ClickException(str(exc)) from exc
     except InvalidNameError as exc:
+        # Validation gate fires before any per-project loop runs; surface
+        # the message verbatim so the user knows which name was rejected.
+        raise click.ClickException(str(exc)) from exc
+    except AssetNotFoundError as exc:
         raise click.ClickException(str(exc)) from exc
 
     if not classifications:

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -31,7 +31,10 @@ from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
     NotInstalledError,
+    ProjectClassification,
     StaleInstallError,
+    _apply_update,
+    _classify_for_all_update,
     install_agent,
     install_command,
     install_skill,
@@ -39,6 +42,7 @@ from memtomem.context.install import (
     update_command,
     update_skill,
 )
+from memtomem.context.projects import KnownProjectsStore
 from memtomem.context.lockfile import LockfileVersionError
 from memtomem.context.generator import (
     GENERATORS,
@@ -55,7 +59,8 @@ from memtomem.context.skills import (
     extract_skills_to_canonical,
     generate_all_skills,
 )
-from memtomem.wiki.store import WikiNotFoundError
+from memtomem.wiki.store import WikiNotFoundError, WikiStore
+from memtomem.config import ContextGatewayConfig
 
 # Phase 1-3 supports skills/agents/commands; Phase D adds settings.
 _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
@@ -693,31 +698,75 @@ def install_cmd(asset_type: str, name: str) -> None:
     click.echo(f"  {result.files_written} file(s) copied")
 
 
+_WIKI_DIRTY_WARN = "warning: wiki has uncommitted changes; using HEAD which doesn't include them"
+
+
 @context.command("update")
 @click.argument("asset_type", type=click.Choice(["skill", "agent", "command"]))
 @click.argument("name")
 @click.option(
+    "--all",
+    "all_projects",
+    is_flag=True,
+    help="Apply across every known project that has this asset installed.",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip the confirmation prompt — intended for automation (cron / CI).",
+)
+@click.option(
     "--force",
     is_flag=True,
-    help="Overwrite local edits; each dirty file is preserved as <file>.bak",
+    help="Overwrite local edits; each dirty file is preserved as <file>.bak.",
 )
-def update_cmd(asset_type: str, name: str, force: bool) -> None:
+def update_cmd(
+    asset_type: str,
+    name: str,
+    all_projects: bool,
+    yes: bool,
+    force: bool,
+) -> None:
     """Refresh an installed wiki asset from the wiki HEAD.
 
-    No-op when the wiki commit pinned in ``.memtomem/lock.json`` already
-    matches the wiki HEAD — the lockfile is not touched and ``unchanged``
-    is reported. Refuses to write when local edits are detected, unless
-    ``--force`` is passed (which preserves each dirty file as a sibling
-    ``.bak`` before overwriting with wiki bytes).
+    Without ``--all``: refresh in the current project only. No-op when
+    the wiki commit pinned in ``.memtomem/lock.json`` already matches
+    the wiki HEAD — the lockfile is not touched and ``unchanged`` is
+    reported. Refuses to write when local edits are detected, unless
+    ``--force`` is passed (each dirty file is preserved as ``<file>.bak``
+    before overwriting with wiki bytes).
+
+    With ``--all``: classify the asset across every known project, print
+    a 4-state preview (update / unchanged / refuse / error), prompt for
+    confirmation, then refresh each project that needs it. ``--yes``
+    skips the prompt for automation. ``--yes --force`` is the
+    automation invariant — destructive batch with WARNING on stderr,
+    no prompt.
     """
     root = _find_project_root()
+
+    # Pin wiki + dirty warn — applies to both single-asset and --all paths.
+    # Warn timing: at update entry, BEFORE classification, BEFORE prompt.
+    try:
+        wiki = WikiStore.at_default()
+        wiki.require_exists()
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if wiki.is_dirty():
+        click.secho(_WIKI_DIRTY_WARN, fg="yellow", err=True)
+
+    if all_projects:
+        _run_update_all(asset_type, name, root, wiki=wiki, yes=yes, force=force)
+        return
+
     try:
         if asset_type == "skill":
-            result = update_skill(root, name, force=force)
+            result = update_skill(root, name, wiki=wiki, force=force)
         elif asset_type == "agent":
-            result = update_agent(root, name, force=force)
+            result = update_agent(root, name, wiki=wiki, force=force)
         elif asset_type == "command":
-            result = update_command(root, name, force=force)
+            result = update_command(root, name, wiki=wiki, force=force)
         else:  # pragma: no cover — guarded by click.Choice
             raise click.ClickException(f"unknown asset type: {asset_type}")
     except WikiNotFoundError as exc:
@@ -753,3 +802,176 @@ def update_cmd(asset_type: str, name: str, force: bool) -> None:
             f"  {len(result.bak_files_written)} dirty file(s) preserved as .bak",
             fg="yellow",
         )
+
+
+def _run_update_all(
+    asset_type: str,
+    name: str,
+    root: Path,
+    *,
+    wiki: WikiStore,
+    yes: bool,
+    force: bool,
+) -> None:
+    """Orchestrate ``mm context update <type> <name> --all``.
+
+    Flow (matches plan locked decisions):
+    1. Load known projects (``KnownProjectsStore.load()`` — gap E
+       correction; the design's earlier ``list_entries()`` reference does
+       not exist in the actual API).
+    2. Classify across all roots in one pass — ``current_commit`` and
+       ``is_asset_dirty`` each run at most once per project, all cached
+       on :class:`ProjectClassification` for the execute phase.
+    3. Print a 4-state preview table.
+    4. Empty store / "no projects have asset" exit 0 informationally —
+       cron/CI safety so a first-run before any registration succeeds.
+    5. ``refuse`` without ``--force`` aborts the entire batch (no partial
+       writes).
+    6. ``--yes --force`` prints WARNING + skips prompt + executes.
+    7. Serial execute consumes cached ``dirty_report`` / ``lock_entry``;
+       no second walk per project.
+    """
+    cfg = ContextGatewayConfig()
+    store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
+    project_entries = store.load()
+
+    if not project_entries:
+        click.echo(
+            "No known projects registered. Add via the `mm web` UI "
+            "or directly in known_projects.json.",
+            err=True,
+        )
+        return
+
+    project_roots = [e.root for e in project_entries if e.root.is_dir()]
+    if not project_roots:
+        click.echo(
+            "No registered projects exist on disk; nothing to update.",
+            err=True,
+        )
+        return
+
+    asset_type_plural = f"{asset_type}s"
+
+    try:
+        new_commit, classifications = _classify_for_all_update(
+            asset_type_plural,
+            name,
+            wiki=wiki,
+            projects=project_roots,
+        )
+    except AssetNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not classifications:
+        click.echo(
+            f"No projects have {asset_type_plural}/{name} installed.",
+            err=True,
+        )
+        return
+
+    _print_classification_table(classifications, asset_type_plural, name, new_commit)
+
+    needs_update = [c for c in classifications if c.state == "update"]
+    needs_force = [c for c in classifications if c.state == "refuse"]
+    has_errors = [c for c in classifications if c.state == "error"]
+
+    if not needs_update and not needs_force and not has_errors:
+        click.echo("\nAll projects are up to date.")
+        return
+
+    if needs_force and not force:
+        click.secho(
+            f"\n{len(needs_force)} project(s) have local edits; "
+            f"pass --force to overwrite (each dirty file gets a .bak sibling). "
+            f"Refusing to write any project — re-run with --force or resolve manually.",
+            fg="red",
+            err=True,
+        )
+        raise click.exceptions.Exit(1)
+
+    if yes and force:
+        click.secho(
+            "WARNING: --yes --force is destructive — all dirty files will be "
+            "overwritten across the batch.",
+            fg="red",
+            err=True,
+        )
+
+    if not yes:
+        click.confirm("\nContinue?", abort=True)
+
+    successes = 0
+    failures = 0
+    for c in classifications:
+        if c.state == "unchanged":
+            click.secho(f"  - {c.project_root}: unchanged", fg="cyan")
+            continue
+        if c.state == "error":
+            click.secho(f"  ✗ {c.project_root}: {c.reason}", fg="red")
+            failures += 1
+            continue
+
+        # state in {"update", "refuse"} — execute via _apply_update with
+        # cached dirty_report + lock_entry (no re-walk).
+        assert c.lock_entry is not None
+        assert c.dirty_report is not None
+        src = wiki.root / asset_type_plural / name
+        dest = c.project_root / ".memtomem" / asset_type_plural / name
+        try:
+            _apply_update(
+                c.project_root,
+                asset_type_plural,
+                name,
+                src=src,
+                dest=dest,
+                wiki_commit=new_commit,
+                lock_entry=c.lock_entry,
+                dirty_report=c.dirty_report,
+                force=force,
+            )
+        except StaleInstallError as exc:
+            click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
+            failures += 1
+        except OSError as exc:
+            click.secho(f"  ✗ {c.project_root}: {exc}", fg="red")
+            failures += 1
+        else:
+            click.secho(f"  ✓ {c.project_root}: updated", fg="green")
+            successes += 1
+
+    click.echo(
+        f"\nSummary: {successes} updated, {failures} failed, "
+        f"{len(classifications) - successes - failures} unchanged."
+    )
+
+
+def _print_classification_table(
+    classifications: list[ProjectClassification],
+    asset_type_plural: str,
+    name: str,
+    new_commit: str,
+) -> None:
+    """Render the 4-state preview table for ``--all`` confirmation.
+
+    Columns: state · project root (relative when possible) · reason
+    (only shown for ``refuse`` and ``error`` rows where it carries info).
+    """
+    click.echo(
+        f"\n{asset_type_plural}/{name} — wiki HEAD {new_commit[:12]} — "
+        f"{len(classifications)} project(s):"
+    )
+    state_color = {
+        "update": "green",
+        "unchanged": "cyan",
+        "refuse": "yellow",
+        "error": "red",
+    }
+    for c in classifications:
+        color = state_color[c.state]
+        line = f"  {c.state:10s}  {c.project_root}"
+        if c.reason:
+            line += f"  ({c.reason})"
+        click.secho(line, fg=color)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -30,9 +30,14 @@ from memtomem.context.detector import (
 from memtomem.context.install import (
     AlreadyInstalledError,
     AssetNotFoundError,
+    NotInstalledError,
+    StaleInstallError,
     install_agent,
     install_command,
     install_skill,
+    update_agent,
+    update_command,
+    update_skill,
 )
 from memtomem.context.lockfile import LockfileVersionError
 from memtomem.context.generator import (
@@ -686,3 +691,65 @@ def install_cmd(asset_type: str, name: str) -> None:
     rel_dest = result.dest.relative_to(root) if result.dest.is_relative_to(root) else result.dest
     click.echo(f"  → {rel_dest}/")
     click.echo(f"  {result.files_written} file(s) copied")
+
+
+@context.command("update")
+@click.argument("asset_type", type=click.Choice(["skill", "agent", "command"]))
+@click.argument("name")
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Overwrite local edits; each dirty file is preserved as <file>.bak",
+)
+def update_cmd(asset_type: str, name: str, force: bool) -> None:
+    """Refresh an installed wiki asset from the wiki HEAD.
+
+    No-op when the wiki commit pinned in ``.memtomem/lock.json`` already
+    matches the wiki HEAD — the lockfile is not touched and ``unchanged``
+    is reported. Refuses to write when local edits are detected, unless
+    ``--force`` is passed (which preserves each dirty file as a sibling
+    ``.bak`` before overwriting with wiki bytes).
+    """
+    root = _find_project_root()
+    try:
+        if asset_type == "skill":
+            result = update_skill(root, name, force=force)
+        elif asset_type == "agent":
+            result = update_agent(root, name, force=force)
+        elif asset_type == "command":
+            result = update_command(root, name, force=force)
+        else:  # pragma: no cover — guarded by click.Choice
+            raise click.ClickException(f"unknown asset type: {asset_type}")
+    except WikiNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except AssetNotFoundError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except NotInstalledError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except StaleInstallError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except LockfileVersionError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if result.was_no_op:
+        click.secho(
+            f"{result.asset_type}/{result.name} unchanged (wiki {result.new_wiki_commit[:12]})",
+            fg="cyan",
+        )
+        return
+
+    click.secho(
+        f"Updated {result.asset_type}/{result.name} "
+        f"({result.old_wiki_commit[:12]} → {result.new_wiki_commit[:12]})",
+        fg="green",
+    )
+    rel_dest = result.dest.relative_to(root) if result.dest.is_relative_to(root) else result.dest
+    click.echo(f"  → {rel_dest}/")
+    click.echo(f"  {result.files_written} file(s) updated")
+    if result.bak_files_written:
+        click.secho(
+            f"  {len(result.bak_files_written)} dirty file(s) preserved as .bak",
+            fg="yellow",
+        )

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -38,12 +38,29 @@ from memtomem.context._atomic import COPY_SKIP_NAMES
 from memtomem.context.lockfile import Lockfile
 
 __all__ = [
+    "DIRTY_SKIP_SUFFIXES",
     "DirtyReason",
     "DirtyReport",
     "is_asset_dirty",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+DIRTY_SKIP_SUFFIXES: frozenset[str] = frozenset({".bak"})
+"""Suffix patterns the dirty walker skips beyond :data:`COPY_SKIP_NAMES`.
+
+``.bak`` — sibling files created by ``mm context update --force`` to
+preserve user edits before overwriting with wiki bytes. They live in
+the dest tree by design and carry the user's pre-update mtime, so
+without this skip they would trip the next ``mm context update`` into
+``reason="dirty"`` purely on the prior backup, refusing every future
+update until the user manually deletes the ``.bak``.
+
+This is a *dirty-walk* skip only — ``copy_tree_atomic`` does not need
+the same exclusion (the wiki is not expected to carry ``.bak`` files
+under normal operation).
+"""
 
 
 DirtyReason = Literal["clean", "dirty", "never_installed", "missing_dest"]
@@ -149,6 +166,8 @@ def _iter_files(root: Path) -> Iterator[Path]:
     """
     for entry in root.iterdir():
         if entry.name in COPY_SKIP_NAMES:
+            continue
+        if entry.suffix in DIRTY_SKIP_SUFFIXES:
             continue
         if entry.is_symlink():
             logger.warning("is_asset_dirty: skipping symlink %s", entry)

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -1,0 +1,159 @@
+"""Detect drift between installed asset bytes and their lockfile snapshot.
+
+Pure classifier used by ``mm context update`` to decide whether the
+on-disk tree at ``<project>/.memtomem/<type>/<name>/`` still matches the
+wiki state recorded in :class:`memtomem.context.lockfile.Lockfile`.
+
+The compare rule is **strict** ``mtime > installed_at_epoch`` — only files
+whose modification time is *strictly* later than the lockfile's
+``installed_at`` are flagged dirty. Equality is clean. PR-D C2a (#630)
+captures ``installed_at`` after :func:`copy_tree_atomic
+<memtomem.context._atomic.copy_tree_atomic>` finishes, so the install's
+own writes can never land at a strictly-later mtime than the captured
+timestamp; the dirty classifier therefore can't false-positive on a fresh
+install.
+
+Skip rules mirror :data:`memtomem.context._atomic.COPY_SKIP_NAMES`:
+``.git``, ``.DS_Store``, ``__pycache__`` are not part of the canonical
+install surface, so user edits to such entries don't make the asset
+dirty. Symlinks are skipped with a warning — ``copy_tree_atomic`` won't
+mirror them into dest in the first place, and dereferencing one here
+would defeat the byte-for-byte tree contract.
+
+This module is read-only. The execute path (``mm context update``)
+consumes a :class:`DirtyReport` and writes ``.bak`` files / overwrites
+the dest tree separately.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from memtomem.context._atomic import COPY_SKIP_NAMES
+from memtomem.context.lockfile import Lockfile
+
+__all__ = [
+    "DirtyReason",
+    "DirtyReport",
+    "is_asset_dirty",
+]
+
+logger = logging.getLogger(__name__)
+
+
+DirtyReason = Literal["clean", "dirty", "never_installed", "missing_dest"]
+
+
+@dataclass(frozen=True)
+class DirtyReport:
+    """Outcome of a dirty check on a single installed asset.
+
+    - ``reason="clean"`` — dest exists and every checked file's mtime is
+      ``<= installed_at_epoch``.
+    - ``reason="dirty"`` — at least one checked file has
+      ``mtime > installed_at_epoch``; the offending paths are in
+      ``dirty_files``.
+    - ``reason="never_installed"`` — no usable lockfile entry;
+      ``installed_at`` is ``None`` and ``dirty_files`` / ``checked_files``
+      are empty. Returned for both "no entry at all" and "entry exists
+      but missing/non-string ``installed_at``" — both are unrecoverable
+      states for a strict mtime compare.
+    - ``reason="missing_dest"`` — lockfile entry exists but
+      ``<project>/.memtomem/<type>/<name>/`` was deleted; ``installed_at``
+      is the lockfile value, ``dirty_files`` empty.
+    """
+
+    reason: DirtyReason
+    installed_at: str | None
+    dirty_files: tuple[Path, ...]
+    checked_files: int
+
+
+def is_asset_dirty(
+    project_root: Path | str,
+    asset_type: str,
+    name: str,
+    *,
+    lock_entry: dict[str, Any] | None = None,
+) -> DirtyReport:
+    """Classify an installed asset as clean / dirty / never_installed / missing_dest.
+
+    Pure: walks the dest tree, reads file mtimes, returns a
+    :class:`DirtyReport`. No writes, no lockfile mutations.
+
+    ``lock_entry`` is optional caller injection — pass it when the caller
+    already loaded the lockfile (e.g. ``mm context update --all``
+    classification reuses one read across N projects). When omitted,
+    we read the entry from ``<project>/.memtomem/lock.json``.
+    """
+    project_root_path = Path(project_root).expanduser()
+
+    if lock_entry is None:
+        lock_entry = Lockfile.at(project_root_path).read_entry(asset_type, name)
+
+    if lock_entry is None:
+        return DirtyReport(
+            reason="never_installed",
+            installed_at=None,
+            dirty_files=(),
+            checked_files=0,
+        )
+
+    installed_at = lock_entry.get("installed_at")
+    if not isinstance(installed_at, str):
+        return DirtyReport(
+            reason="never_installed",
+            installed_at=None,
+            dirty_files=(),
+            checked_files=0,
+        )
+
+    dest = project_root_path / ".memtomem" / asset_type / name
+    if not dest.is_dir():
+        return DirtyReport(
+            reason="missing_dest",
+            installed_at=installed_at,
+            dirty_files=(),
+            checked_files=0,
+        )
+
+    installed_at_epoch = datetime.fromisoformat(installed_at).timestamp()
+
+    dirty: list[Path] = []
+    checked = 0
+    for file_path in _iter_files(dest):
+        checked += 1
+        if file_path.stat().st_mtime > installed_at_epoch:
+            dirty.append(file_path)
+
+    return DirtyReport(
+        reason="dirty" if dirty else "clean",
+        installed_at=installed_at,
+        dirty_files=tuple(dirty),
+        checked_files=checked,
+    )
+
+
+def _iter_files(root: Path) -> Iterator[Path]:
+    """Yield non-skipped, non-symlink files under *root* recursively.
+
+    Mirrors :func:`memtomem.context._atomic.copy_tree_atomic` traversal
+    rules: skip entries named in :data:`COPY_SKIP_NAMES`, skip symlinks
+    with a warning. Caller is responsible for the count semantics
+    (:attr:`DirtyReport.checked_files` reflects yielded entries only).
+    """
+    for entry in root.iterdir():
+        if entry.name in COPY_SKIP_NAMES:
+            continue
+        if entry.is_symlink():
+            logger.warning("is_asset_dirty: skipping symlink %s", entry)
+            continue
+        if entry.is_file():
+            yield entry
+        elif entry.is_dir():
+            yield from _iter_files(entry)

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -31,7 +31,7 @@ from typing import Any, Literal, cast
 from memtomem.context._atomic import copy_tree_atomic
 from memtomem.context._names import validate_name
 from memtomem.context.dirty import DirtyReport, is_asset_dirty
-from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.context.lockfile import Lockfile, LockfileVersionError, utcnow_iso8601_z
 from memtomem.wiki.store import WikiStore
 
 __all__ = [
@@ -112,6 +112,39 @@ class UpdateResult:
     bak_files_written: tuple[Path, ...]
     dest: Path
     files_written: int
+
+
+@dataclass(frozen=True)
+class ProjectClassification:
+    """Per-project classification produced by :func:`_classify_for_all_update`.
+
+    The dataclass *caches* the per-project lockfile read and the dirty walk
+    so the execute phase can reuse them — the same expensive operations
+    must not run twice between preview and write.
+
+    State semantics:
+
+    - ``"update"`` — wiki HEAD ≠ lockfile pin AND dest is clean. Will
+      copy wiki bytes when the user confirms.
+    - ``"unchanged"`` — wiki HEAD == lockfile pin. No-op; ``dirty_report``
+      stays ``None`` because the dirty walk was skipped (cheap by design).
+    - ``"refuse"`` — wiki HEAD ≠ lockfile pin AND dest has local edits.
+      Without ``--force`` the entire batch refuses.
+    - ``"error"`` — the project's lockfile is corrupt or unreadable;
+      ``reason`` carries the detail. Propagates as a row-level failure
+      in the execute summary.
+
+    ``lock_entry`` is the live lockfile entry (carries ``installed_at``
+    and ``wiki_commit``). ``dirty_report`` is populated only for
+    ``"update"`` and ``"refuse"`` states — the two cases where the
+    dirty walk actually ran.
+    """
+
+    project_root: Path
+    state: Literal["update", "unchanged", "refuse", "error"]
+    reason: str | None
+    lock_entry: dict[str, Any] | None
+    dirty_report: DirtyReport | None
 
 
 def install_skill(
@@ -421,3 +454,118 @@ def _apply_update(
         dest=dest,
         files_written=files_written,
     )
+
+
+def _classify_for_all_update(
+    asset_type: str,
+    name: str,
+    *,
+    wiki: WikiStore,
+    projects: list[Path],
+) -> tuple[str, list[ProjectClassification]]:
+    """Classify ``asset_type/name`` across many project roots in one pass.
+
+    Returns ``(new_commit, classifications)`` — the wiki HEAD pinned at
+    the start of the call, paired with the per-project verdicts. The
+    caller is expected to thread ``new_commit`` into each subsequent
+    :func:`_apply_update` invocation so the execute phase writes against
+    the same snapshot the user confirmed.
+
+    Used by ``mm context update --all``. The wiki state is read **once**
+    up front: ``wiki.current_commit()`` and the source-asset existence
+    check both happen before the per-project loop, so every project is
+    classified against the same snapshot. This guarantees the preview
+    table the user confirms against matches what the execute phase will
+    actually see.
+
+    Per-project work cached on the resulting :class:`ProjectClassification`:
+
+    - ``lock_entry`` — the lockfile read result (avoids a second read
+      during the execute phase).
+    - ``dirty_report`` — the :func:`is_asset_dirty` walk for the dest tree
+      (only populated when ``state in {"update", "refuse"}``; the
+      ``unchanged`` short-circuit skips the walk entirely since the
+      lockfile pin matches HEAD and the dest tree is, by definition,
+      what was installed at that pin).
+
+    Projects without a lockfile entry for this asset are silently
+    skipped (no result row): they were never in scope for this
+    asset_type/name, so a "you skipped me" row would just clutter the
+    preview. A corrupt lockfile is the exception — it produces an
+    explicit ``"error"`` row so the user can see and triage.
+
+    The wiki source asset is read once up front. If it's missing,
+    callers get :class:`AssetNotFoundError` here, *before* any project
+    loop runs — preventing a confusing per-project "asset not found"
+    storm.
+    """
+    new_commit = wiki.current_commit()
+    src = wiki.root / asset_type / name
+    if not src.is_dir():
+        raise AssetNotFoundError(f"{asset_type}/{name} not in wiki at {wiki.root}")
+
+    out: list[ProjectClassification] = []
+    for project_root in projects:
+        try:
+            lock = Lockfile.at(project_root)
+            lock_entry = lock.read_entry(asset_type, name)
+        except LockfileVersionError as exc:
+            out.append(
+                ProjectClassification(
+                    project_root=project_root,
+                    state="error",
+                    reason=str(exc),
+                    lock_entry=None,
+                    dirty_report=None,
+                )
+            )
+            continue
+        except OSError as exc:
+            out.append(
+                ProjectClassification(
+                    project_root=project_root,
+                    state="error",
+                    reason=str(exc),
+                    lock_entry=None,
+                    dirty_report=None,
+                )
+            )
+            continue
+
+        if lock_entry is None:
+            # Asset never installed in this project — silently skip
+            # (no preview-table row).
+            continue
+
+        if lock_entry.get("wiki_commit") == new_commit:
+            out.append(
+                ProjectClassification(
+                    project_root=project_root,
+                    state="unchanged",
+                    reason=None,
+                    lock_entry=lock_entry,
+                    dirty_report=None,
+                )
+            )
+            continue
+
+        # Wiki advanced — classify dirty/clean for this project.
+        report = is_asset_dirty(project_root, asset_type, name, lock_entry=lock_entry)
+        if report.reason == "dirty":
+            state: Literal["update", "unchanged", "refuse", "error"] = "refuse"
+            reason: str | None = f"{len(report.dirty_files)} file(s) modified locally since install"
+        else:
+            state = "update"
+            reason = None
+
+        out.append(
+            ProjectClassification(
+                project_root=project_root,
+                state=state,
+                reason=reason,
+                lock_entry=lock_entry,
+                dirty_report=report,
+            )
+        )
+
+    return new_commit, out

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -498,7 +498,16 @@ def _classify_for_all_update(
     callers get :class:`AssetNotFoundError` here, *before* any project
     loop runs — preventing a confusing per-project "asset not found"
     storm.
+
+    ``name`` is validated at the boundary (defense in depth) — even
+    though the CLI ``update_cmd`` is the expected upstream caller, this
+    helper also accepts ``name`` as input to a ``Path`` join (``src =
+    wiki.root / asset_type / name``) and the per-project ``dest``, so
+    a malicious ``../escape`` would escape both. ``feedback_public_api_
+    ship_time_validation`` — validate at the function entry, not just
+    at the convenience caller.
     """
+    name = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
     new_commit = wiki.current_commit()
     src = wiki.root / asset_type / name
     if not src.is_dir():

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -23,12 +23,14 @@ clobbered") without depending on PR-D's mtime/dirty detection. PR-D's
 
 from __future__ import annotations
 
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from memtomem.context._atomic import copy_tree_atomic
 from memtomem.context._names import validate_name
+from memtomem.context.dirty import DirtyReport, is_asset_dirty
 from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
 from memtomem.wiki.store import WikiStore
 
@@ -36,9 +38,15 @@ __all__ = [
     "AlreadyInstalledError",
     "AssetNotFoundError",
     "InstallResult",
+    "NotInstalledError",
+    "StaleInstallError",
+    "UpdateResult",
     "install_agent",
     "install_command",
     "install_skill",
+    "update_agent",
+    "update_command",
+    "update_skill",
 ]
 
 
@@ -50,6 +58,24 @@ class AlreadyInstalledError(RuntimeError):
     """Raised when install would overwrite an existing lockfile entry or dest."""
 
 
+class NotInstalledError(RuntimeError):
+    """Raised by ``_update_asset`` when there is no lockfile entry to refresh.
+
+    Distinguishes "you forgot to install first" from "the wiki asset moved" —
+    the CLI maps both to a non-zero exit code, but the message points the
+    user at ``mm context install`` rather than implying an internal error.
+    """
+
+
+class StaleInstallError(RuntimeError):
+    """Raised by ``_update_asset`` when local edits would be clobbered.
+
+    The dest tree has at least one file with ``mtime > installed_at`` and
+    ``--force`` was not set. The message includes the count and points
+    the user at ``--force`` (which preserves dirty files as ``.bak``).
+    """
+
+
 @dataclass(frozen=True)
 class InstallResult:
     """Outcome of a successful install. Display-oriented; not persisted."""
@@ -58,6 +84,32 @@ class InstallResult:
     name: str
     wiki_commit: str
     installed_at: str
+    dest: Path
+    files_written: int
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Outcome of an ``mm context update`` call. Display-oriented; not persisted.
+
+    - ``was_no_op=True`` means the wiki HEAD already matched the
+      lockfile pin — the lockfile bytes were *not* touched, so
+      ``installed_at`` is the value previously recorded (echoed for
+      display) and ``files_written``/``bak_files_written`` are empty.
+    - ``was_no_op=False`` means a real refresh happened: the dest tree
+      was overwritten with wiki bytes, ``installed_at`` was re-captured
+      after the copy, and any dirty files were preserved at the listed
+      ``.bak`` paths (only populated when ``--force`` was used against
+      a dirty asset).
+    """
+
+    asset_type: Literal["skills", "agents", "commands"]
+    name: str
+    old_wiki_commit: str
+    new_wiki_commit: str
+    installed_at: str
+    was_no_op: bool
+    bak_files_written: tuple[Path, ...]
     dest: Path
     files_written: int
 
@@ -139,13 +191,13 @@ def _install_asset(
     has_lock = existing is not None
     has_dest = dest.exists()
     if has_lock or has_dest:
+        asset_type_singular = asset_type.removesuffix("s")
         raise AlreadyInstalledError(
             f"{asset_type}/{validated}: "
             f"lockfile_entry={'yes' if has_lock else 'no'}, "
             f"dest={'yes' if has_dest else 'no'}; "
-            f"`mm context update` is reserved for PR-D — "
-            f"to reinstall now, remove BOTH .memtomem/{asset_type}/{validated}/ "
-            f"AND the `{asset_type}.{validated}` entry from .memtomem/lock.json"
+            f"run `mm context update {asset_type_singular} {validated}` "
+            f"to refresh from wiki HEAD"
         )
 
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -164,6 +216,208 @@ def _install_asset(
         name=validated,
         wiki_commit=wiki_commit,
         installed_at=installed_at,
+        dest=dest,
+        files_written=files_written,
+    )
+
+
+def update_skill(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+    force: bool = False,
+) -> UpdateResult:
+    """Refresh ``<wiki>/skills/<name>/`` snapshot at ``<project>/.memtomem/skills/<name>/``.
+
+    No-op when wiki HEAD already matches the lockfile pin. Refuses when
+    local edits would be clobbered, unless ``force=True`` (which preserves
+    each dirty file as ``<file>.bak`` before overwriting).
+    """
+    return _update_asset(project_root, "skills", name, wiki=wiki, force=force)
+
+
+def update_agent(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+    force: bool = False,
+) -> UpdateResult:
+    """Refresh ``<wiki>/agents/<name>/`` snapshot at ``<project>/.memtomem/agents/<name>/``."""
+    return _update_asset(project_root, "agents", name, wiki=wiki, force=force)
+
+
+def update_command(
+    project_root: Path | str,
+    name: str,
+    *,
+    wiki: WikiStore | None = None,
+    force: bool = False,
+) -> UpdateResult:
+    """Refresh ``<wiki>/commands/<name>/`` snapshot at ``<project>/.memtomem/commands/<name>/``."""
+    return _update_asset(project_root, "commands", name, wiki=wiki, force=force)
+
+
+def _update_asset(
+    project_root: Path | str,
+    asset_type: str,
+    name: str,
+    *,
+    wiki: WikiStore | None,
+    force: bool = False,
+) -> UpdateResult:
+    """Internal: refresh a single installed asset of any type.
+
+    Pipeline:
+
+    1. Validate ``name`` and project root.
+    2. Locate the wiki + the source asset directory (``AssetNotFoundError``
+       if the wiki has dropped the asset entirely).
+    3. Read the existing lockfile entry — ``NotInstalledError`` if absent.
+    4. Pin wiki HEAD as ``new_commit`` once (concurrent ``git pull`` in the
+       wiki cannot make the recorded commit drift mid-update).
+    5. **True no-op short-circuit**: when ``new_commit`` matches the lockfile
+       pin, return early *without touching the lockfile*. ``installed_at``
+       is echoed from the existing entry; ``was_no_op=True``.
+    6. Classify the dest tree via :func:`is_asset_dirty` (using the lock
+       entry we already loaded — no second lockfile read).
+    7. Delegate to :func:`_apply_update` for the refuse-or-write step.
+
+    The split lets ``mm context update --all`` (commit 4) reuse step 7
+    after performing classification across all known projects up front.
+    """
+    validated = validate_name(name, kind=f"{asset_type.removesuffix('s')} name")
+    project_root = Path(project_root).expanduser()
+    if not project_root.is_dir():
+        raise FileNotFoundError(f"project root does not exist: {project_root}")
+
+    wiki = wiki if wiki is not None else WikiStore.at_default()
+    wiki.require_exists()
+
+    # NotInstalled check before asset check: if the user never installed,
+    # the most useful error points at `mm context install`, not at
+    # `wiki has lost the asset`.
+    lock = Lockfile.at(project_root)
+    lock_entry = lock.read_entry(asset_type, validated)
+    if lock_entry is None:
+        asset_type_singular = asset_type.removesuffix("s")
+        raise NotInstalledError(
+            f"{asset_type}/{validated}: no lockfile entry; "
+            f"run `mm context install {asset_type_singular} {validated}` first"
+        )
+
+    src = wiki.root / asset_type / validated
+    if not src.is_dir():
+        raise AssetNotFoundError(f"{asset_type}/{validated} not in wiki at {wiki.root}")
+
+    new_commit = wiki.current_commit()
+    dest = project_root / ".memtomem" / asset_type / validated
+
+    if lock_entry.get("wiki_commit") == new_commit:
+        # True no-op: lockfile bytes untouched, installed_at echoed.
+        return UpdateResult(
+            asset_type=cast('Literal["skills", "agents", "commands"]', asset_type),
+            name=validated,
+            old_wiki_commit=new_commit,
+            new_wiki_commit=new_commit,
+            installed_at=cast(str, lock_entry.get("installed_at", "")),
+            was_no_op=True,
+            bak_files_written=(),
+            dest=dest,
+            files_written=0,
+        )
+
+    dirty_report = is_asset_dirty(project_root, asset_type, validated, lock_entry=lock_entry)
+
+    return _apply_update(
+        project_root,
+        asset_type,
+        validated,
+        src=src,
+        dest=dest,
+        wiki_commit=new_commit,
+        lock_entry=lock_entry,
+        dirty_report=dirty_report,
+        force=force,
+    )
+
+
+def _apply_update(
+    project_root: Path,
+    asset_type: str,
+    name: str,
+    *,
+    src: Path,
+    dest: Path,
+    wiki_commit: str,
+    lock_entry: dict[str, Any],
+    dirty_report: DirtyReport,
+    force: bool,
+) -> UpdateResult:
+    """Execute an already-classified update.
+
+    Pre-conditions enforced by callers (``_update_asset`` for the single-
+    asset path, ``mm context update --all`` orchestration for the batch
+    path):
+
+    - ``lock_entry`` is non-None (``NotInstalledError`` is raised earlier).
+    - The no-op case (``lock_entry["wiki_commit"] == wiki_commit``) was
+      already short-circuited; this helper unconditionally writes.
+    - ``dirty_report`` was already computed; this helper does **not**
+      re-walk the dest tree.
+
+    Refuses with :class:`StaleInstallError` when ``dirty_report.reason ==
+    "dirty"`` and ``force=False``. With ``force=True`` and a dirty tree,
+    each dirty file is preserved alongside the wiki bytes as
+    ``<file>.bak`` before the copy. ``shutil.copy2`` is used so the
+    user's edit-mtime survives onto the ``.bak`` (atomic_write_bytes
+    would lose it). ``installed_at`` is captured *after* the copy
+    completes, mirroring the C2a (#630) install invariant so a
+    follow-up dirty check can't false-positive on this update's own
+    writes.
+    """
+    if dirty_report.reason == "dirty" and not force:
+        raise StaleInstallError(
+            f"{asset_type}/{name}: {len(dirty_report.dirty_files)} file(s) "
+            f"modified locally since install at {dirty_report.installed_at}; "
+            f"pass --force to overwrite "
+            f"(each dirty file gets a .bak sibling)"
+        )
+
+    bak_paths: list[Path] = []
+    if force and dirty_report.reason == "dirty":
+        for f in dirty_report.dirty_files:
+            bak = f.with_suffix(f.suffix + ".bak")
+            # shutil.copy2 preserves user edit's mtime — atomic_write_bytes
+            # would lose it. Race window between copy2 and copy_tree_atomic
+            # is sub-ms; acceptable for v1. Overwrite-if-exists policy
+            # (prior .bak from earlier --force gets replaced).
+            shutil.copy2(f, bak)
+            bak_paths.append(bak)
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    files_written = copy_tree_atomic(src, dest)
+
+    installed_at = utcnow_iso8601_z()
+    lock = Lockfile.at(project_root)
+    lock.upsert_entry(
+        asset_type,
+        name,
+        wiki_commit=wiki_commit,
+        installed_at=installed_at,
+    )
+
+    old_wiki_commit = cast(str, lock_entry.get("wiki_commit", ""))
+
+    return UpdateResult(
+        asset_type=cast('Literal["skills", "agents", "commands"]', asset_type),
+        name=name,
+        old_wiki_commit=old_wiki_commit,
+        new_wiki_commit=wiki_commit,
+        installed_at=installed_at,
+        was_no_op=False,
+        bak_files_written=tuple(bak_paths),
         dest=dest,
         files_written=files_written,
     )

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -135,6 +136,36 @@ class Lockfile:
         if not isinstance(entry, dict):
             return None
         return entry
+
+    def iter_entries(self) -> Iterator[tuple[str, str, dict[str, Any]]]:
+        """Yield ``(asset_type, name, entry)`` triples in deterministic order.
+
+        Ordering contract: alphabetical by ``(asset_type, name)``. With the
+        current asset matrix this means ``agents`` → ``commands`` →
+        ``skills``, and within each section the names sort alphabetically.
+
+        The iteration is deliberately schema-flexible: any top-level key
+        whose value is a ``dict[str, dict[str, Any]]`` (asset section
+        shape) is yielded — a future asset_type works without code
+        changes here. Top-level scalars like ``version``, and unknown
+        per-entry shapes, are skipped silently so this remains
+        round-trip-safe per ADR-0008.
+
+        Caller surfaces that want a different display order (e.g. ``mm
+        context status`` may prefer a functional order with skills
+        first) should re-sort the output. This method's contract is
+        *deterministic*, not *display-optimal*.
+        """
+        doc = self.load()
+        for asset_type in sorted(doc):
+            section = doc.get(asset_type)
+            if not isinstance(section, dict):
+                continue
+            for name in sorted(section):
+                entry = section[name]
+                if not isinstance(entry, dict):
+                    continue
+                yield asset_type, name, entry
 
     def upsert_entry(
         self,

--- a/packages/memtomem/src/memtomem/wiki/store.py
+++ b/packages/memtomem/src/memtomem/wiki/store.py
@@ -157,6 +157,23 @@ class WikiStore:
         result = _git(["rev-parse", "HEAD"], cwd=self.root)
         return result.stdout.strip()
 
+    def is_dirty(self) -> bool:
+        """``True`` when the wiki working tree has uncommitted modifications.
+
+        Wraps ``git status --porcelain`` — true on any combination of
+        modified-tracked, staged, or untracked files. Used by ``mm
+        context update`` to warn the user that the install/update will
+        reflect HEAD only, not the dirty working tree.
+
+        Returns ``False`` if the wiki is clean. Raises ``WikiNotFoundError``
+        if the wiki itself is missing (no ``.git`` directory) — caller
+        should ``require_exists()`` first if the missing-wiki path is
+        not desired.
+        """
+        self.require_exists()
+        result = _git(["status", "--porcelain"], cwd=self.root)
+        return bool(result.stdout.strip())
+
     def list_assets(self, asset_type: str | None = None) -> list[WikiAsset]:
         """Enumerate asset directories under the wiki.
 

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1,0 +1,407 @@
+"""Tests for ``memtomem.context.install`` update path.
+
+Covers PR-D C2 commit 3: ``mm context update <type> <name>`` semantics —
+clean drift, dirty refuse, ``--force`` + ``.bak``, no-op invariant,
+``NotInstalledError``, and the flipped ``AlreadyInstalledError`` message
+that now points at update.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.context.install import (
+    AlreadyInstalledError,
+    NotInstalledError,
+    StaleInstallError,
+    install_skill,
+    update_agent,
+    update_command,
+    update_skill,
+)
+from memtomem.wiki.store import WikiStore
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _initialized_wiki(wiki_root_path: Path) -> WikiStore:
+    store = WikiStore.at_default()
+    store.init()
+    return store
+
+
+def _seed_wiki_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> str:
+    """Add ``skills/<name>/`` to wiki + git commit. Returns the commit SHA."""
+    skill_dir = wiki_root_path / "skills" / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    for relpath, data in files.items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"add {name}"],
+        check=True,
+        capture_output=True,
+    )
+    return WikiStore.at_default().current_commit()
+
+
+def _modify_wiki_skill(wiki_root_path: Path, name: str, files: dict[str, bytes]) -> str:
+    """Modify wiki skill files + commit. Wiki HEAD advances. Returns new SHA."""
+    skill_dir = wiki_root_path / "skills" / name
+    for relpath, data in files.items():
+        target = skill_dir / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    subprocess.run(["git", "-C", str(wiki_root_path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(wiki_root_path), "commit", "-m", f"modify {name}"],
+        check=True,
+        capture_output=True,
+    )
+    return WikiStore.at_default().current_commit()
+
+
+def _bump_mtime(path: Path, *, seconds_in_future: float = 1.0) -> None:
+    """Force *path*'s mtime to ``now + seconds_in_future``.
+
+    Tests need a deterministic strict ``>`` margin against ``installed_at``
+    that single-second filesystem precision can't eat.
+    """
+    future = datetime.now(timezone.utc).timestamp() + seconds_in_future
+    os.utime(path, (future, future))
+
+
+# ── happy paths ──────────────────────────────────────────────────────────
+
+
+def test_clean_drift_updates(wiki_root: Path, tmp_path: Path) -> None:
+    """Wiki HEAD advances → update copies new bytes + bumps lockfile."""
+    _initialized_wiki(wiki_root)
+    old_commit = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+
+    install_skill(project, "foo")
+
+    new_commit = _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(project, "foo")
+
+    assert result.was_no_op is False
+    assert result.old_wiki_commit == old_commit
+    assert result.new_wiki_commit == new_commit
+    assert old_commit != new_commit
+    assert (project / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+
+    lock_doc = json.loads((project / ".memtomem" / "lock.json").read_text())
+    assert lock_doc["skills"]["foo"]["wiki_commit"] == new_commit
+    assert lock_doc["skills"]["foo"]["installed_at"] == result.installed_at
+
+
+def test_dirty_refuse_without_force(wiki_root: Path, tmp_path: Path) -> None:
+    """Local edit + wiki advance + no --force → StaleInstallError."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+
+    edited = project / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local edit\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    with pytest.raises(StaleInstallError) as excinfo:
+        update_skill(project, "foo")
+    msg = str(excinfo.value)
+    assert "modified locally" in msg
+    assert "--force" in msg
+    # The user's edit MUST still be on disk (no partial write happened).
+    assert edited.read_bytes() == b"local edit\n"
+
+
+def test_dirty_force_writes_bak(wiki_root: Path, tmp_path: Path) -> None:
+    """--force preserves the user edit's bytes in .bak before overwriting."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_skill(project, "foo")
+
+    edited = project / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"my edit\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    result = update_skill(project, "foo", force=True)
+
+    bak = edited.with_suffix(edited.suffix + ".bak")
+    assert bak.is_file()
+    assert bak.read_bytes() == b"my edit\n"
+    # Wiki bytes won the overwrite.
+    assert edited.read_bytes() == b"v2\n"
+    assert result.bak_files_written == (bak,)
+    assert result.was_no_op is False
+
+
+def test_dirty_force_only_dirty_files_get_bak(wiki_root: Path, tmp_path: Path) -> None:
+    """Clean files have no .bak sibling — only edited files get one."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(
+        wiki_root,
+        "foo",
+        {"SKILL.md": b"v1\n", "scripts/run.sh": b"original\n"},
+    )
+    project = tmp_path
+    install_skill(project, "foo")
+
+    skill_dir = project / ".memtomem" / "skills" / "foo"
+    edited = skill_dir / "scripts" / "run.sh"
+    edited.write_bytes(b"my edit\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n", "scripts/run.sh": b"new\n"})
+
+    result = update_skill(project, "foo", force=True)
+
+    skill_md = skill_dir / "SKILL.md"
+    assert not (skill_md.with_suffix(skill_md.suffix + ".bak")).exists()
+    bak = edited.with_suffix(edited.suffix + ".bak")
+    assert bak.is_file()
+    assert bak.read_bytes() == b"my edit\n"
+    assert result.bak_files_written == (bak,)
+
+
+# ── failure paths ────────────────────────────────────────────────────────
+
+
+def test_not_installed_raises(wiki_root: Path, tmp_path: Path) -> None:
+    """No lockfile entry → NotInstalledError points at install."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+
+    with pytest.raises(NotInstalledError) as excinfo:
+        update_skill(project, "foo")
+    msg = str(excinfo.value)
+    assert "no lockfile entry" in msg
+    assert "mm context install skill foo" in msg
+
+
+# ── no-op invariant pin (lockfile mtime + installed_at + flag) ──────────
+
+
+def test_no_op_invariant_pin(wiki_root: Path, tmp_path: Path) -> None:
+    """No-op update MUST NOT touch the lockfile bytes.
+
+    Pin: lockfile mtime + bytes unchanged AND installed_at echoed AND
+    was_no_op=True. The lockfile-mtime pin is the load-bearing assertion
+    — any future regression that re-writes the lockfile on no-op
+    (e.g. someone "refreshing" installed_at) breaks this test loudly.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+    install_result = install_skill(project, "foo")
+
+    lock_path = project / ".memtomem" / "lock.json"
+    pre_bytes = lock_path.read_bytes()
+    pre_mtime = lock_path.stat().st_mtime
+
+    result = update_skill(project, "foo")
+
+    # Positive marker — bytes untouched.
+    assert lock_path.read_bytes() == pre_bytes
+    # Positive marker — mtime untouched (no rewrite happened).
+    assert lock_path.stat().st_mtime == pre_mtime
+    # Positive marker — installed_at echoed from prior install.
+    assert result.installed_at == install_result.installed_at
+    # Positive marker — flag set.
+    assert result.was_no_op is True
+    assert result.bak_files_written == ()
+    assert result.files_written == 0
+
+
+# ── pin-and-invert: AlreadyInstalledError points at update ──────────────
+
+
+def test_already_installed_message_points_to_update(wiki_root: Path, tmp_path: Path) -> None:
+    """``AlreadyInstalledError`` now points at ``mm context update``.
+
+    Pin-and-invert pair (per ``feedback_pin_invert_symmetric_assertion``):
+
+    - Positive marker: ``"mm context update"`` in the message; the
+      asset-type-singular form (``skill``, not ``skills``) matches the
+      CLI argument the user types.
+    - Negative marker: ``"reserved for PR-D"`` is gone; this is the
+      string that lived there before C2 and must not return.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    project = tmp_path
+
+    install_skill(project, "foo")
+
+    with pytest.raises(AlreadyInstalledError) as excinfo:
+        install_skill(project, "foo")
+    msg = str(excinfo.value)
+
+    # Positive markers — current invariant.
+    assert "mm context update skill foo" in msg
+    assert "refresh from wiki HEAD" in msg
+    # Negative marker — the would-be-old message must not be present.
+    assert "reserved for PR-D" not in msg
+    # The diagnostic prefix is preserved (composes with other tests).
+    assert "lockfile_entry=yes" in msg
+    assert "dest=yes" in msg
+
+
+# ── CLI: no-op exit clean ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def project_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Tmp project root (with sentinel ``.git``) wired as cwd for
+    ``_find_project_root``. Same shape as the install CLI tests'
+    fixture so behavior parity is easy to reason about."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def test_cli_update_no_op_exits_clean(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """``mm context update`` no-op prints ``unchanged`` with exit 0."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code == 0, result.output
+    assert "unchanged" in result.output
+
+
+# ── CLI: variant dispatch ────────────────────────────────────────────────
+
+
+def test_cli_update_dispatches_to_correct_wrapper(
+    project_cwd: Path,
+    wiki_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``update_cmd`` routes ``skill / agent / command`` to the right wrapper.
+
+    Mocks the 3 wrappers so the test pins the CLI dispatch shape without
+    needing to seed wiki content for all 3 asset types. A regression
+    that miswires (e.g. ``skill`` calling ``update_agent``) fails this
+    test loudly.
+    """
+    # Need wiki initialized so the CLI doesn't error out before dispatch.
+    _initialized_wiki(wiki_root)
+
+    calls: list[tuple[str, str]] = []
+
+    def _fake(asset_type: str):
+        def _impl(root: Path, name: str, *, wiki: object = None, force: bool = False) -> object:
+            calls.append((asset_type, name))
+            # Return a sentinel UpdateResult — minimal fields the CLI prints.
+            from memtomem.context.install import UpdateResult
+
+            return UpdateResult(
+                asset_type=f"{asset_type}s",  # type: ignore[arg-type]
+                name=name,
+                old_wiki_commit="0" * 40,
+                new_wiki_commit="0" * 40,
+                installed_at="2026-01-01T00:00:00.000000Z",
+                was_no_op=True,
+                bak_files_written=(),
+                dest=root / ".memtomem" / f"{asset_type}s" / name,
+                files_written=0,
+            )
+
+        return _impl
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.update_skill", _fake("skill"))
+    monkeypatch.setattr("memtomem.cli.context_cmd.update_agent", _fake("agent"))
+    monkeypatch.setattr("memtomem.cli.context_cmd.update_command", _fake("command"))
+
+    runner = CliRunner()
+    for asset_type, name in [("skill", "alpha"), ("agent", "beta"), ("command", "gamma")]:
+        result = runner.invoke(context_group, ["update", asset_type, name])
+        assert result.exit_code == 0, f"{asset_type}/{name}: {result.output}"
+
+    assert calls == [("skill", "alpha"), ("agent", "beta"), ("command", "gamma")]
+
+
+# ── CLI: stale refuse → exit non-zero with hint ─────────────────────────
+
+
+def test_cli_update_stale_refuse_message(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """CLI surfaces ``StaleInstallError`` text + non-zero exit."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+
+    edited = project_cwd / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code != 0
+    assert "modified locally" in result.output
+    assert "--force" in result.output
+
+
+# ── coverage: silence unused-import warnings on agent/command wrappers ──
+
+
+def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``update_agent`` / ``update_command`` route through ``_update_asset``
+    with the right ``asset_type`` literal. Direct call sites (not via CLI)
+    must keep the 3-wrapper API stable for downstream Python callers."""
+    seen: list[str] = []
+
+    def _fake_update_asset(
+        project_root: object, asset_type: str, name: str, *, wiki: object, force: bool
+    ) -> object:
+        seen.append(asset_type)
+        from memtomem.context.install import UpdateResult
+
+        return UpdateResult(
+            asset_type=asset_type,  # type: ignore[arg-type]
+            name=name,
+            old_wiki_commit="0" * 40,
+            new_wiki_commit="0" * 40,
+            installed_at="2026-01-01T00:00:00.000000Z",
+            was_no_op=True,
+            bak_files_written=(),
+            dest=Path("/dev/null"),
+            files_written=0,
+        )
+
+    monkeypatch.setattr("memtomem.context.install._update_asset", _fake_update_asset)
+
+    update_agent(Path("/tmp/p"), "a")
+    update_command(Path("/tmp/p"), "c")
+    update_skill(Path("/tmp/p"), "s")
+
+    assert seen == ["agents", "commands", "skills"]

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -23,10 +23,10 @@ from click.testing import CliRunner
 
 import memtomem.context.install as install_module
 from memtomem.cli.context_cmd import context as context_group
+from memtomem.context._names import InvalidNameError
 from memtomem.context.install import (
     AlreadyInstalledError,
     NotInstalledError,
-    ProjectClassification,
     StaleInstallError,
     _classify_for_all_update,
     install_skill,
@@ -570,6 +570,31 @@ def test_classify_for_all_update_4_state_coverage(wiki_root: Path, tmp_path: Pat
     assert by_name["refuse"].dirty_report.reason == "dirty"
 
 
+def test_classify_rejects_path_traversal_name(wiki_root: Path, tmp_path: Path) -> None:
+    """``_classify_for_all_update`` validates ``name`` at its boundary —
+    a traversal name like ``../escape`` raises ``InvalidNameError``
+    *before* any per-project loop runs.
+
+    Defense in depth (`feedback_public_api_ship_time_validation`):
+    even though the CLI ``update_cmd`` is the expected upstream caller
+    and the single-asset path goes through ``_update_asset`` which
+    already validates, the ``--all`` path reaches ``_classify_for_all_
+    update`` directly and would feed ``name`` into ``Path`` joins
+    (``src = wiki.root / asset_type / name``) without this check.
+    """
+    _initialized_wiki(wiki_root)
+    proj = tmp_path / "p"
+    proj.mkdir()
+
+    wiki = WikiStore.at_default()
+    with pytest.raises(InvalidNameError):
+        _classify_for_all_update("skills", "../etc", wiki=wiki, projects=[proj])
+    with pytest.raises(InvalidNameError):
+        _classify_for_all_update("skills", "../../escape", wiki=wiki, projects=[proj])
+    with pytest.raises(InvalidNameError):
+        _classify_for_all_update("skills", "foo/bar", wiki=wiki, projects=[proj])
+
+
 def test_classify_skips_projects_without_lockfile_entry(wiki_root: Path, tmp_path: Path) -> None:
     """Projects without a lockfile entry for this asset are silently
     skipped — no ``"skipped"`` row clutters the preview table."""
@@ -593,6 +618,29 @@ def test_classify_skips_projects_without_lockfile_entry(wiki_root: Path, tmp_pat
 
 
 # ── CLI --all: empty store + no-projects-have-asset ─────────────────────
+
+
+def test_cli_update_all_rejects_path_traversal_name(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI surfaces ``InvalidNameError`` as a non-zero exit before
+    touching any project. Pins that the validation gate is reachable
+    through the user-facing path, not just from direct calls."""
+    _initialized_wiki(wiki_root)
+    proj = tmp_path / "p"
+    proj.mkdir()
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "../etc", "--all", "--yes"])
+
+    assert result.exit_code != 0
+    assert "invalid" in result.output.lower()
 
 
 def test_cli_update_all_empty_known_projects_exits_zero(
@@ -766,6 +814,57 @@ def test_cli_update_all_yes_force_three_way_invariant(
 
 
 # ── CLI --all: cache reuse pin ──────────────────────────────────────────
+
+
+def test_cli_update_all_mid_loop_fs_error_continues(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-project ``OSError`` during execute marks that row ✗ and
+    proceeds to the next project — the batch is not aborted on the
+    first row's failure. The summary reflects the partial outcome.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_a = tmp_path / "proj_a"
+    proj_a.mkdir()
+    install_skill(proj_a, "foo")
+
+    proj_b = tmp_path / "proj_b"
+    proj_b.mkdir()
+    install_skill(proj_b, "foo")
+
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_a, proj_b])
+    _patch_known_projects_path(monkeypatch, known)
+
+    real_apply_update = install_module._apply_update
+    call_count = {"n": 0}
+
+    def _apply_update_first_fails(*args: object, **kwargs: object) -> object:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("simulated fs error on first project")
+        return real_apply_update(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("memtomem.cli.context_cmd._apply_update", _apply_update_first_fails)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    # First project marked ✗, second project marked ✓ — both rows reached.
+    assert "✗" in result.output
+    assert "simulated fs error" in result.output
+    assert "✓" in result.output
+    # Summary: 1 updated, 1 failed.
+    assert "1 updated" in result.output
+    assert "1 failed" in result.output
 
 
 def test_cli_update_all_does_not_re_walk_for_dirty(

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -1,9 +1,13 @@
 """Tests for ``memtomem.context.install`` update path.
 
-Covers PR-D C2 commit 3: ``mm context update <type> <name>`` semantics —
-clean drift, dirty refuse, ``--force`` + ``.bak``, no-op invariant,
-``NotInstalledError``, and the flipped ``AlreadyInstalledError`` message
-that now points at update.
+Covers PR-D C2 commits 3 and 4:
+
+- Commit 3: ``mm context update <type> <name>`` semantics — clean drift,
+  dirty refuse, ``--force`` + ``.bak``, no-op invariant,
+  ``NotInstalledError``, the flipped ``AlreadyInstalledError`` message.
+- Commit 4: ``--all`` orchestration — 4-state classification,
+  batch-once ``current_commit``, cache reuse, refuse-blocks-batch,
+  ``--yes --force`` invariant, wiki-dirty warn timing.
 """
 
 from __future__ import annotations
@@ -17,11 +21,14 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+import memtomem.context.install as install_module
 from memtomem.cli.context_cmd import context as context_group
 from memtomem.context.install import (
     AlreadyInstalledError,
     NotInstalledError,
+    ProjectClassification,
     StaleInstallError,
+    _classify_for_all_update,
     install_skill,
     update_agent,
     update_command,
@@ -405,3 +412,469 @@ def test_update_agent_command_wrappers_dispatch(monkeypatch: pytest.MonkeyPatch)
     update_skill(Path("/tmp/p"), "s")
 
     assert seen == ["agents", "commands", "skills"]
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Commit 4 — --all + wiki dirty warn
+# ════════════════════════════════════════════════════════════════════════
+
+
+# ── helpers for --all tests ─────────────────────────────────────────────
+
+
+def _seed_known_projects(path: Path, project_roots: list[Path]) -> None:
+    """Write a ``known_projects.json`` listing the given roots."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    doc = {
+        "version": 1,
+        "projects": [
+            {"root": str(p), "added_at": "2026-01-01T00:00:00.000000Z", "label": None}
+            for p in project_roots
+        ],
+    }
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _patch_known_projects_path(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    """Make ``ContextGatewayConfig()`` in the CLI return *path*."""
+
+    class _FakeCfg:
+        known_projects_path = path
+
+    monkeypatch.setattr(
+        "memtomem.cli.context_cmd.ContextGatewayConfig",
+        lambda: _FakeCfg(),
+    )
+
+
+# ── _classify_for_all_update: batch-once + 4-state coverage ─────────────
+
+
+def test_classify_for_all_update_calls_current_commit_once(
+    wiki_root: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``current_commit`` runs ONCE regardless of how many projects are scanned."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    project_a = tmp_path / "proj_a"
+    project_a.mkdir()
+    project_b = tmp_path / "proj_b"
+    project_b.mkdir()
+    install_skill(project_a, "foo")
+    install_skill(project_b, "foo")
+
+    wiki = WikiStore.at_default()
+    real_current_commit = wiki.current_commit
+    call_count = {"n": 0}
+
+    def _spy_current_commit() -> str:
+        call_count["n"] += 1
+        return real_current_commit()
+
+    monkeypatch.setattr(WikiStore, "current_commit", lambda self: _spy_current_commit())
+
+    new_commit, classifications = _classify_for_all_update(
+        "skills", "foo", wiki=wiki, projects=[project_a, project_b]
+    )
+
+    # Wiki state read once for the whole batch.
+    assert call_count["n"] == 1
+    assert len(new_commit) == 40  # full SHA
+    assert len(classifications) == 2
+
+
+def test_classify_for_all_update_4_state_coverage(wiki_root: Path, tmp_path: Path) -> None:
+    """One project per state — verifies all 4 states are reachable.
+
+    Setup strategy: wiki has a single commit. All 4 projects install
+    against that commit. Then 3 of them have their lockfile entries
+    back-dated (or corrupted) to simulate drift / dirty / error states.
+    The 4th stays at the live HEAD and classifies as ``unchanged``.
+    """
+    from memtomem.context.lockfile import Lockfile
+
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    wiki = WikiStore.at_default()
+    head_commit = wiki.current_commit()
+
+    # State 1: "unchanged" — fresh install, lockfile pin == HEAD.
+    proj_unchanged = tmp_path / "unchanged"
+    proj_unchanged.mkdir()
+    install_skill(proj_unchanged, "foo")
+
+    # State 2: "update" — install, then back-date lockfile pin so HEAD
+    # looks like a newer commit. Dest mtimes are ahead of installed_at
+    # (just installed → fresh), so we also back-date installed_at to
+    # ensure files are NOT classified dirty. Use a fixed past timestamp.
+    # Wait — we WANT the dest tree to be clean (= reason="clean"), but
+    # back-dating installed_at to far past makes ALL current files look
+    # dirty. We need the OPPOSITE: future installed_at OR explicit clean
+    # mtimes. Easiest: back-date both lockfile fields, then bump every
+    # dest file's mtime to BEFORE installed_at_epoch via os.utime.
+    proj_update = tmp_path / "update_clean"
+    proj_update.mkdir()
+    install_skill(proj_update, "foo")
+    Lockfile.at(proj_update).upsert_entry(
+        "skills",
+        "foo",
+        wiki_commit="0" * 40,  # ≠ HEAD → drift
+        installed_at="2030-01-01T00:00:00.000000Z",  # future → all current files are clean
+    )
+
+    # State 3: "refuse" — drift + dirty.
+    proj_refuse = tmp_path / "refuse"
+    proj_refuse.mkdir()
+    install_skill(proj_refuse, "foo")
+    Lockfile.at(proj_refuse).upsert_entry(
+        "skills",
+        "foo",
+        wiki_commit="0" * 40,
+        # Past installed_at so every current file is dirty.
+        installed_at="2020-01-01T00:00:00.000000Z",
+    )
+
+    # State 4: "error" — unknown lockfile version.
+    proj_error = tmp_path / "error"
+    proj_error.mkdir()
+    (proj_error / ".memtomem").mkdir()
+    (proj_error / ".memtomem" / "lock.json").write_text(
+        json.dumps({"version": 99, "skills": {"foo": {"wiki_commit": "x", "installed_at": "y"}}}),
+        encoding="utf-8",
+    )
+
+    new_commit, classifications = _classify_for_all_update(
+        "skills",
+        "foo",
+        wiki=wiki,
+        projects=[proj_unchanged, proj_update, proj_refuse, proj_error],
+    )
+
+    assert new_commit == head_commit
+    states = {c.project_root.name: c.state for c in classifications}
+    assert states == {
+        "unchanged": "unchanged",
+        "update_clean": "update",
+        "refuse": "refuse",
+        "error": "error",
+    }
+    # Cache pin: unchanged + error have no dirty_report; update + refuse do.
+    by_name = {c.project_root.name: c for c in classifications}
+    assert by_name["unchanged"].dirty_report is None
+    assert by_name["error"].dirty_report is None
+    assert by_name["update_clean"].dirty_report is not None
+    assert by_name["update_clean"].dirty_report.reason == "clean"
+    assert by_name["refuse"].dirty_report is not None
+    assert by_name["refuse"].dirty_report.reason == "dirty"
+
+
+def test_classify_skips_projects_without_lockfile_entry(wiki_root: Path, tmp_path: Path) -> None:
+    """Projects without a lockfile entry for this asset are silently
+    skipped — no ``"skipped"`` row clutters the preview table."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_with = tmp_path / "with_foo"
+    proj_with.mkdir()
+    install_skill(proj_with, "foo")
+
+    proj_without = tmp_path / "without_foo"
+    proj_without.mkdir()  # no lockfile, no install
+
+    wiki = WikiStore.at_default()
+    new_commit, classifications = _classify_for_all_update(
+        "skills", "foo", wiki=wiki, projects=[proj_with, proj_without]
+    )
+
+    assert len(classifications) == 1
+    assert classifications[0].project_root == proj_with
+
+
+# ── CLI --all: empty store + no-projects-have-asset ─────────────────────
+
+
+def test_cli_update_all_empty_known_projects_exits_zero(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--all`` with empty known_projects.json exits 0 with an info message.
+
+    cron/CI safety: a first-run before any project registration must
+    not fail with a non-zero exit.
+    """
+    _initialized_wiki(wiki_root)
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "No known projects" in result.output
+
+
+def test_cli_update_all_no_projects_have_asset_exits_zero(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All registered projects exist on disk but none has the asset → exit 0."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj = tmp_path / "no_lock"
+    proj.mkdir()  # exists but no install
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "No projects have skills/foo" in result.output
+
+
+# ── CLI --all: refuse blocks batch ──────────────────────────────────────
+
+
+def test_cli_update_all_refuse_without_force_blocks_batch(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When any project is dirty and ``--force`` is absent, the entire
+    batch refuses — no per-project writes happen."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    # Install in two projects; dirty one of them.
+    proj_clean = tmp_path / "clean"
+    proj_clean.mkdir()
+    install_skill(proj_clean, "foo")
+
+    proj_dirty = tmp_path / "dirty"
+    proj_dirty.mkdir()
+    install_skill(proj_dirty, "foo")
+    edited = proj_dirty / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_clean, proj_dirty])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all"])
+
+    assert result.exit_code != 0
+    assert "local edits" in result.output
+    assert "--force" in result.output
+
+    # Critical: the clean project's lockfile MUST NOT have been bumped.
+    # If a partial write happened, this would catch the regression.
+    lock_doc = json.loads((proj_clean / ".memtomem" / "lock.json").read_text())
+    # wiki_commit on lockfile entry should still match the original install
+    # (not the new wiki HEAD) — the entire batch refused before any write.
+    assert (proj_clean / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v1\n"
+    assert lock_doc["skills"]["foo"]["wiki_commit"] != WikiStore.at_default().current_commit()
+
+
+# ── CLI --all: --yes invariants (no WARN unless --force) ────────────────
+
+
+def test_cli_update_all_yes_skips_prompt_and_no_destructive_warning(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--yes`` (without ``--force``) skips the confirm prompt and does
+    NOT print the destructive WARNING. Plain ``--yes`` is non-destructive
+    automation; the WARNING only fires for ``--force``-laden batches."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_clean = tmp_path / "clean"
+    proj_clean.mkdir()
+    install_skill(proj_clean, "foo")
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_clean])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    # Prompt-skip pin: input was empty but the command didn't hang.
+    assert "Continue?" not in result.output
+    # WARN-pin (negative): no destructive warning for plain --yes.
+    assert "WARNING:" not in result.output
+    # Update happened.
+    assert "updated" in result.output
+    assert (proj_clean / ".memtomem" / "skills" / "foo" / "SKILL.md").read_bytes() == b"v2\n"
+
+
+def test_cli_update_all_yes_force_three_way_invariant(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--yes --force`` invariant: WARNING printed AND prompt skipped AND
+    batch executed (3-way conjunction). Tested as a single block so a
+    regression in any one of the three is caught."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_dirty = tmp_path / "dirty"
+    proj_dirty.mkdir()
+    install_skill(proj_dirty, "foo")
+    edited = proj_dirty / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_dirty])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    # 1. WARNING printed.
+    assert "WARNING:" in result.output
+    # 2. Prompt skipped.
+    assert "Continue?" not in result.output
+    # 3. Batch executed — bytes changed and .bak survived the dirty edit.
+    bak = edited.with_suffix(edited.suffix + ".bak")
+    assert bak.is_file()
+    assert bak.read_bytes() == b"local\n"
+    assert edited.read_bytes() == b"v2\n"
+
+
+# ── CLI --all: cache reuse pin ──────────────────────────────────────────
+
+
+def test_cli_update_all_does_not_re_walk_for_dirty(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Execute phase MUST consume the cached ``dirty_report`` from
+    classification — no second ``is_asset_dirty`` call per project.
+
+    Spy counts ``is_asset_dirty`` invocations during the whole flow:
+    classify calls it once for the dirty project (state=refuse with
+    --force allowed), and execute reuses the cached report. Total = 1
+    per project that needed classification. Without the cache, total
+    would be 2 per project.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    proj_dirty = tmp_path / "dirty"
+    proj_dirty.mkdir()
+    install_skill(proj_dirty, "foo")
+    edited = proj_dirty / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"local\n")
+    _bump_mtime(edited)
+    _modify_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v2\n"})
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj_dirty])
+    _patch_known_projects_path(monkeypatch, known)
+
+    real_is_asset_dirty = install_module.is_asset_dirty
+    call_count = {"n": 0}
+
+    def _spy(*args: object, **kwargs: object):
+        call_count["n"] += 1
+        return real_is_asset_dirty(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(install_module, "is_asset_dirty", _spy)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    # 1 = classification's call only. Execute used the cached DirtyReport
+    # from ProjectClassification — no second walk.
+    assert call_count["n"] == 1
+
+
+# ── CLI: wiki dirty warn timing (single-asset & --all) ──────────────────
+
+
+def test_cli_update_wiki_dirty_warn_single_asset(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """Single-asset path: wiki dirty → warn on stderr at update entry."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+
+    # Make the wiki dirty.
+    (wiki_root / "untracked_marker.txt").write_text("wip", encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code == 0, result.output
+    assert "wiki has uncommitted changes" in result.output
+
+
+def test_cli_update_wiki_dirty_warn_all(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--all path: wiki dirty → warn on stderr BEFORE classification."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    proj = tmp_path / "p"
+    proj.mkdir()
+    install_skill(proj, "foo")
+
+    (wiki_root / "untracked_marker.txt").write_text("wip", encoding="utf-8")
+
+    known = tmp_path / "known.json"
+    _seed_known_projects(known, [proj])
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "wiki has uncommitted changes" in result.output
+
+
+def test_cli_update_no_wiki_dirty_warn_when_clean(
+    wiki_root: Path,
+    project_cwd: Path,
+) -> None:
+    """Negative pin: clean wiki → no dirty warn line."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    install_skill(project_cwd, "foo")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo"])
+
+    assert result.exit_code == 0, result.output
+    assert "wiki has uncommitted changes" not in result.output

--- a/packages/memtomem/tests/test_dirty.py
+++ b/packages/memtomem/tests/test_dirty.py
@@ -197,6 +197,30 @@ def test_skip_symlinks(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None
     assert any("skipping symlink" in r.message for r in caplog.records)
 
 
+def test_skip_dot_bak_files(tmp_path: Path) -> None:
+    """``.bak`` siblings (from prior ``--force``) do NOT trip the next
+    update into ``reason='dirty'``.
+
+    Regression for the manual-smoke finding: scenario 3 of the PR-D C2
+    smoke run left ``SKILL.md.bak`` carrying the user's pre-update mtime,
+    which then caused scenario 4's ``--all`` classification to refuse
+    proj-a forever. ``.bak`` files are intentional artifacts of the
+    update flow itself; they must not feed back into dirty detection.
+    """
+    _setup_installed(tmp_path, "skills", "foo", {"SKILL.md": b"x"})
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+
+    bak = dest / "SKILL.md.bak"
+    bak.write_bytes(b"prior dirty edit")
+    _bump_mtime(bak)  # absolutely future mtime — would 100% be dirty if checked
+
+    report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "clean"
+    assert report.dirty_files == ()
+    assert report.checked_files == 1  # SKILL.md only — SKILL.md.bak skipped
+
+
 # ── Lockfile.iter_entries ────────────────────────────────────────────────
 
 

--- a/packages/memtomem/tests/test_dirty.py
+++ b/packages/memtomem/tests/test_dirty.py
@@ -1,0 +1,232 @@
+"""Tests for ``memtomem.context.dirty`` and ``Lockfile.iter_entries``.
+
+Covers PR-D C2 commit 2: dirty classification rules feeding ``mm context
+update``, plus the lockfile iteration helper introduced for batch flows.
+
+These tests construct lockfile + dest tree manually (no wiki / install
+roundtrip) so the dirty classifier is exercised in isolation. The
+"installed_at captured post-write" invariant from ADR-0008 PR-B/C2a
+(:func:`memtomem.context.install._install_asset`) is mirrored by
+:func:`_setup_installed` so equality cases land on the clean side of
+the strict ``>`` boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.dirty import is_asset_dirty
+from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _setup_installed(
+    project: Path,
+    asset_type: str,
+    name: str,
+    files: dict[str, bytes],
+) -> str:
+    """Drop *files* into ``<project>/.memtomem/<asset_type>/<name>/`` and
+    write a lockfile entry whose ``installed_at`` is captured AFTER all
+    file writes — mirrors C2a's invariant so a clean check immediately
+    after this helper returns lands at ``mtime <= installed_at_epoch``.
+    """
+    dest = project / ".memtomem" / asset_type / name
+    dest.mkdir(parents=True)
+    for relpath, data in files.items():
+        target = dest / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+
+    installed_at = utcnow_iso8601_z()
+    Lockfile.at(project).upsert_entry(
+        asset_type,
+        name,
+        wiki_commit="0" * 40,
+        installed_at=installed_at,
+    )
+    return installed_at
+
+
+def _bump_mtime(path: Path, *, seconds_in_future: float = 1.0) -> None:
+    """Force *path*'s mtime to ``now + seconds_in_future``.
+
+    Tests need a deterministic strict ``>`` margin against ``installed_at``
+    that can't be eaten by single-second filesystem precision. Bumping
+    mtime explicitly avoids ``time.sleep`` in unit tests.
+    """
+    future = datetime.now(timezone.utc).timestamp() + seconds_in_future
+    os.utime(path, (future, future))
+
+
+# ── is_asset_dirty: clean / dirty paths ──────────────────────────────────
+
+
+def test_clean_immediately_after_install(tmp_path: Path) -> None:
+    """Files at install-time mtime are ``<= installed_at_epoch`` (C2a invariant)."""
+    _setup_installed(
+        tmp_path,
+        "skills",
+        "foo",
+        {"SKILL.md": b"# foo\n", "scripts/run.sh": b"#!/bin/bash\n"},
+    )
+
+    report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "clean"
+    assert report.dirty_files == ()
+    assert report.checked_files == 2
+    assert report.installed_at is not None
+
+
+def test_dirty_after_edit(tmp_path: Path) -> None:
+    """A post-install edit produces ``reason='dirty'`` with the file flagged."""
+    _setup_installed(tmp_path, "skills", "foo", {"SKILL.md": b"original\n"})
+
+    edited = tmp_path / ".memtomem" / "skills" / "foo" / "SKILL.md"
+    edited.write_bytes(b"manual edit\n")
+    _bump_mtime(edited)
+
+    report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "dirty"
+    assert edited in report.dirty_files
+    assert report.checked_files == 1
+
+
+def test_dirty_partial_subdir(tmp_path: Path) -> None:
+    """Only the edited file is flagged; siblings stay clean."""
+    _setup_installed(
+        tmp_path,
+        "skills",
+        "foo",
+        {
+            "SKILL.md": b"a",
+            "scripts/run.sh": b"b",
+            "scripts/helper.py": b"c",
+            "overrides/claude.md": b"d",
+        },
+    )
+
+    edited = tmp_path / ".memtomem" / "skills" / "foo" / "scripts" / "run.sh"
+    edited.write_bytes(b"edited\n")
+    _bump_mtime(edited)
+
+    report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "dirty"
+    assert report.dirty_files == (edited,)
+    assert report.checked_files == 4
+
+
+# ── never_installed / missing_dest ───────────────────────────────────────
+
+
+def test_never_installed(tmp_path: Path) -> None:
+    """No lockfile entry → reason='never_installed' with empty fields."""
+    report = is_asset_dirty(tmp_path, "skills", "missing")
+
+    assert report.reason == "never_installed"
+    assert report.installed_at is None
+    assert report.dirty_files == ()
+    assert report.checked_files == 0
+
+
+def test_missing_dest(tmp_path: Path) -> None:
+    """Lockfile entry exists but the dest dir was deleted out from under it."""
+    installed_at = _setup_installed(tmp_path, "skills", "foo", {"SKILL.md": b"x"})
+    shutil.rmtree(tmp_path / ".memtomem" / "skills" / "foo")
+
+    report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "missing_dest"
+    assert report.installed_at == installed_at
+    assert report.dirty_files == ()
+    assert report.checked_files == 0
+
+
+# ── skip rules: COPY_SKIP_NAMES / symlinks ───────────────────────────────
+
+
+def test_skip_dotgit_dsstore_pycache(tmp_path: Path) -> None:
+    """COPY_SKIP_NAMES entries with *future* mtime do not flip clean→dirty."""
+    _setup_installed(tmp_path, "skills", "foo", {"SKILL.md": b"x"})
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+
+    # All three injected with future mtime: would absolutely be dirty if checked.
+    (dest / ".DS_Store").write_bytes(b"\x00" * 4)
+    _bump_mtime(dest / ".DS_Store")
+
+    git_dir = dest / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_bytes(b"ref: refs/heads/main\n")
+    _bump_mtime(git_dir / "HEAD")
+
+    pycache = dest / "__pycache__"
+    pycache.mkdir()
+    (pycache / "foo.cpython-312.pyc").write_bytes(b"\x00\x00")
+    _bump_mtime(pycache / "foo.cpython-312.pyc")
+
+    report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "clean"
+    assert report.dirty_files == ()
+    assert report.checked_files == 1  # only SKILL.md
+
+
+def test_skip_symlinks(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Symlinks in dest are skipped with a warning, never dereferenced."""
+    _setup_installed(tmp_path, "skills", "foo", {"SKILL.md": b"x"})
+    dest = tmp_path / ".memtomem" / "skills" / "foo"
+
+    # Dangling symlink — entry.is_symlink() fires regardless of target validity.
+    (dest / "danger.md").symlink_to("/nonexistent/target")
+
+    with caplog.at_level("WARNING", logger="memtomem.context.dirty"):
+        report = is_asset_dirty(tmp_path, "skills", "foo")
+
+    assert report.reason == "clean"
+    assert report.checked_files == 1
+    assert any("skipping symlink" in r.message for r in caplog.records)
+
+
+# ── Lockfile.iter_entries ────────────────────────────────────────────────
+
+
+def test_iter_entries_alphabetical_ordering(tmp_path: Path) -> None:
+    """``iter_entries`` yields ``(asset_type, name)`` in alphabetical order
+    regardless of insertion order — deterministic for batch flows."""
+    lock = Lockfile.at(tmp_path)
+
+    # Insert deliberately out of order, mixing asset types.
+    lock.upsert_entry(
+        "skills", "zebra", wiki_commit="0" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    lock.upsert_entry(
+        "agents", "alpha", wiki_commit="0" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    lock.upsert_entry(
+        "commands", "mid", wiki_commit="0" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    lock.upsert_entry(
+        "skills", "alpha", wiki_commit="0" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+
+    entries = list(lock.iter_entries())
+    types_and_names = [(t, n) for t, n, _ in entries]
+
+    assert types_and_names == [
+        ("agents", "alpha"),
+        ("commands", "mid"),
+        ("skills", "alpha"),
+        ("skills", "zebra"),
+    ]
+    # Per-entry payload is the live dict — value must round-trip through.
+    assert all(e["wiki_commit"] == "0" * 40 for _, _, e in entries)

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -189,3 +189,33 @@ class TestRequireExists:
         store = WikiStore.at_default()
         store.init()
         store.require_exists()  # no exception
+
+
+class TestIsDirty:
+    def test_clean_after_init(self, wiki_root: Path) -> None:
+        """Fresh ``init`` leaves the working tree clean — no dirty marker."""
+        store = WikiStore.at_default()
+        store.init()
+        assert store.is_dirty() is False
+
+    def test_dirty_with_untracked_file(self, wiki_root: Path) -> None:
+        """An untracked file inside the wiki flips ``is_dirty`` to True."""
+        store = WikiStore.at_default()
+        store.init()
+        (wiki_root / "untracked_marker.txt").write_text("wip", encoding="utf-8")
+        assert store.is_dirty() is True
+
+    def test_dirty_with_modified_tracked_file(self, wiki_root: Path) -> None:
+        """A modification to a tracked file flips ``is_dirty`` to True."""
+        store = WikiStore.at_default()
+        store.init()
+        readme = wiki_root / "README.md"
+        readme.write_text(readme.read_text() + "\nlocal note\n", encoding="utf-8")
+        assert store.is_dirty() is True
+
+    def test_raises_when_wiki_absent(self, wiki_root: Path) -> None:
+        """``is_dirty`` calls ``require_exists`` first, surfacing the
+        usual ``WikiNotFoundError`` when the wiki itself is missing."""
+        store = WikiStore.at_default()
+        with pytest.raises(WikiNotFoundError):
+            store.is_dirty()


### PR DESCRIPTION
## Summary

- `mm context update <type> <name>` — refresh from wiki HEAD with drift detection (no-op when wiki HEAD == lockfile pin; refuses dirty edits without `--force`; preserves dirty files as `.bak` with `--force`)
- `mm context update <type> <name> --all` — batch update across known projects with 4-state classification (update / unchanged / refuse / error), refuse-blocks-batch invariant, `--yes` automation, `--yes --force` destructive WARNING
- Wiki working-tree dirty warning at update entry (single-asset and `--all`)
- `dirty.py` classifier (`is_asset_dirty`, `DirtyReport`) — pure helper feeding `mm context update` and the future `mm context status` (C3)
- `Lockfile.iter_entries()` — alphabetical iteration for batch flows
- `WikiStore.is_dirty()` — `git status --porcelain` wrapper
- `AlreadyInstalledError` message replaced — points users at `mm context update` instead of the now-obsolete "reserved for PR-D" reinstall instructions

This PR contains the main commits of PR-D C2 (the user-facing peak of
the PR-D series). Commit 1 (`installed_at` post-copy capture) shipped
as #630 (C2a) on 2026-05-01 and is the base for this PR — that capture
timing is the load-bearing invariant the dirty classifier relies on
(`mtime > installed_at_epoch`, strict).

The 4th commit on this branch is a bug fix the manual smoke caught
(`.bak` files from prior `--force` were tripping the dirty walker into
refusing the next update forever); kept as a separate commit so the
smoke→fix story is in the history.

## Test plan
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_dirty.py` (9 scenarios)
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_context_update.py` (23 scenarios)
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_context_install.py` (20 scenarios — `AlreadyInstalledError` pin pair carries the message-flip)
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_lockfile.py` `test_wiki_store.py` (35 total)
- [x] Full memtomem suite: 3511 pass, 0 regression
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` clean
- [x] `uv run mypy` clean on all touched files (advisory)
- [x] Manual smoke 1 — clean no-op (`unchanged`, lockfile mtime stable)
- [x] Manual smoke 2 — dirty refuse without `--force` (`StaleInstallError`, exit 1, hint to `--force`)
- [x] Manual smoke 3 — `--force` writes per-file `.bak` and copies wiki state (wiki bytes win, edit preserved)
- [x] Manual smoke 4 — `--all` over multi-project setup, 4-state preview correct, both projects updated with `--yes`
- [x] Manual smoke 5 — wiki dirty warn appears on stderr at update entry, before any other output

## Notes for reviewers
- Locked design decisions are recorded in the original C2 plan: `--all` is
  Option A (single asset × multi project), no-op is true no-op (lockfile
  bytes untouched), `.bak` policy is per-file (not per-directory), dirty
  compare is strict `>`, `--all --force` scope is batch-level.
- The `KnownProjectsStore.list_entries()` reference in the plan does not
  exist in the actual API; this PR uses `load()` directly — a 1-line
  correction with no design impact.
- The `--yes --force` invariant is encoded as a 3-way conjunction test
  (WARNING printed AND prompt skipped AND batch executed) so a regression
  in any of the three is loud.
- Cache reuse pin: classification's `is_asset_dirty` walk is cached on
  `ProjectClassification.dirty_report`; the execute phase reuses it
  (no second walk per project). The pin is a spy test that asserts
  exactly 1 `is_asset_dirty` call per dirty project across the whole
  `--all` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)