### PR TITLE
fix(runtime-paths): make Windows runtime dir resolution NTFS-aware (closes #637)

### DIFF
--- a/packages/memtomem/src/memtomem/_runtime_paths.py
+++ b/packages/memtomem/src/memtomem/_runtime_paths.py
@@ -11,23 +11,38 @@ Resolution order:
    exports the var). Per-user, ``tmpfs``-backed, kernel-managed lifecycle.
    Accepted only if the base is a real directory (not a symlink), owned
    by the effective uid, and has mode ``0o700`` (no group/world bits).
+   Skipped on Windows: ``XDG_RUNTIME_DIR`` is a Linux/systemd convention,
+   and the POSIX-mode-bit gate that protects it is meaningless against
+   NTFS ACLs.
 2. ``{tempfile.gettempdir()}/memtomem-{uid}`` — macOS (where
-   ``gettempdir()`` resolves to a per-user ``/var/folders/.../T/`` already)
-   and Linux without systemd. ``uid`` suffix disambiguates a shared
-   ``/tmp``; ``mode=0o700`` at creation keeps it private to the user.
+   ``gettempdir()`` resolves to a per-user ``/var/folders/.../T/`` already),
+   Linux without systemd, and Windows (where ``gettempdir()`` returns
+   ``%LOCALAPPDATA%\\Temp\\`` — already per-user). On Windows ``uid``
+   collapses to ``0`` since there is no ``geteuid``; the cross-user
+   collision risk that motivated the suffix on shared ``/tmp`` does not
+   apply on Windows because the temp base is per-user already.
 
 Security posture for the runtime directory itself:
 
 - Never follow a symlink — an attacker on a shared ``/tmp`` could
   pre-create ``memtomem-{uid}`` as a link into the user's home, and a
   naive ``mkdir`` would silently no-op through it. ``os.stat`` with
-  ``follow_symlinks=False`` catches this.
-- Refuse any pre-existing directory not owned by the effective uid or
-  not at mode ``0o700``. This trades convenience for a predictable
-  contract: a ``root``-owned leftover from ``sudo mm …`` or a
-  mode-degraded dir raises :class:`PermissionError` with a remediation
+  ``follow_symlinks=False`` catches this. Enforced on every platform
+  (Windows symlinks require Developer Mode/admin to create but exist
+  and are exploitable the same way once present).
+- POSIX only — refuse any pre-existing directory not owned by the
+  effective uid or not at mode ``0o700``. This trades convenience for a
+  predictable contract: a ``root``-owned leftover from ``sudo mm …`` or
+  a mode-degraded dir raises :class:`PermissionError` with a remediation
   hint instead of silently writing the pid file into a world-readable
   directory. The only fix is ``rm -rf`` the runtime dir and retry.
+- Windows — skip the mode-bit + owner-uid gates. NTFS synthesizes POSIX
+  mode bits as ``0o666``/``0o777`` (the values do not reflect the real
+  ACL), so ``& 0o077`` would always trip and ``ensure_runtime_dir`` would
+  refuse the second invocation against its own previously-created dir.
+  Proper NTFS owner-SID validation needs ``pywin32`` / ``ctypes`` calls
+  into ``GetSecurityInfo`` and is out of scope; we rely on
+  ``%LOCALAPPDATA%\\Temp\\`` already being per-user.
 """
 
 from __future__ import annotations
@@ -39,13 +54,14 @@ from pathlib import Path
 
 
 def _is_safe_dir(path: Path) -> bool:
-    """Return True iff ``path`` is a regular directory, owner-matches the
-    effective uid, and has no group/world permission bits.
+    """POSIX-only safety gate: ``path`` must be a regular directory,
+    owner-match the effective uid, and have no group/world permission
+    bits. Callers must guard with ``os.name != "nt"`` — NTFS synthesizes
+    POSIX mode bits and the owner check has no Windows equivalent here.
 
-    Used by both the ``$XDG_RUNTIME_DIR`` gate (where we silently fall
-    through to the tempdir form on failure) and the ``ensure`` path
-    (where failure becomes a :class:`PermissionError`). ``lstat``-style
-    semantics — we reject a symlink outright, never its target.
+    Used by the ``$XDG_RUNTIME_DIR`` gate (where we silently fall
+    through to the tempdir form on failure). ``lstat``-style semantics
+    — we reject a symlink outright, never its target.
     """
     try:
         st = os.stat(path, follow_symlinks=False)
