### PR TITLE
fix(web): wire force_unsafe to Add Memory privacy-confirm dialog

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3765,6 +3765,7 @@ qs('add-btn').addEventListener('click', async () => {
   // ``enforce_write_guard`` does not — so the client is more
   // permissive (covers more positions). The server boundary remains
   // the source of truth; this client check is a UX-time hint.
+  let forceUnsafe = false;
   const patterns = STATE.privacyPatterns;
   if (patterns && patterns.some(re => re.test(content))) {
     const ok = await showConfirm({
@@ -3773,6 +3774,11 @@ qs('add-btn').addEventListener('click', async () => {
       confirmText: t('compose.privacy_warning_proceed'),
     });
     if (!ok) return;
+    // The server-side ``enforce_write_guard`` defaults to blocking, so
+    // a confirmed warning must travel as ``force_unsafe: true`` or the
+    // submission gets a 403 from the same patterns the client just
+    // surfaced. Without this the confirm dialog would be a no-op.
+    forceUnsafe = true;
   }
 
   const title = qs('add-title').value.trim() || null;
@@ -3786,7 +3792,9 @@ qs('add-btn').addEventListener('click', async () => {
   hide(qs('add-msg'));
 
   try {
-    const data = await api('POST', '/api/add', { content, title, tags, file, namespace });
+    const body = { content, title, tags, file, namespace };
+    if (forceUnsafe) body.force_unsafe = true;
+    const data = await api('POST', '/api/add', body);
     const n = data.indexed_chunks;
     showToast(t('toast.saved_to_file', { path: tildifyPath(data.file), count: n }), 'success');
     qs('add-content').value = '';

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1308,7 +1308,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=99"></script>
+  <script src="/app.js?v=100"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=1"></script>

--- a/packages/memtomem/tests-js/add-memory-force-unsafe.test.mjs
+++ b/packages/memtomem/tests-js/add-memory-force-unsafe.test.mjs
@@ -1,0 +1,95 @@
+/* Regression guard for the Add Memory privacy-warning → server submit
+ * flow. After ``ca483c5`` wired the trust-boundary redaction guard
+ * with ``force_unsafe: bool = False`` defaulting to block, the SPA
+ * still posted ``/api/add`` without the bypass flag even when the user
+ * confirmed the privacy warning — turning the confirm dialog into a
+ * 403-trap. This file pins the three branches:
+ *
+ *   1. clean content → POST without ``force_unsafe``
+ *   2. flagged content + user confirms → POST with ``force_unsafe: true``
+ *   3. flagged content + user cancels → no POST
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+describe('Add Memory — force_unsafe wired to privacy confirm', () => {
+  let window;
+  let document;
+  let captured;
+
+  beforeEach(async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    window = dom.window;
+    document = window.document;
+
+    // Capture every call to /api/add so each test can assert the body
+    // shape. Keep the no-op default for unrelated fetches (the click
+    // path also fires off ``loadStats`` etc.).
+    captured = [];
+    const original = window.fetch;
+    window.fetch = async function fetchSpy(input, init) {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url === '/api/add') {
+        captured.push({
+          url,
+          method: init?.method,
+          body: init?.body ? JSON.parse(init.body) : null,
+        });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ file: '/tmp/x.md', indexed_chunks: 1 }),
+          text: async () => '{}',
+        };
+      }
+      return original(input, init);
+    };
+  });
+
+  async function clickAdd() {
+    const btn = document.getElementById('add-btn');
+    btn.dispatchEvent(new window.Event('click'));
+    // Flush microtasks twice — the handler awaits ``showConfirm`` and
+    // then ``api(...)``; both resolve as resolved promises in this
+    // test, but JSDOM's task queue still needs a tick per ``await``.
+    for (let i = 0; i < 5; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+  }
+
+  it('clean content posts without force_unsafe', async () => {
+    document.getElementById('add-content').value = 'just a normal note';
+    window.STATE.privacyPatterns = [/sk-[A-Za-z0-9]{20,}/];
+
+    await clickAdd();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].method).toBe('POST');
+    expect(captured[0].body.content).toBe('just a normal note');
+    expect(captured[0].body.force_unsafe).toBeUndefined();
+  });
+
+  it('flagged content + confirm posts force_unsafe: true', async () => {
+    document.getElementById('add-content').value =
+      'token sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ rest';
+    window.STATE.privacyPatterns = [/sk-[A-Za-z0-9]{20,}/];
+    window.showConfirm = async () => true;
+
+    await clickAdd();
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].body.force_unsafe).toBe(true);
+  });
+
+  it('flagged content + cancel does not post', async () => {
+    document.getElementById('add-content').value =
+      'token sk-ABCDEFGHIJKLMNOPQRSTUVWXYZ rest';
+    window.STATE.privacyPatterns = [/sk-[A-Za-z0-9]{20,}/];
+    window.showConfirm = async () => false;
+
+    await clickAdd();
+
+    expect(captured).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fix a regression introduced by `ca483c5`. When the trust-boundary `privacy.enforce_write_guard` was wired to `POST /api/add` with `force_unsafe: bool = False` defaulting to block, the SPA's existing privacy-warning flow in `app.js` was not updated to thread the bypass flag through the resulting submit.

Result: confirmed Add Memory submissions of secret-shaped content (or false positives) now get a server-side **403** instead of being saved. The confirm dialog became a no-op trap.

This PR threads `forceUnsafe = true` from a confirmed dialog into the POST body so the user's "I know, store it anyway" choice actually reaches the bypass branch the server already supports.

## What changed

**`web/static/app.js`** — Add Memory submit handler:

```diff
+  let forceUnsafe = false;
   const patterns = STATE.privacyPatterns;
   if (patterns && patterns.some(re => re.test(content))) {
     const ok = await showConfirm({...});
     if (!ok) return;
+    forceUnsafe = true;
   }
   ...
-    const data = await api('POST', '/api/add', { content, title, tags, file, namespace });
+    const body = { content, title, tags, file, namespace };
+    if (forceUnsafe) body.force_unsafe = true;
+    const data = await api('POST', '/api/add', body);
```

**`web/static/index.html`** — `?v=99` → `?v=100` per `feedback_static_asset_cache_bust.md`.

**`tests-js/add-memory-force-unsafe.test.mjs`** — three pinned branches:
1. clean content → POST without `force_unsafe`
2. flagged content + confirm → POST with `force_unsafe: true`
3. flagged content + cancel → no POST

Mutation-validated per `feedback_pin_test_mutation_validation.md`: reverting `body.force_unsafe = true` makes case (2) fail with `expected undefined to be true`, so the regression cannot silently re-land.

## Out of scope (follow-up)

`PATCH /api/chunks/{id}` and `POST /api/upload` accept `force_unsafe` server-side but the SPA has no UI for it (lines 2151 / 3621 / 3875 / 5405 in `app.js`). Those are **new gaps**, not regressions — they never had a confirm flow — and need a different pattern (detect `403 redaction_blocked`, show retry-confirm dialog) plus likely a shared helper. Will track in a separate issue so this PR stays a single regression fix per `feedback_one_change_per_pr.md`.

## Test plan

- [x] `npx vitest run` — 14/14 pass (5 test files)
- [x] Mutation-validated: revert prod fix → case (2) fails as expected → restore → all green
- [x] Static-asset cache-bust bumped (app.js v99 → v100)
- [ ] CI green (lint / js-unit / typecheck / 3-OS python tests / Playwright / golden-path)
- [ ] Manual smoke (after merge): paste a fake `sk-` token into Add Memory → confirm dialog appears → confirm → save succeeds → row appears in results

## References

- Server gate: `web/routes/system.py:1203` (`enforce_write_guard(surface="web_api_add")`).
- Schema: `web/schemas/memory.py:14-18` (the `force_unsafe: bool = False` field this PR finally exercises from the SPA).
- Companion comment cleanup that triggered the audit: #786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
