### PR TITLE
fix(storage): block duplicate chunk inserts via UNIQUE + INSERT OR IGNORE (#691)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -448,8 +448,18 @@ class SqliteBackend(
                     )
 
             if to_insert:
+                # ``INSERT OR IGNORE``: the UNIQUE index on
+                # ``(namespace, source_file, content_hash, start_line)`` is
+                # the multi-process race guard for #691. Two processes
+                # (mm web watcher + mm CLI / MCP) each call ``upsert_chunks``
+                # with their own freshly-generated chunk ids; whichever
+                # commits first wins, the loser's row is silently dropped.
+                # The follow-up ``SELECT id, rowid WHERE id IN (...)`` below
+                # then naturally skips dropped ids when populating
+                # ``chunks_fts`` and ``chunks_vec``, so no orphan sidecars
+                # are created for race losers.
                 db.executemany(
-                    """INSERT INTO chunks
+                    """INSERT OR IGNORE INTO chunks
                        (id, content, content_hash, source_file, heading_hierarchy,
                         chunk_type, start_line, end_line, language, tags,
                         namespace, created_at, updated_at,
@@ -489,40 +499,44 @@ class SqliteBackend(
 
                 # Defensive cleanup: remove orphaned FTS/vec entries for these
                 # rowids. Orphans can arise from interrupted concurrent operations
-                # (e.g. MCP + Web server sharing the same DB).
+                # (e.g. MCP + Web server sharing the same DB). Skipped when
+                # ``new_rowid_map`` is empty — that path fires when every row in
+                # ``to_insert`` was dropped by ``INSERT OR IGNORE`` (the #691
+                # race-loser case): there are no rowids to scrub or repopulate.
                 new_rowids = list(new_rowid_map.values())
-                db.execute(
-                    f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(new_rowids))})",
-                    new_rowids,
-                )
-                if self._has_vec_table:
+                if new_rowids:
                     db.execute(
-                        f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(new_rowids))})",
+                        f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders(len(new_rowids))})",
                         new_rowids,
                     )
-
-                db.executemany(
-                    "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?,?,?)",
-                    [
-                        (
-                            new_rowid_map[str(c.id)],
-                            _fts.tokenize_for_fts(c.retrieval_content),
-                            norm_path(c.metadata.source_file),
+                    if self._has_vec_table:
+                        db.execute(
+                            f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders(len(new_rowids))})",
+                            new_rowids,
                         )
-                        for c in to_insert
-                        if str(c.id) in new_rowid_map
-                    ],
-                )
-                vec_inserts = [
-                    (new_rowid_map[str(c.id)], serialize_f32(c.embedding))
-                    for c in to_insert
-                    if c.embedding and str(c.id) in new_rowid_map
-                ]
-                if vec_inserts and self._has_vec_table:
+
                     db.executemany(
-                        "INSERT INTO chunks_vec(rowid, embedding) VALUES (?,?)",
-                        vec_inserts,
+                        "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?,?,?)",
+                        [
+                            (
+                                new_rowid_map[str(c.id)],
+                                _fts.tokenize_for_fts(c.retrieval_content),
+                                norm_path(c.metadata.source_file),
+                            )
+                            for c in to_insert
+                            if str(c.id) in new_rowid_map
+                        ],
                     )
