### PR TITLE
test(web): add minimal Playwright harness for tag-filter mutation sites (closes #751)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,21 @@ jobs:
           -m "not ollama and not llm"
           --tb=short -q
 
+  test-browser:
+    name: browser (Playwright + Chromium)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - run: uv sync --frozen
+      # ``--with-deps`` pulls the headless-shell apt packages on Ubuntu so
+      # chromium can launch from a clean runner; the install also seeds the
+      # browser cache that ``_playwright_browser_available()`` probes.
+      - run: uv run playwright install --with-deps chromium
+      - run: uv run pytest packages/memtomem/tests/web -m browser --tb=short -q
+
   test-golden-path:
     name: golden-path (ONNX bge-m3)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **Browser test harness for tag-filter mutation sites (closes #751).** A
+  new `packages/memtomem/tests/web/` directory runs a tiny uvicorn-in-thread
+  server against a stub-routed `pytest-playwright` page and pins the
+  click → DOM-state contract for the three sites in `app.js` that mutate
+  `tag-filter` (`_attachResultTagRow`, `renderTagChips`,
+  `_searchByTag`). The #672 regression — the Tags Cloud pill click
+  silently writing the tag into `search-input` — is now caught
+  automatically; previously it relied on manual review. A `browser`
+  pytest marker auto-skips on machines without `pytest-playwright` or
+  Chromium, mirroring the existing `ollama` pattern, so
+  `uv run pytest -m "not ollama"` stays green for contributors who
+  haven't run `uv run playwright install chromium`. CI gets a new
+  `test-browser` job alongside `test-golden-path`.
+
 ### Changed
 
 - **Tag pill clicks no longer overwrite the search query (closes #672).**

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -71,8 +71,38 @@ def _can_create_symlink() -> bool:
     return True
 
 
+def _playwright_browser_available() -> bool:
+    """Probe whether ``pytest-playwright`` *and* a usable Chromium are
+    present.
+
+    Two failure modes are folded together because the symptom — a
+    ``@pytest.mark.browser`` test exploding in fixture setup — is the
+    same: ``pytest-playwright`` not installed (most contributor
+    laptops), or installed but ``playwright install chromium`` was
+    never run (the binary download is ~150 MB and is opt-in for that
+    reason). Either way, auto-skipping is the right behaviour.
+
+    The probe imports the sync API and launches headless chromium with
+    a short timeout; any failure means the marker should skip. Result
+    is cached in ``_PLAYWRIGHT_OK`` so the launch cost (a few hundred
+    ms) is paid once per session, not per item.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return False
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True, timeout=2_000)
+            browser.close()
+        return True
+    except Exception:
+        return False
+
+
 _OLLAMA_UP = _ollama_available()
 _CAN_SYMLINK = _can_create_symlink()
+_PLAYWRIGHT_OK = _playwright_browser_available()
 
 
 def pytest_collection_modifyitems(config, items):
@@ -81,16 +111,24 @@ def pytest_collection_modifyitems(config, items):
     - ``@pytest.mark.ollama`` when Ollama isn't reachable.
     - ``@pytest.mark.requires_symlinks`` when the filesystem can't make
       symlinks (Windows without Developer Mode / admin shell).
+    - ``@pytest.mark.browser`` when ``pytest-playwright`` or Chromium
+      isn't installed (the harness in ``tests/web/`` needs both).
     """
     skip_ollama = pytest.mark.skip(reason="Ollama not running")
     skip_symlink = pytest.mark.skip(
         reason="Filesystem cannot create symlinks (Windows without Developer Mode/admin)"
+    )
+    skip_browser = pytest.mark.skip(
+        reason="pytest-playwright + Chromium not available "
+        "(install via `uv sync && uv run playwright install chromium`)"
     )
     for item in items:
         if not _OLLAMA_UP and "ollama" in item.keywords:
             item.add_marker(skip_ollama)
         if not _CAN_SYMLINK and "requires_symlinks" in item.keywords:
             item.add_marker(skip_symlink)
+        if not _PLAYWRIGHT_OK and "browser" in item.keywords:
+            item.add_marker(skip_browser)
 
 
 @pytest.fixture

--- a/packages/memtomem/tests/web/conftest.py
+++ b/packages/memtomem/tests/web/conftest.py
@@ -1,0 +1,84 @@
+"""Browser-test fixtures for the Web UI.
+
+The harness exists to catch regressions in click → DOM-state wiring inside
+``packages/memtomem/src/memtomem/web/static/app.js`` (see issue #751 for the
+motivating tag-filter mutation cluster). It is deliberately scoped to JS
+behaviour only — every ``/api/**`` call is intercepted via ``page.route()``
+in the individual specs, so the harness needs to serve the static SPA but
+does **not** need real components, a real DB, or a real index.
+
+The lifespan is therefore skipped (``create_app(lifespan=None)``); route
+handlers that try to read ``app.state.storage`` etc. would 500, but
+``page.route()`` intercepts those requests before they reach the server.
+This keeps the fixture under a second to spin up and removes a whole class
+of flake (indexing timing, embedding model presence, port collisions).
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def mm_web_url() -> Iterator[str]:
+    """Run the Web UI in a background thread on an ephemeral port.
+
+    Yields the base URL (``http://127.0.0.1:<port>``). On teardown the
+    uvicorn ``should_exit`` flag is set and the thread joined; the daemon
+    flag is a belt-and-braces guard for the case where teardown raises
+    before the join.
+    """
+    import asyncio
+
+    import uvicorn
+
+    from memtomem.web.app import create_app
+
+    app = create_app(lifespan=None, mode="prod")
+
+    # Bind to port 0, then read the actual port off the listening socket
+    # after startup. Doing the bind ourselves (rather than letting uvicorn
+    # do it) makes the port readable synchronously without polling
+    # ``server.servers[0].sockets``, which is populated lazily.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        lifespan="off",
+    )
+    server = uvicorn.Server(config)
+    sock.close()  # uvicorn rebinds; the probe was just to grab a free port
+
+    def _run() -> None:
+        asyncio.run(server.serve())
+
+    thread = threading.Thread(target=_run, daemon=True, name="mm-web-test-server")
+    thread.start()
+
+    # Wait up to ~5s for the server to come up. ``server.started`` is the
+    # documented flag for this; the loop is bounded so a misconfigured
+    # server fails the suite instead of hanging CI.
+    deadline = time.monotonic() + 5.0
+    while not server.started and time.monotonic() < deadline:
+        time.sleep(0.02)
+    if not server.started:
+        server.should_exit = True
+        thread.join(timeout=2.0)
+        raise RuntimeError("uvicorn server did not start within 5s")
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.should_exit = True
+        thread.join(timeout=5.0)

--- a/packages/memtomem/tests/web/test_tag_filter_mutation.py
+++ b/packages/memtomem/tests/web/test_tag_filter_mutation.py
@@ -1,0 +1,274 @@
+"""Regression tests for the three ``tag-filter`` mutation sites in ``app.js``.
+
+Issue #751 motivates this file. The cluster:
+
+* ``app.js:_attachResultTagRow`` (~line 1888) — result-item tag label click
+  sets ``tag-filter`` and runs ``doSearch()``.
+* ``app.js:_attachResultTagRow`` (~line 1903) — the ✕ on a result-item tag
+  conditionally clears ``tag-filter`` (only when it equals the removed tag).
+* ``app.js:_searchByTag`` (~line 4064) — Tags Cloud / List pill click. PR
+  #749 (issue #672) fixed a bug where this also wrote ``search-input``,
+  silently double-applying the tag as a BM25 query and a tag filter. The
+  bug was caught by code review only — these specs are the missing
+  automated guard.
+
+Each spec stubs every ``/api/**`` call with ``page.route()`` so the harness
+verifies pure click → DOM-state wiring inside ``app.js``. Real backend
+search is exercised by Python-level pytest elsewhere; duplicating it here
+just buys flake.
+
+Specs 2 and 3 inject the result-item DOM by calling the actual
+``_attachResultTagRow`` global from ``page.evaluate`` rather than going
+through ``doSearch()`` → ``renderResults()`` → ``showDetail()``. The
+showDetail path reads ~15 chunk fields (``heading_hierarchy``,
+``start_line``, ``namespace``, …) and any missing one throws. We don't
+care about detail-view rendering — only the chip-click handler — so the
+direct call gives us the exact handler under test with no incidental
+brittleness.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _install_default_stubs(page) -> None:
+    """Stub every endpoint the SPA hits during boot so the page renders
+    cleanly without any real components wired up.
+
+    Boot fetches not stubbed individually get a generic empty-shape
+    response. The pattern is intentionally permissive — specs override
+    only the endpoints they assert on.
+    """
+
+    def _ok(route, payload):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    page.route("**/api/system/ui-mode", lambda r: _ok(r, {"mode": "prod"}))
+    page.route("**/api/system/model-readiness", lambda r: _ok(r, {"ready": True}))
+    page.route("**/api/sources", lambda r: _ok(r, {"sources": []}))
+    page.route("**/api/namespaces", lambda r: _ok(r, {"namespaces": []}))
+    page.route("**/api/stats", lambda r: _ok(r, {}))
+    # Default empty search response — specs that assert on the request
+    # shape override this with a capturing handler.
+    page.route(
+        "**/api/search?**",
+        lambda r: _ok(r, {"results": [], "total": 0, "retrieval_stats": {}}),
+    )
+    # Catch-all for everything else (boot fetches like /api/tags-info,
+    # /api/decay/policy, etc. that may exist in newer builds). The SPA's
+    # boot paths all use ``catch`` blocks around ``api()``, so an empty
+    # object is benign.
+    page.route("**/api/**", lambda r: _ok(r, {}))
+
+
+def test_searchByTag_does_not_pollute_search_input(page, mm_web_url: str) -> None:
+    """#672 regression: clicking a Tags Cloud pill must set only
+    ``tag-filter`` and never touch ``search-input``.
+
+    The double-write was the original bug — `_searchByTag` set
+    ``search-input.value = tag`` *and* ``tag-filter.value = tag``, so the
+    same string flowed into both axes of the search and BM25-ranked
+    documents that merely *mentioned* the tag in prose on top of the
+    tag-filter constraint. PR #749 deleted the search-input write; this
+    spec pins it.
+
+    Defence in depth: we also assert the resulting ``/api/search``
+    request URL contains ``tag_filter=foo`` and *no* ``q=`` param, so a
+    future helper extraction that re-routed the click through a code
+    path that injects ``q`` into the URL would still trip this test.
+    """
+    _install_default_stubs(page)
+
+    captured: dict[str, str] = {}
+
+    def _capture_search(route):
+        captured["url"] = route.request.url
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"results": [], "total": 0, "retrieval_stats": {}}),
+        )
+
+    page.route(
+        "**/api/tags",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"tags": [{"tag": "foo", "count": 3}]}),
+        ),
+    )
+    # Override the default-stub search route. ``page.route`` resolves
+    # last-registered-wins, so this takes precedence over the empty
+    # default registered by ``_install_default_stubs``.
+    page.route("**/api/search?**", _capture_search)
+
+    page.goto(mm_web_url)
+    page.locator('[data-tab="tags"]').click()
+    # ``STATE.tagsView`` defaults to 'cloud' (see app.js STATE init); the
+    # cloud item is the only renderer that exposes a ``data-tag``
+    # selector. The ``foo`` pill is positioned by deterministic hash
+    # rotation, so explicit visibility/stable-position waiting via the
+    # data-tag selector is the right hook.
+    page.locator('.tag-cloud-item[data-tag="foo"]').click()
+
+    page.wait_for_function(
+        "() => document.getElementById('tag-filter').value === 'foo'",
+        timeout=2_000,
+    )
+
+    assert page.locator("#search-input").input_value() == ""
+    assert page.locator("#tag-filter").input_value() == "foo"
+    assert "tag_filter=foo" in captured.get("url", "")
+    assert "q=" not in captured.get("url", "")
+
+
+def test_result_tag_label_click_sets_tag_filter_only(page, mm_web_url: str) -> None:
+    """``_attachResultTagRow`` (~app.js:1888): clicking a result-item tag
+    label sets ``tag-filter`` to the clicked tag but leaves whatever the
+    user typed into ``search-input`` intact.
+
+    This is the dual-axis-when-the-user-typed-it path. #672 did not
+    break it — only ``_searchByTag`` was buggy — but a future "make all
+    three mutation sites symmetric" refactor could quietly clear
+    ``search-input`` here too. Pinning the contract guards that.
+    """
+    _install_default_stubs(page)
+
+    page.goto(mm_web_url)
+    # Pre-populate ``search-input`` to simulate the user mid-search.
+    page.locator("#search-input").fill("hello")
+
+    # Build the chip via the actual production helper. Going through
+    # ``doSearch`` → ``renderResults`` → ``showDetail`` would force us
+    # to mock ~15 fields on ``chunk`` to satisfy the detail panel; the
+    # click handler we're testing is bound inside ``_attachResultTagRow``
+    # itself, so we exercise it directly.
+    page.evaluate(
+        """() => {
+            const list = document.getElementById('results-list');
+            list.innerHTML = '';
+            list.hidden = false;
+            list.style.display = 'block';
+            const empty = document.getElementById('results-empty');
+            if (empty) empty.hidden = true;
+            const item = document.createElement('div');
+            item.className = 'result-item';
+            const body = document.createElement('div');
+            body.className = 'result-body';
+            item.appendChild(body);
+            list.appendChild(item);
+            window._attachResultTagRow(1, ['bar'], body);
+        }"""
+    )
+
+    page.locator(".result-tag-label", has_text="bar").click()
+
+    # ``tag-filter`` is set synchronously inside the handler, so the
+    # value is observable immediately — no need to wait for the
+    # ``doSearch`` fetch to complete.
+    assert page.locator("#tag-filter").input_value() == "bar"
+    assert page.locator("#search-input").input_value() == "hello"
+
+
+def test_result_tag_remove_clears_only_matching_tag_filter(page, mm_web_url: str) -> None:
+    """``_attachResultTagRow`` (~app.js:1903): clicking the ✕ on a result
+    tag must clear ``tag-filter`` *only when* it currently equals the
+    removed tag — otherwise the unrelated filter stays.
+
+    A naïve "always clear on remove" refactor would silently break the
+    case where the user has filtered by tag *X* and removes tag *Y*
+    from a result; the filter on *X* should survive.
+    """
+    _install_default_stubs(page)
+    page.route(
+        "**/api/chunks/7/tags",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ok": True}),
+        ),
+    )
+
+    page.goto(mm_web_url)
+    page.evaluate(
+        """() => {
+            const list = document.getElementById('results-list');
+            list.innerHTML = '';
+            list.hidden = false;
+            list.style.display = 'block';
+            const empty = document.getElementById('results-empty');
+            if (empty) empty.hidden = true;
+            const item = document.createElement('div');
+            item.className = 'result-item';
+            const body = document.createElement('div');
+            body.className = 'result-body';
+            item.appendChild(body);
+            list.appendChild(item);
+            // STATE.lastResults is read inside the remove handler;
+            // seed it so the cache lookup doesn't trip.
+            window.STATE = window.STATE || {};
+            window.STATE.lastResults = [
+                {chunk: {id: 7, tags: ['baz']}, score: 0.5},
+            ];
+            window._attachResultTagRow(7, ['baz'], body);
+        }"""
+    )
+
+    # Case A: ``tag-filter`` matches the tag being removed → clear.
+    # The filters panel is hidden by default, so fill() would fail the
+    # visibility check; the handler reads ``.value`` directly, which a
+    # plain assignment satisfies.
+    page.evaluate("document.getElementById('tag-filter').value = 'baz'")
+    page.locator(".result-tag-remove").first.click()
+    page.wait_for_function(
+        "() => document.getElementById('tag-filter').value === ''",
+        timeout=2_000,
+    )
+    assert page.locator("#tag-filter").input_value() == ""
+
+    # Case B: re-render and remove a different tag → ``tag-filter``
+    # holding an unrelated value must survive.
+    page.evaluate(
+        """() => {
+            const list = document.getElementById('results-list');
+            list.innerHTML = '';
+            list.hidden = false;
+            list.style.display = 'block';
+            const empty = document.getElementById('results-empty');
+            if (empty) empty.hidden = true;
+            const item = document.createElement('div');
+            item.className = 'result-item';
+            const body = document.createElement('div');
+            body.className = 'result-body';
+            item.appendChild(body);
+            list.appendChild(item);
+            window.STATE.lastResults = [
+                {chunk: {id: 8, tags: ['removeme']}, score: 0.5},
+            ];
+            window._attachResultTagRow(8, ['removeme'], body);
+        }"""
+    )
+    page.route(
+        "**/api/chunks/8/tags",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"ok": True}),
+        ),
+    )
+    page.evaluate("document.getElementById('tag-filter').value = 'unrelated'")
+    page.locator(".result-tag-remove").first.click()
+    # The handler doesn't touch ``tag-filter`` in this branch; assert it
+    # stays after a brief settle window so any async rollback path would
+    # have a chance to fire.
+    page.wait_for_timeout(200)
+    assert page.locator("#tag-filter").input_value() == "unrelated"

