### PR TITLE
feat(wizard): explicit guardrails for failed init steps (closes #626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,24 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`mm init` wizard now prompts on failed steps instead of silently
+  advancing (#626).** When `_step_embedding`'s Ollama branch hits a
+  failure (server unreachable, model status indeterminate, `ollama pull`
+  errored), the wizard surfaces a red `✗` line and a
+  `Retry, back, or quit? [R/b/q]` prompt — pre-fix it printed a warning
+  and walked into the next step (Reranker), which masked the real
+  problem. Mechanism is reusable: new `StepRetry` exception +
+  `fail_step()` helper in `memtomem.cli.wizard`. Tri-state
+  `_ollama_has_model` returns `bool | None` so server-error is no longer
+  conflated with "model absent". **Behavior change**: the OpenAI
+  `--provider openai` "API key invalid + decline to continue" path now
+  exits **0** (cancelled by user) instead of **1** (error). Scripts
+  parsing the exit code to detect a bad-key cancel must switch to
+  parsing stdout for `Wizard cancelled.` or use `--yes` mode (which
+  retains the non-zero exit on missing extras). Other wizard steps
+  still use the pre-#626 silent-continue pattern; an audit and follow-up
+  PR will migrate them onto `fail_step` next.
+
 - **`embedding.threads` default flipped from `0` (= ORT default = all
   physical cores) to `4`** so a bulk reindex doesn't pin every core and
   starve the web server / other apps. Live diagnosis of #640 confirmed

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -590,8 +590,6 @@ def _step_embedding(state: dict) -> None:
         else:
             click.secho("  API key test failed. Check your key and try again.", fg="red")
             if not nav_confirm("  Continue anyway?", default=False):
-                # Was ``raise SystemExit(1)`` — switched to ``WizardCancel``
-                # so the wizard exits via the same path as ``q`` (#626).
                 raise WizardCancel()
 
     state["provider"] = provider

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -17,7 +17,16 @@ from typing import Literal
 import click
 
 from memtomem.cli.init_presets import PRESETS, _VALID_PRESETS, get_preset
-from memtomem.cli.wizard import nav_confirm, nav_prompt, run_steps, silent_step, step_header
+from memtomem.cli.wizard import (
+    StepRetry,
+    WizardCancel,
+    fail_step,
+    nav_confirm,
+    nav_prompt,
+    run_steps,
+    silent_step,
+    step_header,
+)
 
 InstallType = Literal["source", "project", "tool", "uvx"]
 CwdInstallType = Literal["source", "project", "pypi"]
@@ -61,11 +70,23 @@ def _ollama_running() -> bool:
         return False
 
 
-def _ollama_has_model(model: str) -> bool:
+def _ollama_has_model(model: str) -> bool | None:
+    """Tri-state: True/False/None.
+
+    ``None`` = couldn't reach the Ollama server (timeout, non-zero exit,
+    binary missing). The caller must distinguish this from ``False``
+    (server reachable, model not installed) — silently treating ``None``
+    as ``False`` was the original #626 bug, where a server timeout was
+    misread as "model absent" and the wizard offered a doomed
+    ``ollama pull`` instead of surfacing the real error.
+    """
     try:
-        return model in _run(["ollama", "list"], timeout=5).stdout
+        result = _run(["ollama", "list"], timeout=5)
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
+        return None
+    if result.returncode != 0:
+        return None
+    return model in result.stdout
 
 
 def _test_openai_key(api_key: str) -> bool:
@@ -471,33 +492,73 @@ def _step_embedding(state: dict) -> None:
                 click.echo(_y_refuse_hint("--provider ollama", "ollama"))
                 click.echo()
                 state.setdefault("_extras_warned_inline", set()).add("ollama")
-            if not _ollama_running():
-                click.secho("  Ollama not running. Starting 'ollama serve'...", fg="yellow")
-                click.echo("  Run 'ollama serve' in another terminal if this fails.")
-                click.echo()
+            # Server reachability + model selection + pull are guarded so
+            # a failed step doesn't silently advance the wizard (#626).
+            # ``StepRetry`` is caught locally so the user doesn't have to
+            # re-pick the provider; ``StepBack`` / ``WizardCancel`` bubble
+            # to ``run_steps``.
+            model = ""
+            dimension = 0
+            while True:
+                try:
+                    if not _ollama_running():
+                        click.secho("  Ollama not running.", fg="yellow")
+                        click.echo("  Start it with 'ollama serve' in another terminal.")
+                        fail_step(
+                            "Ollama server is not reachable.",
+                            retryable=True,
+                        )
 
-            click.echo("  Available models:")
-            click.echo("    [1] nomic-embed-text — English, fast (768d)")
-            click.echo("    [2] bge-m3 — multilingual, higher accuracy (1024d)")
-            model_choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
+                    click.echo("  Available models:")
+                    click.echo("    [1] nomic-embed-text — English, fast (768d)")
+                    click.echo("    [2] bge-m3 — multilingual, higher accuracy (1024d)")
+                    model_choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
 
-            models = {1: ("nomic-embed-text", 768), 2: ("bge-m3", 1024)}
-            model, dimension = models[model_choice]
+                    models = {1: ("nomic-embed-text", 768), 2: ("bge-m3", 1024)}
+                    model, dimension = models[model_choice]
 
-            if _ollama_has_model(model):
-                click.secho(f"  Model '{model}' is ready.", fg="green")
-            else:
-                pull = nav_confirm(f"  Model '{model}' not found. Pull now?", default=True)
-                if pull:
-                    click.echo(f"  Pulling {model}... (this may take a few minutes)")
-                    result = _run(["ollama", "pull", model], timeout=600)
-                    if result.returncode == 0:
-                        click.secho(f"  Model '{model}' pulled successfully.", fg="green")
-                    else:
-                        click.secho(f"  Pull failed: {result.stderr.strip()}", fg="red")
-                        click.echo("  You can pull manually: ollama pull " + model)
-                else:
-                    click.echo(f"  Remember to run: ollama pull {model}")
+                    has_model = _ollama_has_model(model)
+                    if has_model is None:
+                        # Tri-state ``None`` = server unreachable / errored.
+                        # Surface this distinctly instead of falling through
+                        # to a doomed pull (the original #626 misread).
+                        fail_step(
+                            f"Could not verify whether '{model}' is installed — "
+                            "Ollama server returned an error or timed out.",
+                            retryable=True,
+                        )
+
+                    if has_model:
+                        click.secho(f"  Model '{model}' is ready.", fg="green")
+                        break
+
+                    pull = nav_confirm(f"  Model '{model}' not found. Pull now?", default=True)
+                    if not pull:
+                        click.echo(f"  Remember to run: ollama pull {model}")
+                        break
+
+                    # Inner retry loop: re-run only the pull action so a
+                    # transient network failure doesn't drop the user back
+                    # to model selection.
+                    while True:
+                        try:
+                            click.echo(f"  Pulling {model}... (this may take a few minutes)")
+                            result = _run(["ollama", "pull", model], timeout=600)
+                            if result.returncode == 0:
+                                click.secho(
+                                    f"  Model '{model}' pulled successfully.",
+                                    fg="green",
+                                )
+                                break
+                            fail_step(
+                                f"Pull failed: {result.stderr.strip()}",
+                                retryable=True,
+                            )
+                        except StepRetry:
+                            continue
+                    break
+                except StepRetry:
+                    continue
 
     else:
         provider = "openai"
@@ -529,7 +590,9 @@ def _step_embedding(state: dict) -> None:
         else:
             click.secho("  API key test failed. Check your key and try again.", fg="red")
             if not nav_confirm("  Continue anyway?", default=False):
-                raise SystemExit(1)
+                # Was ``raise SystemExit(1)`` — switched to ``WizardCancel``
+                # so the wizard exits via the same path as ``q`` (#626).
+                raise WizardCancel()
 
     state["provider"] = provider
     state["model"] = model

--- a/packages/memtomem/src/memtomem/cli/wizard.py
+++ b/packages/memtomem/src/memtomem/cli/wizard.py
@@ -12,6 +12,17 @@ class StepBack(Exception):
     """Raised to go back to the previous step."""
 
 
+class StepRetry(Exception):
+    """Raised to re-invoke the current step.
+
+    Steps wrap a recoverable action in ``while True: try: ... except
+    StepRetry: continue`` to retry only that action without re-prompting
+    inputs collected earlier in the step. If a step does not catch
+    ``StepRetry`` itself, ``run_steps`` re-invokes the entire step from
+    the top.
+    """
+
+
 class WizardCancel(Exception):
     """Raised to cancel the wizard."""
 
@@ -64,6 +75,47 @@ def nav_confirm(text: str, default: bool = False) -> bool:
         click.echo("  Please answer y or n.")
 
 
+def fail_step(message: str, *, retryable: bool = True) -> None:
+    """Surface a step failure and force the user to choose recovery.
+
+    Replaces the silent ``click.echo("error..."); continue`` pattern that
+    let the wizard advance after a failed action (#626). Always raises —
+    never returns. Caller pattern for retryable actions::
+
+        while True:
+            try:
+                do_action()
+                break
+            except ActionFailed as exc:
+                fail_step(f"Action failed: {exc}", retryable=True)
+
+    ``StepRetry`` from ``fail_step`` is caught by the local ``try`` so
+    only the inner action retries; ``StepBack`` / ``WizardCancel`` bubble
+    up to ``run_steps``.
+
+    ``retryable=False`` is for failures the user can't fix in place
+    (e.g. invalid input that needs re-entry on the previous step) —
+    only ``[b]ack`` / ``[q]uit`` are offered.
+    """
+    click.secho(f"  ✗ {message}", fg="red")
+    if retryable:
+        text = "  Retry, back, or quit? [R/b/q]"
+        default = "r"
+    else:
+        text = "  Back or quit? [B/q]"
+        default = "b"
+    while True:
+        val = click.prompt(text, default=default, show_default=False)
+        v = val.strip().lower()
+        if retryable and v in ("r", "retry"):
+            raise StepRetry()
+        if v in ("b", "back"):
+            raise StepBack()
+        if v in ("q", "quit"):
+            raise WizardCancel()
+        click.echo("  Please answer r, b, or q." if retryable else "  Please answer b or q.")
+
+
 def silent_step(fn: Callable[[dict], None]) -> Callable[[dict], None]:
     """Mark a step as silent (no user prompt — only side effects like banners).
 
@@ -87,7 +139,9 @@ def run_steps(
 
     Each step function receives a shared state dict and modifies it.
     Raising StepBack goes to the previous interactive step (skipping any
-    ``@silent_step`` in between). WizardCancel aborts.
+    ``@silent_step`` in between). StepRetry re-invokes the same step
+    from the top (steps that want partial retry should catch StepRetry
+    locally — see :func:`fail_step`). WizardCancel aborts.
 
     Before each invocation, ``state["_wizard_position"] = (i + 1, len(steps))``
     is seeded so :func:`step_header` (and any other display helper) can render
@@ -105,6 +159,8 @@ def run_steps(
         try:
             steps[i](state)
             i += 1
+        except StepRetry:
+            click.secho("  (retrying...)", dim=True)
         except StepBack:
             target = i - 1
             while target >= 0 and _is_silent(steps[target]):

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6207,3 +6207,259 @@ class TestOllamaWindowsHangFix:
         assert captured.get("stdout") is _sp.DEVNULL
         assert captured.get("stderr") is _sp.DEVNULL
         assert not captured.get("capture_output")
+
+
+class TestOllamaHasModelTriState:
+    """``_ollama_has_model`` returns ``bool | None`` so callers can
+    distinguish "server unreachable" from "model not installed" (#626).
+    The original ``False``-on-error conflation was the root of the
+    "server timeout misread as model absent" bug."""
+
+    def test_returncode_nonzero_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``ollama list`` exiting non-zero (e.g. server unreachable) must
+        return ``None``, not ``False``."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        def _fake_run(cmd: list, **kw: object) -> _sp.CompletedProcess:
+            return _sp.CompletedProcess(cmd, returncode=1, stdout="", stderr="Error: timed out")
+
+        monkeypatch.setattr(init_cmd, "_run", _fake_run)
+        assert init_cmd._ollama_has_model("nomic-embed-text") is None
+
+    def test_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.cli import init_cmd
+
+        def _fake_run(cmd: list, **kw: object) -> object:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+
+        monkeypatch.setattr(init_cmd, "_run", _fake_run)
+        assert init_cmd._ollama_has_model("nomic-embed-text") is None
+
+    def test_filenotfound_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.cli import init_cmd
+
+        def _fake_run(cmd: list, **kw: object) -> object:
+            raise FileNotFoundError()
+
+        monkeypatch.setattr(init_cmd, "_run", _fake_run)
+        assert init_cmd._ollama_has_model("nomic-embed-text") is None
+
+    def test_model_present_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        def _fake_run(cmd: list, **kw: object) -> _sp.CompletedProcess:
+            return _sp.CompletedProcess(
+                cmd, returncode=0, stdout="nomic-embed-text:latest    768d ..."
+            )
+
+        monkeypatch.setattr(init_cmd, "_run", _fake_run)
+        assert init_cmd._ollama_has_model("nomic-embed-text") is True
+
+    def test_model_absent_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Server reachable but model missing — ``False``, distinct from
+        ``None``."""
+        import subprocess as _sp
+
+        from memtomem.cli import init_cmd
+
+        def _fake_run(cmd: list, **kw: object) -> _sp.CompletedProcess:
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="other-model:latest")
+
+        monkeypatch.setattr(init_cmd, "_run", _fake_run)
+        assert init_cmd._ollama_has_model("nomic-embed-text") is False
+
+
+class TestStepEmbeddingOllamaGuards:
+    """``_step_embedding`` Ollama branch must surface failures via
+    ``fail_step`` instead of silently advancing the wizard (#626).
+
+    These tests drive the step directly with monkeypatched probes and
+    fed-in input. The precise pin is: when an action fails, the wizard
+    either retries, returns to the previous step, or cancels — it does
+    NOT fall through to subsequent steps."""
+
+    @staticmethod
+    def _patch_ollama_env(
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        running: object,
+        has_model: object,
+    ) -> None:
+        """Patch the Ollama probes so the step exercises only the path
+        under test. ``running`` and ``has_model`` are callables (allowing
+        per-call sequencing) or constants."""
+        from memtomem.cli import init_cmd
+
+        monkeypatch.setattr(init_cmd, "_ollama_available", lambda: True)
+        monkeypatch.setattr(init_cmd, "_have_module", lambda mod: True)
+        monkeypatch.setattr(
+            init_cmd,
+            "_ollama_running",
+            running if callable(running) else (lambda r=running: r),
+        )
+        monkeypatch.setattr(
+            init_cmd,
+            "_ollama_has_model",
+            has_model if callable(has_model) else (lambda model, hm=has_model: hm),
+        )
+
+    def test_server_not_running_q_cancels_wizard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Server unreachable + user picks 'q' → ``WizardCancel``. The
+        wizard must NOT advance past ``_step_embedding``."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import WizardCancel
+
+        self._patch_ollama_env(monkeypatch, running=False, has_model=True)
+
+        captured: dict[str, BaseException | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                init_cmd._step_embedding({})
+            except WizardCancel as exc:
+                captured["exc"] = exc
+
+        # choice=3 (Ollama) → server check fails → 'q'
+        result = CliRunner().invoke(cmd, [], input="3\nq\n")
+        assert "Ollama server is not reachable" in result.output
+        assert isinstance(captured["exc"], WizardCancel)
+
+    def test_server_not_running_r_retries_until_up(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Server down → 'r' → server up on retry → step completes
+        normally without re-prompting the provider choice."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+
+        running_calls = {"n": 0}
+
+        def fake_running() -> bool:
+            running_calls["n"] += 1
+            return running_calls["n"] >= 2
+
+        self._patch_ollama_env(monkeypatch, running=fake_running, has_model=True)
+
+        state: dict = {}
+
+        @click.command()
+        def cmd() -> None:
+            init_cmd._step_embedding(state)
+
+        # choice=3 → server fails → r → server up → model 1
+        result = CliRunner().invoke(cmd, [], input="3\nr\n1\n")
+        assert result.exit_code == 0
+        assert "Ollama server is not reachable" in result.output
+        assert state.get("provider") == "ollama"
+        assert state.get("model") == "nomic-embed-text"
+        assert running_calls["n"] >= 2
+
+    def test_has_model_none_b_raises_step_back(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Tri-state ``None`` from ``_ollama_has_model`` (server returned
+        an error / timed out) surfaces explicitly — user picks 'b' to
+        return to the embedding choice."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import StepBack
+
+        self._patch_ollama_env(monkeypatch, running=True, has_model=None)
+
+        captured: dict[str, BaseException | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                init_cmd._step_embedding({})
+            except StepBack as exc:
+                captured["exc"] = exc
+
+        # choice=3 → model 1 → has_model None → 'b'
+        result = CliRunner().invoke(cmd, [], input="3\n1\nb\n")
+        assert "Could not verify whether" in result.output
+        assert isinstance(captured["exc"], StepBack)
+
+    def test_pull_failure_r_retries_pull_only(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pull fails → 'r' → second pull succeeds. The retry must NOT
+        re-prompt the model choice (inner retry loop)."""
+        import click
+        import subprocess as _sp
+
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+
+        # Server up, model not yet installed → pull path.
+        self._patch_ollama_env(monkeypatch, running=True, has_model=False)
+
+        pull_calls = {"n": 0}
+
+        def fake_run(cmd: list, **kw: object) -> _sp.CompletedProcess:
+            pull_calls["n"] += 1
+            if pull_calls["n"] == 1:
+                return _sp.CompletedProcess(cmd, returncode=1, stdout="", stderr="Error: timed out")
+            return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(init_cmd, "_run", fake_run)
+
+        state: dict = {}
+
+        @click.command()
+        def cmd() -> None:
+            init_cmd._step_embedding(state)
+
+        # choice=3 → model 1 → pull yes → fail → r → success
+        result = CliRunner().invoke(cmd, [], input="3\n1\nY\nr\n")
+        assert result.exit_code == 0
+        assert "Pull failed" in result.output
+        assert "pulled successfully" in result.output
+        assert state.get("provider") == "ollama"
+        assert pull_calls["n"] == 2
+
+    def test_pull_failure_q_does_not_advance_to_next_step(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The core #626 invariant: when ``ollama pull`` fails and the
+        user picks 'q', the wizard does NOT silently advance to the next
+        step. Pinned by composing ``_step_embedding`` with a sentinel
+        next step that must never run."""
+        import click
+        import subprocess as _sp
+
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import run_steps
+
+        self._patch_ollama_env(monkeypatch, running=True, has_model=False)
+
+        def fake_run(cmd: list, **kw: object) -> _sp.CompletedProcess:
+            return _sp.CompletedProcess(cmd, returncode=1, stdout="", stderr="Error: timed out")
+
+        monkeypatch.setattr(init_cmd, "_run", fake_run)
+
+        next_step_called: list[bool] = []
+
+        def sentinel_next_step(state: dict) -> None:
+            next_step_called.append(True)
+
+        @click.command()
+        def cmd() -> None:
+            run_steps([init_cmd._step_embedding, sentinel_next_step])
+
+        # choice=3 → model 1 → pull yes → fail → q
+        result = CliRunner().invoke(cmd, [], input="3\n1\nY\nq\n")
+        assert "Pull failed" in result.output
+        assert "Wizard cancelled" in result.output
+        # The whole point of #626: a failed pull does NOT silently
+        # advance to the next step.
+        assert next_step_called == []

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6463,3 +6463,102 @@ class TestStepEmbeddingOllamaGuards:
         # The whole point of #626: a failed pull does NOT silently
         # advance to the next step.
         assert next_step_called == []
+
+    def test_has_model_none_r_retries_then_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``has_model=None`` (server returned an error) → 'r' → outer
+        retry loop re-runs the server check and ``_ollama_has_model``;
+        on the second call the model is detected and the step completes.
+        Symmetric counterpart to ``test_pull_failure_r_retries_pull_only``
+        for the tri-state ambiguous branch."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+
+        has_model_calls = {"n": 0}
+
+        def fake_has_model(model: str) -> bool | None:
+            has_model_calls["n"] += 1
+            # First call: server errored. Second call: model is ready.
+            return None if has_model_calls["n"] == 1 else True
+
+        self._patch_ollama_env(monkeypatch, running=True, has_model=fake_has_model)
+
+        state: dict = {}
+
+        @click.command()
+        def cmd() -> None:
+            init_cmd._step_embedding(state)
+
+        # choice=3 → model 1 → has_model None → r → model 1 (re-prompted) → ready
+        result = CliRunner().invoke(cmd, [], input="3\n1\nr\n1\n")
+        assert result.exit_code == 0
+        assert "Could not verify whether" in result.output
+        assert "is ready" in result.output
+        assert state.get("provider") == "ollama"
+        assert state.get("model") == "nomic-embed-text"
+        assert has_model_calls["n"] == 2
+
+
+class TestStepEmbeddingOpenAIGuard:
+    """The OpenAI bad-key + decline path raises ``WizardCancel`` (was
+    ``SystemExit(1)`` pre-#626) so cancellation is uniform with the
+    ``q`` shortcut. The exit-code change (1 → 0 via ``run_steps``) is
+    deliberate: the user actively chose to cancel, not error out."""
+
+    def test_invalid_key_decline_continue_raises_wizard_cancel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import WizardCancel
+
+        monkeypatch.setattr(init_cmd, "_have_module", lambda mod: True)
+        monkeypatch.setattr(init_cmd, "_test_openai_key", lambda key: False)
+
+        captured: dict[str, BaseException | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                init_cmd._step_embedding({})
+            except WizardCancel as exc:
+                captured["exc"] = exc
+
+        # choice=4 (OpenAI) → model 1 → fake-key → "Continue anyway?" N
+        result = CliRunner().invoke(cmd, [], input="4\n1\nfake-key\nN\n")
+        assert "API key test failed" in result.output
+        assert isinstance(captured["exc"], WizardCancel)
+
+    def test_invalid_key_decline_does_not_advance_to_next_step(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Composed pin: when the user declines to continue with a bad
+        OpenAI key, the wizard cancels via the ``q`` path — the next
+        step does NOT run, and ``run_steps`` exits 0 (deliberate cancel,
+        not an error)."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import run_steps
+
+        monkeypatch.setattr(init_cmd, "_have_module", lambda mod: True)
+        monkeypatch.setattr(init_cmd, "_test_openai_key", lambda key: False)
+
+        next_step_called: list[bool] = []
+
+        def sentinel_next_step(state: dict) -> None:
+            next_step_called.append(True)
+
+        @click.command()
+        def cmd() -> None:
+            run_steps([init_cmd._step_embedding, sentinel_next_step])
+
+        result = CliRunner().invoke(cmd, [], input="4\n1\nfake-key\nN\n")
+        assert "Wizard cancelled" in result.output
+        assert next_step_called == []
+        # ``run_steps`` exits 0 on WizardCancel (was 1 under SystemExit(1)).
+        assert result.exit_code == 0

--- a/packages/memtomem/tests/test_wizard.py
+++ b/packages/memtomem/tests/test_wizard.py
@@ -13,16 +13,25 @@ from typing import Callable
 import click
 from click.testing import CliRunner
 
-from memtomem.cli.wizard import StepBack, run_steps, silent_step
+from memtomem.cli.wizard import (
+    StepBack,
+    StepRetry,
+    WizardCancel,
+    fail_step,
+    run_steps,
+    silent_step,
+)
 
 
 def _make_step(
     name: str,
     log: list[str],
     raise_back_on_call: int | None = None,
+    raise_retry_on_call: int | None = None,
 ) -> Callable[[dict], None]:
     """Build an interactive step. Counts its own invocations in ``log`` and
-    optionally raises ``StepBack`` on the Nth invocation (1-indexed)."""
+    optionally raises ``StepBack`` / ``StepRetry`` on the Nth invocation
+    (1-indexed)."""
     calls = {"n": 0}
 
     def step(state: dict) -> None:
@@ -30,6 +39,8 @@ def _make_step(
         log.append(name)
         if raise_back_on_call is not None and calls["n"] == raise_back_on_call:
             raise StepBack()
+        if raise_retry_on_call is not None and calls["n"] == raise_retry_on_call:
+            raise StepRetry()
 
     step.__name__ = name
     return step
@@ -198,3 +209,139 @@ class TestRunStepsRegressions:
 
         assert log == ["a", "b1", "a", "b2"]
         assert final.get("a_ran") is True
+
+
+class TestRunStepsRetry:
+    """``StepRetry`` re-invokes the same step; back-nav semantics are
+    unaffected. Recovery hook for the #626 wizard guardrails."""
+
+    def test_retry_re_invokes_same_step(self) -> None:
+        """``StepRetry`` from step N re-invokes step N — no advance, no
+        back-nav. Surrounding steps are unaffected."""
+        log: list[str] = []
+        step0 = _make_step("s0", log)
+        step1 = _make_step("s1", log, raise_retry_on_call=1)
+        step2 = _make_step("s2", log)
+
+        run_steps([step0, step1, step2])
+
+        # s1 fires twice (retry, then complete), s0/s2 once.
+        assert log == ["s0", "s1", "s1", "s2"]
+
+    def test_retry_does_not_skip_silent_predecessors(self) -> None:
+        """Unlike ``StepBack``, ``StepRetry`` does not move the cursor —
+        silent predecessors stay where they are and are not re-fired."""
+        log: list[str] = []
+        step0 = _make_step("s0", log)
+        silent1 = _make_silent("silent", log)
+        step2 = _make_step("s2", log, raise_retry_on_call=1)
+
+        run_steps([step0, silent1, step2])
+
+        # silent fires once on forward; s2 fires twice (retry + complete).
+        assert log == ["s0", "silent", "s2", "s2"]
+
+    def test_retry_message_emitted(self) -> None:
+        """``run_steps`` echoes a dim ``(retrying...)`` line so the user
+        sees that the re-run was their own choice, not a hung loop."""
+        log: list[str] = []
+        step0 = _make_step("s0", log, raise_retry_on_call=1)
+
+        runner = CliRunner()
+
+        @click.command()
+        def cmd() -> None:
+            run_steps([step0])
+
+        result = runner.invoke(cmd, [])
+        assert result.exit_code == 0
+        assert "(retrying...)" in result.output
+        assert log == ["s0", "s0"]
+
+
+class TestFailStep:
+    """``fail_step`` is the primitive that turns a recoverable failure
+    into an explicit user choice (#626). Verify the choice→exception
+    mapping and the ``retryable`` gate."""
+
+    @staticmethod
+    def _invoke(input_text: str, *, retryable: bool = True) -> Exception | None:
+        """Run ``fail_step`` under a CliRunner with the given stdin and
+        return the raised exception (or None if it returned cleanly,
+        which it must never do)."""
+        runner = CliRunner()
+        captured: dict[str, Exception | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                fail_step("test message", retryable=retryable)
+            except (StepRetry, StepBack, WizardCancel) as exc:
+                captured["exc"] = exc
+
+        runner.invoke(cmd, [], input=input_text)
+        return captured["exc"]
+
+    def test_retry_choice_raises_step_retry(self) -> None:
+        assert isinstance(self._invoke("r\n"), StepRetry)
+
+    def test_retry_long_form_also_works(self) -> None:
+        assert isinstance(self._invoke("retry\n"), StepRetry)
+
+    def test_back_choice_raises_step_back(self) -> None:
+        assert isinstance(self._invoke("b\n"), StepBack)
+
+    def test_back_long_form_also_works(self) -> None:
+        assert isinstance(self._invoke("back\n"), StepBack)
+
+    def test_quit_choice_raises_wizard_cancel(self) -> None:
+        assert isinstance(self._invoke("q\n"), WizardCancel)
+
+    def test_quit_long_form_also_works(self) -> None:
+        assert isinstance(self._invoke("quit\n"), WizardCancel)
+
+    def test_default_when_retryable_is_retry(self) -> None:
+        """Empty input (just Enter) accepts the default — for
+        ``retryable=True`` that's retry."""
+        assert isinstance(self._invoke("\n"), StepRetry)
+
+    def test_default_when_not_retryable_is_back(self) -> None:
+        """For ``retryable=False`` the default is back."""
+        assert isinstance(self._invoke("\n", retryable=False), StepBack)
+
+    def test_retryable_false_rejects_r_choice(self) -> None:
+        """When the action is not retryable, 'r' is not a valid answer.
+        The prompt must reject it and accept a fallback (here: 'b' on
+        the next line)."""
+        exc = self._invoke("r\nb\n", retryable=False)
+        assert isinstance(exc, StepBack)
+
+    def test_invalid_input_reprompts(self) -> None:
+        """Garbage input loops the prompt — the helper must not silently
+        coerce to an unintended choice."""
+        runner = CliRunner()
+        captured: dict[str, Exception | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                fail_step("test message", retryable=True)
+            except (StepRetry, StepBack, WizardCancel) as exc:
+                captured["exc"] = exc
+
+        result = runner.invoke(cmd, [], input="x\nq\n")
+        assert isinstance(captured["exc"], WizardCancel)
+        assert "Please answer r, b, or q." in result.output
+
+    def test_message_rendered_in_output(self) -> None:
+        runner = CliRunner()
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                fail_step("specific failure detail", retryable=True)
+            except (StepRetry, StepBack, WizardCancel):
+                pass
+
+        result = runner.invoke(cmd, [], input="q\n")
+        assert "specific failure detail" in result.output


### PR DESCRIPTION
## Summary

- Adds `StepRetry` exception and `fail_step()` helper to `wizard.py` so a failed wizard step prompts the user to **retry / back / quit** instead of silently advancing.
- Wires the new mechanism into `_step_embedding`'s Ollama branch — server reachability check, model verification, and `ollama pull` are now guarded.
- `_ollama_has_model` now returns `bool | None` (tri-state) so callers distinguish "server unreachable / errored" from "model absent". The original `False`-on-error conflation is the root cause of the #626 misread (a server timeout was being interpreted as "model not installed", triggering a doomed pull and silent fall-through to the Reranker step).
- Drops the misleading "Ollama not running. Starting 'ollama serve'..." line — the wizard never actually started the server, only printed the line.

## Reproduction (the #626 scenario)

```
[3] Ollama → bge-m3 → "model not found" → pull fails → wizard moves on as if nothing happened
```

After this PR the user sees:

```
✗ Pull failed: Error: timed out waiting for server to start
Retry, back, or quit? [R/b/q]:
```

`r` re-runs only the pull (model selection is preserved). `b` returns to the previous step. `q` cancels the wizard via the same path as the `q` shortcut.

## Incidental scope

The OpenAI branch's "API key invalid + decline to continue" path used `raise SystemExit(1)`; switched to `WizardCancel` for uniform cancel UX. Exit code on this path changes from 1 to 0 — this is a deliberate cancel by the user, not an error. No tests pinned the previous exit code.

## Out of scope (follow-up)

- Silent-continue audit of other steps (`_step_memory_dir` dir creation, `_step_settings` writes, etc.). The mechanism added here can be reused per step in a follow-up PR.
- Automatic backoff retry on transient failures.
- Actually starting `ollama serve` from the wizard.

## Test plan

- [x] `uv run ruff check + format --check packages/memtomem/{src,tests}` clean
- [x] `uv run pytest -m "not ollama"` — 3873 passed
- [x] New unit tests pin the `StepRetry` / `fail_step` choice→exception mapping (12 cases) and the `_ollama_has_model` tri-state contract (5 cases)
- [x] New integration tests pin the #626 invariant: `_step_embedding` does NOT silently advance to the next step on Ollama failure (sentinel next-step check)
- [x] Manual pty-driven smoke against `mm init --advanced` with a fake `ollama` binary, in 5 scenarios:
  - **A** (server unreachable + `q`) — red `✗ Ollama server is not reachable.` prompt fires, wizard cancels (exit 0). The `Starting 'ollama serve'...` lie is gone.
  - **B** (server unreachable + `b`) — falls back to `(already at first step)`, re-runs `_step_embedding` from the top. Wizard never advances past it.
  - **C** (server unreachable + `r` with server still broken + `q`) — outer retry loop re-runs the server check only; the embedding-provider menu does NOT re-render.
  - **D** (server up, model missing, pull fails + `r` + still fails + `q`) — inner retry loop re-runs only the pull action; the model-selection menu is NOT re-prompted.
  - **E** (pull fails + `b`) — wizard returns to the embedding choice; `_step_reranker` (next step) never runs. This is the core #626 invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)