### PR TITLE
fix(web): _counts_for tuple-unpack for canonical commands/agents

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -117,7 +117,11 @@ def _counts_for(root: Path) -> dict[str, int]:
 
     try:
         names = {name for _runtime, name, _status in diff_commands(root)}
-        names.update(p.stem for p in list_canonical_commands(root))
+        # ``list_canonical_commands`` returns ``list[tuple[Path, Layout]]``
+        # since ADR-0008 PR-C (#624) added directory layout. Unpack the
+        # tuple — ``p.stem`` on the raw tuple raised AttributeError and
+        # the blanket ``except Exception`` below silently zeroed the count.
+        names.update(p.stem for p, _layout in list_canonical_commands(root))
         counts["commands"] = len(names)
     except Exception:
         logger.warning("counts: commands failed for %s", root, exc_info=True)
@@ -125,7 +129,9 @@ def _counts_for(root: Path) -> dict[str, int]:
 
     try:
         names = {name for _runtime, name, _status in diff_agents(root)}
-        names.update(p.stem for p in list_canonical_agents(root))
+        # Same tuple-unpack as commands above; ``list_canonical_agents``
+        # also returns ``list[tuple[Path, Layout]]`` post PR-C.
+        names.update(p.stem for p, _layout in list_canonical_agents(root))
         counts["agents"] = len(names)
     except Exception:
         logger.warning("counts: agents failed for %s", root, exc_info=True)

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -88,6 +88,40 @@ async def test_get_projects_cwd_only(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_projects_counts_directory_layout_commands_agents(client, cwd_root: Path) -> None:
+    """Counts include canonical commands/agents authored in directory layout.
+
+    Regression: ADR-0008 PR-C (#624) changed
+    ``list_canonical_{commands,agents}`` to return ``list[tuple[Path,
+    Layout]]``, but ``web/routes/context_projects.py:_counts_for``
+    still iterated as ``p.stem for p in ...`` — ``p`` was the tuple,
+    so ``p.stem`` raised ``AttributeError``. The blanket
+    ``except Exception`` hid the failure and silently returned
+    ``count=0``, so the UI showed wrong counts without an error
+    surface. This test seeds canonical entries in directory layout
+    (the new shape that exercises the tuple unpack) and asserts the
+    count reflects them.
+    """
+    # Directory layout: .memtomem/commands/<name>/command.md
+    cmd_dir = cwd_root / ".memtomem" / "commands" / "deploy"
+    cmd_dir.mkdir(parents=True)
+    (cmd_dir / "command.md").write_text("# deploy\n", encoding="utf-8")
+
+    # Directory layout: .memtomem/agents/<name>/agent.md
+    agent_dir = cwd_root / ".memtomem" / "agents" / "reviewer"
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "agent.md").write_text("# reviewer\n", encoding="utf-8")
+
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    scope = resp.json()["scopes"][0]
+    counts = scope["counts"]
+    # With the bug, both would be 0 (blanket except masks AttributeError).
+    assert counts["commands"] >= 1, f"commands count should include 'deploy' (got {counts})"
+    assert counts["agents"] >= 1, f"agents count should include 'reviewer' (got {counts})"
+
+
+@pytest.mark.asyncio
 async def test_get_projects_after_add(client, tmp_path: Path) -> None:
     other = tmp_path / "inflearn"
     other.mkdir()


### PR DESCRIPTION
## Summary

Bug surfaced in production logs as a stack trace on every \`GET /api/context/projects\` call:

\`\`\`
WARNING  counts: commands failed for /Users/.../memtomem
AttributeError: 'tuple' object has no attribute 'stem'
\`\`\`

## Root cause

ADR-0008 PR-C (#624) changed \`list_canonical_commands\` and \`list_canonical_agents\` to return \`list[tuple[Path, Layout]]\` so they can enumerate both legacy flat layout (\`commands/<name>.md\`) and the new directory layout (\`commands/<name>/command.md\`). The fan-out callers in \`context/commands.py\` and \`context/agents.py\` were updated; \`web/routes/context_projects.py:_counts_for\` was missed.

The blanket \`except Exception\` at each \`try\` block logged the error to stderr but returned \`count=0\` to the UI, so users saw "0 commands / 0 agents" for any project authored in directory layout — silent omission rather than a visible error (per \`feedback_defensive_noise\`: blanket defensive is omission; loud is evidence).

\`list_canonical_skills\` still returns \`list[Path]\`, so its existing \`p.name\` callsite (line 112) is correct — only commands and agents needed the fix.

## Fix

Unpack the tuple at both call sites:

\`\`\`python
names.update(p.stem for p, _layout in list_canonical_commands(root))
names.update(p.stem for p, _layout in list_canonical_agents(root))
\`\`\`

## Test plan

- [x] \`uv run pytest -m "not ollama" packages/memtomem/tests/test_web_routes_context_projects.py\` (14 pass, +1 new)
- [x] New \`test_get_projects_counts_directory_layout_commands_agents\` seeds \`.memtomem/commands/deploy/command.md\` and \`.memtomem/agents/reviewer/agent.md\` and asserts \`counts.commands >= 1\` AND \`counts.agents >= 1\`. **Verified fail without the fix** (exact \`AttributeError: 'tuple' object has no attribute 'stem'\` from prod logs), passes with it.
- [x] \`uv run ruff check packages/memtomem/src packages/memtomem/tests tools\` clean
- [x] \`uv run ruff format --check\` clean
- [x] \`uv run mypy packages/memtomem/src/memtomem/web/routes/context_projects.py\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)