### PR TITLE
test(windows): skipif POSIX-only unlink semantics in test_force_overrides_db_lock (#643 cluster H-2)

### DIFF
--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -537,6 +537,15 @@ class TestDbWriterLockRefuses:
             conn.rollback()
             conn.close()
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "Test relies on POSIX unlink-while-open semantics — Windows refuses "
+            "to unlink a file held by an open handle (WinError 32), so --force "
+            "cannot wipe the dir while the lock-holding connection lives in "
+            "the same process. Sibling tests cover the lock-detection path."
+        ),
+    )
     def test_force_overrides_db_lock(self, home):
         db_path, conn = self._make_real_db(home)
         try:


### PR DESCRIPTION
## Summary

Cluster H-2 of [#643](https://github.com/memtomem/memtomem/issues/643) — `test_force_overrides_db_lock` relies on POSIX unlink-while-open semantics that don't exist on Windows.

The test holds a sqlite3 BEGIN IMMEDIATE write lock in the same process, then invokes `mm uninstall -y --force` and asserts the state directory was wiped. On POSIX `rmtree` succeeds because the directory entry is gone even though the inode is still open via the live connection. On Windows the same `unlink` raises:

```
[WinError 32] The process cannot access the file because it is being
used by another process: ...\memtomem.db
```

Sibling tests in `TestDbWriterLockRefuses` (`test_refuses_when_writer_holds_lock`, `test_proceeds_when_db_exists_but_no_writer`) already pass on Windows and cover the lock-detection path. This is a method-level skip rather than class-wide.

## Approach

```python
@pytest.mark.skipif(
    sys.platform == "win32",
    reason=(
        "Test relies on POSIX unlink-while-open semantics — Windows refuses "
        "to unlink a file held by an open handle (WinError 32), so --force "
        "cannot wipe the dir while the lock-holding connection lives in "
        "the same process. Sibling tests cover the lock-detection path."
    ),
)
```

`sys` already imported in the module (`test_uninstall_cmd.py:15`).

This is a **test-only** change — production behavior on Windows under `--force` against a live writer is a separate contract question, now tracked in **#730** ("Windows: contract for `mm uninstall --force` against a live writer is undefined"). That issue documents the half-wipe failure mode (`[WinError 32]` mid-`rmtree`) and the three options for what `--force` *should* mean on Windows; this PR intentionally defers that decision and just unblocks CI.

## Test plan

- [x] POSIX unchanged: `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py -v` — 28/28 passed.
- [x] `uv run ruff check` + `uv run ruff format --check` on the touched file.
- [ ] CI `test (windows-latest)` will skip `test_force_overrides_db_lock` (cluster H-2 of the Windows compat sweep).

After this lands, the only remaining `windows-latest` failures from the sha-88c3e81 run are cluster A (`test_context_status.py`, `test_dirty.py` — wiki dirty classification) — separate root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

