### PR TITLE
fix(web): allow tag-only search on a fresh session (closes #750)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   tag in prose got boosted on top of the tag-filter constraint, and the
   search bar looked as if the user had typed the tag themselves. With
   the BM25 query left alone, a tag pill click is now a pure narrowing
-  filter on whatever the user was already searching for. If
-  `search-input` is empty the click acts as a "filter prep": the Search
-  tab opens with `tag-filter` populated, but `doSearch()` early-returns
-  on the empty query so no results render until the user types one.
-  Follow-up #750 tracks relaxing the empty-q guard so a fresh-session
-  click runs as a true tag-only search.
+  filter on whatever the user was already searching for.
+
+- **Tag pill click runs a tag-only search on a fresh session (closes #750).**
+  After #672 stopped `_searchByTag` from copying the clicked tag into
+  `search-input`, a fresh-session click left `search-input` empty and
+  the search early-returned — landing the user on the Search tab with
+  `tag-filter` populated but no results, requiring an extra keystroke
+  to actually run. The frontend `doSearch()` / `load-more-btn` guards
+  now allow a search whenever either `q` *or* `tag-filter` has a
+  value; the `/api/search` route's `q` parameter is optional
+  (rejecting only "no axis at all" with a 400); and
+  `SearchPipeline.search` routes empty-query calls through a new
+  `_filter_only_search` branch that enumerates via
+  `storage.recall_chunks(tag_filter=…)` and skips
+  BM25/dense/expansion/rescue/rerank — the post-filter stages
+  (validity → decay → access boost → importance boost → context
+  window) still apply so the rank reflects recency × access ×
+  importance. `recall_chunks` gained an optional `tag_filter` kwarg
+  with the same comma-separated OR semantics as the keyword path's
+  post-fusion tag filter.
 
 ## [0.1.35] — 2026-05-02
 

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -1,4 +1,18 @@
-"""Search pipeline: BM25 + Dense + RRF fusion."""
+"""Search pipeline: BM25 + Dense + RRF fusion.
+
+Stage order (keyword path, fixed — see ``CLAUDE.md`` invariants):
+expansion → BM25 + dense (parallel) → RRF fusion → cross-encoder
+rerank (optional) → source/tag filter → validity filter → time-decay
+→ MMR → access-freq boost → importance boost → context-window
+expansion.
+
+Empty-query path (``query=""`` / ``None`` with ``tag_filter`` /
+``source_filter`` set, #750) routes through ``_filter_only_search``
+and skips expansion / BM25 / dense / RRF / rerank / MMR — none of
+those have a meaningful signal without a query. Validity → decay →
+access → importance → context-window still apply so the rank
+reflects recency × access × importance.
+"""
 
 from __future__ import annotations
 
@@ -436,9 +450,20 @@ class SearchPipeline:
         )
 
         # Over-sample so the validity stage can prune without starving
-        # the response. Bounded so a tag with millions of chunks can't
-        # blow up memory — ``top_k * 5`` mirrors the rerank-pool floor
-        # logic and 500 is the route's hard cap on top_k.
+        # the response. ``top_k * 5`` mirrors the rerank-pool floor logic
+        # used in the keyword path; floored at 100 for tiny ``top_k``.
+        # Worst case ≈ 2500 candidates given the route's ``top_k <= 500``
+        # cap, which is the same order as ``bm25_candidates``.
+        #
+        # On a popular tag (chunk count > candidate_limit) older highly
+        # accessed/important chunks beyond this recency cutoff never reach
+        # the boost stages — ``recall_chunks`` orders ``created_at DESC``,
+        # so this is a "browse newest by tag" UX, not "rank everything by
+        # importance". The keyword path doesn't have this floor because
+        # BM25/dense pre-filter on relevance; here recency is the only
+        # signal we have to cap on. Acceptable for the click-the-pill
+        # workflow; revisit if a "show me old-but-important by tag" need
+        # surfaces.
         candidate_limit = max(top_k * 5, 100)
         chunks = await self._storage.recall_chunks(
             source_filter=source_filter,

--- a/packages/memtomem/src/memtomem/search/pipeline.py
+++ b/packages/memtomem/src/memtomem/search/pipeline.py
@@ -408,6 +408,104 @@ class SearchPipeline:
             )
         return expanded
 
+    async def _filter_only_search(
+        self,
+        *,
+        top_k: int | None,
+        source_filter: str | None,
+        tag_filter: str | None,
+        namespace: str | list[str] | None,
+        context_window: int | None,
+        as_of_unix: int | None,
+    ) -> tuple[list[SearchResult], RetrievalStats]:
+        """Empty-query path (#750): enumerate by filter, skip retrievers.
+
+        Tag and/or source filter become the primary selectors via
+        ``recall_chunks``. Each candidate enters with ``score=1.0`` so
+        the post-filter stages (validity → decay → access → importance)
+        produce a meaningful order even without a keyword to rank by.
+        MMR and the reranker are skipped — both need a query/embedding
+        signal that doesn't exist in this mode.
+        """
+        import time
+
+        top_k = self._config.default_top_k if top_k is None else top_k
+        ns_filter = NamespaceFilter.parse(
+            namespace,
+            system_prefixes=tuple(self._config.system_namespace_prefixes),
+        )
+
+        # Over-sample so the validity stage can prune without starving
+        # the response. Bounded so a tag with millions of chunks can't
+        # blow up memory — ``top_k * 5`` mirrors the rerank-pool floor
+        # logic and 500 is the route's hard cap on top_k.
+        candidate_limit = max(top_k * 5, 100)
+        chunks = await self._storage.recall_chunks(
+            source_filter=source_filter,
+            tag_filter=tag_filter,
+            namespace_filter=ns_filter,
+            limit=candidate_limit,
+        )
+
+        fused: list[SearchResult] = [
+            SearchResult(chunk=c, score=1.0, rank=i + 1, source="recall")
+            for i, c in enumerate(chunks)
+        ]
+        stats = RetrievalStats(fused_total=len(fused))
+
+        effective_as_of = as_of_unix if as_of_unix is not None else int(time.time())
+        if fused:
+            fused = _apply_validity_filter(fused, effective_as_of)
+
+        if self._decay_config.enabled and fused:
+            from memtomem.search.decay import apply_score_decay
+
+            fused = apply_score_decay(fused, half_life_days=self._decay_config.half_life_days)
+
+        if self._access_config.enabled and fused:
+            from memtomem.search.access import apply_access_boost
+
+            access_chunk_ids = [r.chunk.id for r in fused]
+            access_counts = await self._storage.get_access_counts(access_chunk_ids)
+            fused = apply_access_boost(
+                fused, access_counts, max_boost=self._access_config.max_boost
+            )
+
+        if self._importance_config and getattr(self._importance_config, "enabled", False) and fused:
+            from memtomem.search.importance import apply_importance_boost
+
+            chunk_ids_imp = [r.chunk.id for r in fused]
+            imp_scores = await self._storage.get_importance_scores(chunk_ids_imp)
+            fused = apply_importance_boost(
+                fused,
+                imp_scores,
+                max_boost=getattr(self._importance_config, "max_boost", 1.5),
+            )
+
+        # Re-sort after boosts and trim to ``top_k``. Boost stages mutate
+        # scores but preserve list order; the keyword path relies on the
+        # reranker / RRF for final ordering, so this branch sorts here.
+        fused.sort(key=lambda r: r.score, reverse=True)
+        fused = fused[:top_k]
+
+        ctx_win = self._resolve_context_window(context_window)
+        if ctx_win > 0 and fused:
+            fused = await self._expand_context(fused, ctx_win)
+
+        stats.final_total = len(fused)
+
+        if fused:
+
+            async def _increment():
+                await self._storage.increment_access([r.chunk.id for r in fused])
+
+            t = asyncio.create_task(_increment())
+            t.add_done_callback(_bg_task_error_cb)
+            self._bg_tasks.add(t)
+            t.add_done_callback(self._bg_tasks.discard)
+
+        return fused, stats
+
     async def search(
         self,
         query: str,
@@ -419,6 +517,25 @@ class SearchPipeline:
         context_window: int | None = None,
         as_of_unix: int | None = None,
     ) -> tuple[list[SearchResult], RetrievalStats]:
+        # #750: tag/source-only branch — no keyword to rank by, so the
+        # filter takes over as the primary selector. We enumerate via
+        # ``recall_chunks`` and skip BM25/dense/expansion/rescue/rerank
+        # entirely; post-filter stages (validity, decay, access,
+        # importance, ctx-window) still apply so ranking reflects
+        # recency × access × importance.
+        query = (query or "").strip()
+        if not query:
+            if not (tag_filter or source_filter):
+                return [], RetrievalStats()
+            return await self._filter_only_search(
+                top_k=top_k,
+                source_filter=source_filter,
+                tag_filter=tag_filter,
+                namespace=namespace,
+                context_window=context_window,
+                as_of_unix=as_of_unix,
+            )
+
         top_k = self._config.default_top_k if top_k is None else top_k
         effective_weights = rrf_weights or self._config.rrf_weights
 

--- a/packages/memtomem/src/memtomem/storage/base.py
+++ b/packages/memtomem/src/memtomem/storage/base.py
@@ -58,6 +58,7 @@ class StorageBackend(Protocol):
         source_filter: str | None = None,
         limit: int = 20,
         namespace_filter: NamespaceFilter | None = None,
+        tag_filter: str | None = None,
     ) -> list[Chunk]: ...
 
     # Namespace

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -948,6 +948,7 @@ class SqliteBackend(
         source_filter: str | None = None,
         limit: int = 20,
         namespace_filter: NamespaceFilter | None = None,
+        tag_filter: str | None = None,
     ) -> list[Chunk]:
         db = self._get_read_db()
         conditions: list[str] = []
