### PR TITLE
feat(web): surface fastembed model load state via banner (#696)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -435,10 +435,21 @@ def _step_embedding(state: dict) -> None:
             click.echo()
             state.setdefault("_extras_warned_inline", set()).add("onnx")
 
+        # Sizes are pulled from ``embedding/aliases.py`` so this wizard
+        # text and the runtime "Downloading {model} (~{size} MB)…" banner
+        # surfaced by ``GET /api/system/model-readiness`` agree exactly.
+        from memtomem.embedding.aliases import ONNX_EMBEDDER_MODELS, format_size
+
+        _all_minilm_size = format_size(ONNX_EMBEDDER_MODELS["all-MiniLM-L6-v2"][2])
+        _bge_small_size = format_size(ONNX_EMBEDDER_MODELS["bge-small-en-v1.5"][2])
+        _bge_m3_size = format_size(ONNX_EMBEDDER_MODELS["bge-m3"][2])
+
         click.echo("  Available models:")
-        click.echo("    [1] all-MiniLM-L6-v2 — English, fast, tiny (~22 MB, 384d)")
-        click.echo("    [2] bge-small-en-v1.5 — English, better accuracy (~33 MB, 384d)")
-        click.echo("    [3] bge-m3 — multilingual KR/EN/JP/CN (~1.2 GB, 1024d)")
+        click.echo(f"    [1] all-MiniLM-L6-v2 — English, fast, tiny (~{_all_minilm_size}, 384d)")
+        click.echo(
+            f"    [2] bge-small-en-v1.5 — English, better accuracy (~{_bge_small_size}, 384d)"
+        )
+        click.echo(f"    [3] bge-m3 — multilingual KR/EN/JP/CN (~{_bge_m3_size}, 1024d)")
         model_choice = nav_prompt("  Select", type=click.IntRange(1, 3), default=1)
 
         models = {
@@ -450,7 +461,7 @@ def _step_embedding(state: dict) -> None:
 
         if model_choice == 3:
             click.secho(
-                "  Note: bge-m3 is ~1.2 GB (similar to Ollama models). "
+                f"  Note: bge-m3 is ~{_bge_m3_size} (substantial download). "
                 "For lightweight EN-only search, choose option 1 or 2.",
                 fg="yellow",
             )
@@ -609,10 +620,17 @@ def _step_reranker(state: dict) -> None:
         click.echo()
         return
 
+    # Sizes pulled from ``embedding/aliases.py:FASTEMBED_RERANKER_SIZES``
+    # so the wizard and the readiness banner agree.
+    from memtomem.embedding.aliases import FASTEMBED_RERANKER_SIZES, format_size
+
+    _en_size = format_size(FASTEMBED_RERANKER_SIZES["Xenova/ms-marco-MiniLM-L-6-v2"])
+    _multi_size = format_size(FASTEMBED_RERANKER_SIZES["jinaai/jina-reranker-v2-base-multilingual"])
+
     click.echo()
     click.echo("  Available models:")
-    click.echo("    [1] English (Xenova/ms-marco-MiniLM-L-6-v2) — 80 MB")
-    click.echo("    [2] Multilingual (jinaai/jina-reranker-v2-base-multilingual) — 1.1 GB")
+    click.echo(f"    [1] English (Xenova/ms-marco-MiniLM-L-6-v2) — {_en_size}")
+    click.echo(f"    [2] Multilingual (jinaai/jina-reranker-v2-base-multilingual) — {_multi_size}")
     click.echo("        Recommended for Korean/Chinese/Japanese/mixed content.")
     choice = nav_prompt("  Select", type=click.IntRange(1, 2), default=1)
 

--- a/packages/memtomem/src/memtomem/embedding/aliases.py
+++ b/packages/memtomem/src/memtomem/embedding/aliases.py
@@ -1,0 +1,95 @@
+"""Single source of truth for fastembed model aliases and approximate sizes.
+
+Used by every surface that references a model name or has to tell the
+user how big the download is:
+
+* ``OnnxEmbedder._get_model`` — short-name → fastembed-id resolution.
+* ``GET /api/system/model-readiness`` — banner annotation
+  ("Downloading bge-m3 (~2300 MB)…").
+* ``cli init`` wizard — size text shown to the user.
+
+Sizes come from fastembed's own ``list_supported_models()`` /
+``size_in_GB`` field (rounded to MB). Custom-registered models — only
+``BAAI/bge-m3`` today, see
+``embedding/onnx.py:_register_custom_models_if_needed`` — carry the
+size declared on their ``add_custom_model`` call. Verify with::
+
+    from fastembed import TextEmbedding
+    [(m['model'], m['size_in_GB']) for m in TextEmbedding.list_supported_models()]
+
+Adding a new model is a one-file edit here; the readiness banner,
+cache probe, embedder loader, and init wizard all read from these
+tables.
+"""
+
+from __future__ import annotations
+
+# Short alias → (fastembed model id, dimension, approximate size in MB).
+# Sizes match fastembed metadata exactly so the readiness banner and
+# the init wizard agree.
+ONNX_EMBEDDER_MODELS: dict[str, tuple[str, int, int]] = {
+    "all-MiniLM-L6-v2": ("sentence-transformers/all-MiniLM-L6-v2", 384, 90),
+    "bge-small-en-v1.5": ("BAAI/bge-small-en-v1.5", 384, 67),
+    # Custom-registered (see embedding/onnx.py:_register_custom_models_if_needed).
+    # Size mirrors ``size_in_gb=2.3`` declared on add_custom_model — the
+    # actual ``model.onnx`` + ``model.onnx_data`` blobs total ~2.3 GB on disk.
+    "bge-m3": ("BAAI/bge-m3", 1024, 2300),
+}
+
+
+# Additional fastembed embedder ids (no short alias). Lookups by full id
+# need an answer too — primarily for the nomic-ai variants in case a
+# user pastes the raw id into ``config.embedding.model`` instead of
+# picking a short alias.
+_EXTRA_EMBEDDER_SIZES: dict[str, int] = {
+    "nomic-ai/nomic-embed-text-v1.5": 520,
+    "nomic-ai/nomic-embed-text-v1.5-Q": 130,
+}
+
+
+# Reranker fastembed id → MB. Reranker config stores the full fastembed
+# id verbatim (no short-name resolution), so only size lookup is needed.
+FASTEMBED_RERANKER_SIZES: dict[str, int] = {
+    "Xenova/ms-marco-MiniLM-L-6-v2": 80,
+    "Xenova/ms-marco-MiniLM-L-12-v2": 120,
+    "BAAI/bge-reranker-base": 1040,
+    "jinaai/jina-reranker-v1-tiny-en": 130,
+    "jinaai/jina-reranker-v1-turbo-en": 150,
+    "jinaai/jina-reranker-v2-base-multilingual": 1110,
+}
+
+
+def resolve_embedder_id(model: str) -> str:
+    """Translate a memtomem short-name to its fastembed id, or pass through."""
+    entry = ONNX_EMBEDDER_MODELS.get(model)
+    return entry[0] if entry else model
+
+
+def approx_size_mb(model_id: str) -> int | None:
+    """Approximate on-disk download size in MB.
+
+    Accepts a memtomem short-name (``bge-m3``), a fastembed embedder id
+    (``BAAI/bge-m3``), or a fastembed reranker id
+    (``jinaai/jina-reranker-v2-base-multilingual``). Returns ``None``
+    for anything not in the documented set.
+    """
+    entry = ONNX_EMBEDDER_MODELS.get(model_id)
+    if entry:
+        return entry[2]
+    for full, _dim, size in ONNX_EMBEDDER_MODELS.values():
+        if full == model_id:
+            return size
+    if model_id in _EXTRA_EMBEDDER_SIZES:
+        return _EXTRA_EMBEDDER_SIZES[model_id]
+    return FASTEMBED_RERANKER_SIZES.get(model_id)
+
+
+def format_size(mb: int) -> str:
+    """Render a size in MB or GB depending on magnitude.
+
+    Used by surfaces that show the size to humans (init wizard,
+    eventually the banner if it ever needs to render directly).
+    """
+    if mb >= 1000:
+        return f"{mb / 1000:.1f} GB"
+    return f"{mb} MB"

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -68,6 +68,12 @@ class OnnxEmbedder:
     def __init__(self, config: EmbeddingConfig) -> None:
         self._config = config
         self._model: object | None = None  # fastembed.TextEmbedding
+        # Observability flags read by ``GET /api/system/model-readiness``.
+        # Plain attribute reads/writes — bool/Optional[str] assignment is
+        # atomic under CPython, and the readiness endpoint is allowed to
+        # observe transient states without taking a lock.
+        self._loading: bool = False
+        self._load_error: str | None = None
 
     def _get_model(self) -> object:
         """Lazily initialise the fastembed model (downloads on first use)."""
@@ -93,7 +99,17 @@ class OnnxEmbedder:
             threads if threads is not None else "ORT default",
             cache_dir,
         )
-        self._model = TextEmbedding(model_name=model_id, threads=threads, cache_dir=str(cache_dir))
+        self._loading = True
+        self._load_error = None
+        try:
+            self._model = TextEmbedding(
+                model_name=model_id, threads=threads, cache_dir=str(cache_dir)
+            )
+        except Exception as exc:
+            self._load_error = str(exc)
+            raise
+        finally:
+            self._loading = False
         return self._model
 
     @property

--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -8,26 +8,11 @@ from collections.abc import Callable
 from typing import Sequence
 
 from memtomem.config import EmbeddingConfig
+from memtomem.embedding.aliases import resolve_embedder_id
 from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
 from memtomem.errors import EmbeddingError
 
 logger = logging.getLogger(__name__)
-
-# Short name -> (fastembed model ID, dimension).
-# Users may also pass a raw fastembed model ID via config.model.
-_ONNX_MODELS: dict[str, tuple[str, int]] = {
-    "all-MiniLM-L6-v2": ("sentence-transformers/all-MiniLM-L6-v2", 384),
-    "bge-small-en-v1.5": ("BAAI/bge-small-en-v1.5", 384),
-    "bge-m3": ("BAAI/bge-m3", 1024),
-}
-
-
-def _resolve_model(name: str) -> str:
-    """Map a short model name to the fastembed model ID."""
-    entry = _ONNX_MODELS.get(name)
-    if entry:
-        return entry[0]
-    return name  # pass through as raw fastembed model ID
 
 
 def _register_custom_models_if_needed() -> None:
@@ -88,7 +73,7 @@ class OnnxEmbedder:
             ) from exc
 
         _register_custom_models_if_needed()
