### PR TITLE
feat(web/ctx): classify /context/overview errors as parse/permission/missing/internal (#762)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends
 
+from memtomem.privacy import scan as _privacy_scan
 from memtomem.web.deps import get_project_root
 
 try:
@@ -26,6 +27,7 @@ router = APIRouter(tags=["context-gateway"])
 
 _HOME = str(Path.home())
 _ERROR_MESSAGE_LIMIT = 200
+_SECRET_REDACTED_MARKER = "<redacted: secret-shape>"
 
 
 def _count_statuses(triples: list[tuple[str, str, str]]) -> dict:
@@ -65,8 +67,26 @@ def _classify_exception(exc: BaseException) -> str:
 
 
 def _redact_message(message: str) -> str:
-    """Collapse ``$HOME`` to ``~`` and truncate to ``_ERROR_MESSAGE_LIMIT``."""
+    """Collapse ``$HOME`` → ``~``, drop secret-shape messages, then truncate.
+
+    The ``internal`` classification is a catch-all for unexpected
+    exceptions, so ``str(exc)`` may incidentally contain provider tokens,
+    PEM headers, or ``api_key=...`` fragments pulled from a config parse
+    or a third-party library's error. Truncation alone leaves the first
+    200 chars verbatim, which is not enough at this trust boundary.
+
+    We reuse the LTM secret-class scanner from ``memtomem.privacy``. If
+    *any* hit is detected, the whole message is replaced with a fixed
+    marker. Span-splicing was considered and rejected: several patterns
+    (notably ``api_key=...``) match the assignment anchor only, so the
+    secret *value* would survive a span splice. Whole-message replace
+    matches the convention already established in
+    ``privacy._sanitize_audit_value``. The ``error_kind`` field still
+    tells the operator which category the failure fell into.
+    """
     redacted = message.replace(_HOME, "~") if _HOME else message
+    if _privacy_scan(redacted):
+        return _SECRET_REDACTED_MARKER
     if len(redacted) > _ERROR_MESSAGE_LIMIT:
         redacted = redacted[:_ERROR_MESSAGE_LIMIT]
     return redacted

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 
@@ -9,9 +10,22 @@ from fastapi import APIRouter, Depends
 
 from memtomem.web.deps import get_project_root
 
+try:
+    import tomllib
+except ImportError:  # pragma: no cover — py<3.11 fallback, repo targets py312
+    tomllib = None  # type: ignore[assignment]
+
+try:
+    import yaml  # type: ignore[import-untyped]
+except ImportError:  # pragma: no cover — PyYAML may be absent on minimal installs
+    yaml = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["context-gateway"])
+
+_HOME = str(Path.home())
+_ERROR_MESSAGE_LIMIT = 200
 
 
 def _count_statuses(triples: list[tuple[str, str, str]]) -> dict:
@@ -23,6 +37,54 @@ def _count_statuses(triples: list[tuple[str, str, str]]) -> dict:
         key = status.replace(" ", "_")
         counts[key] = counts.get(key, 0) + 1
     return {"total": len(names), **counts}
+
+
+def _classify_exception(exc: BaseException) -> str:
+    """Map an exception to one of {parse, permission, missing, internal}.
+
+    Order matters: ``PermissionError`` and ``FileNotFoundError`` are both
+    ``OSError`` subclasses, so they must be checked before bare ``OSError``.
+    Generic ``OSError`` is ``internal`` rather than ``permission``/``missing``
+    because ``errno`` may be ``EIO``/``EMFILE``/``ELOOP`` etc.
+    """
+    if isinstance(exc, PermissionError):
+        return "permission"
+    if isinstance(exc, (FileNotFoundError, NotADirectoryError, IsADirectoryError)):
+        return "missing"
+    if isinstance(exc, ModuleNotFoundError):
+        return "missing"
+    if isinstance(exc, UnicodeDecodeError):
+        return "parse"
+    if isinstance(exc, json.JSONDecodeError):
+        return "parse"
+    if tomllib is not None and isinstance(exc, tomllib.TOMLDecodeError):
+        return "parse"
+    if yaml is not None and isinstance(exc, yaml.YAMLError):
+        return "parse"
+    return "internal"
+
+
+def _redact_message(message: str) -> str:
+    """Collapse ``$HOME`` to ``~`` and truncate to ``_ERROR_MESSAGE_LIMIT``."""
+    redacted = message.replace(_HOME, "~") if _HOME else message
+    if len(redacted) > _ERROR_MESSAGE_LIMIT:
+        redacted = redacted[:_ERROR_MESSAGE_LIMIT]
+    return redacted
+
+
+def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
+    """Build the per-surface error envelope.
+
+    ``shape="total"`` matches skills/commands/agents (count-based summary).
+    ``shape="status"`` matches settings (status-based summary).
+    ``error: True`` and ``total: 0`` are preserved for backwards compatibility
+    so existing front-end and external callers keep working.
+    """
+    kind = _classify_exception(exc)
+    message = _redact_message(str(exc))
+    if shape == "status":
+        return {"status": "error", "error_kind": kind, "error_message": message}
+    return {"total": 0, "error": True, "error_kind": kind, "error_message": message}
 
 
 @router.get("/context/overview")
