### PR TITLE
feat(web): SSE-stream Sources reindex for live progress (refs #640)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1297,7 +1297,7 @@
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=81"></script>
   <script src="/settings-config.js?v=7"></script>
-  <script src="/sources-memory-dirs.js?v=8"></script>
+  <script src="/sources-memory-dirs.js?v=9"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -1082,30 +1082,99 @@ async function mdOpenOne(path, btn) {
   }
 }
 
+// SSE-streamed since #640: the previous ``POST /api/index`` was synchronous
+// and held the JS request open for the full ``index_path`` walk — many
+// minutes for a large memory_dir on CPU-only ONNX. The user saw the header
+// "indexing" indicator on the whole time with no signal that progress was
+// happening, which read like a leak (it wasn't — the engine was legitimately
+// busy embedding). Switching to ``/api/index/stream`` reuses the per-file
+// ``progress`` events the Index tab already consumes and surfaces them as a
+// live ``done/total`` counter on the reindex button itself.
 async function mdReindexOne(path, btn) {
   if (typeof _indexingTryStart === 'function' && !_indexingTryStart()) return;
   if (btn) btnLoading(btn, true);
+  // Cache the original button label so we can restore it after the run —
+  // ``btnLoading`` only toggles disabled+spinner, it doesn't snapshot text.
+  const _origText = btn ? btn.textContent : '';
   showToast(t('toast.memory_dir.reindex_started', { path }), 'info');
-  try {
-    const resp = await api(
-      'POST', '/api/index',
-      { path, recursive: true, force: false },
-      { timeout: 300_000 },
-    );
-    const count = (resp && resp.indexed_chunks) || 0;
-    showToast(
-      t('toast.memory_dir.reindex_done', { path, count }),
-      (resp && resp.errors && resp.errors.length) ? 'error' : 'success',
-    );
-    if (typeof _markDataStale === 'function') _markDataStale();
-    if (typeof loadStats === 'function') loadStats();
-  } catch (err) {
-    showToast(t('toast.memory_dir.reindex_failed', { error: _mdApiErrorText(err) }), 'error');
-  } finally {
-    if (btn) btnLoading(btn, false);
+
+  const _cleanup = () => {
+    if (btn) {
+      btn.textContent = _origText;
+      btnLoading(btn, false);
+    }
     if (typeof _indexingEnd === 'function') _indexingEnd();
     if (typeof loadSources === 'function') loadSources();
+  };
+
+  // EventSource construction can throw synchronously (malformed URL, browser
+  // storage policy edge cases). Mirrors the defensive guard in
+  // ``runIndexStream`` (app.js) — without it a sync throw would leave the
+  // header indicator stuck on and block every subsequent reindex.
+  let es;
+  try {
+    const params = new URLSearchParams({ path, recursive: 'true', force: 'false' });
+    es = new EventSource(`/api/index/stream?${params}`);
+  } catch (err) {
+    showToast(t('toast.memory_dir.reindex_failed', { error: String(err) }), 'error');
+    _cleanup();
+    return;
   }
+
+  let _sseFailCount = 0;
+  const _SSE_MAX_FAILS = 3;
+  let _completed = false;
+
+  es.onmessage = (e) => {
+    let event;
+    try { event = JSON.parse(e.data); }
+    catch {
+      _sseFailCount++;
+      console.warn(`[memory-dir-reindex] malformed SSE (${_sseFailCount}/${_SSE_MAX_FAILS}):`, e.data);
+      if (_sseFailCount >= _SSE_MAX_FAILS) {
+        es.close();
+        showToast(t('toast.stream_fallback'), 'error');
+        _cleanup();
+      }
+      return;
+    }
+    _sseFailCount = 0;
+    if (event.type === 'progress') {
+      if (btn) {
+        btn.textContent = `${event.files_done}/${event.files_total}`;
+      }
+    } else if (event.type === 'complete') {
+      _completed = true;
+      es.close();
+      const indexed = event.indexed_chunks || 0;
+      const errs = Array.isArray(event.errors) ? event.errors : [];
+      showToast(
+        t('toast.memory_dir.reindex_done', { path, count: indexed }),
+        errs.length ? 'error' : 'success',
+      );
+      if (typeof _markDataStale === 'function') _markDataStale();
+      if (typeof loadStats === 'function') loadStats();
+      _cleanup();
+    } else if (event.type === 'error') {
+      _completed = true;
+      es.close();
+      showToast(
+        t('toast.memory_dir.reindex_failed', { error: event.message || 'stream error' }),
+        'error',
+      );
+      _cleanup();
+    }
+  };
+
+  es.onerror = () => {
+    // ``onerror`` also fires when the server closes the stream cleanly after
+    // the last event in some browsers — only treat it as a failure if we
+    // didn't already see ``complete``/``error``.
+    if (_completed) return;
+    es.close();
+    showToast(t('toast.stream_fallback'), 'error');
+    _cleanup();
+  };
 }
 
 async function mdReindexAll(btn) {


### PR DESCRIPTION
## Summary

- Sources tab per-dir reindex now consumes ``GET /api/index/stream`` (SSE) instead of the synchronous ``POST /api/index``.
- Reindex button label updates live to ``done/total`` so the user can see progress instead of a frozen button.
- No engine / Python changes — JS-only refactor reusing the per-file ``progress`` events the Index tab already emits.

## Why

Live diagnosis of #640 confirmed the symptom is **not** a counter leak — `IndexEngine._active_runs` correctly tracks in-flight work, ONNX bge-m3 on CPU is genuinely pinning all cores while embedding, and `/api/indexing/active` is reporting truthfully. The user-facing failure is **diagnosability**: the Sources tab per-dir reindex button held a 5-minute-timeout POST open and showed nothing while the server walked the tree, so a legitimately slow run looked indistinguishable from a wedge.

`/api/index/stream` already emits per-file `progress` events (used by the Index tab). Reusing them on the Sources tab is the smallest change that closes the gap.

## What this does

- ``mdReindexOne`` (the active code path — ``handleReindexOne`` in ``_buildMemoryDirsPanel`` is dead code on the modern view) opens an ``EventSource`` against ``/api/index/stream``.
- ``progress`` event → button text becomes ``${files_done}/${files_total}``.
- ``complete`` event → success/error toast (matches partial-failure UX from before), restore button text, refresh stats + sources.
- ``error`` event or ``onerror`` (when no ``complete`` arrived first) → error toast, restore button.
- Mirrors ``runIndexStream`` (app.js) defensive guards: synchronous ``EventSource`` throw, malformed-event 3-strikes fallback.
- Bumps ``sources-memory-dirs.js?v=8`` → ``?v=9`` per the static-asset cache-bust convention.

## What this does not do

- **Per-chunk progress** — the SSE stream emits between files, not within. A single large file still shows ``0/1`` for the duration of its ``embed_texts`` call. Closing this fully needs engine-level work (mid-file events) and is out of scope here.
- **Multiprocessing / CPU thread limit** — the underlying "ONNX pins all cores" cost is unchanged. Tracking as a separate PR (``embedding.intra_op_threads`` config).

## Test plan

- [x] ``uv run pytest packages/memtomem/tests/test_web_routes.py -m \"not ollama\"`` — 111 passed
- [x] ``uv run pytest packages/memtomem/tests/test_i18n.py`` — 12 passed
- [x] ``uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`` — clean
- [ ] Browser smoke: hard-refresh Sources tab, click reindex on a multi-file memory_dir, confirm button shows live ``done/total`` and clears on complete.
- [ ] Browser smoke: trigger reindex, watch header indicator clear when stream completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)