### PR TITLE
fix(tests): pin utf-8 encoding for wiki README read in is_dirty test (#759 partial)

### DIFF
--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -211,7 +211,7 @@ class TestIsDirty:
         store = WikiStore.at_default()
         store.init()
         readme = wiki_root / "README.md"
-        readme.write_text(readme.read_text() + "\nlocal note\n", encoding="utf-8")
+        readme.write_text(readme.read_text(encoding="utf-8") + "\nlocal note\n", encoding="utf-8")
         assert store.is_dirty() is True
 
     def test_raises_when_wiki_absent(self, wiki_root: Path) -> None:


### PR DESCRIPTION
## Summary

- `test_dirty_with_modified_tracked_file` does `readme.write_text(readme.read_text() + "\nlocal note\n", encoding="utf-8")`. The inner `read_text()` has no `encoding=`, so on Korean Windows (cp949 default) it fails on the em-dashes (`—`, UTF-8 `E2 80 94`) seeded into `README.md` by `_README_TEMPLATE`.
- Pin `encoding="utf-8"` on the read side so the test passes on non-UTF-8 default consoles. The wiki templates are themselves written `encoding="utf-8"` (`store.py:141`); only the test was asymmetric.

Partial fix for #759 — failure 4 of 4. Three sibling fixes (subprocess decode, runtime_dir test isolation, debounce intra-process lock) follow as separate PRs.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_wiki_store.py::TestIsDirty -x` — 4 passed
- [x] `uv run ruff check && uv run ruff format --check`
- [ ] CI windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
