### PR TITLE
feat(web): jump from Timeline to Source tab on chunk/file click

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -35,6 +35,13 @@ const STATE = {
   // immediately on consume so a follow-up filter/sort re-render
   // doesn't re-scrollIntoView an item the user already navigated past.
   pendingActivatePath: '',
+  // Chunk id the next ``browseSource`` should scroll/expand/flash after
+  // rendering the chunk list. Set by ``_navigateToSource`` when the
+  // caller knows the specific chunk (e.g. Timeline → Source jump);
+  // empty string means "source-level only, no chunk highlight".
+  // Cleared on consume in ``browseSource`` so a later same-source
+  // browse (e.g. Load All) doesn't re-flash an old target.
+  pendingActivateChunkId: '',
   // Active Sources vendor sub-tab (one of ``user`` / ``claude`` /
   // ``openai``). Lazily populated from localStorage on first render so
   // the value survives reloads. Keeping it on STATE means re-renders
@@ -1297,7 +1304,7 @@ function _renderStorageHealth(config, sources, embStatus) {
   `;
 }
 
-function _navigateToSource(path) {
+function _navigateToSource(path, chunkId = '') {
   // Two-phase navigation:
   //   1. Eager vendor resolve when the dashboard already cached the
   //      data we need (``loadDashboard`` mirrors /api/sources +
@@ -1309,6 +1316,10 @@ function _navigateToSource(path) {
   //      tree exists. Replaces the old setTimeout(300) gamble that
   //      missed on cold loads (Home was the entry point and the data
   //      hadn't been fetched yet) and on stale-localStorage vendors.
+  //   3. ``chunkId`` is optional — when present (Timeline jump knows
+  //      the exact chunk), ``browseSource`` scrolls + expands + flashes
+  //      that card after the source's chunk list renders.
+  STATE.pendingActivateChunkId = chunkId || '';
   const src = (STATE.allSources || []).find(s => s.path === path);
   const status = src && src.memory_dir
     ? (STATE.memoryStatusByPath || {})[src.memory_dir]
@@ -3196,6 +3207,33 @@ async function browseSource(path, limit = 100) {
       });
     }
     browser.appendChild(content);
+
+    // Consume ``pendingActivateChunkId`` (set by ``_navigateToSource``
+    // when the caller — e.g. Timeline — knows the specific chunk).
+    // Done after appendChild so the card is in the DOM. Cleared
+    // unconditionally so a later same-source browse (Load All, manual
+    // re-click) doesn't re-flash an old target. The accordion-expand
+    // listener attaches in the next rAF, so we run inside one too — but
+    // we don't depend on the listener: we set the ``expanded`` class
+    // directly when the card is collapsible.
+    if (STATE.pendingActivateChunkId) {
+      const targetId = STATE.pendingActivateChunkId;
+      STATE.pendingActivateChunkId = '';
+      requestAnimationFrame(() => {
+        const card = content.querySelector(
+          `.chunk-card[data-chunk-id="${CSS.escape(String(targetId))}"]`,
+        );
+        if (!card) return;
+        card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        const contentDiv = card.querySelector('.chunk-card-content');
+        if (contentDiv && card.classList.contains('chunk-card-collapsible')) {
+          contentDiv.classList.add('expanded');
+          card.setAttribute('aria-expanded', 'true');
+        }
+        card.classList.add('tl-target-flash');
+        setTimeout(() => card.classList.remove('tl-target-flash'), 1400);
+      });
+    }
   } catch (err) {
     browser.innerHTML = `<div class="empty-state"><p>Error: ${escapeHtml(err.message)}</p></div>`;
   }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=72" />
+  <link rel="stylesheet" href="/style.css?v=73" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
 </head>
 <body>
@@ -1295,14 +1295,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=87"></script>
+  <script src="/app.js?v=88"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=1"></script>
-  <script src="/timeline.js?v=1"></script>
+  <script src="/timeline.js?v=2"></script>
   <script src="/context-gateway.js?v=5"></script>
   <script src="/path-picker.js?v=1"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -453,6 +453,7 @@
   "timeline.title_tl": "Time range for timeline",
   "timeline.empty_icon": "🕐",
   "timeline.empty_text": "Click Load to view the timeline",
+  "timeline.open_in_source": "Open in source",
 
   "modal.settings_title": "Settings",
   "modal.default_tab_label": "Default Tab",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -453,6 +453,7 @@
   "timeline.title_tl": "타임라인 기간",
   "timeline.empty_icon": "🕐",
   "timeline.empty_text": "불러오기를 클릭하면 타임라인이 표시됩니다",
+  "timeline.open_in_source": "소스에서 보기",
 
   "modal.settings_title": "설정",
   "modal.default_tab_label": "기본 탭",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -1736,6 +1736,30 @@ kbd {
 }
 .tl-date-flash { animation: tl-flash 1.2s ease-out; }
 
+/* Files-view header "Open in source" — sits next to .tl-file-time on the
+   right edge. Click is stopPropagation()'d so it doesn't toggle the
+   row's expand/collapse. Sized to match the .tl-expand-actions buttons
+   in chunks-view so the two views feel consistent. */
+.tl-file-open-source {
+  font-size: 0.7rem; padding: 2px 8px; background: none;
+  border: 1px solid var(--accent); color: var(--accent);
+  border-radius: var(--radius); cursor: pointer; flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.tl-file-open-source:hover {
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+/* Source-tab chunk card flash for Timeline → Source navigation. The
+   target chunk is scrolled into view and pulsed once so the user can
+   spot which card was the navigation target among the ~100-chunk list.
+   Reuses the same accent-on-surface palette as .tl-date-flash. */
+@keyframes tl-target-flash {
+  0%   { background: color-mix(in srgb, var(--accent) 30%, var(--surface)); }
+  100% { background: transparent; }
+}
+.chunk-card.tl-target-flash { animation: tl-target-flash 1.4s ease-out; }
+
 /* ── Graph ── */
 .graph-controls {
   display: flex; align-items: center; gap: 16px; flex-wrap: wrap;

--- a/packages/memtomem/src/memtomem/web/static/timeline.js
+++ b/packages/memtomem/src/memtomem/web/static/timeline.js
@@ -185,6 +185,8 @@ function renderChunkView(list, groups) {
       const time = c.created_at.slice(11, 16); // HH:MM
       const tagsHtml = c.tags.map(t => `<span class="timeline-tag">${escapeHtml(t)}</span>`).join('');
       const dot = `<span class="tl-type-dot" style="background:${fileTypeColor(c.source_file)}"></span>`;
+      const openLabel = (typeof t === 'function')
+        ? t('timeline.open_in_source') : 'Open in source';
       item.innerHTML = `
         <div class="timeline-item-header">
           <span class="timeline-item-source">${dot}${escapeHtml(truncate(c.source_file, 60))}</span>
@@ -193,11 +195,11 @@ function renderChunkView(list, groups) {
         <div class="timeline-item-snippet">${escapeHtml(c.content)}</div>
         <div class="tl-expand-tags">${tagsHtml}</div>
         <div class="tl-expand-actions">
-          <button class="tl-btn-open">Open</button>
+          <button class="tl-btn-open" data-i18n="timeline.open_in_source">${escapeHtml(openLabel)}</button>
           <button class="tl-btn-copy">Copy</button>
         </div>
       `;
-      // (C) Inline expansion: first click expand/collapse, "Open" button navigates
+      // (C) Inline expansion: first click expand/collapse, action buttons navigate
       item.addEventListener('click', (e) => {
         // If click is on an action button, handle separately
         if (e.target.closest('.tl-expand-actions')) return;
@@ -206,7 +208,7 @@ function renderChunkView(list, groups) {
       });
       item.querySelector('.tl-btn-open').addEventListener('click', (e) => {
         e.stopPropagation();
-        showDetailFromChunk(c);
+        _navigateToSource(c.source_file, c.id);
       });
       item.querySelector('.tl-btn-copy').addEventListener('click', (e) => {
         e.stopPropagation();
@@ -255,13 +257,20 @@ function renderFileView(list, groups) {
       const header = document.createElement('div');
       header.className = 'timeline-file-header';
       const dot = `<span class="tl-type-dot" style="background:${fileTypeColor(filePath)}"></span>`;
+      const openSourceLabel = (typeof t === 'function')
+        ? t('timeline.open_in_source') : 'Open in source';
       header.innerHTML = `
         <span class="tl-file-chevron">▶</span>
         ${dot}<span class="timeline-file-name" title="${escapeHtml(filePath)}">${escapeHtml(fname)}</span>
         <span class="timeline-file-dir">${escapeHtml(truncate(fdir, 50))}</span>
         <span class="tl-file-count">${fileChunks.length}</span>
         <span class="tl-file-time">${lastTime}</span>
+        <button class="tl-file-open-source" data-i18n="timeline.open_in_source">${escapeHtml(openSourceLabel)}</button>
       `;
+      header.querySelector('.tl-file-open-source').addEventListener('click', (e) => {
+        e.stopPropagation();
+        _navigateToSource(filePath);
+      });
       fileItem.appendChild(header);
 
       const preview = document.createElement('div');
@@ -286,7 +295,7 @@ function renderFileView(list, groups) {
           <div class="tl-fci-snippet">${escapeHtml(truncate(c.content, 150))}</div>
           ${tagsHtml ? `<div class="timeline-item-tags">${tagsHtml}</div>` : ''}
         `;
-        ci.addEventListener('click', e => { e.stopPropagation(); showDetailFromChunk(c); });
+        ci.addEventListener('click', e => { e.stopPropagation(); _navigateToSource(c.source_file, c.id); });
         chunkList.appendChild(ci);
       }
       fileItem.appendChild(chunkList);


### PR DESCRIPTION
## Summary

Timeline tab's chunk/file clicks now jump to the **Source** tab instead of
opening Search's detail panel. Search's left-side results pane stays empty
unless the user actually ran a search, so jumping there from Timeline left
a populated detail floating next to a "Enter a query to search" placeholder
— readable as orphaned. Source already has Copy / Edit / Delete on every
chunk, and the cross-tab navigation plumbing landed in #673 + #674
(`_navigateToSource(path)`, vendor sub-tab follow-through, pending-activate
handoff). This PR reuses it from Timeline.

- `_navigateToSource` gains an optional `chunkId`. `STATE.pendingActivate
  ChunkId` is consumed in `browseSource` after the chunk list lands —
  scrolls the matching `.chunk-card[data-chunk-id="…"]` into view, expands
  it if collapsible, pulses `.tl-target-flash` for ~1.4s. Empty chunkId =
  source-level jump only (no flash) — keeps the Home-recent and
  command-palette callers behaving exactly as before.
- Timeline call sites:
  - **Chunks view** "Open" button → `_navigateToSource(c.source_file, c.id)`.
    Label moves from hard-coded "Open" to `timeline.open_in_source` (en
    "Open in source" / ko "소스에서 보기").
  - **Files view file header** gets a small ghost-style `.tl-file-open-
    source` button on the right edge — `stopPropagation`'d so the row's
    existing expand/collapse still works for header non-button clicks.
    No chunkId (file headers don't carry a single canonical chunk).
  - **Files view per-chunk row** click → `_navigateToSource(c.source_file,
    c.id)`.
- `showDetailFromChunk` is **kept** — `app.js:4834` still uses it for
  the Source-chunks side panel inside Search detail (intra-detail "jump to
  a sibling chunk in the same source"), which is a separate flow. Timeline
  call sites are the only ones moving.

Cache-bust per `feedback_static_asset_cache_bust.md` — `style.css v=72→73`,
`app.js v=87→88`, `timeline.js v=1→2` (all three have body changes).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -q` — 12 passed
      (locale parity holds: new key in both en + ko).
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] Manual via Playwright MCP against `mm web`:
  - Chunks-view "Open in source" → `tab=sources`, exactly one
    `.chunk-card.tl-target-flash` on the matching `data-chunk-id`, first
    flash observed ~205ms after click then auto-removed at 1.4s.
  - Files-view header button → `tab=sources`, no chunk flash (intended).
  - Files-view header non-button click → expand/collapse only, tab
    unchanged. `stopPropagation` on the new button confirmed.
  - KO label "소스에서 보기" rendered on first paint via `data-i18n` +
    langchange wiring (already covered since #587).
- [ ] Cross-vendor smoke (claude / openai sources from Timeline) — same
      `_navigateToSource` path used by #673; verified above on user-vendor
      sources, confidence-by-symmetry on the other two but worth a manual
      eyeball post-merge.
- [ ] Cold-load (Source tab never visited in this session) — same
      pendingActivate handoff path proved out for the Home-recent flow in
      #674; mechanically identical here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
