### PR TITLE
test(commands): assert mtime_ns echo on three-phase parity (closes #780)

### DIFF
--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -594,6 +594,7 @@ class TestCommandCRUD:
         assert r.status_code == 409
         data = r.json()
         assert data["status"] == "aborted"
+        assert data["mtime_ns"] == str(cmd_file.stat().st_mtime_ns)
         assert cmd_file.read_text(encoding="utf-8") == _CMD_CONTENT
 
 


### PR DESCRIPTION
## Summary

Closes #780. Adds the one-line `mtime_ns` echo assertion to
`TestCommandCRUD.test_mtime_conflict` so all three phases of the
context-gateway 409-conflict tests assert the retry-hint contract
identically.

| Phase     | `status: "aborted"` | no-write content | `mtime_ns` echo |
| --------- | ------------------- | ---------------- | --------------- |
| A Skills (`test_web_routes_context.py:224`)   | ✓ | ✓ | ✓ (#779)             |
| B Commands (`test_web_routes_context.py:585`) | ✓ | ✓ | ✓ **this PR**        |
| C Agents (`test_web_routes_context.py:793`)   | ✓ | ✓ | ✓                    |

The 409 envelope already returns the echo correctly from
`context_commands.py:248`; the test was just under-asserting.

## Why this isn't an ADR §5 c4 fix

§5 c4 pins the soft-abort label + no-write guarantee — both already
covered for Phase B by PR #777. The `mtime_ns` echo is the
**retry-hint contract** from `context_commands.py:241-250`, not §5 c4.
This is hygiene/parity, not a regression of any ADR requirement.
PR #779 explicitly called this out as a "file separately if the team
wants strict three-phase echo parity" follow-up.

## Mutation-validation

Mirrored PR #779's pattern. Temporarily changed
`context_commands.py:248` from:

```python
"mtime_ns": str(current_mtime_ns),
```

to:

```python
"mtime_ns": "0",
```

Result:

```
>       assert data["mtime_ns"] == str(cmd_file.stat().st_mtime_ns)
E       AssertionError: assert '0' == '1777930477924060002'
```

The new assertion fails as expected. The preceding 409 and
`status == "aborted"` assertions still pass — confirming the new line
is what catches a dropped/wrong echo, not the existing assertions.
Reverted; `git diff` on `context_commands.py` is empty.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_web_routes_context.py` — 58 passed.
- [x] `uv run ruff check packages/memtomem/tests/test_web_routes_context.py` — clean.
- [x] `uv run ruff format --check packages/memtomem/tests/test_web_routes_context.py` — clean.
- [x] Mutation-validation: new assertion fails on mutated production
      code; existing assertions still pass; revert is clean.

Refs: #779 (Phase A tightening, where this was filed as a follow-up),
#777 (Phase B no-write pin), #761 (parent RFC), #769 (ADR §5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
