### PR TITLE
feat(cli): show chunk progress in mm init wizard's _seed_with_progress (closes #655)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1609,6 +1609,41 @@ def _seed_with_progress(paths: list[Path]) -> bool:
     # the first one. Stays accurate across serial iteration.
     expected_total = sum(_collect_seed_scale(p)[0] for p in paths)
 
+    # Throttle clock for ``chunk_progress`` label refreshes. Mirrors the web
+    # Index tab (``web/static/app.js`` ~L4219-4256): 100ms gap between
+    # intermediate renders, final tick (chunks_done >= chunks_total) bypasses
+    # the throttle so ``(N/N)`` lands before the next file boundary, and the
+    # clock resets to 0 on every ``progress`` event so the next file's first
+    # chunk renders immediately. ``time.monotonic()`` (not ``time.time()``)
+    # so a wall-clock jump can't stall the bar. Issue #659 tracks extracting
+    # this into a shared helper once a third call-site appears
+    # (rule-of-three) — keep this implementation self-contained for now.
+    throttle_state: dict = {"last_render": 0.0}
+
+    def _format_item(item: object) -> str:
+        if not item:
+            return ""
+        if isinstance(item, tuple):
+            file, done, total = item
+            return f"{Path(file).name} ({done}/{total})"[:60]
+        # Legacy str case: the existing ``progress`` branch passes a path str.
+        # ``Path(...).name`` (not ``rsplit("/", 1)``) handles Windows
+        # backslash paths correctly.
+        return Path(str(item)).name[:40]
+
+    def _ensure_bar() -> None:
+        # Lazy creation: the bar can come into existence on EITHER the first
+        # ``chunk_progress`` OR the first ``progress`` event, whichever
+        # arrives first. ``chunk_progress`` for a given file is emitted before
+        # that file's ``progress`` summary, so for large files the bar appears
+        # at chunk-level rather than waiting for the first file to finish.
+        if bar_state["bar"] is None:
+            bar_state["bar"] = click.progressbar(
+                length=expected_total,
+                label="  Seeding",
+                item_show_func=_format_item,
+            ).__enter__()
+
     def _close_bar() -> None:
         if bar_state["bar"] is not None:
             try:
@@ -1625,13 +1660,30 @@ def _seed_with_progress(paths: list[Path]) -> bool:
                 async for evt in comp.index_engine.index_path_stream(
                     p, recursive=True, force=False
                 ):
-                    if evt["type"] == "progress":
-                        if bar_state["bar"] is None:
-                            bar_state["bar"] = click.progressbar(
-                                length=expected_total,
-                                label="  Seeding",
-                                item_show_func=lambda item: (item or "").rsplit("/", 1)[-1][:40],
-                            ).__enter__()
+                    if evt["type"] == "chunk_progress":
+                        # Server-side gating in ``indexing/engine.py`` already
+                        # filters out small files (``progress_threshold``,
+                        # default 32), so we don't threshold here — small
+                        # files simply won't emit these events, matching the
+                        # web Index tab's quiet behavior.
+                        done = evt["chunks_done"]
+                        total = evt["chunks_total"]
+                        is_final = done >= total
+                        now = time.monotonic()
+                        if not is_final and now - throttle_state["last_render"] < 0.1:
+                            continue
+                        throttle_state["last_render"] = now
+                        _ensure_bar()
+                        # Refresh the sub-label without advancing the bar —
+                        # length is in **file units**, so chunks must not
+                        # double-count. ``update(0, item)`` re-renders with
+                        # the new ``current_item`` only.
+                        bar_state["bar"].update(0, (evt["file"], done, total))
+                    elif evt["type"] == "progress":
+                        # Reset throttle on file boundary so the next file's
+                        # first chunk_progress renders immediately.
+                        throttle_state["last_render"] = 0.0
+                        _ensure_bar()
                         bar_state["bar"].update(1, evt["file"])
                     elif evt["type"] == "complete":
                         agg["total_files"] += evt["total_files"]

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5254,6 +5254,158 @@ class TestInitialSeedThreshold:
         assert f"mm index {dir_b}" not in out
 
     # ------------------------------------------------------------------
