### PR TITLE
test(context): add subprocess + inline e2e for mm context flow

### DIFF
--- a/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
+++ b/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
@@ -34,16 +34,14 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
+from memtomem.context.generator import GENERATORS
 
-from .helpers import set_home
+from .helpers import _MEMTOMEM_ENV_VARS, set_home
 
-_GENERATED_PROJECT_FILES = (
-    "CLAUDE.md",
-    ".cursorrules",
-    "GEMINI.md",
-    "AGENTS.md",
-    ".github/copilot-instructions.md",
-)
+# Derived from the runtime registry rather than hand-curated so a new
+# runtime added to ``GENERATORS`` (cline, aider, etc.) is automatically
+# covered without this list silently under-asserting.
+_GENERATED_PROJECT_FILES = tuple(g.output_path for g in GENERATORS.values())
 
 
 def _seed_project(root: Path) -> None:
@@ -87,7 +85,7 @@ class TestContextInitGenerateInline:
         assert r.exit_code == 0, f"init failed: {r.output}"
         assert (project / ".memtomem" / "context.md").is_file()
 
-        # 2. generate → 5 runtimes' worth of project memory
+        # 2. generate → every registered runtime's project memory
         r = runner.invoke(cli, ["context", "generate"])
         assert r.exit_code == 0, f"generate failed: {r.output}"
         for rel in _GENERATED_PROJECT_FILES:
@@ -110,7 +108,7 @@ class TestContextInitGenerateInline:
         assert not (home / ".codex" / "agents").exists()
 
 
-class TestContextSubprocess:
+class TestContextInitGenerateSubprocess:
     """Out-of-process ``mm`` round-trip — process-boundary regressions
     that the in-process variant cannot surface (HOME / USERPROFILE /
     cwd / module-level constants bound at import time)."""
@@ -139,6 +137,15 @@ class TestContextSubprocess:
         _seed_project(project)
 
         env = os.environ.copy()
+        # Strip developer ``MEMTOMEM_*`` overrides — ``HOME`` only
+        # isolates ``~/.memtomem/config.json`` reads, but
+        # pydantic-settings still applies env-var overrides from the
+        # parent shell (e.g. ``MEMTOMEM_INDEXING__MEMORY_DIRS``
+        # pointing at a real path) which would un-hermeticize the
+        # subprocess. Mirrors what ``helpers.isolate_memtomem_env``
+        # does for in-process tests.
+        for var in _MEMTOMEM_ENV_VARS:
+            env.pop(var, None)
         env["HOME"] = str(home)
         env["USERPROFILE"] = str(home)  # Windows ``Path.home()`` priority
         env["XDG_CONFIG_HOME"] = str(home / ".config")

