### PR TITLE
feat(config): write home-rooted paths in config.json as ~/...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **`config.json` writers serialize home-rooted paths as `~/...`.**
+  `indexing.memory_dirs` and `storage.sqlite_path` (and any future
+  path-typed config field) are written in tilde form when they sit
+  under `$HOME`, restoring portability for the documented "moving
+  `config.json` between machines" workflow at
+  `docs/guides/configuration.md:96`. Outside-`$HOME` paths stay
+  absolute. Loaders are unchanged — `Path.expanduser()` already runs
+  at use sites, so the round-trip is symmetric. Legacy absolute-path
+  configs continue to load on the same machine; the next save through
+  any writer (`mm config set`, the Web UI, `mm init`) rewrites them
+  into tilde form. New helper `_portable_path_str` plus
+  `_relativize_config_paths_in_place` centralize the transform; all
+  four writer call sites (`save_config_overrides`,
+  `_persist_auto_discover_migration`, `mm config unset`, `mm init`'s
+  `_write_config_and_summary`) now invoke it before
+  `_atomic_write_json`.
+
 ## [0.1.36] — 2026-05-06
 
 ### Added

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -95,13 +95,20 @@ the next save, provided the stale value now matches the comparand.
 
 ### Moving `config.json` between machines
 
+Path-typed fields (`storage.sqlite_path`, `indexing.memory_dirs`)
+under `$HOME` serialize as `~/...` on write, so a config copied to a
+machine with a different `$HOME` resolves correctly via
+`Path.expanduser()` on read. Paths *outside* `$HOME` (`/var/...`,
+`/opt/...`) stay absolute because their meaning is genuinely
+machine-specific.
+
 `indexing.memory_dirs` participates in delta-only save, so on the
 machine where it was set the file typically omits it. When copying an
 existing `config.json` to a new machine, any `indexing.memory_dirs`
-entry carries over as-is — provider memory paths from the source
-machine (e.g. `~/.claude/projects/<project-A>/memory/`) won't exist
-on the destination and won't be replaced by detection on the target.
-Reset it explicitly when migrating:
+entry that points at provider-specific paths (e.g.
+`~/.claude/projects/<project-A>/memory/`) carries over as-is — the
+project-A path won't exist on the destination and won't be replaced
+by detection on the target. Reset it explicitly when migrating:
 
 ```bash
 # Option 1: targeted removal of the carried-over entry
@@ -113,6 +120,12 @@ mm init --fresh
 # Option 3: remove the indexing section by hand
 #          (edit ~/.memtomem/config.json)
 ```
+
+> **Backward compatibility.** Configs written before home-relative
+> serialization landed (≤ 0.1.36) carry absolute paths. Loading them
+> on the same machine still works. The next save through any writer
+> (`mm config set`, the Web UI, `mm init`) rewrites home-rooted paths
+> into `~/...` form automatically.
 
 ### Removing individual overrides (`mm config unset`)
 