--- a/packages/memtomem/tests/web/test_tag_filter_mutation.py
+++ b/packages/memtomem/tests/web/test_tag_filter_mutation.py
@@ -52,22 +52,26 @@ def _install_default_stubs(page) -> None:
             body=json.dumps(payload),
         )
 
+    # Order matters: ``page.route`` resolves last-registered-wins, so the
+    # catch-all has to go FIRST and the specific routes LAST. Inverting
+    # the order would silently shadow the specifics with the empty-{}
+    # default — harmless today (the SPA's boot fetches all use ``catch``
+    # blocks around ``api()``) but a foothold for confusing failures
+    # when a future spec adds a boot-time assertion.
+    page.route("**/api/**", lambda r: _ok(r, {}))
     page.route("**/api/system/ui-mode", lambda r: _ok(r, {"mode": "prod"}))
     page.route("**/api/system/model-readiness", lambda r: _ok(r, {"ready": True}))
     page.route("**/api/sources", lambda r: _ok(r, {"sources": []}))
     page.route("**/api/namespaces", lambda r: _ok(r, {"namespaces": []}))
     page.route("**/api/stats", lambda r: _ok(r, {}))
     # Default empty search response — specs that assert on the request
-    # shape override this with a capturing handler.
+    # shape override this with a capturing handler registered AFTER
+    # ``_install_default_stubs`` returns, so the same last-wins rule
+    # gives the spec-local handler precedence.
     page.route(
         "**/api/search?**",
         lambda r: _ok(r, {"results": [], "total": 0, "retrieval_stats": {}}),
     )
