### PR TITLE
fix(config): use as_posix() for tilde-expanded path_glob (#643 cluster E)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -343,7 +343,12 @@ class NamespacePolicyRule(BaseSettings):
         if not v:
             raise ValueError("path_glob must be non-empty")
         if v == "~" or v.startswith("~/"):
-            v = str(Path(v).expanduser())
+            # ``as_posix()`` not ``str()``: ``pathspec.GitIgnoreSpec`` is the
+            # downstream consumer (engine.py:_build_exclude_spec) and gitignore
+            # patterns require ``/`` separators. On Windows ``str(Path(...))``
+            # would emit backslashes, which pathspec treats as escape characters
+            # and silently mismatches every file.
+            v = Path(v).expanduser().as_posix()
         return v
 
     @field_validator("namespace")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -349,6 +349,14 @@ class NamespacePolicyRule(BaseSettings):
             # would emit backslashes, which pathspec treats as escape characters
             # and silently mismatches every file.
             v = Path(v).expanduser().as_posix()
+        elif Path(v).is_absolute():
+            # Same normalization for already-absolute paths supplied directly
+            # (e.g. a config fragment that pre-expanded ``~/`` to ``C:\...``).
+            # Without this, two fragments declaring the equivalent rule via
+            # different forms (``~/foo`` and ``C:\Users\me\foo``) would dedupe
+            # on POSIX but not on Windows, since ``_dedup_key`` hashes the raw
+            # post-validator string.
+            v = Path(v).as_posix()
         return v
 
     @field_validator("namespace")

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -356,7 +356,13 @@ def test_config_d_namespace_rules_dedup_after_home_expansion(
     producing two rules and fail here.
     """
     _clear_all_memtomem_env(monkeypatch)
-    abs_form = str(Path("~/some/memtomem-test/**").expanduser())
+    # ``as_posix()`` matches the validator's normalization. Pre-#726 this was
+    # ``str(Path(...).expanduser())`` which dedup'd on POSIX by accident
+    # (``str`` of a POSIX absolute path is identical to its as_posix form).
+    # On Windows the raw ``str`` form leaks backslashes; the validator now
+    # normalizes both ``~/`` and absolute inputs to forward slashes so dedup
+    # works on every platform.
+    abs_form = Path("~/some/memtomem-test/**").expanduser().as_posix()
     (config_d_dir / "10-home.json").write_text(
         json.dumps(
             {


### PR DESCRIPTION
## Summary

**Real production bug**, surfaced by Cluster E of the #643 Windows sweep.

`NamespacePolicyRule._expand_and_validate_glob` (`config.py:341-347`) stored expanded path_globs via `str(Path(v).expanduser())`. On Windows that yields backslashes (`C:\Users\runneradmin\some\path\**`). The downstream consumer is `pathspec.GitIgnoreSpec` (`engine.py:_build_exclude_spec`) which interprets gitignore patterns — gitignore syntax is POSIX-only and treats `\` as an escape character. A backslash-bearing pattern **silently never matches any file** on Windows.

### Pre-fix Windows behavior

Any namespace rule with a leading `~/` in its glob — a common config shape (`~/.claude/projects/**`, `~/Documents/notes/**`, etc.) — silently failed to match. Files that should have landed in a project-specific namespace fell through to `default_namespace`, with no warning.

### Fix

`Path(v).expanduser().as_posix()` instead of `str(Path(v).expanduser())`:

- Keeps the tilde expansion (still absolute, still platform-correct via `Path.home()`).
- Forces `/` separators in the stored pattern.
- Matches gitignore semantics on every platform.
- POSIX no-op for absolute paths.

## Test plan

- [x] macOS: `uv run pytest packages/memtomem/tests/test_indexing_engine.py packages/memtomem/tests/test_config_overrides.py packages/memtomem/tests/test_validate_namespace.py` — **339/339 pass**.
- [x] Lint: `ruff check` + `ruff format --check` clean.
- [ ] Windows CI: `test_home_tilde_in_path_glob_expanded` should pass; tilde-prefixed namespace rules should now actually match.

## Why production fix (not test fix)

The failing test (`test_home_tilde_in_path_glob_expanded`) asserted `rule.path_glob.endswith("/some/path/**")` — this **already encoded the POSIX-glob invariant** the rule downstream depends on. The test was right; production was lying about the invariant on Windows.

## Out of scope

Remaining: A (9 — dirty state, production change), H (2 — misc) = **11 fails** after this lands. Cluster B already shipping via parallel work (`fix/720-source-filter-windows` merged as `88c3e81`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
