### PR TITLE
fix(server): swap fcntl→portalocker so memtomem-server runs on Windows (closes #817)

### DIFF
--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -335,13 +335,27 @@ def main() -> None:
     legacy_pid_file = legacy_server_pid_path()
     _legacy_lock_fp = _try_hold_legacy_flock(legacy_pid_file)
     if _legacy_lock_fp is not None:
-        # LIFO: unlink must run before close so the file we delete is still
-        # the one we own the flock on. Without unlink the legacy path
-        # outlives the process and the next server's ``_try_hold_legacy_flock``
-        # can race against the stale file, reporting a phantom "pre-0.1.25
-        # install" holder (issue #437).
-        atexit.register(lambda: _legacy_lock_fp.close())
-        atexit.register(lambda: legacy_pid_file.unlink(missing_ok=True))
+        # POSIX needs unlink-before-close so we delete exactly the inode we
+        # own the flock on (issue #437); otherwise the next server's
+        # ``_try_hold_legacy_flock`` races against a stale file and reports
+        # a phantom "pre-0.1.25 install" holder. Composite cleanup keeps the
+        # ordering correct on POSIX and stays Windows-safe in case a future
+        # change removes the ``_try_hold_legacy_flock`` Windows short-circuit
+        # (#818 review).
+        def _legacy_cleanup() -> None:
+            if os.name == "nt":
+                try:
+                    _legacy_lock_fp.close()
+                finally:
+                    try:
+                        legacy_pid_file.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+            else:
+                legacy_pid_file.unlink(missing_ok=True)
+                _legacy_lock_fp.close()
+
+        atexit.register(_legacy_cleanup)
 
     # Runtime files (pid / flock) live on ``$XDG_RUNTIME_DIR/memtomem``
     # when the platform provides one, otherwise a per-user temp subdir.
@@ -394,8 +408,37 @@ def main() -> None:
         _lock_fp.truncate()
         _lock_fp.write(str(os.getpid()))
         _lock_fp.flush()
-        atexit.register(lambda: _lock_fp.close())  # LIFO: runs second
-        atexit.register(lambda: pid_file.unlink(missing_ok=True))  # LIFO: runs first
+
+        # Composite cleanup — single atexit registration, platform-aware order
+        # (#818 review). Splitting close+unlink across two ``atexit.register``
+        # calls relies on LIFO so unlink runs before close, which works on
+        # POSIX (you can unlink an open file and the inode persists until
+        # close) but breaks on Windows: NTFS refuses to delete an open or
+        # locked handle, so a clean shutdown via ``atexit`` would raise
+        # ``PermissionError`` (WinError 32) and leave a stale ``server.pid``
+        # behind — the next start then misreads it as a live holder.
+        def _cleanup() -> None:
+            if os.name == "nt":
+                # Close → unlock → unlink. The close releases both the
+                # file handle and the portalocker lock; the unlink only
+                # then succeeds because no handle is open against the path.
+                try:
+                    _lock_fp.close()
+                finally:
+                    try:
+                        pid_file.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+            else:
+                # POSIX: unlink while still holding the flock so we delete
+                # exactly the inode we own; without that, a window opens
+                # where another process could ``open`` the same path and
+                # we'd close-then-unlink the wrong inode. Closing the fd
+                # afterwards releases the flock.
+                pid_file.unlink(missing_ok=True)
+                _lock_fp.close()
+
+        atexit.register(_cleanup)
         sigterm_targets = [pid_file]
         if _legacy_lock_fp is not None:
             sigterm_targets.append(legacy_pid_file)

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -203,6 +203,15 @@ def _install_sigterm_handler(*pid_files: Path) -> None:
     Only register after the flock succeeds, so we never unlink a pid
     file another primary owns. ``atexit`` still handles the normal
     stdin-EOF shutdown path.
+
+    Windows note (#817): Python's ``signal.SIGTERM`` is a no-op on
+    Windows — the OS has no equivalent of POSIX SIGTERM that the C
+    runtime delivers to the Python signal layer. We skip registration
+    entirely on ``os.name == "nt"`` so the call is honest about what it
+    does, instead of silently installing a handler that will never
+    fire. The ``atexit`` path remains the only teardown route on
+    Windows; FastMCP's stdio loop exits via stdin-EOF when the MCP
+    host disconnects, which triggers ``atexit`` cleanly.
     """
     import os as _os
     import signal
@@ -215,7 +224,8 @@ def _install_sigterm_handler(*pid_files: Path) -> None:
                 pass
         _os._exit(0)
 
-    signal.signal(signal.SIGTERM, _handle)
+    if _os.name != "nt":
+        signal.signal(signal.SIGTERM, _handle)
 
 
 def _try_hold_legacy_flock(legacy_pid: Path) -> object | None:
@@ -266,9 +276,23 @@ def _try_hold_legacy_flock(legacy_pid: Path) -> object | None:
     Returns ``None`` on the skip paths (fresh install, open error,
     shared-lock acquire failure). The returned fd must stay referenced
     for the lock to persist.
+
+    Windows short-circuit (#817): pre-0.1.25 ``memtomem-server`` was
+    Linux-only by construction — the ``mm`` CLI itself didn't load on
+    Windows until #652 / 0.1.34, so a pre-0.1.25 Windows server is
+    impossible. The whole legacy-flock probe exists only to interlock
+    with that hypothetical holder, so on Windows we return ``None``
+    immediately. This also sidesteps a real correctness concern:
+    portalocker's Windows backend selection (``MsvcrtLocker`` vs
+    ``Win32Locker``) does not uniformly implement ``LOCK_SH`` semantics,
+    and we don't want to bet the cross-version mutex on backend
+    internals.
     """
-    import fcntl
+    import portalocker
     import logging
+
+    if os.name == "nt":
+        return None
 
     log = logging.getLogger(__name__)
 
@@ -282,8 +306,8 @@ def _try_hold_legacy_flock(legacy_pid: Path) -> object | None:
         return None
 
     try:
-        fcntl.flock(legacy_fp, fcntl.LOCK_SH | fcntl.LOCK_NB)
-    except (BlockingIOError, OSError):
+        portalocker.lock(legacy_fp, portalocker.LOCK_SH | portalocker.LOCK_NB)
+    except (portalocker.LockException, BlockingIOError, OSError):
         log.warning(
             "Legacy flock at %s is held exclusively (likely a pre-0.1.25 "
             "install). Continuing — if that holder is a pre-0.1.25 "
@@ -299,7 +323,8 @@ def _try_hold_legacy_flock(legacy_pid: Path) -> object | None:
 def main() -> None:
     """Run the MCP server."""
     import atexit
-    import fcntl
+
+    import portalocker
 
     from memtomem._runtime_paths import ensure_runtime_dir, legacy_server_pid_path
 
@@ -338,14 +363,25 @@ def main() -> None:
     # debugging). ``a+`` keeps the existing content readable until the lock
     # decision is made; we ``truncate`` + write the pid only after acquiring
     # the lock.
+    #
+    # ``a+`` (read+write) is also load-bearing for Windows (#817): portalocker's
+    # ``MsvcrtLocker`` backend calls ``msvcrt.locking``, which the C runtime
+    # rejects on read-only handles with ``EACCES``. ``cli/_liveness.py`` uses
+    # ``"rb+"`` for the same reason. Don't simplify this to ``"w"``.
     _lock_fp = open(pid_file, "a+")  # noqa: SIM115
     try:
-        fcntl.flock(_lock_fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
+        portalocker.lock(_lock_fp, portalocker.LOCK_EX | portalocker.LOCK_NB)
+    except (portalocker.LockException, BlockingIOError, OSError):
         # Another server already holds the lock — proceed anyway (the editor
         # expects the process to stay alive), but log a warning. Don't register
         # atexit unlink or the SIGTERM handler: either would yank the primary
         # server's pid file out from under it.
+        #
+        # Exception tuple matches ``cli/_liveness.py:probe_pid_file`` (#817):
+        # POSIX raises ``BlockingIOError``; portalocker's Windows backend
+        # wraps Win32 errors as ``LockException``. Keep all three explicit so
+        # a future reader doesn't narrow this and accidentally swallow the
+        # wrong exception.
         _lock_fp.close()
         import logging
 

--- a/packages/memtomem/tests/test_no_posix_only_imports.py
+++ b/packages/memtomem/tests/test_no_posix_only_imports.py
@@ -20,13 +20,13 @@ library's POSIX-only modules at module scope:
 Two patterns are allowed because the scan walks ``tree.body`` only
 and does not recurse:
 
-- **Lazy imports inside functions / methods**: the documented pattern
-  in ``server/__init__.py:main``, where ``import fcntl`` lives inside
-  the function body and only evaluates on POSIX call paths. The
-  server is POSIX-only by design (no SIGTERM, different pid semantics
-  on Windows), but the module is import-walked from Windows tooling
-  via ``cli/__init__.py:_register``, so module-level imports must
-  stay safe.
+- **Lazy imports inside functions / methods**: imports living inside
+  a function body that only evaluate on POSIX call paths. The escape
+  hatch stays as general infrastructure, but as of #817 the server
+  itself is fully ``portalocker``-based and contains zero ``import
+  fcntl`` (lazy or otherwise) — so no current ``src/memtomem/`` callsite
+  exercises this exemption. It remains supported for future code that
+  legitimately needs a POSIX-only branch.
 - **Gated ``if sys.platform`` branches**: ``import msvcrt`` /
   ``import fcntl`` inside a top-level ``if/else`` is also fine — the
   wrong-platform branch never executes. The 43ae140 half-fix that
@@ -88,8 +88,8 @@ def _module_level_violations(tree: ast.Module) -> list[tuple[int, str]]:
         #   this shape; portalocker, PR #652, replaced it with a single
         #   unconditional import.)
         # - Lazy imports inside function / method bodies are not flagged
-        #   — that is the documented pattern in
-        #   ``server/__init__.py:main``.
+        #   — historically the pattern used by ``server/__init__.py:main``,
+        #   though as of #817 that file is fully portalocker-based.
         #
         # The regression we're catching is the unguarded module-level
         # ``import fcntl`` from PR #623 — directly in ``tree.body``,
@@ -119,8 +119,7 @@ def test_no_module_level_posix_only_imports(py_file: pathlib.Path) -> None:
     assert violations == [], (
         f"{py_file.relative_to(_SRC_ROOT)} has module-level POSIX-only "
         f"import(s): {violations}. Move the import inside a function, "
-        f"method, or guarded ``sys.platform`` branch — see "
-        f"``server/__init__.py`` for the lazy-import pattern."
+        f"method, or guarded ``sys.platform`` branch."
     )
 
 

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -28,6 +28,10 @@ import pytest
 from memtomem.server import _install_sigterm_handler
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows path skips signal.signal registration (#817); see test_install_sigterm_handler_is_noop_on_windows",
+)
 def test_install_sigterm_handler_registers_for_sigterm(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -39,6 +43,10 @@ def test_install_sigterm_handler_registers_for_sigterm(
     assert signal.SIGTERM in captured, "_install_sigterm_handler must bind SIGTERM"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="depends on signal.signal capture; Windows path does not register SIGTERM (#817)",
+)
 def test_sigterm_handler_unlinks_pid_file_and_hard_exits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -65,6 +73,10 @@ def test_sigterm_handler_unlinks_pid_file_and_hard_exits(
     assert exit_calls == [0], "handler must call os._exit(0), not sys.exit or return"
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="depends on signal.signal capture; Windows path does not register SIGTERM (#817)",
+)
 def test_sigterm_handler_unlinks_all_pid_files(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -86,6 +98,30 @@ def test_sigterm_handler_unlinks_all_pid_files(
 
     assert not xdg_pid.exists(), "XDG pid file must be unlinked"
     assert not legacy_pid.exists(), "legacy pid file must be unlinked (#437)"
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Windows-only: pins the no-op contract added in #817",
+)
+def test_install_sigterm_handler_is_noop_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On Windows, ``_install_sigterm_handler`` must NOT call ``signal.signal``.
+
+    Python's SIGTERM is a no-op on Windows (the C runtime does not
+    deliver it), so registering a handler would silently mislead
+    readers into thinking shutdown was wired. The Windows path relies
+    on FastMCP's stdin-EOF teardown + ``atexit`` instead. Pin the
+    contract here so a future "let's just always register it" tweak
+    surfaces as a test failure.
+    """
+    captured: dict[int, object] = {}
+    monkeypatch.setattr(signal, "signal", lambda sig, h: captured.setdefault(sig, h))
+
+    _install_sigterm_handler(tmp_path / ".server.pid")
+
+    assert captured == {}, "Windows path must not call signal.signal"
 
 
 # ── integration ──────────────────────────────────────────────────────
@@ -134,7 +170,8 @@ def _cleanup_proc(proc: subprocess.Popen) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="SIGTERM semantics differ on Windows; server is POSIX-only"
+    sys.platform == "win32",
+    reason="no SIGTERM equivalent on Windows; teardown path is atexit-only (#817)",
 )
 def test_sigterm_unlinks_pid_file_end_to_end(tmp_path: Path) -> None:
     """Spawn ``memtomem-server`` as a subprocess, send SIGTERM, verify cleanup.
@@ -185,34 +222,55 @@ def test_sigterm_unlinks_pid_file_end_to_end(tmp_path: Path) -> None:
         _cleanup_proc(proc)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
 def test_server_uses_tempdir_fallback_when_xdg_unset(tmp_path: Path) -> None:
     """With ``$XDG_RUNTIME_DIR`` unset the server must land on the
     ``{tempfile.gettempdir()}/memtomem-{uid}/`` fallback, not silently
     refuse to start or write somewhere unexpected.
 
     Covers the code path that the default sigterm test skips (XDG set).
-    Uses an isolated ``TMPDIR`` under ``tmp_path`` so we don't litter
-    the real ``/var/folders/.../T/`` during the run.
+    Uses an isolated tempdir under ``tmp_path`` so we don't litter the
+    real ``/var/folders/.../T/`` (POSIX) or ``%LOCALAPPDATA%\\Temp``
+    (Windows) during the run.
+
+    Cross-platform notes (#817):
+
+    - ``Path.home()`` reads ``HOME`` on POSIX and ``USERPROFILE`` on
+      Windows; setting both keeps the subprocess hermetic on either OS
+      (mirrors ``tests/helpers.py::set_home``, which we cannot reuse here
+      because it operates on ``monkeypatch`` not on a subprocess env dict).
+    - ``tempfile.gettempdir()`` reads ``TMPDIR`` on POSIX but on Windows
+      it picks the first of ``TMP`` / ``TEMP`` / ``USERPROFILE`` it
+      finds. Set all three to land in our isolated dir regardless of
+      backend.
+    - The ``uid`` suffix collapses to ``0`` on Windows (``os.geteuid``
+      doesn't exist) — mirror ``_runtime_paths.runtime_dir()`` line 99.
+    - The ``0o700`` mode-bit assert is POSIX-only: NTFS synthesizes
+      mode bits and ``_runtime_paths.ensure_runtime_dir`` deliberately
+      skips the chmod gate on Windows.
     """
     home = tmp_path / "home"
     home.mkdir()
     tmp_tmp = tmp_path / "tmp"
     tmp_tmp.mkdir()
-    expected_dir = tmp_tmp / f"memtomem-{os.geteuid()}"
+    uid = os.geteuid() if hasattr(os, "geteuid") else 0
+    expected_dir = tmp_tmp / f"memtomem-{uid}"
     expected_pid = expected_dir / "server.pid"
 
     env = os.environ.copy()
     env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
     env["TMPDIR"] = str(tmp_tmp)
+    env["TMP"] = str(tmp_tmp)
+    env["TEMP"] = str(tmp_tmp)
     env.pop("XDG_RUNTIME_DIR", None)
 
     proc = _spawn_server(env)
     try:
         _wait_for_pid_file(proc, expected_pid)
-        assert stat_mode(expected_dir) == 0o700, (
-            "tempdir fallback must create the subdir at owner-only mode"
-        )
+        if os.name != "nt":
+            assert stat_mode(expected_dir) == 0o700, (
+                "tempdir fallback must create the subdir at owner-only mode"
+            )
         assert not (home / ".memtomem").exists()
     finally:
         _cleanup_proc(proc)
@@ -220,7 +278,11 @@ def test_server_uses_tempdir_fallback_when_xdg_unset(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32", reason="SIGTERM semantics differ on Windows; server is POSIX-only"
+    sys.platform == "win32",
+    reason=(
+        "no SIGTERM equivalent on Windows; teardown path is atexit-only "
+        "and the legacy flock probe short-circuits on Windows (#817)"
+    ),
 )
 def test_sigterm_unlinks_legacy_pid_file_end_to_end(tmp_path: Path) -> None:
     """Issue #437: when ``~/.memtomem/`` exists but no live server holds
@@ -266,7 +328,13 @@ def test_sigterm_unlinks_legacy_pid_file_end_to_end(tmp_path: Path) -> None:
         _cleanup_proc(proc)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "legacy flock is POSIX-only by design (#817): #444 contention only "
+        "matters for Linux pre-0.1.25 holdovers, which cannot exist on Windows"
+    ),
+)
 def test_server_warns_but_proceeds_when_legacy_lock_held_exclusively(
     tmp_path: Path,
 ) -> None:
@@ -325,7 +393,13 @@ def test_server_warns_but_proceeds_when_legacy_lock_held_exclusively(
         holder.close()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "LOCK_SH coexistence is only required against pre-0.1.25 legacy servers, "
+        "which are POSIX-only by construction (#817)"
+    ),
+)
 def test_two_post_412_servers_coexist_with_shared_lock(tmp_path: Path) -> None:
     """#444 primary repro: two 0.1.26 servers must be able to run at
     the same time (different projects / Claude Code sessions).
@@ -418,44 +492,51 @@ def test_legacy_lock_sh_allows_multiple_holders(tmp_path: Path) -> None:
         fp2.close()
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="server is POSIX-only")
 def test_contended_server_start_preserves_pid_file_content(tmp_path: Path) -> None:
     """Regression: a contended server start must NOT truncate the live
     server's pid file when the flock probe bails.
 
     Pre-fix, ``main()`` opened the pid file with ``open(..., "w")`` which
-    truncates *before* ``fcntl.flock`` is checked. So a second server
-    starting while the first held the lock zeroed out the file content
-    even though the first server kept running. The user-visible symptom:
-    ``mm uninstall`` reports ``Server still running (pid None)`` and
-    ``lsof`` loses the recorded process identity, defeating the whole
-    point of writing the pid in the first place.
+    truncates *before* the lock is checked. So a second server starting
+    while the first held the lock zeroed out the file content even though
+    the first server kept running. The user-visible symptom: ``mm
+    uninstall`` reports ``Server still running (pid None)`` and ``lsof``
+    loses the recorded process identity, defeating the whole point of
+    writing the pid in the first place.
 
     Repro: pre-create the pid file with known content and hold
     ``LOCK_EX`` on it, spawn the server, and assert the recorded pid
     survived. The fix uses ``open(..., "a+")`` + post-lock truncate so
     contended starts leave the live file alone.
+
+    Cross-platform via portalocker (#817): the simulator holds an
+    exclusive lock the same way ``main()`` does. ``"rb+"`` open keeps
+    the ``MsvcrtLocker`` Windows backend happy (read-only handles
+    fail with ``EACCES``).
     """
     home = tmp_path / "home"
     home.mkdir()
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
-    os.chmod(xdg, 0o700)
+    if os.name != "nt":
+        os.chmod(xdg, 0o700)
     sub = xdg / "memtomem"
     sub.mkdir()
-    os.chmod(sub, 0o700)
+    if os.name != "nt":
+        os.chmod(sub, 0o700)
     pid_file = sub / "server.pid"
     pid_file.write_text("12345")
 
     env = os.environ.copy()
     env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
     env["XDG_RUNTIME_DIR"] = str(xdg)
 
-    import fcntl as _fcntl
+    import portalocker
 
-    holder = open(pid_file, "a+b")  # noqa: SIM115 — held for test scope
+    holder = open(pid_file, "rb+")  # noqa: SIM115 — held for test scope
     try:
-        _fcntl.flock(holder, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        portalocker.lock(holder, portalocker.LOCK_EX | portalocker.LOCK_NB)
         proc = _spawn_server(env)
         try:
             # The open + flock + warning log runs synchronously at
@@ -477,8 +558,8 @@ def test_contended_server_start_preserves_pid_file_content(tmp_path: Path) -> No
             _cleanup_proc(proc)
     finally:
         try:
-            _fcntl.flock(holder, _fcntl.LOCK_UN)
-        except OSError:
+            portalocker.unlock(holder)
+        except (portalocker.LockException, OSError):
             pass
         holder.close()
 
@@ -487,3 +568,83 @@ def stat_mode(path: Path) -> int:
     import stat as _stat
 
     return _stat.S_IMODE(path.stat().st_mode)
+
+
+# ── in-process regression pin (cross-platform, #817) ─────────────────
+
+
+def test_server_main_acquires_portalocker_pid_lock(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run ``memtomem.server.main()`` in-process and pin that it acquires
+    a real exclusive lock on the pid file via ``portalocker``.
+
+    Cross-platform regression net for #817 — works identically on Linux,
+    macOS, and Windows. Without this pin, a future "swap portalocker
+    back to fcntl" tweak would slip past the AST guard (which only
+    catches *module-level* ``import fcntl``) and re-break Windows.
+
+    Aggressive isolation, in this order:
+
+    1. Stub ``_install_sigterm_handler`` to a no-op so ``main()`` does
+       not replace the test process's global ``signal.signal(SIGTERM, ...)``
+       handler. Going through the function-level seam (rather than
+       monkeypatching ``signal.signal``) is cleaner — that's the entire
+       intent boundary.
+    2. Stub ``mcp.run`` to a no-op so the asyncio loop never starts.
+    3. Pin ``Path.home()`` and ``XDG_RUNTIME_DIR`` to tmp paths so
+       ``server_pid_path()`` and ``legacy_server_pid_path()`` land
+       inside ``tmp_path``. Otherwise the test would write a real
+       pid file into the developer's runtime dir.
+    4. Capture ``atexit.register`` calls. Without this the lock fd and
+       pid file outlive the test even though ``mcp.run`` is no-op'd —
+       ``main()`` registers cleanups via ``atexit`` expecting them to
+       fire at process exit, but pytest never exits between tests.
+    """
+    import atexit
+    import pathlib
+
+    from memtomem import server as server_mod
+    from memtomem._runtime_paths import server_pid_path
+    from memtomem.cli._liveness import probe_pid_file
+
+    tmp_home = tmp_path / "home"
+    tmp_home.mkdir()
+    xdg = tmp_path / "xdg_runtime"
+    xdg.mkdir()
+    if os.name != "nt":
+        os.chmod(xdg, 0o700)
+
+    captured_atexit: list[tuple] = []
+
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *a, **kw: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda: None)
+    monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_home))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+    monkeypatch.setattr(
+        atexit,
+        "register",
+        lambda fn, *a, **kw: captured_atexit.append((fn, a, kw)) or fn,
+    )
+
+    try:
+        server_mod.main()
+
+        pid_file = server_pid_path()
+        assert pid_file.exists(), "main() must create the pid file"
+        assert pid_file.read_text().strip() == str(os.getpid()), (
+            "pid file must contain this process's pid"
+        )
+        # The probe opens its own handle and tries LOCK_EX | LOCK_NB —
+        # if main() is holding the lock, the probe must report alive.
+        assert probe_pid_file(pid_file).alive is True, (
+            "probe_pid_file must see the lock as held while main() owns it"
+        )
+    finally:
+        # LIFO mirrors atexit's real ordering: unlink runs before close
+        # so the file we delete is still the one we own the lock on.
+        for fn, args, kwargs in reversed(captured_atexit):
+            try:
+                fn(*args, **kwargs)
+            except Exception:
+                pass

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -627,10 +627,11 @@ def test_server_main_acquires_portalocker_pid_lock(
         lambda fn, *a, **kw: captured_atexit.append((fn, a, kw)) or fn,
     )
 
+    pid_file = server_pid_path()
+    cleanup_ran = False
     try:
         server_mod.main()
 
-        pid_file = server_pid_path()
         assert pid_file.exists(), "main() must create the pid file"
         assert pid_file.read_text().strip() == str(os.getpid()), (
             "pid file must contain this process's pid"
@@ -640,11 +641,28 @@ def test_server_main_acquires_portalocker_pid_lock(
         assert probe_pid_file(pid_file).alive is True, (
             "probe_pid_file must see the lock as held while main() owns it"
         )
-    finally:
-        # LIFO mirrors atexit's real ordering: unlink runs before close
-        # so the file we delete is still the one we own the lock on.
+
+        # Run the captured atexit callbacks in LIFO order (mirrors atexit
+        # itself). After they've all run the pid file MUST be gone — that
+        # is the regression net for #818 review: the original two-callback
+        # ``register(close); register(unlink)`` pattern relied on POSIX's
+        # unlink-while-open semantics, which Windows refuses (PermissionError,
+        # WinError 32). The composite cleanup fixes this; if a future change
+        # reverts to two registrations, this assert fails on Windows because
+        # ``pid_file.unlink`` raises while the lock fd is still open.
         for fn, args, kwargs in reversed(captured_atexit):
-            try:
-                fn(*args, **kwargs)
-            except Exception:
-                pass
+            fn(*args, **kwargs)
+        cleanup_ran = True
+        assert not pid_file.exists(), (
+            "atexit cleanup must unlink the pid file on every platform; "
+            "Windows requires close-before-unlink (#818 review)"
+        )
+    finally:
+        # Belt-and-suspenders: if the asserts above bailed before the
+        # cleanup loop, run it now so the test environment is clean.
+        if not cleanup_ran:
+            for fn, args, kwargs in reversed(captured_atexit):
+                try:
+                    fn(*args, **kwargs)
+                except Exception:
+                    pass

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -26,24 +26,22 @@ from .helpers import set_home
 
 @contextlib.contextmanager
 def _hold_pid_lock(pid_file: Path) -> Iterator[None]:
-    """Hold an exclusive flock on ``pid_file`` for the duration of the block.
+    """Hold an exclusive lock on ``pid_file`` for the duration of the block.
 
     Mirrors what ``server/__init__.py:main`` does at runtime so the
-    flock-based liveness probe (#387) sees a live writer.
-
-    POSIX-only — ``fcntl`` is imported lazily so the module collects on
-    Windows. Tests that depend on this helper are gated with
-    ``skipif(sys.platform == "win32", ...)``.
+    portalocker-based liveness probe (#387, #817) sees a live writer.
+    Cross-platform via ``portalocker``; on Windows ``"rb+"`` open is
+    required by the ``MsvcrtLocker`` backend (see ``cli/_liveness.py:54``).
     """
-    import fcntl
+    import portalocker
 
     fp = open(pid_file, "rb+")
     try:
-        fcntl.flock(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        portalocker.lock(fp, portalocker.LOCK_EX | portalocker.LOCK_NB)
         try:
             yield
         finally:
-            fcntl.flock(fp, fcntl.LOCK_UN)
+            portalocker.unlock(fp)
     finally:
         fp.close()
 
@@ -330,10 +328,6 @@ class TestRuntimeProfileImportPin:
 # -------------------------------------------------------------------- 12
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="flock-based liveness probe is POSIX-only (#448 follow-up)",
-)
 class TestServerAliveRefuses:
     def test_refuses_when_server_alive_at_legacy_path(self, home):
         """Pre-#412 servers still write ``~/.memtomem/.server.pid``. The


### PR DESCRIPTION
## Summary

Closes #817. Follow-up to #625 — that issue's close note promised this work as a separate PR if a Windows server target ever landed.

`memtomem-server` (the MCP server entry point) was the last POSIX-only surface in the codebase: PR #652 swapped the three CLI-side `fcntl` callsites onto `portalocker`, but deliberately left `server/__init__.py`'s two callsites for a follow-up. With users now wanting to point Windows MCP hosts (Claude Desktop / Code) at memtomem directly, that follow-up is here.

## Changes

`packages/memtomem/src/memtomem/server/__init__.py` — three edits:

- **`_try_hold_legacy_flock`** early-returns on Windows. The legacy flock interlocks with pre-0.1.25 `memtomem-server` instances, which were Linux-only by construction. Skipping the probe is semantically correct (no Windows-side counterparty exists) and sidesteps the question of whether portalocker's Windows backend selection (`MsvcrtLocker` vs `Win32Locker`) uniformly implements `LOCK_SH`. On POSIX, the `LOCK_SH | LOCK_NB` lock swaps to `portalocker.lock(...)` 1:1.
- **`main()`** — XDG-runtime pid lock now uses `portalocker.lock(LOCK_EX | LOCK_NB)`. Exception tuple widened to `(portalocker.LockException, BlockingIOError, OSError)` to match the canonical pattern in `cli/_liveness.py:probe_pid_file`.
- **`_install_sigterm_handler`** POSIX-gates the `signal.signal(SIGTERM, ...)` registration. Python's SIGTERM is a no-op on Windows; on Windows the teardown path is FastMCP's stdin-EOF + `atexit`.

Tests:
- `test_server_sigterm.py` — three signal-capture unit tests now Windows-skipped; new Windows-only `test_install_sigterm_handler_is_noop_on_windows` pins the no-op contract; integration-skip reasons refreshed; `test_contended_server_start_preserves_pid_file_content` and `test_server_uses_tempdir_fallback_when_xdg_unset` now Windows-runnable (simulator on portalocker, env dict carries `HOME`+`USERPROFILE`+`TMP`/`TEMP`/`TMPDIR`, `uid` falls back to `0`, mode-bit asserts POSIX-gated).
- New cross-platform `test_server_main_acquires_portalocker_pid_lock` runs `main()` in-process behind aggressive isolation (stubs `_install_sigterm_handler` and `mcp.run`, captures `atexit.register` and runs callbacks LIFO in `finally`) — regression net against any future "swap portalocker back to fcntl" attempt.
- `test_uninstall_cmd.py::_hold_pid_lock` helper now portalocker-based; `TestServerAliveRefuses` class no longer Windows-skipped.
- `test_no_posix_only_imports.py` docstring refreshed — `server/__init__.py` is now portalocker-only, so the lazy-import exemption is general infrastructure rather than that specific callsite. AST scan logic is unchanged.

## Out of scope (separate follow-ups)

- Windows ODR registration (MSIX manifest / MCPB bundle / `odr.exe`). That's packaging, not server code — the [Windows MCP overview](https://learn.microsoft.com/ko-kr/windows/ai/mcp/overview) is registration-side concern and orthogonal to making the server actually run on Windows.
- Flipping the CI Windows job from `continue-on-error: true` to required. That's gated on the Windows-triage umbrella #634.
- Windows-specific shutdown via `SetConsoleCtrlHandler`. Stdin-EOF + `atexit` covers MCP-host disconnect cleanly; the explicit-kill story can come later if real users need it.

## Notes for Windows users

After `memtomem-server` shutdown on Windows, **`~/.memtomem/.server.pid` is not created** — the legacy-flock probe short-circuits because pre-0.1.25 Windows servers cannot exist. The pid file lives at `%LOCALAPPDATA%\Temp\memtomem-0\server.pid` and is unlinked via `atexit` on host disconnect.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_no_posix_only_imports.py packages/memtomem/tests/test_server_sigterm.py packages/memtomem/tests/test_uninstall_cmd.py` — 280 passed, 2 skipped (Windows-only)
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/` — 4228 passed, 9 skipped
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [ ] Windows runner CI (informational) — newly Windows-runnable tests should pass under the existing matrix cell.
- [ ] Manual: `memtomem-server` boots on a real Windows host, MCP host (Claude Desktop / Code) lists tools and answers `mem_status`, pid file appears at `%LOCALAPPDATA%\Temp\memtomem-0\server.pid` and is unlinked at shutdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)