### PR TITLE
fix(web): wrap empty-state spans so message/hint stack instead of overlap

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -891,7 +891,7 @@ function panelLoading(container) {
 }
 
 // ── A5: Empty State ──
-// Wrapper is emitted by the function so callers don't need an `.empty-state` ancestor.
+// Owns its `.empty-state` wrapper — callers must NOT add their own.
 function emptyState(icon, message, hint) {
   const i = icon ? `<span class="empty-state-icon">${icon}</span>` : '';
   const h = hint ? `<span class="empty-state-hint">${escapeHtml(hint)}</span>` : '';

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -891,9 +891,11 @@ function panelLoading(container) {
 }
 
 // ── A5: Empty State ──
+// Wrapper is emitted by the function so callers don't need an `.empty-state` ancestor.
 function emptyState(icon, message, hint) {
+  const i = icon ? `<span class="empty-state-icon">${icon}</span>` : '';
   const h = hint ? `<span class="empty-state-hint">${escapeHtml(hint)}</span>` : '';
-  return `<span class="empty-state-icon">${icon}</span><span>${escapeHtml(message)}</span>${h}`;
+  return `<div class="empty-state">${i}<span>${escapeHtml(message)}</span>${h}</div>`;
 }
 
 // ── A1: Toast Notifications ──

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1380,7 +1380,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=110"></script>
+  <script src="/app.js?v=111"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>


### PR DESCRIPTION
## Summary

Fix the empty-state overlap on Subagents / Skills / Custom Commands / Hooks
in the More tab (Image #4 in user report). Root cause was an implicit
contract break in the shared `emptyState()` helper: it returned three raw
`<span>` siblings (icon / message / hint) with no wrapper, expecting every
caller to provide a `.empty-state` ancestor. Several callsites
(`context-gateway.js`, `settings-hooks-watchdog.js`) wrote the result
directly into plain containers, so the spans flowed inline and the message
and hint visually collided.

## Fix

`packages/memtomem/src/memtomem/web/static/app.js:894-896` — make
`emptyState()` emit its own `<div class="empty-state">…</div>` wrapper.
Pattern-A (HTML container declares `class="empty-state"`) and pattern-B
(caller wraps inline) callsites become harmless `.empty-state > .empty-state`
nesting; both layers are flex-column-centered, so the inner box just lays
out normally inside the outer one.

`packages/memtomem/src/memtomem/web/static/index.html:1383` — bump
`app.js?v=110` → `?v=111` (only `app.js` body changed; other scripts left
alone to avoid false drift signal — see
`feedback_static_asset_cache_bust.md`).

No CSS change needed: `.empty-state` is already flex-column at
`style.css:810` + `style.css:1941` (`flex-direction: column; gap: 6px`).

## Side-effect (intentional)

The previous `emptyState()` always emitted `<span class="empty-state-icon"
></span>` even when called with `icon=''`, reserving a ~1.6rem blank slot
above the message (`.empty-state-icon` has `font-size: 1.6rem`). The new
conditional `icon ? ... : ''` drops the empty span entirely, so all
`emptyState('', ...)` callers (most of `context-gateway.js`, all of
`settings-hooks-watchdog.js`, several in `app.js`) tighten vertically.
Visually always an improvement, but flagging it here so reviewers know
it's deliberate, not accidental drift.

## Verification

Manual smoke (`uv run mm web` against the real `~/.memtomem/`) — programmatic
DOM check via Playwright MCP confirmed:

| Surface | Before | After |
|---|---|---|
| Subagents / Server CWD empty (Image #4) | message + hint overlap inline | `<div class="empty-state"><span>...</span><span class="empty-state-hint">...</span></div>`, message at y=226, hint at y=247, **6px gap** ✓ |
| Hooks (`hooks-sync` / no settings.json) | same overlap | message at y=195, hint at y=216, **6px gap** ✓ |
| Skills, Custom Commands empty | same overlap (same code path) | fixed by same patch (call `_ctxRenderItemsHtml` → `emptyState`) |

Regression checks:
- `tags-empty` (`index.html:1111`, declared `class="empty-state"`) and
  `results-empty` (`index.html:288`, ditto) — initially mis-classified as
  pattern C in the plan; on grep verification they're pattern A. Now
  render with nested `.empty-state > .empty-state`; visually unchanged
  (icon was non-empty, so no slot disappearance either).
- `tl-empty` (Timeline) — pattern A, unchanged.
- Dedup empty (`index.html:898-901`, hand-built without `emptyState()`) —
  untouched.
- `settings-namespaces.js:193` CTA edge case (pattern B + CTA) — couldn't
  trigger on a populated DB; deferred to follow-up QA, plan section 9
  spells out what to check if a regression appears.

`uv run pytest -m "not ollama"` and `uv run ruff check && ruff format --check`
both green.

## Out of scope (follow-up issues to file)

1. Remove redundant `class="empty-state"` from ~12 HTML pattern-A
   declarations now that the wrapper is owned by the function.
2. Remove caller-side `<div class="empty-state">${emptyState(...)}</div>`
   wraps in pattern-B sites (~14, mostly `settings-harness.js`,
   `app.js`, `settings-namespaces.js`).
3. Formalize the CTA pattern by absorbing `cta` as a 4th `emptyState()`
   parameter (currently `settings-namespaces.js:193` wraps externally).

## Test plan

- [ ] Open the More tab → 서브에이전트 (Subagents) on a fresh project: verify
      "agents 없음" is on its own line above the helper text.
- [ ] Open the More tab → 스킬 (Skills) on a fresh project: same.
- [ ] Open the More tab → 커스텀 명령 (Custom Commands) on a fresh project: same.
- [ ] Open the More tab → 훅 (Hooks) when `.memtomem/settings.json` does
      not exist: title and hint stack vertically.
- [ ] Hard-reload (`Cmd+Shift+R`) and confirm `app.js?v=111` is served.
- [ ] Regression: Timeline empty, search results empty, tags empty all
      look identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
