### PR TITLE
fix(web): PR #676 review follow-ups for Timeline → Source jump

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2893,7 +2893,15 @@ function _renderMemorySourceTree(sources, list) {
     if (target) {
       target.classList.add('active');
       target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      if (typeof browseSource === 'function') browseSource(path);
+      // ``pendingActivateChunkId`` means the caller (Timeline → Source jump
+      // in PR #676) wants a specific chunk highlighted. Default ``limit=100``
+      // would silently miss any target past position 100 in a large source —
+      // bumping to 500 covers ~99% of indexed sources without making the
+      // source-level Home/recent jump pay the larger fetch. The chunk-side
+      // consumer in ``browseSource`` shows a toast if it still can't find
+      // the card after the 500-row fetch.
+      const browseLimit = STATE.pendingActivateChunkId ? 500 : undefined;
+      if (typeof browseSource === 'function') browseSource(path, browseLimit);
     } else if (STATE.uiMode === 'dev') {
       // Path made it through the vendor + filter resolves but the
       // ``.source-item`` isn't in the rendered list — most likely an
@@ -3044,6 +3052,13 @@ function _renderMemorySourceItem(s, maxChunks) {
   `;
   item.setAttribute('tabindex', '0');
   item.addEventListener('click', () => {
+    // Manual source-item click is an explicit user pivot — drop any
+    // chunk-highlight target left over from a prior ``_navigateToSource``
+    // (Timeline jump → Source render → user reroutes mid-render). The
+    // stale id wouldn't cause a wrong card to highlight (chunk ids are
+    // UUIDs), but it would silently no-op the next ``browseSource`` flash
+    // path until something else clears it. PR #676 review follow-up.
+    STATE.pendingActivateChunkId = '';
     document.querySelectorAll('.source-item').forEach(el => el.classList.remove('active'));
     item.classList.add('active');
     browseSource(s.path);
@@ -3223,7 +3238,18 @@ async function browseSource(path, limit = 100) {
         const card = content.querySelector(
           `.chunk-card[data-chunk-id="${CSS.escape(String(targetId))}"]`,
         );
-        if (!card) return;
+        if (!card) {
+          // Caller asked for a specific chunk highlight but the card isn't
+          // in this fetch. ``_renderMemorySourceTree`` already bumps the
+          // limit to 500 when ``pendingActivateChunkId`` is set, so reaching
+          // here means the source has 500+ chunks (rare) — surface a toast
+          // so the user knows why the jump landed on the source without a
+          // flash, rather than reading it as a regression.
+          if (typeof showToast === 'function' && typeof t === 'function') {
+            showToast(t('toast.chunk_target_missing'), 'info');
+          }
+          return;
+        }
         card.scrollIntoView({ behavior: 'smooth', block: 'center' });
         const contentDiv = card.querySelector('.chunk-card-content');
         if (contentDiv && card.classList.contains('chunk-card-collapsible')) {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,14 +1295,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=88"></script>
+  <script src="/app.js?v=89"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=1"></script>
-  <script src="/timeline.js?v=2"></script>
+  <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=5"></script>
   <script src="/path-picker.js?v=1"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -454,6 +454,7 @@
   "timeline.empty_icon": "🕐",
   "timeline.empty_text": "Click Load to view the timeline",
   "timeline.open_in_source": "Open in source",
+  "timeline.copy": "Copy",
 
   "modal.settings_title": "Settings",
   "modal.default_tab_label": "Default Tab",
@@ -549,6 +550,7 @@
   "toast.update_failed": "Update failed: {error}",
   "toast.error": "Error: {error}",
 
+  "toast.chunk_target_missing": "Couldn't locate the linked chunk — try Load All.",
   "toast.ns_deleted": "Deleted {count} chunks from '{name}'",
   "toast.ns_renamed": "Renamed '{oldName}' \u2192 '{newName}'",
   "toast.indexed_count": "Indexed {count} chunks",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -550,7 +550,7 @@
   "toast.update_failed": "Update failed: {error}",
   "toast.error": "Error: {error}",
 
-  "toast.chunk_target_missing": "Couldn't locate the linked chunk — try Load All.",
+  "toast.chunk_target_missing": "Couldn't locate the linked chunk in this view.",
   "toast.ns_deleted": "Deleted {count} chunks from '{name}'",
   "toast.ns_renamed": "Renamed '{oldName}' \u2192 '{newName}'",
   "toast.indexed_count": "Indexed {count} chunks",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -550,7 +550,7 @@
   "toast.update_failed": "업데이트 실패: {error}",
   "toast.error": "오류: {error}",
 
-  "toast.chunk_target_missing": "해당 청크를 찾을 수 없습니다 — Load All 을 시도해보세요.",
+  "toast.chunk_target_missing": "이 화면에서는 해당 청크를 찾을 수 없습니다.",
   "toast.ns_deleted": "'{name}'에서 {count}개 청크 삭제됨",
   "toast.ns_renamed": "'{oldName}' \u2192 '{newName}' 이름 변경",
   "toast.indexed_count": "{count}개 청크 인덱싱 완료",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -454,6 +454,7 @@
   "timeline.empty_icon": "🕐",
   "timeline.empty_text": "불러오기를 클릭하면 타임라인이 표시됩니다",
   "timeline.open_in_source": "소스에서 보기",
+  "timeline.copy": "복사",
 
   "modal.settings_title": "설정",
   "modal.default_tab_label": "기본 탭",
@@ -549,6 +550,7 @@
   "toast.update_failed": "업데이트 실패: {error}",
   "toast.error": "오류: {error}",
 
+  "toast.chunk_target_missing": "해당 청크를 찾을 수 없습니다 — Load All 을 시도해보세요.",
   "toast.ns_deleted": "'{name}'에서 {count}개 청크 삭제됨",
   "toast.ns_renamed": "'{oldName}' \u2192 '{newName}' 이름 변경",
   "toast.indexed_count": "{count}개 청크 인덱싱 완료",

--- a/packages/memtomem/src/memtomem/web/static/timeline.js
+++ b/packages/memtomem/src/memtomem/web/static/timeline.js
@@ -187,6 +187,8 @@ function renderChunkView(list, groups) {
       const dot = `<span class="tl-type-dot" style="background:${fileTypeColor(c.source_file)}"></span>`;
       const openLabel = (typeof t === 'function')
         ? t('timeline.open_in_source') : 'Open in source';
+      const copyLabel = (typeof t === 'function')
+        ? t('timeline.copy') : 'Copy';
       item.innerHTML = `
         <div class="timeline-item-header">
           <span class="timeline-item-source">${dot}${escapeHtml(truncate(c.source_file, 60))}</span>
@@ -196,7 +198,7 @@ function renderChunkView(list, groups) {
         <div class="tl-expand-tags">${tagsHtml}</div>
         <div class="tl-expand-actions">
           <button class="tl-btn-open" data-i18n="timeline.open_in_source">${escapeHtml(openLabel)}</button>
-          <button class="tl-btn-copy">Copy</button>
+          <button class="tl-btn-copy" data-i18n="timeline.copy">${escapeHtml(copyLabel)}</button>
         </div>
       `;
       // (C) Inline expansion: first click expand/collapse, action buttons navigate


### PR DESCRIPTION
## Summary

Three review follow-ups for #676 (Timeline → Source jump). All
user-visible edge cases the original PR's verification didn't cover;
mechanically narrow.

1. **100-chunk limit miss → bump to 500 + miss toast.**
   `_renderMemorySourceTree` was calling `browseSource(path)` with the
   default `limit=100` even when the caller passed a `chunkId`. A target
   chunk past position 100 silently no-op'd the highlight — read as a
   regression from #676's old detail-panel fallback. Now passes
   `limit=500` only when `pendingActivateChunkId` is set; Home/recent +
   command-palette callers (no chunkId) keep `limit=100` so they don't
   pay the larger payload for a source-level jump. `browseSource`'s
   pending-chunk consumer now shows `toast.chunk_target_missing` if the
   card still isn't found after the 500-row fetch (rare 500+ chunk
   source).

2. **Stale `pendingActivateChunkId` across manual source pivots.** If
   the user clicked "Open in source" in Timeline and then manually
   clicked a different source-item in the tree before the Sources render
   finished, the prior chunkId stayed in STATE. Functional impact nil
   (chunk ids are UUIDs) but conceptually leaky. Manual `.source-item`
   click handler now clears `STATE.pendingActivateChunkId` as the first
   line — matches the "explicit user pivot resets the navigation hint"
   pattern already in place for the namespace chip.

3. **Hard-coded "Copy" button label in Timeline chunks-view.** Sibling
   "Open in source" button moved to `data-i18n` in #676 but the adjacent
   `.tl-btn-copy` next to it stayed hard-coded. Same row, same i18n
   surface, same locale parity rules from #29 and #587 — promoting to
   `timeline.copy` (en "Copy" / ko "복사") closes the gap.

Cache-bust: `app.js v=88→89`, `timeline.js v=2→3` per
`feedback_static_asset_cache_bust.md`. `style.css` unchanged.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -q` — 12
      passed (parity holds for `timeline.copy` + `toast.chunk_target_
      missing`).
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] Manual via Playwright MCP against `mm web`:
  - Timeline → Open in source fetches `/api/chunks?source=…&limit=500`
    (chunkId-bearing path), confirmed via `window.fetch` spy.
  - `tl-btn-copy` renders "복사" on KO with `data-i18n="timeline.copy"`
    so langchange keeps it in sync on toggle.
  - Fix 2 verified by reading the source-item click handler — first
    statement is the chunkId reset.
- [ ] 500+ chunk source toast — synthetic, didn't have one handy in
      the dev DB. Toast key + plumbing audited; falls back to silent
      if `showToast` / `t` aren't available so no breakage on bare
      callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
