### PR TITLE
fix(cli): force UTF-8 stdout/stderr on Windows console (#643 cluster H-1)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import io
+import sys
+
 import click
 
 
@@ -16,6 +19,16 @@ CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 )
 def cli() -> None:
     """memtomem — markdown-first memory infrastructure for AI agents."""
+    # Windows console default codepage (cp1252/cp437) can't encode the
+    # box-drawing and em-dash glyphs the wizard uses. Reconfigure to UTF-8
+    # with `replace` errors so a missing glyph degrades to `?` instead of
+    # crashing mid-output. POSIX no-op via the sys.platform guard.
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except (AttributeError, io.UnsupportedOperation):
+                pass
 
 
 @cli.command()


### PR DESCRIPTION
## Summary

Cluster H-1 of [#643](https://github.com/memtomem/memtomem/issues/643) — Windows console default codepage (cp1252/cp437) cannot encode the box-drawing and em-dash glyphs the wizard prints, so `mm init` crashes at the very first banner line on a fresh Windows runner.

This is a **production bug**, not a test-only artifact: every Windows user hits it on the first `mm init` invocation.

Stack from the failing CI run (sha 88c3e81):

```
init_cmd.py:2781  click.secho("  ─────────────", fg="cyan")
click/utils.py:321  file.write(out)
UnicodeEncodeError: 'charmap' codec can't encode character '─' (U+2500)
```

## Approach

Spot-fixing line 2781 leaves every other unicode glyph (em-dash, future additions) as a latent crash. Reconfigure `sys.stdout` / `sys.stderr` at the CLI entry point (the `cli()` group callback runs before any subcommand emits output), gated on `sys.platform == "win32"` so POSIX is a no-op:

```python
if sys.platform == "win32":
    for stream in (sys.stdout, sys.stderr):
        try:
            stream.reconfigure(encoding="utf-8", errors="replace")
        except (AttributeError, io.UnsupportedOperation):
            pass
```

`errors="replace"` degrades a missing glyph to `?` instead of crashing — strictly better than the current behavior.

## Test plan

- [x] POSIX unchanged: `uv run pytest -m "not ollama" packages/memtomem/tests/test_cli.py packages/memtomem/tests/test_cli_status.py packages/memtomem/tests/test_init_cmd.py` — 355 passed.
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_cli_index_noop_e2e.py` — 2 passed.
- [x] `uv run ruff check` + `uv run ruff format --check` on the touched file.
- [ ] CI `test (windows-latest)` will turn `test_init_index_search_via_subprocess` from FAIL → PASS (cluster H-1 of the Windows compat sweep).

Cluster H-2 (`test_force_overrides_db_lock`) is a separate root cause and ships in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
