### PR TITLE
fix(cli): refuse `mm uninstall --force` on Windows when writer is alive

### DIFF
--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -583,6 +583,34 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
     label, lines = _binary_uninstall_hint(profile)
     _print_binary_hint(label, lines)
 
+    is_windows = sys.platform == "win32"
+
+    # Windows can't unlink files held by an open handle (WinError 32), so
+    # `--force` cannot override a live writer — pretending it does would
+    # leave the state dir half-wiped after `_delete_inventory` crashes
+    # mid-run. Refuse cleanly with platform-specific guidance instead.
+    # Tracked in #730.
+    if force and is_windows and (server.alive or db_lock.locked):
+        click.echo("")
+        click.secho(
+            "--force cannot wipe an open SQLite database on Windows; stop the writer first.",
+            fg="red",
+        )
+        if server.alive and server.pid is not None:
+            click.secho(
+                f"  Stop the server (pid {server.pid}) and retry. Windows refuses to "
+                "unlink files held by an open handle (WinError 32).",
+                fg="red",
+            )
+        else:
+            click.secho(
+                "  Find the writer (Task Manager, `Get-Process`, or Sysinternals "
+                "`handle.exe`), stop it, and retry. Windows refuses to unlink files "
+                "held by an open handle (WinError 32).",
+                fg="red",
+            )
+        sys.exit(2)
+
     if (server.alive or db_lock.locked) and not force:
         click.echo("")
         if server.alive:
@@ -595,33 +623,55 @@ def uninstall(keep_config: bool, keep_data: bool, force: bool, yes: bool) -> Non
                 # ``_probe_pid_file`` only returns alive=True with the
                 # ``pid_file`` field populated, so it is safe to dereference
                 # here without a fallback.
-                click.secho(
-                    "Server still running (pid unknown — flock is held by an active "
-                    "writer, but the recorded pid is missing). Refusing to delete "
-                    f"state. Find the holder with `lsof {server.pid_file}`.",
-                    fg="red",
-                )
+                if is_windows:
+                    click.secho(
+                        "Server still running (pid unknown — an active writer holds "
+                        "the lock, but the recorded pid is missing). Refusing to "
+                        "delete state. Find the holder via Sysinternals `handle.exe` "
+                        "or Resource Monitor.",
+                        fg="red",
+                    )
+                else:
+                    click.secho(
+                        "Server still running (pid unknown — flock is held by an active "
+                        "writer, but the recorded pid is missing). Refusing to delete "
+                        f"state. Find the holder with `lsof {server.pid_file}`.",
+                        fg="red",
+                    )
             else:
                 click.secho(
                     f"Server still running (pid {server.pid}). Refusing to delete state — "
                     "an active server holds the SQLite WAL and deleting it risks corruption.",
                     fg="red",
                 )
-            click.secho("  Stop the server first, or pass --force to override.", fg="red")
+            if is_windows:
+                # On Windows --force cannot override (see #730 / branch above),
+                # so don't suggest it.
+                click.secho("  Stop the server first.", fg="red")
+            else:
+                click.secho("  Stop the server first, or pass --force to override.", fg="red")
         else:
             # db_lock.locked only — writer without .server.pid (mm web,
-            # mm watchdog, ad-hoc script, ...). Point the user at lsof /
-            # ps so they can find it without another round-trip.
+            # mm watchdog, ad-hoc script, ...). Point the user at the
+            # platform-appropriate process inspection tool so they can
+            # find it without another round-trip.
             click.secho(
                 f"Another process holds a write lock on {db_path}. Refusing to delete "
                 "state — an active writer can corrupt the WAL.",
                 fg="red",
             )
-            click.secho(
-                f"  Find it with `lsof {db_path}` (or `ps aux | grep memtomem`), "
-                "stop it, or pass --force to override.",
-                fg="red",
-            )
+            if is_windows:
+                click.secho(
+                    "  Find the writer (Task Manager, `Get-Process`, or Sysinternals "
+                    "`handle.exe`) and stop it, then retry.",
+                    fg="red",
+                )
+            else:
+                click.secho(
+                    f"  Find it with `lsof {db_path}` (or `ps aux | grep memtomem`), "
+                    "stop it, or pass --force to override.",
+                    fg="red",
+                )
         sys.exit(2)
 
     if will_delete_bytes == 0 and not inv.other_files.paths:

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -528,9 +528,22 @@ class TestDbWriterLockRefuses:
             assert result.exit_code == 2, result.output
             assert "holds a write lock" in result.output
             assert str(db_path) in result.output
-            assert "lsof" in result.output
             # "Server still running" path must NOT trigger — no .server.pid here.
             assert "Server still running" not in result.output