--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -140,7 +140,11 @@ def config_unset(keys: tuple[str, ...]) -> None:
     itself is deleted. For a wholesale reset of wizard-untouched keys, use
     ``mm init --fresh``.
     """
-    from memtomem.config import _atomic_write_json, _override_path
+    from memtomem.config import (
+        _atomic_write_json,
+        _override_path,
+        _relativize_config_paths_in_place,
+    )
 
     canonical = _canonical_unset_keys()
     path = _override_path()
@@ -201,6 +205,7 @@ def config_unset(keys: tuple[str, ...]) -> None:
             lines.append(f"Unset: {key} (already at default)")
 
     if existing:
+        _relativize_config_paths_in_place(existing)
         _atomic_write_json(path, existing)
     elif path.exists():
         path.unlink()

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -2143,8 +2143,9 @@ def _write_config_and_summary(
         else:
             existing[section] = fields
 
-    from memtomem.config import _atomic_write_json
+    from memtomem.config import _atomic_write_json, _relativize_config_paths_in_place
 
+    _relativize_config_paths_in_place(existing)
     _atomic_write_json(config_path, existing)
     click.echo(f"  Config: {config_path}")
 

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -1552,6 +1553,7 @@ def _persist_auto_discover_migration(config_path: Path, full_memory_dirs: list[P
     indexing["memory_dirs"] = [str(d) for d in full_memory_dirs]
     indexing["auto_discover"] = False
 
+    _relativize_config_paths_in_place(existing)
     try:
         _atomic_write_json(config_path, existing)
     except OSError as exc:
@@ -1577,19 +1579,90 @@ _EXTRA_MUTATION_FIELDS: dict[str, set[str]] = {
 }
 
 
+def _portable_path_str(p: Path | str | os.PathLike[str]) -> str:
+    """Serialize a path as ``~/...`` if under ``$HOME``, else absolute.
+
+    Keeps ``config.json`` portable across machines with different
+    ``$HOME`` values: a config written on one machine and copied (or
+    git-synced) to another resolves correctly because loaders already
+    call ``Path.expanduser()`` per-field. Outside-``$HOME`` paths
+    (``/var/log/...``, ``/opt/...``) stay absolute since their meaning
+    is genuinely machine-specific.
+
+    Idempotent: already-tilde input is returned verbatim. Relative
+    inputs are also passed through unchanged. ``$HOME`` lookup
+    failures (rare; bare-bones containers without ``HOME``) fall
+    through to the absolute form.
+    """
+    p_str = os.fspath(p)
+    if p_str.startswith("~"):
+        return p_str
+    p_path = Path(p_str)
+    if not p_path.is_absolute():
+        return p_str
+    try:
+        home = Path.home()
+    except (RuntimeError, KeyError):
+        return p_str
+    try:
+        rel = p_path.relative_to(home)
+    except ValueError:
+        return p_str
+    rel_str = rel.as_posix()
+    if rel_str in ("", "."):
+        return "~"
+    return f"~/{rel_str}"
+
+
+# Schema-aware: which config fields hold path values that benefit from
+# home-relative serialization. Update both tuples when adding new path-
+# typed fields. Loaders apply ``Path.expanduser()`` per-field, so the
+# round-trip ``write tilde -> read absolute`` is symmetric.
+_CONFIG_PATH_SCALAR_FIELDS: tuple[tuple[str, str], ...] = (("storage", "sqlite_path"),)
+_CONFIG_PATH_LIST_FIELDS: tuple[tuple[str, str], ...] = (("indexing", "memory_dirs"),)
+
+
+def _relativize_config_paths_in_place(data: dict) -> None:
+    """Rewrite known path-typed config fields as ``~/...`` if under HOME.
+
+    Mutates *data* in place. Idempotent — safe to call on already-tilde
+    values or on dicts where the target sections are missing. Accepts
+    both ``str`` and ``Path`` values for path fields, so it covers the
+    init-wizard write path (string-typed ``state["db_path"]``) and the
+    ``save_config_overrides`` flow (Pydantic ``Path`` instances pulled
+    via ``getattr``) with one transform.
+    """
+    for section, field in _CONFIG_PATH_SCALAR_FIELDS:
+        sec = data.get(section)
+        if not isinstance(sec, dict):
+            continue
+        val = sec.get(field)
+        if isinstance(val, (str, Path)):
+            sec[field] = _portable_path_str(val)
+    for section, field in _CONFIG_PATH_LIST_FIELDS:
+        sec = data.get(section)
+        if not isinstance(sec, dict):
+            continue
+        val = sec.get(field)
+        if isinstance(val, list):
+            sec[field] = [_portable_path_str(p) if isinstance(p, (str, Path)) else p for p in val]
+
+
 def _json_default(obj: object) -> object:
     """``json.dumps`` fallback for values not natively JSON-serializable.
 
     ``BaseSettings`` entries in fields like ``namespace.rules`` must be
     written as dicts (via ``model_dump(mode="json")``) so the load path
-    can re-validate them on startup. ``Path`` gets ``str()``; unknown
-    types fall back to ``str()`` to preserve the original default=str
-    behaviour.
+    can re-validate them on startup. ``Path`` goes through
+    ``_portable_path_str`` so home-rooted paths land as ``~/...``
+    even if a future field bypasses ``_relativize_config_paths_in_place``;
+    unknown types fall back to ``str()`` to preserve the original
+    default=str behaviour.
     """
     if isinstance(obj, BaseSettings):
         return obj.model_dump(mode="json")
     if isinstance(obj, Path):
-        return str(obj)
+        return _portable_path_str(obj)
     return str(obj)
 
 
@@ -1727,4 +1800,5 @@ def save_config_overrides(
         else:
             existing.pop(section_name, None)
 
+    _relativize_config_paths_in_place(existing)
     _atomic_write_json(path, existing)

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -541,7 +541,7 @@ def test_migration_persists_to_config_json(
 
     persisted = json.loads(override_path.read_text(encoding="utf-8"))
     assert persisted["indexing"]["auto_discover"] is False
-    assert str(fake) in persisted["indexing"]["memory_dirs"]
+    assert _cfg._portable_path_str(str(fake)) in persisted["indexing"]["memory_dirs"]
 
 
 def test_migration_idempotent(

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -2968,8 +2968,14 @@ class TestProviderDirsStep:
         """``_write_config_and_summary`` concatenates ``state["memory_dir"]``
         with ``state["provider_dirs"]`` (deduped) when persisting
         ``indexing.memory_dirs``. Also pins ``auto_discover: false`` so a