-        model_id = _resolve_model(self._config.model)
+        model_id = resolve_embedder_id(self._config.model)
         # threads=0 → leave ORT default (all physical cores); threads>0 caps
         # the intra-op pool so seeding doesn't saturate the machine.
         threads = self._config.threads or None

--- a/packages/memtomem/src/memtomem/embedding/readiness.py
+++ b/packages/memtomem/src/memtomem/embedding/readiness.py
@@ -1,4 +1,4 @@
-"""Readiness helpers for the lazy-loaded fastembed models.
+"""Cache-presence helper for the lazy-loaded fastembed models.
 
 Used by the ``GET /api/system/model-readiness`` endpoint to distinguish
 "download in flight" from "loaded" from "cold cache, no work started"
@@ -18,24 +18,18 @@ where ``<sanitized-id>`` = ``model_id.replace("/", "--")``. A snapshot
 is considered complete when ``config.json``, ``tokenizer.json``, and
 either flat or nested ``model.onnx`` are all present (``Path.exists``
 follows symlinks, so the underlying blobs must be there too).
+
+Approximate-size lookups for the readiness banner live in the sibling
+``aliases`` module — see ``embedding/aliases.py:approx_size_mb``.
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-# Approximate sizes for the model identifiers documented in
-# ``cli/init_cmd.py``. Used by the readiness endpoint to populate banner
-# copy ("Downloading bge-m3 (~2.3 GB)…"). Unknown models map to None;
-# the banner falls back to a size-less message.
-_APPROX_SIZE_MB: dict[str, int] = {
-    "BAAI/bge-m3": 2300,
-    "BAAI/bge-small-en-v1.5": 130,
-    "sentence-transformers/all-MiniLM-L6-v2": 90,
-    "nomic-ai/nomic-embed-text-v1.5": 280,
-    "jinaai/jina-reranker-v2-base-multilingual": 1100,
-    "Xenova/ms-marco-MiniLM-L-6-v2": 80,
-}
+# Re-exported for backwards compatibility with the readiness endpoint
+# import site. Source of truth is ``embedding/aliases.py``.
+from memtomem.embedding.aliases import approx_size_mb as approx_size_mb  # noqa: F401
 
 
 def model_snapshot_present(cache_dir: Path, model_id: str) -> bool:
@@ -61,8 +55,3 @@ def model_snapshot_present(cache_dir: Path, model_id: str) -> bool:
         if (snap / "model.onnx").exists() or (snap / "onnx" / "model.onnx").exists():
             return True
     return False
-
-
-def approx_size_mb(model_id: str) -> int | None:
-    """Return the documented approximate size for ``model_id`` in MB, or ``None``."""
-    return _APPROX_SIZE_MB.get(model_id)

