### PR TITLE
style(web): strengthen btn-active tint and add grip on resize dividers

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=74" />
+  <link rel="stylesheet" href="/style.css?v=75" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
 </head>
 <body>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -354,6 +354,21 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
   transition: background 0.15s; flex-shrink: 0; position: relative;
 }
 .results-divider:hover, .results-divider.dragging { background: var(--accent); }
+.results-divider::before,
+.sources-divider::before {
+  content: ''; position: absolute;
+  left: 50%; top: 50%; transform: translate(-50%, -50%);
+  width: 2px; height: 24px; border-radius: 2px;
+  background: var(--muted); opacity: 0.35;
+  pointer-events: none;
+  transition: opacity 0.15s, background 0.15s;
+}
+.results-divider:hover::before,
+.sources-divider:hover::before,
+.results-divider.dragging::before,
+.sources-divider.dragging::before {
+  background: var(--bg); opacity: 1;
+}
 
 /* Detail code view */
 .detail-code-view {
@@ -526,7 +541,7 @@ mark {
 .sources-sidebar { border-right: none; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
 .sources-divider {
   width: 4px; cursor: col-resize; background: var(--border);
-  transition: background 0.15s; flex-shrink: 0;
+  transition: background 0.15s; flex-shrink: 0; position: relative;
 }
 .sources-divider:hover, .sources-divider.dragging { background: var(--accent); }
 .sources-header { display: flex; align-items: center; justify-content: space-between; }
@@ -2318,7 +2333,11 @@ select:focus-visible {
 #score-threshold { width: 120px; accent-color: var(--accent); cursor: pointer; }
 
 /* ── Sprint 6: Advanced toggle active ── */
-.btn-ghost.btn-active { color: var(--accent); border-color: var(--accent); }
+.btn-ghost.btn-active {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(var(--accent-rgb), 0.1);
+}
 
 /* ── Sprint 6: List view ── */
 #results-list.list-view .result-item { padding: 5px 16px; }


### PR DESCRIPTION
## Summary

Two affordances were technically present but visually quiet enough that
UX walk-through users kept missing them:

1. **`.btn-ghost.btn-active`** only flipped `color` and `border-color`
   to the accent. On dense toolbars (filter toggle, group toggle, view
   toggle) the active border blended with hover/focus, so users could
   not tell at a glance which toggle was on.
2. **`.results-divider` / `.sources-divider`** only revealed
   themselves on hover via a `background` flip. With the cursor
   parked elsewhere there was nothing to suggest the divider was
   draggable, even though the resize handler has been wired up for a
   while.

This PR keeps the existing structure and just paints harder:

- Add a `rgba(var(--accent-rgb), 0.1)` body tint to `btn-active` so the
  filled body matches the existing `.active-filter-chip` visual
  language.
- Add a centred 2×24-px grip pseudo-element to both dividers, muted at
  `opacity: 0.35` while idle and flipped to `var(--bg)` at full
  opacity on hover / drag. `pointer-events: none` keeps the existing
  `col-resize` cursor and drag handler intact.

No JS or HTML structure changes. Cache-bust `style.css?v=73 → v=74`.

## Why

A reviewer's UX report said "filter active state isn't obvious" and
"the resize divider is invisible." Both turn out to be discoverability,
not missing functionality — confirmed by inspection of the existing
listeners in `app.js` (`btn-active` toggle) and the resize handlers
around `results-divider` / `sources-divider`. So the cheapest fix is
better paint, not new behaviour.

## Test plan

- [x] `git diff --stat` confirms only `style.css` and `index.html`
      change (22 insertions, 3 deletions)
- [x] Mode 1 (`uv run mm web`) + Playwright MCP: with
      `style.css?v=74` loaded, applying `btn-active` to
      `#filter-toggle` resolves `background-color` to
      `rgba(108, 143, 255, 0.1)` and the `.results-divider::before`
      pseudo computes `width: 2px / height: 24px / opacity: 0.35`
- [ ] Manual: hover the search detail divider and the sources sidebar
      divider, confirm the grip mark brightens; toggle filter / group
      / view toggles, confirm the filled tint reads as "on"
- [ ] Manual: light theme + dark theme — the grip stays legible in
      both because `var(--muted)` and `var(--bg)` are theme-aware

🤖 Generated with [Claude Code](https://claude.com/claude-code)
