### PR TITLE
fix(web): show real chunk count on search drag-zone upload toast

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -5722,7 +5722,11 @@ qs('group-toggle').addEventListener('click', () => {
         // followed by a contradicting "indexed N files" message.
         const partial = upload.blockedFileCount > 0 && !upload.bypassed;
         if (!partial) {
-          const chunks = (data.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
+          // ``/api/upload`` returns ``{files, total_indexed}`` — never a
+          // ``results`` field. The original ``data.results`` read fell
+          // back to ``[]`` so this toast has been showing "indexed N
+          // files (0 chunks)" since v0.1.0.
+          const chunks = (data.files || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
           showToast(t('toast.indexed_files_chunks', { files: files.length, chunks }), 'success');
         }
       }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1335,7 +1335,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=109"></script>
+  <script src="/app.js?v=110"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/tests-js/search-drag-zone-toast-chunks.test.mjs
+++ b/packages/memtomem/tests-js/search-drag-zone-toast-chunks.test.mjs
@@ -1,0 +1,96 @@
+/* Regression guard for the search-tab drag-zone success toast.
+ *
+ * The toast handler at the bottom of the search drag-zone reads
+ * ``(data.results || []).reduce(...)`` to compute its chunk count, but
+ * ``/api/upload`` returns ``{files, total_indexed}`` and has never
+ * exposed a ``results`` field — see ``UploadResponse`` in
+ * ``web/routes/system.py``. The fallback to ``[]`` silently gave
+ * "Indexed N files → 0 chunks" since v0.1.0 even when files indexed
+ * cleanly. This pins the fix: aggregate over ``data.files`` so the
+ * displayed chunk count matches the actual write.
+ *
+ * The mutation that proves this test bites: revert to
+ * ``(data.results || []).reduce(...)`` and the chunk-count assertion
+ * fails because the toast reads "0 chunks".
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+describe('Search drag-zone — success toast aggregates real chunk count', () => {
+  let window;
+  let document;
+  let toasts;
+
+  beforeEach(async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    window = dom.window;
+    document = window.document;
+
+    // ``showToast`` writes DOM through helpers we don't need to exercise
+    // here — the test cares about (msg, level) pairs, so swap in a spy.
+    toasts = [];
+    window.showToast = (msg, level) => {
+      toasts.push({ msg, level });
+    };
+
+    // Stub ``/api/upload`` with a clean two-file response (no ``error``
+    // field on either row). The drag-zone helper takes the early
+    // ``!blockedRows.length`` return, so the retry path doesn't fire
+    // and the success-toast branch is the only thing under test.
+    const original = window.fetch;
+    window.fetch = async function fetchSpy(input, init) {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url === '/api/upload') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            files: [
+              { filename: 'a.md', indexed_chunks: 3, path: '/x/a.md' },
+              { filename: 'b.md', indexed_chunks: 4, path: '/x/b.md' },
+            ],
+            total_indexed: 7,
+          }),
+          text: async () => '{}',
+        };
+      }
+      return original(input, init);
+    };
+  });
+
+  it('drop two clean .md files → toast reports the summed chunk count', async () => {
+    // The drag-zone helper builds FormData and posts to ``/api/upload``;
+    // the stub above ignores the body, so the file objects only need to
+    // pass the extension regex filter and survive ``FormData.append``.
+    const fileA = new window.File(['a body'], 'a.md', { type: 'text/markdown' });
+    const fileB = new window.File(['b body'], 'b.md', { type: 'text/markdown' });
+
+    const tab = document.getElementById('tab-search');
+    const drop = new window.Event('drop', { bubbles: true, cancelable: true });
+    // ``Event`` doesn't carry ``dataTransfer`` in JSDOM; assign it
+    // manually so the handler's ``e.dataTransfer.files`` path runs.
+    Object.defineProperty(drop, 'dataTransfer', {
+      value: { files: [fileA, fileB], items: [{ kind: 'file' }, { kind: 'file' }] },
+    });
+    tab.dispatchEvent(drop);
+
+    // Drop handler is async (awaits fetch + toast). Flush microtasks
+    // generously — same pattern as add-memory-force-unsafe.test.mjs.
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+
+    const success = toasts.find(toast => toast.level === 'success');
+    expect(
+      success,
+      `expected a success toast; saw: ${JSON.stringify(toasts)}`,
+    ).toBeDefined();
+    // Locale en: "Indexed {files} files → {chunks} chunks".
+    // The fix is the ``7 chunks`` half — the bug always rendered ``0
+    // chunks`` regardless of what the server reported.
+    expect(success.msg).toContain('2 files');
+    expect(success.msg).toContain('7 chunks');
+    expect(success.msg).not.toContain('0 chunks');
+  });
+});


### PR DESCRIPTION
## Summary

- The search-tab drag-zone success toast at `app.js:5725` aggregated chunks via `(data.results || []).reduce(...)`, but `/api/upload` returns `{files, total_indexed}` and has never exposed a `results` field (see `UploadResponse` in `web/routes/system.py`). The fallback to `[]` silently rendered "Indexed N files → 0 chunks" since v0.1.0 even when the backend reported a non-zero indexed count.
- Fix: read from `data.files` — same shape the upload-tab caller already uses for its merged response.
- Caught while reviewing PR #805 — the diff didn't introduce the bug but did wrap the affected branch in a new partial-suppression guard, which made the stale field name visible. Splitting into its own PR because #805 had already landed and the scope is unrelated to the narrowed-retry change there.
- Cache-bust `app.js?v=109 → v=110` so cached SPAs reload the fixed toast (per `feedback_static_asset_cache_bust.md`).

## Test plan

- [x] New vitest spec `packages/memtomem/tests-js/search-drag-zone-toast-chunks.test.mjs` — boots the JS under JSDOM, dispatches a `drop` on `#tab-search` with two stub files (3 + 4 chunks), asserts the success toast reads "Indexed 2 files → 7 chunks" not 0.
- [x] **Mutation-validated**: reverting the fix to `(data.results || [])` fails the spec with the literal `"Indexed 2 files → 0 chunks"` text — this is the toast that users have actually been seeing since v0.1.0.
- [x] `cd packages/memtomem/tests-js && npm test` — 19/19 vitest specs green (1 new + 18 existing).
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean.

## Notes

- No i18n change — the locale string `toast.indexed_files_chunks` is unchanged; only the JS that fills its `{chunks}` placeholder.
- The upload-tab caller (Index → Upload mode) was always correct because it uses `data.total_indexed` directly. Only the search-tab drag-zone path was affected.
- Net diff: +98 / −2 (mostly the new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
