### PR TITLE
feat(web): Context Gateway as Agent Integrations group dashboard card

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=78" />
+  <link rel="stylesheet" href="/style.css?v=79" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -611,7 +611,7 @@
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.integrations">Agent Integrations</span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🔄</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_overview">Context Gateway</span>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -192,6 +192,15 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
 .settings-nav-btn--danger:hover { background: rgba(var(--danger-rgb), 0.08); color: var(--danger); }
 .settings-nav-btn--danger.active { color: var(--danger); background: rgba(var(--danger-rgb), 0.12); border-left-color: var(--danger); }
 .settings-nav-btn--danger.active .nav-sub { color: var(--danger); opacity: 0.75; }
+.settings-nav-btn--landing {
+  width: auto;
+  background: rgba(var(--accent-rgb), 0.04);
+  border-radius: 6px;
+  margin: 6px 8px;
+  padding: 10px 14px;
+}
+.settings-nav-btn--landing .nav-label { font-weight: 600; }
+.settings-nav-btn--landing.active { background: rgba(var(--accent-rgb), 0.14); }
 .settings-content { flex: 1; padding: 16px 24px; overflow-y: auto; }
 .settings-section { display: none; }
 .settings-section.active { display: block; }
@@ -208,6 +217,7 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
 @media (max-width: 900px) {
   .settings-nav { width: 180px; }
   .settings-nav-btn { padding: 7px 10px; }
+  .settings-nav-btn--landing { padding: 9px 10px; margin: 4px 6px; }
   .settings-content { padding: 12px 16px; }
   .settings-nav-btn .nav-sub { display: none; }
 }

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -325,6 +325,36 @@ def test_html_settings_nav_btns_all_carry_ui_tier_attr() -> None:
         assert "data-ui-tier=" in tag, f"settings-nav-btn missing data-ui-tier: {tag[:120]}"
 
 
+def test_ctx_overview_has_landing_modifier_for_group_dashboard() -> None:
+    """ctx-overview is the Agent Integrations group's dashboard card and must
+    carry the ``settings-nav-btn--landing`` modifier so CSS gives it visual
+    hierarchy distinct from the leaf rows."""
+    html = _read_static("index.html")
+    overview_btn = re.search(r'<button[^>]*data-section="ctx-overview"[^>]*>', html)
+    assert overview_btn is not None, "ctx-overview button not found in markup"
+    assert "settings-nav-btn--landing" in overview_btn.group(0), (
+        "ctx-overview must carry settings-nav-btn--landing modifier "
+        "(group dashboard, not a leaf); "
+        f"got: {overview_btn.group(0)[:200]}"
+    )
+
+
+def test_other_integration_leaves_lack_landing_modifier() -> None:
+    """Symmetric negative pin: only ctx-overview is the landing card. The
+    other Agent Integrations leaves (Skills / Custom Commands / Subagents /
+    Hooks) must not carry the ``--landing`` modifier, otherwise the visual
+    hierarchy collapses again."""
+    html = _read_static("index.html")
+    for section in ("ctx-skills", "ctx-commands", "ctx-agents", "hooks-sync"):
+        tag = re.search(rf'<button[^>]*data-section="{section}"[^>]*>', html)
+        assert tag is not None, f"{section} button not found in markup"
+        assert "settings-nav-btn--landing" not in tag.group(0), (
+            f"{section} must NOT carry --landing modifier "
+            "(reserved for ctx-overview only); "
+            f"got: {tag.group(0)[:200]}"
+        )
+
+
 def test_html_dev_mode_banner_is_present_and_starts_hidden() -> None:
     html = _read_static("index.html")
     assert 'id="dev-mode-banner"' in html, "dev-mode banner removed from markup"


### PR DESCRIPTION
## Summary

- Promote the Context Gateway row to a "landing card" inside the Agent Integrations sidebar group so it visually reads as the group's dashboard rather than another sibling of Skills / Custom Commands / Subagents / Hooks. Resolves the visual-hierarchy concern Codex raised in #813's review.
- CSS-only — no routing, DOM, or i18n change. New `settings-nav-btn--landing` modifier (width:auto, tinted background, rounded corners, 6/8 margin, heavier label) with explicit active-state override and a mobile-breakpoint variant. Bumps `style.css?v=78 → ?v=79`.
- Pin tests in `test_web_mode.py` lock the modifier to ctx-overview and assert the four Integrations leaves do not carry it; mutation-checked by removing the class locally.

## Why this is the smallest possible cut

After PR #813 (sidebar relabel) and PR #815 (leaf desc + directional tooltips), the remaining ambiguity was purely visual — the row was correctly named but rendered at the same depth as its leaves. The previous plan listed three options:

- **Option α** — group click auto-enters Context Gateway, drop the leaf row. Touches routing + sidebar list + tests.
- **Option β** — promote ctx-overview to a dashboard card, leave routing alone. Touches CSS + 1 markup line. *(this PR)*
- **Drop** — rely on PR-1 + PR-2 alone. We confirmed there is no external confusion signal (PR comments empty, no issues filed against navigation/IA), so drop was a defensible default.

Option β was chosen because it is the minimum change that addresses Codex's specific feedback without disturbing the IA contract everywhere else.

## Verification

- `uv run pytest packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/test_i18n.py` → 55 passed.
- `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` → clean.
- Manual via Playwright MCP at http://127.0.0.1:8080/#settings:
  - **Prod (220px sidebar)** — ctx-overview width 203px (no overflow), background `rgba(108,143,255,0.04)`, radius 6px, label weight 600. Skills/Subagents/Hooks default. Active state overrides background to `rgba(...,0.14)` and applies accent border-left + text color. Group caret collapses + restores both overview and leaves.
  - **Mobile (≤900px, sidebar 180px)** — overview width 167px (still no overflow), padding 9/10, margin 4/6, nav-sub hidden as expected.
- Dev-mode (4-leaf) layout: the landing-card hierarchy is independent of leaf count, so adding Custom Commands does not change the visual contract; verified via the static markup pin tests rather than a separate dev-mode run.

## Test plan

- [ ] CI green on the new branch.
- [ ] Local sanity: `uv run mm web` and confirm the Agent Integrations group renders Context Gateway as a card above the four leaves.
- [ ] Codex review focus: (a) active-state specificity vs the modifier background, (b) mobile padding, (c) does the visual cue actually communicate "group summary, not a leaf".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
