### PR TITLE
fix(web): stack Hooks badge + target path with scope-prefix label

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1386,7 +1386,7 @@
   <script src="/settings-maintenance.js?v=2"></script>
   <script src="/settings-namespaces.js?v=5"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=4"></script>
+  <script src="/settings-hooks-watchdog.js?v=5"></script>
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=28"></script>
   <script src="/path-picker.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -402,6 +402,7 @@
   "settings.hooks.error_hint": "Fix the JSON file and reload.",
   "settings.hooks.no_hooks_defined": "No hooks defined in .memtomem/settings.json.",
   "settings.hooks.load_failed": "Failed to load sync status",
+  "settings.hooks.target_label": "User-scope target:",
   "settings.hooks.badge_in_sync": "in sync",
   "settings.hooks.badge_out_of_sync": "out of sync",
   "settings.hooks.badge_error": "error",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -402,6 +402,7 @@
   "settings.hooks.error_hint": "JSON 파일을 수정한 뒤 다시 불러오세요.",
   "settings.hooks.no_hooks_defined": ".memtomem/settings.json 에 정의된 훅이 없습니다.",
   "settings.hooks.load_failed": "동기화 상태를 불러오지 못했습니다",
+  "settings.hooks.target_label": "User-scope 대상:",
   "settings.hooks.badge_in_sync": "동기화됨",
   "settings.hooks.badge_out_of_sync": "불일치",
   "settings.hooks.badge_error": "오류",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -41,8 +41,11 @@ async function loadHooksSync() {
       error: { cls: 'badge-danger', text: data.error || 'Error' },
     };
     const badge = badges[data.status] || badges.error;
-    statusEl.innerHTML = `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
-      + `<span class="text-muted" style="margin-left:0.5rem;font-size:0.85rem">${escapeHtml(data.target_path || '')}</span>`;
+    statusEl.innerHTML =
+      `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
+      + (data.target_path
+        ? `<div class="hooks-status-target">${escapeHtml(t('settings.hooks.target_label'))} <code>${escapeHtml(data.target_path)}</code></div>`
+        : '');
 
     if (data.status === 'no_source' || data.status === 'error') {
       // Status badge above already names the condition — keep the body to

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2163,6 +2163,9 @@ select:focus-visible {
 .diff-eq  { color: var(--muted); }
 
 /* ── Hooks Sync ── */
+#hooks-sync-status { display: flex; flex-direction: column; align-items: flex-start; gap: 4px; }
+.hooks-status-target { font-size: 0.78rem; color: var(--muted); }
+.hooks-status-target code { font-family: var(--mono); font-size: 0.78rem; }
 .hooks-sync-card {
   border: 1px solid var(--border); border-radius: var(--radius);
   padding: 12px; margin-bottom: 12px; background: var(--surface);


### PR DESCRIPTION
## Summary

Fix the awkward layout of the Hooks detail panel reported via image #1
(More tab → Hooks, `no_source` state):

| Before | After |
|---|---|
| Badge "No .memtomem/settings.json found" + path "/Users/.../.claude/settings.json" rendered as two inline `<span>` siblings inside a non-flex `#hooks-sync-status`, so the path floats to the right of the badge with hardcoded inline `margin-left:0.5rem` and an undefined `.text-muted` class. | Badge stays on its own row; the canonical-fanout target path stacks below in a `.hooks-status-target` line, prefixed with a localized scope label so it reads "User-scope target: `<code>~/.claude/settings.json</code>`". |

The two strings also point at *different* files (project-scope canonical
`<project>/.memtomem/settings.json` vs user-scope target
`~/.claude/settings.json`), so the original horizontal adjacency invited the
misreading "the badge text and the path are the same thing". The new
explicit `User-scope target:` prefix names the relationship.

## Files modified

| File | Change |
|---|---|
| `packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js:44-48` | Replace inline-style two-`<span>` render with a flex-column-friendly `<span>` badge + `<div class="hooks-status-target">` row carrying the label and `<code>` path. |
| `packages/memtomem/src/memtomem/web/static/style.css:2166-2169` | New `#hooks-sync-status { display:flex; flex-direction:column; align-items:flex-start; gap:4px }`; new `.hooks-status-target` (0.78rem / `var(--muted)`) and inner `code` (`var(--mono)`). Same tone as the existing `.empty-state-hint` and `.hooks-sync-preview` rules. |
| `packages/memtomem/src/memtomem/web/static/index.html:1389` | Cache-bust bump `settings-hooks-watchdog.js?v=4 → ?v=5` (only this file's body changed; other scripts left alone — see `feedback_static_asset_cache_bust.md`). |
| `packages/memtomem/src/memtomem/web/static/locales/en.json:405` | New key `settings.hooks.target_label = "User-scope target:"`. |
| `packages/memtomem/src/memtomem/web/static/locales/ko.json:405` | New key `settings.hooks.target_label = "User-scope 대상:"`. |

`i18n.js` fetches `/locales/{lang}.json` with `cache: 'no-store'`, so the
locale edits don't need a separate version bump.

## Verification

- `uv run pytest -m "not ollama" packages/memtomem/tests/test_i18n.py` — 44/44 passing (parity guard catches the new key in both locales).
- `uv run ruff check packages/memtomem/src` and `uv run ruff format --check packages/memtomem/src` — clean.
- All five non-`no_source` states (`in_sync`, `out_of_sync`, `conflicts`, `error`, plus the populated-list paths) traverse the same `statusEl.innerHTML` site, so the layout uplift applies symmetrically; no per-state branching was added.

## Out of scope

While investigating, surfaced a deeper asymmetry: only **hooks** fan out
to a user-scope target (`~/.claude/settings.json`); agents, skills, and
commands all fan out to project-scope (`<project>/.claude/...`). The
canonical store is project-scope across the board. Resolving that
properly needs a dedicated ADR and (likely) a tiered-context-gateway
milestone — well beyond this visual cleanup. Filing a separate issue
to track that thread; this PR doesn't presume which way that decision
lands.

## Test plan

- [ ] Open More → Hooks on a checkout where `.memtomem/settings.json` is missing. Confirm:
  - [ ] Badge "No .memtomem/settings.json found" sits on its own row, left-aligned.
  - [ ] Path stacks below, muted/small, prefixed with `User-scope target:` and the path itself in monospace `<code>`.
  - [ ] No raw inline-style margin between badge and path.
- [ ] Hard-reload (`Cmd+Shift+R`) and confirm `settings-hooks-watchdog.js?v=5` is served (Network tab).
- [ ] Switch locale to KO: prefix becomes `User-scope 대상:`, layout unchanged.
- [ ] Regression: with a populated `.memtomem/settings.json`, the in_sync / out_of_sync / conflicts states still render their badge + path stack the same way; hook list and sync button below behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