-        fresh wizard run on a legacy install doesn't keep migrating."""
+        fresh wizard run on a legacy install doesn't keep migrating.
+
+        Both ``state["memory_dir"]`` and ``state["provider_dirs"]`` sit
+        under ``tmp_path`` (the test ``$HOME``), so the writer's home-
+        relative serialization rewrites them as ``~/...`` on disk.
+        """
         from memtomem.cli.init_cmd import _write_config_and_summary
+        from memtomem.config import _portable_path_str
 
         set_home(monkeypatch, tmp_path)
         provider_dir = tmp_path / "claude-mem"
@@ -2981,9 +2987,11 @@ class TestProviderDirsStep:
 
         data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
         dirs = data["indexing"]["memory_dirs"]
-        assert state["memory_dir"] in dirs
-        assert str(provider_dir) in dirs
-        assert dirs.count(state["memory_dir"]) == 1  # no duplicates
+        memory_dir_portable = _portable_path_str(state["memory_dir"])
+        provider_dir_portable = _portable_path_str(str(provider_dir))
+        assert memory_dir_portable in dirs
+        assert provider_dir_portable in dirs
+        assert dirs.count(memory_dir_portable) == 1  # no duplicates
         assert data["indexing"]["auto_discover"] is False
 
 
@@ -3307,8 +3315,10 @@ class TestIncludeProviderFlag:
         )
         assert result.exit_code == 0, result.output
 
+        from memtomem.config import _portable_path_str
+
         data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
-        assert str(codex) in data["indexing"]["memory_dirs"]
+        assert _portable_path_str(str(codex)) in data["indexing"]["memory_dirs"]
 
     def test_flag_silently_skips_unavailable_categories(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3338,9 +3348,11 @@ class TestIncludeProviderFlag:
             ],
         )
         assert result.exit_code == 0, result.output
+        from memtomem.config import _portable_path_str
+
         data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
         # Only the user's primary memory_dir survives; no fake codex path.
-        assert data["indexing"]["memory_dirs"] == [str(tmp_path / "memories")]
+        assert data["indexing"]["memory_dirs"] == [_portable_path_str(str(tmp_path / "memories"))]
 
     def test_no_flag_writes_no_provider_dirs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/packages/memtomem/tests/test_portable_paths.py
+++ b/packages/memtomem/tests/test_portable_paths.py
@@ -1,0 +1,348 @@
+"""Tests for home-relative path serialization in config.json.
+
+Pins the contract that writers serialize paths under ``$HOME`` as
+``~/...`` while loaders continue to apply ``Path.expanduser()`` so the
+round-trip is symmetric. Covers the feasibility goal documented in
+``docs/guides/configuration.md`` "Moving config.json between machines"
+section: a config written on one machine remains usable when copied
+(or git-synced) to another with a different ``$HOME``.
+
+Outside-``$HOME`` paths (``/var/log/...``, ``/opt/...``) stay absolute
+because their meaning is genuinely machine-specific.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from memtomem import config as _cfg
+from memtomem.config import (
+    Mem2MemConfig,
+    _portable_path_str,
+    _relativize_config_paths_in_place,
+    load_config_overrides,
+    save_config_overrides,
+)
+
+from .helpers import set_home
+
+
+# ---------------------------------------------------------------------------
+# _portable_path_str — direct unit tests (pure function)
+# ---------------------------------------------------------------------------
+
+
+def test_path_under_home_becomes_tilde(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    set_home(monkeypatch, tmp_path)
+    p = tmp_path / ".memtomem" / "memtomem.db"
+    assert _portable_path_str(p) == "~/.memtomem/memtomem.db"
+
+
+def test_path_outside_home_stays_absolute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    set_home(monkeypatch, tmp_path)
+    # Use a sibling tmp dir that is guaranteed not under HOME.
+    elsewhere = tmp_path.parent / "elsewhere" / "data.db"
+    elsewhere.parent.mkdir(parents=True, exist_ok=True)
+    assert _portable_path_str(elsewhere) == str(elsewhere)
+
+
+def test_already_tilde_input_passes_through() -> None:
+    assert _portable_path_str("~/.memtomem/memtomem.db") == "~/.memtomem/memtomem.db"
+    assert _portable_path_str("~") == "~"
+
+
+def test_relative_path_unchanged() -> None:
+    assert _portable_path_str("relative/sub/dir") == "relative/sub/dir"
+
+
+def test_home_root_collapses_to_bare_tilde(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    set_home(monkeypatch, tmp_path)
+    assert _portable_path_str(tmp_path) == "~"
+
+
+def test_path_object_and_string_produce_same_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_home(monkeypatch, tmp_path)
+    p = tmp_path / "memories"
+    assert _portable_path_str(p) == _portable_path_str(str(p)) == "~/memories"
+
+
+# ---------------------------------------------------------------------------
+# _relativize_config_paths_in_place — schema-aware transform
+# ---------------------------------------------------------------------------
+
+
+def test_relativize_in_place_handles_known_scalar_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_home(monkeypatch, tmp_path)
+    data: dict = {"storage": {"sqlite_path": str(tmp_path / "db.sqlite")}}
+    _relativize_config_paths_in_place(data)
+    assert data["storage"]["sqlite_path"] == "~/db.sqlite"
+
+
+def test_relativize_in_place_handles_known_list_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_home(monkeypatch, tmp_path)
+    data: dict = {
+        "indexing": {
+            "memory_dirs": [
+                str(tmp_path / "memories"),
+                str(tmp_path / "notes"),
+            ],
+        }
+    }
+    _relativize_config_paths_in_place(data)
+    assert data["indexing"]["memory_dirs"] == ["~/memories", "~/notes"]
+
+
+def test_relativize_in_place_accepts_path_objects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_home(monkeypatch, tmp_path)
+    data: dict = {
+        "storage": {"sqlite_path": tmp_path / "db.sqlite"},
+        "indexing": {"memory_dirs": [tmp_path / "memories"]},
+    }
+    _relativize_config_paths_in_place(data)
+    assert data["storage"]["sqlite_path"] == "~/db.sqlite"
+    assert data["indexing"]["memory_dirs"] == ["~/memories"]
+
+
+def test_relativize_in_place_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    set_home(monkeypatch, tmp_path)
+    data: dict = {
+        "storage": {"sqlite_path": "~/db.sqlite"},
+        "indexing": {"memory_dirs": ["~/memories"]},
+    }
+    _relativize_config_paths_in_place(data)
+    _relativize_config_paths_in_place(data)
+    assert data["storage"]["sqlite_path"] == "~/db.sqlite"
+    assert data["indexing"]["memory_dirs"] == ["~/memories"]
+
+
+def test_relativize_in_place_missing_sections_no_error() -> None:
+    data: dict = {"unrelated": {"foo": "bar"}}
+    _relativize_config_paths_in_place(data)
+    assert data == {"unrelated": {"foo": "bar"}}
+
+
+def test_relativize_in_place_preserves_outside_home_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    set_home(monkeypatch, tmp_path)
+    elsewhere = tmp_path.parent / "outside" / "db.sqlite"
+    elsewhere.parent.mkdir(parents=True, exist_ok=True)
+    data: dict = {"storage": {"sqlite_path": str(elsewhere)}}
+    _relativize_config_paths_in_place(data)
+    assert data["storage"]["sqlite_path"] == str(elsewhere)
+
+
+# ---------------------------------------------------------------------------
+# save_config_overrides — end-to-end write produces tilde paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Redirect ``$HOME`` and the override path so saves land in tmp_path."""
+    set_home(monkeypatch, tmp_path)
+    override = tmp_path / "config.json"
+    monkeypatch.setattr(_cfg, "_override_path", lambda: override)
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [])
+    return tmp_path, override
+
+
+def test_save_writes_memory_dirs_as_tilde(
+    isolated_config: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``indexing.memory_dirs`` participates in delta-only save and is the
+    primary path-typed mutable field — exercises the ``save_config_overrides``
+    write path end-to-end."""
+    home, override = isolated_config
+    cfg = Mem2MemConfig()
+    cfg.indexing.memory_dirs = [home / "team-notes", home / "personal-notes"]
+    save_config_overrides(cfg)
+    raw = json.loads(override.read_text(encoding="utf-8"))
+    assert raw["indexing"]["memory_dirs"] == ["~/team-notes", "~/personal-notes"]
+
+
+def test_save_keeps_outside_home_memory_dirs_absolute(
+    isolated_config: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home, override = isolated_config
+    elsewhere_dir = home.parent / "shared-volume"
+    elsewhere_dir.mkdir(parents=True, exist_ok=True)
+    cfg = Mem2MemConfig()
+    cfg.indexing.memory_dirs = [elsewhere_dir / "team"]
+    save_config_overrides(cfg)
+    raw = json.loads(override.read_text(encoding="utf-8"))
+    assert raw["indexing"]["memory_dirs"] == [str(elsewhere_dir / "team")]
+
+
+def test_save_writes_sqlite_path_via_read_merge_write(
+    isolated_config: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``storage.sqlite_path`` is init-only and not mutable through
+    ``save_config_overrides`` directly — it lands in ``config.json``
+    via the wizard, then survives subsequent saves through
+    read-merge-write. This pins the relativize pass on the carry-over
+    path so a wizard-written tilde stays a tilde and a wizard-written
+    absolute gets rewritten on the next non-trivial save."""
+    home, override = isolated_config
+    # Simulate a wizard-written file with an absolute sqlite_path.
+    pre_existing: dict = {
+        "storage": {
+            "backend": "sqlite",
+            "sqlite_path": str(home / "wizard" / "memtomem.db"),
+        },
+    }
+    override.write_text(json.dumps(pre_existing), encoding="utf-8")
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    cfg.search.default_top_k = 17  # force a save through a mutable field
+    save_config_overrides(cfg)
+
+    raw = json.loads(override.read_text(encoding="utf-8"))
+    assert raw["storage"]["sqlite_path"] == "~/wizard/memtomem.db"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: write tilde -> load resolves to absolute under current HOME
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_tilde_resolves_under_current_home(
+    isolated_config: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Write tilde-form, load, expect callers' ``expanduser()`` to resolve
+    under the current HOME.
+
+    ``load_config_overrides`` does not auto-expand tildes (Pydantic
+    ``setattr`` skips validators with ``validate_assignment=False``).
+    Downstream code that uses the paths runs ``Path(d).expanduser()``
+    explicitly — that's the contract the stored tilde form preserves
+    across machines.
+    """
+    home, override = isolated_config
+    cfg = Mem2MemConfig()
+    cfg.indexing.memory_dirs = [home / "shared", home / "personal"]
+    save_config_overrides(cfg)
+
+    fresh = Mem2MemConfig()
+    load_config_overrides(fresh)
+    expanded = [Path(d).expanduser() for d in fresh.indexing.memory_dirs]
+    assert expanded == [home / "shared", home / "personal"]
+
+
+def test_cross_machine_simulation_different_home_resolves_correctly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Save under HOME-A; copy file; load under HOME-B; paths track HOME-B.
+
+    Mimics the documented "moving config.json between machines" workflow:
+    a `~/...` path written on machine A resolves to machine B's home when
+    the config file is copied and reloaded there.
+    """
+    home_a = tmp_path / "home_a"
+    home_a.mkdir()
+    home_b = tmp_path / "home_b"
+    home_b.mkdir()
+
+    # Phase 1 — write config under HOME-A. Pre-seed an absolute
+    # ``sqlite_path`` (init-only field) so the relativize pass on the
+    # subsequent save converts it to tilde form alongside the mutable
+    # ``memory_dirs`` write.
+    set_home(monkeypatch, home_a)
+    override_a = home_a / "config.json"
+    monkeypatch.setattr(_cfg, "_override_path", lambda: override_a)
+    monkeypatch.setattr(_cfg, "_canonical_provider_dirs", lambda: [])
+    pre: dict = {"storage": {"sqlite_path": str(home_a / "memtomem.db")}}
+    override_a.write_text(json.dumps(pre), encoding="utf-8")
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    cfg.indexing.memory_dirs = [home_a / "memories"]
+    save_config_overrides(cfg)
+
+    # Confirm the on-disk file uses tilde form, not absolute.
+    raw = json.loads(override_a.read_text(encoding="utf-8"))
+    assert raw["storage"]["sqlite_path"] == "~/memtomem.db"
+    assert raw["indexing"]["memory_dirs"] == ["~/memories"]
+
+    # Copy to HOME-B (simulating git pull / machine migration).
+    override_b = home_b / "config.json"
+    override_b.write_bytes(override_a.read_bytes())
+
+    # Phase 2 — load under HOME-B, expect the tilde to expand to home_b.
+    set_home(monkeypatch, home_b)
+    monkeypatch.setattr(_cfg, "_override_path", lambda: override_b)
+
+    fresh = Mem2MemConfig()
+    load_config_overrides(fresh)
+    # Downstream code calls ``expanduser()`` per-path; the tilde-form on
+    # disk lets that expansion track HOME-B even though the file came
+    # from HOME-A.
+    assert Path(fresh.storage.sqlite_path).expanduser() == home_b / "memtomem.db"
+    expanded_dirs = [Path(d).expanduser() for d in fresh.indexing.memory_dirs]
+    assert expanded_dirs == [home_b / "memories"]
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: legacy absolute-path configs still load
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_absolute_path_in_config_still_loads(
+    isolated_config: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-existing config.json with absolute paths must load unchanged.
+
+    Backward compat for users on the same machine the config was first
+    written on. Phase 1 only changes the *writer*; the reader has always
+    accepted absolute paths and continues to.
+    """
+    home, override = isolated_config
+    legacy: dict = {
+        "storage": {"sqlite_path": str(home / "legacy" / "memtomem.db")},
+        "indexing": {
+            "memory_dirs": [str(home / "legacy_dir1"), str(home / "legacy_dir2")],
+        },
+    }
+    override.write_text(json.dumps(legacy), encoding="utf-8")
+
+    fresh = Mem2MemConfig()
+    load_config_overrides(fresh)
+    assert Path(fresh.storage.sqlite_path).expanduser() == home / "legacy" / "memtomem.db"
+    expanded_dirs = [Path(d).expanduser() for d in fresh.indexing.memory_dirs]
+    assert expanded_dirs == [home / "legacy_dir1", home / "legacy_dir2"]
+
+
+def test_legacy_absolute_rewrites_to_tilde_on_next_save(
+    isolated_config: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy absolute-path config gets converted to tilde on the next
+    save — user opts into portability the moment they touch the config."""
+    home, override = isolated_config
+    legacy: dict = {
+        "storage": {"sqlite_path": str(home / "legacy" / "memtomem.db")},
+    }
+    override.write_text(json.dumps(legacy), encoding="utf-8")
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    # Touch a different field so save_config_overrides actually writes.
+    cfg.search.default_top_k = 42
+    save_config_overrides(cfg)
+
+    raw = json.loads(override.read_text(encoding="utf-8"))
+    # storage.sqlite_path is a non-mutable init-only field, so
+    # save_config_overrides preserves it via read-merge-write. The
+    # relativize pass rewrites it into tilde form on the way out.
+    assert raw["storage"]["sqlite_path"] == "~/legacy/memtomem.db"

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -209,10 +209,14 @@ async def test_memory_dirs_add_reloads_before_write(
     )
     assert resp.status_code == 200, resp.text
 
+    from memtomem.config import _portable_path_str
+
     on_disk = json.loads((home / ".memtomem" / "config.json").read_text())
     # External mmr edit survived the memory-dirs write.
     assert on_disk.get("mmr", {}).get("enabled") is True
-    assert str(second.resolve()) in on_disk.get("indexing", {}).get("memory_dirs", [])
+    assert _portable_path_str(str(second.resolve())) in on_disk.get("indexing", {}).get(
+        "memory_dirs", []
+    )
 
 
 async def test_memory_dirs_remove_reloads_before_write(


### PR DESCRIPTION
## Summary

- Writers now serialize home-rooted paths (`indexing.memory_dirs`, `storage.sqlite_path`) in `~/...` form instead of absolute when they sit under `$HOME`. Restores the backup/restore-to-different-machine workflow that `docs/guides/configuration.md:96` already documented as broken.
- Loaders are unchanged — `Path.expanduser()` already runs at use sites, so the round-trip is symmetric.
- Outside-`$HOME` paths (`/var/...`, `/opt/...`) stay absolute because their meaning is genuinely machine-specific.
- Phase 1 of the multi-device sync stack ([RFC #34 in memtomem-docs](https://github.com/memtomem/memtomem-docs/pull/34)). Independent value beyond sync — helps any same-user-different-`$HOME` scenario (backup/restore, machine migration, dotfiles sharing).

## Implementation

Single-touch transform via two helpers in `packages/memtomem/src/memtomem/config.py`:

- `_portable_path_str(p)` — converts a path under `$HOME` to `~/...` and leaves everything else (outside-HOME absolute, relative, already-tilde) verbatim.
- `_relativize_config_paths_in_place(data)` — schema-aware dict mutation. Knows the two path-typed config fields today (`storage.sqlite_path` scalar + `indexing.memory_dirs` list); update both tuples when adding a new path field.

Both helpers accept `str | Path`, so they cover the init-wizard write path (string-typed `state["db_path"]`) and the `save_config_overrides` flow (Pydantic `Path` instances from `getattr`) with one transform.

`_json_default` also routes `Path` through `_portable_path_str` as defense-in-depth.

All four `_atomic_write_json` call sites invoke `_relativize_config_paths_in_place(existing)` before write:

- `save_config_overrides` (`config.py`)
- `_persist_auto_discover_migration` (`config.py`)
- `mm config unset` (`cli/config_cmd.py`)
- `mm init`'s `_write_config_and_summary` (`cli/init_cmd.py`)

## Backward compatibility

- **Same-machine reads of legacy configs** keep working. `Path.expanduser()` is a no-op on absolute paths. Pinned by `test_legacy_absolute_path_in_config_still_loads`.
- **Next save rewrites legacy absolutes** to `~/...` automatically — users opt into portability the moment they touch the config (Web UI Save, `mm config set`, `mm init`). Pinned by `test_legacy_absolute_rewrites_to_tilde_on_next_save`.

## Tests

New file `packages/memtomem/tests/test_portable_paths.py` (19 cases):

- `_portable_path_str` unit tests: under HOME, outside HOME, already-tilde, relative, bare home root, `Path` vs `str` parity.
- `_relativize_config_paths_in_place` unit tests: scalar field, list field, `Path` objects, idempotence, missing sections, outside-HOME preservation.
- `save_config_overrides` end-to-end: tilde for `memory_dirs`, absolute for outside-HOME, `sqlite_path` via read-merge-write.
- **Round-trip** under one HOME and **cross-HOME simulation** (write under HOME-A, copy file, load under HOME-B → tilde expands to HOME-B). The cross-HOME case mirrors the multi-device-sync RFC's verification scenario.
- Backward compat: legacy absolute loads + next-save rewrites.

Three pre-existing tests updated to the new tilde-form contract (each previously asserted `str(absolute_path)` in the on-disk list):

- `test_init_cmd.py::test_write_merges_provider_dirs_into_memory_dirs`
- `test_init_cmd.py::TestIncludeProviderFlag` (two cases)
- `test_web_hot_reload.py::test_memory_dirs_add_reloads_before_write`
- `test_config_overrides.py::test_migration_persists_to_config_json`

Full non-ollama suite: 4252 passed, 10 skipped, 46 deselected. No skips/errors introduced.

## Docs

- `docs/guides/configuration.md` "Moving `config.json` between machines" updated for the new portability semantics + a backward-compat callout for pre-fix configs.
- `CHANGELOG.md` `[Unreleased]` entry under `### Changed`.

## Out of scope

- **Phase 2 — `mm sync-doctor` validator.** Read-only diagnostic that catches the multi-device-sync footguns (no `*.db` staged, `config.json` absent from synced repo, etc.). Lands as a separate PR after RFC #34 review settles the anti-pattern list it checks against.
- **Cross-platform `expanduser()` differences.** Tests pin on the loaded `Path` value (`Path(d).expanduser()`), not on literal string comparison, so `~`-handling differences across OSes don't false-fail.
- **`config.d/` fragment semantics.** Untouched. Fragments are pure-data and remain portable on their own (`~/` already expands at load time per `configuration.md:548`).

## Test plan

- [ ] `uv run pytest packages/memtomem/tests/test_portable_paths.py -v` — 19 cases pass.
- [ ] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — full suite green.
- [ ] `uv run ruff check packages/memtomem/src` and `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — both clean.
- [ ] Smoke-test `mm config set` against a tmp HOME → confirm `~/.memtomem/config.json` writes `~/...` rather than absolute paths.
- [ ] Smoke-test `mm init` against a tmp HOME → same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
