### PR TITLE
test(context-gateway): tighten Skills mtime-conflict to pin §5 c4 no-write semantics (closes #778)

### DIFF
--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -222,7 +222,11 @@ class TestUpdateSkill:
 
     @pytest.mark.anyio
     async def test_mtime_conflict(self, client: AsyncClient, tmp_path: Path):
+        # ADR-0001 §5 c4: pin no-write semantics on the conflict path. The
+        # response label alone would still pass a regression that wrote
+        # body.content and *then* returned the abort envelope.
         _make_skill(tmp_path, "conflict")
+        manifest_path = tmp_path / ".memtomem" / "skills" / "conflict" / SKILL_MANIFEST
         r = await client.put(
             "/api/context/skills/conflict",
             json={"content": "# Changed\n", "mtime_ns": "0"},  # wrong mtime_ns
@@ -230,6 +234,8 @@ class TestUpdateSkill:
         assert r.status_code == 409
         data = r.json()
         assert data["status"] == "aborted"
+        assert data["mtime_ns"] == str(manifest_path.stat().st_mtime_ns)
+        assert manifest_path.read_text(encoding="utf-8") == "# Test skill\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Closes #778 — tighten Phase A (Skills) `TestUpdateSkill.test_mtime_conflict` to pin ADR-0001 §5 c4 no-write semantics on the canonical PUT route.
- Mirrors the strict shape of the Agents counterpart at `test_web_routes_context.py:801-802` (which already asserts both `mtime_ns` echo + content-unchanged).
- Companion to PR #777 (Phase B / Commands). Phase C (Agents) was already strict.
- The 409 path itself (`packages/memtomem/src/memtomem/web/routes/context_skills.py:199-208`) is unchanged — this is purely test-coverage hardening.

## What §5 c4 actually requires

§5 c4 pins **conflict semantics**, not just the response label. The
existing `TestUpdateSkill.test_mtime_conflict` (status_code == 409 +
status == "aborted") would still pass a regression that wrote
`body.content` and *then* returned the abort envelope.

This PR adds **two** assertions on top of the existing pair:

1. `data["mtime_ns"] == str(manifest_path.stat().st_mtime_ns)` — pins the retry-hint contract from `context_skills.py:199-208`.
2. `manifest_path.read_text(...) == "# Test skill\n"` — pins the no-write semantics §5 c4 actually targets.

## Mutation validation

Before commit, I verified the hardened test is regression-tight by
mutating `context_skills.py:198-209` to perform `atomic_write_text`
*before* the mtime-guard. The 409 / `status == "aborted"` / `mtime_ns`
echo assertions all still passed (the response shape is unchanged),
but the new content assertion failed on `'# Changed' == '# Test skill'`
— confirming the test catches exactly the class of regression §5 c4 is
designed to prevent. The mutation was reverted before the commit
(`git diff packages/memtomem/src/memtomem/web/routes/context_skills.py`
returns empty in the final commit).

## Phase strictness map (post-merge)

| Phase     | `status: "aborted"` | no-write content | `mtime_ns` echo |
| --------- | ------------------- | ---------------- | --------------- |
| A Skills (this PR)  | ✓ | ✓ (new) | ✓ (new) |
| B Commands (PR #777) | ✓ | ✓ | ✗ |
| C Agents | ✓ | ✓ | ✓ |

The Phase B `mtime_ns` echo gap is intentionally out of scope here —
§5 c4's "conflict semantics" requirement is satisfied by the no-write
assertion alone, which #777 already pins. File a separate hygiene
issue if the team wants strict three-phase echo parity.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_web_routes_context.py` — 57/57 green
- [x] `uv run ruff check packages/memtomem/tests/test_web_routes_context.py`
- [x] `uv run ruff format --check packages/memtomem/tests/test_web_routes_context.py`
- [x] Mutation test (write-before-guard) → assertion fail confirmed → mutation reverted

Refs: #778, #777 (Phase B sibling), #761 (parent RFC), #769 (ADR §5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
