### PR TITLE
fix(web): role=button + aria-label on search result rows (#700)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1999,6 +1999,7 @@ function _buildResultItem(r) {
   item.className = 'result-item';
   item.dataset.id = r.chunk.id;
   item.setAttribute('tabindex', '0');
+  item.setAttribute('role', 'button');
 
   const checkLabel = document.createElement('label');
   checkLabel.className = 'result-check-wrap';
@@ -2017,6 +2018,14 @@ function _buildResultItem(r) {
   const fname = basename(r.chunk.source_file || '');
   const dir = shortDir((r.chunk.source_file || '').split('/').slice(0, -1).join('/') || '/');
   const age = relativeTime(r.chunk.created_at);
+  const lineRange = (r.chunk.start_line && r.chunk.end_line)
+    ? `lines ${r.chunk.start_line}-${r.chunk.end_line}`
+    : null;
+  const nsLabel = r.chunk.namespace && r.chunk.namespace !== 'default'
+    ? `namespace ${r.chunk.namespace}`
+    : null;
+  const ariaParts = [fname, lineRange, nsLabel, age].filter(Boolean);
+  item.setAttribute('aria-label', ariaParts.join(', '));
   const nsBadge = r.chunk.namespace && r.chunk.namespace !== 'default'
     ? ` <span class="badge badge-ns">${escapeHtml(r.chunk.namespace)}</span>` : '';
   const validityBadge = _validityBadgeHtml(r.chunk.valid_from_unix, r.chunk.valid_to_unix);

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -1,0 +1,57 @@
+"""Pin tests for list-row accessibility attributes in the static web UI.
+
+Search/source/timeline list-rows are constructed in JS, so behavior tests would
+require a browser. These source-scan tests pin the a11y semantics so removing
+``role=`` or ``aria-label`` silently can't slip past review (issue #700).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_STATIC_DIR = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" / "static"
+_APP_JS = _STATIC_DIR / "app.js"
+
+
+@pytest.fixture(scope="module")
+def app_js() -> str:
+    assert _APP_JS.exists(), f"app.js missing: {_APP_JS}"
+    return _APP_JS.read_text(encoding="utf-8")
+
+
+def _extract_function(source: str, name: str) -> str:
+    """Extract a top-level ``function name(...) { ... }`` body via brace matching."""
+    m = re.search(rf"\bfunction\s+{re.escape(name)}\s*\(", source)
+    assert m, f"function {name} not found in app.js"
+    i = source.index("{", m.end())
+    depth = 0
+    for j in range(i, len(source)):
+        c = source[j]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return source[i : j + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+class TestSearchResultItemA11y:
+    """Pin a11y attributes on ``.result-item`` rows (issue #700)."""
+
+    def test_buildresultitem_sets_role_button(self, app_js: str) -> None:
+        body = _extract_function(app_js, "_buildResultItem")
+        assert "setAttribute('role', 'button')" in body, (
+            "result-item must expose role=button so screen readers announce it "
+            "as a selectable row, not a generic group"
+        )
+
+    def test_buildresultitem_sets_aria_label(self, app_js: str) -> None:
+        body = _extract_function(app_js, "_buildResultItem")
+        assert "setAttribute('aria-label'" in body, (
+            "result-item must set aria-label from filename/lines/namespace/age "
+            "so screen readers announce a meaningful name"
+        )


### PR DESCRIPTION
## Summary

Search result rows (`.result-item`) are rendered as bare `<div>` with `tabindex="0"` only — screen readers announce them as anonymous "group" landmarks, and keyboard users can't tell from the focus ring whether a row is interactive. The row already had `click` + `Enter`/`Space` handlers wiring it as a button; the role and accessible name were the only thing missing.

This PR fixes the **search results** surface only — first of three split PRs against #700. Source detail chunk cards and Timeline rows ship separately. The umbrella tracker (#702) explicitly notes the fix can land incrementally.

## Changes

- `app.js` `_buildResultItem` — add `role="button"` + dynamic `aria-label` assembled from filename, line range, non-default namespace, and relative age. Same pattern `.home-source-item` already uses (`app.js:1703`).
- `tests/test_web_a11y.py` — new source-scan pin test so neither attribute can drop silently. Mutation-validated: removing either line fails its own test.

## Why this surface, this scope

- The row is fully selectable (toggles `.selected`, opens detail) — `role="button"` is the right semantic, not `role="listitem"`.
- The `aria-label` is generated from the same data already on the row, so no new server data or i18n keys are needed.
- The internal `.result-checkbox` keeps its native semantics (compound widget); same as `home-source-item` precedent.

## Out of scope

- Source detail chunk cards (`app.js:3650` `.chunk-card`) — separate PR.
- Timeline rows (`timeline.js:188` `.timeline-item`) — separate PR.
- Parent `#results-list` `role="list"` — skipped because children are buttons, not listitems.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_a11y.py` — new pin test passes.
- [x] Mutation check — removing `role=` or `aria-label=` each fail their own test.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` clean.
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py packages/memtomem/tests/test_web_routes.py` — adjacent web tests still pass.
- [ ] Manual: focus a result-item with keyboard, confirm screen reader announces "<filename>, lines X-Y, namespace Z, ago — button".

Refs #700, umbrella #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
