### PR TITLE
fix(web): bucket Home activity heatmap by local date too

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -288,6 +288,25 @@ function relativeTime(dateStr) {
   return t('time.relative.years_ago', { y: Math.floor(mo / 12) });
 }
 
+// Bucketing/display by chunk timestamp must reflect the browser's local
+// zone, not the literal UTC ISO string. Slicing ``created_at.slice(0,10)``
+// puts users east of UTC into the previous calendar day for hours after
+// local midnight (and shifts ``HH:MM`` by the offset). Both helpers
+// round-trip through ``new Date(iso)`` so callers — Timeline grouping,
+// Timeline ``HH:MM`` display, Home activity heatmap counts — share one
+// local-zone source of truth.
+function localDateKey(iso) {
+  const d = new Date(iso);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+function localTimeShort(iso) {
+  const d = new Date(iso);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
 // ── Temporal-validity badge (RFC §Goal 7) ──
 // Renders ``Valid: 2025-08-15 → 2026-03-31`` (∞ for unbounded sides) when
 // either bound is set. Always-valid chunks (both bounds null) hide the
@@ -1074,8 +1093,9 @@ function _renderActivityMap(chunks) {
   // Count chunks per date
   const countByDate = {};
   chunks.forEach(c => {
-    const key = (c.created_at || '').slice(0, 10);
-    if (key) countByDate[key] = (countByDate[key] || 0) + 1;
+    if (!c.created_at) return;
+    const key = localDateKey(c.created_at);
+    countByDate[key] = (countByDate[key] || 0) + 1;
   });
 
   // Start from Sunday before 364 days ago

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,14 +1295,14 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=88"></script>
+  <script src="/app.js?v=89"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=1"></script>
-  <script src="/timeline.js?v=2"></script>
+  <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=5"></script>
   <script src="/path-picker.js?v=1"></script>
 </body>

--- a/packages/memtomem/src/memtomem/web/static/timeline.js
+++ b/packages/memtomem/src/memtomem/web/static/timeline.js
@@ -11,21 +11,9 @@
 let tlViewMode = 'chunks';
 let currentTlChunks = null;
 
-// created_at arrives as a UTC ISO string. Slicing the literal string would
-// bucket chunks by UTC calendar date, so users east of UTC see entries land
-// on the previous day for hours after local midnight (and times display in
-// UTC). Convert to the browser's local zone before grouping/displaying.
-function localDateKey(iso) {
-  const d = new Date(iso);
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
-}
-function localTimeShort(iso) {
-  const d = new Date(iso);
-  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
-}
+// localDateKey / localTimeShort live in app.js (loaded first) so the
+// Home activity heatmap can share the same local-zone helpers. See the
+// comment block above their definition.
 
 function resetTimelinePanel() {
   hide(qs('tl-list'));


### PR DESCRIPTION
## Summary

Follow-up to #677 — same UTC-slice trap in `_renderActivityMap` (Home tab GitHub-style 364-day heatmap):

```js
// before
const key = (c.created_at || '').slice(0, 10);
countByDate[key] = ...
```

`countByDate` is keyed by UTC date strings, but the cell-iteration loop builds keys from local date components (`getFullYear/getMonth+1/getDate`). For users east of UTC, chunks created in the local 00:00–TZ-offset window land on the previous day's cell while the current day's cell undercounts.

This promotes `localDateKey` / `localTimeShort` from `timeline.js` to `app.js` so both consumers share one local-zone source of truth, and routes the heatmap counter through `localDateKey`.

## Notes

- `app.js` loads before `timeline.js` (per `index.html`), so Timeline keeps referencing the names without redeclaration.
- With two callsites a dedicated `utils/date.js` would be premature; helpers live next to the existing `relativeTime` date helper.
- Cache-bust bumped: `app.js?v=88 → ?v=89`, `timeline.js?v=2 → ?v=3`.
- Same data behavior already verified end-to-end in #677 (boundary chunks at UTC 23:xx → local next-day 08:xx move to the correct bucket). The Home heatmap consumes the identical `/api/timeline` chunks via `_renderActivityMap`, so the fix is mechanically equivalent — no separate quantitative re-run needed.

## Test plan

- [ ] Manual: Home tab activity heatmap in a `+09:00` (or any non-UTC) zone — chunks added between local 00:00 and the UTC offset count toward today's cell, not yesterday's.
- [ ] Manual: Timeline tab unchanged in behavior (helpers moved, callsites identical).
- [ ] `node --check` clean (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
