### PR TITLE
feat(embedding): default ONNX intra-op threads from 0 (all cores) to 4 (refs #640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`embedding.threads` default flipped from `0` (= ORT default = all
+  physical cores) to `4`** so a bulk reindex doesn't pin every core and
+  starve the web server / other apps. Live diagnosis of #640 confirmed
+  the prior default made a normal indexing run feel like a hang because
+  nothing else on the machine could respond. Existing installs without
+  a `threads` override will see ONNX use 4 cores after upgrade — slower
+  on machines with > 4 cores but visibly responsive. To restore the
+  previous behavior on dedicated machines, set
+  `embedding.threads = 0` in `~/.memtomem/config.json` (or
+  `MEMTOMEM_EMBEDDING__THREADS=0`) and restart `mm web`. Network-bound
+  providers (Ollama, OpenAI) ignore the field. Field is restart-required
+  per the `MUTABLE_FIELDS` exclusion noted in `EmbeddingConfig`.
+
 - **Force-reindex preserves chunk identity and per-chunk personalization
   (`mem_edit` / `mem_delete` / `mm index --force` / `POST /reindex`).**
   Pre-fix the force path called `delete_by_source` followed by fresh

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -47,9 +47,14 @@ class EmbeddingConfig(BaseSettings):
     batch_size: int = 64
     max_concurrent_batches: int = 4
     # ONNX Runtime intra-op thread cap for the local fastembed provider.
-    # 0 = use ORT's default (typically all physical CPU cores). Set to a
-    # small integer (e.g. 4) to keep seeding from monopolising the machine.
-    # Forwarded to ``fastembed.TextEmbedding(threads=...)``; ignored by the
+    # Default 4 — caps ONNX so a bulk reindex doesn't pin every physical
+    # core and starve the web server / other apps. Live diagnosis of #640
+    # showed the prior default (0 = ORT default = all cores) made a normal
+    # indexing run feel like a hang because nothing else on the machine
+    # could respond. Set to 0 to opt back into ORT's default (all physical
+    # cores) for maximum throughput on dedicated machines; set to any
+    # other small integer for finer control. Forwarded to
+    # ``fastembed.TextEmbedding(threads=...)``; ignored by the
     # network-bound providers (Ollama, OpenAI). Bounds ORT's intra-op pool
     # only — does not affect numpy/scipy thread pools (use OMP_NUM_THREADS
     # for those).
@@ -58,7 +63,7 @@ class EmbeddingConfig(BaseSettings):
     # ``TextEmbedding`` instance is cached on first use, so a runtime change
     # would not take effect until restart anyway. Same precedent as
     # ``rerank.provider``/``model``/``api_key`` below.
-    threads: int = 0
+    threads: int = 4
 
     @field_validator("dimension")
     @classmethod

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -14,11 +14,13 @@ class ConfigEmbeddingOut(BaseModel):
     base_url: str
     batch_size: int
     api_key: str = "***"
-    # ONNX Runtime intra-op thread cap; 0 = ORT default (all physical cores).
-    # Surfaced read-only here so users can discover the knob in the Config tab
-    # before they edit ``~/.memtomem/config.json``. Restart-required and
-    # excluded from ``MUTABLE_FIELDS`` per ``EmbeddingConfig`` in config.py.
-    threads: int = 0
+    # ONNX Runtime intra-op thread cap. Default 4 (caps ONNX so a bulk
+    # reindex doesn't pin every core); 0 = ORT default (all physical
+    # cores). Surfaced read-only here so users can discover the knob in
+    # the Config tab before they edit ``~/.memtomem/config.json``.
+    # Restart-required and excluded from ``MUTABLE_FIELDS`` per
+    # ``EmbeddingConfig`` in config.py.
+    threads: int = 4
 
 
 class ConfigStorageOut(BaseModel):

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1296,7 +1296,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=81"></script>
-  <script src="/settings-config.js?v=8"></script>
+  <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=9"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -472,7 +472,7 @@ const _CONFIG_GUIDES = {
       { label: 'Base URL', text: 'API endpoint. Ollama: http://localhost:11434. OpenAI: https://api.openai.com/v1 (or compatible endpoint).' },
       { label: 'Batch Size', text: 'Number of texts embedded per API call. Higher = faster indexing but more memory. Default 64.' },
       { label: 'API Key', text: 'Required for OpenAI provider. Not needed for local Ollama. Masked in UI for security.' },
