### PR TITLE
fix(web/a11y): role=button + aria-label on search/source/timeline rows

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1999,6 +1999,7 @@ function _buildResultItem(r) {
   item.className = 'result-item';
   item.dataset.id = r.chunk.id;
   item.setAttribute('tabindex', '0');
+  item.setAttribute('role', 'button');
 
   const checkLabel = document.createElement('label');
   checkLabel.className = 'result-check-wrap';
@@ -2017,6 +2018,14 @@ function _buildResultItem(r) {
   const fname = basename(r.chunk.source_file || '');
   const dir = shortDir((r.chunk.source_file || '').split('/').slice(0, -1).join('/') || '/');
   const age = relativeTime(r.chunk.created_at);
+  const lineRange = (r.chunk.start_line && r.chunk.end_line)
+    ? `lines ${r.chunk.start_line}-${r.chunk.end_line}`
+    : null;
+  const nsLabel = r.chunk.namespace && r.chunk.namespace !== 'default'
+    ? `namespace ${r.chunk.namespace}`
+    : null;
+  const ariaParts = [fname, lineRange, nsLabel, age].filter(Boolean);
+  item.setAttribute('aria-label', ariaParts.join(', '));
   const nsBadge = r.chunk.namespace && r.chunk.namespace !== 'default'
     ? ` <span class="badge badge-ns">${escapeHtml(r.chunk.namespace)}</span>` : '';
   const validityBadge = _validityBadgeHtml(r.chunk.valid_from_unix, r.chunk.valid_to_unix);
@@ -3649,6 +3658,14 @@ async function browseSource(path, limit = 100) {
         const card = document.createElement('div');
         card.className = 'chunk-card';
         card.dataset.chunkId = c.id;
+        const cardTypeLabel = c.chunk_type.replace('_', ' ');
+        const cardTrail = c.heading_hierarchy.length
+          ? `, ${c.heading_hierarchy.join(' › ')}`
+          : '';
+        card.setAttribute(
+          'aria-label',
+          `${cardTypeLabel}, lines ${c.start_line}-${c.end_line}${cardTrail}`,
+        );
         card.innerHTML = `
           <div class="chunk-card-meta">
             <span class="badge badge-gray">${c.chunk_type.replace('_',' ')}</span>
@@ -3725,13 +3742,25 @@ async function browseSource(path, limit = 100) {
           if (contentDiv.scrollHeight > 120) {
             card.classList.add('chunk-card-collapsible');
             card.setAttribute('aria-expanded', 'false');
+            card.setAttribute('role', 'button');
+            card.setAttribute('tabindex', '0');
+            const toggleCard = () => {
+              contentDiv.classList.toggle('expanded');
+              card.setAttribute('aria-expanded', contentDiv.classList.contains('expanded'));
+            };
             let dragStartX = 0, dragStartY = 0;
             card.addEventListener('mousedown', e => { dragStartX = e.clientX; dragStartY = e.clientY; });
             card.addEventListener('click', e => {
               if (Math.abs(e.clientX - dragStartX) > 4 || Math.abs(e.clientY - dragStartY) > 4) return;
               if (e.target.closest('.chunk-card-edit-area')) return;
-              contentDiv.classList.toggle('expanded');
-              card.setAttribute('aria-expanded', contentDiv.classList.contains('expanded'));
+              toggleCard();
+            });
+            card.addEventListener('keydown', e => {
+              if (e.target.closest('.chunk-card-actions, .chunk-card-edit-area')) return;
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                toggleCard();
+              }
             });
           }
         });

--- a/packages/memtomem/src/memtomem/web/static/timeline.js
+++ b/packages/memtomem/src/memtomem/web/static/timeline.js
@@ -129,7 +129,7 @@ function renderTimeline(chunks) {
     const short = date.slice(5); // MM-DD
     const fmtTip = new Date(date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
     const tipText = `${fmtTip} — ${items.length} chunk${items.length !== 1 ? 's' : ''}`;
-    return `<div class="tl-heatmap-col" data-tooltip="${escapeAttr(tipText)}" data-date="${date}">
+    return `<div class="tl-heatmap-col" data-tooltip="${escapeAttr(tipText)}" data-date="${date}" role="button" tabindex="0" aria-label="${escapeAttr(tipText)}">
       <span class="tl-heatmap-count">${items.length}</span>
       <div class="tl-heatmap-bar" style="height:${pct}%"></div>
       <span class="tl-heatmap-label">${short}</span>
@@ -137,7 +137,7 @@ function renderTimeline(chunks) {
   });
   heatmap.innerHTML = `<div class="tl-heatmap-track">${cols.join('')}</div>`;
   heatmap.querySelectorAll('.tl-heatmap-col').forEach(col => {
-    col.addEventListener('click', () => {
+    const activate = () => {
       heatmap.querySelectorAll('.tl-heatmap-col').forEach(c => c.classList.remove('active'));
       col.classList.add('active');
       const target = list.querySelector(`[data-tl-date="${col.dataset.date}"]`);
@@ -151,6 +151,10 @@ function renderTimeline(chunks) {
           heading.classList.add('tl-date-flash');
         }
       }
+    };
+    col.addEventListener('click', activate);
+    col.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate(); }
     });
   });
   show(heatmap);
@@ -186,7 +190,11 @@ function renderChunkView(list, groups) {
     for (const c of items) {
       const item = document.createElement('div');
       item.className = 'timeline-item';
+      item.setAttribute('role', 'button');
+      item.setAttribute('tabindex', '0');
+      item.setAttribute('aria-expanded', 'false');
       const time = localTimeShort(c.created_at); // local HH:MM
+      item.setAttribute('aria-label', `${basename(c.source_file)}, ${time}`);
       const tagsHtml = c.tags.map(t => `<span class="timeline-tag">${escapeHtml(t)}</span>`).join('');
       const dot = `<span class="tl-type-dot" style="background:${fileTypeColor(c.source_file)}"></span>`;
       const openLabel = (typeof t === 'function')
@@ -206,11 +214,21 @@ function renderChunkView(list, groups) {
         </div>
       `;
       // (C) Inline expansion: first click expand/collapse, action buttons navigate
+      const toggleExpand = () => {
+        item.classList.toggle('tl-item-expanded');
+        item.setAttribute('aria-expanded', item.classList.contains('tl-item-expanded'));
+      };
       item.addEventListener('click', (e) => {
         // If click is on an action button, handle separately
         if (e.target.closest('.tl-expand-actions')) return;
-        item.classList.toggle('tl-item-expanded');
-        item.setAttribute('aria-expanded', item.classList.contains('tl-item-expanded'));
+        toggleExpand();
+      });
+      item.addEventListener('keydown', (e) => {
+        if (e.target.closest('.tl-expand-actions')) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggleExpand();
+        }
       });
       item.querySelector('.tl-btn-open').addEventListener('click', (e) => {
         e.stopPropagation();
@@ -259,6 +277,13 @@ function renderFileView(list, groups) {
 
       const fileItem = document.createElement('div');
       fileItem.className = 'timeline-file-item';
+      fileItem.setAttribute('role', 'button');
+      fileItem.setAttribute('tabindex', '0');
+      fileItem.setAttribute('aria-expanded', 'false');
+      fileItem.setAttribute(
+        'aria-label',
+        `${fname}, ${fileChunks.length} chunk${fileChunks.length !== 1 ? 's' : ''}, last ${lastTime}`,
+      );
 
       const header = document.createElement('div');
       header.className = 'timeline-file-header';
@@ -291,7 +316,10 @@ function renderFileView(list, groups) {
       for (const c of sorted) {
         const ci = document.createElement('div');
         ci.className = 'tl-file-chunk-item';
+        ci.setAttribute('role', 'button');
+        ci.setAttribute('tabindex', '0');
         const time = localTimeShort(c.created_at);
+        ci.setAttribute('aria-label', `${c.chunk_type}, ${time}`);
         const tagsHtml = c.tags.map(t => `<span class="timeline-tag">${escapeHtml(t)}</span>`).join('');
         ci.innerHTML = `
           <div class="tl-fci-header">
@@ -301,17 +329,33 @@ function renderFileView(list, groups) {
           <div class="tl-fci-snippet">${escapeHtml(truncate(c.content, 150))}</div>
           ${tagsHtml ? `<div class="timeline-item-tags">${tagsHtml}</div>` : ''}
         `;
-        ci.addEventListener('click', e => { e.stopPropagation(); _navigateToSource(c.source_file, c.id); });
+        const navigateChunk = () => _navigateToSource(c.source_file, c.id);
+        ci.addEventListener('click', e => { e.stopPropagation(); navigateChunk(); });
+        ci.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            navigateChunk();
+          }
+        });
         chunkList.appendChild(ci);
       }
       fileItem.appendChild(chunkList);
 
-      fileItem.addEventListener('click', () => {
+      const toggleFileExpand = () => {
         const expanded = !chunkList.hidden;
         chunkList.hidden = expanded;
         header.querySelector('.tl-file-chevron').textContent = expanded ? '▶' : '▼';
         fileItem.classList.toggle('tl-file-expanded', !expanded);
         fileItem.setAttribute('aria-expanded', !expanded);
+      };
+      fileItem.addEventListener('click', toggleFileExpand);
+      fileItem.addEventListener('keydown', e => {
+        if (e.target.closest('.tl-file-open-source, .tl-file-chunk-item')) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          toggleFileExpand();
+        }
       });
 
       group.appendChild(fileItem);

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -1,0 +1,200 @@
+"""Pin tests for list-row accessibility attributes in the static web UI.
+
+Search / source-detail / timeline list-rows are constructed in JS, so behavior
+tests would require a browser. These source-scan tests pin the a11y semantics
+so removing ``role=`` / ``tabindex`` / ``aria-label`` silently can't slip past
+review (issue #700).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_STATIC_DIR = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" / "static"
+_APP_JS = _STATIC_DIR / "app.js"
+_TIMELINE_JS = _STATIC_DIR / "timeline.js"
+
+
+@pytest.fixture(scope="module")
+def app_js() -> str:
+    assert _APP_JS.exists(), f"app.js missing: {_APP_JS}"
+    return _APP_JS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def timeline_js() -> str:
+    assert _TIMELINE_JS.exists(), f"timeline.js missing: {_TIMELINE_JS}"
+    return _TIMELINE_JS.read_text(encoding="utf-8")
+
+
+def _extract_function(source: str, name: str) -> str:
+    """Extract a top-level ``function name(...) { ... }`` body via brace matching."""
+    m = re.search(rf"\bfunction\s+{re.escape(name)}\s*\(", source)
+    assert m, f"function {name} not found"
+    i = source.index("{", m.end())
+    depth = 0
+    for j in range(i, len(source)):
+        c = source[j]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return source[i : j + 1]
+    raise AssertionError(f"unterminated function body for {name}")
+
+
+class TestSearchResultItemA11y:
+    """Pin a11y attributes on ``.result-item`` rows.
+
+    Already-implemented in ``main`` — this class is regression protection so
+    the role/tabindex/aria-label/keydown quad can't be silently dropped.
+    """
+
+    def test_result_item_role_button(self, app_js: str) -> None:
+        body = _extract_function(app_js, "_buildResultItem")
+        assert "setAttribute('role', 'button')" in body, (
+            "result-item must expose role=button so screen readers announce it "
+            "as a selectable row, not a generic group"
+        )
+
+    def test_result_item_aria_label(self, app_js: str) -> None:
+        body = _extract_function(app_js, "_buildResultItem")
+        assert "setAttribute('aria-label'" in body, (
+            "result-item must set aria-label from filename/lines/namespace/age "
+            "so screen readers announce a meaningful name"
+        )
+
+    def test_result_item_keydown_handler(self, app_js: str) -> None:
+        body = _extract_function(app_js, "_buildResultItem")
+        assert "addEventListener('keydown'" in body, (
+            "result-item with role=button must respond to Enter/Space — "
+            "otherwise screen-reader announce promises behavior that doesn't "
+            "fire from the keyboard"
+        )
+
+
+class TestChunkCardA11y:
+    """Pin a11y attributes on ``.chunk-card`` rows in the source-detail view.
+
+    aria-label is set unconditionally; role=button + tabindex + keydown are
+    added only on the collapsible branch (cards taller than 120px). Both
+    surfaces are pinned.
+    """
+
+    def test_chunk_card_always_aria_label(self, app_js: str) -> None:
+        # The card creation site is in an anonymous closure inside the source
+        # detail loader; we anchor on the literal construction sequence so
+        # the test fails loudly if someone reshuffles the lines.
+        anchor = "card.className = 'chunk-card';"
+        idx = app_js.find(anchor)
+        assert idx != -1, f"chunk-card construction anchor not found: {anchor!r}"
+        # Look at the next 600 chars — generous slack for future small edits,
+        # tight enough that aria-label has to be at the construction site.
+        window = app_js[idx : idx + 600]
+        assert "setAttribute(\n          'aria-label'" in window or (
+            "setAttribute('aria-label'" in window
+        ), (
+            "chunk-card must set aria-label at construction time so every "
+            "card — collapsible or not — has an accessible name"
+        )
+
+    def test_chunk_card_collapsible_role_and_tabindex(self, app_js: str) -> None:
+        # Pin the collapsible branch by anchoring on the existing
+        # `chunk-card-collapsible` className guard.
+        anchor = "card.classList.add('chunk-card-collapsible');"
+        idx = app_js.find(anchor)
+        assert idx != -1, "chunk-card-collapsible branch not found"
+        # Window covers the full collapsible wiring (mousedown + click + keydown).
+        window = app_js[idx : idx + 1200]
+        assert "setAttribute('role', 'button')" in window, (
+            "collapsible chunk-card must expose role=button so screen readers "
+            "announce it as a togglable control"
+        )
+        assert "setAttribute('tabindex', '0')" in window, (
+            "collapsible chunk-card must be keyboard-focusable (tabindex=0)"
+        )
+
+    def test_chunk_card_collapsible_keydown_handler(self, app_js: str) -> None:
+        anchor = "card.classList.add('chunk-card-collapsible');"
+        idx = app_js.find(anchor)
+        assert idx != -1
+        window = app_js[idx : idx + 1200]
+        assert "addEventListener('keydown'" in window, (
+            "collapsible chunk-card must respond to Enter/Space so the role=button "
+            "promise is real for keyboard users"
+        )
+
+
+class TestTimelineRowA11y:
+    """Pin a11y attributes on Timeline rows — chunks view, files view outer
+    row, files view inner chunk row, and the heatmap column buttons.
+    """
+
+    def test_timeline_item_chunks_view_role_button(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderChunkView")
+        assert "setAttribute('role', 'button')" in body, (
+            "chunks-view .timeline-item must expose role=button — the row is the "
+            "expand/collapse trigger, not a generic group"
+        )
+
+    def test_timeline_item_chunks_view_aria_label(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderChunkView")
+        assert "setAttribute('aria-label'" in body, (
+            "chunks-view .timeline-item must set aria-label — at minimum filename "
+            "and time, which are already on the row"
+        )
+
+    def test_timeline_item_chunks_view_keydown_handler(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderChunkView")
+        assert "addEventListener('keydown'" in body, (
+            "chunks-view .timeline-item with role=button must respond to "
+            "Enter/Space — otherwise screen-reader announce is a lie"
+        )
+
+    def test_timeline_file_item_files_view_role_button(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderFileView")
+        assert "setAttribute('role', 'button')" in body, (
+            "files-view rows (.timeline-file-item / .tl-file-chunk-item) must expose role=button"
+        )
+
+    def test_timeline_file_item_files_view_aria_label(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderFileView")
+        # Files view has two row classes (.timeline-file-item + .tl-file-chunk-item),
+        # both clickable; both need aria-label. Pin via count >= 2.
+        assert body.count("setAttribute(") >= 2 and "aria-label" in body, (
+            "files-view must aria-label both the outer .timeline-file-item and "
+            "each inner .tl-file-chunk-item"
+        )
+
+    def test_timeline_file_item_files_view_keydown(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderFileView")
+        # Both row types need keydown — outer toggles expand, inner navigates.
+        assert body.count("addEventListener('keydown'") >= 2, (
+            "files-view must wire keydown on both the outer expand row and the "
+            "inner navigate row — Enter/Space activation parity with click"
+        )
+
+    def test_heatmap_col_role_button(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderTimeline")
+        assert 'role="button"' in body, (
+            ".tl-heatmap-col is a clickable date-jump button — must expose "
+            "role=button so screen readers announce it as such"
+        )
+
+    def test_heatmap_col_aria_label(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderTimeline")
+        assert "aria-label=" in body, (
+            ".tl-heatmap-col must set aria-label so the date and chunk count "
+            "are announced — bar chart is otherwise opaque to assistive tech"
+        )
+
+    def test_heatmap_col_keydown_handler(self, timeline_js: str) -> None:
+        body = _extract_function(timeline_js, "renderTimeline")
+        assert "addEventListener('keydown'" in body, (
+            ".tl-heatmap-col with role=button must respond to Enter/Space — "
+            "tabindex=0 makes it focusable, so keyboard activation must work"
+        )


### PR DESCRIPTION
## Summary

Closes #700. Brings list-row a11y semantics to the rest of the static surface — `home-source-item` was the only row exposing `role=button` before this PR.

Five row classes now ship with `role="button"`, `tabindex="0"`, `aria-label`, and an Enter/Space keydown handler that mirrors the existing click handler:

| Surface | File | Notes |
| --- | --- | --- |
| `.result-item` | `app.js` `_buildResultItem` | role + aria-label new; keydown was already there |
| `.chunk-card` | `app.js` `browseSource` | aria-label always; role/tabindex/keydown only on the collapsible branch (`scrollHeight > 120`) |
| `.timeline-item` | `timeline.js` `renderChunkView` | full quad |
| `.timeline-file-item` | `timeline.js` `renderFileView` outer | full quad; keydown ignores Enter inside `.tl-file-open-source` / `.tl-file-chunk-item` so nested controls keep their behavior |
| `.tl-file-chunk-item` | `timeline.js` `renderFileView` inner | full quad; click and keydown both `e.stopPropagation()` to avoid bubbling into the outer expand toggle |
| `.tl-heatmap-col` | `timeline.js` `renderTimeline` | bar-chart columns get role/tabindex/aria-label + keydown — the chart was previously opaque to assistive tech |

`aria-label` strings are built from data the row already exposes (filename, line range, namespace, time, count). No new strings to translate.

## Tests

`packages/memtomem/tests/test_web_a11y.py` — 15 source-scan pin tests anchored on the construction site of each row class. Source-scan rather than browser tests because the static surface has no JS test harness and the regression class to catch is "a future contributor deletes an attribute," which a literal-string scan handles directly.

Mutation-validated: `git checkout` of `app.js` + `timeline.js` to `origin/main` then re-running the file fails 14 of 15. The surviving pass is `test_result_item_keydown_handler` because the keydown handler already existed on `result-item` pre-PR.

## How to test

```
cd /tmp/mm-i700
uv run pytest packages/memtomem/tests/test_web_a11y.py -v
uv run ruff check packages/memtomem/src packages/memtomem/tests
uv run ruff format --check packages/memtomem/src packages/memtomem/tests
```

A manual sanity pass in `mm web`:
- Tab to a search result → screen-reader should announce `<filename>, lines X-Y, ...`
- Tab to a long chunk-card → Enter/Space should expand/collapse
- Tab to a Timeline row in either chunks or files view → Enter/Space mirrors click
- Tab to a heatmap bar → Enter/Space scrolls to the matching date

## Verification adjustment to issue #700

The issue body claimed `home-source-item` was the only list-row exposing `role=button` and that `result-item` was a bare `<div>`. The first part was correct on `origin/main`; the second was effectively correct (`tabindex` was set but neither `role=button` nor `aria-label` was). Both gaps are closed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