@@ -967,6 +968,19 @@ class SqliteBackend(
             if frag:
                 conditions.append(frag)
                 params.extend(ns_params)
+        if tag_filter is not None:
+            # Comma-separated tags = OR matching, mirroring the
+            # post-fusion semantics in ``SearchPipeline.search`` so the
+            # tag-only path (#750) ranks the same set the keyword path
+            # would have filtered down to.
+            tags = [t.strip() for t in tag_filter.split(",") if t.strip()]
+            if tags:
+                placeholders = ",".join("?" for _ in tags)
+                conditions.append(
+                    f"EXISTS (SELECT 1 FROM json_each(chunks.tags) "
+                    f"WHERE json_each.value IN ({placeholders}))"
+                )
+                params.extend(tags)
 
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.append(limit)

--- a/packages/memtomem/src/memtomem/web/routes/search.py
+++ b/packages/memtomem/src/memtomem/web/routes/search.py
@@ -17,7 +17,7 @@ router = APIRouter(tags=["search"])
 
 @router.get("/search", response_model=SearchResponse)
 async def search(
-    q: str = Query(..., description="Search query", min_length=1, max_length=10_000),
+    q: str | None = Query(None, description="Search query", max_length=10_000),
     top_k: int | None = Query(None, ge=1, le=500),
     source_filter: str | None = Query(None),
     tag_filter: str | None = Query(None),
@@ -25,9 +25,16 @@ async def search(
     context_window: int = Query(0, ge=0, le=10, description="Expand ±N adjacent chunks"),
     pipeline=Depends(get_search_pipeline),
 ) -> SearchResponse:
-    q = q.strip()
-    if not q:
-        raise HTTPException(status_code=422, detail="Query cannot be empty or whitespace-only")
+    # #750: ``q`` is optional so a tag/source-only search (no keyword)
+    # is a first-class path. The pipeline handles the empty-query branch
+    # (filter becomes the primary selector); the API guard here only
+    # rejects "no axis at all" — search needs *something* to scope by.
+    q = (q or "").strip()
+    if not q and not (tag_filter or source_filter):
+        raise HTTPException(
+            status_code=400,
+            detail="Provide at least one of q, tag_filter, or source_filter.",
+        )
 
     try:
         results, rstats = await pipeline.search(

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1672,7 +1672,12 @@ let _searchAbortCtrl = null;
 
 async function doSearch() {
   const q = qs('search-input').value.trim();
-  if (!q) return;
+  const tf = qs('tag-filter').value.trim();
+  // #750: tag-only search is a valid path — clicking a tag pill on a
+  // fresh session leaves ``q`` empty but populates ``tag-filter``, and
+  // the user expects "show me all memos with this tag" rather than a
+  // no-op. The early-return now only fires when both axes are empty.
+  if (!q && !tf) return;
   // #696: kick the readiness poll. Fire-and-forget; the search request
   // proceeds normally — its response covers the spinner. The poll's job
   // is to surface "Downloading bge-m3 (~2.3 GB)…" while the backend's
@@ -1682,13 +1687,13 @@ async function doSearch() {
   // non-terminal for this entry point (see ``_modelComponentDone``).
   _modelReadinessPoll();
   STATE.lastQuery = q;
-  saveToHistory(q);
+  if (q) saveToHistory(q);
   hide(qs('search-history-dropdown'));
   STATE.currentTopK = parseInt(qs('top-k').value, 10);
-  const tf  = qs('tag-filter').value.trim();
   const nsFilter = qs('ns-filter').value;
 
-  const params = new URLSearchParams({ q, top_k: STATE.currentTopK });
+  const params = new URLSearchParams({ top_k: STATE.currentTopK });
+  if (q) params.set('q', q);
   if (tf) params.set('tag_filter', tf);
   if (nsFilter) params.set('namespace', nsFilter);
   const ctxWin = parseInt((qs('context-window') || {}).value || '0', 10);
@@ -4637,10 +4642,12 @@ function _syncSearchToURL() {
 
 qs('load-more-btn').addEventListener('click', async () => {
   const q = qs('search-input').value.trim();
-  if (!q) return;
-  STATE.currentTopK = Math.min(STATE.currentTopK + 10, 100);
   const tf = qs('tag-filter').value.trim();
-  const params = new URLSearchParams({ q, top_k: STATE.currentTopK });
+  // #750: mirror doSearch — load-more is valid in tag-only mode too.
+  if (!q && !tf) return;
+  STATE.currentTopK = Math.min(STATE.currentTopK + 10, 100);
+  const params = new URLSearchParams({ top_k: STATE.currentTopK });
+  if (q) params.set('q', q);
   if (tf) params.set('tag_filter', tf);
   const btn = qs('load-more-btn');
   btnLoading(btn, true);

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -506,3 +506,106 @@ class TestRerankCandidatePool:
         assert FIELD_CONSTRAINTS["rerank.min_pool"]["type"] is int
         assert FIELD_CONSTRAINTS["rerank.max_pool"]["type"] is int
         assert FIELD_CONSTRAINTS["rerank.enabled"]["type"] is bool
+
+
+class TestFilterOnlySearch:
+    """Empty-query path (#750): tag/source filter is the primary selector.
+
+    Tag-pill click on a fresh session lands here — ``q`` is empty but
+    ``tag_filter`` is set, and the user expects "show me all memos with
+    this tag" rather than the pre-#750 no-op. The pipeline must skip
+    BM25/dense/rerank (they need a query) and enumerate via
+    ``recall_chunks`` so the filter can take over as the primary selector.
+    """
+
+    @staticmethod
+    def _make_chunk(name: str, tags: tuple[str, ...] = ()) -> Chunk:
+        return Chunk(
+            content=name,
+            metadata=ChunkMetadata(source_file=Path(f"/tmp/{name}.md"), tags=tags),
+            id=uuid4(),
+            embedding=[],
+        )
+
+    def _make_pipeline(self, recall_return: list[Chunk]):
+        from unittest.mock import AsyncMock
+
+        from memtomem.config import SearchConfig
+        from memtomem.search.pipeline import SearchPipeline
+
+        storage = AsyncMock()
+        storage.recall_chunks = AsyncMock(return_value=recall_return)
+        # bm25/dense should never be reached on the empty-q path — set
+        # them to raise so a regression that drops the early-return
+        # branch fails loudly instead of silently returning [].
+        storage.bm25_search = AsyncMock(side_effect=AssertionError("bm25 must not run"))
+        storage.dense_search = AsyncMock(side_effect=AssertionError("dense must not run"))
+        storage.increment_access = AsyncMock()
+        storage.get_access_counts = AsyncMock(return_value={})
+        storage.get_importance_scores = AsyncMock(return_value={})
+        storage.count_chunks_by_ns_prefix = AsyncMock(return_value=0)
+
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(side_effect=AssertionError("embed_query must not run"))
+
+        return storage, SearchPipeline(
+            storage=storage,
+            embedder=embedder,
+            config=SearchConfig(enable_bm25=True, enable_dense=True),
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_query_with_tag_filter_uses_recall(self):
+        """``q="" + tag_filter`` enumerates via ``recall_chunks`` and
+        forwards the tag through — not via BM25 with an empty query."""
+        chunks = [
+            self._make_chunk("a", tags=("redis",)),
+            self._make_chunk("b", tags=("redis",)),
+        ]
+        storage, pipeline = self._make_pipeline(chunks)
+
+        results, stats = await pipeline.search(query="", tag_filter="redis", top_k=5)
+
+        storage.recall_chunks.assert_awaited_once()
+        kwargs = storage.recall_chunks.await_args.kwargs
+        assert kwargs["tag_filter"] == "redis"
+        assert kwargs["source_filter"] is None
+        assert len(results) == 2
+        assert stats.fused_total == 2
+        assert stats.final_total == 2
+        assert all(r.source == "recall" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_empty_query_with_source_filter_uses_recall(self):
+        """Source-only path mirrors tag-only — same enumeration branch."""
+        chunks = [self._make_chunk("notes")]
+        storage, pipeline = self._make_pipeline(chunks)
+
+        results, _ = await pipeline.search(query="  ", source_filter="notes.md", top_k=5)
+
+        storage.recall_chunks.assert_awaited_once()
+        kwargs = storage.recall_chunks.await_args.kwargs
+        assert kwargs["source_filter"] == "notes.md"
+        assert kwargs["tag_filter"] is None
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_query_no_filters_returns_empty(self):
+        """No keyword *and* no filter → return empty fast, do not enumerate."""
+        storage, pipeline = self._make_pipeline([])
+
+        results, stats = await pipeline.search(query="", top_k=5)
+
+        storage.recall_chunks.assert_not_awaited()
+        assert results == []
+        assert stats.final_total == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_query_trims_to_top_k(self):
+        """Filter-only path honours ``top_k`` after the post-filter sort."""
+        chunks = [self._make_chunk(f"c{i}", tags=("redis",)) for i in range(15)]
+        _, pipeline = self._make_pipeline(chunks)
+
+        results, _ = await pipeline.search(query="", tag_filter="redis", top_k=5)
+
+        assert len(results) == 5

--- a/packages/memtomem/tests/test_pipeline.py
+++ b/packages/memtomem/tests/test_pipeline.py
@@ -519,10 +519,20 @@ class TestFilterOnlySearch:
     """
 
     @staticmethod
-    def _make_chunk(name: str, tags: tuple[str, ...] = ()) -> Chunk:
+    def _make_chunk(
+        name: str,
+        tags: tuple[str, ...] = (),
+        valid_from_unix: int | None = None,
+        valid_to_unix: int | None = None,
+    ) -> Chunk:
         return Chunk(
             content=name,
-            metadata=ChunkMetadata(source_file=Path(f"/tmp/{name}.md"), tags=tags),
+            metadata=ChunkMetadata(
+                source_file=Path(f"/tmp/{name}.md"),
+                tags=tags,
+                valid_from_unix=valid_from_unix,
+                valid_to_unix=valid_to_unix,
+            ),
             id=uuid4(),
             embedding=[],
         )
@@ -609,3 +619,74 @@ class TestFilterOnlySearch:
         results, _ = await pipeline.search(query="", tag_filter="redis", top_k=5)
 
         assert len(results) == 5
+
+    @pytest.mark.asyncio
+    async def test_validity_filter_drops_expired_on_filter_only(self):
+        """Validity stage prunes expired chunks on the filter-only path
+        too — without this guard a tag-only click on a fresh session
+        could surface chunks whose ``valid_to`` has already passed,
+        which the keyword path always filters out. Regression pin for
+        the post-filter parity claim in the docstring."""
+        live = self._make_chunk("live", tags=("redis",))
+        expired = self._make_chunk(
+            "expired",
+            tags=("redis",),
+            valid_to_unix=1_000_000_000,  # 2001 — long expired by any ``as_of``
+        )
+        _, pipeline = self._make_pipeline([live, expired])
+
+        results, _ = await pipeline.search(query="", tag_filter="redis", top_k=10)
+
+        ids = {r.chunk.id for r in results}
+        assert live.id in ids
+        assert expired.id not in ids
+
+    @pytest.mark.asyncio
+    async def test_decay_re_ranks_fresh_above_ancient(self):
+        """The post-filter sort isn't just trim-then-truncate — decay
+        actually re-scores so the freshest chunk lands first. Pins the
+        "rank reflects recency × access × importance" contract: with
+        decay enabled, a brand-new chunk must outrank a 10-year-old one
+        even though both enter at score=1.0.
+        """
+        from datetime import datetime, timedelta, timezone
+        from memtomem.config import DecayConfig
+
+        from unittest.mock import AsyncMock
+        from memtomem.config import SearchConfig
+        from memtomem.search.pipeline import SearchPipeline
+
+        now = datetime.now(timezone.utc)
+        fresh = self._make_chunk("fresh", tags=("redis",))
+        fresh.created_at = now
+        fresh.updated_at = now
+        ancient = self._make_chunk("ancient", tags=("redis",))
+        ancient.created_at = now - timedelta(days=365 * 10)
+        ancient.updated_at = now - timedelta(days=365 * 10)
+
+        # Storage returns ancient first (mimicking ``ORDER BY created_at
+        # DESC LIMIT`` returning a recency-ordered slice that happens to
+        # not be in score order). The post-stages must re-rank.
+        storage = AsyncMock()
+        storage.recall_chunks = AsyncMock(return_value=[ancient, fresh])
+        storage.bm25_search = AsyncMock(side_effect=AssertionError("bm25 must not run"))
+        storage.dense_search = AsyncMock(side_effect=AssertionError("dense must not run"))
+        storage.increment_access = AsyncMock()
+        storage.get_access_counts = AsyncMock(return_value={})
+        storage.get_importance_scores = AsyncMock(return_value={})
+        storage.count_chunks_by_ns_prefix = AsyncMock(return_value=0)
+
+        embedder = AsyncMock()
+        embedder.embed_query = AsyncMock(side_effect=AssertionError("embed_query must not run"))
+
+        pipeline = SearchPipeline(
+            storage=storage,
+            embedder=embedder,
+            config=SearchConfig(enable_bm25=True, enable_dense=True),
+            decay_config=DecayConfig(enabled=True, half_life_days=30.0),
+        )
+
+        results, _ = await pipeline.search(query="", tag_filter="redis", top_k=10)
+
+        assert [r.chunk.id for r in results] == [fresh.id, ancient.id]
+        assert results[0].score > results[1].score

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -542,9 +542,23 @@ class TestSearch:
         assert result["score"] == pytest.approx(0.95)
         assert result["chunk"]["content"] == "test chunk content"
 
-    async def test_search_missing_query_returns_422(self, client: AsyncClient):
+    async def test_search_no_axis_returns_400(self, client: AsyncClient):
+        """#750: ``q`` is now optional, but at least one of
+        ``q``/``tag_filter``/``source_filter`` must be present — search
+        needs *something* to scope by. A missing-everything call is
+        still rejected, just with a 400 + actionable detail rather than
+        FastAPI's default 422 for missing required params."""
         resp = await client.get("/api/search")
-        assert resp.status_code == 422
+        assert resp.status_code == 400
+        detail = resp.json().get("detail", "")
+        assert "tag_filter" in detail and "source_filter" in detail
+
+    async def test_search_tag_only_returns_results(self, client: AsyncClient):
+        """#750: ``tag_filter`` alone is a valid axis — the pipeline's
+        empty-query branch enumerates by filter and returns results
+        without needing a keyword."""
+        resp = await client.get("/api/search", params={"tag_filter": "redis"})
+        assert resp.status_code == 200
 
     async def test_search_with_filters(self, client: AsyncClient):
         resp = await client.get(


### PR DESCRIPTION
## Summary

Follow-up to #672 / PR #749. After PR #749 stopped `_searchByTag` from polluting `search-input`, a fresh-session tag pill click left `search-input` empty and `doSearch()` early-returned — Search tab opened with `tag-filter` populated but no results rendered until the user typed a query. This lifts the empty-`q` guard on all three layers so the click works as the intuitive "show me all memos with this tag".

## Changes

- **Frontend** (`packages/memtomem/src/memtomem/web/static/app.js`): `doSearch()` and the load-more button now run whenever `q` *or* `tag-filter` has a value. `saveToHistory(q)` is gated on a non-empty `q` so tag-only searches don't pollute the suggest history. Both paths build the URL with conditional params (`q` only when set).
- **Route** (`packages/memtomem/src/memtomem/web/routes/search.py`): `q` is optional (`str | None`). The "no axis at all" guard returns 400 with an actionable detail ("Provide at least one of q, tag_filter, or source_filter.") — explicit replacement for FastAPI's default 422 on missing required params.
- **Pipeline** (`packages/memtomem/src/memtomem/search/pipeline.py`): empty-query calls route through a new `_filter_only_search` branch that enumerates via `storage.recall_chunks(tag_filter=…, source_filter=…)` and skips BM25/dense/expansion/rescue/rerank (they need a query/embedding signal). The post-filter stages — validity → decay → access boost → importance boost → context window — still apply so rank reflects recency × access × importance even without a keyword. MMR is skipped (no semantic axis to diversify on).
- **Storage** (`packages/memtomem/src/memtomem/storage/{base,sqlite_backend}.py`): `recall_chunks` gained an optional `tag_filter` kwarg with the same comma-separated OR semantics as the keyword path's post-fusion tag filter. SQLite uses `EXISTS (SELECT 1 FROM json_each(chunks.tags) WHERE json_each.value IN (…))`.

## Why this is one focused PR (per CONTRIBUTING.md)

The three layers form one user-visible behaviour change ("tag-only search works"). Splitting them would land a frontend change that immediately 400s, or a backend that's never called. The pipeline branch and the `recall_chunks` kwarg are co-evolved because the pipeline can't enumerate without a tag-aware storage primitive — they ship together or neither does.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests && uv run ruff format --check …` — clean.
- [x] `uv run pytest -m "not ollama"` — **4005 passed**, 7 skipped, 46 deselected.
- [x] New non-ollama regression tests in `test_pipeline.py::TestFilterOnlySearch` (4): empty-q + tag enumerates via `recall_chunks`; empty-q + source mirrors that; empty-q + no filter returns empty fast (does not enumerate); empty-q honours `top_k`. The mocks wire `bm25_search` / `dense_search` / `embed_query` to raise so a future regression that drops the early-return branch fails loudly.
- [x] `test_web_routes.py::TestSearch` updated: `test_search_missing_query_returns_422` → `test_search_no_axis_returns_400` to match the new contract; new `test_search_tag_only_returns_results`.
- [ ] Manual `mm web`:
  - [ ] Fresh session → Tags tab → click pill → Search tab activates, `tag-filter` populated, `search-input` empty, results render scoped to the tag (recency-ranked).
  - [ ] Type a query in Search → Tags tab → click pill → Search tab returns, `search-input` keeps original query, `tag-filter` populated, results = (query ∩ tag) — i.e. PR #749's narrowing path is unchanged.
  - [ ] `tag-filter` chip X clear with empty `q` → tab stays on Search but results clear; subsequent searches work.
  - [ ] Tag-only search history: type "foo" + search → tag-only click → query history dropdown still shows "foo" (no tag-only entries leaked in).

## Stacking note

This change is independent of PR #749 in code (different functions touched) — branched off `main`. The intuitive UX only emerges once both #749 and this land, but each is mergeable in either order.

## References

- #672 — original axis-duplication bug
- PR #749 — drops `search-input` pollution from `_searchByTag`
- #750 — this issue