### PR TITLE
test: scrub /tmp metadata + .gitattributes LF pin (preps #634)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,15 +3,12 @@
 # comparisons. The motivating case is `test_install_skill_copies_tree`,
 # which asserts `read_bytes() == b"#!/bin/bash\necho hi\n"` against a
 # tracked fixture file — under autocrlf the bytes become `\r\n` and the
-# assertion fails. Source has no `\r\n` literals today; this just
-# preserves the existing on-disk contract across platforms.
+# assertion fails. Source has no `\r\n` literals today (verified via
+# `git ls-files --eol`: 494 LF, 0 CRLF, 0 mixed); this just preserves
+# the existing on-disk contract across platforms.
+#
+# A single global rule is sufficient — git's `text=auto` reliably
+# detects text vs binary for the file types in this repo, and `eol=lf`
+# overrides any developer's `core.autocrlf` setting on checkout.
 
 * text=auto eol=lf
-
-*.sh   text eol=lf
-*.py   text eol=lf
-*.md   text eol=lf
-*.toml text eol=lf
-*.yml  text eol=lf
-*.yaml text eol=lf
-*.json text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Pin LF line endings on text files so a Windows checkout (default
+# `core.autocrlf=true`) doesn't normalize to CRLF and break byte-exact
+# comparisons. The motivating case is `test_install_skill_copies_tree`,
+# which asserts `read_bytes() == b"#!/bin/bash\necho hi\n"` against a
+# tracked fixture file — under autocrlf the bytes become `\r\n` and the
+# assertion fails. Source has no `\r\n` literals today; this just
+# preserves the existing on-disk contract across platforms.
+
+* text=auto eol=lf
+
+*.sh   text eol=lf
+*.py   text eol=lf
+*.md   text eol=lf
+*.toml text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf

--- a/packages/memtomem/tests/test_ask.py
+++ b/packages/memtomem/tests/test_ask.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 from memtomem.models import Chunk, ChunkMetadata, SearchResult
 
 
-def _make_chunk(content, source="/tmp/test.md", tags=(), heading=()):
+def _make_chunk(content, source="test.md", tags=(), heading=()):
     return Chunk(
         content=content,
         metadata=ChunkMetadata(
@@ -19,7 +19,7 @@ def _make_chunk(content, source="/tmp/test.md", tags=(), heading=()):
     )
 
 
-def _make_result(content, score, rank, source="/tmp/test.md", tags=(), heading=()):
+def _make_result(content, score, rank, source="test.md", tags=(), heading=()):
     chunk = _make_chunk(content, source, tags, heading)
     return SearchResult(chunk=chunk, score=score, rank=rank, source="fused")
 
@@ -45,7 +45,7 @@ class TestMemAskFormatting:
                 if r.chunk.metadata.heading_hierarchy
                 else ""
             )
-            source = str(r.chunk.metadata.source_file).split("/")[-1]
+            source = Path(r.chunk.metadata.source_file).name
             label = heading or source
             lines.append(f"### [{r.rank}] {label} (relevance: {r.score:.2f})")
             lines.append(r.chunk.content.strip())

--- a/packages/memtomem/tests/test_ask.py
+++ b/packages/memtomem/tests/test_ask.py
@@ -45,7 +45,7 @@ class TestMemAskFormatting:
                 if r.chunk.metadata.heading_hierarchy
                 else ""
             )
-            source = Path(r.chunk.metadata.source_file).name
+            source = r.chunk.metadata.source_file.name
             label = heading or source
             lines.append(f"### [{r.rank}] {label} (relevance: {r.score:.2f})")
             lines.append(r.chunk.content.strip())

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -26,7 +26,7 @@ from memtomem.models import Chunk, ChunkMetadata
 
 def _make_chunk_with(
     content: str,
-    source: str = "/tmp/test.md",
+    source: str = "test.md",
     heading: tuple[str, ...] = (),
     namespace: str = "default",
 ) -> Chunk:
@@ -1065,14 +1065,14 @@ class TestApplyNamespace:
         """Other metadata fields should be preserved."""
         chunk = _make_chunk_with(
             "content",
-            source="/tmp/src.md",
+            source="src.md",
             heading=("H1", "H2"),
         )
         chunk_list = [chunk]
         result = IndexEngine._apply_namespace(chunk_list, "project")
 
         r = result[0]
-        assert r.metadata.source_file == Path("/tmp/src.md")
+        assert r.metadata.source_file == Path("src.md")
         assert r.metadata.heading_hierarchy == ("H1", "H2")
         assert r.content == "content"
         assert r.metadata.namespace == "project"
@@ -1128,8 +1128,8 @@ class TestMergeShortChunks:
 
     def test_no_merge_different_sources(self):
         """Chunks from different source files should NOT merge."""
-        c1 = _make_chunk_with("file A", source="/tmp/a.md", heading=("H1",))
-        c2 = _make_chunk_with("file B", source="/tmp/b.md", heading=("H1",))
+        c1 = _make_chunk_with("file A", source="a.md", heading=("H1",))
+        c2 = _make_chunk_with("file B", source="b.md", heading=("H1",))
 
         result = _merge_short_chunks([c1, c2], min_tokens=50, max_tokens=2000)
         assert len(result) == 2
@@ -1173,7 +1173,7 @@ class TestMergeShortChunks:
         c1 = Chunk(
             content="first",
             metadata=ChunkMetadata(
-                source_file=Path("/tmp/t.md"),
+                source_file=Path("t.md"),
                 heading_hierarchy=("H1",),
                 start_line=1,
                 end_line=5,
@@ -1182,7 +1182,7 @@ class TestMergeShortChunks:
         c2 = Chunk(
             content="second",
             metadata=ChunkMetadata(
-                source_file=Path("/tmp/t.md"),
+                source_file=Path("t.md"),
                 heading_hierarchy=("H1",),
                 start_line=6,
                 end_line=10,
@@ -1277,8 +1277,8 @@ class TestAddOverlap:
 
     def test_different_sources_no_overlap(self):
         """Chunks from different files should NOT get overlap."""
-        c1 = _make_chunk_with("File A", source="/tmp/a.md")
-        c2 = _make_chunk_with("File B", source="/tmp/b.md")
+        c1 = _make_chunk_with("File A", source="a.md")
+        c2 = _make_chunk_with("File B", source="b.md")
 
         result = _add_overlap([c1, c2], overlap_tokens=10)
         assert result[0].metadata.overlap_after == 0

--- a/packages/memtomem/tests/test_reranker_fastembed.py
+++ b/packages/memtomem/tests/test_reranker_fastembed.py
@@ -79,7 +79,7 @@ async def test_unknown_model_error_surfaces_supported_hint() -> None:
     )
     chunk = Chunk(
         content="any content",
-        metadata=ChunkMetadata(source_file=Path("/tmp/test.md")),
+        metadata=ChunkMetadata(source_file=Path("test.md")),
         id=uuid4(),
         embedding=[],
     )

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -249,8 +249,8 @@ class TestBinaryHintPerOrigin:
         fake_profile = init_cmd.RuntimeProfile(
             cwd_install_type="pypi",
             cwd_install_dir=None,
-            runtime_interpreter=Path("/usr/bin/python3"),
-            workspace_venv_path=Path("/tmp/foo/.venv") if origin == "venv-relative" else None,
+            runtime_interpreter=Path("python3"),
+            workspace_venv_path=Path("foo/.venv") if origin == "venv-relative" else None,
             mm_binary_origin=origin,
             runtime_matches_workspace=(origin == "venv-relative"),
         )


### PR DESCRIPTION
## Summary

Pre-flight POSIX scrub for #634 (add Windows + macOS to the `test:` CI
matrix). Issue body explicitly anticipates a red first run; this PR's
job is to make that signal **interpretable** by removing breakage we
already know about, so the matrix PR's failures are real Windows/macOS
issues rather than \`/tmp/\`-shaped noise.

No matrix change in this PR — that ships separately so each surface
gets its own focused review.

## Changes

**1. `/tmp/...` metadata literals (9 sites, 4 files)**

All decorative — `ChunkMetadata.source_file` / `RuntimeProfile` fields
constructed for in-memory test assertions, never opened. Verified
src-side: no `.is_absolute()` / `.parent` / `source_file ==
Path(...absolute...)` calls, so relative replacements are call-graph-safe.

| File | Sites | Replacement |
| --- | --- | --- |
| `test_reranker_fastembed.py` | 1 | `Path("test.md")` |
| `test_uninstall_cmd.py` | 2 | `Path("python3")`, `Path("foo/.venv")` (decorative — only hit by `f\"system Python ({...})\"` and `str(...)` formatting in `uninstall_cmd.py`; parametrized assertions check `expected_substring` like \`\"pip uninstall memtomem\"\`, never the path) |
| `test_ask.py` | 2 (helper defaults) | `\"test.md\"` |
| `test_indexing_engine.py` | 4 (×4 distinct values, ×7 occurrences) | `\"test.md\"` / `\"src.md\"` / `\"a.md\"` / `\"b.md\"` / `\"t.md\"` |

`Path(\"python3\")` chosen over `sys.executable` deliberately — the field
is decorative, and `sys.executable` would re-introduce env-dependence
(varies per CI runner / venv) for no gain.

Replacements are **separator-free** by design — see fix #2.

**2. Piggyback fix in `test_ask.py:48`**

`str(r.chunk.metadata.source_file).split(\"/\")[-1]` silently returns the
whole path on Windows because \`str(Path(...))\` uses backslash separators
there. Replaced with cross-platform \`Path(r.chunk.metadata.source_file).name\`.
1-line same-file tag-along.

**3. New `.gitattributes`**

Pins LF on text files so a Windows checkout (default
\`core.autocrlf=true\`) doesn't normalize \`.sh\` fixtures to CRLF and
break \`test_install_skill_copies_tree\`'s byte-exact assertion
(\`read_bytes() == b\"#!/bin/bash\\necho hi\\n\"\`). Source has no \`\\r\\n\`
literals today; this just preserves the existing on-disk contract.

## Test plan

- [x] \`uv run ruff check packages/memtomem/src packages/memtomem/tests tools && uv run ruff format --check ...\` clean
- [x] \`uv run pytest --ignore=packages/memtomem/tests/test_golden_path.py -m \"not ollama and not llm\"\` — 3554 passed locally
- [ ] CI green on the merge commit (Ubuntu only — matrix arrives in the follow-up PR)

Refs #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)