### PR TITLE
fix(tests): replace jitter-sensitive duration assertion with phase-ordering pin (closes #821)

### DIFF
--- a/packages/memtomem/tests/test_locking_contention.py
+++ b/packages/memtomem/tests/test_locking_contention.py
@@ -124,12 +124,22 @@ class TestAtomicLockContention:
         assert p1.exitcode == 0
         assert p2.exitcode == 0
 
+        # Phase-ordering pin (jitter-immune): p2 made its request while p1
+        # still held the lock, and only acquired once p1 had released. The
+        # earlier ``(p2_acquired - p2_requested) >= hold_seconds * 0.5``
+        # check measured wall-clock wait and flaked on macOS CI when
+        # ``Process.start()`` jitter pushed p2_requested past p1's hold
+        # midpoint — the lock was working, the duration just didn't make
+        # the cutoff (#821).
+        assert p2_requested < p1_released, (
+            f"p2 requested {p2_requested} after p1 released {p1_released} — "
+            "spawn jitter exceeded hold window; the lock can't be proven "
+            "to have blocked p2 in this run"
+        )
         # 50ms scheduler slack: p2 must not have entered before p1 left.
         assert p2_acquired >= p1_released - 0.05, (
             f"p2 acquired {p2_acquired} before p1 released {p1_released}"
         )
-        # And p2 was actually blocked for most of the hold window.
-        assert (p2_acquired - p2_requested) >= hold_seconds * 0.5
 
     def test_uncontended_acquire_is_immediate(self, tmp_path: Path):
         """Negative pin: with no holder, _file_lock acquires without


### PR DESCRIPTION
## Summary

Closes #821. The atomic-lock contention test (`TestAtomicLockContention::test_second_process_blocks_until_first_releases` in `packages/memtomem/tests/test_locking_contention.py`) flaked on macOS CI when `multiprocessing.Process.start()` jitter pushed p2's request timestamp into the back half of p1's 0.5 s hold window. Last occurrence: PR #820's macOS run — 0.197 s waited vs. 0.25 s required. The lock implementation is fine; the test shape was wrong.

## Root cause

```python
assert (p2_acquired - p2_requested) >= hold_seconds * 0.5
```

measures wall-clock duration between p2's request and acquisition. Spawn jitter on slow runners shrinks this window even though the lock blocked p2 correctly.

## Fix

Swap the duration assertion for a phase-ordering pin recommended in the issue:

```python
assert p2_requested < p1_released, ...   # p2 actually contended while p1 held
assert p2_acquired  >= p1_released - 0.05, ...   # p2 didn't sneak in before release (already present)
```

Phase-ordering proves contention semantics without depending on wall-clock duration ratios. If the new assertion trips, it indicates spawn jitter exceeded the hold window (no contention was actually staged this run) — not a lock bug. The assertion message says so.

## Out of scope

- `TestDebounceLockContention::test_second_process_blocks_until_first_releases` already uses phase-ordering only; not touched to keep the PR focused.
- No product code change.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_locking_contention.py -v` — all 5 tests pass locally.
- [x] Stress loop: ran the contention test 20× back-to-back, all pass.
- [x] `uv run ruff check` + `ruff format --check` — green.
- [ ] CI matrix (Linux / macOS / Windows) — covered by PR checks.