### PR TITLE
feat(cli): mm sync-doctor — read-only validator for private-repo multi-device sync

### DIFF
--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -56,6 +56,7 @@ def _register() -> None:
     from memtomem.cli.session_cmd import activity, session
     from memtomem.cli.shell import shell
     from memtomem.cli.status_cmd import status
+    from memtomem.cli.sync_doctor_cmd import sync_doctor
     from memtomem.cli.uninstall_cmd import uninstall
     from memtomem.cli.upgrade_cmd import upgrade
     from memtomem.cli.watchdog_cmd import watchdog
@@ -76,6 +77,7 @@ def _register() -> None:
     cli.add_command(session)
     cli.add_command(activity)
     cli.add_command(status)
+    cli.add_command(sync_doctor)
     cli.add_command(watchdog)
     cli.add_command(schedule)
     cli.add_command(web)

--- a/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
@@ -28,35 +28,51 @@ import click
 
 # ---- Cloud-mount path-prefix helper ----------------------------------------
 #
-# Pure path-prefix match against the user's expanded ``$HOME``. No fs probing,
-# no platform branching — the prefix list is fixed (RFC §Phase 2). Intended to
-# be applied to each entry in ``memory_dirs[]`` after ``Path.expanduser()``.
-
-CLOUD_MOUNT_PREFIXES: tuple[str, ...] = (
-    "~/Library/CloudStorage/",
-    "~/Library/Mobile Documents/com~apple~CloudDocs/",
-    "~/Dropbox/",
-    "~/OneDrive",  # matches OneDrive, OneDrive-Personal, "OneDrive - Foo", etc.
-)
+# Pure path comparison against a fixed list of cloud-sync mounts under
+# ``$HOME`` (RFC §Phase 2). No fs probing. ``Path.relative_to`` keeps the
+# match separator-safe on Windows (``\\``) as well as POSIX (``/``).
+#
+# Matched prefixes (display form):
+#   ~/Library/CloudStorage/                          (macOS sync clients)
+#   ~/Library/Mobile Documents/com~apple~CloudDocs/  (iCloud Drive on macOS)
+#   ~/Dropbox/                                       (Dropbox legacy fallback)
+#   ~/OneDrive*/                                     (OneDrive, any suffix variant)
 
 
 def cloud_mount_prefix(path: Path, *, home: Path | None = None) -> str | None:
     """Return matched cloud-mount prefix (display form), or ``None`` if none.
 
     ``path`` should already be expanded (``Path.expanduser()``). ``home`` is
-    overridable for tests; defaults to ``Path.home()``.
+    overridable for tests; defaults to ``Path.home()``. Comparison goes through
+    ``Path.relative_to`` so the result is separator-safe on Windows (``\\`` vs
+    ``/``).
     """
-    home_s = str(home or Path.home())
-    s = str(path)
-    for prefix in CLOUD_MOUNT_PREFIXES:
-        expanded = prefix.replace("~", home_s, 1)
-        if prefix == "~/OneDrive":
-            if s.startswith(expanded):
-                rest = s[len(expanded) :]
-                if not rest or rest[0] in "-_ /":
-                    return "~/OneDrive*/"
-        elif s.startswith(expanded):
-            return prefix
+    home_p = home or Path.home()
+    fixed = (
+        ("~/Library/CloudStorage/", home_p / "Library" / "CloudStorage"),
+        (
+            "~/Library/Mobile Documents/com~apple~CloudDocs/",
+            home_p / "Library" / "Mobile Documents" / "com~apple~CloudDocs",
+        ),
+        ("~/Dropbox/", home_p / "Dropbox"),
+    )
+    for label, root in fixed:
+        try:
+            path.relative_to(root)
+        except ValueError:
+            continue
+        return label
+    # OneDrive variants: matches ``OneDrive``, ``OneDrive-Personal``,
+    # ``OneDrive - Acme``; rejects substring false positives like ``OneDriveX``.
+    try:
+        rel = path.relative_to(home_p)
+    except ValueError:
+        return None
+    if not rel.parts:
+        return None
+    head = rel.parts[0]
+    if head == "OneDrive" or (head.startswith("OneDrive") and len(head) > 8 and head[8] in "-_ "):
+        return "~/OneDrive*/"
     return None
 
 

--- a/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
@@ -99,15 +99,46 @@ def _emit(result: CheckResult) -> None:
 # ---- Individual checks -----------------------------------------------------
 
 
