### PR TITLE
test(context-gateway): pin Commands sync 409 mtime-conflict path (closes #772)

### DIFF
--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -574,6 +574,21 @@ class TestCommandCRUD:
         r = await client.delete("/api/context/commands/test-cmd")
         assert r.status_code == 200
 
+    @pytest.mark.anyio
+    async def test_mtime_conflict(self, client: AsyncClient, tmp_path: Path):
+        # ADR-0001 §5 c4: pin no-write semantics on the conflict path. Asserting
+        # the 409 response label alone would still pass a regression that wrote
+        # body.content and *then* returned the abort envelope.
+        cmd_file = _make_command(tmp_path, "conflict")
+        r = await client.put(
+            "/api/context/commands/conflict",
+            json={"content": "---\ndescription: changed\n---\nNew\n", "mtime_ns": "0"},
+        )
+        assert r.status_code == 409
+        data = r.json()
+        assert data["status"] == "aborted"
+        assert cmd_file.read_text(encoding="utf-8") == _CMD_CONTENT
+
 
 class TestSyncCommands:
     @pytest.mark.anyio


### PR DESCRIPTION
## Summary

- Closes #772 — backfill HTTP 409 conflict-path fixture for Phase B (Commands) sync route.
- Mirrors `TestUpdateSkill.test_mtime_conflict` (`tests/test_web_routes_context.py:222-231`) for Commands, satisfying ADR-0001 §5 c4 (`docs/adr/0001-context-gateway-sync-policies.md` §5 c4).
- The 409 path itself (`packages/memtomem/src/memtomem/web/routes/context_commands.py:241-250`) already exists in production — this is purely test-coverage backfill. No production code changes.

## What §5 c4 actually requires

§5 c4 pins **conflict semantics**, not just the response label. A pure
`status_code == 409` + `status == "aborted"` assertion would still pass a
regression that wrote `body.content` and *then* returned the abort envelope.

This PR adds **two** assertions on the conflict path:

1. `r.status_code == 409` and `data["status"] == "aborted"` — pins the soft-abort response shape (verbatim parity with Skills).
2. `cmd_file.read_text() == _CMD_CONTENT` — pins the no-write semantics that §5 c4 actually targets.

## Mutation validation

Before commit, I verified the new test is regression-tight by mutating
`context_commands.py:241-250` to perform `atomic_write_text` *before* the
mtime-guard. The status-code assertion still passed (409 was still
returned), but the content assertion failed — confirming the test catches
the very class of regression §5 c4 is designed to prevent. The mutation
was reverted before the commit.

## Sibling-test parity observation (not in scope)

The Skills counterpart at `test_web_routes_context.py:222-231` only
asserts the response label, not the no-write semantics. That's a
hygiene gap of the same shape as #772 but for Phase A (Skills); it is
not a regression of any current behavior and is out of scope here.
Worth tracking as a follow-up if the team wants strict parity across
all three phases.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_web_routes_context.py` — 57/57 green
- [x] `uv run ruff check packages/memtomem/tests/test_web_routes_context.py`
- [x] `uv run ruff format --check packages/memtomem/tests/test_web_routes_context.py`
- [x] Mutation test (write-before-guard) → assertion fail confirmed → mutation reverted

Refs: #772, #761 (parent RFC), #769 (ADR §5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
