### PR TITLE
feat(web/ctx): pre-click tooltip + aria-disabled on Sync All gate

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -150,9 +150,11 @@ async function loadCtxOverview() {
 
     // Gate the Sync All button: when every artifact type's items are
     // entirely runtime-only (no canonicals to fan out), Sync All resolves
-    // to a series of `no_canonical_root` skips. Surface that pre-click via
-    // a data attribute so CSS can dim the button and the click handler can
-    // short-circuit with a guidance toast.
+    // to a series of `no_canonical_root` skips. Surface that pre-click
+    // via a data attribute (CSS dims the button) plus a native ``title``
+    // hover tooltip + ``aria-disabled`` so the user understands the
+    // dimmed state without having to click first; the post-click toast
+    // stays as a fallback for users who don't hover (mobile, keyboard).
     const syncAllBtn = document.getElementById('ctx-sync-all-btn');
     if (syncAllBtn) {
       const totals = ['skills', 'commands', 'agents'].reduce((acc, k) => {
@@ -163,8 +165,12 @@ async function loadCtxOverview() {
       }, { total: 0, runtimeOnly: 0 });
       if (totals.total > 0 && totals.runtimeOnly === totals.total) {
         syncAllBtn.dataset.runtimeOnly = 'true';
+        syncAllBtn.title = t('settings.ctx.sync_all_disabled_tooltip');
+        syncAllBtn.setAttribute('aria-disabled', 'true');
       } else {
         delete syncAllBtn.dataset.runtimeOnly;
+        syncAllBtn.removeAttribute('title');
+        syncAllBtn.removeAttribute('aria-disabled');
       }
     }
 
@@ -176,6 +182,18 @@ async function loadCtxOverview() {
     el.innerHTML = emptyState('', 'Failed to load overview', err.message);
   }
 }
+
+// JS-owned ``title`` strings (as opposed to ``data-i18n-title`` which
+// I18N.applyDOM handles automatically) need a langchange refresh so the
+// hover tooltip stays in sync with the active locale. Only rewrites the
+// attribute when the gate is still active — clearing it during normal
+// state would erase any caller's title.
+window.addEventListener('langchange', () => {
+  const btn = document.getElementById('ctx-sync-all-btn');
+  if (btn && btn.dataset.runtimeOnly === 'true') {
+    btn.title = t('settings.ctx.sync_all_disabled_tooltip');
+  }
+});
 
 // Sync All button
 document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () => {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1316,7 +1316,7 @@
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=2"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=9"></script>
+  <script src="/context-gateway.js?v=10"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs
@@ -1,0 +1,113 @@
+/* Regression guard for the Sync All disabled-state hover tooltip.
+ *
+ * When every surface is runtime-only, ``loadCtxOverview`` previously
+ * only set ``data-runtime-only="true"`` (CSS dim) and routed click
+ * to a guidance toast. The user had to click first to learn why the
+ * button looked dimmed. This guard pins the new pre-click affordance:
+ * the button gains a localized ``title`` + ``aria-disabled`` whenever
+ * the gate fires, and clears them when the gate releases.
+ *
+ * A second guard pins the ``langchange`` refresh — JS-owned ``title``
+ * strings (vs. ``data-i18n-title``) don't auto-translate, so the
+ * locale toggle must rewrite the attribute as long as the gate is
+ * still active.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function stubOverviewFetch(window, { allRuntimeOnly }) {
+  // ``allRuntimeOnly`` flips the gate: when true every surface reports
+  // ``missing_canonical === total`` so ``loadCtxOverview`` should set
+  // the disabled affordances. When false at least one canonical exists
+  // so the button stays enabled.
+  const data = allRuntimeOnly
+    ? {
+      skills:   { total: 2, missing_canonical: 2 },
+      commands: { total: 1, missing_canonical: 1 },
+      agents:   { total: 1, missing_canonical: 1 },
+    }
+    : {
+      skills:   { total: 2, in_sync: 2 },
+      commands: { total: 1, in_sync: 1 },
+      agents:   { total: 1, in_sync: 1 },
+    };
+  // Delegate locale fetches to bootApp's stub so I18N caches both
+  // languages — without this ``setLang('ko')`` would resolve to ``{}``
+  // and ``t()`` would silently fall back to English, masking the
+  // langchange refresh assertion.
+  const upstream = window.fetch;
+  window.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    if (url.endsWith('/api/context/overview')) {
+      return { ok: true, status: 200, json: async () => data };
+    }
+    return upstream(input);
+  };
+}
+
+describe('Sync All — disabled-state tooltip', () => {
+  it('sets title + aria-disabled when every surface is runtime-only', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubOverviewFetch(window, { allRuntimeOnly: true });
+    // Drain the I18N.init langchange that app.js's DCL handler kicks
+    // off before calling loadCtxOverview — otherwise that langchange
+    // races with the loadCtxOverview await and the listener at
+    // ``context-gateway.js:191`` ends up doubling for the in-function
+    // title-set (mutation tests miss it).
+    await window.I18N.init();
+
+    await window.loadCtxOverview();
+
+    const btn = window.document.getElementById('ctx-sync-all-btn');
+    expect(btn.dataset.runtimeOnly).toBe('true');
+    expect(btn.getAttribute('aria-disabled')).toBe('true');
+    expect(btn.title).toBeTruthy();
+    expect(btn.title).not.toBe('settings.ctx.sync_all_disabled_tooltip');
+  });
+
+  it('clears title + aria-disabled when at least one canonical exists', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    // Pre-stamp the button as if a previous gate had fired so the
+    // negative branch's "remove" path is exercised. Without this the
+    // assertions could pass simply because the attributes were never
+    // touched.
+    const btn = window.document.getElementById('ctx-sync-all-btn');
+    btn.dataset.runtimeOnly = 'true';
+    btn.setAttribute('aria-disabled', 'true');
+    btn.title = 'stale tooltip';
+
+    stubOverviewFetch(window, { allRuntimeOnly: false });
+    await window.loadCtxOverview();
+
+    expect(btn.dataset.runtimeOnly).toBeUndefined();
+    expect(btn.getAttribute('aria-disabled')).toBeNull();
+    expect(btn.title).toBe('');
+  });
+
+  it('refreshes title on langchange while the gate is still active', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubOverviewFetch(window, { allRuntimeOnly: true });
+    await window.loadCtxOverview();
+
+    const btn = window.document.getElementById('ctx-sync-all-btn');
+    const titleEn = btn.title;
+    expect(titleEn).toBeTruthy();
+
+    // setLang flips the locale, applies DOM, dispatches langchange —
+    // the listener in context-gateway.js should rewrite the title.
+    await window.I18N.setLang('ko');
+    const titleKo = btn.title;
+    expect(titleKo).toBeTruthy();
+    expect(titleKo).not.toBe(titleEn);
+  });
+});


### PR DESCRIPTION
## Summary

When every Context Gateway surface is runtime-only, `loadCtxOverview`
already dims the Sync All button via `data-runtime-only="true"` (CSS
opacity 0.45 + `cursor: not-allowed`). But the only feedback for the
disabled state was a **post-click** toast — a user staring at the
dimmed button had to click it first to learn *why*.

This PR adds a **pre-click** affordance:

- Native `title` attribute on the button → hover tooltip with the
  same string the post-click toast uses
  (`settings.ctx.sync_all_disabled_tooltip`).
- `aria-disabled="true"` for screen readers and keyboard users so the
  disabled state surfaces without hover.
- Both attributes clear when the gate releases (any canonical
  appears).
- A `langchange` listener rewrites the title on locale toggle — a
  JS-owned `title` doesn't auto-translate via `data-i18n-title`
  (per `feedback_data_i18n_placeholder_clobber.md`).
- Post-click toast stays as a fallback for users who don't hover
  (mobile, keyboard navigation).

Resolves the "Sync All 상태 피드백 강화" point from the Tier B review.

## Test plan

- [x] `npm test` in `tests-js/` — 8/8 green (3 new + 5 existing).
  - Gate-on: `data-runtime-only`, `aria-disabled`, `title` all set
    with localized text.
  - Gate-off (after pre-stamping the disabled state): all three
    attributes are cleared.
  - Locale refresh: `setLang('ko')` flips the title to the Korean
    string while the gate is still active.
- [x] **Mutation-validated**: dropping `syncAllBtn.title = t(...)`
  inside `loadCtxOverview` flipped the gate-on test to red. Reverting
  → green. The test explicitly `await`s `I18N.init()` before
  `loadCtxOverview` so init's one-shot langchange drains *before* the
  listener can mask the in-function title-set.
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 16/16
  green (no JSON change in this PR — `sync_all_disabled_tooltip` key
  already exists in en + ko from #766).
- [x] `node --check` clean.
- [ ] CI green.
- [ ] Manual smoke (recommended for reviewer):
  - [ ] Settings → Context Gateway with no canonicals across all
        surfaces: hover Sync All → tooltip shows; click → toast
        confirms (no regression on the toast path).
  - [ ] After running Import → at least one canonical exists →
        re-enter Settings → tooltip + aria-disabled gone.
  - [ ] Toggle locale (KO ↔ EN) while the gate is active: tooltip
        text follows the new locale.

## Notes for reviewers

- Same i18n key drives both surfaces (tooltip + post-click toast) so
  the messages stay consistent. Single source of truth.
- The langchange listener guards on `dataset.runtimeOnly === 'true'`
  so it never clobbers a caller-set `title` outside the disabled
  state.
- Cache-bust: `context-gateway.js?v=9` (sibling PR #767 also bumps
  to v=9 — trivial conflict expected on whichever lands second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