@@ -39,21 +101,21 @@ async def context_overview(
 
     try:
         result["skills"] = _count_statuses(diff_skills(project_root))
-    except Exception:
+    except Exception as exc:
         logger.exception("diff_skills failed")
-        result["skills"] = {"total": 0, "error": True}
+        result["skills"] = _error_payload(exc, shape="total")
 
     try:
         result["commands"] = _count_statuses(diff_commands(project_root))
-    except Exception:
+    except Exception as exc:
         logger.exception("diff_commands failed")
-        result["commands"] = {"total": 0, "error": True}
+        result["commands"] = _error_payload(exc, shape="total")
 
     try:
         result["agents"] = _count_statuses(diff_agents(project_root))
-    except Exception:
+    except Exception as exc:
         logger.exception("diff_agents failed")
-        result["agents"] = {"total": 0, "error": True}
+        result["agents"] = _error_payload(exc, shape="total")
 
     try:
         settings_diff = diff_settings(project_root)
@@ -61,11 +123,13 @@ async def context_overview(
         if all(s in ("in sync", "skipped") for s in statuses):
             result["settings"] = {"status": "in_sync"}
         elif any(s == "error" for s in statuses):
+            # In-band error: per-file failure already classified by diff_settings.
+            # No error_kind here — adding one would conflate distinct per-file causes.
             result["settings"] = {"status": "error"}
         else:
             result["settings"] = {"status": "out_of_sync"}
-    except Exception:
+    except Exception as exc:
         logger.exception("diff_settings failed")
-        result["settings"] = {"status": "error"}
+        result["settings"] = _error_payload(exc, shape="status")
 
     return result

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -233,6 +233,57 @@ class TestContextOverviewErrorTaxonomy:
         assert "error_kind" in skills
         assert "error_message" in skills
 
+    @pytest.mark.anyio
+    async def test_error_message_redacts_api_key_assignment(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        # ``internal`` is a catch-all and exception text may incidentally
+        # contain secret-shape fragments. ``api_key=`` matches the privacy
+        # scanner's assignment anchor, so the whole message is replaced
+        # with the redaction marker — splicing alone would leave the
+        # value (``hunter2``) intact.
+        monkeypatch.setattr(
+            "memtomem.context.skills.diff_skills",
+            _raises(RuntimeError("parse failed near api_key=hunter2 in config")),
+        )
+        r = await client.get("/api/context/overview")
+        msg = r.json()["skills"]["error_message"]
+        assert "hunter2" not in msg
+        assert "api_key" not in msg
+        assert msg == "<redacted: secret-shape>"
+
+    @pytest.mark.anyio
+    async def test_error_message_redacts_provider_token(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Provider-prefixed token (``sk-`` / ``ghp_`` / ``github_pat_``)
+        # must not survive into ``error_message``.
+        secret = "sk-" + "A" * 40
+        monkeypatch.setattr(
+            "memtomem.context.commands.diff_commands",
+            _raises(RuntimeError(f"upstream returned {secret} in body")),
+        )
+        r = await client.get("/api/context/overview")
+        msg = r.json()["commands"]["error_message"]
+        assert secret not in msg
+        assert msg == "<redacted: secret-shape>"
+
+    @pytest.mark.anyio
+    async def test_error_message_clean_message_passes_through(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        # No secret-shape hits → message must pass through unchanged
+        # (modulo the existing ``$HOME`` collapse + 200-char cap). This
+        # pins the redaction so it doesn't accidentally swallow every
+        # ``internal`` error.
+        monkeypatch.setattr(
+            "memtomem.context.agents.diff_agents",
+            _raises(RuntimeError("disk full while reading agents dir")),
+        )
+        r = await client.get("/api/context/overview")
+        msg = r.json()["agents"]["error_message"]
+        assert msg == "disk full while reading agents dir"
+
 
 # ---------------------------------------------------------------------------
 # Skills — List

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -86,6 +86,155 @@ class TestOverview:
 
 
 # ---------------------------------------------------------------------------
+# Overview — error taxonomy (issue #762)
+# ---------------------------------------------------------------------------
+
+
+def _raises(exc: BaseException):
+    """Return a callable that raises ``exc`` when invoked."""
+
+    def _fn(*_args, **_kwargs):
+        raise exc
+
+    return _fn
+
+
+class TestContextOverviewErrorTaxonomy:
+    """Pin the {parse, permission, missing, internal} classification.
+
+    Patches the source modules (``memtomem.context.skills.diff_skills`` etc.)
+    rather than the route-local re-imports — the route does function-level
+    ``from ... import ...`` so the lookup hits the patched module attribute.
+    """
+
+    @pytest.mark.anyio
+    async def test_skills_permission_error_classified_as_permission(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            "memtomem.context.skills.diff_skills",
+            _raises(PermissionError("denied")),
+        )
+        r = await client.get("/api/context/overview")
+        assert r.status_code == 200
+        skills = r.json()["skills"]
+        assert skills["error"] is True
+        assert skills["total"] == 0
+        assert skills["error_kind"] == "permission"
+        assert "denied" in skills["error_message"]
+
+    @pytest.mark.anyio
+    async def test_commands_file_not_found_classified_as_missing(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            "memtomem.context.commands.diff_commands",
+            _raises(FileNotFoundError("no such dir")),
+        )
+        r = await client.get("/api/context/overview")
+        assert r.json()["commands"]["error_kind"] == "missing"
+
+    @pytest.mark.anyio
+    async def test_agents_unicode_decode_classified_as_parse(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            "memtomem.context.agents.diff_agents",
+            _raises(UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")),
+        )
+        r = await client.get("/api/context/overview")
+        assert r.json()["agents"]["error_kind"] == "parse"
+
+    @pytest.mark.anyio
+    async def test_skills_runtime_error_classified_as_internal(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            "memtomem.context.skills.diff_skills",
+            _raises(RuntimeError("boom")),
+        )
+        r = await client.get("/api/context/overview")
+        assert r.json()["skills"]["error_kind"] == "internal"
+
+    @pytest.mark.anyio
+    async def test_skills_generic_oserror_classified_as_internal(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        # Bare OSError with errno=EIO — not permission/missing — should fall
+        # through to ``internal`` rather than be guessed as permission/missing.
+        monkeypatch.setattr(
+            "memtomem.context.skills.diff_skills",
+            _raises(OSError(5, "Input/output error")),
+        )
+        r = await client.get("/api/context/overview")
+        assert r.json()["skills"]["error_kind"] == "internal"
+
+    @pytest.mark.anyio
+    async def test_settings_bare_exception_uses_status_shape(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setattr(
+            "memtomem.context.settings.diff_settings",
+            _raises(RuntimeError("settings exploded")),
+        )
+        r = await client.get("/api/context/overview")
+        settings = r.json()["settings"]
+        assert settings == {
+            "status": "error",
+            "error_kind": "internal",
+            "error_message": "settings exploded",
+        }
+
+    @pytest.mark.anyio
+    async def test_settings_inband_error_has_no_error_kind(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        # In-band per-file error: diff_settings succeeds but returns a result
+        # with status="error". Aggregated as {"status": "error"} with no
+        # error_kind — adding one would conflate per-file causes.
+        from memtomem.context.settings import SettingsSyncResult
+
+        monkeypatch.setattr(
+            "memtomem.context.settings.diff_settings",
+            lambda *_a, **_k: {"claude": SettingsSyncResult(status="error")},
+        )
+        r = await client.get("/api/context/overview")
+        assert r.json()["settings"] == {"status": "error"}
+
+    @pytest.mark.anyio
+    async def test_error_message_truncated_and_homedir_collapsed(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        long_msg = str(Path.home()) + "/oops-" + "z" * 500
+        monkeypatch.setattr(
+            "memtomem.context.skills.diff_skills",
+            _raises(RuntimeError(long_msg)),
+        )
+        r = await client.get("/api/context/overview")
+        msg = r.json()["skills"]["error_message"]
+        assert len(msg) <= 200
+        assert msg.startswith("~/oops-")
+        assert str(Path.home()) not in msg
+
+    @pytest.mark.anyio
+    async def test_back_compat_error_true_preserved(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The new fields are additive — existing consumers reading `error`
+        # boolean and `total` int must keep seeing them on the failure path.
+        monkeypatch.setattr(
+            "memtomem.context.skills.diff_skills",
+            _raises(PermissionError("nope")),
+        )
+        r = await client.get("/api/context/overview")
+        skills = r.json()["skills"]
+        assert skills["error"] is True
+        assert skills["total"] == 0
+        assert "error_kind" in skills
+        assert "error_message" in skills
+
+
+# ---------------------------------------------------------------------------
 # Skills — List
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Replaces the single boolean `error: true` per surface in `/api/context/overview` with a machine-readable `error_kind ∈ {parse, permission, missing, internal}` plus a redacted `error_message`. The boolean `error` and `total: 0` are preserved so the existing front-end red-badge path keeps working unchanged — this PR is purely additive.

Closes #762.

## Why

Before this change, a user staring at "error" in the Context Gateway summary couldn't tell whether to fix a malformed file, chmod a directory, install a missing dependency, or file a bug. All four ended in the same toast, and the traceback lived only in server logs that most users never read.

## Behavior

```jsonc
// Skills/commands/agents (count-shape):
{
  "total": 0,
  "error": true,
  "error_kind": "permission",         // new
  "error_message": "denied"           // new
}

// Settings (status-shape):
{
  "status": "error",
  "error_kind": "internal",           // new (only on bare-except path)
  "error_message": "settings exploded" // new
}
```

### Classification (precedence-aware)

| Order | Exception | `error_kind` |
|------:|-----------|--------------|
| 1 | `PermissionError` | `permission` |
| 2 | `FileNotFoundError`, `NotADirectoryError`, `IsADirectoryError`, `ModuleNotFoundError` | `missing` |
| 3 | `UnicodeDecodeError` | `parse` |
| 4 | `json.JSONDecodeError`, `tomllib.TOMLDecodeError`, `yaml.YAMLError` (if PyYAML installed) | `parse` |
| 5 | bare `OSError`, everything else | `internal` |

## Pushback on the issue's table

- The issue suggests bare `OSError(EACCES)` → `permission`. I implemented this only for the `PermissionError` subclass — generic `OSError` (errno may be `EIO`/`EMFILE`/`ELOOP`) falls through to `internal`. Guessing would mislead; `internal` is honest. A regression test pins this stance.
- `yaml.YAMLError` / `tomllib.TOMLDecodeError` / `JSONDecodeError` branches are defense-in-depth — the four diff helpers today catch these internally and surface them as per-file `"parse error"` statuses, so they don't actually leak to the route's `except Exception`. The classification stays correct if a helper is later refactored.

## Privacy

`error_message` is `str(exc)` with `$HOME → ~` collapse and a 200-char cap. `mm web` is a local-UI tool and the user already owns these paths, but the collapse + truncation reduces leakage in pasted screenshots / bug reports without losing actionable info.

## Settings asymmetry (intentional)

`diff_settings` rarely raises; per-file failures usually surface as in-band `status: "error"` per result, which is already classified by `diff_settings`. This PR only adds `error_kind` on the bare-except path. The in-band aggregation branch keeps emitting bare `{"status": "error"}` — adding `error_kind` there would conflate distinct per-file causes. A test pins this asymmetry.

## Out of scope (follow-ups)

- **Front-end** rendering of `error_kind` (per-kind tooltip / i18n keys, structured guidance per kind). The boolean `d.error` read at `web/static/context-gateway.js:123` is preserved, so today's red badge keeps working.
- **Detail routes** (`PUT /context/{type}/{name}`) — already use 404/409/500; taxonomy extension is consistency-only and lower-value.
- **Counter metric** per `error_kind` for watchdog visibility.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_routes_context.py -m "not ollama"` — 67 passed (including 9 new in `TestContextOverviewErrorTaxonomy`)
- [x] `uv run ruff check` + `ruff format --check` clean on touched files
- [x] `uv run mypy packages/memtomem/src/memtomem/web/routes/context_gateway.py` clean
- [x] Regression cases: `PermissionError` → permission, `FileNotFoundError` → missing, `UnicodeDecodeError` → parse, `RuntimeError` → internal, bare `OSError(EIO)` → internal, settings bare-exception uses status-shape, settings in-band has no `error_kind`, message truncated + `$HOME` collapsed, `error: True` + `total: 0` preserved on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
