### PR TITLE
fix(search): normalize separators in source_filter match (#720)

### DIFF
--- a/packages/memtomem/src/memtomem/search/decay.py
+++ b/packages/memtomem/src/memtomem/search/decay.py
@@ -109,12 +109,12 @@ async def expire_chunks(
 
     sources = await storage.get_all_source_files()
     if source_filter:
-        # Fold separators on both sides so a POSIX-typed ``/tmp/keep/``
-        # filter still matches Windows-stored ``\tmp\keep\file.md``
-        # paths (#720). POSIX is a no-op (``"\"`` doesn't appear in
-        # native paths there).
-        norm_filter = source_filter.replace("\\", "/")
-        sources = {s for s in sources if norm_filter in str(s).replace("\\", "/")}
+        from memtomem.search.pipeline import match_source_filter_substring
+
+        # Substring-only contract — see ``match_source_filter_substring``
+        # for the separator-fold rule (#720) and rationale for not
+        # sharing the glob-aware ``match_source_filter``.
+        sources = {s for s in sources if match_source_filter_substring(source_filter, str(s))}
 
     total = 0
     to_delete: list[UUID] = []

--- a/packages/memtomem/src/memtomem/search/decay.py
+++ b/packages/memtomem/src/memtomem/search/decay.py
@@ -109,7 +109,12 @@ async def expire_chunks(
 
     sources = await storage.get_all_source_files()
     if source_filter:
-        sources = {s for s in sources if source_filter in str(s)}
+        # Fold separators on both sides so a POSIX-typed ``/tmp/keep/``
+        # filter still matches Windows-stored ``\tmp\keep\file.md``
+        # paths (#720). POSIX is a no-op (``"\"`` doesn't appear in
+        # native paths there).
+        norm_filter = source_filter.replace("\\", "/")
+        sources = {s for s in sources if norm_filter in str(s).replace("\\", "/")}
 
     total = 0
     to_delete: list[UUID] = []

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -47,13 +47,13 @@ def match_source_filter(filter_str: str, source_path: str) -> bool:
     paths don't contain backslashes.
 
     The ``source_filter`` parameter is shared across the search pipeline
-    and several MCP tools (``mem_list``, ``mem_consolidate``,
-    ``mem_export_chunks``, ``mem_auto_tag``, ``mem_extract_entities``,
-    ``mem_decay``); this helper is the canonical substring + glob matcher
-    for the substring + glob contract. The substring-only and glob-only
-    callers apply the same separator fold inline at their call sites
-    rather than calling this helper, so the contract differences stay
-    explicit.
+    and several MCP tools (``mem_list``, ``mem_consolidate``); this
+    helper is the canonical matcher for callers whose contract is
+    "substring or glob, autodetected by pattern chars". Callers with a
+    stricter contract use one of the two siblings below
+    (``match_source_filter_substring``, ``match_source_filter_glob``)
+    so the separator-fold rule still lives in one module per contract
+    while the contract differences stay explicit at the call site.
 
     POSIX edge case: backslash is a legal filename character on POSIX, so
     a chunk indexed under ``foo\\bar.md`` would match a filter
@@ -66,6 +66,36 @@ def match_source_filter(filter_str: str, source_path: str) -> bool:
     if any(c in norm_filter for c in ("*", "?", "[")):
         return fnmatch(norm_source, norm_filter)
     return norm_filter in norm_source
+
+
+def match_source_filter_substring(filter_str: str, source_path: str) -> bool:
+    """Substring-only variant of :func:`match_source_filter`.
+
+    Same separator-fold rule (#720), no glob fallback. Used by callers
+    whose contract is substring-only (``mem_decay`` /
+    :func:`~memtomem.search.decay.expire_chunks`, ``mem_auto_tag``,
+    ``mem_export_chunks``). Sharing the substring + glob auto-detecting
+    helper would silently broaden their behaviour to glob, which is a
+    contract change. The fold lives in this single helper so a future
+    "tidy-up" that strips the ``.replace("\\", "/")`` calls fails the
+    POSIX-runnable pin in ``TestMatchSourceFilterSubstring`` instead of
+    only the Windows CI leg.
+    """
+    return filter_str.replace("\\", "/") in source_path.replace("\\", "/")
+
+
+def match_source_filter_glob(filter_str: str, source_path: str) -> bool:
+    """Glob-only variant of :func:`match_source_filter`.
+
+    Same separator-fold rule (#720), no substring fallback. Used by
+    callers whose contract is glob-only (``mem_entity_scan``); a
+    substring filter that lacks ``*?[`` characters returns ``False``
+    here unless it happens to be an exact-match glob, mirroring the
+    pre-fix behaviour. The fold lives in this single helper so the
+    POSIX-runnable pin in ``TestMatchSourceFilterGlob`` catches a
+    revert without depending on the Windows CI leg.
+    """
+    return fnmatch(source_path.replace("\\", "/"), filter_str.replace("\\", "/"))
 
 
 def _apply_validity_filter(results: list[SearchResult], as_of_unix: int) -> list[SearchResult]:

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -38,10 +38,18 @@ def _bg_task_error_cb(task: asyncio.Task) -> None:
 
 
 def _match_source(filter_str: str, source_path: str) -> bool:
-    """Match source_filter: glob when pattern chars present, substring otherwise."""
-    if any(c in filter_str for c in ("*", "?", "[")):
-        return fnmatch(source_path, filter_str)
-    return filter_str in source_path
+    """Match source_filter: glob when pattern chars present, substring otherwise.
+
+    Both sides are folded to forward-slash form before comparing so a
+    user-typed ``/tmp/keep/`` matches a Windows-stored
+    ``\\tmp\\keep\\file.md`` (#720, sibling of #647). On POSIX
+    ``str.replace("\\", "/")`` is identity, so behaviour is unchanged.
+    """
+    norm_filter = filter_str.replace("\\", "/")
+    norm_source = source_path.replace("\\", "/")
+    if any(c in norm_filter for c in ("*", "?", "[")):
+        return fnmatch(norm_source, norm_filter)
+    return norm_filter in norm_source
 
 
 def _apply_validity_filter(results: list[SearchResult], as_of_unix: int) -> list[SearchResult]:

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -37,13 +37,29 @@ def _bg_task_error_cb(task: asyncio.Task) -> None:
         logger.warning("Background task %s failed: %s", task.get_name(), exc)
 
 
-def _match_source(filter_str: str, source_path: str) -> bool:
+def match_source_filter(filter_str: str, source_path: str) -> bool:
     """Match source_filter: glob when pattern chars present, substring otherwise.
 
     Both sides are folded to forward-slash form before comparing so a
     user-typed ``/tmp/keep/`` matches a Windows-stored
     ``\\tmp\\keep\\file.md`` (#720, sibling of #647). On POSIX
-    ``str.replace("\\", "/")`` is identity, so behaviour is unchanged.
+    ``str.replace("\\", "/")`` is a no-op for the typical case where
+    paths don't contain backslashes.
+
+    The ``source_filter`` parameter is shared across the search pipeline
+    and several MCP tools (``mem_list``, ``mem_consolidate``,
+    ``mem_export_chunks``, ``mem_auto_tag``, ``mem_extract_entities``,
+    ``mem_decay``); this helper is the canonical substring + glob matcher
+    for the substring + glob contract. The substring-only and glob-only
+    callers apply the same separator fold inline at their call sites
+    rather than calling this helper, so the contract differences stay
+    explicit.
+
+    POSIX edge case: backslash is a legal filename character on POSIX, so
+    a chunk indexed under ``foo\\bar.md`` would match a filter
+    ``foo/bar`` after the fold. This is rare in practice (most tools and
+    users avoid backslashes in POSIX filenames) and is the trade-off for
+    a Windows-portable comparison.
     """
     norm_filter = filter_str.replace("\\", "/")
     norm_source = source_path.replace("\\", "/")
@@ -613,7 +629,9 @@ class SearchPipeline:
         # Filter by source file if requested
         if source_filter:
             fused = [
-                r for r in fused if _match_source(source_filter, str(r.chunk.metadata.source_file))
+                r
+                for r in fused
+                if match_source_filter(source_filter, str(r.chunk.metadata.source_file))
             ]
 
         # Filter by tag if requested (comma-separated = OR matching)

--- a/packages/memtomem/src/memtomem/server/tools/browse.py
+++ b/packages/memtomem/src/memtomem/server/tools/browse.py
@@ -29,7 +29,7 @@ async def mem_list(
         mem_list(source_filter="docs/")          — files with "docs/" in path (substring)
         mem_list(namespace="work")               — files in the "work" namespace
     """
-    from fnmatch import fnmatch
+    from memtomem.search.pipeline import match_source_filter
 
     app = await _get_app_initialized(ctx)
     rows = await app.storage.get_source_files_with_counts()
@@ -37,14 +37,11 @@ async def mem_list(
     if not rows:
         return "No indexed files."
 
-    # Apply source_filter
+    # Apply source_filter — same substring + glob contract as
+    # ``mem_search(source_filter=...)``, including separator-fold for
+    # Windows portability (#720).
     if source_filter:
-        has_glob = any(c in source_filter for c in ("*", "?", "["))
-        rows = [
-            r
-            for r in rows
-            if (fnmatch(str(r[0]), source_filter) if has_glob else source_filter in str(r[0]))
-        ]
+        rows = [r for r in rows if match_source_filter(source_filter, str(r[0]))]
 
     # Apply namespace filter
     if namespace:

--- a/packages/memtomem/src/memtomem/server/tools/consolidation.py
+++ b/packages/memtomem/src/memtomem/server/tools/consolidation.py
@@ -45,14 +45,11 @@ async def mem_consolidate(
     # Group chunks by source file
     sources = await app.storage.get_source_files_with_counts()
     if source_filter:
-        from fnmatch import fnmatch
+        from memtomem.search.pipeline import match_source_filter
 
-        has_glob = any(c in source_filter for c in ("*", "?", "["))
-        sources = [
-            s
-            for s in sources
-            if (fnmatch(str(s[0]), source_filter) if has_glob else source_filter in str(s[0]))
-        ]
+        # Same substring + glob contract as ``mem_search(source_filter=...)``,
+        # including separator-fold for Windows portability (#720).
+        sources = [s for s in sources if match_source_filter(source_filter, str(s[0]))]
 
     # Filter by namespace if specified
     if effective_ns:

--- a/packages/memtomem/src/memtomem/server/tools/entity.py
+++ b/packages/memtomem/src/memtomem/server/tools/entity.py
@@ -34,8 +34,6 @@ async def mem_entity_scan(
         overwrite: Replace existing entities for scanned chunks (default: false, skip already-scanned)
         dry_run: Preview extraction without saving (default: false)
     """
-    from fnmatch import fnmatch
-
     from memtomem.tools.entity_extraction import extract_entities_with_llm
 
     app = await _get_app_initialized(ctx)
@@ -50,13 +48,13 @@ async def mem_entity_scan(
     scanned_sources = 0
     entity_type_counts: dict[str, int] = {}
 
-    # Fold separators on both sides so a POSIX-typed glob like
-    # ``/tmp/keep/*`` still matches Windows-stored ``\tmp\keep\...``
-    # paths (#720). Glob-only by contract — substring inputs are handled
-    # by ``match_source_filter`` elsewhere; entity scan stays glob.
-    norm_filter = source_filter.replace("\\", "/") if source_filter else None
+    # Glob-only contract — see ``match_source_filter_glob`` for the
+    # separator-fold rule (#720) and rationale for not sharing the
+    # substring-aware ``match_source_filter``.
+    from memtomem.search.pipeline import match_source_filter_glob
+
     for source in sources:
-        if norm_filter and not fnmatch(str(source).replace("\\", "/"), norm_filter):
+        if source_filter and not match_source_filter_glob(source_filter, str(source)):
             continue
 
         chunks = await storage.list_chunks_by_source(source)

--- a/packages/memtomem/src/memtomem/server/tools/entity.py
+++ b/packages/memtomem/src/memtomem/server/tools/entity.py
@@ -50,8 +50,13 @@ async def mem_entity_scan(
     scanned_sources = 0
     entity_type_counts: dict[str, int] = {}
 
+    # Fold separators on both sides so a POSIX-typed glob like
+    # ``/tmp/keep/*`` still matches Windows-stored ``\tmp\keep\...``
+    # paths (#720). Glob-only by contract — substring inputs are handled
+    # by ``match_source_filter`` elsewhere; entity scan stays glob.
+    norm_filter = source_filter.replace("\\", "/") if source_filter else None
     for source in sources:
-        if source_filter and not fnmatch(str(source), source_filter):
+        if norm_filter and not fnmatch(str(source).replace("\\", "/"), norm_filter):
             continue
 
         chunks = await storage.list_chunks_by_source(source)

--- a/packages/memtomem/src/memtomem/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/tools/auto_tag.py
@@ -321,11 +321,11 @@ async def auto_tag_storage(
 
     sources = await storage.get_all_source_files()
     if source_filter:
-        # Fold separators on both sides so a POSIX-typed substring like
-        # ``/tmp/keep/`` still matches Windows-stored ``\tmp\keep\...``
-        # paths (#720). Substring-only by contract.
-        norm_filter = source_filter.replace("\\", "/")
-        sources = {s for s in sources if norm_filter in str(s).replace("\\", "/")}
+        from memtomem.search.pipeline import match_source_filter_substring
+
+        # Substring-only contract — see ``match_source_filter_substring``
+        # for the separator-fold rule (#720).
+        sources = {s for s in sources if match_source_filter_substring(source_filter, str(s))}
 
     total = 0
     tagged = 0

--- a/packages/memtomem/src/memtomem/tools/auto_tag.py
+++ b/packages/memtomem/src/memtomem/tools/auto_tag.py
@@ -321,7 +321,11 @@ async def auto_tag_storage(
 
     sources = await storage.get_all_source_files()
     if source_filter:
-        sources = {s for s in sources if source_filter in str(s)}
+        # Fold separators on both sides so a POSIX-typed substring like
+        # ``/tmp/keep/`` still matches Windows-stored ``\tmp\keep\...``
+        # paths (#720). Substring-only by contract.
+        norm_filter = source_filter.replace("\\", "/")
+        sources = {s for s in sources if norm_filter in str(s).replace("\\", "/")}
 
     total = 0
     tagged = 0

--- a/packages/memtomem/src/memtomem/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/tools/export_import.py
@@ -101,9 +101,13 @@ async def export_chunks(
     """
     source_files = await storage.get_all_source_files()
 
+    # Fold separators on both sides so a POSIX-typed substring like
+    # ``/tmp/keep/`` still matches Windows-stored ``\tmp\keep\...``
+    # paths (#720). Substring-only by contract.
+    norm_filter = source_filter.replace("\\", "/") if source_filter else None
     records: list[dict] = []
     for source in sorted(source_files):
-        if source_filter and source_filter not in str(source):
+        if norm_filter and norm_filter not in str(source).replace("\\", "/"):
             continue
         chunks = await storage.list_chunks_by_source(source, limit=100_000)
         for chunk in chunks:

--- a/packages/memtomem/src/memtomem/tools/export_import.py
+++ b/packages/memtomem/src/memtomem/tools/export_import.py
@@ -99,15 +99,15 @@ async def export_chunks(
     Returns:
         ExportBundle with the selected chunks.
     """
+    from memtomem.search.pipeline import match_source_filter_substring
+
     source_files = await storage.get_all_source_files()
 
-    # Fold separators on both sides so a POSIX-typed substring like
-    # ``/tmp/keep/`` still matches Windows-stored ``\tmp\keep\...``
-    # paths (#720). Substring-only by contract.
-    norm_filter = source_filter.replace("\\", "/") if source_filter else None
+    # Substring-only contract with negation — see
+    # ``match_source_filter_substring`` for the separator-fold rule (#720).
     records: list[dict] = []
     for source in sorted(source_files):
-        if norm_filter and norm_filter not in str(source).replace("\\", "/"):
+        if source_filter and not match_source_filter_substring(source_filter, str(source)):
             continue
         chunks = await storage.list_chunks_by_source(source, limit=100_000)
         for chunk in chunks:

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -8,6 +8,45 @@ from uuid import uuid4
 from memtomem.models import Chunk, ChunkMetadata, SearchResult
 
 
+class TestMatchSource:
+    """Pin: ``_match_source`` folds separators on both sides before
+    comparing, so a POSIX-typed ``/tmp/keep/`` matches a Windows-stored
+    ``\\tmp\\keep\\file.md`` (#720, sibling of #647).
+
+    Without this pin a regression where someone removes the
+    ``.replace("\\", "/")`` calls would still pass on POSIX (where
+    backslashes never appear in native path strings) and only break on
+    the Windows CI leg. Each row exercises a (filter shape, source
+    shape) cross-product so both code branches (substring + glob) are
+    covered with mixed separator inputs.
+    """
+
+    @pytest.mark.parametrize(
+        "filter_str,source_path,expected",
+        [
+            # Substring branch — POSIX shape (identity on POSIX).
+            ("/tmp/keep/", "/tmp/keep/policy.md", True),
+            ("/tmp/other/", "/tmp/keep/policy.md", False),
+            # Substring branch — POSIX filter, Windows-shape source.
+            ("/tmp/keep/", "\\tmp\\keep\\policy.md", True),
+            ("/tmp/other/", "\\tmp\\keep\\policy.md", False),
+            # Substring branch — Windows filter, POSIX-shape source.
+            ("\\tmp\\keep\\", "/tmp/keep/policy.md", True),
+            # Substring branch — Windows-shape both sides.
+            ("\\tmp\\keep\\", "\\tmp\\keep\\policy.md", True),
+            # Glob branch — POSIX pattern, Windows-shape source.
+            ("/tmp/*/policy.md", "\\tmp\\keep\\policy.md", True),
+            ("/tmp/keep/*.txt", "\\tmp\\keep\\policy.md", False),
+            # Glob branch — Windows pattern, POSIX-shape source.
+            ("\\tmp\\*\\policy.md", "/tmp/keep/policy.md", True),
+        ],
+    )
+    def test_separator_normalised_both_sides(self, filter_str, source_path, expected):
+        from memtomem.search.pipeline import _match_source
+
+        assert _match_source(filter_str, source_path) is expected
+
+
 class TestPipelineQueryExpansion:
     """Test that query expansion modifies queries before retrieval."""
 

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -47,6 +47,70 @@ class TestMatchSourceFilter:
         assert match_source_filter(filter_str, source_path) is expected
 
 
+class TestMatchSourceFilterSubstring:
+    """Pin: ``match_source_filter_substring`` folds separators on both
+    sides before comparing — covers ``mem_decay`` /
+    ``expire_chunks``, ``mem_auto_tag``, ``mem_export_chunks`` (#720).
+
+    Substring-only contract: glob characters in the filter are treated
+    as literals (no ``fnmatch`` fallback). The pin lets POSIX CI catch
+    a future revert of the ``.replace("\\", "/")`` calls without
+    depending on the Windows CI leg.
+    """
+
+    @pytest.mark.parametrize(
+        "filter_str,source_path,expected",
+        [
+            # POSIX shape (identity on POSIX).
+            ("/tmp/keep/", "/tmp/keep/policy.md", True),
+            ("/tmp/other/", "/tmp/keep/policy.md", False),
+            # POSIX filter, Windows-shape source — the #720 case.
+            ("/tmp/keep/", "\\tmp\\keep\\policy.md", True),
+            ("/tmp/other/", "\\tmp\\keep\\policy.md", False),
+            # Windows filter, POSIX-shape source.
+            ("\\tmp\\keep\\", "/tmp/keep/policy.md", True),
+            # Windows-shape both sides.
+            ("\\tmp\\keep\\", "\\tmp\\keep\\policy.md", True),
+            # Glob characters in filter are literal — no fnmatch fallback.
+            ("*.md", "\\tmp\\keep\\policy.md", False),
+        ],
+    )
+    def test_separator_normalised_both_sides(self, filter_str, source_path, expected):
+        from memtomem.search.pipeline import match_source_filter_substring
+
+        assert match_source_filter_substring(filter_str, source_path) is expected
+
+
+class TestMatchSourceFilterGlob:
+    """Pin: ``match_source_filter_glob`` folds separators on both sides
+    before ``fnmatch`` — covers ``mem_entity_scan`` (#720).
+
+    Glob-only contract: substring filters that lack ``*?[`` characters
+    only match exact filenames. The pin lets POSIX CI catch a future
+    revert of the ``.replace("\\", "/")`` calls without depending on
+    the Windows CI leg.
+    """
+
+    @pytest.mark.parametrize(
+        "filter_str,source_path,expected",
+        [
+            # POSIX glob, Windows-shape source — the #720 case.
+            ("/tmp/*/policy.md", "\\tmp\\keep\\policy.md", True),
+            ("/tmp/keep/*.txt", "\\tmp\\keep\\policy.md", False),
+            # Windows glob, POSIX-shape source.
+            ("\\tmp\\*\\policy.md", "/tmp/keep/policy.md", True),
+            # POSIX shape (identity on POSIX).
+            ("/tmp/*/policy.md", "/tmp/keep/policy.md", True),
+            # Substring-only filter — glob-only contract → no match.
+            ("/tmp/keep", "\\tmp\\keep\\policy.md", False),
+        ],
+    )
+    def test_separator_normalised_both_sides(self, filter_str, source_path, expected):
+        from memtomem.search.pipeline import match_source_filter_glob
+
+        assert match_source_filter_glob(filter_str, source_path) is expected
+
+
 class TestPipelineQueryExpansion:
     """Test that query expansion modifies queries before retrieval."""
 

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -8,8 +8,8 @@ from uuid import uuid4
 from memtomem.models import Chunk, ChunkMetadata, SearchResult
 
 
-class TestMatchSource:
-    """Pin: ``_match_source`` folds separators on both sides before
+class TestMatchSourceFilter:
+    """Pin: ``match_source_filter`` folds separators on both sides before
     comparing, so a POSIX-typed ``/tmp/keep/`` matches a Windows-stored
     ``\\tmp\\keep\\file.md`` (#720, sibling of #647).
 
@@ -42,9 +42,9 @@ class TestMatchSource:
         ],
     )
     def test_separator_normalised_both_sides(self, filter_str, source_path, expected):
-        from memtomem.search.pipeline import _match_source
+        from memtomem.search.pipeline import match_source_filter
 
-        assert _match_source(filter_str, source_path) is expected
+        assert match_source_filter(filter_str, source_path) is expected
 
 
 class TestPipelineQueryExpansion:


### PR DESCRIPTION
## Summary

Apply the same Windows separator fold at **every** `source_filter` comparison site, with **three contract-specific helpers** so the fold rule lives in exactly three places (each POSIX-pinned) rather than scattered inline at every call site:

| Tool | File | Contract | Approach |
|---|---|---|---|
| `mem_search` | `search/pipeline.py` | substring + glob | `match_source_filter` |
| `mem_list` | `server/tools/browse.py` | substring + glob | calls `match_source_filter` |
| `mem_consolidate` | `server/tools/consolidation.py` | substring + glob | calls `match_source_filter` |
| `mem_decay` | `search/decay.py:expire_chunks` | substring-only | calls `match_source_filter_substring` |
| `mem_auto_tag` | `tools/auto_tag.py` | substring-only | calls `match_source_filter_substring` |
| `mem_export_chunks` | `tools/export_import.py` | substring-only (negated) | calls `match_source_filter_substring` |
| `mem_entity_scan` | `server/tools/entity.py` | glob-only | calls `match_source_filter_glob` |

## Why

Sibling of #647 (closed via #717) but in a different code path. The search-pipeline `source_filter` parameter (and the same parameter on six other MCP tools) was substring-matched (or `fnmatch`-globbed) directly against the chunk's stored `source_file` string with no separator normalisation. On Windows that meant a caller-supplied filter like `/tmp/keep/` (POSIX literal — what tests and most users type) never matched a chunk whose stored path was `\tmp\keep\policy.md`.

Symptom on Windows CI (caught after #717 merged):

```
FAILED packages/memtomem/tests/test_temporal_validity.py::TestValidityFilterPipelineWiring::test_and_with_source_filter
  AssertionError: assert [] == ['chunk-ok']
```

That test was the visible failure, but the bug is family-wide: review of the first commit found 5 more sites with the same shape. Fixing only `mem_search` would have been a partial fix — `mem_list(source_filter="docs/")` on Windows would still return empty.

## Approach

Match-side normalise (read-time fold) — same pattern as #716 (`categorize_memory_dir`) and #717 (`norm_dir_prefix` via `os.sep`). Three contract-specific helpers in `search/pipeline.py`, one parametrized pin per helper, all callers route through them:

- **`match_source_filter`** — substring + glob auto-detect (existing). Pinned by 9-row `TestMatchSourceFilter`.
- **`match_source_filter_substring`** — substring-only, no glob fallback. Pinned by 7-row `TestMatchSourceFilterSubstring`.
- **`match_source_filter_glob`** — glob-only, no substring fallback. Pinned by 5-row `TestMatchSourceFilterGlob`.

The contract differences stay explicit at the call sites: substring-only callers can't accidentally gain glob, glob-only callers can't accidentally gain substring. `feedback_default_off_when_opt_out_exists.md` regression class avoided.

`norm_path` (`storage/sqlite_helpers.py`) is unchanged — persisted `chunks.source_file` rows stay native-form on every platform; only the **comparison** picks a canonical form.

### POSIX edge case (documented)

Backslash is a legal filename character on POSIX, so a chunk indexed under `foo\bar.md` would match a filter `foo/bar` after the fold. Rare in practice. Documented in `match_source_filter`'s docstring as the explicit trade-off for Windows portability.

## What's not in this PR

- **No `norm_path` change.** Same reasoning as #717 — write+read symmetry already collapses drive case, 8.3, and `\\?\` long-path prefix to a canonical form via `Path.resolve()`.
- **No promotion of the helper module out of `search/pipeline.py`.** It currently lives there because that's where `match_source_filter` was already defined. If a future site lives outside `search/` AND the layering of `server.tools` → `search` becomes painful, moving the trio to e.g. `storage/sqlite_helpers.py` is a clean follow-up.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_pipeline.py::TestMatchSourceFilter packages/memtomem/tests/test_pipeline.py::TestMatchSourceFilterSubstring packages/memtomem/tests/test_pipeline.py::TestMatchSourceFilterGlob -v` — 21 passed (9 + 7 + 5).
- [x] **Mutation-validated** all three helpers (per `feedback_pin_test_mutation_validation.md`): locally reverted each helper's `.replace()` calls and confirmed Windows-shape rows fail on macOS.
- [x] `uv run pytest packages/memtomem/tests/{test_pipeline,test_temporal_validity,test_user_workflows,test_server_tools_core,test_storage_extended,test_server_tools_advanced,test_export_import_roundtrip,test_auto_tag_llm,test_entity_extraction_llm}.py -m "not ollama and not llm"` — 316 passed (POSIX no-op confirmed across every `source_filter` consumer including the inline-site test files).
- [x] `uv run ruff check` and `ruff format --check` on `search/`, `server/tools/`, `tools/`, `tests/test_pipeline.py` — clean.
- [ ] Windows-CI leg: `test_temporal_validity::test_and_with_source_filter` turns green; the 6 other `source_filter` consumers (`mem_list`, `mem_consolidate`, `mem_decay`, `mem_auto_tag`, `mem_export_chunks`, `mem_entity_scan`) integration tests stay green.

Closes #720. Refs #647 (closed via #717), #716, #634 (Windows CI matrix umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
