### PR TITLE
test(sync-doctor): pin cloud scope and config.d symlink bridge

### DIFF
--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -172,6 +172,30 @@ class TestCheckConfigDPresent:
         r = check_config_d_present(tmp_path / "absent")
         assert r.status == "warn"
 
+    def test_symlinked_fragment_is_counted(self, tmp_path: Path) -> None:
+        # The multi-device sync guide recommends bridging synced fragments
+        # into ``~/.memtomem/config.d/`` via symlink so edits flow back to
+        # the synced repo automatically. ``Path.glob("*.json")`` follows
+        # symlinks today; pinning so a refactor to a non-following
+        # iteration (e.g. Python 3.13's ``glob(..., follow_symlinks=False)``
+        # or a ``set(d.iterdir())`` walk that stat-filters them out) trips
+        # the test.
+        synced_dir = tmp_path / "synced-repo" / "config.d"
+        synced_dir.mkdir(parents=True)
+        target = synced_dir / "10-namespace-rules.json"
+        target.write_text("{}")
+
+        canonical_dir = tmp_path / ".memtomem" / "config.d"
+        canonical_dir.mkdir(parents=True)
+        try:
+            (canonical_dir / "10-namespace-rules.json").symlink_to(target)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable in this environment: {exc}")
+
+        r = check_config_d_present(canonical_dir)
+        assert r.status == "pass"
+        assert "1 files" in r.message
+
 
 # ---- check_memory_dirs_under_home ------------------------------------------
 
@@ -207,6 +231,23 @@ class TestCheckCloudMount:
     def test_dropbox_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _set_home(monkeypatch, tmp_path)
         r = check_cloud_mount([tmp_path / "Dropbox" / "memories"])
+        assert r.status == "warn"
+        assert "Dropbox" in r.message
+
+    def test_outside_synced_worktree_still_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pin the broader-scope decision from PR #838 review: the cloud-mount
+        # check is a watcher-reliability check, not a worktree-hygiene check,
+        # so it scans every entry in ``memory_dirs[]`` — including entries
+        # outside the synced repo's worktree. Narrowing to "only entries
+        # inside the synced worktree" was the alternative that didn't land;
+        # this test makes a future flip a deliberate fixture edit.
+        _set_home(monkeypatch, tmp_path)
+        synced_repo = tmp_path / "synced-repo"
+        inside_worktree = synced_repo / "memories"  # not on a cloud mount
+        outside_worktree = tmp_path / "Dropbox" / "agent-memory"
+        r = check_cloud_mount([inside_worktree, outside_worktree])
         assert r.status == "warn"
         assert "Dropbox" in r.message
 


### PR DESCRIPTION
## Summary

Two regression pins for decisions made during the PR #838 review window. No production code change — `mm sync-doctor` behavior is identical.

## What's pinned

**1. `check_cloud_mount` scans every `memory_dirs[]` entry, not just entries under the synced worktree.**

The cloud-mount warning is a watcher-reliability check, not a worktree-hygiene check. The PR #838 open question — "scan only entries inside the synced repo's worktree" — was rejected because most users hit cloud-sync watcher gaps with `memory_dirs[]` entries that sit *outside* the synced repo (per `feedback_gdrive_watcher_gap.md`). The new test frames the intent in the fixture (`inside_worktree` vs `outside_worktree`) so a future narrow-scope flip becomes a deliberate edit.

**2. `check_config_d_present` counts symlinked fragments as real fragments.**

`docs/guides/multi-device-sync.md` recommends symlinking `~/.memtomem/config.d/10-namespace-rules.json` → the synced repo's copy so edits flow back automatically. `Path.glob("*.json")` follows symlinks today; pinning so a switch to non-following iteration (Python 3.13's `glob(..., follow_symlinks=False)` or a stat-filtering walk) trips the test.

The symlink test skips when `Path.symlink_to` raises (Windows without dev mode, restrictive sandboxes) rather than failing hard, since the bridge pattern itself is unavailable in those environments.

## What's *not* in scope

Per the PR #838 review thread:

- **OneDrive integration coverage** — helper-level variant tests already exist (`TestCloudMountPrefix::test_onedrive_variants`), and `check_cloud_mount` consumes the helper result almost verbatim. Broader-scope pin is the more valuable regression guard.
- **Multi-device round-trip** — release-confidence test, not a unit test. Belongs in a separate acceptance pass before the next minor.
- **Windows path coverage** — cloud-mount prefixes are `$HOME`-rooted and the helper already routes through `Path.relative_to` for separator-safety; a full Windows fixture pass is its own design discussion.
- **UX: surface offending path in `check_cloud_mount` detail** — real but separable improvement (broader scope makes "which `memory_dir`?" more pertinent), out of scope for a pure pin PR.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_sync_doctor_cli.py` — 35 pass (was 33, +2)
- [x] `uv run ruff check packages/memtomem/tests/test_sync_doctor_cli.py` — clean
- [x] `uv run ruff format --check packages/memtomem/tests/test_sync_doctor_cli.py` — clean
- [x] Mental mutation: removing `outside_worktree` from the cloud-mount list (simulating narrow scope) → status flips `warn` → `pass` → test fails as expected
- [x] Mental mutation: switching `Path.glob("*.json")` to a non-following iteration → symlinked fragment count drops to 0 → status flips `pass` → `warn` → test fails as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
