### PR TITLE
fix(web): align Config guide indexing section with current UI

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -555,14 +555,16 @@ const _CONFIG_GUIDES = {
     title: 'Indexing',
     desc: 'Controls how files are discovered, chunked, and stored as searchable units.',
     items: [
-      { label: 'Memory Dirs', text: 'Directories that can be indexed. Add or remove entries inline; grouped by origin (user-chosen, Claude projects, Claude plans, Codex). Each change persists immediately.' },
-      { label: 'Extensions', text: 'File types recognized for chunking: .md, .py, .js, .ts, .tsx, .jsx, .json, .yaml, .yml, .toml.' },
+      { label: 'Extensions', text: 'File types recognized for chunking: .md, .py, .js, .ts, .tsx, .jsx, .json, .yaml, .yml, .toml. Edit inline; changes persist immediately.' },
+      { label: 'Exclude Patterns', text: 'Glob patterns skipped during indexing. Built-in secret/noise groups are read-only; user patterns are editable inline.' },
       { label: 'Max Chunk Tokens', text: 'Upper bound for chunk size. Long sections are split to stay under this limit.' },
+      { label: 'Target Chunk Tokens', text: 'Soft target the chunker aims for between Min and Max. Most chunks land near this size; Max is the hard cap.' },
       { label: 'Min Chunk Tokens', text: 'Short chunks below this threshold are merged with their neighbor. 0 = no merging.' },
       { label: 'Chunk Overlap', text: 'Token overlap between adjacent chunks. Adds shared context at boundaries for better retrieval. 0 = no overlap.' },
       { label: 'Structured Chunk Mode', text: 'For JSON/YAML/TOML files. "original": extracts raw text lines per key (preserves formatting, line numbers). "recursive": serializes via json.dumps, recursively splits deep nested structures by sub-keys.' },
     ],
     envs: [
+      'MEMTOMEM_INDEXING__SUPPORTED_EXTENSIONS=\'[".md",".py",".js",".ts"]\'',
       'MEMTOMEM_INDEXING__MAX_CHUNK_TOKENS=512',
       'MEMTOMEM_INDEXING__MIN_CHUNK_TOKENS=128',
       'MEMTOMEM_INDEXING__CHUNK_OVERLAP_TOKENS=0',
@@ -572,12 +574,11 @@ const _CONFIG_GUIDES = {
       title: 'Indexing Settings',
       restart: false,
       steps: [
-        'Memory Dirs: use the inline [+ Add] / [✕] / [↻] controls; each change hits the server immediately',
+        'Extensions / Exclude Patterns: edit inline; each change persists immediately and may prompt a re-index',
         'Chunk token settings: edit here + Save (immediate, no restart)',
         'After changing chunk settings, re-index to apply to existing data',
-        'Or set env: MEMTOMEM_INDEXING__MEMORY_DIRS=\'["/path1","/path2"]\'',
       ],
-      warn: 'Extensions are read-only in UI. Chunk setting changes require re-index to take effect on existing data.',
+      warn: 'Extensions / Exclude Patterns / chunk size changes only affect data indexed after the change. Re-index to apply to existing chunks.',
     },
   },
   decay: {

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -564,8 +564,9 @@ const _CONFIG_GUIDES = {
       { label: 'Structured Chunk Mode', text: 'For JSON/YAML/TOML files. "original": extracts raw text lines per key (preserves formatting, line numbers). "recursive": serializes via json.dumps, recursively splits deep nested structures by sub-keys.' },
     ],
     envs: [
-      'MEMTOMEM_INDEXING__SUPPORTED_EXTENSIONS=\'[".md",".py",".js",".ts"]\'',
+      'MEMTOMEM_INDEXING__SUPPORTED_EXTENSIONS=\'[".md",".json",".yaml",".yml",".toml",".py",".js",".ts",".tsx",".jsx"]\'',
       'MEMTOMEM_INDEXING__MAX_CHUNK_TOKENS=512',
+      'MEMTOMEM_INDEXING__TARGET_CHUNK_TOKENS=384',
       'MEMTOMEM_INDEXING__MIN_CHUNK_TOKENS=128',
       'MEMTOMEM_INDEXING__CHUNK_OVERLAP_TOKENS=0',
       'MEMTOMEM_INDEXING__STRUCTURED_CHUNK_MODE=original',
@@ -574,7 +575,7 @@ const _CONFIG_GUIDES = {
       title: 'Indexing Settings',
       restart: false,
       steps: [
-        'Extensions / Exclude Patterns: edit inline; each change persists immediately and may prompt a re-index',
+        'Extensions / Exclude Patterns: edit inline; each change persists immediately. Changing Extensions also surfaces a re-index hint toast.',
         'Chunk token settings: edit here + Save (immediate, no restart)',
         'After changing chunk settings, re-index to apply to existing data',
       ],


### PR DESCRIPTION
## Summary

The right-side **Configuration Guide** in the Web UI's Config tab drifted from the actual `indexing` form. The dictionary that drives the guide (`_CONFIG_GUIDES.indexing` in `packages/memtomem/src/memtomem/web/static/settings-config.js`) still described a widget that moved away and a field that's no longer read-only, while two newer editable fields had no entry at all.

Concrete drift:

| Drift | Source of truth | Guide before |
| ----- | --------------- | ------------ |
| `memory_dirs` widget moved to Sources tab in #300 and is suppressed in Config via `_HIDDEN_CONFIG_FIELDS.indexing` (`settings-config.js:46`) | hidden | `items[0]` + `howto.steps[0]` + `howto` env line still walked users through "[+ Add] / [✕] / [↻] controls" |
| `supported_extensions` became GUI-editable in #603 (`_buildSupportedExtensionsWidget`, with a re-index hint toast at `settings-config.js:1378`) | editable | `howto.warn` claimed *"Extensions are read-only in UI."* |
| `target_chunk_tokens` is in `_CONFIG_LABELS` (`:24`) and `_PERSISTED_FIELDS` (`:1392`) — sliders persist via section Save | editable | no `items` entry |
| `exclude_patterns` has its own widget (`_buildExcludePatternsWidget`, `:721`) with secret/noise/user groups | editable | no `items` entry |

## Changes

Single-section edit to `_CONFIG_GUIDES.indexing` (no other section, label, widget, or i18n file touched):

- **`items`** — drop the Memory Dirs entry; add `Exclude Patterns` after Extensions; add `Target Chunk Tokens` between Max and Min.
- **`howto.steps`** — drop the two Memory Dirs lines (widget step + `MEMORY_DIRS` env tip); replace the lead step with one that covers Extensions / Exclude Patterns inline editing and the re-index nudge.
- **`howto.warn`** — replace the "read-only" claim with a single sentence covering Extensions / Exclude Patterns / chunk size: changes only affect data indexed *after* the change, re-index to apply to existing chunks.
- **`envs`** — add `MEMTOMEM_INDEXING__SUPPORTED_EXTENSIONS=...` so the env example block matches the new editability.

`EXCLUDE_PATTERNS` is intentionally **not** added to `envs` — built-in secret/noise vs user patterns aren't expressible as a single env value, and the inline widget is the source of truth.

## Out of scope

- i18n of the guide item text. Today only the container `title`/`text` lines have `data-i18n` keys; `items`/`howto`/`envs` strings are English-hardcoded across all sections. A separate task.
- Sources tab UX (no cross-link added back to "Chunk settings live in Config tab" — symmetric pointer can come later if needed).

## Test plan

- [x] `uv run pytest -m "not ollama" -k "web or i18n or config_guide"` → **661 passed, 3737 deselected**, 3 unrelated `DeprecationWarning`s (rerank.top_k, websockets.legacy).
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` → clean (236 files already formatted). JS isn't in ruff scope; ran for CI parity.
- [x] `node --check packages/memtomem/src/memtomem/web/static/settings-config.js` → silent OK.
- [x] `grep -rn "Memory Dirs\|MEMORY_DIRS=\|read-only in UI"` across `tests/` and `web/` → no test fixture or other surface still references the dropped strings; remaining "Memory Dirs" hits are inside the Sources tab module and locale entries (correct).
- [ ] **Live UI smoke not run by CI**: I attempted `mm web` against an isolated `HOME` for a visual check, but the fresh-HOME server hung on the first HTTP request (unrelated to this change — pure-client static dictionary). Suggested manual check on a real workspace:
  - `uv run mm web` → Settings → Config → click **Indexing** card.
  - Right pane should show: no "Memory Dirs" item; new "Exclude Patterns" + "Target Chunk Tokens"; warn line about "Extensions / Exclude Patterns / chunk size changes only affect data indexed after the change"; envs block leads with `SUPPORTED_EXTENSIONS`.
  - Left pane unchanged: Extensions widget still editable, re-index toast still fires on save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
