### PR TITLE
docs: copy-paste-safe exclude_patterns example + jsonc guard (#854)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   Also adds an `**/.obsidian/**` example to the
   `configuration.md#exclude-patterns` block.
 
+- **`configuration.md#exclude-patterns` example is now copy-paste-safe
+  (#854).** The block previously used a ` ```jsonc ` fence with a
+  path-label comment on the first line and `//` comments inside the
+  array, but the fragment loader at
+  `packages/memtomem/src/memtomem/config.py:1157` calls strict
+  `json.loads`, so a verbatim copy into `~/.memtomem/config.d/*.json`
+  was dropped after only a single startup-log WARN — practically silent
+  to most users. The example is rewritten to mirror the canonical PR
+  #853 shape: prose lead-in, pure-JSON fence, per-pattern `Why` table
+  underneath, and an explicit strict-loader note. A new
+  `TestNoJsoncFenceInPublicGuides` regression in
+  `packages/memtomem/tests/test_docs_guards.py` fails CI if any
+  `docs/guides/**/*.md` reintroduces a ` ```jsonc ` fence.
+
 ## [0.1.36] — 2026-05-06
 
 ### Added

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -330,21 +330,32 @@ root**. Built-in denylists for credentials and noise (`oauth_creds.json`,
 `*.pem`, `**/.ssh/**`, etc.) are always applied on top — user patterns can
 extend them but cannot override them.
 
-```jsonc
-// ~/.memtomem/config.d/noise.json — APPEND semantics, layers on defaults
+Save the following as `~/.memtomem/config.d/noise.json` (APPEND
+semantics — fragments layer on top of the defaults, they don't replace
+them):
+
+```json
 {
   "indexing": {
     "exclude_patterns": [
-      "**/subagents/**",         // Claude Code subagent metadata
+      "**/subagents/**",
       "**/antigravity-browser-profile/**",
-      "**/.gemini/**/*.json",    // defensive — only relevant if you manually
-                                 // add ~/.gemini/ to memory_dirs
-      "**/.obsidian/**"          // Obsidian vault metadata (workspace.json,
-                                 // plugin state) when a vault is a memory_dir
+      "**/.gemini/**/*.json",
+      "**/.obsidian/**"
     ]
   }
 }
 ```
+
+| Pattern | Why |
+|---|---|
+| `**/subagents/**` | Claude Code subagent metadata |
+| `**/antigravity-browser-profile/**` | Antigravity browser profile data |
+| `**/.gemini/**/*.json` | Defensive — only relevant if you manually add `~/.gemini/` to `memory_dirs` |
+| `**/.obsidian/**` | Obsidian vault metadata (`workspace.json`, plugin state) when a vault is itself a `memory_dir` |
+
+The fragment loader uses strict `json.loads`, so the file must be pure
+JSON — no `//` comments, no trailing commas, no `jsonc` extensions.
 
 > **Caveats:**
 > - **Not retroactive.** Adding a pattern only stops *future* indexing. Files

--- a/packages/memtomem/tests/test_docs_guards.py
+++ b/packages/memtomem/tests/test_docs_guards.py
@@ -17,6 +17,11 @@ These guards protect invariants that code cannot enforce directly:
   the plugin's shipped ``hooks.json`` for every event the snippet
   covers. Drift between the two sites silently ships an outdated
   user-facing recipe.
+- Public guides must not use `````jsonc`` fences for
+  ``config.d`` examples — the fragment loader at
+  ``packages/memtomem/src/memtomem/config.py:1157`` calls strict
+  ``json.loads`` and a ``//`` comment drops the fragment with only a
+  startup-log WARNING (see #854).
 """
 
 from __future__ import annotations
@@ -221,4 +226,37 @@ class TestPluginHooksDocsParity:
             "hooks.json. The two sites must declare byte-identical commands "
             "for every (event, matcher) the docs render. Diffs:\n"
             + "\n".join(f"  {em}:\n    plugin: {p}\n    docs:   {d}" for em, p, d in diffs)
+        )
+
+
+class TestNoJsoncFenceInPublicGuides:
+    """Public guides must not use ```` ```jsonc ```` fences.
+
+    The fragment loader at
+    ``packages/memtomem/src/memtomem/config.py:1157`` calls
+    ``json.loads`` strictly; ``//`` comments and trailing commas raise
+    ``JSONDecodeError`` which the surrounding ``except`` swallows with
+    only a startup-log WARNING (lines 1158-1160). A user who copy-pastes
+    a ``jsonc`` block from a guide ends up with a fragment that never
+    loads and an "exclude_patterns aren't applied" symptom that's hard
+    to trace back to that warn line. The canonical post-fix shape is
+    the pure-JSON fence + prose lead-in + per-row table established by
+    PR #853 in ``multi-device-sync.md`` and applied to
+    ``configuration.md`` in #854.
+    """
+
+    def test_no_jsonc_fence_in_any_public_guide(self) -> None:
+        offenders = sorted(
+            str(md.relative_to(_REPO_ROOT))
+            for md in _GUIDES.rglob("*.md")
+            if "```jsonc" in md.read_text(encoding="utf-8")
+        )
+        assert not offenders, (
+            "Public guides use ```jsonc fences which the strict "
+            "json.loads fragment loader cannot parse "
+            "(packages/memtomem/src/memtomem/config.py:1157). Use "
+            "```json + pure JSON inside the fence and move any //-style "
+            "annotations to surrounding prose or a per-row table — see "
+            "PR #853 / multi-device-sync.md:262-268 for the canonical "
+            f"shape, and #854 for the trap. Offenders: {offenders}"
         )


### PR DESCRIPTION
## Summary

- Closes #854.
- Rewrites the `exclude_patterns` example in `docs/guides/configuration.md` so a verbatim copy-paste actually loads under the strict `json.loads` fragment loader.
- Adds a `TestNoJsoncFenceInPublicGuides` regression in `packages/memtomem/tests/test_docs_guards.py` to catch future drift at CI.
- No `src/` change.

## Why this looked silent (clarification on the issue body)

The issue body says the loader `silently` drops the fragment. Strictly speaking it does emit `_log.warning("Failed to read config fragment %s: %s", ...)` at `packages/memtomem/src/memtomem/config.py:1159`, but every user-facing call site (`mm web`, `mm config show`, `mm embedding reset`, ...) invokes it with `quiet=False`, so all that surfaces in real use is a single startup-log WARN that most users don't connect to "my `exclude_patterns` aren't applied." Practically silent — the `feedback_silent_policy_enforcement_gap.md` shape — but technically a WARN.

## What changes in `configuration.md` (lines 325-358)

The §Exclude patterns body is rewritten to mirror the canonical PR #853 shape at `docs/guides/multi-device-sync.md:262-270`:

1. **Path label moves out of the fence**, into a prose lead-in: *"Save the following as `~/.memtomem/config.d/noise.json` (APPEND semantics — fragments layer on top of the defaults, they don't replace them):"*
2. **Fence becomes ` ```json `** (was ` ```jsonc `), and the four inline `//` comments are removed. The block is now pure valid JSON.
3. **Per-pattern explanations move to a `Pattern | Why` table** under the fence (consistent with the env-var table at lines 320-322 and the provider-categories table at line 368).
4. **Strict-loader note** added under the table, copied near-verbatim from `multi-device-sync.md:270`: *"The fragment loader uses strict `json.loads`, so the file must be pure JSON — no `//` comments, no trailing commas, no `jsonc` extensions."*

## Regression guard

Added a `TestNoJsoncFenceInPublicGuides` class at the bottom of `packages/memtomem/tests/test_docs_guards.py`. It walks `docs/guides/**/*.md` and asserts no file contains a ` ```jsonc ` fence. Future-proofs the fix beyond `configuration.md` so a new guide can't reintroduce the same trap.