-def _git_ls_files(cwd: Path) -> list[str] | None:
-    """Return ``git ls-files`` output split per line, or ``None`` if not a repo."""
+def _repo_top_level(start: Path) -> Path | None:
+    """Return the git top-level above ``start``, or ``None`` if not in a repo."""
     git = shutil.which("git")
     if git is None:
         return None
     try:
         proc = subprocess.run(
+            [git, "rev-parse", "--show-toplevel"],
+            cwd=str(start),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    top = proc.stdout.strip()
+    return Path(top) if top else None
+
+
+def _git_ls_files(start: Path) -> list[str] | None:
+    """List every tracked path in the enclosing repo, or ``None`` if not a repo.
+
+    Resolves the repository top-level first so the listing covers the whole
+    private repo regardless of the subdirectory the doctor was invoked from.
+    Plain ``git ls-files`` from a nested dir only yields paths *under* that
+    dir, which would let the doctor miss a tracked root-level
+    ``config.json`` or ``*.db``.
+    """
+    git = shutil.which("git")
+    if git is None:
+        return None
+    repo_root = _repo_top_level(start)
+    if repo_root is None:
+        return None
+    try:
+        proc = subprocess.run(
             [git, "ls-files"],
-            cwd=str(cwd),
+            cwd=str(repo_root),
             capture_output=True,
             text=True,
             check=False,
@@ -192,27 +223,100 @@ def check_cloud_mount(memory_dirs: list[Path]) -> CheckResult:
 
 
 def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
-    """Verify ``~/.claude/projects/<slug>`` for the current cwd exists.
+    """Verify ``~/.claude/projects/<slug>`` matches the current cwd.
 
     Skipped silently when ``~/.claude/projects/`` is absent (user doesn't run
-    Claude Code). When present, the cwd must round-trip to a real entry under
-    that directory; otherwise the synced auto-memory layout is broken for this
-    machine.
+    Claude Code). Two-tier match:
+
+    1. **Fast path** — encode ``cwd`` (POSIX ``/`` → ``-``, Windows ``\\`` /
+       drive ``:`` → ``-``) and look up the resulting directory directly. The
+       previous one-shot ``str(cwd).replace("/", "-")`` only handled POSIX
+       and produced an invalid slug on Windows (drive prefix + backslashes
+       remained), causing false failures for valid Windows layouts.
+    2. **Slow path** — iterate real entries and decode-then-``samefile`` each
+       against ``cwd``. Catches cases where the encoded form isn't
+       predictable (e.g., the entry on disk uses an encoding variant we
+       didn't enumerate) but skips entries whose name has literal dashes
+       and so doesn't round-trip to a real directory.
     """
     projects = (home or Path.home()) / ".claude" / "projects"
     if not projects.is_dir():
         return CheckResult("info", "~/.claude/projects/ absent — auto-memory check skipped")
-    encoded = str(cwd.resolve()).replace("/", "-")
-    if (projects / encoded).is_dir():
-        return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
+    try:
+        cwd_resolved = cwd.resolve()
+    except OSError:
+        return CheckResult("info", "cwd resolution failed — Claude slug check skipped")
+    cwd_str = str(cwd_resolved)
+    encoded_candidates = {
+        cwd_str.replace("/", "-"),  # POSIX absolute
+        cwd_str.replace("\\", "-").replace(":", ""),  # Windows: drop drive colon
+        cwd_str.replace("\\", "-").replace(":", "-"),  # Windows: encode drive colon as "-"
+    }
+    for cand in encoded_candidates:
+        # Skip candidates that still contain a path separator — the encoding
+        # didn't fully strip them (wrong platform), and ``projects / cand``
+        # would silently resolve to ``cand`` itself when it's absolute.
+        if "/" in cand or "\\" in cand:
+            continue
+        if (projects / cand).is_dir():
+            return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
+    # Slow path: decode existing entries and samefile-compare.
+    for child in projects.iterdir():
+        if not child.is_dir():
+            continue
+        # Decode follows ``_decode_claude_project_dirname`` in
+        # ``memtomem.context.projects``: every ``-`` becomes ``/``.
+        decoded = Path(child.name.replace("-", "/"))
+        try:
+            if decoded.is_dir() and decoded.samefile(cwd):
+                return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
+        except OSError:
+            continue
     return CheckResult(
         "fail",
         "~/.claude/projects/ slug differs from synced layout — see doc",
-        detail=f"expected entry: {projects}/{encoded}",
+        detail=f"no entry under {projects} matches cwd",
     )
 
 
 # ---- Click entry point -----------------------------------------------------
+
+
+def _apply_memory_dirs_override_no_write(cfg: object) -> None:
+    """Read ``~/.memtomem/config.json``'s ``indexing.memory_dirs`` into ``cfg``.
+
+    Read-only mirror of the relevant slice of ``load_config_overrides`` — the
+    full loader also calls ``_migrate_auto_discover_once`` which rewrites
+    ``config.json`` on legacy ``auto_discover=True`` installs. The doctor
+    must not mutate config (RFC §Non-goals: read-only).
+
+    Env precedence (``MEMTOMEM_INDEXING__MEMORY_DIRS``) is preserved by
+    deferring to whatever ``Mem2MemConfig()`` already loaded.
+    """
+    import json
+    import os
+
+    from memtomem.config import _override_path
+
+    path = _override_path()
+    if not path.exists():
+        return
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    indexing = data.get("indexing") if isinstance(data, dict) else None
+    if not isinstance(indexing, dict):
+        return
+    md = indexing.get("memory_dirs")
+    if not isinstance(md, list):
+        return
+    if "MEMTOMEM_INDEXING__MEMORY_DIRS" in os.environ:
+        return  # env wins, mirroring load_config_overrides
+    try:
+        cfg.indexing.memory_dirs = [Path(p) for p in md if isinstance(p, str)]  # type: ignore[attr-defined]
+    except (TypeError, ValueError):
+        return
 
 
 @click.command("sync-doctor")
@@ -223,13 +327,17 @@ def sync_doctor() -> None:
     + ``config.d/``). Reports six checks; exits non-zero on any failure. Warns
     don't fail the exit code (a future ``--strict`` may flip that).
     """
-    from memtomem.config import Mem2MemConfig, _config_d_path, load_config_d, load_config_overrides
+    from memtomem.config import Mem2MemConfig, _config_d_path, load_config_d
 
     cfg = Mem2MemConfig()
     load_config_d(cfg, quiet=True)
-    load_config_overrides(cfg)
+    _apply_memory_dirs_override_no_write(cfg)
 
     cwd = Path.cwd()
+    # Slug check anchors at the repo top-level so subdir invocations still
+    # match the project Claude Code recorded for the repo (which is the dir
+    # ``claude`` was launched from — typically the repo root, not a subdir).
+    repo_root = _repo_top_level(cwd) or cwd
     memory_dirs = list(cfg.indexing.memory_dirs)
     config_d = _config_d_path()
 
@@ -237,7 +345,7 @@ def sync_doctor() -> None:
         check_no_db_staged(cwd),
         check_config_json_absent(cwd),
         check_config_d_present(config_d),
-        check_claude_slug(cwd),
+        check_claude_slug(repo_root),
         check_memory_dirs_under_home(memory_dirs),
         check_cloud_mount(memory_dirs),
     ]

--- a/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
@@ -1,0 +1,233 @@
+"""CLI: ``mm sync-doctor`` — read-only validator for private-repo multi-device sync.
+
+Implements Phase 2 of the multi-device sync RFC (memtomem-docs#34). Catches the
+common footguns the RFC documents:
+
+- ``*.db`` files staged in the worktree (would propagate to other devices and
+  corrupt SQLite under WAL).
+- ``config.json`` staged (machine-local; only ``config.d/`` is portable).
+- ``~/.memtomem/config.d/`` fragments missing on this machine (the synced
+  ``config.d/`` was never bridged into the canonical location).
+- ``memory_dirs`` paths under cloud-sync mounts where the fs watcher is
+  unreliable; recommend ``startup_backfill=true``.
+- ``~/.claude/projects/`` cwd slug doesn't match the current working tree (the
+  per-project auto-memory layout is broken for this machine).
+
+No ``push`` / ``pull`` / auto-fix. Read-only by design (RFC §Non-goals).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+import click
+
+
+# ---- Cloud-mount path-prefix helper ----------------------------------------
+#
+# Pure path-prefix match against the user's expanded ``$HOME``. No fs probing,
+# no platform branching — the prefix list is fixed (RFC §Phase 2). Intended to
+# be applied to each entry in ``memory_dirs[]`` after ``Path.expanduser()``.
+
+CLOUD_MOUNT_PREFIXES: tuple[str, ...] = (
+    "~/Library/CloudStorage/",
+    "~/Library/Mobile Documents/com~apple~CloudDocs/",
+    "~/Dropbox/",
+    "~/OneDrive",  # matches OneDrive, OneDrive-Personal, "OneDrive - Foo", etc.
+)
+
+
+def cloud_mount_prefix(path: Path, *, home: Path | None = None) -> str | None:
+    """Return matched cloud-mount prefix (display form), or ``None`` if none.
+
+    ``path`` should already be expanded (``Path.expanduser()``). ``home`` is
+    overridable for tests; defaults to ``Path.home()``.
+    """
+    home_s = str(home or Path.home())
+    s = str(path)
+    for prefix in CLOUD_MOUNT_PREFIXES:
+        expanded = prefix.replace("~", home_s, 1)
+        if prefix == "~/OneDrive":
+            if s.startswith(expanded):
+                rest = s[len(expanded) :]
+                if not rest or rest[0] in "-_ /":
+                    return "~/OneDrive*/"
+        elif s.startswith(expanded):
+            return prefix
+    return None
+
+
+# ---- Check result model ----------------------------------------------------
+
+Status = Literal["pass", "fail", "warn", "info"]
+
+_GLYPH = {"pass": "✓", "fail": "✗", "warn": "!", "info": "·"}
+_COLOR = {"pass": "green", "fail": "red", "warn": "yellow", "info": None}
+
+
+class CheckResult(NamedTuple):
+    status: Status
+    message: str
+    detail: str | None = None  # second-line elaboration, optional
+
+
+def _emit(result: CheckResult) -> None:
+    click.secho(f"{_GLYPH[result.status]} {result.message}", fg=_COLOR[result.status])
+    if result.detail:
+        click.echo(f"  {result.detail}")
+
+
+# ---- Individual checks -----------------------------------------------------
+
+
+def _git_ls_files(cwd: Path) -> list[str] | None:
+    """Return ``git ls-files`` output split per line, or ``None`` if not a repo."""
+    git = shutil.which("git")
+    if git is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [git, "ls-files"],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return [line for line in proc.stdout.splitlines() if line]
+
+
+def check_no_db_staged(cwd: Path) -> CheckResult:
+    files = _git_ls_files(cwd)
+    if files is None:
+        return CheckResult("warn", "not a git repo at cwd — skipping git checks")
+    db_suffixes = (".db", ".db-wal", ".db-shm")
+    matches = [f for f in files if f.endswith(db_suffixes)]
+    if matches:
+        sample = ", ".join(matches[:3]) + (" …" if len(matches) > 3 else "")
+        return CheckResult("fail", f"{len(matches)} *.db file(s) staged", detail=sample)
+    return CheckResult("pass", "no *.db files staged")
+
+
+def check_config_json_absent(cwd: Path) -> CheckResult:
+    files = _git_ls_files(cwd)
+    if files is None:
+        return CheckResult("warn", "config.json staging — not a git repo at cwd")
+    if any(f == "config.json" or f.endswith("/config.json") for f in files):
+        return CheckResult("fail", "config.json staged (machine-local — should not sync)")
+    return CheckResult("pass", "config.json absent from worktree")
+
+
+def check_config_d_present(config_d: Path) -> CheckResult:
+    if not config_d.is_dir():
+        return CheckResult(
+            "warn",
+            "~/.memtomem/config.d/ does not exist on this machine",
+            detail="bridge synced fragments via symlink/copy per RFC §Design",
+        )
+    fragments = sorted(config_d.glob("*.json"))
+    if not fragments:
+        return CheckResult("warn", "config.d/ has no fragments — sync bridge may be missing")
+    return CheckResult("pass", f"config.d/ fragments present ({len(fragments)} files)")
+
+
+def check_memory_dirs_under_home(memory_dirs: list[Path]) -> CheckResult:
+    home = Path.home().resolve()
+    outside: list[str] = []
+    for d in memory_dirs:
+        try:
+            resolved = Path(d).expanduser().resolve()
+        except (OSError, RuntimeError):
+            continue
+        try:
+            resolved.relative_to(home)
+        except ValueError:
+            outside.append(str(d))
+    if outside:
+        return CheckResult(
+            "warn",
+            f"{len(outside)} memory_dir(s) outside $HOME — not portable across users",
+            detail=outside[0] + (" …" if len(outside) > 1 else ""),
+        )
+    return CheckResult("pass", "memory_dir paths resolve under $HOME")
+
+
+def check_cloud_mount(memory_dirs: list[Path]) -> CheckResult:
+    hits: list[tuple[str, str]] = []  # (display_path, prefix_label)
+    for d in memory_dirs:
+        expanded = Path(d).expanduser()
+        prefix = cloud_mount_prefix(expanded)
+        if prefix:
+            hits.append((str(d), prefix))
+    if not hits:
+        return CheckResult("pass", "no memory_dir under known cloud-sync mounts")
+    label = hits[0][1]
+    return CheckResult(
+        "warn",
+        f"cloud-sync mount detected at {label} — fs watcher may miss events",
+        detail="recommend startup_backfill=true",
+    )
+
+
+def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
+    """Verify ``~/.claude/projects/<slug>`` for the current cwd exists.
+
+    Skipped silently when ``~/.claude/projects/`` is absent (user doesn't run
+    Claude Code). When present, the cwd must round-trip to a real entry under
+    that directory; otherwise the synced auto-memory layout is broken for this
+    machine.
+    """
+    projects = (home or Path.home()) / ".claude" / "projects"
+    if not projects.is_dir():
+        return CheckResult("info", "~/.claude/projects/ absent — auto-memory check skipped")
+    encoded = str(cwd.resolve()).replace("/", "-")
+    if (projects / encoded).is_dir():
+        return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
+    return CheckResult(
+        "fail",
+        "~/.claude/projects/ slug differs from synced layout — see doc",
+        detail=f"expected entry: {projects}/{encoded}",
+    )
+
+
+# ---- Click entry point -----------------------------------------------------
+
+
+@click.command("sync-doctor")
+def sync_doctor() -> None:
+    """Validate the current working tree as a memtomem private-sync repo (read-only).
+
+    Run from inside the private repo (the one tracking your synced ``memories/``
+    + ``config.d/``). Reports six checks; exits non-zero on any failure. Warns
+    don't fail the exit code (a future ``--strict`` may flip that).
+    """
+    from memtomem.config import Mem2MemConfig, _config_d_path, load_config_d, load_config_overrides
+
+    cfg = Mem2MemConfig()
+    load_config_d(cfg, quiet=True)
+    load_config_overrides(cfg)
+
+    cwd = Path.cwd()
+    memory_dirs = list(cfg.indexing.memory_dirs)
+    config_d = _config_d_path()
+
+    results = [
+        check_no_db_staged(cwd),
+        check_config_json_absent(cwd),
+        check_config_d_present(config_d),
+        check_claude_slug(cwd),
+        check_memory_dirs_under_home(memory_dirs),
+        check_cloud_mount(memory_dirs),
+    ]
+
+    for r in results:
+        _emit(r)
+
+    if any(r.status == "fail" for r in results):
+        raise SystemExit(1)

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -99,6 +99,18 @@ class TestCheckNoDbStaged:
         r = check_no_db_staged(tmp_path)
         assert r.status == "warn"
 
+    def test_subdir_invocation_sees_root_files(self, tmp_path: Path) -> None:
+        # When invoked from a nested subdir, the check must still see
+        # tracked *.db at the repo root (reviewer note from PR #838).
+        _git_init(tmp_path)
+        (tmp_path / "snapshot.db").write_bytes(b"")
+        _git_add(tmp_path, "snapshot.db")
+        nested = tmp_path / "deep" / "nested"
+        nested.mkdir(parents=True)
+        r = check_no_db_staged(nested)
+        assert r.status == "fail"
+        assert "snapshot.db" in (r.detail or "")
+
 
 # ---- check_config_json_absent ----------------------------------------------
 
@@ -257,3 +269,70 @@ class TestSyncDoctorCli:
         assert result.exit_code == 0
         assert "no *.db files staged" in result.output
         assert "config.json absent from worktree" in result.output
+
+    def test_does_not_rewrite_legacy_config_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Reviewer note from PR #838: legacy installs (auto_discover=True
+        # + existing config.json) trigger _migrate_auto_discover_once via
+        # load_config_overrides, which rewrites config.json on disk. The
+        # doctor must be read-only (RFC §Non-goals).
+        import json
+
+        _set_home(monkeypatch, tmp_path)
+        memtomem_dir = tmp_path / ".memtomem"
+        memtomem_dir.mkdir()
+        config_json = memtomem_dir / "config.json"
+        config_json.write_text(
+            json.dumps({"indexing": {"auto_discover": True, "memory_dirs": ["~/notes"]}})
+        )
+        before = config_json.read_bytes()
+
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+        runner = CliRunner()
+        runner.invoke(cli, ["sync-doctor"])
+
+        assert config_json.read_bytes() == before, "sync-doctor must not rewrite config.json"
+
+    def test_subdir_invocation_finds_root_db(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End-to-end variant of the subdir-invocation fix: running
+        # ``mm sync-doctor`` from a nested subdir must still flag a *.db
+        # tracked at the repo root.
+        _set_home(monkeypatch, tmp_path)
+        _git_init(tmp_path)
+        (tmp_path / "leaked.db").write_bytes(b"")
+        _git_add(tmp_path, "leaked.db")
+        nested = tmp_path / "memories" / "shared"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync-doctor"])
+        assert result.exit_code == 1
+        assert "leaked.db" in result.output
+
+    def test_subdir_invocation_anchors_slug_at_repo_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The slug check should use the repo top-level, not the subdir cwd —
+        # otherwise a subdir invocation would see ``slug differs`` even when
+        # Claude Code has the repo root indexed correctly.
+        _set_home(monkeypatch, tmp_path)
+        _git_init(tmp_path)
+        nested = tmp_path / "memories" / "shared"
+        nested.mkdir(parents=True)
+
+        # Create a Claude project entry for the repo root (not the subdir).
+        projects = tmp_path / ".claude" / "projects"
+        projects.mkdir(parents=True)
+        slug = str(tmp_path.resolve()).replace("/", "-")
+        (projects / slug).mkdir()
+
+        monkeypatch.chdir(nested)
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync-doctor"])
+        assert "slug matches synced layout" in result.output
+        assert "slug differs" not in result.output

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -1,0 +1,248 @@
+"""Tests for ``mm sync-doctor`` (Phase 2 of multi-device sync RFC)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.cli.sync_doctor_cmd import (
+    check_claude_slug,
+    check_cloud_mount,
+    check_config_d_present,
+    check_config_json_absent,
+    check_memory_dirs_under_home,
+    check_no_db_staged,
+    cloud_mount_prefix,
+)
+
+
+def _git_init(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+
+
+def _git_add(repo: Path, *paths: str) -> None:
+    subprocess.run(["git", "add", *paths], cwd=repo, check=True)
+
+
+# ---- cloud_mount_prefix helper ---------------------------------------------
+
+
+class TestCloudMountPrefix:
+    def test_cloudstorage(self, tmp_path: Path) -> None:
+        p = tmp_path / "Library" / "CloudStorage" / "GoogleDrive-foo" / "memories"
+        assert cloud_mount_prefix(p, home=tmp_path) == "~/Library/CloudStorage/"
+
+    def test_icloud(self, tmp_path: Path) -> None:
+        p = tmp_path / "Library" / "Mobile Documents" / "com~apple~CloudDocs" / "memories"
+        assert (
+            cloud_mount_prefix(p, home=tmp_path)
+            == "~/Library/Mobile Documents/com~apple~CloudDocs/"
+        )
+
+    def test_dropbox(self, tmp_path: Path) -> None:
+        p = tmp_path / "Dropbox" / "memories"
+        assert cloud_mount_prefix(p, home=tmp_path) == "~/Dropbox/"
+
+    @pytest.mark.parametrize(
+        "name",
+        ["OneDrive", "OneDrive-Personal", "OneDrive - Acme"],
+    )
+    def test_onedrive_variants(self, tmp_path: Path, name: str) -> None:
+        p = tmp_path / name / "memories"
+        assert cloud_mount_prefix(p, home=tmp_path) == "~/OneDrive*/"
+
+    def test_no_match_under_home(self, tmp_path: Path) -> None:
+        p = tmp_path / ".memtomem" / "memories"
+        assert cloud_mount_prefix(p, home=tmp_path) is None
+
+    def test_onedrive_substring_no_false_positive(self, tmp_path: Path) -> None:
+        # ``~/OneDriveStuff`` is not a OneDrive mount — must not match.
+        p = tmp_path / "OneDriveStuff" / "x"
+        assert cloud_mount_prefix(p, home=tmp_path) is None
+
+
+# ---- check_no_db_staged ----------------------------------------------------
+
+
+class TestCheckNoDbStaged:
+    def test_clean(self, tmp_path: Path) -> None:
+        _git_init(tmp_path)
+        r = check_no_db_staged(tmp_path)
+        assert r.status == "pass"
+
+    @pytest.mark.parametrize("name", ["snapshot.db", "notes.db-wal", "notes.db-shm"])
+    def test_db_family_staged_fails(self, tmp_path: Path, name: str) -> None:
+        _git_init(tmp_path)
+        (tmp_path / name).write_bytes(b"")
+        _git_add(tmp_path, name)
+        r = check_no_db_staged(tmp_path)
+        assert r.status == "fail"
+
+    def test_not_a_git_repo_warns(self, tmp_path: Path) -> None:
+        r = check_no_db_staged(tmp_path)
+        assert r.status == "warn"
+
+
+# ---- check_config_json_absent ----------------------------------------------
+
+
+class TestCheckConfigJsonAbsent:
+    def test_clean(self, tmp_path: Path) -> None:
+        _git_init(tmp_path)
+        r = check_config_json_absent(tmp_path)
+        assert r.status == "pass"
+
+    def test_staged_at_root(self, tmp_path: Path) -> None:
+        _git_init(tmp_path)
+        (tmp_path / "config.json").write_text("{}")
+        _git_add(tmp_path, "config.json")
+        r = check_config_json_absent(tmp_path)
+        assert r.status == "fail"
+
+    def test_staged_at_subpath(self, tmp_path: Path) -> None:
+        _git_init(tmp_path)
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "config.json").write_text("{}")
+        _git_add(tmp_path, "sub/config.json")
+        r = check_config_json_absent(tmp_path)
+        assert r.status == "fail"
+
+
+# ---- check_config_d_present ------------------------------------------------
+
+
+class TestCheckConfigDPresent:
+    def test_present_with_fragments(self, tmp_path: Path) -> None:
+        d = tmp_path / "config.d"
+        d.mkdir()
+        (d / "10-rules.json").write_text("{}")
+        (d / "20-other.json").write_text("{}")
+        r = check_config_d_present(d)
+        assert r.status == "pass"
+        assert "2 files" in r.message
+
+    def test_dir_present_but_empty(self, tmp_path: Path) -> None:
+        d = tmp_path / "config.d"
+        d.mkdir()
+        r = check_config_d_present(d)
+        assert r.status == "warn"
+
+    def test_dir_missing(self, tmp_path: Path) -> None:
+        r = check_config_d_present(tmp_path / "absent")
+        assert r.status == "warn"
+
+
+# ---- check_memory_dirs_under_home ------------------------------------------
+
+
+class TestCheckMemoryDirsUnderHome:
+    def test_under_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        d = tmp_path / "memories"
+        d.mkdir()
+        r = check_memory_dirs_under_home([d])
+        assert r.status == "pass"
+
+    def test_outside_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        outside_home = tmp_path / "home"
+        outside_home.mkdir()
+        monkeypatch.setenv("HOME", str(outside_home))
+        # An entry under tmp_path but not under tmp_path/home.
+        outside = tmp_path / "elsewhere"
+        outside.mkdir()
+        r = check_memory_dirs_under_home([outside])
+        assert r.status == "warn"
+
+
+# ---- check_cloud_mount -----------------------------------------------------
+
+
+class TestCheckCloudMount:
+    def test_no_cloud(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        r = check_cloud_mount([tmp_path / "memories"])
+        assert r.status == "pass"
+
+    def test_dropbox_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        r = check_cloud_mount([tmp_path / "Dropbox" / "memories"])
+        assert r.status == "warn"
+        assert "Dropbox" in r.message
+
+
+# ---- check_claude_slug -----------------------------------------------------
+
+
+class TestCheckClaudeSlug:
+    def test_projects_dir_absent_is_info(self, tmp_path: Path) -> None:
+        # No ~/.claude/projects → skip the check entirely.
+        r = check_claude_slug(tmp_path, home=tmp_path / "home")
+        assert r.status == "info"
+
+    def test_slug_matches(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        cwd = home / "work" / "repo"
+        cwd.mkdir(parents=True)
+        projects = home / ".claude" / "projects"
+        projects.mkdir(parents=True)
+        slug = str(cwd.resolve()).replace("/", "-")
+        (projects / slug).mkdir()
+        r = check_claude_slug(cwd, home=home)
+        assert r.status == "pass"
+
+    def test_slug_mismatch_fails(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        cwd = home / "work" / "repo"
+        cwd.mkdir(parents=True)
+        projects = home / ".claude" / "projects"
+        projects.mkdir(parents=True)
+        (projects / "-Users-someone-else-repo").mkdir()
+        r = check_claude_slug(cwd, home=home)
+        assert r.status == "fail"
+
+
+# ---- CLI end-to-end --------------------------------------------------------
+
+
+class TestSyncDoctorCli:
+    def test_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync-doctor", "--help"])
+        assert result.exit_code == 0
+        assert "Validate" in result.output
+
+    def test_exits_nonzero_when_db_staged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+        (tmp_path / "snapshot.db").write_bytes(b"")
+        _git_add(tmp_path, "snapshot.db")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync-doctor"])
+        assert result.exit_code == 1
+        assert "*.db" in result.output
+
+    def test_pass_path_clean_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["sync-doctor"])
+        # Clean repo with a fresh fake HOME has no fragments and no claude
+        # projects dir; that's "warn" + "info", not "fail" — exit 0.
+        assert result.exit_code == 0
+        assert "no *.db files staged" in result.output
+        assert "config.json absent from worktree" in result.output

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -30,6 +30,17 @@ def _git_add(repo: Path, *paths: str) -> None:
     subprocess.run(["git", "add", *paths], cwd=repo, check=True)
 
 
+def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
+    """Point ``Path.home()`` at ``home`` on both POSIX and Windows.
+
+    ``os.path.expanduser`` consults ``USERPROFILE`` on Windows; setting only
+    ``HOME`` leaves Windows CI looking at the real user profile (reviewer
+    note from PR #838).
+    """
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+
 # ---- cloud_mount_prefix helper ---------------------------------------------
 
 
@@ -144,7 +155,7 @@ class TestCheckConfigDPresent:
 
 class TestCheckMemoryDirsUnderHome:
     def test_under_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_home(monkeypatch, tmp_path)
         d = tmp_path / "memories"
         d.mkdir()
         r = check_memory_dirs_under_home([d])
@@ -153,7 +164,7 @@ class TestCheckMemoryDirsUnderHome:
     def test_outside_home(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         outside_home = tmp_path / "home"
         outside_home.mkdir()
-        monkeypatch.setenv("HOME", str(outside_home))
+        _set_home(monkeypatch, outside_home)
         # An entry under tmp_path but not under tmp_path/home.
         outside = tmp_path / "elsewhere"
         outside.mkdir()
@@ -166,12 +177,12 @@ class TestCheckMemoryDirsUnderHome:
 
 class TestCheckCloudMount:
     def test_no_cloud(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_home(monkeypatch, tmp_path)
         r = check_cloud_mount([tmp_path / "memories"])
         assert r.status == "pass"
 
     def test_dropbox_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_home(monkeypatch, tmp_path)
         r = check_cloud_mount([tmp_path / "Dropbox" / "memories"])
         assert r.status == "warn"
         assert "Dropbox" in r.message
@@ -223,7 +234,7 @@ class TestSyncDoctorCli:
     def test_exits_nonzero_when_db_staged(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         _git_init(tmp_path)
         (tmp_path / "snapshot.db").write_bytes(b"")
@@ -235,7 +246,7 @@ class TestSyncDoctorCli:
         assert "*.db" in result.output
 
     def test_pass_path_clean_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_home(monkeypatch, tmp_path)
         monkeypatch.chdir(tmp_path)
         _git_init(tmp_path)
 

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -41,6 +41,17 @@ def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
     monkeypatch.setenv("USERPROFILE", str(home))
 
 
+def _claude_slug_for(cwd: Path) -> str:
+    """Encode ``cwd`` into a Claude-style hyphenated slug, cross-platform.
+
+    POSIX cwd ``/Users/foo/bar`` → ``-Users-foo-bar``.
+    Windows cwd ``C:\\Users\\foo\\bar`` → ``CUsers-foo-bar`` (drive colon
+    dropped) — matches the Windows-no-colon candidate the doctor's
+    ``check_claude_slug`` fast path looks up.
+    """
+    return str(cwd.resolve()).replace("\\", "-").replace(":", "").replace("/", "-")
+
+
 # ---- cloud_mount_prefix helper ---------------------------------------------
 
 
@@ -216,8 +227,7 @@ class TestCheckClaudeSlug:
         cwd.mkdir(parents=True)
         projects = home / ".claude" / "projects"
         projects.mkdir(parents=True)
-        slug = str(cwd.resolve()).replace("/", "-")
-        (projects / slug).mkdir()
+        (projects / _claude_slug_for(cwd)).mkdir()
         r = check_claude_slug(cwd, home=home)
         assert r.status == "pass"
 
@@ -328,8 +338,7 @@ class TestSyncDoctorCli:
         # Create a Claude project entry for the repo root (not the subdir).
         projects = tmp_path / ".claude" / "projects"
         projects.mkdir(parents=True)
-        slug = str(tmp_path.resolve()).replace("/", "-")
-        (projects / slug).mkdir()
+        (projects / _claude_slug_for(tmp_path)).mkdir()
 
         monkeypatch.chdir(nested)
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- Implements Phase 2 of the multi-device sync RFC ([memtomem-docs#34](https://github.com/memtomem/memtomem-docs/pull/34)).
- New `mm sync-doctor` — read-only validator that catches the common private-repo sync footguns Phase 0 documents.
- Adds a small (~22 LOC) cloud-mount path-prefix helper alongside the command (RFC §Phase 2 ≤30 LOC budget).

## What it does

Run from inside the private synced repo's working tree. Six checks, exits non-zero on any `✗`:

```
$ mm sync-doctor
✓ no *.db files staged
✓ config.json absent from worktree
! ~/.memtomem/config.d/ does not exist on this machine
  bridge synced fragments via symlink/copy per RFC §Design
✓ ~/.claude/projects/ slug matches synced layout
✓ memory_dir paths resolve under $HOME
✓ no memory_dir under known cloud-sync mounts
```

| Check | Maps to RFC |
|---|---|
| `*.db` family staged via `git ls-files` | §What syncs, what does not |
| `config.json` staged anywhere in tree | §Anti-patterns #4 |
| `~/.memtomem/config.d/*.json` fragment count | §The convention bridge |
| `~/.claude/projects/<encoded-cwd>` exists | §Auto-memory sub-section |
| `memory_dirs[]` resolve under `$HOME` | portability hint |
| `memory_dirs[]` cloud-mount detection | §Phase 2 helper |

Out of scope, explicitly: no `push`, no `pull`, no auto-fix (RFC §Non-goals).

## Helper design

`cloud_mount_prefix(path) -> str | None` is a pure path-prefix match against a fixed list of expanded `$HOME` prefixes — no fs probing, no platform branching:

```
~/Library/CloudStorage/    macOS sync clients
~/Library/Mobile Documents/com~apple~CloudDocs/   iCloud Drive
~/Dropbox/                                         Dropbox legacy
~/OneDrive*/                                       OneDrive (any variant)
```

The OneDrive matcher accepts `OneDrive`, `OneDrive-Personal`, `OneDrive - Foo` but rejects substring false positives like `OneDriveStuff`.

## Open question for review

Per RFC §Open question 3: **what does cloud-mount detection scan?**

- This PR scans **all `memory_dirs[]`** (entries both inside and outside the synced repo's worktree). Matches the §Phase 2 example output.
- Alternative: only `memory_dirs[]` entries that sit inside the synced repo's worktree (narrower surface, cleaner boundary).

Defaulted to the broader scan because most users hit cloud-mount issues with paths *outside* the sync repo (per `feedback_gdrive_watcher_gap.md`). Happy to flip if review prefers the tighter boundary.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_sync_doctor_cli.py` — 29 cases (helper variants, each check, CLI exit codes)
- [x] `uv run ruff check packages/memtomem/src` + `ruff format --check` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py` — clean
- [x] `uv run mm sync-doctor` smoke from this checkout — exits 0, output matches RFC example shape
- [x] `mm sync-doctor --help` registered under `mm --help`
- [ ] Maintainer: verify boundary decision for `memory_dirs` scope (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
