### PR TITLE
test(windows): skipif POSIX-only claude-projects discovery tests (#643)

### DIFF
--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -273,6 +273,12 @@ def test_discover_experimental_scan_disabled(
     assert "claude-projects" not in scopes[0].sources
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: relies on `/tmp` existing as a real directory and on "
+    "the claude-projects encoding (`-tmp` → `/tmp` via `replace('-', '/')`) "
+    "which is POSIX-only by production design (see _decode_claude_project_dirname)",
+)
 def test_discover_experimental_scan_enabled_filters_misdecoded(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -306,6 +312,11 @@ def test_discover_experimental_scan_enabled_filters_misdecoded(
     assert all("no/such/place" not in str(s.root or "") for s in scopes)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: uses cwd=Path('/tmp') and the `-tmp` → `/tmp` encoding; "
+    "/tmp does not exist on Windows and the encoding scheme is POSIX-only",
+)
 def test_discover_experimental_dedup_with_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Cluster C of the #643 Windows sweep — 2 tests in `test_context_projects.py` exercising claude-projects directory discovery. Both fail on Windows because the entire flow is POSIX-only by production design:

1. The encoding scheme is literally `name.replace("-", "/")` in `_decode_claude_project_dirname` (`projects.py:229`) — it cannot represent Windows drive-letter paths (`C:\...`).
2. Both tests rely on `/tmp` existing as a real directory; production filters via `Path.is_dir()` and Windows has no `/tmp`.

Production returns an empty discovery list on Windows by intention. The right fix is `skipif`, mirroring PR #713 / #721 / #724 / Cluster G's pattern.

## Diff

`+11 / -0` — two `@pytest.mark.skipif(sys.platform == "win32", reason="...")` decorators with reasons that name the specific POSIX dependency. `sys` and `pytest` already imported.

## Why skipif (not rewrite for Windows)

Adding Windows support to claude-projects discovery is a separate design call: the encoding scheme would need to represent `C:\Users\foo\bar` as a directory name, which requires changing both Claude Code's encoder and memtomem's decoder. That is well out of scope for a #643 mechanical sweep.

## Test plan

- [x] macOS: `uv run pytest packages/memtomem/tests/test_context_projects.py` — 25/25 pass (skipif inactive).
- [x] Lint: `ruff check` + `ruff format --check` clean.
- [ ] Windows CI: 2 tests skip cleanly.

## Out of scope

Remaining: A (9 — dirty state, production change likely), E (1 — tilde expansion), H (2 — misc). Cluster B (9, memory_dir prefix) intentionally skipped — parallel work in flight on `fix/647-windows-memory-dir-prefix` / `fix/720-source-filter-windows`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