--- a/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
+++ b/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
@@ -1,0 +1,184 @@
+"""End-to-end pins for ``mm context`` subcommands across the process boundary.
+
+The bulk of context-gateway coverage lives in unit/integration tests
+(``test_context_settings.py``, ``test_context_agents.py``,
+``test_context_install.py`` etc.), but those run in-process via
+``CliRunner``. Module-level constants like ``_bootstrap._CONFIG_PATH``
+are bound at import time, so an in-process invocation can mask
+regressions that only surface across the ``HOME`` / ``Path.home()`` /
+cwd boundary (see #759 for an analogous case in ``mm index``).
+
+This module mirrors the inline + subprocess split from
+``test_cli_index_noop_e2e.py``: the inline class catches behavioral
+regressions cheaply, and the subprocess class re-runs the same scenario
+against the installed ``mm`` entry point so process-boundary plumbing
+(env var resolution, cwd-anchored ``_find_project_root()``, lazy
+imports) is covered.
+
+The host-write invariant (``mm context generate`` without
+``--include=settings`` MUST NOT touch the fake ``HOME``'s
+``~/.claude/settings.json`` or ``~/.codex/agents/``) is asserted in
+both modes — the central guard for the "context-gateway sync
+user-scope pollution" memo.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+
+from .helpers import set_home
+
+_GENERATED_PROJECT_FILES = (
+    "CLAUDE.md",
+    ".cursorrules",
+    "GEMINI.md",
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+)
+
+
+def _seed_project(root: Path) -> None:
+    """Make ``root`` look like a memtomem-eligible project root.
+
+    ``_find_project_root()`` (``cli/context_cmd.py:87``) walks up from
+    cwd looking for ``.git`` or ``pyproject.toml``; a bare ``tmp_path``
+    has neither, and the walk would escape into the developer's real
+    repo. A minimal ``pyproject.toml`` is the cheapest marker.
+    """
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "e2e-test-project"\nversion = "0"\n',
+        encoding="utf-8",
+    )
+
+
+class TestContextInitGenerateInline:
+    """In-process ``CliRunner`` round-trip over the empty-project flow.
+
+    Pinpoints behavioral regressions cheaply; complements the subprocess
+    class below which catches process-boundary regressions.
+    """
+
+    def test_init_then_generate_then_detect_then_status(self, tmp_path, monkeypatch):
+        from memtomem.cli import _bootstrap
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        _seed_project(project)
+
+        set_home(monkeypatch, home)
+        monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+        monkeypatch.chdir(project)
+
+        runner = CliRunner()
+
+        # 1. init → empty template (no agent files exist yet)
+        r = runner.invoke(cli, ["context", "init"])
+        assert r.exit_code == 0, f"init failed: {r.output}"
+        assert (project / ".memtomem" / "context.md").is_file()
+
+        # 2. generate → 5 runtimes' worth of project memory
+        r = runner.invoke(cli, ["context", "generate"])
+        assert r.exit_code == 0, f"generate failed: {r.output}"
+        for rel in _GENERATED_PROJECT_FILES:
+            assert (project / rel).is_file(), f"missing {rel}\noutput={r.output}"
+
+        # 3. detect → agent files now present
+        r = runner.invoke(cli, ["context", "detect"])
+        assert r.exit_code == 0, f"detect failed: {r.output}"
+        assert "agent file(s)" in r.output
+
+        # 4. status → no wiki assets installed; exit 0
+        r = runner.invoke(cli, ["context", "status"])
+        assert r.exit_code == 0, f"status failed: {r.output}"
+
+        # 5. Host-write invariant — fake HOME must remain untouched
+        #    when --include=settings is not passed. If this ever flips
+        #    to "settings sync runs by default", the failure here is
+        #    the loud signal we want.
+        assert not (home / ".claude" / "settings.json").exists()
+        assert not (home / ".codex" / "agents").exists()
+
+
+class TestContextSubprocess:
+    """Out-of-process ``mm`` round-trip — process-boundary regressions
+    that the in-process variant cannot surface (HOME / USERPROFILE /
+    cwd / module-level constants bound at import time)."""
+
+    def test_init_generate_detect_status_via_mm_binary(self, tmp_path):
+        # ``shutil.which`` adds the platform-correct suffix (``.exe`` on
+        # Windows via PATHEXT, none on POSIX), so the same lookup works
+        # against both ``.venv/bin/mm`` and ``.venv/Scripts/mm.exe``.
+        bin_dir = os.path.dirname(sys.executable)
+        mm_bin = shutil.which("mm", path=bin_dir)
+        # Fail loudly instead of pytest.skip — any valid test environment
+        # (``uv run pytest`` or ``uv pip install -e``) provides the
+        # ``mm`` entry point. A silent skip would turn this subprocess
+        # regression guard into CI false-green if the editable install
+        # is ever dropped.
+        if mm_bin is None:
+            pytest.fail(
+                f"mm binary not found in {bin_dir}. "
+                "Run `uv pip install -e packages/memtomem[all]` before testing."
+            )
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        _seed_project(project)
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)  # Windows ``Path.home()`` priority
+        env["XDG_CONFIG_HOME"] = str(home / ".config")
+
+        def _run(*args: str) -> subprocess.CompletedProcess:
+            # ``encoding="utf-8"`` is required: ``text=True`` alone falls
+            # back to ``locale.getpreferredencoding(False)``, which is
+            # ``cp949`` on Korean Windows. The CLI emits UTF-8 (em-dashes,
+            # box-drawing) so the reader thread crashes mid-decode and
+            # ``r.stdout`` / ``r.stderr`` come back as ``None`` (#759).
+            return subprocess.run(
+                [mm_bin, *args],
+                env=env,
+                cwd=str(project),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=60,
+            )
+
+        r = _run("context", "init")
+        assert r.returncode == 0, f"init failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+        assert (project / ".memtomem" / "context.md").is_file()
+
+        r = _run("context", "generate")
+        assert r.returncode == 0, f"generate failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+        for rel in _GENERATED_PROJECT_FILES:
+            assert (project / rel).is_file(), f"missing {rel}\nstdout={r.stdout}"
+
+        r = _run("context", "detect")
+        assert r.returncode == 0, f"detect failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+        assert "agent file(s)" in r.stdout
+
+        r = _run("context", "status")
+        assert r.returncode == 0, f"status failed:\nstdout={r.stdout}\nstderr={r.stderr}"
+
+        # Host-write invariant — same as the inline class. Subprocess
+        # mode is what catches a ``Path.home()`` call that bypasses
+        # ``HOME`` env on Windows (``USERPROFILE``-priority), or a
+        # module-level path constant bound before the env override.
+        assert not (home / ".claude" / "settings.json").exists()
+        assert not (home / ".codex" / "agents").exists()


### PR DESCRIPTION
## Summary

- Add `packages/memtomem/tests/test_context_cli_subprocess_e2e.py` with inline + subprocess round-trip pins for `mm context init → generate → detect → status` on an empty project.
- Both classes assert the host-write invariant: without `--include=settings`, `mm context generate` must not touch the fake HOME's `~/.claude/settings.json` or `~/.codex/agents/`.
- Subprocess class catches regressions that only surface across the process boundary (`HOME` / `USERPROFILE` resolution, module-level path constants bound at import time, lazy imports) — same class of bug as #759 in `mm index`.

Pattern mirrors `test_cli_index_noop_e2e.py` (`TestFreshNoopIndexInline` + `TestFreshNoopIndexSubprocess`) exactly: same `shutil.which("mm", path=bin_dir)` lookup, same `encoding="utf-8"` / `errors="replace"` cp949-safety guard, same `set_home(monkeypatch, ...)` + `_bootstrap._CONFIG_PATH` patching for the inline variant.

## Why

Most context-gateway coverage today runs in-process via `CliRunner` (`test_context_settings.py`, `test_context_agents.py`, `test_context_install.py`, etc.). That misses regressions that only manifest across the process boundary — e.g. a `Path.home()` call that runs before the `HOME` env override, or an import-time bound `_CONFIG_PATH` that points at the developer's real home. #759 was exactly that for `mm index`; the `mm context` family deserves the same guard.

The host-write invariant is the loud signal we want if `mm context generate` ever flips to running settings sync by default — that would be a critical regression and the assertion here would catch it before it ships.

## Test plan

- [x] `uv run ruff check packages/memtomem/tests/test_context_cli_subprocess_e2e.py` — passes
- [x] `uv run ruff format --check packages/memtomem/tests/test_context_cli_subprocess_e2e.py` — passes
- [x] `uv run pytest packages/memtomem/tests/test_context_cli_subprocess_e2e.py -v` — 2 passed in 0.51s locally
- [ ] CI verifies on Linux / macOS / Windows (subprocess path on Windows is the cp949 cross-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
