### PR TITLE
fix(config): support Windows backslash paths in categorize_memory_dir (#316)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1344,12 +1344,11 @@ def categorize_memory_dir(path: str | Path) -> ProviderCategory:
 
     Returns one of ``ProviderCategory``'s literal values, defaulting to
     ``"user"`` for anything that doesn't match a known provider layout.
-    Classification only — does not check existence or validity. Uses
-    forward-slash regex, so on Windows a backslash-normalised path will
-    fall through to ``"user"`` until a future path-sep-agnostic pass
-    lands (tracked in #316).
+    Classification only — does not check existence or validity. Matching
+    normalizes separators to forward slashes first, so POSIX, Windows,
+    UNC, and mixed-separator strings hit the same provider patterns.
     """
-    s = str(path).rstrip("/")
+    s = str(path).replace("\\", "/").rstrip("/")
     for cat, pat in _PROVIDER_CATEGORY_PATTERNS:
         if pat.search(s):
             return cat

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -591,6 +591,25 @@ def test_detect_provider_dirs_categories_are_fixed() -> None:
     assert set(grouped) == {"claude-memory", "claude-plans", "codex"}
 
 
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        (r"C:\Users\foo\.claude\projects\abc\memory", "claude-memory"),
+        (r"C:\Users\foo\.claude\plans", "claude-plans"),
+        (r"C:\Users\foo\.codex\memories", "codex"),
+        (r"C:\Users\foo\Documents\notes", "user"),
+        (r"C:\Users\foo/.claude/plans", "claude-plans"),
+        (r"C:\Users\foo\.claude\plans" + "\\", "claude-plans"),
+        (r"\\server\share\.codex\memories", "codex"),
+    ],
+)
+def test_categorize_memory_dir_accepts_windows_separators(
+    path: str, expected: _cfg.ProviderCategory
+) -> None:
+    """Provider category matching is path-separator agnostic (#316)."""
+    assert _cfg.categorize_memory_dir(path) == expected
+
+
 def test_detect_provider_dirs_excludes_gemini(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

`categorize_memory_dir` (`config.py:1342-1355`) matched provider patterns against `str(path)` directly. On Windows the stringified `Path` is backslash-separated, so the forward-slash regex table (`r"/\.claude/projects/[^/]+/memory/?$"`, etc.) never matched and every Windows provider directory silently fell through to `"user"`. User-visible symptom: `mm init`'s wizard could not auto-detect Claude Code / Codex memory folders for Windows users, so the preset namespace rules from #312 were never applied.

## Fix

```python
-    s = str(path).rstrip("/")
+    s = str(path).replace("\\", "/").rstrip("/")
```

Input normalisation only — the regex table, the vocabulary lock (#313), the `ProviderCategory` Literal, and the `_CATEGORY_TO_PROVIDER` map all stay untouched. RFC #304 (axis/wire-format) is unaffected.

## Tests

`test_categorize_memory_dir_accepts_windows_separators` covers 7 parametrized cases:

| Path | Expected category |
|---|---|
| `C:\Users\foo\.claude\projects\abc\memory` | `claude-memory` |
| `C:\Users\foo\.claude\plans` | `claude-plans` |
| `C:\Users\foo\.codex\memories` | `codex` |
| `C:\Users\foo\Documents\notes` | `user` (fallback) |
| `C:\Users\foo/.claude/plans` | `claude-plans` (mixed sep) |
| `C:\Users\foo\.claude\plans\` (trailing) | `claude-plans` |
| `\\server\share\.codex\memories` | `codex` (UNC) |

Raw-string fixtures execute on the Ubuntu CI host without needing a Windows runner — this matches the testing-notes pattern in #316.

Existing POSIX-path tests in `test_init_cmd.py` (`TestCategorizeMemoryDir`, `TestDetectProviderDirsRoundtrip`) continue to pass — no behaviour change for forward-slash paths.

## Cascade with #714

PR #714 flagged two `test_detect_provider_dirs_*` cases as "still failing — pending #316". With this PR landed alongside the `set_home` migration, those two cases should go green on the Windows informational job. Tracked in the next Windows fail-count delta.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_config_overrides.py -m "not ollama" -q` — 35 passed locally
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -m "not ollama" -k "categorize or provider_dirs"` — 12 passed (POSIX regression guard)
- [x] `uv run ruff check` + `ruff format --check` on the 2 changed files — clean
- [ ] CI Windows informational job: confirm Windows fail count drops by ≥3 (the two `test_detect_provider_dirs_*` plus any cascade from `_detect_provider_dirs` callers). macOS / Ubuntu pass count unchanged (negative pin).

Closes #316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