+                    vec_inserts = [
+                        (new_rowid_map[str(c.id)], serialize_f32(c.embedding))
+                        for c in to_insert
+                        if c.embedding and str(c.id) in new_rowid_map
+                    ]
+                    if vec_inserts and self._has_vec_table:
+                        db.executemany(
+                            "INSERT INTO chunks_vec(rowid, embedding) VALUES (?,?)",
+                            vec_inserts,
+                        )
 
             if not self._in_transaction:
                 db.commit()

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -233,6 +233,20 @@ def create_tables(
             USING vec0(embedding float[{dimension}])
         """)
 
+    # Idempotent migration (#691): collapse duplicate-hash rows and add a
+    # UNIQUE constraint so multi-process indexing (mm web watcher + mm CLI /
+    # MCP) cannot insert ghost rows that share
+    # ``(namespace, source_file, content_hash, start_line)``. The cleanup
+    # only runs once — its presence/absence is gated by
+    # ``idx_chunks_unique_content`` so subsequent startups are a no-op.
+    has_vec_table = (
+        db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='chunks_vec'"
+        ).fetchone()
+        is not None
+    )
+    _migrate_chunks_uniqueness(db, has_vec_table=has_vec_table)
+
     db.execute("""
         CREATE INDEX IF NOT EXISTS idx_chunks_source
         ON chunks(source_file)
@@ -528,3 +542,90 @@ def _backfill_chunk_links(db: sqlite3.Connection, meta: MetaManager) -> int:
 
     meta.set_meta(_CHUNK_LINKS_BACKFILL_KEY, "done")
     return inserted
+
+
+def _migrate_chunks_uniqueness(db: sqlite3.Connection, *, has_vec_table: bool) -> None:
+    """One-time cleanup + UNIQUE constraint for ``chunks`` (#691).
+
+    Multi-process indexing (``mm web`` watcher + ``mm`` CLI / MCP) on a
+    shared SQLite DB used to insert duplicate rows that shared
+    ``(namespace, source_file, content_hash, start_line)`` but differed
+    only in ``id``. Each process holds its own ``asyncio.Lock`` and there
+    was no storage-layer guard, so both ``INSERT`` calls succeeded with
+    fresh UUIDs. The differ then reused only one of the IDs per
+    re-indexing round, leaving the others as silent ghosts.
+
+    Migration steps, gated on ``idx_chunks_unique_content`` so subsequent
+    startups are a no-op:
+
+    1. Group rows by ``(namespace, source_file, content_hash, start_line)``.
+    2. Within each group, keep the row with the most accumulated
+       personalization (``access_count + use_count``) — tie-break by oldest
+       ``created_at``, then by ``id`` — and mark the rest for deletion.
+    3. Delete the loser rowids from ``chunks_fts`` and ``chunks_vec``
+       (the latter only when present), then from ``chunks``.
+    4. Create the UNIQUE INDEX. Once present, future
+       ``INSERT OR IGNORE`` calls in ``upsert_chunks`` silently drop
+       race-loser rows at the storage layer.
+    """
+    already_migrated = (
+        db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_chunks_unique_content'"
+        ).fetchone()
+        is not None
+    )
+    if already_migrated:
+        return
+
+    # Collect rowids of duplicate losers in one pass. ``ROW_NUMBER()`` over
+    # the partition picks the keeper (rn=1) by usage then age then id; rn>1
+    # are ghosts. Returns ``[]`` on a clean DB so the rest of the migration
+    # is a single ``CREATE UNIQUE INDEX``.
+    loser_rowids = [
+        row[0]
+        for row in db.execute(
+            """
+            SELECT rowid FROM (
+                SELECT rowid, ROW_NUMBER() OVER (
+                    PARTITION BY namespace, source_file, content_hash, start_line
+                    ORDER BY (access_count + use_count) DESC,
+                             created_at ASC,
+                             id ASC
+                ) AS rn
+                FROM chunks
+            )
+            WHERE rn > 1
+            """
+        ).fetchall()
+    ]
+
+    if loser_rowids:
+        group_count = db.execute(
+            "SELECT COUNT(*) FROM ("
+            "SELECT 1 FROM chunks "
+            "GROUP BY namespace, source_file, content_hash, start_line "
+            "HAVING COUNT(*) > 1"
+            ")"
+        ).fetchone()[0]
+        # Chunked deletes keep the parameter list under SQLite's 999-host
+        # limit on older builds. Sidecars first so an interrupted run never
+        # leaves an FTS/vec entry pointing at a non-existent ``chunks.rowid``.
+        chunk_size = 500
+        for i in range(0, len(loser_rowids), chunk_size):
+            batch = loser_rowids[i : i + chunk_size]
+            placeholders = ",".join("?" * len(batch))
+            db.execute(f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders})", batch)
+            if has_vec_table:
+                db.execute(f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders})", batch)
+            db.execute(f"DELETE FROM chunks WHERE rowid IN ({placeholders})", batch)
+        logger.info(
+            "Cleaned up %d duplicate chunk row(s) across %d group(s) before "
+            "adding UNIQUE(namespace, source_file, content_hash, start_line) — see #691",
+            len(loser_rowids),
+            group_count,
+        )
+
+    db.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_unique_content "
+        "ON chunks(namespace, source_file, content_hash, start_line)"
+    )

--- a/packages/memtomem/src/memtomem/storage/sqlite_schema.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_schema.py
@@ -567,65 +567,98 @@ def _migrate_chunks_uniqueness(db: sqlite3.Connection, *, has_vec_table: bool) -
     4. Create the UNIQUE INDEX. Once present, future
        ``INSERT OR IGNORE`` calls in ``upsert_chunks`` silently drop
        race-loser rows at the storage layer.
