### PR TITLE
feat(context): mm context settings-migrate (ADR-0010 §4, #872)

### DIFF
--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -261,9 +261,24 @@ mm context settings-doctor --scope=project_local   # one-shot scope override
 
 The match is by canonical signature (event + matcher + command shape, with
 whitespace normalized) so a hand-edited variant of a memtomem-managed entry
-still classifies. Detection is non-mutating; the `mm context settings-migrate`
-subcommand (see [issue #872](https://github.com/memtomem/memtomem/issues/872))
-will be the action surface that moves duplicate entries into the active scope.
+still classifies. Detection is non-mutating; the action surface is the
+companion `mm context settings-migrate` subcommand:
+
+```bash
+mm context settings-migrate --from=user --to=project_local           # dry-run
+mm context settings-migrate --from=user --to=project_local --apply   # mutate
+mm context settings-migrate --from=user --to=project_local --json    # CI / scripting
+```
+
+Default is a dry-run preview; pass `--apply` to mutate disk. The migrator
+takes the canonical rule from `.memtomem/settings.json` (so the target
+ends up byte-clean rather than carrying the source-side whitespace
+variant) and removes the matched inner-hook entries from the source tier.
+Idempotent — re-running after a clean migration finds nothing to move.
+
+When the source or target lives outside the project root (e.g.
+`--from=user`, which resolves to `~/.claude/settings.json`), `--apply`
+prompts for confirmation; pass `--yes` to skip the prompt in scripts.
 
 ---
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -69,6 +69,11 @@ from memtomem.context.settings_doctor import (
     detect_duplicate_tiers,
     format_warning,
 )
+from memtomem.context.settings_migrate import (
+    apply_migration,
+    format_plan_summary,
+    plan_migration,
+)
 from memtomem.context.skills import (
     diff_skills,
     extract_skills_to_canonical,
@@ -1699,9 +1704,241 @@ def settings_doctor_cmd(json_out: bool, scope_flag: str | None) -> None:
                     label = f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
                     click.echo(f"      [{label}] {sig.command_shape}")
             click.echo(
-                "\nRun the future `mm context settings-migrate` subcommand "
-                "(#872) to move these into the active scope."
+                "\nRun `mm context settings-migrate --from=<scope> "
+                "--to=<scope>` to move these into the active scope."
             )
 
     if duplicates:
         raise click.exceptions.Exit(1)
+
+
+# ── settings-migrate (ADR-0010 §4) ─────────────────────────────────
+
+
+_MIGRATE_SCOPE_FROM = click.option(
+    "--from",
+    "from_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    required=True,
+    help="Source tier holding the canonical-matched hook entries.",
+)
+
+
+_MIGRATE_SCOPE_TO = click.option(
+    "--to",
+    "to_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    required=True,
+    help="Target tier the entries move into.",
+)
+
+
+def _print_migrate_plan_human(plan, *, scope: str) -> None:
+    """Render the settings-migrate dry-run / pre-apply preview."""
+    if not plan.moves:
+        click.echo(
+            f"  no memtomem-managed hook entries in {plan.source_scope} "
+            f"({plan.source_path}) match the canonical source — nothing to migrate."
+        )
+        return
+
+    click.echo(
+        f"\nWill migrate hook entries from {plan.source_scope} ({plan.source_path}) "
+        f"→ {plan.target_scope} ({plan.target_path}):"
+    )
+    for move in plan.moves:
+        sig = move.signature
+        label = f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
+        if move.conflict_at_target:
+            glyph, color = "✗", "red"
+            note = f"skip (conflict: {move.conflict_reason})"
+        elif move.already_at_target:
+            glyph, color = "·", "cyan"
+            note = "already at target — source clean-up only"
+        else:
+            glyph, color = "→", "green"
+            note = "move"
+        click.secho(f"  {glyph}  [{label}]  {sig.command_shape}  ({note})", fg=color)
+
+
+@context.command("settings-migrate")
+@_MIGRATE_SCOPE_FROM
+@_MIGRATE_SCOPE_TO
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    default=False,
+    help="Execute the migration. Default is a dry-run preview.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    "yes",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt and the host-write prompt. Requires --apply.",
+)
+@click.option(
+    "--json",
+    "json_out",
+    is_flag=True,
+    default=False,
+    help="Emit a structured JSON result instead of human-readable output.",
+)
+def settings_migrate_cmd(
+    from_scope: str,
+    to_scope: str,
+    apply_: bool,
+    yes: bool,
+    json_out: bool,
+) -> None:
+    """Move memtomem-managed hook entries between settings tiers.
+
+    Implements ADR-0010 §4's third follow-up. Reads canonical-signature-
+    matched entries from the source tier (``--from``) and lands them in
+    the target tier (``--to``) using the canonical rule from
+    ``.memtomem/settings.json`` so the target ends up byte-clean rather
+    than carrying any source-side whitespace variant. Idempotent —
+    re-running after a clean migration finds nothing to move.
+
+    Default is a dry-run; pass ``--apply`` to mutate disk. The host-
+    write prompt mirrors ``mm context sync --include=settings``: writes
+    outside the project root require an interactive confirmation (or
+    ``--yes``).
+
+    Exit codes: ``0`` clean (or dry-run), ``1`` user declined the
+    confirmation prompt or the plan reported conflicts requiring manual
+    resolution.
+    """
+    root = _find_project_root()
+    try:
+        plan = plan_migration(root, source_scope=from_scope, target_scope=to_scope)
+    except ValueError as exc:
+        if json_out:
+            click.echo(json.dumps({"status": "error", "error": str(exc)}, indent=2))
+        else:
+            click.secho(f"error: {exc}", fg="red", err=True)
+        raise click.exceptions.Exit(1)
+
+    conflicts = [m for m in plan.moves if m.conflict_at_target]
+    summary = format_plan_summary(plan)
+
+    if json_out:
+        payload = {
+            "status": "noop" if plan.is_noop else ("conflicts" if conflicts else "ok"),
+            "applied": False,
+            "from": plan.source_scope,
+            "to": plan.target_scope,
+            "source_path": str(plan.source_path),
+            "target_path": str(plan.target_path),
+            "summary": summary,
+            "moves": [
+                {
+                    "event": m.signature.event,
+                    "matcher": m.signature.matcher,
+                    "command_preview": m.signature.command_shape,
+                    "already_at_target": m.already_at_target,
+                    "conflict_at_target": m.conflict_at_target,
+                    "conflict_reason": m.conflict_reason,
+                }
+                for m in plan.moves
+            ],
+        }
+    else:
+        _print_migrate_plan_human(plan, scope=from_scope)
+        if plan.moves:
+            click.echo(f"\nSummary: {summary}")
+
+    if not apply_:
+        if json_out:
+            click.echo(json.dumps(payload, indent=2))
+        else:
+            click.echo("\nRun with --apply to execute.")
+        return
+
+    # --apply path
+    if plan.is_noop:
+        if json_out:
+            payload["applied"] = True
+            click.echo(json.dumps(payload, indent=2))
+        return
+
+    # Host-write confirmation: target outside the project root requires
+    # the same gate as `mm context sync --include=settings` so a stray
+    # `--apply` from a worktree can't silently rewrite ~/.claude/.
+    target_outside = not _is_within(plan.target_path, root)
+    source_outside = not _is_within(plan.source_path, root)
+    if (target_outside or source_outside) and not yes:
+        if not json_out:
+            click.secho(
+                "settings-migrate will modify the following files outside this project:",
+                fg="yellow",
+            )
+            if target_outside:
+                click.echo(f"  {plan.target_path}  (target)")
+            if source_outside:
+                click.echo(f"  {plan.source_path}  (source)")
+            if not click.confirm("Continue?", default=False):
+                click.echo("Aborted.")
+                raise click.exceptions.Exit(1)
+        else:
+            # JSON callers must be explicit — refuse without --yes.
+            click.echo(
+                json.dumps(
+                    {
+                        "status": "needs_confirmation",
+                        "applied": False,
+                        "from": plan.source_scope,
+                        "to": plan.target_scope,
+                        "source_path": str(plan.source_path),
+                        "target_path": str(plan.target_path),
+                        "host_writes": [
+                            str(p)
+                            for p, outside in [
+                                (plan.target_path, target_outside),
+                                (plan.source_path, source_outside),
+                            ]
+                            if outside
+                        ],
+                        "hint": "Re-run with --yes after confirming.",
+                    },
+                    indent=2,
+                )
+            )
+            raise click.exceptions.Exit(1)
+
+    result = apply_migration(plan)
+
+    if json_out:
+        payload["applied"] = True
+        payload["target_written"] = result.target_written
+        payload["source_written"] = result.source_written
+        click.echo(json.dumps(payload, indent=2))
+    else:
+        if result.target_written:
+            click.secho(
+                f"  ✓ wrote target {plan.target_path}",
+                fg="green",
+            )
+        if result.source_written:
+            click.secho(
+                f"  ✓ cleaned source {plan.source_path}",
+                fg="green",
+            )
+        if not result.target_written and not result.source_written:
+            click.echo("  (no changes written — source was already clean)")
+
+    if conflicts:
+        # Conflicts left in source; user must resolve manually before
+        # re-running migrate. Match `mm context migrate`'s exit-1 on
+        # any partial failure.
+        raise click.exceptions.Exit(1)
+
+
+def _is_within(path: Path, project_root: Path) -> bool:
+    """``True`` when *path* resolves under *project_root*. Symlink-safe."""
+    try:
+        return path.resolve(strict=False).is_relative_to(project_root.resolve(strict=False))
+    except (OSError, RuntimeError):
+        return False

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1733,7 +1733,7 @@ _MIGRATE_SCOPE_TO = click.option(
 )
 
 
-def _print_migrate_plan_human(plan, *, scope: str) -> None:
+def _print_migrate_plan_human(plan) -> None:
     """Render the settings-migrate dry-run / pre-apply preview."""
     if not plan.moves:
         click.echo(
@@ -1846,7 +1846,7 @@ def settings_migrate_cmd(
             ],
         }
     else:
-        _print_migrate_plan_human(plan, scope=from_scope)
+        _print_migrate_plan_human(plan)
         if plan.moves:
             click.echo(f"\nSummary: {summary}")
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1857,8 +1857,12 @@ def settings_migrate_cmd(
             click.echo("\nRun with --apply to execute.")
         return
 
-    # --apply path
-    if plan.is_noop:
+    # --apply path. ``is_noop`` is True both when there is nothing to
+    # migrate at all AND when every move is a conflict (applicable_moves
+    # is empty in both cases). Differentiate so all-conflict still exits
+    # 1 — the user has unresolved drift to fix.
+    applicable = plan.applicable_moves
+    if plan.is_noop and not conflicts:
         if json_out:
             payload["applied"] = True
             click.echo(json.dumps(payload, indent=2))
@@ -1866,10 +1870,12 @@ def settings_migrate_cmd(
 
     # Host-write confirmation: target outside the project root requires
     # the same gate as `mm context sync --include=settings` so a stray
-    # `--apply` from a worktree can't silently rewrite ~/.claude/.
+    # `--apply` from a worktree can't silently rewrite ~/.claude/. Only
+    # prompt when we'd actually write — an all-conflict plan touches
+    # nothing on disk.
     target_outside = not _is_within(plan.target_path, root)
     source_outside = not _is_within(plan.source_path, root)
-    if (target_outside or source_outside) and not yes:
+    if applicable and (target_outside or source_outside) and not yes:
         if not json_out:
             click.secho(
                 "settings-migrate will modify the following files outside this project:",
@@ -1927,7 +1933,13 @@ def settings_migrate_cmd(
                 fg="green",
             )
         if not result.target_written and not result.source_written:
-            click.echo("  (no changes written — source was already clean)")
+            if conflicts:
+                click.secho(
+                    "  (no changes written — conflicts must be resolved first)",
+                    fg="yellow",
+                )
+            else:
+                click.echo("  (no changes written — source was already clean)")
 
     if conflicts:
         # Conflicts left in source; user must resolve manually before

--- a/packages/memtomem/src/memtomem/context/settings_doctor.py
+++ b/packages/memtomem/src/memtomem/context/settings_doctor.py
@@ -21,8 +21,8 @@ A tier counts as a duplicate when it holds a hook entry whose
 signature appears in the project's canonical ``.memtomem/settings.json``
 **and** the tier is not the active scope.
 
-This module is detection-only. Migration of duplicate entries is the
-job of the future ``mm context settings-migrate`` subcommand (#872).
+This module is detection-only. Migration of duplicate entries lives
+in :mod:`memtomem.context.settings_migrate`.
 """
 
 from __future__ import annotations
@@ -240,16 +240,16 @@ def detect_duplicate_tiers(
 def format_warning(duplicate: DuplicateTier, *, active_scope: str) -> str:
     """Human-readable warning string for one duplicate tier.
 
-    Names the offending tier path and points at the future
-    ``mm context settings-migrate`` (#872) subcommand per ADR-0010 §4.
-    Used by both the CLI sync surface and any caller that wants the
-    same wording.
+    Names the offending tier path and points at the
+    ``mm context settings-migrate`` subcommand per ADR-0010 §4. Used by
+    both the CLI sync surface and any caller that wants the same
+    wording.
     """
     count = len(duplicate.entries)
     plural = "entry" if count == 1 else "entries"
     return (
         f"memtomem-managed hook {plural} ({count}) already exist in the "
-        f"{duplicate.tier} tier ({duplicate.path}); the future "
-        f"`mm context settings-migrate` subcommand will move them. "
-        f"Active scope: {active_scope}."
+        f"{duplicate.tier} tier ({duplicate.path}); run "
+        f"`mm context settings-migrate --from={duplicate.tier} "
+        f"--to={active_scope}` to move them. Active scope: {active_scope}."
     )

--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -48,12 +48,23 @@ class MigrateMove:
     ``rule_to_write_at_target`` is the canonical ``{matcher, hooks}``
     rule that :func:`apply_migration` appends to target; the canonical
     inner shape (not the source-tier variant) is used so target ends
-    up byte-clean. ``already_at_target`` is True when target already
-    holds an inner hook with the same ``command_shape`` under the
-    same ``(event, matcher)`` — apply skips the target write but
-    still cleans the source entry. ``conflict_at_target`` is reserved
-    for a future planner enhancement (different inner shape under the
-    same matcher); the v1 planner never sets it.
+    up byte-clean. The three states a move can land in are decided by
+    :func:`_classify_target` and surface here as a pair of booleans:
+
+    * ``already_at_target=True``, ``conflict_at_target=False`` —
+      target already carries an inner **byte-equal** to the canonical
+      one. Target write is skipped; source is still cleaned.
+    * ``already_at_target=False``, ``conflict_at_target=False`` —
+      target either has no rule under ``(event, matcher)`` or has one
+      that we can extend safely. Target gets the canonical rule
+      appended; source is cleaned.
+    * ``conflict_at_target=True`` — target has a rule under
+      ``(event, matcher)`` whose inner hooks differ from canonical
+      (different ``timeout``, extra keys, or a wholly different
+      command). ``apply`` does **not** write target (would create a
+      same-matcher duplicate) and does **not** clean source (would
+      leave target permanently drifted from the canonical contract).
+      ``conflict_reason`` carries the human-readable explanation.
     """
 
     signature: HookSignature
@@ -180,18 +191,54 @@ def _target_rule_lookup(
     return out
 
 
-def _target_already_has(
+def _classify_target(
     target_index: dict[tuple[str, str], list[dict]],
     sig: HookSignature,
-) -> bool:
-    """True if any target rule under ``(event, matcher)`` carries an
-    inner hook with the same normalized command_shape."""
-    for rule in target_index.get((sig.event, sig.matcher), []):
+    canonical_inner: dict,
+) -> tuple[str, str]:
+    """Classify how target relates to a canonical inner under ``(event, matcher)``.
+
+    Three outcomes drive the planner:
+
+    * ``("missing", "")`` — no rule under ``(event, matcher)`` exists at
+      target. Safe: the canonical rule will be appended.
+    * ``("exact", "")`` — a rule under ``(event, matcher)`` carries an
+      inner **byte-equal** to ``canonical_inner``. Safe: target write is
+      skipped, source can still be cleaned (the canonical entry is
+      already exactly there).
+    * ``("conflict", reason)`` — a rule under ``(event, matcher)``
+      exists but **no** inner is byte-equal to ``canonical_inner``.
+      Refuse: blindly appending the canonical rule would create a
+      second same-matcher rule (Claude Code merges them additively, so
+      both would fire); skipping target while cleaning source would
+      drift away from the canonical contract since target has a
+      different inner shape (e.g. different ``timeout`` or extra keys).
+      The user resolves manually.
+
+    The ``signature``-level command-shape match (used by the detector
+    for "is this a memtomem-managed entry" classification) is too loose
+    here: a same-command-but-different-timeout inner at target is a
+    drift we must surface, not silently treat as already-present.
+    """
+    rules = target_index.get((sig.event, sig.matcher), [])
+    if not rules:
+        return ("missing", "")
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
         for inner in rule.get("hooks", []):
-            if isinstance(inner, dict):
-                if _normalize_command(inner.get("command", "")) == sig.command_shape:
-                    return True
-    return False
+            if isinstance(inner, dict) and inner == canonical_inner:
+                return ("exact", "")
+    label = f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
+    return (
+        "conflict",
+        (
+            f"target tier already has a rule under '{label}' whose inner "
+            f"hooks differ from the canonical entry. Resolve manually "
+            f"(remove the conflicting rule, then re-run migrate) before "
+            f"the source can be cleaned."
+        ),
+    )
 
 
 def plan_migration(
@@ -282,13 +329,14 @@ def plan_migration(
                         "matcher": sig.matcher,
                         "hooks": [canonical_inner],
                     }
-                    already = _target_already_has(target_index, sig)
+                    status, reason = _classify_target(target_index, sig, canonical_inner)
                     moves.append(
                         MigrateMove(
                             signature=sig,
                             rule_to_write_at_target=rule_to_write,
-                            already_at_target=already,
-                            conflict_at_target=False,
+                            already_at_target=(status == "exact"),
+                            conflict_at_target=(status == "conflict"),
+                            conflict_reason=reason,
                         )
                     )
 

--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -1,0 +1,458 @@
+"""Move memtomem-managed hook entries between settings tiers (ADR-0010 §4).
+
+Companion module to :mod:`memtomem.context.settings_doctor`. The
+detector reports tiers holding canonical-matched hook entries; this
+module moves those entries from the source tier to the target tier.
+
+Granularity is the **inner hook entry** (one ``{type, command, …}``
+record under one ``(event, matcher)`` rule), not the whole rule. A
+user who hand-authored a non-memtomem inner entry under the same
+matcher keeps it where it is; only the canonical-signature-matched
+entries move.
+
+Write order is **target first, then source** (issue #872 acceptance
+"`user → project_local` migration moves the entries cleanly"). If
+target write succeeds but source write fails, the user sees a
+transient cross-tier duplicate that the next ``settings-migrate`` run
+heals idempotently — the target already has the entries, so target is
+a no-op and source is then cleaned. If target write fails first, the
+source is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from memtomem.context._atomic import atomic_write_text
+from memtomem.context.settings import (
+    CANONICAL_SETTINGS_FILE,
+    resolve_scope_path,
+)
+from memtomem.context.settings_doctor import (
+    HookSignature,
+    _normalize_command,
+    _normalize_matcher,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MigrateMove:
+    """One inner hook entry being moved from source to target.
+
+    ``signature`` is the canonical-signature key used for matching.
+    ``rule_to_write_at_target`` is the canonical ``{matcher, hooks}``
+    rule that :func:`apply_migration` appends to target; the canonical
+    inner shape (not the source-tier variant) is used so target ends
+    up byte-clean. ``already_at_target`` is True when target already
+    holds an inner hook with the same ``command_shape`` under the
+    same ``(event, matcher)`` — apply skips the target write but
+    still cleans the source entry. ``conflict_at_target`` is reserved
+    for a future planner enhancement (different inner shape under the
+    same matcher); the v1 planner never sets it.
+    """
+
+    signature: HookSignature
+    rule_to_write_at_target: dict
+    already_at_target: bool
+    conflict_at_target: bool = False
+    conflict_reason: str = ""
+
+
+@dataclass(frozen=True)
+class MigratePlan:
+    """The full set of moves for one source → target migration."""
+
+    source_scope: str
+    target_scope: str
+    source_path: Path
+    target_path: Path
+    moves: tuple[MigrateMove, ...]
+
+    @property
+    def is_noop(self) -> bool:
+        """True when no entries need writing at either side.
+
+        A plan with all-conflict moves is *not* a no-op — it has
+        warnings to surface; but it does not write either file.
+        """
+        return not any(not m.conflict_at_target for m in self.moves)
+
+    @property
+    def applicable_moves(self) -> tuple[MigrateMove, ...]:
+        """Moves that will actually mutate disk on apply (no conflicts)."""
+        return tuple(m for m in self.moves if not m.conflict_at_target)
+
+
+@dataclass
+class MigrateResult:
+    """Outcome of an apply step."""
+
+    plan: MigratePlan
+    target_written: bool = False
+    source_written: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+
+# ── Planning ────────────────────────────────────────────────────────
+
+
+def _safe_load_json_dict(path: Path) -> dict | None:
+    """Read a settings.json file; ``None`` on missing / unreadable / non-dict.
+
+    Self-contained dup of :func:`settings_doctor._load_settings_dict` so
+    this module does not depend on that helper's private location.
+    """
+    if not path.is_file():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    return raw
+
+
+def _signature_for_inner(event: str, matcher: str, inner: dict) -> HookSignature | None:
+    """Return the canonical signature for one inner hook entry, or None."""
+    if not isinstance(inner, dict):
+        return None
+    command = _normalize_command(inner.get("command", ""))
+    if not command:
+        return None
+    return HookSignature(
+        event=event,
+        matcher=_normalize_matcher(matcher),
+        command_shape=command,
+    )
+
+
+def _index_canonical_inners(
+    canonical_hooks: dict,
+) -> dict[HookSignature, dict]:
+    """Map canonical signature → the canonical inner hook entry (dict).
+
+    The canonical entry is what gets appended to target on apply, so
+    target ends up byte-clean rather than carrying the user's
+    whitespace variant from source.
+    """
+    out: dict[HookSignature, dict] = {}
+    if not isinstance(canonical_hooks, dict):
+        return out
+    for event, rules in canonical_hooks.items():
+        if not isinstance(event, str) or not isinstance(rules, list):
+            continue
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            matcher = rule.get("matcher", "")
+            inner_list = rule.get("hooks", [])
+            if not isinstance(inner_list, list):
+                continue
+            for inner in inner_list:
+                sig = _signature_for_inner(event, matcher, inner)
+                if sig is None:
+                    continue
+                out.setdefault(sig, inner)
+    return out
+
+
+def _target_rule_lookup(
+    target_hooks: dict,
+) -> dict[tuple[str, str], list[dict]]:
+    """Index target rules by ``(event, matcher_normalized)``."""
+    out: dict[tuple[str, str], list[dict]] = {}
+    if not isinstance(target_hooks, dict):
+        return out
+    for event, rules in target_hooks.items():
+        if not isinstance(event, str) or not isinstance(rules, list):
+            continue
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            matcher = _normalize_matcher(rule.get("matcher", ""))
+            out.setdefault((event, matcher), []).append(rule)
+    return out
+
+
+def _target_already_has(
+    target_index: dict[tuple[str, str], list[dict]],
+    sig: HookSignature,
+) -> bool:
+    """True if any target rule under ``(event, matcher)`` carries an
+    inner hook with the same normalized command_shape."""
+    for rule in target_index.get((sig.event, sig.matcher), []):
+        for inner in rule.get("hooks", []):
+            if isinstance(inner, dict):
+                if _normalize_command(inner.get("command", "")) == sig.command_shape:
+                    return True
+    return False
+
+
+def plan_migration(
+    project_root: Path,
+    *,
+    source_scope: str,
+    target_scope: str,
+) -> MigratePlan:
+    """Compute the set of moves for ``source → target`` (no I/O writes).
+
+    The planner is read-only — it inspects the canonical source, the
+    source tier, and the target tier, and returns a :class:`MigratePlan`
+    whose ``moves`` describe each canonical-matched inner-hook entry in
+    source and how it would land at target.
+
+    Raises :class:`ValueError` when ``source_scope == target_scope`` or
+    when their resolved paths point at the same file (symlink) — both
+    are user errors, not no-ops; surface them loudly.
+    """
+    if source_scope == target_scope:
+        raise ValueError(
+            f"settings-migrate source and target scopes must differ; "
+            f"got source={source_scope!r}, target={target_scope!r}."
+        )
+
+    source_path = resolve_scope_path(project_root, source_scope)
+    target_path = resolve_scope_path(project_root, target_scope)
+    try:
+        if source_path.resolve(strict=False) == target_path.resolve(strict=False):
+            raise ValueError(
+                f"settings-migrate source and target resolve to the same "
+                f"file ({source_path}); refusing to migrate in-place."
+            )
+    except (OSError, RuntimeError):
+        pass
+
+    canonical = _safe_load_json_dict(project_root / CANONICAL_SETTINGS_FILE)
+    canonical_inners = _index_canonical_inners(canonical.get("hooks", {}) if canonical else {})
+    if not canonical_inners:
+        return MigratePlan(
+            source_scope=source_scope,
+            target_scope=target_scope,
+            source_path=source_path,
+            target_path=target_path,
+            moves=(),
+        )
+
+    source = _safe_load_json_dict(source_path)
+    if source is None:
+        return MigratePlan(
+            source_scope=source_scope,
+            target_scope=target_scope,
+            source_path=source_path,
+            target_path=target_path,
+            moves=(),
+        )
+
+    target = _safe_load_json_dict(target_path) or {}
+    target_index = _target_rule_lookup(target.get("hooks", {}))
+
+    # Walk source tier; for each inner entry whose signature is in
+    # canonical_inners, build a MigrateMove. Multiple source inners
+    # under the same (event, matcher) sharing one signature collapse
+    # to one move (idempotent canonical contribution).
+    source_hooks = source.get("hooks", {})
+    seen_sigs: set[HookSignature] = set()
+    moves: list[MigrateMove] = []
+    if isinstance(source_hooks, dict):
+        for event, rules in source_hooks.items():
+            if not isinstance(event, str) or not isinstance(rules, list):
+                continue
+            for rule in rules:
+                if not isinstance(rule, dict):
+                    continue
+                matcher = rule.get("matcher", "")
+                inner_list = rule.get("hooks", [])
+                if not isinstance(inner_list, list):
+                    continue
+                for inner in inner_list:
+                    sig = _signature_for_inner(event, matcher, inner)
+                    if sig is None or sig not in canonical_inners:
+                        continue
+                    if sig in seen_sigs:
+                        continue
+                    seen_sigs.add(sig)
+                    canonical_inner = canonical_inners[sig]
+                    rule_to_write = {
+                        "matcher": sig.matcher,
+                        "hooks": [canonical_inner],
+                    }
+                    already = _target_already_has(target_index, sig)
+                    moves.append(
+                        MigrateMove(
+                            signature=sig,
+                            rule_to_write_at_target=rule_to_write,
+                            already_at_target=already,
+                            conflict_at_target=False,
+                        )
+                    )
+
+    return MigratePlan(
+        source_scope=source_scope,
+        target_scope=target_scope,
+        source_path=source_path,
+        target_path=target_path,
+        moves=tuple(moves),
+    )
+
+
+# ── Apply ───────────────────────────────────────────────────────────
+
+
+def _strip_source_inner_entries(
+    source: dict,
+    sigs: set[HookSignature],
+) -> dict:
+    """Return a new source dict with the matching inner entries dropped.
+
+    Empty rules / events are pruned. Non-hooks top-level keys (e.g.
+    ``permissions``) are preserved verbatim.
+    """
+    out = dict(source)
+    hooks = source.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return out
+
+    new_hooks: dict[str, list] = {}
+    for event, rules in hooks.items():
+        if not isinstance(event, str) or not isinstance(rules, list):
+            new_hooks[event] = rules  # preserve unknown shape verbatim
+            continue
+        new_rules: list[dict] = []
+        for rule in rules:
+            if not isinstance(rule, dict):
+                new_rules.append(rule)
+                continue
+            matcher = rule.get("matcher", "")
+            inner_list = rule.get("hooks", [])
+            if not isinstance(inner_list, list):
+                new_rules.append(rule)
+                continue
+            kept_inners: list = []
+            for inner in inner_list:
+                sig = _signature_for_inner(event, matcher, inner)
+                if sig is not None and sig in sigs:
+                    continue
+                kept_inners.append(inner)
+            if not kept_inners and isinstance(inner_list, list) and inner_list:
+                # Whole rule's inner hooks all moved out → drop the rule.
+                continue
+            new_rule = dict(rule)
+            new_rule["hooks"] = kept_inners
+            new_rules.append(new_rule)
+        if new_rules:
+            new_hooks[event] = new_rules
+    out["hooks"] = new_hooks
+    return out
+
+
+def _add_target_rules(
+    target: dict,
+    moves_to_write: list[MigrateMove],
+) -> dict:
+    """Append canonical rules for the given moves to target's hooks record.
+
+    Moves where ``already_at_target`` is True are skipped — target
+    already carries an inner hook with the same ``command_shape`` under
+    the same ``(event, matcher)``. We do **not** also dedupe on rule
+    identity here because the rule we're adding is the canonical
+    `{matcher, hooks: [canonical_inner]}` shape; the
+    ``already_at_target`` check above guarantees we don't double-fire.
+    """
+    out = dict(target)
+    hooks = dict(out.get("hooks", {})) if isinstance(out.get("hooks"), dict) else {}
+    for move in moves_to_write:
+        if move.already_at_target:
+            continue
+        event = move.signature.event
+        existing = hooks.get(event, [])
+        if not isinstance(existing, list):
+            existing = []
+        existing.append(move.rule_to_write_at_target)
+        hooks[event] = existing
+    out["hooks"] = hooks
+    return out
+
+
+def _write_json(path: Path, data: dict) -> None:
+    """Atomic write matching :func:`memtomem.context.settings._write_json`.
+
+    :func:`atomic_write_text` already ensures ``path.parent`` exists.
+    """
+    payload = json.dumps(data, indent=2, sort_keys=False, ensure_ascii=False) + "\n"
+    atomic_write_text(path, payload, mode=0o600)
+
+
+def apply_migration(plan: MigratePlan) -> MigrateResult:
+    """Apply *plan* to disk.
+
+    Write order: **target first, then source.** A crash between the two
+    leaves the user with a transient duplicate that the next plan run
+    detects and heals (idempotent — target's inner hook now matches the
+    canonical signature, so ``already_at_target`` is True and only the
+    source clean-up step runs).
+    """
+    result = MigrateResult(plan=plan)
+    if plan.is_noop:
+        return result
+
+    applicable = list(plan.applicable_moves)
+
+    # --- Target write ---------------------------------------------------
+    target_existing = _safe_load_json_dict(plan.target_path) or {}
+    target_new_inners = [m for m in applicable if not m.already_at_target]
+    if target_new_inners:
+        target_merged = _add_target_rules(target_existing, target_new_inners)
+        _write_json(plan.target_path, target_merged)
+        result.target_written = True
+
+    # --- Source write ---------------------------------------------------
+    source_existing = _safe_load_json_dict(plan.source_path)
+    if source_existing is None:
+        # Source vanished between plan and apply (rare). Source is already
+        # clean from this command's POV; leave as-is.
+        return result
+
+    sigs_to_drop = {m.signature for m in applicable}
+    source_new = _strip_source_inner_entries(source_existing, sigs_to_drop)
+    if source_new != source_existing:
+        _write_json(plan.source_path, source_new)
+        result.source_written = True
+
+    return result
+
+
+# ── Reporting ───────────────────────────────────────────────────────
+
+
+def format_plan_summary(plan: MigratePlan) -> str:
+    """One-line summary used by the CLI summary footer."""
+    if not plan.moves:
+        return "0 entries to migrate (source is already clean)."
+    moves_apply = sum(1 for m in plan.moves if not m.conflict_at_target)
+    moves_already = sum(1 for m in plan.moves if m.already_at_target and not m.conflict_at_target)
+    moves_conflict = sum(1 for m in plan.moves if m.conflict_at_target)
+    parts: list[str] = []
+    fresh = moves_apply - moves_already
+    if fresh:
+        parts.append(f"{fresh} to add at target")
+    if moves_already:
+        parts.append(f"{moves_already} already at target (source clean-up only)")
+    if moves_conflict:
+        parts.append(f"{moves_conflict} skipped (conflict)")
+    return ", ".join(parts) if parts else "0 entries to migrate."
+
+
+__all__ = [
+    "MigrateMove",
+    "MigratePlan",
+    "MigrateResult",
+    "apply_migration",
+    "format_plan_summary",
+    "plan_migration",
+]

--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -86,12 +86,19 @@ class MigratePlan:
 
     @property
     def is_noop(self) -> bool:
-        """True when no entries need writing at either side.
+        """True when :func:`apply_migration` will write nothing.
 
-        A plan with all-conflict moves is *not* a no-op — it has
-        warnings to surface; but it does not write either file.
+        Two situations land here:
+
+        * No moves at all — source has no canonical-matched entries.
+        * Every move is a conflict — :attr:`applicable_moves` is empty,
+          so apply writes nothing, but the user **does** have unresolved
+          drift to surface. Callers that need to distinguish "genuinely
+          nothing to do" from "all-conflict drift" should pair this
+          property with a non-empty conflict check (the CLI does this
+          at the ``--apply`` exit-1 gate).
         """
-        return not any(not m.conflict_at_target for m in self.moves)
+        return not self.applicable_moves
 
     @property
     def applicable_moves(self) -> tuple[MigrateMove, ...]:

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -539,8 +539,11 @@ class TestSettingsMigrateCli:
         payload = json.loads(result.output)
         assert payload["status"] == "needs_confirmation"
         assert payload["applied"] is False
-        # Source is user-tier → outside project root → must appear in host_writes.
-        assert any(".claude/settings.json" in p and "/home" in p for p in payload["host_writes"])
+        # Source is user-tier → outside project root → must appear in
+        # host_writes. Compare against the actual source path so the
+        # check is separator-agnostic (Windows uses ``\`` not ``/``).
+        expected_source = str(fake_home / ".claude" / "settings.json")
+        assert expected_source in payload["host_writes"]
         assert "--yes" in payload["hint"]
         # Disk untouched.
         assert not (project_root / ".claude" / "settings.local.json").is_file()

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -161,6 +161,71 @@ class TestPlanMigration:
         # The rule written to target uses the canonical (clean) command.
         assert plan.moves[0].rule_to_write_at_target["hooks"][0]["command"] == "mm session start"
 
+    def test_target_same_matcher_different_inner_is_conflict(self, project_root, fake_home):
+        """Codex review (PR #876): target has the canonical matcher but
+        carries a *different* inner hook (user-authored). Without this
+        check the planner would set ``conflict_at_target=False``,
+        ``apply`` would append the canonical rule alongside the user's,
+        and Claude Code would fire both same-matcher rules — the kind of
+        silent double-execution ADR-0010 §4 was written to prevent.
+        """
+        _write_canonical(project_root, _bundled_hook())
+        # Source has the canonical entry.
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        # Target has a user-authored hook under the same matcher.
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc({"PostToolUse": [_rule("Edit|Write", inners=[_inner("user-script")])]}),
+        )
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert len(plan.moves) == 1
+        move = plan.moves[0]
+        assert move.conflict_at_target is True
+        assert move.already_at_target is False
+        assert "Resolve manually" in move.conflict_reason
+        # ``is_noop`` is True (applicable_moves is empty) — the apply
+        # path must still exit 1 to surface the unresolved drift.
+        assert plan.is_noop is True
+        assert plan.applicable_moves == ()
+
+    def test_target_near_match_with_drifted_timeout_is_conflict(self, project_root, fake_home):
+        """Codex review (PR #876): target has the same matcher AND the
+        same command, but a different ``timeout`` (or any other inner
+        key drift). The signature-only check would mark this as
+        ``already_at_target=True`` and ``apply`` would clean source
+        without writing target — leaving target permanently drifted
+        from ``.memtomem/settings.json``. The planner must classify
+        this as a conflict instead.
+        """
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        # Target has the canonical command but a different timeout.
+        drifted_inner = {"type": "command", "command": "mm session start", "timeout": 99999}
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc({"PostToolUse": [{"matcher": "Edit|Write", "hooks": [drifted_inner]}]}),
+        )
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert len(plan.moves) == 1
+        move = plan.moves[0]
+        assert move.conflict_at_target is True
+        assert move.already_at_target is False
+
+    def test_target_byte_equal_canonical_inner_is_already_at_target(self, project_root, fake_home):
+        """Sanity: when target carries an inner byte-equal to canonical,
+        the planner classifies it as ``already_at_target`` (not
+        conflict) — apply skips target write, source clean-up still
+        runs."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc(_bundled_hook()),
+        )
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan.moves[0].already_at_target is True
+        assert plan.moves[0].conflict_at_target is False
+
 
 # ── Apply unit tests ───────────────────────────────────────────────
 
@@ -243,6 +308,40 @@ class TestApplyMigration:
         commands = [inner.get("command") for inner in post[0].get("hooks", [])]
         assert "user-script" in commands
         assert "mm session start" not in commands
+
+    def test_conflict_leaves_both_source_and_target_untouched(self, project_root, fake_home):
+        """Codex review (PR #876): when ``conflict_at_target=True`` for
+        every move, ``apply_migration`` must not write either tier.
+        Otherwise we either silently double-fire (target append) or
+        silently drift target away from canonical (source clean-up
+        without target update)."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        # Target has a user-authored hook under the same matcher.
+        target_doc = _settings_doc(
+            {"PostToolUse": [_rule("Edit|Write", inners=[_inner("user-script")])]}
+        )
+        _write_settings(project_root / ".claude" / "settings.local.json", target_doc)
+
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        result = apply_migration(plan)
+        assert result.target_written is False
+        assert result.source_written is False
+
+        # Source still has the canonical entry.
+        source_after = _read_settings(fake_home / ".claude" / "settings.json")
+        post = source_after["hooks"]["PostToolUse"]
+        assert any(
+            inner.get("command") == "mm session start"
+            for rule in post
+            for inner in rule.get("hooks", [])
+        )
+        # Target still carries only the user-authored entry.
+        target_after = _read_settings(project_root / ".claude" / "settings.local.json")
+        target_post = target_after["hooks"]["PostToolUse"]
+        assert len(target_post) == 1
+        target_cmds = [inner.get("command") for inner in target_post[0].get("hooks", [])]
+        assert target_cmds == ["user-script"]
 
     def test_other_top_level_keys_preserved(self, project_root, fake_home):
         """Source's non-hooks top-level keys (e.g. ``permissions``)
@@ -379,6 +478,25 @@ class TestSettingsMigrateCli:
         result = CliRunner().invoke(settings_migrate_cmd, ["--from=user", "--to=user"])
         assert result.exit_code == 1
         assert "must differ" in result.output
+
+    def test_apply_with_target_conflict_exits_one(self, project_root, fake_home, monkeypatch):
+        """Codex review (PR #876): all-conflict apply must exit 1
+        (previously the ``is_noop`` early-return swallowed it)."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc({"PostToolUse": [_rule("Edit|Write", inners=[_inner("user-script")])]}),
+        )
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply", "--yes"],
+        )
+        assert result.exit_code == 1, result.output
+        assert "conflict" in result.output.lower()
 
     def test_project_to_project_no_host_prompt(self, project_root, fake_home, monkeypatch):
         """project_shared → project_local stays in-tree, so no

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -1,0 +1,399 @@
+"""Tests for settings_migrate — move memtomem-managed hooks between tiers (#872).
+
+Covers two surfaces:
+
+* Pure planner / applier unit tests (``settings_migrate.plan_migration``
+  and ``apply_migration``).
+* CLI ``mm context settings-migrate`` subcommand — dry-run preview,
+  ``--apply`` mutation, idempotent re-run, partial-overlap, host-write
+  prompt, ``--json`` schema.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.context.settings import CANONICAL_SETTINGS_FILE
+from memtomem.context.settings_migrate import (
+    apply_migration,
+    plan_migration,
+)
+from .helpers import set_home
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _inner(command: str = "mm session start", *, type_: str = "command") -> dict:
+    """One inner hook entry."""
+    return {"type": type_, "command": command, "timeout": 5000}
+
+
+def _rule(matcher: str = "Edit|Write", *, inners: list[dict] | None = None) -> dict:
+    """One hook rule with one or more inner hooks."""
+    return {
+        "matcher": matcher,
+        "hooks": list(inners) if inners is not None else [_inner()],
+    }
+
+
+def _settings_doc(hooks: dict) -> dict:
+    return {"hooks": hooks}
+
+
+def _write_settings(path, doc: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_canonical(project_root, hooks: dict) -> None:
+    _write_settings(project_root / CANONICAL_SETTINGS_FILE, _settings_doc(hooks))
+
+
+def _bundled_hook() -> dict:
+    return {"PostToolUse": [_rule("Edit|Write", inners=[_inner("mm session start")])]}
+
+
+def _read_settings(path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    set_home(monkeypatch, home)
+    return home
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    (root / ".git").mkdir()
+    (root / ".claude").mkdir()
+    return root
+
+
+# ── Planner unit tests ─────────────────────────────────────────────
+
+
+class TestPlanMigration:
+    def test_same_scope_rejected(self, project_root, fake_home):
+        with pytest.raises(ValueError, match="must differ"):
+            plan_migration(project_root, source_scope="user", target_scope="user")
+
+    def test_no_canonical_means_empty_plan(self, project_root, fake_home):
+        # Source has the bundled hook but canonical is missing → planner
+        # has nothing to match against → empty plan.
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan.moves == ()
+        assert plan.is_noop is True
+
+    def test_no_source_means_empty_plan(self, project_root, fake_home):
+        _write_canonical(project_root, _bundled_hook())
+        # Source tier file does not exist.
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan.moves == ()
+
+    def test_simple_user_to_project_local(self, project_root, fake_home):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert len(plan.moves) == 1
+        move = plan.moves[0]
+        assert move.signature.event == "PostToolUse"
+        assert move.signature.matcher == "Edit|Write"
+        assert move.signature.command_shape == "mm session start"
+        assert move.already_at_target is False
+        assert move.conflict_at_target is False
+        # Rule to write at target uses the canonical inner shape.
+        assert move.rule_to_write_at_target["matcher"] == "Edit|Write"
+        assert move.rule_to_write_at_target["hooks"][0]["command"] == "mm session start"
+
+    def test_partial_overlap_already_at_target(self, project_root, fake_home):
+        """Target already has the same canonical-signature inner hook —
+        the plan still includes the move (so source gets cleaned) but
+        marks ``already_at_target`` so target write is a no-op."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc(_bundled_hook()),
+        )
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert len(plan.moves) == 1
+        assert plan.moves[0].already_at_target is True
+
+    def test_non_canonical_source_entries_ignored(self, project_root, fake_home):
+        """A user-authored hook that is NOT in canonical does not move."""
+        _write_canonical(project_root, _bundled_hook())
+        # User has the bundled hook plus a hand-authored Bash hook.
+        user_doc = _settings_doc(
+            {
+                "PostToolUse": [
+                    _rule("Edit|Write", inners=[_inner("mm session start")]),
+                    _rule("Bash", inners=[_inner("echo something")]),
+                ]
+            }
+        )
+        _write_settings(fake_home / ".claude" / "settings.json", user_doc)
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        # Only the bundled hook signature is moved; Bash one stays.
+        assert len(plan.moves) == 1
+        assert plan.moves[0].signature.matcher == "Edit|Write"
+
+    def test_whitespace_variant_in_source_still_moves(self, project_root, fake_home):
+        """Source has a whitespace-variant of the canonical command —
+        signature normalization still picks it up."""
+        _write_canonical(project_root, _bundled_hook())
+        variant = {"PostToolUse": [_rule("Edit|Write", inners=[_inner("mm   session   start  ")])]}
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(variant))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert len(plan.moves) == 1
+        # The rule written to target uses the canonical (clean) command.
+        assert plan.moves[0].rule_to_write_at_target["hooks"][0]["command"] == "mm session start"
+
+
+# ── Apply unit tests ───────────────────────────────────────────────
+
+
+class TestApplyMigration:
+    def test_round_trip_user_to_project_local(self, project_root, fake_home):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        result = apply_migration(plan)
+        assert result.target_written is True
+        assert result.source_written is True
+
+        # User tier no longer carries the canonical-signature entry.
+        user_doc = _read_settings(fake_home / ".claude" / "settings.json")
+        # Either the event was pruned entirely or the rules list is empty.
+        assert user_doc.get("hooks", {}).get("PostToolUse", []) == [] or (
+            "PostToolUse" not in user_doc.get("hooks", {})
+        )
+
+        # Project_local now carries the canonical rule.
+        target_doc = _read_settings(project_root / ".claude" / "settings.local.json")
+        post = target_doc["hooks"]["PostToolUse"]
+        assert any(
+            rule.get("matcher") == "Edit|Write"
+            and any(inner.get("command") == "mm session start" for inner in rule.get("hooks", []))
+            for rule in post
+        )
+
+    def test_idempotent_rerun(self, project_root, fake_home):
+        """After a successful apply, a second plan/apply is a no-op."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan1 = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        apply_migration(plan1)
+
+        plan2 = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan2.is_noop is True
+        result2 = apply_migration(plan2)
+        assert result2.target_written is False
+        assert result2.source_written is False
+
+    def test_partial_overlap_idempotent(self, project_root, fake_home):
+        """Target already has the entry; apply only cleans source."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc(_bundled_hook()),
+        )
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        result = apply_migration(plan)
+        # Target already had the entry → no rewrite needed.
+        assert result.target_written is False
+        # Source was cleaned.
+        assert result.source_written is True
+
+    def test_source_with_mixed_inner_hooks_preserves_user_entry(self, project_root, fake_home):
+        """User has the bundled hook AND a user-authored inner hook
+        sharing the same matcher. Migration moves only the bundled one;
+        the user-authored entry stays in source verbatim."""
+        _write_canonical(project_root, _bundled_hook())
+        # Source has Edit|Write rule with TWO inners — bundled + user.
+        mixed = {
+            "PostToolUse": [
+                _rule(
+                    "Edit|Write",
+                    inners=[_inner("mm session start"), _inner("user-script")],
+                )
+            ]
+        }
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(mixed))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        apply_migration(plan)
+
+        user_doc = _read_settings(fake_home / ".claude" / "settings.json")
+        post = user_doc["hooks"]["PostToolUse"]
+        # The user-script inner is still there; the bundled one was removed.
+        assert len(post) == 1
+        commands = [inner.get("command") for inner in post[0].get("hooks", [])]
+        assert "user-script" in commands
+        assert "mm session start" not in commands
+
+    def test_other_top_level_keys_preserved(self, project_root, fake_home):
+        """Source's non-hooks top-level keys (e.g. ``permissions``)
+        survive the migration verbatim."""
+        _write_canonical(project_root, _bundled_hook())
+        source_doc = {
+            "hooks": _bundled_hook(),
+            "permissions": {"allow": ["Bash(ls *)"]},
+            "model": "claude-3-5-sonnet",
+        }
+        _write_settings(fake_home / ".claude" / "settings.json", source_doc)
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        apply_migration(plan)
+
+        user_doc = _read_settings(fake_home / ".claude" / "settings.json")
+        assert user_doc["permissions"] == {"allow": ["Bash(ls *)"]}
+        assert user_doc["model"] == "claude-3-5-sonnet"
+
+
+# ── CLI subcommand tests ───────────────────────────────────────────
+
+
+class TestSettingsMigrateCli:
+    def test_dry_run_no_changes(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(settings_migrate_cmd, ["--from=user", "--to=project_local"])
+        assert result.exit_code == 0, result.output
+        assert "Will migrate" in result.output
+        assert "Run with --apply" in result.output
+        # Disk is untouched.
+        user_doc = _read_settings(fake_home / ".claude" / "settings.json")
+        assert "PostToolUse" in user_doc["hooks"]
+
+    def test_apply_round_trip_user_to_project_local(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        # --yes skips the host-write confirmation (user → project_local
+        # touches ~/.claude/, which is outside the project root).
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply", "--yes"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (project_root / ".claude" / "settings.local.json").is_file()
+        target_doc = _read_settings(project_root / ".claude" / "settings.local.json")
+        assert "PostToolUse" in target_doc["hooks"]
+
+    def test_apply_idempotent_rerun(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        runner = CliRunner()
+        first = runner.invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply", "--yes"],
+        )
+        assert first.exit_code == 0, first.output
+        second = runner.invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply", "--yes"],
+        )
+        assert second.exit_code == 0, second.output
+        # Re-run plan finds nothing to migrate.
+        assert "nothing to migrate" in second.output
+
+    def test_host_write_prompt_declined_aborts(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        # No --yes → prompt fires; declining ('n') aborts.
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply"],
+            input="n\n",
+        )
+        assert result.exit_code == 1
+        assert "Aborted" in result.output
+        # Source untouched.
+        user_doc = _read_settings(fake_home / ".claude" / "settings.json")
+        assert "PostToolUse" in user_doc["hooks"]
+
+    def test_json_dry_run_schema(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "ok"
+        assert payload["applied"] is False
+        assert payload["from"] == "user"
+        assert payload["to"] == "project_local"
+        assert len(payload["moves"]) == 1
+        move = payload["moves"][0]
+        assert move["event"] == "PostToolUse"
+        assert move["already_at_target"] is False
+
+    def test_json_apply_writes_disk(self, project_root, fake_home, monkeypatch):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply", "--yes", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["applied"] is True
+        assert payload["target_written"] is True
+        assert payload["source_written"] is True
+
+    def test_same_scope_errors(self, project_root, fake_home, monkeypatch):
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(settings_migrate_cmd, ["--from=user", "--to=user"])
+        assert result.exit_code == 1
+        assert "must differ" in result.output
+
+    def test_project_to_project_no_host_prompt(self, project_root, fake_home, monkeypatch):
+        """project_shared → project_local stays in-tree, so no
+        host-write prompt fires even without --yes."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(
+            project_root / ".claude" / "settings.json",
+            _settings_doc(_bundled_hook()),
+        )
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=project_shared", "--to=project_local", "--apply"],
+        )
+        assert result.exit_code == 0, result.output
+        assert (project_root / ".claude" / "settings.local.json").is_file()

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -18,10 +18,35 @@ from click.testing import CliRunner
 
 from memtomem.context.settings import CANONICAL_SETTINGS_FILE
 from memtomem.context.settings_migrate import (
+    MigrateMove,
+    MigratePlan,
     apply_migration,
+    format_plan_summary,
     plan_migration,
 )
+from memtomem.context.settings_doctor import HookSignature
 from .helpers import set_home
+
+
+def _make_move(
+    *,
+    matcher: str = "Edit|Write",
+    command: str = "mm session start",
+    already: bool = False,
+    conflict: bool = False,
+) -> MigrateMove:
+    """Build a synthetic MigrateMove for direct unit tests."""
+    sig = HookSignature(event="PostToolUse", matcher=matcher, command_shape=command)
+    return MigrateMove(
+        signature=sig,
+        rule_to_write_at_target={
+            "matcher": matcher,
+            "hooks": [{"type": "command", "command": command, "timeout": 5000}],
+        },
+        already_at_target=already,
+        conflict_at_target=conflict,
+        conflict_reason="synthetic" if conflict else "",
+    )
 
 
 # ── Helpers ────────────────────────────────────────────────────────
@@ -498,6 +523,28 @@ class TestSettingsMigrateCli:
         assert result.exit_code == 1, result.output
         assert "conflict" in result.output.lower()
 
+    def test_json_needs_confirmation_payload(self, project_root, fake_home, monkeypatch):
+        """JSON ``--apply`` without ``--yes`` must refuse host writes
+        explicitly: the prompt would never reach a JSON caller."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        monkeypatch.chdir(project_root)
+        from memtomem.cli.context_cmd import settings_migrate_cmd
+
+        result = CliRunner().invoke(
+            settings_migrate_cmd,
+            ["--from=user", "--to=project_local", "--apply", "--json"],
+        )
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "needs_confirmation"
+        assert payload["applied"] is False
+        # Source is user-tier → outside project root → must appear in host_writes.
+        assert any(".claude/settings.json" in p and "/home" in p for p in payload["host_writes"])
+        assert "--yes" in payload["hint"]
+        # Disk untouched.
+        assert not (project_root / ".claude" / "settings.local.json").is_file()
+
     def test_project_to_project_no_host_prompt(self, project_root, fake_home, monkeypatch):
         """project_shared → project_local stays in-tree, so no
         host-write prompt fires even without --yes."""
@@ -515,3 +562,68 @@ class TestSettingsMigrateCli:
         )
         assert result.exit_code == 0, result.output
         assert (project_root / ".claude" / "settings.local.json").is_file()
+
+
+# ── Reporting invariants ───────────────────────────────────────────
+
+
+class TestFormatPlanSummary:
+    """Pin the count-conservation invariant on ``format_plan_summary``.
+
+    Per ``feedback_count_conservation_invariant_pin.md``: any per-
+    category count surface must hold ``sum(parts) == total`` so a
+    future status enum addition (e.g. a new ``conflict_kind``) is
+    caught by tests rather than silently dropped from the summary.
+    """
+
+    def _plan(self, *moves: MigrateMove) -> MigratePlan:
+        from pathlib import Path
+
+        return MigratePlan(
+            source_scope="user",
+            target_scope="project_local",
+            source_path=Path("/tmp/from"),
+            target_path=Path("/tmp/to"),
+            moves=tuple(moves),
+        )
+
+    def test_empty_plan(self):
+        summary = format_plan_summary(self._plan())
+        assert "0 entries" in summary
+
+    def test_fresh_only(self):
+        plan = self._plan(_make_move(command="mm session start"))
+        summary = format_plan_summary(plan)
+        assert "1 to add at target" in summary
+
+    def test_already_only(self):
+        plan = self._plan(_make_move(command="mm index", already=True))
+        summary = format_plan_summary(plan)
+        assert "1 already at target" in summary
+
+    def test_conflict_only(self):
+        plan = self._plan(_make_move(command="mm session end", conflict=True))
+        summary = format_plan_summary(plan)
+        assert "1 skipped (conflict)" in summary
+
+    def test_conservation_across_three_categories(self):
+        """fresh + already + conflict counts must sum to len(moves).
+
+        If a future enum value is added without summary plumbing, the
+        sum check fails and surfaces the gap.
+        """
+        plan = self._plan(
+            _make_move(command="cmd-fresh-1"),
+            _make_move(command="cmd-fresh-2"),
+            _make_move(command="cmd-already-1", already=True),
+            _make_move(command="cmd-conflict-1", conflict=True),
+        )
+        summary = format_plan_summary(plan)
+        assert "2 to add at target" in summary
+        assert "1 already at target" in summary
+        assert "1 skipped (conflict)" in summary
+        # Conservation: counts mentioned in the summary must equal len(moves).
+        import re
+
+        nums = [int(n) for n in re.findall(r"\b(\d+)\b", summary)]
+        assert sum(nums) == len(plan.moves)


### PR DESCRIPTION
## Summary

Third and final follow-up from ADR-0010. With #870 (target_scope field) and
#874 (canonical-signature detection) shipped, this adds the action surface
that moves memtomem-managed hook entries between settings tiers — closing
the §5 default-flip path.

CLI:

```bash
mm context settings-migrate --from=user --to=project_local           # dry-run
mm context settings-migrate --from=user --to=project_local --apply   # mutate
mm context settings-migrate --from=user --to=project_local --json    # CI
```

- Operates at **inner-hook granularity** — a user's hand-authored entry
  sharing a matcher with a memtomem-managed entry stays put; only
  canonical-signature-matched inners move.
- Target receives the **canonical rule** from `.memtomem/settings.json`,
  not the source-tier whitespace variant, so target ends up byte-clean.
- Write order is **target first, then source**. A crash between the two
  leaves a transient cross-tier duplicate that the next migrate heals
  idempotently — target write is a no-op (already_at_target), source
  clean-up is the only step left.
- Default is a dry-run; `--apply` to mutate; `--yes` skips the
  host-write confirmation when the target / source resolves outside the
  project root (e.g. `--from=user`); `--json` for scripting.

CLI shape mirrors the existing `mm context migrate` (default dry-run +
`--apply`) rather than the issue's literal "--dry-run" wording, on the
grounds that this command is destructive (rewrites two settings files)
and the conservative default matches the established repo idiom.

This unblocks ADR-0010 §5's third default-flip criterion. The flip
itself remains a separate ADR-light commit per §5.

## ADR-0010 §4 acceptance

- ✅ Round-trip: `user → project_local` migration moves entries
  cleanly, `~/.claude/settings.json` no longer carries them, the
  project's `settings.local.json` does (`test_round_trip_user_to_project_local`).
- ✅ `--dry-run` (the default) prints the plan without disk writes
  (`test_dry_run_no_changes`).
- ✅ Idempotent re-run: second invocation finds nothing to move
  (`test_apply_idempotent_rerun`, `test_idempotent_rerun`).
- ✅ Partial overlap (some entries already at target): target write is
  skipped, source clean-up still runs
  (`test_partial_overlap_already_at_target`, `test_partial_overlap_idempotent`).
- ✅ Lint + tests + typecheck green locally.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — passes
- [x] `uv run ruff format --check packages/memtomem/src` — passes
- [x] `uv run mypy` on touched files — passes
- [x] `uv run pytest -m "not ollama"` — 4409 passed, 10 skipped
- [ ] CI green
- [ ] Manual smoke: dry-run + `--apply --yes` user → project_local with
  bundled hook in a fresh checkout

## Closes

Closes #872. Builds on #870, #874, ADR-0010 §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
