### PR TITLE
fix(cli): drive mm index bar length from engine discovery event (#743)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/_index_progress.py
+++ b/packages/memtomem/src/memtomem/cli/_index_progress.py
@@ -2,21 +2,19 @@
 seed flow.
 
 Both call sites stream :meth:`IndexEngine.index_path_stream` and render the
-same ``click.progressbar`` shape: file-unit length pre-computed up front,
-``progress`` events advance the bar by one and reset the chunk-throttle clock,
-``chunk_progress`` events refresh the sub-label only (no advance), throttled
-to a 100 ms gap with a forced final-tick render so ``(N/N)`` lands before the
-next file boundary. Issue #659 tracks extracting the throttle into a helper
-shared with the web Index tab (``web/static/app.js``); that's deferred to
-rule-of-three on the JS side. The CLI side fires now (two callers: the
-wizard's :func:`_seed_with_progress` and ``mm index``'s ``_index``).
+same ``click.progressbar`` shape: file-unit length supplied by the engine's
+``discovery`` event, ``progress`` events advance the bar by one and reset
+the chunk-throttle clock, ``chunk_progress`` events refresh the sub-label
+only (no advance), throttled to a 100 ms gap with a forced final-tick render
+so ``(N/N)`` lands before the next file boundary. Issue #659 tracks
+extracting the throttle into a helper shared with the web Index tab
+(``web/static/app.js``); that's deferred to rule-of-three on the JS side.
+The CLI side fires now (two callers: the wizard's
+:func:`_seed_with_progress` and ``mm index``'s ``_index``).
 
 Caller responsibilities (deliberately split out so the two surfaces can keep
 their distinct UX):
 
-* Compute ``expected_total`` (file-unit bar length) — the wizard sums it
-  across multiple paths via :func:`_collect_seed_scale`; ``mm index`` passes
-  the single-path count.
 * Catch :class:`KeyboardInterrupt` for the resume hint (``mm index <path>``
   vs ``mm web`` Reindex All — different copy per surface).
 * Print the final summary line — ``mm index`` mirrors the legacy
@@ -27,7 +25,7 @@ their distinct UX):
 Helper guarantees: bar is always closed on exit (including raise), stream
 runs serially over the supplied ``paths``, returned aggregate dict has
 stable keys ``total_files``, ``indexed``, ``skipped``, ``deleted``,
-``total_chunks``, ``duration_ms``, ``errors``."""
+``total_chunks``, ``duration_ms``, ``errors``, ``bar_rendered``."""
 
 from __future__ import annotations
 
@@ -42,13 +40,14 @@ import click
 def _collect_seed_scale(memory_dir: Path) -> tuple[int, int]:
     """Count ``.md`` files and total bytes under ``memory_dir``, recursive.
 
-    Two-axis decision input for :func:`_maybe_seed_initial_index` and the
-    progress-bar length precomputation in :func:`run_with_progress`. ``.md``
-    only — other supported extensions (``.json``, ``.py``, etc.) exist but
-    the dominant CLI workflow indexes human-written markdown memos, and the
-    bar length is "good enough" so long as it doesn't undercount the common
-    case. Silent on stat/permission errors: a dir the user can't read is
-    one the index can't process either, so return (0, 0) and fall through.
+    Decision input for :func:`_maybe_seed_initial_index`'s seed-or-skip
+    threshold gate (file-count + size axis). ``.md`` only — other supported
+    extensions (``.json``, ``.py``, etc.) exist but the dominant wizard
+    workflow seeds human-written markdown memos. The progress-bar length is
+    no longer derived here; the engine emits a ``discovery`` event with the
+    actual file count it plans to process (issue #743). Silent on
+    stat/permission errors: a dir the user can't read is one the index
+    can't process either, so return (0, 0) and fall through.
     """
     if not memory_dir.exists():
         return 0, 0
@@ -70,7 +69,6 @@ async def run_with_progress(
     paths: Sequence[Path],
     *,
     label: str,
-    expected_total: int,
     recursive: bool = True,
     force: bool = False,
     namespace: str | None = None,
@@ -84,10 +82,6 @@ async def run_with_progress(
         in turn; complete-event counters aggregate across the run.
     label:
         Progress-bar label (e.g. ``"  Indexing"`` or ``"  Seeding"``).
-    expected_total:
-        Pre-computed bar length in **file units**. Caller uses
-        :func:`_collect_seed_scale` (or sums it across multiple paths) so
-        the percent indicator is stable from the first event onwards.
     recursive, force, namespace:
         Forwarded verbatim to ``index_path_stream``. ``namespace`` is
         ``None`` for the wizard seed (preserves prior behavior — namespace
@@ -99,7 +93,10 @@ async def run_with_progress(
     dict
         Aggregate of all ``complete`` events with keys ``total_files``,
         ``indexed``, ``skipped``, ``deleted``, ``total_chunks``,
-        ``duration_ms``, and ``errors`` (a list of human-readable strings).
+        ``duration_ms``, ``errors`` (a list of human-readable strings),
+        and ``bar_rendered`` (bool — whether any event triggered bar
+        creation; callers use this to gate trailing-newline output that
+        would otherwise leave a stray blank line on empty discovers).
         Caller renders its own summary line from this.
 
     Raises
@@ -121,6 +118,7 @@ async def run_with_progress(
         "total_chunks": 0,
         "duration_ms": 0.0,
         "errors": [],
+        "bar_rendered": False,
     }
 
     # Throttle clock for ``chunk_progress`` label refreshes. Mirrors the web
@@ -145,19 +143,28 @@ async def run_with_progress(
         # backslash paths correctly.
         return Path(str(item)).name[:40]
 
-    def _ensure_bar() -> None:
-        # Lazy creation: the bar can come into existence on EITHER the first
-        # ``chunk_progress`` OR the first ``progress`` event, whichever
-        # arrives first. ``chunk_progress`` for a given file is emitted before
-        # that file's ``progress`` summary, so for large files the bar
-        # appears at chunk-level rather than waiting for the first file to
-        # finish.
+    def _ensure_bar(length: int) -> None:
+        # Lazy creation. Callers pass the file-unit length they know about
+        # (engine ``discovery`` event → exact count for that stream;
+        # progress / chunk_progress fallback → ``files_total`` from the
+        # event, used when a stub engine doesn't emit ``discovery``).
         if bar_state["bar"] is None:
             bar_state["bar"] = click.progressbar(
-                length=expected_total,
+                length=length,
                 label=label,
                 item_show_func=_format_item,
             ).__enter__()
+            agg["bar_rendered"] = True
+
+    def _grow_bar(extra: int) -> None:
+        # Multi-path streams: each ``index_path_stream`` call emits its own
+        # ``discovery``. The first sets the bar length; subsequent ones
+        # extend it so the percent indicator stays accurate across the whole
+        # run instead of resetting per path.
+        if bar_state["bar"] is None:
+            _ensure_bar(extra)
+        else:
+            bar_state["bar"].length += extra
 
     def _close_bar() -> None:
         if bar_state["bar"] is not None:
@@ -175,7 +182,16 @@ async def run_with_progress(
                 async for evt in comp.index_engine.index_path_stream(
                     p, recursive=recursive, force=force, namespace=namespace
                 ):
-                    if evt["type"] == "chunk_progress":
+                    if evt["type"] == "discovery":
+                        # Authoritative bar-length source. Engine emits this
+                        # exactly once per stream call after ``_discover_files``
+                        # has run, so the bar appears immediately even when
+                        # the first file's embedding takes a while (no
+                        # ``chunk_progress`` for small files, ``progress``
+                        # only at file completion — without ``discovery``
+                        # the bar would stay invisible until that point).
+                        _grow_bar(evt["files_total"])
+                    elif evt["type"] == "chunk_progress":
                         # Server-side gating in ``indexing/engine.py`` already
                         # filters out small files (``progress_threshold``,
                         # default 32), so we don't threshold here — small
@@ -188,7 +204,11 @@ async def run_with_progress(
                         if not is_final and now - throttle_state["last_render"] < 0.1:
                             continue
                         throttle_state["last_render"] = now
-                        _ensure_bar()
+                        # Bar length normally comes from the discovery event
+                        # above; this is just the lazy-create fallback for
+                        # legacy stubs that skip discovery and jump straight
+                        # to chunk_progress.
+                        _ensure_bar(evt["files_total"])
                         # Refresh the sub-label without advancing the bar —
                         # length is in **file units**, so chunks must not
                         # double-count. ``update(0, item)`` re-renders with
@@ -198,7 +218,7 @@ async def run_with_progress(
                         # Reset throttle on file boundary so the next file's
                         # first chunk_progress renders immediately.
                         throttle_state["last_render"] = 0.0
-                        _ensure_bar()
+                        _ensure_bar(evt["files_total"])
                         bar_state["bar"].update(1, evt["file"])
                     elif evt["type"] == "complete":
                         agg["total_files"] += evt["total_files"]

--- a/packages/memtomem/src/memtomem/cli/indexing.py
+++ b/packages/memtomem/src/memtomem/cli/indexing.py
@@ -120,19 +120,14 @@ async def _index(path: str, recursive: bool, force: bool, namespace: str | None)
     pre-stream implementation since scripts may grep it; the helper
     aggregates ``deleted`` and ``duration_ms`` from the stream's
     ``complete`` events so the format is preserved verbatim."""
-    from memtomem.cli._index_progress import _collect_seed_scale, run_with_progress
+    from memtomem.cli._index_progress import run_with_progress
 
     resolved = Path(path).resolve()
-    # File-unit bar length. ``_collect_seed_scale`` counts ``.md`` only,
-    # which is the dominant case; a percent indicator that slightly
-    # under/over-shoots for non-md files is still useful UX vs a spinner.
-    expected_total = _collect_seed_scale(resolved)[0]
 
     try:
         agg = await run_with_progress(
             [resolved],
             label="  Indexing",
-            expected_total=expected_total,
             recursive=recursive,
             force=force,
             namespace=namespace,
@@ -148,8 +143,11 @@ async def _index(path: str, recursive: bool, force: bool, namespace: str | None)
     # duration). Summary line follows the bar so click's
     # progressbar.__exit__ has already cleaned up the trailing carriage
     # return; an explicit ``click.echo()`` separates them cleanly when the
-    # bar actually rendered.
-    if expected_total > 0:
+    # bar actually rendered. Bar-rendered comes from the helper (issue #743 —
+    # was previously gated on ``expected_total > 0``, which itself counted
+    # ``.md`` files only and thus suppressed the separator on legitimate
+    # non-``.md`` indexes).
+    if agg["bar_rendered"]:
         click.echo()
     click.echo(
         f"Indexed {agg['total_files']} file(s): "

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1596,9 +1596,11 @@ def _seed_with_progress(paths: list[Path]) -> bool:
     union of ``memory_dir`` + ``provider_dirs`` (issue #360 followup).
 
     Paths are streamed serially and their complete-event counters are
-    aggregated into one green summary line. The progress bar length is
-    pre-computed via :func:`_collect_seed_scale` so the percent indicator
-    is stable even when the streamed file list spans multiple roots.
+    aggregated into one green summary line. The progress bar length comes
+    from each stream's ``discovery`` event (issue #743) — first path's
+    discovery creates the bar, subsequent paths' discoveries extend it so
+    the percent indicator stays accurate across the whole multi-root run
+    without a duplicate ``rglob`` walk up front.
 
     Cancellation: a ``KeyboardInterrupt`` inside the async stream escapes
     through ``asyncio.run`` as a regular ``KeyboardInterrupt`` — caught
@@ -1626,10 +1628,6 @@ def _seed_with_progress(paths: list[Path]) -> bool:
     if not paths:
         return False
 
-    # Pre-compute so the progress bar length spans all paths, not just
-    # the first one. Stays accurate across serial iteration.
-    expected_total = sum(_collect_seed_scale(p)[0] for p in paths)
-
     resume_hint = f"mm index {paths[0]}" if len(paths) == 1 else "mm web  (Sources → Reindex All)"
 
     try:
@@ -1637,7 +1635,6 @@ def _seed_with_progress(paths: list[Path]) -> bool:
             _run_index_with_progress(
                 paths,
                 label="  Seeding",
-                expected_total=expected_total,
                 recursive=True,
                 force=False,
                 namespace=None,

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -836,6 +836,15 @@ class IndexEngine:
         """Like index_path(), but yields progress dicts as each file is processed.
 
         Yields dicts with ``type`` key:
+        - ``"discovery"``: emitted exactly once after the file walk has
+          determined ``files_total`` and before any per-file work begins.
+          Fields: ``files_total``. Lets CLI progress bars set their length
+          without re-walking the tree (the helper would otherwise have to
+          pre-compute ``expected_total`` via its own ``rglob``, duplicating
+          I/O and undercounting non-``.md`` corpora — see issue #743).
+          Skipped only when the path doesn't resolve to a file or
+          directory (in which case the next event is ``complete`` with
+          ``total_files=0``).
         - ``"chunk_progress"``: emitted *during* a single file's embedding
           when the file produces more chunks than
           ``EmbeddingConfig.progress_threshold``. Fields: ``file,
@@ -880,6 +889,13 @@ class IndexEngine:
                 return
 
             total_files = len(files)
+            # Discovery event lets CLI progress bars set their length from the
+            # actual indexable file count instead of pre-computing via a
+            # duplicate ``rglob`` walk (issue #743). Emitted unconditionally
+            # so the helper's lazy-bar branch fires for empty discovers too
+            # (length=0 bar is still a valid render and avoids a special case
+            # downstream).
+            yield {"type": "discovery", "files_total": total_files}
             # Pre-compute the namespace echo so the complete event surfaces
             # what was actually applied — single render across both stream
             # and non-stream paths (see ``_index_path_inner``).

--- a/packages/memtomem/tests/test_indexing_cli.py
+++ b/packages/memtomem/tests/test_indexing_cli.py
@@ -212,3 +212,86 @@ class TestIndexFlagPassthrough:
         assert kwargs.get("recursive") is True
         assert kwargs.get("force") is False
         assert kwargs.get("namespace") is None
+
+
+class TestIndexBarLengthFromDiscovery:
+    """Issue #743: progress-bar length comes from the engine's ``discovery``
+    event, not from a pre-computed ``.md``-only ``rglob`` walk.
+    """
+
+    def test_no_collect_seed_scale_call_during_index(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm index`` must not invoke ``_collect_seed_scale`` (the
+        wizard's ``.md``-only counter). Regression guard for the duplicate
+        ``rglob`` walk that #743 removed — the engine's ``discovery`` event
+        is the only bar-length source on the indexing path now."""
+        target = tmp_path / "src"
+        target.mkdir()
+        (target / "module.py").write_text("def f():\n    return 1\n")
+
+        called = {"count": 0}
+
+        def _spy(p):
+            called["count"] += 1
+            return (0, 0)
+
+        monkeypatch.setattr("memtomem.cli._index_progress._collect_seed_scale", _spy)
+
+        events = [
+            {"type": "discovery", "files_total": 1},
+            _make_complete_event(total_files=1, indexed=1),
+        ]
+        _install_fake_engine(monkeypatch, events=events)
+
+        asyncio.run(_index(str(target), recursive=True, force=False, namespace=None))
+        assert called["count"] == 0, (
+            "_collect_seed_scale must not be called from mm index — "
+            "discovery event is the bar-length source (#743)"
+        )
+
+    def test_bar_renders_for_non_md_corpus(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``mm index ./src/`` (no ``.md`` files) must still render a
+        progress bar. Pre-#743 the bar was suppressed because
+        ``_collect_seed_scale`` returned 0 → ``expected_total=0`` → click
+        rendered nothing. With discovery driving length, the bar appears
+        with the engine's actual file count."""
+        target = tmp_path / "src"
+        target.mkdir()
+        (target / "module.py").write_text("def f():\n    return 1\n")
+
+        captured: dict = {}
+        events = [
+            {"type": "discovery", "files_total": 1},
+            {
+                "type": "progress",
+                "file": str(target / "module.py"),
+                "files_done": 1,
+                "files_total": 1,
+                "indexed": 1,
+                "skipped": 0,
+            },
+            _make_complete_event(total_files=1, indexed=1),
+        ]
+        _install_fake_engine(monkeypatch, events=events)
+
+        import click
+
+        from memtomem.cli import _index_progress as ip_mod
+
+        real_progressbar = click.progressbar
+
+        def _spy(*args, **kwargs):
+            bar = real_progressbar(*args, **kwargs)
+            captured["bar"] = bar
+            captured["initial_length"] = kwargs.get("length")
+            return bar
+
+        # Helper imports click at module scope — patch there.
+        monkeypatch.setattr(ip_mod.click, "progressbar", _spy)
+
+        asyncio.run(_index(str(target), recursive=True, force=False, namespace=None))
+        assert "bar" in captured, "bar must be created from discovery event"
+        assert captured["initial_length"] == 1

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -401,6 +401,61 @@ class TestExcludePatterns:
         )
         assert any("blob.md" in err for err in complete["errors"])
 
+    async def test_index_path_stream_emits_discovery_first(self, components, memory_dir):
+        """Issue #743: ``index_path_stream`` emits a ``discovery`` event with
+        ``files_total`` BEFORE any ``progress`` / ``chunk_progress`` /
+        ``complete`` event so CLI helpers can size their progress bar without
+        a duplicate ``rglob`` walk. Pinned ordering: discovery is the first
+        non-empty event whenever ``files_total > 0``.
+        """
+        # Two files, one excluded by the binary-detection branch — discovery
+        # counts what ``_discover_files`` returns (post-extension filter,
+        # pre-binary check), so this should report 2.
+        (memory_dir / "a.md").write_text("# a\n\nbody a")
+        (memory_dir / "b.md").write_text("# b\n\nbody b")
+
+        engine = components.index_engine
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+
+        assert events, "expected at least one event"
+        assert events[0]["type"] == "discovery", (
+            f"first event must be discovery, got {events[0]['type']}"
+        )
+        assert events[0]["files_total"] == 2
+
+    async def test_index_path_stream_discovery_for_non_md_corpus(self, components, memory_dir):
+        """Discovery should reflect the engine's own extension filter, not the
+        ``.md``-only count that the wizard's ``_collect_seed_scale`` uses.
+        Regression for #743 — ``mm index ./src/`` (Python project) silently
+        rendered a length-0 bar because the helper pre-computed via
+        ``_collect_seed_scale``. Engine discovery covers all supported
+        extensions.
+        """
+        (memory_dir / "module.py").write_text("def f():\n    return 1\n")
+        (memory_dir / "notes.md").write_text("# n\n\nbody")
+
+        engine = components.index_engine
+        events = [ev async for ev in engine.index_path_stream(memory_dir, recursive=True)]
+
+        discovery = next(e for e in events if e["type"] == "discovery")
+        # Both files counted — the .md-only filter would have undercounted by 1.
+        assert discovery["files_total"] == 2
+
+    async def test_index_path_stream_no_discovery_for_invalid_path(self, components, memory_dir):
+        """When the path doesn't resolve to a file or directory the stream
+        shortcuts to a single ``complete`` event and skips ``discovery`` —
+        consumers should not see a discovery=0 event followed by complete=0
+        for nonexistent paths (would falsely create a 0-length bar).
+        """
+        engine = components.index_engine
+        events = [ev async for ev in engine.index_path_stream(memory_dir / "nope", recursive=False)]
+
+        assert all(e["type"] != "discovery" for e in events), (
+            "discovery must be skipped for nonexistent paths"
+        )
+        assert events[-1]["type"] == "complete"
+        assert events[-1]["total_files"] == 0
+
 
 # ===========================================================================
 # 1.a.2 Per-chunk progress: chunk_progress events + threshold gate
@@ -593,9 +648,12 @@ class TestChunkProgressStream:
         assert engine._active_runs == 0
 
         gen = engine.index_path_stream(memory_dir, recursive=True)
+        # Discovery event arrives first now (#743). Consume it and continue —
+        # the actual subject of this test is the chunk_progress event the
+        # slow embedder parks on.
         first = await gen.__anext__()
-        # First yield must be the chunk_progress event (chunker + first
-        # progress fire happen before _index_file completes).
+        assert first["type"] == "discovery"
+        first = await gen.__anext__()
         assert first["type"] == "chunk_progress"
         assert engine._active_runs == 1
 
@@ -670,7 +728,10 @@ class TestActiveRunsCounter:
 
         gen = engine.index_path_stream(memory_dir, recursive=True)
         first = await gen.__anext__()
-        assert first.get("type") in ("progress", "complete")
+        # ``discovery`` arrives first when the path resolves to a real
+        # file or directory (#743); ``progress`` / ``complete`` only when
+        # the dir is empty or the path is invalid (legacy paths).
+        assert first.get("type") in ("discovery", "progress", "complete")
         assert engine.is_active is True
 
         async for _ in gen:
@@ -721,6 +782,10 @@ class TestActiveRunsCounter:
         assert engine.is_active is False
 
         gen = engine.index_path_stream(memory_dir, recursive=True)
+        # Discovery arrives first (#743); skip past it to land on progress
+        # so the aclose still tests cancellation between per-file events.
+        ev = await gen.__anext__()
+        assert ev.get("type") == "discovery"
         ev = await gen.__anext__()
         assert ev.get("type") == "progress"
         assert engine._active_runs == 1

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -4930,6 +4930,7 @@ class TestInitialSeedThreshold:
 
         class _FakeEngine:
             async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+                yield {"type": "discovery", "files_total": 1}
                 yield {
                     "type": "progress",
                     "file": str(memory_dir / "a.md"),
@@ -4985,6 +4986,7 @@ class TestInitialSeedThreshold:
 
         class _FakeEngine:
             async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+                yield {"type": "discovery", "files_total": 1}
                 yield {
                     "type": "progress",
                     "file": str(memory_dir / "a.md"),
@@ -5171,9 +5173,11 @@ class TestInitialSeedThreshold:
         dir_a.mkdir()
         dir_b = tmp_path / "b"
         dir_b.mkdir()
-        # _seed_with_progress pre-computes expected_total from
-        # _collect_seed_scale; write one .md each so the scan reports
-        # non-zero and the bar doesn't trip the "no files" fallback.
+        # Real source files for the on-disk roots — the fake engine returns
+        # synthetic event counts, but the directories still need to exist
+        # and contain something so any future assertion that walks the tree
+        # has something to find. (No longer load-bearing for the bar length
+        # since #743 — that comes from the engine's discovery event.)
         self._write_md(dir_a, "a.md", "hello")
         self._write_md(dir_b, "b.md", "world")
 
@@ -5186,6 +5190,7 @@ class TestInitialSeedThreshold:
             async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
                 key = str(path)
                 counts = path_counts[key]
+                yield {"type": "discovery", "files_total": counts["total_files"]}
                 yield {
                     "type": "progress",
                     "file": f"{key}/file.md",
@@ -5282,6 +5287,7 @@ class TestInitialSeedThreshold:
 
         class _FakeEngine:
             async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+                yield {"type": "discovery", "files_total": 1}
                 file = str(memory_dir / "big.md")
                 # Server only emits chunk_progress when the file exceeds the
                 # ``progress_threshold`` (default 32). Mimic a 50-chunk file.
@@ -5363,6 +5369,7 @@ class TestInitialSeedThreshold:
 
         class _FakeEngine:
             async def index_path_stream(self, path, recursive=True, force=False, namespace=None):
+                yield {"type": "discovery", "files_total": 2}
                 for name in ("a.md", "b.md"):
                     yield {
                         "type": "progress",


### PR DESCRIPTION
## Summary

- ``IndexEngine.index_path_stream`` now emits a ``discovery`` event with the engine's actual ``files_total`` right after ``_discover_files`` runs.
- ``cli/_index_progress.run_with_progress`` consumes ``discovery`` to lazy-create (and, for multi-path runs, grow) the ``click.progressbar``. The ``expected_total`` parameter is gone.
- ``mm index`` and the wizard's ``_seed_with_progress`` no longer pre-compute via ``_collect_seed_scale`` — bar length comes from the stream.

## Why

Pre-#743 ``mm index ./src/`` (Python project, no ``.md`` files) showed no progress bar because ``_collect_seed_scale`` only counted ``.md``. Long runs looked hung. The pre-compute also duplicated the ``rglob`` walk that the engine itself does in ``_discover_files``.

## Notes

- ``_collect_seed_scale`` stays in place for ``_maybe_seed_initial_index``'s seed-or-skip threshold gate (file-count + size axis), per the issue's acceptance.
- Helper return now includes ``bar_rendered`` (bool); ``mm index`` uses it to gate the trailing newline that the legacy ``expected_total > 0`` check used to gate.
- 3 existing engine tests updated to skip-past or accept the new ``discovery`` event as the first ``index_path_stream`` yield.

## Test plan

- [x] ``uv run pytest packages/memtomem/tests -m \"not ollama\"`` — 3996 passed, 7 skipped
- [x] ``uv run ruff check packages/memtomem/src packages/memtomem/tests`` — clean
- [x] ``uv run ruff format --check ...`` — clean
- [x] New: ``test_index_path_stream_emits_discovery_first`` (engine emits discovery first)
- [x] New: ``test_index_path_stream_discovery_for_non_md_corpus`` (.py file counted; the #743 reproducer)
- [x] New: ``test_index_path_stream_no_discovery_for_invalid_path`` (no spurious 0-length bar)
- [x] New: ``test_no_collect_seed_scale_call_during_index`` (no duplicate rglob)
- [x] New: ``test_bar_renders_for_non_md_corpus`` (bar appears for ``mm index ./src/``)

Closes #743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)