### PR TITLE
feat(context): warn when Cursor/Codex/Copilot would merge Rules + Style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Changed
 
+- **`mm context generate` warns when Cursor/Codex/Copilot would merge
+  Rules + Style.** These three runtimes fold the canonical `Rules` and
+  `Style` sections into a single block via `_compact_rules`, so the
+  split does not survive a hand-edit of the generated file followed by
+  `mm context init` re-extraction. The CLI now emits a single yellow
+  stderr notice naming only the affected runtimes that intersect with
+  the target set (no warning for `--agent=claude`/`--agent=gemini`, no
+  warning when only one of Rules/Style is populated). Generated file
+  format is unchanged; `context.md` remains the source of truth.
 - **`config.json` writers serialize home-rooted paths as `~/...`.**
   `indexing.memory_dirs` and `storage.sqlite_path` (and any future
   path-typed config field) are written in tilde form when they sit

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -437,6 +437,8 @@ mm context sync --include=skills,agents,commands
 
 Run `mm context --help` for the full fan-out matrix across editors (Claude Code, Cursor, Gemini CLI, OpenAI Codex, GitHub Copilot) and per-runtime field-drop details.
 
+> Cursor, OpenAI Codex, and GitHub Copilot generators concatenate the `Rules` and `Style` sections from `context.md` into a single block — `mm context generate` warns on stderr when both are populated. `context.md` remains the source of truth; edit there, not in the generated files.
+
 ---
 
 ## Optional: STM Proxy — Proactive Memory Surfacing

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1073,6 +1073,9 @@ mm context diff                        # check sync status
 mm context sync                        # sync context.md → agent files
 mm context generate --include=settings # merge hooks → ~/.claude/settings.json
 mm context diff --include=settings     # check hook sync status
+# Note: cursor / codex / copilot fold ## Rules + ## Style into a single block;
+# `generate` warns on stderr when both sections are populated. context.md is
+# the source of truth — edit there, not in generated files.
 
 # Sessions & activity
 mm session start                                              # start a tracked session

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -360,6 +360,32 @@ def _print_settings_diff(root: Path) -> None:
             click.secho(f"  error {name}: {r.reason}", fg="red")
 
 
+_RULES_STYLE_MERGE_RUNTIMES: frozenset[str] = frozenset({"cursor", "codex", "copilot"})
+
+
+def _warn_rules_style_merge(sections: dict[str, str], targets: list[str]) -> None:
+    """Warn when generated targets fold Rules and Style into one block.
+
+    Cursor / Codex / Copilot generators concatenate Rules + Style under a
+    single heading via ``_compact_rules`` in :mod:`memtomem.context.generator`.
+    Claude / Gemini emit them as separate ``##`` blocks. When both sections
+    are present in ``context.md`` and at least one merging runtime is in the
+    target list, surface a single stderr notice naming only the affected
+    runtimes — file format itself is unchanged.
+    """
+    if not (sections.get("Rules", "").strip() and sections.get("Style", "").strip()):
+        return
+    affected = [t for t in targets if t in _RULES_STYLE_MERGE_RUNTIMES]
+    if not affected:
+        return
+    click.secho(
+        f"warning: {'/'.join(affected)} merge Rules and Style into a single block; "
+        "context.md remains the source of truth — edit there, not in generated files.",
+        err=True,
+        fg="yellow",
+    )
+
+
 @click.group("context")
 def context() -> None:
     """Manage unified agent context (CLAUDE.md, .cursorrules, GEMINI.md, etc.)."""
@@ -420,7 +446,7 @@ def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
     # Detect existing files
     files = detect_agent_files(root)
     if not files:
