### PR TITLE
feat(web): expose embedding.threads in Config tab (refs #640)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -177,6 +177,7 @@ def _build_config_response(
             base_url=cfg.embedding.base_url,
             batch_size=cfg.embedding.batch_size,
             api_key="***" if cfg.embedding.api_key else "",
+            threads=cfg.embedding.threads,
         ),
         storage=ConfigStorageOut(
             backend=cfg.storage.backend,

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -14,6 +14,11 @@ class ConfigEmbeddingOut(BaseModel):
     base_url: str
     batch_size: int
     api_key: str = "***"
+    # ONNX Runtime intra-op thread cap; 0 = ORT default (all physical cores).
+    # Surfaced read-only here so users can discover the knob in the Config tab
+    # before they edit ``~/.memtomem/config.json``. Restart-required and
+    # excluded from ``MUTABLE_FIELDS`` per ``EmbeddingConfig`` in config.py.
+    threads: int = 0
 
 
 class ConfigStorageOut(BaseModel):

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1296,7 +1296,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=81"></script>
-  <script src="/settings-config.js?v=7"></script>
+  <script src="/settings-config.js?v=8"></script>
   <script src="/sources-memory-dirs.js?v=9"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -10,7 +10,8 @@
 
 const _CONFIG_LABELS = {
   embedding: { provider: 'Provider', model: 'Model', dimension: 'Dimension',
-                base_url: 'Base URL', batch_size: 'Batch Size', api_key: 'API Key' },
+                base_url: 'Base URL', batch_size: 'Batch Size', api_key: 'API Key',
+                threads: 'ONNX Threads' },
   storage:   { backend: 'Backend', sqlite_path: 'SQLite Path', collection_name: 'Collection' },
   search:    { default_top_k: 'Default top-k', bm25_candidates: 'BM25 Candidates',
                 dense_candidates: 'Dense Candidates', rrf_k: 'RRF k',
@@ -471,6 +472,7 @@ const _CONFIG_GUIDES = {
       { label: 'Base URL', text: 'API endpoint. Ollama: http://localhost:11434. OpenAI: https://api.openai.com/v1 (or compatible endpoint).' },
       { label: 'Batch Size', text: 'Number of texts embedded per API call. Higher = faster indexing but more memory. Default 64.' },
       { label: 'API Key', text: 'Required for OpenAI provider. Not needed for local Ollama. Masked in UI for security.' },
+      { label: 'ONNX Threads', text: 'ONNX Runtime intra-op thread cap for the local fastembed provider. 0 = ORT default (all physical cores). Set to a small integer (e.g. 4) to keep indexing from monopolising the CPU while you use other apps. Ignored for ollama/openai. Restart required.' },
     ],
     envs: [
       'MEMTOMEM_EMBEDDING__PROVIDER=ollama',
@@ -479,6 +481,7 @@ const _CONFIG_GUIDES = {
       'MEMTOMEM_EMBEDDING__BASE_URL=http://localhost:11434',
       'MEMTOMEM_EMBEDDING__API_KEY=sk-...',
       'MEMTOMEM_EMBEDDING__BATCH_SIZE=64',
+      'MEMTOMEM_EMBEDDING__THREADS=4',
     ],
     howto: {
       title: 'Embedding Model Change',

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -63,6 +63,7 @@ class FakeConfig:
         base_url = "http://localhost:11434"
         batch_size = 64
         api_key = ""
+        threads = 0
 
     class _Storage:
         backend = "sqlite"
@@ -295,6 +296,12 @@ class TestConfig:
         data = resp.json()
         assert "embedding" in data
         assert data["embedding"]["provider"] == "ollama"
+        # ``embedding.threads`` exposed read-only so the Config tab can
+        # render the ORT intra-op cap. Pinning the field's presence here
+        # so a future schema trim doesn't silently re-hide it (#640
+        # discoverability follow-up).
+        assert "threads" in data["embedding"]
+        assert data["embedding"]["threads"] == 0
         assert "search" in data
         assert "indexing" in data
         assert "decay" in data


### PR DESCRIPTION
## Summary

- Surfaces ``embedding.threads`` (ONNX Runtime intra-op cap) in the Config tab. It was already wired all the way to ``OnnxEmbedder`` — just never exposed by ``ConfigEmbeddingOut`` so the UI couldn't render it.
- Read-only by design — the field is intentionally excluded from ``MUTABLE_FIELDS`` (cached ``TextEmbedding`` instance), so users still edit ``~/.memtomem/config.json`` and restart. This PR just makes the knob discoverable.

## Why

Live diagnosis of #640 confirmed ONNX is legitimately busy (not a counter leak), but also showed the user has no in-app signal that the all-cores-by-default behavior is configurable. Server log printed ``Loading ONNX embedding model BAAI/bge-m3 (threads=ORT default) …`` — the field was right there in the wiring but invisible from the UI.

## Changes

- ``ConfigEmbeddingOut.threads: int = 0``.
- ``_build_config_response`` populates it from ``cfg.embedding.threads``.
- Config tab label + guide entry explaining the knob, plus an env-var line (``MEMTOMEM_EMBEDDING__THREADS=4``).
- Cache-bust ``settings-config.js?v=7`` → ``?v=8``.
- Test pin in ``test_config_returns_sections`` so a future schema trim doesn't silently re-hide it.

## What this does not do

- **Doesn't make it runtime-mutable.** The model object is cached on first use; a hot edit wouldn't take effect. Restart-required matches the ``rerank.provider/model/api_key`` precedent.
- **Doesn't fix the underlying "30 minutes for 25 chunks" cost in #640.** That needs chunk-level progress and/or multi-process indexing — both larger PRs.

## Test plan

- [x] ``uv run pytest packages/memtomem/tests/test_web_routes.py::TestConfig packages/memtomem/tests/test_embedding_providers.py -m 'not ollama'`` — 67 passed
- [x] ``uv run pytest packages/memtomem/tests/test_web_routes.py -m 'not ollama'`` — 111 passed
- [x] ``uv run ruff check packages/memtomem/src packages/memtomem/tests && uv run ruff format --check packages/memtomem/src packages/memtomem/tests`` — clean
- [ ] Browser smoke after restart: Config tab → Embedding section shows ``ONNX Threads: 0``; Config Guide shows the new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)