### PR TITLE
test(windows): auto-skip symlink tests when filesystem can't symlink

### DIFF
--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -30,17 +30,50 @@ def _ollama_available() -> bool:
         return False
 
 
+def _can_create_symlink() -> bool:
+    """Probe whether the test runner can create filesystem symlinks.
+
+    On Windows, ``os.symlink`` requires either Developer Mode or
+    administrator privileges; without them every symlink-touching test
+    raises ``OSError: [WinError 1314]`` ("client does not hold the
+    required privilege"). CI is Linux-only, so this probe exists purely
+    to keep the suite runnable for contributors on a locked-down Windows
+    shell — they get a tidy SKIPPED row instead of a hard error in
+    fixture setup.
+    """
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        target = Path(td) / "probe-target"
+        link = Path(td) / "probe-link"
+        target.touch()
+        try:
+            link.symlink_to(target)
+        except (OSError, NotImplementedError):
+            return False
+    return True
+
+
 _OLLAMA_UP = _ollama_available()
+_CAN_SYMLINK = _can_create_symlink()
 
 
 def pytest_collection_modifyitems(config, items):
-    """Auto-skip tests marked with @pytest.mark.ollama when Ollama is down."""
-    if _OLLAMA_UP:
-        return
-    skip = pytest.mark.skip(reason="Ollama not running")
+    """Auto-skip tests whose marker prerequisites aren't met:
+
+    - ``@pytest.mark.ollama`` when Ollama isn't reachable.
+    - ``@pytest.mark.requires_symlinks`` when the filesystem can't make
+      symlinks (Windows without Developer Mode / admin shell).
+    """
+    skip_ollama = pytest.mark.skip(reason="Ollama not running")
+    skip_symlink = pytest.mark.skip(
+        reason="Filesystem cannot create symlinks (Windows without Developer Mode/admin)"
+    )
     for item in items:
-        if "ollama" in item.keywords:
-            item.add_marker(skip)
+        if not _OLLAMA_UP and "ollama" in item.keywords:
+            item.add_marker(skip_ollama)
+        if not _CAN_SYMLINK and "requires_symlinks" in item.keywords:
+            item.add_marker(skip_symlink)
 
 
 @pytest.fixture

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -40,15 +40,32 @@ def _can_create_symlink() -> bool:
     to keep the suite runnable for contributors on a locked-down Windows
     shell — they get a tidy SKIPPED row instead of a hard error in
     fixture setup.
+
+    Both file *and* directory symlinks are probed: historically Windows
+    treated them as separate privilege classes, and ``TestFsList.fs_tree``
+    needs ``symlink_to(..., target_is_directory=True)`` specifically.
+    Note: the probe runs in ``tempfile.gettempdir()``, which is what
+    ``tmp_path`` defaults to — users who pass ``pytest --basetemp=...``
+    pointed at a filesystem with different symlink semantics (e.g. FAT32,
+    certain network mounts) may still see marked tests fail despite the
+    probe passing.
     """
     import tempfile
 
     with tempfile.TemporaryDirectory() as td:
-        target = Path(td) / "probe-target"
-        link = Path(td) / "probe-link"
-        target.touch()
+        # File-to-file symlink.
+        file_target = Path(td) / "probe-file-target"
+        file_link = Path(td) / "probe-file-link"
+        file_target.touch()
         try:
-            link.symlink_to(target)
+            file_link.symlink_to(file_target)
+        except (OSError, NotImplementedError):
+            return False
+        # Directory symlink — separate Windows privilege historically.
+        dir_target = Path(td) / "probe-dir-target"
+        dir_target.mkdir()
+        try:
+            (Path(td) / "probe-dir-link").symlink_to(dir_target, target_is_directory=True)
         except (OSError, NotImplementedError):
             return False
     return True

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -184,6 +184,7 @@ def test_install_skips_dsstore_and_pycache(wiki_root: Path, tmp_path: Path) -> N
     assert not (dest / "__pycache__").exists()
 
 
+@pytest.mark.requires_symlinks
 def test_install_skips_symlinks_in_source(
     wiki_root: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -219,6 +219,7 @@ def test_discover_dedup_cwd_overlap_with_known(tmp_path: Path) -> None:
     assert scopes[0].label == "Server CWD"
 
 
+@pytest.mark.requires_symlinks
 def test_discover_symlink_dedup(tmp_path: Path) -> None:
     real = tmp_path / "real_project"
     real.mkdir()

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -605,6 +605,7 @@ class TestGenerateAllSettingsHostWriteGate:
         project = self._setup(tmp_path)
         assert host_write_targets(project) == []
 
+    @pytest.mark.requires_symlinks
     def test_symlink_target_is_treated_as_host_write(self, claude_home, tmp_path):
         """A symlink whose project-relative path *appears* under the project
         root must be classified by the resolved location (review item 4):