+
+    **Concurrent-startup safety**: the same multi-process scenario that
+    caused #691 in the first place applies to the migration too — two
+    processes booting simultaneously could each see ``already_migrated=False``
+    on the cheap fast-path. We therefore wrap the migration body in
+    ``BEGIN IMMEDIATE`` / ``COMMIT`` (acquires SQLite's RESERVED lock so
+    the second process blocks until the first commits) and re-check the
+    index existence inside the transaction. The deletes themselves are
+    idempotent against missing rowids, so even an interrupted run on a
+    fresh process restart converges.
+
+    **SQLite version requirement**: the keeper-selection query uses
+    ``ROW_NUMBER()`` which needs SQLite ≥ 3.25 (2018-09). Python 3.12's
+    bundled ``sqlite3`` is well past that floor on every supported OS.
     """
-    already_migrated = (
+    # Cheap fast-path so already-migrated DBs don't take the lock.
+    if (
         db.execute(
             "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_chunks_unique_content'"
         ).fetchone()
         is not None
-    )
-    if already_migrated:
+    ):
         return
 
-    # Collect rowids of duplicate losers in one pass. ``ROW_NUMBER()`` over
-    # the partition picks the keeper (rn=1) by usage then age then id; rn>1
-    # are ghosts. Returns ``[]`` on a clean DB so the rest of the migration
-    # is a single ``CREATE UNIQUE INDEX``.
-    loser_rowids = [
-        row[0]
-        for row in db.execute(
-            """
-            SELECT rowid FROM (
-                SELECT rowid, ROW_NUMBER() OVER (
-                    PARTITION BY namespace, source_file, content_hash, start_line
-                    ORDER BY (access_count + use_count) DESC,
-                             created_at ASC,
-                             id ASC
-                ) AS rn
-                FROM chunks
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        # Re-check inside the transaction in case another startup beat us
+        # to the index between our fast-path check and the lock acquisition.
+        if (
+            db.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='index' AND name='idx_chunks_unique_content'"
+            ).fetchone()
+            is not None
+        ):
+            db.execute("COMMIT")
+            return
+
+        # Collect rowids of duplicate losers in one pass. ``ROW_NUMBER()``
+        # over the partition picks the keeper (rn=1) by usage then age then
+        # id; rn>1 are ghosts. Returns ``[]`` on a clean DB so the rest of
+        # the migration is a single ``CREATE UNIQUE INDEX``.
+        loser_rowids = [
+            row[0]
+            for row in db.execute(
+                """
+                SELECT rowid FROM (
+                    SELECT rowid, ROW_NUMBER() OVER (
+                        PARTITION BY namespace, source_file, content_hash, start_line
+                        ORDER BY (access_count + use_count) DESC,
+                                 created_at ASC,
+                                 id ASC
+                    ) AS rn
+                    FROM chunks
+                )
+                WHERE rn > 1
+                """
+            ).fetchall()
+        ]
+
+        if loser_rowids:
+            group_count = db.execute(
+                "SELECT COUNT(*) FROM ("
+                "SELECT 1 FROM chunks "
+                "GROUP BY namespace, source_file, content_hash, start_line "
+                "HAVING COUNT(*) > 1"
+                ")"
+            ).fetchone()[0]
+            # Chunked deletes keep the parameter list under SQLite's 999-host
+            # limit on older builds. Sidecars first so an interrupted run
+            # never leaves an FTS/vec entry pointing at a non-existent
+            # ``chunks.rowid``.
+            chunk_size = 500
+            for i in range(0, len(loser_rowids), chunk_size):
+                batch = loser_rowids[i : i + chunk_size]
+                placeholders = ",".join("?" * len(batch))
+                db.execute(f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders})", batch)
+                if has_vec_table:
+                    db.execute(f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders})", batch)
+                db.execute(f"DELETE FROM chunks WHERE rowid IN ({placeholders})", batch)
+            logger.info(
+                "Cleaned up %d duplicate chunk row(s) across %d group(s) before "
+                "adding UNIQUE(namespace, source_file, content_hash, start_line) — see #691",
+                len(loser_rowids),
+                group_count,
             )
