### PR TITLE
test(windows): skipif POSIX-only pwd.getpwuid simulation in fastembed_cache (#643)

### DIFF
--- a/packages/memtomem/tests/test_fastembed_cache.py
+++ b/packages/memtomem/tests/test_fastembed_cache.py
@@ -8,6 +8,7 @@ the directory-creation contract; they do not exercise fastembed itself.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -81,6 +82,11 @@ def test_tilde_in_env_is_expanded(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     assert resolved.is_dir()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: simulates pwd.getpwuid failure mode of expanduser; "
+    "Windows expanduser uses USERPROFILE/HOMEDRIVE+HOMEPATH instead of pwent",
+)
 def test_unexpandable_home_raises_actionable_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """When ``$HOME`` is unset and pwent lookup fails, ``Path.expanduser()`` on
     Python 3.12+ raises ``RuntimeError("Could not determine home directory.")``


### PR DESCRIPTION
## Summary

- Cluster D of the #643 Windows sweep: `test_unexpandable_home_raises_actionable_error` failed on Windows with `ModuleNotFoundError: No module named 'pwd'` because the test imports `pwd` and monkeypatches `pwd.getpwuid` to simulate a POSIX-specific expanduser failure mode.
- On Windows there is no `pwd` module; `Path.expanduser()` falls back to `USERPROFILE` / `HOMEDRIVE`+`HOMEPATH` env vars rather than pwent. The simulated failure mode does not exist on Windows, so `skipif` is the right call (not "rewrite for Windows").
- Mirrors PR #713's pattern for POSIX-only assertions and the existing `@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")` form already used at 5 sites in `test_server_*.py`.

## Diff

`+6 / -0` — adds `import sys` (file didn't use it) and the skipif decorator with a reason that names the specific POSIX dependency.

## Test plan

- [x] macOS: `uv run pytest packages/memtomem/tests/test_fastembed_cache.py` — 6/6 pass (skipif inactive on POSIX, original test still runs).
- [x] Lint: `ruff check` + `ruff format --check` clean.
- [ ] Windows CI: this test will skip rather than ImportError.

## Out of scope

The other 27 Windows failures from the previous run cluster into ~7 separate root causes (dirty-state misclassification, memory_dir prefix matching, claude-projects scope, mm.exe binary path, tilde expansion, init_cmd POSIX assumptions, misc) — each will get its own PR per `feedback_one_change_per_pr.md`. Cluster B (memory_dir prefix) is intentionally skipped here as parallel work is in flight on `fix/647-windows-memory-dir-prefix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
