### PR TITLE
sec(privacy): scan full content at LTM trust boundary, not first 10K chars

### DIFF
--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -231,8 +231,6 @@ JS_PATTERNS_SHA: str = hashlib.sha256(
 ).hexdigest()
 
 
-_SCAN_WINDOW = 10_000
-
 # Outcome labels recorded for every gated content scan.
 #   blocked  — at least one hit; ``force_unsafe`` not set; write rejected.
 #   pass     — no hits; write proceeded.
@@ -266,19 +264,29 @@ def _compile(patterns: tuple[str, ...]) -> tuple[re.Pattern[str], ...]:
 
 
 def scan(text: str, patterns: tuple[str, ...] | None = None) -> list[RedactionHit]:
-    """Return all redaction hits in the first ``_SCAN_WINDOW`` chars of ``text``.
+    """Return all redaction hits in ``text``.
 
-    The 10 K-char window matches STM's compression-side scanner so the two
-    views of "is this content sensitive" stay aligned at the floor.
+    Scans the entire string. An earlier revision capped at the first 10 K
+    chars to mirror STM's compression-side scanner, but at the LTM trust
+    boundary that cap is a silent bypass: a secret pasted past the 10 K
+    mark wrote through unredacted. The asymmetry with STM is intentional
+    and one-directional — STM's window is a compression-routing signal
+    (does this block contain anything sensitive enough to skip), while
+    the LTM scan is a write-rejection gate. The two contracts diverge,
+    and the trust boundary lives here.
+
+    All current ``DEFAULT_PATTERNS`` are short, prefix-anchored regexes
+    (provider tokens, PEM headers, etc.); ``re.finditer`` over a 1 MB
+    input completes well under the 50 ms ceiling pinned by
+    ``test_privacy_long_content``.
     """
     effective = patterns if patterns is not None else DEFAULT_PATTERNS
     if not effective:
         return []
-    sample = text[:_SCAN_WINDOW]
     compiled = _compile(tuple(effective))
     hits: list[RedactionHit] = []
     for idx, pat in enumerate(compiled):
-        for m in pat.finditer(sample):
+        for m in pat.finditer(text):
             hits.append(RedactionHit(pattern_index=idx, span=(m.start(), m.end())))
     return hits
 

--- a/packages/memtomem/src/memtomem/privacy.py
+++ b/packages/memtomem/src/memtomem/privacy.py
@@ -275,10 +275,11 @@ def scan(text: str, patterns: tuple[str, ...] | None = None) -> list[RedactionHi
     the LTM scan is a write-rejection gate. The two contracts diverge,
     and the trust boundary lives here.
 
-    All current ``DEFAULT_PATTERNS`` are short, prefix-anchored regexes
-    (provider tokens, PEM headers, etc.); ``re.finditer`` over a 1 MB
-    input completes well under the 50 ms ceiling pinned by
-    ``test_privacy_long_content``.
+    All current ``DEFAULT_PATTERNS`` are simple short regexes (provider
+    tokens, PEM headers, etc.); ``re.finditer`` runs in linear time and
+    a 1 MB input stays comfortably under the perf ceiling pinned by
+    ``test_privacy_long_content``. A future quadratic regression in the
+    pattern set or scan implementation fails that test loudly.
     """
     effective = patterns if patterns is not None else DEFAULT_PATTERNS
     if not effective:

--- a/packages/memtomem/src/memtomem/server/tools/memory_crud.py
+++ b/packages/memtomem/src/memtomem/server/tools/memory_crud.py
@@ -199,10 +199,11 @@ async def mem_add(
     are recorded with a ``bypassed`` outcome label so guard effectiveness
     and bypass usage stay observable. See ``mem_add_redaction_stats``.
 
-    The redaction scan covers the first 10,000 characters of ``content``;
-    matches beyond that window are not seen by the guard. This is parity
-    with the STM compression-side scanner — split very long content into
-    multiple calls if every region must be inspected.
+    The redaction scan covers the entire ``content`` regardless of length —
+    a secret pasted past any byte offset still triggers the guard. The
+    asymmetry with STM's compression-side scanner is intentional: STM's
+    window is a routing signal, while the LTM scan is the write-rejection
+    gate at the trust boundary.
 
     Args:
         content: The memory content to store
@@ -425,9 +426,9 @@ async def mem_batch_add(
     bypass for the whole batch (each hit item is recorded with a
     ``bypassed`` outcome label per audit).
 
-    The scan covers only the first 10,000 characters of each entry's
-    value; matches beyond that per-entry window are not seen by the
-    guard.
+    Each entry's full value is scanned regardless of length — the scan
+    no longer truncates at a fixed window, so a secret embedded past any
+    byte offset still trips the guard.
 
     Args:
         entries: List of {"key": "title", "value": "content", "tags": [...]}

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3758,13 +3758,10 @@ qs('add-btn').addEventListener('click', async () => {
   // clean input would be peak false security since the regex misses
   // many real secrets.
   //
-  // Scan-window asymmetry: ``re.test()`` here scans the entire
-  // textarea, while server-side ``privacy.scan()`` caps at the first
-  // 10K chars (``_SCAN_WINDOW`` in privacy.py). For very long content
-  // with a secret past that cap, the client warns and the server's
-  // ``enforce_write_guard`` does not — so the client is more
-  // permissive (covers more positions). The server boundary remains
-  // the source of truth; this client check is a UX-time hint.
+  // Both client ``re.test()`` and server ``privacy.scan()`` cover the
+  // entire content — there is no scan-window asymmetry. The server's
+  // ``enforce_write_guard`` remains the source of truth; this client
+  // check is a UX-time hint that fires before the request goes out.
   let forceUnsafe = false;
   const patterns = STATE.privacyPatterns;
   if (patterns && patterns.some(re => re.test(content))) {

--- a/packages/memtomem/tests/test_privacy.py
+++ b/packages/memtomem/tests/test_privacy.py
@@ -76,15 +76,31 @@ class TestScan:
     def test_clean_text_returns_empty_list(self):
         assert privacy.scan("Just a regular note about coffee.") == []
 
-    def test_scan_window_capped_at_10k(self):
-        # Secret beyond the scan window is invisible — parity with STM's
-        # compression-side scanner (10K-char window).
-        hidden = "a" * 10_001 + "AKIAIOSFODNN7EXAMPLE"
-        assert privacy.scan(hidden) == []
+    def test_secret_within_first_10k_is_seen(self):
+        # Baseline: a secret near the old 10 K boundary still hits. Pin
+        # both edges of the former cap so a future re-introduction of a
+        # truncation can't hide a regression behind "the test only used
+        # short inputs."
+        within = "a" * 9_900 + "sk-" + "a" * 30
+        assert privacy.scan(within)
 
-    def test_secret_just_within_window_is_seen(self):
-        visible = "a" * 9_900 + " AKIAIOSFODNN7EXAMPLE"
-        assert privacy.scan(visible)
+    def test_secret_past_former_10k_window_is_seen(self):
+        # Pin-and-invert (memory: pin_invert_symmetric_assertion): the
+        # earlier revision truncated at 10K chars and asserted ``== []``
+        # for a secret past that mark. ``scan()`` now covers the entire
+        # input, so the same shape must hit. A regression that re-adds
+        # the cap fails this assertion loudly.
+        #
+        # Uses the ``sk-`` prefix shape (DEFAULT_PATTERNS index 2)
+        # rather than the AWS AKIA shape — the latter is anchored with
+        # ``\b`` and would silently no-match against a leading run of
+        # word chars even when the scan does cover the position, which
+        # would conflate two distinct regression modes.
+        past = "a" * 10_001 + "sk-" + "a" * 30
+        assert privacy.scan(past), (
+            "scan() must cover the entire input — secrets past the former "
+            "10K window must not silently bypass the trust boundary"
+        )
 
     def test_explicit_empty_pattern_set_returns_no_hit(self):
         assert privacy.scan("AKIAIOSFODNN7EXAMPLE", patterns=()) == []

--- a/packages/memtomem/tests/test_privacy_long_content.py
+++ b/packages/memtomem/tests/test_privacy_long_content.py
@@ -1,0 +1,124 @@
+"""Long-content scan coverage — pin against the silent-truncation bypass.
+
+The earlier revision of ``privacy.scan()`` truncated at the first 10 K
+chars to mirror STM's compression-side scanner. At the LTM trust
+boundary that cap is a silent bypass: any secret pasted past the mark
+wrote through unredacted. These tests pin the post-fix contract — the
+entire input is scanned — at three sizes spanning the former cap, and
+each assertion has a paired negative (clean prose of identical shape
+must produce zero hits).
+
+Pin-and-invert + mutation-validation rationale:
+
+- Each positive case asserts ``hits`` is non-empty AND that the recorded
+  span lies inside the embedded-secret slice. A future regression that
+  re-introduces a truncation would produce ``hits == []`` and fail
+  loudly. A regression that broadens the patterns would mismatch the
+  span and also fail.
+- Each negative case asserts ``hits == []`` so a future false-positive
+  drift on benign long prose surfaces immediately.
+
+The perf pin is a soft ceiling — generous enough that platform-jitter
+won't flake but tight enough to catch a quadratic regression (e.g. a
+naive overlap-window rewrite that re-scans large prefixes).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from memtomem import privacy
+
+
+# OpenAI-style ``sk-`` prefix — matches DEFAULT_PATTERNS index 2.
+# Picked over the AWS ``AKIA…`` shape because that pattern is
+# word-boundary-anchored (``\b…\b``), and a leading run of word chars
+# (e.g. ``"a" * N + "AKIA…"``) would silently fail to hit on \b
+# rather than on a truncation regression — the test would conflate
+# "scan ran past N" with "boundary found." Using the prefix-only
+# ``sk-`` shape removes that ambiguity: the only way to miss this
+# secret is to not scan its position.
+_SECRET = "sk-" + "a" * 30
+
+
+# Sizes straddle the former 10K cap. 12K is just past it; 100K and 1MB
+# stress the linear-scan claim in the docstring.
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+class TestLongContentScan:
+    @pytest.mark.parametrize(
+        "size",
+        [12_000, 100_000, 1_000_000],
+        ids=["12K", "100K", "1MB"],
+    )
+    def test_secret_at_end_of_long_input_is_caught(self, size: int):
+        prefix = "a" * (size - len(_SECRET))
+        text = prefix + _SECRET
+        hits = privacy.scan(text)
+        assert hits, (
+            f"Secret at the end of a {size}-char input must hit. "
+            f"A silent truncation regression would return []."
+        )
+        # At least one hit's span lands on the trailing secret slice.
+        secret_start = size - len(_SECRET)
+        assert any(h.span[0] >= secret_start for h in hits), (
+            f"No hit landed on the trailing secret slice ({secret_start}..{size}); "
+            f"got spans {[h.span for h in hits]}"
+        )
+
+    @pytest.mark.parametrize(
+        "size",
+        [12_000, 100_000, 1_000_000],
+        ids=["12K", "100K", "1MB"],
+    )
+    def test_long_clean_prose_has_no_hit(self, size: int):
+        # Repeated benign sentence. Picked from the existing clean-input
+        # fixtures in ``test_privacy.py`` so a future PII-pattern drift
+        # would fail both surfaces consistently.
+        sentence = "Met with John today to discuss Q2 plans. "
+        text = (sentence * (size // len(sentence) + 1))[:size]
+        assert len(text) == size
+        assert privacy.scan(text) == [], (
+            f"{size}-char benign prose must produce zero hits; "
+            "a non-empty result here means the pattern set is overreaching"
+        )
+
+    def test_secret_in_middle_of_1mb_is_caught(self):
+        # Trailing-position pin alone could be satisfied by a "scan only
+        # the last N chars" rewrite. This anchors the contract at an
+        # arbitrary interior position so a truncation in either
+        # direction fails.
+        size = 1_000_000
+        mid = size // 2
+        prefix = "a" * mid
+        suffix = "a" * (size - mid - len(_SECRET))
+        text = prefix + _SECRET + suffix
+        hits = privacy.scan(text)
+        assert hits
+        assert any(mid <= h.span[0] < mid + len(_SECRET) for h in hits), (
+            f"No hit landed on the mid-buffer secret at offset {mid}; "
+            f"got spans {[h.span for h in hits]}"
+        )
+
+    def test_one_megabyte_scan_under_perf_ceiling(self):
+        # Soft ceiling — not a microbenchmark, just a quadratic-regression
+        # guard. The 9 current patterns are short prefix-anchored regexes
+        # and ``re.finditer`` over 1 MB completes in single-digit ms on
+        # CI hardware; 200 ms gives ample headroom for jitter while
+        # still catching an accidental O(N^2) rewrite.
+        text = ("a" * 999_980) + _SECRET
+        start = time.perf_counter()
+        hits = privacy.scan(text)
+        elapsed = time.perf_counter() - start
+        assert hits, "Sanity check: the secret must still be detected"
+        assert elapsed < 0.2, (
+            f"1MB scan took {elapsed * 1000:.1f} ms — exceeds the 200 ms "
+            "ceiling, suggesting a non-linear regression"
+        )


### PR DESCRIPTION
## Summary

PR-3 of the security hardening plan. `privacy.scan()` previously truncated at the first 10 K chars (`_SCAN_WINDOW = 10_000`) to mirror STM's compression-side scanner. At the LTM trust boundary that cap is a silent bypass: any secret pasted past the 10 K mark wrote through `enforce_write_guard` unredacted, hitting storage with the matched bytes intact.

This change drops the truncation and scans the full input. The asymmetry with STM is intentional and one-directional — STM's window is a routing signal, the LTM scan is a write-rejection gate. The trust boundary lives in this module.

## Changes

- `packages/memtomem/src/memtomem/privacy.py` — remove `_SCAN_WINDOW`, run `re.finditer` over full text. Updated docstring captures the STM-asymmetry rationale so a future contributor doesn't try to "restore parity" by re-adding the cap.
- `packages/memtomem/src/memtomem/web/static/app.js` — replace the stale "client scans entire textarea while server caps at 10 K" comment block on the compose-mode confirm dialog with the post-fix shape (both sides cover the full content). No behavior change in the SPA path.
- `packages/memtomem/tests/test_privacy.py` — invert the existing `test_scan_window_capped_at_10k` pin into `test_secret_past_former_10k_window_is_seen`. See "Test-fixture note" below for why the original test was actually testing the wrong invariant.
- `packages/memtomem/tests/test_privacy_long_content.py` (new) — pin the full-content contract at 12 K / 100 K / 1 MB with positive + negative pairs, an interior-position case, and a 1 MB perf ceiling.

## Test plan

- [x] `uv run pytest -m "not ollama"` — `4060 passed, 11 skipped, 46 deselected` (full CI filter, no regressions)
- [x] `uv run pytest packages/memtomem/tests/test_privacy.py packages/memtomem/tests/test_privacy_long_content.py packages/memtomem/tests/test_memory_crud_redaction.py packages/memtomem/tests/test_redaction_write_surfaces.py -q` — `80 passed`
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — all checks passed
- [x] **Mutation validation** (per `feedback_pin_test_mutation_validation.md`): temporarily reintroduced `text = text[:10_000]` in `scan()` and confirmed the new tests fail with the expected shape — `6 failed, 15 passed` in the privacy suite, all 6 failures on the new pin (3 size variants of the trailing-secret case + the interior-position case + the 1 MB perf-sanity case + the inverted test in `test_privacy.py`). Mutation reverted before commit.

## Test-fixture note

Investigating the existing `test_scan_window_capped_at_10k` showed it was asserting `scan("a" * 10_001 + "AKIAIOSFODNN7EXAMPLE") == []` and attributing the empty result to the truncation. The real cause was the AKIA pattern's `\b` word boundary failing to fire between `a` (word char) and `A` (word char) — the test would have returned `[]` even without truncation. The replacement uses the `sk-` prefix shape (`DEFAULT_PATTERNS` index 2, no boundary anchor) so the only failure mode is "scan did not cover the position." A separate test `test_secret_within_first_10k_is_seen` keeps the within-10 K baseline pinned for symmetry.

## Out of scope (intentional)

- Pattern set itself is unchanged. The PII / secret-class split rule in the module docstring still applies; broadening to PII patterns would reverse the false-positive profile and is a separate decision pass.
- STM-side `_SCAN_WINDOW` stays. STM's scanner is routing-only; the LTM scan is the trust boundary.
- PRs 4–10 from the hardening plan (DNS rebinding, supported_extensions constraint, SHA pin drift detection, `mm reset` env override, etc.) are independent and tracked separately per `feedback_one_change_per_pr.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