-    # Catch-all for everything else (boot fetches like /api/tags-info,
-    # /api/decay/policy, etc. that may exist in newer builds). The SPA's
-    # boot paths all use ``catch`` blocks around ``api()``, so an empty
-    # object is benign.
-    page.route("**/api/**", lambda r: _ok(r, {}))
 
 
 def test_searchByTag_does_not_pollute_search_input(page, mm_web_url: str) -> None:
@@ -266,9 +270,11 @@ def test_result_tag_remove_clears_only_matching_tag_filter(page, mm_web_url: str
         ),
     )
     page.evaluate("document.getElementById('tag-filter').value = 'unrelated'")
-    page.locator(".result-tag-remove").first.click()
-    # The handler doesn't touch ``tag-filter`` in this branch; assert it
-    # stays after a brief settle window so any async rollback path would
-    # have a chance to fire.
-    page.wait_for_timeout(200)
+    # ``expect_request`` lets us await the PATCH the handler fires *after*
+    # the conditional clear, without a hard sleep. The whole handler has
+    # then run to completion, so any rollback path would already have
+    # touched ``tag-filter`` if it was going to.
+    with page.expect_request("**/api/chunks/8/tags") as patch_info:
+        page.locator(".result-tag-remove").first.click()
+    patch_info.value
     assert page.locator("#tag-filter").input_value() == "unrelated"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ markers = [
     "llm: requires a live LLM API key (OpenAI/Anthropic); CI runs these in the nightly job only",
     "multilingual: multilingual/large-corpus regression tests (runs in the test-golden-path CI job)",
     "requires_symlinks: needs a filesystem that can create symlinks (auto-skipped on Windows without Developer Mode/admin)",
+    "browser: requires pytest-playwright + a Chromium install (auto-skipped when unavailable)",
 ]
 
 [tool.mypy]
