### PR TITLE
fix(indexing/debounce): intra-process threading.Lock for Windows same-process enqueue serialization (#759 partial)

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/debounce.py
+++ b/packages/memtomem/src/memtomem/indexing/debounce.py
@@ -38,6 +38,7 @@ import json
 import logging
 import os
 import tempfile
+import threading
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -139,6 +140,33 @@ def _save(path: Path, entries: dict[str, QueueEntry]) -> None:
         raise
 
 
+# Per-lockfile ``threading.Lock`` for intra-process serialization. The
+# file lock (``portalocker.lock``) is the cross-process barrier, but on
+# Windows ``LockFileEx`` does not reliably block a *second handle* from
+# the *same* process holding the file open through ``open(..., "a+b")`` —
+# two threads in one Python process each opening the sidecar lockfile
+# can both pass ``portalocker.lock(LOCK_EX)`` and race the read-modify-
+# write of the queue, losing entries (#759 failure 2). Holding a
+# threading.Lock keyed to the lockfile path before acquiring the file
+# lock collapses same-process contention to a single waiter, so
+# portalocker only ever sees one handle per process competing.
+_intra_process_locks: dict[Path, threading.Lock] = {}
+_intra_process_locks_guard = threading.Lock()
+
+
+def _intra_process_lock_for(path: Path) -> threading.Lock:
+    """Return the threading.Lock associated with ``path``, creating it
+    on first use. The dict accumulates one entry per distinct lockfile
+    path observed in the process — bounded in practice by the number of
+    queue files (one in normal usage)."""
+    with _intra_process_locks_guard:
+        lock = _intra_process_locks.get(path)
+        if lock is None:
+            lock = threading.Lock()
+            _intra_process_locks[path] = lock
+        return lock
+
+
 class _Lock:
     """``portalocker.lock(LOCK_EX)`` on a sidecar lockfile next to the queue.
 
@@ -151,30 +179,51 @@ class _Lock:
 
     The sidecar (``.<queue_name>.lock``) is never replaced; every
     process locks the same inode for the duration of its critical
-    section, so serialization is correct.
+    section, so serialization is correct across processes.
 
-    Cross-platform via ``portalocker``; concurrent callers serialize
-    on Windows the same as POSIX (replaces the prior Windows-no-op
-    fallback that relied on hooks firing serially per Claude Code
-    session — see #625).
+    Two-layer locking (#759):
+
+    - **Intra-process** ``threading.Lock`` keyed by the lockfile path
+      (``_intra_process_lock_for``). Acquired first; serializes threads
+      inside a single Python process before any file-handle work.
+      Required because Windows ``LockFileEx`` does not reliably block a
+      second handle from the same process — without this layer, a
+      multi-threaded plugin host (e.g. Claude Code's bursty ``Write``
+      hook fanout) loses queue entries on Windows.
+    - **Cross-process** ``portalocker.lock(LOCK_EX)`` on the sidecar
+      lockfile. Acquired second; serializes parallel ``mm index
+      --debounce-window`` invocations that don't share Python state.
+
+    Both layers release in reverse order in ``__exit__``.
     """
 
     def __init__(self, path: Path) -> None:
         self._lock_path = path.parent / f".{path.name}.lock"
+        self._intra_lock = _intra_process_lock_for(self._lock_path)
         self._fp: IO[bytes] | None = None
 
     def __enter__(self) -> "_Lock":
-        self._lock_path.parent.mkdir(parents=True, exist_ok=True)
-        self._fp = open(self._lock_path, "a+b")
-        portalocker.lock(self._fp, portalocker.LOCK_EX)
+        self._intra_lock.acquire()
+        try:
+            self._lock_path.parent.mkdir(parents=True, exist_ok=True)
+            self._fp = open(self._lock_path, "a+b")
+            portalocker.lock(self._fp, portalocker.LOCK_EX)
+        except BaseException:
+            # File-lock acquisition failed — must release the intra
+            # lock so other threads aren't permanently blocked.
+            self._intra_lock.release()
+            raise
         return self
 
     def __exit__(self, *exc) -> None:
-        if self._fp is None:
-            return
-        portalocker.unlock(self._fp)
-        self._fp.close()
-        self._fp = None
+        try:
+            if self._fp is None:
+                return
+            portalocker.unlock(self._fp)
+            self._fp.close()
+            self._fp = None
+        finally:
+            self._intra_lock.release()
 
 
 def enqueue(

--- a/packages/memtomem/tests/test_index_debounce.py
+++ b/packages/memtomem/tests/test_index_debounce.py
@@ -276,6 +276,40 @@ class TestPersistenceAndConcurrency:
         entries = _read_raw(queue_file)["entries"]
         assert len(entries) == 20
 
+    def test_intra_process_lock_serializes_threads_when_file_lock_is_noop(
+        self, queue_file: Path, monkeypatch
+    ) -> None:
+        """Pin the in-process ``threading.Lock`` independently of the
+        cross-process file lock.
+
+        On Windows, ``LockFileEx`` is unreliable between two handles in
+        the *same* process — if the file lock is the only barrier,
+        same-process threads race the read-modify-write and lose
+        entries (#759 failure 2). By stubbing ``portalocker.lock`` /
+        ``unlock`` to no-ops, this test simulates that regression on
+        every platform: the test passes only because the intra-process
+        ``threading.Lock`` is the actual serializer. Removing the
+        threading.Lock layer from ``_Lock`` flips this to a flaky
+        ``len(entries) < 20`` failure.
+        """
+        monkeypatch.setattr(debounce.portalocker, "lock", lambda *a, **kw: None)
+        monkeypatch.setattr(debounce.portalocker, "unlock", lambda *a, **kw: None)
+
+        threads: list[threading.Thread] = []
+        for i in range(20):
+            t = threading.Thread(
+                target=debounce.enqueue,
+                args=(f"/tmp/file_{i:02d}.py",),
+                kwargs={"now": 100.0 + i, "queue_file": queue_file},
+            )
+            threads.append(t)
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        entries = _read_raw(queue_file)["entries"]
+        assert len(entries) == 20
+
     def test_partial_drain_writes_remaining_back(self, queue_file: Path) -> None:
         """Two entries, one indexer-errors. The successful one is gone from
         disk; the failing one remains so the next hook call retries."""


### PR DESCRIPTION
## Summary

`_Lock` in `indexing/debounce.py` previously serialized queue mutations with `portalocker.lock(LOCK_EX)` on a sidecar lockfile only. `portalocker` uses `LockFileEx` on Windows, which serializes correctly **across processes** but does *not* reliably block a second handle opened in the **same** process — two threads that each `open(lockpath, "a+b")` and call `portalocker.lock(LOCK_EX)` can both pass and race the read-modify-write inside the queue file. `test_concurrent_enqueue_does_not_lose_entries` saw `11 == 20` on Windows for this reason (#759 failure 2 of 4). POSIX is unaffected: `fcntl.flock` correctly serializes per-handle even within one process.

Add a per-lockfile `threading.Lock` keyed by lockfile path (`_intra_process_lock_for`) acquired **before** the file lock and released **after** it:

- **intra-process** `threading.Lock` — same-process serialization (the layer that was missing on Windows).
- **cross-process** `portalocker.lock` — cross-process serialization (preserved unchanged).

## Test plan

- [x] Existing `test_concurrent_enqueue_does_not_lose_entries` (20-thread, 20-entry) — pass
- [x] **New** `test_intra_process_lock_serializes_threads_when_file_lock_is_noop` — pins the intra-process layer independently. Stubs `portalocker.lock`/`unlock` to no-ops, runs 20 concurrent `enqueue`, asserts 20 entries land. Fails to `len(entries) == 3` (i.e. ~85% loss) without the new threading.Lock.
- [x] **Mutation-validated**: temporarily commented out `_intra_lock.acquire()` / `release()` and reran — new test fails as expected; restored and reran — passes.
- [x] All 20 tests in `test_index_debounce.py` pass
- [x] `uv run ruff check && uv run ruff format --check`
- [ ] CI windows-latest (this is the platform that the fix actually targets)

## Companion PRs

This is PR 4 of 4 in the #759 cluster:

- #847 — `fix(tests): pin utf-8 encoding for wiki README read in is_dirty test` (failure 4)
- #848 — `fix(tests): pin utf-8 for mm subprocess in CLI e2e` (failure 1)
- #849 — `fix(tests): per-test tempfile.tempdir so Windows runtime_dir prune is hermetic` (failure 3)
- this PR — debounce intra-process lock (failure 2; the only production change)

Closes #759 once all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
