### PR TITLE
fix(langgraph): raise on unknown config_overrides + pin multi-agent × redaction call order

### DIFF
--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -32,6 +32,7 @@ follow-up; for now the multi-agent helpers live on
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 from uuid import UUID, uuid4
@@ -46,6 +47,8 @@ from memtomem.constants import (
 if TYPE_CHECKING:
     from memtomem.server.component_factory import Components
 
+logger = logging.getLogger(__name__)
+
 
 class MemtomemStore:
     """LangGraph-compatible memory store wrapping memtomem components.
@@ -54,7 +57,12 @@ class MemtomemStore:
     Components are lazily initialized on first use.
 
     Args:
-        config_overrides: Optional dict of config overrides (e.g. {"storage": {"sqlite_path": "..."}})
+        config_overrides: Optional dict of config overrides
+            (e.g. ``{"storage": {"sqlite_path": "..."}}``). Sections and
+            keys that do not exist on :class:`Mem2MemConfig` are skipped
+            with a ``logger.warning`` rather than silently no-op'd, so a
+            typo in either the section name (``storge``) or a field name
+            (``sqlite_pat``) is detectable without raising.
     """
 
     def __init__(self, config_overrides: dict[str, Any] | None = None):
@@ -72,13 +80,38 @@ class MemtomemStore:
 
             config = Mem2MemConfig()
 
-            # Apply overrides
+            # Apply overrides. Unknown sections / keys are skipped with a
+            # warning so a typo (e.g. ``{"storge": ...}`` or
+            # ``{"storage": {"sqlite_pat": ...}}``) is loud rather than
+            # silently no-op'd. We log instead of raising because the dict is
+            # implementation-defined — a future memtomem release may rename a
+            # section, and a callers' lock-in shouldn't break on import.
             for section, updates in self._config_overrides.items():
                 section_obj = getattr(config, section, None)
-                if section_obj and isinstance(updates, dict):
-                    for key, value in updates.items():
-                        if hasattr(section_obj, key):
-                            setattr(section_obj, key, value)
+                if section_obj is None:
+                    logger.warning(
+                        "MemtomemStore.config_overrides: unknown section %r — skipping",
+                        section,
+                    )
+                    continue
+                if not isinstance(updates, dict):
+                    logger.warning(
+                        "MemtomemStore.config_overrides: section %r value is %s, "
+                        "expected dict — skipping",
+                        section,
+                        type(updates).__name__,
+                    )
+                    continue
+                for key, value in updates.items():
+                    if not hasattr(section_obj, key):
+                        logger.warning(
+                            "MemtomemStore.config_overrides: unknown key %r in section "
+                            "%r — skipping",
+                            key,
+                            section,
+                        )
+                        continue
+                    setattr(section_obj, key, value)
 
             self._components = await create_components(config)
         return self._components

--- a/packages/memtomem/src/memtomem/integrations/langgraph.py
+++ b/packages/memtomem/src/memtomem/integrations/langgraph.py
@@ -32,7 +32,6 @@ follow-up; for now the multi-agent helpers live on
 from __future__ import annotations
 
 import asyncio
-import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self
 from uuid import UUID, uuid4
@@ -47,8 +46,6 @@ from memtomem.constants import (
 if TYPE_CHECKING:
     from memtomem.server.component_factory import Components
 
-logger = logging.getLogger(__name__)
-
 
 class MemtomemStore:
     """LangGraph-compatible memory store wrapping memtomem components.
@@ -59,10 +56,12 @@ class MemtomemStore:
     Args:
         config_overrides: Optional dict of config overrides
             (e.g. ``{"storage": {"sqlite_path": "..."}}``). Sections and
-            keys that do not exist on :class:`Mem2MemConfig` are skipped
-            with a ``logger.warning`` rather than silently no-op'd, so a
-            typo in either the section name (``storge``) or a field name
-            (``sqlite_pat``) is detectable without raising.
+            keys that do not exist on :class:`Mem2MemConfig` raise
+            ``ValueError`` from :meth:`_ensure_init` so a typo cannot
+            silently land writes/index calls in the default
+            ``~/.memtomem`` location. The constructor itself does not
+            validate (the config object is built lazily) — the first
+            ``await``-ed call surfaces the error.
     """
 
     def __init__(self, config_overrides: dict[str, Any] | None = None):
@@ -80,37 +79,32 @@ class MemtomemStore:
 
             config = Mem2MemConfig()
 
-            # Apply overrides. Unknown sections / keys are skipped with a
-            # warning so a typo (e.g. ``{"storge": ...}`` or
-            # ``{"storage": {"sqlite_pat": ...}}``) is loud rather than
-            # silently no-op'd. We log instead of raising because the dict is
-            # implementation-defined — a future memtomem release may rename a
-            # section, and a callers' lock-in shouldn't break on import.
+            # Apply overrides. Unknown sections / keys raise immediately:
+            # ``config_overrides`` is a programmatic constructor argument, so
+            # a typo like ``{"storge": ...}`` or ``{"storage":
+            # {"sqlite_pat": ...}}`` would otherwise fall back to the default
+            # DB / memory_dirs and silently land writes in the wrong place.
+            # Logging-only would be hidden by callers who don't surface
+            # ``WARNING`` from ``memtomem.integrations.langgraph``.
             for section, updates in self._config_overrides.items():
                 section_obj = getattr(config, section, None)
                 if section_obj is None:
-                    logger.warning(
-                        "MemtomemStore.config_overrides: unknown section %r — skipping",
-                        section,
+                    raise ValueError(
+                        f"MemtomemStore.config_overrides: unknown section {section!r}. "
+                        "Section must match a Mem2MemConfig section "
+                        "(e.g. 'storage', 'indexing', 'embedding')."
                     )
-                    continue
                 if not isinstance(updates, dict):
-                    logger.warning(
-                        "MemtomemStore.config_overrides: section %r value is %s, "
-                        "expected dict — skipping",
-                        section,
-                        type(updates).__name__,
+                    raise ValueError(
+                        f"MemtomemStore.config_overrides: section {section!r} value "
+                        f"is {type(updates).__name__}, expected dict."
                     )
-                    continue
                 for key, value in updates.items():
                     if not hasattr(section_obj, key):
-                        logger.warning(
-                            "MemtomemStore.config_overrides: unknown key %r in section "
-                            "%r — skipping",
-                            key,
-                            section,
+                        raise ValueError(
+                            f"MemtomemStore.config_overrides: unknown key {key!r} "
+                            f"in section {section!r}."
                         )
-                        continue
                     setattr(section_obj, key, value)
 
             self._components = await create_components(config)

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -39,8 +39,13 @@ class TestMemtomemStoreInit:
         assert store._current_agent_id is None
 
 
-class TestConfigOverridesWarn:
-    """Unknown sections / keys in ``config_overrides`` should be loud."""
+class TestConfigOverridesStrict:
+    """Unknown sections / keys in ``config_overrides`` raise ``ValueError``.
+
+    The constructor takes a Python dict, so a typo silently falling back to
+    the default DB / memory_dirs would mean writes land in the wrong place.
+    We surface the error at first ``_ensure_init`` instead of warn-and-skip.
+    """
 
     @staticmethod
     def _patch_factory(monkeypatch):
@@ -59,52 +64,50 @@ class TestConfigOverridesWarn:
         monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
 
     @pytest.mark.asyncio
-    async def test_unknown_section_emits_warning(self, caplog, monkeypatch):
-        """Typo in ``config_overrides`` section name surfaces as a warning."""
+    async def test_unknown_section_raises(self, monkeypatch):
+        """Typo in ``config_overrides`` section name raises ValueError."""
         from memtomem.integrations.langgraph import MemtomemStore
 
         self._patch_factory(monkeypatch)
 
         store = MemtomemStore(config_overrides={"storge": {"sqlite_path": "/tmp/x.db"}})
-        with caplog.at_level("WARNING", logger="memtomem.integrations.langgraph"):
+        with pytest.raises(ValueError, match="unknown section 'storge'"):
             await store._ensure_init()
 
-        assert any("unknown section 'storge'" in r.getMessage() for r in caplog.records), (
-            caplog.text
-        )
-
     @pytest.mark.asyncio
-    async def test_unknown_key_emits_warning(self, caplog, monkeypatch):
-        """Typo in a known section's field name surfaces as a warning."""
+    async def test_unknown_key_raises(self, monkeypatch):
+        """Typo in a known section's field name raises ValueError."""
         from memtomem.integrations.langgraph import MemtomemStore
 
         self._patch_factory(monkeypatch)
 
         store = MemtomemStore(config_overrides={"storage": {"sqlite_pat": "/tmp/x.db"}})
-        with caplog.at_level("WARNING", logger="memtomem.integrations.langgraph"):
+        with pytest.raises(ValueError, match="unknown key 'sqlite_pat'"):
             await store._ensure_init()
 
-        assert any("unknown key 'sqlite_pat'" in r.getMessage() for r in caplog.records), (
-            caplog.text
-        )
+    @pytest.mark.asyncio
+    async def test_non_dict_section_value_raises(self, monkeypatch):
+        """A scalar where a section dict is expected also raises (catches
+        e.g. ``{"storage": "/tmp/x.db"}`` from a caller skimming the docs).
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        self._patch_factory(monkeypatch)
+
+        store = MemtomemStore(config_overrides={"storage": "/tmp/x.db"})
+        with pytest.raises(ValueError, match="section 'storage' value is str"):
+            await store._ensure_init()
 
     @pytest.mark.asyncio
-    async def test_known_override_does_not_warn(self, caplog, monkeypatch):
-        """Negative pin: a valid override stays silent (no false-positive warns)."""
+    async def test_known_override_succeeds(self, monkeypatch):
+        """Negative pin: a valid override does NOT raise (no false-positive)."""
         from memtomem.integrations.langgraph import MemtomemStore
 
         self._patch_factory(monkeypatch)
 
         store = MemtomemStore(config_overrides={"storage": {"sqlite_path": "/tmp/x.db"}})
-        with caplog.at_level("WARNING", logger="memtomem.integrations.langgraph"):
-            await store._ensure_init()
-
-        warns = [
-            r
-            for r in caplog.records
-            if r.levelname == "WARNING" and r.name == "memtomem.integrations.langgraph"
-        ]
-        assert warns == [], "valid overrides should not warn"
+        # Should complete without raising.
+        await store._ensure_init()
 
 
 class TestResolveSearchNamespace:

--- a/packages/memtomem/tests/test_langgraph.py
+++ b/packages/memtomem/tests/test_langgraph.py
@@ -39,6 +39,74 @@ class TestMemtomemStoreInit:
         assert store._current_agent_id is None
 
 
+class TestConfigOverridesWarn:
+    """Unknown sections / keys in ``config_overrides`` should be loud."""
+
+    @staticmethod
+    def _patch_factory(monkeypatch):
+        import memtomem.config as _cfg
+        import memtomem.server.component_factory as _factory
+
+        async def _fake_create(_):
+            return MagicMock()
+
+        async def _fake_close(_):
+            return None
+
+        monkeypatch.setattr(_factory, "create_components", _fake_create)
+        monkeypatch.setattr(_factory, "close_components", _fake_close)
+        # Block real ~/.memtomem/config.json from polluting the override chain.
+        monkeypatch.setattr(_cfg, "load_config_overrides", lambda c: None)
+
+    @pytest.mark.asyncio
+    async def test_unknown_section_emits_warning(self, caplog, monkeypatch):
+        """Typo in ``config_overrides`` section name surfaces as a warning."""
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        self._patch_factory(monkeypatch)
+
+        store = MemtomemStore(config_overrides={"storge": {"sqlite_path": "/tmp/x.db"}})
+        with caplog.at_level("WARNING", logger="memtomem.integrations.langgraph"):
+            await store._ensure_init()
+
+        assert any("unknown section 'storge'" in r.getMessage() for r in caplog.records), (
+            caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_emits_warning(self, caplog, monkeypatch):
+        """Typo in a known section's field name surfaces as a warning."""
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        self._patch_factory(monkeypatch)
+
+        store = MemtomemStore(config_overrides={"storage": {"sqlite_pat": "/tmp/x.db"}})
+        with caplog.at_level("WARNING", logger="memtomem.integrations.langgraph"):
+            await store._ensure_init()
+
+        assert any("unknown key 'sqlite_pat'" in r.getMessage() for r in caplog.records), (
+            caplog.text
+        )
+
+    @pytest.mark.asyncio
+    async def test_known_override_does_not_warn(self, caplog, monkeypatch):
+        """Negative pin: a valid override stays silent (no false-positive warns)."""
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        self._patch_factory(monkeypatch)
+
+        store = MemtomemStore(config_overrides={"storage": {"sqlite_path": "/tmp/x.db"}})
+        with caplog.at_level("WARNING", logger="memtomem.integrations.langgraph"):
+            await store._ensure_init()
+
+        warns = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING" and r.name == "memtomem.integrations.langgraph"
+        ]
+        assert warns == [], "valid overrides should not warn"
+
+
 class TestResolveSearchNamespace:
     """``_resolve_search_namespace`` encodes the 6-case ``include_shared``
     table documented in ``MemtomemStore.search``. Drift here would let the

--- a/packages/memtomem/tests/test_redaction_write_surfaces.py
+++ b/packages/memtomem/tests/test_redaction_write_surfaces.py
@@ -283,18 +283,21 @@ class TestLangGraphAddRedactionGuard:
         assert mem._current_agent_id == "planner"
 
     @pytest.mark.asyncio
-    async def test_force_unsafe_under_agent_session_uses_agent_namespace(self, caplog, tmp_path):
-        """Multi-agent × redaction bypass: when ``force_unsafe=True`` is
-        chosen under an active agent session, the resulting
-        ``index_engine.index_file`` call must carry
-        ``namespace="agent-runtime:<id>"`` even though the caller passed
-        no ``namespace=`` kwarg. This pins the boundary between the
-        bypass decision and the namespace resolver — agent scope must
-        survive the bypass path, otherwise a bypassed secret silently
-        lands in the default bucket and can't be attributed back to the
-        agent in audit.
+    async def test_force_unsafe_under_agent_session_pins_call_order(self, tmp_path, monkeypatch):
+        """Multi-agent × redaction bypass: under an active agent session,
+        ``force_unsafe=True`` must run **redaction guard → namespace
+        resolve → write → index** in that exact order, with
+        ``namespace="agent-runtime:<id>"`` reaching the index layer.
+
+        A naked "final ``index_file`` got the agent namespace" assertion
+        would still pass if a refactor moved the namespace resolve
+        *before* the redaction guard — losing the trust-boundary
+        invariant that no namespace work happens on rejected content.
+        We sequence-pin via spies on each stage.
         """
+        from memtomem import privacy as _privacy
         from memtomem.integrations.langgraph import MemtomemStore
+        from memtomem.tools import memory_writer as _memory_writer
 
         mem = MemtomemStore.__new__(MemtomemStore)
         mem._current_session_id = "fake-session"
@@ -304,7 +307,6 @@ class TestLangGraphAddRedactionGuard:
         memory_dir.mkdir()
 
         index_engine = AsyncMock()
-        index_engine.index_file.return_value = MagicMock(indexed_chunks=1)
         mem._ensure_init = AsyncMock(  # type: ignore[attr-defined]
             return_value=MagicMock(
                 config=MagicMock(indexing=MagicMock(memory_dirs=[memory_dir])),
@@ -312,19 +314,64 @@ class TestLangGraphAddRedactionGuard:
             )
         )
 
-        target_file = str(tmp_path / "agent_target.md")
-        with caplog.at_level(logging.WARNING, logger="memtomem.privacy"):
-            result = await mem.add(
-                content=_SECRET_SAMPLE,
-                file=target_file,
-                force_unsafe=True,
+        events: list[tuple[str, dict]] = []
+
+        real_guard = _privacy.enforce_write_guard
+
+        def _spy_guard(content, *, surface, force_unsafe, audit_context):
+            events.append(("guard", {"force_unsafe": force_unsafe, "surface": surface}))
+            return real_guard(
+                content,
+                surface=surface,
+                force_unsafe=force_unsafe,
+                audit_context=audit_context,
             )
 
-        # The write reached index_file under the agent-runtime namespace.
-        index_engine.index_file.assert_called_once()
-        _, kwargs = index_engine.index_file.call_args
-        assert kwargs.get("namespace") == "agent-runtime:planner"
+        monkeypatch.setattr(_privacy, "enforce_write_guard", _spy_guard)
 
-        # And the caller still gets a success-shaped dict (not the error shape).
+        real_resolve = mem._resolve_add_namespace
+
+        def _spy_resolve(namespace):
+            events.append(("resolve_namespace", {"input": namespace}))
+            return real_resolve(namespace)
+
+        # Method spy via direct attribute set — ``add`` calls
+        # ``self._resolve_add_namespace(namespace)`` which resolves
+        # through the instance dict before falling back to the class.
+        mem._resolve_add_namespace = _spy_resolve  # type: ignore[method-assign]
+
+        real_append = _memory_writer.append_entry
+
+        def _spy_append(target, content, *, title=None, tags=None):
+            events.append(("append", {"target": str(target)}))
+            return real_append(target, content, title=title, tags=tags)
+
+        monkeypatch.setattr(_memory_writer, "append_entry", _spy_append)
+
+        async def _spy_index(*args, **kwargs):
+            events.append(("index", {"namespace": kwargs.get("namespace")}))
+            return MagicMock(indexed_chunks=1)
+
+        index_engine.index_file = _spy_index
+
+        target_file = str(tmp_path / "agent_target.md")
+        result = await mem.add(
+            content=_SECRET_SAMPLE,
+            file=target_file,
+            force_unsafe=True,
+        )
+
+        # Order pin: redaction guard fires first, then namespace resolve,
+        # then write, then index. Any reorder trips the equality check.
+        assert [name for name, _ in events] == [
+            "guard",
+            "resolve_namespace",
+            "append",
+            "index",
+        ], events
+
+        # Index call carried the agent-runtime namespace.
+        assert events[3][1]["namespace"] == "agent-runtime:planner"
+        # Caller saw the success shape (not the redaction-block dict).
         assert result.get("error") is None
         assert "indexed_chunks" in result

--- a/packages/memtomem/tests/test_redaction_write_surfaces.py
+++ b/packages/memtomem/tests/test_redaction_write_surfaces.py
@@ -254,3 +254,77 @@ class TestLangGraphAddRedactionGuard:
 
         assert after["bypassed"] == before["bypassed"] + 1
         assert "redaction bypass" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_blocked_under_agent_session_keeps_error_dict_shape(self):
+        """Multi-agent × redaction: a redaction block under an active
+        agent session still returns the same error-dict contract and ticks
+        the same ``blocked`` counter — the agent identity must not change
+        how the trust boundary surfaces failures.
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        mem = MemtomemStore.__new__(MemtomemStore)
+        mem._current_session_id = "fake-session"
+        mem._current_agent_id = "planner"
+        mem._ensure_init = AsyncMock(return_value=MagicMock())  # type: ignore[attr-defined]
+
+        before = privacy.snapshot()["by_tool"].get(
+            "langgraph_add", {"blocked": 0, "pass": 0, "bypassed": 0}
+        )
+        result = await mem.add(content=_SECRET_SAMPLE)
+        after = privacy.snapshot()["by_tool"]["langgraph_add"]
+
+        assert isinstance(result, dict)
+        assert result.get("error") == "redaction_blocked"
+        assert "hits" in result
+        assert after["blocked"] == before["blocked"] + 1
+        # Agent state survives the block — the call is rejected, not the session.
+        assert mem._current_agent_id == "planner"
+
+    @pytest.mark.asyncio
+    async def test_force_unsafe_under_agent_session_uses_agent_namespace(self, caplog, tmp_path):
+        """Multi-agent × redaction bypass: when ``force_unsafe=True`` is
+        chosen under an active agent session, the resulting
+        ``index_engine.index_file`` call must carry
+        ``namespace="agent-runtime:<id>"`` even though the caller passed
+        no ``namespace=`` kwarg. This pins the boundary between the
+        bypass decision and the namespace resolver — agent scope must
+        survive the bypass path, otherwise a bypassed secret silently
+        lands in the default bucket and can't be attributed back to the
+        agent in audit.
+        """
+        from memtomem.integrations.langgraph import MemtomemStore
+
+        mem = MemtomemStore.__new__(MemtomemStore)
+        mem._current_session_id = "fake-session"
+        mem._current_agent_id = "planner"
+
+        memory_dir = tmp_path / "memory"
+        memory_dir.mkdir()
+
+        index_engine = AsyncMock()
+        index_engine.index_file.return_value = MagicMock(indexed_chunks=1)
+        mem._ensure_init = AsyncMock(  # type: ignore[attr-defined]
+            return_value=MagicMock(
+                config=MagicMock(indexing=MagicMock(memory_dirs=[memory_dir])),
+                index_engine=index_engine,
+            )
+        )
+
+        target_file = str(tmp_path / "agent_target.md")
+        with caplog.at_level(logging.WARNING, logger="memtomem.privacy"):
+            result = await mem.add(
+                content=_SECRET_SAMPLE,
+                file=target_file,
+                force_unsafe=True,
+            )
+
+        # The write reached index_file under the agent-runtime namespace.
+        index_engine.index_file.assert_called_once()
+        _, kwargs = index_engine.index_file.call_args
+        assert kwargs.get("namespace") == "agent-runtime:planner"
+
+        # And the caller still gets a success-shaped dict (not the error shape).
+        assert result.get("error") is None
+        assert "indexed_chunks" in result


### PR DESCRIPTION
## Summary

Two gaps the 2026-05-08 production-readiness audit caught in the LangGraph adapter ahead of any public guide promotion. Initial commit followed a "warn-and-skip" approach for `config_overrides` typos; **Codex review** flagged that as too lenient for a programmatic constructor (silent default fallback writes data in the wrong place). The follow-up commit (`d4706a7`) switches to `ValueError` and replaces the namespace-only assertion with a proper sequence pin.

## Change

### `integrations/langgraph.py`

`_ensure_init` raises `ValueError` for:
- unknown `section` (not on `Mem2MemConfig`)
- non-dict value where a section dict is expected
- unknown field inside a known section

The error fires from the first `await`-ed call (e.g. `await store.search(...)` or `await store.add(...)`), not at construction — the config object is built lazily.

Docstring on `MemtomemStore.config_overrides` describes the new contract.

### Tests

**`test_langgraph.py::TestConfigOverridesStrict`** (4 pins):
- `test_unknown_section_raises` — typo in section name → `ValueError("unknown section 'storge'")`.
- `test_unknown_key_raises` — typo in field name → `ValueError("unknown key 'sqlite_pat'")`.
- `test_non_dict_section_value_raises` — `{"storage": "/tmp/x.db"}` (scalar) → `ValueError("section 'storage' value is str")`.
- `test_known_override_succeeds` — negative pin: a valid override completes without raising (no false-positive, per `feedback_pin_invert_symmetric_assertion.md`).

**`test_redaction_write_surfaces.py::TestLangGraphAddRedactionGuard::test_force_unsafe_under_agent_session_pins_call_order`**:
Sequence pin via spies on `privacy.enforce_write_guard`, `MemtomemStore._resolve_add_namespace`, `memtomem.tools.memory_writer.append_entry`, and `index_engine.index_file`. Asserts `[guard, resolve_namespace, append, index]` exactly. Drops the unused `caplog` (codex minor).

Plus the existing `test_blocked_under_agent_session_keeps_error_dict_shape` (regression guard for the error-dict shape under an active agent session).

## Pin-mutation validation

Per `feedback_pin_test_mutation_validation.md`:
- Reverting `_ensure_init`'s override loop to the previous silent-skip: 3/4 strict tests fail, the negative pin (`test_known_override_succeeds`) stays green.
- Swapping `_resolve_add_namespace` ahead of the guard call in `add()`: the sequence pin fails with `'resolve_namespace' != 'guard'`, everything else passes.

Both restored before commit.

## Codex review applied

| Codex finding | Resolution |
|---|---|
| Major 1: warn-and-skip on programmatic typos can silently land writes in the default DB | Switched to `ValueError`; tests rewritten as `TestConfigOverridesStrict` |
| Major 2: namespace-only assertion does not pin call order | Replaced with sequence pin via 4 spies |
| Minor: unused `caplog` in force-unsafe test | Removed |

## Test plan

- [x] `pytest packages/memtomem/tests/test_langgraph.py packages/memtomem/tests/test_redaction_write_surfaces.py -m "not ollama"` — 39 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Mutation validation for both new pin classes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
