### PR TITLE
fix(web): formalize emptyState CTA and fix namespaces layout regression

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -973,10 +973,14 @@ function panelLoading(container) {
 
 // ── A5: Empty State ──
 // Owns its `.empty-state` wrapper — callers must NOT add their own.
-function emptyState(icon, message, hint) {
+// cta is structured as { href, label } for safe escaping.
+function emptyState(icon, message, hint, cta) {
   const i = icon ? `<span class="empty-state-icon">${icon}</span>` : '';
   const h = hint ? `<span class="empty-state-hint">${escapeHtml(hint)}</span>` : '';
-  return `<div class="empty-state">${i}<span>${escapeHtml(message)}</span>${h}</div>`;
+  const c = cta
+    ? `<a class="empty-state-cta" href="${escapeHtml(cta.href)}" target="_blank" rel="noopener">${escapeHtml(cta.label)} →</a>`
+    : '';
+  return `<div class="empty-state">${i}<span>${escapeHtml(message)}</span>${h}${c}</div>`;
 }
 
 // ── A1: Toast Notifications ──
@@ -1764,7 +1768,7 @@ function _renderNsChart(namespaces) {
 function _renderHomeRecent(allSources) {
   const recentList = qs('home-recent-list');
   if (!allSources.length) {
-    recentList.innerHTML = '<div class="empty-state">' + emptyState('📁', 'No sources indexed yet', 'Add files from the Index tab') + '</div>';
+    recentList.innerHTML = emptyState('📁', 'No sources indexed yet', 'Add files from the Index tab');
     return;
   }
 
@@ -3197,7 +3201,7 @@ function _renderSourcesStats(activeVendor) {
 function hideBrowser() {
   hide(qs('chunks-browser-content'));
   const browser = qs('chunks-browser');
-  browser.innerHTML = '<div class="empty-state">' + emptyState('📄', 'Select a source to browse its chunks') + '</div>';
+  browser.innerHTML = emptyState('📄', 'Select a source to browse its chunks');
 }
 
 // ── Memory-mode source tree ─────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1381,11 +1381,11 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=114"></script>
+  <script src="/app.js?v=115"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>
-  <script src="/settings-namespaces.js?v=5"></script>
+  <script src="/settings-namespaces.js?v=6"></script>
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=5"></script>
   <script src="/timeline.js?v=3"></script>

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -189,8 +189,10 @@ async function loadNamespacesTab() {
     const data = await api('GET', '/api/namespaces');
     const namespaces = data.namespaces || [];
     if (!namespaces.length) {
-      const cta = `<a class="empty-state-cta" href="https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md#namespace" target="_blank" rel="noopener">${escapeHtml(t('settings.ns.empty.cta'))} →</a>`;
-      list.innerHTML = `<div class="empty-state">${emptyState('🗂', t('settings.ns.empty.title'), t('settings.ns.empty.body'))}${cta}</div>`;
+      list.innerHTML = emptyState('🗂', t('settings.ns.empty.title'), t('settings.ns.empty.body'), {
+        href: 'https://github.com/memtomem/memtomem/blob/main/docs/guides/configuration.md#namespace',
+        label: t('settings.ns.empty.cta'),
+      });
       return;
     }
     list.innerHTML = '';


### PR DESCRIPTION
Addresses issue #859 by adding dedicated ctaHtml support to emptyState() helper. This removes the need for redundant outer wrappers in settings-namespaces.js and app.js, preventing nested .empty-state divs and vertical over-stretching.
Fixes #859 