### PR TITLE
fix(web/ctx): cache last overview payload, skip panelLoading on lang toggle (#825)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -87,34 +87,41 @@ function renderImportResult(data) {
 
 // -- Overview -----------------------------------------------------------------
 
-// Sequence guard for fast lang toggles. ``loadCtxOverview`` is also called from
-// the ``langchange`` listener so the inline-templated card text picks up the
-// new locale; without a guard a slow first fetch can land *after* a second
-// toggle and clobber the newer locale's cards with stale text.
+// Sequence guard for in-flight fetch races. ``loadCtxOverview`` is called
+// from the cold mount, the Refresh button, and the end of Sync All; rapid
+// triggers can leave a stale response landing *after* a newer one and
+// clobber the fresher render. Toggling language does NOT re-fetch — see
+// ``_ctxOverviewCache`` and the ``langchange`` listener below.
 let _ctxOverviewSeq = 0;
 
-async function loadCtxOverview() {
-  const seq = ++_ctxOverviewSeq;
+// Cache the last successful ``/api/context/overview`` payload so a
+// ``langchange`` toggle can re-render the inline ``t()`` card text from
+// the existing data — no fetch, no ``panelLoading`` spinner flash. The
+// dashboard data itself is locale-independent (counts, statuses); only
+// the labels and badge copy translate, so a cached re-render is
+// equivalent to a re-fetch + re-render for translation-only events and
+// drops the round-trip the langchange listener used to issue (#824
+// review P2 / #825). Cleared on fetch errors so the next call falls
+// back to a fresh fetch path.
+let _ctxOverviewCache = null;
+
+function _renderCtxOverview(data) {
   const el = qs('ctx-overview-content');
-  panelLoading(el);
-  try {
-    const res = await fetch('/api/context/overview');
-    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Failed to load overview');
-    const data = await res.json();
+  if (!el) return;
 
-    // Custom Commands sidebar leaf is dev-tier (Anthropic merged
-    // .claude/commands/ into Skills); the overview tile mirrors that —
-    // surfacing it in prod would let users click through and trigger
-    // the dev-only-section toast in switchSettingsSection.
-    const types = [
-      { key: 'skills',   label: t('settings.ctx.skills_title'),   section: 'ctx-skills' },
-      { key: 'commands', label: t('settings.ctx.commands_title'), section: 'ctx-commands', devOnly: true },
-      { key: 'agents',   label: t('settings.ctx.agents_title'),   section: 'ctx-agents' },
-      { key: 'settings', label: t('settings.hooks.title'),        section: 'hooks-sync' },
-    ];
+  // Custom Commands sidebar leaf is dev-tier (Anthropic merged
+  // .claude/commands/ into Skills); the overview tile mirrors that —
+  // surfacing it in prod would let users click through and trigger
+  // the dev-only-section toast in switchSettingsSection.
+  const types = [
+    { key: 'skills',   label: t('settings.ctx.skills_title'),   section: 'ctx-skills' },
+    { key: 'commands', label: t('settings.ctx.commands_title'), section: 'ctx-commands', devOnly: true },
+    { key: 'agents',   label: t('settings.ctx.agents_title'),   section: 'ctx-agents' },
+    { key: 'settings', label: t('settings.hooks.title'),        section: 'hooks-sync' },
+  ];
 
-    let html = '<div class="ctx-overview-grid">';
-    for (const typ of types) {
+  let html = '<div class="ctx-overview-grid">';
+  for (const typ of types) {
       if (typ.devOnly && STATE.uiMode !== 'dev') continue;
       const d = data[typ.key] || {};
       const total = d.total || 0;
@@ -189,57 +196,70 @@ async function loadCtxOverview() {
       </div>`;
     }
     html += '</div>';
-    if (seq !== _ctxOverviewSeq) return;
     el.innerHTML = html;
 
-    // Gate the Sync All button: when every artifact type's items are
-    // entirely runtime-only (no canonicals to fan out), Sync All resolves
-    // to a series of `no_canonical_root` skips. Surface that pre-click
-    // via a data attribute (CSS dims the button) plus a native ``title``
-    // hover tooltip + ``aria-disabled`` so the user understands the
-    // dimmed state without having to click first; the post-click toast
-    // stays as a fallback for users who don't hover (mobile, keyboard).
-    const syncAllBtn = document.getElementById('ctx-sync-all-btn');
-    if (syncAllBtn) {
-      // Mirror the overview-tile gate: in prod the Custom Commands
-      // surface is hidden, so its missing_canonical count must not
-      // gate the Sync All button (otherwise prod users would see Sync
-      // All disabled because of an artifact set they can't even see).
-      const syncKinds = STATE.uiMode === 'dev'
-        ? ['skills', 'commands', 'agents']
-        : ['skills', 'agents'];
-      const totals = syncKinds.reduce((acc, k) => {
-        const d = data[k] || {};
-        acc.total += d.total || 0;
-        acc.runtimeOnly += d.missing_canonical || 0;
-        return acc;
-      }, { total: 0, runtimeOnly: 0 });
-      if (totals.total > 0 && totals.runtimeOnly === totals.total) {
-        syncAllBtn.dataset.runtimeOnly = 'true';
-        syncAllBtn.title = t('settings.ctx.sync_all_disabled_tooltip');
-        syncAllBtn.setAttribute('aria-disabled', 'true');
+  // Gate the Sync All button: when every artifact type's items are
+  // entirely runtime-only (no canonicals to fan out), Sync All resolves
+  // to a series of `no_canonical_root` skips. Surface that pre-click
+  // via a data attribute (CSS dims the button) plus a native ``title``
+  // hover tooltip + ``aria-disabled`` so the user understands the
+  // dimmed state without having to click first; the post-click toast
+  // stays as a fallback for users who don't hover (mobile, keyboard).
+  const syncAllBtn = document.getElementById('ctx-sync-all-btn');
+  if (syncAllBtn) {
+    // Mirror the overview-tile gate: in prod the Custom Commands
+    // surface is hidden, so its missing_canonical count must not
+    // gate the Sync All button (otherwise prod users would see Sync
+    // All disabled because of an artifact set they can't even see).
+    const syncKinds = STATE.uiMode === 'dev'
+      ? ['skills', 'commands', 'agents']
+      : ['skills', 'agents'];
+    const totals = syncKinds.reduce((acc, k) => {
+      const d = data[k] || {};
+      acc.total += d.total || 0;
+      acc.runtimeOnly += d.missing_canonical || 0;
+      return acc;
+    }, { total: 0, runtimeOnly: 0 });
+    if (totals.total > 0 && totals.runtimeOnly === totals.total) {
+      syncAllBtn.dataset.runtimeOnly = 'true';
+      syncAllBtn.title = t('settings.ctx.sync_all_disabled_tooltip');
+      syncAllBtn.setAttribute('aria-disabled', 'true');
+    } else {
+      delete syncAllBtn.dataset.runtimeOnly;
+      syncAllBtn.removeAttribute('aria-disabled');
+      // The button has a default ``data-i18n-title`` (sync_all_tooltip);
+      // wiping the attribute outright would clobber the locale-driven
+      // hover tooltip that ``I18N.applyDOM`` set on page load.
+      // Restore it from the dataset key instead.
+      const titleKey = syncAllBtn.dataset.i18nTitle;
+      if (titleKey) {
+        syncAllBtn.title = t(titleKey);
       } else {
-        delete syncAllBtn.dataset.runtimeOnly;
-        syncAllBtn.removeAttribute('aria-disabled');
-        // The button has a default ``data-i18n-title`` (sync_all_tooltip);
-        // wiping the attribute outright would clobber the locale-driven
-        // hover tooltip that ``I18N.applyDOM`` set on page load.
-        // Restore it from the dataset key instead.
-        const titleKey = syncAllBtn.dataset.i18nTitle;
-        if (titleKey) {
-          syncAllBtn.title = t(titleKey);
-        } else {
-          syncAllBtn.removeAttribute('title');
-        }
+        syncAllBtn.removeAttribute('title');
       }
     }
+  }
 
-    // Click to navigate
-    el.querySelectorAll('.ctx-overview-stat').forEach(card => {
-      card.addEventListener('click', () => switchSettingsSection(card.dataset.section));
-    });
+  // Click to navigate
+  el.querySelectorAll('.ctx-overview-stat').forEach(card => {
+    card.addEventListener('click', () => switchSettingsSection(card.dataset.section));
+  });
+}
+
+async function loadCtxOverview() {
+  const seq = ++_ctxOverviewSeq;
+  const el = qs('ctx-overview-content');
+  panelLoading(el);
+  try {
+    const res = await fetch('/api/context/overview');
+    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Failed to load overview');
+    const data = await res.json();
+    if (seq !== _ctxOverviewSeq) return;
+    _ctxOverviewCache = data;
+    _renderCtxOverview(data);
   } catch (err) {
     if (seq !== _ctxOverviewSeq) return;
+    _ctxOverviewCache = null;
     el.innerHTML = emptyState('', 'Failed to load overview', err.message);
   }
 }
@@ -251,7 +271,7 @@ async function loadCtxOverview() {
 // state would erase any caller's title.
 //
 // The overview cards themselves are inline-templated via ``t()`` in
-// ``loadCtxOverview``'s innerHTML, so ``I18N.applyDOM`` cannot re-translate
+// ``_renderCtxOverview``'s innerHTML, so ``I18N.applyDOM`` cannot re-translate
 // the rendered text on toggle (it only walks ``data-i18n*`` attributes).
 // Re-render only when both gates are active:
 //   * the Settings *main tab* (``#tab-settings``) is the visible panel —
@@ -263,9 +283,15 @@ async function loadCtxOverview() {
 // Without both checks, switching from Settings → Search keeps the
 // section's ``.active`` class set (``activateTab`` hides the panel but
 // doesn't reach into sub-section classes), and a language toggle from
-// Search would still issue ``/api/context/overview`` for an off-screen
-// dashboard (#824 review P2). ``loadCtxOverview``'s own sequence guard
-// handles the multi-toggle race.
+// Search would re-render an off-screen dashboard (#824 review P2).
+//
+// Re-render path: when ``_ctxOverviewCache`` holds a prior payload, render
+// directly from it — translation is locale-only, so no fetch and no
+// ``panelLoading`` spinner flash (#825). The cold-mount fallback to
+// ``loadCtxOverview`` only fires when the dashboard has never successfully
+// loaded (initial mount race, or prior fetch error cleared the cache);
+// in that case ``loadCtxOverview``'s sequence guard handles the
+// fetch-in-flight scenario.
 window.addEventListener('langchange', () => {
   const btn = document.getElementById('ctx-sync-all-btn');
   if (btn && btn.dataset.runtimeOnly === 'true') {
@@ -276,7 +302,11 @@ window.addEventListener('langchange', () => {
   const settingsVisible = settingsTab && settingsTab.classList.contains('active');
   const overviewActive = overviewSection && overviewSection.classList.contains('active');
   if (settingsVisible && overviewActive) {
-    loadCtxOverview();
+    if (_ctxOverviewCache) {
+      _renderCtxOverview(_ctxOverviewCache);
+    } else {
+      loadCtxOverview();
+    }
   }
 });
 

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -650,15 +650,16 @@ class TestNoHardcodedStrings:
         )
 
     def test_q_pr1_overview_has_sequence_guard(self) -> None:
-        """Bug-1 multi-toggle race guard: ``loadCtxOverview`` must read +
+        """In-flight fetch race guard: ``loadCtxOverview`` must read +
         check a module-level sequence counter so a slow fetch from an
-        earlier toggle cannot clobber the cards rendered by a later
-        toggle. The browser test in ``test_context_gateway_overview.py``
-        pins the multi-toggle *outcome* but cannot deterministically
-        reproduce the race window (Playwright sync route handlers serialize
-        on the dispatcher thread, so a delay on one fetch also delays the
-        next). The guard itself — counter + capture + bail-on-stale — is
-        what this static check enforces."""
+        earlier call cannot clobber the cards rendered by a later one.
+        Lang toggles re-render from ``_ctxOverviewCache`` (#825) and do
+        not fetch, but the cold-mount, Refresh button, and end-of-Sync-All
+        paths can still race each other under rapid clicks; the guard
+        protects all of those. The browser-side cache pin in
+        ``test_context_gateway_overview.py`` covers the langchange path
+        directly; this static check enforces the guard's structural
+        invariants — counter + capture + bail-on-stale."""
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
         assert "_ctxOverviewSeq" in text, (
             "missing _ctxOverviewSeq module counter — Bug-1 race guard"
@@ -677,12 +678,16 @@ class TestNoHardcodedStrings:
 
     def test_q_pr1_langchange_listener_reloads_overview(self) -> None:
         """Bug-1 single-toggle pin: the ``langchange`` listener in
-        context-gateway.js must call ``loadCtxOverview`` when the
-        overview section is the active settings pane — and only then.
+        context-gateway.js must re-render the inline-templated cards
+        when the overview section is the active settings pane — and only
+        then. After #825 the listener prefers ``_renderCtxOverview`` from
+        ``_ctxOverviewCache`` (no fetch, no spinner flash) and falls back
+        to ``loadCtxOverview`` only when the cache is empty (cold mount
+        race / prior fetch error).
 
         ``#settings-ctx-overview`` always exists in the DOM regardless of
         which page the user is on; gating on mere element existence
-        (``qs('ctx-overview-content')`` truthiness) would fire a fetch on
+        (``qs('ctx-overview-content')`` truthiness) would re-render on
         every language toggle from any page, not just the dashboard.
         The active-class gate matches ``switchSettingsSection``'s own
         ``section.classList.add('active')`` contract (app.js:1191).
@@ -695,8 +700,17 @@ class TestNoHardcodedStrings:
         )
         assert m, "langchange listener missing from context-gateway.js"
         body = m.group(1)
+        # Cache-driven re-render path is the primary action; the
+        # ``loadCtxOverview()`` cold-mount fallback covers the case when
+        # the cache is empty (initial mount race or prior fetch error).
+        # Both must be referenced inside the listener.
+        assert "_renderCtxOverview(_ctxOverviewCache)" in body, (
+            "langchange listener must re-render from _ctxOverviewCache directly "
+            "(#825 — no fetch, no panelLoading flash on toggle)"
+        )
         assert "loadCtxOverview()" in body, (
-            "langchange listener must call loadCtxOverview() for the inline-templated cards"
+            "langchange listener must keep the loadCtxOverview() cold-mount "
+            "fallback for when _ctxOverviewCache is null"
         )
         # Two-gate active check: both the main Settings tab
         # (``#tab-settings``) AND the Context Gateway settings sub-section

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -1,19 +1,18 @@
-"""Browser tests for the Context Gateway overview dashboard (Q-PR1).
+"""Browser tests for the Context Gateway overview dashboard (Q-PR1, #825).
 
 Pin three pieces of audit-driven behavior that file-scan regression guards
 in ``test_i18n.py`` cannot exercise:
 
-* **Bug-1, multi-toggle race**: rapid lang toggles must surface only the
-  newest locale on the cards. Without the ``_ctxOverviewSeq`` guard in
-  ``loadCtxOverview`` (context-gateway.js), a slow first fetch can land
-  *after* a second toggle and clobber the newer locale's cards with stale
-  text. The timing is forced by delaying the KO response in the route
-  handler so the EN response wins the render race; the late KO arrival
-  must then be dropped by the seq guard.
 * **Bug-1, single-toggle re-render**: lang toggle must re-render the cards
   when the section is mounted. ``I18N.applyDOM`` does not handle inline
-  ``t()`` text in innerHTML, so ``loadCtxOverview`` itself runs on
-  ``langchange``.
+  ``t()`` text in innerHTML, so the ``langchange`` listener calls
+  ``_renderCtxOverview`` directly.
+* **#825, no spinner flash on lang toggle**: a healthy mounted dashboard
+  caches its last ``/api/context/overview`` payload in
+  ``_ctxOverviewCache``; subsequent lang toggles re-render from the
+  cache — no refetch, no ``panelLoading`` spinner flash. Drops the
+  round-trip the langchange listener used to issue (also addresses #824
+  review P2 about langchange firing one fetch per toggle).
 * **Bug-2, zero-state empty badge**: a ``total === 0`` tile must render
   the ``Empty`` badge (``settings.ctx.badge_empty``) with ``badge-gray``,
   not the green ``0/0 synced`` fallthrough.
@@ -25,7 +24,6 @@ is off (see ``conftest.py`` docstring) so no real backend writes happen.
 from __future__ import annotations
 
 import json
-import time
 
 import pytest
 
@@ -171,17 +169,26 @@ def test_zero_total_renders_empty_badge_not_green_synced(page, mm_web_url: str) 
 def test_langchange_rerenders_card_label_text(page, mm_web_url: str) -> None:
     """Bug-1 single-toggle pin: ``langchange`` must re-render
     ``ctx-overview-content`` so inline-templated ``t()`` text picks up the
-    new locale. ``I18N.applyDOM`` only walks ``data-i18n*`` attributes; the
-    cards are inline-templated, so without the explicit ``loadCtxOverview``
-    call in the langchange listener, the EN→KO toggle leaves cards in EN.
-    """
+    new locale. ``I18N.applyDOM`` only walks ``data-i18n*`` attributes;
+    the cards are inline-templated, so without the explicit
+    ``_renderCtxOverview`` call in the langchange listener the EN→KO
+    toggle leaves cards in EN.
+
+    Cross-pinned with #825: the cache-driven re-render path means no
+    refetch on toggle — the assertion captures the call count before
+    and after to catch a regression that re-introduced the
+    fetch-on-langchange behavior."""
     _install_default_stubs(page)
-    page.route(
-        "**/api/context/overview",
-        lambda r: r.fulfill(
+
+    overview_calls: list[str] = []
+
+    def _overview_handler(route):
+        overview_calls.append(route.request.url)
+        route.fulfill(
             status=200, content_type="application/json", body=json.dumps(_HEALTHY_OVERVIEW)
-        ),
-    )
+        )
+
+    page.route("**/api/context/overview", _overview_handler)
     page.goto(mm_web_url)
     _open_context_gateway(page)
 
@@ -191,18 +198,16 @@ def test_langchange_rerenders_card_label_text(page, mm_web_url: str) -> None:
     label = skills_tile.locator(".ctx-overview-label")
     pre = (label.text_content() or "").strip()
     assert pre == "Skills", f"default locale (EN) tile label should be 'Skills', got {pre!r}"
+    initial_calls = len(overview_calls)
+    assert initial_calls >= 1, (
+        f"dashboard mount should fire at least one overview fetch; got {overview_calls!r}"
+    )
 
     # Toggle EN→KO. ``I18N.setLang`` awaits the locale fetch, applyDOM, and
     # then dispatches ``langchange`` (i18n.js L65-76); the ``langchange``
-    # listener in context-gateway.js calls ``loadCtxOverview`` which
-    # re-fires ``/api/context/overview``. Wait for the request to land
-    # so the assertion below doesn't race the re-render.
-    with page.expect_request("**/api/context/overview", timeout=2_000):
-        page.evaluate("() => I18N.setLang('ko')")
-    # ``loadCtxOverview`` calls ``panelLoading(el)`` before the new fetch
-    # resolves; that wipes the inner tiles and replaces them with a
-    # spinner. Use a null-safe wait so the polling doesn't trip on the
-    # transient empty state between the wipe and the re-render.
+    # listener in context-gateway.js re-renders synchronously from
+    # ``_ctxOverviewCache`` — no fetch, no spinner.
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
     page.wait_for_function(
         "() => {"
         "  const el = document.querySelector("
@@ -226,45 +231,39 @@ def test_langchange_rerenders_card_label_text(page, mm_web_url: str) -> None:
     # behavior would also pass the positive assertion above on a partial
     # rerender that updated some attributes but not the inline text).
     assert "Skills" not in post, f"EN literal must not linger after KO toggle: {post!r}"
+    # #825: cache-driven re-render means no extra fetch on toggle.
+    assert len(overview_calls) == initial_calls, (
+        f"lang toggle must re-render from _ctxOverviewCache, no refetch; "
+        f"baseline={initial_calls}, after={len(overview_calls)}, "
+        f"calls={overview_calls!r} (#825)"
+    )
 
 
-def test_multi_toggle_race_keeps_newest_locale_on_cards(page, mm_web_url: str) -> None:
-    """Bug-1 multi-toggle race pin: when a slow first fetch lands *after*
-    a second lang toggle, the newer locale's cards must remain — the
-    older response's stale render must be dropped by the
-    ``_ctxOverviewSeq`` guard in ``loadCtxOverview``.
+def test_langchange_uses_cache_no_spinner_flash(page, mm_web_url: str) -> None:
+    """#825 pin: lang toggle on a healthy mounted dashboard must re-render
+    from ``_ctxOverviewCache`` directly — no refetch and, crucially, no
+    ``panelLoading`` spinner flash between the wipe and the response
+    render. The cards should feel like an in-place text swap, not a
+    panel reload.
 
-    Drive the race deterministically: the first ``/api/context/overview``
-    response is held until after a second ``setLang`` has fired its own
-    request and rendered. Then we release the first response. Without
-    the seq guard the first (KO) response would clobber the second (EN)
-    render and the assertion would catch it.
+    Two regressions this catches:
 
-    Mutation check: temporarily removing the
-    ``if (seq !== _ctxOverviewSeq) return`` line in ``loadCtxOverview``
-    fails this spec because the held KO response wins on arrival order.
-    """
+    * Approach-1 partial fix (``loadCtxOverview({ silent: true })``) that
+      keeps the fetch but skips ``panelLoading`` — the ``overview_calls``
+      assertion catches the unnecessary round-trip.
+    * Reverting to the pre-#825 ``loadCtxOverview()`` call from the
+      langchange listener — both the spinner-flash assertion and the
+      ``overview_calls`` assertion catch this.
+
+    Three sequential toggles (EN→KO→EN→KO) stress the cache-hit path
+    repeatedly so a one-shot cache-fill that then falls back to fetch
+    would still surface as ``overview_calls > initial_calls``."""
     _install_default_stubs(page)
 
-    # Three calls hit ``/api/context/overview`` during this spec:
-    #   1) initial EN load by ``_open_context_gateway``     (immediate)
-    #   2) KO toggle dispatched (delayed in stub so it races EN)
-    #   3) EN toggle dispatched after, returns immediately
-    # The KO response is delayed inside the route handler — Playwright
-    # runs each handler on a worker thread, so a sync ``time.sleep`` here
-    # parks call 2's response without stalling the page event loop or
-    # blocking call 3 from being served on a separate worker thread.
-    # Awaiting each ``setLang`` promise from Python guarantees call 2 is
-    # the KO request and call 3 is the EN one (without the await, the
-    # second toggle's ``langchange`` could be dispatched before the
-    # first's, swapping which request is delayed).
-    call_seq = {"calls": 0}
-    KO_DELAY = 0.6  # seconds; long enough that EN fully renders before KO arrives
+    overview_calls: list[str] = []
 
     def _overview_handler(route):
-        call_seq["calls"] += 1
-        if call_seq["calls"] == 2:
-            time.sleep(KO_DELAY)
+        overview_calls.append(route.request.url)
         route.fulfill(
             status=200, content_type="application/json", body=json.dumps(_HEALTHY_OVERVIEW)
         )
@@ -272,28 +271,42 @@ def test_multi_toggle_race_keeps_newest_locale_on_cards(page, mm_web_url: str) -
     page.route("**/api/context/overview", _overview_handler)
     page.goto(mm_web_url)
     _open_context_gateway(page)
+    initial_calls = len(overview_calls)
+    assert initial_calls >= 1, (
+        f"dashboard mount should fire at least one overview fetch; got {overview_calls!r}"
+    )
 
-    # First toggle EN→KO. Awaiting the setLang promise guarantees the KO
-    # ``langchange`` (and its ``loadCtxOverview`` fetch) has been dispatched
-    # before the EN toggle starts. ``loadCtxOverview`` itself is
-    # fire-and-forget from inside the listener, so the await returns
-    # while the KO fetch is still in flight — which is exactly the race
-    # window we want.
+    # Spinner-flash detection. ``panelLoading`` injects
+    # ``<div class="loading-panel">…</div>`` into ``#ctx-overview-content``;
+    # the cache-driven re-render rewrites innerHTML directly with the
+    # rendered grid (no intermediate spinner state). A MutationObserver
+    # that latches on any ``.loading-panel`` appearance during the
+    # toggle window catches both the ``panelLoading`` flash *and* a
+    # partial fix that kept the spinner but dropped the fetch.
+    page.evaluate(
+        """() => {
+            window._spinnerSeen = false;
+            const el = document.getElementById('ctx-overview-content');
+            const obs = new MutationObserver(() => {
+                if (el.querySelector('.loading-panel')) {
+                    window._spinnerSeen = true;
+                }
+            });
+            obs.observe(el, { childList: true, subtree: true });
+            window._spinnerObserver = obs;
+        }"""
+    )
+
     page.evaluate("async () => { await I18N.setLang('ko'); }")
-    # Belt-and-braces: don't proceed to EN until the KO request is
-    # actually parked in the route handler. Use ``page.wait_for_timeout``
-    # to poll — a pure-Python ``time.sleep`` would hold the sync_playwright
-    # main thread and starve Playwright's own callback dispatch (the
-    # very route handler whose ``calls`` we're polling).
-    deadline = time.monotonic() + 2.0
-    while call_seq["calls"] < 2 and time.monotonic() < deadline:
-        page.wait_for_timeout(20)
-    assert call_seq["calls"] >= 2, "KO toggle's overview fetch did not dispatch"
-
-    # Second toggle KO→EN. Wait for the EN response to render. The EN
-    # request is call 3 and fulfills immediately (no delay branch), so
-    # the cards land on Skills well within timeout while the KO response
-    # is still parked in its delay sleep.
+    page.wait_for_function(
+        "() => {"
+        "  const el = document.querySelector("
+        '    \'#ctx-overview-content .ctx-overview-stat[data-section="ctx-skills"] '
+        ".ctx-overview-label');"
+        "  return el && el.textContent.trim() === '스킬';"
+        "}",
+        timeout=2_000,
+    )
     page.evaluate("async () => { await I18N.setLang('en'); }")
     page.wait_for_function(
         "() => {"
@@ -302,26 +315,30 @@ def test_multi_toggle_race_keeps_newest_locale_on_cards(page, mm_web_url: str) -
         ".ctx-overview-label');"
         "  return el && el.textContent.trim() === 'Skills';"
         "}",
-        timeout=3_000,
+        timeout=2_000,
+    )
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
+    page.wait_for_function(
+        "() => {"
+        "  const el = document.querySelector("
+        '    \'#ctx-overview-content .ctx-overview-stat[data-section="ctx-skills"] '
+        ".ctx-overview-label');"
+        "  return el && el.textContent.trim() === '스킬';"
+        "}",
+        timeout=2_000,
     )
 
-    # Wait long enough for the delayed KO response to land (or be dropped
-    # by the seq guard). KO_DELAY is the upper bound on its arrival; pad
-    # a bit so the assertion is sampled after the late response has
-    # had its chance to clobber the EN render.
-    page.wait_for_timeout(int(KO_DELAY * 1000) + 300)
-
-    label = page.locator(
-        "#ctx-overview-content .ctx-overview-stat[data-section='ctx-skills'] .ctx-overview-label"
+    assert len(overview_calls) == initial_calls, (
+        f"three lang toggles must re-render from _ctxOverviewCache without "
+        f"refetching; baseline={initial_calls}, after={len(overview_calls)}, "
+        f"calls={overview_calls!r} (#825)"
     )
-    final = (label.text_content() or "").strip()
-    assert final == "Skills", (
-        f"newest locale (EN) must remain after late KO arrival; got {final!r}. "
-        "Without _ctxOverviewSeq the KO render would overwrite EN."
+    spinner_seen = page.evaluate("() => window._spinnerSeen")
+    assert spinner_seen is False, (
+        "lang toggle on a cached dashboard must not flash panelLoading; the "
+        "cache-driven _renderCtxOverview path rewrites innerHTML directly "
+        "without an intermediate spinner state (#825)"
     )
-    # Negative: the KO literal must not be present anywhere on the
-    # tile, even partially — a half-clobber is still a regression.
-    assert "스킬" not in final, f"old locale must not bleed through after race: {final!r}"
 
 
 def test_langchange_after_tab_switch_does_not_refetch_overview(page, mm_web_url: str) -> None:


### PR DESCRIPTION
## Summary

- **Closes #825.** Lang toggles on the Context Gateway dashboard wiped the cards to a `panelLoading` spinner for the duration of `/api/context/overview`, producing a brief disappear/reappear flash for what should be an in-place text swap. The fetch was also redundant — the data is locale-independent (counts, statuses); only the labels and badge copy translate.
- **Approach 2 from the issue (cache-driven re-render).** A module-scope `_ctxOverviewCache` holds the last successful payload; the `langchange` listener re-renders directly from it via the new `_renderCtxOverview(data)` helper — no fetch, no spinner. Cold-mount fallback to `loadCtxOverview()` covers the empty-cache case (initial mount race / prior fetch error).
- **Drops a network round-trip per toggle**, addressing the side concern from PR #824 review P2 (`langchange listener fires the fetch`).

## What changed

- `_renderCtxOverview(data)` extracted from `loadCtxOverview()`. The fetch path now: fetch → seq-guard → cache → render.
- `_ctxOverviewCache` populated on success, cleared on fetch error so the next call falls back to a fresh fetch path.
- `langchange` listener: `if (_ctxOverviewCache) _renderCtxOverview(...)` else cold-mount `loadCtxOverview()`.
- Sequence guard kept in `loadCtxOverview` for in-flight races still reachable from the Refresh button, end of Sync All, and rapid cold mounts.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_context_gateway_overview.py -m "not ollama"` — 7/7 pass
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -m "not ollama"` — 33/33 pass (source-scan guards updated for the new `_renderCtxOverview(_ctxOverviewCache)` reference + `loadCtxOverview()` cold-mount fallback)
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` + `ruff format --check` — clean
- [x] Mutation check: reverting the langchange listener to `loadCtxOverview()` unconditionally fails both the new no-fetch assertion and the MutationObserver-based no-spinner assertion in `test_langchange_uses_cache_no_spinner_flash`.

## New / updated browser pins

- `test_langchange_uses_cache_no_spinner_flash` — three sequential toggles (EN→KO→EN→KO), asserts (a) no extra `/api/context/overview` fetch beyond the mount baseline, (b) no `.loading-panel` appearance during any toggle (MutationObserver scoped to `#ctx-overview-content`).
- `test_langchange_rerenders_card_label_text` — kept the label-flip + EN-literal-gone pins; replaced `expect_request` (premise gone) with a no-fetch assertion that catches a regression to fetch-on-langchange.
- Removed `test_multi_toggle_race_keeps_newest_locale_on_cards`. Its premise — langchange firing fetches that race each other — no longer applies. The seq guard's structural invariants still pass static-source coverage in `test_q_pr1_overview_has_sequence_guard` (docstring updated to reflect the new role: cold-mount / Refresh / Sync-All races, not lang toggles).