@@ -41,6 +42,7 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.25",
     "pytest-cov>=6.0",
+    "pytest-playwright>=0.5",
     "ruff>=0.9",
     "mypy>=1.14",
     "types-PyYAML>=6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -435,6 +435,53 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cb/baa584cb00532126ffe12d9787db0a60c5a4f55c27bfe2666df5d4c30a32/greenlet-3.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:83ed9f27f1680b50e89f40f6df348a290ea234b249a4003d366663a12eab94f2", size = 235615, upload-time = "2026-04-27T12:21:38.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -919,6 +966,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-playwright" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -932,6 +980,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
     { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-playwright", specifier = ">=0.5" },
     { name = "ruff", specifier = ">=0.9" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
@@ -1293,6 +1342,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/48/abab23f40643b4de8f2665816f0a1bf0994eeecda39d6d62f0f292b2ad01/playwright-1.59.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:bfc6940100b57423175c819ce2422ec5880d55fa2769987f62ab7a1f5fe6783e", size = 43156922, upload-time = "2026-04-29T08:11:08.921Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/5e4d98b2ce3641b4343623c6450ff33b9de1c979d12a957505e392338b07/playwright-1.59.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:af068143a0c045ec11608b67d6c42e58db7e9cf65a742dd21fddedc1a9802c47", size = 41947177, upload-time = "2026-04-29T08:11:12.867Z" },
+    { url = "https://files.pythonhosted.org/packages/80/91/fd219aa78ca03d37e93aaedaed4e224131e3090a9264f9bb773c8271d67e/playwright-1.59.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:4a4a2d4842b0e4120de3fa48636e4b69085a05b81d8a35ad4353f530ade72ed6", size = 43156922, upload-time = "2026-04-29T08:11:16.595Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0c/1e513d37c5be07d12829ebce93dbfe7baee230084cb66966c423432799c4/playwright-1.59.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c5792aad9e22b91a09264b9edbc18553cf05ea5a39404d65dc19a012c6b2e51d", size = 47151793, upload-time = "2026-04-29T08:11:19.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2d/15f72288cb65d690134e18fefb9483cc4976f7579b580648c45e494481a7/playwright-1.59.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c881a19377d2b900af855fb525b5f22a27bf3cfbecba6d1edb36766d56cb100", size = 46877615, upload-time = "2026-04-29T08:11:23.863Z" },
+    { url = "https://files.pythonhosted.org/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1466,6 +1534,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1518,6 +1598,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1529,6 +1622,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/6b/913e36aa421b35689ec95ed953ff7e8df3f2ee1c7b8ab2a3f1fd39d95faf/pytest_playwright-0.7.2.tar.gz", hash = "sha256:247b61123b28c7e8febb993a187a07e54f14a9aa04edc166f7a976d88f04c770", size = 16928, upload-time = "2025-11-24T03:43:22.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/61/4d333d8354ea2bea2c2f01bad0a4aa3c1262de20e1241f78e73360e9b620/pytest_playwright-0.7.2-py3-none-any.whl", hash = "sha256:8084e015b2b3ecff483c2160f1c8219b38b66c0d4578b23c0f700d1b0240ea38", size = 16881, upload-time = "2025-11-24T03:43:24.423Z" },
 ]
 
 [[package]]
@@ -1559,6 +1667,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
 ]
 
 [[package]]
