### PR TITLE
fix(embedding): pin fastembed cache to stable path under ~/.memtomem

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/_fastembed_cache.py
+++ b/packages/memtomem/src/memtomem/embedding/_fastembed_cache.py
@@ -1,0 +1,45 @@
+"""Stable cache directory for fastembed model snapshots.
+
+fastembed's default cache lives under ``tempfile.gettempdir()`` (on macOS
+that resolves to ``/var/folders/.../T/fastembed_cache/``), which the OS
+periodically reaps. After a reap, the smaller graph blob (``model.onnx``)
+disappears while the larger weight blob (``model.onnx_data``) — accessed
+recently during reindex — survives, leaving dangling symlinks. fastembed
+then logs ``Local file sizes do not match the metadata`` and ONNX Runtime
+fails with ``NO_SUCHFILE``, silently turning every ``Auto-reindexed`` run
+into ``indexed=0``.
+
+Pin the cache to a stable path so the reaper does not see it.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_DEFAULT_CACHE_PATH = "~/.memtomem/cache/fastembed"
+
+
+def resolve_fastembed_cache_dir() -> Path:
+    """Return the directory fastembed should use for model snapshots.
+
+    Precedence (first non-empty wins):
+
+    1. ``MEMTOMEM_FASTEMBED_CACHE`` — memtomem-specific override.
+    2. ``FASTEMBED_CACHE_PATH`` — fastembed's own convention; honoured so
+       users who already set it for other tools see consistent behaviour.
+    3. ``~/.memtomem/cache/fastembed`` — default, alongside the rest of the
+       memtomem state under ``~/.memtomem/``.
+
+    The directory is created if missing — fastembed expects to be able to
+    write into it on first use.
+    """
+    for env in ("MEMTOMEM_FASTEMBED_CACHE", "FASTEMBED_CACHE_PATH"):
+        raw = os.environ.get(env)
+        if raw:
+            path = Path(raw).expanduser()
+            break
+    else:
+        path = Path(_DEFAULT_CACHE_PATH).expanduser()
+    path.mkdir(parents=True, exist_ok=True)
+    return path

--- a/packages/memtomem/src/memtomem/embedding/fastembed_cache.py
+++ b/packages/memtomem/src/memtomem/embedding/fastembed_cache.py
@@ -37,9 +37,21 @@ def resolve_fastembed_cache_dir() -> Path:
     for env in ("MEMTOMEM_FASTEMBED_CACHE", "FASTEMBED_CACHE_PATH"):
         raw = os.environ.get(env)
         if raw:
-            path = Path(raw).expanduser()
+            raw_path = raw
             break
     else:
-        path = Path(_DEFAULT_CACHE_PATH).expanduser()
+        raw_path = _DEFAULT_CACHE_PATH
+    # ``Path.expanduser()`` raises ``RuntimeError("Could not determine home
+    # directory.")`` on Python 3.12+ when ``~`` cannot be resolved (no
+    # ``$HOME`` and no pwent — happens in some container/CI setups). Wrap
+    # that in a message that names the env vars the operator can set.
+    try:
+        path = Path(raw_path).expanduser()
+    except RuntimeError as exc:
+        raise RuntimeError(
+            f"fastembed cache path {raw_path!r} could not be expanded — "
+            "$HOME is unset and no pwent is available. Set MEMTOMEM_FASTEMBED_CACHE "
+            "to an absolute path, or ensure $HOME is set in the environment."
+        ) from exc
     path.mkdir(parents=True, exist_ok=True)
     return path

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from typing import Sequence
 
 from memtomem.config import EmbeddingConfig
-from memtomem.embedding._fastembed_cache import resolve_fastembed_cache_dir
+from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
 from memtomem.errors import EmbeddingError
 
 logger = logging.getLogger(__name__)

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from typing import Sequence
 
 from memtomem.config import EmbeddingConfig
+from memtomem.embedding._fastembed_cache import resolve_fastembed_cache_dir
 from memtomem.errors import EmbeddingError
 
 logger = logging.getLogger(__name__)
@@ -85,12 +86,14 @@ class OnnxEmbedder:
         # threads=0 → leave ORT default (all physical cores); threads>0 caps
         # the intra-op pool so seeding doesn't saturate the machine.
         threads = self._config.threads or None
+        cache_dir = resolve_fastembed_cache_dir()
         logger.info(
-            "Loading ONNX embedding model %s (threads=%s) …",
+            "Loading ONNX embedding model %s (threads=%s, cache_dir=%s) …",
             model_id,
             threads if threads is not None else "ORT default",
+            cache_dir,
         )
-        self._model = TextEmbedding(model_name=model_id, threads=threads)
+        self._model = TextEmbedding(model_name=model_id, threads=threads, cache_dir=str(cache_dir))
         return self._model
 
     @property

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
+
 if TYPE_CHECKING:
     from memtomem.config import RerankConfig
     from memtomem.models import SearchResult
@@ -41,9 +43,12 @@ class FastEmbedReranker:
                 "Install it with: pip install memtomem[onnx]"
             ) from exc
 
-        from memtomem.embedding._fastembed_cache import resolve_fastembed_cache_dir
-
         cache_dir = resolve_fastembed_cache_dir()
+        logger.info(
+            "Loading fastembed reranker %s (cache_dir=%s) …",
+            self._config.model,
+            cache_dir,
+        )
         try:
             self._model = TextCrossEncoder(model_name=self._config.model, cache_dir=str(cache_dir))
         except ValueError as exc:
@@ -57,7 +62,6 @@ class FastEmbedReranker:
                 "must be registered via TextCrossEncoder.add_custom_model() before the "
                 "reranker is invoked."
             ) from exc
-        logger.info("Loaded fastembed reranker: %s", self._config.model)
         return self._model
 
     def _rerank_sync(self, query: str, documents: list[str]) -> list[float]:

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -19,7 +19,8 @@ class FastEmbedReranker:
     Runs on the CPU via ONNX Runtime — no external server and no PyTorch
     dependency. Reuses the ``memtomem[onnx]`` extra so enabling this provider
     adds no new packages. The model is downloaded on first use and cached in
-    ``~/.cache/fastembed/``.
+    the path returned by ``resolve_fastembed_cache_dir()`` (default
+    ``~/.memtomem/cache/fastembed``).
     """
 
     def __init__(self, config: RerankConfig) -> None:
