### PR TITLE
fix(web/ctx): echo current mtime_ns on Settings resolve 409 abort

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -259,10 +259,15 @@ async def resolve_conflict(
 
                 # mtime check before write — protects against cross-process
                 # writers (CLI, manual edit) that the in-process lock can't see.
-                if target_path.stat().st_mtime_ns != mtime_ns:
+                # Echo the current ``mtime_ns`` on abort so clients can refresh
+                # local state without an extra round-trip — matches the
+                # Skills/Commands/Agents 409 envelope contract.
+                current_mtime_ns = target_path.stat().st_mtime_ns
+                if current_mtime_ns != mtime_ns:
                     return {
                         "status": "aborted",
                         "reason": "Target file was modified by another process. Retry.",
+                        "mtime_ns": str(current_mtime_ns),
                     }
 
                 target_hooks[body.event] = rules

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -736,7 +736,14 @@ class TestSettingsHttpLayer:
         route captures ``target_path.stat().st_mtime_ns`` before the
         load and rechecks before write. We bump mtime as a side effect
         of the load so the recheck mismatches → HTTP 200 + ``{"status":
-        "aborted", "reason": <... modified by another process ...>}``.
+        "aborted", "reason": <... modified by another process ...>,
+        "mtime_ns": <current st_mtime_ns>}``.
+
+        Asserts the same triplet the Skills/Commands/Agents conflict
+        tests pin (status / no-write content / current mtime_ns echo)
+        — without all three a regression that wrote the proposed rule
+        before returning aborted, or dropped the mtime_ns echo from
+        the envelope, would still pass.
         """
         _make_canonical_settings(
             tmp_path,
@@ -782,3 +789,13 @@ class TestSettingsHttpLayer:
         body = resp.json()
         assert body["status"] == "aborted"
         assert "modified by another process" in body["reason"]
+        # mtime_ns echo — clients refresh local state without an extra
+        # round-trip; matches Skills/Commands/Agents 409 envelopes.
+        assert body["mtime_ns"] == str(target.stat().st_mtime_ns)
+        # No-write content — pinned both ways: the original user rule
+        # survives, and the canonical rule is *not* persisted to disk.
+        # A regression that wrote before returning aborted would flip
+        # the second assertion.
+        on_disk = target.read_text(encoding="utf-8")
+        assert "echo user" in on_disk
+        assert "echo canonical" not in on_disk


### PR DESCRIPTION
## Summary

- **Behavioral fix**: Settings resolve route now echoes the current `st_mtime_ns` in its 409 abort envelope, matching the Skills/Commands/Agents contract. This lets clients refresh local state on conflict without an extra round-trip.
- **Test tightened to ADR-0001 §5 c4 triplet**: response `status` + envelope `mtime_ns` echo + no-write content (asserted symmetrically with positive marker + negative `!=`).
- **Mutation-validated**: dropping the envelope echo or moving `_write_json` above the recheck both flip the test red.

## Why

Codex review on the three-phase parity series (#776/#777/#779/#781) flagged Settings as the lone surface that was *not* asserting the strict triplet. The reviewer's inspection of `settings_sync.py:262` confirmed it was a real envelope-shape gap — the recheck already re-stat()'d the target, so adding the echo is one line. Tightening the test alone (without the route fix) would have papered over an asymmetric API surface.

| Surface | `status: "aborted"` | no-write content | `mtime_ns` echo |
| ------- | ------------------- | ---------------- | --------------- |
| Skills (PR #779)   | ✓ | ✓ | ✓ |
| Commands (PR #781) | ✓ | ✓ | ✓ |
| Agents (PR #776)   | ✓ | ✓ | ✓ |
| Settings — **before** this PR | ✓ | ✗ | ✗ |
| Settings — **after** this PR  | ✓ | ✓ | ✓ |

## Compatibility

- `mtime_ns` is **additive** in the response. The only known consumer (`settings-hooks-watchdog.js:123–139`) reads `result.status` and `result.reason` — adding a new key cannot break it.
- Reason text wording is unchanged.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_settings.py` — 37 passed
- [x] Wider sweep across `test_web_routes_context*.py` + `test_context_settings.py` — 104 passed
- [x] All settings-keyword tests across the suite — 62 passed
- [x] `uv run ruff check` + `uv run ruff format --check` — clean
- [x] Mutation 1 (drop envelope echo) → `KeyError: 'mtime_ns'` ✓ caught
- [x] Mutation 2 (write before recheck) → `assert 'echo user' in on_disk` fails ✓ caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)
