### PR TITLE
fix(tests): unblock Windows pytest cleanup of components fixture (#206)

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/onnx.py
+++ b/packages/memtomem/src/memtomem/embedding/onnx.py
@@ -205,4 +205,12 @@ class OnnxEmbedder:
         return embeddings[0]
 
     async def close(self) -> None:
+        # Force-collect after dropping the fastembed reference: the underlying
+        # ORT InferenceSession holds an mmap on the model file plus thread-local
+        # arenas, and on Windows that handle can outlive ``self._model = None``
+        # long enough for pytest's tmp_path rmtree to fail with WinError 183
+        # on the next session. See #206.
+        import gc
+
         self._model = None
+        gc.collect()

--- a/packages/memtomem/src/memtomem/search/reranker/fastembed.py
+++ b/packages/memtomem/src/memtomem/search/reranker/fastembed.py
@@ -109,4 +109,10 @@ class FastEmbedReranker:
         ]
 
     async def close(self) -> None:
+        # Same shape as ``OnnxEmbedder.close``: force-collect so the underlying
+        # ORT InferenceSession releases its mmap and thread-local arenas before
+        # pytest cleans up tmp_path on Windows. See #206.
+        import gc
+
         self._model = None
+        gc.collect()

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -101,7 +101,10 @@ async def components(tmp_path):
 
     db_path = str(tmp_path / "test.db")
     mem_dir = str(tmp_path / "memories")
-    (tmp_path / "memories").mkdir()
+    # exist_ok: pytest reuses tmp_path roots; on Windows a previous session's
+    # SQLite/ONNX handle leak can leave this dir behind and trip WinError 183.
+    # See #206.
+    (tmp_path / "memories").mkdir(exist_ok=True)
 
     os.environ["MEMTOMEM_STORAGE__SQLITE_PATH"] = db_path
     os.environ["MEMTOMEM_INDEXING__MEMORY_DIRS"] = json.dumps([mem_dir])
@@ -170,7 +173,8 @@ async def bm25_only_components(tmp_path, monkeypatch):
     """
     db_path = tmp_path / "bm25.db"
     mem_dir = tmp_path / "memories"
-    mem_dir.mkdir()
+    # exist_ok: see ``components`` fixture above — Windows tmp_path reuse. #206.
+    mem_dir.mkdir(exist_ok=True)
 
     from helpers import isolate_memtomem_env
 
@@ -204,7 +208,8 @@ async def onnx_components(tmp_path, monkeypatch):
     """
     db_path = tmp_path / "golden.db"
     mem_dir = tmp_path / "memories"
-    mem_dir.mkdir()
+    # exist_ok: see ``components`` fixture above — Windows tmp_path reuse. #206.
+    mem_dir.mkdir(exist_ok=True)
 
     for var in (
         "MEMTOMEM_EMBEDDING__PROVIDER",

--- a/packages/memtomem/tests/test_cli_ingest.py
+++ b/packages/memtomem/tests/test_cli_ingest.py
@@ -551,8 +551,14 @@ class TestGeminiIngestIntegration:
 @pytest.mark.ollama
 class TestCodexIngestIntegration:
     async def test_happy_path_indexes_codex_memories(self, components, tmp_path):
+        import shutil
+
         mem_dir = tmp_path / "codex_memories"
-        mem_dir.mkdir()
+        # rmtree+exist_ok: pytest reuses tmp_path roots; on Windows a prior
+        # session's handle leak can leave this dir (with stale .md files)
+        # behind. See #206.
+        shutil.rmtree(mem_dir, ignore_errors=True)
+        mem_dir.mkdir(exist_ok=True)
         (mem_dir / "fact_a.md").write_text(
             "# Workspace preference\n\nAlways use workspace-write sandbox mode.\n", encoding="utf-8"
         )
@@ -581,8 +587,12 @@ class TestCodexIngestIntegration:
                 assert "codex-memory" in c.metadata.tags
 
     async def test_rerun_skips_unchanged(self, components, tmp_path):
+        import shutil
+
         mem_dir = tmp_path / "codex_memories"
-        mem_dir.mkdir()
+        # rmtree+exist_ok: see test_happy_path_indexes_codex_memories. #206.
+        shutil.rmtree(mem_dir, ignore_errors=True)
+        mem_dir.mkdir(exist_ok=True)
         (mem_dir / "fact.md").write_text("# Fact\n\nSome important fact.\n", encoding="utf-8")
 
         files = _codex_discover_files(mem_dir)


### PR DESCRIPTION
## Summary

- `OnnxEmbedder.close()` and `FastEmbedReranker.close()` now `gc.collect()` after dropping `self._model`, forcing the underlying ORT `InferenceSession` (mmap on the model file + thread-local arenas) to release promptly. Best-effort handle hygiene.
- Three `components`-style fixtures (`conftest.py`) and two `test_cli_ingest` Codex tests now `mkdir(exist_ok=True)` (with `shutil.rmtree(..., ignore_errors=True)` first where `.md` content gets written), so reused `tmp_path` roots from a prior failed-cleanup session no longer trip `FileExistsError [WinError 183]`. Each site has an inline `#206` reference.

`Storage.close()` already runs `PRAGMA wal_checkpoint(TRUNCATE)` and closes the read-pool — no change needed there.

Closes #206. Original report by @powerzist during #162.

## Why both source-level and site-targeted

The issue's acceptance bullets allow either approach:
- If source fix is sufficient: no `exist_ok=True` needed at sites.
- If site-targeted: each site needs a comment pointing at upstream cause.

Neither is fully reliable on its own under Windows file-locking semantics (handles get released when the previous Python process dies, but Windows takes a moment; AV/indexing services can also briefly hold scans). The site-targeted change is the load-bearing one — without it, any future regression in a `.close()` method silently re-introduces the failure. The source-level change makes it less likely the leftover ever happens in the first place. Defense in depth, with comments at every site so neither layer becomes invisible.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests` — 4012 passed, 7 skipped, 46 deselected
- [ ] Windows verification — pinging @powerzist who originally reported the leak in their environment, since this repo doesn't run a Windows CI matrix (#634)

🤖 Generated with [Claude Code](https://claude.com/claude-code)