### PR TITLE
test(windows): force distinguishable mtime in concurrent-merge abort test (closes #645)

### DIFF
--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -259,6 +259,18 @@ class TestClaudeSettingsMergeConcurrent:
                 target.write_text(
                     json.dumps({"hooks": {}, "_bumped": True}) + "\n", encoding="utf-8"
                 )
+                # Two writes inside the same system-clock tick can report the
+                # same ``st_mtime_ns`` on Windows (NTFS native resolution is
+                # 100ns but ``WriteFile``-induced metadata updates use the
+                # system clock, which often advances at ~15.6ms). Bump
+                # explicitly so the simulated concurrent-writer is
+                # distinguishable regardless of OS timer granularity — a
+                # real-world second writer is naturally well above this
+                # threshold, so this only covers the test-induced race.
+                import os as _os
+
+                st = target.stat()
+                _os.utime(target, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000))
             return result
 
         import unittest.mock


### PR DESCRIPTION
## Summary

- `test_aborts_on_mtime_change` is the last residual Windows CI failure from #645. The test simulates a concurrent writer by patching `_read_with_mtime` to write to the target between the read and the production code's mtime re-check. On Windows the two `write_text` calls can land inside the same system-clock tick, so `st_mtime_ns` reports the same value and the abort branch never fires.
- Force a distinguishable mtime via `os.utime(..., ns=(atime, mtime + 1ms))` after the simulated write so the test deterministically exercises the production guard regardless of OS timer granularity. A real-world second writer (separate `mm context sync` run, user editing in editor) is naturally well above the threshold — this only covers the test-induced race.
- Test-only change, no production impact.

## Why mtime collides on Windows

NTFS native FILETIME resolution is 100ns, but `WriteFile`-induced metadata updates use the *system clock*, which advances at ~15.6ms on typical Windows hosts (default timer interrupt). Two writes within that tick get the same mtime even though the second strictly happened after the first. The fix bumps mtime by 1ms (1_000_000 ns) — well above the synthetic resolution, well below any real-world inter-process gap.

## Status of the broader #645 cluster

The issue body listed 17 `test_web_hot_reload.py` failures. The latest Windows CI run on `main` (run [25264999636](https://github.com/memtomem/memtomem/actions/runs/25264999636), 2026-05-02) reports **0** hot-reload failures — those have been cleared by previous Windows CI work (PRs #711, #713, #714, #716, #732). Only this single `test_context_settings.py::test_aborts_on_mtime_change` failure remained, and this PR closes it.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_settings.py -v` — all 35 tests pass on macOS
- [x] `uv run ruff check` + `ruff format --check` — clean
- [ ] Windows CI matrix — should drop from 1 failure to 0

## References

- Closes #645
- Sibling Windows fixes: #714 (HOME → USERPROFILE), #716 (#316 backslash regex), #713 (POSIX skipifs), #711 (path separators), #732 (installed_at us ceiling), #738 (#637 NTFS runtime dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)