### PR TITLE
chore: gitignore docs/reports/ local audit-report scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ node_modules/
 # Internal development artifacts
 docs/testing/
 docs/marketing/
+docs/reports/
 .claude-memory/
 BUG_REPORT.md
 *.png


### PR DESCRIPTION
## Summary

Add `docs/reports/` to `.gitignore`, alongside the sibling `docs/testing/` and `docs/marketing/` entries already in the "Internal development artifacts" block.

`docs/reports/` collects machine-local audit / review artifacts (security scans, Playwright review reports, `ultrareview` outputs, etc.) that are not part of the public docs surface listed in `CLAUDE.local.md`:

- `README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, `CLA.md`, `SECURITY.md`
- `docs/adr/`, `docs/guides/` (4 entry + 4 power-user docs)
- `packages/memtomem/README.md` (PyPI page)

Anything not in that list is intentionally not committed.

Same shape as #788 (which added `.agents-dev/`).

## Test plan

- [x] `git status` no longer lists `docs/reports/` as untracked locally
- [x] `rg --glob '!docs/reports/**' --glob '!.gitignore' 'docs/reports'` returns zero hits → no tracked source/test/doc references it
- [x] Diff is one line, slotted between the sibling `docs/*` entries
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