--- a/packages/memtomem/tests/test_runtime_paths.py
+++ b/packages/memtomem/tests/test_runtime_paths.py
@@ -75,6 +75,7 @@ class TestRuntimeDir:
 
         assert result.parent == Path(tempfile.gettempdir())
 
+    @pytest.mark.requires_symlinks
     def test_falls_back_when_xdg_is_symlink(self, tmp_path, monkeypatch):
         """Attacker on a shared host pre-creates ``$XDG_RUNTIME_DIR`` as a
         symlink into the user's home. ``_is_safe_dir`` must reject it —
@@ -155,6 +156,7 @@ class TestEnsureRuntimeDir:
         # must return the same path.
         ensure_runtime_dir()
 
+    @pytest.mark.requires_symlinks
     def test_refuses_existing_symlink(self, tmp_path, monkeypatch):
         """Symlink-at-the-runtime-path attack: attacker symlinks
         ``$XDG_RUNTIME_DIR/memtomem`` into the user's home. Pre-M1 fix,

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1937,6 +1937,7 @@ class TestRequireConfigured:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_symlinks
 class TestFsList:
     """Exercise the picker endpoint's allow-list, symlink, and i18n
     boundary handling. The endpoint isn't a security gate — ``mm web`` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ markers = [
     "ollama: requires a running Ollama instance (auto-skipped when unavailable)",
     "llm: requires a live LLM API key (OpenAI/Anthropic); CI runs these in the nightly job only",
     "multilingual: multilingual/large-corpus regression tests (runs in the test-golden-path CI job)",
+    "requires_symlinks: needs a filesystem that can create symlinks (auto-skipped on Windows without Developer Mode/admin)",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Summary

Five tests (and one whole class via its fixture) call `Path.symlink_to` /
`os.symlink` directly. On Windows without Developer Mode or admin
privileges, that raises `OSError: [WinError 1314] (client does not hold
the required privilege)` — and because most failures land in **fixture
setup**, they take down otherwise-unrelated tests in the same class.
Surfaced when running `uv run pytest` on a fresh Windows shell. CI is
Linux-only (tracked separately in #634) so the regression is silent
there.

This PR adds a `requires_symlinks` pytest marker. `conftest.py` runs a
one-shot probe at import time (mirrors the existing `ollama` probe) that
attempts both a **file-to-file** and a **directory** symlink, and
`pytest_collection_modifyitems` auto-skips marked tests when either
branch fails. POSIX runs and Windows-with-Developer-Mode runs have the
probe return `True`, so the marker is a no-op there.

Both symlink kinds are probed because Windows historically treated them
as separate privilege classes, and `TestFsList.fs_tree` specifically
uses `symlink_to(..., target_is_directory=True)`.

Tests marked:

| File | Site | Why marked |
| --- | --- | --- |
| `test_runtime_paths.py` | `test_falls_back_when_xdg_is_symlink` | calls `os.symlink` |
| `test_runtime_paths.py` | `test_refuses_existing_symlink` | calls `os.symlink` |
| `test_context_settings.py` | `test_symlink_target_is_treated_as_host_write` | `Path.symlink_to` |
| `test_context_projects.py` | `test_discover_symlink_dedup` | `Path.symlink_to` |
| `test_context_install.py` | `test_install_skips_symlinks_in_source` | `Path.symlink_to` |
| `test_web_routes.py` | **`TestFsList` class** | the `fs_tree` fixture creates 3 symlinks (incl. directory symlinks); all 14 tests in the class inherit the dependency |

The marker is registered in root `pyproject.toml` so unknown-marker
warnings stay quiet.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] macOS (probe → `True`, both file + dir branches): all 19 marked
      tests **PASS** — no behavior change on POSIX or on Developer-Mode
      Windows
- [x] Probe forced to `False` (simulating locked-down Windows): all 19
      marked tests **SKIPPED** with reason `"Filesystem cannot create
      symlinks (Windows without Developer Mode/admin)"` — including the
      full 14-test `TestFsList` class
- [ ] Real Windows runner is tracked in #634 — until then this fix is
      verified by the forced-probe simulation

## Notes

This is a test-runner ergonomics fix only — production code is
unchanged. The actual root fix (a Windows CI runner that would have
caught this on its own) is out of scope and tracked separately in #634.

Caveat: the probe runs in `tempfile.gettempdir()`, which is what
`tmp_path` defaults to. Users running `pytest --basetemp=...` pointed at
a filesystem with different symlink semantics (FAT32, certain network
mounts) may still see marked tests fail despite the probe passing — see
`_can_create_symlink` docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)