### PR TITLE
feat(indexing): per-chunk progress events for SSE indexing stream

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -75,6 +75,14 @@ class EmbeddingConfig(BaseSettings):
     #     event flows at all).
     # Runtime-mutable: the gate lives in the engine, not in cached
     # embedder state, so a config change takes effect on the next file.
+    #
+    # Why 32 (vs ``batch_size`` default 64)? Files producing ≤ batch_size
+    # chunks finish in one batch — there's no mid-progress to show, so
+    # any threshold ≥ batch_size would suppress them naturally. Picking
+    # 32 = batch_size/2 means "1-batch files stay quiet, 2+-batch files
+    # start ticking", which is the natural break-point between "instant"
+    # and "user wonders if anything is happening". Adjustable per
+    # operator preference.
     progress_threshold: int = 32
 
     @field_validator("dimension")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -64,6 +64,18 @@ class EmbeddingConfig(BaseSettings):
     # would not take effect until restart anyway. Same precedent as
     # ``rerank.provider``/``model``/``api_key`` below.
     threads: int = 4
+    # Per-chunk progress emission gate for the SSE indexing stream.
+    # The index engine only forwards ``chunk_progress`` events to the
+    # stream when a single file produces more than this many chunks —
+    # avoids spamming the UI with one event per tiny file. Semantics:
+    #   * ``> 0`` (default): emit only when ``chunks_total > threshold``.
+    #   * ``0``: always emit (debug affordance — useful when validating
+    #     the SSE plumbing on small fixtures, or when a user reports
+    #     "I never see chunk_progress" and you want to confirm the
+    #     event flows at all).
+    # Runtime-mutable: the gate lives in the engine, not in cached
+    # embedder state, so a config change takes effect on the next file.
+    progress_threshold: int = 32
 
     @field_validator("dimension")
     @classmethod
@@ -84,6 +96,13 @@ class EmbeddingConfig(BaseSettings):
     def threads_non_negative(cls, v: int) -> int:
         if v < 0:
             raise ValueError("threads must be non-negative (0 = ORT default)")
+        return v
+
+    @field_validator("progress_threshold")
+    @classmethod
+    def progress_threshold_non_negative(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("progress_threshold must be non-negative (0 = always emit)")
         return v
 
 
@@ -765,7 +784,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
         "auto_discover",
         "supported_extensions",
     },
-    "embedding": {"batch_size"},
+    "embedding": {"batch_size", "progress_threshold"},
     "decay": {"enabled", "half_life_days"},
     "mmr": {"enabled", "lambda_param"},
     "namespace": {"default_namespace", "enable_auto_ns", "rules"},
@@ -795,6 +814,7 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     },
     "indexing.auto_discover": {"type": bool},
     "embedding.batch_size": {"type": int, "min": 1, "max": 1024},
+    "embedding.progress_threshold": {"type": int, "min": 0, "max": 100000},
     "decay.enabled": {"type": bool},
     "decay.half_life_days": {"type": float, "min": 0.1},
     "mmr.enabled": {"type": bool},

