### PR TITLE
feat(web): meta row chunk progress for Memory Dirs reindex (#654)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1297,7 +1297,7 @@
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=82"></script>
   <script src="/settings-config.js?v=9"></script>
-  <script src="/sources-memory-dirs.js?v=9"></script>
+  <script src="/sources-memory-dirs.js?v=10"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -1096,6 +1096,20 @@ async function mdReindexOne(path, btn) {
   // Cache the original button label so we can restore it after the run —
   // ``btnLoading`` only toggles disabled+spinner, it doesn't snapshot text.
   const _origText = btn ? btn.textContent : '';
+  // Slot-reuse for chunk_progress (#654): the meta row already carries
+  // mutable count text ("12 files · 1,847 chunks"), already has the
+  // nowrap+ellipsis CSS guards, and is the only single-line slot near
+  // the button that won't shift adjacent dirs cards when its content
+  // grows. We borrow it for in-flight ``file.md — N/M chunks`` ticks
+  // and snap back via ``_origMeta`` on file boundary / cleanup.
+  const _item = btn ? btn.closest('.memory-dirs-item') : null;
+  const metaEl = _item ? _item.querySelector('.memory-dirs-item-meta') : null;
+  const _origMeta = metaEl ? metaEl.textContent : '';
+  // Throttle state — function-local so two concurrent reindex clicks
+  // (one per dir) don't share each other's clocks. Mirrors the
+  // ``runIndexStream`` closure scope in ``app.js``.
+  let _lastChunkRender = 0;
+  let _metaIsChunkLabel = false;
   showToast(t('toast.memory_dir.reindex_started', { path }), 'info');
 
   const _cleanup = () => {
@@ -1103,6 +1117,7 @@ async function mdReindexOne(path, btn) {
       btn.textContent = _origText;
       btnLoading(btn, false);
     }
+    if (metaEl) metaEl.textContent = _origMeta;
     if (typeof _indexingEnd === 'function') _indexingEnd();
     if (typeof loadSources === 'function') loadSources();
   };
@@ -1140,9 +1155,40 @@ async function mdReindexOne(path, btn) {
     }
     _sseFailCount = 0;
     if (event.type === 'progress') {
+      // File boundary: reset chunk throttle so the next file's first
+      // chunk renders immediately, and close the [big, small, ...]
+      // residue case (#654) — once a 250-chunk file ends, a stream of
+      // small files won't emit ``chunk_progress`` (server-side
+      // ``progress_threshold`` gate), which would otherwise leave the
+      // meta row stuck on "CHANGELOG.md — 250/250" through the rest
+      // of the run. The flag avoids a sub-100ms flash on big→big
+      // transitions because the next ``chunk_progress`` overwrites.
+      _lastChunkRender = 0;
+      if (metaEl && _metaIsChunkLabel) {
+        metaEl.textContent = _origMeta;
+        _metaIsChunkLabel = false;
+      }
       if (btn) {
         btn.textContent = `${event.files_done}/${event.files_total}`;
       }
+    } else if (event.type === 'chunk_progress') {
+      // Mirrors ``app.js:runIndexStream`` — 100ms throttle on
+      // intermediate ticks, final tick (done >= total) bypasses so
+      // ``(N/N)`` lands before the next file boundary. ``isConnected``
+      // guards against late events arriving after ``loadSources()``
+      // detached the row (silent no-op today, but cheap insurance).
+      if (!metaEl || !metaEl.isConnected) return;
+      const now = (typeof performance !== 'undefined' && performance.now)
+        ? performance.now() : Date.now();
+      const isFinal = event.chunks_done >= event.chunks_total;
+      if (!isFinal && now - _lastChunkRender < 100) return;
+      _lastChunkRender = now;
+      metaEl.textContent = t('index.file_chunk_progress', {
+        file: basename(event.file),
+        done: event.chunks_done,
+        total: event.chunks_total,
+      });
+      _metaIsChunkLabel = true;
     } else if (event.type === 'complete') {
       _completed = true;
       es.close();


### PR DESCRIPTION
## Summary

Closes #654. Surfaces per-chunk progress (`file.md — 100/250 chunks`) during a Memory Dirs reindex by **reusing the existing `.memory-dirs-item-meta` slot** — no new CSS, no new i18n key, no button-width churn.

The Memory Dirs reindex flow already consumed the same SSE stream as the Index tab (PR #653), but only handled `progress` events. While a single 250-chunk file embedded, the button counter sat silently on `5/12` for tens of seconds. Widening the button text was rejected at plan time (button polo polo, vertical alignment jank); the meta row already carries mutable counts (`12 files · 1,847 chunks`), already has the nowrap+ellipsis CSS guards (`style.css:1214-1222`), and is the same one-line semantic as `app.js:runIndexStream`'s `fileEl` — so the user's mental model is consistent across tabs.

### Implementation

- **`mdReindexOne`** (`sources-memory-dirs.js`): cache `metaEl` + `_origMeta` next to `_origText`; add `chunk_progress` branch (100ms throttle + final-tick bypass + `isConnected` guard, mirroring `app.js:3739`); `progress` branch resets the throttle and snaps the meta row back to stats via a flag.
- **`progress` flag-gated reset** closes the **[big, small, small, ...] residue case** explicitly: server-side `progress_threshold` gates `chunk_progress` events, so a 250-chunk file followed by small notes would otherwise leave the meta row stuck on `"CHANGELOG.md — 250/250"` through the rest of the run. The flag also avoids a sub-100ms flash on big→big transitions because the next `chunk_progress` overwrites in-place.
- **i18n key reused** (`index.file_chunk_progress` in `en.json:168` / `ko.json:168`) — namespace mismatch (`index.*` used in Sources tab) is a knowingly accepted debt; helper-extraction follow-up issue covers the rename.
- **`index.html` cache-buster** bumped (`/sources-memory-dirs.js?v=9` → `?v=10`).

### Out of scope (follow-ups)

- Helper extraction sharing the `_lastChunkRender` + 100ms-throttle + final-tick-bypass pattern between `app.js:runIndexStream` and `sources-memory-dirs.js:mdReindexOne` (rule-of-three: defer until a third call-site appears; the helper PR will also rename the i18n key to `common.*`). — separate issue.
- JS DOM interaction test infrastructure (Playwright / Vitest+jsdom). — separate issue.
- Wizard `_seed_with_progress` chunk label / `mm index` CLI progress (PR #653 follow-ups, unchanged here).

## Test plan

- [ ] **Threshold-below**: small markdown dir → reindex → meta row stays on stats, button ticks `N/M`. No `chunk_progress` noise.
- [ ] **Threshold-above (single big file)**: dir with `CHANGELOG.md`-style 100+ heading file → button ticks `5/12` etc., meta row ticks `CHANGELOG.md — 100/250 chunks` at ~100ms gap, final `(N/N)` lands before the next file boundary.
- [ ] **Mixed [big, small, ...]**: dir with one 100+-heading file + 8 small notes → after the big file's `(N/N)`, the meta row snaps back to stats *immediately* and stays there through the small tail. (Critical regression check — without the flag-gated reset, the meta row would freeze on `250/250` through the back half.)
- [ ] **Layout (1280 / 1024 / mobile)**: chunk label ellipsis-truncates, no row height/width shift on adjacent dirs cards.
- [ ] **Cancel mid-flight**: close browser tab during reindex → `/api/indexing/active` returns to 0 (PR #653 behavior reused).
- [ ] **i18n toggle (KO ⇄ EN)**: locale switch mid-reindex → next `chunk_progress` event reflects the new locale string.
- [ ] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — green.

## References

- Parent feature: PR #653.
- Layout-primitives-first rationale (Memory: `feedback_layout_primitives_first.md`) — meta row's existing CSS guards make this a zero-CSS change.
- Plan: `~/.claude/plans/go-velvety-penguin.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)