### PR TITLE
docs(adr): RFC-761 ADR-0001 §4 history fix + §5 phase readiness criteria

### DIFF
--- a/docs/adr/0001-context-gateway-sync-policies.md
+++ b/docs/adr/0001-context-gateway-sync-policies.md
@@ -87,13 +87,26 @@ A Context Gateway phase graduates from `_DEV_ONLY_ROUTERS` to
 `_PROD_ROUTERS` (in `packages/memtomem/src/memtomem/web/app.py`) and
 removes its `STATE.uiMode === 'dev'` UI gate(s) when **all four** hold:
 
-1. **No P0/P1 issues open against the surface for ≥2 weeks.**  Verify
-   via `gh issue list --label context-gateway,P0,P1` scoped to the
-   phase.
-2. **Round-trip integration test** in the Python suite — write
-   canonical → diff via the read route → import back via
-   `extract_*_to_canonical()`, asserting that canonical state survives
-   the cycle.
+1. **No P0/P1 (or equivalent severity) open issues against the
+   surface for ≥2 weeks.**  Phase scope is determined by inspecting
+   open issues that reference the phase's routes, JS modules, or
+   `extract_*_to_canonical()` symbols — repository label convention
+   for context-gateway / severity is not yet fixed and may evolve.
+2. **Round-trip integration test** in the Python suite, scoped to the
+   phase's data flow:
+   - **Bidirectional phases** (Skills, Commands, Agents — runtime
+     edits flow back to canonical): write canonical → diff via the
+     read route → import-back via `extract_*_to_canonical()`; assert
+     canonical state survives the cycle.
+   - **Unidirectional phases** (Settings — canonical → runtime only,
+     no reverse-import API by design because additive-merge cannot
+     distinguish canonical-authored from user-authored entries): write
+     canonical → apply via the sync route (`POST
+     /api/context/<phase>/sync`) → re-read via the diff route (`GET
+     /api/context/<phase>`); assert the diff reports the expected
+     synced state and any target-side merge invariants (e.g., for
+     Settings: additive merge does not clobber user-authored hook
+     entries).
 3. **i18n key parity (en + ko)** verified by `tests/test_i18n.py`.
    The parity test is auto-discovery based, so adding the phase's keys
    to `en.json` + `ko.json` is sufficient — no test changes needed.

--- a/docs/adr/0001-context-gateway-sync-policies.md
+++ b/docs/adr/0001-context-gateway-sync-policies.md
@@ -69,13 +69,58 @@ Phases 0 through D are fully independent:
 
 ### 4. GUI expansion order
 
-The web UI currently supports Settings Hooks sync only.  Future expansion
-should follow complexity order:
+The web UI rolled out sync surfaces in this complexity order:
 
-1. **Skills** — byte-identical copy, 3-state diff (simplest)
-2. **Commands** — placeholder normalization in diff view
-3. **Agents** — per-runtime dropped-field visualization, TOML vs MD diff
-   (most complex; requires the priority policy from §1 to be decided first)
+1. **Skills (Phase A)** — byte-identical copy, 3-state diff (simplest)
+2. **Commands (Phase B)** — placeholder normalization in diff view
+3. **Agents (Phase C)** — per-runtime dropped-field visualization,
+   TOML vs MD diff (most complex; requires the priority policy from §1
+   to be decided first)
+
+Phases A–C shipped to prod in that order.  Phase D (Settings Hooks) —
+the original dev-mode surface this ADR was authored against — remains
+dev-only until it satisfies the readiness contract in §5.
+
+### 5. Phase readiness criteria
+
+A Context Gateway phase graduates from `_DEV_ONLY_ROUTERS` to
+`_PROD_ROUTERS` (in `packages/memtomem/src/memtomem/web/app.py`) and
+removes its `STATE.uiMode === 'dev'` UI gate(s) when **all four** hold:
+
+1. **No P0/P1 issues open against the surface for ≥2 weeks.**  Verify
+   via `gh issue list --label context-gateway,P0,P1` scoped to the
+   phase.
+2. **Round-trip integration test** in the Python suite — write
+   canonical → diff via the read route → import back via
+   `extract_*_to_canonical()`, asserting that canonical state survives
+   the cycle.
+3. **i18n key parity (en + ko)** verified by `tests/test_i18n.py`.
+   The parity test is auto-discovery based, so adding the phase's keys
+   to `en.json` + `ko.json` is sufficient — no test changes needed.
+4. **Conflict path covered by a test fixture** — either HTTP 409
+   (e.g., Skills' optimistic-locking via `mtime_ns`) **or** a documented
+   soft-abort response (e.g., Settings' `200 + {"status": "aborted"}`
+   on stale-mtime resolve).  Both shapes qualify; the requirement is
+   that the conflict semantics are pinned by a test, not the specific
+   status code.
+
+**Why these four:** the round-trip test catches lossy serialization
+(the most common context-gateway regression class); the i18n parity
+test catches missing translations (the most common prod-only UX gap);
+the conflict-path test pins optimistic-write behavior so a future
+refactor cannot silently drop external-write detection.  The 2-week
+dwell time mirrors ADR-0007's "prod-user feedback ≥2 reports / waiting
+period" trigger and serves the same purpose.
+
+**Procedure precedent:** ADR-0007 (Namespace CRUD prod exposure) used
+trigger-criteria-then-flip with no env kill-switch; rollback was
+`git revert` of the gate-removal commit.  Future phase promotions
+follow the same pattern — no `*_DEV_ONLY` config knob.
+
+**Retroactive scope:** §5 applies to *future* phase promotions.  It
+does not retroactively fail Phases A–C — those shipped under earlier
+review and gaps (e.g., missing 409 fixtures in B/C) are tracked as
+hygiene follow-ups, not regressions.
 
 ## Consequences
 
@@ -84,3 +129,5 @@ should follow complexity order:
 - CI pipelines using `--strict` continue to work unchanged.
 - The `warn` level enables "fail-fast in local dev, log-only in CI" workflows
   via environment-driven `--on-drop` values.
+- Future phase promotions (Phase D Settings Hooks → prod, and any
+  subsequent phases) follow §5's four-point readiness contract.


### PR DESCRIPTION
## Summary

- Fix ADR-0001 §4 prose — Phases A (Skills), B (Commands), C (Agents)
  shipped to `_PROD_ROUTERS`, but the doc still claimed "web UI
  currently supports Settings Hooks sync only" (historically inverted).
- Add new ADR-0001 §5 "Phase readiness criteria" — the four-point
  contract gating any future phase's promotion from `_DEV_ONLY_ROUTERS`
  to `_PROD_ROUTERS` and the removal of its `STATE.uiMode === 'dev'`
  UI gate.

## Why

This is the decision-artifact PR for RFC #761 (Settings Hooks dev-only
gate → prod transition). The RFC's primary deliverable is the
stability criteria — without them, the same RFC repeats for each
future phase. The actual gate flip and Settings test backfill ship as
follow-up PRs against this contract.

