### PR TITLE
feat(config): add hooks.target_scope + plumb _claude_target/target_file (ADR-0010 §3)

### DIFF
--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -161,6 +161,14 @@ mem_index(path="~/notes", recursive=True)
 You can automate memtomem using Claude Code's hooks system.
 Add the following to `~/.claude/settings.json`:
 
+> **Scope** (ADR-0010 §3): the path memtomem writes to is controlled by
+> the `hooks.target_scope` config field (default: `user` →
+> `~/.claude/settings.json`). Set `hooks.target_scope = project_shared`
+> to land hooks at `<project>/.claude/settings.json` (committed) or
+> `project_local` for `<project>/.claude/settings.local.json`
+> (gitignored). Per-invocation override: `mm context sync
+> --include=settings --scope=project_local`.
+
 ```json
 {
   "hooks": {

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -70,7 +70,15 @@ from memtomem.context.skills import (
     generate_all_skills,
 )
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
-from memtomem.config import ContextGatewayConfig
+from typing import get_args
+
+from memtomem.config import (
+    ContextGatewayConfig,
+    Mem2MemConfig,
+    TargetScope,
+    load_config_d,
+    load_config_overrides,
+)
 
 # Phase 1-3 supports skills/agents/commands; Phase D adds settings.
 _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
@@ -292,8 +300,26 @@ def _print_commands_diff(root: Path) -> None:
 # ── Settings sub-handlers (Phase D) ─────────────────────────────────
 
 
-def _print_settings_detect() -> None:
-    files = detect_settings_files()
+def _resolve_cli_scope(override: str | None) -> str:
+    """Return the resolved ``hooks.target_scope`` for a CLI invocation.
+
+    Per-invocation ``--scope`` flag wins; otherwise build a fresh
+    ``Mem2MemConfig`` and apply the user-level config + env overrides.
+    Always passes ``migrate=False`` because scope resolution is itself
+    a read-only lookup — even from mutating commands (sync/generate)
+    the migration belongs in the path that actually persists state, not
+    in the scope read (see ``feedback_doctor_no_migration_loader``).
+    """
+    if override is not None:
+        return override
+    cfg = Mem2MemConfig()
+    load_config_d(cfg, quiet=True)
+    load_config_overrides(cfg, migrate=False)
+    return cfg.hooks.target_scope
+
+
+def _print_settings_detect(root: Path, scope: str) -> None:
+    files = detect_settings_files(root, scope)
     if not files:
         click.echo("  (no settings files detected)")
         return
@@ -303,7 +329,7 @@ def _print_settings_detect() -> None:
         click.echo(f"    {f.agent:17s}  {f.path}  {status}")
 
 
-def _confirm_settings_host_writes(root: Path, *, yes: bool) -> bool:
+def _confirm_settings_host_writes(root: Path, *, scope: str, yes: bool) -> bool:
     """Prompt before mutating settings files outside the project root.
 
     Returns ``True`` when the caller may pass ``allow_host_writes=True``
@@ -311,8 +337,12 @@ def _confirm_settings_host_writes(root: Path, *, yes: bool) -> bool:
     supplied, or user confirmed at the prompt). Returns ``False`` when
     the user declines, in which case the caller should not invoke
     settings sync at all.
+
+    The host-write check is computed against *scope* so
+    ``--scope=project_local`` skips the prompt: project-tier writes stay
+    inside *root* and never leave the project.
     """
-    pending = host_write_targets(root)
+    pending = host_write_targets(root, scope=scope)
     if not pending:
         return True
     if yes:
@@ -326,8 +356,8 @@ def _confirm_settings_host_writes(root: Path, *, yes: bool) -> bool:
     return click.confirm("Continue?", default=False)
 
 
-def _print_settings_generate(root: Path, *, allow_host_writes: bool) -> None:
-    results = generate_all_settings(root, allow_host_writes=allow_host_writes)
+def _print_settings_generate(root: Path, *, scope: str, allow_host_writes: bool) -> None:
+    results = generate_all_settings(root, scope=scope, allow_host_writes=allow_host_writes)
     for name, r in results.items():
         if r.status == "ok":
             click.secho(f"  Settings: {name} → {r.target}", fg="green")
@@ -343,8 +373,8 @@ def _print_settings_generate(root: Path, *, allow_host_writes: bool) -> None:
             click.secho(f"  {r.status} {name}: {r.reason}", fg="red")
 
 
-def _print_settings_diff(root: Path) -> None:
-    results = diff_settings(root)
+def _print_settings_diff(root: Path, *, scope: str) -> None:
+    results = diff_settings(root, scope=scope)
     if not results:
         click.echo("  (no settings to compare)")
         return
@@ -358,6 +388,20 @@ def _print_settings_diff(root: Path) -> None:
             click.secho(f"  skipped {name}: {r.reason}", fg="yellow")
         elif r.status == "error":
             click.secho(f"  error {name}: {r.reason}", fg="red")
+
+
+_SCOPE_OPTION = click.option(
+    "--scope",
+    "scope_flag",
+    type=click.Choice(list(get_args(TargetScope))),
+    default=None,
+    help=(
+        "Override hooks.target_scope for this invocation only "
+        "(user / project_shared / project_local). "
+        "Host-write confirmation is computed against the resolved scope, "
+        "so --scope=project_local skips the prompt (writes stay in-project)."
+    ),
+)
 
 
 _RULES_STYLE_MERGE_RUNTIMES: frozenset[str] = frozenset({"cursor", "codex", "copilot"})
@@ -423,7 +467,7 @@ def detect_cmd(include: tuple[str, ...]) -> None:
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_detect()
+        _print_settings_detect(root, _resolve_cli_scope(None))
 
 
 @context.command("init")
@@ -512,8 +556,14 @@ def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
     is_flag=True,
     help="Skip confirmation prompts before writing settings files outside this project.",
 )
+@_SCOPE_OPTION
 def generate_cmd(
-    agent: str, include: tuple[str, ...], strict: bool, on_drop: str, yes: bool
+    agent: str,
+    include: tuple[str, ...],
+    strict: bool,
+    on_drop: str,
+    yes: bool,
+    scope_flag: str | None,
 ) -> None:
     """Generate agent files from .memtomem/context.md."""
     inc = _parse_include(include)
@@ -563,8 +613,9 @@ def generate_cmd(
 
     if "settings" in inc:
         click.echo("")
-        if _confirm_settings_host_writes(root, yes=yes):
-            _print_settings_generate(root, allow_host_writes=True)
+        scope = _resolve_cli_scope(scope_flag)
+        if _confirm_settings_host_writes(root, scope=scope, yes=yes):
+            _print_settings_generate(root, scope=scope, allow_host_writes=True)
         else:
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 
@@ -618,7 +669,7 @@ def diff_cmd(include: tuple[str, ...]) -> None:
 
     if "settings" in inc:
         click.echo("")
-        _print_settings_diff(root)
+        _print_settings_diff(root, scope=_resolve_cli_scope(None))
 
 
 @context.command("sync")
@@ -642,7 +693,14 @@ def diff_cmd(include: tuple[str, ...]) -> None:
     is_flag=True,
     help="Skip confirmation prompts before writing settings files outside this project.",
 )
-def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) -> None:
+@_SCOPE_OPTION
+def sync_cmd(
+    include: tuple[str, ...],
+    strict: bool,
+    on_drop: str,
+    yes: bool,
+    scope_flag: str | None,
+) -> None:
     """Sync context.md to all detected agent files."""
     inc = _parse_include(include)
     root = _find_project_root()
@@ -688,8 +746,9 @@ def sync_cmd(include: tuple[str, ...], strict: bool, on_drop: str, yes: bool) ->
 
     if "settings" in inc:
         click.echo("")
-        if _confirm_settings_host_writes(root, yes=yes):
-            _print_settings_generate(root, allow_host_writes=True)
+        scope = _resolve_cli_scope(scope_flag)
+        if _confirm_settings_host_writes(root, scope=scope, yes=yes):
+            _print_settings_generate(root, scope=scope, allow_host_writes=True)
         else:
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -953,7 +953,12 @@ def _step_settings(state: dict) -> None:
             except StepRetry:
                 continue
 
-        results = generate_all_settings(project_root)
+        # ``mm init`` runs *before* ``~/.memtomem/config.json`` is
+        # necessarily persisted, so we hardcode the v1 default scope here
+        # (ADR-0010 §3) instead of loading config — loading would mask
+        # the wizard's own write. Users can flip the scope post-install
+        # via ``mm config set hooks.target_scope …`` and re-run sync.
+        results = generate_all_settings(project_root, scope="user")
         for name, r in results.items():
             if r.status == "ok":
                 click.secho(f"  Merged → {r.target}", fg="green")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -697,6 +697,22 @@ class SessionSummaryConfig(BaseSettings):
         return v
 
 
+TargetScope = Literal["user", "project_shared", "project_local"]
+
+
+class HooksConfig(BaseSettings):
+    """Settings-hooks fan-out scope (ADR-0010 §3).
+
+    ``target_scope`` selects where memtomem-managed Claude Code hooks land:
+    user-tier (``~/.claude/settings.json``), project-shared
+    (``<project>/.claude/settings.json``), or project-local
+    (``<project>/.claude/settings.local.json``). v1 default is ``user`` for
+    zero behavior change; the default-flip trigger lives in ADR-0010 §5.
+    """
+
+    target_scope: TargetScope = "user"
+
+
 class ContextGatewayConfig(BaseSettings):
     """Settings for the multi-project context UI (skills / commands / agents).
 
@@ -748,6 +764,7 @@ class Mem2MemConfig(BaseSettings):
     llm: LLMConfig = Field(default_factory=LLMConfig)
     session_summary: SessionSummaryConfig = Field(default_factory=SessionSummaryConfig)
     context_gateway: ContextGatewayConfig = Field(default_factory=ContextGatewayConfig)
+    hooks: HooksConfig = Field(default_factory=HooksConfig)
 
 
 # ---------------------------------------------------------------------------
@@ -814,6 +831,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
     # instance is cached on startup), so only the pool-sizing knobs are
     # runtime-mutable.
     "rerank": {"enabled", "oversample", "min_pool", "max_pool"},
+    "hooks": {"target_scope"},
 }
 
 FIELD_CONSTRAINTS: dict[str, dict] = {
@@ -849,6 +867,7 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     "rerank.oversample": {"type": float, "min": 0.1, "max": 10.0},
     "rerank.min_pool": {"type": int, "min": 1, "max": 1000},
     "rerank.max_pool": {"type": int, "min": 1, "max": 1000},
+    "hooks.target_scope": {"type": str, "allowed": set(get_args(TargetScope))},
 }
 
 
@@ -980,12 +999,17 @@ def _override_path() -> Path:
     return _CONFIG_OVERRIDE_PATH.expanduser()
 
 
-def load_config_overrides(config: Mem2MemConfig) -> None:
+def load_config_overrides(config: Mem2MemConfig, *, migrate: bool = True) -> None:
     """Apply persisted overrides from ~/.memtomem/config.json (if exists).
 
     Precedence: ``MEMTOMEM_<SECTION>__<FIELD>`` env vars win over
     ``config.json``. If an env var is set for a field, the corresponding
     ``config.json`` entry is skipped so the env-bound value remains in effect.
+
+    Pass ``migrate=False`` to skip the auto-discover legacy migration —
+    required for read-only diagnostic surfaces (e.g. ``mm context detect``,
+    scope resolution from config) that must not touch disk as a side
+    effect (see ``feedback_doctor_no_migration_loader``).
     """
     import json as _json
     import logging
@@ -1046,8 +1070,10 @@ def load_config_overrides(config: Mem2MemConfig) -> None:
 
     # One-shot migration of legacy auto_discover=True installs to explicit
     # provider memory_dirs entries. No-op for fresh installs (no config.json)
-    # and for already-migrated installs (auto_discover=False).
-    _migrate_auto_discover_once(config)
+    # and for already-migrated installs (auto_discover=False). Skipped when
+    # ``migrate=False`` so read-only callers don't trigger a disk write.
+    if migrate:
+        _migrate_auto_discover_once(config)
 
 
 _CONFIG_D_PATH = Path("~/.memtomem/config.d")

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -205,13 +205,15 @@ def detect_command_dirs(project_root: Path) -> list[DetectedFile]:
     return sorted(found, key=lambda f: (f.agent, str(f.path)))
 
 
-def detect_settings_files() -> list[DetectedFile]:
-    """Detect user-scope settings files for registered runtimes.
+def detect_settings_files(project_root: Path, scope: str) -> list[DetectedFile]:
+    """Detect the resolved-scope settings file for each registered runtime.
 
-    Unlike the other ``detect_*`` functions this does **not** take a
-    *project_root* because settings files live in the user's home directory.
-    A runtime is reported only when its home directory exists (e.g.
-    ``~/.claude/``), matching :meth:`ClaudeSettingsGenerator.is_available`.
+    Per ADR-0010 §3 the active scope is user-selectable (``user`` /
+    ``project_shared`` / ``project_local``). Callers pass the project
+    root + resolved scope; the function probes that single tier so the
+    UI's "what's where" listing matches what
+    :func:`memtomem.context.settings.generate_all_settings` will actually
+    write.
 
     Delegates to generators from ``context/settings.py`` at call time (lazy
     import) to ensure ``monkeypatch``-based HOME overrides in tests work.
@@ -220,11 +222,9 @@ def detect_settings_files() -> list[DetectedFile]:
 
     found: list[DetectedFile] = []
     for name, gen in SETTINGS_GENERATORS.items():
-        if not gen.is_available():
+        if not gen.is_available(project_root):
             continue
-        # project_root is not used by user-scope generators, but the
-        # protocol requires it — pass cwd as a harmless default.
-        target = gen.target_file(Path.cwd())
+        target = gen.target_file(project_root, scope)
         if target.is_file():
             found.append(
                 DetectedFile(
@@ -246,14 +246,21 @@ def detect_settings_files() -> list[DetectedFile]:
     return sorted(found, key=lambda f: (f.agent, str(f.path)))
 
 
-def detect_all(project_root: Path) -> list[DetectedFile]:
-    """Return project-memory files, skill dirs, sub-agents, commands, and settings."""
+def detect_all(project_root: Path, scope: str = "user") -> list[DetectedFile]:
+    """Return project-memory files, skill dirs, sub-agents, commands, and settings.
+
+    *scope* is the resolved ``hooks.target_scope`` (ADR-0010 §3); see
+    :func:`detect_settings_files` for why it's relevant. Defaults to
+    ``"user"`` so external consumers of this public function don't see
+    a breaking signature change in v1 — the value matches the default
+    of ``hooks.target_scope`` (ADR-0010 §2).
+    """
     return (
         detect_agent_files(project_root)
         + detect_skill_dirs(project_root)
         + detect_agent_dirs(project_root)
         + detect_command_dirs(project_root)
-        + detect_settings_files()
+        + detect_settings_files(project_root, scope)
     )
 
 

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -52,6 +52,24 @@ CANONICAL_SETTINGS_FILE = ".memtomem/settings.json"
 _MALFORMED = object()
 
 
+def resolve_scope_path(project_root: Path, scope: str) -> Path:
+    """Resolve ``hooks.target_scope`` to the runtime settings file path.
+
+    Single source of truth for the ADR-0010 §3 path math; shared by
+    :class:`ClaudeSettingsGenerator`, the Web ``_claude_target`` helper,
+    and the detector. Raises ``ValueError`` on unknown scope so a typo in
+    config.json surfaces loudly instead of silently writing to the
+    fallback path.
+    """
+    if scope == "user":
+        return Path.home() / ".claude" / "settings.json"
+    if scope == "project_shared":
+        return project_root / ".claude" / "settings.json"
+    if scope == "project_local":
+        return project_root / ".claude" / "settings.local.json"
+    raise ValueError(f"Unknown target_scope: {scope!r}")
+
+
 # ── Protocol + Result ───────────────────────────────────────────────
 
 
@@ -60,16 +78,19 @@ class SettingsGenerator(Protocol):
 
     name: str
 
-    def is_available(self) -> bool:
-        """``True`` if the runtime is installed (e.g. ``~/.claude/`` exists).
+    def is_available(self, project_root: Path) -> bool:
+        """``True`` if the runtime is installed for this project.
 
-        Used to skip generators whose runtime isn't installed.  Generators
-        must **not** auto-create the runtime's home directory.
+        Per ADR-0010 §3 the probe is "any of the resolved scopes is a
+        plausible target dir": ``~/.claude/`` for user-tier, or
+        ``<project_root>/.claude/`` for project-tier. Used to skip
+        generators whose runtime isn't installed.  Generators must
+        **not** auto-create the runtime's home directory.
         """
         ...
 
-    def target_file(self, project_root: Path) -> Path:
-        """Return the path to the runtime's settings file."""
+    def target_file(self, project_root: Path, scope: str) -> Path:
+        """Return the path to the runtime's settings file for *scope*."""
         ...
 
     def canonical_source(self, project_root: Path) -> Path:
@@ -116,11 +137,13 @@ class ClaudeSettingsGenerator:
 
     name: str = "claude_settings"
 
-    def is_available(self) -> bool:
-        return (Path.home() / ".claude").is_dir()
+    def is_available(self, project_root: Path) -> bool:
+        # Loosened per ADR-0010 §3: tile shows up if Claude Code has any
+        # settings home for this project — user-tier or project-tier.
+        return (Path.home() / ".claude").is_dir() or (project_root / ".claude").is_dir()
 
-    def target_file(self, project_root: Path) -> Path:
-        return Path.home() / ".claude" / "settings.json"
+    def target_file(self, project_root: Path, scope: str) -> Path:
+        return resolve_scope_path(project_root, scope)
 
     def canonical_source(self, project_root: Path) -> Path:
         return project_root / CANONICAL_SETTINGS_FILE
@@ -207,7 +230,7 @@ def _is_under_project_root(target: Path, project_root: Path) -> bool:
     return resolved_target.is_relative_to(resolved_root)
 
 
-def host_write_targets(project_root: Path) -> list[Path]:
+def host_write_targets(project_root: Path, *, scope: str) -> list[Path]:
     """Target paths a settings sync would write *outside* the project root.
 
     A target counts as a "host write" when its resolved path is not under
@@ -217,17 +240,22 @@ def host_write_targets(project_root: Path) -> list[Path]:
     ``mm context sync --include=settings`` from a worktree must not silently
     edit the real home directory.
 
+    *scope* is the resolved ``hooks.target_scope`` (per ADR-0010 §3); it
+    determines which tier each generator's ``target_file`` resolves to.
+    Project-tier scopes (``project_shared`` / ``project_local``) yield an
+    empty list because writes stay inside the project root.
+
     Generators whose runtime is unavailable (``is_available()`` is False) or
     that have no canonical source are skipped, so the list mirrors what
     :func:`generate_all_settings` would actually try to write.
     """
     pending: list[Path] = []
     for gen in SETTINGS_GENERATORS.values():
-        if not gen.is_available():
+        if not gen.is_available(project_root):
             continue
         if not gen.canonical_source(project_root).exists():
             continue
-        target = gen.target_file(project_root)
+        target = gen.target_file(project_root, scope)
         if not _is_under_project_root(target, project_root):
             pending.append(target)
     return pending
@@ -268,24 +296,34 @@ def _write_json(path: Path, data: dict) -> None:
 def generate_all_settings(
     project_root: Path,
     *,
+    scope: str,
     allow_host_writes: bool = False,
 ) -> dict[str, SettingsSyncResult]:
     """Fan out ``.memtomem/settings.json`` to registered runtimes.
 
+    *scope* is the resolved ``hooks.target_scope`` (per ADR-0010 §3) and
+    is required keyword-only — every caller (CLI, MCP, Web) is expected
+    to resolve it from its own config layer rather than have this
+    function lazy-load ``Mem2MemConfig`` (which would trigger the
+    auto-discover migration as a side effect, see
+    ``feedback_doctor_no_migration_loader``).
+
     ``allow_host_writes`` defaults to ``False`` so any caller — CLI, MCP
     server, or Web route — that does not first prompt the user is
     automatically refused for targets that resolve outside *project_root*
-    (e.g. ``~/.claude/settings.json``). Refused generators come back with
-    ``status="needs_confirmation"`` and ``reason`` containing the host
-    path; callers decide how to surface that. Passing
-    ``allow_host_writes=True`` after acknowledgement (CLI ``--yes``,
-    MCP ``allow_host_writes=True``, Web confirmation modal) restores the
-    previous behavior. Project-scope generators are written unconditionally.
+    (e.g. ``~/.claude/settings.json`` when ``scope="user"``). Refused
+    generators come back with ``status="needs_confirmation"`` and
+    ``reason`` containing the host path; callers decide how to surface
+    that. Passing ``allow_host_writes=True`` after acknowledgement (CLI
+    ``--yes``, MCP ``allow_host_writes=True``, Web confirmation modal)
+    restores the previous behavior. Project-scope writes (``scope`` is
+    ``project_shared`` or ``project_local``) stay inside the project
+    root and never trigger the gate.
     """
     results: dict[str, SettingsSyncResult] = {}
 
     for name, gen in SETTINGS_GENERATORS.items():
-        if not gen.is_available():
+        if not gen.is_available(project_root):
             results[name] = SettingsSyncResult(
                 status="skipped",
                 reason=(f"{name} runtime not installed (target dir missing)"),
@@ -309,7 +347,7 @@ def generate_all_settings(
             continue
         contributions: dict = raw  # type: ignore[assignment]
 
-        target_path = gen.target_file(project_root)
+        target_path = gen.target_file(project_root, scope)
         if not allow_host_writes and not _is_under_project_root(target_path, project_root):
             results[name] = SettingsSyncResult(
                 status="needs_confirmation",
@@ -359,12 +397,19 @@ def generate_all_settings(
 
 def diff_settings(
     project_root: Path,
+    *,
+    scope: str,
 ) -> dict[str, SettingsSyncResult]:
-    """Dry-run: compute what :func:`generate_all_settings` would do."""
+    """Dry-run: compute what :func:`generate_all_settings` would do.
+
+    *scope* is the resolved ``hooks.target_scope`` (ADR-0010 §3); see
+    :func:`generate_all_settings` for the rationale on why callers pass
+    this in rather than having it lazy-loaded here.
+    """
     results: dict[str, SettingsSyncResult] = {}
 
     for name, gen in SETTINGS_GENERATORS.items():
-        if not gen.is_available():
+        if not gen.is_available(project_root):
             results[name] = SettingsSyncResult(
                 status="skipped",
                 reason=f"{name} runtime not installed",
@@ -388,7 +433,7 @@ def diff_settings(
             continue
         contributions: dict = raw  # type: ignore[assignment]
 
-        target_path = gen.target_file(project_root)
+        target_path = gen.target_file(project_root, scope)
         existing_raw, _ = _read_with_mtime(target_path)
         if existing_raw is _MALFORMED:
             results[name] = SettingsSyncResult(
@@ -429,6 +474,7 @@ __all__ = [
     "SETTINGS_GENERATORS",
     "SettingsGenerator",
     "SettingsSyncResult",
+    "resolve_scope_path",
     "diff_settings",
     "generate_all_settings",
     "host_write_targets",

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -24,6 +24,23 @@ def _find_project_root() -> Path:
     return Path.cwd()
 
 
+def _resolve_mcp_scope() -> str:
+    """Return the resolved ``hooks.target_scope`` for an MCP tool call.
+
+    Builds a fresh ``Mem2MemConfig`` and applies user-level overrides
+    with ``migrate=False`` — scope resolution is read-only, and the
+    same MCP tool dispatcher is shared by read-only entry points
+    (mem_context_detect, mem_context_diff) where a disk-write side
+    effect would be wrong (see ``feedback_doctor_no_migration_loader``).
+    """
+    from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+
+    cfg = Mem2MemConfig()
+    load_config_d(cfg, quiet=True)
+    load_config_overrides(cfg, migrate=False)
+    return cfg.hooks.target_scope
+
+
 def _parse_include(include: str) -> set[str]:
     """Parse a comma-separated ``include`` argument coming from an MCP caller."""
     values: set[str] = set()
@@ -112,7 +129,7 @@ async def mem_context_detect(
     if "settings" in inc:
         from memtomem.context.detector import detect_settings_files
 
-        settings = detect_settings_files()
+        settings = detect_settings_files(root, _resolve_mcp_scope())
         if lines:
             lines.append("")
         if settings:
@@ -239,7 +256,9 @@ async def mem_context_generate(
     if "settings" in inc:
         from memtomem.context.settings import generate_all_settings
 
-        settings_results = generate_all_settings(root, allow_host_writes=allow_host_writes)
+        settings_results = generate_all_settings(
+            root, scope=_resolve_mcp_scope(), allow_host_writes=allow_host_writes
+        )
         for sname, sr in settings_results.items():
             if sr.status == "ok":
                 results.append(f"\nSettings: {sname} → {sr.target}")
@@ -336,7 +355,7 @@ async def mem_context_diff(
     if "settings" in inc:
         from memtomem.context.settings import diff_settings as _diff_settings
 
-        settings_results = _diff_settings(root)
+        settings_results = _diff_settings(root, scope=_resolve_mcp_scope())
         if settings_results:
             if lines:
                 lines.append("")
@@ -472,7 +491,9 @@ async def mem_context_sync(
     if "settings" in inc:
         from memtomem.context.settings import generate_all_settings
 
-        settings_results = generate_all_settings(root, allow_host_writes=allow_host_writes)
+        settings_results = generate_all_settings(
+            root, scope=_resolve_mcp_scope(), allow_host_writes=allow_host_writes
+        )
         for sname, sr in settings_results.items():
             if sr.status == "ok":
                 if results:

--- a/packages/memtomem/src/memtomem/web/deps.py
+++ b/packages/memtomem/src/memtomem/web/deps.py
@@ -54,6 +54,17 @@ def get_project_root(request: Request) -> Path:
     return request.app.state.project_root
 
 
+def get_hooks_target_scope(request: Request) -> str:
+    """Return ``hooks.target_scope`` from the live ``app.state.config``.
+
+    ``hot_reload.py`` swaps ``app.state.config`` atomically on
+    ``config.json`` edits, so handlers depending on this Depends
+    automatically pick up scope changes without a server restart
+    (mirrors :func:`get_config`).
+    """
+    return request.app.state.config.hooks.target_scope
+
+
 def require_configured() -> None:
     """Refuse mutating index routes when ``mm init`` has not run.
 

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from fastapi import APIRouter, Depends
 
 from memtomem.privacy import scan as _privacy_scan
-from memtomem.web.deps import get_project_root
+from memtomem.web.deps import get_hooks_target_scope, get_project_root
 
 try:
     import tomllib
@@ -110,6 +110,7 @@ def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
 @router.get("/context/overview")
 async def context_overview(
     project_root: Path = Depends(get_project_root),
+    scope: str = Depends(get_hooks_target_scope),
 ) -> dict:
     """Aggregate sync status across skills, commands, agents, and settings."""
     from memtomem.context.agents import diff_agents
@@ -138,7 +139,7 @@ async def context_overview(
         result["agents"] = _error_payload(exc, shape="total")
 
     try:
-        settings_diff = diff_settings(project_root)
+        settings_diff = diff_settings(project_root, scope=scope)
         statuses = [r.status for r in settings_diff.values()]
         # `total` counts only **applicable** generators (runtime installed +
         # canonical source present). `skipped` items are N/A — including them

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -11,11 +11,12 @@ from pydantic import BaseModel
 
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
+    resolve_scope_path,
     _safe_load_json,
     _write_json,
     generate_all_settings,
 )
-from memtomem.web.deps import get_project_root
+from memtomem.web.deps import get_hooks_target_scope, get_project_root
 from memtomem.web.routes._locks import _gateway_lock
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,14 @@ router = APIRouter(tags=["settings-sync", "context-gateway"])
 _MALFORMED = object()
 
 
-def _claude_target() -> Path:
-    return Path.home() / ".claude" / "settings.json"
+def _claude_target(project_root: Path, scope: str) -> Path:
+    """Resolve the Claude Code settings file under *scope* (ADR-0010 §3).
+
+    Thin wrapper over :func:`memtomem.context.settings.resolve_scope_path`
+    so this module owns no path math of its own — keeps the route helper
+    in lock-step with :class:`ClaudeSettingsGenerator` and the detector.
+    """
+    return resolve_scope_path(project_root, scope)
 
 
 def _rule_label(event: str, matcher: str) -> str:
@@ -146,10 +153,11 @@ def _compare_hooks(
 @router.get("/context/settings")
 async def get_settings_sync(
     project_root: Path = Depends(get_project_root),
+    scope: str = Depends(get_hooks_target_scope),
 ) -> dict:
     """Return structured settings sync status with conflict details."""
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
-    target_path = _claude_target()
+    target_path = _claude_target(project_root, scope)
     return _compare_hooks(canonical_path, target_path)
 
 
@@ -171,6 +179,7 @@ class ApplySettingsSyncRequest(BaseModel):
 async def apply_settings_sync(
     body: ApplySettingsSyncRequest | None = None,
     project_root: Path = Depends(get_project_root),
+    scope: str = Depends(get_hooks_target_scope),
 ) -> dict:
     """Run the full settings merge (generate_all_settings).
 
@@ -183,7 +192,11 @@ async def apply_settings_sync(
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                results = generate_all_settings(project_root, allow_host_writes=allow_host_writes)
+                results = generate_all_settings(
+                    project_root,
+                    scope=scope,
+                    allow_host_writes=allow_host_writes,
+                )
     except TimeoutError:
         raise HTTPException(503, "Settings sync timed out — another sync may be in progress")
     out: list[dict] = []
@@ -211,6 +224,7 @@ class ResolveRequest(BaseModel):
 async def resolve_conflict(
     body: ResolveRequest,
     project_root: Path = Depends(get_project_root),
+    scope: str = Depends(get_hooks_target_scope),
 ) -> dict:
     """Resolve a single hook conflict by replacing the target's rule."""
     if body.action != "use_proposed":
@@ -219,7 +233,7 @@ async def resolve_conflict(
     label = _rule_label(body.event, body.matcher)
 
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
-    target_path = _claude_target()
+    target_path = _claude_target(project_root, scope)
 
     try:
         async with asyncio.timeout(60):

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -16,6 +16,8 @@ from httpx import ASGITransport, AsyncClient
 
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
+    ClaudeSettingsGenerator,
+    resolve_scope_path,
     diff_settings,
     generate_all_settings,
     host_write_targets,
@@ -87,7 +89,7 @@ class TestClaudeSettingsMergeEmpty:
             tmp_path,
             {"hooks": {"PostToolUse": [_rule("Write", "echo ok")]}},
         )
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "ok"
 
         written = _read_target(claude_home)
@@ -109,7 +111,7 @@ class TestClaudeSettingsMergeSemantic:
         target.write_text(json.dumps(existing, indent=4) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {}})
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "ok"
 
         written = _read_target(claude_home)
@@ -130,7 +132,7 @@ class TestClaudeSettingsMergeAdditive:
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
 
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "ok"
 
         written = _read_target(claude_home)
@@ -148,7 +150,7 @@ class TestClaudeSettingsMergeAdditive:
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
 
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "ok"
 
         written = _read_target(claude_home)
@@ -170,7 +172,7 @@ class TestClaudeSettingsMergeConflict:
         mm_rule = _rule("Write", "mm index")
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [mm_rule]}})
 
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         r = results["claude_settings"]
         assert r.status == "ok"
         assert len(r.warnings) == 1
@@ -186,7 +188,7 @@ class TestClaudeSettingsMergeConflict:
         target.write_text(json.dumps({"hooks": {"PostToolUse": [rule]}}) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [rule]}})
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "ok"
         assert results["claude_settings"].warnings == []
 
@@ -210,7 +212,7 @@ class TestClaudeSettingsMergeConflict:
         # Contribution exactly matches the first user rule.
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [existing_a]}})
 
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         r = results["claude_settings"]
         assert r.status == "ok"
         assert r.warnings == []  # was 1 before the fix
@@ -233,7 +235,7 @@ class TestClaudeSettingsMergeWarningContent:
             tmp_path,
             {"hooks": {"PostToolUse": [_rule("Write", "new")]}},
         )
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         w = results["claude_settings"].warnings[0]
 
         # (a) rule label
@@ -253,7 +255,7 @@ class TestClaudeSettingsMergeMalformed:
         target.write_text('{"hooks":{', encoding="utf-8")  # truncated
 
         _make_canonical_settings(tmp_path, {"hooks": {}})
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         r = results["claude_settings"]
         assert r.status == "error"
         assert "not valid JSON" in r.reason
@@ -263,7 +265,7 @@ class TestClaudeSettingsMergeMalformed:
 
     def test_malformed_canonical_returns_error(self, claude_home, tmp_path):
         _make_canonical_settings(tmp_path, "{bad json")
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         r = results["claude_settings"]
         assert r.status == "error"
         assert "not valid JSON" in r.reason
@@ -308,7 +310,7 @@ class TestClaudeSettingsMergeConcurrent:
         import unittest.mock
 
         with unittest.mock.patch.object(settings_mod, "_read_with_mtime", patched_read_with_mtime):
-            results = generate_all_settings(tmp_path)
+            results = generate_all_settings(tmp_path, scope="user")
 
         r = results["claude_settings"]
         assert r.status == "aborted"
@@ -336,7 +338,7 @@ class TestClaudeSettingsAtomicWrite:
         monkeypatch.setattr("memtomem.context._atomic.os.replace", _boom)
 
         with pytest.raises(OSError, match="simulated crash"):
-            generate_all_settings(tmp_path)
+            generate_all_settings(tmp_path, scope="user")
 
         # Old file survives, no .tmp sibling leaked.
         assert json.loads(target.read_text(encoding="utf-8")) == original
@@ -354,7 +356,7 @@ class TestClaudeSettingsAtomicWrite:
             tmp_path,
             {"hooks": {"PostToolUse": [_rule("Edit", "echo")]}},
         )
-        generate_all_settings(tmp_path)
+        generate_all_settings(tmp_path, scope="user")
 
         target = claude_home / ".claude" / "settings.json"
         assert _stat.S_IMODE(target.stat().st_mode) == 0o600
@@ -365,7 +367,7 @@ class TestClaudeSettingsNoClaudeCodeInstalled:
 
     def test_skips_when_claude_not_installed(self, claude_home_missing, tmp_path):
         _make_canonical_settings(tmp_path, {"hooks": {}})
-        results = generate_all_settings(tmp_path)
+        results = generate_all_settings(tmp_path, scope="user")
         r = results["claude_settings"]
         assert r.status == "skipped"
         assert "not installed" in r.reason
@@ -385,7 +387,7 @@ class TestClaudeSettingsDryRun:
             tmp_path,
             {"hooks": {"PostToolUse": [_rule("Write")]}},
         )
-        results = diff_settings(tmp_path)
+        results = diff_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "missing target"
 
     def test_reports_in_sync(self, claude_home, tmp_path):
@@ -394,7 +396,7 @@ class TestClaudeSettingsDryRun:
         target.write_text(json.dumps(content, indent=2) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, content)
-        results = diff_settings(tmp_path)
+        results = diff_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "in sync"
 
     def test_reports_out_of_sync(self, claude_home, tmp_path):
@@ -402,7 +404,7 @@ class TestClaudeSettingsDryRun:
         target.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}})
-        results = diff_settings(tmp_path)
+        results = diff_settings(tmp_path, scope="user")
         assert results["claude_settings"].status == "out of sync"
 
     def test_does_not_write(self, claude_home, tmp_path):
@@ -412,7 +414,7 @@ class TestClaudeSettingsDryRun:
         target.write_text(original, encoding="utf-8")
 
         _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write")]}})
-        diff_settings(tmp_path)
+        diff_settings(tmp_path, scope="user")
         assert target.read_text(encoding="utf-8") == original
 
 
@@ -598,7 +600,7 @@ class TestGenerateAllSettingsHostWriteGate:
         """Default ``allow_host_writes=False`` → status=needs_confirmation,
         no file written."""
         project = self._setup(tmp_path)
-        results = generate_all_settings(project)
+        results = generate_all_settings(project, scope="user")
         r = results["claude_settings"]
         assert r.status == "needs_confirmation"
         target = claude_home / ".claude" / "settings.json"
@@ -609,7 +611,7 @@ class TestGenerateAllSettingsHostWriteGate:
     def test_allow_host_writes_true_proceeds(self, claude_home, tmp_path):
         """``allow_host_writes=True`` → previous behavior, file written."""
         project = self._setup(tmp_path)
-        results = generate_all_settings(project, allow_host_writes=True)
+        results = generate_all_settings(project, scope="user", allow_host_writes=True)
         r = results["claude_settings"]
         assert r.status == "ok"
         target = claude_home / ".claude" / "settings.json"
@@ -621,18 +623,18 @@ class TestGenerateAllSettingsHostWriteGate:
         """``diff_settings`` is read-only — host-write gate must not make it
         report ``needs_confirmation``."""
         project = self._setup(tmp_path)
-        results = diff_settings(project)
+        results = diff_settings(project, scope="user")
         assert results["claude_settings"].status in {"in sync", "out of sync", "missing target"}
 
     def test_no_runtime_installed_skips_not_needs_confirmation(self, claude_home_missing, tmp_path):
         project = self._setup(tmp_path)
-        results = generate_all_settings(project)
+        results = generate_all_settings(project, scope="user")
         assert results["claude_settings"].status == "skipped"
 
     def test_no_canonical_skips_not_needs_confirmation(self, claude_home, tmp_path):
         project = tmp_path / "proj"
         project.mkdir()
-        results = generate_all_settings(project)
+        results = generate_all_settings(project, scope="user")
         assert results["claude_settings"].status == "skipped"
 
     def test_host_write_targets_lists_pending_paths(self, claude_home, tmp_path):
@@ -640,18 +642,18 @@ class TestGenerateAllSettingsHostWriteGate:
         would refuse — used by every front-end to surface the pending
         paths to the user."""
         project = self._setup(tmp_path)
-        pending = host_write_targets(project)
+        pending = host_write_targets(project, scope="user")
         target = claude_home / ".claude" / "settings.json"
         assert pending == [target]
 
     def test_host_write_targets_empty_when_no_canonical(self, claude_home, tmp_path):
         project = tmp_path / "proj"
         project.mkdir()
-        assert host_write_targets(project) == []
+        assert host_write_targets(project, scope="user") == []
 
     def test_host_write_targets_empty_when_runtime_missing(self, claude_home_missing, tmp_path):
         project = self._setup(tmp_path)
-        assert host_write_targets(project) == []
+        assert host_write_targets(project, scope="user") == []
 
     @pytest.mark.requires_symlinks
     def test_symlink_target_is_treated_as_host_write(self, claude_home, tmp_path):
@@ -665,8 +667,252 @@ class TestGenerateAllSettingsHostWriteGate:
 
         # The generator's target_file still computes Path.home() / .claude /
         # settings.json (the host path), and that resolves outside ``project``.
-        results = generate_all_settings(project)
+        results = generate_all_settings(project, scope="user")
         assert results["claude_settings"].status == "needs_confirmation"
+
+
+# ── ADR-0010 §3 hooks.target_scope plumbing (issue #870) ────────────────────
+
+
+class TestTargetScopeResolution:
+    """6 path resolutions: 3 scope values × 2 entry points.
+
+    Pins ADR-0010 §3 path math at both the resolver function and the
+    end-to-end ``generate_all_settings`` call, so a regression in either
+    layer surfaces. Mutation-validation per
+    ``feedback_pin_test_mutation_validation``: swap the resolver's
+    ``"user"`` branch return and at least one of these tests must fail.
+    """
+
+    @pytest.mark.parametrize(
+        "scope,expected_relpath",
+        [
+            ("user", None),  # special: lives under HOME, computed at call time
+            ("project_shared", ".claude/settings.json"),
+            ("project_local", ".claude/settings.local.json"),
+        ],
+    )
+    def test_resolver_function(self, claude_home, tmp_path, scope, expected_relpath):
+        path = resolve_scope_path(tmp_path, scope)
+        if scope == "user":
+            assert path == claude_home / ".claude" / "settings.json"
+        else:
+            assert path == tmp_path / expected_relpath
+
+    @pytest.mark.parametrize(
+        "scope,expected_relpath",
+        [
+            ("user", None),
+            ("project_shared", ".claude/settings.json"),
+            ("project_local", ".claude/settings.local.json"),
+        ],
+    )
+    def test_generator_target_file(self, claude_home, tmp_path, scope, expected_relpath):
+        gen = ClaudeSettingsGenerator()
+        path = gen.target_file(tmp_path, scope)
+        if scope == "user":
+            assert path == claude_home / ".claude" / "settings.json"
+        else:
+            assert path == tmp_path / expected_relpath
+
+    @pytest.mark.parametrize(
+        "scope,relpath",
+        [
+            ("project_shared", ".claude/settings.json"),
+            ("project_local", ".claude/settings.local.json"),
+        ],
+    )
+    def test_generate_writes_to_resolved_project_tier(self, claude_home, tmp_path, scope, relpath):
+        """End-to-end: project-tier scopes write under the project root and
+        do *not* touch ``~/.claude/settings.json``."""
+        (tmp_path / ".claude").mkdir(exist_ok=True)
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "echo project")]}},
+        )
+
+        results = generate_all_settings(tmp_path, scope=scope, allow_host_writes=False)
+        assert results["claude_settings"].status == "ok"
+        assert (tmp_path / relpath).is_file()
+        # The user-tier path must remain untouched.
+        assert not (claude_home / ".claude" / "settings.json").exists()
+
+    def test_generate_writes_to_user_tier_with_user_scope(self, claude_home, tmp_path):
+        """End-to-end: ``scope="user"`` lands the merge at
+        ``~/.claude/settings.json`` (the existing-install behavior)."""
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "echo user")]}},
+        )
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["claude_settings"].status == "ok"
+        assert (claude_home / ".claude" / "settings.json").is_file()
+        # No project-tier file written.
+        assert not (tmp_path / ".claude" / "settings.json").exists()
+        assert not (tmp_path / ".claude" / "settings.local.json").exists()
+
+
+class TestIsAvailableLoosened:
+    """ADR-0010 §3: loosen ``is_available`` so the tile shows up if Claude
+    Code has *any* settings home for this project (user-tier or
+    project-tier). Pins the case the loosening is for: the user has only
+    project-local settings."""
+
+    def test_user_only(self, claude_home, tmp_path):
+        gen = ClaudeSettingsGenerator()
+        assert gen.is_available(tmp_path) is True
+
+    def test_project_only(self, claude_home_missing, tmp_path):
+        gen = ClaudeSettingsGenerator()
+        # Only project tier exists (with the local-tier settings file).
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".claude" / "settings.local.json").write_text("{}", encoding="utf-8")
+        assert gen.is_available(tmp_path) is True
+
+    def test_neither_returns_false(self, claude_home_missing, tmp_path):
+        gen = ClaudeSettingsGenerator()
+        assert gen.is_available(tmp_path) is False
+
+
+class TestDefaultScopePreservation:
+    """Pin: an install with no ``hooks.target_scope`` config — and no env
+    var override — defaults to ``user`` and writes to
+    ``~/.claude/settings.json``. This is the contract for "zero behavior
+    change for existing installs" in ADR-0010 §2."""
+
+    def test_default_scope_writes_to_user_home(self, claude_home, tmp_path, monkeypatch):
+        from memtomem.config import Mem2MemConfig
+
+        # Deterministic env: drop any host-shell scope override.
+        monkeypatch.delenv("MEMTOMEM_HOOKS__TARGET_SCOPE", raising=False)
+        # ``feedback_path_home_cross_platform``: also pin USERPROFILE on
+        # Windows so the test is deterministic across platforms.
+        monkeypatch.setenv("USERPROFILE", str(claude_home))
+
+        cfg = Mem2MemConfig()
+        assert cfg.hooks.target_scope == "user"
+
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write")]}},
+        )
+        results = generate_all_settings(
+            tmp_path, scope=cfg.hooks.target_scope, allow_host_writes=True
+        )
+        assert results["claude_settings"].status == "ok"
+        assert results["claude_settings"].target == claude_home / ".claude" / "settings.json"
+
+
+class TestCliScopeFlag:
+    """``mm context sync --scope=project_local`` writes to
+    ``<project>/.claude/settings.local.json`` and leaves
+    ``~/.claude/settings.json`` untouched. The codex-review regression
+    pin: per-invocation override flows end-to-end through the click
+    pipeline (``_SCOPE_OPTION`` → ``_resolve_cli_scope`` → both
+    ``_confirm_settings_host_writes`` and ``_print_settings_generate``).
+    """
+
+    def test_sync_with_scope_project_local(self, claude_home, tmp_path, monkeypatch):
+        # ``mm context sync`` walks up from cwd; chdir into the project so
+        # ``_find_project_root`` lands here.
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".claude").mkdir()
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "echo flag")]}},
+        )
+        monkeypatch.chdir(tmp_path)
+
+        from memtomem.cli.context_cmd import sync_cmd
+
+        result = CliRunner().invoke(
+            sync_cmd, ["--include=settings", "--scope=project_local", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".claude" / "settings.local.json").is_file()
+        assert not (claude_home / ".claude" / "settings.json").exists()
+
+    def test_generate_with_scope_project_local(self, claude_home, tmp_path, monkeypatch):
+        """Symmetric pin for ``mm context generate --scope=…``. Both commands
+        share ``_SCOPE_OPTION`` but a future drift in only one of them would
+        slip past a sync-only test (codex review test-gap)."""
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".claude").mkdir()
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "echo gen-flag")]}},
+        )
+        monkeypatch.chdir(tmp_path)
+
+        from memtomem.cli.context_cmd import generate_cmd
+
+        result = CliRunner().invoke(
+            generate_cmd, ["--include=settings", "--scope=project_local", "--yes"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".claude" / "settings.local.json").is_file()
+        assert not (claude_home / ".claude" / "settings.json").exists()
+
+
+class TestTargetScopeValidation:
+    """Pin: an unknown ``hooks.target_scope`` is rejected at construction
+    time by Pydantic's ``Literal`` validator. This is the safety net
+    behind ``_resolve_scope_path`` raising ``ValueError`` only as a
+    defense-in-depth — production code never reaches that branch
+    because Pydantic catches the typo first (codex review #5)."""
+
+    def test_garbage_scope_raises_validation_error(self):
+        from pydantic import ValidationError
+
+        from memtomem.config import HooksConfig
+
+        with pytest.raises(ValidationError):
+            HooksConfig(target_scope="garbage")
+
+    def test_resolver_rejects_unknown_scope(self, tmp_path):
+        from memtomem.context.settings import resolve_scope_path
+
+        with pytest.raises(ValueError, match="Unknown target_scope"):
+            resolve_scope_path(tmp_path, "garbage")
+
+
+class TestResolveScopeMigrationFree:
+    """Pin: ``_resolve_cli_scope`` and ``_resolve_mcp_scope`` MUST NOT
+    trigger the auto-discover migration (per
+    ``feedback_doctor_no_migration_loader``). Scope reads are read-only
+    diagnostic surfaces; touching disk as a side effect is the same
+    footgun PR #838 hit."""
+
+    def test_cli_scope_resolver_does_not_invoke_migration(self, monkeypatch):
+        from memtomem.cli import context_cmd
+
+        called: list[bool] = []
+
+        def fake_migrate(_cfg):
+            called.append(True)
+
+        monkeypatch.setattr("memtomem.config._migrate_auto_discover_once", fake_migrate)
+        # Drop env override so config-load path runs fully.
+        monkeypatch.delenv("MEMTOMEM_HOOKS__TARGET_SCOPE", raising=False)
+
+        scope = context_cmd._resolve_cli_scope(None)
+        assert scope in ("user", "project_shared", "project_local")
+        assert called == []
+
+    def test_mcp_scope_resolver_does_not_invoke_migration(self, monkeypatch):
+        from memtomem.server.tools import context as mcp_ctx
+
+        called: list[bool] = []
+
+        def fake_migrate(_cfg):
+            called.append(True)
+
+        monkeypatch.setattr("memtomem.config._migrate_auto_discover_once", fake_migrate)
+        monkeypatch.delenv("MEMTOMEM_HOOKS__TARGET_SCOPE", raising=False)
+
+        scope = mcp_ctx._resolve_mcp_scope()
+        assert scope in ("user", "project_shared", "project_local")
+        assert called == []
 
 
 # ── HTTP-route contract tests (RFC #761 PR-2 — ADR-0001 §5 c2/c4) ────────────
@@ -690,10 +936,14 @@ class TestSettingsHttpLayer:
 
     @pytest.fixture
     def app(self, claude_home, tmp_path):
+        from memtomem.config import Mem2MemConfig
+
         application = create_app(lifespan=None, mode="dev")
         application.state.project_root = tmp_path
         application.state.storage = AsyncMock()
-        application.state.config = None
+        # Real config so ``get_hooks_target_scope`` Depends can read
+        # ``cfg.hooks.target_scope`` (default "user").
+        application.state.config = Mem2MemConfig()
         application.state.search_pipeline = None
         application.state.index_engine = None
         application.state.embedder = None
@@ -828,3 +1078,65 @@ class TestSettingsHttpLayer:
         on_disk = target.read_text(encoding="utf-8")
         assert "echo user" in on_disk
         assert "echo canonical" not in on_disk
+
+    async def test_resolve_respects_target_scope(self, app, client, claude_home, tmp_path):
+        """Codex blocker #2 regression pin: ``POST /settings-sync/resolve``
+        must use ``hooks.target_scope`` from ``app.state.config``, not
+        the hardcoded user-tier path. With ``target_scope="project_local"``
+        a resolve must mutate ``<project>/.claude/settings.local.json``
+        and leave ``~/.claude/settings.json`` untouched.
+
+        Without the fix, ``_claude_target()`` was a parameterless helper
+        that always returned ``Path.home() / .claude / settings.json``
+        and the resolve handler would have written there regardless of
+        the configured scope.
+        """
+        # Configure project_local scope on the live app state.
+        app.state.config.hooks.target_scope = "project_local"
+
+        # Seed canonical with a hook differing from the user-authored rule
+        # so the route surfaces a conflict.
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "echo canonical")]}},
+        )
+
+        # Project-local target: <project>/.claude/settings.local.json
+        (tmp_path / ".claude").mkdir()
+        project_local_target = tmp_path / ".claude" / "settings.local.json"
+        project_local_target.write_text(
+            json.dumps(
+                {"hooks": {"PostToolUse": [_rule("Write", "echo user")]}},
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        # User-tier target: ``~/.claude/settings.json`` — must remain
+        # byte-identical after the resolve.
+        user_target = claude_home / ".claude" / "settings.json"
+        user_authored = (
+            json.dumps(
+                {"hooks": {"PreToolUse": [_rule("Bash", "echo untouched")]}},
+                indent=2,
+            )
+            + "\n"
+        )
+        user_target.write_text(user_authored, encoding="utf-8")
+
+        resp = await client.post(
+            "/api/context/settings/resolve",
+            json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "ok", body
+
+        # The project-local file mutated to the canonical rule.
+        merged = json.loads(project_local_target.read_text(encoding="utf-8"))
+        assert any(
+            "echo canonical" in r["hooks"][0]["command"] for r in merged["hooks"]["PostToolUse"]
+        )
+        # The user-tier file was NOT touched.
+        assert user_target.read_text(encoding="utf-8") == user_authored

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -6979,7 +6979,7 @@ class TestStepSettingsFsGuards:
         # the guard under test.
         monkeypatch.setattr(
             "memtomem.context.settings.generate_all_settings",
-            lambda root: {},
+            lambda root, *, scope, **_: {},
         )
 
         state: dict = {}

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -21,11 +21,15 @@ from memtomem.web.app import create_app
 @pytest.fixture
 def ctx_app(tmp_path: Path):
     """App with project_root pointing to a temp directory."""
+    from memtomem.config import Mem2MemConfig
+
     application = create_app(lifespan=None, mode="dev")
     application.state.project_root = tmp_path
     # Minimal stubs for deps the app might check
     application.state.storage = AsyncMock()
-    application.state.config = None
+    # Real config so ``get_hooks_target_scope`` Depends resolves
+    # ``cfg.hooks.target_scope`` (default "user").
+    application.state.config = Mem2MemConfig()
     application.state.search_pipeline = None
     application.state.index_engine = None
     application.state.embedder = None

--- a/packages/memtomem/tests/test_web_routes_context_locks.py
+++ b/packages/memtomem/tests/test_web_routes_context_locks.py
@@ -46,10 +46,14 @@ def gateway_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.fixture
 def app(gateway_home: Path):
+    from memtomem.config import Mem2MemConfig
+
     application = create_app(lifespan=None, mode="dev")
     application.state.project_root = gateway_home
     application.state.storage = AsyncMock()
-    application.state.config = None
+    # Real config so ``get_hooks_target_scope`` Depends resolves
+    # ``cfg.hooks.target_scope`` (default "user").
+    application.state.config = Mem2MemConfig()
     application.state.search_pipeline = None
     application.state.index_engine = None
     application.state.embedder = None

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -102,6 +102,9 @@ class FakeConfig:
         enable_auto_ns = False
         rules: list = []
 
+    class _Hooks:
+        target_scope = "user"
+
     embedding = _Embedding()
     storage = _Storage()
     search = _Search()
@@ -109,6 +112,7 @@ class FakeConfig:
     decay = _Decay()
     mmr = _MMR()
     namespace = _Namespace()
+    hooks = _Hooks()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lands the **first** of three ADR-0010 follow-ups: a new
`hooks.target_scope` config field (`user` / `project_shared` /
`project_local`) selects where memtomem-managed Claude Code hooks
land. v1 default `user` for zero behavior change; default-flip
trigger remains gated on issues 2 and 3 plus the §5 dwell criterion.

Closes #870. ADR-0010 reference: `docs/adr/0010-settings-hooks-target-scope.md`.

## What changed

- `HooksConfig` + `TargetScope` literal in `config.py` with
  `MUTABLE_FIELDS` / `FIELD_CONSTRAINTS` registered inline (so
  `mm config set hooks.target_scope …`, `PATCH /api/config`, and the
  MCP `mem_config` path all validate via the existing
  `coerce_and_validate` flow).
- `load_config_overrides` gains `migrate=True` flag; scope readers
  pass `migrate=False` so reading the field never triggers the
  auto-discover migration as a disk-write side effect
  (`feedback_doctor_no_migration_loader`).
- Single `resolve_scope_path` helper in `context/settings.py` shared
  by the generator, the Web `_claude_target` route helper, and the
  detector — one source of truth for the ADR-0010 path math.
- `SettingsGenerator` Protocol broadened to `is_available(project_root)`
  + `target_file(project_root, scope)`. `ClaudeSettingsGenerator.is_available`
  loosened so the tile shows up if `~/.claude/` OR `<project>/.claude/`
  exists.
- Pipeline functions (`generate_all_settings`, `diff_settings`,
  `host_write_targets`) take `*, scope: str` as **required**
  keyword-only — every caller resolves scope from its own config
  layer.
- Web: new `get_hooks_target_scope` Depends threaded through GET,
  POST sync, POST resolve, and `/context/overview` aggregator. The
  resolve handler being scope-aware is a regression fix.
- CLI: `--scope` flag (shared `_SCOPE_OPTION`) on both
  `mm context sync` and `mm context generate`. `_resolve_cli_scope`
  applies the override or reads config (migration-free).
- MCP: `_resolve_mcp_scope` mirrors the CLI shape; threaded into the
  three context tool entry points.
- `mm init` hardcodes `scope="user"` (with a comment) — the wizard
  runs before `config.json` is necessarily persisted, so loading
  config there would mask its own write.
- Doc stub in `docs/guides/integrations/claude-code.md` pointing at
  ADR-0010 and the override flag; full hooks-tier prose lands with
  issue 2's duplicate-hook warning.

## Out of scope (explicitly deferred per ADR-0010)

- Sync-time duplicate-hook warning — issue 2.
- Settings-migrate subcommand — issue 3.
- Web scope picker / `<project>/.memtomem/config.json` project-level
  layer — gated on a future ADR.
- Default flip to `project_local` — gated on §5 trigger (this PR ships
  + issues 2 & 3 ship + ≥2 weeks no P0/P1).

## Test plan

- [x] `uv run pytest -m "not ollama"` — 4362 passed, 10 skipped, 46
      deselected. 15 new tests in `test_context_settings.py`.
- [x] `uv run ruff check` + `ruff format --check` clean.
- [x] `uv run mypy` clean on all 9 touched source files.
- [x] Manual round-trip: `mm config set hooks.target_scope project_local`
      persists to `~/.memtomem/config.json`; subsequent
      `mm context sync --include=settings -y` writes to
      `<project>/.claude/settings.local.json` and leaves
      `~/.claude/settings.json` untouched. `--scope=user` per-invocation
      override flips back. Constraint validation rejects `bogus`.
- [x] Mutation-validation per `feedback_pin_test_mutation_validation`:
      mutating `resolve_scope_path` to swap scope-to-path mappings
      caused 8 of the new pin tests to fail before the fix was
      reverted.
- [x] Migration-free pin: `TestResolveScopeMigrationFree` patches
      `_migrate_auto_discover_once` and asserts neither
      `_resolve_cli_scope` nor `_resolve_mcp_scope` invokes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
