### PR TITLE
feat(web/ctx): auto-open Diff tab on detail entry for out-of-sync items

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -283,7 +283,14 @@ function _ctxRenderItemsHtml(items, type, projectRoot, { clickable }) {
     const canonAttr = item.canonical_path
       ? ` data-canonical-path="${escapeHtml(item.canonical_path)}"`
       : ' data-canonical-path=""';
-    html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}"${canonAttr}>
+    // ``data-out-of-sync`` lets the list-click handler hint to
+    // ``loadCtxDetail`` that the user should land on the Diff tab —
+    // otherwise the canonical pane is the default and the user has
+    // to click Diff to discover *what* is out of sync. Computed here
+    // because the list response carries the per-runtime statuses;
+    // ``loadCtxDetail`` would otherwise need a second fetch.
+    const outOfSync = (item.runtimes || []).some(r => r.status === 'out of sync');
+    html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}">
       <div class="ctx-card-header">
         <div>
           <div class="ctx-card-name">${escapeHtml(item.name)}</div>
@@ -324,7 +331,9 @@ async function _loadScopeGroupItems(type, scope, container) {
           // endpoint returns 404. Branch into the diff-backed renderer so the
           // user sees the actual runtime contents instead of a "not found".
           if (card.dataset.canonicalPath) {
-            loadCtxDetail(type, card.dataset.name);
+            loadCtxDetail(type, card.dataset.name, {
+              autoOpenDiff: card.dataset.outOfSync === 'true',
+            });
           } else {
             const detailEl = qs(`ctx-${type}-detail`);
             _ctxLoadRuntimeOnlyDetail(type, card.dataset.name, detailEl);
@@ -463,7 +472,15 @@ async function loadCtxList(type) {
 
 // -- Detail -------------------------------------------------------------------
 
-async function loadCtxDetail(type, name) {
+async function loadCtxDetail(type, name, opts = {}) {
+  // ``opts.autoOpenDiff`` (default false): when the list-click handler
+  // sees an "out of sync" runtime on the card, it passes ``true`` here
+  // so the detail view lands on the Diff tab pre-fetched, instead of
+  // forcing the user to discover what's drifted by clicking Diff
+  // themselves. Other call paths (post-save / post-delete reload at
+  // line ~575/588) leave it false to preserve their canonical-pane
+  // default.
+  const autoOpenDiff = opts.autoOpenDiff === true;
   const detailEl = qs(`ctx-${type}-detail`);
   detailEl.hidden = false;
   _ctxCurrentDetail = { type, name };
@@ -530,6 +547,15 @@ async function loadCtxDetail(type, name) {
         if (tab.dataset.pane === 'diff') _ctxLoadDiff(type, name, detailEl);
       });
     });
+
+    // Out-of-sync prefetch + tab activation. Uses a synthetic ``click()``
+    // on the Diff tab so the same handler above runs — keeps the active
+    // class + pane wiring in one place. ``click()`` is sync but the
+    // delegated ``_ctxLoadDiff`` is async; that's fine, we don't await.
+    if (autoOpenDiff) {
+      const diffTab = detailEl.querySelector('.ctx-detail-tab[data-pane="diff"]');
+      if (diffTab) diffTab.click();
+    }
 
     // Edit
     detailEl.querySelector('.ctx-detail-edit-btn')?.addEventListener('click', () => {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1316,7 +1316,7 @@
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=2"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=8"></script>
+  <script src="/context-gateway.js?v=9"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/tests-js/ctx-out-of-sync-prefetch.test.mjs
+++ b/packages/memtomem/tests-js/ctx-out-of-sync-prefetch.test.mjs
@@ -1,0 +1,100 @@
+/* Regression guard for the out-of-sync auto-open Diff behaviour.
+ *
+ * When the list-click handler sees a card with ``data-out-of-sync="true"``
+ * it calls ``loadCtxDetail(type, name, { autoOpenDiff: true })`` so the
+ * detail view lands on the Diff tab pre-fetched. The default path
+ * (no opts / autoOpenDiff false) must keep the Canonical tab active
+ * — a positive + negative pair per ``feedback_pin_invert_symmetric_assertion.md``.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function stubCtxDetailFetch(window) {
+  window.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    // Canonical detail (``GET /api/context/{type}/{name}``)
+    if (url.match(/\/api\/context\/[^/]+\/[^/]+$/)) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          name: 'demo',
+          content: '# demo skill\n',
+          mtime_ns: '1',
+          files: [],
+          fields: {},
+        }),
+      };
+    }
+    // Diff endpoint — minimal payload so ``_ctxLoadDiff`` doesn't throw
+    if (url.endsWith('/diff')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          runtimes: [],
+          canonical_content: '# demo skill\n',
+        }),
+      };
+    }
+    // Locale or anything else — empty 200
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    };
+  };
+}
+
+describe('loadCtxDetail — autoOpenDiff', () => {
+  it('activates the Diff tab when autoOpenDiff: true', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubCtxDetailFetch(window);
+
+    await window.loadCtxDetail('skills', 'demo', { autoOpenDiff: true });
+
+    const detailEl = window.document.getElementById('ctx-skills-detail');
+    const diffTab = detailEl.querySelector('.ctx-detail-tab[data-pane="diff"]');
+    const canonTab = detailEl.querySelector('.ctx-detail-tab[data-pane="canonical"]');
+    expect(diffTab).not.toBeNull();
+    expect(canonTab).not.toBeNull();
+    expect(diffTab.classList.contains('active')).toBe(true);
+    expect(canonTab.classList.contains('active')).toBe(false);
+  });
+
+  it('keeps Canonical tab active by default (no opts)', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubCtxDetailFetch(window);
+
+    await window.loadCtxDetail('skills', 'demo');
+
+    const detailEl = window.document.getElementById('ctx-skills-detail');
+    const diffTab = detailEl.querySelector('.ctx-detail-tab[data-pane="diff"]');
+    const canonTab = detailEl.querySelector('.ctx-detail-tab[data-pane="canonical"]');
+    expect(canonTab.classList.contains('active')).toBe(true);
+    expect(diffTab.classList.contains('active')).toBe(false);
+  });
+
+  it('keeps Canonical tab active when autoOpenDiff: false', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubCtxDetailFetch(window);
+
+    await window.loadCtxDetail('skills', 'demo', { autoOpenDiff: false });
+
+    const detailEl = window.document.getElementById('ctx-skills-detail');
+    const diffTab = detailEl.querySelector('.ctx-detail-tab[data-pane="diff"]');
+    const canonTab = detailEl.querySelector('.ctx-detail-tab[data-pane="canonical"]');
+    expect(canonTab.classList.contains('active')).toBe(true);
+    expect(diffTab.classList.contains('active')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

When a Context Gateway list item is "out of sync", the user
previously had to enter the detail view (Canonical pane shown) and
click the Diff tab to discover *what* had drifted. This PR shifts
that one click to the framework: the list-click handler hints to
`loadCtxDetail` whether the card was out-of-sync, and the detail
render auto-activates the Diff tab in that case.

Resolves the "Diff 뷰의 접근성" point from the Tier B review.

## Mechanics

- `_ctxRenderItemsHtml` stamps `data-out-of-sync` on each card,
  computed from per-runtime statuses already in the list response —
  no extra fetch.
- List-click handler reads the dataset and calls
  `loadCtxDetail(type, name, { autoOpenDiff })`.
- `loadCtxDetail` gains an `opts.autoOpenDiff` flag (default `false`)
  and, after rendering tabs, synthetically `click()`s the Diff tab so
  the existing tab-switch handler does the heavy lifting (active
  classes + `_ctxLoadDiff`).
- Other `loadCtxDetail` call paths (post-save / post-delete reload at
  `~575/588`) pass no opts → default behaviour preserved.

## Test plan

- [x] `npm test` in `tests-js/` — 8/8 green (3 new + 5 existing).
  - Positive: `autoOpenDiff: true` → Diff tab active, Canonical not.
  - Default (no opts): Canonical active, Diff not.
  - Explicit `autoOpenDiff: false`: same as default.
- [x] **Mutation-validated**: gating the autoOpenDiff branch with
  `if (false && autoOpenDiff)` flipped the positive test to red,
  reverting → 3/3 green.
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 16/16
  green (no JSON change in this PR).
- [x] `node --check` clean.
- [ ] CI green.
- [ ] Manual smoke (recommended for reviewer):
  - [ ] Settings → Context Gateway → Skills with at least one
        "out of sync" runtime: click the card → Diff tab opens
        pre-fetched.
  - [ ] Settings → Context Gateway → Skills with all-green: click
        the card → Canonical tab stays active (no regression).
  - [ ] Save / Delete reload: Canonical pane is the landing tab as
        before (no opts in those call paths).

## Notes for reviewers

- The hint travels via the DOM dataset, not a structural API change.
  Cards that already encode `data-canonical-path` make the dataset a
  natural surface for one more boolean.
- "Out of sync" detection uses the wire string `'out of sync'`
  literally. If the backend ever reshapes that status, the hint
  silently degrades to `false` (Canonical default) — fail-soft, not
  fail-loud.
- Cache-bust: `context-gateway.js?v=9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