+            # Hint contents differ per platform (#730): POSIX advertises
+            # `lsof` + `--force`; Windows can't override --force, so it must
+            # NOT advertise it and must point at Windows-native tools.
+            if sys.platform == "win32":
+                assert "lsof" not in result.output
+                assert "pass --force" not in result.output
+                assert (
+                    "handle.exe" in result.output
+                    or "Task Manager" in result.output
+                    or "Get-Process" in result.output
+                )
+            else:
+                assert "lsof" in result.output
+                assert "pass --force" in result.output
             # Nothing deleted while the writer is alive.
             assert db_path.exists()
         finally:
@@ -540,13 +553,12 @@ class TestDbWriterLockRefuses:
     @pytest.mark.skipif(
         sys.platform == "win32",
         reason=(
-            "Test relies on POSIX unlink-while-open semantics — Windows refuses "
-            "to unlink a file held by an open handle (WinError 32), so --force "
-            "cannot wipe the dir while the lock-holding connection lives in "
-            "the same process. Sibling tests cover the lock-detection path."
+            "POSIX-only contract: --force wipes via unlink-while-open even "
+            "though the writer still holds the inode. Windows variant lives "
+            "in test_force_refuses_on_windows_when_writer_alive (#730)."
         ),
     )
-    def test_force_overrides_db_lock(self, home):
+    def test_force_overrides_db_lock_posix(self, home):
         db_path, conn = self._make_real_db(home)
         try:
             conn.execute("BEGIN IMMEDIATE")
@@ -560,6 +572,43 @@ class TestDbWriterLockRefuses:
                 conn.rollback()
             except sqlite3.ProgrammingError:
                 pass  # connection may be invalidated after the file vanished
+            conn.close()
+
+    @pytest.mark.skipif(
+        sys.platform != "win32",
+        reason=(
+            "Windows-only contract (#730): --force cannot wipe an open SQLite "
+            "DB on Windows (WinError 32 on unlink-while-open), so --force "
+            "must refuse cleanly instead of producing a half-wiped state dir."
+        ),
+    )
+    def test_force_refuses_on_windows_when_writer_alive(self, home):
+        db_path, conn = self._make_real_db(home)
+        # _make_real_db seeds config.json + memories/ alongside the DB.
+        # _delete_inventory wipes those BEFORE the DB, so checking they
+        # survive proves the refusal fired before any deletion ran (#730).
+        config_path = home / ".memtomem" / "config.json"
+        memories_dir = home / ".memtomem" / "memories"
+        assert config_path.exists()
+        assert memories_dir.exists()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            result = CliRunner().invoke(cli, ["uninstall", "-y", "--force"])
+            assert result.exit_code == 2, result.output
+            assert "Windows" in result.output
+            assert "stop the writer" in result.output.lower()
+            # Refusal fired BEFORE _delete_inventory: nothing wiped.
+            assert db_path.exists()
+            assert config_path.exists()
+            assert memories_dir.exists()
+            # Partial-wipe message must NOT appear — that would mean
+            # _delete_inventory ran and crashed mid-way.
+            assert "Deletion failed at" not in result.output
+        finally:
+            try:
+                conn.rollback()
+            except sqlite3.ProgrammingError:
+                pass
             conn.close()
 
     def test_proceeds_when_db_exists_but_no_writer(self, home):


### PR DESCRIPTION
Closes #730.

## Summary
- POSIX `--force` semantics rely on **unlink-while-open** — `shutil.rmtree` succeeds with a live SQLite writer because the directory entry vanishes while the inode lives until the fd closes.
- Windows refuses to unlink files held by an open handle (`WinError 32`), so the previous behavior crashed mid-`_delete_inventory` and left the state directory **half-wiped**.
- This PR pins the contract to **option (a)** from the issue: refuse cleanly with a Windows-specific message instead of attempting a partial wipe. Exit code `2`, mirroring the existing refusal path.
- The trailing `pass --force to override` advice in the existing not-force refusal block is also dropped on Windows (it would just refuse again), and `lsof` / `ps aux` hints are replaced with `handle.exe` / Task Manager / `Get-Process` so the guidance is actionable on each platform.
- The previously-skipped `test_force_overrides_db_lock` is replaced with a POSIX/Windows pair. The Windows variant seeds a sentinel non-DB file (`config.json` + `memories/`) and asserts they survive — proving the refusal fired **before** `_delete_inventory` ran, not after a partial wipe.

## Out of scope (orthogonal follow-up)
**Q2 from the issue — transactional wipe** (stage to a sibling dir + atomic rename on success) is intentionally NOT in this PR. It helps even on POSIX (mid-rmtree perm/FS errors leave half-gone state today), but bundling it would muddle the contract decision. Will file a separate issue/PR.

## Test plan
- [x] `uv run ruff check` + `ruff format --check` (clean)
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/uninstall_cmd.py` (clean)
- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py -m "not ollama"` — 28 passed, 1 skipped (the Windows-only test, as expected on macOS)
- [ ] Windows CI lane: new `test_force_refuses_on_windows_when_writer_alive` runs and passes; `test_force_overrides_db_lock_posix` is skipped; `test_refuses_when_writer_holds_lock` passes with the platform-conditional `lsof`/`handle.exe` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)