The class reuses the module-level `_GUIDES` and `_REPO_ROOT` helpers and follows the same docstring/assert-message style as the existing `TestPluginHooksDocsParity`.

## What's deliberately out of scope

- **Full docs-as-tests guard** — extracting every ```json fence preceded by a `~/.memtomem/config.d/*.json` lead-in and feeding it through `json.loads`. Stronger than the jsonc-fence guard above but a separate change per `feedback_one_change_per_pr.md`. Will open a follow-up issue after this lands; natural home is the same `test_docs_guards.py`, reusing the `_extract_hooks_snippet` template at lines 139-155.
- **Loader-side jsonc support** (issue body Option B). Out of scope — expanding the loader to a permissive parser to absorb a docs bug inverts the trust direction; the docs are wrong, not the loader.

## Test plan

- [x] `python -c "import json; json.loads(open('/tmp/noise.json').read())"` on a file copy-pasted from the new fenced block — exits 0.
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_docs_guards.py -v` — 12 pass (11 existing + 1 new).
- [x] Mutation check: temporarily reintroduced ` ```jsonc ` in `docs/guides/configuration.md` and confirmed `TestNoJsoncFenceInPublicGuides` fails with the offender path. Reverted before staging.
- [x] `uv run ruff check packages/memtomem/tests/test_docs_guards.py` — clean.
- [x] `uv run ruff format --check packages/memtomem/tests/test_docs_guards.py` — already formatted.
- [x] Repo-wide `grep '```jsonc'` across `docs/`, `README.md`, `CHANGELOG.md`, `packages/memtomem/README.md` — only matches are the prose mentions in the new `CHANGELOG.md` entry (escaped, so the guard doesn't fire on them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
