### PR TITLE
fix(web): bucket Timeline by local date instead of UTC slice

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1302,7 +1302,7 @@
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=1"></script>
-  <script src="/timeline.js?v=1"></script>
+  <script src="/timeline.js?v=2"></script>
   <script src="/context-gateway.js?v=5"></script>
   <script src="/path-picker.js?v=1"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/timeline.js
+++ b/packages/memtomem/src/memtomem/web/static/timeline.js
@@ -11,6 +11,22 @@
 let tlViewMode = 'chunks';
 let currentTlChunks = null;
 
+// created_at arrives as a UTC ISO string. Slicing the literal string would
+// bucket chunks by UTC calendar date, so users east of UTC see entries land
+// on the previous day for hours after local midnight (and times display in
+// UTC). Convert to the browser's local zone before grouping/displaying.
+function localDateKey(iso) {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+function localTimeShort(iso) {
+  const d = new Date(iso);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
 function resetTimelinePanel() {
   hide(qs('tl-list'));
   hide(qs('tl-heatmap'));
@@ -75,8 +91,8 @@ async function loadTimeline() {
     if (daysVal === 'custom') {
       const fromVal = qs('tl-date-from').value;
       const toVal = qs('tl-date-to').value;
-      if (fromVal) chunks = chunks.filter(c => c.created_at.slice(0, 10) >= fromVal);
-      if (toVal) chunks = chunks.filter(c => c.created_at.slice(0, 10) <= toVal);
+      if (fromVal) chunks = chunks.filter(c => localDateKey(c.created_at) >= fromVal);
+      if (toVal) chunks = chunks.filter(c => localDateKey(c.created_at) <= toVal);
     }
     currentTlChunks = chunks;
     renderTimeline(chunks);
@@ -101,7 +117,7 @@ function renderTimeline(chunks) {
   // Group by calendar date (created_at)
   const groups = new Map();
   for (const c of chunks) {
-    const date = c.created_at.slice(0, 10); // YYYY-MM-DD
+    const date = localDateKey(c.created_at); // local YYYY-MM-DD
     if (!groups.has(date)) groups.set(date, []);
     groups.get(date).push(c);
   }
@@ -182,7 +198,7 @@ function renderChunkView(list, groups) {
     for (const c of items) {
       const item = document.createElement('div');
       item.className = 'timeline-item';
-      const time = c.created_at.slice(11, 16); // HH:MM
+      const time = localTimeShort(c.created_at); // local HH:MM
       const tagsHtml = c.tags.map(t => `<span class="timeline-tag">${escapeHtml(t)}</span>`).join('');
       const dot = `<span class="tl-type-dot" style="background:${fileTypeColor(c.source_file)}"></span>`;
       item.innerHTML = `
@@ -245,7 +261,7 @@ function renderFileView(list, groups) {
 
     for (const [filePath, fileChunks] of fileGroups) {
       const sorted = [...fileChunks].sort((a, b) => a.created_at.localeCompare(b.created_at));
-      const lastTime = sorted[sorted.length - 1].created_at.slice(11, 16);
+      const lastTime = localTimeShort(sorted[sorted.length - 1].created_at);
       const fname = basename(filePath);
       const fdir = filePath.slice(0, filePath.length - fname.length - 1) || '/';
 
@@ -276,7 +292,7 @@ function renderFileView(list, groups) {
       for (const c of sorted) {
         const ci = document.createElement('div');
         ci.className = 'tl-file-chunk-item';
-        const time = c.created_at.slice(11, 16);
+        const time = localTimeShort(c.created_at);
         const tagsHtml = c.tags.map(t => `<span class="timeline-tag">${escapeHtml(t)}</span>`).join('');
         ci.innerHTML = `
           <div class="tl-fci-header">


### PR DESCRIPTION
## Summary

The Timeline tab grouped chunks by date with `c.created_at.slice(0, 10)`, which slices the literal UTC ISO string. For users east of UTC (e.g. KST, UTC+9), any chunk created between local midnight and the UTC offset (00:00–09:00 KST) was filed under the previous calendar day, and the per-chunk `HH:MM` display was UTC, not local.

This routes the chunk view, file view, and custom-range filter through new `localDateKey` / `localTimeShort` helpers that round-trip through `new Date(iso)` so the browser's local zone drives both bucketing and display.

The heatmap re-parse (`new Date(date + 'T00:00:00')`) is unchanged because its input is now already a local date key — the round-trip stays consistent.

## Verified

Against `~/.memtomem` timeline data (last 2 days, 500 chunks) at KST 09:11 on 2026-05-02:

| | OLD (UTC slice) | NEW (local) |
|---|---|---|
| 2026-05-01 | 481 | 447 |
| 2026-05-02 | 19 | **53** |

34 chunks added in KST 08:xx (UTC 23:xx 2026-05-01) now correctly group under "today" instead of "yesterday."

`index.html` cache-buster bumped `timeline.js?v=1` → `?v=2` so existing browser sessions pick up the new code.

## Test plan

- [ ] Manual: open Timeline tab in a `+09:00` (or any non-UTC) zone; chunks added between local 00:00 and the UTC offset land under today's date with correct local `HH:MM`.
- [ ] Manual: switch View to "Files" — last-seen times reflect local clock.
- [ ] Manual: Custom range filter `from`/`to` (HTML date inputs are local) groups chunks consistent with the heatmap selection.
- [ ] `node --check` clean (verified).
- [ ] No backend change; `recall_chunks` window remains UTC-based, which can leave the earliest day of the requested window partially populated by ≤ TZ-offset hours. Acceptable trade-off; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
