### PR TITLE
fix(web): clear _ctxPendingEdit on superseded/un-appliable bails

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -362,67 +362,55 @@ window.addEventListener('langchange', () => {
     const editPane = detailEl ? detailEl.querySelector('#ctx-pane-edit') : null;
     const editTextarea = detailEl ? detailEl.querySelector('#ctx-edit-content') : null;
     const wasEditing = editPane != null && !editPane.hidden;
-    // ``myStashGen`` defaults to a sentinel that no future capture can
-    // match (gen counter only increments) so the post-mount ``.then()``
-    // never identifies an unrelated stash as "ours" when this listener
-    // didn't actually capture one.
-    let myStashGen = -1;
     if (wasEditing && editTextarea && openName && !openRuntimeOnly) {
-      myStashGen = ++_ctxPendingEditGen;
       _ctxPendingEdit = {
         type,
         name: openName,
         content: editTextarea.value,
         mtimeNs: detailEl ? (detailEl.dataset.mtimeNs || '') : '',
-        gen: myStashGen,
       };
     }
 
     loadCtxList(type);
 
     if (openName) {
+      // ``preservePendingEdit: true`` opts these mounts out of the
+      // navigation-drop guard inside ``loadCtxDetail`` /
+      // ``_ctxLoadRuntimeOnlyDetail`` — the langchange listener IS the
+      // intended stash consumer, the drop only fires on user-initiated
+      // navigations to a different (or same-name post-edit-discard)
+      // mount. Without the flag here, the listener's own list-rebuild +
+      // detail re-mount would clear the stash that the post-mount
+      // ``.then()`` is about to apply (rapid-toggle regression).
       if (openRuntimeOnly) {
-        _ctxLoadRuntimeOnlyDetail(type, openName, detailEl);
+        _ctxLoadRuntimeOnlyDetail(type, openName, detailEl, {
+          preservePendingEdit: true,
+        });
       } else {
-        const detailPromise = loadCtxDetail(type, openName, { autoOpenDiff: wasDiffActive });
+        const detailPromise = loadCtxDetail(type, openName, {
+          autoOpenDiff: wasDiffActive,
+          preservePendingEdit: true,
+        });
         // ``loadCtxDetail`` synchronously bumps ``_ctxDetailSeq[type]``
         // before returning the promise, so reading it here captures
         // *this* invocation's seq. A subsequent invocation (e.g. from
         // a rapid second toggle) will bump the counter further; this
-        // .then() then bails by inequality.
+        // .then() then bails by inequality. The bail intentionally
+        // does NOT clear the stash — a later .then() (rapid-toggle
+        // L2) is the consumer; navigation orphans are caught up-front
+        // by the navigation-drop guard, not here.
         const myDetailSeq = _ctxDetailSeq[type];
         if (detailPromise && typeof detailPromise.then === 'function') {
           detailPromise.then(() => {
+            if (myDetailSeq !== _ctxDetailSeq[type]) return;
             const pending = _ctxPendingEdit;
-            // ``stashIsOurs`` gates every clear and apply: a clear path
-            // must never delete a stash that belongs to a *later*
-            // langchange (see the (a) race in the doc-comment near
-            // ``_ctxPendingEditGen``), and an apply path must never
-            // resurrect an unrelated capture.
-            const stashIsOurs = pending != null && pending.gen === myStashGen;
-            if (myDetailSeq !== _ctxDetailSeq[type]) {
-              // Superseded. If a later langchange fired, ``pending``
-              // already reflects its capture (different gen) so we
-              // leave the stash alone and let that ``.then()`` apply.
-              // If only a navigation superseded us, the stash is an
-              // orphan that no future ``.then()`` will pick up; drop
-              // it now so it can't resurrect on a remount of the same
-              // card (race (b) in the doc-comment).
-              if (stashIsOurs) _ctxPendingEdit = null;
-              return;
-            }
-            if (!stashIsOurs) return;
+            if (!pending || pending.type !== type || pending.name !== openName) return;
             // Re-resolve panes — the previous detailEl children were
             // wiped by loadCtxDetail's innerHTML rewrite.
             const newTa = detailEl.querySelector('#ctx-edit-content');
             const newCanonPane = detailEl.querySelector('#ctx-pane-canonical');
             const newEditPane = detailEl.querySelector('#ctx-pane-edit');
-            if (!newTa || !newEditPane) {
-              // Ours but un-appliable (DOM didn't render the edit
-              // pane). Drop the stash rather than let it leak forward.
-              _ctxPendingEdit = null;
-              return;
-            }
+            if (!newTa || !newEditPane) return;
             newTa.value = pending.content;
             if (newCanonPane) newCanonPane.hidden = true;
             newEditPane.hidden = false;
@@ -571,18 +559,22 @@ let _ctxDetailSeq = { skills: 0, commands: 0, agents: 0 };
 // from) but ``_ctxPendingEdit`` still carries T1's stash, and T2's
 // own (now-latest) detail mount applies it.
 //
-// ``_ctxPendingEditGen`` is a monotonically incrementing token tagged
-// onto each capture. The post-mount ``.then()`` reads its closure-local
-// ``myStashGen`` and only clears / applies the stash when its own gen
-// still matches — preventing two distinct races:
-//   (a) ``T1`` clearing ``T2``'s overwritten stash when T1's superseded
-//       ``.then()`` resolves later.
-//   (b) An orphaned stash from a langchange-then-navigate sequence
-//       resurrecting on a future remount of the same card. The orphan
-//       case is detected by seq mismatch + ``stashIsOurs`` and the
-//       stash is dropped instead of leaking.
+// Lifetime is bounded by two clear sites — there is intentionally no
+// stash-clear inside the langchange ``.then()`` supersede branch, so a
+// rapid same-card retoggle hands the stash forward to the latest
+// mount's consumer:
+//
+//   1. **Apply-success** — the latest detail mount's ``.then()`` paints
+//      the buffer back into the new textarea, then clears.
+//   2. **Navigation-drop** — ``loadCtxDetail`` /
+//      ``_ctxLoadRuntimeOnlyDetail`` clear the stash at the top of any
+//      mount that was NOT initiated by the langchange listener. This
+//      catches the langchange-then-navigate orphan (P2 review): the
+//      user toggles language while editing card A, navigates to card
+//      B before T1's reload settles, and the stash would otherwise
+//      survive forever. The langchange listener opts back in to
+//      preservation via ``opts.preservePendingEdit: true``.
 let _ctxPendingEdit = null;
-let _ctxPendingEditGen = 0;
 
 // ``runtimeOnly`` disambiguates the two detail loaders: ``loadCtxDetail``
 // fetches the canonical file, ``_ctxLoadRuntimeOnlyDetail`` (line ~1134)
@@ -1019,6 +1011,16 @@ async function loadCtxDetail(type, name, opts = {}) {
   // themselves. Other call paths (post-save / post-delete reload at
   // line ~575/588) leave it false to preserve their canonical-pane
   // default.
+  //
+  // ``opts.preservePendingEdit`` (default false): only set by the
+  // langchange listener, which IS the intended consumer of
+  // ``_ctxPendingEdit``. Every other caller (card-click navigation,
+  // save/delete post-mount reload, etc.) is a user-initiated change
+  // of context — drop any pending stash here so a future remount of
+  // the original card cannot resurrect a stale draft.
+  if (!opts.preservePendingEdit) {
+    _ctxPendingEdit = null;
+  }
   const seq = ++_ctxDetailSeq[type];
   const autoOpenDiff = opts.autoOpenDiff === true;
   const detailEl = qs(`ctx-${type}-detail`);
@@ -1341,12 +1343,21 @@ async function _ctxLoadDiff(type, name, detailEl) {
 // returns ``runtime_content`` for each runtime, so we reuse it as the
 // preview source and surface an "Import all" CTA so the user can pull every
 // runtime-only artifact in one click.
-async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl) {
+async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
   // Shares ``_ctxDetailSeq[type]`` with ``loadCtxDetail`` — both paint
   // into the same detailEl, so a runtime-only fetch racing against a
   // canonical fetch (or another runtime-only fetch) must obey the same
   // seq invariant. Review P2 specifically called out the runtime-only
   // path as having the same stale-response window.
+  //
+  // ``opts.preservePendingEdit`` mirrors the canonical sibling — see
+  // ``loadCtxDetail`` for the rationale. A runtime-only mount is no
+  // less of a navigation than a canonical one; orphan-drop must apply
+  // to both paths or a langchange-then-navigate-to-runtime-only
+  // sequence still leaks the stash.
+  if (!opts.preservePendingEdit) {
+    _ctxPendingEdit = null;
+  }
   const seq = ++_ctxDetailSeq[type];
   detailEl.hidden = false;
   _ctxCurrentDetail = { type, name, runtimeOnly: true };

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -362,12 +362,19 @@ window.addEventListener('langchange', () => {
     const editPane = detailEl ? detailEl.querySelector('#ctx-pane-edit') : null;
     const editTextarea = detailEl ? detailEl.querySelector('#ctx-edit-content') : null;
     const wasEditing = editPane != null && !editPane.hidden;
+    // ``myStashGen`` defaults to a sentinel that no future capture can
+    // match (gen counter only increments) so the post-mount ``.then()``
+    // never identifies an unrelated stash as "ours" when this listener
+    // didn't actually capture one.
+    let myStashGen = -1;
     if (wasEditing && editTextarea && openName && !openRuntimeOnly) {
+      myStashGen = ++_ctxPendingEditGen;
       _ctxPendingEdit = {
         type,
         name: openName,
         content: editTextarea.value,
         mtimeNs: detailEl ? (detailEl.dataset.mtimeNs || '') : '',
+        gen: myStashGen,
       };
     }
 
@@ -386,15 +393,36 @@ window.addEventListener('langchange', () => {
         const myDetailSeq = _ctxDetailSeq[type];
         if (detailPromise && typeof detailPromise.then === 'function') {
           detailPromise.then(() => {
-            if (myDetailSeq !== _ctxDetailSeq[type]) return;
             const pending = _ctxPendingEdit;
-            if (!pending || pending.type !== type || pending.name !== openName) return;
+            // ``stashIsOurs`` gates every clear and apply: a clear path
+            // must never delete a stash that belongs to a *later*
+            // langchange (see the (a) race in the doc-comment near
+            // ``_ctxPendingEditGen``), and an apply path must never
+            // resurrect an unrelated capture.
+            const stashIsOurs = pending != null && pending.gen === myStashGen;
+            if (myDetailSeq !== _ctxDetailSeq[type]) {
+              // Superseded. If a later langchange fired, ``pending``
+              // already reflects its capture (different gen) so we
+              // leave the stash alone and let that ``.then()`` apply.
+              // If only a navigation superseded us, the stash is an
+              // orphan that no future ``.then()`` will pick up; drop
+              // it now so it can't resurrect on a remount of the same
+              // card (race (b) in the doc-comment).
+              if (stashIsOurs) _ctxPendingEdit = null;
+              return;
+            }
+            if (!stashIsOurs) return;
             // Re-resolve panes — the previous detailEl children were
             // wiped by loadCtxDetail's innerHTML rewrite.
             const newTa = detailEl.querySelector('#ctx-edit-content');
             const newCanonPane = detailEl.querySelector('#ctx-pane-canonical');
             const newEditPane = detailEl.querySelector('#ctx-pane-edit');
-            if (!newTa || !newEditPane) return;
+            if (!newTa || !newEditPane) {
+              // Ours but un-appliable (DOM didn't render the edit
+              // pane). Drop the stash rather than let it leak forward.
+              _ctxPendingEdit = null;
+              return;
+            }
             newTa.value = pending.content;
             if (newCanonPane) newCanonPane.hidden = true;
             newEditPane.hidden = false;
@@ -542,7 +570,19 @@ let _ctxDetailSeq = { skills: 0, commands: 0, agents: 0 };
 // detail fetch completes, T2 sees a wiped DOM (no editPane to capture
 // from) but ``_ctxPendingEdit`` still carries T1's stash, and T2's
 // own (now-latest) detail mount applies it.
+//
+// ``_ctxPendingEditGen`` is a monotonically incrementing token tagged
+// onto each capture. The post-mount ``.then()`` reads its closure-local
+// ``myStashGen`` and only clears / applies the stash when its own gen
+// still matches — preventing two distinct races:
+//   (a) ``T1`` clearing ``T2``'s overwritten stash when T1's superseded
+//       ``.then()`` resolves later.
+//   (b) An orphaned stash from a langchange-then-navigate sequence
+//       resurrecting on a future remount of the same card. The orphan
+//       case is detected by seq mismatch + ``stashIsOurs`` and the
+//       stash is dropped instead of leaking.
 let _ctxPendingEdit = null;
+let _ctxPendingEditGen = 0;
 
 // ``runtimeOnly`` disambiguates the two detail loaders: ``loadCtxDetail``
 // fetches the canonical file, ``_ctxLoadRuntimeOnlyDetail`` (line ~1134)

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -81,6 +81,35 @@ class TestLocaleFiles:
 _STATIC_JS_DIR = _LOCALES_DIR.parent
 
 
+def _langchange_listener_body(text: str) -> str:
+    """Sentinel-slice the langchange listener body in ``context-gateway.js``.
+
+    Earlier specs used a lazy regex ``\\{(.+?)\\}\\);`` to grab the body —
+    that pattern stops at the first ``});`` it sees, which fails the
+    moment a call inside the listener body uses an inline object
+    argument like::
+
+        loadCtxDetail(type, name, { autoOpenDiff: true });
+
+    The inline ``});`` is the call's closing parenthesis, not the
+    listener's, but the lazy regex doesn't know that. Switch to a
+    stable pair of sentinels: the listener's
+    ``window.addEventListener('langchange', ...)`` registration on the
+    upper end and the file's ``// Sync All button`` comment that
+    immediately follows on the lower end. Both have been stable for
+    months and are scoped to this single listener.
+
+    See ``feedback_listener_body_lazy_regex_trips_inline_objects.md``
+    (PR #840 review) — same pattern surfaced there and was fixed with
+    the same sentinel slice.
+    """
+    start = text.find("window.addEventListener('langchange'")
+    assert start >= 0, "langchange listener registration missing"
+    end = text.find("// Sync All button", start)
+    assert end > start, "couldn't locate end-of-listener sentinel"
+    return text[start:end]
+
+
 class TestNoHardcodedStrings:
     """Guard against regressions in i18n coverage for user-facing dialogs.
 
@@ -693,13 +722,7 @@ class TestNoHardcodedStrings:
         ``section.classList.add('active')`` contract (app.js:1191).
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
-        m = re.search(
-            r"window\.addEventListener\('langchange',\s*\(\)\s*=>\s*\{(.+?)\}\);",
-            text,
-            re.DOTALL,
-        )
-        assert m, "langchange listener missing from context-gateway.js"
-        body = m.group(1)
+        body = _langchange_listener_body(text)
         # Cache-driven re-render path is the primary action; the
         # ``loadCtxOverview()`` cold-mount fallback covers the case when
         # the cache is empty (initial mount race or prior fetch error).
@@ -778,13 +801,7 @@ class TestNoHardcodedStrings:
         the overview cards.
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
-        m = re.search(
-            r"window\.addEventListener\('langchange',\s*\(\)\s*=>\s*\{(.+?)\}\);",
-            text,
-            re.DOTALL,
-        )
-        assert m, "langchange listener missing from context-gateway.js"
-        body = m.group(1)
+        body = _langchange_listener_body(text)
         # All three per-type sections must be referenced — using the
         # template literal ``settings-ctx-${type}`` is the canonical form,
         # but we accept literal strings too in case a refactor inlines them.
@@ -812,13 +829,7 @@ class TestNoHardcodedStrings:
         the ``runtimeOnly`` flag on ``_ctxCurrentDetail``.
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
-        m = re.search(
-            r"window\.addEventListener\('langchange',\s*\(\)\s*=>\s*\{(.+?)\}\);",
-            text,
-            re.DOTALL,
-        )
-        assert m, "langchange listener missing from context-gateway.js"
-        body = m.group(1)
+        body = _langchange_listener_body(text)
         assert "loadCtxDetail(" in body, (
             "langchange listener must call loadCtxDetail() to re-mount the canonical detail pane"
         )
@@ -846,13 +857,7 @@ class TestNoHardcodedStrings:
         P1.
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
-        m = re.search(
-            r"window\.addEventListener\('langchange',\s*\(\)\s*=>\s*\{(.+?)\}\);",
-            text,
-            re.DOTALL,
-        )
-        assert m, "langchange listener missing from context-gateway.js"
-        body = m.group(1)
+        body = _langchange_listener_body(text)
         # Active-tab capture: must query for the .ctx-detail-tab[data-pane="diff"]
         # element and check whether it carries ``.active``.
         assert 'data-pane="diff"' in body or "data-pane='diff'" in body, (
@@ -879,13 +884,7 @@ class TestNoHardcodedStrings:
         itself.
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
-        m = re.search(
-            r"window\.addEventListener\('langchange',\s*\(\)\s*=>\s*\{(.+?)\}\);",
-            text,
-            re.DOTALL,
-        )
-        assert m, "langchange listener missing from context-gateway.js"
-        body = m.group(1)
+        body = _langchange_listener_body(text)
         # The clear happens implicitly via ``loadCtxList`` (which clears
         # ``statusEl.innerHTML`` near its top). Pin both the call and the
         # absence of any caching of the import-result payload.
@@ -939,13 +938,7 @@ class TestNoHardcodedStrings:
         bug if a future refactor weakened the section-active invariant.
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
-        m = re.search(
-            r"window\.addEventListener\('langchange',\s*\(\)\s*=>\s*\{(.+?)\}\);",
-            text,
-            re.DOTALL,
-        )
-        assert m, "langchange listener missing from context-gateway.js"
-        body = m.group(1)
+        body = _langchange_listener_body(text)
         # Find the overview branch (settings-ctx-overview gate) and
         # confirm it ends with ``return;`` before the per-type loop.
         # Using a permissive regex to avoid coupling to brace placement.
@@ -975,15 +968,9 @@ class TestNoHardcodedStrings:
         # Slice from the listener's `addEventListener('langchange',` line
         # to the next "// -- " section comment header (or, defensively,
         # the next `// Sync All button` block which follows the listener).
-        # A simple lazy-regex body extraction trips on inline object
-        # literals like ``{ autoOpenDiff: wasDiffActive }`` inside
-        # ``loadCtxDetail(...)`` — those ``});`` balance against the
-        # listener's outer ``});``.
-        start = text.find("window.addEventListener('langchange'")
-        assert start >= 0, "langchange listener missing from context-gateway.js"
-        end = text.find("// Sync All button", start)
-        assert end > start, "couldn't locate end-of-listener sentinel"
-        body = text[start:end]
+        # See ``_langchange_listener_body`` for why this is a sentinel
+        # slice rather than a lazy regex.
+        body = _langchange_listener_body(text)
         # Must reference the edit-pane element + textarea so the dirty
         # buffer is captured before loadCtxList wipes it.
         assert "ctx-pane-edit" in body, (
@@ -1062,11 +1049,7 @@ class TestNoHardcodedStrings:
             "missing module-level _ctxPendingEdit declaration"
         )
         # Listener reads + writes the stash + clears after consumption.
-        start = text.find("window.addEventListener('langchange'")
-        assert start >= 0, "langchange listener missing"
-        end = text.find("// Sync All button", start)
-        assert end > start, "couldn't locate end-of-listener sentinel"
-        body = text[start:end]
+        body = _langchange_listener_body(text)
         assert "_ctxPendingEdit = {" in body, (
             "listener must populate _ctxPendingEdit with the captured buffer"
         )
@@ -1151,10 +1134,7 @@ class TestNoHardcodedStrings:
         )
 
         # 3+4. Langchange listener opts both mounts in to preservation.
-        start = text.find("window.addEventListener('langchange'")
-        end = text.find("// Sync All button", start)
-        assert end > start, "couldn't locate end-of-listener sentinel"
-        body = text[start:end]
+        body = _langchange_listener_body(text)
 
         canonical_call_match = re.search(
             r"loadCtxDetail\s*\(\s*type\s*,\s*openName\s*,\s*\{"

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -1087,80 +1087,115 @@ class TestNoHardcodedStrings:
             "(otherwise an older .then() races a newer one for the DOM)"
         )
 
-    def test_pending_edit_stash_clears_in_all_bail_paths(self) -> None:
-        """Pin the orphan-drop invariant on ``_ctxPendingEdit``.
+    def test_pending_edit_navigation_drop_guards_against_orphan_resurrect(
+        self,
+    ) -> None:
+        """P2 review: a langchange-then-navigate sequence must not orphan
+        the ``_ctxPendingEdit`` stash. The fix is a navigation-drop guard
+        at the top of ``loadCtxDetail`` and ``_ctxLoadRuntimeOnlyDetail``
+        — every mount initiated by a path other than the langchange
+        listener clears the stash before the new mount paints. The
+        langchange listener, which IS the intended consumer, opts back
+        in via ``opts.preservePendingEdit: true``.
 
-        The langchange listener captures an unsaved edit buffer into the
-        module-level stash. The post-mount ``.then()`` has three exit
-        modes — supersede (seq mismatch), un-appliable (DOM panes not
-        rendered), and apply (success). Without a generation token,
-        clearing the stash on supersede races against a *later*
-        capture's apply (T1's superseded ``.then()`` would delete T2's
-        stash). Without clearing on supersede or un-appliable, an
-        orphaned stash from a langchange-then-navigate sequence can
-        resurrect on a future remount of the same card.
+        Pinning here rather than via Playwright because the
+        resurrection scenario takes 4–5 user-initiated DOM events to
+        reproduce reliably and a static-source guard catches the
+        regression at the line that introduces it.
 
-        This test pins five invariants that together resolve both
-        races:
+        Five invariants together close both the resurrection race and
+        the rapid-toggle preservation race:
 
-        1. ``_ctxPendingEditGen`` exists at module scope as a counter.
-        2. The langchange capture writes a ``gen: myStashGen`` field.
-        3. The ``.then()`` derives ``stashIsOurs`` from the gen.
-        4. The ``.then()`` clears the stash in the seq-mismatch path
-           when ``stashIsOurs`` is true (orphan drop).
-        5. The stash is cleared on every exit where it is "ours" — the
-           file contains exactly three ``_ctxPendingEdit = null``
-           assignments inside the listener (supersede orphan,
-           un-appliable, apply success).
+        1+2. Both detail-mount entry points (canonical + runtime-only)
+             accept ``opts = {}`` and start with the navigation-drop
+             guard ``if (!opts.preservePendingEdit) _ctxPendingEdit = null;``.
+        3+4. The langchange listener calls each entry point with
+             ``preservePendingEdit: true`` so the listener's own
+             re-mount cycle does not clear the stash that its
+             ``.then()`` is about to consume.
+        5.   The listener's post-mount ``.then()`` does NOT clear the
+             stash on the seq-mismatch (supersede) bail. A rapid
+             same-card retoggle (L1 superseded by L2) hands the stash
+             to L2's ``.then()``; clearing on supersede would race
+             against L2's apply.
         """
         text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
 
-        assert re.search(r"^let _ctxPendingEditGen\s*=\s*0;", text, re.MULTILINE), (
-            "missing module-level _ctxPendingEditGen counter — required to "
-            "tag each capture so the post-mount .then() can identify its own "
-            "stash and avoid clearing a later capture's"
+        # 1+2. Both entry points carry the guard.
+        canonical_match = re.search(
+            r"async\s+function\s+loadCtxDetail\s*\([^)]*opts\s*=\s*\{\}\s*\)\s*\{"
+            r"(?:[^{}]|\{[^{}]*\})*?"
+            r"if\s*\(\s*!\s*opts\.preservePendingEdit\s*\)\s*\{\s*"
+            r"_ctxPendingEdit\s*=\s*null;\s*\}",
+            text,
+        )
+        assert canonical_match, (
+            "loadCtxDetail must drop _ctxPendingEdit at entry unless "
+            "opts.preservePendingEdit is true — without the guard a "
+            "langchange-then-navigate sequence orphans the stash and a "
+            "future remount of the original card resurrects stale draft "
+            "content (review P2)"
+        )
+        runtime_only_match = re.search(
+            r"async\s+function\s+_ctxLoadRuntimeOnlyDetail\s*\([^)]*opts\s*=\s*\{\}\s*\)\s*\{"
+            r"(?:[^{}]|\{[^{}]*\})*?"
+            r"if\s*\(\s*!\s*opts\.preservePendingEdit\s*\)\s*\{\s*"
+            r"_ctxPendingEdit\s*=\s*null;\s*\}",
+            text,
+        )
+        assert runtime_only_match, (
+            "_ctxLoadRuntimeOnlyDetail must mirror loadCtxDetail's "
+            "navigation-drop guard. A user navigating from an edited "
+            "canonical card to a runtime-only card otherwise leaves the "
+            "stash live for a future remount of the original card."
         )
 
+        # 3+4. Langchange listener opts both mounts in to preservation.
         start = text.find("window.addEventListener('langchange'")
         end = text.find("// Sync All button", start)
         assert end > start, "couldn't locate end-of-listener sentinel"
         body = text[start:end]
 
-        # Capture writes the gen onto the stash so the .then() can match.
-        assert re.search(r"gen\s*:\s*myStashGen", body), (
-            "capture must tag stash with ``gen: myStashGen`` — without the "
-            "tag the .then() cannot distinguish its own stash from a later "
-            "langchange's overwrite"
-        )
-
-        # The .then() derives stashIsOurs and uses it to gate every clear.
-        assert re.search(r"const\s+stashIsOurs\s*=", body), (
-            ".then() must compute ``stashIsOurs`` (gen-based) — every clear "
-            "and apply path is gated on it so a later capture's stash never "
-            "gets deleted by an older .then()"
-        )
-
-        # Supersede path clears the stash when it's ours (orphan-drop case).
-        assert re.search(
-            r"myDetailSeq\s*!==\s*_ctxDetailSeq\[type\]\s*\)\s*\{\s*"
+        canonical_call_match = re.search(
+            r"loadCtxDetail\s*\(\s*type\s*,\s*openName\s*,\s*\{"
             r"(?:[^{}]|\{[^{}]*\})*?"
-            r"if\s*\(\s*stashIsOurs\s*\)\s*_ctxPendingEdit\s*=\s*null;",
+            r"preservePendingEdit\s*:\s*true",
             body,
-        ), (
-            "seq-mismatch bail must clear the stash when stashIsOurs is "
-            "true — otherwise a langchange-then-navigate sequence orphans "
-            "the stash and a future remount of the same card resurrects "
-            "stale draft content"
+        )
+        assert canonical_call_match, (
+            "langchange listener's canonical-detail call must pass "
+            "preservePendingEdit: true. Without it the listener's own "
+            "loadCtxDetail invocation clears the stash before its "
+            ".then() can apply it (rapid-toggle regression)."
+        )
+        runtime_only_call_match = re.search(
+            r"_ctxLoadRuntimeOnlyDetail\s*\(\s*type\s*,\s*openName\s*,"
+            r"\s*detailEl\s*,\s*\{"
+            r"(?:[^{}]|\{[^{}]*\})*?"
+            r"preservePendingEdit\s*:\s*true",
+            body,
+        )
+        assert runtime_only_call_match, (
+            "langchange listener's runtime-only call must also pass "
+            "preservePendingEdit: true — symmetric with the canonical "
+            "path so a runtime-only-card retoggle preserves its buffer."
         )
 
-        # Exactly three clears: orphan-drop, un-appliable, and apply-success.
-        # If a fourth path leaks the stash without clearing, this count fails.
-        clear_count = len(re.findall(r"_ctxPendingEdit\s*=\s*null", body))
-        assert clear_count == 3, (
-            f"expected exactly 3 ``_ctxPendingEdit = null`` clears in the "
-            f"langchange listener (orphan-drop, un-appliable, apply-success); "
-            f"got {clear_count}. A new bail path that doesn't clear a "
-            f"stash that's ours leaks the stash and risks resurrection."
+        # 5. Supersede bail does NOT clear the stash.
+        # The seq-mismatch branch must be a bare ``return;`` — any
+        # stash-clear there would race against a rapid-toggle L2's
+        # apply path. The navigation-drop guard at the loadCtxDetail
+        # entry is the single source of orphan cleanup.
+        supersede_match = re.search(
+            r"if\s*\(\s*myDetailSeq\s*!==\s*_ctxDetailSeq\[type\]\s*\)\s*return;",
+            body,
+        )
+        assert supersede_match, (
+            "supersede branch in the langchange listener .then() must "
+            "be a bare ``return;`` — clearing _ctxPendingEdit there "
+            "would race against a rapid-toggle L2's apply path. The "
+            "navigation-drop guard at loadCtxDetail entry is the "
+            "single source of orphan cleanup."
         )
 
     def test_q_pr4_ctxCurrentDetail_carries_runtime_only_flag(self) -> None:

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -1087,6 +1087,82 @@ class TestNoHardcodedStrings:
             "(otherwise an older .then() races a newer one for the DOM)"
         )
 
+    def test_pending_edit_stash_clears_in_all_bail_paths(self) -> None:
+        """Pin the orphan-drop invariant on ``_ctxPendingEdit``.
+
+        The langchange listener captures an unsaved edit buffer into the
+        module-level stash. The post-mount ``.then()`` has three exit
+        modes — supersede (seq mismatch), un-appliable (DOM panes not
+        rendered), and apply (success). Without a generation token,
+        clearing the stash on supersede races against a *later*
+        capture's apply (T1's superseded ``.then()`` would delete T2's
+        stash). Without clearing on supersede or un-appliable, an
+        orphaned stash from a langchange-then-navigate sequence can
+        resurrect on a future remount of the same card.
+
+        This test pins five invariants that together resolve both
+        races:
+
+        1. ``_ctxPendingEditGen`` exists at module scope as a counter.
+        2. The langchange capture writes a ``gen: myStashGen`` field.
+        3. The ``.then()`` derives ``stashIsOurs`` from the gen.
+        4. The ``.then()`` clears the stash in the seq-mismatch path
+           when ``stashIsOurs`` is true (orphan drop).
+        5. The stash is cleared on every exit where it is "ours" — the
+           file contains exactly three ``_ctxPendingEdit = null``
+           assignments inside the listener (supersede orphan,
+           un-appliable, apply success).
+        """
+        text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
+
+        assert re.search(r"^let _ctxPendingEditGen\s*=\s*0;", text, re.MULTILINE), (
+            "missing module-level _ctxPendingEditGen counter — required to "
+            "tag each capture so the post-mount .then() can identify its own "
+            "stash and avoid clearing a later capture's"
+        )
+
+        start = text.find("window.addEventListener('langchange'")
+        end = text.find("// Sync All button", start)
+        assert end > start, "couldn't locate end-of-listener sentinel"
+        body = text[start:end]
+
+        # Capture writes the gen onto the stash so the .then() can match.
+        assert re.search(r"gen\s*:\s*myStashGen", body), (
+            "capture must tag stash with ``gen: myStashGen`` — without the "
+            "tag the .then() cannot distinguish its own stash from a later "
+            "langchange's overwrite"
+        )
+
+        # The .then() derives stashIsOurs and uses it to gate every clear.
+        assert re.search(r"const\s+stashIsOurs\s*=", body), (
+            ".then() must compute ``stashIsOurs`` (gen-based) — every clear "
+            "and apply path is gated on it so a later capture's stash never "
+            "gets deleted by an older .then()"
+        )
+
+        # Supersede path clears the stash when it's ours (orphan-drop case).
+        assert re.search(
+            r"myDetailSeq\s*!==\s*_ctxDetailSeq\[type\]\s*\)\s*\{\s*"
+            r"(?:[^{}]|\{[^{}]*\})*?"
+            r"if\s*\(\s*stashIsOurs\s*\)\s*_ctxPendingEdit\s*=\s*null;",
+            body,
+        ), (
+            "seq-mismatch bail must clear the stash when stashIsOurs is "
+            "true — otherwise a langchange-then-navigate sequence orphans "
+            "the stash and a future remount of the same card resurrects "
+            "stale draft content"
+        )
+
+        # Exactly three clears: orphan-drop, un-appliable, and apply-success.
+        # If a fourth path leaks the stash without clearing, this count fails.
+        clear_count = len(re.findall(r"_ctxPendingEdit\s*=\s*null", body))
+        assert clear_count == 3, (
+            f"expected exactly 3 ``_ctxPendingEdit = null`` clears in the "
+            f"langchange listener (orphan-drop, un-appliable, apply-success); "
+            f"got {clear_count}. A new bail path that doesn't clear a "
+            f"stash that's ours leaks the stash and risks resurrection."
+        )
+
     def test_q_pr4_ctxCurrentDetail_carries_runtime_only_flag(self) -> None:
         """Q-PR4 (#826) review finding P2: ``_ctxCurrentDetail`` must carry
         a ``runtimeOnly`` flag so the langchange listener can route the


### PR DESCRIPTION
## Summary

- Adds a **navigation-drop guard** at the top of `loadCtxDetail` and `_ctxLoadRuntimeOnlyDetail` so any mount initiated by a path other than the langchange listener clears `_ctxPendingEdit` before painting. The langchange listener — the only intended consumer of the stash — opts back in via `opts.preservePendingEdit: true`.
- Closes the resurrection race the original P2 review surfaced: a langchange-then-navigate sequence (toggle locale while editing card A, navigate to card B before T1 resolves) used to leave the stash live. A future remount of card A would resurrect a stale draft after the user had moved on. The navigation-drop guard now clears the stash on the click-driven mount of B.
- Pins the design in `test_i18n.py`: both detail-mount entry points carry the guard, the langchange listener passes `preservePendingEdit: true` on both canonical and runtime-only mounts, and the `.then()` supersede branch is a bare `return;` (clearing the stash there would race against rapid-toggle L2's apply path).
- **Incidental cleanup**: unifies eight callsites onto a `_langchange_listener_body(text)` sentinel-slice helper. The pre-existing lazy regex `\{(.+?)\}\);` was fragile against any inline-object argument inside the listener body — exactly the regression CI hit when the new `preservePendingEdit: true` calls split onto multiple lines.

This PR is independent of ADR-0009 / Info-1 — it touches only `context-gateway.js` and `test_i18n.py`. No backend, no i18n locale data, no CSS.

### History

- **3e45f42** — first attempt: gen-token approach (`stashIsOurs` gate). CI surfaced that L2 invocations of a rapid same-card toggle find an already-wiped DOM, don't capture, and end up with `myStashGen = -1` — making them treat the stash as not-ours and silently drop it. The `test_q_pr4_rapid_toggle_preserves_edit_buffer` regression broke as a result.
- **228af0f** — replaced gen-token with the navigation-drop guard described above. Both races now resolve without trading off against each other.
- **c147fee** — incidental: unified eight `langchange listener body` extractions onto a single helper after CI exposed the same lazy-regex fragility documented in `feedback_listener_body_lazy_regex_trips_inline_objects.md` (PR #840 review).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -m "not ollama"` → 44 passed (incl. new `test_pending_edit_navigation_drop_guards_against_orphan_resurrect` and existing `test_q_pr4_listener_uses_pending_edit_module_stash`).
- [x] `uv run pytest packages/memtomem/tests/web -m browser` → 30 passed (incl. `test_q_pr4_rapid_toggle_preserves_edit_buffer` — the rapid-toggle preservation race).
- [x] `uv run ruff check` + `format --check` on touched Python file → clean.
- [ ] Manual repro on the previously-leaky scenario: open a card, click Edit, type unsaved content, toggle EN↔KO, navigate to another card before the reload settles, navigate back to the first card. Confirm no stale draft re-appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