+    # chunk_progress sub-label refresh (issue #655) — wizard surfaces
+    # per-chunk progress so multi-minute embedder runs don't look hung.
+    # ------------------------------------------------------------------
+
+    def test_seed_with_progress_chunk_events_do_not_advance_bar(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``chunk_progress`` events refresh the progress bar's sub-label
+        without advancing ``pos``. Bar length is in **file units**, so the
+        final ``pos`` after a 1-file run with N intermediate chunk events
+        must equal 1 (the file count), not 1 + N. Regression guard for the
+        "label refresh, no advance" design — Option 1 from issue #655."""
+        from contextlib import asynccontextmanager
+
+        import click
+
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        self._write_md(memory_dir, "big.md", "lots of chunks")
+
+        captured: dict[str, object] = {}
+
+        class _FakeEngine:
+            async def index_path_stream(self, path, recursive=True, force=False):
+                file = str(memory_dir / "big.md")
+                # Server only emits chunk_progress when the file exceeds the
+                # ``progress_threshold`` (default 32). Mimic a 50-chunk file.
+                for done in (10, 25, 40, 50):
+                    yield {
+                        "type": "chunk_progress",
+                        "file": file,
+                        "chunks_done": done,
+                        "chunks_total": 50,
+                        "files_done": 0,
+                        "files_total": 1,
+                    }
+                yield {
+                    "type": "progress",
+                    "file": file,
+                    "files_done": 1,
+                    "files_total": 1,
+                    "indexed": 50,
+                    "skipped": 0,
+                }
+                yield {
+                    "type": "complete",
+                    "total_files": 1,
+                    "total_chunks": 50,
+                    "indexed_chunks": 50,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        # Wrap click.progressbar so we can read the bar's final state after
+        # ``__exit__`` is called inside _close_bar.
+        real_progressbar = click.progressbar
+
+        def _spy_progressbar(*args, **kwargs):
+            bar = real_progressbar(*args, **kwargs)
+            captured["bar"] = bar
+            return bar
+
+        monkeypatch.setattr("memtomem.cli.init_cmd.click.progressbar", _spy_progressbar)
+
+        assert init_cmd._seed_with_progress([memory_dir]) is True
+        bar = captured["bar"]
+        # 4 chunk_progress events + 1 progress event → only the progress
+        # event advances. Chunk events refresh the label only.
+        assert bar.pos == 1, f"expected pos==1 (file count), got {bar.pos}"
+
+    def test_seed_with_progress_no_chunk_events_unchanged(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pre-existing behavior pin: a stream with no ``chunk_progress``
+        events behaves identically to today — final ``pos`` equals the file
+        count, label is the file basename. Small files (under
+        ``progress_threshold``) take this path; the wizard must stay quiet
+        for them, matching the web Index tab."""
+        from contextlib import asynccontextmanager
+
+        import click
+
+        from memtomem.cli import init_cmd
+
+        memory_dir = tmp_path / "memories"
+        memory_dir.mkdir()
+        self._write_md(memory_dir, "a.md", "small")
+        self._write_md(memory_dir, "b.md", "small too")
+
+        captured: dict[str, object] = {}
+
+        class _FakeEngine:
+            async def index_path_stream(self, path, recursive=True, force=False):
+                for name in ("a.md", "b.md"):
+                    yield {
+                        "type": "progress",
+                        "file": str(memory_dir / name),
+                        "files_done": 1,
+                        "files_total": 2,
+                        "indexed": 1,
+                        "skipped": 0,
+                    }
+                yield {
+                    "type": "complete",
+                    "total_files": 2,
+                    "total_chunks": 2,
+                    "indexed_chunks": 2,
+                    "skipped_chunks": 0,
+                    "deleted_chunks": 0,
+                    "duration_ms": 1.0,
+                }
+
+        class _FakeComp:
+            index_engine = _FakeEngine()
+
+        @asynccontextmanager  # type: ignore[misc]
+        async def _fake_components():
+            yield _FakeComp()
+
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+        real_progressbar = click.progressbar
+
+        def _spy_progressbar(*args, **kwargs):
+            bar = real_progressbar(*args, **kwargs)
+            captured["bar"] = bar
+            return bar
+
+        monkeypatch.setattr("memtomem.cli.init_cmd.click.progressbar", _spy_progressbar)
+
+        assert init_cmd._seed_with_progress([memory_dir]) is True
+        bar = captured["bar"]
+        # 2 progress events advance the bar by 1 each → pos == 2 (file count).
+        assert bar.pos == 2, f"expected pos==2 (file count), got {bar.pos}"
+
+    # ------------------------------------------------------------------
     # Next-steps step 1 hint — seeded / single-dir / multi-dir branches
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The wizard's `_seed_with_progress` consumed `chunk_progress` SSE events from `index_path_stream` (added in #653) but ignored them, so multi-minute embedder runs from `mm init` looked hung — exactly the UX issue `chunk_progress` was introduced to fix, just on a different surface. This wires the wizard up to the same chunk-level signal the web Index tab uses.

## Design

Option 1 from #655: refresh the bar's sub-label without advancing.

- Bar length stays in **file units** (no chunk pre-count).
- `chunk_progress` -> `bar.update(0, (file, done, total))` re-renders the label only.
- `item_show_func` dispatches on `tuple` vs `str` so the existing `progress`-event path keeps the basename label.
- Throttle/render rules mirror the web Index tab (`app.js` ~L4219-4256): 100ms gap between intermediate renders via `time.monotonic()`, final tick (`chunks_done >= total`) bypasses throttle, clock resets to 0 on every `progress` event so the next file's first chunk renders immediately.
- `_ensure_bar()` extracted so the bar can lazily appear on either the first `chunk_progress` or `progress` event.
- Drive-by: switched basename render from `rsplit("/", 1)` to `Path(...).name` so Windows backslash paths display correctly.

Server-side gating in `indexing/engine.py:786` already filters small files (default `progress_threshold=32`), so the CLI doesn't need to threshold itself — small files stay quiet, matching the web Index tab.

## Invariants preserved

- KeyboardInterrupt cleanup unchanged (`_close_bar()` + `try/except` block intact).
- Multi-path aggregation summary line unchanged (only the `complete` event feeds it).
- No changes to `index_path_stream` / `engine.py` / any web static file.
- `#659` (shared throttle helper between CLI and JS sites) deferred to rule-of-three; becomes natural after `#656` lands. This is the second of the three call-sites it tracks.

## Test plan

- [x] Two new tests in `TestInitialSeedThreshold` pin the no-advance contract (chunk events leave `bar.pos == file_count`) and the no-regression contract (zero `chunk_progress` events == today's behavior).
- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -m "not ollama" -q` -> 264 passed.
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` clean.

Closes #655

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>