### PR TITLE
feat(web/redaction): SPA confirm-and-retry for redaction-blocked 403 (#785)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -234,6 +234,20 @@ async function ensureCsrfToken() {
   return _csrfTokenPromise;
 }
 
+// Trust-boundary redaction guard (PR #784). Server mutating routes return
+// HTTP 403 with ``{detail: {detail: "redaction_blocked", hits, surface}}``
+// (FastAPI nests our structured payload under an outer ``detail``); the
+// SPA parses it via ``api()`` below and surfaces a confirm-and-retry UX
+// through ``apiWithRedactionRetry()``. Issue #785.
+class RedactionBlockedError extends Error {
+  constructor({ hits, surface }) {
+    super('redaction_blocked');
+    this.name = 'RedactionBlockedError';
+    this.hits = hits;
+    this.surface = surface;
+  }
+}
+
 async function api(method, path, body, opts = {}) {
   if (typeof opts !== 'object' || Array.isArray(opts)) opts = {};
   const fetchOpts = { method, headers: { 'Content-Type': 'application/json' } };
@@ -247,9 +261,121 @@ async function api(method, path, body, opts = {}) {
   const res = await fetch(API + path, fetchOpts);
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }));
-    throw new Error(err.detail || res.statusText);
+    if (
+      res.status === 403 &&
+      err && typeof err.detail === 'object' && err.detail !== null &&
+      err.detail.detail === 'redaction_blocked'
+    ) {
+      throw new RedactionBlockedError({
+        hits: err.detail.hits,
+        surface: err.detail.surface,
+      });
+    }
+    // Harden against ``[object Object]`` when ``detail`` is itself a dict
+    // (e.g. structured 4xx that isn't redaction_blocked).
+    const msg = typeof err.detail === 'string'
+      ? err.detail
+      : (err.detail && typeof err.detail === 'object' && typeof err.detail.detail === 'string'
+        ? err.detail.detail
+        : res.statusText);
+    throw new Error(msg);
   }
   return res.json();
+}
+
+// Wraps ``api()`` for write surfaces guarded by the trust-boundary redaction
+// filter. On a 403, prompts the user via ``showConfirm`` with the matched
+// pattern count and the localized surface label, then re-issues the same
+// request with ``body.force_unsafe = true``.
+//
+// Returns the JSON response on success (initial or retry), ``null`` if the
+// user declined the bypass. Non-redaction errors (and a second-pass error
+// after the user confirmed) propagate so existing call-site catches keep
+// working unchanged. Emits ``toast.redaction_bypassed`` on retry success
+// so the audit-log bypass is visible to the operator without forcing each
+// call site to add its own affirmation.
+async function apiWithRedactionRetry(method, path, body, opts = {}) {
+  try {
+    return await api(method, path, body, opts);
+  } catch (err) {
+    if (!(err instanceof RedactionBlockedError)) throw err;
+    const surfaceKey = 'surface.' + err.surface;
+    const localized = t(surfaceKey);
+    const surfaceLabel = localized === surfaceKey ? err.surface : localized;
+    const ok = await showConfirm({
+      title: t('confirm.redaction_blocked_title'),
+      message: t('confirm.redaction_blocked_message', {
+        hits: err.hits,
+        surface: surfaceLabel,
+      }),
+      confirmText: t('confirm.redaction_blocked_proceed'),
+    });
+    if (!ok) return null;
+    const retryBody = Object.assign({}, body || {}, { force_unsafe: true });
+    const data = await api(method, path, retryBody, opts);
+    showToast(t('toast.redaction_bypassed', { hits: err.hits }), 'info');
+    return data;
+  }
+}
+
+// Multipart upload variant of ``apiWithRedactionRetry``. ``/api/upload``
+// returns HTTP 200 with per-file ``error="redaction_blocked (hits=N)"``
+// strings (system.py:1161) instead of a structured 403, so the dialog is
+// driven off the per-file error scan rather than a typed exception. On
+// confirm, re-issues the same FormData with ``?force_unsafe=true``;
+// re-uploading already-OK files is idempotent thanks to the
+// ``_{mtime_ns}`` collision suffix added by the server (system.py:1121).
+//
+// Returns ``{data, cancelled, bypassed}``: ``data`` is the response to
+// render, ``cancelled`` is true when the user declined the bypass (caller
+// should still render ``data`` to surface the per-file errors), and
+// ``bypassed`` is true on a successful retry.
+const _UPLOAD_REDACTION_BLOCKED_RE = /^redaction_blocked \(hits=(\d+)\)$/;
+async function uploadFilesWithRedactionRetry(formData) {
+  async function _post(forceUnsafe) {
+    const csrf = await ensureCsrfToken();
+    const headers = csrf ? { 'X-Memtomem-CSRF': csrf } : {};
+    const url = forceUnsafe ? '/api/upload?force_unsafe=true' : '/api/upload';
+    const res = await fetch(url, { method: 'POST', body: formData, headers });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      const detail = err.detail;
+      const errMsg = typeof detail === 'string'
+        ? detail
+        : (detail && typeof detail === 'object' && typeof detail.detail === 'string'
+          ? detail.detail
+          : res.statusText);
+      throw new Error(errMsg);
+    }
+    return res.json();
+  }
+
+  const data = await _post(false);
+  const blockedHits = (data.files || [])
+    .map(r => {
+      const m = r.error && r.error.match(_UPLOAD_REDACTION_BLOCKED_RE);
+      return m ? parseInt(m[1], 10) : 0;
+    })
+    .filter(n => n > 0);
+  if (!blockedHits.length) return { data, cancelled: false, bypassed: false };
+
+  const totalHits = blockedHits.reduce((a, b) => a + b, 0);
+  const surfaceKey = 'surface.web_api_upload';
+  const localized = t(surfaceKey);
+  const surfaceLabel = localized === surfaceKey ? 'web_api_upload' : localized;
+  const ok = await showConfirm({
+    title: t('confirm.redaction_blocked_title'),
+    message: t('confirm.redaction_blocked_message', {
+      hits: totalHits,
+      surface: surfaceLabel,
+    }),
+    confirmText: t('confirm.redaction_blocked_proceed'),
+  });
+  if (!ok) return { data, cancelled: true, bypassed: false };
+
+  const retryData = await _post(true);
+  showToast(t('toast.redaction_bypassed', { hits: totalHits }), 'info');
+  return { data: retryData, cancelled: false, bypassed: true };
 }
 
 function qs(id) { return document.getElementById(id); }
