### PR TITLE
docs(web): name the resolve() invariant in routes/system.py (closes #669)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1,4 +1,14 @@
-"""Stats, indexing, and memory-add endpoints."""
+"""Stats, indexing, and memory-add endpoints.
+
+Path canonicalization invariant: every site in this module that accepts
+or returns a ``memory_dir`` path uses ``str(Path(p).expanduser().resolve())``.
+The Web UI keys per-row state on the resolved string (see
+``static/app.js`` ``_renderMemoryDirGroup``), so reverting any single
+site to ``expanduser``-only re-introduces #666 — the per-row stats
+badge silently disappears for tilde-prefixed (``~/memories``) or
+symlinked-prefix entries (macOS ``/tmp`` → ``/private/tmp``). Mirrored
+on the read side at ``memtomem.indexing.engine.memory_dir_stats``.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Add a single module-level docstring paragraph to
  `packages/memtomem/src/memtomem/web/routes/system.py` naming the
  `expanduser().resolve()` invariant the 14 `memory_dir`-handling
  sites in this module rely on. Closes #669.
- Pure docs change — no behavior, test, or call-site changes.
  Counterpart-pointer to the existing
  `engine.memory_dir_stats:282-287` docstring; the two now meet in
  the middle.

## Why

PR #668 (#666 fix) added a docstring on the engine side
(`/api/memory-dirs/status`'s producer) naming the contract the
sibling `system.py` writers/readers depend on. The mirror direction
was left as a follow-up — `system.py`'s 14 `Path(p).expanduser().resolve()`
sites (lines 184, 198, 444, 457, 472, 528, 574, 644, 698, 830, 866,
914, 1035, 1044) had no marker pointing at the cross-endpoint
contract, so a drive-by simplification that drops `.resolve()` at
any of them — especially `/api/config` line 198, the direct
counterpart to `/api/memory-dirs/status` — would re-introduce #666
with identical UI symptoms (per-row stats badge silently missing
for tilde- or symlink-prefixed entries).

The cross-endpoint parity test added in PR #668
(`test_path_matches_config_endpoint`) catches this behaviorally for
the `/api/config` ↔ `/api/memory-dirs/status` pair, but the docstring
is the cheaper guard for the wider set of writers
(`add`/`remove`/`move`/`open`/etc.) that aren't paired under a
similar test, and points a reviewer at *why* the pattern is uniform.

## Test plan

- [x] `uv run ruff check` + `ruff format --check` on changed file
- [x] No code paths touched — existing test suite unchanged
- [ ] Reviewer eyeballs the wording (the value is the wording, not
      the byte change)
