### PR TITLE
feat(web/ctx): expose cascade / overwrite / folder picker in UI

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -590,21 +590,35 @@ async function loadCtxDetail(type, name) {
 
     // Delete
     detailEl.querySelector('.ctx-detail-delete-btn')?.addEventListener('click', async () => {
-      const ok = await showConfirm({
+      // Cascade is opt-in: the canonical artifact is the ``.memtomem/``
+      // entry, runtime files are mirrored copies. Default-off keeps the
+      // dialog conservative — a stray click only removes the canonical,
+      // and the user has to consciously check the box to fan-out delete
+      // into ``~/.claude/skills/``, ``~/.codex/...``, etc.
+      const result = await showConfirm({
         title: t('settings.ctx.confirm_delete').replace('{name}', name),
         message: t('settings.ctx.confirm_delete_msg'),
         confirmText: t('settings.ctx.delete'),
+        extraOption: {
+          id: 'cascade',
+          label: t('settings.ctx.cascade_delete'),
+          defaultChecked: false,
+        },
       });
-      if (!ok) return;
+      if (!result || !result.ok) return;
+      const cascade = !!(result.extras && result.extras.cascade);
       try {
-        const r = await fetch(`/api/context/${type}/${encodeURIComponent(name)}?cascade=false`, { method: 'DELETE' });
+        const r = await fetch(
+          `/api/context/${type}/${encodeURIComponent(name)}?cascade=${cascade}`,
+          { method: 'DELETE' },
+        );
         if (!r.ok) {
           const err = await r.json().catch(() => ({}));
           showToast(err.detail || t('toast.request_failed'), 'error');
           return;
         }
-        const result = await r.json();
-        if (result.deleted) {
+        const data = await r.json();
+        if (data.deleted) {
           showToast(t('settings.ctx.delete_success').replace('{name}', name));
           detailEl.hidden = true;
           loadCtxList(type);
@@ -797,18 +811,30 @@ document.querySelectorAll('.ctx-sync-btn').forEach(btn => {
 document.querySelectorAll('.ctx-import-btn').forEach(btn => {
   btn.addEventListener('click', async () => {
     const type = btn.dataset.type;
-    const ok = await showConfirm({
+    // Overwrite is opt-in: the default skip-when-canonical-exists rule
+    // protects user-maintained canonicals from a stray Import wiping
+    // them out with a stale runtime copy. The checkbox lets the user
+    // explicitly say "yes, the runtime is the source of truth this
+    // round" — used after editing in-place in ``~/.claude/skills/``
+    // and wanting to flow that back into ``.memtomem/``.
+    const result = await showConfirm({
       title: t('settings.ctx.import'),
       message: t('settings.ctx.confirm_import').replace('{type}', type),
       confirmText: t('settings.ctx.import'),
+      extraOption: {
+        id: 'overwrite',
+        label: t('settings.ctx.confirm_import_overwrite_label'),
+        defaultChecked: false,
+      },
     });
-    if (!ok) return;
+    if (!result || !result.ok) return;
+    const overwrite = !!(result.extras && result.extras.overwrite);
     btnLoading(btn, true);
     try {
       const r = await fetch(`/api/context/${type}/import`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ overwrite }),
       });
       if (!r.ok) {
         const err = await r.json().catch(() => ({}));
@@ -899,11 +925,47 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
 // -- Add Project button (delegated) ------------------------------------------
 
 document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
-  btn.addEventListener('click', async () => {
+  btn.addEventListener('click', () => {
     const type = btn.dataset.type;
-    // Reuse showConfirm-with-input-style by handing the user a prompt — the
-    // browser dialog is enough for PR2 (no native folder picker is reachable
-    // from the SPA layer; per-RFC §Non-goals item 5 we don't try).
+    // Defer to the shared folder picker (``path-picker.js``) instead of
+    // ``window.prompt``: visual breadcrumb navigation, validation
+    // against the server's ``/api/fs/list`` allow-list, and no
+    // copy-paste path errors. ``PathPicker.open`` is async w.r.t.
+    // the user; we hand it a callback that runs the POST when the
+    // picker resolves a path. ``window.prompt`` fallback survives in
+    // case ``path-picker.js`` failed to load (vendor cache miss, etc.)
+    // — better than a non-functional Add Project button.
+    const onSelect = async (root) => {
+      if (!root) return;
+      btnLoading(btn, true);
+      try {
+        const r = await fetch('/api/context/known-projects', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ root }),
+        });
+        if (!r.ok) {
+          const err = await r.json().catch(() => ({}));
+          showToast(err.detail || t('toast.request_failed'), 'error');
+          return;
+        }
+        const data = await r.json();
+        if (data.warning) {
+          showToast(data.warning, 'warning');
+        } else {
+          showToast(t('settings.ctx.add_project_success'), 'success');
+        }
+        loadCtxList(type);
+      } catch (err) {
+        showToast(t('toast.request_failed', { error: err.message }), 'error');
+      } finally {
+        btnLoading(btn, false);
+      }
+    };
+    if (window.PathPicker && typeof window.PathPicker.open === 'function') {
+      window.PathPicker.open({ onSelect });
+      return;
+    }
     const raw = window.prompt(
       t('settings.ctx.add_project_prompt'),
       '',
@@ -911,29 +973,6 @@ document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
     if (!raw) return;
     const root = raw.trim();
     if (!root) return;
-    btnLoading(btn, true);
-    try {
-      const r = await fetch('/api/context/known-projects', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ root }),
-      });
-      if (!r.ok) {
-        const err = await r.json().catch(() => ({}));
-        showToast(err.detail || t('toast.request_failed'), 'error');
-        return;
-      }
-      const data = await r.json();
-      if (data.warning) {
-        showToast(data.warning, 'warning');
-      } else {
-        showToast(t('settings.ctx.add_project_success'), 'success');
-      }
-      loadCtxList(type);
-    } catch (err) {
-      showToast(t('toast.request_failed', { error: err.message }), 'error');
-    } finally {
-      btnLoading(btn, false);
-    }
+    onSelect(root);
   });
 });

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1317,6 +1317,6 @@
   <script src="/settings-hooks-watchdog.js?v=2"></script>
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=7"></script>
-  <script src="/path-picker.js?v=1"></script>
+  <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -286,6 +286,7 @@
   "settings.ctx.confirm_cascade_codex": "This will also delete files in ~/.codex/ (user-scope). Continue?",
   "settings.ctx.confirm_sync": "Fan out {type} to all runtimes?",
   "settings.ctx.confirm_import": "Import {type} from runtimes into .memtomem/?",
+  "settings.ctx.confirm_import_overwrite_label": "Overwrite existing canonical files",
   "settings.ctx.sync_success": "Sync completed",
   "settings.ctx.sync_dropped": "{count} field(s) dropped during sync",
   "settings.ctx.import_priority": "Import priority: Claude \u2192 Gemini (Codex is forward-only)",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -286,6 +286,7 @@
   "settings.ctx.confirm_cascade_codex": "~/.codex/ (사용자 범위) 의 파일도 삭제됩니다. 계속하시겠습니까?",
   "settings.ctx.confirm_sync": "{type} 을(를) 모든 런타임으로 동기화하시겠습니까?",
   "settings.ctx.confirm_import": "런타임에서 {type} 을(를) .memtomem/ 으로 가져오시겠습니까?",
+  "settings.ctx.confirm_import_overwrite_label": "기존 canonical 파일 덮어쓰기",
   "settings.ctx.sync_success": "동기화 완료",
   "settings.ctx.sync_dropped": "동기화 중 {count}개 필드가 제거됨",
   "settings.ctx.import_priority": "가져오기 우선순위: Claude \u2192 Gemini (Codex는 단방향)",

--- a/packages/memtomem/src/memtomem/web/static/path-picker.js
+++ b/packages/memtomem/src/memtomem/web/static/path-picker.js
@@ -6,6 +6,12 @@
  * back into #index-path on Select. Navigation is bounded by the server's
  * allow-list (memory_dirs + ~); going outside requires closing the modal
  * and typing the path manually — the input itself stays free-form.
+ *
+ * Also exposes ``window.PathPicker.open({ onSelect })`` for other
+ * surfaces (Context Gateway "Add Project") so they can reuse the
+ * modal instead of falling back to ``window.prompt``. ``onSelect`` is
+ * invoked with the selected absolute path; ``close`` is called by the
+ * picker itself once the callback returns.
  */
 'use strict';
 
@@ -13,6 +19,10 @@
   let currentPath = null;     // null = roots view
   let currentEntries = [];
   let initialized = false;
+  // Per-open callback. Cleared on close so a stale callback from a
+  // previous invocation can't fire when the picker is reopened by the
+  // default Index-tab path.
+  let onSelectCb = null;
 
   function modal() { return qs('path-picker-modal'); }
   function listEl() { return qs('path-picker-list'); }
@@ -166,7 +176,8 @@
     (firstItem || cancelBtn()).focus();
   }
 
-  function open() {
+  function open(opts) {
+    onSelectCb = (opts && typeof opts.onSelect === 'function') ? opts.onSelect : null;
     modal().hidden = false;
     document.addEventListener('keydown', _onKey, true);
     modal().addEventListener('click', _onBackdrop);
@@ -180,6 +191,7 @@
     modal().removeEventListener('click', _onBackdrop);
     currentPath = null;
     currentEntries = [];
+    onSelectCb = null;
     listEl().textContent = '';
     crumbEl().textContent = '';
     emptyEl().hidden = true;
@@ -187,9 +199,19 @@
 
   function commit() {
     if (!currentPath) return;
+    const path = currentPath;
+    if (onSelectCb) {
+      // External caller supplied a sink — let them route the path
+      // (Context Gateway "Add Project" POSTs to /known-projects, etc.)
+      // instead of writing to ``#index-path``.
+      const cb = onSelectCb;
+      close();
+      cb(path);
+      return;
+    }
     const input = qs('index-path');
     if (input) {
-      input.value = currentPath;
+      input.value = path;
       input.dispatchEvent(new Event('input', { bubbles: true }));
       input.dispatchEvent(new Event('change', { bubbles: true }));
     }
@@ -229,7 +251,9 @@
     if (initialized) return;
     initialized = true;
     const browseBtn = qs('path-picker-browse-btn');
-    if (browseBtn) browseBtn.addEventListener('click', open);
+    // ``open`` takes an optional opts arg; pass none for the default
+    // Index-tab flow so it falls through to the ``#index-path`` writer.
+    if (browseBtn) browseBtn.addEventListener('click', () => open());
     if (cancelBtn()) cancelBtn().addEventListener('click', close);
     if (selectBtn()) selectBtn().addEventListener('click', commit);
   }
@@ -239,4 +263,9 @@
   } else {
     _init();
   }
+
+  // Public API for other surfaces (e.g. Context Gateway "Add Project"
+  // in ``context-gateway.js``). Keeping this small — open and close are
+  // enough; commit is internal.
+  window.PathPicker = { open, close };
 })();


### PR DESCRIPTION
## Summary

Three small UX gaps in the Context Gateway that all share the same
shape: the backend already supports the capability, the UI just never
wired it. Each is opt-in (default-off) so a user who clicks through
the dialogs gets the conservative behavior.

- **Cascade Delete** — `DELETE /api/context/{type}/{name}` accepts a
  `cascade` query param (skills `:222`, agents `:275`, commands
  `:250`); the delete handler hardcoded `cascade=false`. The confirm
  dialog now carries an opt-in checkbox driven by the existing-but-
  orphan `settings.ctx.cascade_delete` i18n key.
- **Import Overwrite** — `POST /api/context/{type}/import` accepts
  `{ overwrite: bool }` in the body (skills `:355`, agents `:402`,
  commands `:378`); the import handler sent an empty body. The
  confirm dialog now carries an opt-in checkbox; new i18n key
  `settings.ctx.confirm_import_overwrite_label` (en + ko).
- **Add Project folder picker** — `path-picker.js` (the Index-tab
  Browse modal) is refactored to expose
  `window.PathPicker.open({ onSelect })`; `Add Project` defers to
  it instead of `window.prompt`. Backwards-compatible for the Index
  tab (no opts → writes to `#index-path`). `window.prompt` survives
  as a fallback when the picker module failed to load.

Cache-bust: `context-gateway.js?v=7`, `path-picker.js?v=2`.

Closes the first three "Tier A" items from the Context Gateway
review (audit notes left in the issue/PR conversation, not a
standalone tracker).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 16/16
      green, en + ko parity preserved (one new key on both sides).
- [x] `node --check` on both modified JS files — syntax clean.
- [ ] CI green.
- [ ] Manual smoke (recommended for reviewer):
  - [ ] Settings → Context Gateway → Skills → Delete: verify checkbox
        renders; box ON → URL has `cascade=true` (DevTools Network);
        box OFF → URL has `cascade=false`.
  - [ ] Settings → Context Gateway → Skills → Import: verify checkbox
        renders; box ON → POST body has `{ overwrite: true }`.
  - [ ] Settings → Context Gateway → Skills → Add Project: verify the
        Browse modal opens (not `window.prompt`); selecting a path
        POSTs to `/api/context/known-projects`.
  - [ ] Index tab → 📁 Browse: verify still writes to the path input
        (regression check on the path-picker refactor).

## Notes for reviewers

- Behavior tests would naturally land as `tests-js/` jsdom fixtures,
  but that infrastructure is in #760 (still open). I'll add the
  fixtures as a follow-up PR once #760 lands. The orphan-render
  fixture there is the template — same `bootApp` helper extends to
  these flows.
- `settings.ctx.confirm_cascade_codex` ("This will also delete files
  in `~/.codex/` (user-scope). Continue?") is still orphan after
  this PR. It looks like a secondary "are you really sure?" warning
  for codex-scope cascades — out of scope for this PR.
- Out of scope: `_count_statuses` error taxonomy (RFC #762), 409
  conflict UX (RFC #763), Settings prod transition (RFC #761),
  Commands Field Map (separate PR — see Tier B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
