### PR TITLE
test(embedding): wait on Event for ONNX progress flush instead of single sleep(0) (#663)

### DIFF
--- a/packages/memtomem/tests/test_embedding_progress.py
+++ b/packages/memtomem/tests/test_embedding_progress.py
@@ -59,6 +59,33 @@ def _record() -> tuple[list[tuple[int, int]], callable]:
     return calls, cb
 
 
+def _record_with_done_event() -> tuple[list[tuple[int, int]], callable, asyncio.Event]:
+    """Like :func:`_record`, but also returns an ``asyncio.Event`` set
+    when a callback fires with ``done == total`` — i.e. the final tick.
+
+    Used by the ONNX tests to wait for trailing
+    ``loop.call_soon_threadsafe`` callbacks to drain off the loop's
+    ready queue before asserting on call count. ``asyncio.to_thread``
+    can resume its awaiter before the worker thread's queued
+    callbacks dispatch — a single ``await asyncio.sleep(0)`` yields
+    only one loop iteration and the macOS GH runner under Python 3.14
+    has been observed to need more (#663). Awaiting an Event set by
+    the final callback is robust regardless of how many iterations
+    the loop needs to fully drain the FIFO queue: once the
+    ``done == total`` callback runs we know every earlier callback
+    has already run (FIFO ordering of ``call_soon_threadsafe``).
+    """
+    calls: list[tuple[int, int]] = []
+    done_event = asyncio.Event()
+
+    def cb(done: int, total: int) -> None:
+        calls.append((done, total))
+        if done == total:
+            done_event.set()
+
+    return calls, cb, done_event
+
+
 def _assert_progress_contract(calls: list[tuple[int, int]], total: int, expected_calls: int):
     assert len(calls) == expected_calls, f"expected {expected_calls} calls, got {calls}"
     # All totals match
@@ -206,15 +233,17 @@ async def test_onnx_streams_progress_per_yield():
         return out
 
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
-    calls, cb = _record()
+    calls, cb, done_event = _record_with_done_event()
     result = await embedder.embed_texts(["a", "b", "c", "d", "e"], on_progress=cb)
     assert len(result) == 5
     # Flush ``call_soon_threadsafe`` callbacks the worker scheduled but
-    # the loop hasn't dequeued yet by the time ``to_thread`` resumed —
-    # macOS exposes the race ~30% of the time on a 5-text burst (#667).
+    # the loop hasn't dequeued yet by the time ``to_thread`` resumed.
+    # Awaiting the final-tick Event drains the loop's FIFO queue
+    # however many iterations it takes — macOS Py3.14 has been
+    # observed to need more than a single ``sleep(0)`` yield (#663).
     # Production behavior is fire-and-forget; tightening that contract
     # would be a separate PR.
-    await asyncio.sleep(0)
+    await asyncio.wait_for(done_event.wait(), timeout=5.0)
     _assert_progress_contract(calls, total=5, expected_calls=5)
     assert [d for d, _ in calls] == [1, 2, 3, 4, 5]
 
@@ -240,13 +269,14 @@ async def test_onnx_throttles_thread_hops_for_large_input():
         return out
 
     embedder._embed_sync = fake_sync  # type: ignore[method-assign]
-    calls, cb = _record()
+    calls, cb, done_event = _record_with_done_event()
     await embedder.embed_texts(["x"] * n, on_progress=cb)
-    # Same threadsafe-callback flush as test_onnx_streams_progress_per_yield
-    # — defensive here, since 200 ticks throttled to ~20 hasn't been seen
-    # to flake in CI (only the 5-text burst does), but the race window is
-    # the same code path.
-    await asyncio.sleep(0)
+    # Wait for the final-tick (``done == n``) callback to drain off the
+    # loop's queue — same race as test_onnx_streams_progress_per_yield,
+    # but more visible at n=200 because the throttled run has more
+    # in-flight ``call_soon_threadsafe`` items pending when ``to_thread``
+    # resumes (#663).
+    await asyncio.wait_for(done_event.wait(), timeout=5.0)
     # Throttle step = max(1, n // 20) = 10 → ~20 ticks + final
     # (final-tick bypass guarantees one extra if the last-step boundary
     # doesn't land exactly on N).


### PR DESCRIPTION
## Summary

- `test_onnx_streams_progress_per_yield` and `test_onnx_throttles_thread_hops_for_large_input` were flaking on the macOS GH runner with Python 3.14 — `on_progress` callbacks intermittently registered as **0 calls** (issue body's three consecutive failures on PR #661 reruns + the same shape on `main` at `e034d10`).
- The existing flush `await asyncio.sleep(0)` yields exactly **one** loop iteration. That was enough on Linux and on macOS Py3.13 but not on Py3.14's macOS runner — the `loop.call_soon_threadsafe` items the embedding worker scheduled were still pending in the loop's ready queue when `await asyncio.to_thread` resumed and the assertion ran.
- Replace with awaiting an `asyncio.Event` set inside the callback when `done == total`. FIFO ordering of `call_soon_threadsafe` guarantees that once the final-tick callback runs, every earlier callback has already run — count assertions no longer race the queue regardless of how many loop iterations the drain takes. This is the issue body's suggestion (1).

Diagnostic-friendly failure mode: if no callback ever fires (the worst-case version of the original flake), `wait_for(timeout=5.0)` raises `TimeoutError` instead of silently failing the count assertion at 0.

Production behavior unchanged — `OnnxEmbedder.embed_texts`'s `_thread_cb` / `call_soon_threadsafe` pipeline is fire-and-forget and untouched. This PR only tightens the test harness's wait semantics. Closes #663.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_embedding_progress.py -v` — 12 passed
- [x] 30× stress loop on the two ONNX tests — 30/30 clean (local macOS Py3.13)
- [x] `uv run pytest -m "not ollama"` — 3991 passed, 7 skipped
- [x] `uv run ruff check` + `ruff format --check` on the test file
- [ ] Validation on the macOS Py3.14 GH runner once CI runs — the actual flake host

🤖 Generated with [Claude Code](https://claude.com/claude-code)