### PR TITLE
feat(web/ctx): commands field_map + render matrix in detail Diff pane

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -128,7 +128,13 @@ async def read_command(
     return {"name": name, "content": content, "mtime_ns": str(mtime_ns), "fields": fields}
 
 
-# ── Rendered (per-runtime output with dropped fields) ────────────────────
+# ── Rendered (per-runtime output with dropped fields + field map) ────────
+
+# Frontmatter keys that any command generator may drop. Hyphenated to match
+# the strings the renderers emit on ``dropped_fields`` (see
+# ``memtomem.context.commands._subcommand_to_gemini_toml``). Required fields
+# (``name``, ``description``) are never dropped, so they aren't tracked here.
+_ALL_OPTIONAL_FIELDS = ("argument-hint", "allowed-tools", "model")
 
 
 @router.get("/context/commands/{name}/rendered")
@@ -149,6 +155,10 @@ async def rendered_command(
     runtimes = []
     diffs = diff_commands(project_root)
     status_map: dict[tuple[str, str], str] = {(rt, n): s for rt, n, s in diffs}
+    # ``field_map[field][runtime] = bool`` — True when the runtime keeps the
+    # field, False when it drops it. Mirrors ``context_agents.rendered_agent``
+    # so the front-end can render a single matrix for either surface.
+    field_map: dict[str, dict[str, bool]] = {f: {} for f in _ALL_OPTIONAL_FIELDS}
 
     for gen_name, gen in COMMAND_GENERATORS.items():
         rendered_content, dropped_fields = gen.render(parsed)
@@ -161,12 +171,16 @@ async def rendered_command(
                 "status": status,
             }
         )
+        dropped_set = set(dropped_fields)
+        for f in _ALL_OPTIONAL_FIELDS:
+            field_map[f][gen_name] = f not in dropped_set
 
     return JSONResponse(
         content={
             "name": name,
             "canonical_content": content,
             "runtimes": runtimes,
+            "field_map": field_map,
         }
     )
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -633,18 +633,78 @@ async function loadCtxDetail(type, name) {
   }
 }
 
