### PR TITLE
fix(web/ctx): widen Sync All status coverage to error/aborted (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Fixed
 
+- **Sync All classifies every non-`ok` Settings status, not just
+  `needs_confirmation` (closes #799).** `generate_all_settings` returns
+  one of five per-result statuses — `ok` / `skipped` / `error` /
+  `needs_confirmation` / `aborted`. #774 (PR #798) added a branch for
+  `needs_confirmation` only, so an `error` (canonical or target file
+  malformed JSON) or `aborted` (concurrent-write mtime conflict) result
+  still toasted `sync_success` even though the merge never landed —
+  the same class of "resp.ok hides per-result failure" bug, just with
+  different status values. Sync All now surfaces `error` as an
+  error-level toast carrying the route's `reason` and `aborted` as a
+  warning-level `mtime_conflict` toast — both reusing the same i18n
+  keys the per-target Sync flow already uses, so no new strings to
+  translate. Severity ladder: `error` > `aborted` >
+  `needs_confirmation` > all-`ok`/`skipped` (success). The Settings
+  panel's `Sync Now` host-write confirmation flow stays out of scope
+  per #774.
+
 - **Sync All no longer lies when Settings host writes need confirmation
   (closes #774).** The Context Gateway "Sync All" button posts to four
   endpoints sequentially; the Settings hop's `POST /api/context/settings/sync`

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -233,23 +233,33 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
     // entries. Promoted from dev-only via RFC #761 (ADR-0001 §5 criteria
     // + HTTP-layer test fixtures).
     //
-    // The route returns HTTP 200 even when host-write targets need user
-    // confirmation — each per-result entry carries its own ``status``
-    // (``needs_confirmation`` for ``~/.claude/settings.json`` when the
-    // body's ``allow_host_writes`` defaults to false, which is the case
-    // for Sync All — the dedicated Settings panel owns the confirmation
-    // flow). ``resp.ok`` alone would let that pass as a full success and
-    // the ``sync_success`` toast would lie about a merge that never
-    // happened. Inspect the body and surface partial-success with a
-    // one-tap navigation to the Settings panel where the user can drive
-    // the host-write confirmation. (#774)
+    // The route returns HTTP 200 even when individual generators fail —
+    // each per-result entry carries its own ``status`` (one of ``ok`` /
+    // ``skipped`` / ``error`` / ``needs_confirmation`` / ``aborted``,
+    // see ``generate_all_settings``). ``resp.ok`` alone would let any
+    // non-``ok`` result pass as a full success and the ``sync_success``
+    // toast would lie about a merge that never happened. Inspect the
+    // body and surface the most severe per-result status with the
+    // matching toast class. Severity order matches the user-facing
+    // signal from the dedicated Settings panel:
+    //
+    //   error              → error toast with reason   (#799)
+    //   aborted            → mtime_conflict warning    (#799)
+    //   needs_confirmation → info partial + Open Settings action (#774)
+    //   all ok / skipped   → sync_success
     const settingsResp = await fetch('/api/context/settings/sync', { method: 'POST', headers });
     if (!settingsResp.ok) throw new Error('Settings sync failed');
     const settingsData = await settingsResp.json().catch(() => ({}));
-    const needsConfirmation = (settingsData.results || []).some(
-      r => r && r.status === 'needs_confirmation',
-    );
-    if (needsConfirmation) {
+    const settingsResults = settingsData.results || [];
+    const firstWithStatus = (s) => settingsResults.find(r => r && r.status === s);
+    const errored = firstWithStatus('error');
+    const aborted = firstWithStatus('aborted');
+    const needsConfirmation = firstWithStatus('needs_confirmation');
+    if (errored) {
+      showToast(t('toast.sync_failed', { error: errored.reason || '' }), 'error');
+    } else if (aborted) {
+      showToast(t('settings.ctx.mtime_conflict'), 'warning');
+    } else if (needsConfirmation) {
       showToast(
         t('toast.sync_partial_settings_needs_confirmation'),
         'info',

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1316,7 +1316,7 @@
   <script src="/settings-harness.js?v=1"></script>
   <script src="/settings-hooks-watchdog.js?v=3"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=14"></script>
+  <script src="/context-gateway.js?v=15"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -431,6 +431,56 @@ class TestNoHardcodedStrings:
             "every Sync All would now toast partial-success (#774)"
         )
 
+    def test_issue_799_sync_all_status_coverage(self) -> None:
+        """Sync All must classify *every* non-``ok`` per-result status (#799).
+
+        ``generate_all_settings`` returns one of five statuses per generator:
+        ``ok`` / ``skipped`` / ``error`` / ``needs_confirmation`` / ``aborted``
+        (see ``packages/memtomem/src/memtomem/context/settings.py``). #774
+        added a branch for ``needs_confirmation`` only, leaving ``error``
+        and ``aborted`` to fall through to the unconditional success
+        toast — the same class of "resp.ok hides per-result failure" bug
+        the parent issue closed for the host-write case. #799 widens the
+        Sync All handler to surface ``error`` (error toast) and
+        ``aborted`` (mtime_conflict warning) in their own classes.
+
+        Symmetric pin per ``feedback_pin_invert_symmetric_assertion.md``:
+        positive markers for each new branch + inverted assertion that
+        the unconditional ``sync_success`` path is no longer reachable
+        for ``error`` / ``aborted`` results. The pre-#799 shape only
+        named ``'needs_confirmation'`` literal in the handler — pinning
+        both ``'error'`` and ``'aborted'`` literals catches a regression
+        that drops one branch back into the success fallthrough.
+        """
+        text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
+        # Both new statuses are inspected.
+        assert "'error'" in text and "firstWithStatus('error')" in text, (
+            "context-gateway.js Sync All must classify ``status === 'error'`` "
+            "as an error toast (#799)"
+        )
+        assert "firstWithStatus('aborted')" in text, (
+            "context-gateway.js Sync All must classify ``status === 'aborted'`` "
+            "as an mtime_conflict warning (#799)"
+        )
+        # Reuses existing toast keys rather than introducing duplicates —
+        # the per-target Sync flow already surfaces these classes the
+        # same way.
+        assert "t('toast.sync_failed'" in text, (
+            "context-gateway.js Sync All ``error`` branch must reuse ``toast.sync_failed`` (#799)"
+        )
+        assert "t('settings.ctx.mtime_conflict')" in text, (
+            "context-gateway.js Sync All ``aborted`` branch must reuse "
+            "``settings.ctx.mtime_conflict`` (#799)"
+        )
+        # Inverted pin: the success fallthrough must remain reachable —
+        # only for the all-``ok``/``skipped`` case. ``test_issue_774_*``
+        # already pins the literal; this assertion guards a regression
+        # that *removes* the else branch in the new severity ladder.
+        assert "showToast(t('settings.ctx.sync_success'))" in text, (
+            "context-gateway.js Sync All lost its success fallthrough — "
+            "the new severity ladder collapsed to a single branch (#799)"
+        )
+
     def test_issue_698_new_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
         """Locale keys introduced for #698 must exist in both files. The
         existing ``test_placeholder_parity`` will catch ``{count}`` /


### PR DESCRIPTION
## Summary

- Sync All now classifies **every** non-`ok` Settings status, not
  just `needs_confirmation` (#774 left two siblings on the table).
- New branches: `error` → error toast carrying the route's `reason`
  via `toast.sync_failed`; `aborted` → warning toast via
  `settings.ctx.mtime_conflict`. Both reuse i18n keys already used by
  the per-target Sync flow — zero new translations.
- Severity ladder: `error` > `aborted` > `needs_confirmation` >
  all-`ok`/`skipped`.

## Why

Closes #799. `generate_all_settings`
(`packages/memtomem/src/memtomem/context/settings.py:261`) returns one
of five per-result statuses: `ok` / `skipped` / `error` /
`needs_confirmation` / `aborted`. PR #798 (#774) only added a branch
for `needs_confirmation`, so the underlying "resp.ok hides per-result
failure" pathology still applied to `error` and `aborted`:

- `error` — canonical or target file is malformed JSON. Route returns
  `{"results": [{"name": "claude_settings", "status": "error",
  "reason": "/path/to/file is not valid JSON. Fix the file
  manually..."}]}`. Pre-#799 JS toasted `sync_success` regardless.
- `aborted` — concurrent-write mtime conflict. Route returns
  `{"results": [{"status": "aborted", ...}]}`. Same lie.

The dedicated per-target Sync flow at
`web/static/context-gateway.js:653, 946-955` already surfaces these
as `mtime_conflict` (warning) / `request_failed` (error). This PR
brings Sync All in line with the same shape.

## Concrete edits

| File | Change |
|---|---|
| `web/static/context-gateway.js` | Sync All handler replaces the single-status `.some()` check with a `firstWithStatus(s)` helper + severity ladder (`error` → `aborted` → `needs_confirmation` → success). Comment block updated to enumerate all five statuses + map to toast classes. |
| `web/static/index.html` | `context-gateway.js?v=14` → `?v=15` (cache-bust per `feedback_static_asset_cache_bust`). |
| `tests/test_i18n.py` | New `test_issue_799_sync_all_status_coverage` — symmetric pin with positive markers (`firstWithStatus('error')`, `firstWithStatus('aborted')`, `t('toast.sync_failed'`, `t('settings.ctx.mtime_conflict')`) + inverted marker (`showToast(t('settings.ctx.sync_success'))` survives the new ladder's else branch). |
| `CHANGELOG.md` | `[Unreleased] → ### Fixed` entry. |

Total diff: 4 files, +92 / −15.

## Pin shape

`test_issue_799_sync_all_status_coverage` asserts:

1. `firstWithStatus('error')` literal exists — pre-PR shape only had
   `'needs_confirmation'`, so the assertion fails on the old code.
2. `firstWithStatus('aborted')` literal exists — same.
3. `t('toast.sync_failed'` exists in the file — already there in the
   `catch` block, so the assertion holds; the new `error` branch
   shares the same key, so a regression that drops the new branch
   leaves `toast.sync_failed` reachable only on transport-layer
   failure (no positive marker remains for the per-result `error`
   case — which is exactly what `firstWithStatus('error')` catches).
4. `t('settings.ctx.mtime_conflict')` exists — pre-PR the only
   reference was the per-target Sync handler, so this assertion
   formerly held; with the new branch it has a *second* reference
   and the assertion still holds. The `firstWithStatus('aborted')`
   marker provides the strict positive pin for the new site.
5. **Inverted marker:** `showToast(t('settings.ctx.sync_success'))`
   must remain in the file. A regression that collapses the new
   severity ladder into a single error toast (e.g. removes the else
   branch) drops this literal and fails the assertion.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_i18n.py
   packages/memtomem/tests/test_context_settings.py` — 57/57 green
   (incl. the new `test_issue_799_sync_all_status_coverage`).
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format
   --check packages/memtomem/src` — clean. Tests file ruff-formatted
   in the same commit.
- [ ] Manual smoke: trigger Sync All against a project root whose
   canonical `.memtomem/settings.json` is malformed JSON (route
   returns `status="error"`); confirm an error-level toast surfaces
   the reason instead of `sync_success`.

## Out of scope

- The dedicated Settings panel's `Sync Now` host-write confirmation
  flow (`settings-hooks-watchdog.js`) — Option 2 from #774, larger UX
  cut.
- Per-generator naming in the toast text (e.g. "Sync All complete
  except claude_settings — ..."). The current ladder uses generic
  reasons; a future cut can name the generator if multi-generator
  settings sync becomes more common.

Refs: #774 (parent), PR #798 (`needs_confirmation` branch), #761 /
#771 (gate-flip that exposed the silent-skip class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
