### PR TITLE
fix(web/ctx): surface Settings needs_confirmation in Sync All toast (#774)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   existing 21 tests in `tests/test_context_settings.py`. Rollback:
   `git revert` the gate-flip commit restores dev-only gating.
 
+### Fixed
+
+- **Sync All no longer lies when Settings host writes need confirmation
+  (closes #774).** The Context Gateway "Sync All" button posts to four
+  endpoints sequentially; the Settings hop's `POST /api/context/settings/sync`
+  body-less request defaults `allow_host_writes` to false, and the route
+  returns HTTP 200 with `{"results": [{"status": "needs_confirmation",
+  ...}]}` for host-write targets like `~/.claude/settings.json` — the
+  merge is skipped. Previously the JS only checked `resp.ok`, so the
+  post-merge `sync_success` toast lied about a merge that never
+  happened. After RFC #761 (#771) flipped Settings to prod, this
+  silent-skip behavior reached every prod user instead of just the
+  `mm web --dev` audience. The frontend now inspects per-result
+  `status` and surfaces an info-level toast (`Sync All complete except
+  Settings — confirm host writes in the Settings panel.`) with an
+  `Open Settings` action that navigates to the Settings panel where
+  the user can drive the host-write confirmation. The Skills /
+  Commands / Agents fanout keeps its all-or-nothing failure shape.
+
 ## [0.1.35] — 2026-05-02
 
 ### Added

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -232,9 +232,37 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
     // entries to ~/.claude/settings.json without clobbering user-authored
     // entries. Promoted from dev-only via RFC #761 (ADR-0001 §5 criteria
     // + HTTP-layer test fixtures).
+    //
+    // The route returns HTTP 200 even when host-write targets need user
+    // confirmation — each per-result entry carries its own ``status``
+    // (``needs_confirmation`` for ``~/.claude/settings.json`` when the
+    // body's ``allow_host_writes`` defaults to false, which is the case
+    // for Sync All — the dedicated Settings panel owns the confirmation
+    // flow). ``resp.ok`` alone would let that pass as a full success and
+    // the ``sync_success`` toast would lie about a merge that never
+    // happened. Inspect the body and surface partial-success with a
+    // one-tap navigation to the Settings panel where the user can drive
+    // the host-write confirmation. (#774)
     const settingsResp = await fetch('/api/context/settings/sync', { method: 'POST', headers });
     if (!settingsResp.ok) throw new Error('Settings sync failed');
-    showToast(t('settings.ctx.sync_success'));
+    const settingsData = await settingsResp.json().catch(() => ({}));
+    const needsConfirmation = (settingsData.results || []).some(
+      r => r && r.status === 'needs_confirmation',
+    );
+    if (needsConfirmation) {
+      showToast(
+        t('toast.sync_partial_settings_needs_confirmation'),
+        'info',
+        {
+          action: {
+            label: t('toast.open_settings_action'),
+            onClick: () => switchSettingsSection('hooks-sync'),
+          },
+        },
+      );
+    } else {
+      showToast(t('settings.ctx.sync_success'));
+    }
     loadCtxOverview();
   } catch (err) {
     showToast(t('toast.sync_failed', { error: err.message }), 'error');

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1316,7 +1316,7 @@
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=3"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=13"></script>
+  <script src="/context-gateway.js?v=14"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -616,6 +616,8 @@
   "toast.reindex_complete": "Re-index complete \u2014 {count} chunks indexed",
   "toast.indexing_in_progress": "Indexing already in progress",
   "toast.hooks_warnings": "Synced with {count} warning(s)",
+  "toast.sync_partial_settings_needs_confirmation": "Sync All complete except Settings — confirm host writes in the Settings panel.",
+  "toast.open_settings_action": "Open Settings",
   "toast.request_failed": "Request failed",
   "toast.unexpected_response": "Unexpected response",
   "toast.sync_failed": "Sync failed: {error}",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -616,6 +616,8 @@
   "toast.reindex_complete": "재인덱스 완료 \u2014 {count}개 청크 인덱싱",
   "toast.indexing_in_progress": "이미 인덱싱이 진행 중입니다",
   "toast.hooks_warnings": "동기화 완료 (경고 {count}건)",
+  "toast.sync_partial_settings_needs_confirmation": "Sync All 완료 (Settings 제외) — Settings 패널에서 호스트 쓰기를 확인하세요.",
+  "toast.open_settings_action": "Settings 열기",
   "toast.request_failed": "요청 실패",
   "toast.unexpected_response": "예상치 못한 응답",
   "toast.sync_failed": "동기화 실패: {error}",

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -373,6 +373,64 @@ class TestNoHardcodedStrings:
                 f"_SETTINGS_STATUS_I18N missing entry for emitted status {status!r} (#775)"
             )
 
+    def test_issue_774_sync_all_inspects_settings_body(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """Sync All must inspect the Settings sync response body (#774).
+
+        The route at ``/api/context/settings/sync`` returns HTTP 200 with
+        ``{"results": [{"status": "needs_confirmation", ...}]}`` when the
+        body's ``allow_host_writes`` defaults to false — the case for Sync
+        All, which posts no body. ``resp.ok`` alone is therefore not
+        enough to confirm the merge actually happened: before #774 the
+        ``sync_success`` toast lied to the user even though
+        ``~/.claude/settings.json`` was untouched. The fix branches on
+        ``status === 'needs_confirmation'`` and surfaces partial-success
+        with a one-tap navigation to the Settings panel.
+
+        Symmetric pin per ``feedback_pin_invert_symmetric_assertion.md``:
+        the partial-success branch (positive marker) is paired with the
+        unconditional ``settings.ctx.sync_success`` for the negative case
+        (still present so a regression that always toasts partial-success
+        also fails). i18n keys for both locales are pinned to catch a
+        rename.
+        """
+        # i18n keys exist in both locales.
+        required = {
+            "toast.sync_partial_settings_needs_confirmation",
+            "toast.open_settings_action",
+        }
+        missing_en = required - set(en)
+        missing_ko = required - set(ko)
+        assert not missing_en, f"#774 keys missing from en.json: {sorted(missing_en)}"
+        assert not missing_ko, f"#774 keys missing from ko.json: {sorted(missing_ko)}"
+
+        # JS branches on the per-result status, not on resp.ok alone.
+        text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
+        assert "settingsResp.json()" in text, (
+            "context-gateway.js Sync All must read the Settings sync "
+            "response body — resp.ok alone hides ``needs_confirmation``"
+        )
+        assert "'needs_confirmation'" in text, (
+            "context-gateway.js Sync All must branch on per-result "
+            "``status === 'needs_confirmation'`` (#774)"
+        )
+        # Action button wires through to the Settings panel, not a dead
+        # toast — the user has to be able to drive the host-write
+        # confirmation from somewhere reachable.
+        assert "switchSettingsSection('hooks-sync')" in text, (
+            "context-gateway.js Sync All partial-success toast must "
+            "expose a navigation action to the Settings panel (#774)"
+        )
+        # Inverted pin: the unconditional success branch must still
+        # exist. A regression that universally toasts partial-success
+        # would drop ``settings.ctx.sync_success`` from the Sync All
+        # handler — fail loudly.
+        assert "t('settings.ctx.sync_success')" in text, (
+            "context-gateway.js Sync All lost its full-success branch — "
+            "every Sync All would now toast partial-success (#774)"
+        )
+
     def test_issue_698_new_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
         """Locale keys introduced for #698 must exist in both files. The
         existing ``test_placeholder_parity`` will catch ``{count}`` /


### PR DESCRIPTION
## Summary

- **Sync All** in `mm web` Context Gateway now inspects the Settings
  sync response body and surfaces `needs_confirmation` instead of
  toasting `sync_success` over a merge that never happened.
- New action button (`Open Settings`) in the partial-success toast
  navigates the user to the Settings panel where the host-write
  confirmation flow lives.
- Skills / Commands / Agents fanout is unchanged (all-or-nothing).

## Why

Closes #774. After RFC #761 (#771) graduated the Settings sync
surface from `mm web --dev` to all prod users, the pre-existing
silent-skip behavior reached every prod audience.

The route at `/api/context/settings/sync` returns HTTP 200 with

```json
{"results": [{"name": "claude_settings", "status": "needs_confirmation", ...}]}
```

when the body's `allow_host_writes` defaults to `false` — which is
the case for Sync All, since it posts no body. The frontend at
`web/static/context-gateway.js` only checked `settingsResp.ok`, so
the post-merge `sync_success` toast lied about a merge that didn't
happen for host-write targets like `~/.claude/settings.json`.

## Approach

The issue offered two options. Implemented **Option 1 (lightweight)**:
inspect per-result `status`, branch on `needs_confirmation`, surface
an info-level toast with a one-tap navigation to the Settings panel.
Option 2 (auto-trigger the confirmation dialog from Sync All) was
rejected because it would expand Sync All's responsibility past its
current "quick fanout" UX shape — a follow-up if the asymmetric flow
turns out to be a friction point in practice.

## Concrete edits

| File | Change |
|---|---|
| `web/static/context-gateway.js` | Sync All handler reads `settingsResp.json()`, branches on `result.status === 'needs_confirmation'`, surfaces partial-success toast with `Open Settings` action calling `switchSettingsSection('hooks-sync')`. |
| `web/static/locales/en.json` + `ko.json` | Two new keys: `toast.sync_partial_settings_needs_confirmation`, `toast.open_settings_action`. |
| `web/static/index.html` | `context-gateway.js?v=13` → `?v=14` (cache-bust per `feedback_static_asset_cache_bust`). |
| `tests/test_i18n.py` | New `test_issue_774_sync_all_inspects_settings_body` — symmetric pin (positive `needs_confirmation` branch marker + inverted `sync_success` negative-path marker) per `feedback_pin_invert_symmetric_assertion`. |
| `CHANGELOG.md` | `[Unreleased] → ### Fixed` entry. |

Total diff: 6 files, +111 / −2.

## Pin shape

`test_issue_774_sync_all_inspects_settings_body` asserts:

1. Both new i18n keys exist in en + ko.
2. JS reads `settingsResp.json()` (response body, not just `resp.ok`).
3. JS branches on `'needs_confirmation'` literal.
4. JS calls `switchSettingsSection('hooks-sync')` so the action wires
   to a reachable destination, not a dead toast.
5. **Inverted marker:** the unconditional `t('settings.ctx.sync_success')`
   path is still present — a regression that universally toasts
   partial-success would drop it and fail this assertion.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_i18n.py` — 19/19 green.
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/test_context_settings.py` — 69/69 green.
- [x] `uv run ruff check packages/memtomem/tests/test_i18n.py && uv run ruff format --check packages/memtomem/tests/test_i18n.py` — clean.
- [ ] Manual smoke (`mm web` on prod default): trigger Sync All against a project root with `.memtomem/settings.json` containing hooks; confirm the info-level toast appears with `Open Settings` action when the route returns `needs_confirmation` for `claude_settings`. After clicking `Open Settings`, land on the Hooks Sync panel.

## Out of scope

The dedicated Settings panel's `Sync Now` button (`settings-hooks-watchdog.js:150`)
also posts no body and inherits the same `allow_host_writes=false`
default. That path emits `toast.hooks_warnings` when warnings are
present, so the user does see *some* signal — but it's not the same
shape as a needs-confirmation prompt. Wiring the panel's flow into a
proper host-write confirmation dialog (Option 2 territory) is left
as a follow-up; this PR fixes only the Sync All mis-toast.

Refs: #761 (parent RFC), #771 (gate-flip introducing prod surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