@@ -72,11 +88,13 @@ def runtime_dir() -> Path:
     a misconfigured export (``XDG_RUNTIME_DIR=/tmp``, or a user-created
     symlink) silently falls through to the tempdir form so we never
     place the pid file in a world-readable location just because the
-    environment was wrong.
+    environment was wrong. The branch is skipped entirely on Windows
+    (see module docstring).
     """
-    xdg = os.environ.get("XDG_RUNTIME_DIR", "")
-    if xdg and _is_safe_dir(Path(xdg)):
-        return Path(xdg) / "memtomem"
+    if os.name != "nt":
+        xdg = os.environ.get("XDG_RUNTIME_DIR", "")
+        if xdg and _is_safe_dir(Path(xdg)):
+            return Path(xdg) / "memtomem"
 
     uid = os.geteuid() if hasattr(os, "geteuid") else 0
     return Path(tempfile.gettempdir()) / f"memtomem-{uid}"
@@ -115,19 +133,20 @@ def ensure_runtime_dir() -> Path:
             raise PermissionError(
                 f"runtime dir {target} exists but is not a directory. Remove it: rm -f {target}"
             )
-        if hasattr(os, "geteuid") and st.st_uid != os.geteuid():
-            raise PermissionError(
-                f"runtime dir {target} is owned by uid {st.st_uid} "
-                f"(expected {os.geteuid()}). Remove it and retry: rm -rf {target}"
-            )
-        unsafe = stat.S_IMODE(st.st_mode) & 0o077
-        if unsafe:
-            raise PermissionError(
-                f"runtime dir {target} has unsafe permissions "
-                f"0o{stat.S_IMODE(st.st_mode):o} (expected 0o700, "
-                f"group/world bits: 0o{unsafe:o}). "
-                f"Remove it and retry: rm -rf {target}"
-            )
+        if os.name != "nt":
+            if hasattr(os, "geteuid") and st.st_uid != os.geteuid():
+                raise PermissionError(
+                    f"runtime dir {target} is owned by uid {st.st_uid} "
+                    f"(expected {os.geteuid()}). Remove it and retry: rm -rf {target}"
+                )
+            unsafe = stat.S_IMODE(st.st_mode) & 0o077
+            if unsafe:
+                raise PermissionError(
+                    f"runtime dir {target} has unsafe permissions "
+                    f"0o{stat.S_IMODE(st.st_mode):o} (expected 0o700, "
+                    f"group/world bits: 0o{unsafe:o}). "
+                    f"Remove it and retry: rm -rf {target}"
+                )
         return target
 
     # Missing — create with 0o700, then chmod explicitly to neutralize any

--- a/packages/memtomem/tests/test_runtime_paths.py
+++ b/packages/memtomem/tests/test_runtime_paths.py
@@ -39,8 +39,8 @@ def _make_safe_xdg(tmp_path: Path) -> Path:
 
 
 @pytest.mark.skipif(
-    not hasattr(os, "geteuid"),
-    reason="XDG/mode-bit semantics are POSIX-only; Windows-equivalent tracked in #637",
+    os.name == "nt",
+    reason="XDG / POSIX mode-bit semantics; Windows coverage lives in TestWindowsRuntimeDir",
 )
 class TestRuntimeDir:
     def test_uses_xdg_runtime_dir_when_set(self, tmp_path, monkeypatch):
@@ -128,8 +128,9 @@ class TestRuntimeDir:
 
 
 @pytest.mark.skipif(
-    not hasattr(os, "geteuid"),
-    reason="0o700 mode bits + umask + chmod don't translate to NTFS; tracked in #637",
+    os.name == "nt",
+    reason="0o700 mode bits + umask + chmod don't translate to NTFS; "
+    "Windows coverage lives in TestWindowsRuntimeDir",
 )
 class TestEnsureRuntimeDir:
     def test_creates_directory_with_owner_only_mode(self, tmp_path, monkeypatch):
@@ -242,8 +243,9 @@ class TestEnsureRuntimeDir:
 
 
 @pytest.mark.skipif(
-    not hasattr(os, "geteuid"),
-    reason="depends on _make_safe_xdg fixture's POSIX chmod; tracked in #637",
+    os.name == "nt",
+    reason="depends on _make_safe_xdg fixture's POSIX chmod; "
+    "Windows path is covered indirectly in TestWindowsRuntimeDir",
 )
 class TestServerPidPath:
     def test_resolves_to_runtime_dir_server_pid(self, tmp_path, monkeypatch):
@@ -262,6 +264,130 @@ class TestServerPidPath:
             "server_pid_path() is a path resolver; use ensure_runtime_dir() "
             "explicitly when opening the file"
         )
+
+
+@pytest.mark.skipif(
+    os.name != "nt",
+    reason="NTFS-specific: tempdir-only resolution, mode-bit gate disabled",
+)
+class TestWindowsRuntimeDir:
+    """Windows counterpart to ``TestRuntimeDir`` / ``TestEnsureRuntimeDir``.
+
+    The runtime resolver collapses to one branch on Windows
+    (``tempfile.gettempdir() / 'memtomem-0'``) and the security gates
+    that depend on POSIX mode bits or ``geteuid`` are off — see the
+    module docstring of ``_runtime_paths``. These tests pin the
+    NTFS-equivalent behaviour so a future contributor can't silently
+    re-enable a check that doesn't have NTFS semantics.
+    """
+
+    def test_runtime_dir_uses_tempdir_with_uid_zero(self, monkeypatch):
+        """Windows has no ``geteuid``, so the suffix collapses to ``0``;
+        ``%LOCALAPPDATA%\\Temp\\`` is already per-user, so the cross-user
+        collision risk that motivates the suffix on shared ``/tmp`` does
+        not apply here."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+        result = runtime_dir()
+
+        assert result == Path(tempfile.gettempdir()) / "memtomem-0"
+
+    def test_runtime_dir_does_not_create(self, monkeypatch):
+        """Pure resolver — same contract as POSIX. The uninstall
+        inventory walk needs this to be side-effect free."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+
+        result = runtime_dir()
+        # Don't assert non-existence: a previous test in the session may
+        # have created it. The contract is "this call doesn't create",
+        # not "the path is missing".
+        before = result.exists()
+        runtime_dir()
+        assert result.exists() == before
+
+    def test_runtime_dir_ignores_xdg_on_windows(self, tmp_path, monkeypatch):
+        """``XDG_RUNTIME_DIR`` is a Linux/systemd convention; honoring
+        it on Windows would require validating the base without POSIX
+        mode bits, which is half-baked. Always fall through to tempdir
+        on Windows so behaviour is uniform regardless of environment."""
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+
+        result = runtime_dir()
+
+        assert result.parent == Path(tempfile.gettempdir())
+        assert result.name == "memtomem-0"
+
+    def test_ensure_creates_directory(self, tmp_path, monkeypatch):
+        """``ensure_runtime_dir`` mkdirs the resolved path. Mode bits
+        are not asserted: NTFS synthesizes them and the ``chmod`` call
+        is effectively a no-op for POSIX-style permissions."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("TEMP", str(tmp_path))
+        monkeypatch.setenv("TMP", str(tmp_path))
+        tempfile.tempdir = None  # invalidate the gettempdir() cache
+
+        try:
+            d = ensure_runtime_dir()
+            assert d.exists() and d.is_dir()
+            assert d == Path(tempfile.gettempdir()) / "memtomem-0"
+        finally:
+            tempfile.tempdir = None
+
+    def test_ensure_idempotent_on_windows(self, tmp_path, monkeypatch):
+        """Regression for #637 — pre-fix, the second call would refuse
+        the dir it had just created because NTFS reports synthesized
+        mode bits like ``0o666`` and ``stat.S_IMODE(...) & 0o077`` is
+        non-zero. After the fix the mode-bit gate is skipped on
+        Windows so successive calls are idempotent."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("TEMP", str(tmp_path))
+        monkeypatch.setenv("TMP", str(tmp_path))
+        tempfile.tempdir = None
+
+        try:
+            ensure_runtime_dir()
+            # Must not raise on the second pass.
+            ensure_runtime_dir()
+        finally:
+            tempfile.tempdir = None
+
+    def test_ensure_refuses_non_directory(self, tmp_path, monkeypatch):
+        """Same contract as POSIX: a regular file at the runtime path
+        is rejected with a clear remediation hint, regardless of NTFS
+        mode-bit synthesis."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("TEMP", str(tmp_path))
+        monkeypatch.setenv("TMP", str(tmp_path))
+        tempfile.tempdir = None
+
+        try:
+            (Path(tempfile.gettempdir()) / "memtomem-0").write_text("a file")
+            with pytest.raises(PermissionError, match="not a directory"):
+                ensure_runtime_dir()
+        finally:
+            tempfile.tempdir = None
+
+    @pytest.mark.requires_symlinks
+    def test_ensure_refuses_existing_symlink(self, tmp_path, monkeypatch):
+        """Windows symlinks need Developer Mode or admin to create,
+        but once present they are exploitable identically to POSIX
+        symlinks. Auto-skipped via ``requires_symlinks`` when the
+        runner can't create one (see conftest)."""
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setenv("TEMP", str(tmp_path))
+        monkeypatch.setenv("TMP", str(tmp_path))
+        tempfile.tempdir = None
+
+        try:
+            target = tmp_path / "real-target"
+            target.mkdir()
+            os.symlink(target, Path(tempfile.gettempdir()) / "memtomem-0")
+            with pytest.raises(PermissionError, match="symlink"):
+                ensure_runtime_dir()
+        finally:
+            tempfile.tempdir = None
 
 
 class TestLegacyServerPidPath:


