### PR TITLE
test(embedding): flush threadsafe progress callbacks in ONNX tests (refs #667)

### DIFF
--- a/packages/memtomem/tests/test_embedding_progress.py
+++ b/packages/memtomem/tests/test_embedding_progress.py
@@ -15,6 +15,7 @@ These guarantees are what the SSE indexing stream relies on to forward
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -208,6 +209,12 @@ async def test_onnx_streams_progress_per_yield():
     calls, cb = _record()
     result = await embedder.embed_texts(["a", "b", "c", "d", "e"], on_progress=cb)
     assert len(result) == 5
+    # Flush ``call_soon_threadsafe`` callbacks the worker scheduled but
+    # the loop hasn't dequeued yet by the time ``to_thread`` resumed —
+    # macOS exposes the race ~30% of the time on a 5-text burst (#667).
+    # Production behavior is fire-and-forget; tightening that contract
+    # would be a separate PR.
+    await asyncio.sleep(0)
     _assert_progress_contract(calls, total=5, expected_calls=5)
     assert [d for d, _ in calls] == [1, 2, 3, 4, 5]
 
@@ -235,6 +242,11 @@ async def test_onnx_throttles_thread_hops_for_large_input():
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
     calls, cb = _record()
     await embedder.embed_texts(["x"] * n, on_progress=cb)
+    # Same threadsafe-callback flush as test_onnx_streams_progress_per_yield
+    # — defensive here, since 200 ticks throttled to ~20 hasn't been seen
+    # to flake in CI (only the 5-text burst does), but the race window is
+    # the same code path.
+    await asyncio.sleep(0)
     # Throttle step = max(1, n // 20) = 10 → ~20 ticks + final
     # (final-tick bypass guarantees one extra if the last-step boundary
     # doesn't land exactly on N).


### PR DESCRIPTION
## Summary
- `test_onnx_streams_progress_per_yield[asyncio]` fails ~30% on `test (macos-latest)` with `expected 5 calls, got []` (#667).
- Race: the worker's `loop.call_soon_threadsafe(_safe_on_progress, ...)` calls and the moment `await asyncio.to_thread(...)` resumes share the same `_run_once` boundary on macOS — the test asserts before the ready queue has drained the pending progress callbacks.
- Fix: `await asyncio.sleep(0)` after `embed_texts` in both ONNX progress tests to flush pending callbacks before assertions. Test-only — production behavior stays fire-and-forget.

## Why test-only
Tightening the production progress contract (so callers can rely on "all ticks fire before the await returns") would be a separate PR and is only justified if a real production tick-loss is observed. #667's first suggested check is exactly this `sleep(0)` flush in the test.

## 200-iter test audit
`test_onnx_throttles_thread_hops_for_large_input` (200 texts, ~20 ticks throttled) shares the same code path but has not been observed to flake. Confirmed across two recent macos failures by reading the run logs:

| Run | Trigger | macOS failures |
|---|---|---|
| [25212314392](https://github.com/memtomem/memtomem/actions/runs/25212314392) | PR #665 (JS-only) | only `test_onnx_streams_progress_per_yield` |
| [25211859166](https://github.com/memtomem/memtomem/actions/runs/25211859166) | main 7c74c49 | only `test_onnx_streams_progress_per_yield` |

The 5-text burst's short race window is the macOS edge case (worker likely finishes before the loop ever wakes between `cb1` and `_set_state`); the throttled 200-iter run gives the loop enough opportunities to drain the queue mid-flight. The flush is added to the 200-iter test too as defense-in-depth since the underlying wiring is identical and silent regressions there would be costlier to spot.

## CI verification — macOS force-rerun 5/5 PASS
Run [25216595215](https://github.com/memtomem/memtomem/actions/runs/25216595215), `test (macos-latest)` job:

| Attempt | macOS job ID | Result |
|---|---|---|
| 1 (initial) | 73938321857 | ✅ success (3m5s) |
| 2 (rerun) | 73938841268 | ✅ success |
| 3 (rerun) | 73939129405 | ✅ success |
| 4 (rerun) | 73939399358 | ✅ success |
| 5 (rerun) | 73939731839 | ✅ success |

Pre-fix flake rate per the issue write-up was ~30% on macOS (2/6 recent main runs); 5 consecutive PASS attempts on this PR is a `(1 - 0.3)^5 ≈ 17%` baseline if the race window were unchanged, so 5/5 is consistent with the window being closed (not proof — but a useful signal).

`test (windows-latest)` fails on this PR for unrelated reasons — same ~20 failures present on main (path separators, file modes 0o600 vs 0o666, mm binary discovery on Windows). None of the failing tests are in the embedding/progress path, and `test_onnx_*` tests pass on Windows. Out of scope.

`test (ubuntu-latest)`, `lint`, `typecheck`, `notebooks`, `golden-path (ONNX bge-m3)` all green.

## Test plan
- [x] Force-rerun `test (macos-latest)` 5+ times on this PR — **5/5 PASS** (table above)
- [x] Local 50-iter soak of both ONNX progress tests: 50/50 PASS
- [x] Full `test_embedding_progress.py` (12 tests): all PASS
- [x] `ruff check` + `ruff format --check`: pass
- [x] Sibling test surface scan — `to_thread` + `on_progress` combo only exists in `onnx.py`; other `to_thread` sites (`fastembed.py:76`, `engine.py:246`, `sqlite_backend.py:681`, etc.) don't take a progress callback, so no other tests need this flush

## Out of scope
- Production `embed_texts` `asyncio.sleep(0)` — separate PR, only if a real tick-loss is observed
- The exact OS-level mechanism for why the FIFO `_run_once` model fails on macOS — this PR closes the race window empirically; precise root-cause attribution is left as an open question
- #666 (path-canonicalization) and #660 escalation — tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
