### PR TITLE
docs(guides): document Obsidian as the editor layer on git transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `_write_config_and_summary`) now invoke it before
   `_atomic_write_json`.
 
+### Documentation
+
+- **Obsidian as editor on top of git transport.** New section in the
+  multi-device sync guide (`docs/guides/multi-device-sync.md`) describing
+  vault layout (vault root = synced repo vs. vault contains a `memories/`
+  sub-folder), the required `**/.obsidian/**` exclude_patterns step (vault
+  metadata includes JSON which memtomem indexes by default), `.gitignore`
+  guidance for vault-local state, and plugin-generated formats (`.canvas`,
+  `.excalidraw.md`). Cross-references to the existing one-shot
+  `mem_do(action="import_obsidian", …)` flow in `reference.md` clarify
+  that they cover different use cases (live sync vs. one-shot ingest).
+  Also adds an `**/.obsidian/**` example to the
+  `configuration.md#exclude-patterns` block.
+
 ## [0.1.36] — 2026-05-06
 
 ### Added

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -337,8 +337,10 @@ extend them but cannot override them.
     "exclude_patterns": [
       "**/subagents/**",         // Claude Code subagent metadata
       "**/antigravity-browser-profile/**",
-      "**/.gemini/**/*.json"     // defensive — only relevant if you manually
+      "**/.gemini/**/*.json",    // defensive — only relevant if you manually
                                  // add ~/.gemini/ to memory_dirs
+      "**/.obsidian/**"          // Obsidian vault metadata (workspace.json,
+                                 // plugin state) when a vault is a memory_dir
     ]
   }
 }

--- a/docs/guides/multi-device-sync.md
+++ b/docs/guides/multi-device-sync.md
@@ -255,17 +255,20 @@ the synced repo or to *contain* it:
 Obsidian stores vault metadata in a top-level `.obsidian/` directory —
 workspace layout, plugin state, hotkeys, etc. — much of which is JSON.
 memtomem indexes `.json` by default, so without an explicit rule this
-metadata ends up in your search results. Add the following fragment to
-`~/.memtomem/config.d/` so the rule is portable across machines:
+metadata ends up in your search results. Save the following fragment as
+`~/.memtomem/config.d/30-obsidian.json` so the rule is portable across
+machines:
 
 ```json
-// ~/.memtomem/config.d/30-obsidian.json
 {
   "indexing": {
     "exclude_patterns": ["**/.obsidian/**"]
   }
 }
 ```
