### PR TITLE
feat(web): jump from Home heatmap to Timeline tab on cell click

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1162,7 +1162,14 @@ function _renderActivityMap(chunks) {
       html += '<div class="activity-cell activity-empty"></div>';
     } else {
       const level = getLevel(cell.count);
-      html += `<div class="activity-cell activity-cell-link" data-level="${level}" data-date="${cell.date}" role="button" tabindex="0" title="${cell.date}: ${cell.count}"></div>`;
+      const ariaKey = cell.count === 1
+        ? 'home.activity.cell_aria_one'
+        : 'home.activity.cell_aria_other';
+      const ariaRaw = (typeof t === 'function')
+        ? t(ariaKey, { date: cell.date, count: cell.count })
+        : `${cell.date}, ${cell.count} chunks. View in Timeline.`;
+      const ariaSafe = ariaRaw.replace(/"/g, '&quot;');
+      html += `<div class="activity-cell activity-cell-link" data-level="${level}" data-date="${cell.date}" role="button" tabindex="0" title="${cell.date}: ${cell.count}" aria-label="${ariaSafe}"></div>`;
     }
   });
   html += '</div>';

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1162,12 +1162,46 @@ function _renderActivityMap(chunks) {
       html += '<div class="activity-cell activity-empty"></div>';
     } else {
       const level = getLevel(cell.count);
-      html += `<div class="activity-cell" data-level="${level}" title="${cell.date}: ${cell.count}"></div>`;
+      html += `<div class="activity-cell activity-cell-link" data-level="${level}" data-date="${cell.date}" role="button" tabindex="0" title="${cell.date}: ${cell.count}"></div>`;
     }
   });
   html += '</div>';
 
   map.innerHTML = html;
+
+  // Wire cell click / Enter / Space to jump into the Timeline tab,
+  // pre-filled with a single-day custom range. Future / before-range
+  // cells are rendered without the .activity-cell-link class so they
+  // never receive a handler.
+  map.querySelectorAll('.activity-cell-link').forEach(cell => {
+    const date = cell.dataset.date;
+    const trigger = () => _jumpToTimelineDate(date);
+    cell.addEventListener('click', trigger);
+    cell.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        trigger();
+      }
+    });
+  });
+}
+
+function _jumpToTimelineDate(dateKey) {
+  const tlDays = qs('tl-days');
+  const tlCustom = qs('tl-date-custom');
+  const tlFrom = qs('tl-date-from');
+  const tlTo = qs('tl-date-to');
+  if (tlDays && tlCustom && tlFrom && tlTo) {
+    tlDays.value = 'custom';
+    tlCustom.hidden = false;
+    tlFrom.value = dateKey;
+    tlTo.value = dateKey;
+    const tlSource = qs('tl-source');
+    const tlNs = qs('tl-namespace');
+    if (tlSource) tlSource.value = '';
+    if (tlNs) tlNs.value = '';
+  }
+  activateTab('timeline');
 }
 
 // D. File Type Distribution

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=90"></script>
+  <script src="/app.js?v=91"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=73" />
+  <link rel="stylesheet" href="/style.css?v=74" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
 </head>
 <body>
@@ -1295,7 +1295,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=89"></script>
+  <script src="/app.js?v=90"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -28,6 +28,8 @@
   "home.section.namespaces": "Namespaces",
   "home.section.file_types": "File Types",
   "home.section.activity": "Activity (1 year)",
+  "home.activity.cell_aria_one": "{date}, {count} chunk. Click to view in Timeline.",
+  "home.activity.cell_aria_other": "{date}, {count} chunks. Click to view in Timeline.",
   "home.section.chunk_sizes": "Chunk Sizes",
   "home.section.chunk_sizes_unit": "(tokens)",
   "home.section.recent_sources": "Recent Sources",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -28,6 +28,8 @@
   "home.section.namespaces": "네임스페이스",
   "home.section.file_types": "파일 유형",
   "home.section.activity": "활동 (1년)",
+  "home.activity.cell_aria_one": "{date}, 청크 {count}개. 클릭하면 타임라인에서 확인합니다.",
+  "home.activity.cell_aria_other": "{date}, 청크 {count}개. 클릭하면 타임라인에서 확인합니다.",
   "home.section.chunk_sizes": "청크 크기",
   "home.section.chunk_sizes_unit": "(토큰)",
   "home.section.recent_sources": "최근 소스",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2130,6 +2130,12 @@ select:focus-visible {
 :root[data-theme="light"] .activity-cell[data-level="2"] { background: #40c463; }
 :root[data-theme="light"] .activity-cell[data-level="3"] { background: #30a14e; }
 :root[data-theme="light"] .activity-cell[data-level="4"] { background: #216e39; }
+.activity-cell-link { cursor: pointer; transition: outline-color 120ms ease; }
+.activity-cell-link:hover { outline: 1px solid var(--accent); outline-offset: 1px; }
+.activity-cell-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
 
 .home-chart-card { min-width: 0; }
 .home-bar-chart { display: flex; flex-direction: column; gap: 6px; }


### PR DESCRIPTION
## Summary

- The 1-year contribution-style heatmap on Home rendered cells with only
  a hover tooltip — clicking a spike required four manual steps in the
  Timeline tab (switch → Custom → From → To → Load) to actually look at
  what happened that day.
- Each in-range cell now jumps to the Timeline tab pre-filled with a
  single-day custom range, leftover `source`/`namespace` filters cleared
  so the global Home view stays global, and the existing tab-switch
  hook fires `loadTimeline()`.
- Future and before-range cells stay non-interactive (gated behind a
  separate `.activity-cell-link` class). Cells gain
  `role="button"`/`tabindex="0"` plus `Enter`/`Space` handlers so the
  jump is keyboard-reachable. CSS adds accent hover + focus outlines so
  the new affordance is discoverable.
- Local-date semantics match PR #677: the Home heatmap and Timeline
  both bucket by local-zone `YYYY-MM-DD`, so cross-zone drift is
  impossible by construction.
- Cache-busts: `app.js?v=89` → `v=90`, `style.css?v=73` → `v=74`.

## Why

Reported in a UX walkthrough — once a user spots a busy day on the
heatmap, the gesture they want is "show me what happened then." This
keeps Home as a launchpad rather than a dead-end visualization, and
hooks cleanly into the Timeline plumbing already in place after PRs
#676–#679.

## Test plan

- [x] `node --check packages/memtomem/src/memtomem/web/static/app.js`
      (parse OK)
- [x] `uv run ruff check packages/memtomem/src` and
      `uv run ruff format --check packages/memtomem/src`
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py`
- [x] Mode 1 (`uv run mm web`) + Playwright MCP: navigate to `/`,
      activate Home, find a non-zero cell. After click:
      - URL hash flips to `#timeline`
      - `#tl-days` value is `custom`
      - `#tl-date-custom` is no longer hidden
      - `#tl-date-from` and `#tl-date-to` both equal the clicked
        `YYYY-MM-DD`
      - `#tl-source` and `#tl-namespace` are cleared
      - `#tl-list` re-renders with `.timeline-date-group` entries
- [ ] Manual: keyboard reach (`Tab` to a cell, `Enter` triggers the
      same jump) and the focus outline is visible against both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
