### PR TITLE
chore(context): graduate Gemini agent fan-out from experimental

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -6,7 +6,7 @@ superset) and a Markdown body that acts as the system prompt. From that single
 canonical source we fan out to:
 
 * ``.claude/agents/<name>.md`` — Claude Code (project-scope)
-* ``.gemini/agents/<name>.md`` — Gemini CLI (project-scope; experimental in 2026-03)
+* ``.gemini/agents/<name>.md`` — Gemini CLI (project-scope)
 * ``.codex/agents/<name>.toml`` — OpenAI Codex CLI (project-scope)
 
 Codex CLI accepts both ``~/.codex/agents/`` (user-scope) and ``.codex/agents/``


### PR DESCRIPTION
## Summary

- The `experimental in 2026-03` marker on the Gemini agent fan-out target has gone stale — drop it.
- The Gemini writer has the same hardening + test coverage as the Claude writer at this point; the inline note now misleads more than it informs.

## Evidence (production-readiness audit, 2026-05-08)

**Test coverage**: 18 Gemini-specific tests in `test_context_agents.py` (field rendering, round-trip in_sync, dropped-field reporting, runtime detection), plus 1,000+ shared lines across the rest of the context fan-out suite.

**Hardening PRs that apply equally to Gemini**:
- atomic writes — #283
- CRLF + full TOML escape — #285
- name validation — #283
- override application — #627 / #628
- Windows mtime ceiling — #733
- fcntl → portalocker — #652

**Schema lock-in**: Gemini drops `skills` + `isolation` from the canonical frontmatter; this is documented in the docstring and pinned by the round-trip tests. No drift in the last two release cycles.

**Open backlog**: zero issues block the Gemini writer specifically. The remaining context-gateway TODOs (#829–834) are dashboard enhancements, unrelated to fan-out correctness.

## What's not in this PR

The companion private doc (`memtomem-docs/memtomem/guides-archived/agent-context.md`) still carries an inline `(experimental)` marker on Gemini in the Supported targets table at line 395. That's outside this repo and gets reconciled when/if the doc is promoted to public.

## Test plan

- [ ] CI green (lint + tests)
- [ ] Confirm no other in-repo doc still says "Gemini ... experimental"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
