### PR TITLE
test(windows): set_home helper + sweep ~133 HOME monkeypatch sites (refs #644)

### DIFF
--- a/packages/memtomem/tests/helpers.py
+++ b/packages/memtomem/tests/helpers.py
@@ -50,6 +50,13 @@ def set_home(monkeypatch: pytest.MonkeyPatch, path: Path | str) -> None:
     runners and tests end up reading/writing the real user home. Setting
     both env vars is harmless on POSIX (stdlib ignores ``USERPROFILE``)
     and correct on Windows.
+
+    A handful of pre-existing call sites still set ``HOME`` and
+    ``USERPROFILE`` by hand (``test_context_settings.py``,
+    ``test_web_routes.py``, ``test_web_routes_extended.py``,
+    ``test_context_agents.py``, ``test_server_tools_context_settings_gate.py``);
+    they should migrate to ``set_home`` in the follow-up that sweeps the
+    remaining ~130 ``monkeypatch.setenv("HOME", ...)`` sites.
     """
     monkeypatch.setenv("HOME", str(path))
     monkeypatch.setenv("USERPROFILE", str(path))

--- a/packages/memtomem/tests/helpers.py
+++ b/packages/memtomem/tests/helpers.py
@@ -50,13 +50,6 @@ def set_home(monkeypatch: pytest.MonkeyPatch, path: Path | str) -> None:
     runners and tests end up reading/writing the real user home. Setting
     both env vars is harmless on POSIX (stdlib ignores ``USERPROFILE``)
     and correct on Windows.
-
-    A handful of pre-existing call sites still set ``HOME`` and
-    ``USERPROFILE`` by hand (``test_context_settings.py``,
-    ``test_web_routes.py``, ``test_web_routes_extended.py``,
-    ``test_context_agents.py``, ``test_server_tools_context_settings_gate.py``);
-    they should migrate to ``set_home`` in the follow-up that sweeps the
-    remaining ~130 ``monkeypatch.setenv("HOME", ...)`` sites.
     """
     monkeypatch.setenv("HOME", str(path))
     monkeypatch.setenv("USERPROFILE", str(path))

--- a/packages/memtomem/tests/helpers.py
+++ b/packages/memtomem/tests/helpers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from uuid import uuid4
 
+import pytest
+
 from memtomem.models import Chunk, ChunkMetadata
 from memtomem.server.context import AppContext
 
@@ -36,6 +38,21 @@ def isolate_memtomem_env(monkeypatch) -> None:
     import memtomem.config as _cfg
 
     monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
+
+
+def set_home(monkeypatch: pytest.MonkeyPatch, path: Path | str) -> None:
+    """Override the home directory for tests that exercise ``Path.home()``
+    or ``Path("~/...").expanduser()``.
+
+    On POSIX, ``Path.home()`` reads ``HOME``. On Windows it reads
+    ``USERPROFILE`` first (then ``HOMEDRIVE``+``HOMEPATH``), so a bare
+    ``monkeypatch.setenv("HOME", ...)`` is silently ignored on Windows
+    runners and tests end up reading/writing the real user home. Setting
+    both env vars is harmless on POSIX (stdlib ignores ``USERPROFILE``)
+    and correct on Windows.
+    """
+    monkeypatch.setenv("HOME", str(path))
+    monkeypatch.setenv("USERPROFILE", str(path))
 
 
 class StubCtx:

--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -25,6 +25,7 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
+from .helpers import set_home
 
 
 def _make_memory_dir(home: str) -> str:
@@ -53,7 +54,7 @@ class TestFreshNoopIndexInline:
 
         home = tmp_path / "home"
         home.mkdir()
-        monkeypatch.setenv("HOME", str(home))
+        set_home(monkeypatch, home)
         monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
 
         mem_dir = _make_memory_dir(str(home))

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -17,6 +17,8 @@ import pytest
 from memtomem import config as _cfg
 from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
 
+from .helpers import set_home
+
 
 @pytest.fixture
 def override_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
@@ -599,7 +601,7 @@ def test_detect_provider_dirs_excludes_gemini(
     home = tmp_path / "home"
     (home / ".gemini").mkdir(parents=True)
     (home / ".gemini" / "GEMINI.md").write_text("# memory", encoding="utf-8")
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, home)
 
     grouped = _cfg._detect_provider_dirs()
     assert "gemini" not in grouped
@@ -618,7 +620,7 @@ def test_detect_provider_dirs_filters_empty_claude_memory(
     proj_with.mkdir(parents=True)
     (proj_with / "MEMORY.md").write_text("# index", encoding="utf-8")
     proj_without.mkdir(parents=True)  # empty memory dir
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, home)
 
     grouped = _cfg._detect_provider_dirs()
     paths = {str(p) for p in grouped["claude-memory"]}
@@ -636,7 +638,7 @@ def test_detect_provider_dirs_finds_claude_plans_and_codex(
     codex = home / ".codex" / "memories"
     plans.mkdir(parents=True)
     codex.mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, home)
 
     grouped = _cfg._detect_provider_dirs()
     assert grouped["claude-plans"] == [plans]

--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -21,6 +21,7 @@ from memtomem.context.agents import (
     parse_canonical_agent,
 )
 from memtomem.context.detector import detect_agent_dirs
+from .helpers import set_home
 
 SAMPLE_FULL_AGENT = """---
 name: code-reviewer
@@ -58,8 +59,7 @@ def codex_home(tmp_path, monkeypatch):
     """
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.setenv("USERPROFILE", str(fake_home))  # Windows safety (no-op on macOS)
+    set_home(monkeypatch, fake_home)
     return fake_home
 
 

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -18,6 +18,7 @@ from memtomem.context.settings import (
     generate_all_settings,
     host_write_targets,
 )
+from .helpers import set_home
 
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -40,8 +41,7 @@ def claude_home(tmp_path, monkeypatch):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     (fake_home / ".claude").mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    set_home(monkeypatch, fake_home)
     return fake_home
 
 
@@ -50,8 +50,7 @@ def claude_home_missing(tmp_path, monkeypatch):
     """Redirect HOME **without** creating ``~/.claude/``."""
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    set_home(monkeypatch, fake_home)
     return fake_home
 
 

--- a/packages/memtomem/tests/test_fastembed_cache.py
+++ b/packages/memtomem/tests/test_fastembed_cache.py
@@ -13,12 +13,13 @@ from pathlib import Path
 import pytest
 
 from memtomem.embedding.fastembed_cache import resolve_fastembed_cache_dir
+from .helpers import set_home
 
 
 def test_default_is_under_memtomem_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv("MEMTOMEM_FASTEMBED_CACHE", raising=False)
     monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
 
     resolved = resolve_fastembed_cache_dir()
 
@@ -62,7 +63,7 @@ def test_empty_env_falls_through_to_default(
     whichever directory the user happened to launch ``mm`` from."""
     monkeypatch.setenv("MEMTOMEM_FASTEMBED_CACHE", "")
     monkeypatch.setenv("FASTEMBED_CACHE_PATH", "")
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
 
     resolved = resolve_fastembed_cache_dir()
 
@@ -70,7 +71,7 @@ def test_empty_env_falls_through_to_default(
 
 
 def test_tilde_in_env_is_expanded(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     monkeypatch.setenv("MEMTOMEM_FASTEMBED_CACHE", "~/custom-cache")
     monkeypatch.delenv("FASTEMBED_CACHE_PATH", raising=False)
 

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -18,6 +18,7 @@ from memtomem.indexing.engine import (
     _estimate_tokens,
 )
 from memtomem.models import Chunk, ChunkMetadata
+from .helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -2452,7 +2453,7 @@ class TestMemoryDirStats:
         """
         from memtomem.indexing.engine import memory_dir_stats
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         (tmp_path / "memories").mkdir()
         storage = _FakeStorageForStats([])
 
@@ -2643,7 +2644,7 @@ class TestResolveOwningMemoryDir:
         configured dirs would never match concrete source paths."""
         from memtomem.indexing.engine import resolve_owning_memory_dir
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         (tmp_path / "memories").mkdir()
         f = tmp_path / "memories" / "note.md"
         f.write_text("#")

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -19,6 +19,8 @@ import pytest
 from memtomem.cli.init_cmd import MmBinaryOrigin, RuntimeProfile, _write_mcp_json
 from memtomem.config import Mem2MemConfig
 
+from .helpers import set_home
+
 
 def test_write_mcp_json_omits_env_when_empty(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -2957,7 +2959,7 @@ class TestProviderDirsStep:
         fresh wizard run on a legacy install doesn't keep migrating."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         provider_dir = tmp_path / "claude-mem"
         provider_dir.mkdir()
 
@@ -3270,7 +3272,7 @@ class TestIncludeProviderFlag:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         codex = tmp_path / "codex"
         codex.mkdir()
         monkeypatch.setattr(
@@ -3304,7 +3306,7 @@ class TestIncludeProviderFlag:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -3337,7 +3339,7 @@ class TestIncludeProviderFlag:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         # Pretend a Codex dir exists; the test asserts it's NOT pulled in.
         codex = tmp_path / "codex"
         codex.mkdir()

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -141,7 +141,7 @@ class TestInitConfigMerge:
         from memtomem.cli.init_cmd import _write_config_and_summary
 
         # Redirect ~/.memtomem to tmp_path/.memtomem
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
 
@@ -179,7 +179,7 @@ class TestInitConfigMerge:
         """First init (no config.json) must work exactly as before."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
 
@@ -207,7 +207,7 @@ class TestStartupBackfillOptIn:
         the config file with redundant defaults."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         (tmp_path / ".memtomem").mkdir()
 
         state = _make_init_state(tmp_path)
@@ -224,7 +224,7 @@ class TestStartupBackfillOptIn:
         ``mm web`` / ``mm server`` startup honours it."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         (tmp_path / ".memtomem").mkdir()
 
         state = _make_init_state(tmp_path)
@@ -286,7 +286,7 @@ class TestRerankerStep:
         resurrect a stale enabled flag)."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         _write_config_and_summary(state, tmp_path)
 
@@ -300,7 +300,7 @@ class TestRerankerStep:
         and the jina multilingual model ID."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         state["rerank_enabled"] = True
         state["rerank_model"] = "jinaai/jina-reranker-v2-base-multilingual"
@@ -320,7 +320,7 @@ class TestRerankerStep:
         section the user added manually (e.g. custom top_k)."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -350,7 +350,7 @@ def test_write_config_and_summary_without_base_dir_falls_back_to_home(
     """
     from memtomem.cli.init_cmd import _write_config_and_summary
 
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
 
     state = _make_init_state(tmp_path)
     _write_config_and_summary(state)
@@ -520,7 +520,7 @@ class TestMissingExtrasWarning:
         from memtomem.cli import init_cmd
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "importlib.util.find_spec",
             lambda name: None if name == "fastembed" else object(),
@@ -691,7 +691,7 @@ class TestInstallAxesReconcile:
             lambda name: None if name == "fastembed" else object(),
         )
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: "fastapi", raising=False)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = _make_init_state(tmp_path)
         state["provider"] = "onnx"
@@ -773,7 +773,7 @@ class TestInstallAxesReconcile:
             "_probe_workspace_extras",
             lambda py: {"fastembed", "fastapi", "uvicorn"},
         )
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = _make_init_state(tmp_path)
         state["provider"] = "onnx"
@@ -804,7 +804,7 @@ class TestInstallAxesReconcile:
 
         monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
         monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: False)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._make_state_source_with_venv(tmp_path)
         state["provider"] = "onnx"
@@ -832,7 +832,7 @@ class TestInstallAxesReconcile:
 
         monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
         monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: True)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._make_state_source_with_venv(tmp_path)
         state["provider"] = "onnx"
@@ -1199,7 +1199,7 @@ class TestMismatchBanner:
             "_probe_workspace_extras",
             lambda py: {"fastembed", "fastapi", "uvicorn"},
         )
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._source_state_with_venv(tmp_path)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1228,7 +1228,7 @@ class TestMismatchBanner:
             "_probe_workspace_extras",
             lambda py: {"fastembed", "fastapi", "uvicorn"},
         )
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = _make_init_state(tmp_path)
         state["_profile"] = _make_test_profile(tmp_path, kind="project")
@@ -1259,7 +1259,7 @@ class TestMismatchBanner:
             "_probe_workspace_extras",
             lambda py: {"fastembed", "fastapi", "uvicorn"},
         )
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._source_state_with_venv(tmp_path)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1282,7 +1282,7 @@ class TestMismatchBanner:
         monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
         monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = _make_init_state(tmp_path)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1307,7 +1307,7 @@ class TestMismatchBanner:
         monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
         monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
         monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: False)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._source_state_with_venv(tmp_path)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1332,7 +1332,7 @@ class TestMismatchBanner:
         from memtomem.cli import init_cmd
 
         monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         # NOTE: no .venv/ created — triggers _workspace_needs_sync branch.
         state = _make_init_state(tmp_path)
@@ -1362,7 +1362,7 @@ class TestMismatchBanner:
         monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
         monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
         monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: True)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._source_state_with_venv(tmp_path)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1803,7 +1803,7 @@ class TestProjectInstallE2E:
         monkeypatch.setattr(
             init_cmd, "_probe_workspace_extras", lambda py: {"fastembed", "fastapi", "uvicorn"}
         )
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._project_state(tmp_path, with_venv=True)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1827,7 +1827,7 @@ class TestProjectInstallE2E:
         monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
         monkeypatch.setattr(init_cmd, "_probe_workspace_extras", lambda py: set())
         monkeypatch.setattr(init_cmd, "_install_extras", lambda *a, **kw: False)
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._project_state(tmp_path, with_venv=True)
         init_cmd._write_config_and_summary(state, tmp_path)
@@ -1851,7 +1851,7 @@ class TestProjectInstallE2E:
         from memtomem.cli import init_cmd
 
         monkeypatch.setattr(init_cmd.sys, "executable", "/usr/local/bin/python")
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = self._project_state(tmp_path, with_venv=False)
         assert init_cmd._workspace_needs_sync(state) is True
@@ -1882,7 +1882,7 @@ class TestProjectInstallE2E:
             "_probe_workspace_extras",
             lambda py: {"fastembed", "fastapi", "uvicorn"},
         )
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         # First run
         state1 = self._project_state(tmp_path, with_venv=True)
@@ -1933,7 +1933,7 @@ class TestUvxBranching:
         )
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
         monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         state = _make_init_state(tmp_path)
         # Explicit uvx profile — pypi classification + uvx binary origin
@@ -2019,7 +2019,7 @@ class TestPreservedSummary:
         need to include ``mmr.*`` to avoid flagging the user's own choice)."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         _write_config_and_summary(state, tmp_path)
 
@@ -2041,7 +2041,7 @@ class TestPreservedSummary:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
@@ -2069,7 +2069,7 @@ class TestPreservedSummary:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
@@ -2098,7 +2098,7 @@ class TestPreservedSummary:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
@@ -2132,7 +2132,7 @@ class TestPreservedSummary:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2176,7 +2176,7 @@ class TestFreshFlag:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2240,7 +2240,7 @@ class TestFreshFlag:
         adding a new key to one without the other will fail this test."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2284,7 +2284,7 @@ class TestFreshFlag:
             _write_config_and_summary,
         )
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2329,7 +2329,7 @@ class TestFreshFlag:
         only considers canonical keys."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2363,7 +2363,7 @@ class TestFreshFlag:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         # Seed only fields the wizard will overwrite — nothing untouched
@@ -2398,7 +2398,7 @@ class TestFreshFlag:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2434,7 +2434,7 @@ class TestFreshFlag:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2466,7 +2466,7 @@ class TestFreshFlag:
         clock = {"t": 1_700_000_000}
         monkeypatch.setattr("memtomem.cli.init_cmd.time.time", lambda: clock["t"])
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2508,7 +2508,7 @@ class TestFreshFlag:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         config_path = config_dir / "config.json"
@@ -2553,7 +2553,7 @@ class TestMcpPasteHints:
 
         from memtomem.cli.init_cmd import _claude_desktop_config_hint, _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
 
         state = _make_init_state(tmp_path)
@@ -2581,7 +2581,7 @@ class TestMcpPasteHints:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)  # mcp_choice = 3 by default
         _write_config_and_summary(state, tmp_path)
 
@@ -2637,7 +2637,7 @@ class TestMcpChoiceOneClaudeAddBranches:
 
         from memtomem.cli import init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(
             init_cmd,
@@ -2669,7 +2669,7 @@ class TestMcpChoiceOneClaudeAddBranches:
 
         from memtomem.cli import init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(
             init_cmd,
@@ -2713,7 +2713,7 @@ class TestMcpChoiceOneClaudeAddBranches:
 
         from memtomem.cli import init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(
             init_cmd,
@@ -2752,7 +2752,7 @@ class TestMcpChoiceOneClaudeAddBranches:
         def _missing(cmd: list[str], timeout: int = 10) -> subprocess.CompletedProcess:
             raise FileNotFoundError(2, "No such file or directory: 'claude'")
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(init_cmd, "_run", _missing)
 
@@ -2782,7 +2782,7 @@ class TestMcpChoiceOneClaudeAddBranches:
         def _hang(cmd: list[str], timeout: int = 10) -> subprocess.CompletedProcess:
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=timeout)
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(init_cmd, "_run", _hang)
 
@@ -3129,7 +3129,7 @@ class TestDetectProviderDirsRoundtrip:
     ) -> None:
         from memtomem.config import _detect_provider_dirs, categorize_memory_dir
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         # Populate one entry per category so every branch of detection
         # fires and every resulting Path goes through the classifier.
@@ -3459,7 +3459,7 @@ class TestProviderPresetRules:
         the persisted ``namespace.rules`` list."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         state["provider_rules"] = [
             (
@@ -3485,7 +3485,7 @@ class TestProviderPresetRules:
         not duplicate rules — dedup is by ``path_glob``."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         state["provider_rules"] = [
             ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
@@ -3506,7 +3506,7 @@ class TestProviderPresetRules:
         ``namespace`` wins — the wizard does not overwrite it."""
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         # Seed config with a user-authored rule using the preset's glob.
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
@@ -3555,7 +3555,7 @@ class TestProviderPresetRules:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         codex = tmp_path / "codex"
         codex.mkdir()
         monkeypatch.setattr(
@@ -3590,7 +3590,7 @@ class TestProviderPresetRules:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -3622,7 +3622,7 @@ class TestProviderPresetRules:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         # Seed: codex rule already present, claude-plans not.
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
@@ -3657,7 +3657,7 @@ class TestProviderPresetRules:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         state["provider_rules"] = []
         _write_config_and_summary(state, tmp_path)
@@ -3675,7 +3675,7 @@ class TestProviderPresetRules:
 
         from memtomem.cli.init_cmd import _write_config_and_summary
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
@@ -3789,7 +3789,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -3826,7 +3826,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         runner = CliRunner()
         result = runner.invoke(
             init,
@@ -3849,7 +3849,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -3890,7 +3890,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -3931,7 +3931,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -3967,7 +3967,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         runner = CliRunner()
         result = runner.invoke(
             init,
@@ -3985,7 +3985,7 @@ class TestPresetSelection:
 
         import memtomem.cli.init_cmd as init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         recorded: dict[str, object] = {}
 
@@ -4058,7 +4058,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         runner = CliRunner()
         # CliRunner's stdin is a pipe → isatty() == False.
         result = runner.invoke(init, [])
@@ -4074,7 +4074,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -4123,7 +4123,7 @@ class TestPresetSelection:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
             lambda: {"claude-memory": [], "claude-plans": [], "codex": []},
@@ -4177,7 +4177,7 @@ class TestPresetWizardBackNav:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         # CliRunner swaps sys.stdin mid-invoke so `sys.stdin.isatty` can't be
         # patched through that boundary; init_cmd exposes the ``_isatty``
         # seam for exactly this case.
@@ -4214,7 +4214,7 @@ class TestPresetWizardBackNav:
 
         import memtomem.cli.init_cmd as init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
 
         recorded: list[list[str]] = []
@@ -4329,7 +4329,7 @@ class TestPresetWizardBackNav:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
@@ -4362,7 +4362,7 @@ class TestPresetWizardBackNav:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
@@ -5257,7 +5257,7 @@ class TestInitialSeedThreshold:
 
         from memtomem.cli import init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_maybe_seed_initial_index", lambda paths, state: False)
 
         state = _make_init_state(tmp_path)
@@ -5298,7 +5298,7 @@ class TestInitialSeedThreshold:
 
         from memtomem.cli import init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_maybe_seed_initial_index", lambda paths, state: False)
 
         state = _make_init_state(tmp_path)
@@ -5332,7 +5332,7 @@ class TestInitialSeedThreshold:
 
         from memtomem.cli import init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_maybe_seed_initial_index", lambda paths, state: True)
 
         state = _make_init_state(tmp_path)
@@ -5403,7 +5403,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         # Force the runtime profile to PyPI so the in-process find_spec probe
         # is authoritative (no workspace-python subprocess to consider).
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
@@ -5442,7 +5442,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr(
             "importlib.util.find_spec",
@@ -5466,7 +5466,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr(
             "importlib.util.find_spec",
@@ -5504,7 +5504,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr(
             "importlib.util.find_spec",
@@ -5524,7 +5524,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr("importlib.util.find_spec", lambda name: object())
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
@@ -5549,7 +5549,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr(
             "importlib.util.find_spec",
@@ -5588,7 +5588,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr(
             "importlib.util.find_spec",
@@ -5631,7 +5631,7 @@ class TestNonInteractiveExtrasValidation:
 
         from memtomem.cli import cli, init_cmd
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr(init_cmd, "_runtime_profile", lambda: _make_test_profile(kind="pypi"))
         monkeypatch.setattr(
             "importlib.util.find_spec",
@@ -5755,7 +5755,7 @@ class TestBackNavThroughSilentStep:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         # CliRunner substitutes sys.stdin; route through init_cmd._isatty seam
         # so the picker's non-TTY gate doesn't short-circuit (per
         # feedback_clirunner_isatty_seam.md).
@@ -5799,7 +5799,7 @@ class TestBackNavThroughSilentStep:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
@@ -5937,7 +5937,7 @@ class TestStepHeaderPosition:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
 
         runner = CliRunner()
@@ -5986,7 +5986,7 @@ class TestStepHeaderPosition:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
@@ -6017,7 +6017,7 @@ class TestStepHeaderPosition:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
@@ -6060,7 +6060,7 @@ class TestPresetMcpFlagPreAnswer:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",
@@ -6096,7 +6096,7 @@ class TestPresetMcpFlagPreAnswer:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
@@ -6131,7 +6131,7 @@ class TestPresetMcpFlagPreAnswer:
 
         from memtomem.cli.init_cmd import init
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         monkeypatch.setattr("memtomem.cli.init_cmd._isatty", lambda: True)
         monkeypatch.setattr(
             "memtomem.config._detect_provider_dirs",

--- a/packages/memtomem/tests/test_lazy_init_acceptance.py
+++ b/packages/memtomem/tests/test_lazy_init_acceptance.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from memtomem.server import lifespan as lifespan_mod
+from .helpers import set_home
 
 
 @pytest.fixture
@@ -43,7 +44,7 @@ def isolated_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str,
     home = tmp_path / "home"
     home.mkdir()
     db_path = tmp_path / "memtomem.db"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, home)
     monkeypatch.setenv("MEMTOMEM_STORAGE__SQLITE_PATH", str(db_path))
     monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", "[]")
     monkeypatch.setenv("MEMTOMEM_EMBEDDING__PROVIDER", "none")

--- a/packages/memtomem/tests/test_runtime_paths.py
+++ b/packages/memtomem/tests/test_runtime_paths.py
@@ -22,6 +22,7 @@ from memtomem._runtime_paths import (
     runtime_dir,
     server_pid_path,
 )
+from .helpers import set_home
 
 
 def _make_safe_xdg(tmp_path: Path) -> Path:
@@ -268,7 +269,7 @@ class TestLegacyServerPidPath:
         """Import-time ``Path.home()`` would capture the developer's
         real home and leak across fixtures; the function must re-read
         ``$HOME`` every call."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         assert legacy_server_pid_path() == tmp_path / ".memtomem" / ".server.pid"
 

--- a/packages/memtomem/tests/test_server_tools_context_settings_gate.py
+++ b/packages/memtomem/tests/test_server_tools_context_settings_gate.py
@@ -14,6 +14,7 @@ import pytest
 
 from memtomem.context.settings import CANONICAL_SETTINGS_FILE
 from memtomem.server.tools.context import mem_context_generate, mem_context_sync
+from .helpers import set_home
 
 
 @pytest.fixture
@@ -22,8 +23,7 @@ def claude_home(tmp_path, monkeypatch):
     fake_home = tmp_path / "home"
     fake_home.mkdir()
     (fake_home / ".claude").mkdir()
-    monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.setenv("USERPROFILE", str(fake_home))
+    set_home(monkeypatch, fake_home)
     return fake_home
 
 

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -20,6 +20,7 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
+from .helpers import set_home
 
 
 @contextlib.contextmanager
@@ -71,7 +72,7 @@ def home(tmp_path, monkeypatch):
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
     os.chmod(xdg, 0o700)  # _runtime_paths validator requires owner-only
-    monkeypatch.setenv("HOME", str(h))
+    set_home(monkeypatch, h)
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
     monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", h / ".memtomem" / "config.json")
     monkeypatch.setattr(uninstall_cmd, "_DEFAULT_STATE_DIR", h / ".memtomem")

--- a/packages/memtomem/tests/test_web_exclude_guard.py
+++ b/packages/memtomem/tests/test_web_exclude_guard.py
@@ -18,6 +18,7 @@ from httpx import ASGITransport, AsyncClient
 from memtomem.config import Mem2MemConfig
 from memtomem.server.component_factory import close_components, create_components
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 @pytest.fixture
@@ -26,7 +27,7 @@ async def real_stack_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     for k in list(os.environ):
         if k.startswith("MEMTOMEM_"):
             monkeypatch.delenv(k, raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
 
     # Mark the tmp HOME as ``mm init``-completed so the
     # ``require_configured`` gate (issue #577) lets

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -34,6 +34,7 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.web import hot_reload as _hot_reload
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +68,7 @@ def _write_fragment(home: Path, name: str, data: dict[str, Any]) -> Path:
 
 @pytest.fixture
 def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     # pydantic-settings reads env; clear any memtomem env vars that may leak
     # from the developer shell and make the test non-hermetic.
     for k in list(os.environ):

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -20,6 +20,7 @@ from httpx import ASGITransport, AsyncClient
 from memtomem.models import Chunk, ChunkMetadata, IndexingStats, SearchResult
 from memtomem.search.pipeline import RetrievalStats
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -511,7 +512,7 @@ class TestPrivacyPatterns:
         from memtomem.web.deps import require_configured
 
         del app.dependency_overrides[require_configured]
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
 
         resp = await client.get("/api/privacy/patterns")
         assert resp.status_code == 200, resp.text
@@ -1635,8 +1636,7 @@ class TestMemoryDirsStatus:
         # the POSIX home var; Windows ``Path.expanduser()`` reads
         # ``USERPROFILE`` first and ignores ``HOME``, so monkeypatch
         # both for cross-platform coverage.
-        monkeypatch.setenv("HOME", str(tmp_path))
-        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         target = tmp_path / "memories"
         target.mkdir()
 
@@ -1795,7 +1795,7 @@ class TestUploadsUsage:
         monkeypatch: pytest.MonkeyPatch,
     ):
         """Fresh install — ``~/.memtomem`` itself does not exist."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         resp = await client.get("/api/uploads/usage")
         assert resp.status_code == 200, resp.text
         assert resp.json() == {"file_count": 0, "total_bytes": 0, "oldest_mtime": None}
@@ -1809,7 +1809,7 @@ class TestUploadsUsage:
         """Config wizard ran but no upload yet — ``.memtomem/`` exists,
         ``uploads/`` does not. Same code path as the missing-HOME case
         but a distinct user state worth pinning."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         (tmp_path / ".memtomem").mkdir()
         resp = await client.get("/api/uploads/usage")
         assert resp.status_code == 200, resp.text
@@ -1823,7 +1823,7 @@ class TestUploadsUsage:
     ):
         import os
 
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         upload_dir = tmp_path / ".memtomem" / "uploads"
         upload_dir.mkdir(parents=True)
         a = upload_dir / "a.md"
@@ -1849,7 +1849,7 @@ class TestUploadsUsage:
     ):
         """``is_file()`` filter must skip nested dirs so a stray
         directory doesn't inflate ``file_count``."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         upload_dir = tmp_path / ".memtomem" / "uploads"
         upload_dir.mkdir(parents=True)
         (upload_dir / "real.md").write_bytes(b"hello")
@@ -1904,7 +1904,7 @@ class TestRequireConfigured:
         not be invoked (gate runs *before* indexing, so a regression
         that moves the gate after ``index_path`` would catch the
         artifact-only assertion but fail this one)."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         app.state.index_engine.index_path.reset_mock()
 
         target = tmp_path / "target"
@@ -1927,7 +1927,7 @@ class TestRequireConfigured:
     ):
         """``POST /api/index`` is the second path the issue calls out
         (the manual reindex trigger). Same gate, same message."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         app.state.index_engine.index_path.reset_mock()
 
         target = tmp_path / "target"
@@ -1949,7 +1949,7 @@ class TestRequireConfigured:
         of the indexing surface (``/index``, ``/index/stream``,
         ``/reindex``) — uniform 409 on a not-yet-configured server.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         resp = await client.get("/api/indexing/active")
         assert resp.status_code == 409, resp.text
         assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")
@@ -1964,7 +1964,7 @@ class TestRequireConfigured:
     ):
         """Same gate, configured HOME (``~/.memtomem/config.json``
         exists) → request proceeds normally."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         cfg_dir = tmp_path / ".memtomem"
         cfg_dir.mkdir()
         (cfg_dir / "config.json").write_text("{}")
@@ -2011,7 +2011,7 @@ class TestRequireConfigured:
         the dep on ``/reindex`` (say) without dropping it on
         ``/memory-dirs/add`` would still pass the deep tests above —
         these parametrized cases lock the perimeter."""
-        monkeypatch.setenv("HOME", str(tmp_path))
+        set_home(monkeypatch, tmp_path)
         resp = await getattr(client, method)(path, **kwargs)
         assert resp.status_code == 409, resp.text
         assert resp.json()["detail"] == ("memtomem is not configured. Run 'mm init' to set up.")
@@ -2085,7 +2085,7 @@ class TestFsList:
     ):
         # HOME goes first, then memory_dirs in config order, deduped.
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         # Same dir twice + Home (= tmp_path) — the dedup must collapse to two.
         self._wire_memory_dirs(app, [memdir, memdir], monkeypatch)
 
@@ -2113,7 +2113,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}")
@@ -2142,7 +2142,7 @@ class TestFsList:
     ):
         memdir = fs_tree["memdir"]
         # Pretend the memory_dir lives under a fake HOME.
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         rel = memdir.relative_to(fs_tree["home"])
@@ -2159,7 +2159,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         # /…/memdir/alpha/../beta resolves to /…/memdir/beta — inside.
@@ -2176,7 +2176,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         outside = fs_tree["outside"] / "target"
@@ -2192,7 +2192,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}/no_such_subdir")
@@ -2207,7 +2207,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}/a_file.md")
@@ -2222,7 +2222,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}")
@@ -2242,7 +2242,7 @@ class TestFsList:
         if sys.platform == "win32":
             pytest.skip("chmod 000 not meaningful on Windows")
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         guarded = memdir / "guarded"
@@ -2267,7 +2267,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}")
@@ -2285,7 +2285,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}")
@@ -2313,7 +2313,7 @@ class TestFsList:
         than teleporting them to wherever the target lives.
         """
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         ln = memdir / "ln_inside"
@@ -2333,7 +2333,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         resp = await client.get(f"/api/fs/list?path={memdir}")
@@ -2348,7 +2348,7 @@ class TestFsList:
         monkeypatch: pytest.MonkeyPatch,
     ):
         memdir = fs_tree["memdir"]
-        monkeypatch.setenv("HOME", str(fs_tree["home"]))
+        set_home(monkeypatch, fs_tree["home"])
         self._wire_memory_dirs(app, [memdir], monkeypatch)
 
         # Listing the memdir surfaces the Korean entry.

--- a/packages/memtomem/tests/test_web_routes_context_locks.py
+++ b/packages/memtomem/tests/test_web_routes_context_locks.py
@@ -27,6 +27,7 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -37,7 +38,7 @@ from memtomem.web.app import create_app
 @pytest.fixture
 def gateway_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Pin ``HOME`` to ``tmp_path`` so settings-sync writes stay sandboxed."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     # ClaudeSettingsGenerator.is_available() requires the dir to exist.
     (tmp_path / ".claude").mkdir(parents=True, exist_ok=True)
     return tmp_path

--- a/packages/memtomem/tests/test_web_routes_context_mutators.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutators.py
@@ -27,6 +27,7 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -37,7 +38,7 @@ from memtomem.web.app import create_app
 @pytest.fixture
 def gateway_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Sandbox ``HOME`` and return the project root."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     (tmp_path / ".claude").mkdir(parents=True, exist_ok=True)
     return tmp_path
 

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -18,6 +18,7 @@ from httpx import ASGITransport, AsyncClient
 from memtomem.config import ContextGatewayConfig, Mem2MemConfig
 from memtomem.context.projects import compute_scope_id
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────
@@ -26,7 +27,7 @@ from memtomem.web.app import create_app
 @pytest.fixture
 def cwd_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Sandbox HOME; return the cwd project root with a .claude marker."""
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, tmp_path)
     cwd = tmp_path / "cwd"
     cwd.mkdir()
     (cwd / ".claude").mkdir()

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -19,6 +19,7 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.models import Chunk, ChunkMetadata
 from memtomem.web.app import create_app
+from .helpers import set_home
 
 
 # ---------------------------------------------------------------------------
@@ -705,10 +706,7 @@ class TestSettingsSync:
         fake_home = tmp_path / "home"
         fake_home.mkdir()
         (fake_home / ".claude").mkdir()
-        monkeypatch.setenv("HOME", str(fake_home))
-        monkeypatch.setenv("USERPROFILE", str(fake_home))
-
-        # Project lives in a sibling dir so the Claude target is a host write.
+        set_home(monkeypatch, fake_home)
         project = tmp_path / "proj"
         project.mkdir()
         canonical = project / ".memtomem" / "settings.json"
@@ -736,8 +734,7 @@ class TestSettingsSync:
         fake_home = tmp_path / "home"
         fake_home.mkdir()
         (fake_home / ".claude").mkdir()
-        monkeypatch.setenv("HOME", str(fake_home))
-        monkeypatch.setenv("USERPROFILE", str(fake_home))
+        set_home(monkeypatch, fake_home)
 
         project = tmp_path / "proj"
         project.mkdir()


### PR DESCRIPTION
## Summary

`Path.home()` on Windows reads `USERPROFILE` first (then `HOMEDRIVE`+`HOMEPATH`), so `monkeypatch.setenv("HOME", str(tmp_path))` is silently ignored on the runner and tests end up touching the real `C:\Users\runneradmin\` instead of `tmp_path`. Per #644 this was the largest single class of Windows CI failures.

This PR introduces a small `set_home(monkeypatch, path)` helper in `tests/helpers.py` that sets both `HOME` and `USERPROFILE` (no-op on POSIX, correct on Windows), then sweeps **all ~133 HOME monkeypatch sites** in `packages/memtomem/tests/` to use it. Manual `HOME` + `USERPROFILE` pairs that already existed in 5 files (`test_context_settings.py`, `test_web_routes_extended.py`, `test_web_routes.py`, `test_context_agents.py`, `test_server_tools_context_settings_gate.py`) are collapsed into single `set_home(...)` calls — exactly the redundancy that motivated centralizing the helper.

Mechanical, test-only change. No production code touched. `ruff check` + `ruff format --check` clean.

## What's covered

- 88 sites in `test_init_cmd.py`
- 25 sites in `test_web_routes.py` (24 HOME-only + 1 manual pair)
- 4 sites across `test_web_routes_extended.py` (2 manual pairs collapsed)
- 4 sites across `test_context_settings.py` (2 manual pairs collapsed)
- Manual pairs in `test_context_agents.py` and `test_server_tools_context_settings_gate.py` collapsed
- 11 other test files with single sites (`test_cli_index_noop_e2e.py`, `test_fastembed_cache.py`, `test_indexing_engine.py`, `test_lazy_init_acceptance.py`, `test_runtime_paths.py`, `test_uninstall_cmd.py`, `test_web_exclude_guard.py`, `test_web_hot_reload.py`, `test_web_routes_context_locks.py`, `test_web_routes_context_mutators.py`, `test_web_routes_context_projects.py`)

18 files modified, +149 / -149 (1:1 mechanical substitutions). The full sweep makes the helper the only HOME-redirection pattern in the test suite — no two-pattern drift to manage.

## Cross-check (BLOCKING per plan)

Source: `gh run view 25245215735 --log-failed --job=74028225027` (latest main run after PR #711 / #713 merged, 2026-05-02).

Originally-targeted "auto-discovery" tests:

| Test | Was failing on Windows? | Status after this PR |
|---|:-:|---|
| `test_config_overrides.py::test_detect_provider_dirs_excludes_gemini` | ❌ (false-positive pass) | ✅ now exercises invariant correctly |
| `test_config_overrides.py::test_detect_provider_dirs_filters_empty_claude_memory` | ✅ | ⚠️ **still failing** — set_home now redirects discovery, but `_bucket()` calls `categorize_memory_dir()` whose forward-slash regex (#316) classifies the backslash path as `"user"` so the claude-memory bucket stays empty |
| `test_config_overrides.py::test_detect_provider_dirs_finds_claude_plans_and_codex` | ✅ | ⚠️ **still failing** — same #316 root cause |
| `test_init_cmd.py::TestProviderDirsStep::test_write_merges_provider_dirs_into_memory_dirs` | ❌ (inert HOME patch) | ✅ migrated for correctness |
| `test_init_cmd.py::TestIncludeProviderFlag::test_flag_resolves_categories_to_dirs` | ✅ | ✅ **fixed** |
| `test_init_cmd.py::TestIncludeProviderFlag::test_flag_silently_skips_unavailable_categories` | ✅ | ✅ **fixed** |
| `test_init_cmd.py::TestIncludeProviderFlag::test_no_flag_writes_no_provider_dirs` | ✅ | ✅ **fixed** |

The 2 still-failing tests need both this PR (USERPROFILE redirect so `_detect_provider_dirs` looks at `tmp_path` instead of the runner home) **and** the #316 production fix (so `categorize_memory_dir` accepts backslash paths). After #316 lands, these 2 tests should immediately go green on Windows with no further test changes — the migration this PR ships is necessary, just not sufficient on its own.

The full sweep brings ~30 additional HOME-related Windows failures into scope (notably the `test_init_cmd.py` and `test_web_routes.py` clusters from #644's symptom report).

## Windows CI impact

| Metric | Before (run 25245215735) | After sweep (run 25245680115) |
|---|---:|---:|
| Total Windows failures | 105 | **44** |
| Reduction |  | **−61** |
| Auto-discovery failures still pending #316 |  | 2 |

macOS, Ubuntu, lint, typecheck, golden-path, notebooks all green on the sweep run — negative pin held, no POSIX regression. Helper is a no-op on POSIX (stdlib `Path.home()` ignores `USERPROFILE`).

## Out of scope (explicit follow-ups)

- **PR 6**: production fix for `categorize_memory_dir`'s forward-slash regex (#316). Production change, separate concern. Closes the 2 still-failing `test_detect_provider_dirs_*` cases.
- **PR 7+**: re-triage Windows fail residual after #316 lands. The original splashing-dragon roadmap's PR 4 (symlink/git status) and PR 5+ (multi-factor) follow.
- **Final PR**: flip `.github/workflows/ci.yml` Windows job from `continue-on-error: true` → `false` once Windows fails are deterministic-skip-only.

`#644` can close on this PR's merge — the helper sweep delivers its full scope (HOME redirect across the whole suite). The 2 lingering `_detect_provider_dirs_*` tests stay open under #316.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama" -q` — full suite green locally on macOS (3951 passed)
- [x] `uv run ruff check packages/memtomem/tests` + `ruff format --check packages/memtomem/tests` — clean across all 158 files
- [x] Mypy advisory: no new errors (the 2 pre-existing errors in `cli/agent_cmd.py` and `storage/mixins/schedules.py` are unrelated)
- [x] CI Windows job (informational): 105 → 44 failures (−61); macOS / Ubuntu green with no pass-count delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)
