### PR TITLE
fix(web): resolve memory_dir paths in /api/memory-dirs/status (closes #666)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -254,6 +254,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **`mm web` Sources page per-row stats badge now renders for
+  config-raw memory_dirs.** `/api/memory-dirs/status` was the only
+  `/api/memory-dirs/*` endpoint that returned the path with
+  `expanduser()` only — every sibling endpoint and `/api/config` use
+  `expanduser().resolve()`. When `mm init` (or any wizard pass) wrote
+  a tilde-prefixed entry like `~/memories` or a path under a symlinked
+  prefix like macOS `/tmp` to `config.indexing.memory_dirs`, the
+  frontend's `STATE.memoryDirs` (resolved) and
+  `STATE.memoryStatusByPath` keys (unresolved) diverged, the per-row
+  lookup missed, and the file/chunk/created badge was skipped. Status
+  now resolves on read so the badge renders regardless of how the
+  config row was originally persisted. (#666)
 - **`mm web` Sources tab now shows orphan-indexed files instead of
   silently dropping them.** The `/api/sources` response carries rows
   with `memory_dir=null, kind=null` for two paths — Index-tab uploads

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -258,7 +258,7 @@ async def memory_dir_stats(
 
     out: list[dict[str, object]] = []
     for d, file_count in zip(dir_list, file_counts):
-        dir_path = Path(d).expanduser()
+        dir_path = Path(d).expanduser().resolve()
         exists = dir_path.exists()
         prefix = norm_dir_prefix(d)
 
@@ -279,13 +279,11 @@ async def memory_dir_stats(
         category = categorize_memory_dir(d)
         out.append(
             {
-                # Return the expanded path so the response shape matches
-                # the other ``/api/memory-dirs/*`` endpoints (all of which
-                # use ``str(Path(p).expanduser().resolve())``). Returning
-                # the config-raw form (e.g. ``~/memories``) caused the web
-                # UI's per-row lookup to miss tilde-prefixed entries —
-                # every other dir rendered file/chunk/created badges
-                # while ``~/memories`` came back blank.
+                # Return the resolved form so per-row keys match the
+                # sibling ``/api/memory-dirs/*`` and ``/api/config``
+                # endpoints (all use ``str(Path(p).expanduser().resolve())``).
+                # Reverting to expanduser-only makes Web UI badge lookup
+                # miss tilde- or symlink-prefixed entries (#666).
                 "path": str(dir_path),
                 "chunk_count": chunk_count,
                 "source_file_count": source_file_count,

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1571,6 +1571,50 @@ class TestMemoryDirsStatus:
         assert by_path[str(plans)]["provider"] == "claude"
         assert by_path[str(claude_mem)]["provider"] == "claude"
 
+    async def test_response_path_resolves_symlink(
+        self, app, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        # Wizard-written config never goes through ``/api/memory-dirs/add``,
+        # so a symlinked prefix (e.g. macOS ``/tmp`` → ``/private/tmp``)
+        # lands in ``config.indexing.memory_dirs`` unresolved. Frontend
+        # ``STATE.memoryDirs`` keys come from ``/api/config`` (resolved),
+        # so the status response must also return the resolved form or
+        # the per-row badge lookup misses (#666).
+        real = (tmp_path / "real").resolve()
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+
+        app.state.config.indexing.memory_dirs = [link]
+
+        resp = await client.get("/api/memory-dirs/status")
+        assert resp.status_code == 200, resp.text
+        dirs = resp.json()["dirs"]
+        assert len(dirs) == 1
+        assert dirs[0]["path"] == str(real)
+
+    async def test_response_path_resolves_tilde(
+        self,
+        app,
+        client: AsyncClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Pins the invariant the docstring originally guarded — a config
+        # entry like ``~/memories`` must come back as the expanded
+        # absolute path, not the literal tilde form (#666).
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / "memories"
+        target.mkdir()
+
+        app.state.config.indexing.memory_dirs = ["~/memories"]
+
+        resp = await client.get("/api/memory-dirs/status")
+        assert resp.status_code == 200, resp.text
+        dirs = resp.json()["dirs"]
+        assert len(dirs) == 1
+        assert dirs[0]["path"] == str(target.resolve())
+
 
 class TestOpenMemoryDir:
     """``POST /api/memory-dirs/open`` reveals a registered dir in the OS

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1580,7 +1580,7 @@ class TestMemoryDirsStatus:
         # ``STATE.memoryDirs`` keys come from ``/api/config`` (resolved),
         # so the status response must also return the resolved form or
         # the per-row badge lookup misses (#666).
-        real = (tmp_path / "real").resolve()
+        real = tmp_path / "real"
         real.mkdir()
         link = tmp_path / "link"
         link.symlink_to(real, target_is_directory=True)
@@ -1591,7 +1591,36 @@ class TestMemoryDirsStatus:
         assert resp.status_code == 200, resp.text
         dirs = resp.json()["dirs"]
         assert len(dirs) == 1
-        assert dirs[0]["path"] == str(real)
+        assert dirs[0]["path"] == str(real.resolve())
+
+    async def test_path_matches_config_endpoint(
+        self, app, client: AsyncClient, tmp_path: Path
+    ) -> None:
+        # Cross-endpoint parity guard. ``/api/config`` and
+        # ``/api/memory-dirs/status`` are read by the same frontend
+        # render pass (``STATE.memoryDirs`` keyed against
+        # ``STATE.memoryStatusByPath``); any future divergence in their
+        # path canonicalization re-introduces #666 with the same
+        # symptoms (per-row badge missing). Pin the parity invariant
+        # directly so the regression doesn't have to surface through
+        # the UI again.
+        real = tmp_path / "x"
+        real.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real, target_is_directory=True)
+
+        app.state.config.indexing.memory_dirs = [link]
+
+        cfg_resp = await client.get("/api/config")
+        sts_resp = await client.get("/api/memory-dirs/status")
+        assert cfg_resp.status_code == 200, cfg_resp.text
+        assert sts_resp.status_code == 200, sts_resp.text
+
+        cfg_dirs = cfg_resp.json()["indexing"]["memory_dirs"]
+        sts_dirs = sts_resp.json()["dirs"]
+        assert len(cfg_dirs) == 1
+        assert len(sts_dirs) == 1
+        assert sts_dirs[0]["path"] == cfg_dirs[0]
 
     async def test_response_path_resolves_tilde(
         self,

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1631,8 +1631,12 @@ class TestMemoryDirsStatus:
     ) -> None:
         # Pins the invariant the docstring originally guarded — a config
         # entry like ``~/memories`` must come back as the expanded
-        # absolute path, not the literal tilde form (#666).
+        # absolute path, not the literal tilde form (#666). ``HOME`` is
+        # the POSIX home var; Windows ``Path.expanduser()`` reads
+        # ``USERPROFILE`` first and ignores ``HOME``, so monkeypatch
+        # both for cross-platform coverage.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         target = tmp_path / "memories"
         target.mkdir()
 


### PR DESCRIPTION
## Summary

- Resolve `memory_dir` paths in `/api/memory-dirs/status` so the
  response shape matches every sibling `/api/memory-dirs/*` endpoint
  and `/api/config` (all use `Path(p).expanduser().resolve()`).
- Fixes the missing per-row stats badge in the Web UI's Sources page
  for any `memory_dir` persisted as the config-raw form
  (tilde-prefixed, or under a symlinked prefix like macOS `/tmp` →
  `/private/tmp`). Closes #666.
- Unblocks PR #665's `chunk_progress` SSE meta-row update, which
  queries `.source-group-stats` and silently no-op'd when the badge
  was never rendered.

## Root cause

`mm init` (CLI wizard) writes the user's path to
`config.indexing.memory_dirs` with `expanduser()` only
(`init_cmd.py:2025-2030`). `/api/config` resolves on read so
`STATE.memoryDirs` is canonicalized. But
`/api/memory-dirs/status` was returning paths via
`Path(d).expanduser()` (no `.resolve()`), so frontend
`statusByPath[dir]` lookup at `app.js:2603` missed and `if (status)`
at `app.js:2779` skipped the badge.

The docstring at `engine.py:282-288` already documented this
invariant — it was added when tilde-prefixed entries (`~/memories`)
rendered blank for the same reason — but only `expanduser()` was
applied in code, leaving the symlink-prefix mode broken.

## Approach

Sketch (1) from the issue: normalize at the API boundary in
`engine.memory_dir_stats`. One-line change at `engine.py:261`
(`Path(d).expanduser().resolve()`) plus a tightened docstring that
names both failure modes (tilde + symlink) so a future
expanduser-only revert is harder to land. Existing installs self-heal
on the next status read — no migration, no config rewrite.

The wizard-side resolve (sketch 2) is deliberately deferred: with
status normalizing on read, the divergence is invisible to the UI;
config-raw entries stay in `~/.memtomem/config.json` until the user
removes/re-adds, which is acceptable.

## Tests

Two engine-level regression tests in `TestMemoryDirsStatus`. Both
assign directly to `app.state.config.indexing.memory_dirs` rather
than going through `/api/memory-dirs/add` — the route mutators
already resolve before persisting, so testing through them would be
vacuous (the bug only surfaces with wizard-written config).

- `test_response_path_resolves_symlink` — `tmp_path` with a
  `symlink_to(real_dir, target_is_directory=True)`, asserts
  response `path == str(real_dir.resolve())`. Cross-platform.
- `test_response_path_resolves_tilde` — `monkeypatch.setenv("HOME",
  str(tmp_path))`, config entry `"~/memories"`, asserts response
  `path == str((tmp_path / "memories").resolve())`. Pins the
  docstring's original tilde-mode intent.

## Test plan

- [x] `uv run pytest -m "not ollama"
  packages/memtomem/tests/test_web_routes.py::TestMemoryDirsStatus -x`
  → 3 passed (including 2 new)
- [x] `uv run pytest -m "not ollama"
  packages/memtomem/tests/test_web_routes.py -x` → 113 passed
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/ -k
  "memory_dir or engine or indexing"` → 237 passed
- [x] `uv run ruff check` + `ruff format --check` on changed files
- [ ] Post-merge manual smoke (per
  `feedback_post_merge_smoke.md`): `mm init -y --memory-dir
  /tmp/some-dir`, `mm web`, confirm Sources tab default-row badge
  renders and PR #665's `chunk_progress` meta-row updates on
  reindex.
