### PR TITLE
PR-D C4: mm context migrate (ADR-0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **`mm context migrate` (PR-D C4, ADR-0008)** — converts agents and
+  commands from the legacy flat layout (`<type>/<name>.md`) to the
+  canonical directory layout (`<type>/<name>/agent.md` or
+  `<type>/<name>/command.md`) introduced in PR-C. Pre-PR-C installs and
+  reverse-imports left flat files on disk; this verb normalizes them so
+  the dir-only paths can simplify in a future cleanup PR.
+
+  - **Three signatures**: `mm context migrate` (every flat asset across
+    `agents/` and `commands/`), `mm context migrate <type>` (one type),
+    `mm context migrate <type> <name>` (single asset). Skills are always
+    directory layout (Agent Skills spec); invoking the verb on
+    `skills` exits 0 with an informational message rather than an error.
+  - **Dry-run by default**; `--apply` mutates the filesystem via
+    `os.replace` (atomic single-rename). The lockfile is not touched —
+    layout is inferred from the filesystem authoritatively
+    (`list_canonical_agents` / `list_canonical_commands`), and
+    `installed_at` is preserved so dirty detection (Invariant 2) keeps
+    working across migrations.
+  - **Eight-row truth table**: the classifier surfaces every combination
+    of `flat? × dir? × lockfile-entry? × dirty?` as one of six states
+    (`migrate`, `noop`, `cleanup_flat`, `refuse_dirty`, `skip_manual`,
+    `skip_orphan`). Manual flat files (no lockfile entry) and orphan
+    lockfile entries are surfaced and left untouched — those are out of
+    scope for the install/upgrade lifecycle.
+  - **Dirty handling mirrors `mm context update --force`** — flat files
+    with `mtime > installed_at` are refused unless `--apply --force` is
+    passed. With `--force`, a `.bak` sibling is written before mutation
+    so the user's edits survive in a forensic snapshot. For `flat+dir`
+    collisions the dir layout is left untouched (it carries the
+    canonical wiki bytes per PR-C policy); the user reviews the `.bak`
+    manually if they want to merge.
+  - Pairs with `mm context status`: status walks the dir-only dest tree
+    (`is_asset_dirty` is dir-scoped) and so flat-only installs surface
+    as `missing` rows; `mm context migrate` is the verb to normalize
+    them in place.
+
 - **Multi-project read-only discovery for `mm web` Skills/Commands/Agents
   (PR2 of the multi-project context UI series).** Each tab now renders
   collapsible scope groups so a user running `mm web` from `memtomem`

--- a/docs/adr/0008-wiki-layer.md
+++ b/docs/adr/0008-wiki-layer.md
@@ -119,11 +119,33 @@ mm context install <type> <name>
 mm context install --all                # lockfile-driven re-setup
 mm context update  <type> <name> [--all]
 mm context status
+mm context migrate [<type> [<name>]] [--apply] [--force] [--yes]
 ```
 
 `mm context sync --include=skills` (existing, ADR-0001 §3) is unchanged.
 The `mm wiki` group is single-asset; `mm context sync` remains the
 multi-asset bulk verb.
+
+`mm context migrate` converts agents and commands from the legacy flat
+layout (`<type>/<name>.md`) to the canonical directory layout
+(`<type>/<name>/agent.md` or `<type>/<name>/command.md`) introduced in
+PR-C. Skills are always directory layout; invoking the command on
+skills exits 0 with an informational message.
+
+The verb is **dry-run by default** — running it without `--apply` prints
+the migration plan and exits without writing. `--apply` mutates the
+filesystem with `os.replace` (atomic single-rename). The lockfile is
+untouched on every path: layout is inferred from the filesystem
+authoritatively (`list_canonical_agents` / `list_canonical_commands`),
+and `installed_at` is preserved so dirty detection (Invariant 2) keeps
+working across migrations.
+
+Per Invariant 2, dirty flat files (mtime > installed_at) are refused
+unless `--apply --force` is passed; `--force` writes a `.bak` sibling
+before mutation, mirroring `mm context update --force`. Manual flat
+files (no lockfile entry) and orphan lockfile entries (entry but no
+files on disk) are surfaced as `skip` rows and left untouched — those
+are out of scope for the install/upgrade lifecycle.
 
 ## Lockfile schema
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -46,6 +46,11 @@ from memtomem.context.install import (
     update_command,
     update_skill,
 )
+from memtomem.context.migrate import (
+    MigrateRow,
+    classify_migrate,
+    migrate_one,
+)
 from memtomem.context.projects import KnownProjectsStore
 from memtomem.context.lockfile import LockfileVersionError
 from memtomem.context.status import classify_status, load_with_recovery
@@ -1264,3 +1269,263 @@ def _print_install_classification_table(
         if c.reason:
             line += f"  ({c.reason})"
         click.secho(line, fg=color)
+
+
+# ── migrate (PR-D C4) ───────────────────────────────────────────────────
+
+
+_MIGRATE_GLYPH: dict[str, tuple[str, str]] = {
+    # state -> (glyph, click color)
+    "migrate": ("→", "green"),
+    "noop": ("·", "white"),
+    "cleanup_flat": ("±", "yellow"),
+    "refuse_dirty": ("✗", "red"),
+    "skip_manual": ("?", "yellow"),
+    "skip_orphan": ("?", "yellow"),
+}
+
+# Glyphs are intentionally distinct from `_STATUS_GLYPH` for cleanup_flat
+# (`±` vs status's `⚠`) so users running `mm context status` and `mm
+# context migrate` back-to-back don't conflate "stale-pin (red)" with
+# "flat+dir collision (yellow)". `✗` is shared but the colour differs
+# (status: yellow=dirty in dest tree; migrate: red=blocked by --force).
+
+
+_MIGRATE_ACTION_LABEL: dict[str, str] = {
+    "migrate": "flat → dir",
+    "noop": "no-op",
+    "cleanup_flat": "flat+dir collision",
+    "skip_manual": "skip (manual)",
+    "skip_orphan": "skip (orphan)",
+}
+
+
+def _migrate_action_label(row: MigrateRow) -> str:
+    if row.state == "refuse_dirty":
+        return "flat+dir collision" if row.dir_exists else "flat → dir"
+    return _MIGRATE_ACTION_LABEL.get(row.state, row.state)
+
+
+def _print_migrate_preview(rows: list[MigrateRow], *, skills_section: bool) -> None:
+    """Render the migrate dry-run / pre-apply preview.
+
+    Sectioned by asset_type alphabetically (matches `_classify_for_install_all`
+    convention). When ``skills_section`` is true, print an informational
+    footer noting that skills are always directory layout.
+    """
+    click.echo("\nWill migrate (review; pass --apply to execute):")
+    last_type: str | None = None
+    for row in rows:
+        if row.asset_type != last_type:
+            click.secho(f"\n{row.asset_type}", fg="cyan")
+            last_type = row.asset_type
+        glyph, color = _MIGRATE_GLYPH[row.state]
+        action = _migrate_action_label(row)
+        line = f"  {glyph}  {row.name:24s}  {action:24s}  ({row.reason})"
+        click.secho(line, fg=color)
+    if skills_section:
+        click.secho("\nskills", fg="cyan")
+        click.secho(
+            "  i  always directory layout — no migration needed",
+            fg="cyan",
+        )
+
+
+def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
+    """Build the post-preview summary line."""
+    counts: dict[str, int] = {s: 0 for s in _MIGRATE_GLYPH}
+    for row in rows:
+        counts[row.state] += 1
+    parts: list[str] = []
+    if counts["migrate"]:
+        parts.append(f"{counts['migrate']} ready")
+    if counts["cleanup_flat"]:
+        parts.append(f"{counts['cleanup_flat']} cleanup (flat+dir)")
+    if counts["refuse_dirty"]:
+        parts.append(f"{counts['refuse_dirty']} need --force")
+    if counts["skip_manual"]:
+        parts.append(f"{counts['skip_manual']} skip (manual)")
+    if counts["skip_orphan"]:
+        parts.append(f"{counts['skip_orphan']} skip (orphan)")
+    if counts["noop"]:
+        parts.append(f"{counts['noop']} no-op")
+    return ", ".join(parts) if parts else "0 actions"
+
+
+@context.command("migrate")
+@click.argument(
+    "asset_type",
+    type=click.Choice(["agents", "commands", "skills"]),
+    required=False,
+)
+@click.argument("name", required=False)
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    default=False,
+    help="Execute the migration (default is a dry-run preview).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Migrate dirty flat files; each gets a .bak sibling. Requires --apply.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt. Requires --apply.",
+)
+def migrate_cmd(
+    asset_type: str | None,
+    name: str | None,
+    apply_: bool,
+    force: bool,
+    yes: bool,
+) -> None:
+    """Convert flat-layout context assets to canonical directory layout.
+
+    PR-C made the directory layout canonical for agents and commands;
+    pre-PR-C installs and reverse-imports leave behind flat files
+    (``agents/<name>.md``). This command renames each such file to
+    ``agents/<name>/agent.md`` (and the equivalent for commands) atomically
+    via ``os.replace``.
+
+    Skills are always directory layout (Agent Skills spec) and are not
+    in scope. Invoking ``migrate skills`` exits 0 with an informational
+    message rather than an error.
+
+    Default mode is a dry-run preview; pass ``--apply`` to execute. Dirty
+    flat files (mtime > installed_at) require ``--force`` and produce a
+    ``.bak`` sibling before mutation, mirroring ``mm context update --force``.
+    """
+    if (force or yes) and not apply_:
+        raise click.UsageError("--force / --yes are only valid with --apply")
+    if name is not None and asset_type is None:
+        raise click.UsageError("name argument requires asset_type")
+
+    if asset_type == "skills":
+        click.secho(
+            "skills are always directory layout (Agent Skills spec) — no migration needed.",
+            fg="cyan",
+        )
+        return
+
+    root = _find_project_root()
+
+    try:
+        rows = classify_migrate(root, asset_type=asset_type, name=name)
+    except (FileNotFoundError, ValueError, InvalidNameError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    # When the user passes no asset_type, mention skills in the preview
+    # footer so the absence is explicit rather than silent.
+    skills_section = asset_type is None
+
+    if not rows:
+        if name is not None:
+            click.echo(
+                f"No matching asset to migrate (checked {asset_type}/{name}).",
+                err=True,
+            )
+        else:
+            click.echo("No flat-layout assets to migrate.")
+        if skills_section:
+            click.secho(
+                "  (skills are always directory layout — no migration needed.)",
+                fg="cyan",
+            )
+        return
+
+    _print_migrate_preview(rows, skills_section=skills_section)
+    summary = _summarize_migrate_rows(rows)
+    click.echo(f"\nSummary: {summary}.")
+
+    needs_force = [r for r in rows if r.state == "refuse_dirty"]
+    actionable = [r for r in rows if r.state in {"migrate", "cleanup_flat"}]
+
+    if not apply_:
+        click.echo("\nRun with --apply to execute.")
+        if needs_force:
+            click.echo("Dirty/collision assets need --apply --force (creates .bak per dirty file).")
+        return
+
+    # --apply path
+    if needs_force and not force:
+        click.secho(
+            f"\n{len(needs_force)} entry(ies) have local edits since install; "
+            f"pass --force to migrate (each dirty flat file gets a .bak sibling). "
+            f"Refusing to write any entry — re-run with --force or resolve manually.",
+            fg="red",
+            err=True,
+        )
+        raise click.exceptions.Exit(1)
+
+    if not actionable and not (force and needs_force):
+        click.echo("\nNothing to migrate.")
+        return
+
+    if yes and force:
+        click.secho(
+            "WARNING: --yes --force will migrate dirty flat files without prompting.",
+            fg="red",
+            err=True,
+        )
+
+    if not yes:
+        plan_count = len(actionable) + (len(needs_force) if force else 0)
+        click.confirm(f"\nMigrate {plan_count} asset(s)? Continue?", abort=True)
+
+    successes = 0
+    failures = 0
+    skipped = 0
+    for row in rows:
+        if row.state in {"noop", "skip_manual", "skip_orphan"}:
+            glyph, color = _MIGRATE_GLYPH[row.state]
+            click.secho(
+                f"  {glyph}  {row.asset_type}/{row.name}: {row.reason}",
+                fg=color,
+            )
+            skipped += 1
+            continue
+        if row.state == "refuse_dirty" and not force:
+            # Already gated above; defense in depth.
+            click.secho(
+                f"  ✗  {row.asset_type}/{row.name}: dirty without --force",
+                fg="red",
+            )
+            failures += 1
+            continue
+
+        result = migrate_one(root, row, force=force)
+        if result.ok:
+            tag = "migrated"
+            if row.state == "cleanup_flat" or (row.state == "refuse_dirty" and row.dir_exists):
+                tag = "flat removed (dir wins)"
+            bak_note = f" (.bak: {result.bak_path.name})" if result.bak_path is not None else ""
+            click.secho(
+                f"  ✓  {row.asset_type}/{row.name}: {tag}{bak_note}",
+                fg="green",
+            )
+            successes += 1
+        else:
+            click.secho(
+                f"  ✗  {row.asset_type}/{row.name}: {result.error}",
+                fg="red",
+            )
+            failures += 1
+
+    parts: list[str] = []
+    if successes:
+        parts.append(f"{successes} migrated")
+    if skipped:
+        parts.append(f"{skipped} skipped")
+    if failures:
+        parts.append(f"{failures} failed")
+    click.echo("\nSummary: " + (", ".join(parts) if parts else "0 actions") + ".")
+
+    if failures:
+        raise click.exceptions.Exit(1)

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -1,0 +1,447 @@
+"""Convert flat-layout context assets to canonical directory layout.
+
+ADR-0008 PR-D C4. PR-C made the directory layout (e.g.
+``agents/<name>/agent.md``) canonical for agents and commands; pre-PR-C
+installs and reverse-imports left flat-layout files (``agents/<name>.md``)
+on disk. This module classifies and converts those flat assets to the
+dir layout in place.
+
+Pure module: filesystem + lockfile only, no wiki dependency (ADR-0008
+Invariants 1 / 3). The CLI wrapper in
+:func:`memtomem.cli.context_cmd.migrate_cmd` adds the dry-run preview,
+``--apply`` gating, and confirmation prompts.
+
+Skills are always directory layout (Agent Skills spec) and are not in
+scope here — :func:`classify_migrate` returns an empty list when invoked
+with ``asset_type="skills"`` and the CLI surfaces a friendly informational
+message rather than an error.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context.agents import (
+    AGENT_DIR_FILENAME,
+    CANONICAL_AGENT_ROOT,
+    list_canonical_agents,
+)
+from memtomem.context.commands import (
+    CANONICAL_COMMAND_ROOT,
+    COMMAND_DIR_FILENAME,
+    list_canonical_commands,
+)
+from memtomem.context.lockfile import Lockfile
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ASSET_DIR_FILENAMES",
+    "MIGRATABLE_ASSET_TYPES",
+    "MigrateResult",
+    "MigrateRow",
+    "MigrateState",
+    "classify_migrate",
+    "migrate_one",
+]
+
+
+MigrateState = Literal[
+    "migrate",
+    "noop",
+    "cleanup_flat",
+    "refuse_dirty",
+    "skip_manual",
+    "skip_orphan",
+]
+"""Per-asset classification produced by :func:`classify_migrate`.
+
+- ``migrate`` — flat exists, dir absent, lockfile entry clean → safe to
+  rename flat into dir layout.
+- ``noop`` — already directory layout, nothing to do.
+- ``cleanup_flat`` — both flat and dir exist (PR-C dir-wins collision);
+  remove the flat sibling.
+- ``refuse_dirty`` — flat has user edits since the recorded
+  ``installed_at`` timestamp; require ``--force``.
+- ``skip_manual`` — flat exists but has no lockfile entry, so it sits
+  outside the install/upgrade lifecycle. Migrate refuses to touch it; the
+  user resolves manually (typically by running ``mm context install``).
+- ``skip_orphan`` — lockfile entry exists but neither flat nor dir is on
+  disk. Rare; surfaced so users notice the dangling entry.
+"""
+
+MIGRATABLE_ASSET_TYPES: tuple[str, ...] = ("agents", "commands")
+"""Asset types this command can migrate.
+
+Skills are always directory layout (Agent Skills spec). The CLI accepts
+``"skills"`` as an argument but exits with an informational message
+rather than running classification.
+"""
+
+ASSET_DIR_FILENAMES: dict[str, str] = {
+    "agents": AGENT_DIR_FILENAME,
+    "commands": COMMAND_DIR_FILENAME,
+}
+
+_CANONICAL_ROOTS: dict[str, str] = {
+    "agents": CANONICAL_AGENT_ROOT,
+    "commands": CANONICAL_COMMAND_ROOT,
+}
+
+
+@dataclass(frozen=True)
+class MigrateRow:
+    """One asset's migration plan.
+
+    ``flat_path`` and ``dir_path`` are the canonical destinations whether
+    or not the file currently exists on disk; executors use them as
+    targets. ``flat_dirty`` is ``None`` when the dirty check did not
+    apply — either no flat file is on disk or no lockfile entry was
+    found (per locked decisions #5 and #12).
+    """
+
+    asset_type: str
+    name: str
+    flat_path: Path
+    dir_path: Path
+    flat_exists: bool
+    dir_exists: bool
+    has_lock_entry: bool
+    flat_dirty: bool | None
+    state: MigrateState
+    reason: str
+
+
+@dataclass(frozen=True)
+class MigrateResult:
+    """Outcome of executing one row's plan.
+
+    ``bak_path`` is set only when ``force`` was true and the flat file
+    was dirty: a ``shutil.copy2`` snapshot is written next to the flat
+    file before mutation. Mirrors the ``mm context update --force``
+    convention (locked decision #6).
+    """
+
+    row: MigrateRow
+    bak_path: Path | None
+    ok: bool
+    error: str | None
+
+
+def _is_flat_file_dirty(flat_path: Path, lock_entry: dict[str, Any]) -> bool:
+    """Strict ``mtime > installed_at_epoch`` for a single flat file.
+
+    :func:`memtomem.context.dirty.is_asset_dirty` walks
+    ``<root>/<type>/<name>/`` (directory only) and returns
+    ``missing_dest`` for a flat file. This helper applies the same rule
+    one level up. Equality with ``installed_at`` is clean (strict ``>``).
+
+    Timezone handling matches ``dirty.py`` — ``datetime.fromisoformat``
+    on the ISO-8601Z string. Python 3.11+ accepts the ``Z`` suffix
+    natively, so no manual replacement is needed.
+    """
+    installed_at = lock_entry.get("installed_at")
+    if not isinstance(installed_at, str):
+        return False
+    installed_at_epoch = datetime.fromisoformat(installed_at).timestamp()
+    return flat_path.stat().st_mtime > installed_at_epoch
+
+
+def _flat_path_for(project_root: Path, asset_type: str, name: str) -> Path:
+    return project_root / _CANONICAL_ROOTS[asset_type] / f"{name}.md"
+
+
+def _dir_path_for(project_root: Path, asset_type: str, name: str) -> Path:
+    return project_root / _CANONICAL_ROOTS[asset_type] / name
+
+
+def _classify_row(
+    project_root: Path,
+    asset_type: str,
+    name: str,
+    lock_entry: dict[str, Any] | None,
+) -> MigrateRow | None:
+    """Classify one ``(asset_type, name)`` pair.
+
+    Returns ``None`` when neither flat nor dir is on disk and there is
+    no lockfile entry — there's nothing to surface. Otherwise the
+    eight-row truth table in the C4 plan is implemented here.
+    """
+    flat_path = _flat_path_for(project_root, asset_type, name)
+    dir_path = _dir_path_for(project_root, asset_type, name)
+    asset_filename = ASSET_DIR_FILENAMES[asset_type]
+    flat_exists = flat_path.is_file()
+    dir_exists = (dir_path / asset_filename).is_file()
+    has_lock_entry = lock_entry is not None
+
+    if not flat_exists and not dir_exists and not has_lock_entry:
+        return None
+
+    flat_dirty: bool | None = None
+    state: MigrateState
+    reason: str
+
+    if not flat_exists and dir_exists:
+        state = "noop"
+        reason = "already dir layout"
+    elif not flat_exists and not dir_exists:
+        state = "skip_orphan"
+        reason = "lockfile entry but no files on disk"
+    elif flat_exists and not has_lock_entry:
+        state = "skip_manual"
+        reason = (
+            "manual flat file collides with dir; resolve manually"
+            if dir_exists
+            else "manual flat file (no lockfile entry); resolve manually"
+        )
+    else:
+        # flat_exists and has_lock_entry → dirty check applies
+        assert lock_entry is not None
+        flat_dirty = _is_flat_file_dirty(flat_path, lock_entry)
+        if dir_exists:
+            if flat_dirty:
+                state = "refuse_dirty"
+                reason = "flat+dir collision; flat has local edits since install"
+            else:
+                state = "cleanup_flat"
+                reason = "flat+dir collision; dir wins, will remove flat"
+        elif flat_dirty:
+            state = "refuse_dirty"
+            reason = "flat has local edits since install"
+        else:
+            state = "migrate"
+            reason = "flat → dir"
+
+    return MigrateRow(
+        asset_type=asset_type,
+        name=name,
+        flat_path=flat_path,
+        dir_path=dir_path,
+        flat_exists=flat_exists,
+        dir_exists=dir_exists,
+        has_lock_entry=has_lock_entry,
+        flat_dirty=flat_dirty,
+        state=state,
+        reason=reason,
+    )
+
+
+def classify_migrate(
+    project_root: Path | str,
+    asset_type: str | None = None,
+    name: str | None = None,
+) -> list[MigrateRow]:
+    """Build a row per migratable asset under *project_root*.
+
+    Iteration source (per locked decision #12): the union of lockfile
+    entries (``Lockfile.iter_entries``) and on-disk enumeration via
+    :func:`list_canonical_agents` / :func:`list_canonical_commands`,
+    deduplicated by ``(asset_type, name)``. This catches both manual
+    flat files (disk only → ``skip_manual``) and orphan lockfile
+    entries (entry only → ``skip_orphan``).
+
+    Wiki is not consulted (Invariants 1 / 3) — pure filesystem +
+    lockfile.
+
+    Race policy (per locked decision #11): the result is a snapshot at
+    call time. The CLI executes serially against this snapshot without
+    re-reading the disk; mid-batch external mutations are not detected.
+
+    ``asset_type=None`` enumerates ``agents`` and ``commands`` together.
+    ``"skills"`` returns an empty list. ``name`` may only be passed
+    alongside ``asset_type``; an asset whose name is not present anywhere
+    yields an empty list (the CLI surfaces "no asset to migrate").
+    """
+    project_root_path = Path(project_root).expanduser()
+    if not project_root_path.is_dir():
+        raise FileNotFoundError(f"project_root {project_root_path} is not a directory")
+
+    if asset_type == "skills":
+        return []
+
+    if asset_type is not None and asset_type not in MIGRATABLE_ASSET_TYPES:
+        raise ValueError(
+            f"invalid asset_type {asset_type!r}: expected one of "
+            f"{MIGRATABLE_ASSET_TYPES} or 'skills' (no-op)"
+        )
+    if name is not None and asset_type is None:
+        raise ValueError("name requires asset_type")
+    if name is not None:
+        validate_name(name, kind="asset name")
+
+    types_to_scan: tuple[str, ...] = (asset_type,) if asset_type else MIGRATABLE_ASSET_TYPES
+    lockfile = Lockfile.at(project_root_path)
+    doc = lockfile.load(strict=False)
+
+    rows: list[MigrateRow] = []
+    for at in types_to_scan:
+        if at == "agents":
+            disk_pairs = list_canonical_agents(project_root_path)
+        else:
+            disk_pairs = list_canonical_commands(project_root_path)
+        disk_names = {(p.parent.name if layout == "dir" else p.stem) for p, layout in disk_pairs}
+
+        section = doc.get(at)
+        lock_names: set[str] = set()
+        if isinstance(section, dict):
+            lock_names = {n for n, v in section.items() if isinstance(v, dict)}
+
+        if name is not None:
+            all_names = [name] if name in (disk_names | lock_names) else []
+        else:
+            all_names = sorted(disk_names | lock_names)
+
+        for nm in all_names:
+            try:
+                validate_name(nm, kind=f"{at[:-1]} name")
+            except InvalidNameError as exc:
+                logger.warning("migrate: skipping invalid %s name %r: %s", at, nm, exc)
+                continue
+
+            entry: dict[str, Any] | None = None
+            if isinstance(section, dict):
+                section_entry = section.get(nm)
+                if isinstance(section_entry, dict):
+                    entry = section_entry
+
+            row = _classify_row(project_root_path, at, nm, entry)
+            if row is not None:
+                rows.append(row)
+
+    return rows
+
+
+def _execute_migrate(row: MigrateRow, *, force: bool) -> Path | None:
+    """Rename the flat file into ``<dir>/<asset_filename>`` atomically.
+
+    Sequence:
+
+    1. ``shutil.copy2(flat, flat.bak)`` if the flat file is dirty and
+       ``force`` is true (preserves mtime).
+    2. ``mkdir(parents=True, exist_ok=True)`` on the destination dir.
+    3. ``os.replace(flat, dir/<asset_filename>)`` — the single atomic
+       rename. Steps 1 and 2 are preparation and don't break atomicity.
+
+    ``installed_at`` is **not** updated: bytes are byte-identical post
+    rename, so the asset's dirty-detection state must remain accurate.
+    """
+    bak_path: Path | None = None
+    if row.flat_dirty and force:
+        bak_path = row.flat_path.with_suffix(row.flat_path.suffix + ".bak")
+        shutil.copy2(row.flat_path, bak_path)
+
+    target_dir = row.dir_path
+    target_dir.mkdir(parents=True, exist_ok=True)
+    asset_filename = ASSET_DIR_FILENAMES[row.asset_type]
+    os.replace(row.flat_path, target_dir / asset_filename)
+    return bak_path
+
+
+def _execute_cleanup_flat(row: MigrateRow, *, force: bool) -> Path | None:
+    """Remove the flat sibling of an existing dir layout.
+
+    User-edit policy (locked decision #10): when flat is dirty and
+    ``force`` is true, the flat content is snapshotted to a ``.bak``
+    sibling before deletion. The dir layout is **not modified** — it
+    carries the canonical (wiki) bytes per PR-C policy. Users who want
+    to merge the flat edit into the dir layout review the ``.bak`` and
+    apply the change manually.
+    """
+    bak_path: Path | None = None
+    if row.flat_dirty and force:
+        bak_path = row.flat_path.with_suffix(row.flat_path.suffix + ".bak")
+        shutil.copy2(row.flat_path, bak_path)
+    row.flat_path.unlink()
+    return bak_path
+
+
+def migrate_one(
+    project_root: Path | str,
+    row: MigrateRow,
+    *,
+    force: bool,
+) -> MigrateResult:
+    """Execute a single row's migration plan.
+
+    No-op for ``noop`` / ``skip_manual`` / ``skip_orphan``. Active
+    states are ``migrate`` and ``cleanup_flat``; ``refuse_dirty`` is
+    promoted to one of those two when ``force`` is true (the choice
+    follows ``dir_exists``).
+
+    Boundary self-validation (per
+    ``feedback_public_api_ship_time_validation``): re-validates the
+    row's name and confirms the derived destination paths fall inside
+    ``<project_root>/.memtomem/<type>/``. Click already gates these at
+    the CLI; this defends future callers (MCP, web routes, tests) that
+    bypass Click.
+    """
+    project_root_path = Path(project_root).expanduser().resolve()
+    if row.asset_type not in MIGRATABLE_ASSET_TYPES:
+        return MigrateResult(row=row, bak_path=None, ok=True, error=None)
+    validate_name(row.name, kind=f"{row.asset_type[:-1]} name")
+
+    install_root = (project_root_path / _CANONICAL_ROOTS[row.asset_type]).resolve()
+    if not (
+        _is_within(row.flat_path.resolve(), install_root)
+        and _is_within(row.dir_path.resolve(), install_root)
+    ):
+        return MigrateResult(
+            row=row,
+            bak_path=None,
+            ok=False,
+            error=f"path escapes install root: {row.flat_path} / {row.dir_path}",
+        )
+
+    bak_path: Path | None = None
+    try:
+        if row.state == "migrate":
+            if row.flat_dirty and not force:
+                return MigrateResult(
+                    row=row,
+                    bak_path=None,
+                    ok=False,
+                    error="dirty flat requires --force",
+                )
+            bak_path = _execute_migrate(row, force=force)
+        elif row.state == "cleanup_flat":
+            if row.flat_dirty and not force:
+                return MigrateResult(
+                    row=row,
+                    bak_path=None,
+                    ok=False,
+                    error="dirty flat requires --force",
+                )
+            bak_path = _execute_cleanup_flat(row, force=force)
+        elif row.state == "refuse_dirty":
+            if not force:
+                return MigrateResult(
+                    row=row,
+                    bak_path=None,
+                    ok=False,
+                    error="dirty flat requires --force",
+                )
+            if row.dir_exists:
+                bak_path = _execute_cleanup_flat(row, force=True)
+            else:
+                bak_path = _execute_migrate(row, force=True)
+        # noop / skip_manual / skip_orphan → no writes
+    except OSError as exc:
+        return MigrateResult(row=row, bak_path=None, ok=False, error=str(exc))
+
+    return MigrateResult(row=row, bak_path=bak_path, ok=True, error=None)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True if *path* equals *root* or is a descendant of it."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -179,6 +179,21 @@ def _classify_row(
     asset_filename = ASSET_DIR_FILENAMES[asset_type]
     flat_exists = flat_path.is_file()
     dir_exists = (dir_path / asset_filename).is_file()
+
+    # Treat a lockfile entry without a usable ``installed_at`` as "no
+    # entry" — mirrors :func:`memtomem.context.dirty.is_asset_dirty`,
+    # which collapses both "no entry" and "entry but missing/non-string
+    # installed_at" into ``never_installed``. Otherwise migrate would
+    # silently proceed against a corrupt entry (no dirty check possible)
+    # and could overwrite user edits.
+    if lock_entry is not None and not isinstance(lock_entry.get("installed_at"), str):
+        logger.warning(
+            "migrate: %s/%s lockfile entry missing or invalid installed_at; "
+            "treating as never installed",
+            asset_type,
+            name,
+        )
+        lock_entry = None
     has_lock_entry = lock_entry is not None
 
     if not flat_exists and not dir_exists and not has_lock_entry:
@@ -340,7 +355,16 @@ def _execute_migrate(row: MigrateRow, *, force: bool) -> Path | None:
     target_dir = row.dir_path
     target_dir.mkdir(parents=True, exist_ok=True)
     asset_filename = ASSET_DIR_FILENAMES[row.asset_type]
-    os.replace(row.flat_path, target_dir / asset_filename)
+    target_file = target_dir / asset_filename
+    # Race defensive: classify ran with ``dir_exists=False`` but an
+    # external mutation between classify and execute could have created
+    # ``target_file``. ``os.replace`` would silently overwrite it; abort
+    # instead. The race policy (decision #11) accepts this gap as
+    # batch-level, not per-asset — surfacing it as an error keeps the
+    # other rows in the batch isolated and lets the user re-run.
+    if target_file.exists():
+        raise OSError(f"target {target_file} appeared after classify; refusing to overwrite")
+    os.replace(row.flat_path, target_file)
     return bak_path
 
 

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -559,23 +559,6 @@ def test_cli_force_without_apply_usage_error(tmp_path: Path, monkeypatch) -> Non
     assert "only valid with --apply" in result.output
 
 
-def test_cli_name_without_type_usage_error(tmp_path: Path, monkeypatch) -> None:
-    monkeypatch.chdir(tmp_path)
-    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
-
-    runner = CliRunner()
-    # Click's `nargs` consumes the single token as TYPE, so to trigger the
-    # "name requires type" branch we use `--` to force two positionals.
-    # In practice the misuse `mm context migrate -- foo` is detected here.
-    # If Click absorbs the token as TYPE it will fall through to the
-    # Choice() validator first; that's also acceptable behaviour.
-    result = runner.invoke(context_group, ["migrate", "agents", "missing"])
-
-    # `agents missing` parses cleanly; just verify no crash. The name-w/o-type
-    # branch is exercised programmatically via classify_migrate above.
-    assert result.exit_code == 0
-
-
 def test_cli_yes_force_prints_warning(tmp_path: Path, monkeypatch) -> None:
     flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
     _add_lock_entry(tmp_path, "agents", "foo")
@@ -634,3 +617,106 @@ def test_cli_targeted_missing_asset(tmp_path: Path, monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert "No matching asset" in result.output
+
+
+# ── corrupt lockfile + race + adjacent-files defensive coverage ──────────
+
+
+def test_classify_lockfile_entry_missing_installed_at(tmp_path: Path) -> None:
+    """Corrupt lockfile entry (no installed_at) is treated as never_installed.
+
+    Mirrors ``dirty.is_asset_dirty`` semantics: a malformed entry must
+    NOT silently let migrate proceed with no dirty check. The flat file
+    falls through to ``skip_manual`` (manual provenance) instead.
+    """
+    import json
+
+    _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    # Hand-craft a lockfile entry without ``installed_at`` — bypasses
+    # ``Lockfile.upsert_entry`` which would have written one.
+    lock_path = tmp_path / ".memtomem" / "lock.json"
+    lock_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "agents": {"foo": {"wiki_commit": "0" * 40}},
+            }
+        )
+    )
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    # No installed_at → entry treated as missing → flat falls into manual
+    assert rows[0].state == "skip_manual"
+    assert rows[0].has_lock_entry is False
+
+
+def test_migrate_one_target_appears_mid_execution(tmp_path: Path) -> None:
+    """Race between classify and execute: target_file appears, refuse to overwrite.
+
+    Builds a clean classify result (state=migrate, dir absent) and then
+    materializes ``dir/agent.md`` before calling ``migrate_one``. The
+    execute path must surface the race rather than silently overwriting
+    the new bytes.
+    """
+    flat = _write_flat(tmp_path, "agents", "foo", b"flat-bytes\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    rows = classify_migrate(tmp_path)
+    assert rows[0].state == "migrate"
+
+    # Simulate an external writer creating the target between classify
+    # and execute.
+    target_dir = tmp_path / ".memtomem" / "agents" / "foo"
+    target_dir.mkdir(parents=True)
+    target_file = target_dir / "agent.md"
+    target_file.write_bytes(b"raced bytes\n")
+
+    result = migrate_one(tmp_path, rows[0], force=False)
+
+    assert result.ok is False
+    assert "appeared after classify" in (result.error or "")
+    # Raced bytes preserved (NOT overwritten by flat content).
+    assert target_file.read_bytes() == b"raced bytes\n"
+    # Flat preserved too (operation atomic — either both move or neither).
+    assert flat.read_bytes() == b"flat-bytes\n"
+
+
+def test_migrate_one_keeps_unrelated_dir_contents(tmp_path: Path) -> None:
+    """Empty target dir with unrelated siblings is fine; non-target files survive.
+
+    Edge case: ``target_dir`` already exists (e.g. partial install left
+    ``scripts/`` or other extras) but does not contain ``agent.md`` /
+    ``command.md``. Migration should proceed and leave the unrelated
+    files untouched — only the asset manifest file is created.
+    """
+    flat = _write_flat(tmp_path, "agents", "foo", b"agent body\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    # Pre-create the dir with a sibling file (simulates a previous
+    # partial install / user-created scaffolding).
+    target_dir = tmp_path / ".memtomem" / "agents" / "foo"
+    target_dir.mkdir(parents=True)
+    sibling = target_dir / "scripts" / "helper.sh"
+    sibling.parent.mkdir(parents=True)
+    sibling.write_bytes(b"#!/bin/sh\necho hi\n")
+    pre_sibling_bytes = sibling.read_bytes()
+    pre_sibling_mtime = sibling.stat().st_mtime
+
+    rows = classify_migrate(tmp_path)
+    assert rows[0].state == "migrate"
+    result = migrate_one(tmp_path, rows[0], force=False)
+
+    assert result.ok is True
+    # Asset manifest landed
+    assert (target_dir / "agent.md").read_bytes() == b"agent body\n"
+    # Unrelated sibling untouched
+    assert sibling.read_bytes() == pre_sibling_bytes
+    assert sibling.stat().st_mtime == pre_sibling_mtime
+    # Flat removed
+    assert not flat.exists()

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1,0 +1,636 @@
+"""Tests for ``memtomem.context.migrate`` and the ``mm context migrate`` CLI.
+
+Covers PR-D C4: flat → dir layout normalization. The truth table in the
+plan file has eight rows (`flat? × dir? × lock? × dirty?`); each is
+exercised here as a unit test. CLI integration tests use ``CliRunner``
+and stand on the same fixtures as the unit tests.
+
+No wiki involvement — migrate is a pure filesystem + lockfile operation
+(ADR-0008 Invariants 1 / 3), so unlike ``test_context_status`` we don't
+need a ``wiki_root`` fixture.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context as context_group
+from memtomem.context._names import InvalidNameError
+from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.context.migrate import (
+    MigrateRow,
+    _is_flat_file_dirty,
+    classify_migrate,
+    migrate_one,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+_ASSET_DIR_FILES = {"agents": "agent.md", "commands": "command.md"}
+
+
+def _write_flat(project: Path, asset_type: str, name: str, body: bytes) -> Path:
+    target = project / ".memtomem" / asset_type / f"{name}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(body)
+    return target
+
+
+def _write_dir(project: Path, asset_type: str, name: str, body: bytes) -> Path:
+    target = project / ".memtomem" / asset_type / name / _ASSET_DIR_FILES[asset_type]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(body)
+    return target
+
+
+def _add_lock_entry(project: Path, asset_type: str, name: str) -> str:
+    installed_at = utcnow_iso8601_z()
+    Lockfile.at(project).upsert_entry(
+        asset_type, name, wiki_commit="0" * 40, installed_at=installed_at
+    )
+    return installed_at
+
+
+def _bump_mtime(path: Path, *, seconds_in_future: float = 60.0) -> None:
+    future = datetime.now(timezone.utc).timestamp() + seconds_in_future
+    os.utime(path, (future, future))
+
+
+# ── _is_flat_file_dirty ──────────────────────────────────────────────────
+
+
+def test_is_flat_file_dirty_strict_gt(tmp_path: Path) -> None:
+    """Equality with installed_at is clean; only strictly newer is dirty."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+
+    # Identical mtime → clean (mirrors dirty.py contract).
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+    entry = Lockfile.at(tmp_path).read_entry("agents", "foo")
+    assert entry is not None
+    assert _is_flat_file_dirty(flat, entry) is False
+
+    # Strictly later → dirty.
+    _bump_mtime(flat)
+    assert _is_flat_file_dirty(flat, entry) is True
+
+
+def test_is_flat_file_dirty_missing_installed_at_returns_false(tmp_path: Path) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    assert _is_flat_file_dirty(flat, {}) is False
+    assert _is_flat_file_dirty(flat, {"installed_at": 123}) is False
+
+
+# ── classify_migrate (8-row truth table) ─────────────────────────────────
+
+
+def test_classify_flat_only_with_lock_clean(tmp_path: Path) -> None:
+    """Row 1: flat ✓, dir ✗, lock ✓, clean → state=migrate."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "migrate"
+    assert rows[0].flat_dirty is False
+    assert rows[0].asset_type == "agents"
+    assert rows[0].name == "foo"
+
+
+def test_classify_flat_only_with_lock_dirty(tmp_path: Path) -> None:
+    """Row 2: flat ✓, dir ✗, lock ✓, dirty → state=refuse_dirty."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "refuse_dirty"
+    assert rows[0].flat_dirty is True
+
+
+def test_classify_flat_only_no_lock(tmp_path: Path) -> None:
+    """Row 3: flat ✓, dir ✗, lock ✗ → state=skip_manual."""
+    _write_flat(tmp_path, "agents", "foo", b"v1\n")
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "skip_manual"
+    assert rows[0].flat_dirty is None
+    assert rows[0].has_lock_entry is False
+
+
+def test_classify_dir_only(tmp_path: Path) -> None:
+    """Row 4: flat ✗, dir ✓ → state=noop (already migrated)."""
+    _write_dir(tmp_path, "agents", "foo", b"v1\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "noop"
+
+
+def test_classify_flat_plus_dir_clean(tmp_path: Path) -> None:
+    """Row 5: flat ✓, dir ✓, lock ✓, clean → state=cleanup_flat."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"flat-bytes\n")
+    _write_dir(tmp_path, "agents", "foo", b"dir-bytes\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "cleanup_flat"
+    assert rows[0].flat_dirty is False
+
+
+def test_classify_flat_plus_dir_dirty(tmp_path: Path) -> None:
+    """Row 6: flat ✓, dir ✓, lock ✓, dirty → state=refuse_dirty."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"flat-bytes\n")
+    _write_dir(tmp_path, "agents", "foo", b"dir-bytes\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "refuse_dirty"
+    assert rows[0].dir_exists is True
+
+
+def test_classify_flat_plus_dir_no_lock(tmp_path: Path) -> None:
+    """Row 7: flat ✓, dir ✓, lock ✗ → state=skip_manual."""
+    _write_flat(tmp_path, "agents", "foo", b"flat\n")
+    _write_dir(tmp_path, "agents", "foo", b"dir\n")
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "skip_manual"
+    assert "collides" in rows[0].reason or "collision" in rows[0].reason
+
+
+def test_classify_orphan_lockfile_entry(tmp_path: Path) -> None:
+    """Row 8 (extension): flat ✗, dir ✗, lock ✓ → state=skip_orphan."""
+    (tmp_path / ".memtomem").mkdir()
+    _add_lock_entry(tmp_path, "agents", "foo")
+
+    rows = classify_migrate(tmp_path)
+
+    assert len(rows) == 1
+    assert rows[0].state == "skip_orphan"
+
+
+def test_classify_neither_no_rows(tmp_path: Path) -> None:
+    """Row 9 (extension): flat ✗, dir ✗, lock ✗ → no rows."""
+    (tmp_path / ".memtomem").mkdir()
+
+    rows = classify_migrate(tmp_path)
+
+    assert rows == []
+
+
+def test_classify_skills_returns_empty(tmp_path: Path) -> None:
+    """Skills are always dir layout — classification short-circuits."""
+    rows = classify_migrate(tmp_path, asset_type="skills")
+    assert rows == []
+
+
+def test_classify_skills_with_name_returns_empty(tmp_path: Path) -> None:
+    rows = classify_migrate(tmp_path, asset_type="skills", name="foo")
+    assert rows == []
+
+
+def test_classify_invalid_asset_type_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="invalid asset_type"):
+        classify_migrate(tmp_path, asset_type="bogus")
+
+
+def test_classify_name_without_type_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="name requires asset_type"):
+        classify_migrate(tmp_path, name="foo")
+
+
+def test_classify_invalid_name_raises(tmp_path: Path) -> None:
+    with pytest.raises(InvalidNameError):
+        classify_migrate(tmp_path, asset_type="agents", name="../etc/passwd")
+
+
+def test_classify_filters_to_named_asset(tmp_path: Path) -> None:
+    _write_flat(tmp_path, "agents", "foo", b"a\n")
+    _write_flat(tmp_path, "agents", "bar", b"b\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _add_lock_entry(tmp_path, "agents", "bar")
+
+    rows = classify_migrate(tmp_path, asset_type="agents", name="foo")
+
+    assert len(rows) == 1
+    assert rows[0].name == "foo"
+
+
+def test_classify_unknown_named_asset_returns_empty(tmp_path: Path) -> None:
+    rows = classify_migrate(tmp_path, asset_type="agents", name="missing")
+    assert rows == []
+
+
+def test_classify_iterates_lockfile_union_disk(tmp_path: Path) -> None:
+    """Ensure both lockfile-only and disk-only assets surface."""
+    # disk-only (manual flat)
+    _write_flat(tmp_path, "agents", "manual", b"a\n")
+    # lockfile-only (orphan)
+    _add_lock_entry(tmp_path, "agents", "ghost")
+
+    rows = classify_migrate(tmp_path)
+    states = {(r.name, r.state) for r in rows}
+
+    assert ("manual", "skip_manual") in states
+    assert ("ghost", "skip_orphan") in states
+
+
+# ── migrate_one execution ────────────────────────────────────────────────
+
+
+def test_migrate_one_atomic_rename_clean(tmp_path: Path) -> None:
+    """state=migrate clean: flat → dir/agent.md, flat removed.
+
+    Symmetric assertion (positive + negative markers per
+    ``feedback_pin_invert_symmetric_assertion``):
+    POSITIVE — dir/agent.md exists with the original bytes.
+    NEGATIVE — flat path is gone.
+    """
+    flat = _write_flat(tmp_path, "agents", "foo", b"agent body\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    rows = classify_migrate(tmp_path)
+    assert rows[0].state == "migrate"
+    result = migrate_one(tmp_path, rows[0], force=False)
+
+    target = tmp_path / ".memtomem" / "agents" / "foo" / "agent.md"
+    # POSITIVE
+    assert target.is_file()
+    assert target.read_bytes() == b"agent body\n"
+    # NEGATIVE
+    assert not flat.exists()
+    assert result.ok is True
+    assert result.bak_path is None
+
+
+def test_migrate_one_preserves_installed_at(tmp_path: Path) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    pre_entry = Lockfile.at(tmp_path).read_entry("agents", "foo")
+    rows = classify_migrate(tmp_path)
+    migrate_one(tmp_path, rows[0], force=False)
+
+    post_entry = Lockfile.at(tmp_path).read_entry("agents", "foo")
+    assert post_entry == pre_entry  # unchanged
+
+
+def test_migrate_one_dirty_no_force_refuses(tmp_path: Path) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+
+    rows = classify_migrate(tmp_path)
+    result = migrate_one(tmp_path, rows[0], force=False)
+
+    assert result.ok is False
+    assert "force" in (result.error or "")
+    assert flat.exists()  # unchanged
+    assert not (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").exists()
+
+
+def test_migrate_one_dirty_force_creates_bak(tmp_path: Path) -> None:
+    """Dirty + --force: .bak written, then atomic migrate."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"user-edit\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+    pre_mtime = flat.stat().st_mtime
+
+    rows = classify_migrate(tmp_path)
+    result = migrate_one(tmp_path, rows[0], force=True)
+
+    assert result.ok is True
+    assert result.bak_path is not None
+    bak = result.bak_path
+    assert bak.is_file()
+    assert bak.read_bytes() == b"user-edit\n"
+    # mtime preserved on the bak (shutil.copy2 contract)
+    assert abs(bak.stat().st_mtime - pre_mtime) < 0.001
+    # Migrated content lands in dir layout with the user's edit (not lost).
+    target = tmp_path / ".memtomem" / "agents" / "foo" / "agent.md"
+    assert target.read_bytes() == b"user-edit\n"
+    assert not flat.exists()
+
+
+def test_cleanup_flat_clean_preserves_dir(tmp_path: Path) -> None:
+    """cleanup_flat clean: dir mtime/content unchanged, flat removed."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"flat-bytes\n")
+    dir_target = _write_dir(tmp_path, "agents", "foo", b"dir-bytes\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+    pre_dir_mtime = dir_target.stat().st_mtime
+    pre_dir_bytes = dir_target.read_bytes()
+
+    rows = classify_migrate(tmp_path)
+    assert rows[0].state == "cleanup_flat"
+    result = migrate_one(tmp_path, rows[0], force=False)
+
+    assert result.ok is True
+    assert not flat.exists()  # NEGATIVE: flat removed
+    # POSITIVE: dir untouched
+    assert dir_target.read_bytes() == pre_dir_bytes
+    assert dir_target.stat().st_mtime == pre_dir_mtime
+
+
+def test_cleanup_flat_dirty_force_keeps_dir_writes_bak(tmp_path: Path) -> None:
+    """cleanup_flat dirty + force: .bak preserves user edits, dir untouched."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"flat-edit\n")
+    dir_target = _write_dir(tmp_path, "agents", "foo", b"canonical\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+    pre_dir_bytes = dir_target.read_bytes()
+
+    rows = classify_migrate(tmp_path)
+    assert rows[0].state == "refuse_dirty"  # collision + dirty
+    result = migrate_one(tmp_path, rows[0], force=True)
+
+    assert result.ok is True
+    assert result.bak_path is not None
+    assert result.bak_path.read_bytes() == b"flat-edit\n"
+    assert not flat.exists()
+    # Dir bytes unchanged — user edits live only in .bak (locked decision #10)
+    assert dir_target.read_bytes() == pre_dir_bytes
+
+
+def test_migrate_one_invalid_name_raises(tmp_path: Path) -> None:
+    """Boundary defense: migrate_one re-validates the name."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    rows = classify_migrate(tmp_path)
+    bad_row = MigrateRow(
+        asset_type=rows[0].asset_type,
+        name="../etc/passwd",
+        flat_path=rows[0].flat_path,
+        dir_path=rows[0].dir_path,
+        flat_exists=rows[0].flat_exists,
+        dir_exists=rows[0].dir_exists,
+        has_lock_entry=rows[0].has_lock_entry,
+        flat_dirty=rows[0].flat_dirty,
+        state=rows[0].state,
+        reason=rows[0].reason,
+    )
+    with pytest.raises(InvalidNameError):
+        migrate_one(tmp_path, bad_row, force=False)
+
+
+def test_migrate_one_path_outside_root_returns_error(tmp_path: Path) -> None:
+    """Containment check: paths escaping install root are refused."""
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+
+    rows = classify_migrate(tmp_path)
+    escaping_row = MigrateRow(
+        asset_type=rows[0].asset_type,
+        name=rows[0].name,
+        flat_path=tmp_path.parent / "evil.md",  # outside .memtomem/agents
+        dir_path=tmp_path.parent / "evil",
+        flat_exists=False,
+        dir_exists=False,
+        has_lock_entry=True,
+        flat_dirty=False,
+        state="migrate",
+        reason="escaping",
+    )
+    result = migrate_one(tmp_path, escaping_row, force=False)
+    assert result.ok is False
+    assert "escapes" in (result.error or "")
+
+
+def test_migrate_one_noop_no_writes(tmp_path: Path) -> None:
+    _write_dir(tmp_path, "agents", "foo", b"v1\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+
+    rows = classify_migrate(tmp_path)
+    assert rows[0].state == "noop"
+    pre_lockfile = (tmp_path / ".memtomem" / "lock.json").read_bytes()
+    result = migrate_one(tmp_path, rows[0], force=False)
+
+    assert result.ok is True
+    # Lockfile unchanged (no rewrite).
+    assert (tmp_path / ".memtomem" / "lock.json").read_bytes() == pre_lockfile
+
+
+# ── CLI integration ──────────────────────────────────────────────────────
+
+
+def _invoke(args: list[str], project: Path) -> object:
+    runner = CliRunner()
+    return runner.invoke(context_group, args, catch_exceptions=False, env={"PWD": str(project)})
+
+
+def test_cli_dry_run_default_no_writes(tmp_path: Path, monkeypatch) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate"])
+
+    assert result.exit_code == 0, result.output
+    assert "flat → dir" in result.output
+    assert "Run with --apply to execute." in result.output
+    # Filesystem unchanged: the flat file still exists.
+    assert flat.exists()
+    assert not (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").exists()
+
+
+def test_cli_apply_yes_migrates(tmp_path: Path, monkeypatch) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    installed_at = _add_lock_entry(tmp_path, "agents", "foo")
+    epoch = datetime.fromisoformat(installed_at).timestamp()
+    os.utime(flat, (epoch, epoch))
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "--apply", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    # POSITIVE
+    assert (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").is_file()
+    # NEGATIVE
+    assert not flat.exists()
+
+
+def test_cli_apply_refuses_dirty_no_force(tmp_path: Path, monkeypatch) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "--apply", "--yes"])
+
+    assert result.exit_code == 1, result.output
+    assert "--force" in result.output
+    assert flat.exists()
+
+
+def test_cli_apply_force_migrates_dirty_with_bak(tmp_path: Path, monkeypatch) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"user-edit\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "--apply", "--yes", "--force"])
+
+    assert result.exit_code == 0, result.output
+    bak = tmp_path / ".memtomem" / "agents" / "foo.md.bak"
+    assert bak.is_file()
+    assert bak.read_bytes() == b"user-edit\n"
+    target = tmp_path / ".memtomem" / "agents" / "foo" / "agent.md"
+    assert target.is_file()
+    assert not flat.exists()
+
+
+def test_cli_skills_explicit_exits_zero(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "skills"])
+
+    assert result.exit_code == 0, result.output
+    assert "always directory layout" in result.output
+
+
+def test_cli_skills_with_name_exits_zero(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "skills", "any"])
+
+    assert result.exit_code == 0
+    assert "always directory layout" in result.output
+
+
+def test_cli_force_without_apply_usage_error(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "--force"])
+
+    assert result.exit_code != 0
+    assert "only valid with --apply" in result.output
+
+
+def test_cli_name_without_type_usage_error(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    # Click's `nargs` consumes the single token as TYPE, so to trigger the
+    # "name requires type" branch we use `--` to force two positionals.
+    # In practice the misuse `mm context migrate -- foo` is detected here.
+    # If Click absorbs the token as TYPE it will fall through to the
+    # Choice() validator first; that's also acceptable behaviour.
+    result = runner.invoke(context_group, ["migrate", "agents", "missing"])
+
+    # `agents missing` parses cleanly; just verify no crash. The name-w/o-type
+    # branch is exercised programmatically via classify_migrate above.
+    assert result.exit_code == 0
+
+
+def test_cli_yes_force_prints_warning(tmp_path: Path, monkeypatch) -> None:
+    flat = _write_flat(tmp_path, "agents", "foo", b"v1\n")
+    _add_lock_entry(tmp_path, "agents", "foo")
+    _bump_mtime(flat)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "--apply", "--yes", "--force"])
+
+    assert result.exit_code == 0
+    # Click 8.2 mixes stderr into result.output by default.
+    assert "WARNING" in result.output
+
+
+def test_cli_empty_no_flat_assets(tmp_path: Path, monkeypatch) -> None:
+    """Empty project tree → exit 0 with informational message."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate"])
+
+    assert result.exit_code == 0
+    assert "No flat-layout assets to migrate." in result.output
+
+
+def test_cli_batch_mixes_agents_and_commands(tmp_path: Path, monkeypatch) -> None:
+    flat_a = _write_flat(tmp_path, "agents", "foo", b"a\n")
+    flat_c = _write_flat(tmp_path, "commands", "build", b"c\n")
+    installed_a = _add_lock_entry(tmp_path, "agents", "foo")
+    installed_c = _add_lock_entry(tmp_path, "commands", "build")
+    epoch_a = datetime.fromisoformat(installed_a).timestamp()
+    epoch_c = datetime.fromisoformat(installed_c).timestamp()
+    os.utime(flat_a, (epoch_a, epoch_a))
+    os.utime(flat_c, (epoch_c, epoch_c))
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "--apply", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".memtomem" / "agents" / "foo" / "agent.md").is_file()
+    assert (tmp_path / ".memtomem" / "commands" / "build" / "command.md").is_file()
+    assert not flat_a.exists()
+    assert not flat_c.exists()
+
+
+def test_cli_targeted_missing_asset(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["migrate", "agents", "missing"])
+
+    assert result.exit_code == 0
+    assert "No matching asset" in result.output


### PR DESCRIPTION
## Summary

Adds `mm context migrate` to convert agents and commands from the legacy
flat layout (`<type>/<name>.md`) to the canonical directory layout
(`<type>/<name>/agent.md` / `<type>/<name>/command.md`) introduced in
PR-C. Closes the last subcommand in PR-D's surface row of ADR-0008
(`{update, install --all, status, migrate}`).

## Surface

```
mm context migrate                                # all flat assets across types
mm context migrate <type>                         # one type
mm context migrate <type> <name>                  # single asset
mm context migrate --apply                        # mutate (default is dry-run)
mm context migrate --apply --force                # also migrate dirty flat (writes .bak)
mm context migrate --apply --yes                  # skip confirmation prompt
mm context migrate skills [...]                   # info message + exit 0
```

## Design

- **Pure module** (`memtomem.context.migrate`): filesystem + lockfile only,
  no wiki dependency (Invariants 1 / 3). Mirrors C3 status's
  read/classify split.
- **Eight-row truth table.** `classify_migrate` iterates lockfile
  entries ∪ disk enumeration (`list_canonical_*`), deduplicated by
  `(asset_type, name)`. Six states cover `migrate` / `noop` /
  `cleanup_flat` / `refuse_dirty` / `skip_manual` / `skip_orphan`.
- **Atomic rename** via `os.replace`; `mkdir(parents=True)` first.
  `installed_at` is **preserved** across migration so dirty detection
  remains accurate (bytes are byte-identical post-rename, so the asset
  is not "re-installed").
- **Lockfile schema unchanged.** Layout is filesystem-inferred
  (`list_canonical_*` is authoritative); a `layout` field would create
  a dual source of truth that every install/update/status/migrate
  would have to keep in sync.
- **`cleanup_flat`** (flat+dir collision) leaves the dir untouched —
  the dir carries the canonical (wiki) bytes per PR-C policy. When
  `force` + dirty, writes `.bak` so the user's flat edit lives in a
  forensic snapshot for manual review.
- **Boundary self-validation** (`feedback_public_api_ship_time_validation`):
  `migrate_one` re-validates `name`, `asset_type`, and confirms the
  resolved paths fall inside the install root, defending future
  MCP / web callers that bypass Click.

### Migration truth table

| flat | dir | lock | dirty?  | action |
|------|-----|------|---------|--------|
| ✓    | ✗   | ✓    | clean   | flat → dir (atomic os.replace) |
| ✓    | ✗   | ✓    | dirty   | refuse w/o --force; --force: .bak + flat → dir |
| ✓    | ✗   | ✗    | N/A     | skip + warn (manual flat) |
| ✗    | ✓   | —    | —       | no-op (already migrated) |
| ✓    | ✓   | ✓    | clean   | flat silent delete (dir wins) |
| ✓    | ✓   | ✓    | dirty   | refuse w/o --force; --force: .bak + flat delete |
| ✓    | ✓   | ✗    | N/A     | skip + warn (manual flat collides with dir) |
| ✗    | ✗   | —    | —       | no-op (no asset) |

## Pairs with C3

`mm context status` (PR #635) walks the dir-only dest tree
(`is_asset_dirty` is dir-scoped), so flat-only installs surface there
as `missing` rows; `mm context migrate` is the verb to normalize them
in place. Run `status` first to see what migrate will touch.

## Test plan

- [x] 40 new tests in `test_context_migrate.py` cover all 8 truth-table
      rows + symmetric assertions (positive + negative markers per
      `feedback_pin_invert_symmetric_assertion`).
- [x] Boundary self-validation: invalid name raises, path traversal
      refused, lockfile preserved on no-op.
- [x] CLI integration via `CliRunner`: dry-run no-writes, `--apply
      --yes` migrates, `--apply` refuses dirty, `--apply --force`
      succeeds with `.bak`, skills info message, `--force` without
      `--apply` `UsageError`, `--yes --force` WARNING surfaced.
- [x] Adjacent regression: 117 tests across migrate + status + install
      + install --all + update all green.
- [x] `uv run ruff check packages/memtomem/src` ✓
- [x] `uv run ruff format --check packages/memtomem/src` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)