### PR TITLE
fix(web): show full namespace on hover in Home bar chart

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1276,8 +1276,14 @@ function _renderNsChart(namespaces) {
   chart.innerHTML = sorted.map((ns, i) => {
     const pct = Math.round((ns.chunk_count / max) * 100);
     const color = ns.color || palette[i % palette.length];
-    return `<div class="home-bar-row">
-      <span class="home-bar-label">${escapeHtml(ns.namespace)}</span>
+    // ``.home-bar-label`` is CSS-clipped at 120px with text-overflow:ellipsis,
+    // which hides the tail of long auto-namespaces like
+    // ``claude:-Users-...-projectname``. The row-level ``title`` makes the
+    // full string visible on hover so users can identify which namespace is
+    // selected.
+    const fullNs = escapeHtml(ns.namespace);
+    return `<div class="home-bar-row" title="${fullNs}">
+      <span class="home-bar-label">${fullNs}</span>
       <div class="home-bar-track"><div class="home-bar-fill" style="width:${pct}%;background:${color}"></div></div>
       <span class="home-bar-count">${ns.chunk_count.toLocaleString()}</span>
     </div>`;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1303,7 +1303,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=94"></script>
+  <script src="/app.js?v=95"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>


### PR DESCRIPTION
## Summary

- Add a `title` attribute to each row in the Home tab's namespace bar chart so the full namespace string is reachable on hover.
- Bump `app.js?v=94` → `v=95` so the change reaches users behind the disk cache.

## Why

`.home-bar-label` is CSS-clipped at 120 px with `text-overflow: ellipsis`. Long auto-namespaces like `claude:-Users-<user>-Work-<project>` truncate to `claude:-Users-...` with no way to see the rest — users can't identify which project a row belongs to.

The d3 donut override in `settings-namespaces.js:479` is not exercised because d3 is never loaded by the SPA (no `<script>` tag, no module resolution), so the bar chart at `app.js:1265` is what every user actually sees.

## Out of scope

- The dead d3 override in `settings-namespaces.js` is left alone — separate cleanup PR if anyone cares.
- This is a frontend-only fix; the underlying long auto-namespace strings (e.g. path-derived `claude:` namespaces) are unchanged.

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` clean.
- [ ] Manual: load Home tab, hover a long-namespace row, verify the full string appears in the browser's title tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
