### PR TITLE
fix(web): drop search-input pollution from _searchByTag (closes #672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   filter on whatever the user was already searching for. If
   `search-input` is empty the click acts as a "filter prep": the Search
   tab opens with `tag-filter` populated, but `doSearch()` early-returns
-  on the empty query so no results render until the user types one. A
-  follow-up will allow tag-only searches without a query.
+  on the empty query so no results render until the user types one.
+  Follow-up #750 tracks relaxing the empty-q guard so a fresh-session
+  click runs as a true tag-only search.
 
 ## [0.1.35] — 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **Tag pill clicks no longer overwrite the search query (closes #672).**
+  Clicking a tag in the Tags Cloud or List view now sets only `tag-filter`,
+  leaving any text already in `search-input` intact. Previously
+  `_searchByTag` copied the tag string into both fields, so the backend
+  ran a confusing dual-axis search where the BM25 query and the tag
+  filter were the same string — documents that merely *mentioned* the
+  tag in prose got boosted on top of the tag-filter constraint, and the
+  search bar looked as if the user had typed the tag themselves. With
+  the BM25 query left alone, a tag pill click is now a pure narrowing
+  filter on whatever the user was already searching for. If
+  `search-input` is empty the click acts as a "filter prep": the Search
+  tab opens with `tag-filter` populated, but `doSearch()` early-returns
+  on the empty query so no results render until the user types one. A
+  follow-up will allow tag-only searches without a query.
+
 ## [0.1.35] — 2026-05-02
 
 ### Added

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4057,10 +4057,10 @@ function _renderTagCloud(tags, maxCount) {
 }
 
 function _searchByTag(tag) {
-  // Navigate to Search tab with tag filter pre-filled
+  // Navigate to Search tab with tag filter pre-filled.
+  // search-input is intentionally left untouched so the tag is a filter axis
+  // only, not a duplicate BM25 query. doSearch early-returns on empty q.
   document.querySelector('[data-tab="search"]').click();
-  qs('search-input').value = tag;
-  // Open filters row if hidden
   const filters = document.querySelector('.search-filters');
   if (filters.hidden) qs('filter-toggle').click();
   qs('tag-filter').value = tag;


### PR DESCRIPTION
## Summary
- `_searchByTag` no longer copies the clicked tag into `search-input` — it sets only `tag-filter`. The Tags Cloud / Tags List pill click is now a pure narrowing filter on whatever the user was already searching for, instead of running a confusing dual-axis search where BM25 ranked documents that merely *mentioned* the tag in prose on top of the tag-filter constraint.
- When `search-input` is empty, the click acts as a "filter prep": Search tab opens, `tag-filter` populated, but `doSearch()` early-returns on the empty `q` so no results render. Follow-up tracked in #750 (relax frontend + backend empty-q guard so a fresh-session click runs as a true tag-only search).
- CHANGELOG entry added under `[Unreleased] / Changed` (Keep a Changelog format) — user-visible behaviour change, so noted explicitly.

## Why this is one focused PR (per CONTRIBUTING.md)
The bug is a UX axis-duplication: the same tag string was being applied as both BM25 query and tag filter. Removing the duplication (this PR) is independent of supporting empty-q tag-only searches (#750). Doing both together would force a backend `q` schema change into a frontend behaviour fix, which `CONTRIBUTING.md` explicitly discourages.

## Test plan
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run pytest -m "not ollama"` — 3994 passed, 7 skipped, 46 deselected
- [ ] Manual `mm web`:
  - [ ] **Narrowing**: type a query in Search → Tags tab → click pill → Search tab returns, `search-input` keeps original query, `tag-filter` shows clicked tag, results = (query ∩ tag).
  - [ ] **Filter prep**: fresh session → Tags tab → click pill → Search tab activates, `tag-filter` populated, `search-input` empty, no results render. Type query → results.
  - [ ] **Result-panel tag chip click** (`app.js:2413`): unchanged — still overwrites `tag-filter` and re-runs.
  - [ ] **Filter chip X clear**: unchanged.