### PR TITLE
fix(web): role=button + aria-label on source-detail chunk cards (#700)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3658,6 +3658,14 @@ async function browseSource(path, limit = 100) {
         const card = document.createElement('div');
         card.className = 'chunk-card';
         card.dataset.chunkId = c.id;
+        const cardTypeLabel = c.chunk_type.replace('_', ' ');
+        const cardTrail = c.heading_hierarchy.length
+          ? `, ${c.heading_hierarchy.join(' › ')}`
+          : '';
+        card.setAttribute(
+          'aria-label',
+          `${cardTypeLabel}, lines ${c.start_line}-${c.end_line}${cardTrail}`,
+        );
         card.innerHTML = `
           <div class="chunk-card-meta">
             <span class="badge badge-gray">${c.chunk_type.replace('_',' ')}</span>
@@ -3734,13 +3742,25 @@ async function browseSource(path, limit = 100) {
           if (contentDiv.scrollHeight > 120) {
             card.classList.add('chunk-card-collapsible');
             card.setAttribute('aria-expanded', 'false');
+            card.setAttribute('role', 'button');
+            card.setAttribute('tabindex', '0');
+            const toggleCard = () => {
+              contentDiv.classList.toggle('expanded');
+              card.setAttribute('aria-expanded', contentDiv.classList.contains('expanded'));
+            };
             let dragStartX = 0, dragStartY = 0;
             card.addEventListener('mousedown', e => { dragStartX = e.clientX; dragStartY = e.clientY; });
             card.addEventListener('click', e => {
               if (Math.abs(e.clientX - dragStartX) > 4 || Math.abs(e.clientY - dragStartY) > 4) return;
               if (e.target.closest('.chunk-card-edit-area')) return;
-              contentDiv.classList.toggle('expanded');
-              card.setAttribute('aria-expanded', contentDiv.classList.contains('expanded'));
+              toggleCard();
+            });
+            card.addEventListener('keydown', e => {
+              if (e.target.closest('.chunk-card-actions, .chunk-card-edit-area')) return;
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleCard();
+              }
             });
           }
         });

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -30,8 +30,8 @@ def timeline_js() -> str:
 
 
 def _extract_function(source: str, name: str) -> str:
-    """Extract a top-level ``function name(...) { ... }`` body via brace matching."""
-    m = re.search(rf"\bfunction\s+{re.escape(name)}\s*\(", source)
+    """Extract a top-level ``[async ]function name(...) { ... }`` body via brace matching."""
+    m = re.search(rf"\b(?:async\s+)?function\s+{re.escape(name)}\s*\(", source)
     assert m, f"function {name} not found"
     i = source.index("{", m.end())
     depth = 0
@@ -44,6 +44,11 @@ def _extract_function(source: str, name: str) -> str:
             if depth == 0:
                 return source[i : j + 1]
     raise AssertionError(f"unterminated function body for {name}")
+
+
+def _count_setattr(body: str, attr: str) -> int:
+    """Count ``setAttribute('<attr>', ...)`` regardless of formatter line wrap."""
+    return len(re.findall(rf"setAttribute\(\s*['\"]{re.escape(attr)}['\"]", body))
 
 
 class TestSearchResultItemA11y:
@@ -118,4 +123,57 @@ class TestTimelineRowA11y:
         assert body.count("addEventListener('keydown'") >= 2, (
             "files-view must wire keydown on both the outer expand row and the "
             "inner navigate row — Enter/Space activation parity with click"
+        )
+
+
+class TestChunkCardA11y:
+    """Pin a11y attributes on source-detail ``.chunk-card`` rows (issue #700).
+
+    All cards must have an accessible name; collapsible (toggle-able) cards
+    must additionally have ``role=button`` + keyboard activation.
+    """
+
+    def test_chunk_card_has_aria_label(self, app_js: str) -> None:
+        body = _extract_function(app_js, "browseSource")
+        # The aria-label is set on the card before the rAF accordion pass —
+        # i.e. unconditionally for every card, not just collapsible ones.
+        assert "card.setAttribute" in body, "card.setAttribute missing"
+        assert _count_setattr(body, "aria-label") >= 1, (
+            "every chunk-card must set aria-label so screen readers announce a "
+            "meaningful name (chunk type + line range + heading trail)"
+        )
+
+    def test_collapsible_chunk_card_role_button(self, app_js: str) -> None:
+        body = _extract_function(app_js, "browseSource")
+        # Slice to the accordion activation block — role=button must be set
+        # ALONGSIDE the chunk-card-collapsible class, not on every card.
+        m = re.search(r"chunk-card-collapsible.*?\}\s*\}\s*\)\s*;", body, re.DOTALL)
+        assert m, "chunk-card-collapsible block not found"
+        block = m.group(0)
+        assert "setAttribute('role', 'button')" in block, (
+            "collapsible chunk-cards must expose role=button — they are the "
+            "expand/collapse trigger, mirroring home-source-item / result-item"
+        )
+        assert "setAttribute('tabindex'" in block, (
+            "collapsible chunk-cards must be keyboard-focusable"
+        )
+
+    def test_collapsible_chunk_card_keydown_handler(self, app_js: str) -> None:
+        body = _extract_function(app_js, "browseSource")
+        m = re.search(r"chunk-card-collapsible.*?\}\s*\}\s*\)\s*;", body, re.DOTALL)
+        assert m, "chunk-card-collapsible block not found"
+        block = m.group(0)
+        assert "addEventListener('keydown'" in block, (
+            "role=button without Enter/Space activation is a lie — pair the "
+            "click handler with a keydown handler"
+        )
+        # Must guard against firing while the user is editing or pressing
+        # Enter on an action button — those cases should not toggle the card.
+        assert "chunk-card-edit-area" in block, (
+            "keydown handler must skip when focus is in .chunk-card-edit-area "
+            "(textarea Enter must not collapse the card)"
+        )
+        assert "chunk-card-actions" in block, (
+            "keydown handler must skip when focus is in .chunk-card-actions "
+            "(button Enter must not also toggle the parent card)"
         )


### PR DESCRIPTION
## Summary

Source-detail `.chunk-card` rows had no accessible name, and the collapsible variant — added in the rAF accordion pass when `contentDiv.scrollHeight > 120` — had **only mouse-click** wired for expand/collapse. Screen readers announced cards as anonymous "group" landmarks and keyboard users could neither tab to a card nor expand it.

Third of three split PRs against #700 (`Source detail chunk cards` target). Independent of #808 (search) and #809 (timeline).

## Changes (`app.js`, `browseSource`)

- Set `aria-label` on **every** card (chunk type + line range + heading-hierarchy trail) right after `card.dataset.chunkId` — informational cards still need an accessible name.
- In the `requestAnimationFrame` accordion-activation block, when a card becomes `.chunk-card-collapsible`, also set `role="button"` + `tabindex="0"` and add a `keydown` handler that mirrors the existing click toggle.
- Refactor the toggle body into a local `toggleCard()` helper so click and keydown share one path.

The keydown handler **skips** when focus is in:
- `.chunk-card-actions` — so a Copy/Edit/Delete button's Enter doesn't *also* toggle the parent card.
- `.chunk-card-edit-area` — so a textarea's Enter newline doesn't collapse the card mid-edit.

Drag-vs-click detection on the click path is preserved unchanged.

`tests/test_web_a11y.py` — new `TestChunkCardA11y` class, three pin assertions:
- `aria-label` is set on every card.
- `role="button"` + `tabindex` live inside the `.chunk-card-collapsible` activation block (i.e. only on toggle-able cards, matching the issue's "informational" vs "clickable" distinction).
- `keydown` handler exists with both required exclusion zones.

Mutation-validated: removing `role=` from the activation block fails the relevant test.

## Why this scoping

- Non-collapsible cards have an aria-label but **no role** — they're informational, not interactive. Adding `role="button"` to a non-toggle card would be a lie. This matches issue #700's option-1 / option-2 distinction.
- `aria-label` text uses data already on the card; no new server data, no i18n keys (chunk_type / line numbers are not localized prose).

## Out of scope

- Search results — separate PR (#808).
- Timeline rows — separate PR (#809).
- `role="list"` on the chunk-list container + `role="listitem"` on non-collapsible cards — could be a small follow-up but isn't required to close #700.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_a11y.py` — all green (this PR + #808 + #809 each contribute their own class).
- [x] Mutation check — removing `role=` from the collapsible block fails the specific test.
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` clean.
- [ ] Manual: open a source detail with a long markdown chunk, Tab to a `.chunk-card-collapsible` card, press Enter — confirm expand. Press Enter while inside the textarea after Edit — confirm the card does NOT collapse.

## Merge interaction with #808 and #809

All three PRs touch `tests/test_web_a11y.py`: each creates the file with the same fixtures + helpers and adds its own test class. Whichever lands first leaves the others with a trivial rebase to keep all classes side-by-side.

Refs #700, umbrella #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
