### PR TITLE
docs: sync full-mode tool count 79 → 80

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -748,7 +748,7 @@ Requires `MEMTOMEM_LLM__ENABLED=true` and a configured provider. Generated summa
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (37 incl. `mem_do`), `full` (79) |
+| `MEMTOMEM_TOOL_MODE` | `core` | Which MCP tools are exposed: `core` (9 tools), `standard` (37 incl. `mem_do`), `full` (80) |
 
 In `core` mode, use `mem_do(action="...", params={...})` to access any of the 70+ non-core actions. Fewer tools means less context usage for AI agents.
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -303,7 +303,7 @@ mm status
 uses, so the output is identical. Useful as a sanity check between
 `mm init` and the first editor-side call.
 
-### Available MCP Tools (79)
+### Available MCP Tools (80)
 
 | Category | Tools |
 |----------|-------|
@@ -339,7 +339,7 @@ uses, so the output is identical. Useful as a sanity check between
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 
-> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 79 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
+> **Tool mode**: Set `MEMTOMEM_TOOL_MODE` to `core` (9 tools, default), `standard` (core + common packs + `mem_do`), or `full` (all 80 tools individually) to control how many tools are exposed. In `core` mode, use `mem_do(action="...", params={...})` to access any non-core action. Fewer tools = less context usage for AI agents.
 
 ### STM Proxy Tools (optional, separate package)
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -63,7 +63,7 @@ sequenceDiagram
 
 ## MCP Tools at a Glance
 
-memtomem provides **79 MCP tools** organized into categories:
+memtomem provides **80 MCP tools** organized into categories:
 
 | Category | Tools | What they do |
 |----------|-------|-------------|
@@ -1204,4 +1204,4 @@ See [`uninstall.md`](uninstall.md) for the five-step removal flow: detach the MC
 - [LLM Providers](llm-providers.md) — Optional LLM features (auto-tag, entity extraction, ask)
 - [MCP Client Setup](mcp-clients.md) — Editor-specific configuration
 - [memtomem-stm](https://github.com/memtomem/memtomem-stm) — Proactive surfacing, compression, caching (separate package)
-- [Full Tool Reference](../../packages/memtomem/README.md) — All 79 tools with parameters
+- [Full Tool Reference](../../packages/memtomem/README.md) — All 80 tools with parameters

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -94,7 +94,7 @@ the editor: `~/.cursor/mcp.json` (Cursor),
 - **🧹 Maintenance** — near-duplicate detection with merge, time-based score decay, TTL expiration, auto-tagging
 - **🔄 Export / import** — JSON bundle backup and restore with re-embedding
 - **🌐 Web UI** — polished SPA dashboard for search, sources, indexing, tags, and timeline (`mm web --dev` unlocks the full maintainer surface including Sessions, Working Memory, and Health Report)
-- **🛠️ 79 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
+- **🛠️ 80 MCP tools** — full feature surface as MCP tools, with `mem_do` meta-tool routing all registered actions in `core` mode (default) for minimal context usage
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- The full-mode MCP tool surface grew to **80** tools, but six doc occurrences still cite the legacy **79** figure
- Production-readiness audit (2026-05-08) caught the drift via `grep -c '^@mcp.tool' packages/memtomem/src/memtomem/`
- Pure doc sync — no code change, no category-table row edits (those are summaries, not exhaustive listings)

## Touches

- `docs/guides/mcp-clients.md` — section header `### Available MCP Tools (79→80)` + tool-mode callout
- `docs/guides/reference.md` — "MCP Tools at a Glance" intro + "Full Tool Reference" link
- `docs/guides/configuration.md` — `MEMTOMEM_TOOL_MODE` env table
- `packages/memtomem/README.md` — PyPI feature bullet

## Verification source

```bash
grep -rh "^@mcp.tool" packages/memtomem/src/memtomem/ | wc -l
# 80
```

## Test plan

- [ ] CI green (lint + tests; doc-only change so behavior unaffected)
- [ ] Visual sanity-check rendered tables on GitHub (4 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