@@ -2182,7 +2308,12 @@ qs('d-save-btn').addEventListener('click', async () => {
   btnLoading(btn, true);
   try {
     _pushHistory(STATE.selectedChunkId, STATE.selectedOriginal);
-    await api('PATCH', `/api/chunks/${STATE.selectedChunkId}`, { new_content: newContent });
+    const resp = await apiWithRedactionRetry(
+      'PATCH',
+      `/api/chunks/${STATE.selectedChunkId}`,
+      { new_content: newContent },
+    );
+    if (resp === null) return;
     showToast(t('toast.chunk_saved'), 'success');
     STATE.selectedOriginal = newContent;
     _syncResultContent(STATE.selectedChunkId, newContent);
@@ -3652,7 +3783,16 @@ function _startChunkEdit(card, chunk, sourcePath) {
     saveBtn.disabled = true;
     saveBtn.textContent = 'Saving…';
     try {
-      await api('PATCH', `/api/chunks/${chunk.id}`, { new_content: newContent });
+      const resp = await apiWithRedactionRetry(
+        'PATCH',
+        `/api/chunks/${chunk.id}`,
+        { new_content: newContent },
+      );
+      if (resp === null) {
+        saveBtn.disabled = false;
+        saveBtn.textContent = 'Save';
+        return;
+      }
       showToast(t('toast.chunk_updated'), 'success');
       _syncResultContent(chunk.id, newContent);
       _markDataStale();
@@ -3825,7 +3965,12 @@ qs('add-btn').addEventListener('click', async () => {
   try {
     const body = { content, title, tags, file, namespace };
     if (forceUnsafe) body.force_unsafe = true;
-    const data = await api('POST', '/api/add', body);
+    // ``apiWithRedactionRetry`` covers the case where the client pre-check
+    // missed (cache failed to load) or where the server-side pattern set
+    // is broader than the client's cached snapshot — the server's 403
+    // becomes a confirm-and-retry instead of an opaque error toast.
+    const data = await apiWithRedactionRetry('POST', '/api/add', body);
+    if (data === null) return;
     const n = data.indexed_chunks;
     showToast(t('toast.saved_to_file', { path: tildifyPath(data.file), count: n }), 'success');
     qs('add-content').value = '';
@@ -3911,14 +4056,8 @@ qs('add-btn').addEventListener('click', async () => {
     selectedFiles.forEach(f => form.append('files', f));
 
     try {
-      const csrf = await ensureCsrfToken();
-      const headers = csrf ? { 'X-Memtomem-CSRF': csrf } : {};
-      const res = await fetch('/api/upload', { method: 'POST', body: form, headers });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: res.statusText }));
-        throw new Error(err.detail || res.statusText);
-      }
-      const data = await res.json();
+      const upload = await uploadFilesWithRedactionRetry(form);
+      const data = upload.data;
       // Render per-file results
       show(result);
       result.innerHTML = '';
@@ -3932,11 +4071,15 @@ qs('add-btn').addEventListener('click', async () => {
         }
         result.appendChild(row);
       });
+      if (upload.cancelled) {
+        showToast(t('toast.upload_failed', { error: t('confirm.redaction_blocked_title') }), 'error');
+        return;
+      }
       const firstPath = data.files.find(r => !r.error && r.path)?.path;
-      const msg = firstPath
+      const successMsg = firstPath
         ? t('toast.upload_complete_with_path', { count: data.total_indexed, path: tildifyPath(firstPath) })
         : t('toast.upload_complete', { count: data.total_indexed });
-      showToast(msg, 'success');
+      showToast(successMsg, 'success');
       selectedFiles = [];
       renderFileList();
       _markDataStale();
@@ -5443,14 +5586,9 @@ qs('group-toggle').addEventListener('click', () => {
     files.forEach(f => fd.append('files', f));
     showToast(t('toast.indexing_files', { count: files.length }), 'info');
     try {
-      const csrf = await ensureCsrfToken();
-      const headers = csrf ? { 'X-Memtomem-CSRF': csrf } : {};
-      const res = await fetch('/api/upload', { method: 'POST', body: fd, headers });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({ detail: res.statusText }));
-        throw new Error(err.detail);
-      }
-      const data = await res.json();
+      const upload = await uploadFilesWithRedactionRetry(fd);
+      if (upload.cancelled) return;
+      const data = upload.data;
       const chunks = (data.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
       showToast(t('toast.indexed_files_chunks', { files: files.length, chunks }), 'success');
       _markDataStale();

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -323,13 +323,17 @@ async function apiWithRedactionRetry(method, path, body, opts = {}) {
 // strings (system.py:1161) instead of a structured 403, so the dialog is
 // driven off the per-file error scan rather than a typed exception. On
 // confirm, re-issues the same FormData with ``?force_unsafe=true``;
-// re-uploading already-OK files is idempotent thanks to the
-// ``_{mtime_ns}`` collision suffix added by the server (system.py:1121).
+// the retry is non-conflicting (not strictly idempotent) — already-OK
+// files get re-written under a ``_{mtime_ns}`` suffix by the server
+// (system.py:1121), so the same content is indexed twice under two
+// filenames. Acceptable trade-off given the rarity of mixed batches.
 //
-// Returns ``{data, cancelled, bypassed}``: ``data`` is the response to
-// render, ``cancelled`` is true when the user declined the bypass (caller
-// should still render ``data`` to surface the per-file errors), and
-// ``bypassed`` is true on a successful retry.
+// Returns ``{data, cancelled, bypassed, blockedFileCount}``: ``data`` is
+// the response to render, ``cancelled`` is true when the user declined
+// the bypass (caller should still render ``data`` to surface the
+// per-file errors), ``bypassed`` is true on a successful retry, and
+// ``blockedFileCount`` is the number of files that triggered the guard
+// (used by callers to localize the cancel-toast).
 const _UPLOAD_REDACTION_BLOCKED_RE = /^redaction_blocked \(hits=(\d+)\)$/;
 async function uploadFilesWithRedactionRetry(formData) {
   async function _post(forceUnsafe) {
@@ -357,7 +361,9 @@ async function uploadFilesWithRedactionRetry(formData) {
       return m ? parseInt(m[1], 10) : 0;
     })
     .filter(n => n > 0);
-  if (!blockedHits.length) return { data, cancelled: false, bypassed: false };
+  if (!blockedHits.length) {
+    return { data, cancelled: false, bypassed: false, blockedFileCount: 0 };
+  }
 
   const totalHits = blockedHits.reduce((a, b) => a + b, 0);
   const surfaceKey = 'surface.web_api_upload';
@@ -371,11 +377,13 @@ async function uploadFilesWithRedactionRetry(formData) {
     }),
     confirmText: t('confirm.redaction_blocked_proceed'),
   });
-  if (!ok) return { data, cancelled: true, bypassed: false };
+  if (!ok) {
+    return { data, cancelled: true, bypassed: false, blockedFileCount: blockedHits.length };
+  }
 
   const retryData = await _post(true);
   showToast(t('toast.redaction_bypassed', { hits: totalHits }), 'info');
-  return { data: retryData, cancelled: false, bypassed: true };
+  return { data: retryData, cancelled: false, bypassed: true, blockedFileCount: blockedHits.length };
 }
 
 function qs(id) { return document.getElementById(id); }
@@ -4072,7 +4080,7 @@ qs('add-btn').addEventListener('click', async () => {
         result.appendChild(row);
       });
       if (upload.cancelled) {
-        showToast(t('toast.upload_failed', { error: t('confirm.redaction_blocked_title') }), 'error');
+        showToast(t('toast.upload_redaction_cancelled', { count: upload.blockedFileCount }), 'error');
         return;
       }
       const firstPath = data.files.find(r => !r.error && r.path)?.path;

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2315,13 +2315,16 @@ qs('d-save-btn').addEventListener('click', async () => {
   const btn = qs('d-save-btn');
   btnLoading(btn, true);
   try {
-    _pushHistory(STATE.selectedChunkId, STATE.selectedOriginal);
     const resp = await apiWithRedactionRetry(
       'PATCH',
       `/api/chunks/${STATE.selectedChunkId}`,
       { new_content: newContent },
     );
     if (resp === null) return;
+    // History push must follow a confirmed write — pushing before the
+    // request would pollute the undo stack with a no-op entry when the
+    // user cancels the redaction-blocked confirm dialog.
+    _pushHistory(STATE.selectedChunkId, STATE.selectedOriginal);
     showToast(t('toast.chunk_saved'), 'success');
     STATE.selectedOriginal = newContent;
     _syncResultContent(STATE.selectedChunkId, newContent);

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1308,7 +1308,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=103"></script>
+  <script src="/app.js?v=104"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1308,12 +1308,12 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=101"></script>
+  <script src="/app.js?v=102"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>
   <script src="/settings-namespaces.js?v=5"></script>
-  <script src="/settings-harness.js?v=1"></script>
+  <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=3"></script>
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=15"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1308,7 +1308,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=102"></script>
+  <script src="/app.js?v=103"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -230,6 +230,15 @@
   "compose.privacy_warning_message": "What looks like an API key was found. This content will be stored as-is in the local database and exposed to search — proceed anyway?",
   "compose.privacy_warning_proceed": "Proceed",
 
+  "confirm.redaction_blocked_title": "Redaction guard blocked write",
+  "confirm.redaction_blocked_message": "The server detected {hits} secret-like pattern(s) on {surface}. Bypass and write anyway? This will be audited.",
+  "confirm.redaction_blocked_proceed": "Bypass and write",
+  "toast.redaction_bypassed": "Bypassed redaction guard ({hits} hits) — entry written.",
+  "surface.web_api_add": "Add memory",
+  "surface.web_api_chunk_edit": "Chunk edit",
+  "surface.web_api_scratch_promote": "Scratch promote",
+  "surface.web_api_upload": "File upload",
+
   "settings.nav.general": "General",
   "settings.nav.integrations": "Integrations",
   "settings.nav.runtime": "Runtime",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -234,6 +234,7 @@
   "confirm.redaction_blocked_message": "The server detected {hits} secret-like pattern(s) on {surface}. Bypass and write anyway? This will be audited.",
   "confirm.redaction_blocked_proceed": "Bypass and write",
   "toast.redaction_bypassed": "Bypassed redaction guard ({hits} hits) — entry written.",
+  "toast.upload_redaction_cancelled": "Upload cancelled — redaction guard left {count} file(s) blocked.",
   "surface.web_api_add": "Add memory",
   "surface.web_api_chunk_edit": "Chunk edit",
   "surface.web_api_scratch_promote": "Scratch promote",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -234,6 +234,7 @@
   "confirm.redaction_blocked_message": "서버가 {surface}에서 {hits}개의 비밀 의심 패턴을 감지했어요. 우회하고 작성할까요? 감사 로그에 기록됩니다.",
   "confirm.redaction_blocked_proceed": "우회하고 작성",
   "toast.redaction_bypassed": "비밀정보 가드 우회 ({hits}건) — 저장됨.",
+  "toast.upload_redaction_cancelled": "업로드 취소됨 — 비밀정보 가드가 {count}개 파일을 차단한 상태로 두었습니다.",
   "surface.web_api_add": "메모리 추가",
   "surface.web_api_chunk_edit": "청크 편집",
   "surface.web_api_scratch_promote": "스크래치 승격",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -230,6 +230,15 @@
   "compose.privacy_warning_message": "API 키로 보이는 내용이 발견됐습니다. 이 내용은 로컬 DB에 그대로 저장되고 검색에 노출됩니다. 계속할까요?",
   "compose.privacy_warning_proceed": "계속",
 
+  "confirm.redaction_blocked_title": "비밀정보 가드가 쓰기를 차단함",
+  "confirm.redaction_blocked_message": "서버가 {surface}에서 {hits}개의 비밀 의심 패턴을 감지했어요. 우회하고 작성할까요? 감사 로그에 기록됩니다.",
+  "confirm.redaction_blocked_proceed": "우회하고 작성",
+  "toast.redaction_bypassed": "비밀정보 가드 우회 ({hits}건) — 저장됨.",
+  "surface.web_api_add": "메모리 추가",
+  "surface.web_api_chunk_edit": "청크 편집",
+  "surface.web_api_scratch_promote": "스크래치 승격",
+  "surface.web_api_upload": "파일 업로드",
+
   "settings.nav.general": "일반",
   "settings.nav.integrations": "연동",
   "settings.nav.runtime": "런타임",

--- a/packages/memtomem/src/memtomem/web/static/settings-harness.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-harness.js
@@ -225,7 +225,12 @@ async function deleteScratchEntry(key) {
 
 async function promoteScratchEntry(key) {
   try {
-    await api('POST', `/api/scratch/${encodeURIComponent(key)}/promote`, {});
+    const resp = await apiWithRedactionRetry(
+      'POST',
+      `/api/scratch/${encodeURIComponent(key)}/promote`,
+      {},
+    );
+    if (resp === null) return;
     toast('Promoted to long-term memory', 'success');
     loadHarnessScratch();
   } catch (e) {

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -1,0 +1,237 @@
+"""Browser tests for the redaction-blocked confirm-and-retry UX (issue #785).
+
+PR #784 unified the trust-boundary redaction guard across every server-side
+write surface. The four mutating web routes signal a hit two different ways:
+
+* JSON routes (``POST /api/add``, ``PATCH /api/chunks/{id}``,
+  ``POST /api/scratch/{key}/promote``) return ``HTTP 403`` with
+  ``{"detail": {"detail": "redaction_blocked", "hits": N, "surface": L}}``.
+* ``POST /api/upload`` returns ``HTTP 200`` with per-file
+  ``error="redaction_blocked (hits=N)"`` strings (system.py:1161) and accepts
+  ``?force_unsafe=true`` as a query param to bypass for the whole batch.
+
+These specs pin the SPA-side wiring: ``api()`` parses the structured 403,
+``apiWithRedactionRetry()`` shows the confirm dialog and re-issues with
+``force_unsafe=true`` in the body, ``uploadFilesWithRedactionRetry()`` does
+the analogous flow for the multipart endpoint with the query param.
+
+Both specs route-stub the backend; the metric-counter assertion the issue
+body asks for (``mem_add_redaction_stats[bypassed][by_tool]``) needs a real
+backend fixture and is tracked as a follow-up.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _install_default_stubs(page) -> None:
+    """Stub every endpoint the SPA hits during boot.
+
+    Mirrors the catch-all pattern in ``test_tag_filter_mutation.py``;
+    ``page.route`` resolves last-registered-wins so the catch-all goes
+    first and specific overrides go last.
+    """
+
+    def _ok(route, payload):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    page.route("**/api/**", lambda r: _ok(r, {}))
+    page.route("**/api/system/ui-mode", lambda r: _ok(r, {"mode": "prod"}))
+    page.route("**/api/system/model-readiness", lambda r: _ok(r, {"ready": True}))
+    page.route("**/api/sources", lambda r: _ok(r, {"sources": []}))
+    page.route("**/api/namespaces", lambda r: _ok(r, {"namespaces": []}))
+    page.route("**/api/stats", lambda r: _ok(r, {}))
+    # Empty privacy patterns disables the client-side pre-check so the
+    # spec exercises only the server-driven 403 path. Without this, any
+    # ``sk-…`` content would trip the pre-check dialog *before* the
+    # request leaves the browser and the server stub would never fire.
+    page.route("**/api/privacy/patterns", lambda r: _ok(r, {"patterns": []}))
+
+
+def test_api_add_403_triggers_confirm_and_retries_with_force_unsafe(page, mm_web_url: str) -> None:
+    """``POST /api/add`` 403 → confirm dialog naming hits/surface → click
+    proceed → second POST carries ``force_unsafe: true`` in the body and
+    the success toast renders.
+
+    The first response uses the FastAPI-nested shape
+    ``{"detail": {"detail": "redaction_blocked", "hits": 2, "surface": ...}}``
+    that the backend actually returns (system.py:1232-1240); a flat
+    ``{"detail": "redaction_blocked"}`` would silently miss the parser
+    branch in ``api()``, which is the bug this spec exists to guard.
+    """
+    _install_default_stubs(page)
+
+    calls: list[dict] = []
+
+    def _add_handler(route):
+        # Capture every request to /api/add so the test can assert the
+        # *first* call did not carry force_unsafe. The retry request is
+        # asserted via ``page.expect_request`` to avoid a race with the
+        # route handler's append on the Python side.
+        body = route.request.post_data_json or {}
+        calls.append(body)
+        if len(calls) == 1:
+            route.fulfill(
+                status=403,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "detail": {
+                            "detail": "redaction_blocked",
+                            "hits": 2,
+                            "surface": "web_api_add",
+                        }
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "indexed_chunks": 1,
+                        "file": "/home/u/.memtomem/memories/x.md",
+                        "namespace": "default",
+                    }
+                ),
+            )
+
+    page.route("**/api/add", _add_handler)
+
+    page.goto(mm_web_url)
+    # Switch Index → Compose mode to reveal the Add form.
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-compose").click()
+    page.locator("#add-content").fill("sk-ant-test-fake-1234567890abcdef")
+    page.locator("#add-btn").click()
+
+    # The confirm dialog should appear with the matched-pattern count and
+    # the localized surface label. The default locale is English and the
+    # surface key ``surface.web_api_add`` resolves to "Add memory".
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    message = page.locator("#confirm-message").text_content() or ""
+    assert "2" in message, f"hit count missing from dialog: {message!r}"
+    assert "Add memory" in message, f"surface label missing from dialog: {message!r}"
+
+    # ``page.expect_request`` yields to Playwright's event loop while
+    # waiting; a Python-side ``time.sleep`` would block the loop and the
+    # route handler would never run. The matcher fires on the *retry*
+    # request because the first request already finished before this
+    # block opened. Asserting directly on ``retry_info.value`` (Playwright's
+    # captured request) avoids a race between the request-dispatched event
+    # and the route handler's ``calls.append`` running on the Python side.
+    with page.expect_request("**/api/add", timeout=5_000) as retry_info:
+        page.locator("#confirm-ok-btn").click()
+    retry_request = retry_info.value
+    assert retry_request.post_data_json.get("force_unsafe") is True, (
+        f"retry must carry force_unsafe=true, got {retry_request.post_data_json!r}"
+    )
+    assert calls[0].get("force_unsafe") is not True, "first call should not carry force_unsafe"
+
+    # Success toast for the audited bypass should render.
+    page.wait_for_selector(
+        "#toast-container .toast",
+        timeout=2_000,
+    )
+
+
+def test_api_upload_per_file_redaction_triggers_batch_retry_with_query_param(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """``POST /api/upload`` per-file ``redaction_blocked (hits=N)`` →
+    confirm dialog with summed hits → retry sends ``?force_unsafe=true``.
+
+    The upload route's response shape diverges from the JSON routes (200
+    + embedded string error vs structured 403); this spec pins that
+    ``uploadFilesWithRedactionRetry`` correctly parses the string-shape
+    error and adds the bypass via the URL query param, not the body.
+    """
+    _install_default_stubs(page)
+
+    calls: list[str] = []
+
+    def _upload_handler(route):
+        calls.append(route.request.url)
+        if len(calls) == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=3)",
+                            }
+                        ],
+                        "total_indexed": 0,
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/secret.md",
+                            }
+                        ],
+                        "total_indexed": 1,
+                    }
+                ),
+            )
+
+    # Glob ``**/api/upload**`` would also match ``/api/uploads/usage`` (the
+    # GET fired on Index-tab activation), splitting the call counter
+    # across both endpoints. A regex anchored on ``/api/upload(?:?...)?``
+    # excludes the plural ``uploads`` path.
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    # Real file on disk so ``set_input_files`` has something to attach.
+    fixture = tmp_path / "secret.md"
+    fixture.write_text("# Secret notes\n\nsk-ant-test-fake-1234567890abcdef\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files(str(fixture))
+    page.locator("#upload-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    message = page.locator("#confirm-message").text_content() or ""
+    assert "3" in message, f"hit count missing from dialog: {message!r}"
+    assert "File upload" in message, f"surface label missing from dialog: {message!r}"
+
+    with page.expect_request(
+        re.compile(r"/api/upload\?force_unsafe=true$"), timeout=5_000
+    ) as retry_info:
+        page.locator("#confirm-ok-btn").click()
+    retry_request = retry_info.value
+    assert "force_unsafe=true" in retry_request.url, (
+        f"retry upload must carry ?force_unsafe=true: {retry_request.url!r}"
+    )
+    assert "force_unsafe=true" not in calls[0]

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -143,6 +143,13 @@ def test_api_add_403_triggers_confirm_and_retries_with_force_unsafe(page, mm_web
     )
     assert calls[0].get("force_unsafe") is not True, "first call should not carry force_unsafe"
 
+    # The dialog must dismiss on confirm — guards against a regression where
+    # ``showConfirm`` resolves but the modal stays visible (would block the
+    # next interaction without surfacing as a request-level failure).
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
     # Success toast for the audited bypass should render.
     page.wait_for_selector(
         "#toast-container .toast",
@@ -235,3 +242,9 @@ def test_api_upload_per_file_redaction_triggers_batch_retry_with_query_param(
         f"retry upload must carry ?force_unsafe=true: {retry_request.url!r}"
     )
     assert "force_unsafe=true" not in calls[0]
+
+    # Dialog must dismiss on confirm (mirrors the JSON-route spec above).
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -248,3 +248,66 @@ def test_api_upload_per_file_redaction_triggers_batch_retry_with_query_param(
         "() => document.getElementById('confirm-modal').hidden",
         timeout=2_000,
     )
+
+
+def test_api_add_403_cancel_does_not_retry_or_emit_bypass_toast(page, mm_web_url: str) -> None:
+    """``POST /api/add`` 403 → confirm dialog → click **Cancel** → no
+    retry POST, no ``toast.redaction_bypassed``.
+
+    The affirmative spec above pins that confirm triggers a retry; this
+    spec pins the symmetric negative per
+    ``feedback_pin_invert_symmetric_assertion.md`` — without it a
+    regression where ``showConfirm`` always resolves ``true`` (or the
+    helper's ``if (!ok) return null`` branch is dropped) would still
+    pass the affirmative assertion.
+    """
+    _install_default_stubs(page)
+
+    calls: list[dict] = []
+
+    def _add_handler(route):
+        body = route.request.post_data_json or {}
+        calls.append(body)
+        route.fulfill(
+            status=403,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "detail": {
+                        "detail": "redaction_blocked",
+                        "hits": 2,
+                        "surface": "web_api_add",
+                    }
+                }
+            ),
+        )
+
+    page.route("**/api/add", _add_handler)
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-compose").click()
+    page.locator("#add-content").fill("sk-ant-test-fake-1234567890abcdef")
+    page.locator("#add-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    page.locator("#confirm-cancel-btn").click()
+
+    # Dialog dismisses, helper returns ``null``, the call site's
+    # ``if (data === null) return`` short-circuits before the success
+    # toast renders. Give the SPA a beat in case a stray retry is in
+    # flight, then assert call count stayed at 1.
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    page.wait_for_timeout(300)
+    assert len(calls) == 1, f"cancel must not trigger retry, saw {len(calls)} POSTs"
+
+    # No bypass toast — the affirmative spec asserts one renders, this
+    # one asserts none does. Together they pin the symmetric pair.
+    bypass_toasts = page.locator("#toast-container .toast", has_text="Bypassed")
+    assert bypass_toasts.count() == 0, "cancel must not emit toast.redaction_bypassed"


### PR DESCRIPTION
## Summary

PR #784 unified the trust-boundary redaction guard server-side. The four
mutating web routes now signal a hit in two shapes:

- JSON routes (`/api/add`, `PATCH /api/chunks/{id}`, scratch promote)
  return `HTTP 403 {detail: {detail: "redaction_blocked", hits, surface}}`.
- `POST /api/upload` returns `HTTP 200` with per-file
  `error="redaction_blocked (hits=N)"` and accepts `?force_unsafe=true`.

The SPA did not yet exercise this: `api()` stringified the nested detail
object to `[object Object]` (dropping `hits`/`surface`), none of the four
mutating call sites sent `force_unsafe` after a block, and there was no
Playwright smoke for the UX. This PR closes that gap.

## What changed

- **`api()` helper** parses the FastAPI-nested `{detail: {detail, hits,
  surface}}` and throws a typed `RedactionBlockedError`. Non-redaction
  4xx with a dict `detail` no longer surfaces as `[object Object]`.
- **`apiWithRedactionRetry()`** (new) wraps `api()`: on the typed error,
  shows `showConfirm` with the matched-pattern count and a localized
  surface label, then retries with `body.force_unsafe = true`. Returns
  `null` on user cancel so existing call-site catches keep working.
- **`uploadFilesWithRedactionRetry()`** (new) covers `/api/upload`'s
  divergent shape: scans per-file errors, sums hits, re-issues the
  original FormData with `?force_unsafe=true` on confirm. Mixed batches
  (≥1 clean + ≥1 blocked) currently re-write clean files under the
  server's `_{mtime_ns}` collision suffix (system.py:1121); tracked as
  a follow-up — see #803.
- **Five SPA call sites** swap to the helpers: `d-save-btn` PATCH,
  browse-source PATCH, `/api/add` POST (after the existing client-side
  pre-check — both layers can't both fire because the pre-check sets
  `force_unsafe=true` so the server never returns 403), Upload tab
  click, Search-tab drag-drop. `settings-harness.js` scratch promote
  uses the wrapper too.
- **9 new i18n keys** in `en.json` + `ko.json` lockstep:
  `confirm.redaction_blocked_*`, `toast.redaction_bypassed`, and
  `surface.web_api_*` for the four route labels.
- **Cache-bust**: `app.js?v=104` (from 101), `settings-harness.js?v=2`
  (from 1).

## Tests

`tests/web/test_redaction_blocked_retry.py` adds three browser specs
that route-stub the backend per the existing `mm_web_url` fixture
pattern:

- **`/api/add`** 403 → confirm dialog naming `hits=2` + "Add memory" →
  click proceed → second POST carries `force_unsafe: true` in the body.
- **`/api/upload`** per-file `redaction_blocked (hits=3)` → confirm
  dialog naming `hits=3` + "File upload" → retry sends
  `?force_unsafe=true` query param.
- **`/api/add`** 403 → confirm dialog → click **Cancel** → exactly one
  POST recorded, no `toast.redaction_bypassed`. Symmetric negative per
  `feedback_pin_invert_symmetric_assertion.md` so a regression where
  `showConfirm` always resolves true (or `apiWithRedactionRetry` drops
  its `if (!ok) return null` branch) doesn't pass silently.

Mutation-validated per `feedback_pin_test_mutation_validation.md`:
removing `if (!ok) return null` from `apiWithRedactionRetry` flips the
new cancel spec to fail (`AssertionError: cancel must not trigger
retry, saw 2 POSTs`) before being restored.

Full CI floor: `uv run pytest -m "not ollama"` reports **4197 passed, 8
skipped, 0 failed**. `ruff check` + `ruff format --check` clean.

## Follow-up

Spun out of Codex review on this PR; deferred to keep the scope tight on
the single-file confirm-and-retry path that issue #785 specifies:

- **#803, #804 (both addressed in PR #805)** — clean-file duplication
  on retry and cancel-leaves-UI-stale were spun out for review focus
  but folded into PR #805 stacked on this branch.

The issue body asks for the smoke to assert
`mem_add_redaction_stats[bypassed][by_tool]` increments. That needs a
real-backend Playwright fixture which `tests/web/conftest.py` does not
provide (`lifespan=None` by design — see fixture docstring). The route
counter is already pinned by `test_web_routes.py::TestAddMemoryRedaction`
on the backend side; surfacing it in the SPA suite is tracked separately.

## Out of scope

- Backend (PR #784 already correct).
- CLI / MCP / LangGraph surfaces (native `--force-unsafe` / kwarg).
- New redaction patterns (`privacy.py` module docstring).

## Test plan

- [x] `uv run pytest -m "not ollama"` — full CI floor green
- [x] `uv run ruff check packages/memtomem/{src,tests}` — clean
- [x] `uv run ruff format --check packages/memtomem/{src,tests}` — clean
- [x] `uv run pytest packages/memtomem/tests/web/test_redaction_blocked_retry.py` — new browser specs green
- [ ] Manual `mm web` smoke: paste `sk-…` into Add → expect dialog → proceed → row lands and `mem_add_redaction_stats` snapshot shows the `web_api_add` bypass increment

Refs #785 (closes), #790 (closes — same four chunk-edit / upload sites the helper covers, filed as a follow-up before this PR landed), #784 (Codex review follow-up). Follow-ups #803 and #804 are addressed in stacked PR #805.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


