### PR TITLE
fix(web): render orphan-indexed sources in Sources tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,27 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mm web` Sources tab now shows orphan-indexed files instead of
+  silently dropping them.** The `/api/sources` response carries rows
+  with `memory_dir=null, kind=null` for two paths — Index-tab uploads
+  saved to `~/.memtomem/uploads/` (which isn't a configured
+  `memory_dir`) and chunks whose owning dir was removed from
+  `memory_dirs` post-indexing. The server already grouped these as
+  "general" with the explicit intent that orphans "ride along" so
+  users can find and prune them, but the Sources tab's
+  `_renderMemorySourceTree` keyed grouping by `s.memory_dir || ''` and
+  then filtered out the empty key (`if (k) allDirs.add(k)`), so the
+  orphan rows ended up assigned to no vendor group at all and never
+  rendered. The user-facing failure mode: a file uploaded via Index
+  tab appeared in `mem_search` and the namespaces tab, but clicking
+  its source link from namespaces landed on a Sources tab that didn't
+  contain it. The renderer now collects orphan rows separately and
+  appends them as a collapsed "Other (unregistered)" sub-section under
+  the `user` vendor's active panel, with file rows sharing the same
+  click-to-browse-chunks behaviour as indexed dirs. The user vendor's
+  sub-tab badge and the empty-state guard count orphans too, so a
+  user with only Index-tab uploads sees a populated `user` tab
+  instead of "user memory not found".
 - **`mm web` now starts a `FileWatcher` and runs a startup backfill.**
   Two gaps fixed together because they presented as one bug ("files
   added to a `memory_dir` don't show up in Sources"):

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2630,6 +2630,11 @@ function _renderMemorySourceTree(sources, list) {
   // chunks drill-in works identically to indexed dirs. Rendered only
   // when ``activeVendor === 'user'`` because ``orphans`` is populated
   // exclusively for that vendor in the stats pass above.
+  //
+  // Bar normalisation: passes the outer ``maxChunks`` (tree-wide max,
+  // line ~2477) rather than a local max so the chunk-bar widths stay
+  // visually comparable to the indexed groups above — same chunk_count
+  // → same bar length regardless of which sub-section a row sits in.
   const renderOrphanBlock = (items) => {
     if (!items.length) return null;
     const det = document.createElement('details');
@@ -2645,8 +2650,7 @@ function _renderMemorySourceTree(sources, list) {
     cnt.textContent = String(items.length);
     sum.appendChild(cnt);
     det.appendChild(sum);
-    const localMax = Math.max(1, ...items.map(s => s.chunk_count || 0));
-    for (const s of items) det.appendChild(_renderMemorySourceItem(s, localMax));
+    for (const s of items) det.appendChild(_renderMemorySourceItem(s, maxChunks));
     return det;
   };
 
@@ -2709,7 +2713,12 @@ function _renderMemorySourceTree(sources, list) {
       if (disc) section.appendChild(disc);
       products.appendChild(section);
     }
-    list.appendChild(products);
+    // Skip the wrapper when every category was filtered out — happens
+    // when a ``user`` vendor has only orphan rows (no indexed / no
+    // discovered dirs). Without this guard an empty
+    // ``.source-vendor-products`` div would still ship its CSS margin
+    // before the orphan block sits below.
+    if (products.children.length) list.appendChild(products);
   }
 
   // Append the orphan block last so indexed groups stay primary. Only

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2431,9 +2431,26 @@ function _renderMemorySourceTree(sources, list) {
   const memDirs = STATE.memoryDirs || [];
   const statusByPath = STATE.memoryStatusByPath || {};
 
+  // Orphan = indexed source whose ``memory_dir`` is null on the
+  // ``/api/sources`` row. Two paths feed into this bucket:
+  //   1. Index tab uploads land in ``~/.memtomem/uploads/`` (see
+  //      ``system.py:upload_files``), which isn't a configured
+  //      ``memory_dir`` — server returns ``memory_dir=null, kind=null``.
+  //   2. A configured dir was removed from ``memory_dirs`` after its
+  //      files were indexed; the chunks survive but no longer have an
+  //      owning dir. Server-side intent (sources.py: "orphans ride
+  //      along with general") is to surface these so users can find and
+  //      prune them — without the bucket below they vanish entirely.
+  // Rendered as a collapsed sub-section under the ``user`` vendor since
+  // both feed paths are user-driven.
   const sourcesByDir = {};
+  const orphanItems = [];
   for (const s of sources) {
-    const key = s.memory_dir || '';
+    if (!s.memory_dir) {
+      orphanItems.push(s);
+      continue;
+    }
+    const key = s.memory_dir;
     if (!sourcesByDir[key]) sourcesByDir[key] = [];
     sourcesByDir[key].push(s);
   }
@@ -2534,15 +2551,25 @@ function _renderMemorySourceTree(sources, list) {
       return [cat, indexedSorted, discovered];
     });
 
-    const isEmptyVendor = !visibleCats.some(([, indexed, discovered]) => indexed.length || discovered.length);
+    // Orphan rows ride along with the ``user`` vendor (see comment on
+    // ``orphanItems`` above for why). Counted toward both the sub-tab
+    // badge and the vendor's emptiness check so a user with only
+    // uploaded files sees a populated tab instead of "user memory not
+    // found".
+    const vendorOrphans = (provider === 'user') ? orphanItems : [];
+    const isEmptyVendor = !visibleCats.some(([, indexed, discovered]) => indexed.length || discovered.length)
+      && vendorOrphans.length === 0;
     const totalFiles = visibleCats.reduce(
       (sum, [, indexed]) => sum + indexed.reduce((s, d) => s + (sourcesByDir[d] || []).length, 0),
       0,
-    );
+    ) + vendorOrphans.length;
     const visibleIndexedCats = visibleCats.filter(([, indexed]) => indexed.length);
     const isSingleLeaf = visibleIndexedCats.length === 1
       || (visibleIndexedCats.length === 0 && visibleCats.length === 1);
-    vendorPlans[provider] = { visibleCats, visibleIndexedCats, isEmptyVendor, totalFiles, isSingleLeaf };
+    vendorPlans[provider] = {
+      visibleCats, visibleIndexedCats, isEmptyVendor, totalFiles, isSingleLeaf,
+      orphans: vendorOrphans,
+    };
 
     // Update the sub-tab badge + empty class so all three vendor tabs
     // reflect current state, not just the active one.
@@ -2594,6 +2621,32 @@ function _renderMemorySourceTree(sources, list) {
     sum.appendChild(cnt);
     det.appendChild(sum);
     for (const d of dirs) det.appendChild(renderDir(d));
+    return det;
+  };
+
+  // Orphan section: rows whose owning ``memory_dir`` is null on the
+  // server response (Index tab uploads + chunks whose dir was removed
+  // from config). Reuses the ``source-item`` card shape so file-click →
+  // chunks drill-in works identically to indexed dirs. Rendered only
+  // when ``activeVendor === 'user'`` because ``orphans`` is populated
+  // exclusively for that vendor in the stats pass above.
+  const renderOrphanBlock = (items) => {
+    if (!items.length) return null;
+    const det = document.createElement('details');
+    det.className = 'source-vendor-orphan';
+    const sum = document.createElement('summary');
+    sum.className = 'source-vendor-orphan-summary';
+    const lbl = document.createElement('span');
+    lbl.className = 'source-vendor-orphan-label';
+    lbl.textContent = (typeof t === 'function') ? t('sources.orphan_label') : 'Other (unregistered)';
+    sum.appendChild(lbl);
+    const cnt = document.createElement('span');
+    cnt.className = 'source-vendor-count';
+    cnt.textContent = String(items.length);
+    sum.appendChild(cnt);
+    det.appendChild(sum);
+    const localMax = Math.max(1, ...items.map(s => s.chunk_count || 0));
+    for (const s of items) det.appendChild(_renderMemorySourceItem(s, localMax));
     return det;
   };
 
@@ -2659,13 +2712,22 @@ function _renderMemorySourceTree(sources, list) {
     list.appendChild(products);
   }
 
+  // Append the orphan block last so indexed groups stay primary. Only
+  // shows up when ``activeVendor === 'user'`` because ``plan.orphans``
+  // is populated for that vendor only.
+  const orphanBlock = renderOrphanBlock(plan.orphans || []);
+  if (orphanBlock) list.appendChild(orphanBlock);
+
   // Empty-state fallbacks scoped to the active vendor. If no memory
   // dirs exist anywhere, show the "Add one with + Add path" hint
-  // regardless of which tab is active. If a filter is active and the
-  // active vendor has no matches but other vendors do, the muted "no
-  // matches" hint sits inside the panel — the populated badge on
-  // sibling tabs tells the user where to look.
-  if (!allDirs.size) {
+  // regardless of which tab is active. The orphan check keeps a user
+  // who has only Index-tab uploads (no configured dirs) from seeing
+  // the "No memory directories" hint — their uploads are real content.
+  // If a filter is active and the active vendor has no matches but
+  // other vendors do, the muted "no matches" hint sits inside the
+  // panel — the populated badge on sibling tabs tells the user where
+  // to look.
+  if (!allDirs.size && !orphanItems.length) {
     list.innerHTML = '<div class="empty-state">' + emptyState('📁', 'No memory directories', 'Add one with the + Add path button') + '</div>';
   } else if (filterActive && !plan.totalFiles && !plan.isEmptyVendor) {
     list.innerHTML = '<div class="empty-state">' + emptyState('🔍', 'No matches for that filter') + '</div>';

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=80"></script>
+  <script src="/app.js?v=81"></script>
   <script src="/settings-config.js?v=7"></script>
   <script src="/sources-memory-dirs.js?v=8"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=79"></script>
+  <script src="/app.js?v=80"></script>
   <script src="/settings-config.js?v=7"></script>
   <script src="/sources-memory-dirs.js?v=8"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -142,6 +142,7 @@
   "sources.empty_icon": "📄",
   "sources.empty_text": "Select a source to browse its chunks",
   "sources.discovered_label": "Discovered",
+  "sources.orphan_label": "Other (unregistered)",
   "sources.empty_vendor_placeholder": "{vendor} memory not found",
   "sources.add_manually_btn": "+ Add manually",
   "sources.default_pill": "default",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -142,6 +142,7 @@
   "sources.empty_icon": "📄",
   "sources.empty_text": "소스를 선택하면 청크를 탐색할 수 있습니다",
   "sources.discovered_label": "발견됨",
+  "sources.orphan_label": "기타 (등록되지 않은 위치)",
   "sources.empty_vendor_placeholder": "{vendor} 메모리 없음",
   "sources.add_manually_btn": "+ 수동 추가",
   "sources.default_pill": "기본",


### PR DESCRIPTION
## Summary

The ``/api/sources`` response carries rows with ``memory_dir=null, kind=null`` for two paths:

1. **Index-tab uploads** land in ``~/.memtomem/uploads/`` ([system.py:upload_files](https://github.com/memtomem/memtomem/blob/main/packages/memtomem/src/memtomem/web/routes/system.py)) — not a configured ``memory_dir``.
2. **Removed-from-config dirs** — chunks survive after a dir is dropped from ``memory_dirs`` but no longer have an owning dir.

Server-side intent (pinned by [`test_orphan_source_kind_is_null`](https://github.com/memtomem/memtomem/blob/main/packages/memtomem/tests/test_web_routes.py#L573) / [`test_kind_general_filter_includes_orphans`](https://github.com/memtomem/memtomem/blob/main/packages/memtomem/tests/test_web_routes.py#L599)) is that orphans "ride along with general" so users can find and prune them. The Sources tab client renderer violated that intent by:

```js
const key = s.memory_dir || '';
// …
for (const k of Object.keys(sourcesByDir)) if (k) allDirs.add(k);  // empty key dropped
```

…leaving orphan rows unassigned to any vendor group and therefore unrendered.

## User-facing failure mode

File uploaded via the Index tab appears in ``mem_search`` and the namespaces tab, but the source link from namespaces lands on a Sources tab that doesn't contain it. Reported via ``mm web``: Index-tab upload → namespaces source-link cross-link → "있는데 없음" state.

## Fix

Client-only change in ``_renderMemorySourceTree``:

- Collect rows with ``!s.memory_dir`` into a separate ``orphanItems`` list.
- Attribute them to the ``user`` vendor (both feed paths are user-driven).
- Append a collapsed **"Other (unregistered)"** ``<details>`` block at the end of that vendor's active panel.
- Reuse ``_renderMemorySourceItem`` card shape so file-click → chunks drill-in works identically to indexed dirs.
- The user vendor's sub-tab badge and the empty-state guard count orphans too — a user with only Index-tab uploads sees a populated ``user`` tab instead of "user memory not found".

Server contract is unchanged. ``index.html`` ``app.js?v=`` bumped 79 → 81 (two-commit body changes) to bust disk cache. New i18n key ``sources.orphan_label`` added to ``en.json`` / ``ko.json``.

Follow-up commit (`55c091b`) addresses two self-review nits:
- `renderOrphanBlock` now passes the outer tree-wide `maxChunks` to `_renderMemorySourceItem` instead of a local max, so chunk-bar widths stay visually comparable across indexed groups and the orphan section.
- The multi-product render branch guards `products.children.length` before appending, so an orphan-only `user` vendor doesn't ship an empty `.source-vendor-products` wrapper before the orphan block.

## Test plan

- [x] ``test_i18n.py`` parity (en/ko key set + placeholder shape) — 12 tests pass
- [x] ``-k source`` slice (75 tests) — pass against the worktree
- [x] Server contract for orphans was already pinned (3 tests in ``test_web_routes.py``); this PR doesn't loosen it
- [x] Manual: ``mm web`` → Index tab upload a file → switch to Sources tab → confirm file appears under "Other (unregistered)" inside the User sub-tab — **verified via Playwright in an isolated `HOME=/tmp/mm-orphan-test` env**
- [x] Manual: remove a configured ``memory_dir`` that has indexed chunks → confirm those chunks now show under "Other (unregistered)" instead of disappearing — **verified via Playwright; both upload and ex-registered-dir files end up in the same orphan section, count=2, User badge=2**

See the [verification comment](https://github.com/memtomem/memtomem/pull/639#issuecomment-) below for full Playwright assertion output.

## Out of scope

- ``_active_runs`` polling-loop suspicion → filed as #640
- JS unit-test infrastructure (would have caught this regression cheaply) → filed as #641
- Heavy bge-m3 indexing UX (config-side discussion, not a bug fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)