### PR TITLE
chore: gitignore .agents-dev/ orchestration scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ BUG_REPORT.md
 *.png
 main.py
 scripts/
+.agents-dev/
 
 # Experimental plugins kept private until promoted
 packages/memtomem-openclaw-plugin/


### PR DESCRIPTION
## Summary

Add `.agents-dev/` to `.gitignore`. This is the per-checkout scratch directory for the 3-agent orchestration policy (PM + Coder + Researcher + Reviewer roles, with logs in `.agents-dev/log/`) documented in `CLAUDE.local.md` (which is itself gitignored).

The log subdir was already labelled "gitignored" in the policy text, but the parent directory was never added to `.gitignore`, so anyone running the local orchestrator saw the directory's README, USER_GUIDE, role configs, helper scripts, and tmux glue showing up as untracked. Sliding the entry into the existing "Internal development artifacts" block keeps it next to the other user-local opt-outs (`.claude-memory/`, `scripts/`, `BUG_REPORT.md`, etc.).

`feedback_silent_policy_enforcement_gap.md` — docs-only is not enforcement; this closes that gap for the directory itself.

## Test plan

- [x] `git status` no longer lists `.agents-dev/` as untracked locally
- [x] `rg --glob '!.agents-dev/**' --glob '!.gitignore' '\.agents-dev'` returns zero hits → no tracked source/test/doc surface depends on it
- [x] `.gitignore` diff is one line, in the existing internal-artifacts block
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
