### PR TITLE
test(config): green up Windows CI — compare resolved paths in portable-path round-trip

### DIFF
--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -6,6 +6,7 @@ basic config operations with mocked components.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -452,7 +453,14 @@ class TestSaveConfigOverrides:
     # ── Load-path defensive tests (unrelated to delta semantic) ────────
 
     def test_memory_dirs_survives_save_load(self, isolated):
-        """User-added memory_dirs (distinct from factory) must survive save→load."""
+        """User-added memory_dirs (distinct from factory) must survive save→load.
+
+        Compare via ``Path.expanduser().resolve()`` rather than raw string
+        equality. Phase 1 (#836) persists home-rooted paths in ``~/...``
+        portable form, so the loaded list won't match the raw input string
+        verbatim when ``tmp_path`` happens to land under ``$HOME`` (true on
+        Windows CI under ``C:\\Users\\runneradmin\\AppData\\Local\\Temp``).
+        """
         tmp_path = isolated["tmp_path"]
 
         cfg = Mem2MemConfig()
@@ -462,9 +470,9 @@ class TestSaveConfigOverrides:
         fresh = Mem2MemConfig()
         load_config_overrides(fresh)
 
-        loaded_dirs = [str(p) for p in fresh.indexing.memory_dirs]
-        assert str(tmp_path / "a") in loaded_dirs
-        assert str(tmp_path / "b") in loaded_dirs
+        loaded_resolved = {Path(p).expanduser().resolve() for p in fresh.indexing.memory_dirs}
+        assert (tmp_path / "a").resolve() in loaded_resolved
+        assert (tmp_path / "b").resolve() in loaded_resolved
 
     def test_invalid_value_falls_back_to_default(self, isolated):
         """Invalid values in config.json should be skipped with warning, not crash."""

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -520,9 +520,16 @@ def test_migration_preserves_existing_user_memory_dirs(
     assert cfg.indexing.auto_discover is False
 
     persisted = json.loads(override_path.read_text(encoding="utf-8"))
-    persisted_dirs = set(persisted["indexing"]["memory_dirs"])
-    assert str(user_dir) in persisted_dirs
-    assert str(fake_provider) in persisted_dirs
+    # Phase 1 (#836) persists home-rooted paths in ``~/...`` portable form,
+    # so compare the persisted list via ``Path.expanduser().resolve()``
+    # rather than raw string equality. ``tmp_path`` lands under ``$HOME``
+    # on Windows CI but typically not on POSIX, so a raw-string assertion
+    # is platform-fragile.
+    persisted_resolved = {
+        Path(p).expanduser().resolve() for p in persisted["indexing"]["memory_dirs"]
+    }
+    assert user_dir.resolve() in persisted_resolved
+    assert fake_provider.resolve() in persisted_resolved
     assert persisted["indexing"]["auto_discover"] is False
 
 
@@ -556,13 +563,18 @@ def test_migration_idempotent(
 
     cfg1 = Mem2MemConfig()
     load_config_overrides(cfg1)
-    first_dirs = sorted(str(p) for p in cfg1.indexing.memory_dirs)
+    # First load goes through migration: memory_dirs is the in-memory list
+    # of raw ``Path`` values. Second load reads back the persisted tilde-form
+    # written by Phase 1 (#836). Resolve both before comparison so the round
+    # trip is checked by filesystem identity rather than raw string form
+    # (which differs on Windows where ``tmp_path`` sits under ``$HOME``).
+    first_resolved = sorted(Path(p).expanduser().resolve() for p in cfg1.indexing.memory_dirs)
 
     cfg2 = Mem2MemConfig()
     load_config_overrides(cfg2)
-    second_dirs = sorted(str(p) for p in cfg2.indexing.memory_dirs)
+    second_resolved = sorted(Path(p).expanduser().resolve() for p in cfg2.indexing.memory_dirs)
 
-    assert first_dirs == second_dirs
+    assert first_resolved == second_resolved
 
 
 def test_migration_env_var_false_skips(


### PR DESCRIPTION
## Summary

- Fix the three Windows-only test failures introduced by #836 (Phase 1 portable paths). Main has been red on `test (windows-latest)` since 2026-05-08; this clears it.
- No production-code change. The portable-path serialization shape is intentional (RFC §Phase 1); the tests just weren't platform-aware.

## Root cause

Three round-trip tests asserted raw `str(path)` equality against persisted/loaded `memory_dirs`:

| Test | File |
|---|---|
| `test_memory_dirs_survives_save_load` | `tests/test_cli.py` |
| `test_migration_preserves_existing_user_memory_dirs` | `tests/test_config_overrides.py` |
| `test_migration_idempotent` | `tests/test_config_overrides.py` |

Phase 1 serializes home-rooted paths in `~/...` portable form. The platform difference comes from where `pytest`'s `tmp_path` happens to land:

- **POSIX**: `/private/var/folders/...` or `/tmp/...` — *not* under `$HOME`, so `_portable_path_str` keeps the absolute spelling. Raw-string assertion matches → green.
- **Windows CI**: `C:\Users\runneradmin\AppData\Local\Temp\...` — *is* under `USERPROFILE`, so the rewriter produces `~/AppData/Local/Temp/...`. The raw `str(WindowsPath('C:\\\\...'))` the test looked for no longer matches → red.

## Fix

Compare via `Path(p).expanduser().resolve()` so the round trip is checked by filesystem identity rather than string form. A short comment at each call site links the change back to #836 so future readers don't reintroduce the raw-string shape.

## Local verification

Can't run Windows tests locally, so simulated the Windows behavior on macOS by pointing `HOME` / `USERPROFILE` at a tempdir parent of `tmp_path`:

```text
persisted: ['~/subdir/a', '~/subdir/b']
loaded raw: ['~/subdir/a', '~/subdir/b']
loaded resolved contains:
  a in: True
  b in: True
```

Round trip is correct under both serialization shapes (absolute on POSIX where tmp_path is outside `$HOME`, tilde on Windows where it isn't).

## Test plan

- [x] `uv run pytest tests/test_cli.py tests/test_config_overrides.py` → 121/121 green locally
- [x] `uv run ruff check` + `ruff format --check` → clean
- [ ] Maintainer: verify Windows CI goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
