### PR TITLE
fix(context): preserve same-matcher user rules during settings merge

### DIFF
--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -148,20 +148,27 @@ class ClaudeSettingsGenerator:
                 existing_hooks[event] = list(rules)
                 continue
 
-            # Index existing rules by matcher for conflict detection
+            # Index existing rules by matcher for conflict detection. Keep
+            # the value as a list, not a single dict — Claude Code allows the
+            # same matcher to appear more than once under one event (e.g. a
+            # user keeping two PostToolUse rules without explicit matchers).
+            # Collapsing to a dict-of-rule means whichever same-matcher rule
+            # comes last silently shadows the rest, so byte-identical
+            # contributions can mismatch and emit a noisy warning.
             existing_rules: list = list(existing_hooks[event])
-            existing_by_matcher: dict[str, dict] = {}
+            existing_by_matcher: dict[str, list[dict]] = {}
             for rule in existing_rules:
                 if isinstance(rule, dict):
-                    existing_by_matcher[rule.get("matcher", "")] = rule
+                    existing_by_matcher.setdefault(rule.get("matcher", ""), []).append(rule)
 
             for rule in rules:
                 if not isinstance(rule, dict):
                     continue
                 matcher = rule.get("matcher", "")
-                if matcher in existing_by_matcher:
-                    if existing_by_matcher[matcher] == rule:
-                        continue  # already in sync
+                same_matcher = existing_by_matcher.get(matcher, [])
+                if same_matcher:
+                    if any(existing == rule for existing in same_matcher):
+                        continue  # already in sync (with at least one)
                     label = f"{event}:{matcher}" if matcher else event
                     warnings.append(
                         f"Hook rule '{label}' already exists in the target "

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -190,6 +190,35 @@ class TestClaudeSettingsMergeConflict:
         assert results["claude_settings"].status == "ok"
         assert results["claude_settings"].warnings == []
 
+    def test_dedup_when_user_has_multiple_same_matcher_rules(self, claude_home, tmp_path):
+        """Pin: existing rules with the same matcher should not collapse during indexing.
+
+        Claude Code allows two rules under the same event to share a matcher
+        (or omit it). Earlier indexing keyed ``existing_by_matcher`` as
+        ``dict[str, dict]``, so the second rule silently shadowed the first.
+        A byte-identical contribution that matched the *first* rule then
+        emitted a spurious warning by comparing against the second.
+        """
+        target = claude_home / ".claude" / "settings.json"
+        existing_a = _rule("", "echo first")
+        existing_b = _rule("", "echo second")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [existing_a, existing_b]}}) + "\n",
+            encoding="utf-8",
+        )
+
+        # Contribution exactly matches the first user rule.
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [existing_a]}})
+
+        results = generate_all_settings(tmp_path)
+        r = results["claude_settings"]
+        assert r.status == "ok"
+        assert r.warnings == []  # was 1 before the fix
+
+        written = _read_target(claude_home)
+        # Both user rules preserved verbatim, no contribution appended.
+        assert written["hooks"]["PostToolUse"] == [existing_a, existing_b]
+
 
 class TestClaudeSettingsMergeWarningContent:
     """Warning messages must contain the rule label, reason, and remediation."""


### PR DESCRIPTION
## Summary

Caught during the 2026-05-08 production-readiness audit: `ClaudeSettingsGenerator.merge()` was indexing existing user rules into `dict[str, dict]` keyed by matcher, so when the user kept **two rules under the same event sharing a matcher** (record-format hooks allow this — including the matcher-less case where both default to `""`), the second rule silently shadowed the first in the index. A byte-identical contribution that exactly matched the *first* rule was then compared against the *second*, and emitted a spurious `"already exists … with different config"` warning.

The mtime guard around the merge already prevents lost writes, so this was never a correctness bug — but the warning drives the "remove the existing rule, then re-run sync" remediation, so a false-positive there has its own small cost.

## Change

- `existing_by_matcher` becomes `dict[str, list[dict]]`. Dedup compares against any same-matcher rule via `any(...)`.
- Policy is **unchanged**: user rules still always win on a real conflict (same matcher, different body); the contribution is dropped and the warning fires as before. Only the no-op case (contribution matches at least one same-matcher rule) is now silent.

## Pin test

New `test_dedup_when_user_has_multiple_same_matcher_rules` in `TestClaudeSettingsMergeConflict`:
- Two existing matcher-less PostToolUse rules.
- Contribution byte-identical to the first.
- Asserts: `warnings == []` and the user's two rules survive verbatim with no extra append.

Per `feedback_pin_test_mutation_validation.md`: revert was applied locally (`existing_by_matcher: dict[str, dict]` shadowing) and the new test fails with the expected warning, confirming the assertion would catch a regression. Restored before commit.

## Test plan

- [x] `pytest packages/memtomem/tests/test_context_settings.py` — 38 passed locally
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
