### PR TITLE
fix(tests): pin utf-8 for mm subprocess in CLI e2e (#759 partial)

### DIFF
--- a/packages/memtomem/tests/test_cli_index_noop_e2e.py
+++ b/packages/memtomem/tests/test_cli_index_noop_e2e.py
@@ -123,11 +123,20 @@ class TestFreshNoopIndexSubprocess:
         env["XDG_CONFIG_HOME"] = str(home / ".config")
 
         def _run(*args: str) -> subprocess.CompletedProcess:
+            # ``encoding="utf-8"`` is required: ``text=True`` alone falls
+            # back to ``locale.getpreferredencoding(False)``, which is
+            # ``cp949`` on Korean Windows. The CLI emits UTF-8 (em-dashes,
+            # box-drawing) so the reader thread crashes mid-decode and
+            # ``r.stdout`` / ``r.stderr`` come back as ``None``, surfacing
+            # later as ``"argument of type 'NoneType' is not iterable"``
+            # on the assertion below (#759).
             return subprocess.run(
                 [mm_bin, *args],
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=60,
             )
 


### PR DESCRIPTION
## Summary

- `test_init_index_search_via_subprocess` calls `subprocess.run(text=True, capture_output=True)` with no `encoding=`. Python falls back to `locale.getpreferredencoding(False)` — `cp949` on Korean Windows.
- The `mm` CLI emits UTF-8 (em-dashes, box-drawing in headers). The first non-ASCII byte trips the per-thread `_readerthread` decode; the thread raises and `_communicate` returns `None` for the buffer. Subsequent `"no such table" not in (r.stdout + r.stderr)` then crashes with the misleading `argument of type 'NoneType' is not iterable` (#759 failure 1 of 4).
- Pin `encoding="utf-8"` + `errors="replace"` on the inner `_run` helper. `errors="replace"` is deliberate — these are diagnostic strings the assertions grep for, not data the test round-trips, so a U+FFFD on a malformed byte is strictly better than a thread crash that loses the entire buffer.

Partial fix for #759. Sibling PRs follow for the other three failures (test_wiki_store cp949 → #847, test_uninstall runtime_dir, debounce intra-process lock).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_cli_index_noop_e2e.py -x` — 2 passed
- [x] `uv run ruff check && uv run ruff format --check`
- [ ] CI windows-latest

## Follow-up (not in this PR)

Production `subprocess.run(text=True)` callers without `encoding=` exist at `cli/init_cmd.py:48` and `cli/upgrade_cmd.py:156, 337`. Same `cp949` failure mode applies when `mm init` shells out to `gh` / `uv` on Korean Windows. Tracking as the optional 5th PR in the #759 cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
