### PR TITLE
refactor(cli): drop namespace stub-compat conditional in _index_progress (#742)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/_index_progress.py
+++ b/packages/memtomem/src/memtomem/cli/_index_progress.py
@@ -171,16 +171,10 @@ async def run_with_progress(
         from memtomem.cli._bootstrap import cli_components
 
         async with cli_components() as comp:
-            # Namespace is only forwarded when the caller passed one — keeps
-            # us compatible with stream consumers (wizard tests' fake engine,
-            # third-party stubs) whose ``index_path_stream`` predates the
-            # namespace kwarg. The real ``IndexEngine.index_path_stream``
-            # accepts it; the conditional is purely for stub-compat.
-            stream_kwargs: dict[str, Any] = {"recursive": recursive, "force": force}
-            if namespace is not None:
-                stream_kwargs["namespace"] = namespace
             for p in paths:
-                async for evt in comp.index_engine.index_path_stream(p, **stream_kwargs):
+                async for evt in comp.index_engine.index_path_stream(
+                    p, recursive=recursive, force=force, namespace=namespace
+                ):
                     if evt["type"] == "chunk_progress":
                         # Server-side gating in ``indexing/engine.py`` already
                         # filters out small files (``progress_threshold``,

--- a/packages/memtomem/tests/test_indexing_cli.py
+++ b/packages/memtomem/tests/test_indexing_cli.py
@@ -196,10 +196,9 @@ class TestIndexFlagPassthrough:
     def test_default_recursive_true_no_namespace(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Default invocation: ``recursive=True``, ``force=False``, and no
-        ``namespace`` kwarg leaks through (the helper conditionally omits
-        it so stub engines without the param keep working). Pinned so the
-        defaults stay aligned with the click option declarations."""
+        """Default invocation: ``recursive=True``, ``force=False``, and
+        ``namespace=None`` are all forwarded verbatim to the engine. Pinned
+        so the defaults stay aligned with the click option declarations."""
         target = tmp_path / "memories"
         target.mkdir()
         (target / "a.md").write_text("# memo\n", encoding="utf-8")
@@ -212,6 +211,4 @@ class TestIndexFlagPassthrough:
         kwargs = record["kwargs"]
         assert kwargs.get("recursive") is True
         assert kwargs.get("force") is False
-        # ``namespace=None`` should NOT be forwarded — keeps stub-engine
-        # compat (existing wizard tests' fake engines predate the kwarg).
-        assert "namespace" not in kwargs
+        assert kwargs.get("namespace") is None

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4929,7 +4929,7 @@ class TestInitialSeedThreshold:
         memory_dir.mkdir()
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False):
+            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
                 yield {
                     "type": "progress",
                     "file": str(memory_dir / "a.md"),
@@ -4984,7 +4984,7 @@ class TestInitialSeedThreshold:
         memory_dir.mkdir()
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False):
+            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
                 yield {
                     "type": "progress",
                     "file": str(memory_dir / "a.md"),
@@ -5183,7 +5183,7 @@ class TestInitialSeedThreshold:
         }
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False):
+            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
                 key = str(path)
                 counts = path_counts[key]
                 yield {
@@ -5281,7 +5281,7 @@ class TestInitialSeedThreshold:
         captured: dict[str, object] = {}
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False):
+            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
                 file = str(memory_dir / "big.md")
                 # Server only emits chunk_progress when the file exceeds the
                 # ``progress_threshold`` (default 32). Mimic a 50-chunk file.
@@ -5362,7 +5362,7 @@ class TestInitialSeedThreshold:
         captured: dict[str, object] = {}
 
         class _FakeEngine:
-            async def index_path_stream(self, path, recursive=True, force=False):
+            async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
                 for name in ("a.md", "b.md"):
                     yield {
                         "type": "progress",


### PR DESCRIPTION
## Summary

- The wizard test fake engines in `test_init_cmd.py` predated the `namespace` kwarg on `IndexEngine.index_path_stream`. `run_with_progress` worked around the gap by conditionally omitting `namespace=None` from the forwarded kwargs, with a comment that the conditional was purely for stub-compat.
- Update the 5 wizard fake engines (and the `test_indexing_cli` passthrough guard) to accept the `namespace` kwarg, then forward it unconditionally. Helper signature now matches the real engine.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 3991 passed, 7 skipped
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check ...` — clean

Closes #742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)