-            WHERE rn > 1
-            """
-        ).fetchall()
-    ]
 
-    if loser_rowids:
-        group_count = db.execute(
-            "SELECT COUNT(*) FROM ("
-            "SELECT 1 FROM chunks "
-            "GROUP BY namespace, source_file, content_hash, start_line "
-            "HAVING COUNT(*) > 1"
-            ")"
-        ).fetchone()[0]
-        # Chunked deletes keep the parameter list under SQLite's 999-host
-        # limit on older builds. Sidecars first so an interrupted run never
-        # leaves an FTS/vec entry pointing at a non-existent ``chunks.rowid``.
-        chunk_size = 500
-        for i in range(0, len(loser_rowids), chunk_size):
-            batch = loser_rowids[i : i + chunk_size]
-            placeholders = ",".join("?" * len(batch))
-            db.execute(f"DELETE FROM chunks_fts WHERE rowid IN ({placeholders})", batch)
-            if has_vec_table:
-                db.execute(f"DELETE FROM chunks_vec WHERE rowid IN ({placeholders})", batch)
-            db.execute(f"DELETE FROM chunks WHERE rowid IN ({placeholders})", batch)
-        logger.info(
-            "Cleaned up %d duplicate chunk row(s) across %d group(s) before "
-            "adding UNIQUE(namespace, source_file, content_hash, start_line) — see #691",
-            len(loser_rowids),
-            group_count,
+        db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_unique_content "
+            "ON chunks(namespace, source_file, content_hash, start_line)"
         )
-
-    db.execute(
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_unique_content "
-        "ON chunks(namespace, source_file, content_hash, start_line)"
-    )
+        db.execute("COMMIT")
+    except Exception:
+        db.execute("ROLLBACK")
+        raise

--- a/packages/memtomem/src/memtomem/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/tools/export_import.py
@@ -173,9 +173,14 @@ async def import_chunks(
       * ``"update"``: records matching an existing hash overwrite that
         existing row's metadata (tags, namespace, heading hierarchy,
         source_file, created_at). The existing UUID is preserved.
-      * ``"duplicate"``: no hash check — every record is inserted with a
-        fresh UUID. This is the pre-v2 behaviour and produces row-level
-        duplicates when re-importing or merging overlapping bundles.
+      * ``"duplicate"``: no hash check at the import layer — every record
+        is sent to ``upsert_chunks`` with a fresh UUID. This was the
+        pre-v2 behaviour, but since #691 the storage layer now enforces
+        ``UNIQUE(namespace, source_file, content_hash, start_line)`` via
+        ``INSERT OR IGNORE``: rows that would have produced duplicates
+        are silently dropped at insert time. The mode is kept for
+        back-compat with existing callers but no longer materialises
+        duplicate rows on disk.
 
     For non-conflicting records, UUID assignment is controlled by
     ``preserve_ids``: when True *and* the bundle is v2 (carries
@@ -237,7 +242,12 @@ async def import_chunks(
     updated = 0
 
     if on_conflict == "duplicate":
-        # Back-compat path: every record gets a fresh UUID, no hash check.
+        # Back-compat path: every record gets a fresh UUID, no hash check
+        # at this layer. Since #691 the storage UNIQUE index +
+        # ``INSERT OR IGNORE`` collapses any rows that would have shared
+        # ``(namespace, source_file, content_hash, start_line)``, so this
+        # mode no longer materialises duplicate rows even though the
+        # caller surface still accepts it.
         to_upsert = [c for c, _ in parsed]
     else:
         all_hashes = [c.content_hash for c, _ in parsed]

--- a/packages/memtomem/tests/test_chunk_links_reader.py
+++ b/packages/memtomem/tests/test_chunk_links_reader.py
@@ -35,11 +35,17 @@ async def backend(tmp_path):
 
 def _seed_chunk(backend: SqliteBackend, chunk_id: UUID, *, namespace: str = "default") -> None:
     db = backend._get_db()
+    # ``content_hash`` per-row uniqueness here is incidental: chunk_links
+    # tests don't care about the chunk body, but the
+    # ``UNIQUE(namespace, source_file, content_hash, start_line)`` index on
+    # ``chunks`` (#691) refuses two seeded rows that collide on those four
+    # columns. Keying ``content_hash`` off ``chunk_id`` keeps every seed row
+    # distinct without making the test setup any more interesting.
     db.execute(
         "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
         "tags, created_at, updated_at) "
-        "VALUES (?, '', '', '', ?, '[]', '2026-01-01T00:00:00', '2026-01-01T00:00:00')",
-        (str(chunk_id), namespace),
+        "VALUES (?, '', ?, '', ?, '[]', '2026-01-01T00:00:00', '2026-01-01T00:00:00')",
+        (str(chunk_id), str(chunk_id), namespace),
     )
     db.commit()
 

--- a/packages/memtomem/tests/test_chunk_links_schema.py
+++ b/packages/memtomem/tests/test_chunk_links_schema.py
@@ -58,11 +58,14 @@ def _insert_chunk(
     tags_json: str = "[]",
 ) -> None:
     now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    # ``content_hash`` keyed off ``chunk_id`` so multiple seeded chunks under
+    # the same namespace + (empty) source_file don't collide on the
+    # ``UNIQUE(namespace, source_file, content_hash, start_line)`` index (#691).
     db.execute(
         "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
         "tags, created_at, updated_at) "
-        "VALUES (?, '', '', '', ?, ?, ?, ?)",
-        (chunk_id, namespace, tags_json, now, now),
+        "VALUES (?, '', ?, '', ?, ?, ?, ?)",
+        (chunk_id, chunk_id, namespace, tags_json, now, now),
     )
 
 

--- a/packages/memtomem/tests/test_chunk_links_writer.py
+++ b/packages/memtomem/tests/test_chunk_links_writer.py
@@ -42,11 +42,14 @@ async def backend(tmp_path):
 def _seed_chunk(backend: SqliteBackend, chunk_id: UUID, *, namespace: str = "default") -> None:
     """Insert a minimal ``chunks`` row so FK checks pass without indexing."""
     db = backend._get_db()
+    # ``content_hash`` keyed off ``chunk_id`` so multiple seeded chunks under
+    # the same namespace + (empty) source_file don't collide on the
+    # ``UNIQUE(namespace, source_file, content_hash, start_line)`` index (#691).
     db.execute(
         "INSERT INTO chunks (id, content, content_hash, source_file, namespace, "
         "tags, created_at, updated_at) "
-        "VALUES (?, '', '', '', ?, '[]', '2026-01-01T00:00:00', '2026-01-01T00:00:00')",
-        (str(chunk_id), namespace),
+        "VALUES (?, '', ?, '', ?, '[]', '2026-01-01T00:00:00', '2026-01-01T00:00:00')",
+        (str(chunk_id), str(chunk_id), namespace),
     )
     db.commit()
 

--- a/packages/memtomem/tests/test_export_import_roundtrip.py
+++ b/packages/memtomem/tests/test_export_import_roundtrip.py
@@ -410,8 +410,17 @@ class TestRoundtripBaseline:
 class TestOnConflictModes:
     """Pin each ``on_conflict`` mode individually."""
 
-    async def test_duplicate_mode_backcompat(self, tmp_path):
-        """``on_conflict="duplicate"`` reproduces pre-v2 row-duplication."""
+    async def test_duplicate_mode_dedups_at_storage_layer(self, tmp_path):
+        """``on_conflict="duplicate"`` used to force fresh UUIDs without
+        any hash check — pre-v2 row-duplication semantics. Since #691
+        added ``UNIQUE(namespace, source_file, content_hash, start_line)``
+        plus ``INSERT OR IGNORE`` in ``upsert_chunks``, the storage layer
+        is authoritative: a second import's attempted inserts are silently
+        dropped, and the DB ends up with one row per content_hash even
+        when the caller asks for the legacy "duplicate" behaviour. The
+        mode is kept so existing callers don't break, but it no longer
+        produces row duplication.
+        """
         comp_a, mem_a = await _make_onnx_components(tmp_path, "pc_a_dup")
         comp_b, _ = await _make_onnx_components(tmp_path, "pc_b_dup")
         try:
@@ -421,21 +430,17 @@ class TestOnConflictModes:
             bundle_path = tmp_path / "bundle.json"
             await export_chunks(comp_a.storage, output_path=bundle_path)
 
-            s1 = await import_chunks(
+            await import_chunks(
                 comp_b.storage, comp_b.embedder, bundle_path, on_conflict="duplicate"
             )
-            s2 = await import_chunks(
+            await import_chunks(
                 comp_b.storage, comp_b.embedder, bundle_path, on_conflict="duplicate"
             )
             b2 = await comp_b.storage.recall_chunks(limit=10_000)
             dup_counter = Counter(c.content_hash for c in b2)
 
-            assert s1.imported_chunks == len(chunks_a)
-            assert s2.imported_chunks == len(chunks_a)
-            assert s1.conflict_skipped_chunks == 0
-            assert s2.conflict_skipped_chunks == 0
-            assert len(b2) == 2 * len(chunks_a)
-            assert max(dup_counter.values()) == 2
+            assert len(b2) == len(chunks_a)
+            assert max(dup_counter.values()) == 1
         finally:
             await close_components(comp_a)
             await close_components(comp_b)

--- a/packages/memtomem/tests/test_sqlite_schema.py
+++ b/packages/memtomem/tests/test_sqlite_schema.py
@@ -156,3 +156,108 @@ class TestDim0ProviderMismatch:
             assert vec_row is not None
         finally:
             db.close()
+
+
+class TestDuplicateChunksMigration:
+    """One-time cleanup of pre-#691 duplicate chunk rows on startup.
+
+    Real-world DBs that ran ``mm web`` watcher + ``mm`` MCP / CLI on the same
+    files accumulated rows that share
+    ``(namespace, source_file, content_hash, start_line)`` but differ only in
+    ``id``. ``create_tables`` must collapse those groups exactly once, then
+    install the UNIQUE index so future ``INSERT OR IGNORE`` writes block any
+    new ones at the storage layer.
+    """
+
+    @staticmethod
+    def _seed_dup_rows(db: sqlite3.Connection) -> None:
+        # Two identical-hash rows differing only in id, created_at, and access
+        # stats. The keeper must be the row with the higher
+        # ``access_count + use_count`` — that is the row the differ has been
+        # actively reusing across re-indexes; the loser is the silent ghost.
+        db.executemany(
+            """INSERT INTO chunks
+               (id, content, content_hash, source_file, namespace,
+                start_line, end_line, created_at, updated_at,
+                access_count, use_count)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                (
+                    "00000000-0000-0000-0000-000000000001",
+                    "duplicate body",
+                    "hash-X",
+                    "/tmp/dup.md",
+                    "default",
+                    10,
+                    20,
+                    "2026-04-29T00:00:00+00:00",
+                    "2026-04-29T00:00:00+00:00",
+                    7,
+                    3,
+                ),
+                (
+                    "00000000-0000-0000-0000-000000000002",
+                    "duplicate body",
+                    "hash-X",
+                    "/tmp/dup.md",
+                    "default",
+                    10,
+                    20,
+                    "2026-04-30T00:00:00+00:00",
+                    "2026-04-30T00:00:00+00:00",
+                    0,
+                    0,
+                ),
+            ],
+        )
+        db.commit()
+
+    def test_collapses_existing_dup_rows_and_installs_unique_index(self) -> None:
+        db = _connect_with_vec()
+        try:
+            meta = MetaManager(lambda: db)
+            # First call sets up schema; on a fresh DB the cleanup loop has
+            # nothing to do but the UNIQUE index is created.
+            create_tables(db, meta, dimension=0, embedding_provider="none", embedding_model="")
+
+            # Drop the index so we can simulate an upgrade from a pre-#691
+            # DB that already accumulated duplicates.
+            db.execute("DROP INDEX idx_chunks_unique_content")
+            self._seed_dup_rows(db)
+
+            # Second call re-runs create_tables, which now sees the UNIQUE
+            # index missing and triggers the cleanup migration.
+            create_tables(db, meta, dimension=0, embedding_provider="none", embedding_model="")
+
+            rows = db.execute(
+                "SELECT id, access_count FROM chunks WHERE content_hash='hash-X'"
+            ).fetchall()
+            assert len(rows) == 1, f"expected 1 row after cleanup, got {len(rows)}"
+            kept_id, kept_access = rows[0]
+            # Keeper rule: highest (access_count + use_count) wins so we
+            # preserve the actively-reused row, not the older ghost.
+            assert kept_id == "00000000-0000-0000-0000-000000000001"
+            assert kept_access == 7
+
+            idx_row = db.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='index' AND name='idx_chunks_unique_content'"
+            ).fetchone()
+            assert idx_row is not None, "UNIQUE index must be present after migration"
+        finally:
+            db.close()
+
+    def test_migration_is_idempotent_after_first_run(self) -> None:
+        db = _connect_with_vec()
+        try:
+            meta = MetaManager(lambda: db)
+            create_tables(db, meta, dimension=0, embedding_provider="none", embedding_model="")
+            # No dups exist; second call must be a no-op (no errors, index stays).
+            create_tables(db, meta, dimension=0, embedding_provider="none", embedding_model="")
+            idx_row = db.execute(
+                "SELECT 1 FROM sqlite_master "
+                "WHERE type='index' AND name='idx_chunks_unique_content'"
+            ).fetchone()
+            assert idx_row is not None
+        finally:
+            db.close()

