### PR TITLE
test: skipif POSIX-only assertions on Windows (mode bits, fcntl, signal) — Windows CI PR 2/N

### DIFF
--- a/packages/memtomem/tests/test_context_atomic.py
+++ b/packages/memtomem/tests/test_context_atomic.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -41,6 +42,10 @@ def test_atomic_write_replaces_existing_file(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "new"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX file mode (stat.S_IMODE) — Windows ignores POSIX permission bits",
+)
 def test_atomic_write_explicit_mode_0o600(tmp_path: Path) -> None:
     """Mode is applied via fchmod — independent of process umask."""
     target = tmp_path / "secret.json"
@@ -54,6 +59,10 @@ def test_atomic_write_explicit_mode_0o600(tmp_path: Path) -> None:
     assert perms == 0o600, f"expected 0o600, got {oct(perms)}"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX file mode (stat.S_IMODE) — Windows ignores POSIX permission bits",
+)
 def test_atomic_write_respects_custom_mode(tmp_path: Path) -> None:
     target = tmp_path / "public.md"
     atomic_write_text(target, "readable", mode=0o644)

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -11,6 +11,7 @@ import json
 import multiprocessing as mp
 import shutil
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -213,6 +214,10 @@ def test_install_skips_symlinks_in_source(
     assert any("skipping symlink" in r.message for r in caplog.records)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX file mode (stat.S_IMODE) — Windows ignores POSIX permission bits",
+)
 def test_install_files_written_with_default_mode(wiki_root: Path, tmp_path: Path) -> None:
     """Asset content lands at 0o644 (readable by other tools), not at the
     0o600 atomic_write_bytes default reserved for state files."""

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -7,6 +7,7 @@ Uses record-format hooks (Claude Code ≥ 2.1.104):
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -299,6 +300,10 @@ class TestClaudeSettingsAtomicWrite:
         siblings = [p for p in target.parent.iterdir() if p.name.startswith(".settings.json.")]
         assert siblings == []
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX file mode (stat.S_IMODE) — Windows ignores POSIX permission bits",
+    )
     def test_mode_is_0o600(self, claude_home, tmp_path):
         import stat as _stat
 

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -373,6 +373,10 @@ def test_two_post_412_servers_coexist_with_shared_lock(tmp_path: Path) -> None:
             _cleanup_proc(proc2)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: fcntl module does not exist on Windows",
