### PR TITLE
test: normalize path separators in 7 cross-platform assertions (#643)

### DIFF
--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -84,7 +84,7 @@ def test_env_var_wins_over_config_json_scalar(
     )
     cfg = Mem2MemConfig()
     load_config_overrides(cfg)
-    assert str(cfg.storage.sqlite_path) == "/from/env.db"
+    assert Path(cfg.storage.sqlite_path).as_posix() == "/from/env.db"
 
 
 def test_env_var_wins_over_config_json_list(
@@ -97,7 +97,7 @@ def test_env_var_wins_over_config_json_list(
     )
     cfg = Mem2MemConfig()
     load_config_overrides(cfg)
-    assert [str(p) for p in cfg.indexing.memory_dirs] == ["/from/env"]
+    assert [Path(p).as_posix() for p in cfg.indexing.memory_dirs] == ["/from/env"]
 
 
 def test_env_and_config_coexist_on_different_fields(
@@ -117,7 +117,7 @@ def test_env_and_config_coexist_on_different_fields(
     )
     cfg = Mem2MemConfig()
     load_config_overrides(cfg)
-    assert str(cfg.storage.sqlite_path) == "/from/env.db"
+    assert Path(cfg.storage.sqlite_path).as_posix() == "/from/env.db"
     assert cfg.embedding.model == "from-config"
 
 
@@ -142,8 +142,8 @@ def test_regression_pr247_mcp_json_env_block(
     )
     cfg = Mem2MemConfig()
     load_config_overrides(cfg)
-    assert str(cfg.storage.sqlite_path) == "~/.memtomem/memtomem.db"
-    assert [str(p) for p in cfg.indexing.memory_dirs] == ["~/notes"]
+    assert Path(cfg.storage.sqlite_path).as_posix() == "~/.memtomem/memtomem.db"
+    assert [Path(p).as_posix() for p in cfg.indexing.memory_dirs] == ["~/notes"]
 
 
 # ---------------------------------------------------------------------------
@@ -221,7 +221,7 @@ def test_config_d_env_wins_over_fragments(
     )
     cfg = Mem2MemConfig()
     load_config_d(cfg)
-    assert str(cfg.storage.sqlite_path) == "/from/env.db"
+    assert Path(cfg.storage.sqlite_path).as_posix() == "/from/env.db"
 
 
 def test_config_d_unknown_section_warned_but_not_fatal(

--- a/packages/memtomem/tests/test_session_summary_rescue.py
+++ b/packages/memtomem/tests/test_session_summary_rescue.py
@@ -182,7 +182,7 @@ class TestBoostSourcesHelper:
 
         pipeline = _make_pipeline(storage, session_summary_config=cfg)
         sources = await pipeline._session_summary_boost_sources("q")
-        assert sources == {"/tmp/src/a.md", "/tmp/src/b.md"}
+        assert {Path(s).as_posix() for s in sources} == {"/tmp/src/a.md", "/tmp/src/b.md"}
         # Walk used the correct link_type
         call_args = storage.get_chunks_shared_from.await_args
         assert call_args.kwargs.get("link_type") == "summarizes"

--- a/packages/memtomem/tests/test_storage.py
+++ b/packages/memtomem/tests/test_storage.py
@@ -201,7 +201,10 @@ class TestNormPathUnicode:
 
     def test_norm_path_osError_fallback_still_normalizes(self, monkeypatch):
         # If ``Path.resolve`` raises, ``norm_path`` falls back to the input
-        # string — it must still NFC-normalize that fallback.
+        # string — it must still NFC-normalize that fallback. Comparison goes
+        # through ``as_posix()`` so the assertion is portable: norm_path uses
+        # ``str(p)`` on fallback which is platform-separator-dependent
+        # (backslash on Windows), but the NFC property under test is not.
         nfd = unicodedata.normalize("NFD", "/tmp/내 드라이브/file.md")
 
         def _boom(self, strict=False):
@@ -210,4 +213,4 @@ class TestNormPathUnicode:
         monkeypatch.setattr(Path, "resolve", _boom)
 
         out = norm_path(Path(nfd))
-        assert out == unicodedata.normalize("NFC", nfd)
+        assert Path(out).as_posix() == unicodedata.normalize("NFC", nfd)


### PR DESCRIPTION
Closes #643.

## Summary

The Windows CI job runs as `informational` (`continue-on-error: true` at `.github/workflows/ci.yml:45`). On the latest main run it accumulated **117 test failures**, falling into 6 distinct classes. This PR addresses the smallest, lowest-risk class — **path-separator literals in test assertions** — so the rest can be tackled cleanly in follow-up PRs.

7 tests across 3 files compared production output (a `Path` whose `str()` uses the platform separator) against hardcoded forward-slash literals. Wrapping the LHS in `Path(...).as_posix()` makes the comparison portable without changing what the test actually exercises.

**Test-only PR.** No production source touched (notably `norm_path()` in `storage/sqlite_helpers.py:24-38` is left as-is — its `str(p.resolve())` behaviour is on-disk-key-shaped and changing it would force a migration of every existing chunk row).

## Cross-check table

Triage was done against `gh run view 25244100712 --log-failed --job=74025071567`. Of the 14 candidates flagged by exploration, only the 7 below were genuinely path-separator failures; the others were misclassified and belong to other failure classes (see *Out of scope* below).

| Test | Path-sep? | Pattern | Notes |
|------|:---------:|:-------:|-------|
| `test_config_overrides.py::test_env_var_wins_over_config_json_scalar` | ✅ | 1 | `'\\from\\env.db' == '/from/env.db'` |
| `test_config_overrides.py::test_env_var_wins_over_config_json_list` | ✅ | 1 (list) | `['\\from\\env'] == ['/from/env']` |
| `test_config_overrides.py::test_env_and_config_coexist_on_different_fields` | ✅ | 1 | same scalar shape |
| `test_config_overrides.py::test_regression_pr247_mcp_json_env_block` | ✅ | 1 (×2) | scalar + list, tilde-prefixed |
| `test_config_overrides.py::test_config_d_env_wins_over_fragments` | ✅ | 1 | env-over-fragment |
| `test_session_summary_rescue.py::TestBoostSourcesHelper::test_above_threshold_walks_chunk_links_to_source_files` | ✅ | 1 (set comp) | `{'\\tmp\\src\\…'} == {'/tmp/src/…'}` |
| `test_storage.py::TestNormPathUnicode::test_norm_path_osError_fallback_still_normalizes` | ✅ | 1 (NFC-preserving) | `'\\\\tmp\\\\내 드라이브\\\\file.md' == '/tmp/내 드라이브/file.md'` |

The Pattern-1 fix wraps the LHS in `Path(...).as_posix()`. For the `norm_path` test, the comparison is structured so the NFC property is still pinned (RHS goes through `unicodedata.normalize("NFC", nfd)`); `as_posix()` only flattens the platform-dependent separator that the OSError fallback's `str(p)` introduces.

## Verification

- `uv run pytest packages/memtomem/tests/test_config_overrides.py packages/memtomem/tests/test_session_summary_rescue.py packages/memtomem/tests/test_storage.py -m "not ollama" -q` → **60 passed** (macOS regression check).
- `uv run ruff check` + `uv run ruff format --check` on the three files → clean.

### Windows CI impact

Measured on this branch's run (`gh run view 25244446944 --log-failed --job=74026052967`).

| Metric | Before (run 25244100712) | After (run 25244446944) |
|--------|-------------------------:|------------------------:|
| Total Windows failures | 117 | 113 |
| Path-sep candidates fixed | 7 of 7 | 7 of 7 (all gone from fail list) |
| Net reduction | — | **−4** |

The net (−4) understates the path-sep contribution (−7) because the **symlink / git-status failure class is flaky** on Windows. Two tests from that class disappeared between runs (`test_stale_pin_when_history_rewritten`, `test_skip_symlinks`) and five others appeared (`test_behind_state_pin_below_head`, `test_cli_status_renders_states`, `test_stale_pin_when_wiki_absent`, `test_dirty_partial_subdir`, `test_skip_dotgit_dsstore_pycache`) — all in the same flaky class, none caused by this PR. They will be addressed in the dedicated symlink/git-status follow-up.

macOS / Ubuntu / lint / typecheck / golden-path / notebooks / CLA all green on this branch.

## Out of scope (separate follow-up PRs)

The other 110 Windows failures fall into classes that need different mechanics. Each has its own tracking issue:

- **POSIX file-mode** (`stat.S_IMODE`, NTFS doesn't honour POSIX permission bits) — issue #637
- **HOME monkeypatch reach** (`Path.home()` uses `USERPROFILE` on Windows so `monkeypatch.setenv("HOME", …)` doesn't take effect) — issue #644
- **Path canonicalization in indexing** (`kind` detection + `memory_dir` comparisons) — issue #647
- **`'home'` fs alias / tilde expansion in web fs-list** — issue #646
- **`config_signature` NTFS mtime resolution / cache** — issue #645
- **Wizard auto-detect Claude/Codex memory dirs** (backslash path regex) — issue #316
- **Symlink + git-status detection** (no umbrella issue yet)
- **`fcntl` + signal handling** (POSIX-only — needs `skipif` markers)

The next-simplest follow-up is the POSIX-only `skipif` batch (file-mode + `fcntl` + signal = ~14 tests, single uniform change).

## Test plan

- [x] Local pytest passes on touched files (macOS, 60 tests).
- [x] Ruff lint + format clean.
- [x] Windows CI failure count drops by 7 — all 7 targeted tests confirmed gone from the fail list (run 25244446944, net −4 due to symlink-class flake noise).
- [x] macOS / Ubuntu pass counts unchanged on this branch (both green; no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
