### PR TITLE
feat(context): detect duplicate hooks across settings tiers (ADR-0010 §4)

### DIFF
--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -242,6 +242,29 @@ Claude Code starts
 - **Debounce mechanics**: `mm index --debounce-window 5` records the file in `~/.memtomem/index_debounce_queue.json` (flock-protected) and drains entries that have been silent ≥5 seconds. Each Write hook fire restarts the window for that path, so a codegen burst indexes the final state once after the burst ends rather than once per Write. The Stop hook chains `mm index --flush` (synchronous drain — blocks until every queued file is indexed) before `mm session end --auto` to ensure session-end indexing isn't deferred. `mm index --status` prints a snapshot of the queue (depth + oldest entry) for telemetry; it's race-prone and not a correctness primitive — for "is the queue empty?" use `--flush`. RFC-B (PreCompact, deferred — needs Claude Code's PreCompact payload contract) will use a future `mm index --flush --paths <list>` for selective drain at checkpoint time.
 - **STM proxy overlap**: If using [memtomem-stm](https://github.com/memtomem/memtomem-stm) (separate package), hooks are redundant — the proxy already handles surfacing and indexing.
 
+### Detecting duplicate hooks across tiers
+
+Claude Code 2.x merges hook entries from all three settings tiers
+(`~/.claude/settings.json`, `<project>/.claude/settings.json`,
+`<project>/.claude/settings.local.json`) additively, so a memtomem-managed
+hook duplicated across tiers fires once per tier — silent double-execution.
+
+`mm context sync --include=settings` and the Web UI hooks panel scan the
+non-active tiers before write and surface a non-blocking warning when
+duplicates exist. For CI / scripting use, run the on-demand check:
+
+```bash
+mm context settings-doctor               # exits 0 if clean, 1 if duplicates
+mm context settings-doctor --json        # structured output for scripting
+mm context settings-doctor --scope=project_local   # one-shot scope override
+```
+
+The match is by canonical signature (event + matcher + command shape, with
+whitespace normalized) so a hand-edited variant of a memtomem-managed entry
+still classifies. Detection is non-mutating; the `mm context settings-migrate`
+subcommand (see [issue #872](https://github.com/memtomem/memtomem/issues/872))
+will be the action surface that moves duplicate entries into the active scope.
+
 ---
 
 ## Tool Usage Guidelines (Add to CLAUDE.md)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import click
@@ -63,6 +64,10 @@ from memtomem.context.settings import (
     diff_settings,
     generate_all_settings,
     host_write_targets,
+)
+from memtomem.context.settings_doctor import (
+    detect_duplicate_tiers,
+    format_warning,
 )
 from memtomem.context.skills import (
     diff_skills,
@@ -356,7 +361,21 @@ def _confirm_settings_host_writes(root: Path, *, scope: str, yes: bool) -> bool:
     return click.confirm("Continue?", default=False)
 
 
+def _print_duplicate_tier_warnings(root: Path, *, scope: str) -> None:
+    """Emit non-blocking warnings for memtomem hooks duplicated across tiers.
+
+    Per ADR-0010 §4 this is the primary detection surface: it fires in
+    the user's actual sync workflow rather than behind a separate
+    command. Output goes to stderr with yellow color and never blocks
+    the sync — duplicates are informational.
+    """
+    duplicates = detect_duplicate_tiers(root, active_scope=scope)
+    for dup in duplicates:
+        click.secho(f"  warning: {format_warning(dup, active_scope=scope)}", err=True, fg="yellow")
+
+
 def _print_settings_generate(root: Path, *, scope: str, allow_host_writes: bool) -> None:
+    _print_duplicate_tier_warnings(root, scope=scope)
     results = generate_all_settings(root, scope=scope, allow_host_writes=allow_host_writes)
     for name, r in results.items():
         if r.status == "ok":
@@ -374,6 +393,7 @@ def _print_settings_generate(root: Path, *, scope: str, allow_host_writes: bool)
 
 
 def _print_settings_diff(root: Path, *, scope: str) -> None:
+    _print_duplicate_tier_warnings(root, scope=scope)
     results = diff_settings(root, scope=scope)
     if not results:
         click.echo("  (no settings to compare)")
@@ -1615,4 +1635,73 @@ def migrate_cmd(
     click.echo("\nSummary: " + (", ".join(parts) if parts else "0 actions") + ".")
 
     if failures:
+        raise click.exceptions.Exit(1)
+
+
+@context.command("settings-doctor")
+@click.option(
+    "--json",
+    "json_out",
+    is_flag=True,
+    default=False,
+    help="Emit a structured JSON result instead of human-readable output.",
+)
+@_SCOPE_OPTION
+def settings_doctor_cmd(json_out: bool, scope_flag: str | None) -> None:
+    """Detect memtomem-managed hooks duplicated across settings tiers.
+
+    Implements ADR-0010 §4's scoped on-demand check. Same canonical-
+    signature detection used by the sync-time warning, exposed as a
+    standalone subcommand for CI / scripting use.
+
+    Exit codes: ``0`` clean, ``1`` duplicates found.
+    """
+    root = _find_project_root()
+    scope = _resolve_cli_scope(scope_flag)
+    duplicates = detect_duplicate_tiers(root, active_scope=scope)
+
+    if json_out:
+        payload = {
+            "status": "duplicates" if duplicates else "clean",
+            "active_scope": scope,
+            "duplicates": [
+                {
+                    "tier": dup.tier,
+                    "path": str(dup.path),
+                    "entries": [
+                        {
+                            "event": sig.event,
+                            "matcher": sig.matcher,
+                            "command_preview": sig.command_shape,
+                        }
+                        for sig in dup.entries
+                    ],
+                }
+                for dup in duplicates
+            ],
+        }
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        if not duplicates:
+            click.secho(
+                f"✓ No memtomem-managed hooks duplicated outside the active scope ({scope}).",
+                fg="green",
+            )
+        else:
+            click.secho(
+                f"✗ Found memtomem-managed hooks in {len(duplicates)} other "
+                f"tier(s) (active scope: {scope}):",
+                fg="yellow",
+            )
+            for dup in duplicates:
+                click.secho(f"  • {dup.tier} ({dup.path})", fg="yellow")
+                for sig in dup.entries:
+                    label = f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
+                    click.echo(f"      [{label}] {sig.command_shape}")
+            click.echo(
+                "\nRun the future `mm context settings-migrate` subcommand "
+                "(#872) to move these into the active scope."
+            )
+
+    if duplicates:
         raise click.exceptions.Exit(1)

--- a/packages/memtomem/src/memtomem/context/settings_doctor.py
+++ b/packages/memtomem/src/memtomem/context/settings_doctor.py
@@ -1,0 +1,239 @@
+"""Duplicate-tier hook detection (ADR-0010 §4).
+
+Claude Code 2.x merges hook entries from all three settings tiers
+(user / project_shared / project_local) additively, so a memtomem-
+managed hook duplicated across tiers fires once per tier — silent
+double-execution.
+
+This module provides the shared detection used by both surfaces
+mandated by ADR-0010 §4:
+
+* Sync-time warning in ``mm context sync --include=settings`` and the
+  Web UI hooks panel — runs before write so the user sees the
+  duplicate state in their actual workflow.
+* Scoped on-demand check via ``mm context settings-doctor`` — same
+  logic, callable from CI / scripting.
+
+Detection compares **canonical signatures** (event + normalized
+matcher + normalized command) rather than literal equality so a
+user's whitespace-variant of a memtomem-authored entry still matches.
+A tier counts as a duplicate when it holds a hook entry whose
+signature appears in the project's canonical ``.memtomem/settings.json``
+**and** the tier is not the active scope.
+
+This module is detection-only. Migration of duplicate entries is the
+job of the future ``mm context settings-migrate`` subcommand (#872).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator
+
+from memtomem.context.settings import (
+    CANONICAL_SETTINGS_FILE,
+    _MALFORMED,
+    _safe_load_json,
+    resolve_scope_path,
+)
+
+logger = logging.getLogger(__name__)
+
+# All three tier scopes. Listed in the order users typically reason
+# about them (user is the v1 default, project tiers are the team-shared
+# alternatives) so doctor output is stable.
+ALL_SCOPES: tuple[str, ...] = ("user", "project_shared", "project_local")
+
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class HookSignature:
+    """Normalized identity of a single ``(event, matcher, command)`` hook.
+
+    Two signatures compare equal when the canonical signatures match
+    after whitespace normalization — enough to defeat the variants
+    ADR-0010 §4 names ("robust to whitespace / matcher variants")
+    without going so far as to shlex-tokenize, which would normalize
+    away differences a user intentionally introduced (``--top-k 3`` vs
+    ``--top-k=3``) and choke on bash one-liners with ``||`` / ``2>>``.
+    """
+
+    event: str
+    matcher: str
+    command_shape: str
+
+
+@dataclass(frozen=True)
+class DuplicateTier:
+    """One non-active tier holding canonical-matched hook signatures."""
+
+    tier: str
+    path: Path
+    entries: tuple[HookSignature, ...] = field(default_factory=tuple)
+
+
+def _normalize_matcher(value: object) -> str:
+    """Strip whitespace + unify missing/empty matcher strings.
+
+    The matcher is a regex source consumed by Claude Code; alpha-sort
+    of alternations is **not** applied because ``Edit|Write`` and
+    ``Write|Edit`` are not interchangeable from Claude Code's side.
+    """
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
+
+def _normalize_command(value: object) -> str:
+    """Collapse runs of internal whitespace to single space + strip.
+
+    Sufficient for the variants ADR-0010 §4 names. Stops short of
+    shlex-tokenization (see :class:`HookSignature` rationale).
+    """
+    if not isinstance(value, str):
+        return ""
+    return _WHITESPACE_RUN.sub(" ", value.strip())
+
+
+def _iter_signatures(hooks_record: object) -> Iterator[HookSignature]:
+    """Yield :class:`HookSignature` for every inner hook in a hooks record.
+
+    Defensive: any non-dict / non-list shape encountered is skipped so a
+    malformed sub-tree never crashes the doctor — the user's other
+    tiers still classify cleanly. Mirrors the same shape guards in
+    :mod:`memtomem.web.routes.settings_sync._compare_hooks`.
+    """
+    if not isinstance(hooks_record, dict):
+        return
+    for event, rules in hooks_record.items():
+        if not isinstance(event, str) or not isinstance(rules, list):
+            continue
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            matcher = _normalize_matcher(rule.get("matcher", ""))
+            inner = rule.get("hooks", [])
+            if not isinstance(inner, list):
+                continue
+            for entry in inner:
+                if not isinstance(entry, dict):
+                    continue
+                command = _normalize_command(entry.get("command", ""))
+                if not command:
+                    continue
+                yield HookSignature(
+                    event=event,
+                    matcher=matcher,
+                    command_shape=command,
+                )
+
+
+def load_canonical_signatures(project_root: Path) -> set[HookSignature]:
+    """Read ``.memtomem/settings.json`` and return its hook signatures.
+
+    Returns an empty set when the canonical file is missing or
+    malformed — a missing canonical means there is nothing for the
+    doctor to flag as duplicated; the file is not the doctor's
+    responsibility to fix.
+    """
+    canonical_path = project_root / CANONICAL_SETTINGS_FILE
+    if not canonical_path.is_file():
+        return set()
+    raw = _safe_load_json(canonical_path)
+    if raw is _MALFORMED or not isinstance(raw, dict):
+        logger.debug("canonical settings at %s unreadable; skipping", canonical_path)
+        return set()
+    hooks = raw.get("hooks", {})
+    return set(_iter_signatures(hooks))
+
+
+def _resolved(path: Path) -> Path:
+    """``Path.resolve(strict=False)`` with OSError-tolerance.
+
+    Used to dedupe tier paths that point at the same real file via
+    symlink (e.g. ``<project>/.claude`` symlinked into ``~/.claude/``).
+    Mirrors :func:`memtomem.context.settings._is_under_project_root`.
+    """
+    try:
+        return path.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return path
+
+
+def detect_duplicate_tiers(
+    project_root: Path,
+    *,
+    active_scope: str,
+) -> list[DuplicateTier]:
+    """Find non-active tiers holding canonical-matched hook entries.
+
+    A tier is reported as a duplicate when **all** hold:
+
+    * It is not the active scope.
+    * Its resolved path differs from the active scope's resolved path
+      (symlink dedup).
+    * It exists and parses as JSON.
+    * It contains at least one hook entry whose canonical signature
+      appears in ``project_root / .memtomem/settings.json``.
+
+    Returns an empty list when the canonical source has no hooks (the
+    doctor has nothing to compare against).
+    """
+    canonical = load_canonical_signatures(project_root)
+    if not canonical:
+        return []
+
+    active_resolved = _resolved(resolve_scope_path(project_root, active_scope))
+    seen_paths: set[Path] = {active_resolved}
+    duplicates: list[DuplicateTier] = []
+
+    for scope in ALL_SCOPES:
+        if scope == active_scope:
+            continue
+        tier_path = resolve_scope_path(project_root, scope)
+        tier_resolved = _resolved(tier_path)
+        if tier_resolved in seen_paths:
+            # Symlinked into a tier we already accounted for; do not
+            # report the same real file twice.
+            continue
+        seen_paths.add(tier_resolved)
+        if not tier_path.is_file():
+            continue
+        raw = _safe_load_json(tier_path)
+        if raw is _MALFORMED or not isinstance(raw, dict):
+            logger.debug("tier %s at %s unreadable; skipping", scope, tier_path)
+            continue
+        hooks = raw.get("hooks", {})
+        matched = tuple(sig for sig in _iter_signatures(hooks) if sig in canonical)
+        if matched:
+            duplicates.append(
+                DuplicateTier(
+                    tier=scope,
+                    path=tier_path,
+                    entries=matched,
+                )
+            )
+
+    return duplicates
+
+
+def format_warning(duplicate: DuplicateTier, *, active_scope: str) -> str:
+    """Human-readable warning string for one duplicate tier.
+
+    Names the offending tier path and points at the future
+    ``mm context settings-migrate`` (#872) subcommand per ADR-0010 §4.
+    Used by both the CLI sync surface and any caller that wants the
+    same wording.
+    """
+    count = len(duplicate.entries)
+    plural = "entry" if count == 1 else "entries"
+    return (
+        f"memtomem-managed hook {plural} ({count}) already exist in the "
+        f"{duplicate.tier} tier ({duplicate.path}); the future "
+        f"`mm context settings-migrate` subcommand will move them. "
+        f"Active scope: {active_scope}."
+    )

--- a/packages/memtomem/src/memtomem/context/settings_doctor.py
+++ b/packages/memtomem/src/memtomem/context/settings_doctor.py
@@ -27,16 +27,15 @@ job of the future ``mm context settings-migrate`` subcommand (#872).
 
 from __future__ import annotations
 
+import json
 import logging
 import re
-from dataclasses import dataclass, field
+from collections.abc import Iterator
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
 
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
-    _MALFORMED,
-    _safe_load_json,
     resolve_scope_path,
 )
 
@@ -73,7 +72,28 @@ class DuplicateTier:
 
     tier: str
     path: Path
-    entries: tuple[HookSignature, ...] = field(default_factory=tuple)
+    entries: tuple[HookSignature, ...]
+
+
+def _load_settings_dict(path: Path) -> dict | None:
+    """Read a settings.json file; return ``None`` on any read failure.
+
+    Self-contained JSON load so this module doesn't depend on
+    :func:`memtomem.context.settings._safe_load_json` /
+    :data:`memtomem.context.settings._MALFORMED` (private to that
+    module). Returns ``None`` when the file is missing, unreadable, or
+    not valid JSON, **or** when the parsed root is not a dict —
+    callers can treat all three the same way (skip this tier).
+    """
+    if not path.is_file():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return raw
 
 
 def _normalize_matcher(value: object) -> str:
@@ -141,11 +161,9 @@ def load_canonical_signatures(project_root: Path) -> set[HookSignature]:
     responsibility to fix.
     """
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
-    if not canonical_path.is_file():
-        return set()
-    raw = _safe_load_json(canonical_path)
-    if raw is _MALFORMED or not isinstance(raw, dict):
-        logger.debug("canonical settings at %s unreadable; skipping", canonical_path)
+    raw = _load_settings_dict(canonical_path)
+    if raw is None:
+        logger.debug("canonical settings at %s missing or unreadable", canonical_path)
         return set()
     hooks = raw.get("hooks", {})
     return set(_iter_signatures(hooks))
@@ -201,11 +219,9 @@ def detect_duplicate_tiers(
             # report the same real file twice.
             continue
         seen_paths.add(tier_resolved)
-        if not tier_path.is_file():
-            continue
-        raw = _safe_load_json(tier_path)
-        if raw is _MALFORMED or not isinstance(raw, dict):
-            logger.debug("tier %s at %s unreadable; skipping", scope, tier_path)
+        raw = _load_settings_dict(tier_path)
+        if raw is None:
+            logger.debug("tier %s at %s missing or unreadable; skipping", scope, tier_path)
             continue
         hooks = raw.get("hooks", {})
         matched = tuple(sig for sig in _iter_signatures(hooks) if sig in canonical)

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -16,6 +16,10 @@ from memtomem.context.settings import (
     _write_json,
     generate_all_settings,
 )
+from memtomem.context.settings_doctor import (
+    DuplicateTier,
+    detect_duplicate_tiers,
+)
 from memtomem.web.deps import get_hooks_target_scope, get_project_root
 from memtomem.web.routes._locks import _gateway_lock
 
@@ -39,6 +43,30 @@ def _claude_target(project_root: Path, scope: str) -> Path:
 def _rule_label(event: str, matcher: str) -> str:
     """Human-readable label for a hook rule: ``event`` or ``event:matcher``."""
     return f"{event}:{matcher}" if matcher else event
+
+
+def _serialize_duplicate_tiers(duplicates: list[DuplicateTier]) -> list[dict]:
+    """Serialize :class:`DuplicateTier` results for the JSON response.
+
+    Per ADR-0010 §4 the Web hooks panel surfaces this list as a
+    read-only banner; the schema mirrors the CLI ``settings-doctor
+    --json`` payload so both surfaces stay in lock-step.
+    """
+    return [
+        {
+            "tier": dup.tier,
+            "path": str(dup.path),
+            "entries": [
+                {
+                    "event": sig.event,
+                    "matcher": sig.matcher,
+                    "command_preview": sig.command_shape,
+                }
+                for sig in dup.entries
+            ],
+        }
+        for dup in duplicates
+    ]
 
 
 def _compare_hooks(
@@ -158,7 +186,11 @@ async def get_settings_sync(
     """Return structured settings sync status with conflict details."""
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
     target_path = _claude_target(project_root, scope)
-    return _compare_hooks(canonical_path, target_path)
+    payload = _compare_hooks(canonical_path, target_path)
+    payload["duplicate_tier_warnings"] = _serialize_duplicate_tiers(
+        detect_duplicate_tiers(project_root, active_scope=scope)
+    )
+    return payload
 
 
 class ApplySettingsSyncRequest(BaseModel):
@@ -189,6 +221,10 @@ async def apply_settings_sync(
     ``{"allow_host_writes": true}`` once the user has confirmed.
     """
     allow_host_writes = body.allow_host_writes if body else False
+    # Detect duplicate-tier hooks BEFORE the merge so the warning
+    # reflects pre-write state (ADR-0010 §4: the warning fires in the
+    # user's actual workflow, not behind a separate command).
+    duplicates = detect_duplicate_tiers(project_root, active_scope=scope)
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
@@ -210,7 +246,10 @@ async def apply_settings_sync(
                 "target": str(r.target) if r.target else None,
             }
         )
-    return {"results": out}
+    return {
+        "results": out,
+        "duplicate_tier_warnings": _serialize_duplicate_tiers(duplicates),
+    }
 
 
 class ResolveRequest(BaseModel):

--- a/packages/memtomem/tests/test_settings_doctor.py
+++ b/packages/memtomem/tests/test_settings_doctor.py
@@ -1,0 +1,464 @@
+"""Tests for settings_doctor — duplicate-tier hook detection (ADR-0010 §4).
+
+Covers four surfaces:
+
+* Pure detector unit tests (``settings_doctor.detect_duplicate_tiers``)
+* CLI ``mm context settings-doctor`` subcommand (clean/duplicates exit
+  codes, ``--json`` schema)
+* CLI sync warning wired through ``_print_settings_generate`` /
+  ``_print_settings_diff``
+* Web ``/api/settings-sync`` GET / POST response payloads
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.context.settings import CANONICAL_SETTINGS_FILE
+from memtomem.context.settings_doctor import (
+    HookSignature,
+    detect_duplicate_tiers,
+    load_canonical_signatures,
+)
+from memtomem.web.app import create_app
+from .helpers import set_home
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _rule(matcher: str = "", command: str = "mm session start") -> dict:
+    """Build a single hook rule in record format."""
+    return {
+        "matcher": matcher,
+        "hooks": [{"type": "command", "command": command, "timeout": 5000}],
+    }
+
+
+def _write_settings(path, hooks: dict) -> None:
+    """Write a settings.json file with the given hooks record."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": hooks}, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_canonical(project_root, hooks: dict) -> None:
+    """Write ``.memtomem/settings.json`` with the given hooks record."""
+    canonical_path = project_root / CANONICAL_SETTINGS_FILE
+    _write_settings(canonical_path, hooks)
+
+
+def _bundled_hook() -> dict:
+    """A canonical-shape memtomem-managed hook record."""
+    return {"PostToolUse": [_rule("Edit|Write", "mm session start")]}
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """HOME pointing into tmp_path so the user-tier settings.json is
+    isolated. Mirrors ``test_context_settings.claude_home`` but does not
+    create ``.claude/`` — individual tests opt into populating it.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    """Project root with ``.git`` so ``_find_project_root`` lands here."""
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".git").mkdir()
+    (root / ".claude").mkdir()
+    return root
+
+
+# ── Detector unit tests ────────────────────────────────────────────
+
+
+class TestDetectorCanonical:
+    """``load_canonical_signatures`` extracts signatures from
+    ``.memtomem/settings.json``."""
+
+    def test_returns_empty_when_canonical_missing(self, project_root):
+        assert load_canonical_signatures(project_root) == set()
+
+    def test_returns_empty_when_canonical_malformed(self, project_root):
+        canonical = project_root / CANONICAL_SETTINGS_FILE
+        canonical.parent.mkdir(parents=True, exist_ok=True)
+        canonical.write_text("{not valid json", encoding="utf-8")
+        assert load_canonical_signatures(project_root) == set()
+
+    def test_extracts_signatures(self, project_root):
+        _write_canonical(project_root, _bundled_hook())
+        signatures = load_canonical_signatures(project_root)
+        assert HookSignature(
+            event="PostToolUse",
+            matcher="Edit|Write",
+            command_shape="mm session start",
+        ) in signatures
+
+
+class TestDetectDuplicateTiers:
+    """Core detector behavior."""
+
+    def test_no_canonical_means_no_duplicates(self, project_root, fake_home):
+        # Even though user tier has a hook, no canonical means nothing to
+        # compare against → empty list (the doctor doesn't invent matches).
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        assert detect_duplicate_tiers(project_root, active_scope="project_local") == []
+
+    def test_no_duplicates_when_active_tier_only(self, project_root, fake_home):
+        _write_canonical(project_root, _bundled_hook())
+        # Active scope = user; hook lives in user tier → not a duplicate.
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        assert detect_duplicate_tiers(project_root, active_scope="user") == []
+
+    def test_duplicate_in_user_when_active_is_project_local(
+        self, project_root, fake_home
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        assert len(duplicates) == 1
+        assert duplicates[0].tier == "user"
+        assert duplicates[0].path == fake_home / ".claude" / "settings.json"
+        assert len(duplicates[0].entries) == 1
+
+    def test_duplicate_in_project_shared_when_active_is_user(
+        self, project_root, fake_home
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(project_root / ".claude" / "settings.json", _bundled_hook())
+        duplicates = detect_duplicate_tiers(project_root, active_scope="user")
+        assert len(duplicates) == 1
+        assert duplicates[0].tier == "project_shared"
+
+    def test_duplicates_in_two_other_tiers(self, project_root, fake_home):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        _write_settings(project_root / ".claude" / "settings.json", _bundled_hook())
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        tiers = {dup.tier for dup in duplicates}
+        assert tiers == {"user", "project_shared"}
+
+    def test_canonical_signature_whitespace_robustness(self, project_root, fake_home):
+        """Internal-whitespace variants still match (ADR-0010 §4)."""
+        _write_canonical(project_root, _bundled_hook())
+        # Same command but with extra spaces — must still be detected.
+        variant = {
+            "PostToolUse": [_rule("Edit|Write", "mm   session   start  ")]
+        }
+        _write_settings(fake_home / ".claude" / "settings.json", variant)
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        assert len(duplicates) == 1
+        assert duplicates[0].entries[0].command_shape == "mm session start"
+
+    def test_canonical_signature_matcher_whitespace_strip(
+        self, project_root, fake_home
+    ):
+        """Leading/trailing whitespace in matcher unifies."""
+        _write_canonical(project_root, _bundled_hook())
+        variant = {
+            "PostToolUse": [_rule("  Edit|Write  ", "mm session start")]
+        }
+        _write_settings(fake_home / ".claude" / "settings.json", variant)
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        assert len(duplicates) == 1
+
+    def test_missing_matcher_unified_with_empty(self, project_root, fake_home):
+        """Missing matcher key is equivalent to ``matcher=""``."""
+        _write_canonical(
+            project_root,
+            {"SessionStart": [_rule("", "mm index")]},
+        )
+        # Other tier omits the matcher key entirely.
+        rule_no_matcher = {
+            "hooks": [{"type": "command", "command": "mm index", "timeout": 5000}]
+        }
+        _write_settings(
+            fake_home / ".claude" / "settings.json",
+            {"SessionStart": [rule_no_matcher]},
+        )
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        assert len(duplicates) == 1
+
+    def test_non_canonical_hook_in_other_tier_ignored(self, project_root, fake_home):
+        """A hook in the user tier that doesn't match the canonical
+        signature is NOT reported — only canonical-matched entries
+        count as duplicates per ADR-0010 §4."""
+        _write_canonical(project_root, _bundled_hook())
+        # User has a totally unrelated hand-authored hook.
+        _write_settings(
+            fake_home / ".claude" / "settings.json",
+            {"PreToolUse": [_rule("Bash", "echo something")]},
+        )
+        assert detect_duplicate_tiers(project_root, active_scope="project_local") == []
+
+    def test_malformed_other_tier_skipped(self, project_root, fake_home):
+        """Malformed JSON in a non-active tier doesn't crash — that
+        tier is skipped, the rest still classify."""
+        _write_canonical(project_root, _bundled_hook())
+        bad = fake_home / ".claude" / "settings.json"
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("{not valid", encoding="utf-8")
+        _write_settings(project_root / ".claude" / "settings.json", _bundled_hook())
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        # User tier was malformed → skipped. Project_shared still reported.
+        tiers = {dup.tier for dup in duplicates}
+        assert tiers == {"project_shared"}
+
+    def test_missing_other_tier_silently_skipped(self, project_root, fake_home):
+        """A non-existent tier file is not a duplicate (nothing to flag)."""
+        _write_canonical(project_root, _bundled_hook())
+        # User tier file does not exist; project_shared has the duplicate.
+        _write_settings(project_root / ".claude" / "settings.json", _bundled_hook())
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        tiers = {dup.tier for dup in duplicates}
+        assert tiers == {"project_shared"}
+
+    def test_active_scope_excluded_even_when_path_resolves_via_symlink(
+        self, project_root, fake_home, tmp_path
+    ):
+        """Symlink dedup: when ``project_shared`` symlinks into
+        ``~/.claude/`` the same real file MUST NOT be reported twice.
+        """
+        # Make project_root/.claude a symlink to fake_home/.claude.
+        (project_root / ".claude").rmdir()
+        (fake_home / ".claude").mkdir(exist_ok=True)
+        (project_root / ".claude").symlink_to(fake_home / ".claude")
+
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+
+        # Active scope = project_local. Both 'user' and 'project_shared'
+        # are non-active; both resolve through .claude/, but the
+        # settings.json filenames differ (settings.json vs
+        # settings.local.json), so only the user-tier file actually
+        # exists. project_shared's resolved path matches user's.
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        # Only one duplicate emitted, not two — the symlink dedup kept
+        # the second iteration from re-reporting the same real file.
+        assert len(duplicates) == 1
+
+
+# ── CLI doctor subcommand ──────────────────────────────────────────
+
+
+class TestSettingsDoctorCli:
+    """``mm context settings-doctor`` exit codes + JSON schema."""
+
+    def test_clean_exit_zero(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        # Active scope = user; the user-tier match is the active scope,
+        # not a duplicate → clean.
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "user")
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import settings_doctor_cmd
+
+        result = CliRunner().invoke(settings_doctor_cmd, [])
+        assert result.exit_code == 0, result.output
+        assert "No memtomem-managed hooks duplicated" in result.output
+
+    def test_duplicates_exit_one(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "project_local")
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import settings_doctor_cmd
+
+        result = CliRunner().invoke(settings_doctor_cmd, [])
+        assert result.exit_code == 1, result.output
+        assert "user" in result.output
+        assert "settings-migrate" in result.output
+
+    def test_scope_flag_overrides_config(self, project_root, fake_home, monkeypatch):
+        """Per-invocation ``--scope=`` wins over the user config field."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        # Config says active=user, but flag says active=project_local
+        # so the user-tier match becomes a duplicate.
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "user")
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import settings_doctor_cmd
+
+        result = CliRunner().invoke(
+            settings_doctor_cmd, ["--scope=project_local"]
+        )
+        assert result.exit_code == 1, result.output
+
+    def test_json_clean_schema(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "user")
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import settings_doctor_cmd
+
+        result = CliRunner().invoke(settings_doctor_cmd, ["--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload == {
+            "status": "clean",
+            "active_scope": "user",
+            "duplicates": [],
+        }
+
+    def test_json_duplicates_schema(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "project_local")
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import settings_doctor_cmd
+
+        result = CliRunner().invoke(settings_doctor_cmd, ["--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "duplicates"
+        assert payload["active_scope"] == "project_local"
+        assert len(payload["duplicates"]) == 1
+        dup = payload["duplicates"][0]
+        assert dup["tier"] == "user"
+        assert dup["path"].endswith("/.claude/settings.json")
+        assert len(dup["entries"]) == 1
+        entry = dup["entries"][0]
+        assert entry == {
+            "event": "PostToolUse",
+            "matcher": "Edit|Write",
+            "command_preview": "mm session start",
+        }
+
+
+# ── CLI sync warning ───────────────────────────────────────────────
+
+
+class TestSyncWarning:
+    """``mm context sync --include=settings`` emits the duplicate-tier
+    warning before write and does NOT block the sync (ADR-0010 §4
+    "informational, non-blocking")."""
+
+    def test_sync_emits_warning_for_other_tier(
+        self, project_root, fake_home, monkeypatch
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        # Pre-populate user tier with the duplicate.
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import sync_cmd
+
+        # Active scope = project_local via flag; user-tier becomes a
+        # duplicate.
+        result = CliRunner().invoke(
+            sync_cmd,
+            ["--include=settings", "--scope=project_local", "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+        # Sync still runs (file was written).
+        assert (project_root / ".claude" / "settings.local.json").is_file()
+        # Warning appears in the (mixed) output.
+        assert "memtomem-managed hook" in result.output
+        assert "user" in result.output
+
+    def test_diff_emits_warning_for_other_tier(
+        self, project_root, fake_home, monkeypatch
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        # Bare diff command runs through ``_print_settings_diff`` which
+        # also wires the warning. Default scope = user, so user-tier
+        # entry is NOT a duplicate; flip the env to make project_local
+        # active so user-tier becomes a duplicate for this invocation.
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "project_local")
+        monkeypatch.chdir(project_root)
+
+        from memtomem.cli.context_cmd import diff_cmd
+
+        result = CliRunner().invoke(diff_cmd, ["--include=settings"])
+        assert result.exit_code == 0, result.output
+        assert "memtomem-managed hook" in result.output
+
+
+# ── Web route response ─────────────────────────────────────────────
+
+
+class TestWebDuplicateTierWarnings:
+    """``GET /api/settings-sync`` and ``POST /api/settings-sync`` both
+    expose ``duplicate_tier_warnings`` (ADR-0010 §4 data surface). The
+    frontend banner that consumes this is gated for a follow-up PR;
+    these tests pin the data layer."""
+
+    @pytest.fixture
+    def app(self, project_root, fake_home, monkeypatch):
+        from memtomem.config import Mem2MemConfig
+
+        # Active scope = project_local so user-tier hooks count as
+        # duplicates.
+        monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "project_local")
+        application = create_app(lifespan=None, mode="dev")
+        application.state.project_root = project_root
+        application.state.storage = AsyncMock()
+        application.state.config = Mem2MemConfig()
+        application.state.search_pipeline = None
+        application.state.index_engine = None
+        application.state.embedder = None
+        application.state.dedup_scanner = None
+        application.state.last_reload_error = None
+        return application
+
+    @pytest.fixture
+    async def client(self, app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c
+
+    async def test_get_includes_empty_warnings_when_clean(
+        self, client, project_root
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        # No other tiers populated → empty list.
+        response = await client.get("/api/settings-sync")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["duplicate_tier_warnings"] == []
+
+    async def test_get_includes_warnings_when_duplicates(
+        self, client, project_root, fake_home
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        response = await client.get("/api/settings-sync")
+        assert response.status_code == 200
+        data = response.json()
+        warnings = data["duplicate_tier_warnings"]
+        assert len(warnings) == 1
+        assert warnings[0]["tier"] == "user"
+        assert warnings[0]["entries"][0]["event"] == "PostToolUse"
+
+    async def test_post_includes_warnings(
+        self, client, project_root, fake_home
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
+        response = await client.post(
+            "/api/settings-sync",
+            json={"allow_host_writes": False},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "results" in data
+        assert "duplicate_tier_warnings" in data
+        assert len(data["duplicate_tier_warnings"]) == 1

--- a/packages/memtomem/tests/test_settings_doctor.py
+++ b/packages/memtomem/tests/test_settings_doctor.py
@@ -13,6 +13,7 @@ Covers four surfaces:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -321,7 +322,12 @@ class TestSettingsDoctorCli:
         assert len(payload["duplicates"]) == 1
         dup = payload["duplicates"][0]
         assert dup["tier"] == "user"
-        assert dup["path"].endswith("/.claude/settings.json")
+        # ``str.endswith("/.claude/settings.json")`` would break on Windows
+        # (backslash separator). Compare via ``Path.parts`` for
+        # cross-platform stability per ``feedback_path_comparison_relative_to``.
+        dup_path = Path(dup["path"])
+        assert dup_path.name == "settings.json"
+        assert dup_path.parent.name == ".claude"
         assert len(dup["entries"]) == 1
         entry = dup["entries"][0]
         assert entry == {

--- a/packages/memtomem/tests/test_settings_doctor.py
+++ b/packages/memtomem/tests/test_settings_doctor.py
@@ -101,11 +101,14 @@ class TestDetectorCanonical:
     def test_extracts_signatures(self, project_root):
         _write_canonical(project_root, _bundled_hook())
         signatures = load_canonical_signatures(project_root)
-        assert HookSignature(
-            event="PostToolUse",
-            matcher="Edit|Write",
-            command_shape="mm session start",
-        ) in signatures
+        assert (
+            HookSignature(
+                event="PostToolUse",
+                matcher="Edit|Write",
+                command_shape="mm session start",
+            )
+            in signatures
+        )
 
 
 class TestDetectDuplicateTiers:
@@ -123,9 +126,7 @@ class TestDetectDuplicateTiers:
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
         assert detect_duplicate_tiers(project_root, active_scope="user") == []
 
-    def test_duplicate_in_user_when_active_is_project_local(
-        self, project_root, fake_home
-    ):
+    def test_duplicate_in_user_when_active_is_project_local(self, project_root, fake_home):
         _write_canonical(project_root, _bundled_hook())
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
         duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
@@ -134,9 +135,7 @@ class TestDetectDuplicateTiers:
         assert duplicates[0].path == fake_home / ".claude" / "settings.json"
         assert len(duplicates[0].entries) == 1
 
-    def test_duplicate_in_project_shared_when_active_is_user(
-        self, project_root, fake_home
-    ):
+    def test_duplicate_in_project_shared_when_active_is_user(self, project_root, fake_home):
         _write_canonical(project_root, _bundled_hook())
         _write_settings(project_root / ".claude" / "settings.json", _bundled_hook())
         duplicates = detect_duplicate_tiers(project_root, active_scope="user")
@@ -155,22 +154,16 @@ class TestDetectDuplicateTiers:
         """Internal-whitespace variants still match (ADR-0010 §4)."""
         _write_canonical(project_root, _bundled_hook())
         # Same command but with extra spaces — must still be detected.
-        variant = {
-            "PostToolUse": [_rule("Edit|Write", "mm   session   start  ")]
-        }
+        variant = {"PostToolUse": [_rule("Edit|Write", "mm   session   start  ")]}
         _write_settings(fake_home / ".claude" / "settings.json", variant)
         duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
         assert len(duplicates) == 1
         assert duplicates[0].entries[0].command_shape == "mm session start"
 
-    def test_canonical_signature_matcher_whitespace_strip(
-        self, project_root, fake_home
-    ):
+    def test_canonical_signature_matcher_whitespace_strip(self, project_root, fake_home):
         """Leading/trailing whitespace in matcher unifies."""
         _write_canonical(project_root, _bundled_hook())
-        variant = {
-            "PostToolUse": [_rule("  Edit|Write  ", "mm session start")]
-        }
+        variant = {"PostToolUse": [_rule("  Edit|Write  ", "mm session start")]}
         _write_settings(fake_home / ".claude" / "settings.json", variant)
         duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
         assert len(duplicates) == 1
@@ -182,9 +175,7 @@ class TestDetectDuplicateTiers:
             {"SessionStart": [_rule("", "mm index")]},
         )
         # Other tier omits the matcher key entirely.
-        rule_no_matcher = {
-            "hooks": [{"type": "command", "command": "mm index", "timeout": 5000}]
-        }
+        rule_no_matcher = {"hooks": [{"type": "command", "command": "mm index", "timeout": 5000}]}
         _write_settings(
             fake_home / ".claude" / "settings.json",
             {"SessionStart": [rule_no_matcher]},
@@ -295,9 +286,7 @@ class TestSettingsDoctorCli:
 
         from memtomem.cli.context_cmd import settings_doctor_cmd
 
-        result = CliRunner().invoke(
-            settings_doctor_cmd, ["--scope=project_local"]
-        )
+        result = CliRunner().invoke(settings_doctor_cmd, ["--scope=project_local"])
         assert result.exit_code == 1, result.output
 
     def test_json_clean_schema(self, project_root, fake_home, monkeypatch):
@@ -350,9 +339,7 @@ class TestSyncWarning:
     warning before write and does NOT block the sync (ADR-0010 §4
     "informational, non-blocking")."""
 
-    def test_sync_emits_warning_for_other_tier(
-        self, project_root, fake_home, monkeypatch
-    ):
+    def test_sync_emits_warning_for_other_tier(self, project_root, fake_home, monkeypatch):
         _write_canonical(project_root, _bundled_hook())
         # Pre-populate user tier with the duplicate.
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
@@ -373,9 +360,7 @@ class TestSyncWarning:
         assert "memtomem-managed hook" in result.output
         assert "user" in result.output
 
-    def test_diff_emits_warning_for_other_tier(
-        self, project_root, fake_home, monkeypatch
-    ):
+    def test_diff_emits_warning_for_other_tier(self, project_root, fake_home, monkeypatch):
         _write_canonical(project_root, _bundled_hook())
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
         # Bare diff command runs through ``_print_settings_diff`` which
@@ -425,9 +410,7 @@ class TestWebDuplicateTierWarnings:
         async with AsyncClient(transport=transport, base_url="http://test") as c:
             yield c
 
-    async def test_get_includes_empty_warnings_when_clean(
-        self, client, project_root
-    ):
+    async def test_get_includes_empty_warnings_when_clean(self, client, project_root):
         _write_canonical(project_root, _bundled_hook())
         # No other tiers populated → empty list.
         response = await client.get("/api/settings-sync")
@@ -435,9 +418,7 @@ class TestWebDuplicateTierWarnings:
         data = response.json()
         assert data["duplicate_tier_warnings"] == []
 
-    async def test_get_includes_warnings_when_duplicates(
-        self, client, project_root, fake_home
-    ):
+    async def test_get_includes_warnings_when_duplicates(self, client, project_root, fake_home):
         _write_canonical(project_root, _bundled_hook())
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
         response = await client.get("/api/settings-sync")
@@ -448,9 +429,7 @@ class TestWebDuplicateTierWarnings:
         assert warnings[0]["tier"] == "user"
         assert warnings[0]["entries"][0]["event"] == "PostToolUse"
 
-    async def test_post_includes_warnings(
-        self, client, project_root, fake_home
-    ):
+    async def test_post_includes_warnings(self, client, project_root, fake_home):
         _write_canonical(project_root, _bundled_hook())
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
         response = await client.post(


### PR DESCRIPTION
## Summary

Implements ADR-0010 §4: detect memtomem-managed hooks duplicated across
the three settings tiers (`~/.claude/settings.json`,
`<project>/.claude/settings.json`,
`<project>/.claude/settings.local.json`). Closes #871.

Claude Code 2.x merges hook entries across tiers additively, so a user
who flips `hooks.target_scope` (added in #870) and runs `mm context sync`
would silently leave hook entries in the previous tier — duplicates
fire once per tier.

## Changes

- **Shared detector** (`memtomem.context.settings_doctor`): canonical
  signature matching (event + matcher + command shape, whitespace
  normalized), symlink-aware tier dedup. Detection-only — migration is
  the future #872.
- **Sync-time warning** (primary surface): `_print_settings_generate`
  / `_print_settings_diff` emit non-blocking yellow stderr warnings
  before write, naming the offending tier and pointing at #872. Covers
  `mm context sync --include=settings`, `generate`, and `diff`.
- **`mm context settings-doctor`**: new subcommand with `--json` and
  `--scope=…` override. Exit `0` clean / `1` duplicates. Mirrors the
  existing `@context.command("migrate")` flat shape.
- **Web `GET/POST /api/settings-sync`**: responses gain a
  `duplicate_tier_warnings` list with the same payload shape as the
  CLI `--json` output. Frontend banner deferred — data layer only.
- **Doc**: short "Detecting duplicate hooks across tiers" subsection in
  `docs/guides/integrations/claude-code.md`.
- **Tests**: 25 new cases — detector unit behavior (whitespace
  variants, missing/empty matcher, malformed JSON, active-scope
  exclusion, symlink dedup), CLI exit codes + `--json` schema, end-to-
  end sync warning via `CliRunner`, Web response shape. Mutation-
  validated.

## Stacked on #873

This PR depends on `hooks.target_scope` from #870 (#873). The base of
this PR is `feat/issue-870-target-scope`; once #873 squash-merges,
this branch will need `git rebase --onto origin/main`.

## Out of scope (per issue body / ADR-0010 §4)

- Auto-fix / move logic — that's #872.
- `mm sync-doctor` extension — explicitly excluded; that command stays
  scoped to multi-device sync hygiene.
- Web UI scope picker — gated on the future project-config ADR.
- Migration of non-memtomem-managed hook entries.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 4388
      passed, 10 skipped, 46 deselected
- [x] `uv run ruff check packages/memtomem/src` — clean
- [x] `uv run ruff format --check packages/memtomem/src` — clean after
      auto-format
- [x] `uv run mypy packages/memtomem/src/memtomem/context/settings_doctor.py
      packages/memtomem/src/memtomem/cli/context_cmd.py
      packages/memtomem/src/memtomem/web/routes/settings_sync.py` — clean
- [x] Mutation validation: stubbing `detect_duplicate_tiers` to return
      `[]` immediately fails 6+ tests, confirming the assertions are
      load-bearing (not false-pass).
- [ ] CI green on PR (will check after push)

## References

- ADR-0010 §4 — `docs/adr/0010-settings-hooks-target-scope.md`
- #870 (PR #873) — `hooks.target_scope` foundation; must land first
- #872 — settings-migrate subcommand (target of the warning's
  remediation pointer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