--- a/packages/memtomem/tests/test_sqlite_schema.py
+++ b/packages/memtomem/tests/test_sqlite_schema.py
@@ -170,11 +170,14 @@ class TestDuplicateChunksMigration:
     """
 
     @staticmethod
-    def _seed_dup_rows(db: sqlite3.Connection) -> None:
+    def _seed_dup_rows(db: sqlite3.Connection) -> dict[str, int]:
         # Two identical-hash rows differing only in id, created_at, and access
         # stats. The keeper must be the row with the higher
         # ``access_count + use_count`` — that is the row the differ has been
         # actively reusing across re-indexes; the loser is the silent ghost.
+        # Returns ``{chunk_id: rowid}`` so callers can pin sidecar cleanup
+        # against the loser's rowid (chunks_fts entries here; no chunks_vec
+        # because this test path runs at dimension=0).
         db.executemany(
             """INSERT INTO chunks
                (id, content, content_hash, source_file, namespace,
@@ -210,7 +213,22 @@ class TestDuplicateChunksMigration:
                 ),
             ],
         )
+        rowid_by_id = {
+            row[0]: row[1]
+            for row in db.execute(
+                "SELECT id, rowid FROM chunks WHERE content_hash='hash-X'"
+            ).fetchall()
+        }
+        # Mirror the prod write path: every chunks row has a matching
+        # chunks_fts row at the same rowid. Without these the negative pin
+        # below couldn't tell whether the migration cleaned up the sidecar
+        # or whether it was simply never seeded.
+        db.executemany(
+            "INSERT INTO chunks_fts(rowid, content, source_file) VALUES (?, ?, ?)",
+            [(rowid, "duplicate body", "/tmp/dup.md") for rowid in rowid_by_id.values()],
+        )
         db.commit()
