### PR TITLE
fix(context): installed_at capture from FS mtime + us ceiling (#732)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -24,6 +24,7 @@ import logging
 import os
 import tempfile
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
@@ -37,6 +38,7 @@ __all__ = [
     "atomic_write_bytes",
     "atomic_write_text",
     "copy_tree_atomic",
+    "installed_at_from_dest",
     "iter_installed_files",
 ]
 
@@ -192,9 +194,10 @@ def iter_installed_files(root: Path) -> Iterator[Path]:
     in :data:`COPY_SKIP_NAMES`, skip suffixes in
     :data:`DIRTY_SKIP_SUFFIXES`, skip symlinks with a warning. Shared by
     :func:`memtomem.context.dirty.is_asset_dirty` (the dirty walker) and
-    the install-timestamp capture helper, so both consume the exact same
-    set of files — ``installed_at`` cannot reference a file the
-    dirty-checker will later ignore, and vice versa.
+    :func:`installed_at_from_dest` (the install-timestamp capture
+    helper), so both consume the exact same set of files —
+    ``installed_at`` cannot reference a file the dirty-checker will
+    later ignore, and vice versa.
     """
     for entry in root.iterdir():
         if entry.name in COPY_SKIP_NAMES:
@@ -208,3 +211,50 @@ def iter_installed_files(root: Path) -> Iterator[Path]:
             yield entry
         elif entry.is_dir():
             yield from iter_installed_files(entry)
+
+
+def installed_at_from_dest(dst: Path) -> str:
+    """Return ISO-8601Z timestamp >= max(st_mtime) of files under *dst*.
+
+    Two-layer fix for the Windows dirty-cluster (#634):
+
+    1. **Source** — read ``st_mtime_ns`` (int, lossless) from the
+       filesystem rather than Python's wall clock. NTFS records mtimes
+       from ``FILETIME``, a different timer from ``time.time()``;
+       just-written files can carry mtimes strictly later than a
+       wall-clock-captured timestamp, breaking the strict
+       ``mtime > installed_at_epoch`` invariant in
+       :func:`memtomem.context.dirty.is_asset_dirty`.
+    2. **Precision** — ceiling-divide ``st_mtime_ns`` to microseconds
+       before formatting. ISO-8601Z's ``%f`` directive is microsecond
+       only, so truncating NTFS's 100-ns residual would leave the
+       formatted ``installed_at`` up to 1µs **less than** some files'
+       round-tripped mtimes, defeating the same invariant.
+
+    Combined: the formatted timestamp round-trips through
+    ``datetime.fromisoformat().timestamp()`` to a value ``>=`` every
+    walked file's ``st_mtime`` — byte-identical to today on POSIX
+    (where ``st_mtime_ns % 1000 == 0`` for ordinary writes; ceil is a
+    no-op) and with a ``<= 1µs`` safety margin on NTFS.
+
+    The walker is :func:`iter_installed_files`, so capture and
+    dirty-check observe the same file set: a file the dirty-checker
+    will later ignore (``.git``, ``.DS_Store``, ``__pycache__``,
+    ``.bak``, symlinks) cannot bump the captured timestamp, and a
+    file we walk here is one the dirty-checker will walk later.
+
+    Empty install (0 files) — fall back to wall clock. With no
+    filesystem source there is nothing to skew off, so the format
+    still matches :func:`memtomem.context.lockfile.utcnow_iso8601_z`
+    byte-for-byte. The strftime call is duplicated here rather than
+    importing the helper to avoid a circular import (``lockfile``
+    already imports from ``_atomic``).
+    """
+    files = list(iter_installed_files(dst))
+    if not files:
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    max_ns = max(p.stat().st_mtime_ns for p in files)
+    max_us = -(-max_ns // 1000)  # math.ceil(max_ns / 1000) without the import
+    return datetime.fromtimestamp(max_us / 1_000_000, tz=timezone.utc).strftime(
+        "%Y-%m-%dT%H:%M:%S.%fZ"
+    )

--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -33,9 +33,11 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "COPY_SKIP_NAMES",
+    "DIRTY_SKIP_SUFFIXES",
     "atomic_write_bytes",
     "atomic_write_text",
     "copy_tree_atomic",
+    "iter_installed_files",
 ]
 
 
@@ -48,6 +50,24 @@ COPY_SKIP_NAMES: frozenset[str] = frozenset({".git", ".DS_Store", "__pycache__"}
   clean even when curated through the GUI.
 - ``__pycache__`` — Python bytecode caches that test/automation runs may
   drop into a wiki tree; never wanted in a project's canonical surface.
+"""
+
+
+DIRTY_SKIP_SUFFIXES: frozenset[str] = frozenset({".bak"})
+"""Suffix patterns the installed-file walker excludes.
+
+Shared by :func:`copy_tree_atomic` (no-op there in practice; wikis don't
+carry ``.bak`` files under normal operation) and
+:func:`iter_installed_files` (the real filter for
+:func:`memtomem.context.dirty.is_asset_dirty` and the install-time
+capture helper).
+
+``.bak`` — sibling files created by ``mm context update --force`` to
+preserve user edits before overwriting with wiki bytes. They live in the
+dest tree by design and carry the user's pre-update mtime, so without
+this skip they would trip the next ``mm context update`` into
+``reason="dirty"`` purely on the prior backup, refusing every future
+update until the user manually deletes the ``.bak``.
 """
 
 
@@ -163,3 +183,28 @@ def copy_tree_atomic(src: Path, dst: Path, *, mode: int = 0o644) -> int:
         elif entry.is_dir():
             written += copy_tree_atomic(entry, target, mode=mode)
     return written
+
+
+def iter_installed_files(root: Path) -> Iterator[Path]:
+    """Yield non-skipped, non-symlink files under *root* recursively.
+
+    Mirrors :func:`copy_tree_atomic` traversal rules: skip entries named
+    in :data:`COPY_SKIP_NAMES`, skip suffixes in
+    :data:`DIRTY_SKIP_SUFFIXES`, skip symlinks with a warning. Shared by
+    :func:`memtomem.context.dirty.is_asset_dirty` (the dirty walker) and
+    the install-timestamp capture helper, so both consume the exact same
+    set of files — ``installed_at`` cannot reference a file the
+    dirty-checker will later ignore, and vice versa.
+    """
+    for entry in root.iterdir():
+        if entry.name in COPY_SKIP_NAMES:
+            continue
+        if entry.suffix in DIRTY_SKIP_SUFFIXES:
+            continue
+        if entry.is_symlink():
+            logger.warning("iter_installed_files: skipping symlink %s", entry)
+            continue
+        if entry.is_file():
+            yield entry
+        elif entry.is_dir():
+            yield from iter_installed_files(entry)

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -6,19 +6,20 @@ wiki state recorded in :class:`memtomem.context.lockfile.Lockfile`.
 
 The compare rule is **strict** ``mtime > installed_at_epoch`` — only files
 whose modification time is *strictly* later than the lockfile's
-``installed_at`` are flagged dirty. Equality is clean. PR-D C2a (#630)
-captures ``installed_at`` after :func:`copy_tree_atomic
-<memtomem.context._atomic.copy_tree_atomic>` finishes, so the install's
-own writes can never land at a strictly-later mtime than the captured
-timestamp; the dirty classifier therefore can't false-positive on a fresh
-install.
+``installed_at`` are flagged dirty. Equality is clean. ``installed_at``
+is captured from the filesystem itself by
+:func:`memtomem.context._atomic.installed_at_from_dest` (``max
+st_mtime_ns`` ceiled to microsecond), so on every platform the install's
+own writes round-trip to a value ``<= installed_at_epoch`` and the
+classifier can't false-positive on a fresh install — including Windows,
+where NTFS ``FILETIME`` is a different timer from Python's wall clock
+(#634).
 
-Skip rules mirror :data:`memtomem.context._atomic.COPY_SKIP_NAMES`:
-``.git``, ``.DS_Store``, ``__pycache__`` are not part of the canonical
+Skip rules live in :func:`memtomem.context._atomic.iter_installed_files`
+(shared with the capture helper above): ``.git``, ``.DS_Store``,
+``__pycache__``, ``.bak`` and symlinks are not part of the canonical
 install surface, so user edits to such entries don't make the asset
-dirty. Symlinks are skipped with a warning — ``copy_tree_atomic`` won't
-mirror them into dest in the first place, and dereferencing one here
-would defeat the byte-for-byte tree contract.
+dirty and don't perturb the captured ``installed_at`` either.
 
 This module is read-only. The execute path (``mm context update``)
 consumes a :class:`DirtyReport` and writes ``.bak`` files / overwrites

--- a/packages/memtomem/src/memtomem/context/dirty.py
+++ b/packages/memtomem/src/memtomem/context/dirty.py
@@ -27,40 +27,19 @@ the dest tree separately.
 
 from __future__ import annotations
 
-import logging
-from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from memtomem.context._atomic import COPY_SKIP_NAMES
+from memtomem.context._atomic import iter_installed_files
 from memtomem.context.lockfile import Lockfile
 
 __all__ = [
-    "DIRTY_SKIP_SUFFIXES",
     "DirtyReason",
     "DirtyReport",
     "is_asset_dirty",
 ]
-
-logger = logging.getLogger(__name__)
-
-
-DIRTY_SKIP_SUFFIXES: frozenset[str] = frozenset({".bak"})
-"""Suffix patterns the dirty walker skips beyond :data:`COPY_SKIP_NAMES`.
-
-``.bak`` — sibling files created by ``mm context update --force`` to
-preserve user edits before overwriting with wiki bytes. They live in
-the dest tree by design and carry the user's pre-update mtime, so
-without this skip they would trip the next ``mm context update`` into
-``reason="dirty"`` purely on the prior backup, refusing every future
-update until the user manually deletes the ``.bak``.
-
-This is a *dirty-walk* skip only — ``copy_tree_atomic`` does not need
-the same exclusion (the wiki is not expected to carry ``.bak`` files
-under normal operation).
-"""
 
 
 DirtyReason = Literal["clean", "dirty", "never_installed", "missing_dest"]
@@ -143,7 +122,7 @@ def is_asset_dirty(
 
     dirty: list[Path] = []
     checked = 0
-    for file_path in _iter_files(dest):
+    for file_path in iter_installed_files(dest):
         checked += 1
         if file_path.stat().st_mtime > installed_at_epoch:
             dirty.append(file_path)
@@ -154,25 +133,3 @@ def is_asset_dirty(
         dirty_files=tuple(dirty),
         checked_files=checked,
     )
-
-
-def _iter_files(root: Path) -> Iterator[Path]:
-    """Yield non-skipped, non-symlink files under *root* recursively.
-
-    Mirrors :func:`memtomem.context._atomic.copy_tree_atomic` traversal
-    rules: skip entries named in :data:`COPY_SKIP_NAMES`, skip symlinks
-    with a warning. Caller is responsible for the count semantics
-    (:attr:`DirtyReport.checked_files` reflects yielded entries only).
-    """
-    for entry in root.iterdir():
-        if entry.name in COPY_SKIP_NAMES:
-            continue
-        if entry.suffix in DIRTY_SKIP_SUFFIXES:
-            continue
-        if entry.is_symlink():
-            logger.warning("is_asset_dirty: skipping symlink %s", entry)
-            continue
-        if entry.is_file():
-            yield entry
-        elif entry.is_dir():
-            yield from _iter_files(entry)

--- a/packages/memtomem/src/memtomem/context/install.py
+++ b/packages/memtomem/src/memtomem/context/install.py
@@ -28,10 +28,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from memtomem.context._atomic import copy_tree_atomic
+from memtomem.context._atomic import copy_tree_atomic, installed_at_from_dest
 from memtomem.context._names import validate_name
 from memtomem.context.dirty import DirtyReport, is_asset_dirty
-from memtomem.context.lockfile import Lockfile, LockfileVersionError, utcnow_iso8601_z
+from memtomem.context.lockfile import Lockfile, LockfileVersionError
 from memtomem.wiki.store import CommitNotFoundError as CommitNotFoundError
 from memtomem.wiki.store import WikiStore
 
@@ -239,7 +239,7 @@ def _install_asset(
     dest.parent.mkdir(parents=True, exist_ok=True)
     files_written = copy_tree_atomic(src, dest)
 
-    installed_at = utcnow_iso8601_z()
+    installed_at = installed_at_from_dest(dest)
     lock.upsert_entry(
         asset_type,
         validated,
@@ -435,7 +435,7 @@ def _apply_update(
     dest.parent.mkdir(parents=True, exist_ok=True)
     files_written = copy_tree_atomic(src, dest)
 
-    installed_at = utcnow_iso8601_z()
+    installed_at = installed_at_from_dest(dest)
     lock = Lockfile.at(project_root)
     lock.upsert_entry(
         asset_type,
@@ -793,7 +793,7 @@ def _apply_pinned_install(
 
     files_written = wiki.copy_asset_at_commit(pin, asset_type, name, dest)
 
-    installed_at = utcnow_iso8601_z()
+    installed_at = installed_at_from_dest(dest)
     lock = Lockfile.at(project_root)
     # CRITICAL: wiki_commit stays at the pin we just restored to —
     # install --all is reproducibility (Option A), not "advance to HEAD".

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -23,8 +23,8 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli.context_cmd import context as context_group
-from memtomem.context._atomic import atomic_write_bytes
-from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.context._atomic import atomic_write_bytes, installed_at_from_dest
+from memtomem.context.lockfile import Lockfile
 from memtomem.context.status import StatusRow, classify_status
 from memtomem.wiki.store import WikiStore
 
@@ -85,7 +85,7 @@ def _setup_installed_at_pin(
         target = dest / relpath
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
-    installed_at = utcnow_iso8601_z()
+    installed_at = installed_at_from_dest(dest)
     Lockfile.at(project).upsert_entry(asset_type, name, wiki_commit=pin, installed_at=installed_at)
     return installed_at
 

--- a/packages/memtomem/tests/test_dirty.py
+++ b/packages/memtomem/tests/test_dirty.py
@@ -5,23 +5,27 @@ update``, plus the lockfile iteration helper introduced for batch flows.
 
 These tests construct lockfile + dest tree manually (no wiki / install
 roundtrip) so the dirty classifier is exercised in isolation. The
-"installed_at captured post-write" invariant from ADR-0008 PR-B/C2a
-(:func:`memtomem.context.install._install_asset`) is mirrored by
+"installed_at captured from filesystem after writes" invariant from
+ADR-0008 PR-B / C2a / #634
+(:func:`memtomem.context.install._install_asset` →
+:func:`memtomem.context._atomic.installed_at_from_dest`) is mirrored by
 :func:`_setup_installed` so equality cases land on the clean side of
-the strict ``>`` boundary.
+the strict ``>`` boundary on every platform.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
+from memtomem.context._atomic import installed_at_from_dest
 from memtomem.context.dirty import is_asset_dirty
-from memtomem.context.lockfile import Lockfile, utcnow_iso8601_z
+from memtomem.context.lockfile import Lockfile
 
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -45,7 +49,7 @@ def _setup_installed(
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(data)
 
-    installed_at = utcnow_iso8601_z()
+    installed_at = installed_at_from_dest(dest)
     Lockfile.at(project).upsert_entry(
         asset_type,
         name,
@@ -254,3 +258,124 @@ def test_iter_entries_alphabetical_ordering(tmp_path: Path) -> None:
     ]
     # Per-entry payload is the live dict — value must round-trip through.
     assert all(e["wiki_commit"] == "0" * 40 for _, _, e in entries)
+
+
+# ── installed_at_from_dest: capture helper (#634) ────────────────────────
+
+
+class TestInstalledAtFromDest:
+    """Pin :func:`memtomem.context._atomic.installed_at_from_dest`.
+
+    Two-layer fix for the Windows dirty-cluster (#634):
+
+    1. Capture from the filesystem (not Python's wall clock).
+    2. Ceiling-divide ``st_mtime_ns`` to microseconds so the formatted
+       ISO-8601Z round-trips ``>=`` every walked file's actual mtime.
+
+    Each test exercises one or both layers. Mutation validation lives in
+    the PR description: reverting just the ceiling (``max_us = max_ns //
+    1000``) makes :meth:`test_us_residual_round_trips_monotonically`
+    fail; reverting capture to ``utcnow_iso8601_z()`` makes
+    :meth:`test_multi_file_returns_max_of_actual_mtimes` fail.
+    """
+
+    ISO_8601Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$")
+
+    @staticmethod
+    def _round_trip(ts: str) -> float:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+
+    def test_empty_dest_falls_back_to_wall_clock(self, tmp_path: Path) -> None:
+        """No files → wall-clock fallback; format matches utcnow_iso8601_z."""
+        dest = tmp_path / "empty"
+        dest.mkdir()
+        before = datetime.now(timezone.utc).timestamp()
+        result = installed_at_from_dest(dest)
+        after = datetime.now(timezone.utc).timestamp()
+        assert self.ISO_8601Z_RE.match(result), result
+        round_tripped = self._round_trip(result)
+        assert before <= round_tripped <= after
+
+    def test_single_file_round_trips_at_least_its_mtime(self, tmp_path: Path) -> None:
+        """Captured installed_at parses back >= the file's actual st_mtime."""
+        dest = tmp_path / "single"
+        dest.mkdir()
+        f = dest / "SKILL.md"
+        f.write_bytes(b"x")
+        round_tripped = self._round_trip(installed_at_from_dest(dest))
+        assert round_tripped >= f.stat().st_mtime
+
+    def test_multi_file_returns_max_of_actual_mtimes(self, tmp_path: Path) -> None:
+        """With heterogeneous mtimes the result is >= the latest one.
+
+        Reverting the helper to ``utcnow_iso8601_z()`` makes this fail —
+        the bumped mtime is in the future relative to wall clock.
+        """
+        dest = tmp_path / "multi"
+        dest.mkdir()
+        a = dest / "a.md"
+        b = dest / "b.md"
+        a.write_bytes(b"a")
+        b.write_bytes(b"b")
+        future_ns = a.stat().st_mtime_ns + 5_000_000_000  # +5 seconds
+        os.utime(b, ns=(future_ns, future_ns))
+        round_tripped = self._round_trip(installed_at_from_dest(dest))
+        assert round_tripped >= b.stat().st_mtime
+        assert round_tripped >= a.stat().st_mtime
+
+    def test_skip_rules_excluded_from_max(self, tmp_path: Path) -> None:
+        """``.git``, ``.DS_Store``, ``__pycache__``, ``.bak`` are ignored.
+
+        Each skipped entry gets a far-future mtime; if any leaked into the
+        ``max`` the result would round-trip past it.
+        """
+        dest = tmp_path / "skip"
+        dest.mkdir()
+        canonical = dest / "SKILL.md"
+        canonical.write_bytes(b"canonical")
+        skipped = [
+            dest / "SKILL.md.bak",
+            dest / ".DS_Store",
+            dest / ".git" / "config",
+            dest / "__pycache__" / "x.pyc",
+        ]
+        for s in skipped:
+            s.parent.mkdir(parents=True, exist_ok=True)
+            s.write_bytes(b"skip")
+        future_ns = canonical.stat().st_mtime_ns + 60_000_000_000  # +60s
+        for s in skipped:
+            os.utime(s, ns=(future_ns, future_ns))
+        round_tripped = self._round_trip(installed_at_from_dest(dest))
+        assert round_tripped < future_ns / 1_000_000_000
+        assert round_tripped >= canonical.stat().st_mtime
+
+    def test_us_residual_round_trips_monotonically(self, tmp_path: Path) -> None:
+        """The microsecond ceiling is load-bearing.
+
+        Models NTFS's 100-ns residual via ``os.utime(..., ns=base+750)``.
+        Truncating to µs (``max_ns // 1000``) would format ``base`` and
+        parse back to a value strictly less than the file's actual
+        ``st_mtime``, defeating the strict ``>`` invariant in
+        ``dirty.py:is_asset_dirty`` on the install's own writes. The
+        ceiling rounds up so round-trip stays monotonic.
+
+        On filesystems that quantise to µs (older ext4 / FAT-class
+        targets) ``os.utime`` rounds the ns down and the residual is 0
+        — the ceiling is then a no-op and the assertion still holds.
+        """
+        dest = tmp_path / "residual"
+        dest.mkdir()
+        f = dest / "a.md"
+        f.write_bytes(b"x")
+        base_ns = f.stat().st_mtime_ns - (f.stat().st_mtime_ns % 1000)
+        target_ns = base_ns + 750
+        os.utime(f, ns=(target_ns, target_ns))
+        result = installed_at_from_dest(dest)
+        round_tripped = self._round_trip(result)
+        actual_mtime = f.stat().st_mtime
+        assert round_tripped >= actual_mtime, (
+            f"installed_at {result} (round-tripped to {round_tripped}) is "
+            f"strictly less than the file's just-captured mtime "
+            f"{actual_mtime} ({f.stat().st_mtime_ns}ns) — the µs ceiling "
+            "regressed."
+        )


### PR DESCRIPTION
## Summary

- Captures `installed_at` from the **filesystem** itself (max `st_mtime_ns`) rather than Python's wall clock — eliminates the FILETIME / `time.time()` clock-domain skew that false-positives `dirty` on Windows for an install's own writes.
- **Ceiling-divides nanoseconds to microseconds** before ISO-8601Z formatting so the round-trip stays monotonic across NTFS's 100-ns residual. POSIX is byte-identical for ordinary writes.
- `dirty.py:148`'s strict `>` invariant (locked decision #5 in PR-D C2) is preserved; we strengthen the capture, not the comparison.

Closes #732. Discovered as a follow-up to #634 (umbrella Windows CI matrix) and #630 (PR-D C2a `installed_at` post-copy capture). Comparison-side fixes already shipped were #717 (`os.sep` for memory_dir prefix) and #722 (`source_filter` separator fold) — this is the third, capture-side defect in the same #634 cluster.

## Two-layer root cause (one fix)

1. **Capture domain** — wall clock captured via `utcnow_iso8601_z()` and NTFS `FILETIME` are different timers. Just-written files can land strictly later than the captured timestamp on Windows, breaking `mtime > installed_at_epoch`.
2. **µs round-trip truncation** — even with FS capture, `st_mtime` (float) → `%f` (µs only) → `datetime.fromisoformat().timestamp()` drops NTFS's 100-ns residual. Self-comparison violates the invariant by ≤1µs. **This is the actual failure surface** — fixing only layer 1 leaves the bug.

## Sites changed (2 commits, 5 production / test sites)

### Commit 1 — pure refactor, no behaviour change

- `packages/memtomem/src/memtomem/context/_atomic.py` — receives `iter_installed_files` (lifted from `dirty.py:_iter_files`) + `DIRTY_SKIP_SUFFIXES`.
- `packages/memtomem/src/memtomem/context/dirty.py` — switches to imported walker; module otherwise unchanged.

`DIRTY_SKIP_SUFFIXES` stays in `_atomic.py` rather than splitting a `_walk.py` — the constant binds capture and dirty-check together, and a separate walker module is scope creep.

### Commit 2 — capture helper + 5-site swap + pin tests

- `packages/memtomem/src/memtomem/context/_atomic.py` — new `installed_at_from_dest(dst)`. Empty-dest fallback inlines the strftime call (lockfile already imports `_atomic`, so `utcnow_iso8601_z` would be a circular import).
- `packages/memtomem/src/memtomem/context/dirty.py` — module docstring refreshed (the prior text claimed POSIX-only invariant safety).
- `packages/memtomem/src/memtomem/context/install.py` — three capture sites swap to `installed_at_from_dest(dest)`: `_install_asset` (fresh install), `_apply_update` (refresh), `install_at_pin` (batch / `--all`). `utcnow_iso8601_z` import dropped (unused).
- `packages/memtomem/tests/test_dirty.py` — `_setup_installed` mirrors production. New `TestInstalledAtFromDest` class covers empty fallback, single/multi mtime, skip rules, and the load-bearing µs residual.
- `packages/memtomem/tests/test_context_status.py` — `_setup_installed_at_pin` mirrors production.

### Deliberately not touched

- `packages/memtomem/src/memtomem/context/migrate.py` — read-only consumer of legacy `installed_at`. ISO-8601Z format unchanged; migration tests stay green.
- `packages/memtomem/tests/test_context_migrate.py:_add_lock_entry` — fixture creation helper, not production. Wall-clock capture is fine there because the fixture's purpose is to seed an arbitrary historical `installed_at`, not to model an install's own write.
- `packages/memtomem/src/memtomem/cli/context_cmd.py:1088` — display-only consumer (`row.installed_at[:10]`). Format unchanged → display unchanged.

## Out of scope (separate follow-up if needed)

- Switching `is_asset_dirty` to `st_mtime_ns` int compare. With the capture fix the float compare is already correct (formatted timestamp is monotonic ≥ every nano-tick); ns alignment can be a follow-up if a future regression suggests float drift.
- mtime precision on FAT/exFAT. Not a real-world target — memtomem dest is under user project root → NTFS / APFS / ext4.
- `is_asset_dirty` walker caching (the `v2 caching candidate` in PR-D C2 design notes). Implement only if `mm context status` surfaces large-wiki sluggishness.

## Mutation validation

Per repo policy (`feedback_pin_test_mutation_validation.md`), the µs-residual pin test is the load-bearing assertion. Mutating production in two ways and confirming the right test fails:

| Mutation | Expected failing test | Why |
| --- | --- | --- |
| Revert helper to `utcnow_iso8601_z()` | `test_multi_file_returns_max_of_actual_mtimes` | Wall clock has no relationship to a file's bumped mtime |
| Replace ceil with truncation (`max_us = max_ns // 1000`) | `test_us_residual_round_trips_monotonically` | The 750ns residual is dropped → round-trip < actual mtime |

POSIX behaviour is byte-identical for ordinary writes (`st_mtime_ns % 1000 == 0`); the ceiling is a no-op there.

## Validation surface = Windows-CI (verified)

`test (windows-latest)` is `continue-on-error` so the workflow conclusion can stay green even with platform-specific failures; the row count below is from job logs (`gh run view --job ... --log`).

| Job | Failures | Cluster A failures (this PR's target) |
| --- | --- | --- |
| `main @ b72197d` (this PR's base) — [job 74039475175](https://github.com/memtomem/memtomem/actions/runs/25249586590/job/74039475175) | 7 | 5 |
| `PR #733` (this PR) — [job 74041826482](https://github.com/memtomem/memtomem/actions/runs/25250537264/job/74041826482) | 2 | **0** |

The 5 cluster-A tests resolved by this PR, all matching the `'dirty' == X` shape the plan predicted:

- `test_context_status.py::test_ok_state_pin_at_head` — `'dirty' == 'ok'` → ✅
- `test_context_status.py::test_behind_state_pin_below_head` — `'dirty' == 'behind'` → ✅
- `test_context_status.py::test_stale_pin_when_history_rewritten` — `'dirty' == 'stale-pin'` → ✅
- `test_dirty.py::test_skip_dotgit_dsstore_pycache` — `'dirty' == 'clean'` → ✅
- `test_dirty.py::test_skip_dot_bak_files` — `'dirty' == 'clean'` → ✅

The 2 remaining Windows failures on this PR are **pre-existing on `main` and out of scope** for the dirty-cluster fix:

- `test_cli_index_noop_e2e.py::TestFreshNoopIndexSubprocess::test_init_index_search_via_subprocess` — `UnicodeEncodeError: 'charmap' codec can't encode characters in position 2-14` at `init_cmd.py:2781` (`click.secho("  ─────────────")`). Windows console default codec (`cp1252`) can't render the box-drawing run. Separate cluster.
- `test_uninstall_cmd.py::TestDbWriterLockRefuses::test_force_overrides_db_lock` — `[WinError 32] The process cannot access the file because it is being used by another process: '...memtomem.db'`. POSIX-only `os.unlink`-while-open semantics in the uninstall path; tracked alongside the cluster H-2 work currently in flight.

Net effect: **5 cluster-A failures resolved, 0 new regressions.**

## Test plan

- [x] `uv run ruff check` + `ruff format --check` on `context/`, `tests/test_dirty.py`, `tests/test_context_status.py`
- [x] `uv run pytest packages/memtomem/tests/test_dirty.py packages/memtomem/tests/test_context_status.py packages/memtomem/tests/test_context_install.py packages/memtomem/tests/test_context_migrate.py -m "not ollama"` — 91 passed
- [x] `grep -rn "installed_at = utcnow_iso8601_z()" packages/memtomem/src/` — zero hits
- [x] Windows-CI: cluster A 5/5 green ([job 74041826482](https://github.com/memtomem/memtomem/actions/runs/25250537264/job/74041826482)); 2 unrelated pre-existing failures remain (table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
