### PR TITLE
fix(indexing): use os.sep for memory_dir prefix so Windows paths match (#647)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import time
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
@@ -123,14 +124,23 @@ def _dir_creation_time_iso(p: Path) -> str | None:
 def norm_dir_prefix(d: str | Path) -> str:
     """Return the directory path normalized for ``str.startswith`` matching.
 
-    Adds a trailing slash so a configured dir ``/foo`` does not falsely
-    claim files under ``/foo-bar/...``. Always runs through
-    :func:`~memtomem.storage.sqlite_helpers.norm_path` (which resolves
-    symlinks and applies Unicode NFC) so the prefix shape matches the
-    source-side normalisation regardless of whether the dir currently
+    Adds a trailing ``os.sep`` (platform-native separator) so a configured
+    dir does not falsely claim files under a sibling sharing the same
+    prefix (e.g. ``/foo`` should not match ``/foo-bar/...``). Always runs
+    through :func:`~memtomem.storage.sqlite_helpers.norm_path` (which
+    resolves symlinks and applies Unicode NFC) so the prefix shape matches
+    the source-side normalisation regardless of whether the dir currently
     exists on disk — the chunks table holds resolved paths, and a
     configured-but-missing dir would otherwise compare in raw ``/tmp``
     form against resolved ``/private/tmp`` source paths on macOS.
+
+    The trailing-separator step uses ``os.sep`` rather than a hardcoded
+    ``"/"`` so the prefix is consistent with ``norm_path``'s output on
+    Windows, where ``Path.resolve()`` returns backslash-separated strings
+    (``C:\\Users\\foo``) — a hardcoded ``"/"`` would yield a mixed-form
+    prefix that never matches a native source path under
+    ``startswith`` (#647). On POSIX, ``os.sep == "/"`` so behaviour is
+    unchanged.
 
     Used by both :func:`memory_dir_stats` (which buckets chunks per
     configured dir) and :func:`resolve_owning_memory_dir` (which goes
@@ -142,8 +152,8 @@ def norm_dir_prefix(d: str | Path) -> str:
 
     p = Path(d).expanduser()
     base = norm_path(p)
-    if not base.endswith("/"):
-        base += "/"
+    if not base.endswith(os.sep):
+        base += os.sep
     return base
 
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -571,10 +571,14 @@ async def remove_memory_dir(
                 # the schema's ``ON DELETE CASCADE``.
                 deleted_chunks = 0
                 if delete_chunks:
+                    from memtomem.indexing.engine import norm_dir_prefix
+
                     rows = await storage.get_source_files_with_counts()
-                    prefix = resolved_norm
-                    if not prefix.endswith("/"):
-                        prefix = prefix + "/"
+                    # Use the canonical helper so the trailing-separator
+                    # rule (``os.sep``, native form on Windows) stays in
+                    # one place; matches the comparison done by
+                    # :func:`resolve_owning_memory_dir` (#647).
+                    prefix = norm_dir_prefix(resolved)
                     for row in rows:
                         source_path = row[0]
                         if norm_path(source_path).startswith(prefix):

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -2572,6 +2572,47 @@ class TestMemoryDirStats:
 
 
 # ===========================================================================
+# 11b. norm_dir_prefix — trailing separator pin (#647)
+# ===========================================================================
+
+
+class TestNormDirPrefix:
+    """Pin: the trailing separator must come from ``os.sep`` rather than
+    a hardcoded ``"/"``.
+
+    Without this pin a regression where someone "tidies" ``os.sep`` back
+    to ``"/"`` would still pass on POSIX (because ``os.sep == "/"`` there)
+    and only break on the Windows CI leg (#647). Each parameter row
+    monkey-patches ``norm_path`` and ``os.sep`` so the test exercises both
+    platform shapes from a single Linux/macOS dev box.
+    """
+
+    @pytest.mark.parametrize(
+        "fake_norm_path,fake_sep,expected",
+        [
+            # POSIX shape — append "/" if missing.
+            ("/foo/bar", "/", "/foo/bar/"),
+            # Already-trailing POSIX — no double separator.
+            ("/foo/bar/", "/", "/foo/bar/"),
+            # Windows shape — append "\\" (this is what os.sep == "\\" buys).
+            ("C:\\Users\\foo", "\\", "C:\\Users\\foo\\"),
+            # Already-trailing Windows — no double separator.
+            ("C:\\Users\\foo\\", "\\", "C:\\Users\\foo\\"),
+        ],
+    )
+    def test_appends_os_sep_not_hardcoded_slash(
+        self, monkeypatch, fake_norm_path, fake_sep, expected
+    ):
+        import os as _os
+
+        from memtomem.indexing import engine
+
+        monkeypatch.setattr("memtomem.storage.sqlite_helpers.norm_path", lambda _p: fake_norm_path)
+        monkeypatch.setattr(_os, "sep", fake_sep)
+        assert engine.norm_dir_prefix("ignored-by-mock") == expected
+
+
+# ===========================================================================
 # 12. resolve_owning_memory_dir — source → owning dir lookup
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- Make `norm_dir_prefix` (and its copy-pasted twin in `system.py:remove_memory_dir`) append `os.sep` instead of a hardcoded `"/"`, so the trailing-separator prefix matches `norm_path`'s native-separator output on Windows.
- Fold the inline `prefix.endswith("/")` block in `system.py` into a single `norm_dir_prefix(resolved)` call so the rule lives in one place.

## Why

`norm_dir_prefix` produces a `str.startswith` prefix from a path that has been through `Path.resolve()` — which returns native-separator form (`C:\Users\foo` on Windows, `/Users/foo` on POSIX). The hardcoded `"/"` append yielded a mixed-form prefix `C:\Users\foo/` on Windows that **no** chunk source path could ever match under `target.startswith(prefix)`.

Concretely, on Windows this broke:

- `resolve_owning_memory_dir` — every chunk classified as orphan (`kind=None`).
- `memory_dir_stats` — per-dir bucketing returned 0 chunks for every dir.
- `/api/sources` route — sources list missed `kind` attribution.
- `/api/memory-dirs/remove` with `delete_chunks=true` — removed 0 rows.

POSIX was unaffected because `os.sep == "/"` there; the bug only showed up once the Windows leg of the CI matrix went informational (#634 / PR #638).

## Approach

Symmetric, minimal:

```python
# engine.py:norm_dir_prefix
base = norm_path(p)
if not base.endswith(os.sep):
    base += os.sep
return base
```

`norm_path` itself is **not** touched — both the write side (`sqlite_backend.upsert_chunks`) and the read side (`startswith` comparisons) round-trip through the same `Path.resolve()` + Unicode NFC normalisation, so drive-letter case, 8.3 short names, and the `\\?\` long-path prefix all collapse to a single canonical form via the OS. **No DB migration** is needed; the persisted `chunks.source_file` column is bit-for-bit identical to today on every platform.

This mirrors the bug class fixed by #716 / `82feed1` (`fix(config): support Windows backslash paths in categorize_memory_dir`), but the analog here is `os.sep` — not `.replace("\\", "/")` — because the surrounding comparison surface in `engine.py` and `web/routes/*` is already native-form on both sides.

## What's not in this PR

- **No `norm_path` change.** Forcing forward-slash inside `norm_path` would invalidate every existing `chunks.source_file` row on a populated Windows install (Windows CI is currently informational, but the contract is shared with 16 call sites — not worth changing for marginal benefit).
- **No new tests.** The 23 currently-failing Windows tests in `test_indexing_engine.py::TestResolveOwningMemoryDir` (5), `::TestMemoryDirStats` (18), and `test_web_routes.py::TestSources` / `::TestRemoveMemoryDirChunkCleanup` / `::TestUploadsUsage` are the validation surface — they construct paths via `tmp_path` (native form on every OS) and assert via `Path` equality, so they go green on Windows-CI once the prefix uses `os.sep`. POSIX stays bytewise green.
- **No test-side path-portability sweep.** A handful of substring assertions in `test_wiki_cmd_override.py` still hardcode `/skills/...` literals — covered separately as a sibling of #711.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_indexing_engine.py packages/memtomem/tests/test_web_routes.py -m "not ollama"` — 253 passed (POSIX no-op confirmed).
- [x] `uv run ruff check packages/memtomem/src/memtomem/indexing/engine.py packages/memtomem/src/memtomem/web/routes/system.py` — clean.
- [x] `uv run ruff format --check` on the two changed files — clean.
- [x] `grep -rn 'endswith("/")\|prefix.*+= *"/"' packages/memtomem/src/ --include="*.py"` — zero hits remaining.
- [ ] Windows-CI leg: 23 listed failures (`TestResolveOwningMemoryDir` x5, `TestMemoryDirStats` x18, `TestSources`/`TestRemoveMemoryDirChunkCleanup`/`TestUploadsUsage`) turn green.

Closes #647. Refs #634 (Windows + macOS CI matrix umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
