### PR TITLE
ci: matrix infrastructure + macOS gating; Windows informational (#634)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,11 @@ jobs:
         continue-on-error: true
 
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # Windows ships informational pending the test-portability triage tracked
+    # in #634 (umbrella) — ubuntu + macOS are the gating cells today. Flip
+    # this to `false` (or remove) once the Windows triage sub-issues close.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -20,13 +20,18 @@ module and covers ``~/.memtomem/config.json`` specifically.
 
 from __future__ import annotations
 
-import fcntl
 import logging
 import os
+import sys
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
 
 logger = logging.getLogger(__name__)
 
@@ -59,15 +64,31 @@ def _file_lock(lock_path: Path) -> Iterator[None]:
     so concurrent writers race on stale fds. The fix is to lock a sibling
     (``feedback_sidecar_lockfile_for_replaced_files.md``, PR #548). The
     lockfile itself is never renamed, so its inode is stable.
+
+    Cross-platform: POSIX uses ``fcntl.flock`` (advisory whole-file lock);
+    Windows uses ``msvcrt.locking`` (mandatory byte-range lock at offset 0).
+    Semantic differences (advisory vs mandatory, whole-file vs single byte)
+    don't matter here because the lockfile is private — only this
+    contextmanager opens it — so all contenders see the same lock.
     """
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if sys.platform == "win32":
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(fd, fcntl.LOCK_EX)
         yield
     finally:
         try:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if sys.platform == "win32":
+                # msvcrt.locking acts on the byte range starting at the
+                # current file position; reset to 0 so we unlock the
+                # same byte we locked above.
+                os.lseek(fd, 0, os.SEEK_SET)
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(fd, fcntl.LOCK_UN)
         finally:
             os.close(fd)
 
@@ -80,14 +101,18 @@ def _lock_path_for(data_path: Path) -> Path:
 def atomic_write_bytes(path: Path, data: bytes, mode: int = 0o600) -> None:
     """Atomically write *data* to *path* with an explicit file mode.
 
-    ``mode`` is applied via ``os.fchmod`` on the tempfile before the rename,
-    so the result is independent of the process umask.
+    ``mode`` is applied via ``os.fchmod`` on the tempfile before the rename
+    where available, so the result is independent of the process umask.
+    Windows Python < 3.13 lacks ``os.fchmod``; on those interpreters the
+    file is created with the process default permissions, which NTFS
+    largely ignores beyond the read-only flag.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_name)
     try:
-        os.fchmod(tmp_fd, mode)
+        if hasattr(os, "fchmod"):
+            os.fchmod(tmp_fd, mode)
         with os.fdopen(tmp_fd, "wb") as f:
             f.write(data)
             f.flush()

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -70,6 +70,15 @@ def _file_lock(lock_path: Path) -> Iterator[None]:
     Semantic differences (advisory vs mandatory, whole-file vs single byte)
     don't matter here because the lockfile is private — only this
     contextmanager opens it — so all contenders see the same lock.
+
+    Windows note: ``msvcrt.locking(LK_LOCK)`` blocks for ~10 seconds before
+    raising ``OSError``, unlike POSIX ``flock(LOCK_EX)`` which blocks
+    indefinitely. The lock window here is intentionally narrow (see callers
+    in :mod:`memtomem.context.lockfile` / :mod:`memtomem.context.projects`
+    — only the ``load → mutate dict → atomic_write_bytes`` triple), so the
+    timeout is generous; heavy contention (antivirus scans, interactive
+    debuggers) could still surface as a transient ``OSError`` rather than
+    a wait.
     """
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
@@ -105,7 +114,12 @@ def atomic_write_bytes(path: Path, data: bytes, mode: int = 0o600) -> None:
     where available, so the result is independent of the process umask.
     Windows Python < 3.13 lacks ``os.fchmod``; on those interpreters the
     file is created with the process default permissions, which NTFS
-    largely ignores beyond the read-only flag.
+    largely ignores beyond the read-only flag. The user-private intent of
+    ``mode=0o600`` for state files (e.g. ``~/.memtomem/config.json``) is
+    preserved on Windows in practice via NTFS ACL inheritance from
+    user-private parents like ``%LOCALAPPDATA%`` — the on-disk ACL is
+    user-only by default in those locations, providing functionally
+    equivalent access control.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_fd, tmp_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.", suffix=".tmp")

--- a/packages/memtomem/tests/test_runtime_paths.py
+++ b/packages/memtomem/tests/test_runtime_paths.py
@@ -37,6 +37,10 @@ def _make_safe_xdg(tmp_path: Path) -> Path:
     return xdg
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid"),
+    reason="XDG/mode-bit semantics are POSIX-only; Windows-equivalent tracked in #637",
+)
 class TestRuntimeDir:
     def test_uses_xdg_runtime_dir_when_set(self, tmp_path, monkeypatch):
         xdg = _make_safe_xdg(tmp_path)
@@ -122,6 +126,10 @@ class TestRuntimeDir:
         assert result.parent == Path(tempfile.gettempdir())
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid"),
+    reason="0o700 mode bits + umask + chmod don't translate to NTFS; tracked in #637",
+)
 class TestEnsureRuntimeDir:
     def test_creates_directory_with_owner_only_mode(self, tmp_path, monkeypatch):
         xdg = _make_safe_xdg(tmp_path)
@@ -232,6 +240,10 @@ class TestEnsureRuntimeDir:
             ensure_runtime_dir()
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "geteuid"),
+    reason="depends on _make_safe_xdg fixture's POSIX chmod; tracked in #637",
+)
 class TestServerPidPath:
     def test_resolves_to_runtime_dir_server_pid(self, tmp_path, monkeypatch):
         xdg = _make_safe_xdg(tmp_path)


### PR DESCRIPTION
## Summary

Lands the CI matrix infrastructure for issue #634 — \`test:\` job now runs on \`[ubuntu-latest, windows-latest, macos-latest]\` with \`fail-fast: false\` so all three cells report per push. **ubuntu + macOS are gating-green**; **Windows is informational** (\`continue-on-error\`) while the cross-platform test triage tracked in #637 / #643 / #644 / #645 / #646 / #647 lands incrementally.

PR-A (#636) cleared the predictable POSIX literal noise. This PR adds the matrix, a class-level skip on \`test_runtime_paths.py\` for the POSIX mode-bit XDG tests (#637), and a portability fix to \`memtomem.context._atomic\` whose unconditional \`import fcntl\` blocked Windows test collection on the first matrix run.

#634 stays open as the umbrella; it closes when each Windows triage sub-issue closes and we flip \`continue-on-error\` off in a tiny follow-up PR.

## Why scope was reframed mid-PR

The plan called for "fix in-place if cheap, otherwise platform-skip + sub-issue". On the first matrix push, Windows reported 121 failures across 23 test files — not noise, real Windows-specific bugs spread across 5 distinct categories (path separators, \`Path.home()\` vs \`HOME\` env, NTFS mtime resolution, \`'home'\` fs alias, path canonicalization). Skipping all of them in this PR would have meant module/class-level \`skipif\` markers across ~10 files plus 5 sub-issues — substantial scope creep for a single PR.

The \`continue-on-error\` reframe lets the matrix infrastructure ship now, trades "single PR closes #634" for "ubuntu/macOS gating immediately + concrete Windows backlog", and keeps the Windows triage parallelizable across multiple small follow-up PRs.

## Changes

**1. \`.github/workflows/ci.yml\`** — \`test:\` job:

\`\`\`yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, windows-latest, macos-latest]
runs-on: ${{ matrix.os }}
continue-on-error: ${{ matrix.os == 'windows-latest' }}
\`\`\`

Other jobs stay ubuntu (per the per-job rationale in #634):

| Job | OS | Why |
| --- | --- | --- |
| \`lint\` | ubuntu | Ruff is platform-agnostic |
| \`typecheck\` | ubuntu | mypy is platform-agnostic |
| \`test\` | **matrix** (ubuntu/windows/macos) | The actual surface |
| \`test-golden-path\` | ubuntu (for now) | ONNX/fastembed cross-platform deserves its own focused PR; cache key already uses \`runner.os\` |
| \`test-llm-nightly\` | ubuntu | Opt-in nightly |
| \`notebooks\` | ubuntu | Jupyter+Windows quirks; defer |

**2. \`packages/memtomem/tests/test_runtime_paths.py\`** — three class-level skips for POSIX mode-bit semantics that don't translate to NTFS, tracked in #637. Uses \`@pytest.mark.skipif(not hasattr(os, "geteuid"), ...)\` to match the existing convention at lines 110, 188, 264 of the same file.

**3. \`packages/memtomem/src/memtomem/context/_atomic.py\`** — drive-by Windows-portability fix surfaced by the matrix:

- Module-level \`import fcntl\` → \`if sys.platform == "win32": import msvcrt; else: import fcntl\` (matches the existing \`indexing/debounce.py\` and \`cli/_liveness.py\` pattern).
- \`_file_lock\`: POSIX still uses \`fcntl.flock\`; Windows uses \`msvcrt.locking\` (mandatory byte-range lock at offset 0). Documented timeout difference (\`msvcrt.locking(LK_LOCK)\` is ~10s vs \`flock(LOCK_EX)\` indefinite).
- \`atomic_write_bytes\`: \`os.fchmod\` was added to Windows in Python 3.13; CI runs Python 3.12. Guarded with \`hasattr(os, "fchmod")\`. NTFS ACL inheritance from \`%LOCALAPPDATA%\`-style parents preserves the \`mode=0o600\` user-private intent in practice.

Without this fix, Windows test collection failed at import time on 46 modules (\`mm\` CLI imports → \`context.agents\` → \`context._atomic\`), masking the actual cross-platform test failures we wanted to triage.

## Iterate-on-red findings

PR's matrix run after the \`_atomic.py\` fix:

- \`test (ubuntu-latest)\`: ✅ 3554 pass
- \`test (macos-latest)\`: ✅ 3554 pass
- \`test (windows-latest)\`: ⚠️ 3399 pass / 121 fail / 34 skip — see #634 for the triage breakdown by category and tracker

## Test plan

- [x] \`uv run ruff check ... && uv run ruff format --check ...\` clean
- [x] \`uv run pytest --ignore=packages/memtomem/tests/test_golden_path.py -m "not ollama and not llm"\` — 3554 passed locally on macOS
- [x] \`test (ubuntu-latest)\` green
- [x] \`test (macos-latest)\` green (first try)
- [ ] \`test (windows-latest)\` informational — currently 121 fail, tracked in #637 / #643 / #644 / #645 / #646 / #647
- [x] Other jobs (lint / typecheck / golden-path / notebooks / CLA) green

## References

- Tracks #634 (umbrella)
- Tracks #637 (runtime_paths NTFS rewrite — pre-emptively skipped in this PR)
- Tracks #643 (path separator assertions)
- Tracks #644 (\`Path.home()\` / HOME monkeypatch)
- Tracks #645 (NTFS mtime / config_signature)
- Tracks #646 (\`'home'\` fs alias)
- Tracks #647 (Path canonicalization in indexing)
- Builds on #636 (POSIX literal scrub) and #633 (symlink auto-skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)