+
+The fragment loader uses strict `json.loads`, so the file contents must be
+valid JSON — no `//` comments, no path-label header inside the file.
 
 See [`exclude_patterns`](configuration.md#exclude-patterns) for the broader
 semantics (root-relative matching, non-retroactive behavior, layering on

--- a/docs/guides/multi-device-sync.md
+++ b/docs/guides/multi-device-sync.md
@@ -222,6 +222,105 @@ Both work. (a) is simpler if path discipline is feasible; (b) is
 username/path-agnostic at the cost of one symlink per project per
 machine.
 
+## Obsidian as editor on top of git transport
+
+Obsidian fits cleanly on top of this layout because the source of truth is
+already plain markdown — Obsidian opens any folder as a *vault* and edits the
+files in place. There is **no separate sync layer** to configure on the
+Obsidian side: the private git repo described above is still the transport,
+and Obsidian is purely the editor. This guide does not cover Obsidian Sync
+(the paid SaaS), iCloud, Dropbox, or other transports as alternatives —
+their reliability characteristics (especially fs-watcher behavior) differ
+from git's and would invalidate the layout / anti-patterns above.
+
+### Vault layout
+
+Two arrangements work, depending on whether you want the vault root to *be*
+the synced repo or to *contain* it:
+
+- **(a) Vault root = synced repo root.** Open `~/.memtomem-private/` itself
+  as the vault. The namespace tree (`shared/`, `personal/`, `work/`,
+  `local/`) becomes the vault's top-level folders, and the existing
+  `path_glob` rules from [The layout](#the-layout--namespace-aligned-directory-tree)
+  apply unchanged.
+- **(b) Vault contains a `memories/` sub-folder.** If your vault root is
+  somewhere else (e.g. `~/Obsidian/`) and the synced memtomem files live at
+  `~/Obsidian/memories/{shared,personal,work}/`, adjust the `path_glob`
+  fragments accordingly — e.g. `~/Obsidian/memories/shared/**` →
+  `shared:{parent}`. The semantics are identical; only the absolute path
+  differs.
+
+### Required: exclude `.obsidian/` from indexing
+
+Obsidian stores vault metadata in a top-level `.obsidian/` directory —
+workspace layout, plugin state, hotkeys, etc. — much of which is JSON.
+memtomem indexes `.json` by default, so without an explicit rule this
+metadata ends up in your search results. Add the following fragment to
+`~/.memtomem/config.d/` so the rule is portable across machines:
+
+```json
+// ~/.memtomem/config.d/30-obsidian.json
+{
+  "indexing": {
+    "exclude_patterns": ["**/.obsidian/**"]
+  }
+}
+```
+
+See [`exclude_patterns`](configuration.md#exclude-patterns) for the broader
+semantics (root-relative matching, non-retroactive behavior, layering on
+top of built-in denylists).
+
+### `.gitignore` — vault-local state
+
+In addition to the entries in [What syncs, what does not](#what-syncs-what-does-not),
+Obsidian-specific paths that are commonly *not* useful to sync:
+
+```
+.obsidian/workspace*.json
+.obsidian/cache/
+```
+
+`workspace.json` and `workspace-mobile.json` track per-device pane layouts
+and tend to thrash on every Obsidian launch; the cache dir is reproducible
+state. The remaining `.obsidian/` files (`community-plugins.json`,
+`themes/`, `hotkeys.json`, `app.json`) are often useful to sync if you
+want consistent vault behavior across devices, but this is an Obsidian-side
+preference rather than a memtomem one — defer to Obsidian's own guidance.
+
+### Plugin-generated markdown
+
+Two formats produced by common plugins to be aware of:
+
+- **`.canvas`** (Obsidian Canvas, JSON-backed). Not in memtomem's default
+  indexed extensions, so it's ignored automatically. No action needed.
+- **`.excalidraw.md`** (Excalidraw plugin's plugin-generated markdown
+  files). These match the `.md` filter and *will* be indexed unless
+  excluded. If you treat them as drawings rather than searchable notes,
+  add `**/*.excalidraw.md` to `exclude_patterns`.
+
+### Workflow
+
+Day-to-day flow once the layout is in place:
+
+1. Edit notes in Obsidian. The file watcher picks up `.md` changes and
+   re-embeds incrementally. Obsidian writes via temp-file + rename, which
+   the watcher already handles correctly — no extra configuration.
+2. Commit and push from the synced repo on whatever cadence suits you.
+3. On another device, `git pull` and follow [Post-pull workflow](#post-pull-workflow)
+   to pick the right re-index strategy for your runtime mode (Web,
+   long-running MCP, or per-call).
+
+### Different from one-shot import
+
+If you have an existing Obsidian vault you want to ingest *without*
+reorganising it into the synced layout — a one-time copy into
+`~/.memtomem/memories/_imported/obsidian/` — use the existing
+[Importing from Obsidian](reference.md#importing-from-obsidian) action
+(`mem_do(action="import_obsidian", …)`) instead. That's a different use
+case: one-shot ingest of a non-synced vault, rather than continuous live
+sync of the vault as your `memory_dirs[]`.
+
 ## `mm sync-doctor` — read-only validator
 
 Run from inside your private repo's working tree. The command performs six

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -626,6 +626,9 @@ How Obsidian files are processed:
 - **Heading-based chunking**: Each `##` heading becomes a separate chunk, just like native memtomem files.
 - **Output**: Imported files are copied to `~/.memtomem/memories/_imported/obsidian/`.
 
+> For *continuous* sync of an Obsidian vault as your live `memory_dirs` (rather
+> than one-shot ingest), see [Multi-device sync § Obsidian as editor](multi-device-sync.md#obsidian-as-editor-on-top-of-git-transport).
+
 ### Importing from Notion
 
 ```


### PR DESCRIPTION
## Summary

Docs-only enrichment of the multi-device sync guide: a focused "Obsidian as editor on top of git transport" section that explains how to reuse the existing markdown-as-SoT + git-as-transport layout with Obsidian as a pure editor layer. No code change.

Other transports (Obsidian Sync paid SaaS, iCloud, Dropbox) are deliberately out of scope — their fs-watcher / consistency characteristics differ from git's and would invalidate the layout / anti-patterns the rest of the guide depends on.

## Files

| File | Change |
|---|---|
| `docs/guides/multi-device-sync.md` | New section "Obsidian as editor on top of git transport" inserted between "Auto-memory (Claude Code)" and `mm sync-doctor`. ~95 lines. |
| `docs/guides/configuration.md` | Adds `**/.obsidian/**` to the canonical `exclude_patterns` example block so the rule is discoverable from the configuration reference, not only the sync guide. |
| `docs/guides/reference.md` | One-line see-also under `### Importing from Obsidian` pointing at the new live-sync section, explicitly framed as "rather than one-shot ingest" so the existing import flow is not read as deprecated. |
| `CHANGELOG.md` | New `### Documentation` subsection in `[Unreleased]` (none existed yet) describing the change. |

## What the new section covers

1. **Premise.** Obsidian = editor only. Transport stays git. Other transports excluded.
2. **Vault layout.** Two arrangements — (a) vault root = synced repo root, (b) vault contains a `memories/` sub-folder — both reusing the existing namespace tree.
3. **Required `.obsidian/` exclude.** Vault metadata is JSON-heavy and memtomem indexes `.json` by default, so an explicit `**/.obsidian/**` entry in `exclude_patterns` is needed. Provided as a `~/.memtomem/config.d/30-obsidian.json` fragment so the rule itself is portable.
4. **`.gitignore` for vault-local state.** Suggests gitignoring `.obsidian/workspace*.json` and `.obsidian/cache/`; treats the rest as Obsidian-side preferences rather than memtomem concerns.
5. **Plugin-generated markdown.** `.canvas` is ignored automatically; `.excalidraw.md` matches the `.md` filter and can be excluded with `**/*.excalidraw.md`.
6. **Workflow.** Save in Obsidian → watcher handles temp-rename → incremental re-embed. Post-pull workflow applies unchanged.
7. **Distinction from one-shot import.** Cross-link to `mem_do(action="import_obsidian", …)` with explicit "different use case" framing.

## Cross-link / anchor audit

All anchors verified against existing headings:

- `#the-layout--namespace-aligned-directory-tree` → `## The layout — namespace-aligned directory tree` (em-dash collapses, double dash from preserved spaces)
- `#what-syncs-what-does-not` → `## What syncs, what does not`
- `#post-pull-workflow` → `## Post-pull workflow`
- `#obsidian-as-editor-on-top-of-git-transport` → new heading at line 225
- `configuration.md#exclude-patterns` → `### Exclude patterns` (line 325, unchanged)
- `reference.md#importing-from-obsidian` → `### Importing from Obsidian` (line 617, unchanged)

## Source-of-truth verification

Per `feedback_docs_as_tests.md` — every claim about memtomem behavior in the new section was checked against current `main`:

- `.json` is default-indexed → confirmed in `packages/memtomem/src/memtomem/config.py` default `supported_extensions`.
- watchdog handles temp-rename atomic writes → confirmed via `packages/memtomem/src/memtomem/indexing/watcher.py:_MarkdownEventHandler`.
- `.canvas` not in defaults; `.excalidraw.md` matched by `.md` → confirmed by inspection of the same default extension list.
- `exclude_patterns` semantics (root-relative, non-retroactive, layered on built-in denylists) → consistent with `configuration.md:325-357`.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — clean (no Python touched)
- [x] `uv run ruff format --check packages/memtomem/src` — clean
- [x] All cross-links manually resolved against actual heading slugs (table above)
- [ ] Reviewer: spot-check the new section reads coherently relative to the surrounding "Auto-memory (Claude Code)" and `mm sync-doctor` sections
- [ ] Reviewer: confirm the `.gitignore` recommendations (`workspace*.json`, `cache/`) match Obsidian's actual non-portable state — softened to "often useful to sync" / "Obsidian-side preference" rather than prescriptive

## Out of scope

- **Adding `.obsidian` to default `_EXCLUDED_DIRS`** — would let users skip the manual `exclude_patterns` step entirely. Tracked separately as a possible follow-up; not bundled here per `feedback_one_change_per_pr.md`.
- **Notion** — proprietary block tree, lossy markdown round-trip; SoT contract incompatible with this guide. Not documented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