+)
 def test_legacy_lock_sh_allows_multiple_holders(tmp_path: Path) -> None:
     """Unit-level pin for the core fcntl semantics the fix relies on.
 

--- a/packages/memtomem/tests/test_upgrade_cmd.py
+++ b/packages/memtomem/tests/test_upgrade_cmd.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
 from click.testing import CliRunner
@@ -63,6 +64,10 @@ def _patch_liveness(monkeypatch, state: ServerState) -> None:
 # ---------------------------------------------------------------- tests
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Asserts the POSIX message; Windows takes the skipping-process-termination branch (covered by test_windows_skips_kill)",
+)
 def test_no_running_server_just_reinstalls(monkeypatch, fake_uv, force_tty):
     calls, _configure = fake_uv
     _patch_liveness(monkeypatch, ServerState(alive=False, pid=None, pid_file=None))
@@ -73,6 +78,10 @@ def test_no_running_server_just_reinstalls(monkeypatch, fake_uv, force_tty):
     assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem"]]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: SIGTERM kill path; Windows skips process termination entirely (covered by test_windows_skips_kill)",
+)
 def test_running_server_sigterm_path(monkeypatch, tmp_path, fake_uv, force_tty):
     calls, _configure = fake_uv
     pid_file = tmp_path / "server.pid"
@@ -96,6 +105,10 @@ def test_running_server_sigterm_path(monkeypatch, tmp_path, fake_uv, force_tty):
     assert calls  # uv was invoked
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: SIGKILL escalation path; Windows skips process termination entirely (covered by test_windows_skips_kill)",
+)
 def test_running_server_escalates_to_sigkill(monkeypatch, tmp_path, fake_uv, force_tty):
     _calls, _configure = fake_uv
     pid_file = tmp_path / "server.pid"
@@ -235,6 +248,10 @@ def test_extras_combined_with_version_pin(monkeypatch, fake_uv, force_tty):
     assert calls == [["uv", "tool", "install", "--refresh", "--reinstall", "memtomem[all]==0.1.32"]]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: exercises the SIGKILL respawn-detection path; Windows skips kill entirely (covered by test_windows_skips_kill)",
+)
 def test_pid_file_unlink_skipped_if_respawned(monkeypatch, tmp_path, fake_uv, force_tty):
     """SIGKILL path: a fresh server respawns at the same pid file path
     inside the settle window. We must NOT delete its lockfile."""


### PR DESCRIPTION
PR 2 of N in the Windows-CI green-up roadmap. (PR 1 was #711.)

## Summary

Adds `@pytest.mark.skipif(sys.platform == "win32", reason="…")` to **9 tests across 5 files** that exercise features which either don't exist on Windows or take a deliberately-different code path that's already covered by an existing `test_windows_skips_kill`-style sibling. Single uniform change axis — no assertion logic touched, no production source modified.

## Cross-check table

Triaged against the latest Windows fail log (`gh run view 25244446944 --log-failed --job=74026052967`, 113 failures total).

| Test | Class | Why POSIX-only |
|------|-------|---------------|
| `test_context_atomic.py::test_atomic_write_explicit_mode_0o600` | mode bits | NTFS ignores `stat.S_IMODE` |
| `test_context_atomic.py::test_atomic_write_respects_custom_mode` | mode bits | same |
| `test_context_install.py::test_install_files_written_with_default_mode` | mode bits | same |
| `test_context_settings.py::TestClaudeSettingsAtomicWrite::test_mode_is_0o600` | mode bits | same |
| `test_server_sigterm.py::test_legacy_lock_sh_allows_multiple_holders` | fcntl | `ModuleNotFoundError: No module named 'fcntl'` at body-import time |
| `test_upgrade_cmd.py::test_no_running_server_just_reinstalls` | signal/path | Windows takes the "Detected Windows; skipping process termination" branch (covered by `test_windows_skips_kill`) |
| `test_upgrade_cmd.py::test_running_server_sigterm_path` | signal | exercises SIGTERM kill path; Windows skips it |
| `test_upgrade_cmd.py::test_running_server_escalates_to_sigkill` | signal | SIGKILL escalation path |
| `test_upgrade_cmd.py::test_pid_file_unlink_skipped_if_respawned` | signal | SIGKILL respawn-detection path |

**No Windows coverage is lost for the upgrade flow** — `test_windows_skips_kill` (line 124 of `test_upgrade_cmd.py`) explicitly tests the Windows branch and continues to run.

## Why skipif and not test rewrite

For the file-mode and `fcntl` tests, the property under test is meaningful only on POSIX. NTFS doesn't honour `stat.S_IMODE` and Python on Windows doesn't ship `fcntl` — there is nothing equivalent to assert.

For the four `test_upgrade_cmd.py` tests, the production code already has a Windows-aware branch (`upgrade_cmd.py:256` — `sys.platform == "win32"` guard) and the existing `test_windows_skips_kill` already pins that branch's behaviour. Asserting a SIGTERM-shaped output on Windows would just duplicate the redirect that Windows test already covers.

## Verification

- `uv run pytest` on the 5 touched files (macOS): **91 passed**.
- `uv run ruff check + format --check` clean on the same files.

### Windows CI impact

Measured on this branch's run (`gh run view 25245004184 --log-failed --job=74027634112`).

| Metric | Before (run 25244446944) | After (run 25245004184) |
|--------|-------------------------:|------------------------:|
| Total Windows failures | 113 | 105 |
| POSIX-only candidates fixed | 9 of 9 | 9 of 9 (all gone from fail list) |
| Net reduction | — | **−8** |

The net (−8) understates the POSIX-skipif contribution (−9) because the **symlink / git-status failure class is flaky** on Windows — same flake noise the PR #711 run also hit. Two more tests from that class disappeared between runs (`test_cli_status_renders_states`, `test_dirty_partial_subdir`) and three new ones appeared (`test_stale_pin_when_history_rewritten`, `test_clean_immediately_after_install`, `test_skip_symlinks`) — all in the same flaky class, none caused by this PR. They will be addressed in the dedicated symlink/git-status follow-up PR.

macOS / Ubuntu / lint / typecheck / golden-path / notebooks / CLA all green on this branch.

## Out of scope (separate follow-up PRs)

- **HOME monkeypatch reach** (`Path.home()` uses `USERPROFILE` on Windows) — issue #644
- **Path canonicalization in indexing** — issue #647
- **`'home'` fs alias / tilde expansion** — issue #646
- **`config_signature` NTFS mtime resolution** — issue #645
- **Wizard auto-detect Claude/Codex memory dirs** (backslash regex) — issue #316
- **Symlink + git-status detection** (flaky class)
- **`test_uninstall_cmd.py` failures**: surface NTFS file-locking semantics (`.db` / `.db-shm` / `.db-wal` open-file-handle deletes, lock detection, inventory text differences). Multi-factor; needs investigation, not a blanket skipif. Deferred.

Refs #637 (file-mode class umbrella). This PR doesn't touch the XDG_RUNTIME_DIR tests that #637 was originally written for, so leaving #637 open.

## Test plan

- [x] Local pytest passes on touched files (macOS, 91 tests).
- [x] Ruff lint + format clean.
- [x] Windows CI failure count drops by 9 — all 9 targeted tests confirmed gone from the fail list (run 25245004184, net −8 due to symlink-class flake noise).
- [x] macOS / Ubuntu pass counts unchanged on this branch (both green; no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
