### PR TITLE
docs(web): fix stale '/api/add does not invoke privacy.scan' comments

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3727,9 +3727,9 @@ qs('folder-hint-sources-link')?.addEventListener('click', e => {
 // objects, cached on STATE.privacyPatterns. Soft-fail on network /
 // translator error: leave the cache null and the submit handler skips
 // the scan rather than break Add on a transient blip. The server's
-// /api/add route does not invoke privacy.scan either, so a strict
-// client gate would not be real security — this is defense-in-depth
-// for accidental paste, not the trust boundary.
+// /api/add route enforces ``privacy.enforce_write_guard`` (the trust
+// boundary); this client-side check is defense-in-depth that warns
+// before submit so a paste-then-cancel doesn't have to round-trip.
 async function loadPrivacyPatterns() {
   try {
     const data = await api('GET', '/api/privacy/patterns');
@@ -3760,11 +3760,11 @@ qs('add-btn').addEventListener('click', async () => {
   //
   // Scan-window asymmetry: ``re.test()`` here scans the entire
   // textarea, while server-side ``privacy.scan()`` caps at the first
-  // 10K chars (``_SCAN_WINDOW`` in privacy.py). Today moot —
-  // ``/api/add`` does not invoke ``privacy.scan`` — but if the
-  // ADR-tracked server gate ever lands, the two would disagree on
-  // very long content. The client is more permissive (covers more);
-  // the server boundary is the source of truth.
+  // 10K chars (``_SCAN_WINDOW`` in privacy.py). For very long content
+  // with a secret past that cap, the client warns and the server's
+  // ``enforce_write_guard`` does not — so the client is more
+  // permissive (covers more positions). The server boundary remains
+  // the source of truth; this client check is a UX-time hint.
   const patterns = STATE.privacyPatterns;
   if (patterns && patterns.some(re => re.test(content))) {
     const ok = await showConfirm({


### PR DESCRIPTION
## Summary

Fix two stale comment blocks around the Add Memory submit handler in `web/static/app.js` that claimed `POST /api/add` did **not** invoke `privacy.scan`. That has not been true since the trust-boundary write guard was wired to the web add path — `web/routes/system.py:1203` calls `privacy.enforce_write_guard()`, which scans server-side and rejects on hit.

Updated both blocks to describe the current invariant:

- Server `/api/add` is the trust boundary via `enforce_write_guard`.
- Client-side regex is defense-in-depth — a UX-time warning before submit so a flagged paste doesn't have to round-trip.
- The scan-window asymmetry note is reframed factually: client scans the full textarea, server caps at `_SCAN_WINDOW` (10K), so the client is the more permissive side (warns on more positions); the server stays the source of truth.

## Context

Discovered while spot-checking `docs/reports/security-hardening-plan-2026-05-05.md` against the source — the plan's claim that `/api/add` was missing the redaction guard was already-fixed code, but the JS comment had drifted in the same direction and gave a false read of the trust model. Comment-only change; no behavior, no API, no test surface impact.

Per `feedback_deictic_pr_references.md` — exactly the kind of "today moot" / "if X ever lands" prose that rots after the gate actually lands.

## Test plan

- [x] Diff is comments-only inside `// ...` blocks
- [x] Static-asset cache-bust `?v=N` in `index.html` unchanged (no JS body changes that downstream cache would need to bust)
- [x] No i18n string keys touched
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
