### PR TITLE
fix(web/redaction): narrow retry FormData to blocked files only (#803)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -322,25 +322,31 @@ async function apiWithRedactionRetry(method, path, body, opts = {}) {
 // returns HTTP 200 with per-file ``error="redaction_blocked (hits=N)"``
 // strings (system.py:1161) instead of a structured 403, so the dialog is
 // driven off the per-file error scan rather than a typed exception. On
-// confirm, re-issues the same FormData with ``?force_unsafe=true``;
-// the retry is non-conflicting (not strictly idempotent) — already-OK
-// files get re-written under a ``_{mtime_ns}`` suffix by the server
-// (system.py:1121), so the same content is indexed twice under two
-// filenames. Acceptable trade-off given the rarity of mixed batches.
+// confirm, re-issues a *narrowed* FormData containing only the blocked
+// entries with ``?force_unsafe=true``; clean files from the first pass
+// are already persisted server-side and are not re-sent (issue #803 —
+// the previous full-batch retry let the server's ``_{mtime_ns}``
+// collision suffix at system.py:1121 silently duplicate every clean
+// file in any mixed batch, since that suffix was meant for genuine
+// name collisions, not retry-batch deduplication).
+//
+// The retry result rows are merged back into the original ``data.files``
+// at their original positions, so the caller renders one row per input
+// file regardless of which pass produced it.
 //
 // Returns ``{data, cancelled, bypassed, blockedFileCount}``: ``data`` is
-// the response to render, ``cancelled`` is true when the user declined
-// the bypass (caller should still render ``data`` to surface the
-// per-file errors), ``bypassed`` is true on a successful retry, and
+// the (merged) response to render, ``cancelled`` is true when the user
+// declined the bypass (caller should still render ``data`` to surface
+// the per-file errors), ``bypassed`` is true on a successful retry, and
 // ``blockedFileCount`` is the number of files that triggered the guard
 // (used by callers to localize the cancel-toast).
 const _UPLOAD_REDACTION_BLOCKED_RE = /^redaction_blocked \(hits=(\d+)\)$/;
 async function uploadFilesWithRedactionRetry(formData) {
-  async function _post(forceUnsafe) {
+  async function _post(form, forceUnsafe) {
     const csrf = await ensureCsrfToken();
     const headers = csrf ? { 'X-Memtomem-CSRF': csrf } : {};
     const url = forceUnsafe ? '/api/upload?force_unsafe=true' : '/api/upload';
-    const res = await fetch(url, { method: 'POST', body: formData, headers });
+    const res = await fetch(url, { method: 'POST', body: form, headers });
     if (!res.ok) {
       const err = await res.json().catch(() => ({ detail: res.statusText }));
       const detail = err.detail;
@@ -354,18 +360,21 @@ async function uploadFilesWithRedactionRetry(formData) {
     return res.json();
   }
 
-  const data = await _post(false);
-  const blockedHits = (data.files || [])
-    .map(r => {
-      const m = r.error && r.error.match(_UPLOAD_REDACTION_BLOCKED_RE);
-      return m ? parseInt(m[1], 10) : 0;
-    })
-    .filter(n => n > 0);
-  if (!blockedHits.length) {
+  const data = await _post(formData, false);
+  // Walk per-file rows once, recording (rowIndex, hits) pairs for blocked
+  // entries. Index-based matching handles duplicate basenames in the same
+  // batch — the server tags rows positionally (one result per ``files``
+  // entry, in order), and we mirror that here when narrowing the retry.
+  const blockedRows = [];
+  (data.files || []).forEach((r, i) => {
+    const m = r.error && r.error.match(_UPLOAD_REDACTION_BLOCKED_RE);
+    if (m) blockedRows.push({ index: i, hits: parseInt(m[1], 10) });
+  });
+  if (!blockedRows.length) {
     return { data, cancelled: false, bypassed: false, blockedFileCount: 0 };
   }
 
-  const totalHits = blockedHits.reduce((a, b) => a + b, 0);
+  const totalHits = blockedRows.reduce((a, r) => a + r.hits, 0);
   const surfaceKey = 'surface.web_api_upload';
   const localized = t(surfaceKey);
   const surfaceLabel = localized === surfaceKey ? 'web_api_upload' : localized;
@@ -378,12 +387,36 @@ async function uploadFilesWithRedactionRetry(formData) {
     confirmText: t('confirm.redaction_blocked_proceed'),
   });
   if (!ok) {
-    return { data, cancelled: true, bypassed: false, blockedFileCount: blockedHits.length };
+    return { data, cancelled: true, bypassed: false, blockedFileCount: blockedRows.length };
   }
 
-  const retryData = await _post(true);
+  // Build a narrowed FormData with only the blocked entries, preserving
+  // original order. ``getAll('files')`` returns the entries in insertion
+  // order, so blockedRows[k].index aligns with allFiles[blockedRows[k].index].
+  const allFiles = formData.getAll('files');
+  const retryForm = new FormData();
+  for (const row of blockedRows) retryForm.append('files', allFiles[row.index]);
+  const retryData = await _post(retryForm, true);
+
+  // Merge retry rows back into their original positions. The server
+  // returns retry results in the same order as the narrowed FormData,
+  // so retryData.files[k] corresponds to blockedRows[k].
+  const mergedFiles = (data.files || []).slice();
+  (retryData.files || []).forEach((row, k) => {
+    if (k < blockedRows.length) mergedFiles[blockedRows[k].index] = row;
+  });
+  const mergedData = {
+    ...data,
+    files: mergedFiles,
+    total_indexed: mergedFiles.reduce((s, r) => s + (r.indexed_chunks || 0), 0),
+  };
   showToast(t('toast.redaction_bypassed', { hits: totalHits }), 'info');
-  return { data: retryData, cancelled: false, bypassed: true, blockedFileCount: blockedHits.length };
+  return {
+    data: mergedData,
+    cancelled: false,
+    bypassed: true,
+    blockedFileCount: blockedRows.length,
+  };
 }
 
 function qs(id) { return document.getElementById(id); }

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4166,12 +4166,20 @@ qs('add-btn').addEventListener('click', async () => {
       // through to the unified refresh below in every branch.
       if (upload.cancelled) {
         showToast(t('toast.upload_redaction_cancelled', { count: upload.blockedFileCount }), 'error');
+        // Prune already-landed clean files from the selection so a
+        // user-driven re-upload doesn't trip the server's
+        // ``_{mtime_ns}`` collision suffix on rows that already exist on
+        // disk (issue #803 — the same dup-write the narrowed retry
+        // FormData fixed). The first-pass response aligns positionally
+        // with ``selectedFiles`` (one row per input file, in order), so
+        // an index-based filter is duplicate-basename-safe.
+        selectedFiles = selectedFiles.filter((_, i) => data.files[i]?.error);
+        renderFileList();
       } else {
         // Partial bypass: helper already emitted ``toast.redaction_bypass_partial``
         // with the succeeded/total counts. Skip the generic "Upload complete"
         // success toast (it would falsely audit a successful write on top of
-        // the partial warning) and keep the file selection so the operator
-        // can adjust and retry.
+        // the partial warning).
         const partial = upload.blockedFileCount > 0 && !upload.bypassed;
         if (!partial) {
           const firstPath = data.files.find(r => !r.error && r.path)?.path;
@@ -4180,6 +4188,16 @@ qs('add-btn').addEventListener('click', async () => {
             : t('toast.upload_complete', { count: data.total_indexed });
           showToast(successMsg, 'success');
           selectedFiles = [];
+          renderFileList();
+        } else {
+          // Same prune as the cancel branch: clean files from the first
+          // pass and any retry rows that landed are now on disk; only
+          // rows that still carry ``error`` in mergedData should remain
+          // selected so a follow-up Upload click sends just the unwritten
+          // ones. Without this prune, partial bypass is functionally
+          // identical to the original #803 dup bug for users who retry
+          // after a partial outcome.
+          selectedFiles = selectedFiles.filter((_, i) => data.files[i]?.error);
           renderFileList();
         }
       }

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -337,9 +337,13 @@ async function apiWithRedactionRetry(method, path, body, opts = {}) {
 // Returns ``{data, cancelled, bypassed, blockedFileCount}``: ``data`` is
 // the (merged) response to render, ``cancelled`` is true when the user
 // declined the bypass (caller should still render ``data`` to surface
-// the per-file errors), ``bypassed`` is true on a successful retry, and
-// ``blockedFileCount`` is the number of files that triggered the guard
-// (used by callers to localize the cancel-toast).
+// the per-file errors), ``bypassed`` is true only when **every** blocked
+// row came back from the retry without an ``error`` field (a partial or
+// malformed retry response keeps ``bypassed`` false and substitutes
+// ``toast.redaction_bypass_partial`` for the success toast — see the
+// validation block below), and ``blockedFileCount`` is the number of
+// files that triggered the guard (used by callers to localize the
+// cancel-toast).
 const _UPLOAD_REDACTION_BLOCKED_RE = /^redaction_blocked \(hits=(\d+)\)$/;
 async function uploadFilesWithRedactionRetry(formData) {
   async function _post(form, forceUnsafe) {
@@ -402,7 +406,8 @@ async function uploadFilesWithRedactionRetry(formData) {
   // returns retry results in the same order as the narrowed FormData,
   // so retryData.files[k] corresponds to blockedRows[k].
   const mergedFiles = (data.files || []).slice();
-  (retryData.files || []).forEach((row, k) => {
+  const retryFiles = retryData.files || [];
+  retryFiles.forEach((row, k) => {
     if (k < blockedRows.length) mergedFiles[blockedRows[k].index] = row;
   });
   const mergedData = {
@@ -410,11 +415,40 @@ async function uploadFilesWithRedactionRetry(formData) {
     files: mergedFiles,
     total_indexed: mergedFiles.reduce((s, r) => s + (r.indexed_chunks || 0), 0),
   };
-  showToast(t('toast.redaction_bypassed', { hits: totalHits }), 'info');
+
+  // Validate that the bypass actually wrote every blocked file. ``/api/upload``
+  // reports per-file failures inside an HTTP-200 response, so a clean status
+  // alone is not proof that the retry landed — emitting
+  // ``toast.redaction_bypassed`` ("entry written") on a malformed or partially
+  // failed retry would falsely audit a non-write. Two ways the retry can lie:
+  //   - ``retryFiles.length !== blockedRows.length`` (server returned fewer
+  //     rows than we re-sent — shape regression or upstream truncation).
+  //   - any retry row still carries ``error`` (force_unsafe was honored at the
+  //     route level but the per-file write hit a different failure, e.g. a
+  //     non-redaction validation error or a second redaction class the bypass
+  //     didn't cover).
+  // On either, suppress the bypass-success toast and emit
+  // ``toast.redaction_bypass_partial`` with the actual succeeded/total counts
+  // so the operator sees that some blocked files did not land. ``bypassed``
+  // tracks the same boolean so callers can branch off it.
+  const succeededCount = retryFiles.filter(r => !r.error).length;
+  const fullySucceeded =
+    retryFiles.length === blockedRows.length && succeededCount === blockedRows.length;
+  if (fullySucceeded) {
+    showToast(t('toast.redaction_bypassed', { hits: totalHits }), 'info');
+  } else {
+    showToast(
+      t('toast.redaction_bypass_partial', {
+        succeeded: succeededCount,
+        total: blockedRows.length,
+      }),
+      'error',
+    );
+  }
   return {
     data: mergedData,
     cancelled: false,
-    bypassed: true,
+    bypassed: fullySucceeded,
     blockedFileCount: blockedRows.length,
   };
 }

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -431,7 +431,14 @@ async function uploadFilesWithRedactionRetry(formData) {
   // ``toast.redaction_bypass_partial`` with the actual succeeded/total counts
   // so the operator sees that some blocked files did not land. ``bypassed``
   // tracks the same boolean so callers can branch off it.
-  const succeededCount = retryFiles.filter(r => !r.error).length;
+  //
+  // ``succeededCount`` is clamped to ``blockedRows.length`` rows so that an
+  // over-long retry response (server returns more rows than we re-sent —
+  // shape regression in the other direction) cannot produce nonsense counts
+  // like "3 of 2 written" in the partial toast.
+  const succeededCount = retryFiles
+    .slice(0, blockedRows.length)
+    .filter(r => !r.error).length;
   const fullySucceeded =
     retryFiles.length === blockedRows.length && succeededCount === blockedRows.length;
   if (fullySucceeded) {
@@ -4153,13 +4160,22 @@ qs('add-btn').addEventListener('click', async () => {
         showToast(t('toast.upload_redaction_cancelled', { count: upload.blockedFileCount }), 'error');
         return;
       }
-      const firstPath = data.files.find(r => !r.error && r.path)?.path;
-      const successMsg = firstPath
-        ? t('toast.upload_complete_with_path', { count: data.total_indexed, path: tildifyPath(firstPath) })
-        : t('toast.upload_complete', { count: data.total_indexed });
-      showToast(successMsg, 'success');
-      selectedFiles = [];
-      renderFileList();
+      // Partial bypass: helper already emitted ``toast.redaction_bypass_partial``
+      // with the succeeded/total counts. Skip the generic "Upload complete"
+      // success toast (it would falsely audit a successful write on top of the
+      // partial warning) and keep the file selection so the operator can adjust
+      // and retry. First-pass clean files DID land on disk, so stats / source
+      // filter / usage refresh still happens below.
+      const partial = upload.blockedFileCount > 0 && !upload.bypassed;
+      if (!partial) {
+        const firstPath = data.files.find(r => !r.error && r.path)?.path;
+        const successMsg = firstPath
+          ? t('toast.upload_complete_with_path', { count: data.total_indexed, path: tildifyPath(firstPath) })
+          : t('toast.upload_complete', { count: data.total_indexed });
+        showToast(successMsg, 'success');
+        selectedFiles = [];
+        renderFileList();
+      }
       _markDataStale();
       loadSourceFilter();
       loadStats();
@@ -5667,8 +5683,16 @@ qs('group-toggle').addEventListener('click', () => {
       const upload = await uploadFilesWithRedactionRetry(fd);
       if (upload.cancelled) return;
       const data = upload.data;
-      const chunks = (data.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
-      showToast(t('toast.indexed_files_chunks', { files: files.length, chunks }), 'success');
+      // See upload-mode caller for the rationale: on partial bypass the
+      // helper already surfaced the per-file failure via
+      // ``toast.redaction_bypass_partial``; suppress the generic success
+      // toast here so the audit-relevant warning isn't followed by a
+      // contradicting "indexed N files" message.
+      const partial = upload.blockedFileCount > 0 && !upload.bypassed;
+      if (!partial) {
+        const chunks = (data.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
+        showToast(t('toast.indexed_files_chunks', { files: files.length, chunks }), 'success');
+      }
       _markDataStale();
       loadSourceFilter();
       loadStats();

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4156,25 +4156,32 @@ qs('add-btn').addEventListener('click', async () => {
         }
         result.appendChild(row);
       });
+      // Mixed-batch refresh: the first ``_post(false)`` already persisted /
+      // indexed every clean file in the batch (only the redaction-blocked
+      // rows came back with an ``error`` field). Whether the user proceeds,
+      // cancels, or the retry partially succeeds, the stats / source filter
+      // / usage panels are stale and must refresh — the early-return cancel
+      // path used to skip them, leaving the per-file result list showing
+      // newly saved files while the rest of the UI lagged behind. Drop
+      // through to the unified refresh below in every branch.
       if (upload.cancelled) {
         showToast(t('toast.upload_redaction_cancelled', { count: upload.blockedFileCount }), 'error');
-        return;
-      }
-      // Partial bypass: helper already emitted ``toast.redaction_bypass_partial``
-      // with the succeeded/total counts. Skip the generic "Upload complete"
-      // success toast (it would falsely audit a successful write on top of the
-      // partial warning) and keep the file selection so the operator can adjust
-      // and retry. First-pass clean files DID land on disk, so stats / source
-      // filter / usage refresh still happens below.
-      const partial = upload.blockedFileCount > 0 && !upload.bypassed;
-      if (!partial) {
-        const firstPath = data.files.find(r => !r.error && r.path)?.path;
-        const successMsg = firstPath
-          ? t('toast.upload_complete_with_path', { count: data.total_indexed, path: tildifyPath(firstPath) })
-          : t('toast.upload_complete', { count: data.total_indexed });
-        showToast(successMsg, 'success');
-        selectedFiles = [];
-        renderFileList();
+      } else {
+        // Partial bypass: helper already emitted ``toast.redaction_bypass_partial``
+        // with the succeeded/total counts. Skip the generic "Upload complete"
+        // success toast (it would falsely audit a successful write on top of
+        // the partial warning) and keep the file selection so the operator
+        // can adjust and retry.
+        const partial = upload.blockedFileCount > 0 && !upload.bypassed;
+        if (!partial) {
+          const firstPath = data.files.find(r => !r.error && r.path)?.path;
+          const successMsg = firstPath
+            ? t('toast.upload_complete_with_path', { count: data.total_indexed, path: tildifyPath(firstPath) })
+            : t('toast.upload_complete', { count: data.total_indexed });
+          showToast(successMsg, 'success');
+          selectedFiles = [];
+          renderFileList();
+        }
       }
       _markDataStale();
       loadSourceFilter();
@@ -5681,17 +5688,25 @@ qs('group-toggle').addEventListener('click', () => {
     showToast(t('toast.indexing_files', { count: files.length }), 'info');
     try {
       const upload = await uploadFilesWithRedactionRetry(fd);
-      if (upload.cancelled) return;
       const data = upload.data;
-      // See upload-mode caller for the rationale: on partial bypass the
-      // helper already surfaced the per-file failure via
-      // ``toast.redaction_bypass_partial``; suppress the generic success
-      // toast here so the audit-relevant warning isn't followed by a
-      // contradicting "indexed N files" message.
-      const partial = upload.blockedFileCount > 0 && !upload.bypassed;
-      if (!partial) {
-        const chunks = (data.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
-        showToast(t('toast.indexed_files_chunks', { files: files.length, chunks }), 'success');
+      // Mixed-batch refresh: same rationale as upload-mode caller — the
+      // first POST already indexed clean files even when the user later
+      // cancels the bypass dialog. Unlike the upload tab there is no
+      // per-file result list here, so without a cancel toast the operator
+      // has zero signal that some files DID land. Surface the cancel toast
+      // and drop through to the staleness refresh in every branch.
+      if (upload.cancelled) {
+        showToast(t('toast.upload_redaction_cancelled', { count: upload.blockedFileCount }), 'error');
+      } else {
+        // On partial bypass the helper already surfaced the per-file
+        // failure via ``toast.redaction_bypass_partial``; suppress the
+        // generic success toast here so the audit-relevant warning isn't
+        // followed by a contradicting "indexed N files" message.
+        const partial = upload.blockedFileCount > 0 && !upload.bypassed;
+        if (!partial) {
+          const chunks = (data.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
+          showToast(t('toast.indexed_files_chunks', { files: files.length, chunks }), 'success');
+        }
       }
       _markDataStale();
       loadSourceFilter();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1335,7 +1335,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=106"></script>
+  <script src="/app.js?v=107"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1335,7 +1335,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=107"></script>
+  <script src="/app.js?v=108"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1335,7 +1335,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=104"></script>
+  <script src="/app.js?v=105"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1335,7 +1335,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=108"></script>
+  <script src="/app.js?v=109"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1335,7 +1335,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=105"></script>
+  <script src="/app.js?v=106"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -234,6 +234,7 @@
   "confirm.redaction_blocked_message": "The server detected {hits} secret-like pattern(s) on {surface}. Bypass and write anyway? This will be audited.",
   "confirm.redaction_blocked_proceed": "Bypass and write",
   "toast.redaction_bypassed": "Bypassed redaction guard ({hits} hits) — entry written.",
+  "toast.redaction_bypass_partial": "Bypass partial — {succeeded} of {total} blocked file(s) written. Check per-file results below.",
   "toast.upload_redaction_cancelled": "Upload cancelled — redaction guard left {count} file(s) blocked.",
   "surface.web_api_add": "Add memory",
   "surface.web_api_chunk_edit": "Chunk edit",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -234,6 +234,7 @@
   "confirm.redaction_blocked_message": "서버가 {surface}에서 {hits}개의 비밀 의심 패턴을 감지했어요. 우회하고 작성할까요? 감사 로그에 기록됩니다.",
   "confirm.redaction_blocked_proceed": "우회하고 작성",
   "toast.redaction_bypassed": "비밀정보 가드 우회 ({hits}건) — 저장됨.",
+  "toast.redaction_bypass_partial": "우회 일부만 적용됨 — 차단된 {total}개 중 {succeeded}개만 저장됐습니다. 아래 파일별 결과를 확인하세요.",
   "toast.upload_redaction_cancelled": "업로드 취소됨 — 비밀정보 가드가 {count}개 파일을 차단한 상태로 두었습니다.",
   "surface.web_api_add": "메모리 추가",
   "surface.web_api_chunk_edit": "청크 편집",

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -475,6 +475,19 @@ def test_api_upload_retry_with_persistent_error_row_does_not_claim_bypassed(
     assert "0" in partial_text and "1" in partial_text, (
         f"partial toast must include succeeded/total counts: {partial_text!r}"
     )
+    # The audit-relevant promise: caller must not stack a generic "Upload
+    # complete" success toast on top of the partial warning. ``showToast``
+    # tags success-class messages with ``.toast-success`` (app.js:908), so
+    # the upload-mode caller's success branch is detectable as a class
+    # presence — independent of locale text. Without the caller-side
+    # ``partial`` guard added in PR #805 follow-up, this assertion fails
+    # because the success path runs unconditionally after retry.
+    success_toasts = page.locator("#toast-container .toast.toast-success")
+    assert success_toasts.count() == 0, (
+        f"partial bypass must not emit a generic upload-complete success toast; "
+        f"saw {success_toasts.count()}: "
+        f"{[t.text_content() for t in success_toasts.all()]}"
+    )
 
 
 def test_api_upload_retry_with_truncated_row_count_does_not_claim_bypassed(
@@ -570,6 +583,133 @@ def test_api_upload_retry_with_truncated_row_count_does_not_claim_bypassed(
     # 1 of 2 succeeded — the single returned row was clean.
     assert "1" in partial_text and "2" in partial_text, (
         f"partial toast must include 1 of 2: {partial_text!r}"
+    )
+    # Same caller-side guard as the persistent-error spec: a partial
+    # bypass must not be followed by the upload-mode caller's generic
+    # success toast (would imply "all good" on top of the partial warning).
+    success_toasts = page.locator("#toast-container .toast.toast-success")
+    assert success_toasts.count() == 0, (
+        f"truncated retry must not emit a generic upload-complete success toast; "
+        f"saw {success_toasts.count()}"
+    )
+
+
+def test_api_upload_retry_with_extra_row_count_clamps_succeeded_count(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Retry returns *more* rows than the narrowed FormData carried (server
+    shape regression in the over-long direction) → ``succeededCount`` must
+    be clamped to ``blockedRows.length`` so the partial toast cannot show
+    impossible counts like "3 of 2 written", and the success bypass toast
+    must still be suppressed because the row count mismatch breaks the
+    positional alignment the merge depends on.
+
+    This is the symmetric companion to the truncated-retry spec: same
+    failure mode (length mismatch invalidates positional merge) from the
+    other direction. The narrowed FormData carries one blocked file; the
+    server returns three rows. Without the clamp at app.js:434 the
+    partial toast would read "3 of 1 written" — nonsensical and worse,
+    suggests over-success rather than the underlying contract violation.
+    """
+    _install_default_stubs(page)
+
+    def _upload_handler(route):
+        if "force_unsafe=true" in route.request.url:
+            # Over-long retry — three rows back even though we sent one.
+            # All three are clean (no error) so a naive
+            # ``retryFiles.filter(r => !r.error).length`` would yield 3,
+            # then format as "3 of 1" in the partial toast.
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/secret.md",
+                            },
+                            {
+                                "filename": "ghost1.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/ghost1.md",
+                            },
+                            {
+                                "filename": "ghost2.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/ghost2.md",
+                            },
+                        ],
+                        "total_indexed": 3,
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=2)",
+                            }
+                        ],
+                        "total_indexed": 0,
+                    }
+                ),
+            )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    fixture = tmp_path / "secret.md"
+    fixture.write_text("# Secret notes\n\nsk-ant-test-fake-1234567890abcdef\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files(str(fixture))
+    page.locator("#upload-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    with page.expect_request(re.compile(r"/api/upload\?force_unsafe=true$"), timeout=5_000):
+        page.locator("#confirm-ok-btn").click()
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    page.wait_for_selector("#toast-container .toast", timeout=2_000)
+    bypass_toasts = page.locator("#toast-container .toast", has_text="Bypassed redaction guard")
+    assert bypass_toasts.count() == 0, (
+        "over-long retry response must not emit the success bypass toast — "
+        "row count mismatch breaks positional merge"
+    )
+    partial_toasts = page.locator("#toast-container .toast", has_text="Bypass partial")
+    assert partial_toasts.count() == 1, (
+        f"over-long retry must emit toast.redaction_bypass_partial, saw {partial_toasts.count()}"
+    )
+    partial_text = partial_toasts.first.text_content() or ""
+    # Clamp pin: the displayed succeeded count must be ≤ total (1 here),
+    # so the toast reads "1 of 1" rather than "3 of 1". Match the exact
+    # "X of Y" fragment to avoid false positives from other digits in the
+    # surrounding template.
+    assert "1 of 1" in partial_text, (
+        f"partial toast must clamp succeeded to total (1 of 1), got: {partial_text!r}"
+    )
+    assert "3 of 1" not in partial_text, (
+        f"partial toast must not leak the unclamped server-side count: {partial_text!r}"
+    )
+    success_toasts = page.locator("#toast-container .toast.toast-success")
+    assert success_toasts.count() == 0, (
+        f"over-long retry must not emit a generic upload-complete success toast; "
+        f"saw {success_toasts.count()}"
     )
 
 

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -377,6 +377,202 @@ def test_api_upload_mixed_batch_retries_only_blocked_file(
     )
 
 
+def test_api_upload_retry_with_persistent_error_row_does_not_claim_bypassed(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Retry returns the same row count but the row still carries
+    ``error`` → no ``toast.redaction_bypassed`` (the audit toast lies if
+    the bypass didn't actually write), instead the partial-failure toast
+    surfaces the succeeded/total counts.
+
+    This is the per-file-error half of the bypass validation: the server
+    honored ``?force_unsafe=true`` at the route level (HTTP 200), but the
+    write itself reports a different failure (a non-redaction validation
+    error, or a class of redaction the bypass query-param didn't cover —
+    the SPA can't introspect why, just whether the row landed). Without
+    the validation, the operator sees "entry written" while the per-file
+    list shows the file unwritten.
+    """
+    _install_default_stubs(page)
+
+    def _upload_handler(route):
+        if "force_unsafe=true" in route.request.url:
+            # Retry — server claims success at the HTTP layer but the
+            # per-file row still has an error. Same row count as the
+            # original blocked set (1) so the length check passes; the
+            # error-presence check is what catches this.
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 0,
+                                "error": "write_failed: disk full",
+                            }
+                        ],
+                        "total_indexed": 0,
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=3)",
+                            }
+                        ],
+                        "total_indexed": 0,
+                    }
+                ),
+            )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    fixture = tmp_path / "secret.md"
+    fixture.write_text("# Secret notes\n\nsk-ant-test-fake-1234567890abcdef\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files(str(fixture))
+    page.locator("#upload-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    with page.expect_request(re.compile(r"/api/upload\?force_unsafe=true$"), timeout=5_000):
+        page.locator("#confirm-ok-btn").click()
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    # Wait for *some* toast to appear so the assertions below race-free.
+    page.wait_for_selector("#toast-container .toast", timeout=2_000)
+    # The success-bypass toast must not fire — that's the misleading
+    # claim this test exists to catch.
+    bypass_toasts = page.locator("#toast-container .toast", has_text="Bypassed redaction guard")
+    assert bypass_toasts.count() == 0, (
+        "retry with persistent per-file error must not emit the success bypass toast"
+    )
+    # The partial toast surfaces 0/1 succeeded so the operator knows the
+    # write didn't land despite the confirm.
+    partial_toasts = page.locator("#toast-container .toast", has_text="Bypass partial")
+    assert partial_toasts.count() == 1, (
+        f"partial-retry must emit toast.redaction_bypass_partial, saw {partial_toasts.count()}"
+    )
+    partial_text = partial_toasts.first.text_content() or ""
+    assert "0" in partial_text and "1" in partial_text, (
+        f"partial toast must include succeeded/total counts: {partial_text!r}"
+    )
+
+
+def test_api_upload_retry_with_truncated_row_count_does_not_claim_bypassed(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Retry returns fewer rows than the narrowed FormData carried (e.g.,
+    upstream truncation or a server-shape regression) → no
+    ``toast.redaction_bypassed``, partial toast instead.
+
+    Two blocked files go up on retry; server returns only one row. The
+    merged ``data.files`` keeps the unmatched second row at its original
+    ``redaction_blocked`` state, so the per-file UI is honest, but the
+    aggregate toast must not claim the bypass succeeded.
+    """
+    _install_default_stubs(page)
+
+    def _upload_handler(route):
+        if "force_unsafe=true" in route.request.url:
+            # Truncated retry — only one row back even though we sent two.
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "a.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/a.md",
+                            }
+                        ],
+                        "total_indexed": 1,
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "a.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=2)",
+                            },
+                            {
+                                "filename": "b.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=1)",
+                            },
+                        ],
+                        "total_indexed": 0,
+                    }
+                ),
+            )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    a = tmp_path / "a.md"
+    a.write_text("# a\n\nsk-ant-test-fake-1234567890abcdef\n")
+    b = tmp_path / "b.md"
+    b.write_text("# b\n\nsk-ant-test-fake-2222222222222222\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files([str(a), str(b)])
+    page.locator("#upload-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    with page.expect_request(re.compile(r"/api/upload\?force_unsafe=true$"), timeout=5_000):
+        page.locator("#confirm-ok-btn").click()
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    page.wait_for_selector("#toast-container .toast", timeout=2_000)
+    bypass_toasts = page.locator("#toast-container .toast", has_text="Bypassed redaction guard")
+    assert bypass_toasts.count() == 0, (
+        "truncated retry response must not emit the success bypass toast"
+    )
+    partial_toasts = page.locator("#toast-container .toast", has_text="Bypass partial")
+    assert partial_toasts.count() == 1, (
+        f"truncated retry must emit toast.redaction_bypass_partial, saw {partial_toasts.count()}"
+    )
+    partial_text = partial_toasts.first.text_content() or ""
+    # 1 of 2 succeeded — the single returned row was clean.
+    assert "1" in partial_text and "2" in partial_text, (
+        f"partial toast must include 1 of 2: {partial_text!r}"
+    )
+
+
 def test_api_add_403_cancel_does_not_retry_or_emit_bypass_toast(page, mm_web_url: str) -> None:
     """``POST /api/add`` 403 → confirm dialog → click **Cancel** → no
     retry POST, no ``toast.redaction_bypassed``.

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -774,3 +774,101 @@ def test_api_add_403_cancel_does_not_retry_or_emit_bypass_toast(page, mm_web_url
     # one asserts none does. Together they pin the symmetric pair.
     bypass_toasts = page.locator("#toast-container .toast", has_text="Bypassed")
     assert bypass_toasts.count() == 0, "cancel must not emit toast.redaction_bypassed"
+
+
+def test_api_upload_mixed_batch_cancel_refreshes_stale_state(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Mixed batch (1 clean + 1 blocked) → user cancels the bypass dialog
+    → ``loadStats`` / ``loadSourceFilter`` still fire so the rest of the
+    UI doesn't lag behind the per-file result list.
+
+    The first POST already persisted/indexed ``clean.md`` before the
+    confirm dialog opened. The pre-fix early-return on ``cancelled``
+    skipped the staleness refresh, leaving the result list showing a
+    fresh row while sources / stats panels stayed pinned to their
+    pre-upload state. This spec counts ``GET /api/stats`` calls before
+    and after the cancel click; the post-cancel delta must be ≥ 1.
+    """
+    _install_default_stubs(page)
+
+    stats_calls: list[str] = []
+    page.route(
+        "**/api/stats",
+        lambda r: (
+            stats_calls.append(r.request.url),
+            r.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps({}),
+            ),
+        )[1],
+    )
+
+    def _upload_handler(route):
+        # Single fulfillment — the user cancels, so no retry POST fires.
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "files": [
+                        {
+                            "filename": "clean.md",
+                            "indexed_chunks": 2,
+                            "path": "/home/u/.memtomem/uploads/clean.md",
+                        },
+                        {
+                            "filename": "secret.md",
+                            "indexed_chunks": 0,
+                            "error": "redaction_blocked (hits=3)",
+                        },
+                    ],
+                    "total_indexed": 2,
+                }
+            ),
+        )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    clean = tmp_path / "clean.md"
+    clean.write_text("# Clean notes\n\nNo secrets here.\n")
+    secret = tmp_path / "secret.md"
+    secret.write_text("# Secret notes\n\nsk-ant-test-fake-1234567890abcdef\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files([str(clean), str(secret)])
+
+    # Wait for boot ``/api/stats`` calls to settle so the post-cancel
+    # delta isn't fighting against late-arriving boot traffic.
+    page.wait_for_timeout(200)
+    pre_cancel = len(stats_calls)
+
+    page.locator("#upload-btn").click()
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    page.locator("#confirm-cancel-btn").click()
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    # Cancel toast must render so the operator knows the blocked file did
+    # not land. (Drag-upload had no toast at all pre-fix.)
+    page.wait_for_selector(
+        "#toast-container .toast",
+        timeout=2_000,
+    )
+
+    # Staleness refresh must fire on cancel — the unified branch below
+    # the if/else in the upload-tab handler hits ``loadStats``. Give the
+    # SPA a beat for the GET to dispatch.
+    page.wait_for_timeout(300)
+    post_cancel = len(stats_calls)
+    assert post_cancel > pre_cancel, (
+        f"cancel must trigger loadStats refresh; saw {pre_cancel} pre, {post_cancel} post"
+    )

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -872,3 +872,212 @@ def test_api_upload_mixed_batch_cancel_refreshes_stale_state(
     assert post_cancel > pre_cancel, (
         f"cancel must trigger loadStats refresh; saw {pre_cancel} pre, {post_cancel} post"
     )
+
+
+def test_api_upload_mixed_batch_cancel_prunes_landed_clean_file_from_selection(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Mixed batch (1 clean + 1 blocked) → user cancels the bypass dialog
+    → ``#upload-file-list`` must drop ``clean.md`` (already on disk) and
+    keep only ``secret.md`` (still unwritten), so a follow-up Upload
+    click does not re-send the clean file and reintroduce the
+    ``_{mtime_ns}`` dup-write that issue #803 set out to fix.
+
+    Without the selection prune in the cancel branch, ``selectedFiles``
+    keeps every original input regardless of which ones landed in the
+    first pass. A user who cancels the bypass dialog and immediately
+    clicks Upload again then resends ``clean.md`` — the server's
+    collision suffix kicks in and writes ``clean_{mtime_ns}.md``,
+    silently double-indexing the same content. This spec mutation-fails
+    if the prune is removed: the post-cancel ``#upload-file-list``
+    contains both basenames, not just the blocked one.
+    """
+    _install_default_stubs(page)
+
+    def _upload_handler(route):
+        # Single fulfillment — user cancels, no retry POST.
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "files": [
+                        {
+                            "filename": "clean.md",
+                            "indexed_chunks": 2,
+                            "path": "/home/u/.memtomem/uploads/clean.md",
+                        },
+                        {
+                            "filename": "secret.md",
+                            "indexed_chunks": 0,
+                            "error": "redaction_blocked (hits=3)",
+                        },
+                    ],
+                    "total_indexed": 2,
+                }
+            ),
+        )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    clean = tmp_path / "clean.md"
+    clean.write_text("# Clean notes\n\nNo secrets here.\n")
+    secret = tmp_path / "secret.md"
+    secret.write_text("# Secret notes\n\nsk-ant-test-fake-1234567890abcdef\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files([str(clean), str(secret)])
+
+    # Pre-cancel sanity: list shows both basenames.
+    page.wait_for_selector("#upload-file-list", timeout=2_000)
+    pre_text = page.locator("#upload-file-list").text_content() or ""
+    assert "clean.md" in pre_text and "secret.md" in pre_text, (
+        f"pre-upload list must show both: {pre_text!r}"
+    )
+
+    page.locator("#upload-btn").click()
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    page.locator("#confirm-cancel-btn").click()
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    # The list must now show secret.md only — clean.md was indexed in
+    # the first pass and re-sending it would dup via _{mtime_ns}.
+    post_text = page.locator("#upload-file-list").text_content() or ""
+    assert "secret.md" in post_text, (
+        f"blocked file must remain selected for retry: {post_text!r}"
+    )
+    assert "clean.md" not in post_text, (
+        f"already-indexed clean file must be pruned (issue #803 dup-write "
+        f"prevention extended to user-driven re-upload): {post_text!r}"
+    )
+
+
+def test_api_upload_mixed_batch_partial_bypass_prunes_landed_clean_file(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Mixed batch with partial-success retry → ``#upload-file-list`` must
+    drop the clean first-pass file AND any retry rows that landed,
+    keeping only rows whose merged ``data.files`` entry still carries
+    ``error``.
+
+    Three input files: ``clean.md`` (first-pass clean), ``ok.md`` and
+    ``bad.md`` (both blocked first pass; retry writes ``ok.md`` but
+    ``bad.md`` hits a different per-file failure under force_unsafe).
+    After confirm:
+        - merged data.files[0] = clean.md (no error)  → prune
+        - merged data.files[1] = ok.md   (no error)   → prune
+        - merged data.files[2] = bad.md  (error)      → keep
+
+    Pin asserts the list shows only ``bad.md`` post-confirm. Mirrors
+    the cancel-prune spec for the partial branch — both go through the
+    same ``selectedFiles.filter`` logic but via different code paths,
+    so each needs its own pin.
+    """
+    _install_default_stubs(page)
+
+    def _upload_handler(route):
+        if "force_unsafe=true" in route.request.url:
+            # Retry of [ok.md, bad.md]: ok lands clean, bad hits a
+            # different per-file failure (force_unsafe was honored at
+            # the route level but the write hit a separate validation).
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "ok.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/ok.md",
+                            },
+                            {
+                                "filename": "bad.md",
+                                "indexed_chunks": 0,
+                                "error": "write_failed: disk full",
+                            },
+                        ],
+                        "total_indexed": 1,
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "clean.md",
+                                "indexed_chunks": 2,
+                                "path": "/home/u/.memtomem/uploads/clean.md",
+                            },
+                            {
+                                "filename": "ok.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=2)",
+                            },
+                            {
+                                "filename": "bad.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=1)",
+                            },
+                        ],
+                        "total_indexed": 2,
+                    }
+                ),
+            )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    clean = tmp_path / "clean.md"
+    clean.write_text("# Clean\n\nNo secrets.\n")
+    ok = tmp_path / "ok.md"
+    ok.write_text("# OK\n\nsk-ant-test-fake-1234567890abcdef\n")
+    bad = tmp_path / "bad.md"
+    bad.write_text("# Bad\n\nsk-ant-test-fake-2222222222222222\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files([str(clean), str(ok), str(bad)])
+    page.locator("#upload-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    with page.expect_request(re.compile(r"/api/upload\?force_unsafe=true$"), timeout=5_000):
+        page.locator("#confirm-ok-btn").click()
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    # Wait for partial toast so we know the helper finished merging
+    # before sampling the file list (the prune happens in the same tick
+    # but reading too eagerly can race the renderFileList call).
+    page.wait_for_selector(
+        "#toast-container .toast",
+        timeout=2_000,
+    )
+
+    post_text = page.locator("#upload-file-list").text_content() or ""
+    assert "bad.md" in post_text, (
+        f"persistently-failed file must remain selected for retry: {post_text!r}"
+    )
+    assert "clean.md" not in post_text, (
+        f"first-pass clean file must be pruned to avoid #803 dup-write: {post_text!r}"
+    )
+    assert "ok.md" not in post_text, (
+        f"retry-landed file must also be pruned (no error in mergedData): {post_text!r}"
+    )

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -951,9 +951,7 @@ def test_api_upload_mixed_batch_cancel_prunes_landed_clean_file_from_selection(
     # The list must now show secret.md only — clean.md was indexed in
     # the first pass and re-sending it would dup via _{mtime_ns}.
     post_text = page.locator("#upload-file-list").text_content() or ""
-    assert "secret.md" in post_text, (
-        f"blocked file must remain selected for retry: {post_text!r}"
-    )
+    assert "secret.md" in post_text, f"blocked file must remain selected for retry: {post_text!r}"
     assert "clean.md" not in post_text, (
         f"already-indexed clean file must be pruned (issue #803 dup-write "
         f"prevention extended to user-driven re-upload): {post_text!r}"

--- a/packages/memtomem/tests/web/test_redaction_blocked_retry.py
+++ b/packages/memtomem/tests/web/test_redaction_blocked_retry.py
@@ -250,6 +250,133 @@ def test_api_upload_per_file_redaction_triggers_batch_retry_with_query_param(
     )
 
 
+def test_api_upload_mixed_batch_retries_only_blocked_file(
+    page, mm_web_url: str, tmp_path: Path
+) -> None:
+    """Mixed batch (1 clean + 1 blocked) → retry FormData carries **only**
+    the blocked filename, never the clean one (issue #803).
+
+    Before the scope-reduction fix, ``uploadFilesWithRedactionRetry``
+    re-sent the original FormData on retry; the server's ``_{mtime_ns}``
+    collision suffix at system.py:1121 then silently double-indexed the
+    clean file under two filenames. This spec pins the narrowed retry:
+    the blocked entry is sent with ``?force_unsafe=true`` while the
+    clean entry stays out of the request body, so disk and index reflect
+    one copy of each file regardless of mixed-batch confirms.
+    """
+    _install_default_stubs(page)
+
+    calls: list[tuple[str, str]] = []
+
+    def _upload_handler(route):
+        # Capture URL + raw multipart body so the test can inspect both
+        # the bypass query-param and the filenames present in each call.
+        calls.append((route.request.url, route.request.post_data or ""))
+        if len(calls) == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "clean.md",
+                                "indexed_chunks": 2,
+                                "path": "/home/u/.memtomem/uploads/clean.md",
+                            },
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 0,
+                                "error": "redaction_blocked (hits=3)",
+                            },
+                        ],
+                        "total_indexed": 2,
+                    }
+                ),
+            )
+        else:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "files": [
+                            {
+                                "filename": "secret.md",
+                                "indexed_chunks": 1,
+                                "path": "/home/u/.memtomem/uploads/secret.md",
+                            }
+                        ],
+                        "total_indexed": 1,
+                    }
+                ),
+            )
+
+    page.route(re.compile(r"/api/upload(?:\?.*)?$"), _upload_handler)
+
+    clean = tmp_path / "clean.md"
+    clean.write_text("# Clean notes\n\nNo secrets here.\n")
+    secret = tmp_path / "secret.md"
+    secret.write_text("# Secret notes\n\nsk-ant-test-fake-1234567890abcdef\n")
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-index").click()
+    page.locator("#index-mode-upload").click()
+    page.locator("#upload-input").set_input_files([str(clean), str(secret)])
+    page.locator("#upload-btn").click()
+
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    message = page.locator("#confirm-message").text_content() or ""
+    # Hit count is summed over blocked rows only — clean.md contributed 0.
+    assert "3" in message, f"hit count missing from dialog: {message!r}"
+
+    with page.expect_request(
+        re.compile(r"/api/upload\?force_unsafe=true$"), timeout=5_000
+    ) as retry_info:
+        page.locator("#confirm-ok-btn").click()
+    retry_request = retry_info.value
+
+    # Core invariant: retry body must contain the blocked filename and
+    # *not* the clean one. The first call carried both, so this asserts a
+    # genuine narrowing rather than coincidence. Multipart bodies encode
+    # ``filename="<basename>"`` per part (RFC 7578); a simple substring
+    # check is sufficient and avoids parsing the boundary.
+    retry_body = retry_request.post_data or ""
+    assert 'filename="secret.md"' in retry_body, (
+        f"retry must include the blocked file: {retry_body[:500]!r}"
+    )
+    assert 'filename="clean.md"' not in retry_body, (
+        f"retry must NOT re-send the already-persisted clean file (issue #803): "
+        f"{retry_body[:500]!r}"
+    )
+    # First call carried both — sanity-check that the assertion above is
+    # not vacuously true because clean.md never made it into any request.
+    assert 'filename="clean.md"' in calls[0][1], (
+        "first call should have included clean.md; route stub may be misconfigured"
+    )
+
+    page.wait_for_function(
+        "() => document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    # Final UI must show one row per input file (clean from first pass,
+    # secret from retry merged at its original index). Two rows with no
+    # duplication of clean.md is the user-visible promise of the fix.
+    page.wait_for_selector("#upload-result .upload-result-row", timeout=2_000)
+    rows = page.locator("#upload-result .upload-result-row").all_text_contents()
+    assert len(rows) == 2, f"expected 2 result rows, got {len(rows)}: {rows!r}"
+    assert sum("clean.md" in r for r in rows) == 1, (
+        f"clean.md must appear exactly once after merge: {rows!r}"
+    )
+    assert sum("secret.md" in r for r in rows) == 1, (
+        f"secret.md must appear exactly once after merge: {rows!r}"
+    )
+
+
 def test_api_add_403_cancel_does_not_retry_or_emit_bypass_toast(page, mm_web_url: str) -> None:
     """``POST /api/add`` 403 → confirm dialog → click **Cancel** → no
     retry POST, no ``toast.redaction_bypassed``.


### PR DESCRIPTION
## Summary

- Issue #803: SPA upload confirm-and-retry duplicated every clean file in mixed batches (≥1 clean + ≥1 blocked) by re-sending the unmodified `FormData` on retry, then relying on the server's `_{mtime_ns}` collision suffix at `system.py:1121` to "deduplicate" — a suffix designed for genuine name collisions, not retry-batch dedup.
- Fix per issue's option 1 (client-side scope reduction): after parsing per-file results, build a narrowed `FormData` containing **only** the blocked entries (matched positionally against `formData.getAll('files')` to handle duplicate basenames) and POST that to `?force_unsafe=true`. Merge retry rows back into the first-pass `data.files` at their original indices so callers still render exactly one row per input file.
- Follow-up fixups harden the partial-bypass path: validate that the retry actually wrote every blocked file (suppressing a misleading bypass-success toast on truncated, malformed, or per-file-failed retries) and skip the generic upload-complete success toast / selection clear in the callers when the bypass was only partial.
- Issue #804 (folded in): cancelling the bypass on a mixed batch left the source filter / stats / upload-usage panels stale because the early-return on `cancelled` skipped `_markDataStale` / `loadSourceFilter` / `loadStats` / `loadUploadUsage`. Search drag-zone additionally had no cancel toast at all. Both call sites now surface the cancel toast and drop through to the unified staleness refresh in every branch.
- Stacked on PR #802 (`feat/web-redaction-confirm-retry-785`); the helper this fix narrows is introduced there.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_redaction_blocked_retry.py` — 8 specs pass (3 baseline + 1 mixed-batch + 3 partial/over-long-retry guards + 1 cancel-refresh).
- [x] **Mutation-validated** at every layer: reverting to `_post(formData, true)` fails the mixed-batch spec on `'filename="clean.md"' is contained here`; reverting the `succeededCount` clamp produces "Bypass partial — 3 of 1 blocked file(s) written" in the over-long-retry spec; reverting the caller-side `partial` guard fires a `.toast-success` element after the partial warning; restoring the early `return` on `cancelled` fails the cancel-refresh spec on `post_cancel == pre_cancel` (loadStats not re-called). Each assertion catches its own regression rather than passing vacuously.
- [x] `cd packages/memtomem/tests-js && npm test` — 18/18 vitest specs green (regression sweep on adjacent JS).
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 20/20 (en/ko parity for the new `toast.redaction_bypass_partial` key).
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean.
- [ ] Manual `mm web` smoke after merge (Index → Upload mode, mixed batch): confirm only `secret.md` appears under `<stem>_{mtime_ns}.md` in `~/.memtomem/uploads/`, never `clean_{mtime_ns}.md`.

## Notes

- Single-blocked-file batches (the case existing test pinned) still work because `blockedRows = [original index 0]`; the narrowed retry happens to equal the original when 100% of the batch is blocked.
- JSON routes (`/api/add`, `/api/chunks/{id}`, scratch promote) are unaffected — those return a structured 403 before any write happens, so the duplicate pattern doesn't apply (out of scope per the issue body).
- Cache-bust: `app.js?v=104 → v=108` across the original fix and follow-up fixups, per `feedback_static_asset_cache_bust.md`.

Refs PR #802, PR #784, issue #785; closes #803, closes #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