The §5 criteria are:

1. **No P0/P1 issues open against the surface for ≥2 weeks.**
2. **Round-trip integration test** — write canonical → diff →
   import-back via `extract_*_to_canonical()`.
3. **i18n key parity (en + ko)** — `tests/test_i18n.py` auto-discovers,
   so adding the phase's keys is sufficient.
4. **Conflict path covered by a test fixture** — either HTTP 409
   (Skills' `mtime_ns` design) **or** documented soft-abort (Settings'
   `200 + {"status": "aborted"}`). Both shapes qualify; the
   requirement pins conflict semantics, not a specific status code.

## Decisions resolved (RFC open questions)

- **Criteria home:** ADR-0001 §5 (no separate ADR-0009). Existing ADR
  is the right place; cross-phase contract didn't justify a new ADR.
- **Kill-switch env var:** none. ADR-0007 (Namespace CRUD promotion)
  set the precedent for trigger-criteria-then-flip with `git revert`
  rollback. A `MEMTOMEM_WEB__CONTEXT_GATEWAY__SETTINGS_DEV_ONLY` knob
  would be the first feature-level disable, breaking convention.
- **Retroactive application:** §5 is prospective. Phases A–C ship
  as-is; their gaps (missing 409 fixtures in B/C) are tracked as
  hygiene follow-ups, not regressions.
- **Conflict-path criterion #4 wording:** status-code agnostic. The
  earlier "409 conflict" wording would have flagged Settings itself
  (which uses `200 + status:"aborted"` by design) and Phases B/C
  retroactively. Both 409 and documented soft-abort qualify now.

## Out of scope (follow-up PRs)

This PR is **docs-only** — no code changes. Two follow-up PRs land the
behavior:

- **PR-2 (gap-fill):** add `test_settings_round_trip_*` and
  `test_settings_conflict_aborts_with_status` to
  `tests/test_context_settings.py`, plus the `ctx_settings.*`
  navigation i18n keys to `en.json` + `ko.json`.
- **PR-3 (the flip):** move `settings_sync` from `_DEV_ONLY_ROUTERS`
  to `_PROD_ROUTERS` in `web/app.py`, drop the two
  `STATE.uiMode === 'dev'` gates in `web/static/context-gateway.js`,
  CHANGELOG entry.

Phases B/C 409 backfill is filed as a separate hygiene issue (not
blocking).

## Test plan

- [x] Read ADR-0001 end-to-end; §3 → §4 → §5 → Consequences flow is
      coherent and the §4 prose is no longer historically inverted.
- [x] §5 criteria each cite a concrete file or shape (no abstractions
      that drift).
- [ ] CI ruff/mypy/pytest jobs unaffected (docs-only diff, no source
      modifications).

Refs: #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)
