### PR TITLE
fix(web/ctx): preserve same-matcher target rules in settings-sync conflict reporter (#844 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -85,14 +85,19 @@ def _compare_hooks(
     if not isinstance(target_hooks, dict):
         target_hooks = {}
 
-    # Index target rules by (event, matcher)
-    target_index: dict[tuple[str, str], dict] = {}
+    # Index target rules by (event, matcher) preserving multiplicity. Claude
+    # Code allows the same matcher (or no matcher) to appear more than once
+    # under one event, so collapsing to a single dict-of-rule lets a
+    # byte-identical canonical contribution mismatch the *second* user rule
+    # and surface as a false-positive conflict (mirrors the same fix on the
+    # merge side in PR #844).
+    target_index: dict[tuple[str, str], list[dict]] = {}
     for event, rules in target_hooks.items():
         if not isinstance(rules, list):
             continue
         for rule in rules:
             if isinstance(rule, dict):
-                target_index[(event, rule.get("matcher", ""))] = rule
+                target_index.setdefault((event, rule.get("matcher", "")), []).append(rule)
 
     for event, rules in canonical_hooks.items():
         if not isinstance(rules, list):
@@ -102,18 +107,23 @@ def _compare_hooks(
                 continue
             matcher = rule.get("matcher", "")
             key = (event, matcher)
+            same_matcher = target_index.get(key, [])
 
-            if key in target_index:
-                if target_index[key] == rule:
+            if same_matcher:
+                if any(existing == rule for existing in same_matcher):
                     result["hooks"]["synced"].append(
                         {"event": event, "matcher": matcher, "rule": rule}
                     )
                 else:
+                    # Surface the first same-matcher rule as the conflict
+                    # representative — keeps the API payload shape stable
+                    # for the resolve flow while not silently shadowing the
+                    # rest of the user's same-matcher rules.
                     result["hooks"]["conflicts"].append(
                         {
                             "event": event,
                             "matcher": matcher,
-                            "existing": target_index[key],
+                            "existing": same_matcher[0],
                             "proposed": rule,
                         }
                     )

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -702,6 +702,49 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
+    async def test_dedup_when_target_has_multiple_same_matcher_rules(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Pin: target rules with the same (event, matcher) should not collapse during indexing.
+
+        The user can keep two PostToolUse rules under the same matcher (or
+        omit the matcher on both — record-format hooks allow that). Earlier
+        the route indexed ``target_index`` as ``dict[(event, matcher), dict]``,
+        so the second rule silently shadowed the first. A byte-identical
+        canonical contribution then mismatched the second and reported a
+        false-positive conflict. Mirrors the merge-side fix in PR #844 for
+        the corresponding silent-collapse bug on the conflict reporter
+        path.
+        """
+        existing_a = self._rule("Write", "echo first")
+        existing_b = self._rule("Write", "echo second")
+        # Canonical is byte-identical to the user's first rule.
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(json.dumps({"hooks": {"PostToolUse": [existing_a]}}), encoding="utf-8")
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [existing_a, existing_b]}}),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            resp = await client.get("/api/settings-sync")
+            data = resp.json()
+
+            assert data["status"] == "in_sync"  # was "conflicts" before the fix
+            assert data["hooks"]["conflicts"] == []
+            assert len(data["hooks"]["synced"]) == 1
+            assert data["hooks"]["synced"][0]["matcher"] == "Write"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
     async def test_resolve_replaces_rule(self, app, client: AsyncClient, tmp_path):
         """POST /resolve replaces the target's rule with canonical version."""
         canonical_rule = self._rule("Write", "echo new")


### PR DESCRIPTION
## Summary

Follow-up to **#844** (`fix(context): preserve same-matcher user rules during settings merge`). Codex review on **#845** caught that the same `dict[(event, matcher), dict]` silent-overwrite pattern still lived on the **conflict reporter** path: `packages/memtomem/src/memtomem/web/routes/settings_sync.py:88`. Mirrored sibling-paths grep would have caught both at once — adding a memory note for future audits.

## Bug

`GET /api/settings-sync` indexed user (target) rules as `dict[(event, matcher), dict]`. When the user kept two rules under one event sharing a matcher (record-format hooks allow this — including the matcher-less case where both default to `""`), the second rule silently shadowed the first. A canonical contribution byte-identical to the *first* user rule then mismatched the second and surfaced as a false-positive `conflicts` status, prompting an unnecessary "remove the existing rule, then re-run sync" remediation in the UI.

## Fix

Mirror the PR #844 merge-side change:
- `target_index` becomes `dict[(event, matcher), list[dict]]`.
- Dedup runs `any(existing == rule for existing in same_matcher)`.
- Conflict payload still surfaces a single representative `existing` (`same_matcher[0]`), so the resolve flow's API contract is unchanged.

## Pin

`TestSettingsSync::test_dedup_when_target_has_multiple_same_matcher_rules` exercises two same-matcher target rules with a canonical matching the first; asserts `in_sync` + zero conflicts.

Mutation-validated: reverting `target_index` to `dict[(event, matcher), dict]` makes the test fail with `'conflicts' == 'in_sync'`. Restored before commit (per `feedback_pin_test_mutation_validation.md`).

## Test plan

- [x] `pytest packages/memtomem/tests/test_web_routes_extended.py::TestSettingsSync packages/memtomem/tests/test_context_settings.py -m "not ollama"` — 52 passed
- [x] `ruff check` + `ruff format --check` clean
- [x] Mutation validation
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
