### PR TITLE
feat(cli): convert mm index to stream + click.progressbar (closes #656)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/_index_progress.py
+++ b/packages/memtomem/src/memtomem/cli/_index_progress.py
@@ -1,0 +1,230 @@
+"""Shared streaming progress runner for ``mm index`` and the ``mm init``
+seed flow.
+
+Both call sites stream :meth:`IndexEngine.index_path_stream` and render the
+same ``click.progressbar`` shape: file-unit length pre-computed up front,
+``progress`` events advance the bar by one and reset the chunk-throttle clock,
+``chunk_progress`` events refresh the sub-label only (no advance), throttled
+to a 100 ms gap with a forced final-tick render so ``(N/N)`` lands before the
+next file boundary. Issue #659 tracks extracting the throttle into a helper
+shared with the web Index tab (``web/static/app.js``); that's deferred to
+rule-of-three on the JS side. The CLI side fires now (two callers: the
+wizard's :func:`_seed_with_progress` and ``mm index``'s ``_index``).
+
+Caller responsibilities (deliberately split out so the two surfaces can keep
+their distinct UX):
+
+* Compute ``expected_total`` (file-unit bar length) — the wizard sums it
+  across multiple paths via :func:`_collect_seed_scale`; ``mm index`` passes
+  the single-path count.
+* Catch :class:`KeyboardInterrupt` for the resume hint (``mm index <path>``
+  vs ``mm web`` Reindex All — different copy per surface).
+* Print the final summary line — ``mm index`` mirrors the legacy
+  ``Indexed N file(s): …`` shape (stable for scripts that grep the output);
+  the wizard prints a green "Seeded initial index" line plus zero-chunks
+  warning. Different shapes, both want the same aggregate counters.
+
+Helper guarantees: bar is always closed on exit (including raise), stream
+runs serially over the supplied ``paths``, returned aggregate dict has
+stable keys ``total_files``, ``indexed``, ``skipped``, ``deleted``,
+``total_chunks``, ``duration_ms``, ``errors``."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import click
+
+
+def _collect_seed_scale(memory_dir: Path) -> tuple[int, int]:
+    """Count ``.md`` files and total bytes under ``memory_dir``, recursive.
+
+    Two-axis decision input for :func:`_maybe_seed_initial_index` and the
+    progress-bar length precomputation in :func:`run_with_progress`. ``.md``
+    only — other supported extensions (``.json``, ``.py``, etc.) exist but
+    the dominant CLI workflow indexes human-written markdown memos, and the
+    bar length is "good enough" so long as it doesn't undercount the common
+    case. Silent on stat/permission errors: a dir the user can't read is
+    one the index can't process either, so return (0, 0) and fall through.
+    """
+    if not memory_dir.exists():
+        return 0, 0
+    count = 0
+    total = 0
+    try:
+        for f in memory_dir.rglob("*.md"):
+            try:
+                total += f.stat().st_size
+                count += 1
+            except OSError:
+                continue
+    except OSError:
+        return 0, 0
+    return count, total
+
+
+async def run_with_progress(
+    paths: Sequence[Path],
+    *,
+    label: str,
+    expected_total: int,
+    recursive: bool = True,
+    force: bool = False,
+    namespace: str | None = None,
+) -> dict[str, Any]:
+    """Stream ``index_path_stream`` across ``paths`` with a click.progressbar.
+
+    Parameters
+    ----------
+    paths:
+        Roots to stream serially. Each is passed to ``index_path_stream``
+        in turn; complete-event counters aggregate across the run.
+    label:
+        Progress-bar label (e.g. ``"  Indexing"`` or ``"  Seeding"``).
+    expected_total:
+        Pre-computed bar length in **file units**. Caller uses
+        :func:`_collect_seed_scale` (or sums it across multiple paths) so
+        the percent indicator is stable from the first event onwards.
+    recursive, force, namespace:
+        Forwarded verbatim to ``index_path_stream``. ``namespace`` is
+        ``None`` for the wizard seed (preserves prior behavior — namespace
+        defaults are resolved server-side from indexing rules) and
+        threadable from the ``mm index --namespace`` flag.
+
+    Returns
+    -------
+    dict
+        Aggregate of all ``complete`` events with keys ``total_files``,
+        ``indexed``, ``skipped``, ``deleted``, ``total_chunks``,
+        ``duration_ms``, and ``errors`` (a list of human-readable strings).
+        Caller renders its own summary line from this.
+
+    Raises
+    ------
+    KeyboardInterrupt
+        Propagated cleanly after the bar is torn down so the caller can
+        print a surface-specific resume hint. Bar cleanup lives in this
+        helper's ``finally`` so callers don't double-handle it.
+    Exception
+        Any other exception (component bootstrap failure, embedder error,
+        IO) is propagated unchanged after bar cleanup.
+    """
+    bar_state: dict[str, Any] = {"bar": None}
+    agg: dict[str, Any] = {
+        "total_files": 0,
+        "indexed": 0,
+        "skipped": 0,
+        "deleted": 0,
+        "total_chunks": 0,
+        "duration_ms": 0.0,
+        "errors": [],
+    }
+
+    # Throttle clock for ``chunk_progress`` label refreshes. Mirrors the web
+    # Index tab (``web/static/app.js`` ~L4219-4256): 100ms gap between
+    # intermediate renders, final tick (chunks_done >= chunks_total) bypasses
+    # the throttle so ``(N/N)`` lands before the next file boundary, and the
+    # clock resets to 0 on every ``progress`` event so the next file's first
+    # chunk renders immediately. ``time.monotonic()`` (not ``time.time()``)
+    # so a wall-clock jump can't stall the bar. Issue #659 tracks extracting
+    # this into a shared helper with the JS implementation once a third
+    # call-site appears (rule-of-three).
+    throttle_state: dict[str, float] = {"last_render": 0.0}
+
+    def _format_item(item: object) -> str:
+        if not item:
+            return ""
+        if isinstance(item, tuple):
+            file, done, total = item
+            return f"{Path(file).name} ({done}/{total})"[:60]
+        # Legacy str case: the existing ``progress`` branch passes a path str.
+        # ``Path(...).name`` (not ``rsplit("/", 1)``) handles Windows
+        # backslash paths correctly.
+        return Path(str(item)).name[:40]
+
+    def _ensure_bar() -> None:
+        # Lazy creation: the bar can come into existence on EITHER the first
+        # ``chunk_progress`` OR the first ``progress`` event, whichever
+        # arrives first. ``chunk_progress`` for a given file is emitted before
+        # that file's ``progress`` summary, so for large files the bar
+        # appears at chunk-level rather than waiting for the first file to
+        # finish.
+        if bar_state["bar"] is None:
+            bar_state["bar"] = click.progressbar(
+                length=expected_total,
+                label=label,
+                item_show_func=_format_item,
+            ).__enter__()
+
+    def _close_bar() -> None:
+        if bar_state["bar"] is not None:
+            try:
+                bar_state["bar"].__exit__(None, None, None)
+            except Exception:  # pragma: no cover - click bar cleanup
+                pass
+            bar_state["bar"] = None
+
+    try:
+        from memtomem.cli._bootstrap import cli_components
+
+        async with cli_components() as comp:
+            # Namespace is only forwarded when the caller passed one — keeps
+            # us compatible with stream consumers (wizard tests' fake engine,
+            # third-party stubs) whose ``index_path_stream`` predates the
+            # namespace kwarg. The real ``IndexEngine.index_path_stream``
+            # accepts it; the conditional is purely for stub-compat.
+            stream_kwargs: dict[str, Any] = {"recursive": recursive, "force": force}
+            if namespace is not None:
+                stream_kwargs["namespace"] = namespace
+            for p in paths:
+                async for evt in comp.index_engine.index_path_stream(p, **stream_kwargs):
+                    if evt["type"] == "chunk_progress":
+                        # Server-side gating in ``indexing/engine.py`` already
+                        # filters out small files (``progress_threshold``,
+                        # default 32), so we don't threshold here — small
+                        # files simply won't emit these events, matching the
+                        # web Index tab's quiet behavior.
+                        done = evt["chunks_done"]
+                        total = evt["chunks_total"]
+                        is_final = done >= total
+                        now = time.monotonic()
+                        if not is_final and now - throttle_state["last_render"] < 0.1:
+                            continue
+                        throttle_state["last_render"] = now
+                        _ensure_bar()
+                        # Refresh the sub-label without advancing the bar —
+                        # length is in **file units**, so chunks must not
+                        # double-count. ``update(0, item)`` re-renders with
+                        # the new ``current_item`` only.
+                        bar_state["bar"].update(0, (evt["file"], done, total))
+                    elif evt["type"] == "progress":
+                        # Reset throttle on file boundary so the next file's
+                        # first chunk_progress renders immediately.
+                        throttle_state["last_render"] = 0.0
+                        _ensure_bar()
+                        bar_state["bar"].update(1, evt["file"])
+                    elif evt["type"] == "complete":
+                        agg["total_files"] += evt["total_files"]
+                        agg["indexed"] += evt["indexed_chunks"]
+                        agg["skipped"] += evt["skipped_chunks"]
+                        agg["deleted"] += evt.get("deleted_chunks", 0)
+                        agg["total_chunks"] += evt.get("total_chunks", 0)
+                        # Multi-path runs: durations sum, errors concatenate.
+                        # Single-path is the dominant case so this is a
+                        # simple aggregation rather than tracking per-path.
+                        agg["duration_ms"] += evt.get("duration_ms", 0.0)
+                        errs = evt.get("errors") or []
+                        if errs:
+                            agg["errors"].extend(errs)
+    finally:
+        _close_bar()
+
+    return agg
+
+
+# Re-exported asyncio.run wrapper kept thin: callers want the surface-specific
+# error handling around the await, so they manage ``asyncio.run`` themselves.
+__all__ = ["run_with_progress", "_collect_seed_scale"]

--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -100,25 +100,64 @@ def index(
 
 
 async def _index(path: str, recursive: bool, force: bool, namespace: str | None) -> None:
-    from memtomem.cli._bootstrap import cli_components
+    """Stream-index ``path`` with a live progress bar (issue #656).
 
-    async with cli_components() as comp:
-        resolved = Path(path).resolve()
-        stats = await comp.index_engine.index_path(
-            resolved,
+    Uses the shared :func:`memtomem.cli._index_progress.run_with_progress`
+    helper introduced when the ``mm init`` wizard's seed flow was upgraded
+    to the streaming surface (#740) — same throttled chunk-progress label,
+    same lazy-bar creation, same per-file unit length. The non-stream
+    :meth:`IndexEngine.index_path` API is preserved for the debounce
+    closure (``_make_indexer``) and other internal callers (tests, MCP
+    ``mem_index``); progress UI in those paths would be noise rather
+    than signal.
+
+    Cancellation: ``Ctrl-C`` inside the stream propagates as
+    :class:`KeyboardInterrupt` through ``asyncio.run`` — caught here to
+    print the legacy resume hint pointing back at ``mm index <path>``
+    (idempotent re-run via content-hash dedup, same as before).
+
+    Summary line shape ("Indexed N file(s): …") is unchanged from the
+    pre-stream implementation since scripts may grep it; the helper
+    aggregates ``deleted`` and ``duration_ms`` from the stream's
+    ``complete`` events so the format is preserved verbatim."""
+    from memtomem.cli._index_progress import _collect_seed_scale, run_with_progress
+
+    resolved = Path(path).resolve()
+    # File-unit bar length. ``_collect_seed_scale`` counts ``.md`` only,
+    # which is the dominant case; a percent indicator that slightly
+    # under/over-shoots for non-md files is still useful UX vs a spinner.
+    expected_total = _collect_seed_scale(resolved)[0]
+
+    try:
+        agg = await run_with_progress(
+            [resolved],
+            label="  Indexing",
+            expected_total=expected_total,
             recursive=recursive,
             force=force,
             namespace=namespace,
         )
+    except KeyboardInterrupt:
+        click.echo()
+        click.secho(f"  Cancelled. Resume with: mm index {resolved}", fg="yellow")
+        return
 
+    # Format string preserved verbatim from the pre-stream implementation —
+    # downstream scripts may parse this. ``duration_ms`` accumulates across
+    # multi-path runs (single-path here, so it's just the one stream's
+    # duration). Summary line follows the bar so click's
+    # progressbar.__exit__ has already cleaned up the trailing carriage
+    # return; an explicit ``click.echo()`` separates them cleanly when the
+    # bar actually rendered.
+    if expected_total > 0:
+        click.echo()
     click.echo(
-        f"Indexed {stats.total_files} file(s): "
-        f"{stats.indexed_chunks} new, {stats.skipped_chunks} unchanged, "
-        f"{stats.deleted_chunks} deleted ({stats.duration_ms:.0f}ms)"
+        f"Indexed {agg['total_files']} file(s): "
+        f"{agg['indexed']} new, {agg['skipped']} unchanged, "
+        f"{agg['deleted']} deleted ({agg['duration_ms']:.0f}ms)"
     )
-    if stats.errors:
-        for err in stats.errors:
-            click.echo(click.style(f"  ERROR: {err}", fg="red"))
+    for err in agg["errors"]:
+        click.echo(click.style(f"  ERROR: {err}", fg="red"))
 
 
 def _print_status(*, as_json: bool) -> None:

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -16,6 +16,12 @@ from typing import Literal
 
 import click
 
+from memtomem.cli._index_progress import (
+    _collect_seed_scale as _collect_seed_scale,
+)
+from memtomem.cli._index_progress import (
+    run_with_progress as _run_index_with_progress,
+)
 from memtomem.cli.init_presets import PRESETS, _VALID_PRESETS, get_preset
 from memtomem.cli.wizard import (
     StepRetry,
@@ -1513,31 +1519,6 @@ def _install_extras(
     return result.returncode == 0
 
 
-def _collect_seed_scale(memory_dir: Path) -> tuple[int, int]:
-    """Count ``.md`` files and total bytes under ``memory_dir``, recursive.
-
-    Two-axis decision input for :func:`_maybe_seed_initial_index`. ``.md``
-    only — other supported extensions (``.json``, ``.py``, etc.) exist but
-    the wizard's dominant workflow seeds human-written markdown memos, and
-    the embedder cost tuning lives in that regime. Silent on stat/permission
-    errors: a dir the user can't read is one the seed can't index either,
-    so return (0, 0) and fall through to "skip"."""
-    if not memory_dir.exists():
-        return 0, 0
-    count = 0
-    total = 0
-    try:
-        for f in memory_dir.rglob("*.md"):
-            try:
-                total += f.stat().st_size
-                count += 1
-            except OSError:
-                continue
-    except OSError:
-        return 0, 0
-    return count, total
-
-
 def _format_size(total_bytes: int) -> str:
     """Human-readable size — ``<1 KB`` for sub-KB totals (15 tiny memo
     files shouldn't display as "0 KB"), ``N KB`` up to 1024 KB, ``N MB``
@@ -1597,115 +1578,45 @@ def _seed_with_progress(paths: list[Path]) -> bool:
     Failure: any other ``Exception`` (missing config, embedder init
     error, IO) prints a yellow warning + manual-rerun hint and returns
     ``False``. The wizard already succeeded at writing config.json so a
-    seed-only failure must not abort the overall flow."""
+    seed-only failure must not abort the overall flow.
+
+    Streaming + bar lifecycle live in :mod:`memtomem.cli._index_progress`
+    (shared with ``mm index`` since #656); this function owns the
+    wizard-specific copy: green summary line vs ``mm index``'s legacy
+    "Indexed N file(s): …" shape, multi-path resume hint via
+    ``mm web``, zero-chunks yellow warning that gates the Next-steps
+    step-1 annotation."""
     import asyncio
 
     if not paths:
         return False
 
-    bar_state: dict = {"bar": None}
-    agg = {"total_files": 0, "indexed": 0, "skipped": 0}
     # Pre-compute so the progress bar length spans all paths, not just
     # the first one. Stays accurate across serial iteration.
     expected_total = sum(_collect_seed_scale(p)[0] for p in paths)
 
-    # Throttle clock for ``chunk_progress`` label refreshes. Mirrors the web
-    # Index tab (``web/static/app.js`` ~L4219-4256): 100ms gap between
-    # intermediate renders, final tick (chunks_done >= chunks_total) bypasses
-    # the throttle so ``(N/N)`` lands before the next file boundary, and the
-    # clock resets to 0 on every ``progress`` event so the next file's first
-    # chunk renders immediately. ``time.monotonic()`` (not ``time.time()``)
-    # so a wall-clock jump can't stall the bar. Issue #659 tracks extracting
-    # this into a shared helper once a third call-site appears
-    # (rule-of-three) — keep this implementation self-contained for now.
-    throttle_state: dict = {"last_render": 0.0}
-
-    def _format_item(item: object) -> str:
-        if not item:
-            return ""
-        if isinstance(item, tuple):
-            file, done, total = item
-            return f"{Path(file).name} ({done}/{total})"[:60]
-        # Legacy str case: the existing ``progress`` branch passes a path str.
-        # ``Path(...).name`` (not ``rsplit("/", 1)``) handles Windows
-        # backslash paths correctly.
-        return Path(str(item)).name[:40]
-
-    def _ensure_bar() -> None:
-        # Lazy creation: the bar can come into existence on EITHER the first
-        # ``chunk_progress`` OR the first ``progress`` event, whichever
-        # arrives first. ``chunk_progress`` for a given file is emitted before
-        # that file's ``progress`` summary, so for large files the bar appears
-        # at chunk-level rather than waiting for the first file to finish.
-        if bar_state["bar"] is None:
-            bar_state["bar"] = click.progressbar(
-                length=expected_total,
-                label="  Seeding",
-                item_show_func=_format_item,
-            ).__enter__()
-
-    def _close_bar() -> None:
-        if bar_state["bar"] is not None:
-            try:
-                bar_state["bar"].__exit__(None, None, None)
-            except Exception:  # pragma: no cover - click bar cleanup
-                pass
-            bar_state["bar"] = None
-
-    async def _stream() -> None:
-        from memtomem.cli._bootstrap import cli_components
-
-        async with cli_components() as comp:
-            for p in paths:
-                async for evt in comp.index_engine.index_path_stream(
-                    p, recursive=True, force=False
-                ):
-                    if evt["type"] == "chunk_progress":
-                        # Server-side gating in ``indexing/engine.py`` already
-                        # filters out small files (``progress_threshold``,
-                        # default 32), so we don't threshold here — small
-                        # files simply won't emit these events, matching the
-                        # web Index tab's quiet behavior.
-                        done = evt["chunks_done"]
-                        total = evt["chunks_total"]
-                        is_final = done >= total
-                        now = time.monotonic()
-                        if not is_final and now - throttle_state["last_render"] < 0.1:
-                            continue
-                        throttle_state["last_render"] = now
-                        _ensure_bar()
-                        # Refresh the sub-label without advancing the bar —
-                        # length is in **file units**, so chunks must not
-                        # double-count. ``update(0, item)`` re-renders with
-                        # the new ``current_item`` only.
-                        bar_state["bar"].update(0, (evt["file"], done, total))
-                    elif evt["type"] == "progress":
-                        # Reset throttle on file boundary so the next file's
-                        # first chunk_progress renders immediately.
-                        throttle_state["last_render"] = 0.0
-                        _ensure_bar()
-                        bar_state["bar"].update(1, evt["file"])
-                    elif evt["type"] == "complete":
-                        agg["total_files"] += evt["total_files"]
-                        agg["indexed"] += evt["indexed_chunks"]
-                        agg["skipped"] += evt["skipped_chunks"]
-
     resume_hint = f"mm index {paths[0]}" if len(paths) == 1 else "mm web  (Sources → Reindex All)"
 
     try:
-        asyncio.run(_stream())
+        agg = asyncio.run(
+            _run_index_with_progress(
+                paths,
+                label="  Seeding",
+                expected_total=expected_total,
+                recursive=True,
+                force=False,
+                namespace=None,
+            )
+        )
     except KeyboardInterrupt:
-        _close_bar()
         click.echo()
         click.secho(f"  Cancelled. Resume with: {resume_hint}", fg="yellow")
         return False
     except Exception as e:
-        _close_bar()
         click.secho(f"  Skipped initial seed: {e}", fg="yellow")
         click.echo(f"  Run manually later:   {resume_hint}")
         return False
 
-    _close_bar()
     if agg["total_files"] == 0:
         # No files discovered by the stream — shouldn't happen given the
         # callers already ensured file_count > 0, but handle defensively.

--- a/packages/memtomem/tests/test_indexing_cli.py
+++ b/packages/memtomem/tests/test_indexing_cli.py
@@ -1,0 +1,217 @@
+"""Tests for ``mm index`` (``memtomem.cli.indexing``).
+
+Pins the streaming + progress-bar conversion (issue #656). The non-stream
+``IndexEngine.index_path`` path is exercised by ``test_cli_index_noop_e2e``;
+this module focuses on the stream-converted ``_index`` direct-CLI flow:
+
+1. **Stream → summary** — events flow through and the legacy
+   ``Indexed N file(s): N new, N unchanged, N deleted (Nms)`` summary line
+   is preserved verbatim. Scripts may grep this output, so the format string
+   is a stable interface.
+2. **Ctrl-C → resume hint** — a ``KeyboardInterrupt`` mid-stream prints the
+   yellow ``Cancelled. Resume with: mm index <path>`` line and exits cleanly.
+3. **--namespace / --force pass-through** — both flags reach
+   ``index_path_stream`` unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from memtomem.cli.indexing import _index
+
+
+def _make_complete_event(
+    *,
+    total_files: int = 1,
+    indexed: int = 1,
+    skipped: int = 0,
+    deleted: int = 0,
+    duration_ms: float = 12.0,
+    errors: list[str] | None = None,
+) -> dict:
+    return {
+        "type": "complete",
+        "total_files": total_files,
+        "total_chunks": indexed + skipped,
+        "indexed_chunks": indexed,
+        "skipped_chunks": skipped,
+        "deleted_chunks": deleted,
+        "duration_ms": duration_ms,
+        "errors": errors or [],
+    }
+
+
+def _install_fake_engine(
+    monkeypatch: pytest.MonkeyPatch, *, events: list[dict], record: dict | None = None
+) -> None:
+    """Patch ``cli_components`` so ``index_path_stream`` yields ``events`` and
+    optionally records the kwargs it was called with into ``record``."""
+
+    class _FakeEngine:
+        async def index_path_stream(self, path, *args, **kwargs):
+            if record is not None:
+                record["path"] = path
+                record["args"] = args
+                record["kwargs"] = dict(kwargs)
+            for evt in events:
+                if isinstance(evt, BaseException):
+                    raise evt
+                yield evt
+
+    class _FakeComp:
+        index_engine = _FakeEngine()
+
+    @asynccontextmanager  # type: ignore[misc]
+    async def _fake_components():
+        yield _FakeComp()
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake_components)
+
+
+class TestIndexStreamConversion:
+    def test_stream_complete_event_renders_legacy_summary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """``progress`` + ``complete`` events flow through and the printed
+        summary line matches the pre-stream ``Indexed N file(s): N new,
+        N unchanged, N deleted (Nms)`` shape verbatim. Pinned because
+        scripts may grep this output."""
+        target = tmp_path / "memories"
+        target.mkdir()
+        (target / "a.md").write_text("# memo a\n", encoding="utf-8")
+        (target / "b.md").write_text("# memo b\n", encoding="utf-8")
+
+        events = [
+            {
+                "type": "progress",
+                "file": str(target / "a.md"),
+                "files_done": 1,
+                "files_total": 2,
+                "indexed": 3,
+                "skipped": 0,
+            },
+            {
+                "type": "progress",
+                "file": str(target / "b.md"),
+                "files_done": 2,
+                "files_total": 2,
+                "indexed": 2,
+                "skipped": 1,
+            },
+            _make_complete_event(total_files=2, indexed=5, skipped=1, deleted=0, duration_ms=42.0),
+        ]
+        _install_fake_engine(monkeypatch, events=events)
+
+        asyncio.run(_index(str(target), recursive=True, force=False, namespace=None))
+        out = capsys.readouterr().out
+        assert "Indexed 2 file(s): 5 new, 1 unchanged, 0 deleted (42ms)" in out
+
+    def test_stream_errors_render_red_lines(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Per-file error strings carried in the ``complete`` event's
+        ``errors`` list are rendered with the same ``  ERROR: …`` prefix
+        as the pre-stream implementation. Empty list = no error lines."""
+        target = tmp_path / "memories"
+        target.mkdir()
+        (target / "broken.md").write_text("# x\n", encoding="utf-8")
+
+        events = [
+            _make_complete_event(
+                total_files=1,
+                indexed=0,
+                skipped=0,
+                deleted=0,
+                errors=["broken.md: embedder OOM"],
+            ),
+        ]
+        _install_fake_engine(monkeypatch, events=events)
+
+        asyncio.run(_index(str(target), recursive=True, force=False, namespace=None))
+        out = capsys.readouterr().out
+        assert "ERROR: broken.md: embedder OOM" in out
+
+
+class TestIndexKeyboardInterrupt:
+    def test_keyboard_interrupt_prints_resume_hint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Ctrl-C inside the stream surfaces the yellow ``Cancelled. Resume
+        with: mm index <abs-path>`` hint instead of a traceback. The path
+        is the resolved absolute path so the printed command is
+        copy-pasteable from any cwd."""
+        target = tmp_path / "memories"
+        target.mkdir()
+        (target / "a.md").write_text("# memo\n", encoding="utf-8")
+
+        events = [
+            {
+                "type": "progress",
+                "file": str(target / "a.md"),
+                "files_done": 1,
+                "files_total": 2,
+                "indexed": 1,
+                "skipped": 0,
+            },
+            KeyboardInterrupt(),
+        ]
+        _install_fake_engine(monkeypatch, events=events)
+
+        # ``_index`` swallows the KeyboardInterrupt and prints the hint.
+        asyncio.run(_index(str(target), recursive=True, force=False, namespace=None))
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+        assert f"mm index {target.resolve()}" in out
+        # Must NOT print the success summary line — the run was cancelled.
+        assert "Indexed " not in out
+
+
+class TestIndexFlagPassthrough:
+    def test_namespace_and_force_reach_index_path_stream(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``--namespace`` and ``--force`` flags forward verbatim into
+        the engine's ``index_path_stream`` call. Recording stub captures
+        kwargs so a future refactor that drops one of these on the floor
+        fails here instead of in production."""
+        target = tmp_path / "memories"
+        target.mkdir()
+        (target / "a.md").write_text("# memo\n", encoding="utf-8")
+
+        record: dict = {}
+        events = [_make_complete_event(total_files=1, indexed=1)]
+        _install_fake_engine(monkeypatch, events=events, record=record)
+
+        asyncio.run(_index(str(target), recursive=False, force=True, namespace="work"))
+        kwargs = record["kwargs"]
+        assert kwargs.get("recursive") is False
+        assert kwargs.get("force") is True
+        assert kwargs.get("namespace") == "work"
+
+    def test_default_recursive_true_no_namespace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default invocation: ``recursive=True``, ``force=False``, and no
+        ``namespace`` kwarg leaks through (the helper conditionally omits
+        it so stub engines without the param keep working). Pinned so the
+        defaults stay aligned with the click option declarations."""
+        target = tmp_path / "memories"
+        target.mkdir()
+        (target / "a.md").write_text("# memo\n", encoding="utf-8")
+
+        record: dict = {}
+        events = [_make_complete_event(total_files=1, indexed=1)]
+        _install_fake_engine(monkeypatch, events=events, record=record)
+
+        asyncio.run(_index(str(target), recursive=True, force=False, namespace=None))
+        kwargs = record["kwargs"]
+        assert kwargs.get("recursive") is True
+        assert kwargs.get("force") is False
+        # ``namespace=None`` should NOT be forwarded — keeps stub-engine
+        # compat (existing wizard tests' fake engines predate the kwarg).
+        assert "namespace" not in kwargs


### PR DESCRIPTION
Stacked on #740 (rebases onto main once #740 merges).

## Motivation

Direct CLI users running `mm index <large-dir>` previously saw nothing until
the run finished — `index_path()` blocks for the entire duration. On
multi-minute embedder runs (bge-m3 / CPU, large corpus) this looked hung.
Switch `_index()` to consume `index_path_stream()` and render the same
throttled progress bar that #740 just polished for the wizard's seed flow.

## Design

Lifted the streaming + bar lifecycle into a new module
`memtomem.cli._index_progress` so both call sites (`_seed_with_progress` and
`mm index`'s `_index`) drive identical UX (throttled chunk-progress label,
lazy bar creation, file-unit length). `_collect_seed_scale` moved with it,
re-exported from `init_cmd` so existing test imports keep working.

Only `_index()` is converted. The debounce closure at `indexing.py:194`
keeps the non-stream API since hook-driven drains (`--flush` /
`--debounce-window`) don't want progress noise. The non-stream
`index_path()` stays for tests, MCP `mem_index`, and the closure — issue
text covers this explicitly.

## Invariants preserved

- Summary line shape `Indexed N file(s): N new, N unchanged, N deleted (Nms)` — stable interface scripts may grep.
- `--force`, `--namespace`, `--recursive` forward to `index_path_stream`.
- Ctrl-C prints `Cancelled. Resume with: mm index <path>` (idempotent re-run via content-hash dedup).
- Exit code unchanged on success / partial failure / hard failure.
- `_seed_with_progress` keeps its zero-chunks warning, multi-path web hint, graceful-skip — verified by the 264 existing wizard tests (no regressions).

## Test plan

- [x] 5 new tests in `tests/test_indexing_cli.py`: stream-event pass-through with legacy summary-line pin, error-line rendering, Ctrl-C resume hint, `--namespace`/`--force` kwarg propagation, default-no-namespace stub-engine compat.
- [x] Full wizard suite (264 tests in `test_init_cmd.py`) green, including #740's two new chunk-progress regression tests.
- [x] `test_cli_index_noop_e2e.py` (inline + subprocess) green.
- [x] Full sweep: 3991 passed, 46 deselected.
- [x] `ruff check` and `ruff format --check` clean.
- [x] `mypy` clean on `_index_progress.py`, `indexing.py`, `init_cmd.py`.

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)