### PR TITLE
fix(web): re-apply hidden=true on tab deactivation in activateTab() (closes #699)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -803,10 +803,8 @@ function activateTab(tabName, opts = {}) {
     b.setAttribute('tabindex', '-1');
   });
 
-  // Belt-and-braces with `display:none` from the absent `.active` class —
-  // without re-applying `hidden` here, visited panels leak into a11y /
-  // Playwright snapshots and a future CSS-only refactor would silently
-  // regress hiding.
+  // Re-apply `hidden` so DOM state matches CSS — without this, visited panels
+  // leak into a11y / Playwright snapshots (#699).
   document.querySelectorAll('.tab-panel').forEach(p => {
     p.classList.remove('active');
     p.hidden = true;

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -803,8 +803,14 @@ function activateTab(tabName, opts = {}) {
     b.setAttribute('tabindex', '-1');
   });
 
-  // Hide all panels
-  document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+  // Belt-and-braces with `display:none` from the absent `.active` class —
+  // without re-applying `hidden` here, visited panels leak into a11y /
+  // Playwright snapshots and a future CSS-only refactor would silently
+  // regress hiding.
+  document.querySelectorAll('.tab-panel').forEach(p => {
+    p.classList.remove('active');
+    p.hidden = true;
+  });
 
   // Activate the correct button
   const btn = document.querySelector(`.tab-btn[data-tab="${tabName}"]`);

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1308,7 +1308,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=97"></script>
+  <script src="/app.js?v=98"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>


### PR DESCRIPTION
## Summary

- `activateTab()` removed `.active` from all panels but never set `hidden = true` back. After the first activation every visited panel ended the session with `hidden = false`, relying only on the CSS `display:none` from the absent `.active` class to stay hidden.
- Modern browsers do exclude `display:none` from the a11y tree, so this isn't a hard a11y bug — but Playwright `browser_snapshot` walks the DOM and dumps the leaked nodes (this is exactly how #699 surfaced, in the v0.1.34 prod UX review). A future CSS-only refactor that drops `display:none` would also silently regress hiding.
- Pair `classList.remove('active')` with `p.hidden = true` in the deactivation forEach. Belt-and-braces with the existing CSS rule.
- Bump `app.js` cache-buster v97 → v98.

Closes #699.

## Test plan

- [ ] Click through all main tabs once (Home → Sources → Search → Index → Tags → Timeline → Settings) then back to Home; in DevTools check every other `.tab-panel` shows `hidden` attribute set, only the active panel has `hidden = false`.
- [ ] Playwright `browser_snapshot` after the round-trip: only one `tab-panel` should appear unhidden in the snapshot tree.
- [ ] Confirm no regression: panels still render content correctly when re-activated (focus restoration, history pushState, tab-specific loaders all still fire).