### PR TITLE
fix(init): wrap _step_memory_dir / _step_settings filesystem ops in fail_step (#664)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -659,8 +659,28 @@ def _step_memory_dir(state: dict) -> None:
     if not memory_path.exists():
         create = nav_confirm(f"  '{memory_dir}' doesn't exist. Create it?", default=True)
         if create:
-            memory_path.mkdir(parents=True, exist_ok=True)
-            click.secho(f"  Created {memory_path}", fg="green")
+            # Symmetric counterpart to the Ollama-branch fail_step adoption
+            # in ``_step_embedding`` (#626 / #661): an uncaught
+            # PermissionError / OSError here would crash the wizard with a
+            # raw stack trace and force ``mm init`` from the top. Wrap the
+            # mkdir so the user gets the same retry/back/quit recovery as
+            # the rest of the wizard. The nested try is required because
+            # ``fail_step`` raises ``StepRetry`` from inside the
+            # ``except OSError`` handler — a sibling ``except StepRetry``
+            # on the same statement would not catch it. (#664)
+            while True:
+                try:
+                    try:
+                        memory_path.mkdir(parents=True, exist_ok=True)
+                    except OSError as exc:
+                        fail_step(
+                            f"Could not create '{memory_path}': {exc}",
+                            retryable=True,
+                        )
+                    click.secho(f"  Created {memory_path}", fg="green")
+                    break
+                except StepRetry:
+                    continue
     state["memory_dir"] = memory_dir
     click.echo()
 
@@ -910,13 +930,28 @@ def _step_settings(state: dict) -> None:
 
         project_root = Path.cwd()
         canonical = project_root / CANONICAL_SETTINGS_FILE
-        canonical.parent.mkdir(parents=True, exist_ok=True)
-        if not canonical.exists():
-            canonical.write_text(
-                json.dumps({"hooks": {}}, indent=2) + "\n",
-                encoding="utf-8",
-            )
-            click.secho(f"  Created {CANONICAL_SETTINGS_FILE}", fg="green")
+        # Same fail_step adoption as ``_step_memory_dir`` (#664). A read-only
+        # project root or full disk would otherwise crash the wizard mid-step
+        # with a stack trace; wrap both filesystem ops so the user gets the
+        # standard retry/back/quit recovery path.
+        while True:
+            try:
+                try:
+                    canonical.parent.mkdir(parents=True, exist_ok=True)
+                    if not canonical.exists():
+                        canonical.write_text(
+                            json.dumps({"hooks": {}}, indent=2) + "\n",
+                            encoding="utf-8",
+                        )
+                        click.secho(f"  Created {CANONICAL_SETTINGS_FILE}", fg="green")
+                except OSError as exc:
+                    fail_step(
+                        f"Could not write '{CANONICAL_SETTINGS_FILE}': {exc}",
+                        retryable=True,
+                    )
+                break
+            except StepRetry:
+                continue
 
         results = generate_all_settings(project_root)
         for name, r in results.items():

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6731,3 +6731,242 @@ class TestStepEmbeddingOpenAIGuard:
         assert next_step_called == []
         # ``run_steps`` exits 0 on WizardCancel (was 1 under SystemExit(1)).
         assert result.exit_code == 0
+
+
+class TestStepMemoryDirFsGuards:
+    """``_step_memory_dir`` must surface ``mkdir`` failures via
+    ``fail_step`` instead of crashing the wizard with an uncaught
+    PermissionError / OSError stack trace (#664). Symmetric to the
+    Ollama-branch guards in ``TestStepEmbeddingOllamaGuards``."""
+
+    def test_mkdir_permission_error_q_cancels(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``mkdir`` raises PermissionError → user picks 'q' → wizard
+        cancels with ``WizardCancel`` instead of crashing on the raw
+        exception."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import WizardCancel
+
+        target = tmp_path / "nope"
+
+        def boom(self: Path, *a: object, **kw: object) -> None:
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "mkdir", boom)
+
+        captured: dict[str, BaseException | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                init_cmd._step_memory_dir({})
+            except WizardCancel as exc:
+                captured["exc"] = exc
+
+        # path → confirm create → fail → q
+        result = CliRunner().invoke(cmd, [], input=f"{target}\nY\nq\n")
+        assert "Could not create" in result.output
+        assert "Permission denied" in result.output
+        assert isinstance(captured["exc"], WizardCancel)
+
+    def test_mkdir_permission_error_r_retries_until_success(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``mkdir`` fails once, succeeds on retry — the wizard does NOT
+        re-prompt the directory path on retry (recovery is local to the
+        mkdir, not the whole step)."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+
+        target = tmp_path / "memories"
+        calls = {"n": 0}
+
+        original_mkdir = Path.mkdir
+
+        def flaky_mkdir(self: Path, *a: object, **kw: object) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise PermissionError(13, "Permission denied", str(self))
+            return original_mkdir(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "mkdir", flaky_mkdir)
+
+        state: dict = {}
+
+        @click.command()
+        def cmd() -> None:
+            init_cmd._step_memory_dir(state)
+
+        # path → Y → mkdir fails → r → mkdir succeeds (no re-prompt)
+        result = CliRunner().invoke(cmd, [], input=f"{target}\nY\nr\n")
+        assert result.exit_code == 0
+        assert "Could not create" in result.output
+        assert f"Created {target}" in result.output
+        assert state.get("memory_dir") == str(target)
+        assert calls["n"] == 2
+
+    def test_mkdir_failure_does_not_advance_to_next_step(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Core #664 invariant: an uncaught crash is replaced by a
+        deliberate cancel. When mkdir fails and the user picks 'q',
+        the next step must NOT run."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import run_steps
+
+        target = tmp_path / "nope"
+
+        def boom(self: Path, *a: object, **kw: object) -> None:
+            raise OSError(28, "No space left on device", str(self))
+
+        monkeypatch.setattr(Path, "mkdir", boom)
+
+        next_step_called: list[bool] = []
+
+        def sentinel_next_step(state: dict) -> None:
+            next_step_called.append(True)
+
+        @click.command()
+        def cmd() -> None:
+            run_steps([init_cmd._step_memory_dir, sentinel_next_step])
+
+        result = CliRunner().invoke(cmd, [], input=f"{target}\nY\nq\n")
+        assert "No space left on device" in result.output
+        assert "Wizard cancelled" in result.output
+        assert next_step_called == []
+        assert result.exit_code == 0
+
+
+class TestStepSettingsFsGuards:
+    """``_step_settings`` must surface ``mkdir`` / ``write_text`` failures
+    via ``fail_step`` instead of crashing on a read-only project root or
+    full disk (#664)."""
+
+    def test_write_oserror_q_cancels(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """``write_text`` raises OSError → user picks 'q' → wizard
+        cancels cleanly. Without the guard, the wizard would crash with
+        an uncaught stack trace mid-step."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import WizardCancel
+
+        # ``_step_settings`` short-circuits if ``~/.claude`` is missing.
+        # Point HOME at a tmp dir with a fake ``.claude`` so the body runs.
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.chdir(tmp_path)
+
+        def boom(self: Path, *a: object, **kw: object) -> None:
+            raise PermissionError(13, "Permission denied", str(self))
+
+        monkeypatch.setattr(Path, "write_text", boom)
+
+        captured: dict[str, BaseException | None] = {"exc": None}
+
+        @click.command()
+        def cmd() -> None:
+            try:
+                init_cmd._step_settings({})
+            except WizardCancel as exc:
+                captured["exc"] = exc
+
+        # configure-hooks? Y → write fails → q
+        result = CliRunner().invoke(cmd, [], input="Y\nq\n")
+        assert "Could not write" in result.output
+        assert "Permission denied" in result.output
+        assert isinstance(captured["exc"], WizardCancel)
+
+    def test_write_oserror_r_retries_until_success(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``write_text`` fails once, succeeds on retry — the wizard does
+        NOT re-prompt the hooks confirmation on retry."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.chdir(tmp_path)
+
+        calls = {"n": 0}
+        original_write = Path.write_text
+
+        def flaky_write(self: Path, *a: object, **kw: object) -> int:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise PermissionError(13, "Permission denied", str(self))
+            return original_write(self, *a, **kw)
+
+        monkeypatch.setattr(Path, "write_text", flaky_write)
+        # ``generate_all_settings`` writes to ~/.claude/settings.json after
+        # the canonical write succeeds; stub it so the test stays scoped to
+        # the guard under test.
+        monkeypatch.setattr(
+            "memtomem.context.settings.generate_all_settings",
+            lambda root: {},
+        )
+
+        state: dict = {}
+
+        @click.command()
+        def cmd() -> None:
+            init_cmd._step_settings(state)
+
+        # confirm-hooks Y → write fails → r → write succeeds
+        result = CliRunner().invoke(cmd, [], input="Y\nr\n")
+        assert result.exit_code == 0
+        assert "Could not write" in result.output
+        assert state.get("settings_hooks") is True
+        # Two attempts: the first raises, the second writes the file.
+        assert calls["n"] == 2
+
+    def test_write_failure_does_not_advance_to_next_step(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Core #664 invariant for ``_step_settings``: a write failure
+        plus 'q' cancels deliberately — the next step does not run."""
+        import click
+        from click.testing import CliRunner
+
+        from memtomem.cli import init_cmd
+        from memtomem.cli.wizard import run_steps
+
+        home = tmp_path / "home"
+        (home / ".claude").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.chdir(tmp_path)
+
+        def boom(self: Path, *a: object, **kw: object) -> None:
+            raise OSError(28, "No space left on device", str(self))
+
+        monkeypatch.setattr(Path, "write_text", boom)
+
+        next_step_called: list[bool] = []
+
+        def sentinel_next_step(state: dict) -> None:
+            next_step_called.append(True)
+
+        @click.command()
+        def cmd() -> None:
+            run_steps([init_cmd._step_settings, sentinel_next_step])
+
+        result = CliRunner().invoke(cmd, [], input="Y\nq\n")
+        assert "No space left on device" in result.output
+        assert "Wizard cancelled" in result.output
+        assert next_step_called == []
+        assert result.exit_code == 0

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6862,10 +6862,11 @@ class TestStepSettingsFsGuards:
         from memtomem.cli.wizard import WizardCancel
 
         # ``_step_settings`` short-circuits if ``~/.claude`` is missing.
-        # Point HOME at a tmp dir with a fake ``.claude`` so the body runs.
+        # Patch ``Path.home`` so the body runs — the ``HOME`` env var isn't
+        # honored by ``Path.home()`` on Windows (it uses ``USERPROFILE``).
         home = tmp_path / "home"
         (home / ".claude").mkdir(parents=True)
-        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
         monkeypatch.chdir(tmp_path)
 
         def boom(self: Path, *a: object, **kw: object) -> None:
@@ -6900,7 +6901,7 @@ class TestStepSettingsFsGuards:
 
         home = tmp_path / "home"
         (home / ".claude").mkdir(parents=True)
-        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
         monkeypatch.chdir(tmp_path)
 
         calls = {"n": 0}
@@ -6948,7 +6949,7 @@ class TestStepSettingsFsGuards:
 
         home = tmp_path / "home"
         (home / ".claude").mkdir(parents=True)
-        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
         monkeypatch.chdir(tmp_path)
 
         def boom(self: Path, *a: object, **kw: object) -> None:


### PR DESCRIPTION
## Summary

- Both `_step_memory_dir` and `_step_settings` performed filesystem side effects (`mkdir`, `write_text`) without try/except. A read-only project root, full disk, or `PermissionError` would crash `mm init` with an uncaught stack trace and force the user to restart from the top.
- Wraps the failing ops in the standard `fail_step` retry/back/quit pattern adopted by the Ollama branch in #661 — symmetric counterpart to that fix.
- Pins the new behavior with six tests (three per step) shaped after the existing `TestStepEmbeddingOllamaGuards`: `q` cancels via `WizardCancel`, `r` retries the inner op without re-prompting earlier inputs, and a failed op does NOT silently advance to the next step.

The nested try is required because `fail_step` raises `StepRetry` from inside the `except OSError` handler — a sibling `except StepRetry` on the same statement would not catch it. Comment in code explains this.

Closes #664. Out-of-scope per the issue body: the warn-and-save patterns in `_step_embedding` (ONNX/Ollama/OpenAI client missing) and `_step_language` (kiwipiepy missing) are documented UX, not bugs.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_init_cmd.py -k "TestStepMemoryDirFsGuards or TestStepSettingsFsGuards"` — 6 passed
- [x] `uv run pytest -m "not ollama"` — 3997 passed, 7 skipped
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/init_cmd.py` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)