-        click.echo("No agent files found. Creating empty context template.")
+        click.secho("No agent files found. Creating empty context template.", fg="yellow")
         sections: dict[str, str] = {
             "Project": "- Name: \n- Language: \n- Package manager: ",
             "Commands": "- Build: \n- Test: \n- Lint: ",
@@ -501,6 +527,8 @@ def generate_cmd(
             click.secho(f"{CONTEXT_FILENAME} is empty.", fg="yellow")
         else:
             targets = list(GENERATORS.keys()) if agent == "all" else [agent]
+
+            _warn_rules_style_merge(sections, targets)
 
             for name in targets:
                 if name not in GENERATORS:

--- a/packages/memtomem/tests/test_context_generate_warnings.py
+++ b/packages/memtomem/tests/test_context_generate_warnings.py
@@ -1,0 +1,97 @@
+"""Tests for the Rules+Style merge stderr warning in ``mm context generate``.
+
+Cursor / Codex / Copilot generators concatenate the ``Rules`` and ``Style``
+context.md sections under a single heading via ``_compact_rules`` (see
+:mod:`memtomem.context.generator`). When both sections are populated and at
+least one merging runtime is targeted, the CLI should emit a single stderr
+warning naming only the affected runtimes — generated file format itself
+is unchanged.
+
+Click 8.3 keeps ``result.stderr`` separate from ``result.output`` (stdout) by
+default; assertions below pin both surfaces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli.context_cmd import context
+from memtomem.context.parser import CONTEXT_FILENAME
+
+
+_RULES_AND_STYLE = (
+    "## Project\n\n- Name: foo\n\n"
+    "## Rules\n\n- Always use type hints.\n\n"
+    "## Style\n\n- Two blank lines between top-level functions.\n"
+)
+
+
+def _write_context(project_root: Path, body: str) -> None:
+    ctx = project_root / CONTEXT_FILENAME
+    ctx.parent.mkdir(parents=True, exist_ok=True)
+    ctx.write_text(body, encoding="utf-8")
+
+
+@pytest.fixture
+def project_with_rules_and_style(tmp_path, monkeypatch):
+    """Project root with .git + a context.md containing both Rules and Style."""
+    (tmp_path / ".git").mkdir()
+    _write_context(tmp_path, _RULES_AND_STYLE)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_generate_warns_on_rules_style_merge_for_cursor(project_with_rules_and_style):
+    """Positive: --agent=cursor with both sections → warning on stderr."""
+    runner = CliRunner()
+    result = runner.invoke(context, ["generate", "--agent=cursor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Rules and Style" in result.stderr
+    assert "cursor" in result.stderr
+    # Stdout must not contain the warning (Click 8.3 separates streams;
+    # ``result.output`` is interleaved, ``result.stdout`` is stdout-only).
+    assert "Rules and Style" not in result.stdout
+
+
+def test_generate_no_warning_when_only_rules(tmp_path, monkeypatch):
+    """Negative: only Rules (no Style) → no warning, no merge happens."""
+    (tmp_path / ".git").mkdir()
+    _write_context(
+        tmp_path,
+        "## Project\n\n- Name: foo\n\n## Rules\n\n- Always use type hints.\n",
+    )
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(context, ["generate", "--agent=cursor"])
+
+    assert result.exit_code == 0, result.output
+    assert "Rules and Style" not in result.stderr
+
+
+def test_generate_no_warning_for_claude_only_target(project_with_rules_and_style):
+    """Negative: --agent=claude does not use ``_compact_rules`` → no warning."""
+    runner = CliRunner()
+    result = runner.invoke(context, ["generate", "--agent=claude"])
+
+    assert result.exit_code == 0, result.output
+    assert "Rules and Style" not in result.stderr
+
+
+def test_generate_warning_lists_only_intersecting_runtimes(project_with_rules_and_style):
+    """The warning names only runtimes that intersect with the target set.
+
+    With ``--agent=cursor``, codex and copilot must NOT appear — otherwise
+    the message implies the user is generating files they did not request.
+    """
+    runner = CliRunner()
+    result = runner.invoke(context, ["generate", "--agent=cursor"])
+
+    assert result.exit_code == 0, result.output
+    assert "cursor" in result.stderr
+    assert "codex" not in result.stderr
+    assert "copilot" not in result.stderr


### PR DESCRIPTION
## Summary

`mm context generate` now warns on stderr when the Cursor / OpenAI Codex /
GitHub Copilot generators would fold the canonical `Rules` and `Style`
sections of `context.md` into a single block. Generated file format itself
is unchanged — the warning lets users notice the lossy fan-out before they
hand-edit a generated file and run `mm context init` to re-extract.

## Why

Three of the five built-in generators concatenate `Rules` + `Style` under a
single heading via `_compact_rules` in
`packages/memtomem/src/memtomem/context/generator.py`. Claude / Gemini emit
them as separate `##` blocks and round-trip cleanly; Cursor / Codex /
Copilot do not. The extractor (`extract_sections_from_agent_file`) cannot
reconstruct the split from the merged form, so the workflow

```
context.md  ──generate──►  .cursorrules / AGENTS.md / copilot-instructions.md
                                       │
                                       │  user hand-edits generated file
                                       ▼
context.md  ◄──init re-extract──  edited file       ❌ Style merged into Rules
```

silently drops the `Style` section. The remediation isn't a format change
(that would touch every existing user's generated files) but a single
yellow stderr notice — and an explicit "context.md is the source of truth"
recommendation in the docs.

## What

- `_warn_rules_style_merge` (new, CLI module) emits one
  `click.secho(..., err=True, fg="yellow")` notice when:
  1. Both `Rules` and `Style` exist and are non-empty in `sections`, AND
  2. The target set intersects `{cursor, codex, copilot}`.
- The notice names only the *intersecting* runtimes — `--agent=cursor`
  mentions `cursor` only, not codex/copilot, so it never implies the
  user is generating files they didn't request.
- `generator.py` stays click-free: warning lives at the CLI boundary so
  programmatic callers of `generate_for_agent` / `generate_all` (including
  the web routes used by `test_web_routes_context_*`) continue to behave
  identically.
- 4 new tests in `test_context_generate_warnings.py` pin the contract with
  paired positive / negative assertions; mutation-validated by silencing
  the `click.secho` call and confirming the two positive tests fail.
- Click 8.3 stream split: assertions use `result.stderr` for stderr content
  and `result.stdout` for "must not appear on stdout" — `result.output` is
  the interleaved combined stream in this Click version.
- CHANGELOG entry under `### Changed`.
- Doc anchors in `docs/guides/getting-started.md` (Sync section) and
  `docs/guides/reference.md` (Agent context sync block).

### Same-file cosmetic piggyback

`init_cmd` line 423 changes `click.echo("No agent files found...")` →
`click.secho(..., fg="yellow")` so the empty-template branch has a small
visual cue. Disclosed here per `feedback_incidental_fix_scope.md`; not
worth a separate PR per `feedback_piggyback_tiny_fixes.md`.

## Context

Closes the Rules+Style merge stderr warning sub-item of the P3 follow-ups
recorded in `scripts/context-gateway-review-plan.md` (2026-04-26 audit).
The other two P3 items — `load_agent_definition` Python API for LangGraph
users, and the `--scope=project|user` flag for dual-scope generators —
remain deferred on absence of external demand signal and (for `--scope`)
the pending ADR-0009.

The `(a)` empty-template confirm and `(b)` `.cursorrules` heading sub-items
of PR-7 were dropped during design review:

- (a) audit wording ("5 파일 생성") was inaccurate — actual behavior is one
  file with five sections, already announced before write and listed after
  write. No surprise, no fix needed.
- (b) `.cursorrules` heading was already correct (`generator.py:103/108`).

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
      → clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
      → clean
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_context_generate_warnings.py -v`
      → 4 / 4 pass
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/ -k context`
      → 723 pass, 0 fail (regression check)
- [x] `uv run mypy packages/memtomem/src/memtomem/cli/context_cmd.py`
      → clean (advisory)
- [x] Pin test mutation validation: silence the `click.secho` call →
      2 positive tests fail (cursor + intersection list), 2 negative still
      pass → restore → all 4 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
