### PR TITLE
test(windows): use shutil.which for mm entry-point lookup (#643)

### DIFF
--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -18,6 +18,7 @@ Two variants are kept intentionally:
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 
@@ -97,15 +98,19 @@ class TestFreshNoopIndexSubprocess:
         package has no ``__main__`` module, and the installed entry point is
         what real users hit.
         """
-        mm_bin = os.path.join(os.path.dirname(sys.executable), "mm")
+        # ``shutil.which`` adds the platform-correct suffix (``.exe`` on
+        # Windows via PATHEXT, none on POSIX), so the same lookup works
+        # against both ``.venv/bin/mm`` and ``.venv/Scripts/mm.exe``.
+        bin_dir = os.path.dirname(sys.executable)
+        mm_bin = shutil.which("mm", path=bin_dir)
         # Fail loudly instead of pytest.skip — any valid test environment
         # (``uv run pytest`` or ``uv pip install -e``) must provide the
         # ``mm`` entry point. A silent skip here would turn this subprocess
         # regression guard into CI false-green if the editable install is
         # ever dropped.
-        if not os.path.exists(mm_bin):
+        if mm_bin is None:
             pytest.fail(
-                f"mm binary not found at {mm_bin}. "
+                f"mm binary not found in {bin_dir}. "
                 "Run `uv pip install -e packages/memtomem[all]` before testing."
             )
 


### PR DESCRIPTION
## Summary

- Cluster F of the #643 Windows sweep (1 test).
- `TestFreshNoopIndexSubprocess::test_init_index_search_via_subprocess` errored out on Windows with `mm binary not found at D:\a\memtomem\memtomem\.venv\Scripts\mm` because the test built the path with a hardcoded `"mm"` name and `os.path.exists` check. On Windows the uv-installed entry point is `mm.exe`, not `mm`.
- Switch to `shutil.which("mm", path=bin_dir)` — that helper is PATHEXT-aware on Windows (tries `.exe`, `.cmd`, `.bat`) and no-extension on POSIX, returning the platform-correct full path ready to hand to `subprocess.run`.

## Diff

`+8 / -3` — adds `import shutil`, replaces the path construction + `os.path.exists` check with `shutil.which` + `is None` check, and updates the error message to say "not found in `<bin_dir>`" since the binary suffix is now platform-determined.

## Test plan

- [x] macOS: `uv run pytest packages/memtomem/tests/test_cli_index_noop_e2e.py` — 2/2 pass (resolves to `.venv/bin/mm`).
- [x] Lint: `ruff check` + `ruff format --check` clean.
- [ ] Windows CI: should resolve to `.venv\Scripts\mm.exe` and run the subprocess.

## Out of scope

The remaining 26 Windows failures cluster into ~6 separate root causes — each will get its own PR per `feedback_one_change_per_pr.md`. Cluster B (memory_dir prefix) intentionally skipped — parallel work in flight on `fix/647-windows-memory-dir-prefix` and `fix/720-source-filter-windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