@@ -40,8 +41,11 @@ class FastEmbedReranker:
                 "Install it with: pip install memtomem[onnx]"
             ) from exc
 
+        from memtomem.embedding._fastembed_cache import resolve_fastembed_cache_dir
+
+        cache_dir = resolve_fastembed_cache_dir()
         try:
-            self._model = TextCrossEncoder(model_name=self._config.model)
+            self._model = TextCrossEncoder(model_name=self._config.model, cache_dir=str(cache_dir))
         except ValueError as exc:
             supported = [m.get("model", "") for m in TextCrossEncoder.list_supported_models()]
             raise ValueError(

--- a/packages/memtomem/tests/test_fastembed_cache.py
+++ b/packages/memtomem/tests/test_fastembed_cache.py
@@ -1,4 +1,4 @@
-"""Tests for ``embedding._fastembed_cache.resolve_fastembed_cache_dir``.
+"""Tests for ``embedding.fastembed_cache.resolve_fastembed_cache_dir``.
 
 The helper exists to keep the fastembed model snapshot out of macOS's
 periodically-reaped ``/var/folders/.../T/`` tempdir (see the module
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from memtomem.embedding._fastembed_cache import resolve_fastembed_cache_dir
+from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
 
 
 def test_default_is_under_memtomem_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -78,3 +78,29 @@ def test_tilde_in_env_is_expanded(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
 
     assert resolved == tmp_path / "custom-cache"
     assert resolved.is_dir()
+
+
+def test_unexpandable_home_raises_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``$HOME`` is unset and pwent lookup fails, ``Path.expanduser()`` on
+    Python 3.12+ raises ``RuntimeError("Could not determine home directory.")``
+    — a correct fail-fast but with no hint at how to fix it. Wrap the error
+    in a message that names the env vars the operator can set."""
+    import pwd
+
+    monkeypatch.delenv("MEMTOMEM_FASTEMBED_CACHE", raising=False)
+    monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+
+    def _no_pwent(_uid: int) -> object:
+        raise KeyError("simulated missing pwent")
+
+    monkeypatch.setattr(pwd, "getpwuid", _no_pwent)
+    # Precondition: bare expanduser surfaces the unhelpful Python error.
+    with pytest.raises(RuntimeError, match="Could not determine home directory"):
+        Path("~/foo").expanduser()
+
+    with pytest.raises(RuntimeError, match="MEMTOMEM_FASTEMBED_CACHE") as excinfo:
+        resolve_fastembed_cache_dir()
+    # Original Python error is preserved as __cause__ for debugging.
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert not (Path.cwd() / "~").exists(), "wrap must happen before mkdir"

--- a/packages/memtomem/tests/test_fastembed_cache.py
+++ b/packages/memtomem/tests/test_fastembed_cache.py
@@ -1,0 +1,80 @@
+"""Tests for ``embedding._fastembed_cache.resolve_fastembed_cache_dir``.
+
+The helper exists to keep the fastembed model snapshot out of macOS's
+periodically-reaped ``/var/folders/.../T/`` tempdir (see the module
+docstring for the failure mode). These tests pin the precedence rules and
+the directory-creation contract; they do not exercise fastembed itself.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.embedding._fastembed_cache import resolve_fastembed_cache_dir
+
+
+def test_default_is_under_memtomem_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.delenv("MEMTOMEM_FASTEMBED_CACHE", raising=False)
+    monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    resolved = resolve_fastembed_cache_dir()
+
+    assert resolved == tmp_path / ".memtomem" / "cache" / "fastembed"
+    assert resolved.is_dir()
+
+
+def test_memtomem_env_takes_precedence_over_fastembed_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    memtomem_path = tmp_path / "mm-cache"
+    fastembed_path = tmp_path / "fe-cache"
+    monkeypatch.setenv("MEMTOMEM_FASTEMBED_CACHE", str(memtomem_path))
+    monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(fastembed_path))
+
+    resolved = resolve_fastembed_cache_dir()
+
+    assert resolved == memtomem_path
+    assert resolved.is_dir()
+    assert not fastembed_path.exists()
+
+
+def test_fastembed_env_used_when_memtomem_env_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("MEMTOMEM_FASTEMBED_CACHE", raising=False)
+    fastembed_path = tmp_path / "fe-cache"
+    monkeypatch.setenv("FASTEMBED_CACHE_PATH", str(fastembed_path))
+
+    resolved = resolve_fastembed_cache_dir()
+
+    assert resolved == fastembed_path
+    assert resolved.is_dir()
+
+
+def test_empty_env_falls_through_to_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty-string env var must not pin the cache to ``Path("")`` —
+    that would resolve to the cwd and silently scatter snapshots into
+    whichever directory the user happened to launch ``mm`` from."""
+    monkeypatch.setenv("MEMTOMEM_FASTEMBED_CACHE", "")
+    monkeypatch.setenv("FASTEMBED_CACHE_PATH", "")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    resolved = resolve_fastembed_cache_dir()
+
+    assert resolved == tmp_path / ".memtomem" / "cache" / "fastembed"
+
+
+def test_tilde_in_env_is_expanded(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("MEMTOMEM_FASTEMBED_CACHE", "~/custom-cache")
+    monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
+
+    resolved = resolve_fastembed_cache_dir()
+
+    assert resolved == tmp_path / "custom-cache"
+    assert resolved.is_dir()


### PR DESCRIPTION
## Summary

Pin both fastembed providers (`OnnxEmbedder`, `FastEmbedReranker`) to a
stable cache directory so the model snapshot survives OS-level temp-dir
reaping.

`fastembed.TextEmbedding` and `fastembed.rerank.cross_encoder.TextCrossEncoder`
default their `cache_dir` to `tempfile.gettempdir()`, which on macOS
resolves to `/var/folders/.../T/fastembed_cache/` — the per-user temp
tree that the OS periodically reaps. The reaper evicts files by access
time, so the smaller graph blob (`model.onnx`) tends to disappear while
the larger weight blob (`model.onnx_data`) — re-read on every reindex
— survives. The next load follows a now-dangling symlink:

```
WARNING  Local file sizes do not match the metadata.
ERROR    Embedding failed for ...: ONNX embedding failed:
         [ONNXRuntimeError] : 3 : NO_SUCHFILE : Load model from
         /var/folders/.../T/fastembed_cache/.../onnx/model.onnx failed.
         File doesn't exist
INFO     Auto-reindexed example.md: indexed=0 skipped=N deleted=0
```

The failure is silent at the user surface — the watcher reports
`indexed=0` and the reindex appears to have run. The user only finds out
when `mem_search` returns nothing for content they know is in the store.

## Fix

New helper `embedding/_fastembed_cache.py` resolves the cache directory
with explicit precedence:

1. `MEMTOMEM_FASTEMBED_CACHE` (memtomem-specific override)
2. `FASTEMBED_CACHE_PATH` (fastembed's own convention — honoured so
   users who set it for other tools see consistent behaviour)
3. `~/.memtomem/cache/fastembed` (default, alongside other `~/.memtomem`
   state — same lifecycle as the SQLite DB and config)

Both `OnnxEmbedder._get_model()` and `FastEmbedReranker._get_model()`
import the helper and pass `cache_dir=str(...)` to their fastembed
constructor. The `OnnxEmbedder` startup log now includes the resolved
`cache_dir` so the path is visible in any future debug session.

## Why no config field

Cache location is an environment concern, not a behavior tunable. Adding
a setting would expand the settings UI surface for something users
almost never change, and the two env vars cover the cases where an
override is genuinely needed (CI cache mounts, multi-user dev machines).

## Migration

None. Installs that already have a healthy cache in tmpdir will
re-download to the new path on first use after upgrade. The old tmpdir
tree is reaped by the OS regardless, so a one-shot migration script
would solve nothing.

Also fix the `FastEmbedReranker` docstring that claimed the cache lived
in `~/.cache/fastembed/` — it never did.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_fastembed_cache.py` — 5
  cases: default path, MM-env precedence over FE-env, FE-env fallthrough,
  empty-env fallthrough (guards against `Path("")` = cwd), tilde expansion.
- [x] `uv run pytest packages/memtomem/tests/test_onnx_custom_model.py
  test_embedding_progress.py test_embedding_providers.py
  test_reranker_fastembed.py` — 80 existing tests, no regression.
- [x] `uv run ruff check` + `ruff format --check` — clean.
- [ ] Smoke: `mm web` → trigger an indexing run → confirm the new log
  line shows `cache_dir=~/.memtomem/cache/fastembed` and the directory
  is populated. (Not automatable — requires the ~2.3 GB bge-m3
  download.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