-      { label: 'ONNX Threads', text: 'ONNX Runtime intra-op thread cap for the local fastembed provider. 0 = ORT default (all physical cores). Set to a small integer (e.g. 4) to keep indexing from monopolising the CPU while you use other apps. Ignored for ollama/openai. Restart required.' },
+      { label: 'ONNX Threads', text: 'ONNX Runtime intra-op thread cap for the local fastembed provider. Default 4 — caps ONNX so a bulk reindex stays responsive on the same machine. Set to 0 to opt back into ORT default (all physical cores) for maximum throughput on dedicated machines, or any other small integer for finer control. Ignored for ollama/openai. Restart required.' },
     ],
     envs: [
       'MEMTOMEM_EMBEDDING__PROVIDER=ollama',

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -471,9 +471,14 @@ class TestOnnxEmbedder:
         await embedder.close()
         assert embedder._model is None
 
-    def test_threads_default_is_zero(self):
-        """Default preserves prior behavior — ORT picks all physical cores."""
-        assert _onnx_config().threads == 0
+    def test_threads_default_is_four(self):
+        """Default caps ONNX at 4 cores so a bulk reindex doesn't pin every
+        physical core. #640 follow-up: pre-flip the default was 0 (= ORT
+        default = all cores) which made indexing feel like a hang because
+        nothing else on the machine could respond. Users on dedicated
+        servers can opt back into all-cores by explicitly setting threads=0.
+        """
+        assert _onnx_config().threads == 4
 
     def test_threads_rejects_negative(self):
         """Validator catches typos like -1 at config-load time."""

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -63,7 +63,7 @@ class FakeConfig:
         base_url = "http://localhost:11434"
         batch_size = 64
         api_key = ""
-        threads = 0
+        threads = 4
 
     class _Storage:
         backend = "sqlite"
@@ -299,9 +299,10 @@ class TestConfig:
         # ``embedding.threads`` exposed read-only so the Config tab can
         # render the ORT intra-op cap. Pinning the field's presence here
         # so a future schema trim doesn't silently re-hide it (#640
-        # discoverability follow-up).
+        # discoverability follow-up). Default 4 since the #640 follow-up
+        # default flip — pre-flip the assertion was ``== 0``.
         assert "threads" in data["embedding"]
-        assert data["embedding"]["threads"] == 0
+        assert data["embedding"]["threads"] == 4
         assert "search" in data
         assert "indexing" in data
         assert "decay" in data


### PR DESCRIPTION
## Summary

- Flips ``EmbeddingConfig.threads`` default from ``0`` (= ORT default = all physical cores) to ``4`` so a bulk reindex doesn't pin every core and starve the rest of the machine.
- Existing installs without an explicit override get the cap after upgrade. Users on dedicated machines can restore the prior all-cores behavior by setting ``embedding.threads = 0`` in ``~/.memtomem/config.json`` (or ``MEMTOMEM_EMBEDDING__THREADS=0``) and restarting ``mm web``.
- Schema, Web Config Guide, tests, and CHANGELOG all moved together.

## Why

Live diagnosis of #640 confirmed the symptom isn't a counter leak — ONNX inference is genuinely active during a slow reindex (sample stack: ``InferenceSession::Run`` → ``MatMul`` → ``MlasGemmBatch``). What made it *feel* like a hang was the prior default pinning every physical core for the duration of ``embed_texts``: the web server, the browser tab, every other app on the machine became unresponsive at the same time. PR #649 made the run *visible*; PR #650 made the knob *discoverable*; this PR picks a sensible default so users don't have to learn it exists before getting a usable machine.

``threads = 4`` is intentionally simple — caps ONNX at 4 cores on every machine regardless of physical core count. On a 4-core laptop it's a no-op; on a 16-core server it leaves 12 cores for everything else. Server users who actually want to saturate all cores can opt in with one-line config + restart.

## What this changes for upgraders

- **Without override (most users)**: ONNX uses 4 cores during indexing instead of all of them. Indexing is slower on machines with > 4 cores but the web server stays responsive and the rest of the system keeps running smoothly.
- **With explicit ``threads = N`` override**: no change.
- **To opt back into all-cores**: set ``embedding.threads = 0`` (or env ``MEMTOMEM_EMBEDDING__THREADS=0``) and restart.

The ``threads = 0`` → ``None`` semantic in ``OnnxEmbedder._get_model`` is preserved (still tested by ``test_threads_zero_passes_none_to_fastembed``).

## Surfaces touched

- ``EmbeddingConfig.threads: int = 4`` + docstring rewrite explaining new default + opt-back-in path.
- ``ConfigEmbeddingOut.threads: int = 4`` (response schema default) so client caches match.
- Web Config Guide entry leads with "Default 4" and documents the ``threads = 0`` escape hatch. Cache-bust ``?v=8`` → ``?v=9``.
- Tests: ``test_threads_default_is_zero`` → ``test_threads_default_is_four``; ``FakeConfig`` + assertion in ``test_config_returns_sections``.
- ``CHANGELOG.md`` under ``[Unreleased] / Changed``.

## Test plan

- [x] ``uv run pytest packages/memtomem/tests/ -m 'not ollama'`` — 3600 passed
- [x] ``uv run ruff check && uv run ruff format --check`` — clean
- [ ] Browser smoke after restart: Config tab → Embedding section ``ONNX Threads: 4`` (was 0); Config Guide entry leads with "Default 4 …".
- [ ] Smoke: real reindex run with default 4 stays responsive (web UI continues to load other tabs while indexing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)