### PR TITLE
fix(web): wire mdReindexOne meta-row to .source-group-stats (closes #662)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1297,7 +1297,7 @@
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=82"></script>
   <script src="/settings-config.js?v=9"></script>
-  <script src="/sources-memory-dirs.js?v=10"></script>
+  <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -1096,14 +1096,19 @@ async function mdReindexOne(path, btn) {
   // Cache the original button label so we can restore it after the run —
   // ``btnLoading`` only toggles disabled+spinner, it doesn't snapshot text.
   const _origText = btn ? btn.textContent : '';
-  // Slot-reuse for chunk_progress (#654): the meta row already carries
-  // mutable count text ("12 files · 1,847 chunks"), already has the
+  // Slot-reuse for chunk_progress (#654): the stats badge already carries
+  // mutable count text ("0/9 files, 0 chunks"), already has the
   // nowrap+ellipsis CSS guards, and is the only single-line slot near
   // the button that won't shift adjacent dirs cards when its content
   // grows. We borrow it for in-flight ``file.md — N/M chunks`` ticks
   // and snap back via ``_origMeta`` on file boundary / cleanup.
-  const _item = btn ? btn.closest('.memory-dirs-item') : null;
-  const metaEl = _item ? _item.querySelector('.memory-dirs-item-meta') : null;
+  // Renderer lives in ``app.js:_renderMemoryDirGroup`` — ``.source-group``
+  // wraps the row, ``.source-group-stats`` is the count badge. The
+  // ``_buildItemRow`` renderer in this file (with the historic
+  // ``.memory-dirs-item`` classes) is dead since #568 (Memory/General
+  // sub-toggle removal) — tracked separately for cleanup.
+  const _item = btn ? btn.closest('.source-group') : null;
+  const metaEl = _item ? _item.querySelector('.source-group-stats') : null;
   const _origMeta = metaEl ? metaEl.textContent : '';
   // Throttle state — function-local so two concurrent reindex clicks
   // (one per dir) don't share each other's clocks. Mirrors the


### PR DESCRIPTION
## Summary

Closes #662. PR #658 (`46e1a1a`) wired the chunk_progress meta-row update against `.memory-dirs-item` / `.memory-dirs-item-meta` — selectors that match the **legacy** `_buildItemRow` renderer in `sources-memory-dirs.js:611-685`, dead since #568 (Memory/General sub-toggle removal). The active renderer is `app.js:_renderMemoryDirGroup:2752+`, which produces `.source-group source-group-memory` with a `.source-group-stats` count badge. `metaEl` was always `null`, the chunk_progress branch silently early-returned on every event, the user saw nothing. Two-line class swap + cache-buster.

## Verification (Playwright)

Same EventSource + MutationObserver harness used to find the regression. Fixture: `small/` (note1.md + note2.md + an added 44-chunk `big.md`), `force=true` reindex via URL injection (auto-watcher had already indexed `big.md` so a normal reindex would short-circuit).

### Pre-fix on `46e1a1a`

| Probe | Value |
|---|---|
| Server `chunk_progress` events | 23 (CHANGELOG.md / 89 chunks, threshold 32) |
| `document.querySelectorAll('.memory-dirs-item').length` | **0** |
| `document.querySelectorAll('.memory-dirs-item-meta').length` | **0** |
| `.source-group-stats` text mutations | **0** |
| `mdReindexOne` `_item` (`btn.closest('.memory-dirs-item')`) | **null** |

### Post-fix on this branch

| Probe | Value |
|---|---|
| Server `chunk_progress` events | 66 (44-chunk file, force=true) |
| `mdReindexOne` `_item` (`btn.closest('.source-group')`) | non-null (matches the small/ details element) |
| `mdReindexOne` `metaEl` (`.querySelector('.source-group-stats')`) | non-null, `isConnected=true` |
| `.source-group-stats` mutation 1 | `"big.md — 2/44 청크"` (KO locale, `index.file_chunk_progress`) |
| `.source-group-stats` mutation 2 | `"big.md — 44/44 청크"` (final-tick bypass) |
| Reset on file boundary (progress event) | badge restored to `"파일 3/3 · 청크 46"` |
| Throttle effect (100 ms gate) | 66 events → 2 chunk-label renders (one early-fire, one final-tick), no sub-100ms flash |

The flag-gated `_metaIsChunkLabel` reset behaves as the PR #658 description claimed — verified end-to-end now.

## Out of scope (follow-up issue)

The legacy renderer in this same file (`_buildItemRow` line 611-685, `renderMemoryDirsPanel` line 972-981, plus the helpers they call — ~80 lines orphan since #568) is the source of the misleading class names that led to this regression. Removing it is a chore PR, not a fix — will file separately as `chore(web): remove orphaned legacy memory-dirs renderer`.

## Test plan

- [x] Pre-fix Playwright capture confirmed regression (23 server events, 0 DOM mutations)
- [x] Post-fix Playwright capture confirmed feature (66 server events, 2 chunk-label DOM mutations + boundary reset)
- [x] `uv run ruff check packages/memtomem/src` green
- [x] `uv run ruff format --check packages/memtomem/src` green
- [ ] CI on this PR (lint, typecheck, test ubuntu/macos, golden-path, notebooks, CLA)
- [ ] Layout shift check at 1280 / 1024 / mobile widths (CSS guards reused — `.source-group-stats` already has `flex-shrink: 0; white-space: nowrap` per `style.css:558`)
- [ ] KO ⇄ EN locale toggle mid-stream — verified `청크` rendered above; full toggle test deferred to follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