+        return rowid_by_id
 
     def test_collapses_existing_dup_rows_and_installs_unique_index(self) -> None:
         db = _connect_with_vec()
@@ -223,7 +241,8 @@ class TestDuplicateChunksMigration:
             # Drop the index so we can simulate an upgrade from a pre-#691
             # DB that already accumulated duplicates.
             db.execute("DROP INDEX idx_chunks_unique_content")
-            self._seed_dup_rows(db)
+            rowid_by_id = self._seed_dup_rows(db)
+            loser_rowid = rowid_by_id["00000000-0000-0000-0000-000000000002"]
 
             # Second call re-runs create_tables, which now sees the UNIQUE
             # index missing and triggers the cleanup migration.
@@ -238,6 +257,19 @@ class TestDuplicateChunksMigration:
             # preserve the actively-reused row, not the older ghost.
             assert kept_id == "00000000-0000-0000-0000-000000000001"
             assert kept_access == 7
+
+            # Negative pin (per ``feedback_pin_invert_symmetric_assertion``):
+            # asserting the keeper survived isn't enough — the loser must
+            # also be gone, in both ``chunks`` and the ``chunks_fts`` sidecar
+            # that production keeps in lockstep.
+            loser_present = db.execute(
+                "SELECT 1 FROM chunks WHERE id='00000000-0000-0000-0000-000000000002'"
+            ).fetchone()
+            assert loser_present is None, "loser chunk row must be deleted"
+            loser_fts = db.execute(
+                "SELECT 1 FROM chunks_fts WHERE rowid=?", (loser_rowid,)
+            ).fetchone()
+            assert loser_fts is None, "loser chunks_fts sidecar row must be deleted"
 
             idx_row = db.execute(
                 "SELECT 1 FROM sqlite_master "

--- a/packages/memtomem/tests/test_storage.py
+++ b/packages/memtomem/tests/test_storage.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 from helpers import make_chunk as _make_chunk
+from memtomem.models import Chunk, ChunkMetadata
 from memtomem.storage.sqlite_helpers import norm_path
 
 
@@ -31,6 +32,79 @@ class TestChunkCRUD:
     async def test_get_nonexistent(self, storage):
         result = await storage.get_chunk(uuid4())
         assert result is None
+
+
+class TestChunkUniqueness:
+    """Regression for #691: duplicate chunks within a single source.
+
+    Real-world cause: ``mm web`` watcher + ``mm`` MCP / CLI indexing the same
+    file from separate processes. Each process holds its own asyncio.Lock
+    and SQLite is the only shared coordination point — so without a UNIQUE
+    constraint plus INSERT OR IGNORE, both inserts succeed and produce
+    rows that share (namespace, source_file, content_hash, start_line) but
+    differ only in id. Once present, those rows survive subsequent
+    re-indexing because the differ never sees their hash as "stale".
+    """
+
+    @staticmethod
+    def _twin_chunks() -> tuple[Chunk, Chunk]:
+        # ``content_hash`` is filled by ``Chunk.__post_init__`` from the
+        # NFC-normalised content, so two chunks built from the same string
+        # produce the same hash with different uuid4 ids — exactly the
+        # shape the multi-process race produces in the wild.
+        def _mk() -> Chunk:
+            return Chunk(
+                content="duplicate body",
+                metadata=ChunkMetadata(
+                    source_file=Path("/tmp/dup.md"),
+                    start_line=10,
+                    end_line=20,
+                    namespace="default",
+                ),
+                embedding=[0.1] * 1024,
+            )
+
+        return _mk(), _mk()
+
+    @pytest.mark.asyncio
+    async def test_second_upsert_with_same_hash_is_silently_ignored(self, storage):
+        a, b = self._twin_chunks()
+        assert a.content_hash == b.content_hash
+        assert a.id != b.id
+
+        await storage.upsert_chunks([a])
+        await storage.upsert_chunks([b])
+
+        rows = (
+            storage._get_db()
+            .execute(
+                "SELECT id FROM chunks WHERE content_hash=? AND source_file=? "
+                "AND namespace=? AND start_line=?",
+                (a.content_hash, norm_path(Path("/tmp/dup.md")), "default", 10),
+            )
+            .fetchall()
+        )
+        assert len(rows) == 1, (
+            f"expected 1 row after dup upsert, got {len(rows)} — "
+            f"UNIQUE(namespace, source_file, content_hash, start_line) "
+            f"missing or INSERT not using OR IGNORE"
+        )
+
+    @pytest.mark.asyncio
+    async def test_within_batch_dup_collapses_to_one_row(self, storage):
+        # Same race shape, single ``upsert_chunks`` call: a ``new_chunks``
+        # batch with two identical-hash entries (e.g. a chunker bug emitting
+        # the same section twice within one run) must not produce two rows.
+        a, b = self._twin_chunks()
+
+        await storage.upsert_chunks([a, b])
+
+        rows = (
+            storage._get_db()
+            .execute("SELECT id FROM chunks WHERE content_hash=?", (a.content_hash,))
+            .fetchall()
+        )
+        assert len(rows) == 1
 
 
 class TestTags:


### PR DESCRIPTION
## Summary

- Closes #691. Multi-process indexing (`mm web` watcher + `mm` CLI / MCP server) on the same SQLite DB used to insert chunk rows that shared `(namespace, source_file, content_hash, start_line)` but differed only in `id`. Each process held its own `asyncio.Lock`; without a storage-layer guard both `INSERT`s succeeded with fresh UUIDs, and the differ then reused only one of the IDs per re-index — leaving the rest as silent ghosts that survived every subsequent run.
- Fix lands at the storage layer (`UNIQUE(namespace, source_file, content_hash, start_line)` + `INSERT OR IGNORE`), with an idempotent startup migration that collapses each pre-existing duplicate group to its most-actively-used row before installing the index.
- `start_line` is part of the key so legitimate same-content-different-position chunks (e.g. an identical TODO block reused at two locations in one file) are still preserved; race-induced dups always share `start_line` and are caught.

## What was happening

User-reported on a real DB:

```
total_chunks            1546
distinct_content_hash   1469
duplicate_groups          77
duplicate_rows           154
```

Every duplicate group was same-namespace + same-source. 64 of 77 groups had identical `created_at` to second precision, ruling out user-driven re-indexing. Search results visibly repeated content under different chunk ids; chunk counts in `mem_stats` were inflated.

Reproduction with two `multiprocessing.Process` workers indexing the same RFC file against the same DB on `main`:

```
total=26 distinct_hash=13 duplicate_groups=13   # bug
```

Same script after this PR:

```
total=13 distinct_hash=13 duplicate_groups=0    # fixed
```

The reproduced hashes match the prod DB bit-for-bit, confirming the multi-process race is the actual cause (not a chunker bug — `MarkdownChunker.chunk_file` on the same file with the same config emits 0 hash duplicates, and so does the full pre-diff pipeline including `_merge_short_chunks` and `_add_overlap`).

## What changed

`packages/memtomem/src/memtomem/storage/sqlite_schema.py`
- New `_migrate_chunks_uniqueness` helper, gated on whether `idx_chunks_unique_content` already exists. On a clean DB (or already-migrated DB) it's a single index lookup — zero-cost.
- When the index is missing it groups rows by `(namespace, source_file, content_hash, start_line)`, picks the keeper as the row with the highest `(access_count + use_count)` so we preserve whichever row the differ has been actively reusing across re-indexes (tie-break: oldest `created_at`, then `id`), and deletes the loser rowids from `chunks_fts` and `chunks_vec` (when present) before deleting from `chunks`. Sidecars first so an interrupted run never leaves an FTS/vec entry pointing at a non-existent `chunks.rowid`.
- Then `CREATE UNIQUE INDEX IF NOT EXISTS idx_chunks_unique_content ON chunks(namespace, source_file, content_hash, start_line)`.

`packages/memtomem/src/memtomem/storage/sqlite_backend.py`
- `upsert_chunks`: chunk INSERT becomes `INSERT OR IGNORE`. Race losers are dropped silently at insert time.
- The follow-up `SELECT id, rowid FROM chunks WHERE id IN (...)` already filters by actual row existence, so `chunks_fts` and `chunks_vec` inserts naturally skip dropped rows. Wrapped the sidecar block in `if new_rowids:` for the case where every `to_insert` row was a race loser (otherwise `placeholders(0)` raised).

`packages/memtomem/src/memtomem/tools/export_import.py`
- `on_conflict="duplicate"` mode kept for back-compat but documented and commented to reflect that the storage invariant is now authoritative — the mode no longer materialises duplicate rows on disk.

Tests
- `test_storage.py::TestChunkUniqueness` — sequential and within-batch twin chunks (same `content_hash`, different `id`) collapse to one row.
- `test_sqlite_schema.py::TestDuplicateChunksMigration` — pre-#691 dup rows are cleaned up on first startup with the most-active row preserved; second startup is a no-op.
- `test_export_import_roundtrip.py::TestOnConflictModes::test_duplicate_mode_dedups_at_storage_layer` — replaces the old `test_duplicate_mode_backcompat`; pins the new dedup behaviour.
- Seed helpers in `test_chunk_links_{reader,writer,schema}.py` were inserting multiple rows with `content_hash=''` and `source_file=''` under the same namespace — which now correctly violates the UNIQUE index. Helpers updated to key `content_hash` off `chunk_id` so seed-only tests don't double as smoke tests for the constraint.

## Test plan

- [x] `uv run pytest -m "not ollama"` — full suite, 3891 passed.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] Two-process race repro on a clean DB shows `duplicate_groups=0` after fix (was `13`).
- [x] Migration test pins keeper selection: row with higher `access_count + use_count` is preserved over the older but unused row.
- [x] Manual smoke: `create_tables` runs twice on the same DB without error (idempotency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