--- a/packages/memtomem/src/memtomem/embedding/readiness.py
+++ b/packages/memtomem/src/memtomem/embedding/readiness.py
@@ -1,0 +1,68 @@
+"""Readiness helpers for the lazy-loaded fastembed models.
+
+Used by the ``GET /api/system/model-readiness`` endpoint to distinguish
+"download in flight" from "loaded" from "cold cache, no work started"
+without forcing a load itself. The check is filesystem-only.
+
+The fastembed cache layout follows HuggingFace conventions:
+
+    cache_dir/
+      models--<sanitized-id>/
+        snapshots/
+          <commit-sha>/
+            config.json
+            tokenizer.json
+            (model.onnx OR onnx/model.onnx)
+
+where ``<sanitized-id>`` = ``model_id.replace("/", "--")``. A snapshot
+is considered complete when ``config.json``, ``tokenizer.json``, and
+either flat or nested ``model.onnx`` are all present (``Path.exists``
+follows symlinks, so the underlying blobs must be there too).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Approximate sizes for the model identifiers documented in
+# ``cli/init_cmd.py``. Used by the readiness endpoint to populate banner
+# copy ("Downloading bge-m3 (~2.3 GB)…"). Unknown models map to None;
+# the banner falls back to a size-less message.
+_APPROX_SIZE_MB: dict[str, int] = {
+    "BAAI/bge-m3": 2300,
+    "BAAI/bge-small-en-v1.5": 130,
+    "sentence-transformers/all-MiniLM-L6-v2": 90,
+    "nomic-ai/nomic-embed-text-v1.5": 280,
+    "jinaai/jina-reranker-v2-base-multilingual": 1100,
+    "Xenova/ms-marco-MiniLM-L-6-v2": 80,
+}
+
+
+def model_snapshot_present(cache_dir: Path, model_id: str) -> bool:
+    """Return True iff a complete fastembed snapshot for ``model_id`` exists.
+
+    Walks ``cache_dir/models--<sanitized>/snapshots/`` and accepts the
+    first subdirectory that contains ``config.json``, ``tokenizer.json``,
+    and either ``model.onnx`` or ``onnx/model.onnx`` — fastembed uses the
+    nested form for some packages (e.g. ``BAAI/bge-m3``) and the flat
+    form for others.
+    """
+    sanitized = "models--" + model_id.replace("/", "--")
+    base = cache_dir / sanitized / "snapshots"
+    if not base.is_dir():
+        return False
+    for snap in base.iterdir():
+        if not snap.is_dir():
+            continue
+        if not (snap / "config.json").exists():
+            continue
+        if not (snap / "tokenizer.json").exists():
+            continue
+        if (snap / "model.onnx").exists() or (snap / "onnx" / "model.onnx").exists():
+            return True
+    return False
+
+
+def approx_size_mb(model_id: str) -> int | None:
+    """Return the documented approximate size for ``model_id`` in MB, or ``None``."""
+    return _APPROX_SIZE_MB.get(model_id)

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -28,6 +28,11 @@ class FastEmbedReranker:
     def __init__(self, config: RerankConfig) -> None:
         self._config = config
         self._model: object | None = None
+        # Observability flags read by ``GET /api/system/model-readiness``.
+        # Match ``OnnxEmbedder`` so the endpoint can introspect both via a
+        # single contract without each provider having a bespoke surface.
+        self._loading: bool = False
+        self._load_error: str | None = None
 
     def _get_model(self) -> object:
         """Lazily construct the ``TextCrossEncoder`` — downloads on first use."""
@@ -49,10 +54,13 @@ class FastEmbedReranker:
             self._config.model,
             cache_dir,
         )
+        self._loading = True
+        self._load_error = None
         try:
             self._model = TextCrossEncoder(model_name=self._config.model, cache_dir=str(cache_dir))
         except ValueError as exc:
             supported = [m.get("model", "") for m in TextCrossEncoder.list_supported_models()]
+            self._load_error = str(exc)
             raise ValueError(
                 f"fastembed reranker model {self._config.model!r} is not supported. "
                 f"Built-in options: {', '.join(sorted(s for s in supported if s))}. "
@@ -62,6 +70,11 @@ class FastEmbedReranker:
                 "must be registered via TextCrossEncoder.add_custom_model() before the "
                 "reranker is invoked."
             ) from exc
+        except Exception as exc:
+            self._load_error = str(exc)
+            raise
+        finally:
+            self._loading = False
         return self._model
 
     def _rerank_sync(self, query: str, documents: list[str]) -> list[float]:

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -59,6 +59,9 @@ from memtomem.web.schemas.config import (
     EmbeddingConfigInfo,
     EmbeddingResetResponse,
     EmbeddingStatusResponse,
+    ModelComponent,
+    ModelComponentState,
+    ModelReadinessResponse,
     PrivacyPatternEntry,
     PrivacyPatternsResponse,
 )
@@ -747,6 +750,126 @@ async def get_embedding_status(storage=Depends(get_storage)) -> EmbeddingStatusR
         model_mismatch=mismatch["model_mismatch"],
         stored=EmbeddingConfigInfo(**mismatch["stored"]),
         configured=EmbeddingConfigInfo(**mismatch["configured"]),
+    )
+
+
+def _resolve_fastembed_model_id(model: str) -> str:
+    """Map a memtomem short name to the fastembed model id, when known.
+
+    Mirrors ``memtomem.embedding.onnx._resolve_model`` without importing the
+    ONNX module — the readiness check must work even if fastembed is not
+    installed (the endpoint just reports a ``cold`` / ``error`` state).
+    """
+    aliases = {
+        "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
+        "bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
+        "bge-m3": "BAAI/bge-m3",
+    }
+    return aliases.get(model, model)
+
+
+# Providers that route through the lazy fastembed loaders we instrumented
+# for #696 — i.e. ones where introspecting ``_model`` / ``_loading`` /
+# ``_load_error`` is meaningful. The embedder advertises this path as
+# ``"onnx"``; the reranker advertises it as ``"fastembed"``. Other
+# providers (Ollama/Cohere/local) have their own connection-based
+# readiness model and are reported as ``state="skipped"``.
+_INTROSPECTABLE_PROVIDERS = {"onnx", "fastembed"}
+
+
+def _component_for(
+    *,
+    provider: str,
+    model: str | None,
+    holder: object | None,
+    enabled: bool,
+) -> ModelComponent:
+    """Build a ``ModelComponent`` snapshot for one lazy loader.
+
+    ``holder`` is either an ``OnnxEmbedder`` / ``FastEmbedReranker`` (with
+    ``_model``, ``_loading``, ``_load_error`` flags introduced for #696)
+    or ``None`` when the component is disabled. ``enabled=False`` short-
+    circuits to ``state="skipped"`` regardless of the holder.
+    """
+    from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
+    from memtomem.embedding.readiness import approx_size_mb, model_snapshot_present
+
+    if not enabled or provider not in _INTROSPECTABLE_PROVIDERS or holder is None:
+        return ModelComponent(state="skipped", provider=provider, model=model)
+
+    fastembed_id = _resolve_fastembed_model_id(model) if model else None
+    cache_present = False
+    if fastembed_id:
+        try:
+            cache_dir = resolve_fastembed_cache_dir()
+            cache_present = model_snapshot_present(cache_dir, fastembed_id)
+        except Exception:
+            # Resolving the cache dir or stat'ing it should never raise in
+            # practice; fall through to ``cache_present=False`` so the
+            # endpoint still returns a meaningful state.
+            logger.debug("model_snapshot_present probe failed", exc_info=True)
+
+    loaded = getattr(holder, "_model", None) is not None
+    loading = bool(getattr(holder, "_loading", False))
+    load_error = getattr(holder, "_load_error", None)
+
+    if load_error:
+        state: ModelComponentState = "error"
+    elif loaded:
+        state = "ready"
+    elif loading:
+        state = "downloading" if not cache_present else "loading"
+    else:
+        state = "cold"
+
+    return ModelComponent(
+        state=state,
+        provider=provider,
+        model=model,
+        cache_present=cache_present,
+        approx_size_mb=approx_size_mb(fastembed_id) if fastembed_id else None,
+        error=load_error,
+    )
+
+
+@router.get("/system/model-readiness", response_model=ModelReadinessResponse)
+async def get_model_readiness(
+    request: Request,
+    embedder=Depends(get_embedder),
+    config=Depends(get_config),
+) -> ModelReadinessResponse:
+    """Snapshot the load state of the embedder + reranker (issue #696).
+
+    Read-only: inspects the lazy loaders' ``_model`` / ``_loading`` /
+    ``_load_error`` flags and probes the fastembed cache directory. Never
+    triggers a model download itself — the Web UI banner polls this while
+    waiting for ``state="ready"`` so the user sees what's happening
+    instead of a frozen Search button.
+    """
+    emb_cfg = config.embedding
+    embedder_component = _component_for(
+        provider=emb_cfg.provider,
+        model=emb_cfg.model,
+        holder=embedder,
+        enabled=True,
+    )
+
+    # Reranker: lives on the SearchPipeline. ``app.state.search_pipeline``
+    # always exists (lifespan creates it), but ``_reranker`` is None when
+    # ``config.rerank.enabled is False`` — skip the readiness check then.
+    rerank_cfg = config.rerank
+    pipeline = getattr(request.app.state, "search_pipeline", None)
+    reranker_holder = getattr(pipeline, "_reranker", None) if pipeline else None
+    reranker_component = _component_for(
+        provider=rerank_cfg.provider,
+        model=rerank_cfg.model if rerank_cfg.enabled else None,
+        holder=reranker_holder,
+        enabled=rerank_cfg.enabled,
+    )
+
+    return ModelReadinessResponse(
+        embedder=embedder_component,
+        reranker=reranker_component,
     )
 
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -753,21 +753,6 @@ async def get_embedding_status(storage=Depends(get_storage)) -> EmbeddingStatusR
     )
 
 
-def _resolve_fastembed_model_id(model: str) -> str:
-    """Map a memtomem short name to the fastembed model id, when known.
-
-    Mirrors ``memtomem.embedding.onnx._resolve_model`` without importing the
-    ONNX module — the readiness check must work even if fastembed is not
-    installed (the endpoint just reports a ``cold`` / ``error`` state).
-    """
-    aliases = {
-        "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
-        "bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
-        "bge-m3": "BAAI/bge-m3",
-    }
-    return aliases.get(model, model)
-
-
 # Providers that route through the lazy fastembed loaders we instrumented
 # for #696 — i.e. ones where introspecting ``_model`` / ``_loading`` /
 # ``_load_error`` is meaningful. The embedder advertises this path as
@@ -791,13 +776,18 @@ def _component_for(
     or ``None`` when the component is disabled. ``enabled=False`` short-
     circuits to ``state="skipped"`` regardless of the holder.
     """
+    from memtomem.embedding.aliases import approx_size_mb, resolve_embedder_id
     from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
-    from memtomem.embedding.readiness import approx_size_mb, model_snapshot_present
+    from memtomem.embedding.readiness import model_snapshot_present
 
     if not enabled or provider not in _INTROSPECTABLE_PROVIDERS or holder is None:
         return ModelComponent(state="skipped", provider=provider, model=model)
 
-    fastembed_id = _resolve_fastembed_model_id(model) if model else None
+    # Embedder config stores either a short alias (``bge-m3``) or the
+    # raw fastembed id; the reranker config always stores the full
+    # fastembed id directly. ``resolve_embedder_id`` is a no-op for
+    # already-resolved ids, so it's safe to apply uniformly.
+    fastembed_id = resolve_embedder_id(model) if model else None
     cache_present = False
     if fastembed_id:
         try:

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -137,3 +137,35 @@ class EmbeddingStatusResponse(BaseModel):
 class EmbeddingResetResponse(BaseModel):
     ok: bool
     message: str
+
+
+# ── Model readiness (issue #696) ─────────────────────────────────────
+# Surfaces lazy-load state of the fastembed embedder + reranker so the
+# Web UI can render a "Downloading…" / "Loading…" banner instead of
+# leaving the user staring at a frozen Search button while a multi-GB
+# model snapshot streams in. See ``GET /api/system/model-readiness``.
+
+ModelComponentState = Literal[
+    "ready",  # model is loaded in memory and ready to serve
+    "loading",  # cache is on disk; constructor in flight
+    "downloading",  # cache absent; constructor in flight
+    "cold",  # nothing in flight; cache may or may not be present
+    "error",  # last constructor attempt raised
+    "skipped",  # provider not fastembed, or component disabled
+]
+
+
+class ModelComponent(BaseModel):
+    """Per-component (embedder OR reranker) readiness snapshot."""
+
+    state: ModelComponentState
+    provider: str
+    model: str | None = None
+    cache_present: bool = False
+    approx_size_mb: int | None = None
+    error: str | None = None
+
+
+class ModelReadinessResponse(BaseModel):
+    embedder: ModelComponent
+    reranker: ModelComponent

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -115,9 +115,19 @@ const STATE = {
     // header pill if a run is in flight (page-reload survival, second-
     // tab visibility) — see ``_indexingHydrateFromServer``.
     _indexingHydrateFromServer();
+    // #696: hydrate the model-readiness banner so a cold-cache install
+    // sees "Loading model…" / "Downloading bge-m3 (~2.3 GB)…" instead
+    // of a frozen Search button. Hydrate is a no-op when the model is
+    // already loaded.
+    _modelReadinessHydrate();
     document.addEventListener('visibilitychange', () => {
-      if (document.visibilityState === 'visible' && !STATE.indexing) {
-        _indexingHydrateFromServer();
+      if (document.visibilityState === 'visible') {
+        if (!STATE.indexing) {
+          _indexingHydrateFromServer();
+        }
+        // Re-hydrate readiness on tab focus so a load that completed in
+        // a backgrounded tab doesn't leave the banner stuck up.
+        _modelReadinessHydrate();
       }
     });
     // Re-apply i18n when language changes (dynamic JS strings)
@@ -521,6 +531,122 @@ function _indexingPollUntilIdle() {
     }
   };
   STATE._indexingPollHandle = setTimeout(tick, _INDEXING_POLL_MS);
+}
+
+// ── Model readiness banner (issue #696) ──
+// Surfaces the lazy fastembed loader's state in the header so users
+// don't watch a frozen Search button during a multi-GB first-load. The
+// banner copy is built from ``GET /api/system/model-readiness``; see
+// ``packages/memtomem/src/memtomem/web/routes/system.py``.
+const _MODEL_READINESS_POLL_MS = 4000;
+// Cap the poll loop so a stuck server doesn't yield infinite background
+// fetches. 200 × 4s ≈ 13 min — comfortably above the worst observed
+// bge-m3 + reranker cold-download. Visibilitychange + the doSearch
+// pre-flight re-arm the poll if the user comes back later.
+const _MODEL_READINESS_MAX_TICKS = 200;
+
+function _modelComponentActive(c) {
+  return !!c && (c.state === 'loading' || c.state === 'downloading');
+}
+
+function _modelComponentDone(c) {
+  // ``cold`` is intentionally NOT terminal here — when the doSearch
+  // pre-flight kicks the poll, the backend's ``_loading`` flag flips
+  // True only after our request reaches the lazy loader, so the first
+  // poll tick can race the request and see ``cold``. Continuing the
+  // loop lets the next tick catch the transition.
+  return !!c && (c.state === 'ready' || c.state === 'skipped');
+}
+
+function _isModelPollTerminal(d) {
+  if (!d) return false;
+  if (d.embedder?.state === 'error' || d.reranker?.state === 'error') return true;
+  return _modelComponentDone(d.embedder) && _modelComponentDone(d.reranker);
+}
+
+function _renderModelReadinessBanner(d) {
+  const banner = qs('model-readiness-banner');
+  const msg = qs('model-readiness-msg');
+  if (!banner || !msg) return;
+  const emb = (d && d.embedder) || {};
+  const rer = (d && d.reranker) || {};
+  const hasError = emb.state === 'error' || rer.state === 'error';
+  const embDl = emb.state === 'downloading';
+  const rerDl = rer.state === 'downloading';
+  const anyLoading = emb.state === 'loading' || rer.state === 'loading';
+
+  const fallbackEmbName = t('banner.model_fallback_embedder', 'embedder');
+  const fallbackRerName = t('banner.model_fallback_reranker', 'reranker');
+
+  if (hasError) {
+    msg.textContent = t('banner.model_error');
+    banner.removeAttribute('hidden');
+  } else if (embDl && rerDl) {
+    msg.textContent = t('banner.model_downloading_both', {
+      emb: emb.model || fallbackEmbName,
+      emb_size: emb.approx_size_mb != null ? emb.approx_size_mb : '?',
+      rer: rer.model || fallbackRerName,
+      rer_size: rer.approx_size_mb != null ? rer.approx_size_mb : '?',
+    });
+    banner.removeAttribute('hidden');
+  } else if (embDl || rerDl) {
+    const c = embDl ? emb : rer;
+    const fallback = embDl ? fallbackEmbName : fallbackRerName;
+    if (c.approx_size_mb != null) {
+      msg.textContent = t('banner.model_downloading_one', {
+        model: c.model || fallback,
+        size: c.approx_size_mb,
+      });
+    } else {
+      msg.textContent = t('banner.model_downloading_one_no_size', {
+        model: c.model || fallback,
+      });
+    }
+    banner.removeAttribute('hidden');
+  } else if (anyLoading) {
+    msg.textContent = t('banner.model_loading');
+    banner.removeAttribute('hidden');
+  } else {
+    banner.setAttribute('hidden', '');
+  }
+}
+
+async function _modelReadinessHydrate() {
+  // Fire-and-forget single fetch. Renders the banner once and starts the
+  // continuous poll only if a load is actually in flight (or has
+  // errored). Cold + ready paths leave the banner hidden and skip the
+  // background loop — saves a needless 4s/tick on freshly booted setups
+  // where the model is already cached.
+  try {
+    const d = await api('GET', '/api/system/model-readiness');
+    _renderModelReadinessBanner(d);
+    if (_modelComponentActive(d?.embedder) || _modelComponentActive(d?.reranker)) {
+      _modelReadinessPoll();
+    }
+  } catch (err) {
+    console.warn('[model-readiness]', err);
+  }
+}
+
+function _modelReadinessPoll() {
+  if (STATE._modelReadinessPollHandle) return; // single-flight
+  let ticks = 0;
+  const tick = async () => {
+    STATE._modelReadinessPollHandle = null;
+    ticks += 1;
+    try {
+      const d = await api('GET', '/api/system/model-readiness');
+      _renderModelReadinessBanner(d);
+      if (_isModelPollTerminal(d)) return; // ready / skipped / error
+    } catch (err) {
+      // Transient fetch failure — keep last banner state and retry.
+      console.warn('[model-readiness poll]', err);
+    }
+    if (ticks < _MODEL_READINESS_MAX_TICKS) {
+      STATE._modelReadinessPollHandle = setTimeout(tick, _MODEL_READINESS_POLL_MS);
+    }
+  };
+  STATE._modelReadinessPollHandle = setTimeout(tick, _MODEL_READINESS_POLL_MS);
 }
 function panelLoading(container) {
   container.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
@@ -1543,6 +1669,14 @@ let _searchAbortCtrl = null;
 async function doSearch() {
   const q = qs('search-input').value.trim();
   if (!q) return;
+  // #696: kick the readiness poll. Fire-and-forget; the search request
+  // proceeds normally — its response covers the spinner. The poll's job
+  // is to surface "Downloading bge-m3 (~2.3 GB)…" while the backend's
+  // lazy loader blocks our request on a multi-GB cold-cache load. The
+  // first tick may race the request and observe ``cold``; the poll
+  // continues until a terminal state because ``cold`` is intentionally
+  // non-terminal for this entry point (see ``_modelComponentDone``).
+  _modelReadinessPoll();
   STATE.lastQuery = q;
   saveToHistory(q);
   hide(qs('search-history-dropdown'));

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=76" />
+  <link rel="stylesheet" href="/style.css?v=77" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
 </head>
 <body>
@@ -39,6 +39,11 @@
   <div id="dev-mode-banner" class="dev-mode-banner" role="status" hidden>
     <span class="dev-mode-banner-icon" aria-hidden="true">🛠</span>
     <span class="dev-mode-banner-msg" data-i18n="banner.dev_mode">Maintainer mode — all pages are visible. Run <code>mm web</code> without <code>--dev</code> for the polished surface.</span>
+  </div>
+
+  <div id="model-readiness-banner" class="model-readiness-banner" role="status" aria-live="polite" hidden>
+    <span class="model-readiness-icon" aria-hidden="true">⏳</span>
+    <span id="model-readiness-msg" class="model-readiness-msg" data-i18n="banner.model_loading">Loading model…</span>
   </div>
 
   <nav class="tab-nav" role="tablist" aria-label="Navigation">
@@ -1303,7 +1308,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-yaml.min.js"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=95"></script>
+  <script src="/app.js?v=96"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -16,6 +16,13 @@
 
   "banner.emb_reset": "Reset with current settings (deletes vectors)",
   "banner.dismiss_title": "Dismiss for this session",
+  "banner.model_loading": "Loading model…",
+  "banner.model_downloading_one": "Downloading {model} (~{size} MB)…",
+  "banner.model_downloading_one_no_size": "Downloading {model}…",
+  "banner.model_downloading_both": "Downloading {emb} (~{emb_size} MB) and {rer} (~{rer_size} MB)…",
+  "banner.model_error": "Model failed to load — check Settings.",
+  "banner.model_fallback_embedder": "embedder",
+  "banner.model_fallback_reranker": "reranker",
 
   "home.quick_search_placeholder": "Quick search memories...",
   "home.search_btn": "Search",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -16,6 +16,13 @@
 
   "banner.emb_reset": "현재 설정으로 초기화 (벡터 삭제)",
   "banner.dismiss_title": "이 세션에서 닫기",
+  "banner.model_loading": "모델 로딩 중…",
+  "banner.model_downloading_one": "{model} 다운로드 중 (~{size} MB)…",
+  "banner.model_downloading_one_no_size": "{model} 다운로드 중…",
+  "banner.model_downloading_both": "{emb} 다운로드 중 (~{emb_size} MB) · {rer} 다운로드 중 (~{rer_size} MB)…",
+  "banner.model_error": "모델 로드 실패 — 설정 확인.",
+  "banner.model_fallback_embedder": "임베더",
+  "banner.model_fallback_reranker": "리랭커",
 
   "home.quick_search_placeholder": "기억 빠른 검색...",
   "home.search_btn": "검색",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -74,6 +74,17 @@ body { background: var(--bg); color: var(--text); font-family: var(--font); heig
 .dev-mode-banner-icon { font-size: 0.95rem; flex-shrink: 0; }
 .dev-mode-banner-msg { flex: 1; min-width: 0; }
 
+.model-readiness-banner {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  padding: 6px 16px;
+  background: color-mix(in srgb, var(--accent, #3498db) 14%, var(--surface));
+  border-bottom: 1px solid color-mix(in srgb, var(--accent, #3498db) 40%, var(--border));
+  flex-shrink: 0;
+  font-size: 0.82rem; color: var(--text);
+}
+.model-readiness-icon { font-size: 0.95rem; flex-shrink: 0; }
+.model-readiness-msg { flex: 1; min-width: 0; }
+
 header {
   display: flex; align-items: center; gap: 12px;
   padding: 0 16px; height: 52px;

--- a/packages/memtomem/tests/test_embedding_aliases.py
+++ b/packages/memtomem/tests/test_embedding_aliases.py
@@ -1,0 +1,93 @@
+"""Tests for the shared model alias / size table.
+
+Locks the contract three independent surfaces depend on:
+
+* ``OnnxEmbedder._get_model`` — short-name → fastembed-id resolution.
+* ``GET /api/system/model-readiness`` — banner annotation lookup.
+* ``cli init`` wizard — size text shown to the user.
+
+Adding a new short alias means a new row in ``ONNX_EMBEDDER_MODELS``
+plus reading the wizard text below to confirm the format helper still
+renders sanely.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memtomem.embedding.aliases import (
+    FASTEMBED_RERANKER_SIZES,
+    ONNX_EMBEDDER_MODELS,
+    approx_size_mb,
+    format_size,
+    resolve_embedder_id,
+)
+
+
+def test_resolve_short_alias() -> None:
+    assert resolve_embedder_id("bge-m3") == "BAAI/bge-m3"
+    assert resolve_embedder_id("bge-small-en-v1.5") == "BAAI/bge-small-en-v1.5"
+    assert resolve_embedder_id("all-MiniLM-L6-v2") == "sentence-transformers/all-MiniLM-L6-v2"
+
+
+def test_resolve_passthrough_on_unknown() -> None:
+    """Raw fastembed ids that aren't a documented short alias pass through."""
+    raw = "nomic-ai/nomic-embed-text-v1.5"
+    assert resolve_embedder_id(raw) == raw
+
+
+def test_approx_size_by_short_alias() -> None:
+    for short, (_full, _dim, expected_mb) in ONNX_EMBEDDER_MODELS.items():
+        assert approx_size_mb(short) == expected_mb, short
+
+
+def test_approx_size_by_full_id() -> None:
+    for _short, (full, _dim, expected_mb) in ONNX_EMBEDDER_MODELS.items():
+        assert approx_size_mb(full) == expected_mb, full
+
+
+def test_approx_size_for_reranker_ids() -> None:
+    for full, expected_mb in FASTEMBED_RERANKER_SIZES.items():
+        assert approx_size_mb(full) == expected_mb, full
+
+
+def test_approx_size_for_extra_embedder_ids() -> None:
+    """Lookup by raw fastembed id covers models without a short alias."""
+    assert approx_size_mb("nomic-ai/nomic-embed-text-v1.5") == 520
+
+
+def test_approx_size_unknown_returns_none() -> None:
+    assert approx_size_mb("custom/unknown-model") is None
+
+
+def test_resolve_embedder_id_matches_legacy_resolver() -> None:
+    """Drift guard: every short alias must agree with the legacy ``_resolve_model``.
+
+    Until #696 the alias map lived inside ``embedding/onnx.py`` and was
+    duplicated by a hand-rolled ``_resolve_fastembed_model_id`` in the
+    web routes module. Both sites now read from this shared module.
+    Snapshot the contract so a future refactor that re-introduces a
+    private duplicate fails this test instead of silently drifting.
+    """
+    expected = {
+        "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
+        "bge-small-en-v1.5": "BAAI/bge-small-en-v1.5",
+        "bge-m3": "BAAI/bge-m3",
+    }
+    for short, full in expected.items():
+        assert resolve_embedder_id(short) == full
+
+
+@pytest.mark.parametrize(
+    "mb,expected",
+    [
+        (67, "67 MB"),
+        (90, "90 MB"),
+        (999, "999 MB"),
+        (1000, "1.0 GB"),
+        (1110, "1.1 GB"),
+        (2300, "2.3 GB"),
+    ],
+)
+def test_format_size(mb: int, expected: str) -> None:
+    assert format_size(mb) == expected

--- a/packages/memtomem/tests/test_embedding_readiness.py
+++ b/packages/memtomem/tests/test_embedding_readiness.py
@@ -1,0 +1,87 @@
+"""Tests for the cache-presence helper used by the model-readiness endpoint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.embedding.readiness import approx_size_mb, model_snapshot_present
+
+
+def _make_snapshot(
+    cache_dir: Path,
+    model_id: str,
+    *,
+    layout: str = "flat",
+    drop: str | None = None,
+) -> Path:
+    """Lay down a fastembed-style snapshot directory for ``model_id``.
+
+    ``layout="flat"`` puts ``model.onnx`` directly under the snapshot dir;
+    ``layout="nested"`` puts it under ``onnx/model.onnx`` (the form
+    ``BAAI/bge-m3`` and the multilingual reranker use). ``drop`` lets a
+    test omit one of the marker files to assert it then reads as
+    incomplete.
+    """
+    sanitized = "models--" + model_id.replace("/", "--")
+    snap = cache_dir / sanitized / "snapshots" / "deadbeef"
+    snap.mkdir(parents=True)
+
+    files = ["config.json", "tokenizer.json"]
+    if layout == "flat":
+        files.append("model.onnx")
+    else:
+        (snap / "onnx").mkdir()
+        if drop != "model.onnx":
+            (snap / "onnx" / "model.onnx").write_text("")
+    for f in files:
+        if f == drop:
+            continue
+        (snap / f).write_text("")
+    return snap
+
+
+def test_present_flat(tmp_path: Path) -> None:
+    _make_snapshot(tmp_path, "BAAI/bge-small-en-v1.5", layout="flat")
+    assert model_snapshot_present(tmp_path, "BAAI/bge-small-en-v1.5")
+
+
+def test_present_nested(tmp_path: Path) -> None:
+    _make_snapshot(tmp_path, "BAAI/bge-m3", layout="nested")
+    assert model_snapshot_present(tmp_path, "BAAI/bge-m3")
+
+
+@pytest.mark.parametrize("missing", ["config.json", "tokenizer.json", "model.onnx"])
+def test_missing_marker_flat(tmp_path: Path, missing: str) -> None:
+    _make_snapshot(tmp_path, "BAAI/bge-small-en-v1.5", layout="flat", drop=missing)
+    assert not model_snapshot_present(tmp_path, "BAAI/bge-small-en-v1.5")
+
+
+def test_missing_model_onnx_nested(tmp_path: Path) -> None:
+    _make_snapshot(tmp_path, "BAAI/bge-m3", layout="nested", drop="model.onnx")
+    assert not model_snapshot_present(tmp_path, "BAAI/bge-m3")
+
+
+def test_empty_cache(tmp_path: Path) -> None:
+    assert not model_snapshot_present(tmp_path, "BAAI/bge-m3")
+
+
+def test_only_sibling_model(tmp_path: Path) -> None:
+    _make_snapshot(tmp_path, "BAAI/bge-small-en-v1.5", layout="flat")
+    assert not model_snapshot_present(tmp_path, "BAAI/bge-m3")
+
+
+def test_snapshots_dir_missing(tmp_path: Path) -> None:
+    """Cache dir exists but has no ``snapshots/`` subdirectory."""
+    (tmp_path / "models--BAAI--bge-m3").mkdir(parents=True)
+    assert not model_snapshot_present(tmp_path, "BAAI/bge-m3")
+
+
+def test_approx_size_known() -> None:
+    assert approx_size_mb("BAAI/bge-m3") == 2300
+    assert approx_size_mb("jinaai/jina-reranker-v2-base-multilingual") == 1100
+
+
+def test_approx_size_unknown() -> None:
+    assert approx_size_mb("custom/unknown-model") is None

--- a/packages/memtomem/tests/test_embedding_readiness.py
+++ b/packages/memtomem/tests/test_embedding_readiness.py
@@ -79,8 +79,13 @@ def test_snapshots_dir_missing(tmp_path: Path) -> None:
 
 
 def test_approx_size_known() -> None:
+    # Sizes match fastembed's own ``list_supported_models()`` /
+    # ``size_in_GB`` field (and ``size_in_gb=2.3`` declared on bge-m3's
+    # ``add_custom_model`` call). Bumping these here without bumping
+    # ``embedding/aliases.py`` will fail the assertion.
     assert approx_size_mb("BAAI/bge-m3") == 2300
-    assert approx_size_mb("jinaai/jina-reranker-v2-base-multilingual") == 1100
+    assert approx_size_mb("bge-m3") == 2300  # short-name alias also works
+    assert approx_size_mb("jinaai/jina-reranker-v2-base-multilingual") == 1110
 
 
 def test_approx_size_unknown() -> None:

--- a/packages/memtomem/tests/test_web_model_readiness.py
+++ b/packages/memtomem/tests/test_web_model_readiness.py
@@ -1,0 +1,185 @@
+"""Tests for ``GET /api/system/model-readiness`` (issue #696).
+
+The endpoint inspects observability flags on the lazy fastembed loaders
+(``_model``, ``_loading``, ``_load_error``) plus a filesystem probe of
+the cache directory. These tests stub the loaders directly — actually
+loading fastembed would download a multi-GB model and defeats the
+purpose of having a state machine you can introspect from outside.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from memtomem.web.app import create_app
+
+
+def _config(
+    *,
+    embedder_provider: str = "onnx",
+    embedder_model: str = "bge-small-en-v1.5",
+    rerank_enabled: bool = False,
+    rerank_provider: str = "fastembed",
+    rerank_model: str = "Xenova/ms-marco-MiniLM-L-6-v2",
+) -> SimpleNamespace:
+    """Minimal config stand-in with just the fields the readiness endpoint reads."""
+    return SimpleNamespace(
+        embedding=SimpleNamespace(provider=embedder_provider, model=embedder_model),
+        rerank=SimpleNamespace(
+            enabled=rerank_enabled,
+            provider=rerank_provider,
+            model=rerank_model,
+        ),
+    )
+
+
+@dataclass
+class _StubLoader:
+    """Mimics the ``_model`` / ``_loading`` / ``_load_error`` flags
+    that ``OnnxEmbedder`` and ``FastEmbedReranker`` expose for the
+    readiness endpoint."""
+
+    _model: object | None = None
+    _loading: bool = False
+    _load_error: str | None = None
+    embed_query: object = field(default_factory=MagicMock)
+    embed_texts: object = field(default_factory=MagicMock)
+
+
+def _make_app(config: SimpleNamespace, embedder: _StubLoader, reranker: _StubLoader | None):
+    """Build a FastAPI app with the routes wired and minimal app.state."""
+    from memtomem.web.deps import require_configured
+
+    app = create_app(lifespan=None, mode="prod")
+    app.state.config = config
+    app.state.embedder = embedder
+    # The reranker lives on ``search_pipeline._reranker`` in production.
+    # Build a stub pipeline carrying just that attribute.
+    pipeline_stub = SimpleNamespace(_reranker=reranker)
+    app.state.search_pipeline = pipeline_stub
+    # Bypass the require_configured gate (no real ``~/.memtomem/config.json``).
+    app.dependency_overrides[require_configured] = lambda: None
+    return app
+
+
+@pytest.fixture
+def fake_cache_absent():
+    """Patch ``model_snapshot_present`` to always return False (cold cache).
+
+    Patches the source module rather than the import site because
+    ``_component_for`` does the import lazily inside the function body —
+    no module-level reference exists in ``routes.system`` to rebind.
+    """
+    with patch("memtomem.embedding.readiness.model_snapshot_present", return_value=False) as m:
+        yield m
+
+
+@pytest.fixture
+def fake_cache_present():
+    """Patch ``model_snapshot_present`` to always return True (cache populated)."""
+    with patch("memtomem.embedding.readiness.model_snapshot_present", return_value=True) as m:
+        yield m
+
+
+# ─── Embedder states ─────────────────────────────────────────────────
+
+
+def test_embedder_cold_when_no_load_attempt(fake_cache_absent):
+    app = _make_app(_config(), _StubLoader(), reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["embedder"]["state"] == "cold"
+    assert body["embedder"]["provider"] == "onnx"
+    assert body["embedder"]["model"] == "bge-small-en-v1.5"
+    assert body["embedder"]["cache_present"] is False
+
+
+def test_embedder_downloading_when_loading_and_cache_absent(fake_cache_absent):
+    embedder = _StubLoader(_loading=True)
+    app = _make_app(_config(), embedder, reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    assert resp.json()["embedder"]["state"] == "downloading"
+
+
+def test_embedder_loading_when_loading_and_cache_present(fake_cache_present):
+    embedder = _StubLoader(_loading=True)
+    app = _make_app(_config(), embedder, reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    body = resp.json()
+    assert body["embedder"]["state"] == "loading"
+    assert body["embedder"]["cache_present"] is True
+
+
+def test_embedder_ready_when_model_loaded(fake_cache_present):
+    embedder = _StubLoader(_model=object())
+    app = _make_app(_config(), embedder, reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    assert resp.json()["embedder"]["state"] == "ready"
+
+
+def test_embedder_error_when_load_error_set(fake_cache_absent):
+    embedder = _StubLoader(_load_error="boom")
+    app = _make_app(_config(), embedder, reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    body = resp.json()
+    assert body["embedder"]["state"] == "error"
+    assert body["embedder"]["error"] == "boom"
+
+
+def test_embedder_skipped_when_provider_not_onnx(fake_cache_absent):
+    """Ollama/Cohere providers have their own connection model — skip."""
+    app = _make_app(_config(embedder_provider="ollama"), _StubLoader(), reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    assert resp.json()["embedder"]["state"] == "skipped"
+
+
+def test_embedder_approx_size_for_known_model(fake_cache_absent):
+    embedder = _StubLoader(_loading=True)
+    app = _make_app(_config(embedder_model="bge-m3"), embedder, reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    body = resp.json()
+    # ``bge-m3`` aliases to ``BAAI/bge-m3`` which has a 2300 MB entry.
+    assert body["embedder"]["approx_size_mb"] == 2300
+
+
+# ─── Reranker states ─────────────────────────────────────────────────
+
+
+def test_reranker_skipped_when_disabled(fake_cache_absent):
+    app = _make_app(_config(rerank_enabled=False), _StubLoader(), reranker=None)
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    body = resp.json()
+    assert body["reranker"]["state"] == "skipped"
+    assert body["reranker"]["model"] is None
+
+
+def test_reranker_states_when_enabled(fake_cache_present):
+    reranker = _StubLoader(_loading=True)
+    app = _make_app(
+        _config(
+            rerank_enabled=True,
+            rerank_model="jinaai/jina-reranker-v2-base-multilingual",
+        ),
+        _StubLoader(_model=object()),
+        reranker=reranker,
+    )
+    with TestClient(app) as c:
+        resp = c.get("/api/system/model-readiness")
+    body = resp.json()
+    assert body["embedder"]["state"] == "ready"
+    assert body["reranker"]["state"] == "loading"
+    assert body["reranker"]["approx_size_mb"] == 1100

--- a/packages/memtomem/tests/test_web_model_readiness.py
+++ b/packages/memtomem/tests/test_web_model_readiness.py
@@ -182,4 +182,5 @@ def test_reranker_states_when_enabled(fake_cache_present):
     body = resp.json()
     assert body["embedder"]["state"] == "ready"
     assert body["reranker"]["state"] == "loading"
-    assert body["reranker"]["approx_size_mb"] == 1100
+    # 1110 MB matches fastembed's reported size_in_GB for jina-reranker-v2.
+    assert body["reranker"]["approx_size_mb"] == 1110


### PR DESCRIPTION
Closes #696 (option B).

## Summary

- Adds `GET /api/system/model-readiness` reporting per-component (embedder + reranker) load state derived from `_loading` / `_load_error` flags newly attached to `OnnxEmbedder` and `FastEmbedReranker`, plus a filesystem probe of the fastembed cache.
- Wires a header banner that polls the endpoint and renders `Downloading bge-m3 (~2300 MB)…` / `Loading model…` / `Model failed to load — check Settings` so the first search after a cold-cache boot no longer feels like a hung UI.
- Boot hydrate, `visibilitychange` re-hydrate, and a `doSearch()` pre-flight cover the three entry points.

## Why option B

`fastembed` does not expose snapshot-download progress events, so a real percent bar (option C) would mean wrapping `huggingface_hub.snapshot_download` ourselves and replicating fastembed's resolution logic. Option B is the smallest change that converts "frozen Search button" into "I see what's happening" without that complexity. See the issue body for the option A/B/C tradeoffs.

## Commits

Split for review; one PR for atomic ship:

1. `feat(embedding): track loading state on lazy fastembed loaders`
   – `_loading` / `_load_error` flags + `embedding/readiness.py` cache probe + size map.
2. `feat(web): add /api/system/model-readiness endpoint`
   – Schema, route, endpoint tests. No UI.
3. `feat(web): show model-loading banner with polling`
   – Banner DOM + CSS, polling logic, i18n keys, cache busters.

## State machine

| condition | state |
| --- | --- |
| provider not in `{onnx, fastembed}` OR component disabled | `skipped` |
| `_load_error` set | `error` |
| `_model is not None` | `ready` |
| `_loading=True` and cache absent | `downloading` |
| `_loading=True` and cache present | `loading` |
| otherwise | `cold` |

`cold` is intentionally non-terminal for `doSearch()`-initiated polls — the first tick can race the request and observe `cold` before the backend's lazy loader flips `_loading=True`. The boot hydrate does treat `cold` as terminal so a fully-warm install doesn't run a needless 4 s/tick background loop.

## Out of scope (deliberate)

- Real per-file download progress (option C). Documented in #696.
- Pre-warming models at server boot. Adds startup latency; revisit if banner alone proves insufficient.
- Provider-specific readiness for Ollama / Cohere. Their connection-based readiness is a separate concern; both are reported as `state="skipped"` here.

## Cache-buster note

`app.js?v=94→96` and `style.css?v=76→77`. The `v=96` jump leapfrogs an in-flight `v=95` from sibling PR #694 (namespace-tooltip). Whichever lands first, the second will need a rebase + bump.

## Test plan

Backend:

- [x] `uv run pytest packages/memtomem/tests/test_embedding_readiness.py packages/memtomem/tests/test_web_model_readiness.py` — 20 tests cover the cache probe + state machine.
- [x] `uv run pytest -m "not ollama"` — 3908 passed locally.
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src packages/memtomem/tests` clean.

Manual UI (cold-cache reproduction):

```bash
mv ~/.memtomem/cache/fastembed ~/.memtomem/cache/fastembed.bak
uv run mm web --host 127.0.0.1 --port 8765 &
# Open the URL — banner is hidden because no search is in flight.
# Trigger a search — banner appears as "Downloading bge-m3 (~2300 MB)…"
# (assuming the user's config selects bge-m3). Banner persists through
# the load and disappears on completion. Search results render.
kill %1
mv ~/.memtomem/cache/fastembed.bak ~/.memtomem/cache/fastembed
```

Korean toggle: switch language and re-run; banner copy must come from `ko.json` strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
