### PR TITLE
test(architecture): AST guard for module-level POSIX-only imports (refs #625)

### DIFF
--- a/packages/memtomem/tests/test_no_posix_only_imports.py
+++ b/packages/memtomem/tests/test_no_posix_only_imports.py
@@ -17,12 +17,22 @@ library's POSIX-only modules at module scope:
 
   fcntl    pwd    grp    termios    resource
 
-Lazy imports inside functions / methods / nested ``if sys.platform``
-branches do not appear at module scope and are therefore allowed. That
-is the documented pattern for ``server/__init__.py``, which keeps
-``fcntl`` (server is POSIX-only by design — no SIGTERM, different pid
-semantics on Windows — but the module is sometimes import-walked from
-Windows tooling, so the imports stay lazy).
+Two patterns are allowed because the scan walks ``tree.body`` only
+and does not recurse:
+
+- **Lazy imports inside functions / methods**: the documented pattern
+  in ``server/__init__.py:main``, where ``import fcntl`` lives inside
+  the function body and only evaluates on POSIX call paths. The
+  server is POSIX-only by design (no SIGTERM, different pid semantics
+  on Windows), but the module is import-walked from Windows tooling
+  via ``cli/__init__.py:_register``, so module-level imports must
+  stay safe.
+- **Gated ``if sys.platform`` branches**: ``import msvcrt`` /
+  ``import fcntl`` inside a top-level ``if/else`` is also fine — the
+  wrong-platform branch never executes. The 43ae140 half-fix that
+  preceded portalocker (PR #652) used exactly that shape. We do not
+  AST-verify gate correctness; the simpler "prefer functions"
+  convention is the project default.
 
 The negative pin (``test_scan_rejects_module_level_fcntl_in_fixture``)
 proves the assertion is symmetric: the scan logic must fail on a file
@@ -69,14 +79,22 @@ def _module_level_violations(tree: ast.Module) -> list[tuple[int, str]]:
             root = _root_module(node.module)
             if root in POSIX_ONLY_STDLIB:
                 violations.append((node.lineno, node.module or ""))
-        # Note: ``ast.If`` and other compound nodes nest their body items.
-        # We deliberately do NOT recurse — a top-level ``if sys.platform``
-        # block whose body imports POSIX-only modules is technically
-        # module-scope-executed, but that pattern was the source of #625's
-        # crash even with the gate (the import statement itself parses
-        # before the gate runs). The whole point of #625 is that no such
-        # imports should exist at module scope, gated or not — they go
-        # inside functions instead.
+        # Note: ``ast.If``, ``FunctionDef``, ``ClassDef`` etc. nest their
+        # body items. We deliberately do NOT recurse. Two consequences:
+        #
+        # - Properly gated ``if sys.platform == "win32": import msvcrt;
+        #   else: import fcntl`` is not flagged — the wrong-platform
+        #   branch never executes, so the import is safe. (43ae140 used
+        #   this shape; portalocker, PR #652, replaced it with a single
+        #   unconditional import.)
+        # - Lazy imports inside function / method bodies are not flagged
+        #   — that is the documented pattern in
+        #   ``server/__init__.py:main``.
+        #
+        # The regression we're catching is the unguarded module-level
+        # ``import fcntl`` from PR #623 — directly in ``tree.body``,
+        # neither gated nor lazy. A walk of just ``tree.body`` catches
+        # exactly that shape and nothing else.
     return violations
 
 

--- a/packages/memtomem/tests/test_no_posix_only_imports.py
+++ b/packages/memtomem/tests/test_no_posix_only_imports.py
@@ -1,0 +1,166 @@
+"""Architectural guard: no module-level POSIX-only imports in src/memtomem/.
+
+A single ``import fcntl`` at module scope crashes ``mm`` on Windows at
+CLI registration time — the import resolves before any ``--help`` parse,
+before the lazy-import dispatch in ``cli/__init__.py:_register`` ever
+runs. PR #623 introduced exactly this regression by hoisting
+``import fcntl`` into ``context/_atomic.py``; powerzist reported it as
+issue #625, the second time the same shape of bug surfaced (first was
+issue #448 in ``cli/uninstall_cmd.py``).
+
+The previous defence was a regex pin in ``test_uninstall_cmd.py`` that
+scanned a single file. PR #623's regression slipped past it because
+``_atomic.py`` was outside that file's scope. This test replaces the
+single-file pin with an AST scan parametrized over every Python module
+under ``packages/memtomem/src/memtomem/``, rejecting any of the standard
+library's POSIX-only modules at module scope:
+
+  fcntl    pwd    grp    termios    resource
+
+Lazy imports inside functions / methods / nested ``if sys.platform``
+branches do not appear at module scope and are therefore allowed. That
+is the documented pattern for ``server/__init__.py``, which keeps
+``fcntl`` (server is POSIX-only by design — no SIGTERM, different pid
+semantics on Windows — but the module is sometimes import-walked from
+Windows tooling, so the imports stay lazy).
+
+The negative pin (``test_scan_rejects_module_level_fcntl_in_fixture``)
+proves the assertion is symmetric: the scan logic must fail on a file
+that contains the forbidden pattern, not just pass on the current tree.
+Without that, an off-by-one bug in the parser walk would silently make
+this whole guard a no-op.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import textwrap
+
+import pytest
+
+
+POSIX_ONLY_STDLIB = frozenset({"fcntl", "pwd", "grp", "termios", "resource"})
+
+_SRC_ROOT = pathlib.Path(__file__).resolve().parent.parent / "src" / "memtomem"
+
+
+def _root_module(name: str | None) -> str:
+    """``memtomem.context._atomic`` -> ``memtomem``; ``fcntl`` -> ``fcntl``."""
+    if not name:
+        return ""
+    return name.split(".", 1)[0]
+
+
+def _module_level_violations(tree: ast.Module) -> list[tuple[int, str]]:
+    """Return ``(lineno, offending_name)`` for every module-scope POSIX-only
+    import in ``tree``. Walks ``tree.body`` only — anything inside a
+    ``FunctionDef``, ``AsyncFunctionDef``, ``ClassDef``, or any other nested
+    block is module-scope-invisible by definition and therefore allowed.
+    """
+    violations: list[tuple[int, str]] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = _root_module(alias.name)
+                if root in POSIX_ONLY_STDLIB:
+                    violations.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            root = _root_module(node.module)
+            if root in POSIX_ONLY_STDLIB:
+                violations.append((node.lineno, node.module or ""))
+        # Note: ``ast.If`` and other compound nodes nest their body items.
+        # We deliberately do NOT recurse — a top-level ``if sys.platform``
+        # block whose body imports POSIX-only modules is technically
+        # module-scope-executed, but that pattern was the source of #625's
+        # crash even with the gate (the import statement itself parses
+        # before the gate runs). The whole point of #625 is that no such
+        # imports should exist at module scope, gated or not — they go
+        # inside functions instead.
+    return violations
+
+
+_PY_FILES = sorted(_SRC_ROOT.rglob("*.py"))
+assert _PY_FILES, f"AST scan found no .py files under {_SRC_ROOT}"
+
+
+@pytest.mark.parametrize(
+    "py_file",
+    _PY_FILES,
+    ids=lambda p: str(p.relative_to(_SRC_ROOT)),
+)
+def test_no_module_level_posix_only_imports(py_file: pathlib.Path) -> None:
+    """Positive pin: every file under ``src/memtomem/`` parses to zero
+    module-level POSIX-only imports. Catches the #623 / #625 regression
+    shape across all files, not just the one site the prior regex pin
+    covered.
+    """
+    src = py_file.read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=str(py_file))
+    violations = _module_level_violations(tree)
+    assert violations == [], (
+        f"{py_file.relative_to(_SRC_ROOT)} has module-level POSIX-only "
+        f"import(s): {violations}. Move the import inside a function, "
+        f"method, or guarded ``sys.platform`` branch — see "
+        f"``server/__init__.py`` for the lazy-import pattern."
+    )
+
+
+def test_scan_rejects_module_level_fcntl_in_fixture(tmp_path: pathlib.Path) -> None:
+    """Negative pin: hand the scan logic a file with a forbidden import
+    and assert it fails. Without this, an off-by-one in
+    ``_module_level_violations`` would silently make the positive pin a
+    no-op (every file would walk to ``violations == []`` regardless of
+    contents).
+    """
+    bad_file = tmp_path / "fake_module.py"
+    bad_file.write_text(
+        textwrap.dedent(
+            """\
+            import os
+            import fcntl  # this is the forbidden line
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    tree = ast.parse(bad_file.read_text(encoding="utf-8"))
+    violations = _module_level_violations(tree)
+    assert violations == [(2, "fcntl")], violations
+
+
+def test_scan_allows_lazy_imports_inside_functions(tmp_path: pathlib.Path) -> None:
+    """Negative pin (other direction): a file that imports ``fcntl``
+    inside a function body is fine — that is the explicit pattern
+    ``server/__init__.py:main`` uses, and the whole point of the guard
+    is to NOT flag it.
+    """
+    good_file = tmp_path / "lazy_import_module.py"
+    good_file.write_text(
+        textwrap.dedent(
+            """\
+            import os
+
+            def acquire_pid_lock():
+                import fcntl  # lazy — only evaluated on POSIX call paths
+                fcntl.flock(0, fcntl.LOCK_EX)
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    tree = ast.parse(good_file.read_text(encoding="utf-8"))
+    violations = _module_level_violations(tree)
+    assert violations == [], violations
+
+
+def test_scan_catches_from_imports(tmp_path: pathlib.Path) -> None:
+    """Negative pin: ``from fcntl import flock`` at module scope is the
+    same regression shape — must also fail.
+    """
+    bad_file = tmp_path / "from_import_module.py"
+    bad_file.write_text("from fcntl import flock\n", encoding="utf-8")
+
+    tree = ast.parse(bad_file.read_text(encoding="utf-8"))
+    violations = _module_level_violations(tree)
+    assert violations == [(1, "fcntl")], violations

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -621,35 +621,9 @@ class TestConfigFallback:
         assert "Removed:" in result.output
 
 
-class TestWindowsFcntlGuard:
-    """(#448) ``import fcntl`` at module level broke ``cli/__init__.py:_register``
-    on Windows — every ``mm`` subcommand crashed before even parsing argv.
-
-    The fix originally moved ``fcntl`` to a lazy import inside
-    ``_probe_pid_file``. As of #625 the probe routes through
-    ``portalocker``, which is cross-platform, so the Windows fallback
-    that returned conservative ``alive=True`` is gone — the probe now
-    runs the same lock-acquire on every OS. The single regex pin below
-    survives until PR-3 replaces it with an AST scan over all of
-    ``packages/memtomem/src/``.
-    """
-
-    def test_no_module_level_fcntl_import(self):
-        """Source-scan pin: ``fcntl`` must not appear as a top-level import
-        in ``uninstall_cmd.py``. A future refactor that re-hoists the
-        import would silently reintroduce the Windows crash — CI runs on
-        Linux so a runtime test can't catch it.
-        """
-        import inspect
-        import re
-
-        from memtomem.cli import uninstall_cmd
-
-        src = inspect.getsource(uninstall_cmd)
-        # Top-of-file block only — anything nested (``    import fcntl``)
-        # inside a function is fine and in fact the intended layout.
-        top_level = re.findall(r"(?m)^import fcntl\b", src)
-        assert top_level == [], (
-            "uninstall_cmd.py must not import fcntl at module level — "
-            "that crashes `mm` on Windows at CLI registration time (#448)."
-        )
+# (#448 / #625) The single-file regex pin that used to live here is
+# superseded by ``test_no_posix_only_imports.py``, which AST-scans every
+# module under ``packages/memtomem/src/memtomem/`` for module-level
+# POSIX-only imports — fcntl, pwd, grp, termios, resource. The earlier
+# regex covered only ``cli/uninstall_cmd.py``, which is exactly why
+# PR #623's regression in ``context/_atomic.py`` slipped past it.


### PR DESCRIPTION
## Summary

Replaces the single-file regex pin in \`test_uninstall_cmd.py\`
(\`TestWindowsFcntlGuard.test_no_module_level_fcntl_import\`) with a
parametrized AST scan over every Python module under
\`packages/memtomem/src/memtomem/\`.

This is the architectural-guard half of #625's plan: the swap to
portalocker (PR #652) closed the *current* Windows fcntl regression;
this PR makes the *next* one impossible to silently merge.

## Why

The earlier pin lived in \`test_uninstall_cmd.py\` and scanned only
\`cli/uninstall_cmd.py\`. PR #623 hoisted \`import fcntl\` into
\`context/_atomic.py\` — a different file — so the pin let it through.
powerzist hit it on Windows and reported #625, and we discovered the
fix from #448 had a coverage gap.

Same-shape regression shouldn't get to ship a second time. The fix is
to scan the whole tree, not just the file the last incident touched.

## What

\`tests/test_no_posix_only_imports.py\`:

- AST-parses every \`.py\` under \`packages/memtomem/src/memtomem/\`,
  parametrized so each file is its own test case (clearer failure
  output than a single combined test).
- Walks \`tree.body\` only — module-scope statements. Imports inside
  \`FunctionDef\` / \`AsyncFunctionDef\` / \`ClassDef\` bodies are
  invisible to the walk and therefore allowed. That's the documented
  lazy-import pattern \`server/__init__.py\` uses to keep \`fcntl\`
  Windows-import-safe (server is POSIX-only at runtime, but the module
  is import-walked from Windows tooling).
- Forbidden modules: \`{fcntl, pwd, grp, termios, resource}\` —
  CPython's POSIX-only stdlib set. \`fcntl\` is the one we already hit
  twice; the others are included pre-emptively because they have the
  same shape (\`ModuleNotFoundError\` at import time on Windows).

Three negative pins prove the assertion is symmetric (\`feedback_pin_invert_symmetric_assertion.md\`):

- \`test_scan_rejects_module_level_fcntl_in_fixture\` — feed a
  known-bad fixture; assert the scan flags it. Without this, an
  off-by-one in the walk would silently turn the positive pin into a
  no-op (every file would walk to \`violations == []\` regardless of
  contents).
- \`test_scan_allows_lazy_imports_inside_functions\` — feed a file
  where \`import fcntl\` is inside a function body; assert NOT flagged.
- \`test_scan_catches_from_imports\` — \`from fcntl import flock\` at
  module scope; assert flagged.

## Out of scope

- **Windows CI required-status flip** — that's the original PR-3's
  other half. The \`continue-on-error\` stays on \`test (windows-latest)\`
  until the pre-existing 117 Windows failures (#634 territory — path
  separators, HOME assumptions, NTFS mode bits, skipif-missing fcntl
  in tests) are resolved. Filed as PR-3b in the planning notes.

## Test plan

- \`uv run pytest packages/memtomem/tests/test_no_posix_only_imports.py\`
  — 230 / 230 pass (227 src files + 3 negative pins) in 0.18 s.
- \`uv run pytest packages/memtomem/tests -m "not ollama and not llm"\`
  — 3831 passed, 46 deselected, in 78 s.

## Verification

- [x] AST scan reports zero violations on current \`main\`.
- [x] Negative fixtures correctly trigger violations.
- [x] Lazy-inside-function pattern explicitly allowed (\`server/__init__.py\` would fail otherwise).
- [x] \`ruff check\` + \`ruff format --check\` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>