### PR TITLE
fix(tests): per-test tempfile.tempdir so Windows runtime_dir prune is hermetic (#759 partial)

### DIFF
--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -62,7 +62,20 @@ def home(tmp_path, monkeypatch):
     Also isolates ``$XDG_RUNTIME_DIR`` so the new runtime pid file
     location (#412) lives under ``tmp_path`` rather than the developer's
     real ``/run/user/{uid}/memtomem/`` or a shared ``/tmp`` subdir.
+
+    On Windows, ``_runtime_paths.runtime_dir()`` skips the
+    ``XDG_RUNTIME_DIR`` branch entirely (``XDG_RUNTIME_DIR`` is a Linux/
+    systemd convention; the POSIX-mode-bit gate guarding it is
+    meaningless on NTFS) and falls through to
+    ``tempfile.gettempdir() / memtomem-0``. ``gettempdir()`` resolves to
+    the user-shared ``%LOCALAPPDATA%\\Temp\\``, so leftover artifacts
+    from prior pytest runs or concurrent tools blocked the prune
+    assertion in ``TestRuntimePidCleanedWithOther`` (#759 failure 3).
+    Pin ``tempfile.tempdir`` to a per-test path so the runtime dir is
+    always test-scoped, regardless of platform.
     """
+    import tempfile
+
     from memtomem.cli import _bootstrap
     from memtomem.cli import uninstall_cmd
 
@@ -71,6 +84,9 @@ def home(tmp_path, monkeypatch):
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
     os.chmod(xdg, 0o700)  # _runtime_paths validator requires owner-only
+    fake_tempdir = tmp_path / "tempdir"
+    fake_tempdir.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(fake_tempdir))
     set_home(monkeypatch, h)
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
     monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", h / ".memtomem" / "config.json")


### PR DESCRIPTION
## Summary

- `TestRuntimePidCleanedWithOther.test_runtime_pid_deleted_and_subdir_pruned` asserts `not runtime_dir().exists()` after `mm uninstall` cleans the pid file.
- `_runtime_paths.runtime_dir()` skips the `XDG_RUNTIME_DIR` branch on Windows (XDG is a Linux/systemd convention; the POSIX-mode-bit gate is meaningless on NTFS) and falls through to `tempfile.gettempdir() / memtomem-0`. On Windows that resolves to the user-shared `%LOCALAPPDATA%\Temp\`. Leftover artifacts from prior pytest runs (or any other tool touching the same temp tree) populated `memtomem-0`, made `not any(rt.iterdir())` False, and the rmdir got skipped — assertion failed (#759 failure 3 of 4).
- Pin `tempfile.tempdir = tmp_path/tempdir/` in the `home` fixture so the runtime dir is always test-scoped, regardless of platform. POSIX is unaffected (XDG branch fires first); Windows now lands runtime artifacts under the test's `tmp_path` and prunes cleanly.

Partial fix for #759. Companion to #847 (cp949 wiki read), #848 (subprocess utf-8); F2 debounce intra-process lock follows.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py::TestRuntimePidCleanedWithOther -x` — 2 passed
- [x] `uv run pytest packages/memtomem/tests/test_uninstall_cmd.py` — 31 passed, 2 skipped (no fixture regressions)
- [x] `uv run ruff check && uv run ruff format --check`
- [ ] CI windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)
