### PR TITLE
docs(embeddings): warn that embedding-reset needs an idle DB

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -208,10 +208,10 @@ Resolving it is a two-step process — pick **one** of:
 > different embedding models pointing at the same SQLite file, race-loser
 > chunk inserts are silently dropped at the storage layer (the unique key
 > is content-only, so different-model embeddings for the same content are
-> indistinguishable). The startup dimension gate (issue #298) catches the
-> common case where the new model has a different dimension, but **same-
-> dimension** model swaps slip past it. See issue #707 for the full
-> failure mode.
+> indistinguishable). The startup dimension gate (issue #298) catches
+> the common case where the new model has a different dimension, but
+> **same-dimension** model swaps slip past it. See issue #707 for the
+> full failure mode.
 
 `mem_status` emits a `warnings[]` array entry with this schema when a
 mismatch is detected:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -202,6 +202,17 @@ Resolving it is a two-step process — pick **one** of:
   stays untouched; the server swaps its embedder to match what the DB
   already contains.
 
+> **Stop other `mm` processes first.** Run `embedding-reset` against an
+> idle DB — shut down `mm web`, the MCP server, and any background `mm
+> index` runs before invoking it. If two processes briefly co-exist with
+> different embedding models pointing at the same SQLite file, race-loser
+> chunk inserts are silently dropped at the storage layer (the unique key
+> is content-only, so different-model embeddings for the same content are
+> indistinguishable). The startup dimension gate (issue #298) catches the
+> common case where the new model has a different dimension, but **same-
+> dimension** model swaps slip past it. See issue #707 for the full
+> failure mode.
+
 `mem_status` emits a `warnings[]` array entry with this schema when a
 mismatch is detected:
 

--- a/docs/guides/embeddings.md
+++ b/docs/guides/embeddings.md
@@ -87,7 +87,7 @@ export MEMTOMEM_EMBEDDING__DIMENSION=3072
 
 ## Switching Models on an Existing Index
 
-If you switch the embedding model after indexing, run `mm embedding-reset` to detect and resolve the dimension mismatch. See [`configuration.md#reset-flow`](configuration.md#reset-flow) for the full two-mode flow (`apply-current` vs `revert-to-stored`), the `mem_status` warning schema, and the equivalent `mem_embedding_reset` MCP tool.
+If you switch the embedding model after indexing, run `mm embedding-reset` to detect and resolve the dimension mismatch. **Stop any running `mm web` / MCP server / `mm index` first** — running `embedding-reset` against a live DB can leave a mix of old- and new-model vectors silently coexisting (issue #707). See [`configuration.md#reset-flow`](configuration.md#reset-flow) for the full two-mode flow (`apply-current` vs `revert-to-stored`), the `mem_status` warning schema, and the equivalent `mem_embedding_reset` MCP tool.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Closes #707. Documents the single-process invariant for `mm embedding-reset` so users don't trigger the same-dim model-swap race that PR #705's `INSERT OR IGNORE` path can't catch.
- Doc-only change. The fix matches option (1) from the issue's "Suggested handling" list — cheapest, non-invasive. Option (2) (process-level lock file) is left as a separate RFC if real-user reports keep showing up.
- Two surfaces: a callout in the canonical `configuration.md#reset-flow`, and a one-line warning in `embeddings.md` "Switching Models on an Existing Index" (which already links to the canonical section).

## Why now

Issue #707 (review follow-up from #705) flags that `INSERT OR IGNORE` on a content-hash key keeps whichever embedding commits first when two processes embed the same chunk under *different* models. The dim gate (`sqlite_schema.py` ~line 212, issue #298) catches the dimension-mismatch case, but same-dimension model swaps slip past it (e.g. swapping one 1024-d model for another). The realistic trigger is a user leaving `mm web` running, editing `~/.memtomem/config.json` to a new same-dim model, then invoking `mm embedding-reset --mode apply-current` from another shell — exactly the flow our existing docs lay out without warning.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_docs_guards.py -q` — 11 passed.
- [x] `uv run ruff check docs/ packages/memtomem/src` + `ruff format --check packages/memtomem/src` — clean.
- [x] Rendered both edits locally; the link `embeddings.md` → `configuration.md#reset-flow` still resolves and the new callout sits between the two-mode resolution block and the `mem_status` warning schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
