### PR TITLE
fix(web): hide Settings Runtime group header in prod (closes #701)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -647,7 +647,7 @@
           </span>
         </button>
 
-        <button class="settings-nav-group" type="button" data-group="runtime" aria-expanded="false">
+        <button class="settings-nav-group" type="button" data-ui-tier="dev" data-group="runtime" aria-expanded="false">
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.runtime">Runtime</span>
         </button>


### PR DESCRIPTION
## Summary

- The **Runtime** group header in Settings nav had no `data-ui-tier` marker, so `_applyUiModeFilter` (`app.js:170`) walked past it. In prod the header stayed clickable and expanded to **nothing** — caret flipped, no children appeared, content panel kept showing the previously-selected section.
- Mark the group header `data-ui-tier="dev"` so it shares the same hide pass as its four already-dev-tier children (`harness-sessions`, `harness-scratch`, `harness-procedures`, `harness-health`).
- Picked option 1 (smallest diff) from the issue. Option 2 (compute visibility from children) would be more robust if a future runtime child becomes prod-tier, but all four are dev-only by design today, so option 1 is the right scope.

Closes #701.

## Test plan

- [ ] In prod mode (default), open Settings — confirm Runtime group is no longer visible in the nav column.
- [ ] In dev mode (`?ui_mode=dev` or env toggle), confirm Runtime group still expands and shows all four children (Sessions / Working Memory / Procedures / Health Report).
- [ ] Toggle dev → prod → dev round-trip without page reload via the dev-mode banner; confirm Runtime header visibility flips with it (covered by `_applyUiModeFilter` re-run).