### PR TITLE
fix(wiki): use as_posix() for Seeded path display (#643 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/wiki_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/wiki_cmd.py
@@ -68,7 +68,8 @@ def _run_seed_override(
     # surfacing as ValueError, not a silent path mismatch to mask.
     rel = result.path.relative_to(store.root)
     ext = result.path.suffix.lstrip(".")
-    click.secho(f"Seeded {rel}", fg="green")
+    # ``as_posix()`` matches the hardcoded ``/`` in the ``git add`` hint below.
+    click.secho(f"Seeded {rel.as_posix()}", fg="green")
     click.echo(str(result.path))
     click.echo(
         f"# next: cd {store.root} && "


### PR DESCRIPTION
## Summary

- Cosmetic Windows UX fix flagged in PR #718's "out of scope" note. `mm wiki {skill,agent,command} override` printed two adjacent path lines with mixed separators on Windows:
  ```
  Seeded skills\hello\overrides\codex.md
  # next: cd C:\... && git add skills/hello/overrides/codex.md && git commit
  ```
- The `git add` hint hardcodes `/` (line 75); the `Seeded` line interpolated a `Path` object so it picked up `\` from `os.sep` on Windows. Both lines describe the same logical path on the same screen — the inconsistency was purely visual but confusing.
- One-line fix: `f"Seeded {rel.as_posix()}"`.

## What's NOT changed

`click.echo(str(result.path))` (line 72) and `click.edit(filename=str(result.path))` (line 87) intentionally stay platform-native. Those lines hand the absolute path to shell-pipeline consumers and to `$EDITOR` respectively — Windows shells / CMD / PowerShell / notepad.exe prefer backslashes for absolute paths. Same trade-off PR #711 documented for `norm_path()`.

## Test plan

- [x] macOS: `uv run pytest packages/memtomem/tests/test_wiki_cmd_override.py` — 32/32 pass.
- [x] Lint: `ruff check` + `ruff format --check` clean.
- [ ] Windows CI: PR #718's test assertions normalize via `result.output.replace("\\", "/")`, so they remain correct here — `replace` becomes a no-op on Windows now that production emits `/` natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
