### PR TITLE
fix(web): vendor sub-tab follow-through on cross-tab source navigation

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1268,6 +1268,29 @@ function _renderStorageHealth(config, sources, embStatus) {
 }
 
 function _navigateToSource(path) {
+  // Resolve target vendor before switching so a Claude/OpenAI source
+  // clicked from Home recent or the command palette doesn't land on
+  // whichever vendor sub-tab the user last viewed — the
+  // ``.source-item[title=path]`` lookup below would silently miss
+  // because non-active vendors aren't rendered into the DOM. Same
+  // root cause as the navigateToSourcesByNs auto-switch in
+  // ``_renderMemorySourceTree``: a navigation entry-point sets one
+  // axis (path) without aligning the vendor sub-tab axis. Fall through
+  // when the source isn't in ``allSources`` yet (cold load) — current
+  // behaviour preserved, no regression.
+  const src = (STATE.allSources || []).find(s => s.path === path);
+  const status = src && src.memory_dir
+    ? (STATE.memoryStatusByPath || {})[src.memory_dir]
+    : null;
+  const provider = (status && typeof _SOURCES_VENDORS !== 'undefined'
+    && _SOURCES_VENDORS.includes(status.provider))
+    ? status.provider : null;
+  if (provider && STATE.sourcesActiveVendor !== provider) {
+    STATE.sourcesActiveVendor = provider;
+    if (typeof _syncSourcesVendorTabs === 'function') {
+      _syncSourcesVendorTabs(provider);
+    }
+  }
   activateTab('sources');
   setTimeout(() => {
     document.querySelectorAll('.source-item').forEach(el => {
@@ -2455,9 +2478,15 @@ function _renderMemorySourceTree(sources, list) {
     sourcesByDir[key].push(s);
   }
 
-  // Hide dirs whose files are all filtered out so a path filter
-  // doesn't leave empty "Claude (0)" rows behind.
-  const filterActive = !!(qs('sources-filter') && qs('sources-filter').value.trim());
+  // Hide dirs whose files are all filtered out so a path/namespace
+  // filter doesn't leave empty "Claude (0)" rows behind. The NS filter
+  // matters here because clicking a namespace card's Sources button
+  // routes through ``navigateToSourcesByNs`` — without this branch the
+  // tree keeps every dir header and only their file children disappear,
+  // which reads as "the link did nothing" when most dirs have zero
+  // matches.
+  const filterActive = !!(qs('sources-filter') && qs('sources-filter').value.trim())
+    || !!STATE.sourcesNsFilter;
 
   const PROVIDER_ORDER = (typeof _MEMORY_DIR_PROVIDER_ORDER !== 'undefined')
     ? _MEMORY_DIR_PROVIDER_ORDER : ['user', 'claude', 'openai'];
@@ -2593,6 +2622,32 @@ function _renderMemorySourceTree(sources, list) {
     activeVendor = _readActiveSourcesVendor();
     STATE.sourcesActiveVendor = activeVendor;
     _syncSourcesVendorTabs(activeVendor);
+  }
+
+  // NS-filter follow-through: a click on a namespace card's "Sources"
+  // button (settings-namespaces.js → navigateToSourcesByNs) sets
+  // ``sourcesNsFilter`` and switches to the Sources tab, but the
+  // active vendor stays at whatever the user last chose. For a
+  // ``claude:…`` or ``codex:…`` namespace this lands the user on the
+  // ``user`` tab where every dir is empty after filtering — chip says
+  // "ns: claude:…" but the visible tree is unrelated, which reads as
+  // "the link did nothing." When the current vendor has zero matches
+  // we shift to the vendor with the most. Not persisted via
+  // ``_writeActiveSourcesVendor`` — this is a navigation hint, not the
+  // user's stored preference.
+  if (STATE.sourcesNsFilter) {
+    const curPlan = vendorPlans[activeVendor];
+    if (!curPlan || curPlan.totalFiles === 0) {
+      const best = PROVIDER_ORDER
+        .map(p => [p, vendorPlans[p] ? vendorPlans[p].totalFiles : 0])
+        .filter(([, n]) => n > 0)
+        .sort((a, b) => b[1] - a[1])[0];
+      if (best) {
+        activeVendor = best[0];
+        STATE.sourcesActiveVendor = activeVendor;
+        _syncSourcesVendorTabs(activeVendor);
+      }
+    }
   }
 
   // Helpers shared by the active-vendor render branches. Lifted out of

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2400,10 +2400,19 @@ function renderSourceTree(sources) {
   // The active-vendor scoping makes the number always match what the
   // user is currently looking at; global totals can be inferred by
   // summing the three sub-tab badges.
+  // Stats compute is deferred to ``_renderMemorySourceTree`` so it can
+  // observe the *post-auto-switch* active vendor. Reading
+  // ``STATE.sourcesActiveVendor`` here would race the NS-filter
+  // follow-through that shifts the sub-tab inside the tree pass \u2014 the
+  // stats line would then briefly show the pre-switch vendor's totals
+  // sitting above a post-switch tree (review feedback on PR #673).
+  _renderMemorySourceTree(sources, list);
+}
+
+function _renderSourcesStats(activeVendor) {
   const statsEl = qs('sources-stats');
+  if (!statsEl) return;
   const statusByPath = STATE.memoryStatusByPath || {};
-  const activeVendor = STATE.sourcesActiveVendor
-    || (typeof _readActiveSourcesVendor === 'function' ? _readActiveSourcesVendor() : 'user');
   let indexedFiles = 0;
   let totalChunks = 0;
   for (const s of Object.values(statusByPath)) {
@@ -2424,8 +2433,6 @@ function renderSourceTree(sources) {
   } else {
     statsEl.hidden = true;
   }
-
-  _renderMemorySourceTree(sources, list);
 }
 
 
@@ -2638,6 +2645,12 @@ function _renderMemorySourceTree(sources, list) {
   if (STATE.sourcesNsFilter) {
     const curPlan = vendorPlans[activeVendor];
     if (!curPlan || curPlan.totalFiles === 0) {
+      // Tie-break leans on stable sort + ``PROVIDER_ORDER`` =
+      // ``['user', 'claude', 'openai']``: when two vendors hold the
+      // same number of NS matches, the earlier vendor in the order
+      // wins. Intentional — ``user`` is the conventional primary
+      // surface, so a tie shouldn't bury the user's own dirs behind
+      // a less-frequented vendor.
       const best = PROVIDER_ORDER
         .map(p => [p, vendorPlans[p] ? vendorPlans[p].totalFiles : 0])
         .filter(([, n]) => n > 0)
@@ -2649,6 +2662,12 @@ function _renderMemorySourceTree(sources, list) {
       }
     }
   }
+
+  // Stats line uses the *post-auto-switch* vendor so the "N files ·
+  // M chunks" caption above the tree always matches what's rendered
+  // below. Doing this in the caller (``renderSourceTree``) would race
+  // the NS-filter follow-through that mutates ``activeVendor`` here.
+  _renderSourcesStats(activeVendor);
 
   // Helpers shared by the active-vendor render branches. Lifted out of
   // the per-vendor loop because they don't close over the iteration.

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=82"></script>
+  <script src="/app.js?v=84"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=84"></script>
+  <script src="/app.js?v=85"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>


### PR DESCRIPTION
## Summary

Two cross-tab navigation entry-points into the Sources panel set one axis (namespace filter or source path) but did not align the panel's vendor sub-tab axis (user / claude / openai). Because the panel only renders the active vendor's tree (#570), the user-visible chip / active-source state suggested the link succeeded while the rendered content was an unrelated vendor — reported as "Sources 화면으로 넘어가긴 하는데 직접 링크가 안 된다."

Audit (3 parallel Explore agents) found `_navigateToSource` is the same shape of bug; both fixes share the helper and live next to each other in `app.js`, so they ship together as one focused change.

## Changes

### `navigateToSourcesByNs` (Settings → Namespaces → Sources button)

`packages/memtomem/src/memtomem/web/static/app.js` — `_renderMemorySourceTree`:
- `filterActive` now also returns true when `STATE.sourcesNsFilter` is set, not just when the path-text input is non-empty. Empty memory_dir headers (28 of 29 in the repro for a `claude:…` namespace) are now hidden under the existing `visibleCatsRaw` guard.
- After computing per-vendor totals, if the current vendor has zero matches and another vendor has any, the active sub-tab shifts to the vendor with the most. Not persisted via `_writeActiveSourcesVendor` — this is a navigation hint, not the user's stored preference, so the next manual click still wins.

### `_navigateToSource` (Home recent source, command palette)

Same root cause, narrower entry-point. Resolves the target vendor from the source's `memory_dir → provider` (looked up via `STATE.allSources` + `STATE.memoryStatusByPath`) before `activateTab('sources')`, so a Claude/OpenAI source clicked from Home doesn't land on whichever sub-tab the user last viewed and silently miss the `.source-item[title=path]` scroll-into-view that follows. Falls through to current behaviour when `STATE.allSources` isn't populated yet (cold load) — no regression.

### Cache bust

`index.html` `app.js?v=82 → v=84` so the JS body change is actually picked up by browsers (per [`feedback_static_asset_cache_bust.md`](https://github.com/memtomem/memtomem/issues/587), unbumped query strings get served stale from disk cache).

## Verification

- `uv run ruff check packages/memtomem/src` — clean.
- `uv run pytest -m "not ollama" -k "namespace or sources or web"` — 986 passed.
- Playwright (against `mm web`):
  - localStorage forced to `user` vendor → click `claude:-Users-pdstudio-Work-agent-harness-memtomem` namespace's Sources button → vendor tab shifts to `claude`, exactly 1 dir group with 284 file items, chip shows the namespace.
  - Clear chip → 29 dir groups + 356 files reappear under Claude.
  - Click `default` namespace from `user` vendor → vendor stays `user`, 2 dirs + 22 files (auto-switch correctly inert when current vendor has matches).
  - `_navigateToSource(<claude path>)` from `user` vendor → vendor switches to `claude`, target source becomes `.source-item.active` and gets `scrollIntoView`.
  - `_navigateToSource(<user path>)` from `user` vendor → no vendor switch, target source becomes active (regression check).

## Out-of-scope sibling

`_searchByTag(tag)` (`app.js:3631-3640`) populates both `search-input` and `tag-filter` with the tag string — same axis-mismatch shape but `v0.1.0`-since behaviour, not a recent regression. Filed as a separate issue (#672) for an intent-vs-design-flaw decision; user-visible behaviour change so it needs its own CHANGELOG entry.

## Test plan

- [x] `ruff check` clean
- [x] Pytest namespace/sources/web suite green
- [x] Playwright: cross-vendor namespace card → auto-switch to matching vendor sub-tab
- [x] Playwright: chip-clear restores full vendor tree
- [x] Playwright: same-vendor namespace card preserves current vendor
- [x] Playwright: `_navigateToSource` cross-vendor + same-vendor regression
- [ ] Manual: refresh in real browser to confirm `?v=84` bust takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