### PR DESCRIPTION
## Summary

- Pre-fix, `ensure_runtime_dir()` was broken on Windows from the **second** invocation onward: NTFS synthesizes POSIX mode bits as `0o666`/`0o777`, so `stat.S_IMODE(st.st_mode) & 0o077` was always non-zero and the validator raised `PermissionError("unsafe permissions")` against a directory it had just created.
- Make the Windows path explicit: `runtime_dir()` skips the `XDG_RUNTIME_DIR` branch on Windows (it's a Linux/systemd convention, and honoring it without the POSIX mode-bit gate is half-baked); `ensure_runtime_dir()` keeps the symlink + non-directory rejections on every platform but skips the mode-bit + owner-uid gates on Windows (`%LOCALAPPDATA%\Temp\` is already per-user, and proper NTFS owner-SID checks via `GetSecurityInfo` are out of scope).
- Module docstring documents the asymmetric trust posture so a future contributor doesn't re-enable a check that has no NTFS semantics.
- Replace the three `skipif(not hasattr(os, "geteuid"))` guards on the POSIX-only test classes with `skipif(os.name == "nt")` — same effect today but parallel to the production guard.
- Add `TestWindowsRuntimeDir` covering the NTFS-equivalent contract: tempdir-only resolution with `uid=0` suffix, XDG ignored when set, **idempotent** `ensure_runtime_dir` (regression guard for the mode-bit failure), and the symlink + non-directory rejections that survive the NTFS relaxation. Symlink test uses the existing `requires_symlinks` marker so it auto-skips when the Windows runner doesn't have Developer Mode/admin.

## What changed

| File | Change |
|---|---|
| `packages/memtomem/src/memtomem/_runtime_paths.py` | XDG branch gated on `os.name != "nt"`; mode-bit + owner-uid gates in `ensure_runtime_dir` gated on `os.name != "nt"`; module docstring rewritten to call out the asymmetric posture |
| `packages/memtomem/tests/test_runtime_paths.py` | 3× skipif guard reworded; new `TestWindowsRuntimeDir` class (7 tests) |

POSIX behaviour is untouched. `_is_safe_dir` is now POSIX-only by contract — its docstring says so.

## Why these gates can be relaxed on Windows

- `tempfile.gettempdir()` on Windows resolves to `%LOCALAPPDATA%\Temp\` — already a per-user directory. The cross-user threat that motivates `0o700` on shared `/tmp` does not apply.
- POSIX mode bits on NTFS are synthesized (`0o666`/`0o777`) and do not reflect the real ACL — checking `& 0o077` is theatre and false-positives against any directory we ourselves just created.
- Symlinks on Windows exist (require Developer Mode/admin to create) and are exploitable identically to POSIX symlinks once present, so the symlink rejection survives. Non-directory rejection survives for the same reason.
- Proper NTFS owner-SID validation would need `pywin32` / `ctypes` calls into `GetSecurityInfo`. Heavyweight optional dependency for marginal value when the temp base is already per-user — explicitly out of scope.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_runtime_paths.py -v` — 18 passed, 7 skipped on macOS
- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py packages/memtomem/tests/test_runtime_paths.py` — 46 passed, 7 skipped (downstream `runtime_dir()` consumer)
- [x] `uv run pytest packages/memtomem/tests/test_web_routes_context.py packages/memtomem/tests/test_context_skills.py` — 86 passed (other consumers)
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/_runtime_paths.py` — no issues
- [ ] Windows CI matrix run will exercise the new `TestWindowsRuntimeDir` class — currently informational, should pass in this PR's run

## References

- Closes #637
- Builds on #634 (CI matrix expansion) and #638 (matrix infra)
- Sibling Windows fixes: #714 (HOME → USERPROFILE sweep, refs #644), #716 (#316 backslash regex), #713 (POSIX skipifs), #711 (path separator normalization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)