### PR TITLE
chore(release): bump version to 0.1.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.1.34] — 2026-05-02
+
 ### Added
 
 - **`mm context migrate` (PR-D C4, ADR-0008)** — converts agents and

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.1.33"
+version = "0.1.34"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -830,7 +830,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.33"
+version = "0.1.34"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Stamp the accumulated `[Unreleased]` CHANGELOG section as `[0.1.34]` (2026-05-02), insert a new empty `[Unreleased]` heading above it.
- Bump `packages/memtomem/pyproject.toml` and `uv.lock` from `0.1.33` to `0.1.34` (same commit, per repo convention).
- 101 commits since `v0.1.33` — ADR-0008 wiki/context PRs A–D, multi-project read-only discovery for `mm web`, multi-platform CI matrix, portalocker swap, SSE-streamed reindex, plus UI/i18n polish. No breaking API changes, so staying on the 0.1.x patch cadence rather than cutting 0.2.0.

## Release plan (post-merge)

1. Tag `test-v0.1.34` on the merge commit → TestPyPI dry-run via OIDC trusted publisher.
2. Fresh-install smoke (`uv tool install --index-url https://test.pypi.org/simple/ ... memtomem` → `mm web` startup + health).
3. Tag `v0.1.34` on the same SHA → prod PyPI publish (same-SHA approval auto-skips per `v0.1.30` precedent).
4. Post-merge prod smoke (`mm web` startup + health on a fresh isolated `HOME`).

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — passes
- [x] `uv run ruff format --check packages/memtomem/src` — 228 files already formatted
- [x] `uv lock` confirms `memtomem v0.1.33 -> v0.1.34`
- [ ] CI green on this PR before merge
- [ ] TestPyPI install + smoke after `test-v0.1.34`
- [ ] Prod install + smoke after `v0.1.34`
