### PR TITLE
fix(web/i18n): repair Korean empty-state hint (scan_dirs, josa, button names)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -617,13 +617,16 @@ function _ctxScopeCount(scope, type) {
   return (scope.counts && scope.counts[type]) || 0;
 }
 
-function _ctxRenderItemsHtml(items, type, projectRoot, { clickable }) {
+function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable }) {
   if (!items.length) {
     const canonical = `.memtomem/${type}`;
+    // Same fallback as the runtime-only banner (line 732) so the hint stays
+    // grammatical when no scan dirs are reported (fresh project / no runtimes).
+    const scanList = (scannedDirs || []).join(', ') || `.${type}/`;
     const hint = t('settings.ctx.empty_hint')
       .replace(/\{type\}/g, type)
       .replace('{canonical}', canonical)
-      .replace('{scan_dirs}', '');
+      .replace('{scan_dirs}', scanList);
     return emptyState(
       '',
       t('settings.ctx.no_artifacts').replace('{type}', type),
@@ -676,9 +679,13 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
     // re-insert the runtime-only banner above the fresh list.
     if (seq !== _ctxListSeq[type]) return;
     const items = data[type] || [];
-    container.innerHTML = _ctxRenderItemsHtml(items, type, scope.root, {
-      clickable: _ctxScopeIsServerCwd(scope),
-    });
+    container.innerHTML = _ctxRenderItemsHtml(
+      items,
+      type,
+      scope.root,
+      data.scanned_dirs || [],
+      { clickable: _ctxScopeIsServerCwd(scope) },
+    );
 
     if (_ctxScopeIsServerCwd(scope)) {
       // Only the cwd is mutable, so its canonical/runtime split drives the

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1388,7 +1388,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=3"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=27"></script>
+  <script src="/context-gateway.js?v=28"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -331,7 +331,7 @@
   "settings.ctx.dropped_fields": "제거됨",
   "settings.ctx.no_artifacts": "{type} 없음",
   "settings.ctx.no_artifacts_hint": "새로 만들거나 기존 런타임에서 가져올 수 있습니다.",
-  "settings.ctx.empty_hint": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르거나, 이 프로젝트의 {scan_dirs} 에서 이미 있는 {type} 폴더를 가져오기로 불러올 수 있습니다.",
+  "settings.ctx.empty_hint": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르거나, 이 프로젝트의 {scan_dirs} 에서 기존 {type} 폴더를 가져오기로 불러올 수 있습니다.",
   "settings.ctx.import_no_runtimes": "{root} 에서 런타임 {type}을(를) 찾지 못했습니다. 스캔한 경로: {scan_dirs}.",
   "settings.ctx.sync_empty_canonical": "{canonical} 아래에 canonical {type}이(가) 없습니다. 먼저 하나 만들어 주세요.",
   "settings.ctx.runtime_only_banner": "{scan_dirs} 에서 {type} {count}개를 발견했지만 아직 가져오지 않았습니다. Import 를 눌러 canonical 로 만드세요.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -331,7 +331,7 @@
   "settings.ctx.dropped_fields": "제거됨",
   "settings.ctx.no_artifacts": "{type} 없음",
   "settings.ctx.no_artifacts_hint": "새로 만들거나 기존 런타임에서 가져올 수 있습니다.",
-  "settings.ctx.empty_hint": "{type}을(를) {canonical}/<이름>/ 아래에 두고 Sync 를 누르거나, 이 프로젝트의 {scan_dirs} 에 이미 있는 {type}을(를) Import 로 가져올 수 있습니다.",
+  "settings.ctx.empty_hint": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르거나, 이 프로젝트의 {scan_dirs} 에서 이미 있는 {type} 폴더를 가져오기로 불러올 수 있습니다.",
   "settings.ctx.import_no_runtimes": "{root} 에서 런타임 {type}을(를) 찾지 못했습니다. 스캔한 경로: {scan_dirs}.",
   "settings.ctx.sync_empty_canonical": "{canonical} 아래에 canonical {type}이(가) 없습니다. 먼저 하나 만들어 주세요.",
   "settings.ctx.runtime_only_banner": "{scan_dirs} 에서 {type} {count}개를 발견했지만 아직 가져오지 않았습니다. Import 를 눌러 canonical 로 만드세요.",


### PR DESCRIPTION
## Summary

Fix three i18n bugs in the context-gateway empty-state hint, surfaced now
that PR #858 made the hint actually readable (instead of overlapping the
title).

| Bug | Surface | Fix |
|---|---|---|
| `{scan_dirs}` replaced with empty string | KO: `이 프로젝트의 [공백] 에 이미 있는`, EN: `from  within this project.` (double space) | Thread `data.scanned_dirs` into `_ctxRenderItemsHtml`, reuse the same `(scannedDirs \|\| []).join(', ') \|\| `.${type}/`` fallback already used at `context-gateway.js:732` |
| `{type}을(를)` placeholder leaks ("skills을(를)") | KO empty hint | Sentence rewrite — attach josa to the fixed Korean noun "폴더" instead of the dynamic `{type}`. All four current types (`agents`/`skills`/`commands`/`hooks`) read uniformly, no josa picker needed |
| Inline button names stayed English | KO: `Sync 를 누르거나` / `Import 로 가져올 수` while the actual buttons render as 동기화 / 가져오기 | Updated KO copy to match the on-screen labels |

## Files modified

| File | Lines | Change |
|---|---|---|
| `packages/memtomem/src/memtomem/web/static/context-gateway.js` | 620, 622-626, 679-685 | Add `scannedDirs` parameter to `_ctxRenderItemsHtml`, compute scan-list with the line-732 fallback, pass `data.scanned_dirs \|\| []` from the only caller |
| `packages/memtomem/src/memtomem/web/static/locales/ko.json` | 334 | Sentence rewrite: drop `을(를)` placeholder, localize Sync/Import to 동기화/가져오기, switch `{scan_dirs} 에` to `{scan_dirs} 에서` |
| `packages/memtomem/src/memtomem/web/static/index.html` | 1391 | Bump `context-gateway.js?v=27` → `?v=28` |

`en.json` is unchanged: with `{scan_dirs}` correctly interpolated the
existing English template reads grammatically (e.g. `pull existing skills
from .skills/ within this project.`).

`i18n.js` already fetches `/locales/{lang}.json` with `cache: 'no-store'`,
so the ko.json edit needs no version bump.

## Verification (Playwright MCP, real DB)

`uv run mm web` against the existing `~/.memtomem/`. Hard-reload to
serve `?v=28`. Programmatic DOM check on the More tab → 서브에이전트:

**Before** (after #858, before this PR):
```
agents 없음
agents을(를) .memtomem/agents/<이름>/ 아래에 두고 Sync 를 누르거나, 이 프로젝트의  에 이미 있는 agents을(를) Import 로 가져올 수 있습니다.
```

**After** (this PR, KO, with `data.scanned_dirs` populated):
```
agents 없음
.memtomem/agents/<이름>/ 아래에 agents 폴더를 두고 동기화를 누르거나, 이 프로젝트의 .claude/agents, .gemini/agents, .codex/agents 에서 이미 있는 agents 폴더를 가져오기로 불러올 수 있습니다.
```

Skills (KO) reads symmetrically:
```
.memtomem/skills/<이름>/ 아래에 skills 폴더를 두고 동기화를 누르거나, 이 프로젝트의 .claude/skills, .gemini/skills, .agents/skills 에서 이미 있는 skills 폴더를 가져오기로 불러올 수 있습니다.
```

Regression checks:
- Console errors: 0
- Populated list render path (post-signature-change): unchanged
- `pytest -m "not ollama"`, `ruff check`, `ruff format --check`: green

## Out of scope (follow-up PR)

- `ko.json:295/298/299/335` — same `{type}을(를)` artifact in
  `confirm_delete` / `confirm_sync` / `confirm_import` /
  `import_no_runtimes`. Apply the same rewrite-to-fixed-noun playbook.
- `ko.json:337/338/339` — `Import 를 눌러` / `Import 를 먼저 누르세요`
  English-button leakage in `runtime_only_banner` /
  `sync_disabled_tooltip` / `sync_all_disabled_tooltip`. Same scope as
  this PR's button-name fix.
- Korean josa helper (`pickJosa`) — not introduced; only revisit if a
  future `{type}` value can't accept the rewrite-to-fixed-noun shape.

## Test plan

- [ ] More tab → 서브에이전트 / 스킬 / 커스텀 명령 / 훅 on KO with empty
      lists: hint reads grammatically, no `을(를)`, no double space, button
      names match the on-screen 동기화 / 가져오기 buttons.
- [ ] Switch to EN: hint reads `... pull existing X from <paths> within this project.`
      (no double space when `data.scanned_dirs` is populated; falls back to
      `.{type}/` when not).
- [ ] Populated list (any type with entries): items still render, no JS
      console errors from the `_ctxRenderItemsHtml` signature change.
- [ ] Hard-reload after pulling: `Network` tab shows `context-gateway.js?v=28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
