### PR TITLE
test(windows): make test_init_cmd.py Windows-compatible (#643)

### DIFF
--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -1408,6 +1408,12 @@ class TestRuntimeProfile:
         assert profile.runtime_matches_workspace is True
         assert profile.mm_binary_origin == "venv-relative"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX-only fixture: monkeypatches sys.executable to "
+        "'/usr/local/bin/python' which Path() normalizes to backslashes "
+        "on Windows, breaking the system-path classifier",
+    )
     def test_project_install_profile_no_packages_dir(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1737,6 +1743,12 @@ class TestMmBinaryOriginDetection:
         )
         assert origin == "venv-relative"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX-only: tests classification of POSIX system Python paths "
+        "(/usr/bin/, /opt/homebrew/, etc.) which don't exist on Windows; "
+        "Path() also normalizes them to backslashes, defeating the prefix match",
+    )
     def test_origin_system_paths(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Well-known system Python locations classify as ``system``."""
         from memtomem.cli import init_cmd
@@ -4611,7 +4623,10 @@ class TestInitialSeedThreshold:
     @staticmethod
     def _write_md(dir_: Path, name: str, body: str) -> Path:
         f = dir_ / name
-        f.write_text(body, encoding="utf-8")
+        # ``newline=""`` disables platform newline translation so byte-count
+        # assertions (e.g. ``len(body) == _collect_seed_scale(...)`` total)
+        # stay correct on Windows where ``\n`` would otherwise become ``\r\n``.
+        f.write_text(body, encoding="utf-8", newline="")
         return f
 
     def test_collect_seed_scale_counts_md_only_and_sums_bytes(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Cluster G of the #643 Windows sweep — 3 fixes in `test_init_cmd.py`, all making the test suite Windows-compatible without touching production. Bundled because they share the same axis (`test_init_cmd.py` Windows compat) and follow PR #713 / #714's "bundle by mechanism class" pattern.

| # | Test / helper | Fix | Root cause |
|---|---|---|---|
| 1 | `test_project_install_profile_no_packages_dir` | skipif(win32) | Monkeypatches `sys.executable = "/usr/local/bin/python"`; on Windows `Path()` normalizes that to backslashes, defeating production's `startswith("/usr/local/bin/")` check |
| 2 | `test_origin_system_paths` | skipif(win32) | Iterates hardcoded POSIX paths (`/usr/bin/`, `/opt/homebrew/`, etc.); none exist on Windows |
| 3 | `_write_md` helper | `newline=""` on `write_text` | `Path.write_text` translates `\n` → `\r\n` by default on Windows; the dependent test asserts an exact byte count, failing `113 == 112` |

## Why skipif (not rewrite for Windows) for #1 and #2

The classifier under test (`_detect_mm_binary_origin`) is a heuristic that tags well-known POSIX system Python locations. There is no canonical Windows analog (`C:\Python313\python.exe`? `py.exe`? `WindowsApps\PythonSoftwareFoundation.Python.3.13...\python.exe`?), so a "Windows system paths" rewrite would need a separate design call and is out of scope for this mechanical sweep.

## Why production stays untouched

- `_detect_mm_binary_origin` is correct on POSIX and intentionally permissive on Windows (returns `unknown`, which the wizard treats like `uv-tool` — see the docstring at `init_cmd.py:230-251`).
- `_collect_seed_scale` reads raw byte counts via `os.stat` — already correct cross-platform.

## Test plan

- [x] macOS: `uv run pytest packages/memtomem/tests/test_init_cmd.py` — **262/262 pass**.
- [x] Lint: `ruff check` + `ruff format --check` clean.
- [ ] Windows CI: 2 tests skip cleanly, 1 test passes via the fixed helper.

## Out of scope

The remaining 23 Windows failures cluster into A (dirty state, 9 tests), C (claude-projects scope, 2), E (tilde expansion, 1), H (misc, 2). Cluster B (memory_dir prefix, 9) intentionally skipped — parallel work in flight on `fix/647-windows-memory-dir-prefix` and `fix/720-source-filter-windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