+// Surfaces (agents, commands) whose ``/rendered`` endpoint emits a
+// ``field_map`` matrix. Skills don't produce per-runtime field drops,
+// so a matrix would be uniformly green and not worth the row.
+const _CTX_FIELD_MAP_TYPES = new Set(['agents', 'commands']);
+
+function _ctxRenderFieldMapHtml(fieldMap, runtimes) {
+  // ``fieldMap[field][runtime] = bool`` (True = kept). ``runtimes`` is the
+  // ordered list of runtime keys from the same response so column order
+  // matches the runtime sections rendered below.
+  if (!fieldMap || !runtimes || !runtimes.length) return '';
+  const fields = Object.keys(fieldMap);
+  if (!fields.length) return '';
+  const heading = escapeHtml(t('settings.ctx.field_map'));
+  let html = `<table class="ctx-field-map" aria-label="${heading}">`;
+  html += `<thead><tr><th scope="col">${heading}</th>`;
+  for (const rt of runtimes) {
+    html += `<th scope="col">${escapeHtml(rt)}</th>`;
+  }
+  html += '</tr></thead><tbody>';
+  for (const f of fields) {
+    html += `<tr><th scope="row">${escapeHtml(f)}</th>`;
+    for (const rt of runtimes) {
+      const kept = !!(fieldMap[f] && fieldMap[f][rt]);
+      // ✓ for kept, em-dash for dropped — high-contrast, locale-stable
+      // (no translation needed; the matrix headers carry the labels).
+      html += `<td>${kept ? '✓' : '—'}</td>`;
+    }
+    html += '</tr>';
+  }
+  html += '</tbody></table>';
+  return html;
+}
+
+async function _ctxFetchFieldMap(type, name) {
+  // Fail-soft: a missing/invalid /rendered response should not break the
+  // diff pane. The diff fetch is the user-facing source of truth here;
+  // the field map is supplementary.
+  try {
+    const res = await fetch(`/api/context/${type}/${encodeURIComponent(name)}/rendered`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data || !data.field_map) return null;
+    const runtimes = (data.runtimes || []).map(rt => rt.runtime);
+    return { fieldMap: data.field_map, runtimes };
+  } catch (_err) {
+    return null;
+  }
+}
+
 async function _ctxLoadDiff(type, name, detailEl) {
   const pane = detailEl.querySelector('#ctx-pane-diff');
   if (!pane) return;
   pane.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
   try {
-    const res = await fetch(`/api/context/${type}/${encodeURIComponent(name)}/diff`);
+    // Diff is required, field map is optional + parallel-fetched. ``Promise.all``
+    // would fail the whole pane on a /rendered hiccup; the explicit
+    // fail-soft inside ``_ctxFetchFieldMap`` is what we want here.
+    const diffPromise = fetch(`/api/context/${type}/${encodeURIComponent(name)}/diff`);
+    const fieldMapPromise = _CTX_FIELD_MAP_TYPES.has(type)
+      ? _ctxFetchFieldMap(type, name)
+      : Promise.resolve(null);
+    const res = await diffPromise;
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Diff failed');
     const data = await res.json();
+    const fieldMapData = await fieldMapPromise;
 
     let html = '';
+    if (fieldMapData) {
+      html += _ctxRenderFieldMapHtml(fieldMapData.fieldMap, fieldMapData.runtimes);
+    }
     if (!data.runtimes || !data.runtimes.length) {
-      html = '<div class="text-muted">No runtime targets found.</div>';
+      html += '<div class="text-muted">No runtime targets found.</div>';
     } else {
       for (const rt of data.runtimes) {
         html += `<div style="margin-bottom:12px">`;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1316,7 +1316,7 @@
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=2"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=7"></script>
+  <script src="/context-gateway.js?v=8"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -520,6 +520,33 @@ class TestRenderedCommand:
             assert gemini[0]["dropped_fields"]
             assert gemini[0]["content"]  # rendered TOML
 
+    @pytest.mark.anyio
+    async def test_rendered_shows_field_map(self, client: AsyncClient, tmp_path: Path):
+        # Mirrors ``TestRenderedAgent.test_rendered_shows_dropped_and_field_map``.
+        # The matrix surfaces "field × runtime → kept?" so the UI can render
+        # a single table across runtimes instead of forcing the user to scan
+        # per-runtime ``dropped_fields`` chips and reconstruct the picture.
+        _make_command(tmp_path, "review")
+        r = await client.get("/api/context/commands/review/rendered")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["field_map"], "field_map must be present in /rendered response"
+        # Required-fields-only rule: name + description are never tracked.
+        assert "name" not in data["field_map"]
+        assert "description" not in data["field_map"]
+        # Optional fields all expected (hyphenated form matching what the
+        # renderers emit on ``dropped_fields``).
+        for expected in ("argument-hint", "allowed-tools", "model"):
+            assert expected in data["field_map"], f"missing {expected!r} in field_map"
+        # Pin the contract: gemini drops all three optional fields, claude
+        # is pass-through. Without this assertion the field_map could ship
+        # as ``{}`` for every field and the structural check above would
+        # still pass.
+        assert data["field_map"]["argument-hint"].get("gemini_commands") is False
+        assert data["field_map"]["argument-hint"].get("claude_commands") is True
+        assert data["field_map"]["model"].get("gemini_commands") is False
+        assert data["field_map"]["model"].get("claude_commands") is True
+
 
 class TestCommandCRUD:
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

The agents `/rendered` endpoint emits a `field_map` matrix
(`{field: {runtime: kept_bool}}`), useful at a glance to see which
optional frontmatter keys survive each runtime. Two gaps were sitting
in the code:

1. The same matrix wasn't computed for **commands**, even though
   commands have an analogous "Gemini drops `argument-hint` /
   `allowed-tools` / `model`" story.
2. **Neither surface actually rendered the matrix** in the UI — the
   `.ctx-field-map` CSS class and `settings.ctx.field_map` i18n key
   sat unused; the Diff pane only showed per-runtime "Dropped: X"
   chips and forced the user to mentally reconstruct the matrix.

This PR closes both:

### Backend — `context_commands.py:rendered_command`

- Adds `_ALL_OPTIONAL_FIELDS = ("argument-hint", "allowed-tools", "model")`.
- Builds `field_map[field][runtime] = (field not in dropped_fields)` per
  generator, mirroring `context_agents.rendered_agent`.
- Returns `field_map` in the JSON response.

### Frontend — `context-gateway.js:_ctxLoadDiff`

- New `_ctxRenderFieldMapHtml` + `_ctxFetchFieldMap` helpers.
- Diff pane parallel-fetches `/diff` and `/rendered`; the matrix
  renders as a `<table class="ctx-field-map">` above the per-runtime
  sections for agents and commands. Skills skip the extra fetch
  (no field drops).
- Fail-soft: a broken `/rendered` response leaves the diff pane
  intact (the diff is the user-facing source of truth).

### Tests

- `TestRenderedCommand.test_rendered_shows_field_map`: pins the
  matrix shape AND specific drops (gemini drops all three, claude
  pass-through) — paired positive + negative assertions per
  `feedback_pin_invert_symmetric_assertion.md`.
- **Mutation-validated**: inverting `f not in dropped_set` to
  `f in dropped_set` in the production code flipped the pin
  assertions to red, then green again on revert.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_routes_context.py packages/memtomem/tests/test_i18n.py` — 72/72 green.
- [x] `uv run ruff check` + `ruff format --check` clean on touched Python files.
- [x] `node --check` clean on the modified JS file.
- [x] Mutation test: inverted the field_map predicate → test fails;
      reverted → test green.
- [ ] CI green.
- [ ] Manual smoke (recommended for reviewer):
  - [ ] Settings → Context Gateway → Agents → pick an item with
        all-optional-fields populated → Diff tab. Verify a
        `Field Map` table renders above the per-runtime chips,
        with ✓ / — for each (field × runtime) cell.
  - [ ] Same for Commands. Verify gemini column shows — for
        argument-hint / allowed-tools / model.
  - [ ] Skills detail Diff tab: no field-map table (correct —
        skills don't drop fields).

## Notes for reviewers

- Frontend tests for the matrix renderer would naturally land in the
  `tests-js/` infra (PR #760, still open). I'll add them as a
  follow-up once #760 lands.
- Out of scope: an actual "Rendered" tab that previews the rendered
  per-runtime content (the `/rendered` endpoint already returns it
  but no UI surfaces it). The matrix is the smaller, more impactful
  use of the existing data — kept this PR scoped accordingly.
- `dropped_fields` chips (still per-runtime) are kept; the matrix
  is additive, not a replacement. Both serve different reading
  modes ("which runtimes drop X?" vs. "what does runtime Y
  receive?").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