--- a/packages/memtomem/src/memtomem/embedding/base.py
+++ b/packages/memtomem/src/memtomem/embedding/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Protocol, Sequence
 
 
@@ -12,6 +13,19 @@ class EmbeddingProvider(Protocol):
     @property
     def model_name(self) -> str: ...
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]: ...
+    async def embed_texts(
+        self,
+        texts: Sequence[str],
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> list[list[float]]:
+        # ``on_progress(done, total)`` fires after each natural unit of work
+        # (one batch for OpenAI/Ollama/ONNX). ``done`` is a monotonically
+        # non-decreasing count of texts whose embeddings are now available;
+        # it is NOT a positional index — concurrent batches (OpenAI/Ollama
+        # via ``asyncio.gather``) complete in arbitrary order. Best-effort:
+        # exceptions raised by the callback are caught and logged at debug.
+        ...
+
     async def embed_query(self, query: str) -> list[float]: ...
     async def close(self) -> None: ...

--- a/packages/memtomem/src/memtomem/embedding/noop.py
+++ b/packages/memtomem/src/memtomem/embedding/noop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Sequence
 
 
@@ -21,7 +22,15 @@ class NoopEmbedder:
     def model_name(self) -> str:
         return "none"
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+    async def embed_texts(
+        self,
+        texts: Sequence[str],
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> list[list[float]]:
+        # ``on_progress`` is accepted for ``EmbeddingProvider`` Protocol
+        # conformance but not invoked — Noop is instantaneous and the
+        # engine skips embedding entirely when ``dimension == 0``.
         return [[] for _ in texts]
 
     async def embed_query(self, query: str) -> list[float]:

--- a/packages/memtomem/src/memtomem/embedding/ollama.py
+++ b/packages/memtomem/src/memtomem/embedding/ollama.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Sequence
 
 import httpx
@@ -56,16 +57,38 @@ class OllamaEmbedder:
             )
         return embeddings
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+    async def embed_texts(
+        self,
+        texts: Sequence[str],
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> list[list[float]]:
         import asyncio
 
         bs = self._config.batch_size
         batches = [list(texts[i : i + bs]) for i in range(0, len(texts), bs)]
         sem = asyncio.Semaphore(self._config.max_concurrent_batches)
+        # See ``openai.py:embed_texts`` for the rationale on the single-cell
+        # ``done`` counter — same ordering caveat applies (count, not index).
+        done = [0]
+        total = len(texts)
+        progress_warned = [False]
 
         async def _safe_embed(batch: list[str]) -> list[list[float]]:
             async with sem:
-                return await self._embed_batch_with_retry(batch)
+                result = await self._embed_batch_with_retry(batch)
+                done[0] += len(batch)
+                if on_progress is not None:
+                    try:
+                        on_progress(done[0], total)
+                    except Exception:
+                        if not progress_warned[0]:
+                            progress_warned[0] = True
+                            logger.debug(
+                                "on_progress raised; further failures silenced",
+                                exc_info=True,
+                            )
+                return result
 
         try:
             batch_results = await asyncio.gather(*[_safe_embed(b) for b in batches])

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -101,13 +101,35 @@ class OnnxEmbedder:
     def model_name(self) -> str:
         return self._config.model
 
-    def _embed_sync(self, texts: list[str]) -> list[list[float]]:
-        """Run inference synchronously — called inside ``to_thread``."""
+    def _embed_sync(
+        self,
+        texts: list[str],
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> list[list[float]]:
+        """Run inference synchronously — called inside ``to_thread``.
+
+        When ``on_progress`` is provided, iterate fastembed's generator
+        and fire after each yielded vector. The callback is called from
+        the worker thread; callers running on an asyncio loop must wrap
+        with ``loop.call_soon_threadsafe`` (see ``embed_texts``).
+        """
         model = self._get_model()
-        # model.embed() returns a generator of numpy arrays;
-        # materialize fully inside the thread to avoid blocking the
-        # event loop with lazy evaluation.
-        return [vec.tolist() for vec in model.embed(texts)]
+        # Single ``model.embed()`` call — fastembed batches internally
+        # (default batch_size=256) so a 250-text input becomes ONE
+        # ORT session.run. Earlier we did Python-side chunking
+        # (``for batch in batches: model.embed(batch)``); benchmark
+        # showed +20% wall-clock regression vs single call because
+        # each ``model.embed()`` invocation pays per-call ORT setup
+        # cost. Stream-iterating the default-batched call recovers
+        # that to +2.3% while still surfacing per-yield progress.
+        if on_progress is None:
+            return [vec.tolist() for vec in model.embed(texts)]
+        total = len(texts)
+        out: list[list[float]] = []
+        for vec in model.embed(texts):
+            out.append(vec.tolist())
+            on_progress(len(out), total)
+        return out
 
     async def embed_texts(
         self,
@@ -117,36 +139,58 @@ class OnnxEmbedder:
     ) -> list[list[float]]:
         if not texts:
             return []
-        # Batch into ``EmbeddingConfig.batch_size`` slices so per-batch
-        # ``on_progress`` ticks can flow back to the index stream. The model
-        # is lazily cached on first ``_get_model()`` call, so only the first
-        # batch in a run pays the cold-start cost; subsequent batches reuse
-        # the same ``TextEmbedding`` instance + tokenizer + ORT session.
-        bs = max(self._config.batch_size, 1)
         text_list = list(texts)
         total = len(text_list)
-        results: list[list[float]] = []
-        progress_warned = False
+
+        if on_progress is None:
+            # Fast path — no callback plumbing, no cross-thread hops.
+            try:
+                return await asyncio.to_thread(self._embed_sync, text_list, None)
+            except EmbeddingError:
+                raise
+            except Exception as exc:
+                raise EmbeddingError(f"ONNX embedding failed: {exc}") from exc
+
+        # ``on_progress`` was provided. ``_embed_sync`` runs in a worker
+        # thread but ``on_progress`` (e.g. ``queue.put_nowait`` into the
+        # SSE stream) is event-loop-bound and not thread-safe. Wrap with
+        # ``call_soon_threadsafe`` and throttle to at most ~20 ticks per
+        # file so a 1000-text input doesn't fire 1000 cross-thread hops.
+        loop = asyncio.get_running_loop()
+        last_reported = [0]
+        step = max(1, total // 20)
+        progress_warned = [False]
+
+        def _safe_on_progress(done: int, t: int) -> None:
+            try:
+                on_progress(done, t)
+            except Exception:
+                if not progress_warned[0]:
+                    progress_warned[0] = True
+                    logger.debug(
+                        "on_progress raised; further failures silenced",
+                        exc_info=True,
+                    )
+
+        def _thread_cb(done: int, t: int) -> None:
+            # Throttle thread→loop hops; always emit the final tick so
+            # the SSE consumer's "(N/N)" final-render contract holds.
+            if done - last_reported[0] < step and done != t:
+                return
+            last_reported[0] = done
+            try:
+                loop.call_soon_threadsafe(_safe_on_progress, done, t)
+            except RuntimeError:
+                # Event loop is closed (shutdown / cancel). Drop the
+                # tick — embedding work itself continues unaffected.
+                pass
+
         try:
-            for start in range(0, total, bs):
-                batch = text_list[start : start + bs]
-                batch_embs = await asyncio.to_thread(self._embed_sync, batch)
-                results.extend(batch_embs)
-                if on_progress is not None:
-                    try:
-                        on_progress(len(results), total)
-                    except Exception:
-                        if not progress_warned:
-                            progress_warned = True
-                            logger.debug(
-                                "on_progress raised; further failures silenced",
-                                exc_info=True,
-                            )
+            return await asyncio.to_thread(self._embed_sync, text_list, _thread_cb)
         except EmbeddingError:
             raise
         except Exception as exc:
             raise EmbeddingError(f"ONNX embedding failed: {exc}") from exc
-        return results
 
     async def embed_query(self, query: str) -> list[float]:
         if not query or not query.strip():

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import Sequence
 
 from memtomem.config import EmbeddingConfig
@@ -108,15 +109,44 @@ class OnnxEmbedder:
         # event loop with lazy evaluation.
         return [vec.tolist() for vec in model.embed(texts)]
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+    async def embed_texts(
+        self,
+        texts: Sequence[str],
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> list[list[float]]:
         if not texts:
             return []
+        # Batch into ``EmbeddingConfig.batch_size`` slices so per-batch
+        # ``on_progress`` ticks can flow back to the index stream. The model
+        # is lazily cached on first ``_get_model()`` call, so only the first
+        # batch in a run pays the cold-start cost; subsequent batches reuse
+        # the same ``TextEmbedding`` instance + tokenizer + ORT session.
+        bs = max(self._config.batch_size, 1)
+        text_list = list(texts)
+        total = len(text_list)
+        results: list[list[float]] = []
+        progress_warned = False
         try:
-            return await asyncio.to_thread(self._embed_sync, list(texts))
+            for start in range(0, total, bs):
+                batch = text_list[start : start + bs]
+                batch_embs = await asyncio.to_thread(self._embed_sync, batch)
+                results.extend(batch_embs)
+                if on_progress is not None:
+                    try:
+                        on_progress(len(results), total)
+                    except Exception:
+                        if not progress_warned:
+                            progress_warned = True
+                            logger.debug(
+                                "on_progress raised; further failures silenced",
+                                exc_info=True,
+                            )
         except EmbeddingError:
             raise
         except Exception as exc:
             raise EmbeddingError(f"ONNX embedding failed: {exc}") from exc
+        return results
 
     async def embed_query(self, query: str) -> list[float]:
         if not query or not query.strip():

--- a/packages/memtomem/src/memtomem/embedding/openai.py
+++ b/packages/memtomem/src/memtomem/embedding/openai.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from typing import Sequence
 
 import httpx
@@ -73,7 +74,12 @@ class OpenAIEmbedder:
         data.sort(key=lambda x: x["index"])
         return [item["embedding"] for item in data]
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+    async def embed_texts(
+        self,
+        texts: Sequence[str],
+        *,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> list[list[float]]:
         import asyncio
 
         if not texts:
@@ -82,10 +88,30 @@ class OpenAIEmbedder:
         bs = self._config.batch_size
         batches = [list(texts[i : i + bs]) for i in range(0, len(texts), bs)]
         sem = asyncio.Semaphore(self._config.max_concurrent_batches)
+        # ``done`` is a single-cell list so the inner closure can mutate it
+        # without ``nonlocal``. asyncio is single-threaded so the ``+=`` is
+        # race-free across concurrent batch coroutines. ``done`` is monotonic
+        # but does NOT track batch-position — concurrent batches finish in
+        # arbitrary order; consumers should treat it as a count, not an index.
+        done = [0]
+        total = len(texts)
+        progress_warned = [False]
 
         async def _safe_embed(batch: list[str]) -> list[list[float]]:
             async with sem:
-                return await self._embed_batch_with_retry(batch)
+                result = await self._embed_batch_with_retry(batch)
+                done[0] += len(batch)
+                if on_progress is not None:
+                    try:
+                        on_progress(done[0], total)
+                    except Exception:
+                        if not progress_warned[0]:
+                            progress_warned[0] = True
+                            logger.debug(
+                                "on_progress raised; further failures silenced",
+                                exc_info=True,
+                            )
+                return result
 
         try:
             batch_results = await asyncio.gather(*[_safe_embed(b) for b in batches])

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID
@@ -327,10 +328,17 @@ class IndexEngine:
         config: IndexingConfig,
         registry: ChunkerRegistry | None = None,
         namespace_config: NamespaceConfig | None = None,
+        progress_threshold: int = 32,
     ) -> None:
         self._storage = storage
         self._embedder = embedder
         self._config = config
+        # ``chunk_progress`` SSE events are only emitted when a single file
+        # produces more than this many chunks (or always when set to 0).
+        # Sourced from ``EmbeddingConfig.progress_threshold`` by callers
+        # (``component_factory``, ``status_config`` reset path); defaults
+        # to 32 here so test-only direct constructors stay quiet.
+        self._progress_threshold = progress_threshold
         self._ns_config = namespace_config or NamespaceConfig()
         self._ns_rule_specs: list[tuple[pathspec.GitIgnoreSpec, NamespacePolicyRule]] = [
             (_build_exclude_spec([rule.path_glob]), rule) for rule in self._ns_config.rules
@@ -655,6 +663,8 @@ class IndexEngine:
         file_path: Path,
         force: bool,
         namespace: str | None = None,
+        *,
+        on_chunk_progress: Callable[[int, int], None] | None = None,
     ) -> IndexFileResult:
         # Return shape: total/indexed/skipped/deleted (ints), errors (list[str]),
         # new_chunk_ids (list[UUID]). Early zero-result paths may omit
@@ -760,8 +770,19 @@ class IndexEngine:
         # Skip embedding entirely when using the noop provider (BM25-only mode).
         if diff_result.to_upsert and self._embedder.dimension > 0:
             texts = [c.retrieval_content for c in diff_result.to_upsert]
+            # Threshold gate lives here, not inside the embedder, so callers
+            # without a callback (CLI ``index_path``, direct test invocations)
+            # never even compute the gating predicate. ``threshold == 0`` is
+            # the explicit "always emit" debug semantic — see
+            # ``EmbeddingConfig.progress_threshold`` docstring.
+            emit_progress = on_chunk_progress is not None and (
+                self._progress_threshold == 0 or len(texts) > self._progress_threshold
+            )
             try:
-                embeddings = await self._embedder.embed_texts(texts)
+                embeddings = await self._embedder.embed_texts(
+                    texts,
+                    on_progress=on_chunk_progress if emit_progress else None,
+                )
                 for chunk, emb in zip(diff_result.to_upsert, embeddings):
                     chunk.embedding = emb
             except Exception as exc:
@@ -807,6 +828,13 @@ class IndexEngine:
         """Like index_path(), but yields progress dicts as each file is processed.
 
         Yields dicts with ``type`` key:
+        - ``"chunk_progress"``: emitted *during* a single file's embedding
+          when the file produces more chunks than
+          ``EmbeddingConfig.progress_threshold``. Fields: ``file,
+          chunks_done, chunks_total, files_done, files_total``. ``chunks_done``
+          is a monotonically non-decreasing **count** of texts whose embeddings
+          have completed — NOT a positional index, since concurrent batches
+          (OpenAI/Ollama) finish in arbitrary order.
         - ``"progress"``: emitted after each file with fields
           ``file, files_done, files_total, indexed, skipped``.
         - ``"complete"``: final summary — ``total_files, total_chunks,
@@ -852,21 +880,76 @@ class IndexEngine:
             all_errors: list[str] = []
 
             for i, fp in enumerate(files, start=1):
+                # Per-file queue forwards ``chunk_progress`` ticks from the
+                # embedder (running inside the ``runner`` task) back to this
+                # generator in real time. Without the queue+task split the
+                # ``await self._index_file`` would block until the file is
+                # fully embedded, defeating the purpose of mid-file progress.
+                queue: asyncio.Queue = asyncio.Queue()
+                DONE = object()
+
+                # ``fp=fp, idx=i`` default-bind at definition so any future
+                # refactor lifting ``runner`` out of the loop or fanning out
+                # tasks won't silently regress to late-bound closure capture.
+                async def runner(
+                    fp: Path = fp,
+                    idx: int = i,
+                ) -> IndexFileResult:
+                    def cb(done: int, total: int) -> None:
+                        queue.put_nowait(
+                            {
+                                "type": "chunk_progress",
+                                "file": str(fp),
+                                "chunks_done": done,
+                                "chunks_total": total,
+                                "files_done": idx - 1,
+                                "files_total": total_files,
+                            }
+                        )
+
+                    try:
+                        return await self._index_file(
+                            fp,
+                            force,
+                            namespace=namespace,
+                            on_chunk_progress=cb,
+                        )
+                    finally:
+                        queue.put_nowait(DONE)
+
+                task = asyncio.create_task(runner())
                 try:
-                    result = await self._index_file(fp, force, namespace=namespace)
-                except Exception as exc:
-                    logger.error("Stream indexing failed for %s: %s", fp, exc)
-                    # Path-prefix matches non-stream's ``asyncio.gather(return_exceptions=True)``
-                    # branch in ``_index_path_inner`` so consumers see the same error
-                    # shape regardless of whether they used the stream or non-stream
-                    # endpoint.
-                    result = {
-                        "total": 0,
-                        "indexed": 0,
-                        "skipped": 0,
-                        "deleted": 0,
-                        "errors": [f"{fp.name}: {exc}"],
-                    }
+                    while True:
+                        event = await queue.get()
+                        if event is DONE:
+                            break
+                        yield event
+                    try:
+                        result = await task
+                    except Exception as exc:
+                        logger.error("Stream indexing failed for %s: %s", fp, exc)
+                        # Same shape as non-stream's
+                        # ``asyncio.gather(return_exceptions=True)`` branch
+                        # in ``_index_path_inner`` so consumers see the same
+                        # error shape regardless of stream vs non-stream.
+                        result = {
+                            "total": 0,
+                            "indexed": 0,
+                            "skipped": 0,
+                            "deleted": 0,
+                            "errors": [f"{fp.name}: {exc}"],
+                        }
+                except BaseException:
+                    # Generator was closed (HTTPException, client disconnect,
+                    # consumer ``aclose()``). Cancel the in-flight embedding
+                    # task so we don't leak an OpenAI request / ONNX inference
+                    # past the lifetime of the SSE response. The outer
+                    # ``finally`` below still decrements ``_active_runs``.
+                    task.cancel()
+                    with contextlib.suppress(BaseException):
+                        await task
+                    raise
+
                 agg["total_chunks"] += result["total"]
                 agg["indexed"] += result["indexed"]
                 agg["skipped"] += result["skipped"]

--- a/packages/memtomem/src/memtomem/server/component_factory.py
+++ b/packages/memtomem/src/memtomem/server/component_factory.py
@@ -136,6 +136,7 @@ async def create_components(config: Mem2MemConfig | None = None) -> Components:
         config=config.indexing,
         registry=registry,
         namespace_config=config.namespace,
+        progress_threshold=config.embedding.progress_threshold,
     )
     # Create optional reranker
     reranker = None

--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -296,6 +296,7 @@ def _revert_to_stored(app: AppContext) -> str:
         embedder=new_embedder,
         config=config.indexing,
         namespace_config=config.namespace,
+        progress_threshold=config.embedding.progress_threshold,
     )
 
     storage.clear_embedding_mismatch()

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3713,6 +3713,12 @@ async function runIndexStream() {
   }
   let _sseFailCount = 0;
   const _SSE_MAX_FAILS = 3;
+  // Throttle ``chunk_progress`` DOM writes — a 250-chunk file at batch_size=64
+  // emits ~4 events; a 2000-chunk pathological case would emit ~32. 100ms gap
+  // covers both without making the human eye work. The final tick (done==total)
+  // bypasses this so the user actually sees "(N/N)" land before the file row
+  // is replaced by the next file.
+  let _lastChunkRender = 0;
 
   es.onmessage = (e) => {
     let event;
@@ -3730,7 +3736,21 @@ async function runIndexStream() {
       return;
     }
     _sseFailCount = 0;
+    if (event.type === 'chunk_progress') {
+      const now = (typeof performance !== 'undefined' && performance.now)
+        ? performance.now() : Date.now();
+      const isFinal = event.chunks_done >= event.chunks_total;
+      if (!isFinal && now - _lastChunkRender < 100) return;
+      _lastChunkRender = now;
+      fileEl.textContent = t('index.file_chunk_progress', {
+        file: basename(event.file),
+        done: event.chunks_done,
+        total: event.chunks_total,
+      });
+      return;
+    }
     if (event.type === 'progress') {
+      _lastChunkRender = 0;  // reset on file boundary so first chunk of next file renders immediately
       const pct = event.files_total > 0
         ? Math.round((event.files_done / event.files_total) * 100) : 0;
       barEl.style.width = pct + '%';

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=81"></script>
+  <script src="/app.js?v=82"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=9"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -165,6 +165,7 @@
   "index.browse_btn": "📁 Browse",
   "index.browse_aria": "Open folder picker",
   "index.progress_label": "0 / 0 files",
+  "index.file_chunk_progress": "{file} — {done}/{total} chunks",
   "index.indicator": "⏳ Indexing…",
   "index.result.files": "Files scanned",
   "index.result.chunks": "Total chunks",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -165,6 +165,7 @@
   "index.browse_btn": "📁 둘러보기",
   "index.browse_aria": "폴더 선택 창 열기",
   "index.progress_label": "0 / 0 파일",
+  "index.file_chunk_progress": "{file} — {done}/{total} 청크",
   "index.indicator": "⏳ 인덱싱 중…",
   "index.result.files": "스캔된 파일",
   "index.result.chunks": "전체 청크",

--- a/packages/memtomem/tests/test_dedup.py
+++ b/packages/memtomem/tests/test_dedup.py
@@ -60,10 +60,12 @@ class _FakeEmbedder:
         self._storage = storage
         self._next_batch: list[str] = []
 
-    async def embed_texts(self, texts: list[str]) -> list[list[float]]:
+    async def embed_texts(self, texts: list[str], **_kwargs) -> list[list[float]]:
         # Return dummy vectors; stash each query content on the storage so
         # the next dense_search call can look it up (works because scan()
         # alternates embed -> dense_search per chunk, not in parallel).
+        # ``**_kwargs`` absorbs ``on_progress`` from the EmbeddingProvider
+        # Protocol; this fake doesn't fire progress.
         self._next_batch = list(texts)
         return [[1.0, 0.0, 0.0] for _ in texts]
 
@@ -79,7 +81,7 @@ def scanner_factory():
         original_embed = embedder.embed_texts
         original_dense = storage.dense_search
 
-        async def wrapped_embed(texts: list[str]) -> list[list[float]]:
+        async def wrapped_embed(texts: list[str], **_kwargs) -> list[list[float]]:
             storage._pending_markers = list(texts)  # type: ignore[attr-defined]
             return await original_embed(texts)
 

--- a/packages/memtomem/tests/test_embedding_progress.py
+++ b/packages/memtomem/tests/test_embedding_progress.py
@@ -1,0 +1,239 @@
+"""Per-batch ``on_progress`` callback contract for embedding providers.
+
+Each provider must:
+  * accept ``on_progress`` as a keyword-only argument
+  * fire it after each natural unit of work (one batch)
+  * deliver a monotonically non-decreasing ``done`` count
+  * end at ``done == total``
+  * never fail embedding when the callback raises
+  * tolerate omission (existing callers without the kwarg still work)
+
+These guarantees are what the SSE indexing stream relies on to forward
+``chunk_progress`` events to the web UI mid-file (see
+``IndexEngine.index_path_stream``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem.config import EmbeddingConfig
+from memtomem.embedding.noop import NoopEmbedder
+from memtomem.embedding.ollama import OllamaEmbedder
+from memtomem.embedding.onnx import OnnxEmbedder
+from memtomem.embedding.openai import OpenAIEmbedder
+
+
+def _ollama_config(**kw) -> EmbeddingConfig:
+    base = dict(provider="ollama", model="nomic-embed-text", dimension=768)
+    base.update(kw)
+    return EmbeddingConfig(**base)
+
+
+def _openai_config(**kw) -> EmbeddingConfig:
+    base = dict(
+        provider="openai",
+        model="text-embedding-3-small",
+        dimension=1536,
+        api_key="sk-test",
+    )
+    base.update(kw)
+    return EmbeddingConfig(**base)
+
+
+def _onnx_config(**kw) -> EmbeddingConfig:
+    base = dict(provider="onnx", model="all-MiniLM-L6-v2", dimension=3)
+    base.update(kw)
+    return EmbeddingConfig(**base)
+
+
+def _record() -> tuple[list[tuple[int, int]], callable]:
+    calls: list[tuple[int, int]] = []
+
+    def cb(done: int, total: int) -> None:
+        calls.append((done, total))
+
+    return calls, cb
+
+
+def _assert_progress_contract(calls: list[tuple[int, int]], total: int, expected_calls: int):
+    assert len(calls) == expected_calls, f"expected {expected_calls} calls, got {calls}"
+    # All totals match
+    assert all(t == total for _, t in calls), calls
+    # Monotonic non-decreasing done count
+    dones = [d for d, _ in calls]
+    assert dones == sorted(dones), f"done counts not monotonic: {dones}"
+    # Final done equals total — without this the SSE stream's "(N/N)"
+    # final-tick render never fires, leaving the user staring at "(192/250)"
+    # right before the next file's name pops in.
+    assert dones[-1] == total, f"final done={dones[-1]} != total={total}"
+
+
+# ---------------------------------------------------------------------------
+# Noop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_noop_accepts_on_progress_kwarg():
+    """Protocol conformance — Noop must accept the kwarg even though it
+    never fires (Noop returns instantly and the engine skips embedding
+    when ``dimension == 0``)."""
+    embedder = NoopEmbedder()
+    calls, cb = _record()
+    result = await embedder.embed_texts(["a", "b", "c"], on_progress=cb)
+    assert result == [[], [], []]
+    assert calls == []  # Noop never fires the callback
+
+
+# ---------------------------------------------------------------------------
+# OpenAI
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_openai_fires_progress_per_batch():
+    """5 texts at batch_size=2 → 3 batches, 3 callbacks, ending at (5, 5)."""
+    config = _openai_config(batch_size=2, max_concurrent_batches=1)
+    embedder = OpenAIEmbedder(config)
+    # Patch the per-batch worker so we control batch boundaries without
+    # touching httpx at all. Returning a vector per text in the batch
+    # mirrors the real /v1/embeddings response shape.
+    embedder._embed_batch_with_retry = AsyncMock(
+        side_effect=lambda batch: [[0.0] * 3 for _ in batch]
+    )
+    calls, cb = _record()
+    result = await embedder.embed_texts(["a", "b", "c", "d", "e"], on_progress=cb)
+    assert len(result) == 5
+    _assert_progress_contract(calls, total=5, expected_calls=3)
+    # Specifically: batch_size=2 with concurrency=1 forces sequential
+    # completion, so done counts must be exactly 2, 4, 5.
+    assert [d for d, _ in calls] == [2, 4, 5]
+
+
+@pytest.mark.anyio
+async def test_openai_progress_kwarg_omitted_works():
+    """Existing callers without the kwarg still embed normally."""
+    config = _openai_config(batch_size=4)
+    embedder = OpenAIEmbedder(config)
+    embedder._embed_batch_with_retry = AsyncMock(side_effect=lambda batch: [[0.0] for _ in batch])
+    result = await embedder.embed_texts(["a", "b"])
+    assert len(result) == 2
+
+
+@pytest.mark.anyio
+async def test_openai_progress_callback_exception_swallowed():
+    """A buggy callback must not break embedding — best-effort contract."""
+    config = _openai_config(batch_size=2, max_concurrent_batches=1)
+    embedder = OpenAIEmbedder(config)
+    embedder._embed_batch_with_retry = AsyncMock(side_effect=lambda batch: [[0.0] for _ in batch])
+
+    def bad_cb(done: int, total: int) -> None:
+        raise RuntimeError("UI exploded")
+
+    result = await embedder.embed_texts(["a", "b", "c"], on_progress=bad_cb)
+    assert len(result) == 3  # embedding completed despite raising callback
+
+
+# ---------------------------------------------------------------------------
+# Ollama
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ollama_fires_progress_per_batch():
+    config = _ollama_config(batch_size=2, max_concurrent_batches=1)
+    embedder = OllamaEmbedder(config)
+    embedder._embed_batch_with_retry = AsyncMock(
+        side_effect=lambda batch: [[0.0] * 3 for _ in batch]
+    )
+    calls, cb = _record()
+    result = await embedder.embed_texts(["a", "b", "c", "d", "e"], on_progress=cb)
+    assert len(result) == 5
+    _assert_progress_contract(calls, total=5, expected_calls=3)
+    assert [d for d, _ in calls] == [2, 4, 5]
+
+
+@pytest.mark.anyio
+async def test_ollama_progress_callback_exception_swallowed():
+    config = _ollama_config(batch_size=2, max_concurrent_batches=1)
+    embedder = OllamaEmbedder(config)
+    embedder._embed_batch_with_retry = AsyncMock(side_effect=lambda batch: [[0.0] for _ in batch])
+
+    def bad_cb(done: int, total: int) -> None:
+        raise RuntimeError("UI exploded")
+
+    result = await embedder.embed_texts(["a", "b", "c"], on_progress=bad_cb)
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# ONNX (mocked _embed_sync; no fastembed dependency at test time)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_onnx_fires_progress_per_batch():
+    """5 texts at batch_size=2 → 3 batches via the new internal loop."""
+    config = _onnx_config(batch_size=2)
+    embedder = OnnxEmbedder(config)
+
+    def fake_sync(texts: list[str]) -> list[list[float]]:
+        return [[0.0, 0.1, 0.2] for _ in texts]
+
+    embedder._embed_sync = fake_sync  # type: ignore[method-assign]
+    calls, cb = _record()
+    result = await embedder.embed_texts(["a", "b", "c", "d", "e"], on_progress=cb)
+    assert len(result) == 5
+    # ONNX runs sequentially (one to_thread per batch), so done counts
+    # are exactly 2, 4, 5 — no concurrent reordering possible.
+    _assert_progress_contract(calls, total=5, expected_calls=3)
+    assert [d for d, _ in calls] == [2, 4, 5]
+
+
+@pytest.mark.anyio
+async def test_onnx_single_batch_still_fires_once():
+    """When all texts fit in one batch, callback fires once with (N, N)."""
+    config = _onnx_config(batch_size=64)
+    embedder = OnnxEmbedder(config)
+
+    def fake_sync(texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    embedder._embed_sync = fake_sync  # type: ignore[method-assign]
+    calls, cb = _record()
+    await embedder.embed_texts(["a", "b", "c"], on_progress=cb)
+    assert calls == [(3, 3)]
+
+
+@pytest.mark.anyio
+async def test_onnx_progress_callback_exception_swallowed():
+    config = _onnx_config(batch_size=2)
+    embedder = OnnxEmbedder(config)
+
+    def fake_sync(texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    embedder._embed_sync = fake_sync  # type: ignore[method-assign]
+
+    def bad_cb(done: int, total: int) -> None:
+        raise RuntimeError("UI exploded")
+
+    result = await embedder.embed_texts(["a", "b", "c"], on_progress=bad_cb)
+    assert len(result) == 3
+
+
+@pytest.mark.anyio
+async def test_onnx_progress_kwarg_omitted_works():
+    """Regression: existing ``embed_texts(texts)`` call sites still work."""
+    config = _onnx_config(batch_size=2)
+    embedder = OnnxEmbedder(config)
+
+    def fake_sync(texts: list[str]) -> list[list[float]]:
+        return [[0.0] for _ in texts]
+
+    embedder._embed_sync = fake_sync  # type: ignore[method-assign]
+    result = await embedder.embed_texts(["a", "b", "c"])
+    assert len(result) == 3

--- a/packages/memtomem/tests/test_embedding_progress.py
+++ b/packages/memtomem/tests/test_embedding_progress.py
@@ -237,3 +237,66 @@ async def test_onnx_progress_kwarg_omitted_works():
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
     result = await embedder.embed_texts(["a", "b", "c"])
     assert len(result) == 3
+
+
+@pytest.mark.anyio
+async def test_onnx_numerical_parity_across_batch_sizes():
+    """Splitting a single ``embed(all_texts)`` call into batched
+    ``embed(batch_n)`` calls must NOT change the resulting vectors.
+
+    fastembed's tokenizer pads dynamically per ONNX session call (longest
+    sequence in the batch wins). Different batch boundaries → different
+    padding shapes → ONNX runtime can produce numerically different
+    outputs even though the attention mask should mask them out. This
+    test pins the "vector-stable across batch_size" invariant so a
+    silent embedding drift (which would degrade search quality across
+    the entire DB after a reindex, with no error to point at) is caught
+    in CI rather than discovered by a user.
+
+    Skipped when fastembed isn't installed — the in-process fake
+    embedders elsewhere in this file can't exercise real tokenizer/ORT
+    behavior, so the test is meaningful only in environments with the
+    real backend (e.g. the ``golden-path (ONNX bge-m3)`` CI job, which
+    already pulls fastembed for end-to-end indexing).
+    """
+    pytest.importorskip("fastembed")
+    pytest.importorskip("numpy")
+    import numpy as np
+
+    # Use the small all-MiniLM-L6-v2 (384d, ~25MB ONNX) so the test
+    # downloads quickly the first time and stays under typical CI budgets.
+    # bge-m3 would also work but is 2.3GB — overkill for a parity check.
+    config_small = _onnx_config(model="all-MiniLM-L6-v2", dimension=384, batch_size=2)
+    config_large = _onnx_config(model="all-MiniLM-L6-v2", dimension=384, batch_size=64)
+    emb_small = OnnxEmbedder(config_small)
+    emb_large = OnnxEmbedder(config_large)
+
+    # Mixed-length texts — different padding decisions per batch
+    # boundary are exactly what we want to stress-test.
+    texts = [
+        "short one",
+        "this is a slightly longer sentence to skew padding shape",
+        "tiny",
+        "another medium length sentence with some content to embed",
+        "x",
+        "a final reasonably long sentence ending the parity probe set",
+    ]
+
+    try:
+        vecs_small = await emb_small.embed_texts(texts)
+        vecs_large = await emb_large.embed_texts(texts)
+    finally:
+        await emb_small.close()
+        await emb_large.close()
+
+    assert len(vecs_small) == len(vecs_large) == len(texts)
+    arr_small = np.array(vecs_small)
+    arr_large = np.array(vecs_large)
+    # Tight tolerance — ORT floating-point determinism on the same model
+    # + input across batch shapes should hold to ~1e-5. If this fails,
+    # something in the batch-shape → padding → output pipeline shifted.
+    assert np.allclose(arr_small, arr_large, rtol=1e-5, atol=1e-6), (
+        "ONNX embeddings drifted across batch_size boundary — silent "
+        "embedding regression risk; investigate fastembed tokenizer "
+        "padding policy or ORT session options."
+    )

--- a/packages/memtomem/tests/test_embedding_progress.py
+++ b/packages/memtomem/tests/test_embedding_progress.py
@@ -171,50 +171,117 @@ async def test_ollama_progress_callback_exception_swallowed():
 
 # ---------------------------------------------------------------------------
 # ONNX (mocked _embed_sync; no fastembed dependency at test time)
+#
+# Note on ONNX progress shape: the implementation uses a SINGLE
+# ``model.embed(texts)`` call (so fastembed's default internal batching
+# stays in effect — a 250-text run = 1 ORT session.run instead of 4
+# with our config.batch_size=64). Per-yield progress is then surfaced
+# via a thread-safe callback. Earlier versions did Python-side chunking
+# at ``config.batch_size``; benchmarking caught a +20% wall-clock
+# regression vs the single-call path, so the implementation switched
+# to streaming. As a result, ``on_progress`` fires per-text (throttled
+# to ~20 ticks per file), NOT per-config.batch_size batch.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.anyio
-async def test_onnx_fires_progress_per_batch():
-    """5 texts at batch_size=2 → 3 batches via the new internal loop."""
-    config = _onnx_config(batch_size=2)
+async def test_onnx_streams_progress_per_yield():
+    """5 texts → callback fires per yielded vector ending at (5, 5).
+
+    Mocks ``_embed_sync`` so we can directly verify the per-yield
+    contract without touching fastembed/ORT.
+    """
+    config = _onnx_config()
     embedder = OnnxEmbedder(config)
 
-    def fake_sync(texts: list[str]) -> list[list[float]]:
-        return [[0.0, 0.1, 0.2] for _ in texts]
+    def fake_sync(texts, on_progress=None):
+        # Mimic the real _embed_sync's per-yield progress fire
+        out = []
+        total = len(texts)
+        for t in texts:
+            out.append([0.0, 0.1, 0.2])
+            if on_progress is not None:
+                on_progress(len(out), total)
+        return out
 
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
     calls, cb = _record()
     result = await embedder.embed_texts(["a", "b", "c", "d", "e"], on_progress=cb)
     assert len(result) == 5
-    # ONNX runs sequentially (one to_thread per batch), so done counts
-    # are exactly 2, 4, 5 — no concurrent reordering possible.
-    _assert_progress_contract(calls, total=5, expected_calls=3)
-    assert [d for d, _ in calls] == [2, 4, 5]
+    _assert_progress_contract(calls, total=5, expected_calls=5)
+    assert [d for d, _ in calls] == [1, 2, 3, 4, 5]
 
 
 @pytest.mark.anyio
-async def test_onnx_single_batch_still_fires_once():
-    """When all texts fit in one batch, callback fires once with (N, N)."""
-    config = _onnx_config(batch_size=64)
+async def test_onnx_throttles_thread_hops_for_large_input():
+    """A 200-text input must NOT fire 200 cross-thread hops — the
+    ONNX path throttles to ~20 ticks per file (``total // 20``), with
+    the final tick (``done == total``) always emitted so the UI's
+    final-render contract holds.
+    """
+    config = _onnx_config()
     embedder = OnnxEmbedder(config)
+    n = 200
 
-    def fake_sync(texts: list[str]) -> list[list[float]]:
-        return [[0.0] for _ in texts]
+    def fake_sync(texts, on_progress=None):
+        out = []
+        total = len(texts)
+        for t in texts:
+            out.append([0.0])
+            if on_progress is not None:
+                on_progress(len(out), total)
+        return out
 
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
     calls, cb = _record()
-    await embedder.embed_texts(["a", "b", "c"], on_progress=cb)
-    assert calls == [(3, 3)]
+    await embedder.embed_texts(["x"] * n, on_progress=cb)
+    # Throttle step = max(1, n // 20) = 10 → ~20 ticks + final
+    # (final-tick bypass guarantees one extra if the last-step boundary
+    # doesn't land exactly on N).
+    assert 15 <= len(calls) <= 25, (
+        f"expected ~20 throttled ticks for n={n}, got {len(calls)}: {calls}"
+    )
+    # Final tick must equal n — UI render contract.
+    assert calls[-1] == (n, n)
+    # Monotonic
+    assert [d for d, _ in calls] == sorted(d for d, _ in calls)
+
+
+@pytest.mark.anyio
+async def test_onnx_no_progress_skips_callback_plumbing():
+    """When ``on_progress`` is omitted, ``_embed_sync`` is called with
+    ``on_progress=None`` — the fast path. Pin this so a future refactor
+    that always wraps the callback (paying ``call_soon_threadsafe``
+    cost on every yield) is caught.
+    """
+    config = _onnx_config()
+    embedder = OnnxEmbedder(config)
+    received_cb_arg: list = []
+
+    def fake_sync(texts, on_progress=None):
+        received_cb_arg.append(on_progress)
+        return [[0.0] for _ in texts]
+
+    embedder._embed_sync = fake_sync  # type: ignore[method-assign]
+    await embedder.embed_texts(["a", "b", "c"])
+    assert received_cb_arg == [None], (
+        "fast path must pass on_progress=None to _embed_sync to skip the per-yield callback wrap"
+    )
 
 
 @pytest.mark.anyio
 async def test_onnx_progress_callback_exception_swallowed():
-    config = _onnx_config(batch_size=2)
+    config = _onnx_config()
     embedder = OnnxEmbedder(config)
 
-    def fake_sync(texts: list[str]) -> list[list[float]]:
-        return [[0.0] for _ in texts]
+    def fake_sync(texts, on_progress=None):
+        out = []
+        total = len(texts)
+        for t in texts:
+            out.append([0.0])
+            if on_progress is not None:
+                on_progress(len(out), total)
+        return out
 
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
 
@@ -228,10 +295,10 @@ async def test_onnx_progress_callback_exception_swallowed():
 @pytest.mark.anyio
 async def test_onnx_progress_kwarg_omitted_works():
     """Regression: existing ``embed_texts(texts)`` call sites still work."""
-    config = _onnx_config(batch_size=2)
+    config = _onnx_config()
     embedder = OnnxEmbedder(config)
 
-    def fake_sync(texts: list[str]) -> list[list[float]]:
+    def fake_sync(texts, on_progress=None):
         return [[0.0] for _ in texts]
 
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
@@ -240,39 +307,22 @@ async def test_onnx_progress_kwarg_omitted_works():
 
 
 @pytest.mark.anyio
-async def test_onnx_numerical_parity_across_batch_sizes():
-    """Splitting a single ``embed(all_texts)`` call into batched
-    ``embed(batch_n)`` calls must NOT change the resulting vectors.
+async def test_onnx_numerical_parity_with_and_without_progress():
+    """The progress-streaming code path must produce identical vectors
+    to the no-progress fast path on the same input. Catches accidental
+    drift if a future refactor reorders the per-yield iteration or
+    introduces an inadvertent transformation in the callback wrap.
 
-    fastembed's tokenizer pads dynamically per ONNX session call (longest
-    sequence in the batch wins). Different batch boundaries → different
-    padding shapes → ONNX runtime can produce numerically different
-    outputs even though the attention mask should mask them out. This
-    test pins the "vector-stable across batch_size" invariant so a
-    silent embedding drift (which would degrade search quality across
-    the entire DB after a reindex, with no error to point at) is caught
-    in CI rather than discovered by a user.
-
-    Skipped when fastembed isn't installed — the in-process fake
-    embedders elsewhere in this file can't exercise real tokenizer/ORT
-    behavior, so the test is meaningful only in environments with the
-    real backend (e.g. the ``golden-path (ONNX bge-m3)`` CI job, which
-    already pulls fastembed for end-to-end indexing).
+    Skipped without fastembed; runs in the ``golden-path (ONNX bge-m3)``
+    CI job and any local env with fastembed installed.
     """
     pytest.importorskip("fastembed")
     pytest.importorskip("numpy")
     import numpy as np
 
-    # Use the small all-MiniLM-L6-v2 (384d, ~25MB ONNX) so the test
-    # downloads quickly the first time and stays under typical CI budgets.
-    # bge-m3 would also work but is 2.3GB — overkill for a parity check.
-    config_small = _onnx_config(model="all-MiniLM-L6-v2", dimension=384, batch_size=2)
-    config_large = _onnx_config(model="all-MiniLM-L6-v2", dimension=384, batch_size=64)
-    emb_small = OnnxEmbedder(config_small)
-    emb_large = OnnxEmbedder(config_large)
-
-    # Mixed-length texts — different padding decisions per batch
-    # boundary are exactly what we want to stress-test.
+    config = _onnx_config(model="all-MiniLM-L6-v2", dimension=384)
+    emb_a = OnnxEmbedder(config)
+    emb_b = OnnxEmbedder(config)
     texts = [
         "short one",
         "this is a slightly longer sentence to skew padding shape",
@@ -281,22 +331,20 @@ async def test_onnx_numerical_parity_across_batch_sizes():
         "x",
         "a final reasonably long sentence ending the parity probe set",
     ]
-
     try:
-        vecs_small = await emb_small.embed_texts(texts)
-        vecs_large = await emb_large.embed_texts(texts)
+        vecs_no_progress = await emb_a.embed_texts(texts)
+        vecs_with_progress = await emb_b.embed_texts(texts, on_progress=lambda d, t: None)
     finally:
-        await emb_small.close()
-        await emb_large.close()
+        await emb_a.close()
+        await emb_b.close()
 
-    assert len(vecs_small) == len(vecs_large) == len(texts)
-    arr_small = np.array(vecs_small)
-    arr_large = np.array(vecs_large)
-    # Tight tolerance — ORT floating-point determinism on the same model
-    # + input across batch shapes should hold to ~1e-5. If this fails,
-    # something in the batch-shape → padding → output pipeline shifted.
-    assert np.allclose(arr_small, arr_large, rtol=1e-5, atol=1e-6), (
-        "ONNX embeddings drifted across batch_size boundary — silent "
-        "embedding regression risk; investigate fastembed tokenizer "
-        "padding policy or ORT session options."
-    )
+    assert len(vecs_no_progress) == len(vecs_with_progress) == len(texts)
+    # Bit-exact: both paths call the same underlying model.embed() in
+    # the same order; the only difference is whether each yield triggers
+    # a callback. No floating-point reordering involved.
+    assert np.allclose(
+        np.array(vecs_no_progress),
+        np.array(vecs_with_progress),
+        rtol=1e-7,
+        atol=1e-8,
+    ), "fast path and progress path must produce identical embeddings"

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -402,6 +402,210 @@ class TestExcludePatterns:
 
 
 # ===========================================================================
+# 1.a.2 Per-chunk progress: chunk_progress events + threshold gate
+# ===========================================================================
+
+
+class _FakeProgressEmbedder:
+    """Fires ``on_progress`` at 25/50/75/100% milestones — driven enough
+    to exercise stream forwarding without leaning on a real backend."""
+
+    def __init__(self, dim: int = 4) -> None:
+        self._dim = dim
+
+    @property
+    def dimension(self) -> int:
+        return self._dim
+
+    @property
+    def model_name(self) -> str:
+        return "fake-progress"
+
+    async def embed_texts(self, texts, *, on_progress=None):
+        n = len(texts)
+        if on_progress is not None and n >= 4:
+            for ratio in (0.25, 0.5, 0.75, 1.0):
+                on_progress(max(1, int(n * ratio)), n)
+        return [[0.0] * self._dim for _ in texts]
+
+    async def embed_query(self, query: str):
+        return [0.0] * self._dim
+
+    async def close(self) -> None:
+        pass
+
+
+def _many_chunk_md(num_headings: int = 30) -> str:
+    """Build a markdown body that reliably produces many chunks.
+
+    Each H1 gets a body well above the chunker's ``min_chunk_tokens`` so
+    the post-merge pass doesn't collapse them. Used by chunk_progress
+    tests where a low-but-non-trivial chunk count is the only fixture
+    invariant we care about.
+    """
+    body = " ".join(["lorem ipsum dolor sit amet"] * 30)
+    return "\n\n".join(f"# Heading {i}\n\n{body}" for i in range(num_headings))
+
+
+class TestChunkProgressStream:
+    """Tests for ``chunk_progress`` events emitted by ``index_path_stream``
+    during embedding of a single large file. The stream forwards each
+    ``on_progress(done, total)`` call from the embedder via a per-file
+    ``asyncio.Queue`` — see ``index_path_stream`` for the producer/consumer
+    split. These tests pin both the wiring (events flow) and the gate
+    (small files stay quiet).
+    """
+
+    async def test_emits_chunk_progress_above_threshold(self, components, memory_dir):
+        """Big file + low threshold → mid-file ``chunk_progress`` events
+        flow with monotonic non-decreasing ``chunks_done`` ending at total.
+        """
+        (memory_dir / "big.md").write_text(_many_chunk_md(20))
+        engine = components.index_engine
+        engine._progress_threshold = 1  # always emit for any non-trivial file
+        engine._embedder = _FakeProgressEmbedder()
+
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        chunk_events = [e for e in events if e["type"] == "chunk_progress"]
+        assert chunk_events, "expected at least one chunk_progress event for big.md"
+
+        dones = [e["chunks_done"] for e in chunk_events]
+        assert dones == sorted(dones), f"chunks_done not monotonic: {dones}"
+        total = chunk_events[0]["chunks_total"]
+        assert all(e["chunks_total"] == total for e in chunk_events)
+        # Final tick must equal total — UI's final-tick render bypass
+        # depends on this invariant (otherwise users see "(N-1)/N" right
+        # before the file row is replaced).
+        assert dones[-1] == total
+
+    async def test_chunk_progress_ordered_before_progress(self, components, memory_dir):
+        """Strong invariant: every ``chunk_progress`` event for a file
+        must yield BEFORE that file's ``progress`` event. Separated from
+        the monotonic test so a future regression in either property is
+        immediately attributable.
+        """
+        (memory_dir / "big.md").write_text(_many_chunk_md(20))
+        engine = components.index_engine
+        engine._progress_threshold = 1
+        engine._embedder = _FakeProgressEmbedder()
+
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        progress_idx = next(
+            i
+            for i, e in enumerate(events)
+            if e["type"] == "progress" and e["file"].endswith("big.md")
+        )
+        chunk_indices = [
+            i
+            for i, e in enumerate(events)
+            if e["type"] == "chunk_progress" and e["file"].endswith("big.md")
+        ]
+        assert chunk_indices, "expected chunk_progress events to assert ordering on"
+        assert all(ci < progress_idx for ci in chunk_indices), (
+            f"chunk_progress (indices {chunk_indices}) must yield before "
+            f"file's progress (index {progress_idx})"
+        )
+
+    async def test_no_chunk_progress_below_threshold(self, components, memory_dir):
+        """Small file under threshold → no ``chunk_progress`` events emitted.
+        Avoids spamming the SSE stream for trivial files.
+        """
+        (memory_dir / "tiny.md").write_text("# Heading\n\nshort body")
+        engine = components.index_engine
+        engine._progress_threshold = 100  # well above any realistic chunk count
+        engine._embedder = _FakeProgressEmbedder()
+
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        chunk_events = [e for e in events if e["type"] == "chunk_progress"]
+        assert chunk_events == [], (
+            f"expected no chunk_progress for small file under threshold, got {chunk_events}"
+        )
+
+    async def test_threshold_zero_emits_for_any_file(self, components, memory_dir):
+        """``progress_threshold == 0`` is the explicit "always emit" debug
+        affordance — useful when validating the SSE plumbing on small
+        fixtures or chasing a "I never see chunk_progress" report.
+        """
+        (memory_dir / "any.md").write_text(_many_chunk_md(8))
+        engine = components.index_engine
+        engine._progress_threshold = 0
+        engine._embedder = _FakeProgressEmbedder()
+
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        chunk_events = [e for e in events if e["type"] == "chunk_progress"]
+        assert chunk_events, "threshold=0 must emit chunk_progress even for small files"
+
+    async def test_chunk_progress_preserves_complete_errors_contract(self, components, memory_dir):
+        """Adding ``chunk_progress`` events must not regress the #590
+        ``complete.errors`` silent-drop guard. A file that fails embedding
+        must still surface its error in ``complete.errors``.
+        """
+
+        class _RaisingEmbedder(_FakeProgressEmbedder):
+            async def embed_texts(self, texts, *, on_progress=None):
+                # Fire one progress event so the chunk path is exercised,
+                # then fail — mirrors a partial OpenAI rate-limit failure.
+                if on_progress is not None and len(texts) >= 4:
+                    on_progress(max(1, len(texts) // 4), len(texts))
+                from memtomem.errors import EmbeddingError
+
+                raise EmbeddingError("simulated mid-batch failure")
+
+        (memory_dir / "doomed.md").write_text(_many_chunk_md(20))
+        engine = components.index_engine
+        engine._progress_threshold = 1
+        engine._embedder = _RaisingEmbedder()
+
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+        complete = next(e for e in events if e.get("type") == "complete")
+        assert complete["errors"], (
+            "complete.errors must surface the embedding failure even when "
+            "chunk_progress events were emitted earlier (#590 regression guard)"
+        )
+        # ``_index_file`` reports embedding failures as
+        # ``"Embedding failed: <exc>"`` — the file path is logged separately
+        # via ``logger.error`` (see engine.py near the embedding try/except).
+        assert any("Embedding failed" in err for err in complete["errors"])
+
+    async def test_consumer_aclose_cancels_inflight_task(self, components, memory_dir):
+        """Generator close (SSE client disconnect) must cancel the in-flight
+        ``_index_file`` task so we don't leak embedding work past the SSE
+        response lifetime. ``_active_runs`` must return to 0 — same
+        invariant as ``test_decrements_on_stream_aclose`` but exercised on
+        the new task+queue path.
+        """
+
+        class _SlowEmbedder(_FakeProgressEmbedder):
+            async def embed_texts(self, texts, *, on_progress=None):
+                # Fire one progress event to suspend the generator past
+                # the queue.get(), then wait long enough for aclose() to
+                # land while the inner task is still parked.
+                if on_progress is not None and len(texts) >= 4:
+                    on_progress(1, len(texts))
+                await asyncio.sleep(60)  # long enough that aclose lands first
+                return [[0.0] * self._dim for _ in texts]
+
+        (memory_dir / "slow.md").write_text(_many_chunk_md(20))
+        engine = components.index_engine
+        engine._progress_threshold = 1
+        engine._embedder = _SlowEmbedder()
+        assert engine._active_runs == 0
+
+        gen = engine.index_path_stream(memory_dir, recursive=True)
+        first = await gen.__anext__()
+        # First yield must be the chunk_progress event (chunker + first
+        # progress fire happen before _index_file completes).
+        assert first["type"] == "chunk_progress"
+        assert engine._active_runs == 1
+
+        await gen.aclose()
+        # ``_active_runs`` must return to 0 even though the inner task
+        # was cancelled mid-embedding.
+        assert engine._active_runs == 0
+        assert engine.is_active is False
+
+
+# ===========================================================================
 # 1.b _active_runs / is_active counter
 # ===========================================================================
 
@@ -430,7 +634,10 @@ class TestActiveRunsCounter:
         gate = asyncio.Event()
         orig = engine._index_file
 
-        async def blocked(fp, force=False, namespace=None):
+        async def blocked(fp, force=False, namespace=None, **_kwargs):
+            # ``**_kwargs`` absorbs ``on_chunk_progress`` (added in the
+            # per-chunk progress feature) so the patch stays compatible
+            # with both stream and non-stream callers.
             await gate.wait()
             return await orig(fp, force, namespace=namespace)
 
@@ -480,7 +687,7 @@ class TestActiveRunsCounter:
         gate = asyncio.Event()
         orig = engine._index_file
 
-        async def blocked(fp, force=False, namespace=None):
+        async def blocked(fp, force=False, namespace=None, **_kwargs):
             await gate.wait()
             return await orig(fp, force, namespace=namespace)
 
@@ -531,7 +738,7 @@ class TestActiveRunsCounter:
         engine = components.index_engine
         orig = engine._index_file
 
-        async def boom(fp, force=False, namespace=None):
+        async def boom(fp, force=False, namespace=None, **_kwargs):
             raise RuntimeError("simulated failure")
 
         engine._index_file = boom  # type: ignore[method-assign]
@@ -1429,7 +1636,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1448,7 +1655,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1473,7 +1680,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1492,7 +1699,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1505,7 +1712,7 @@ class TestIndexFile:
         """Non-existent file should return zero counts, not raise."""
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1522,7 +1729,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1549,7 +1756,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1585,7 +1792,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1622,7 +1829,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1668,7 +1875,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1712,7 +1919,7 @@ class TestIndexFile:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1757,7 +1964,7 @@ class TestIndexPath:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1772,7 +1979,7 @@ class TestIndexPath:
         """Non-existent path returns zeroed stats."""
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1788,7 +1995,7 @@ class TestIndexPath:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1815,7 +2022,7 @@ class TestIncrementalIndexing:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1843,7 +2050,7 @@ class TestIncrementalIndexing:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder
@@ -1867,7 +2074,7 @@ class TestIncrementalIndexing:
 
         mock_embedder = AsyncMock()
         mock_embedder.embed_texts = AsyncMock(
-            side_effect=lambda texts: [[0.1] * 1024 for _ in texts]
+            side_effect=lambda texts, **_: [[0.1] * 1024 for _ in texts]
         )
         mock_embedder.dimension = 1024
         components.index_engine._embedder = mock_embedder

--- a/packages/memtomem/tests/test_server_degraded_mode.py
+++ b/packages/memtomem/tests/test_server_degraded_mode.py
@@ -42,7 +42,8 @@ class _FakeEmbedder:
     dimension = 1024
     model_name = "bge-m3"
 
-    async def embed_texts(self, texts: Sequence[str]) -> list[list[float]]:
+    async def embed_texts(self, texts: Sequence[str], **_kwargs) -> list[list[float]]:
+        # ``**_kwargs`` absorbs ``on_progress`` from the EmbeddingProvider Protocol.
         return [[0.0] * 1024 for _ in texts]
 
     async def embed_query(self, query: str) -> list[float]:


### PR DESCRIPTION
## Summary

A 250-chunk file used to show `file.md` frozen for 10+ seconds because `_index_file` awaited the embedder's full `embed_texts` before any SSE event escaped. This PR threads per-batch progress through every embedder, forwards it via a per-file `asyncio.Queue` in `index_path_stream`, and surfaces it in the Web Index tab as `file.md — 100/250 chunks`.

- **Embedder Protocol**: optional keyword-only `on_progress: Callable[[int, int], None] | None = None` on `EmbeddingProvider.embed_texts`. OpenAI/Ollama fire after each batch in `_safe_embed`; ONNX switches from a single `to_thread(all_texts)` to a per-batch loop using `EmbeddingConfig.batch_size`. Noop accepts the kwarg for Protocol conformance and ignores it.
- **`EmbeddingConfig.progress_threshold`**: new field (default `32`, non-negative validator, runtime-mutable). Engine only forwards `chunk_progress` events when a file's chunk count exceeds the threshold; `0` is an explicit "always emit" debug affordance.
- **Engine wiring**: `_index_file` accepts `on_chunk_progress`. `index_path_stream` runs each file in a task with a per-file `asyncio.Queue` + `DONE` sentinel — chunk events forward in real time while exceptions still surface via `await task` (preserves the `complete.errors` contract from #590). Consumer cancel (HTTPException, client disconnect, `aclose()`) cancels the in-flight task so embedding work doesn't leak past the SSE response.
- **Web UI**: `app.js` adds a `chunk_progress` branch with 100 ms DOM throttle and a final-tick bypass (otherwise the user sees `(192/250)` right before the next file's name pops in). New i18n key `index.file_chunk_progress` in en/ko.
- **Tests**: new `test_embedding_progress.py` (per-backend contract — monotonic, ends at total, raise-swallow); appended to `test_indexing_engine.py` (event flow above threshold, strict ordering invariant, no-emit below threshold, `threshold=0` always emits, `complete.errors` regression guard, `aclose()` cancels in-flight task).

## Out of scope (follow-ups)

- Wizard `_seed_with_progress` chunk label — `item_show_func` assumes path-tail + 40-char truncate, doesn't accept a free-form chunk count without UX redesign.
- `mm index` (non-stream CLI) progress — uses `index_path`, separate stream-conversion follow-up.
- Memory Dirs reindex button chunk display — button text is too narrow for `5/12 — 100/250`.

## Test plan

- [ ] `uv run pytest -m "not ollama"` (3616 passed locally)
- [ ] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [ ] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [ ] `uv run mypy packages/memtomem/src/memtomem/embedding packages/memtomem/src/memtomem/indexing/engine.py`
- [ ] **Manual web**: index a folder with one large file (CHANGELOG-like, 100+ heading) — `file.md — N/M chunks` ticks in the UI; final tick `(N/N)` lands before file boundary.
- [ ] **Manual web**: index a folder of small files — no `chunk_progress` noise.
- [ ] **Manual web**: close browser tab mid-index — `/api/indexing/active` returns to 0, no leaked embedding work in server logs.
- [ ] **ONNX wall-clock**: `time uv run mm index <250-chunk markdown>` before/after — single `to_thread` → per-batch loop should add only thread-handoff overhead (µs vs 50–200 ms inference). Concerning if regression > 5 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)