@@ -1846,6 +1966,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- New `packages/memtomem/tests/web/` directory with a `pytest-playwright` harness — three regression specs that pin the click → DOM-state contract for the three `tag-filter` mutation sites in `app.js` (`_attachResultTagRow` label click, `_attachResultTagRow` remove ✕, `_searchByTag`).
- The #672 regression (Tags Cloud pill click silently writing the tag into `search-input`) is now caught automatically; previously it relied on manual review only — the issue PR #749 fixed had **zero JS test infrastructure** in the repo.
- Python `pytest-playwright` is the binding choice rather than Node `vitest`/`playwright` so the harness rides on existing `uv run pytest` and doesn't introduce a Node toolchain to a Python-only monorepo.

## Why one focused PR (per CONTRIBUTING.md)
The harness and the three regression specs go together — adding the marker/CI/fixture without specs would land dead infrastructure, and adding specs without the marker auto-skip would break `uv run pytest -m "not ollama"` for contributors who haven't run `uv run playwright install chromium`. The acceptance bar in #751 (regression test for #672 + optional siblings) maps cleanly onto a single change set.

## Design notes
- **Specs 2 and 3 don't go through `doSearch` → `renderResults` → `showDetail`.** That path reads ~15 chunk fields (`heading_hierarchy`, `start_line`, `namespace`, …) and any missing one throws. We only care about the chip-click handler, which is bound inside `_attachResultTagRow` itself, so the specs call that global directly via `page.evaluate` and assert on the synchronous `tag-filter`/`search-input` mutation. This sidesteps a whole class of incidental brittleness.
- **Marker auto-skip mirrors the existing `ollama` pattern.** `_playwright_browser_available()` in `packages/memtomem/tests/conftest.py` launches headless chromium once per session and skips `@pytest.mark.browser` when either the binding or the browser is missing.
- **CI gets a new ubuntu-only `test-browser` job** that runs `playwright install --with-deps chromium` then `pytest -m browser`. The existing `test` matrix is unchanged — auto-skip handles those cells without needing `-m "not browser"`.

## Negative-path verification
Restoring the #672 bug (`qs('search-input').value = tag` in `_searchByTag`) makes the first spec fail with `assert 'foo' == ''` on the `search-input` check — confirms the harness catches the class of regression it exists for.

## Test plan
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check …` — clean
- [x] `uv run playwright install chromium`
- [x] `uv run pytest packages/memtomem/tests/web -m browser -v` — 3 passed in 1.30s
- [x] `uv run pytest --ignore=test_golden_path.py -m "not ollama and not llm" --tb=short -q` — 4013 passed, 7 skipped, 46 deselected
- [x] Negative-path: temporarily re-introduce `qs('search-input').value = tag` → spec 1 fails as expected; revert
- [ ] CI: `test-browser` job green (Playwright + Chromium install, then `pytest -m browser`)
- [ ] CI: existing `test` matrix unchanged (auto-skip handles non-browser machines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)