### PR TITLE
feat(scope): ADR-0011 PR-E draft — agents/skills/commands canonical scope (E1 + E2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `docs/guides/getting-started.md`, and
   `docs/guides/configuration.md` (Moving `config.json` between machines).
 - **`mm context init --scope=...` + Gate A/B for canonical artifact
-  seeding (ADR-0011 PR-E2).** ``mm context init`` gains three new flags:
+  seeding (ADR-0011 PR-E2).** ``mm context init`` (no flag) preserves
+  pre-PR-E2 behaviour end-to-end: same context.md path, no Gate B
+  prompt, no project-signal hard-error from outside a real project.
+  All new behaviour is gated on EXPLICIT ``--scope`` use. ``mm context
+  init`` gains three new flags:
   ``--scope user|project_shared|project_local`` (the canonical artifact
   tier to seed), ``--confirm-project-shared`` (Gate B — required when
   ``--scope`` is explicitly ``project_shared``), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   prompt, no project-signal hard-error from outside a real project —
   with idempotent canonical sub-dir seeding (``agents/``, ``skills/``,
   ``commands/``) added under ``<proj>/.memtomem/`` (or ``<cwd>/`` when
-  no project root is found). All new gating behaviour is restricted
-  to EXPLICIT ``--scope`` invocations. ``mm context init`` gains
+  no project root is found, in which case a yellow hint suggests
+  ``--scope=user`` for the cross-project case). All new gating
+  behaviour is restricted to EXPLICIT ``--scope`` invocations. ``mm context init`` gains
   three new flags:
   ``--scope user|project_shared|project_local`` (the canonical artifact
   tier to seed), ``--confirm-project-shared`` (Gate B — required when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,11 +70,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   `docs/guides/getting-started.md`, and
   `docs/guides/configuration.md` (Moving `config.json` between machines).
 - **`mm context init --scope=...` + Gate A/B for canonical artifact
-  seeding (ADR-0011 PR-E2).** ``mm context init`` (no flag) preserves
-  pre-PR-E2 behaviour end-to-end: same context.md path, no Gate B
-  prompt, no project-signal hard-error from outside a real project.
-  All new behaviour is gated on EXPLICIT ``--scope`` use. ``mm context
-  init`` gains three new flags:
+  seeding (ADR-0011 PR-E2).** ``mm context init`` (no flag) keeps the
+  pre-PR-E2 failure-mode shape — same context.md path, no Gate B
+  prompt, no project-signal hard-error from outside a real project —
+  with idempotent canonical sub-dir seeding (``agents/``, ``skills/``,
+  ``commands/``) added under ``<proj>/.memtomem/`` (or ``<cwd>/`` when
+  no project root is found). All new gating behaviour is restricted
+  to EXPLICIT ``--scope`` invocations. ``mm context init`` gains
+  three new flags:
   ``--scope user|project_shared|project_local`` (the canonical artifact
   tier to seed), ``--confirm-project-shared`` (Gate B — required when
   ``--scope`` is explicitly ``project_shared``), and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,33 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   serialization (#836). Inbound links from `README.md`,
   `docs/guides/getting-started.md`, and
   `docs/guides/configuration.md` (Moving `config.json` between machines).
+- **`mm context init --scope=...` + Gate A/B for canonical artifact
+  seeding (ADR-0011 PR-E2).** ``mm context init`` gains three new flags:
+  ``--scope user|project_shared|project_local`` (the canonical artifact
+  tier to seed), ``--confirm-project-shared`` (Gate B — required when
+  ``--scope`` is explicitly ``project_shared``), and
+  ``--force-unsafe-import`` (Gate A bypass valve for the runtime-import
+  path; user / project_local destinations only). Without ``--scope`` the
+  command preserves pre-PR-E2 behaviour: writes context.md and seeds the
+  implicit ``project_shared`` canonical tree under
+  ``<proj>/.memtomem/{agents,skills,commands}/``. With ``--scope user``
+  the command instead reads ``~/.claude/agents`` etc. and seeds
+  ``~/.memtomem/{agents,skills,commands}/``. With
+  ``--scope project_local`` the command seeds the gitignored draft tier
+  ``<proj>/.memtomem/{agents,skills,commands}.local/`` and idempotently
+  appends a comment-marked block to ``<proj>/.gitignore`` (covering
+  ``.memtomem/*.local/`` and ``.memtomem/.staging/``). Gate A re-scans
+  every imported file's bytes via ``enforce_write_guard``: ``user`` /
+  ``project_local`` destinations skip-and-warn on hits (or honour
+  ``--force-unsafe-import`` with audit-log + raw bytes through);
+  ``project_shared`` destinations hard-abort with a
+  :class:`click.ClickException` on any hit, with or without
+  ``--force-unsafe-import`` (ADR §5: git history is forever). Skill
+  imports walk the entire source skill tree (``scripts/``,
+  ``references/``, ``assets/``) — one blocked file aborts the whole
+  skill atomically. Gemini command imports scan the converted Markdown
+  body (where the source ``prompt`` field lands) rather than the raw
+  TOML.
 
 ### Changed
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1067,7 +1067,11 @@ mm reset --yes                         # skip confirmation prompt
 
 # Agent context sync
 mm context detect                      # find agent config files
-mm context init                        # create unified context.md
+mm context init                        # create unified context.md (project_shared default)
+mm context init --scope user           # seed user-tier canonical (~/.memtomem/{agents,skills,commands}/)
+mm context init --scope project_local  # seed gitignored draft tier + auto-append .gitignore
+mm context init --scope project_shared --confirm-project-shared       # Gate B: explicit opt-in
+mm context init --include=agents --scope user --force-unsafe-import   # bypass Gate A on existing leaks
 mm context generate --agent all        # generate all agent files
 mm context diff                        # check sync status
 mm context sync                        # sync context.md → agent files
@@ -1076,6 +1080,22 @@ mm context diff --include=settings     # check hook sync status
 # Note: cursor / codex / copilot fold ## Rules + ## Style into a single block;
 # `generate` warns on stderr when both sections are populated. context.md is
 # the source of truth — edit there, not in generated files.
+#
+# `--scope` semantics (ADR-0011 PR-E2):
+#   user            → seeds ~/.memtomem/{agents,skills,commands}/; imports from
+#                     ~/.claude/agents, ~/.gemini/agents, ~/.claude/skills, etc.
+#   project_shared  → seeds <proj>/.memtomem/{agents,skills,commands}/; imports
+#                     from <proj>/.claude/agents etc.; git-tracked. Requires
+#                     --confirm-project-shared when --scope is explicit.
+#   project_local   → seeds <proj>/.memtomem/{agents,skills,commands}.local/;
+#                     auto-appends .memtomem/*.local/ + .memtomem/.staging/ to
+#                     <proj>/.gitignore (idempotent). No runtime fan-out
+#                     by design (ADR §3) — nothing to import.
+#
+# Gate A on `--include=...` import path: every source file is re-scanned
+# for secrets via enforce_write_guard. user / project_local destinations
+# can bypass with --force-unsafe-import (audit-logged); project_shared
+# destinations hard-refuse on any hit (no force bypass available).
 
 # Sessions & activity
 mm session start                                              # start a tracked session

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -700,17 +700,22 @@ def init_cmd(
         if not click.confirm(prompt, default=False):
             raise click.Abort()
 
-    # context.md is project-tied (not scope-tiered). Two cases skip the
-    # write WITHOUT killing the rest of init:
-    #   - No project signal anywhere up the cwd chain (rare; ``mm context
-    #     init --scope user`` from a fresh /tmp dir).
-    #   - Existing context.md and the user declines the overwrite prompt
-    #     (common; user wants `--scope user --include=agents` to seed
-    #     ~/.memtomem/agents without touching the project's context.md).
-    # Pre-PR-E2 returned out of the function on decline, which silently
-    # killed the entire scoped seeding + import path. PR-E2 ties the
-    # decline to context.md only — scope dirs and `--include` continue.
-    write_context_md = has_project_signal
+    # context.md is a **project_shared** artifact in nature: it lives at
+    # ``<proj>/.memtomem/context.md``, gets git-tracked when the project
+    # has a ``.git`` (just like the project_shared canonical tree), and
+    # is the source of truth for ``mm context generate``'s fan-out.
+    # Artifact-only scopes (``--scope user``, ``--scope project_local``)
+    # MUST NOT mutate or even prompt on it — that would (a) violate the
+    # local/user scope contract, (b) bypass Gate B for an effective
+    # project_shared write, and (c) re-introduce the "existing context.md
+    # blocks scoped seeding" surprise the C1 review fix ostensibly closed
+    # (PR #889 review P2 round 2). The write fires only when:
+    #   - implicit invocation (no --scope) AND a project context exists
+    #     (pre-PR-E2 back-compat — ``mm context init`` writes context.md), OR
+    #   - explicit ``--scope project_shared`` AND a project context
+    #     exists (Gate B already opted in upstream of this branch).
+    artifact_only_scope = scope_explicit and scope in ("user", "project_local")
+    write_context_md = has_project_signal and not artifact_only_scope
     if write_context_md:
         ctx_path = _context_path(root)
         if ctx_path.exists() and not click.confirm(

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -681,8 +681,12 @@ def init_cmd(
     scope = _resolve_artifact_cli_scope(scope_flag)
     has_project_signal = (root / ".git").exists() or (root / "pyproject.toml").exists()
 
-    # --scope project_* requires a real project context.
-    if scope != "user" and not has_project_signal:
+    # EXPLICIT --scope project_* requires a real project context. Implicit
+    # default (no --scope) preserves pre-PR-E2 behaviour where the command
+    # could run from any cwd (``_find_project_root`` falls back to cwd) —
+    # raising would be a back-compat regression for users who run
+    # ``mm context init`` from a fresh directory.
+    if scope_explicit and scope != "user" and not has_project_signal:
         raise click.ClickException(
             f"--scope={scope} requires a project root (with .git or pyproject.toml). "
             "Use --scope=user from outside a project, or run from inside one."
@@ -696,15 +700,29 @@ def init_cmd(
         if not click.confirm(prompt, default=False):
             raise click.Abort()
 
-    # context.md is project-tied (not scope-tiered). Skip silently when no
-    # project context resolves — `--scope user` from outside any project
-    # is a legitimate user-tier-only invocation.
-    if has_project_signal:
+    # context.md is project-tied (not scope-tiered). Two cases skip the
+    # write WITHOUT killing the rest of init:
+    #   - No project signal anywhere up the cwd chain (rare; ``mm context
+    #     init --scope user`` from a fresh /tmp dir).
+    #   - Existing context.md and the user declines the overwrite prompt
+    #     (common; user wants `--scope user --include=agents` to seed
+    #     ~/.memtomem/agents without touching the project's context.md).
+    # Pre-PR-E2 returned out of the function on decline, which silently
+    # killed the entire scoped seeding + import path. PR-E2 ties the
+    # decline to context.md only — scope dirs and `--include` continue.
+    write_context_md = has_project_signal
+    if write_context_md:
         ctx_path = _context_path(root)
-        if ctx_path.exists():
-            if not click.confirm(f"{CONTEXT_FILENAME} already exists. Overwrite?", default=False):
-                return
+        if ctx_path.exists() and not click.confirm(
+            f"{CONTEXT_FILENAME} already exists. Overwrite?", default=False
+        ):
+            click.secho(
+                f"  (skipped {CONTEXT_FILENAME} rewrite — continuing with scoped artifact seeding)",
+                fg="yellow",
+            )
+            write_context_md = False
 
+    if write_context_md:
         files = detect_agent_files(root)
         if not files:
             click.secho("No agent files found. Creating empty context template.", fg="yellow")

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -10,6 +10,7 @@ import click
 from memtomem.context.agents import (
     ON_DROP_LEVELS,
     StrictDropError,
+    canonical_agent_name,
     diff_agents,
     extract_agents_to_canonical,
     generate_all_agents,
@@ -74,11 +75,13 @@ from memtomem.context.settings_migrate import (
     format_plan_summary,
     plan_migration,
 )
+from memtomem.context.scope_resolver import canonical_artifact_dir
 from memtomem.context.skills import (
     diff_skills,
     extract_skills_to_canonical,
     generate_all_skills,
 )
+from memtomem.context import _skip_reasons as skip_codes
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
 from typing import get_args
 
@@ -150,16 +153,41 @@ def _print_skills_detect(root: Path) -> None:
         click.echo(f"    {s.agent:15s}  {rel}  ({s.size} bytes)")
 
 
-def _print_skills_init(root: Path, overwrite: bool) -> None:
-    result = extract_skills_to_canonical(root, overwrite=overwrite)
+def _print_skills_init(
+    root: Path,
+    overwrite: bool,
+    *,
+    scope: TargetScope = "project_shared",
+    force_unsafe_import: bool = False,
+) -> None:
+    result = extract_skills_to_canonical(
+        root,
+        overwrite=overwrite,
+        scope=scope,
+        force_unsafe_import=force_unsafe_import,
+    )
+    dest_label = (
+        canonical_artifact_dir("skills", scope, root)
+        if scope != "project_local"
+        else "(skipped — project_local has no runtime fan-out)"
+    )
     if result.imported:
-        click.secho(f"  Imported {len(result.imported)} skill(s) → .memtomem/skills/", fg="green")
+        click.secho(f"  Imported {len(result.imported)} skill(s) → {dest_label}", fg="green")
         for p in result.imported:
             click.echo(f"    {p.name}")
     else:
-        click.echo("  (no runtime skills to import)")
-    for name, reason, _code in result.skipped:
-        click.secho(f"    skipped {name}: {reason}", fg="yellow")
+        click.echo(f"  (no runtime skills imported into {scope})")
+    for name, reason, code in result.skipped:
+        color = (
+            "red"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "yellow"
+        )
+        click.secho(f"    skipped {name}: {reason}", fg=color)
 
 
 def _print_skills_generate(root: Path) -> None:
@@ -197,18 +225,41 @@ def _print_agents_detect(root: Path) -> None:
         click.echo(f"    {a.agent:15s}  {rel}  ({a.size} bytes)")
 
 
-def _print_agents_init(root: Path, overwrite: bool) -> None:
-    result = extract_agents_to_canonical(root, overwrite=overwrite)
+def _print_agents_init(
+    root: Path,
+    overwrite: bool,
+    *,
+    scope: TargetScope = "project_shared",
+    force_unsafe_import: bool = False,
+) -> None:
+    result = extract_agents_to_canonical(
+        root,
+        overwrite=overwrite,
+        scope=scope,
+        force_unsafe_import=force_unsafe_import,
+    )
+    dest_label = (
+        canonical_artifact_dir("agents", scope, root)
+        if scope != "project_local"
+        else "(skipped — project_local has no runtime fan-out)"
+    )
     if result.imported:
-        click.secho(
-            f"  Imported {len(result.imported)} sub-agent(s) → .memtomem/agents/", fg="green"
-        )
-        for p in result.imported:
-            click.echo(f"    {p.stem}")
+        click.secho(f"  Imported {len(result.imported)} sub-agent(s) → {dest_label}", fg="green")
+        for path, layout in result.imported:
+            click.echo(f"    {canonical_agent_name(path, layout)}")
     else:
-        click.echo("  (no runtime sub-agents to import)")
-    for name, reason, _code in result.skipped:
-        click.secho(f"    skipped {name}: {reason}", fg="yellow")
+        click.echo(f"  (no runtime sub-agents imported into {scope})")
+    for name, reason, code in result.skipped:
+        color = (
+            "red"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "yellow"
+        )
+        click.secho(f"    skipped {name}: {reason}", fg=color)
 
 
 def _print_agents_generate(root: Path, strict: bool, on_drop: str = "ignore") -> None:
@@ -259,18 +310,42 @@ def _print_commands_detect(root: Path) -> None:
         click.echo(f"    {c.agent:17s}  {rel}  ({c.size} bytes)")
 
 
-def _print_commands_init(root: Path, overwrite: bool) -> None:
-    result = extract_commands_to_canonical(root, overwrite=overwrite)
+def _print_commands_init(
+    root: Path,
+    overwrite: bool,
+    *,
+    scope: TargetScope = "project_shared",
+    force_unsafe_import: bool = False,
+) -> None:
+    result = extract_commands_to_canonical(
+        root,
+        overwrite=overwrite,
+        scope=scope,
+        force_unsafe_import=force_unsafe_import,
+    )
+    dest_label = (
+        canonical_artifact_dir("commands", scope, root)
+        if scope != "project_local"
+        else "(skipped — project_local has no runtime fan-out)"
+    )
     if result.imported:
-        click.secho(
-            f"  Imported {len(result.imported)} command(s) → .memtomem/commands/", fg="green"
-        )
-        for p in result.imported:
-            click.echo(f"    {p.stem}")
+        click.secho(f"  Imported {len(result.imported)} command(s) → {dest_label}", fg="green")
+        for path, layout in result.imported:
+            display = path.parent.name if layout == "dir" else path.stem
+            click.echo(f"    {display}")
     else:
-        click.echo("  (no runtime commands to import)")
-    for name, reason, _code in result.skipped:
-        click.secho(f"    skipped {name}: {reason}", fg="yellow")
+        click.echo(f"  (no runtime commands imported into {scope})")
+    for name, reason, code in result.skipped:
+        color = (
+            "red"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "yellow"
+        )
+        click.secho(f"    skipped {name}: {reason}", fg=color)
 
 
 def _print_commands_generate(root: Path, strict: bool, on_drop: str = "ignore") -> None:
@@ -326,6 +401,67 @@ def _resolve_cli_scope(override: str | None) -> str:
     load_config_d(cfg, quiet=True)
     load_config_overrides(cfg, migrate=False)
     return cfg.hooks.target_scope
+
+
+def _resolve_artifact_cli_scope(scope_flag: str | None) -> TargetScope:
+    """Resolve ``--scope`` for non-memory artifact CLI commands (ADR-0011 PR-E2).
+
+    Unlike :func:`_resolve_cli_scope` this does NOT consult
+    ``cfg.hooks.target_scope``: artifact storage location is a different
+    feature axis from settings host placement. Leaning on the hooks
+    default would silently flip the artifact target whenever a user
+    pinned ``hooks.target_scope = "user"`` for unrelated reasons (e.g.
+    Cursor-style settings layout), which Codex flagged as a
+    ``_resolve_cli_scope`` default-leak risk in PR-E1 review. The
+    artifact-side default is fixed at ``"project_shared"`` to match the
+    pre-PR-E2 import behavior — implicit invocation stays back-compat.
+    """
+    if scope_flag is not None:
+        return scope_flag  # type: ignore[return-value]
+    return "project_shared"
+
+
+# ── ADR-0011 PR-E2 — `.gitignore` auto-append for project_local tier ──
+
+_GITIGNORE_MARKER = "# memtomem local artifacts (ADR-0011 project_local tier)"
+_GITIGNORE_PATTERNS: tuple[str, ...] = (".memtomem/*.local/", ".memtomem/.staging/")
+
+
+def _append_gitignore_marker(project_root: Path) -> tuple[bool, str]:
+    """Idempotent grep-then-append of the project_local block on ``.gitignore``.
+
+    The grep is on the comment marker line, NOT the pattern lines — users
+    may legitimately have ``.memtomem/.staging/`` listed elsewhere for
+    unrelated reasons, and we do not want to consider those "already
+    present".
+
+    Returns ``(wrote, msg)``:
+      - ``(False, "no_git_repo_pyproject_only")`` — ``.git`` absent but
+        ``pyproject.toml`` is present. ``.gitignore`` is meaningful only
+        in a git working tree, so we skip the write and surface a
+        specific warning so the user knows to ``git init`` first.
+      - ``(False, "no_project_signal")`` — neither ``.git`` nor
+        ``pyproject.toml`` present.
+      - ``(False, "already_present")`` — marker comment already on disk.
+      - ``(True, "appended")`` — newly written.
+    """
+    has_git = (project_root / ".git").exists()
+    has_pyproject = (project_root / "pyproject.toml").exists()
+    if not has_git:
+        return (
+            False,
+            "no_git_repo_pyproject_only" if has_pyproject else "no_project_signal",
+        )
+    gi = project_root / ".gitignore"
+    existing = gi.read_text(encoding="utf-8") if gi.exists() else ""
+    if _GITIGNORE_MARKER in existing:
+        return False, "already_present"
+    block = "\n" if existing and not existing.endswith("\n") else ""
+    block += f"\n{_GITIGNORE_MARKER}\n"
+    block += "\n".join(_GITIGNORE_PATTERNS) + "\n"
+    with gi.open("a", encoding="utf-8") as fh:
+        fh.write(block)
+    return True, "appended"
 
 
 def _print_settings_detect(root: Path, scope: str) -> None:
@@ -500,63 +636,165 @@ def detect_cmd(include: tuple[str, ...]) -> None:
 @click.option(
     "--overwrite",
     is_flag=True,
-    help="Overwrite existing entries in .memtomem/skills/ when importing from runtimes.",
+    help="Overwrite existing canonical entries when importing from runtimes.",
 )
-def init_cmd(include: tuple[str, ...], overwrite: bool) -> None:
-    """Create .memtomem/context.md from existing agent files."""
+@_SCOPE_OPTION
+@click.option(
+    "--confirm-project-shared",
+    is_flag=True,
+    default=False,
+    help=(
+        "Confirm seeding the git-tracked project_shared canonical tier. "
+        "Required when --scope is explicitly set to project_shared."
+    ),
+)
+@click.option(
+    "--force-unsafe-import",
+    is_flag=True,
+    default=False,
+    help=(
+        "Bypass Gate A on existing runtime files being imported. "
+        "user / project_local destinations only — project_shared "
+        "hard-refuses (ADR-0011 §5)."
+    ),
+)
+def init_cmd(
+    include: tuple[str, ...],
+    overwrite: bool,
+    scope_flag: str | None,
+    confirm_project_shared: bool,
+    force_unsafe_import: bool,
+) -> None:
+    """Seed canonical artifact dirs and (optionally) import existing runtime files.
+
+    Without ``--scope`` the command preserves pre-PR-E2 behavior: writes
+    ``<proj>/.memtomem/context.md`` and (with ``--include``) imports under
+    ``<proj>/.memtomem/{agents,skills,commands}/`` (the implicit
+    ``project_shared`` tier). Pass ``--scope=user`` /
+    ``--scope=project_local`` to seed at the user or local-draft tier
+    instead. ADR-0011 §5 Gate A scans every imported file's bytes for
+    secrets; project_shared hard-refuses on any hit.
+    """
     inc = _parse_include(include)
     root = _find_project_root()
-    ctx_path = _context_path(root)
+    scope_explicit = scope_flag is not None
+    scope = _resolve_artifact_cli_scope(scope_flag)
+    has_project_signal = (root / ".git").exists() or (root / "pyproject.toml").exists()
 
-    if ctx_path.exists():
-        if not click.confirm(f"{CONTEXT_FILENAME} already exists. Overwrite?", default=False):
-            return
+    # --scope project_* requires a real project context.
+    if scope != "user" and not has_project_signal:
+        raise click.ClickException(
+            f"--scope={scope} requires a project root (with .git or pyproject.toml). "
+            "Use --scope=user from outside a project, or run from inside one."
+        )
 
-    # Detect existing files
-    files = detect_agent_files(root)
-    if not files:
-        click.secho("No agent files found. Creating empty context template.", fg="yellow")
-        sections: dict[str, str] = {
-            "Project": "- Name: \n- Language: \n- Package manager: ",
-            "Commands": "- Build: \n- Test: \n- Lint: ",
-            "Architecture": "",
-            "Rules": "",
-            "Style": "",
-        }
-    else:
-        # Pick the richest file to extract from
-        best = max(files, key=lambda f: f.size)
-        click.echo(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
-        content = best.path.read_text(encoding="utf-8")
-        sections = extract_sections_from_agent_file(content)
+    # Gate B — only on EXPLICIT --scope project_shared. Implicit default
+    # (no --scope) keeps pre-PR-E2 behavior so non-interactive CI invocations
+    # of `mm context init` don't suddenly start prompting.
+    if scope_explicit and scope == "project_shared" and not confirm_project_shared:
+        prompt = f"\n--scope=project_shared writes to git-tracked {root}/.memtomem/. Continue?"
+        if not click.confirm(prompt, default=False):
+            raise click.Abort()
 
-        # Merge other files for missing sections
-        for f in files:
-            if f.path == best.path:
-                continue
-            other_content = f.path.read_text(encoding="utf-8")
-            other_sections = extract_sections_from_agent_file(other_content)
-            for key, val in other_sections.items():
-                if key not in sections and val.strip():
-                    sections[key] = val
+    # context.md is project-tied (not scope-tiered). Skip silently when no
+    # project context resolves — `--scope user` from outside any project
+    # is a legitimate user-tier-only invocation.
+    if has_project_signal:
+        ctx_path = _context_path(root)
+        if ctx_path.exists():
+            if not click.confirm(f"{CONTEXT_FILENAME} already exists. Overwrite?", default=False):
+                return
 
-    ctx_path.parent.mkdir(parents=True, exist_ok=True)
-    ctx_path.write_text(sections_to_markdown(sections), encoding="utf-8")
-    click.secho(f"Created {CONTEXT_FILENAME}", fg="green")
-    click.echo(f"  Sections: {', '.join(sections.keys())}")
-    click.echo("  Edit this file, then run 'mm context generate' to sync.")
+        files = detect_agent_files(root)
+        if not files:
+            click.secho("No agent files found. Creating empty context template.", fg="yellow")
+            sections: dict[str, str] = {
+                "Project": "- Name: \n- Language: \n- Package manager: ",
+                "Commands": "- Build: \n- Test: \n- Lint: ",
+                "Architecture": "",
+                "Rules": "",
+                "Style": "",
+            }
+        else:
+            best = max(files, key=lambda f: f.size)
+            click.echo(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
+            content = best.path.read_text(encoding="utf-8")
+            sections = extract_sections_from_agent_file(content)
+            for f in files:
+                if f.path == best.path:
+                    continue
+                other_content = f.path.read_text(encoding="utf-8")
+                other_sections = extract_sections_from_agent_file(other_content)
+                for key, val in other_sections.items():
+                    if key not in sections and val.strip():
+                        sections[key] = val
 
+        ctx_path.parent.mkdir(parents=True, exist_ok=True)
+        ctx_path.write_text(sections_to_markdown(sections), encoding="utf-8")
+        click.secho(f"Created {CONTEXT_FILENAME}", fg="green")
+        click.echo(f"  Sections: {', '.join(sections.keys())}")
+        click.echo("  Edit this file, then run 'mm context generate' to sync.")
+
+    # Seed canonical sub-artifact dirs at the resolved scope (idempotent).
+    for kind in ("agents", "skills", "commands"):
+        d = canonical_artifact_dir(kind, scope, root)
+        d.mkdir(parents=True, exist_ok=True)
+        click.secho(f"  Created {d}", fg="green")
+
+    # project_local — auto-append the .gitignore block so the local-draft
+    # tier and staging dir never end up tracked by accident.
+    if scope == "project_local":
+        wrote, msg = _append_gitignore_marker(root)
+        if wrote:
+            click.secho(
+                "  Appended .gitignore marker (.memtomem/*.local/, .memtomem/.staging/)",
+                fg="green",
+            )
+        elif msg == "already_present":
+            click.echo("  (.gitignore marker already present — idempotent)")
+        elif msg == "no_git_repo_pyproject_only":
+            click.secho(
+                "  warning: project root resolved via pyproject.toml but `.git` "
+                "missing — .gitignore not appended. Run `git init` first to "
+                "git-protect the local tier.",
+                fg="yellow",
+            )
+        elif msg == "no_project_signal":
+            click.secho(
+                "  warning: no .git and no pyproject.toml in project root — "
+                ".gitignore append skipped.",
+                fg="yellow",
+            )
+
+    # --include runtime-import path. Gate A is applied inside each
+    # extract_*_to_canonical helper (per-file for agents/commands;
+    # tree walk for skills).
     if "skills" in inc:
         click.echo("")
-        _print_skills_init(root, overwrite=overwrite)
+        _print_skills_init(
+            root,
+            overwrite=overwrite,
+            scope=scope,
+            force_unsafe_import=force_unsafe_import,
+        )
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_init(root, overwrite=overwrite)
+        _print_agents_init(
+            root,
+            overwrite=overwrite,
+            scope=scope,
+            force_unsafe_import=force_unsafe_import,
+        )
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_init(root, overwrite=overwrite)
+        _print_commands_init(
+            root,
+            overwrite=overwrite,
+            scope=scope,
+            force_unsafe_import=force_unsafe_import,
+        )
 
 
 @context.command("generate")

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -692,6 +692,21 @@ def init_cmd(
             "Use --scope=user from outside a project, or run from inside one."
         )
 
+    # Round-3 review D-new-1: when implicit ``mm context init`` runs in
+    # a directory with no ``.git``/``pyproject.toml`` we still proceed
+    # (back-compat with pre-PR-E2), but the user is silently dropping
+    # ``.memtomem/`` into a non-project location which is rarely what
+    # they want. Surface a yellow hint pointing to ``--scope=user`` for
+    # the cross-project case. Block is intentionally NOT raised — the
+    # back-compat path stays open.
+    if not scope_explicit and not has_project_signal:
+        click.secho(
+            f"  warning: no .git or pyproject.toml in {root} — "
+            "creating .memtomem/ here. Use --scope=user for cross-project "
+            "artifacts (writes to ~/.memtomem/ instead).",
+            fg="yellow",
+        )
+
     # Gate B — only on EXPLICIT --scope project_shared. Implicit default
     # (no --scope) keeps pre-PR-E2 behavior so non-interactive CI invocations
     # of `mm context init` don't suddenly start prompting.

--- a/packages/memtomem/src/memtomem/context/_gate_a.py
+++ b/packages/memtomem/src/memtomem/context/_gate_a.py
@@ -1,0 +1,53 @@
+"""ADR-0011 PR-E2 — Gate A error formatting helpers shared across extract paths.
+
+Centralises the user-facing error message format for ``project_shared`` Gate A
+hard-abort so ``extract_agents_to_canonical``, ``extract_skills_to_canonical``,
+and ``extract_commands_to_canonical`` cannot drift on the wording. The message
+deliberately echoes only the hit count and source path — never the matched
+bytes themselves (``feedback_force_unsafe_redaction_valve_only.md`` and the
+``RedactionHit`` docstring on the privacy module both pin the
+"never echo secrets" contract).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.config import TargetScope
+
+
+def format_project_shared_block_message(
+    src: Path,
+    *,
+    hits_count: int,
+    scope: TargetScope,
+    kind: str,
+    imported_so_far: int = 0,
+) -> str:
+    """User-facing ``ClickException`` message for project_shared Gate A hard-abort.
+
+    Args:
+        src: Source file (or skill directory's offending file) that hit Gate A.
+        hits_count: Number of pattern hits — count only, never echo bytes.
+        scope: The destination scope. Always ``"project_shared"`` in practice;
+            other scopes never invoke this helper.
+        kind: Singular noun for the artifact kind ("agent", "skill", "command").
+        imported_so_far: Files already imported in this run (clean ones that
+            passed Gate A before this hit). Surface for cleanup hint.
+
+    Returns:
+        A multi-line string suitable for ``raise click.ClickException(...)``.
+    """
+    tail = (
+        f"\n  {imported_so_far} clean {kind}(s) already imported in this run "
+        f"remain in canonical — review or remove manually."
+        if imported_so_far > 0
+        else ""
+    )
+    return (
+        f"Gate A: {src.name} contains {hits_count} privacy pattern hit(s); "
+        f"import to scope='{scope}' rejected. git history is forever — "
+        f"no force bypass available for project_shared (ADR-0011 §5).\n"
+        f"  Retry with --scope=user or --scope=project_local, or remove the "
+        f"secret from {src} first.{tail}"
+    )

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -1,0 +1,152 @@
+"""ADR-0011 PR-E runtime fan-out resolver — explicit per-(artifact, runtime, scope) table.
+
+Sibling of :mod:`memtomem.context.scope_resolver` (canonical-side). The
+canonical resolver answers "where does the source-of-truth file live?";
+this module answers "where does it get fanned out to for runtime X?".
+The two MUST stay separate — earlier plan revisions conflated them and
+got the test expectations wrong.
+
+Design rules:
+
+1. **Every (artifact, runtime, scope) tuple is explicit.** No string
+   interpolation, no ``.get(default=...)``. Lookup is via direct
+   dict access; missing tuples raise ``KeyError`` (fail-loud per
+   ``feedback_defensive_noise.md``).
+2. **`None` means "no fan-out by design"** — emit
+   ``skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME``. This applies to
+   every ``project_local`` entry (ADR §3 — gitignored draft tier
+   has no runtime equivalent) and to a few runtime-specific cases
+   (e.g. Codex CLI prompts are user-tier only by design).
+3. **Project-tier entries store the project-relative tail** as a
+   ``Path`` (e.g. ``Path(".claude/agents")``); ``runtime_fanout_root``
+   prepends ``project_root`` at call-time. User-tier entries store
+   the absolute home-relative path (e.g. ``Path("~/.claude/agents")``).
+   Callers receive a fully expanded absolute ``Path``.
+4. **Codex commands** are reserved as user-only (per ``commands.py:5``
+   docstring) even though no ``CodexCommandsGenerator`` is registered
+   yet. Tests assert ``project_*`` entries are ``None``; the user
+   entry returns ``~/.codex/prompts`` so a future
+   ``CodexCommandsGenerator`` can land without table churn.
+5. **Codex skills user-tier path is a TBD** — Codex's own docs are
+   ambiguous between ``~/.codex/skills`` and ``~/.agents/skills``.
+   We mirror the project-scope path (``.agents/skills``) into the
+   user tier as a placeholder; revise in PR-E follow-up if the
+   Codex CLI's user-scope skill discovery is confirmed elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.config import TargetScope
+from memtomem.context.scope_resolver import ArtifactKind
+
+
+# Sentinel for "no fan-out by design — caller should emit
+# NO_PROJECT_FANOUT_FOR_RUNTIME". Distinct from a missing key (which
+# is a programming error and raises KeyError).
+NO_FANOUT: None = None
+
+
+# Project-relative tails (joined with project_root at call-time).
+_CLAUDE_AGENTS_REL = Path(".claude/agents")
+_GEMINI_AGENTS_REL = Path(".gemini/agents")
+_CODEX_AGENTS_REL = Path(".codex/agents")
+
+_CLAUDE_SKILLS_REL = Path(".claude/skills")
+_GEMINI_SKILLS_REL = Path(".gemini/skills")
+_CODEX_SKILLS_REL = Path(".agents/skills")  # NOT .codex/skills — see skills.py:80
+
+_CLAUDE_COMMANDS_REL = Path(".claude/commands")
+_GEMINI_COMMANDS_REL = Path(".gemini/commands")
+
+
+# Full table — every (artifact, runtime, scope) tuple populated.
+# ``None`` = "no fan-out by design" (loud-emit-on-call). Lookup uses
+# direct dict access; missing keys raise KeyError (fail-loud).
+RUNTIME_FANOUT_TABLE: dict[tuple[ArtifactKind, str, TargetScope], Path | None] = {
+    # ── agents ───────────────────────────────────────────────────────
+    ("agents", "claude", "user"): Path("~/.claude/agents"),
+    ("agents", "claude", "project_shared"): _CLAUDE_AGENTS_REL,
+    ("agents", "claude", "project_local"): NO_FANOUT,  # ADR §3
+    ("agents", "gemini", "user"): Path("~/.gemini/agents"),
+    ("agents", "gemini", "project_shared"): _GEMINI_AGENTS_REL,
+    ("agents", "gemini", "project_local"): NO_FANOUT,
+    ("agents", "codex", "user"): Path("~/.codex/agents"),  # agents.py:12
+    ("agents", "codex", "project_shared"): _CODEX_AGENTS_REL,
+    ("agents", "codex", "project_local"): NO_FANOUT,
+    # ── skills ───────────────────────────────────────────────────────
+    ("skills", "claude", "user"): Path("~/.claude/skills"),
+    ("skills", "claude", "project_shared"): _CLAUDE_SKILLS_REL,
+    ("skills", "claude", "project_local"): NO_FANOUT,
+    ("skills", "gemini", "user"): Path("~/.gemini/skills"),
+    ("skills", "gemini", "project_shared"): _GEMINI_SKILLS_REL,
+    ("skills", "gemini", "project_local"): NO_FANOUT,
+    ("skills", "codex", "user"): Path("~/.agents/skills"),  # TBD per docstring rule 5
+    ("skills", "codex", "project_shared"): _CODEX_SKILLS_REL,
+    ("skills", "codex", "project_local"): NO_FANOUT,
+    # ── commands ─────────────────────────────────────────────────────
+    ("commands", "claude", "user"): Path("~/.claude/commands"),
+    ("commands", "claude", "project_shared"): _CLAUDE_COMMANDS_REL,
+    ("commands", "claude", "project_local"): NO_FANOUT,
+    ("commands", "gemini", "user"): Path("~/.gemini/commands"),
+    ("commands", "gemini", "project_shared"): _GEMINI_COMMANDS_REL,
+    ("commands", "gemini", "project_local"): NO_FANOUT,
+    # Codex commands: user-only by design (commands.py:5). project_*
+    # entries reserved (no CodexCommandsGenerator registered yet but
+    # keeping the table shape uniform across runtimes).
+    ("commands", "codex", "user"): Path("~/.codex/prompts"),
+    ("commands", "codex", "project_shared"): NO_FANOUT,
+    ("commands", "codex", "project_local"): NO_FANOUT,
+}
+
+
+# Closed set of runtime keys this module knows about. Callers can use
+# this to iterate when they need "every runtime for this artifact".
+KNOWN_RUNTIMES: tuple[str, ...] = ("claude", "gemini", "codex")
+
+
+def runtime_fanout_root(
+    artifact: ArtifactKind,
+    runtime: str,
+    scope: TargetScope,
+    project_root: Path | None,
+) -> Path | None:
+    """Resolve where to fan out an artifact for a given runtime + scope.
+
+    Args:
+        artifact: ``agents`` / ``skills`` / ``commands``.
+        runtime: One of :data:`KNOWN_RUNTIMES`.
+        scope: ``user`` / ``project_shared`` / ``project_local``.
+        project_root: Required for ``project_*`` scopes; ignored for ``user``.
+            Callers that have a project context should pass it; ``None`` for
+            project tiers raises ``ValueError`` (fail-loud — silently
+            returning ``None`` would conflate "no project" with "no
+            fan-out by design").
+
+    Returns:
+        Absolute, expanded ``Path`` to the fan-out root directory, or
+        ``None`` when the (artifact, runtime, scope) tuple has no
+        fan-out by design (caller emits
+        ``skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME``).
+
+    Raises:
+        KeyError: When the ``(artifact, runtime, scope)`` tuple is not
+            in :data:`RUNTIME_FANOUT_TABLE` — a programming error
+            (unknown runtime or unknown artifact). Fail-loud.
+        ValueError: When ``scope`` is ``project_shared`` /
+            ``project_local`` but ``project_root`` is ``None``.
+    """
+    # Direct dict access — KeyError fail-loud on unknown tuple.
+    entry = RUNTIME_FANOUT_TABLE[(artifact, runtime, scope)]
+    if entry is None:
+        return None
+    if scope == "user":
+        return entry.expanduser().resolve()
+    # project_shared / project_local — entry is a project-relative tail.
+    if project_root is None:
+        raise ValueError(
+            f"runtime_fanout_root({artifact!r}, {runtime!r}, {scope!r}) "
+            "requires project_root for a project-tier scope."
+        )
+    return (project_root / entry).resolve()

--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -29,6 +29,14 @@ INVALID_NAME: Final = "invalid_name"
 ALREADY_IMPORTED: Final = "already_imported"
 CANONICAL_EXISTS: Final = "canonical_exists"
 TOML_PARSE_ERROR: Final = "toml_parse_error"
+# ADR-0011 PR-E2: emitted when ``enforce_write_guard`` blocks an import to a
+# user/project_local destination. ``PRIVACY_BLOCKED_PROJECT_SHARED`` is the
+# distinct signal that a force-unsafe bypass was attempted into git-tracked
+# memory and hard-refused (ADR §5). project_shared destinations RAISE
+# ``ClickException`` rather than skipping, so these codes only appear in
+# ``ExtractResult.skipped`` for user / project_local destinations.
+PRIVACY_BLOCKED: Final = "privacy_blocked"
+PRIVACY_BLOCKED_PROJECT_SHARED: Final = "privacy_blocked_project_shared"
 
 # Closed set of skip codes — typing dataclass `skipped` triples and route
 # response builders against `SkipCode` catches typos at the construction site
@@ -42,4 +50,6 @@ SkipCode = Literal[
     "already_imported",
     "canonical_exists",
     "toml_parse_error",
+    "privacy_blocked",
+    "privacy_blocked_project_shared",
 ]

--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -17,6 +17,12 @@ from typing import Final, Literal
 NO_CANONICAL_ROOT: Final = "no_canonical_root"
 UNKNOWN_RUNTIME: Final = "unknown_runtime"
 PARSE_ERROR: Final = "parse_error"
+# ADR-0011 PR-E: emitted when ``_runtime_targets.RUNTIME_FANOUT_TABLE`` returns
+# ``None`` for the requested ``(artifact, runtime, scope)`` tuple — i.e. that
+# combination has no fan-out target by design (e.g. ``project_local`` per
+# ADR §3, or ``(commands, codex, project_*)`` since Codex CLI prompts live
+# user-only). Loud emit, not silent — feedback_defensive_noise.md.
+NO_PROJECT_FANOUT_FOR_RUNTIME: Final = "no_project_fanout_for_runtime"
 
 # Import (runtime → canonical) skip codes.
 INVALID_NAME: Final = "invalid_name"
@@ -31,6 +37,7 @@ SkipCode = Literal[
     "no_canonical_root",
     "unknown_runtime",
     "parse_error",
+    "no_project_fanout_for_runtime",
     "invalid_name",
     "already_imported",
     "canonical_exists",

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -41,7 +41,9 @@ from typing import Any, Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
+from memtomem.context._runtime_targets import runtime_fanout_root
 
 logger = logging.getLogger(__name__)
 
@@ -423,12 +425,26 @@ def _subagent_to_codex_toml(agent: SubAgent) -> tuple[str, list[str]]:
 
 
 class AgentGenerator(Protocol):
-    """Protocol for runtime-specific sub-agent generators."""
+    """Protocol for runtime-specific sub-agent generators.
+
+    ``target_file`` accepts an ADR-0011 ``scope`` keyword (default
+    ``project_shared`` preserves pre-PR-E behavior). Returns ``None``
+    when the (runtime, scope) tuple has no fan-out by design — see
+    :data:`memtomem.context._runtime_targets.RUNTIME_FANOUT_TABLE`.
+    Callers must handle ``None`` and emit
+    ``skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME``.
+    """
 
     name: str
 
-    def target_file(self, project_root: Path, agent_name: str) -> Path:
-        """Return the file that should hold the rendered agent."""
+    def target_file(
+        self,
+        project_root: Path,
+        agent_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        """Return the file that should hold the rendered agent (or ``None``)."""
         ...
 
     def render(self, agent: SubAgent) -> tuple[str, list[str]]:
@@ -449,8 +465,15 @@ class ClaudeAgentsGenerator:
     name: str = "claude_agents"
     output_root: str = ".claude/agents"
 
-    def target_file(self, project_root: Path, agent_name: str) -> Path:
-        return project_root / self.output_root / f"{agent_name}.md"
+    def target_file(
+        self,
+        project_root: Path,
+        agent_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("agents", "claude", scope, project_root)
+        return None if root is None else root / f"{agent_name}.md"
 
     def render(self, agent: SubAgent) -> tuple[str, list[str]]:
         return _subagent_to_claude_md(agent)
@@ -461,8 +484,15 @@ class GeminiAgentsGenerator:
     name: str = "gemini_agents"
     output_root: str = ".gemini/agents"
 
-    def target_file(self, project_root: Path, agent_name: str) -> Path:
-        return project_root / self.output_root / f"{agent_name}.md"
+    def target_file(
+        self,
+        project_root: Path,
+        agent_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("agents", "gemini", scope, project_root)
+        return None if root is None else root / f"{agent_name}.md"
 
     def render(self, agent: SubAgent) -> tuple[str, list[str]]:
         return _subagent_to_gemini_md(agent)
@@ -473,8 +503,15 @@ class CodexAgentsGenerator:
     name: str = "codex_agents"
     output_root: str = ".codex/agents"
 
-    def target_file(self, project_root: Path, agent_name: str) -> Path:
-        return project_root / self.output_root / f"{agent_name}.toml"
+    def target_file(
+        self,
+        project_root: Path,
+        agent_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("agents", "codex", scope, project_root)
+        return None if root is None else root / f"{agent_name}.toml"
 
     def render(self, agent: SubAgent) -> tuple[str, list[str]]:
         return _subagent_to_codex_toml(agent)
@@ -572,13 +609,28 @@ def generate_all_agents(
                 if effective_drop == "warn":
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
             out_path = gen.target_file(project_root, agent.name)
+            # ADR-0011 PR-E: target_file may return None for scopes with no
+            # fan-out by design. Default kwarg is project_shared (existing
+            # behavior), which never returns None — so this branch is
+            # currently unreachable, but the assertion makes the contract
+            # explicit for E2/E3 callers that pass scope= kwargs.
+            assert out_path is not None, (
+                f"{target} target_file returned None for default project_shared scope"
+            )
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
             # Race: see PR-D' for the unified write path that closes the
             # canonical→override window. Same pattern as skills.py:213-220.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
-                override_path = _override.resolve(project_root, "agents", agent.name, vendor)
+                # ADR-0011 PR-E: pin scope=project_shared so default fan-out
+                # never picks up a draft project_local override (narrow→broad
+                # is intended for explicit cross-tier reads, not the default
+                # project_shared sync surface). E3 will thread the resolved
+                # scope through when sync becomes scope-aware.
+                override_path = _override.resolve(
+                    project_root, "agents", agent.name, vendor, scope="project_shared"
+                )
                 if override_path is not None:
                     atomic_write_bytes(out_path, override_path.read_bytes())
             generated.append((target, out_path))
@@ -742,6 +794,7 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
                 continue
             expected, _ = gen.render(agent)
             target = gen.target_file(project_root, name)
+            assert target is not None  # ADR-0011 PR-E: default scope=project_shared never None
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -38,12 +38,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+import click
+
+from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._gate_a import format_project_shared_block_message
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
+from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
 
@@ -677,12 +682,28 @@ def extract_agents_to_canonical(
     project_root: Path,
     overwrite: bool = False,
     only_name: str | None = None,
+    *,
+    scope: TargetScope = "project_shared",
+    force_unsafe_import: bool = False,
 ) -> ExtractResult:
     """Import existing Claude / Gemini agent files into ``.memtomem/agents/``.
 
     Codex TOML is **not** imported (one-way conversion; too lossy to round-trip
     without reconstructing fields we dropped on the way out). First occurrence
     wins across runtimes (Claude before Gemini — deterministic order).
+
+    ADR-0011 PR-E2: ``scope`` selects both the canonical destination and the
+    runtime source (per-scope import — ``scope="user"`` reads
+    ``~/.claude/agents`` etc. via :func:`runtime_fanout_root` and writes into
+    ``~/.memtomem/agents/``). ``project_local`` has no runtime fan-out by
+    design (ADR §3) and short-circuits to an empty result.
+
+    Gate A (``privacy.enforce_write_guard``) re-scans every source file's
+    bytes before write. ``project_shared`` destinations hard-abort via
+    :class:`click.ClickException` on any blocked content (with or without
+    ``force_unsafe_import``); ``user`` / ``project_local`` destinations
+    skip-and-warn unless ``force_unsafe_import=True`` flips the decision
+    to ``"bypassed"`` and writes raw bytes through.
 
     Returns an :class:`ExtractResult` with both imported paths and skipped
     items so the caller can warn the user about silent deduplication.
@@ -696,18 +717,38 @@ def extract_agents_to_canonical(
     layout per ADR-0008. Existing flat-layout entries are preserved by
     PR-C — migration to directory layout is a separate command (PR-D).
     """
-    canonical_root = project_root / CANONICAL_AGENT_ROOT
+    if scope == "project_local":
+        # ADR §3 — gitignored draft tier has no runtime fan-out, so there
+        # is nothing to import. Loud-emit (NO_PROJECT_FANOUT_FOR_RUNTIME)
+        # rather than returning silently empty so callers/tests can pin
+        # the explicit reason.
+        return ExtractResult(
+            imported=[],
+            skipped=[
+                (
+                    "<all>",
+                    "project_local has no runtime fan-out (ADR-0011 §3)",
+                    skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+                )
+            ],
+        )
+
+    canonical_root = canonical_artifact_dir("agents", scope, project_root)
     imported: list[tuple[Path, Layout]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # agent_name → first runtime label
 
-    for runtime_dir in (
-        project_root / ".claude/agents",
-        project_root / ".gemini/agents",
-    ):
-        if not runtime_dir.is_dir():
+    for runtime in ("claude", "gemini"):
+        try:
+            runtime_dir = runtime_fanout_root("agents", runtime, scope, project_root)
+        except KeyError:
+            # Defensive — every (agents, claude|gemini, scope) tuple is in
+            # the table at PR-E1 land time, so this only fires on a future
+            # runtime added without table churn.
             continue
-        runtime_label = runtime_dir.relative_to(project_root).as_posix()
+        if runtime_dir is None or not runtime_dir.is_dir():
+            continue
+        runtime_label = f"{runtime} ({runtime_dir})"
         for md_file in sorted(runtime_dir.glob("*.md")):
             agent_name = md_file.stem
             if only_name is not None and agent_name != only_name:
@@ -734,8 +775,72 @@ def extract_agents_to_canonical(
                 logger.warning("skip %s from %s: %s", agent_name, runtime_label, reason)
                 seen[agent_name] = runtime_label
                 continue
+
+            # Gate A — re-scan the source bytes before any write. Use
+            # ``errors="replace"`` so non-UTF8 bytes cannot mask an
+            # embedded ASCII secret (the replacement char `�` does
+            # not overlap with any provider-token alphanumeric pattern).
+            try:
+                content_bytes = md_file.read_bytes()
+            except OSError as exc:
+                skipped.append((agent_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                continue
+            content_text = content_bytes.decode("utf-8", errors="replace")
+            guard = privacy.enforce_write_guard(
+                content_text,
+                surface="cli_context_init",
+                force_unsafe=force_unsafe_import,
+                scope=scope,
+                audit_context={
+                    "source": str(md_file),
+                    "target": str(dst),
+                    "kind": "agents",
+                    "agent_name": agent_name,
+                },
+                record_outcome=True,
+            )
+            if guard.decision in ("blocked", "blocked_project_shared"):
+                if scope == "project_shared":
+                    # Hard-abort: project_shared writes go into git
+                    # history and cannot be retracted from any clone or
+                    # reflog. Files imported earlier in this run that
+                    # passed Gate A stay (each was scanned independently).
+                    raise click.ClickException(
+                        format_project_shared_block_message(
+                            md_file,
+                            hits_count=len(guard.hits),
+                            scope=scope,
+                            kind="agent",
+                            imported_so_far=len(imported),
+                        )
+                    )
+                code: skip_codes.SkipCode = (
+                    skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
+                    if guard.decision == "blocked_project_shared"
+                    else skip_codes.PRIVACY_BLOCKED
+                )
+                hint = (
+                    " — pass --force-unsafe-import to bypass" if guard.decision == "blocked" else ""
+                )
+                skipped.append(
+                    (
+                        agent_name,
+                        f"blocked: {len(guard.hits)} privacy pattern hit(s){hint}",
+                        code,
+                    )
+                )
+                seen[agent_name] = runtime_label
+                continue
+            if guard.decision not in ("pass", "bypassed"):
+                # Symmetric assertion — fail-loud on unknown decision so
+                # a future privacy enum addition surfaces here rather
+                # than silently dropping the write.
+                raise RuntimeError(
+                    f"enforce_write_guard returned unexpected decision: {guard.decision!r}"
+                )
+            # decision in ("pass", "bypassed") — proceed.
             dst.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write_bytes(dst, md_file.read_bytes())
+            atomic_write_bytes(dst, content_bytes)
             imported.append((dst, layout))
             seen[agent_name] = runtime_label
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -488,6 +488,7 @@ def _apply_command_gate_a(
     *,
     content_text: str,
     src: Path,
+    dst: Path,
     cmd_name: str,
     scope: TargetScope,
     runtime: str,
@@ -507,8 +508,12 @@ def _apply_command_gate_a(
         surface="cli_context_init",
         force_unsafe=force_unsafe_import,
         scope=scope,
+        # Mirror agents.py audit_context shape — SOC pipelines grep both
+        # ``source=`` and ``target=`` for incident triage; commands' earlier
+        # omission was a sibling-parity gap (PR #889 review D1).
         audit_context={
             "source": str(src),
+            "target": str(dst),
             "kind": "commands",
             "runtime": runtime,
             "command_name": cmd_name,
@@ -640,6 +645,7 @@ def extract_commands_to_canonical(
             if not _apply_command_gate_a(
                 content_text=content_text,
                 src=md_file,
+                dst=dst,
                 cmd_name=cmd_name,
                 scope=scope,
                 runtime="claude",
@@ -695,6 +701,7 @@ def extract_commands_to_canonical(
             if not _apply_command_gate_a(
                 content_text=canonical_content,
                 src=toml_file,
+                dst=dst,
                 cmd_name=cmd_name,
                 scope=scope,
                 runtime="gemini",

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -38,9 +38,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+import click
+
+from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._gate_a import format_project_shared_block_message
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -49,6 +53,7 @@ from memtomem.context.agents import (
     _parse_flat_yaml,
     _toml_scalar,
 )
+from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
 
@@ -479,45 +484,131 @@ def _resolve_command_extract_target(canonical_root: Path, cmd_name: str) -> tupl
     return dir_target, "dir"
 
 
+def _apply_command_gate_a(
+    *,
+    content_text: str,
+    src: Path,
+    cmd_name: str,
+    scope: TargetScope,
+    runtime: str,
+    force_unsafe_import: bool,
+    imported_so_far: int,
+    skipped: list[tuple[str, str, skip_codes.SkipCode]],
+) -> bool:
+    """Apply Gate A to one command file's scanned content.
+
+    Returns ``True`` when the caller should proceed with the write,
+    ``False`` when the file was rejected and recorded into ``skipped``
+    (or, for ``project_shared`` destinations, raised as
+    :class:`click.ClickException`).
+    """
+    guard = privacy.enforce_write_guard(
+        content_text,
+        surface="cli_context_init",
+        force_unsafe=force_unsafe_import,
+        scope=scope,
+        audit_context={
+            "source": str(src),
+            "kind": "commands",
+            "runtime": runtime,
+            "command_name": cmd_name,
+        },
+        record_outcome=True,
+    )
+    if guard.decision in ("blocked", "blocked_project_shared"):
+        if scope == "project_shared":
+            raise click.ClickException(
+                format_project_shared_block_message(
+                    src,
+                    hits_count=len(guard.hits),
+                    scope=scope,
+                    kind="command",
+                    imported_so_far=imported_so_far,
+                )
+            )
+        code: skip_codes.SkipCode = (
+            skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
+            if guard.decision == "blocked_project_shared"
+            else skip_codes.PRIVACY_BLOCKED
+        )
+        hint = " — pass --force-unsafe-import to bypass" if guard.decision == "blocked" else ""
+        skipped.append(
+            (
+                cmd_name,
+                f"blocked: {len(guard.hits)} privacy pattern hit(s){hint}",
+                code,
+            )
+        )
+        return False
+    if guard.decision not in ("pass", "bypassed"):
+        raise RuntimeError(f"enforce_write_guard returned unexpected decision: {guard.decision!r}")
+    return True
+
+
 def extract_commands_to_canonical(
     project_root: Path,
     overwrite: bool = False,
     only_name: str | None = None,
+    *,
+    scope: TargetScope = "project_shared",
+    force_unsafe_import: bool = False,
 ) -> ExtractResult:
-    """Import existing Claude/Gemini command files into ``.memtomem/commands/``.
+    """Import existing Claude/Gemini command files into the scoped canonical dir.
 
     Phase 3's conversion is lossless in both directions (only two TOML fields,
     placeholder rewrite is reversible), so Gemini commands can be round-tripped
     back into canonical form — unlike Phase 2 Codex TOML.
 
     Codex prompts (``~/.codex/prompts/*.md``) are intentionally **not**
-    imported even though the format is byte-compatible with Claude — the
-    user-scope path spans projects, which would break the "import runtime
-    files from *this* project" semantic (matching the Phase 2 Codex sub-agent
-    policy). Use ``.memtomem/commands/`` as the single authoring surface and
-    let ``generate_all_commands`` populate Codex.
+    imported even though the format is byte-compatible with Claude. The
+    Codex CLI's prompt directory is user-scope (cross-project) and our
+    runtime fan-out table reserves a ``("commands", "codex", "user")``
+    slot for future symmetry, but the import side keeps the existing
+    "use ``.memtomem/commands/`` as the single authoring surface and let
+    ``generate_all_commands`` populate Codex" semantic.
 
-    First occurrence wins: Claude runtime first, then Gemini.  Returns an
-    :class:`ExtractResult` with both imported paths and skipped items so the
-    caller can warn the user about silent deduplication.
+    ADR-0011 PR-E2: ``scope`` selects both the canonical destination and
+    the source runtime root (per-scope import). ``project_local`` has no
+    runtime fan-out by design and short-circuits to an empty result.
+
+    Each branch (Claude bytes-passthrough, Gemini TOML→Markdown) applies
+    Gate A separately. The Gemini branch scans the **converted Markdown**
+    — that is what gets persisted, and the converted body inherits any
+    secret embedded in the source ``prompt`` field.
+
+    First occurrence wins: Claude runtime first, then Gemini.
 
     When ``only_name`` is set, every runtime file with a different stem is
-    silently skipped before any validation/dedupe work. Callers (e.g. the
-    single-item import route) can detect "no such runtime artifact" by
-    inspecting an empty ``imported`` + ``skipped``.
+    silently skipped before any validation/dedupe work.
 
     Layout policy: new commands (no existing canonical) land in directory
     layout per ADR-0008. Existing flat-layout entries are preserved by
     PR-C — migration to directory layout is a separate command (PR-D).
     """
-    canonical_root = project_root / CANONICAL_COMMAND_ROOT
+    if scope == "project_local":
+        return ExtractResult(
+            imported=[],
+            skipped=[
+                (
+                    "<all>",
+                    "project_local has no runtime fan-out (ADR-0011 §3)",
+                    skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+                )
+            ],
+        )
+
+    canonical_root = canonical_artifact_dir("commands", scope, project_root)
     imported: list[tuple[Path, Layout]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # cmd_name → first runtime label
 
-    # Claude — direct copy (both sides are Markdown+YAML frontmatter).
-    claude_dir = project_root / ".claude/commands"
-    if claude_dir.is_dir():
+    # ── Claude branch — byte-level passthrough (Markdown + YAML) ──
+    try:
+        claude_dir = runtime_fanout_root("commands", "claude", scope, project_root)
+    except KeyError:
+        claude_dir = None
+    if claude_dir is not None and claude_dir.is_dir():
+        claude_label = f"claude ({claude_dir})"
         for md_file in sorted(claude_dir.glob("*.md")):
             cmd_name = md_file.stem
             if only_name is not None and cmd_name != only_name:
@@ -526,28 +617,50 @@ def extract_commands_to_canonical(
                 validate_name(cmd_name, kind="command name")
             except InvalidNameError as exc:
                 skipped.append((cmd_name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
-                logger.warning("skip %r from .claude/commands: invalid name", cmd_name)
+                logger.warning("skip %r from %s: invalid name", cmd_name, claude_label)
                 continue
             if cmd_name in seen:
                 reason = f"already imported from {seen[cmd_name]}"
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
-                logger.warning("skip %s from .claude/commands: %s", cmd_name, reason)
+                logger.warning("skip %s from %s: %s", cmd_name, claude_label, reason)
                 continue
             dst, layout = _resolve_command_extract_target(canonical_root, cmd_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
-                logger.warning("skip %s from .claude/commands: %s", cmd_name, reason)
-                seen[cmd_name] = ".claude/commands"
+                logger.warning("skip %s from %s: %s", cmd_name, claude_label, reason)
+                seen[cmd_name] = claude_label
+                continue
+            try:
+                content_bytes = md_file.read_bytes()
+            except OSError as exc:
+                skipped.append((cmd_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                continue
+            content_text = content_bytes.decode("utf-8", errors="replace")
+            if not _apply_command_gate_a(
+                content_text=content_text,
+                src=md_file,
+                cmd_name=cmd_name,
+                scope=scope,
+                runtime="claude",
+                force_unsafe_import=force_unsafe_import,
+                imported_so_far=len(imported),
+                skipped=skipped,
+            ):
+                seen[cmd_name] = claude_label
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write_bytes(dst, md_file.read_bytes())
+            atomic_write_bytes(dst, content_bytes)
             imported.append((dst, layout))
-            seen[cmd_name] = ".claude/commands"
+            seen[cmd_name] = claude_label
 
-    # Gemini — TOML → canonical Markdown conversion.
-    gemini_dir = project_root / ".gemini/commands"
-    if gemini_dir.is_dir():
+    # ── Gemini branch — TOML → canonical Markdown conversion ──
+    try:
+        gemini_dir = runtime_fanout_root("commands", "gemini", scope, project_root)
+    except KeyError:
+        gemini_dir = None
+    if gemini_dir is not None and gemini_dir.is_dir():
+        gemini_label = f"gemini ({gemini_dir})"
         for toml_file in sorted(gemini_dir.glob("*.toml")):
             cmd_name = toml_file.stem
             if only_name is not None and cmd_name != only_name:
@@ -556,31 +669,47 @@ def extract_commands_to_canonical(
                 validate_name(cmd_name, kind="command name")
             except InvalidNameError as exc:
                 skipped.append((cmd_name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
-                logger.warning("skip %r from .gemini/commands: invalid name", cmd_name)
+                logger.warning("skip %r from %s: invalid name", cmd_name, gemini_label)
                 continue
             if cmd_name in seen:
                 reason = f"already imported from {seen[cmd_name]}"
                 skipped.append((cmd_name, reason, skip_codes.ALREADY_IMPORTED))
-                logger.warning("skip %s from .gemini/commands: %s", cmd_name, reason)
+                logger.warning("skip %s from %s: %s", cmd_name, gemini_label, reason)
                 continue
             dst, layout = _resolve_command_extract_target(canonical_root, cmd_name)
             if dst.exists() and not overwrite:
                 reason = "canonical exists (use --overwrite)"
                 skipped.append((cmd_name, reason, skip_codes.CANONICAL_EXISTS))
-                logger.warning("skip %s from .gemini/commands: %s", cmd_name, reason)
-                seen[cmd_name] = ".gemini/commands"
+                logger.warning("skip %s from %s: %s", cmd_name, gemini_label, reason)
+                seen[cmd_name] = gemini_label
                 continue
             try:
                 canonical_content = _gemini_toml_to_canonical(toml_file)
             except (tomllib.TOMLDecodeError, OSError):
                 skipped.append((cmd_name, "TOML parse error", skip_codes.TOML_PARSE_ERROR))
-                logger.warning("skip %s from .gemini/commands: TOML parse error", cmd_name)
+                logger.warning("skip %s from %s: TOML parse error", cmd_name, gemini_label)
+                continue
+            # Scan the CONVERTED Markdown — that's what gets persisted.
+            # A secret in the source `prompt = "..."` field flows into
+            # the body, so this catches it without re-scanning the raw TOML.
+            if not _apply_command_gate_a(
+                content_text=canonical_content,
+                src=toml_file,
+                cmd_name=cmd_name,
+                scope=scope,
+                runtime="gemini",
+                force_unsafe_import=force_unsafe_import,
+                imported_so_far=len(imported),
+                skipped=skipped,
+            ):
+                seen[cmd_name] = gemini_label
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(dst, canonical_content)
             imported.append((dst, layout))
-            seen[cmd_name] = ".gemini/commands"
+            seen[cmd_name] = gemini_label
 
+    # Codex prompts intentionally not imported (see docstring rationale).
     return ExtractResult(imported=imported, skipped=skipped)
 
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -41,7 +41,9 @@ from typing import Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
+from memtomem.context._runtime_targets import runtime_fanout_root
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
@@ -252,12 +254,22 @@ def _subcommand_to_gemini_toml(cmd: SlashCommand) -> tuple[str, list[str]]:
 
 
 class CommandGenerator(Protocol):
-    """Protocol for runtime-specific command generators."""
+    """Protocol for runtime-specific command generators.
+
+    ADR-0011 PR-E: ``target_file`` accepts a ``scope`` keyword (default
+    ``project_shared``). Returns ``None`` when no fan-out by design.
+    """
 
     name: str
 
-    def target_file(self, project_root: Path, command_name: str) -> Path:
-        """Return the file that should hold the rendered command."""
+    def target_file(
+        self,
+        project_root: Path,
+        command_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        """Return the file that should hold the rendered command (or ``None``)."""
         ...
 
     def render(self, cmd: SlashCommand) -> tuple[str, list[str]]:
@@ -278,8 +290,15 @@ class ClaudeCommandsGenerator:
     name: str = "claude_commands"
     output_root: str = ".claude/commands"
 
-    def target_file(self, project_root: Path, command_name: str) -> Path:
-        return project_root / self.output_root / f"{command_name}.md"
+    def target_file(
+        self,
+        project_root: Path,
+        command_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("commands", "claude", scope, project_root)
+        return None if root is None else root / f"{command_name}.md"
 
     def render(self, cmd: SlashCommand) -> tuple[str, list[str]]:
         return _subcommand_to_claude_md(cmd)
@@ -290,8 +309,15 @@ class GeminiCommandsGenerator:
     name: str = "gemini_commands"
     output_root: str = ".gemini/commands"
 
-    def target_file(self, project_root: Path, command_name: str) -> Path:
-        return project_root / self.output_root / f"{command_name}.toml"
+    def target_file(
+        self,
+        project_root: Path,
+        command_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("commands", "gemini", scope, project_root)
+        return None if root is None else root / f"{command_name}.toml"
 
     def render(self, cmd: SlashCommand) -> tuple[str, list[str]]:
         return _subcommand_to_gemini_toml(cmd)
@@ -381,13 +407,23 @@ def generate_all_commands(
                 if effective_drop == "warn":
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
             out_path = gen.target_file(project_root, cmd.name)
+            # ADR-0011 PR-E: target_file may return None for scopes with no
+            # fan-out (default scope=project_shared never None here).
+            assert out_path is not None, (
+                f"{target} target_file returned None for default project_shared scope"
+            )
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
             # Race: see PR-D' for the unified write path that closes the
             # canonical→override window. Same pattern as skills.py:213-220.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
-                override_path = _override.resolve(project_root, "commands", cmd.name, vendor)
+                # ADR-0011 PR-E: pin scope=project_shared (see agents.py for
+                # the same rationale — default sync must not see draft
+                # project_local overrides).
+                override_path = _override.resolve(
+                    project_root, "commands", cmd.name, vendor, scope="project_shared"
+                )
                 if override_path is not None:
                     atomic_write_bytes(out_path, override_path.read_bytes())
             generated.append((target, out_path))
@@ -599,6 +635,7 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
                 continue
             expected, _ = gen.render(cmd)
             target = gen.target_file(project_root, name)
+            assert target is not None  # ADR-0011 PR-E: default scope=project_shared never None
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/override.py
+++ b/packages/memtomem/src/memtomem/context/override.py
@@ -1,24 +1,24 @@
-"""Vendor override resolution — reads project tree only (ADR-0008 Invariant 1).
-
-Fan-out modules call :func:`resolve` per-vendor before writing to the
-runtime target. When the resolver returns a path, the caller MUST
-byte-copy that file to the vendor target and skip auto-conversion for
-that vendor (Invariant 4: full-file replacement).
-
-The resolver intentionally takes only ``project_root`` — never the wiki —
-to enforce Invariant 1: ``mm context install`` already copytreed the
-wiki's ``overrides/`` subdir into the project, so fan-out never needs
-the wiki at sync time. CI machines, archived projects, and machines
-without ``~/.memtomem-wiki/`` all run fan-out unchanged.
-"""
-
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
+from memtomem.config import TargetScope
 from memtomem.context._names import OVERRIDE_FORMATS
+from memtomem.context.scope_resolver import (
+    ArtifactKind,
+    ContextScopeError,
+    canonical_artifact_dir,
+)
 
 __all__ = ["resolve"]
+
+
+# ADR-0011 PR-E: scope lookup order. Narrow tier wins on tie-break,
+# matching memory's project-aware default precedence (project_local
+# overrides project_shared overrides user). Single source of truth so
+# the migration / sync surfaces stay consistent.
+_SCOPE_LOOKUP_ORDER: tuple[TargetScope, ...] = ("project_local", "project_shared", "user")
 
 
 def resolve(
@@ -26,14 +26,54 @@ def resolve(
     asset_type: str,
     name: str,
     vendor: str,
+    *,
+    scope: TargetScope | None = None,
 ) -> Path | None:
-    """Returns project's overrides/<vendor>.<ext> if exists, else None.
+    """Returns the per-vendor override file for a canonical artifact.
 
-    Reads ONLY from project tree. ADR-0008 Invariant 1.
+    Layout (PRESERVED across scopes — ADR-0011 PR-E does not change this):
+
+        <canonical_artifact_dir(asset_type, scope, project_root)>
+          / <name> / "overrides" / f"{vendor}.{ext}"
+
+    Args:
+        project_root: Project root that owns the canonical subtree. For
+            ``scope="user"`` the project_root is unused but still required
+            (passed by every existing caller).
+        asset_type: One of ``agents`` / ``skills`` / ``commands``.
+        name: Artifact name (skill / agent / command identifier).
+        vendor: Runtime vendor key (``claude`` / ``gemini`` / ``codex``)
+            from :data:`memtomem.context._names.OVERRIDE_FORMATS`.
+        scope: When set, look only in that scope. When ``None`` (default,
+            preserves pre-PR-E behavior at the call sites in
+            ``agents.py`` / ``skills.py`` / ``commands.py``), search
+            narrow→broad in :data:`_SCOPE_LOOKUP_ORDER` and return the
+            first hit (project_local > project_shared > user).
+
+    Returns:
+        Path to the override file if it exists, else ``None``.
+
+    Reads ONLY from the canonical tree(s). ADR-0008 Invariant 1; ADR-0011
+    PR-E extends the invariant from project_shared-only to all three
+    scopes with narrow-wins tie-break.
     """
     fmt = OVERRIDE_FORMATS.get((asset_type, vendor))
     if fmt is None:
         return None
     _, ext = fmt
-    candidate = project_root / ".memtomem" / asset_type / name / "overrides" / f"{vendor}.{ext}"
-    return candidate if candidate.is_file() else None
+    artifact = cast(ArtifactKind, asset_type)
+
+    scopes = (scope,) if scope is not None else _SCOPE_LOOKUP_ORDER
+    for s in scopes:
+        try:
+            base = canonical_artifact_dir(artifact, s, project_root)
+        except ContextScopeError:
+            # ``scope="user"`` with project_root=None is fine — the user
+            # base is independent of project_root. But ``project_*`` with
+            # project_root=None raises; skip that scope rather than abort
+            # the whole lookup.
+            continue
+        candidate = base / name / "overrides" / f"{vendor}.{ext}"
+        if candidate.is_file():
+            return candidate
+    return None

--- a/packages/memtomem/src/memtomem/context/scope_resolver.py
+++ b/packages/memtomem/src/memtomem/context/scope_resolver.py
@@ -1,0 +1,139 @@
+"""ADR-0011 PR-E canonical-side scope resolver for non-memory artifacts.
+
+Sibling of :mod:`memtomem.memory_scope` covering agents / skills / commands
+canonical directories under ``.memtomem/``. The runtime fan-out side
+(``~/.claude/agents``, ``<proj>/.gemini/agents``, etc.) lives in
+:mod:`memtomem.context._runtime_targets` — these two concepts must NOT be
+conflated. ``canonical_artifact_dir`` resolves where the source of truth
+file lives; the runtime table resolves where it gets fanned out to.
+
+Used by:
+
+- ``mm context init --scope=...`` (E2)
+- ``mm context sync --scope=...`` (E3)
+- ``mm context migrate <kind> <name>`` (E4)
+- ``context/agents.py``, ``context/skills.py``, ``context/commands.py``
+  in place of hardcoded ``CANONICAL_*_ROOT`` constants
+- Web routes ``/api/context/{agents,skills,commands}`` per-scope listing
+
+Non-memory artifacts have no SQLite chunks table representation and no
+indexing watcher, so this module deliberately omits the
+``is_project_tier_registered`` / ``project_tier_registration_error``
+helpers that ``memory_scope`` provides — Gate B (``--confirm-project-shared``)
+and directory presence are the only gates the artifact write surfaces use.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from memtomem.config import TargetScope
+
+
+ArtifactKind = Literal["agents", "skills", "commands"]
+
+DEFAULT_USER_ARTIFACT_BASE = Path("~/.memtomem")
+
+
+class ContextScopeError(ValueError):
+    """Raised when scope → canonical directory resolution cannot proceed.
+
+    Surface-specific wrappers (``click.ClickException`` for the CLI,
+    HTTP 4xx for web routes) catch and rewrap so each layer surfaces
+    user-facing errors in its native vocabulary.
+    """
+
+
+def canonical_artifact_dir(
+    artifact: ArtifactKind,
+    scope: TargetScope,
+    project_root: Path | None,
+    user_base: Path = DEFAULT_USER_ARTIFACT_BASE,
+) -> Path:
+    """Resolve an ADR-0011 (artifact, scope) pair to its canonical directory.
+
+    Args:
+        artifact: One of ``agents`` / ``skills`` / ``commands``.
+        scope: One of ``user`` / ``project_shared`` / ``project_local``.
+        project_root: Required when ``scope`` is a project tier; the
+            project root that owns the ``.memtomem/`` subtree. Pass
+            ``None`` for ``user`` scope.
+        user_base: Override for the user-tier base directory. Defaults to
+            ``~/.memtomem`` — the artifact name is appended to form e.g.
+            ``~/.memtomem/agents``.
+
+    Returns:
+        The expanded canonical directory ``Path``. May not exist yet;
+        callers create with ``mkdir(parents=True, exist_ok=True)`` before
+        writing.
+
+        - ``user``           → ``user_base / artifact``
+        - ``project_shared`` → ``project_root / ".memtomem" / artifact``
+        - ``project_local``  → ``project_root / ".memtomem" / f"{artifact}.local"``
+
+    Raises:
+        ContextScopeError: When ``scope`` is a project tier but
+            ``project_root`` is ``None``, or when ``scope`` is unknown.
+    """
+    if scope == "user":
+        return (user_base / artifact).expanduser().resolve()
+    if project_root is None:
+        raise ContextScopeError(
+            f"scope='{scope}' requires a project context (cwd has no .memtomem ancestor)."
+        )
+    if scope == "project_shared":
+        return (project_root / ".memtomem" / artifact).resolve()
+    if scope == "project_local":
+        return (project_root / ".memtomem" / f"{artifact}.local").resolve()
+    raise ContextScopeError(f"unsupported artifact scope: {scope!r}")
+
+
+def list_artifact_scopes_present(
+    artifact: ArtifactKind,
+    project_root: Path,
+    user_base: Path = DEFAULT_USER_ARTIFACT_BASE,
+) -> list[TargetScope]:
+    """Return scopes that have on-disk content for this artifact.
+
+    Used by ``mm context diff --scope all`` and the web routes to know
+    which tiers to walk when rendering multi-tier views. Empty
+    directories count as "present" — same semantics as ``Path.is_dir()``.
+    """
+    present: list[TargetScope] = []
+    for scope in ("user", "project_shared", "project_local"):
+        scope_typed: TargetScope = scope  # type: ignore[assignment]
+        try:
+            d = canonical_artifact_dir(artifact, scope_typed, project_root, user_base)
+        except ContextScopeError:
+            continue
+        if d.is_dir():
+            present.append(scope_typed)
+    return present
+
+
+def project_root_from_artifact_path(path: Path) -> Path | None:
+    """Walk parents of ``path`` looking for a ``.memtomem`` ancestor.
+
+    Returns the parent of the first ``.memtomem`` ancestor directory
+    (i.e. the project root that owns the canonical subtree), or
+    ``None`` if ``path`` does not live under any ``.memtomem`` tree.
+
+    The check is "is this ancestor literally named ``.memtomem``?", NOT
+    "does this ancestor contain a ``.memtomem`` child?" — the latter
+    would falsely return a project root for any source file under a
+    project that happens to contain ``.memtomem`` (e.g. ``src/foo.py``
+    in a memtomem-using repo).
+
+    Lifted from the inline helper in ``cli/context_cmd.py:2084-2087``
+    (memory-migrate's project-root detection) so non-memory artifact
+    paths can use the same walk.
+
+    The returned path is not resolved — callers that need symlink
+    canonicalisation should ``.resolve()`` themselves.
+    """
+    path = path.expanduser()
+    for ancestor in (path, *path.parents):
+        if ancestor.name == ".memtomem":
+            return ancestor.parent
+    return None

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -24,12 +24,17 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
+import click
+
+from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
+from memtomem.context._gate_a import format_project_shared_block_message
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
+from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
 
@@ -273,60 +278,157 @@ def extract_skills_to_canonical(
     project_root: Path,
     overwrite: bool = False,
     only_name: str | None = None,
+    *,
+    scope: TargetScope = "project_shared",
+    force_unsafe_import: bool = False,
 ) -> ExtractResult:
-    """Import existing runtime skills into ``.memtomem/skills/``.
+    """Import existing runtime skills into the scoped canonical directory.
 
     When the same skill name appears in multiple runtimes, the first one wins
-    (deterministic order: ``claude_skills`` before ``gemini_skills`` per the
-    ``SKILL_DIRS`` ordering in :mod:`memtomem.context.detector`).
-    Existing canonical entries are preserved unless ``overwrite=True``.
+    (deterministic order: claude → gemini → codex). Existing canonical
+    entries are preserved unless ``overwrite=True``.
 
-    Returns an :class:`ExtractResult` with both imported paths and skipped
-    items so the caller can warn the user about silent deduplication.
+    ADR-0011 PR-E2: ``scope`` selects both the canonical destination
+    (:func:`canonical_artifact_dir`) and the source runtime root
+    (:func:`runtime_fanout_root` per scope — ``user`` reads
+    ``~/.claude/skills`` etc.). ``project_local`` short-circuits to an
+    empty result with ``NO_PROJECT_FANOUT_FOR_RUNTIME``.
+
+    Gate A walks every file in the source skill tree (``rglob``) — secrets
+    routinely live in ``scripts/*.py`` and ``references/*.md`` rather
+    than just ``SKILL.md``. The skill is **atomic**: a single blocked
+    file aborts that skill's import without copying any of its files.
+    ``project_shared`` destinations hard-abort via :class:`click.ClickException`
+    on the first hit (with or without ``force_unsafe_import``).
 
     When ``only_name`` is set, every runtime entry with a different name is
-    silently skipped before any validation/dedupe work. Callers (e.g. the
-    single-item import route) can detect "no such runtime artifact" by
-    inspecting an empty ``imported`` + ``skipped``.
+    silently skipped before any validation/dedupe work.
     """
-    # Lazy import to avoid cycles at module import time.
-    from memtomem.context.detector import detect_skill_dirs
+    if scope == "project_local":
+        return ExtractResult(
+            imported=[],
+            skipped=[
+                (
+                    "<all>",
+                    "project_local has no runtime fan-out (ADR-0011 §3)",
+                    skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+                )
+            ],
+        )
 
-    canonical_root = canonical_skills_root(project_root)
+    canonical_root = canonical_artifact_dir("skills", scope, project_root)
     imported: list[Path] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
     seen: dict[str, str] = {}  # skill_name → first runtime label
 
-    for detected in detect_skill_dirs(project_root):
-        skill_name = detected.path.name
-        if only_name is not None and skill_name != only_name:
-            continue
-        runtime_label = detected.agent  # e.g. "claude_skills"
+    for runtime in ("claude", "gemini", "codex"):
         try:
-            validate_name(skill_name, kind="skill name")
-        except InvalidNameError as exc:
-            skipped.append((skill_name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
-            logger.warning(
-                "skip %r from %s: invalid name",
-                skill_name,
-                runtime_label,
-            )
+            runtime_dir = runtime_fanout_root("skills", runtime, scope, project_root)
+        except KeyError:
             continue
-        if skill_name in seen:
-            reason = f"already imported from {seen[skill_name]}"
-            skipped.append((skill_name, reason, skip_codes.ALREADY_IMPORTED))
-            logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
+        if runtime_dir is None or not runtime_dir.is_dir():
             continue
-        dst = canonical_root / skill_name
-        if dst.exists() and not overwrite:
-            reason = "canonical exists (use --overwrite)"
-            skipped.append((skill_name, reason, skip_codes.CANONICAL_EXISTS))
-            logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
+        runtime_label = f"{runtime} ({runtime_dir})"
+        for skill_dir in sorted(runtime_dir.iterdir()):
+            if not skill_dir.is_dir() or not (skill_dir / SKILL_MANIFEST).is_file():
+                continue
+            skill_name = skill_dir.name
+            if only_name is not None and skill_name != only_name:
+                continue
+            try:
+                validate_name(skill_name, kind="skill name")
+            except InvalidNameError as exc:
+                skipped.append((skill_name, f"invalid name: {exc}", skip_codes.INVALID_NAME))
+                logger.warning("skip %r from %s: invalid name", skill_name, runtime_label)
+                continue
+            if skill_name in seen:
+                reason = f"already imported from {seen[skill_name]}"
+                skipped.append((skill_name, reason, skip_codes.ALREADY_IMPORTED))
+                logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
+                continue
+            dst = canonical_root / skill_name
+            if dst.exists() and not overwrite:
+                reason = "canonical exists (use --overwrite)"
+                skipped.append((skill_name, reason, skip_codes.CANONICAL_EXISTS))
+                logger.warning("skip %s from %s: %s", skill_name, runtime_label, reason)
+                seen[skill_name] = runtime_label
+                continue
+
+            # Gate A — walk every file in the skill tree before copying.
+            # One blocked file aborts the whole skill (atomic — never
+            # leave a partial copy in canonical).
+            blocked_file: Path | None = None
+            blocked_decision: str | None = None
+            blocked_hits: int = 0
+            for src_file in sorted(skill_dir.rglob("*")):
+                if not src_file.is_file():
+                    continue
+                try:
+                    content_text = src_file.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    # Truly unreadable file — skip the scan; copy_skill
+                    # will surface the OSError during the actual copy if
+                    # it is real, otherwise the file passes through as
+                    # a binary asset.
+                    continue
+                guard = privacy.enforce_write_guard(
+                    content_text,
+                    surface="cli_context_init",
+                    force_unsafe=force_unsafe_import,
+                    scope=scope,
+                    audit_context={
+                        "source_file": str(src_file),
+                        "skill_name": skill_name,
+                        "kind": "skills",
+                    },
+                    record_outcome=True,
+                )
+                if guard.decision in ("blocked", "blocked_project_shared"):
+                    blocked_file = src_file
+                    blocked_decision = guard.decision
+                    blocked_hits = len(guard.hits)
+                    break
+                if guard.decision not in ("pass", "bypassed"):
+                    raise RuntimeError(
+                        f"enforce_write_guard returned unexpected decision: {guard.decision!r}"
+                    )
+
+            if blocked_file is not None:
+                if scope == "project_shared":
+                    raise click.ClickException(
+                        format_project_shared_block_message(
+                            blocked_file,
+                            hits_count=blocked_hits,
+                            scope=scope,
+                            kind="skill",
+                            imported_so_far=len(imported),
+                        )
+                    )
+                code: skip_codes.SkipCode = (
+                    skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
+                    if blocked_decision == "blocked_project_shared"
+                    else skip_codes.PRIVACY_BLOCKED
+                )
+                hint = (
+                    " — pass --force-unsafe-import to bypass"
+                    if blocked_decision == "blocked"
+                    else ""
+                )
+                skipped.append(
+                    (
+                        skill_name,
+                        f"blocked: {blocked_file.name} hit {blocked_hits} pattern(s){hint}",
+                        code,
+                    )
+                )
+                seen[skill_name] = runtime_label
+                continue
+
+            # All files clean — copy the whole tree (atomic at directory level).
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            copy_skill(skill_dir, dst)
+            imported.append(dst)
             seen[skill_name] = runtime_label
-            continue
-        copy_skill(detected.path, dst)
-        imported.append(dst)
-        seen[skill_name] = runtime_label
 
     return ExtractResult(imported=imported, skipped=skipped)
 

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -27,7 +27,9 @@ from typing import Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
+from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
+from memtomem.context._runtime_targets import runtime_fanout_root
 
 logger = logging.getLogger(__name__)
 
@@ -36,13 +38,23 @@ SKILL_MANIFEST = "SKILL.md"
 
 
 class SkillGenerator(Protocol):
-    """Protocol for runtime-specific skill targets."""
+    """Protocol for runtime-specific skill targets.
+
+    ADR-0011 PR-E: ``target_dir`` accepts a ``scope`` keyword (default
+    ``project_shared``). Returns ``None`` when no fan-out by design.
+    """
 
     name: str
     output_root: str  # relative to project root, e.g. ".claude/skills"
 
-    def target_dir(self, project_root: Path, skill_name: str) -> Path:
-        """Return the directory that should hold the rendered skill."""
+    def target_dir(
+        self,
+        project_root: Path,
+        skill_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        """Return the directory that should hold the rendered skill (or ``None``)."""
         ...
 
 
@@ -61,8 +73,15 @@ class ClaudeSkillsGenerator:
     name: str = "claude_skills"
     output_root: str = ".claude/skills"
 
-    def target_dir(self, project_root: Path, skill_name: str) -> Path:
-        return project_root / self.output_root / skill_name
+    def target_dir(
+        self,
+        project_root: Path,
+        skill_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("skills", "claude", scope, project_root)
+        return None if root is None else root / skill_name
 
 
 @dataclass
@@ -70,8 +89,15 @@ class GeminiSkillsGenerator:
     name: str = "gemini_skills"
     output_root: str = ".gemini/skills"
 
-    def target_dir(self, project_root: Path, skill_name: str) -> Path:
-        return project_root / self.output_root / skill_name
+    def target_dir(
+        self,
+        project_root: Path,
+        skill_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("skills", "gemini", scope, project_root)
+        return None if root is None else root / skill_name
 
 
 @dataclass
@@ -82,8 +108,15 @@ class CodexSkillsGenerator:
     # slight amount of on-disk overlap — Gemini will silently de-dup it).
     output_root: str = ".agents/skills"
 
-    def target_dir(self, project_root: Path, skill_name: str) -> Path:
-        return project_root / self.output_root / skill_name
+    def target_dir(
+        self,
+        project_root: Path,
+        skill_name: str,
+        *,
+        scope: TargetScope = "project_shared",
+    ) -> Path | None:
+        root = runtime_fanout_root("skills", "codex", scope, project_root)
+        return None if root is None else root / skill_name
 
 
 _register(ClaudeSkillsGenerator())
@@ -207,12 +240,22 @@ def generate_all_skills(
             continue
         for skill_dir in canonicals:
             dst = gen.target_dir(project_root, skill_dir.name)
+            # ADR-0011 PR-E: target_dir may return None for scopes with no
+            # fan-out (default scope=project_shared never None here).
+            assert dst is not None, (
+                f"{target} target_dir returned None for default project_shared scope"
+            )
             copy_skill(skill_dir, dst)
             # ADR-0008 Invariant 4: per-vendor override replaces SKILL.md only.
             # Auxiliary files (scripts/, references/) stay from canonical.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
-                override_path = _override.resolve(project_root, "skills", skill_dir.name, vendor)
+                # ADR-0011 PR-E: pin scope=project_shared (see agents.py for
+                # the same rationale — default sync must not see draft
+                # project_local overrides).
+                override_path = _override.resolve(
+                    project_root, "skills", skill_dir.name, vendor, scope="project_shared"
+                )
                 if override_path is not None:
                     atomic_write_bytes(
                         dst / SKILL_MANIFEST,
@@ -343,6 +386,7 @@ def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
             else:
                 src = canonical_root / name
                 dst = gen.target_dir(project_root, name)
+                assert dst is not None  # ADR-0011 PR-E: default scope=project_shared never None
                 if _skill_dirs_equal(src, dst):
                     results.append((gen_name, name, "in sync"))
                 else:

--- a/packages/memtomem/tests/test_context_extract_scope_kwarg.py
+++ b/packages/memtomem/tests/test_context_extract_scope_kwarg.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from memtomem.context import _skip_reasons as skip_codes
+from .helpers import set_home
 from memtomem.context.agents import extract_agents_to_canonical
 from memtomem.context.commands import extract_commands_to_canonical
 from memtomem.context.skills import extract_skills_to_canonical
@@ -28,7 +29,7 @@ from memtomem.context.skills import extract_skills_to_canonical
 def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     h = tmp_path / "home"
     h.mkdir()
-    monkeypatch.setenv("HOME", str(h))
+    set_home(monkeypatch, str(h))
     return h
 
 

--- a/packages/memtomem/tests/test_context_extract_scope_kwarg.py
+++ b/packages/memtomem/tests/test_context_extract_scope_kwarg.py
@@ -1,0 +1,179 @@
+"""ADR-0011 PR-E2 — per-scope source/destination pinning for ``extract_*_to_canonical``.
+
+Mirrors ``test_context_generator_scope_kwarg.py`` but on the import side:
+each scope reads from a different runtime root (user vs project) and writes
+to a different canonical root.
+
+Source seeded under both ``$HOME/.claude/...`` and ``<proj>/.claude/...``;
+each test verifies the scope kwarg picks the right source AND lands at the
+right canonical destination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context.agents import extract_agents_to_canonical
+from memtomem.context.commands import extract_commands_to_canonical
+from memtomem.context.skills import extract_skills_to_canonical
+
+
+# ── Common fixtures ────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setenv("HOME", str(h))
+    return h
+
+
+@pytest.fixture
+def proj(tmp_path: Path) -> Path:
+    p = tmp_path / "proj"
+    p.mkdir()
+    (p / ".git").mkdir()
+    return p
+
+
+def _write(path: Path, content: str = "---\nname: foo\n---\nbody\n") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+# ── Default kwarg matches project_shared ────────────────────────────────
+
+
+def test_extract_agents_default_kwarg_matches_project_shared(home: Path, proj: Path) -> None:
+    """``extract_agents_to_canonical(proj)`` must equal scope=project_shared."""
+    _write(proj / ".claude" / "agents" / "foo.md")
+    default_run = extract_agents_to_canonical(proj)
+    # Repeat at project_shared with overwrite to get the same imported list.
+    overwrite_run = extract_agents_to_canonical(proj, overwrite=True, scope="project_shared")
+    assert [p for p, _ in default_run.imported] == [p for p, _ in overwrite_run.imported]
+
+
+# ── Agents — per-scope source/destination ──────────────────────────────
+
+
+def test_extract_agents_user_reads_user_runtime(home: Path, proj: Path) -> None:
+    _write(home / ".claude" / "agents" / "foo.md")
+    _write(proj / ".claude" / "agents" / "bar.md")
+
+    result = extract_agents_to_canonical(proj, scope="user")
+    paths = [p for p, _ in result.imported]
+    # foo (user runtime) is imported into user canonical.
+    assert any("foo" in str(p) for p in paths)
+    # bar (project runtime) is NOT imported.
+    assert not any("bar" in str(p) for p in paths)
+    # Destination is user canonical.
+    for p in paths:
+        assert (home / ".memtomem" / "agents") in p.parents
+
+
+def test_extract_agents_project_shared_reads_project_runtime(home: Path, proj: Path) -> None:
+    _write(home / ".claude" / "agents" / "foo.md")
+    _write(proj / ".claude" / "agents" / "bar.md")
+
+    result = extract_agents_to_canonical(proj, scope="project_shared")
+    paths = [p for p, _ in result.imported]
+    assert any("bar" in str(p) for p in paths)
+    assert not any("foo" in str(p) for p in paths)
+    for p in paths:
+        assert (proj / ".memtomem" / "agents") in p.parents
+
+
+def test_extract_agents_project_local_no_fanout(home: Path, proj: Path) -> None:
+    """project_local has no runtime → no source to read from → empty imports."""
+    _write(home / ".claude" / "agents" / "foo.md")
+    _write(proj / ".claude" / "agents" / "bar.md")
+
+    result = extract_agents_to_canonical(proj, scope="project_local")
+    assert result.imported == []
+    codes = [c for _, _, c in result.skipped]
+    assert skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME in codes
+
+
+# ── Skills — per-scope source/destination ──────────────────────────────
+
+
+def _write_skill(root: Path, name: str) -> Path:
+    sk = root / name
+    sk.mkdir(parents=True)
+    (sk / "SKILL.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+    return sk
+
+
+def test_extract_skills_user_reads_user_runtime(home: Path, proj: Path) -> None:
+    _write_skill(home / ".claude" / "skills", "user_skill")
+    _write_skill(proj / ".claude" / "skills", "proj_skill")
+
+    result = extract_skills_to_canonical(proj, scope="user")
+    names = [p.name for p in result.imported]
+    assert "user_skill" in names
+    assert "proj_skill" not in names
+    # Destination user-tier.
+    for p in result.imported:
+        assert (home / ".memtomem" / "skills") in p.parents
+
+
+def test_extract_skills_project_shared_reads_project_runtime(home: Path, proj: Path) -> None:
+    _write_skill(home / ".claude" / "skills", "user_skill")
+    _write_skill(proj / ".claude" / "skills", "proj_skill")
+
+    result = extract_skills_to_canonical(proj, scope="project_shared")
+    names = [p.name for p in result.imported]
+    assert "proj_skill" in names
+    assert "user_skill" not in names
+    for p in result.imported:
+        assert (proj / ".memtomem" / "skills") in p.parents
+
+
+def test_extract_skills_project_local_no_fanout(home: Path, proj: Path) -> None:
+    _write_skill(home / ".claude" / "skills", "user_skill")
+    result = extract_skills_to_canonical(proj, scope="project_local")
+    assert result.imported == []
+
+
+# ── Commands — per-scope, both branches ────────────────────────────────
+
+
+def test_extract_commands_user_reads_user_runtime(home: Path, proj: Path) -> None:
+    _write(home / ".claude" / "commands" / "user_cmd.md", "---\nname: x\n---\nbody\n")
+    _write(proj / ".claude" / "commands" / "proj_cmd.md", "---\nname: x\n---\nbody\n")
+
+    result = extract_commands_to_canonical(proj, scope="user")
+    names = [p.parent.name if layout == "dir" else p.stem for p, layout in result.imported]
+    assert "user_cmd" in names
+    assert "proj_cmd" not in names
+
+
+def test_extract_commands_gemini_user_reads_user_runtime(home: Path, proj: Path) -> None:
+    _write(
+        home / ".gemini" / "commands" / "ucmd.toml",
+        'description = "u"\nprompt = "user prompt"\n',
+    )
+    result = extract_commands_to_canonical(proj, scope="user")
+    names = [p.parent.name if layout == "dir" else p.stem for p, layout in result.imported]
+    assert "ucmd" in names
+
+
+def test_extract_commands_project_shared_reads_project_runtime(home: Path, proj: Path) -> None:
+    _write(home / ".claude" / "commands" / "user_cmd.md", "---\nname: x\n---\nbody\n")
+    _write(proj / ".claude" / "commands" / "proj_cmd.md", "---\nname: x\n---\nbody\n")
+
+    result = extract_commands_to_canonical(proj, scope="project_shared")
+    names = [p.parent.name if layout == "dir" else p.stem for p, layout in result.imported]
+    assert "proj_cmd" in names
+    assert "user_cmd" not in names
+
+
+def test_extract_commands_project_local_no_fanout(home: Path, proj: Path) -> None:
+    _write(home / ".claude" / "commands" / "x.md", "---\nname: x\n---\nbody\n")
+    result = extract_commands_to_canonical(proj, scope="project_local")
+    assert result.imported == []

--- a/packages/memtomem/tests/test_context_generator_scope_kwarg.py
+++ b/packages/memtomem/tests/test_context_generator_scope_kwarg.py
@@ -29,6 +29,8 @@ from memtomem.context.skills import (
     GeminiSkillsGenerator,
 )
 
+from .helpers import set_home
+
 
 # ---------------------------------------------------------------------------
 # Default kwarg preserves pre-PR-E behavior (project_shared)
@@ -62,7 +64,7 @@ def test_default_kwarg_matches_project_shared_commands(tmp_path: Path) -> None:
 
 
 def test_claude_agents_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = ClaudeAgentsGenerator().target_file(Path("/ignored"), "foo", scope="user")
     assert out == (tmp_path / ".claude" / "agents" / "foo.md").resolve()
 
@@ -77,13 +79,13 @@ def test_claude_agents_project_local_returns_none(tmp_path: Path) -> None:
 
 
 def test_gemini_agents_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = GeminiAgentsGenerator().target_file(Path("/ignored"), "foo", scope="user")
     assert out == (tmp_path / ".gemini" / "agents" / "foo.md").resolve()
 
 
 def test_codex_agents_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = CodexAgentsGenerator().target_file(Path("/ignored"), "foo", scope="user")
     assert out == (tmp_path / ".codex" / "agents" / "foo.toml").resolve()
 
@@ -99,7 +101,7 @@ def test_codex_agents_project_shared_uses_toml(tmp_path: Path) -> None:
 
 
 def test_claude_skills_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = ClaudeSkillsGenerator().target_dir(Path("/ignored"), "skill1", scope="user")
     assert out == (tmp_path / ".claude" / "skills" / "skill1").resolve()
 
@@ -120,7 +122,7 @@ def test_gemini_skills_project_local_returns_none(tmp_path: Path) -> None:
 
 
 def test_claude_commands_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = ClaudeCommandsGenerator().target_file(Path("/ignored"), "cmd1", scope="user")
     assert out == (tmp_path / ".claude" / "commands" / "cmd1.md").resolve()
 

--- a/packages/memtomem/tests/test_context_generator_scope_kwarg.py
+++ b/packages/memtomem/tests/test_context_generator_scope_kwarg.py
@@ -1,0 +1,166 @@
+"""ADR-0011 PR-E generator signature regression tests.
+
+Pins exact (generator, scope) → path mapping per runtime so the canonical
+vs runtime mix-up that the earlier plan revision had cannot regress.
+Default kwarg ``scope="project_shared"`` preserves pre-PR-E behavior.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.agents import (
+    AGENT_GENERATORS,
+    ClaudeAgentsGenerator,
+    CodexAgentsGenerator,
+    GeminiAgentsGenerator,
+)
+from memtomem.context.commands import (
+    COMMAND_GENERATORS,
+    ClaudeCommandsGenerator,
+    GeminiCommandsGenerator,
+)
+from memtomem.context.skills import (
+    SKILL_GENERATORS,
+    ClaudeSkillsGenerator,
+    CodexSkillsGenerator,
+    GeminiSkillsGenerator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Default kwarg preserves pre-PR-E behavior (project_shared)
+# ---------------------------------------------------------------------------
+
+
+def test_default_kwarg_matches_project_shared_agents(tmp_path: Path) -> None:
+    p = tmp_path / "proj"
+    assert ClaudeAgentsGenerator().target_file(p, "foo") == ClaudeAgentsGenerator().target_file(
+        p, "foo", scope="project_shared"
+    )
+
+
+def test_default_kwarg_matches_project_shared_skills(tmp_path: Path) -> None:
+    p = tmp_path / "proj"
+    assert ClaudeSkillsGenerator().target_dir(p, "skill1") == ClaudeSkillsGenerator().target_dir(
+        p, "skill1", scope="project_shared"
+    )
+
+
+def test_default_kwarg_matches_project_shared_commands(tmp_path: Path) -> None:
+    p = tmp_path / "proj"
+    assert ClaudeCommandsGenerator().target_file(
+        p, "cmd1"
+    ) == ClaudeCommandsGenerator().target_file(p, "cmd1", scope="project_shared")
+
+
+# ---------------------------------------------------------------------------
+# Per-runtime concrete path pins — agents
+# ---------------------------------------------------------------------------
+
+
+def test_claude_agents_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = ClaudeAgentsGenerator().target_file(Path("/ignored"), "foo", scope="user")
+    assert out == (tmp_path / ".claude" / "agents" / "foo.md").resolve()
+
+
+def test_claude_agents_project_shared(tmp_path: Path) -> None:
+    out = ClaudeAgentsGenerator().target_file(tmp_path, "foo", scope="project_shared")
+    assert out == (tmp_path / ".claude" / "agents" / "foo.md").resolve()
+
+
+def test_claude_agents_project_local_returns_none(tmp_path: Path) -> None:
+    assert ClaudeAgentsGenerator().target_file(tmp_path, "foo", scope="project_local") is None
+
+
+def test_gemini_agents_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = GeminiAgentsGenerator().target_file(Path("/ignored"), "foo", scope="user")
+    assert out == (tmp_path / ".gemini" / "agents" / "foo.md").resolve()
+
+
+def test_codex_agents_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = CodexAgentsGenerator().target_file(Path("/ignored"), "foo", scope="user")
+    assert out == (tmp_path / ".codex" / "agents" / "foo.toml").resolve()
+
+
+def test_codex_agents_project_shared_uses_toml(tmp_path: Path) -> None:
+    out = CodexAgentsGenerator().target_file(tmp_path, "foo", scope="project_shared")
+    assert out == (tmp_path / ".codex" / "agents" / "foo.toml").resolve()
+
+
+# ---------------------------------------------------------------------------
+# Per-runtime concrete path pins — skills (directories, no file suffix)
+# ---------------------------------------------------------------------------
+
+
+def test_claude_skills_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = ClaudeSkillsGenerator().target_dir(Path("/ignored"), "skill1", scope="user")
+    assert out == (tmp_path / ".claude" / "skills" / "skill1").resolve()
+
+
+def test_codex_skills_project_uses_dot_agents(tmp_path: Path) -> None:
+    """Confirm codex skills project-scope is .agents/skills, NOT .codex/skills."""
+    out = CodexSkillsGenerator().target_dir(tmp_path, "skill1", scope="project_shared")
+    assert out == (tmp_path / ".agents" / "skills" / "skill1").resolve()
+
+
+def test_gemini_skills_project_local_returns_none(tmp_path: Path) -> None:
+    assert GeminiSkillsGenerator().target_dir(tmp_path, "skill1", scope="project_local") is None
+
+
+# ---------------------------------------------------------------------------
+# Per-runtime concrete path pins — commands
+# ---------------------------------------------------------------------------
+
+
+def test_claude_commands_user_scope(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = ClaudeCommandsGenerator().target_file(Path("/ignored"), "cmd1", scope="user")
+    assert out == (tmp_path / ".claude" / "commands" / "cmd1.md").resolve()
+
+
+def test_gemini_commands_uses_toml(tmp_path: Path) -> None:
+    out = GeminiCommandsGenerator().target_file(tmp_path, "cmd1", scope="project_shared")
+    assert out == (tmp_path / ".gemini" / "commands" / "cmd1.toml").resolve()
+
+
+def test_claude_commands_project_local_returns_none(tmp_path: Path) -> None:
+    assert ClaudeCommandsGenerator().target_file(tmp_path, "cmd1", scope="project_local") is None
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity — every registered generator accepts the scope kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_all_registered_agent_generators_accept_scope(tmp_path: Path) -> None:
+    for name, gen in AGENT_GENERATORS.items():
+        out = gen.target_file(tmp_path, "x", scope="project_shared")
+        assert out is not None, f"{name}: project_shared should resolve to a path"
+        assert gen.target_file(tmp_path, "x", scope="project_local") is None, (
+            f"{name}: project_local should return None"
+        )
+
+
+def test_all_registered_skill_generators_accept_scope(tmp_path: Path) -> None:
+    for name, gen in SKILL_GENERATORS.items():
+        out = gen.target_dir(tmp_path, "x", scope="project_shared")
+        assert out is not None, f"{name}: project_shared should resolve to a path"
+        assert gen.target_dir(tmp_path, "x", scope="project_local") is None, (
+            f"{name}: project_local should return None"
+        )
+
+
+def test_all_registered_command_generators_accept_scope(tmp_path: Path) -> None:
+    for name, gen in COMMAND_GENERATORS.items():
+        out = gen.target_file(tmp_path, "x", scope="project_shared")
+        assert out is not None, f"{name}: project_shared should resolve to a path"
+        assert gen.target_file(tmp_path, "x", scope="project_local") is None, (
+            f"{name}: project_local should return None"
+        )

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -196,6 +196,61 @@ def test_init_scope_user_seeds_user_dirs(
     assert not (proj / ".memtomem" / "commands").exists()
 
 
+def test_init_scope_user_with_existing_context_md_keeps_user_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """PR #889 review C1/P2 — declining the context.md overwrite prompt
+    must NOT kill the scoped user-tier seeding. The decline applies only
+    to the context.md rewrite; scope dirs (and `--include` import) still
+    run."""
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    # Pre-seed an existing context.md so the prompt fires.
+    (proj / ".memtomem").mkdir()
+    existing = proj / ".memtomem" / "context.md"
+    existing.write_text("# Pre-existing context\n", encoding="utf-8")
+    original_bytes = existing.read_bytes()
+
+    # User declines the overwrite ("n"); user-tier dirs MUST still be created.
+    result = runner.invoke(cli, ["context", "init", "--scope", "user"], input="n\n")
+    assert result.exit_code == 0, result.output
+    for kind in ("agents", "skills", "commands"):
+        assert (home / ".memtomem" / kind).is_dir(), (
+            f"user-tier {kind} should be created even after context.md decline"
+        )
+    # context.md untouched.
+    assert existing.read_bytes() == original_bytes
+    # Friendly skip notice surfaced.
+    assert "skipped" in result.output.lower() or "continuing" in result.output.lower()
+
+
+def test_init_implicit_no_scope_works_from_fresh_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """PR #889 review C2 — implicit ``mm context init`` (no --scope) must
+    still work from a directory without ``.git``/``pyproject.toml``,
+    matching pre-PR-E2 behaviour. The scope-sanity raise is restricted
+    to EXPLICIT --scope project_*."""
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    monkeypatch.chdir(fresh)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(cli, ["context", "init"], input="")
+    assert result.exit_code == 0, result.output
+    # Implicit scope = project_shared → seeds <cwd>/.memtomem/ (matching
+    # pre-PR-E2 fall-through where _find_project_root returned cwd).
+    for kind in ("agents", "skills", "commands"):
+        assert (fresh / ".memtomem" / kind).is_dir()
+
+
 # ── --scope project_local + .gitignore append ──────────────────────────
 
 

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -32,6 +32,7 @@ import pytest
 from click.testing import CliRunner
 
 from memtomem.cli import cli
+from .helpers import set_home
 from memtomem.cli.context_cmd import (
     _GITIGNORE_MARKER,
     _GITIGNORE_PATTERNS,
@@ -121,7 +122,7 @@ def test_init_default_no_scope_does_not_prompt(
     """#1 — implicit default (no --scope) preserves pre-PR-E2 non-interactive shape."""
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(cli, ["context", "init"], input="")  # no input on prompts
     # Should succeed without prompting — context.md exists in proj/.memtomem/.
@@ -138,7 +139,7 @@ def test_init_explicit_project_shared_prompts_and_aborts_on_n(
 ) -> None:
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(
         cli,
@@ -158,7 +159,7 @@ def test_init_explicit_project_shared_with_confirm_no_prompt(
 ) -> None:
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(
         cli,
@@ -186,7 +187,7 @@ def test_init_scope_user_seeds_user_dirs(
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
 
     result = runner.invoke(cli, ["context", "init", "--scope", "user"])
     assert result.exit_code == 0, result.output
@@ -212,7 +213,7 @@ def test_init_scope_user_with_existing_context_md_keeps_user_dirs(
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
 
     # Pre-seed an existing context.md.
     (proj / ".memtomem").mkdir()
@@ -246,7 +247,7 @@ def test_init_scope_project_local_does_not_touch_context_md(
     Gate B."""
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     (proj / ".memtomem").mkdir()
     existing = proj / ".memtomem" / "context.md"
@@ -276,7 +277,7 @@ def test_init_scope_project_local_no_existing_context_md_does_not_create_one(
     directions (no overwrite, no fresh write)."""
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
     assert result.exit_code == 0, result.output
@@ -299,7 +300,7 @@ def test_init_implicit_no_scope_works_from_fresh_dir(
     fresh = tmp_path / "fresh"
     fresh.mkdir()
     monkeypatch.chdir(fresh)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(cli, ["context", "init"], input="")
     assert result.exit_code == 0, result.output
@@ -324,7 +325,7 @@ def test_init_scope_project_local_seeds_local_dirs_and_gitignore(
 ) -> None:
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
     assert result.exit_code == 0, result.output
@@ -345,7 +346,7 @@ def test_init_scope_project_local_gitignore_idempotent(
 ) -> None:
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     runner.invoke(cli, ["context", "init", "--scope", "project_local"])
     first = (proj / ".gitignore").read_bytes()
@@ -362,7 +363,7 @@ def test_init_scope_project_local_pyproject_only_warns(
     """#5 — pyproject.toml present, .git absent: warn but do not abort."""
     proj = _make_project(tmp_path, git=False, pyproject=True)
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
     assert result.exit_code == 0, result.output
@@ -380,7 +381,7 @@ def test_init_scope_project_local_no_signal_aborts(
     proj = tmp_path / "proj"
     proj.mkdir()
     monkeypatch.chdir(proj)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
 
     result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
     assert result.exit_code != 0
@@ -429,7 +430,7 @@ def test_extract_agents_user_scope_blocks_secret_no_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
 
     _seed_user_runtime_agents(home, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
@@ -453,7 +454,7 @@ def test_extract_agents_user_scope_force_unsafe_writes_and_audits(
     """#15 + ``feedback_force_unsafe_redaction_valve_only.md``:
     --force-unsafe-import must (a) write raw bytes AND (b) emit audit log."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
 
     src = _seed_user_runtime_agents(home, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
@@ -476,7 +477,7 @@ def test_extract_agents_project_shared_blocked_hard_aborts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """#2 — project_shared destination + blocked → ClickException."""
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
     proj = _make_project(tmp_path)
     _seed_project_runtime_agents(proj, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
 
@@ -494,7 +495,7 @@ def test_extract_agents_project_shared_force_unsafe_still_aborts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """B-spec smoke #16 — --force-unsafe-import does NOT bypass project_shared."""
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
     proj = _make_project(tmp_path)
     _seed_project_runtime_agents(proj, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
 
@@ -512,7 +513,7 @@ def test_extract_skills_per_file_walk_blocks_scripts_dir(
 ) -> None:
     """B2 — secret in scripts/leak.py blocks the entire skill (atomic)."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
 
     skill = home / ".claude" / "skills" / "myskill"
@@ -533,7 +534,7 @@ def test_extract_skills_clean_skill_copies_normally(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
 
     skill = home / ".claude" / "skills" / "clean"
@@ -557,7 +558,7 @@ def test_extract_commands_gemini_toml_secret_in_prompt_blocked(
 ) -> None:
     """B3 — Gemini TOML's `prompt` field secret caught after conversion."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
 
     gem = home / ".gemini" / "commands"
@@ -579,7 +580,7 @@ def test_extract_commands_codex_not_imported(
 ) -> None:
     """Codex prompts intentionally not imported even at user scope."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
 
     codex = home / ".codex" / "prompts"
@@ -626,7 +627,7 @@ def test_unknown_decision_raises_runtime_error(
 ) -> None:
     """B1 — unexpected enforce_write_guard decision is fail-loud."""
     home = tmp_path / "home"
-    monkeypatch.setenv("HOME", str(home))
+    set_home(monkeypatch, str(home))
     proj = _make_project(tmp_path)
     _seed_user_runtime_agents(home, "agt", "---\nname: agt\n---\nbody\n")
 

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -201,32 +201,78 @@ def test_init_scope_user_with_existing_context_md_keeps_user_dirs(
     monkeypatch: pytest.MonkeyPatch,
     runner: CliRunner,
 ) -> None:
-    """PR #889 review C1/P2 — declining the context.md overwrite prompt
-    must NOT kill the scoped user-tier seeding. The decline applies only
-    to the context.md rewrite; scope dirs (and `--include` import) still
-    run."""
+    """PR #889 review C1/P2 round 1 + round 2 — ``--scope user`` is
+    artifact-only: the project's context.md must NOT be prompted on or
+    rewritten. Pre-seeded context.md stays untouched, no prompt fires,
+    user-tier dirs are seeded."""
     proj = _make_project(tmp_path)
     monkeypatch.chdir(proj)
     home = tmp_path / "home"
     monkeypatch.setenv("HOME", str(home))
 
-    # Pre-seed an existing context.md so the prompt fires.
+    # Pre-seed an existing context.md.
     (proj / ".memtomem").mkdir()
     existing = proj / ".memtomem" / "context.md"
     existing.write_text("# Pre-existing context\n", encoding="utf-8")
     original_bytes = existing.read_bytes()
 
-    # User declines the overwrite ("n"); user-tier dirs MUST still be created.
-    result = runner.invoke(cli, ["context", "init", "--scope", "user"], input="n\n")
+    # No input piped — the prompt must NOT fire (round 2 fix).
+    result = runner.invoke(cli, ["context", "init", "--scope", "user"], input="")
     assert result.exit_code == 0, result.output
     for kind in ("agents", "skills", "commands"):
-        assert (home / ".memtomem" / kind).is_dir(), (
-            f"user-tier {kind} should be created even after context.md decline"
-        )
-    # context.md untouched.
+        assert (home / ".memtomem" / kind).is_dir(), f"user-tier {kind} should be created"
+    # context.md untouched (negative pin per
+    # feedback_pin_invert_symmetric_assertion.md).
     assert existing.read_bytes() == original_bytes
-    # Friendly skip notice surfaced.
-    assert "skipped" in result.output.lower() or "continuing" in result.output.lower()
+    # Prompt prose did NOT fire — symmetric prose-side check.
+    assert "already exists. Overwrite?" not in result.output
+
+
+def test_init_scope_project_local_does_not_touch_context_md(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """PR #889 review P2 round 2 — ``--scope project_local`` is the
+    gitignored draft tier. Writing to or prompting on the project_shared
+    context.md would violate the local-tier contract and bypass
+    Gate B."""
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    (proj / ".memtomem").mkdir()
+    existing = proj / ".memtomem" / "context.md"
+    existing.write_text("# Pre-existing context\n", encoding="utf-8")
+    original_bytes = existing.read_bytes()
+
+    result = runner.invoke(cli, ["context", "init", "--scope", "project_local"], input="")
+    assert result.exit_code == 0, result.output
+    # *.local dirs created.
+    for kind in ("agents", "skills", "commands"):
+        assert (proj / ".memtomem" / f"{kind}.local").is_dir()
+    # context.md untouched + no prompt.
+    assert existing.read_bytes() == original_bytes
+    assert "already exists. Overwrite?" not in result.output
+
+
+def test_init_scope_project_local_no_existing_context_md_does_not_create_one(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """``--scope project_local`` on a fresh project must not create
+    context.md either — the artifact-only contract holds in both
+    directions (no overwrite, no fresh write)."""
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
+    assert result.exit_code == 0, result.output
+    assert not (proj / ".memtomem" / "context.md").exists(), (
+        "project_local must not synthesize project_shared context.md"
+    )
 
 
 def test_init_implicit_no_scope_works_from_fresh_dir(

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -169,6 +169,10 @@ def test_init_explicit_project_shared_with_confirm_no_prompt(
     assert "Continue?" not in result.output
     for kind in ("agents", "skills", "commands"):
         assert (proj / ".memtomem" / kind).is_dir()
+    # Truth table row 2 — explicit --scope project_shared DOES write context.md
+    # (artifact-only-scope qualifier is False here, so the project_shared
+    # write fires). Pinned per round-3 review nit N1.
+    assert (proj / ".memtomem" / "context.md").exists()
 
 
 # ── --scope user seeds user dirs ───────────────────────────────────────
@@ -225,7 +229,10 @@ def test_init_scope_user_with_existing_context_md_keeps_user_dirs(
     # feedback_pin_invert_symmetric_assertion.md).
     assert existing.read_bytes() == original_bytes
     # Prompt prose did NOT fire — symmetric prose-side check.
-    assert "already exists. Overwrite?" not in result.output
+    # Single-keyword grep — robust against prompt-prose reordering
+    # ("already exists. Overwrite?" → "Overwrite this file?" wouldn't
+    # silently pass). Round-3 review nit N2.
+    assert "Overwrite" not in result.output
 
 
 def test_init_scope_project_local_does_not_touch_context_md(
@@ -253,7 +260,10 @@ def test_init_scope_project_local_does_not_touch_context_md(
         assert (proj / ".memtomem" / f"{kind}.local").is_dir()
     # context.md untouched + no prompt.
     assert existing.read_bytes() == original_bytes
-    assert "already exists. Overwrite?" not in result.output
+    # Single-keyword grep — robust against prompt-prose reordering
+    # ("already exists. Overwrite?" → "Overwrite this file?" wouldn't
+    # silently pass). Round-3 review nit N2.
+    assert "Overwrite" not in result.output
 
 
 def test_init_scope_project_local_no_existing_context_md_does_not_create_one(
@@ -283,7 +293,9 @@ def test_init_implicit_no_scope_works_from_fresh_dir(
     """PR #889 review C2 — implicit ``mm context init`` (no --scope) must
     still work from a directory without ``.git``/``pyproject.toml``,
     matching pre-PR-E2 behaviour. The scope-sanity raise is restricted
-    to EXPLICIT --scope project_*."""
+    to EXPLICIT --scope project_*. Round-3 review D-new-1 also surfaces
+    a yellow hint here pointing to ``--scope=user`` for the
+    cross-project case."""
     fresh = tmp_path / "fresh"
     fresh.mkdir()
     monkeypatch.chdir(fresh)
@@ -295,6 +307,11 @@ def test_init_implicit_no_scope_works_from_fresh_dir(
     # pre-PR-E2 fall-through where _find_project_root returned cwd).
     for kind in ("agents", "skills", "commands"):
         assert (fresh / ".memtomem" / kind).is_dir()
+    # Round-3 D-new-1 — non-project warning surfaced. We assert on the
+    # most stable substring "--scope=user" (the actionable hint) rather
+    # than the full prose so future wording polish doesn't break this
+    # pin.
+    assert "--scope=user" in result.output
 
 
 # ── --scope project_local + .gitignore append ──────────────────────────

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -1,0 +1,520 @@
+"""ADR-0011 PR-E2 — `mm context init --scope` + Gate A/B + .gitignore tests.
+
+Pins:
+- ``_resolve_artifact_cli_scope`` defaults to ``"project_shared"`` (NOT
+  ``cfg.hooks.target_scope``).
+- Gate B prompt fires only on EXPLICIT ``--scope project_shared``;
+  implicit default (no flag) is back-compatible (no prompt).
+- ``--scope project_local`` auto-appends a single comment-marker block
+  to ``.gitignore`` and is idempotent on repeat invocations.
+- Pyproject-only project (no ``.git``) gets a specific warning and the
+  init does NOT abort.
+- Gate A blocks secret-bearing imports; ``--force-unsafe-import``
+  bypasses for user/project_local destinations only and emits an
+  audit-log entry; project_shared destinations hard-abort with a
+  :class:`click.ClickException`, including under ``--force-unsafe-import``.
+- Skills tree walk catches secrets in ``scripts/`` even when SKILL.md
+  is clean — atomic skip, no partial copy.
+- Gemini commands TOML→Markdown: scan happens on the converted body.
+- Codex prompts intentionally not imported even at user scope.
+- Unknown decision from ``enforce_write_guard`` raises ``RuntimeError``
+  (symmetric assertion guard).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.cli.context_cmd import (
+    _GITIGNORE_MARKER,
+    _GITIGNORE_PATTERNS,
+    _append_gitignore_marker,
+    _resolve_artifact_cli_scope,
+)
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context.agents import extract_agents_to_canonical
+from memtomem.context.commands import extract_commands_to_canonical
+from memtomem.context.skills import extract_skills_to_canonical
+from memtomem.privacy import WriteGuardResult
+
+
+_AKIA_SECRET = "AKIAIOSFODNN7EXAMPLE"
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+
+def _make_project(tmp_path: Path, *, git: bool = True, pyproject: bool = False) -> Path:
+    """Create a minimal project root under ``tmp_path``."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    if git:
+        (proj / ".git").mkdir()
+    if pyproject:
+        (proj / "pyproject.toml").write_text("[project]\nname = 'x'\n", encoding="utf-8")
+    return proj
+
+
+def _seed_user_runtime_agents(home: Path, name: str, content: str) -> Path:
+    """Drop a fake Claude user-tier agent at ``$HOME/.claude/agents/<name>.md``."""
+    d = home / ".claude" / "agents"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{name}.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def _seed_project_runtime_agents(proj: Path, name: str, content: str) -> Path:
+    d = proj / ".claude" / "agents"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{name}.md"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── _resolve_artifact_cli_scope ─────────────────────────────────────────
+
+
+def test_resolve_artifact_cli_scope_default_project_shared() -> None:
+    """Default is project_shared regardless of cfg.hooks.target_scope."""
+    assert _resolve_artifact_cli_scope(None) == "project_shared"
+
+
+def test_resolve_artifact_cli_scope_explicit_passes_through() -> None:
+    assert _resolve_artifact_cli_scope("user") == "user"
+    assert _resolve_artifact_cli_scope("project_shared") == "project_shared"
+    assert _resolve_artifact_cli_scope("project_local") == "project_local"
+
+
+def test_resolve_artifact_cli_scope_does_not_read_hooks_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify no Mem2MemConfig() is constructed (default leak guard)."""
+
+    def boom(*a: Any, **kw: Any) -> None:
+        raise AssertionError("_resolve_artifact_cli_scope must NOT instantiate Mem2MemConfig")
+
+    monkeypatch.setattr("memtomem.cli.context_cmd.Mem2MemConfig", boom)
+    assert _resolve_artifact_cli_scope(None) == "project_shared"
+
+
+# ── Gate B prompt only on explicit --scope project_shared ──────────────
+
+
+def test_init_default_no_scope_does_not_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """#1 — implicit default (no --scope) preserves pre-PR-E2 non-interactive shape."""
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(cli, ["context", "init"], input="")  # no input on prompts
+    # Should succeed without prompting — context.md exists in proj/.memtomem/.
+    assert result.exit_code == 0, result.output
+    assert (proj / ".memtomem" / "context.md").exists()
+    # No "Continue?" prompt from Gate B fired.
+    assert "Continue?" not in result.output
+
+
+def test_init_explicit_project_shared_prompts_and_aborts_on_n(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(
+        cli,
+        ["context", "init", "--scope", "project_shared"],
+        input="n\n",
+    )
+    assert result.exit_code != 0
+    assert "Continue?" in result.output
+    # No canonical dirs created on abort.
+    assert not (proj / ".memtomem" / "agents").exists()
+
+
+def test_init_explicit_project_shared_with_confirm_no_prompt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(
+        cli,
+        ["context", "init", "--scope", "project_shared", "--confirm-project-shared"],
+        input="",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Continue?" not in result.output
+    for kind in ("agents", "skills", "commands"):
+        assert (proj / ".memtomem" / kind).is_dir()
+
+
+# ── --scope user seeds user dirs ───────────────────────────────────────
+
+
+def test_init_scope_user_seeds_user_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+
+    result = runner.invoke(cli, ["context", "init", "--scope", "user"])
+    assert result.exit_code == 0, result.output
+
+    for kind in ("agents", "skills", "commands"):
+        assert (home / ".memtomem" / kind).is_dir(), f"missing user-tier {kind}"
+
+    # User scope must NOT have written canonical project-tier subdirs.
+    assert not (proj / ".memtomem" / "agents").exists()
+    assert not (proj / ".memtomem" / "skills").exists()
+    assert not (proj / ".memtomem" / "commands").exists()
+
+
+# ── --scope project_local + .gitignore append ──────────────────────────
+
+
+def test_init_scope_project_local_seeds_local_dirs_and_gitignore(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
+    assert result.exit_code == 0, result.output
+
+    for kind in ("agents", "skills", "commands"):
+        assert (proj / ".memtomem" / f"{kind}.local").is_dir()
+
+    gi = (proj / ".gitignore").read_text(encoding="utf-8")
+    assert _GITIGNORE_MARKER in gi
+    for pat in _GITIGNORE_PATTERNS:
+        assert pat in gi
+
+
+def test_init_scope_project_local_gitignore_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    proj = _make_project(tmp_path)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    runner.invoke(cli, ["context", "init", "--scope", "project_local"])
+    first = (proj / ".gitignore").read_bytes()
+    runner.invoke(cli, ["context", "init", "--scope", "project_local"])
+    second = (proj / ".gitignore").read_bytes()
+    assert first == second, "second invocation must not mutate .gitignore"
+
+
+def test_init_scope_project_local_pyproject_only_warns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    """#5 — pyproject.toml present, .git absent: warn but do not abort."""
+    proj = _make_project(tmp_path, git=False, pyproject=True)
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
+    assert result.exit_code == 0, result.output
+    assert "git init" in result.output.lower() or "`.git`" in result.output
+    assert not (proj / ".gitignore").exists()
+    # Dirs still created.
+    assert (proj / ".memtomem" / "agents.local").is_dir()
+
+
+def test_init_scope_project_local_no_signal_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.chdir(proj)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    result = runner.invoke(cli, ["context", "init", "--scope", "project_local"])
+    assert result.exit_code != 0
+    assert "requires a project root" in result.output
+
+
+# ── _append_gitignore_marker direct unit tests ──────────────────────────
+
+
+def test_append_gitignore_marker_idempotent(tmp_path: Path) -> None:
+    proj = _make_project(tmp_path)
+    wrote, msg = _append_gitignore_marker(proj)
+    assert wrote and msg == "appended"
+    wrote2, msg2 = _append_gitignore_marker(proj)
+    assert not wrote2 and msg2 == "already_present"
+
+
+def test_append_gitignore_marker_no_git_repo_pyproject_only(tmp_path: Path) -> None:
+    proj = _make_project(tmp_path, git=False, pyproject=True)
+    wrote, msg = _append_gitignore_marker(proj)
+    assert not wrote and msg == "no_git_repo_pyproject_only"
+    assert not (proj / ".gitignore").exists()
+
+
+def test_append_gitignore_marker_no_project_signal(tmp_path: Path) -> None:
+    proj = tmp_path / "bare"
+    proj.mkdir()
+    wrote, msg = _append_gitignore_marker(proj)
+    assert not wrote and msg == "no_project_signal"
+
+
+def test_append_gitignore_marker_pattern_grep_ignored(tmp_path: Path) -> None:
+    """Marker is the comment line, NOT the patterns — users may have the
+    patterns elsewhere for unrelated reasons."""
+    proj = _make_project(tmp_path)
+    (proj / ".gitignore").write_text(".memtomem/.staging/\n", encoding="utf-8")  # pattern only
+    wrote, msg = _append_gitignore_marker(proj)
+    assert wrote and msg == "appended"  # block written despite pattern present
+
+
+# ── Gate A on import path ──────────────────────────────────────────────
+
+
+def test_extract_agents_user_scope_blocks_secret_no_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+
+    _seed_user_runtime_agents(home, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
+
+    result = extract_agents_to_canonical(proj, scope="user")
+    # Skipped with PRIVACY_BLOCKED, not imported.
+    assert result.imported == []
+    names = [name for name, _, _ in result.skipped]
+    assert "leak" in names
+    codes = [code for _, _, code in result.skipped]
+    assert skip_codes.PRIVACY_BLOCKED in codes
+    # Canonical user-tier dir does not contain leak.
+    assert not (home / ".memtomem" / "agents" / "leak").exists()
+
+
+def test_extract_agents_user_scope_force_unsafe_writes_and_audits(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """#15 + ``feedback_force_unsafe_redaction_valve_only.md``:
+    --force-unsafe-import must (a) write raw bytes AND (b) emit audit log."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+
+    src = _seed_user_runtime_agents(home, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
+
+    with caplog.at_level(logging.INFO, logger="memtomem.privacy"):
+        result = extract_agents_to_canonical(proj, scope="user", force_unsafe_import=True)
+
+    # Imported, with raw bytes preserved.
+    assert len(result.imported) == 1
+    written_path, _layout = result.imported[0]
+    assert written_path.read_bytes() == src.read_bytes()
+
+    # Audit log carries the bypass record.
+    bypass_lines = [rec for rec in caplog.records if "force_unsafe=True" in rec.getMessage()]
+    assert bypass_lines, f"no bypass audit-log line found in {caplog.records}"
+
+
+def test_extract_agents_project_shared_blocked_hard_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#2 — project_shared destination + blocked → ClickException."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    proj = _make_project(tmp_path)
+    _seed_project_runtime_agents(proj, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        extract_agents_to_canonical(proj, scope="project_shared")
+    msg = exc_info.value.message
+    assert "Gate A" in msg
+    assert "project_shared" in msg
+    # No file written.
+    assert not (proj / ".memtomem" / "agents" / "leak").exists()
+
+
+def test_extract_agents_project_shared_force_unsafe_still_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B-spec smoke #16 — --force-unsafe-import does NOT bypass project_shared."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    proj = _make_project(tmp_path)
+    _seed_project_runtime_agents(proj, "leak", f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        extract_agents_to_canonical(proj, scope="project_shared", force_unsafe_import=True)
+    assert "no force bypass" in exc_info.value.message.lower()
+
+
+# ── Skills tree walk ───────────────────────────────────────────────────
+
+
+def test_extract_skills_per_file_walk_blocks_scripts_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B2 — secret in scripts/leak.py blocks the entire skill (atomic)."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+
+    skill = home / ".claude" / "skills" / "myskill"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: myskill\n---\nclean body\n", encoding="utf-8")
+    (skill / "scripts" / "leak.py").write_text(f"# uses {_AKIA_SECRET}\n", encoding="utf-8")
+
+    result = extract_skills_to_canonical(proj, scope="user")
+    assert result.imported == []
+    names = [name for name, _, _ in result.skipped]
+    assert "myskill" in names
+    # No partial copy — even SKILL.md must NOT exist in canonical.
+    assert not (home / ".memtomem" / "skills" / "myskill").exists()
+
+
+def test_extract_skills_clean_skill_copies_normally(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+
+    skill = home / ".claude" / "skills" / "clean"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: clean\n---\nbody\n", encoding="utf-8")
+    (skill / "scripts" / "tool.py").write_text("def run(): pass\n", encoding="utf-8")
+
+    result = extract_skills_to_canonical(proj, scope="user")
+    assert len(result.imported) == 1
+    dst = result.imported[0]
+    assert (dst / "SKILL.md").is_file()
+    assert (dst / "scripts" / "tool.py").is_file()
+
+
+# ── Commands two-branch (B3) ───────────────────────────────────────────
+
+
+def test_extract_commands_gemini_toml_secret_in_prompt_blocked(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B3 — Gemini TOML's `prompt` field secret caught after conversion."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+
+    gem = home / ".gemini" / "commands"
+    gem.mkdir(parents=True)
+    (gem / "leak.toml").write_text(
+        f'description = "leak demo"\nprompt = "uses {_AKIA_SECRET}"\n',
+        encoding="utf-8",
+    )
+
+    result = extract_commands_to_canonical(proj, scope="user")
+    assert result.imported == []
+    codes = [code for _, _, code in result.skipped]
+    assert skip_codes.PRIVACY_BLOCKED in codes
+
+
+def test_extract_commands_codex_not_imported(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex prompts intentionally not imported even at user scope."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+
+    codex = home / ".codex" / "prompts"
+    codex.mkdir(parents=True)
+    (codex / "foo.md").write_text("---\nname: foo\n---\nbody\n", encoding="utf-8")
+
+    result = extract_commands_to_canonical(proj, scope="user")
+    # The runtime fan-out table reserves ("commands", "codex", "user") but the
+    # extract path is Claude+Gemini only.
+    assert all(name != "foo" for name, _, _ in result.skipped)
+    assert all("foo" not in str(p) for p, _ in result.imported)
+
+
+# ── project_local short-circuit ─────────────────────────────────────────
+
+
+def test_extract_agents_project_local_returns_no_fanout_skip(tmp_path: Path) -> None:
+    proj = _make_project(tmp_path)
+    result = extract_agents_to_canonical(proj, scope="project_local")
+    assert result.imported == []
+    assert any(code == skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME for _, _, code in result.skipped)
+
+
+def test_extract_skills_project_local_returns_no_fanout_skip(tmp_path: Path) -> None:
+    proj = _make_project(tmp_path)
+    result = extract_skills_to_canonical(proj, scope="project_local")
+    assert result.imported == []
+    assert any(code == skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME for _, _, code in result.skipped)
+
+
+def test_extract_commands_project_local_returns_no_fanout_skip(tmp_path: Path) -> None:
+    proj = _make_project(tmp_path)
+    result = extract_commands_to_canonical(proj, scope="project_local")
+    assert result.imported == []
+    assert any(code == skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME for _, _, code in result.skipped)
+
+
+# ── B1 — symmetric assertion on unknown decision ───────────────────────
+
+
+def test_unknown_decision_raises_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B1 — unexpected enforce_write_guard decision is fail-loud."""
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    proj = _make_project(tmp_path)
+    _seed_user_runtime_agents(home, "agt", "---\nname: agt\n---\nbody\n")
+
+    def fake_guard(*a: Any, **kw: Any) -> WriteGuardResult:
+        return WriteGuardResult("nonsense", [])
+
+    monkeypatch.setattr("memtomem.context.agents.privacy.enforce_write_guard", fake_guard)
+    with pytest.raises(RuntimeError, match="unexpected decision"):
+        extract_agents_to_canonical(proj, scope="user")

--- a/packages/memtomem/tests/test_context_override_per_scope.py
+++ b/packages/memtomem/tests/test_context_override_per_scope.py
@@ -1,0 +1,150 @@
+"""ADR-0011 PR-E per-scope override resolution.
+
+Layout PRESERVED: ``<canonical>/<asset_type>/<name>/overrides/<vendor>.<ext>``
+per scope. Narrow→broad lookup with first-hit (project_local > project_shared
+> user). Default ``scope=None`` searches all three; explicit scope limits.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memtomem.context.override import resolve
+
+
+VENDOR_EXT = "md"  # claude/agents → .md per OVERRIDE_FORMATS
+
+
+def _write_override(
+    project_root: Path,
+    *,
+    scope_dir_name: str,  # "agents" or "agents.local"
+    name: str,
+    vendor: str,
+    body: str,
+    user_base: Path | None = None,
+) -> Path:
+    """Helper: create an override file under the appropriate canonical tree."""
+    if scope_dir_name.startswith("user:"):
+        # Encode user-tier writes via separate user_base param
+        assert user_base is not None
+        artifact = scope_dir_name.split(":", 1)[1]
+        base = user_base / artifact
+    else:
+        base = project_root / ".memtomem" / scope_dir_name
+    out = base / name / "overrides" / f"{vendor}.{VENDOR_EXT}"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(body)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Single-scope explicit lookups — exact-tier matching
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_project_shared_scope(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    written = _write_override(
+        project, scope_dir_name="agents", name="foo", vendor="claude", body="shared body"
+    )
+    out = resolve(project, "agents", "foo", "claude", scope="project_shared")
+    assert out == written
+
+
+def test_explicit_project_local_scope(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    written = _write_override(
+        project, scope_dir_name="agents.local", name="foo", vendor="claude", body="local body"
+    )
+    out = resolve(project, "agents", "foo", "claude", scope="project_local")
+    assert out == written
+
+
+def test_explicit_project_shared_misses_when_only_local_exists(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    _write_override(
+        project, scope_dir_name="agents.local", name="foo", vendor="claude", body="local"
+    )
+    # Explicit project_shared — must not see project_local override
+    assert resolve(project, "agents", "foo", "claude", scope="project_shared") is None
+
+
+# ---------------------------------------------------------------------------
+# Default scope=None: narrow→broad lookup with first-hit
+# ---------------------------------------------------------------------------
+
+
+def test_narrow_wins_local_over_shared(tmp_path: Path) -> None:
+    """project_local override AND project_shared override → project_local wins."""
+    project = tmp_path / "proj"
+    local = _write_override(
+        project, scope_dir_name="agents.local", name="foo", vendor="claude", body="local"
+    )
+    _write_override(project, scope_dir_name="agents", name="foo", vendor="claude", body="shared")
+    # Default scope=None
+    out = resolve(project, "agents", "foo", "claude")
+    assert out == local
+
+
+def test_narrow_wins_shared_over_user_when_local_absent(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "proj"
+    user_base = tmp_path / "home" / ".memtomem"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    _write_override(
+        project,
+        scope_dir_name="user:agents",
+        name="foo",
+        vendor="claude",
+        body="user",
+        user_base=user_base,
+    )
+    shared = _write_override(
+        project, scope_dir_name="agents", name="foo", vendor="claude", body="shared"
+    )
+    out = resolve(project, "agents", "foo", "claude")
+    assert out == shared  # narrow-wins: shared beats user
+
+
+# ---------------------------------------------------------------------------
+# Broad-only fallback — only user override exists, must resolve to user.
+# (Tie-break-only test would miss this path.)
+# ---------------------------------------------------------------------------
+
+
+def test_broad_only_user_fallback(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    user_base = tmp_path / "home" / ".memtomem"
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    user_override = _write_override(
+        project,
+        scope_dir_name="user:agents",
+        name="foo",
+        vendor="claude",
+        body="user only",
+        user_base=user_base,
+    )
+    out = resolve(project, "agents", "foo", "claude")
+    assert out == user_override
+
+
+def test_no_override_anywhere_returns_none(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    assert resolve(project, "agents", "foo", "claude") is None
+
+
+# ---------------------------------------------------------------------------
+# Asset type filtering — agents override doesn't satisfy skills lookup
+# ---------------------------------------------------------------------------
+
+
+def test_asset_type_filter(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    _write_override(
+        project, scope_dir_name="agents", name="foo", vendor="claude", body="agents body"
+    )
+    assert resolve(project, "agents", "foo", "claude") is not None
+    assert resolve(project, "skills", "foo", "claude") is None
+    assert resolve(project, "commands", "foo", "claude") is None

--- a/packages/memtomem/tests/test_context_override_per_scope.py
+++ b/packages/memtomem/tests/test_context_override_per_scope.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from memtomem.context.override import resolve
+from .helpers import set_home
 
 
 VENDOR_EXT = "md"  # claude/agents → .md per OVERRIDE_FORMATS
@@ -90,7 +91,7 @@ def test_narrow_wins_local_over_shared(tmp_path: Path) -> None:
 def test_narrow_wins_shared_over_user_when_local_absent(tmp_path: Path, monkeypatch) -> None:
     project = tmp_path / "proj"
     user_base = tmp_path / "home" / ".memtomem"
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
     _write_override(
         project,
         scope_dir_name="user:agents",
@@ -116,7 +117,7 @@ def test_broad_only_user_fallback(tmp_path: Path, monkeypatch) -> None:
     project = tmp_path / "proj"
     project.mkdir()
     user_base = tmp_path / "home" / ".memtomem"
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    set_home(monkeypatch, str(tmp_path / "home"))
     user_override = _write_override(
         project,
         scope_dir_name="user:agents",

--- a/packages/memtomem/tests/test_context_runtime_targets.py
+++ b/packages/memtomem/tests/test_context_runtime_targets.py
@@ -16,6 +16,8 @@ from memtomem.context._runtime_targets import (
     RUNTIME_FANOUT_TABLE,
     runtime_fanout_root,
 )
+
+from .helpers import set_home
 from memtomem.context.scope_resolver import ArtifactKind
 
 
@@ -58,13 +60,13 @@ def test_codex_commands_user_only() -> None:
 
 
 def test_user_scope_expands_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = runtime_fanout_root("agents", "claude", "user", project_root=None)
     assert out == (tmp_path / ".claude" / "agents").resolve()
 
 
 def test_user_scope_codex_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HOME", str(tmp_path))
+    set_home(monkeypatch, str(tmp_path))
     out = runtime_fanout_root("commands", "codex", "user", project_root=None)
     assert out == (tmp_path / ".codex" / "prompts").resolve()
 

--- a/packages/memtomem/tests/test_context_runtime_targets.py
+++ b/packages/memtomem/tests/test_context_runtime_targets.py
@@ -1,0 +1,120 @@
+"""Tests for ADR-0011 PR-E ``context._runtime_targets`` runtime-side table.
+
+Pins the full RUNTIME_FANOUT_TABLE so coverage is mechanical and any
+future runtime addition forces a deliberate test update (no silent gaps).
+"""
+
+from __future__ import annotations
+
+from itertools import product
+from pathlib import Path
+
+import pytest
+
+from memtomem.context._runtime_targets import (
+    KNOWN_RUNTIMES,
+    RUNTIME_FANOUT_TABLE,
+    runtime_fanout_root,
+)
+from memtomem.context.scope_resolver import ArtifactKind
+
+
+ARTIFACTS: tuple[ArtifactKind, ...] = ("agents", "skills", "commands")
+SCOPES = ("user", "project_shared", "project_local")
+
+
+# ---------------------------------------------------------------------------
+# Table shape — every (artifact, runtime, scope) tuple is populated
+# ---------------------------------------------------------------------------
+
+
+def test_table_covers_full_cross_product() -> None:
+    """Table must contain every (artifact, runtime, scope) tuple — no gaps."""
+    expected = set(product(ARTIFACTS, KNOWN_RUNTIMES, SCOPES))
+    actual = set(RUNTIME_FANOUT_TABLE.keys())
+    missing = expected - actual
+    extra = actual - expected
+    assert not missing, f"missing tuples: {missing}"
+    assert not extra, f"extra tuples not in cross-product: {extra}"
+
+
+def test_all_project_local_entries_are_none() -> None:
+    """ADR §3: project_local has no runtime fan-out — every entry None."""
+    for (artifact, runtime, scope), value in RUNTIME_FANOUT_TABLE.items():
+        if scope == "project_local":
+            assert value is None, f"{(artifact, runtime, scope)} should be None (ADR §3)"
+
+
+def test_codex_commands_user_only() -> None:
+    """Codex CLI prompts are user-tier only by design (commands.py:5)."""
+    assert RUNTIME_FANOUT_TABLE[("commands", "codex", "user")] is not None
+    assert RUNTIME_FANOUT_TABLE[("commands", "codex", "project_shared")] is None
+    assert RUNTIME_FANOUT_TABLE[("commands", "codex", "project_local")] is None
+
+
+# ---------------------------------------------------------------------------
+# runtime_fanout_root — happy path resolution per scope
+# ---------------------------------------------------------------------------
+
+
+def test_user_scope_expands_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = runtime_fanout_root("agents", "claude", "user", project_root=None)
+    assert out == (tmp_path / ".claude" / "agents").resolve()
+
+
+def test_user_scope_codex_commands(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    out = runtime_fanout_root("commands", "codex", "user", project_root=None)
+    assert out == (tmp_path / ".codex" / "prompts").resolve()
+
+
+def test_project_shared_joins_root(tmp_path: Path) -> None:
+    out = runtime_fanout_root("agents", "gemini", "project_shared", project_root=tmp_path)
+    assert out == (tmp_path / ".gemini" / "agents").resolve()
+
+
+def test_codex_skills_project_uses_dot_agents(tmp_path: Path) -> None:
+    """Codex skills project-scope path is .agents/skills, NOT .codex/skills."""
+    out = runtime_fanout_root("skills", "codex", "project_shared", project_root=tmp_path)
+    assert out == (tmp_path / ".agents" / "skills").resolve()
+
+
+def test_project_local_returns_none(tmp_path: Path) -> None:
+    """Every project_local lookup returns None (no fan-out)."""
+    for artifact, runtime in product(ARTIFACTS, KNOWN_RUNTIMES):
+        out = runtime_fanout_root(artifact, runtime, "project_local", project_root=tmp_path)
+        assert out is None, f"({artifact}, {runtime}, project_local) should be None"
+
+
+def test_codex_commands_project_shared_returns_none(tmp_path: Path) -> None:
+    out = runtime_fanout_root("commands", "codex", "project_shared", project_root=tmp_path)
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — no silent fallback
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_runtime_raises_keyerror(tmp_path: Path) -> None:
+    """An unknown runtime is a programming error — KeyError, not None."""
+    with pytest.raises(KeyError):
+        runtime_fanout_root("agents", "imaginary_runtime", "user", project_root=tmp_path)
+
+
+def test_unknown_artifact_raises_keyerror(tmp_path: Path) -> None:
+    with pytest.raises(KeyError):
+        runtime_fanout_root("imaginary_artifact", "claude", "user", project_root=tmp_path)  # type: ignore[arg-type]
+
+
+def test_project_scope_without_root_raises_valueerror() -> None:
+    """ValueError is preferred over silent None for missing project_root."""
+    with pytest.raises(ValueError, match="requires project_root"):
+        runtime_fanout_root("agents", "claude", "project_shared", project_root=None)
+
+
+def test_project_local_without_root_returns_none_first() -> None:
+    """project_local entries are None — that branch wins before the
+    project_root check, so passing None is harmless for project_local."""
+    assert runtime_fanout_root("agents", "claude", "project_local", project_root=None) is None

--- a/packages/memtomem/tests/test_context_scope_resolver.py
+++ b/packages/memtomem/tests/test_context_scope_resolver.py
@@ -1,0 +1,174 @@
+"""Tests for ADR-0011 PR-E ``context.scope_resolver`` canonical-side API.
+
+The runtime fan-out side has its own test module
+(``test_context_runtime_targets``); this file covers ``canonical_artifact_dir``,
+``list_artifact_scopes_present``, and ``project_root_from_artifact_path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.scope_resolver import (
+    ContextScopeError,
+    canonical_artifact_dir,
+    list_artifact_scopes_present,
+    project_root_from_artifact_path,
+)
+
+
+ARTIFACTS = ("agents", "skills", "commands")
+
+
+# ---------------------------------------------------------------------------
+# canonical_artifact_dir — 9 happy cases (3 artifacts × 3 scopes) + errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("artifact", ARTIFACTS)
+def test_canonical_user_scope(tmp_path: Path, artifact: str) -> None:
+    user_base = tmp_path / "home" / ".memtomem"
+    out = canonical_artifact_dir(artifact, "user", project_root=None, user_base=user_base)  # type: ignore[arg-type]
+    assert out == (user_base / artifact).resolve()
+
+
+@pytest.mark.parametrize("artifact", ARTIFACTS)
+def test_canonical_project_shared(tmp_path: Path, artifact: str) -> None:
+    project = tmp_path / "myproj"
+    project.mkdir()
+    out = canonical_artifact_dir(artifact, "project_shared", project_root=project)  # type: ignore[arg-type]
+    assert out == (project / ".memtomem" / artifact).resolve()
+
+
+@pytest.mark.parametrize("artifact", ARTIFACTS)
+def test_canonical_project_local(tmp_path: Path, artifact: str) -> None:
+    project = tmp_path / "myproj"
+    project.mkdir()
+    out = canonical_artifact_dir(artifact, "project_local", project_root=project)  # type: ignore[arg-type]
+    assert out == (project / ".memtomem" / f"{artifact}.local").resolve()
+
+
+@pytest.mark.parametrize("scope", ["project_shared", "project_local"])
+def test_canonical_project_tier_requires_root(scope: str) -> None:
+    with pytest.raises(ContextScopeError, match="requires a project context"):
+        canonical_artifact_dir("agents", scope, project_root=None)  # type: ignore[arg-type]
+
+
+def test_canonical_unknown_scope(tmp_path: Path) -> None:
+    # Pass a valid project_root so the ``project_root is None`` branch
+    # doesn't intercept; we want the unsupported-scope branch.
+    with pytest.raises(ContextScopeError, match="unsupported artifact scope"):
+        canonical_artifact_dir("agents", "bogus", project_root=tmp_path)  # type: ignore[arg-type]
+
+
+def test_canonical_user_base_default_expands_home() -> None:
+    out = canonical_artifact_dir("agents", "user", project_root=None)
+    # ``~/.memtomem`` resolves to absolute under user's home; just check
+    # the expansion happened (no leading ``~``).
+    assert "~" not in str(out)
+    assert out.name == "agents"
+
+
+# ---------------------------------------------------------------------------
+# list_artifact_scopes_present — directory presence drives membership
+# ---------------------------------------------------------------------------
+
+
+def test_list_scopes_present_empty(tmp_path: Path) -> None:
+    project = tmp_path / "p"
+    project.mkdir()
+    user_base = tmp_path / "home" / ".memtomem"
+    assert list_artifact_scopes_present("agents", project, user_base=user_base) == []
+
+
+def test_list_scopes_present_user_only(tmp_path: Path) -> None:
+    project = tmp_path / "p"
+    project.mkdir()
+    user_base = tmp_path / "home" / ".memtomem"
+    (user_base / "agents").mkdir(parents=True)
+    assert list_artifact_scopes_present("agents", project, user_base=user_base) == ["user"]
+
+
+def test_list_scopes_present_all_three(tmp_path: Path) -> None:
+    project = tmp_path / "p"
+    project.mkdir()
+    (project / ".memtomem" / "agents").mkdir(parents=True)
+    (project / ".memtomem" / "agents.local").mkdir(parents=True)
+    user_base = tmp_path / "home" / ".memtomem"
+    (user_base / "agents").mkdir(parents=True)
+    out = list_artifact_scopes_present("agents", project, user_base=user_base)
+    assert set(out) == {"user", "project_shared", "project_local"}
+
+
+def test_list_scopes_present_isolates_artifacts(tmp_path: Path) -> None:
+    """Skills directory presence does NOT count as agents-tier presence."""
+    project = tmp_path / "p"
+    project.mkdir()
+    (project / ".memtomem" / "skills").mkdir(parents=True)
+    user_base = tmp_path / "home" / ".memtomem"
+    assert list_artifact_scopes_present("agents", project, user_base=user_base) == []
+    assert list_artifact_scopes_present("skills", project, user_base=user_base) == [
+        "project_shared"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# project_root_from_artifact_path — walk parents for .memtomem ancestor
+# ---------------------------------------------------------------------------
+
+
+def test_project_root_happy_path(tmp_path: Path) -> None:
+    project = tmp_path / "myproj"
+    (project / ".memtomem" / "agents").mkdir(parents=True)
+    artifact = project / ".memtomem" / "agents" / "foo.md"
+    artifact.touch()
+    assert project_root_from_artifact_path(artifact) == project
+
+
+def test_project_root_deeply_nested(tmp_path: Path) -> None:
+    project = tmp_path / "myproj"
+    nested = project / ".memtomem" / "skills" / "deep-skill" / "scripts"
+    nested.mkdir(parents=True)
+    leaf = nested / "run.sh"
+    leaf.touch()
+    assert project_root_from_artifact_path(leaf) == project
+
+
+def test_project_root_no_ancestor_returns_none(tmp_path: Path) -> None:
+    orphan = tmp_path / "elsewhere" / "file.md"
+    orphan.parent.mkdir(parents=True)
+    orphan.touch()
+    assert project_root_from_artifact_path(orphan) is None
+
+
+def test_project_root_input_is_memtomem_dir_returns_parent(tmp_path: Path) -> None:
+    """When the input path itself IS ``.memtomem``, return its parent."""
+    project = tmp_path / "myproj"
+    memdir = project / ".memtomem"
+    memdir.mkdir(parents=True)
+    assert project_root_from_artifact_path(memdir) == project
+
+
+def test_project_root_non_artifact_path_inside_project_returns_none(tmp_path: Path) -> None:
+    """A source file under a project that contains ``.memtomem`` is NOT an
+    artifact path. The walk must check ``ancestor.name == ".memtomem"``,
+    not ``(ancestor / ".memtomem").is_dir()`` — otherwise any path under
+    a memtomem-using repo would falsely map to the project root.
+    """
+    project = tmp_path / "myproj"
+    (project / ".memtomem" / "agents").mkdir(parents=True)
+    src_file = project / "src" / "foo.py"
+    src_file.parent.mkdir(parents=True)
+    src_file.touch()
+    # src/foo.py is inside the project but has no .memtomem ancestor.
+    assert project_root_from_artifact_path(src_file) is None
+
+
+def test_project_root_path_under_project_root_itself(tmp_path: Path) -> None:
+    """The project root itself isn't an artifact path; returns None."""
+    project = tmp_path / "myproj"
+    (project / ".memtomem").mkdir(parents=True)
+    # project root has .memtomem as a child but not an ancestor.
+    assert project_root_from_artifact_path(project) is None


### PR DESCRIPTION
## Summary

ADR-0011 PR-E (E1 + E2) — agents / skills / commands canonical scope axis. **Draft until ship gate 2026-05-23** per ADR §9 (≥2-week zero-P0/P1 dwell against ADR-0010 settings-migrate AND PR #882 memory scope plumbing).

This is the umbrella draft that covers both PR-E1 (mechanical resolver
plumbing) and PR-E2 (user-visible `mm context init --scope` surface +
Gate A/B). Sub-PRs E3 (sync filter + privacy_scan) and E4 (cross-tier
migrate) will land separately after ship-gate.

### E1 — canonical/runtime resolvers + per-scope override

- NEW `context/scope_resolver.py` — `canonical_artifact_dir(artifact, scope, project_root)` resolves the canonical-side directory per scope (sibling of `memtomem.memory_scope`, intentionally without DB-tier helpers since artifacts have no SQLite chunk lineage).
- NEW `context/_runtime_targets.py` — explicit `RUNTIME_FANOUT_TABLE` covering every (artifact, runtime, scope) tuple. `None` = no fan-out by design (loud-emit `NO_PROJECT_FANOUT_FOR_RUNTIME`); missing key raises `KeyError` (fail-loud).
- Per-scope `*, scope=` kwarg on `target_file` / `target_dir` of every generator (default `project_shared` → 100% back-compat).
- `_override.resolve(... *, scope=)` with narrow→broad lookup (`project_local > project_shared > user`, first-hit). Existing `<canonical>/<asset_type>/<name>/overrides/<vendor>.<ext>` layout PRESERVED per scope.
- Web routes `context_agents.py` / `context_commands.py` / `context_skills.py` accept `scope` from request (default project_shared).
- `is_dirty` cache key extended to `(artifact, scope)`.

### E2 — `mm context init --scope` + Gate A/B + `.gitignore` auto-append

- Three new flags on `mm context init`:
  - `--scope user|project_shared|project_local` selects the canonical tier to seed AND the runtime root to import from.
  - `--confirm-project-shared` is required only when `--scope` is **explicitly** `project_shared`. Implicit default invocation (`mm context init` no flag) is fully back-compat — no prompt fires in non-interactive CI.
  - `--force-unsafe-import` bypasses Gate A on the runtime-import path for user / project_local destinations only. `project_shared` destinations hard-refuse on any privacy hit (ADR §5: git history is forever).
- `extract_*_to_canonical(... *, scope, force_unsafe_import)` resolves source via `runtime_fanout_root(...)` per scope (so `--scope user` reads `~/.claude/agents` etc.) and destination via `canonical_artifact_dir(...)`. `project_local` short-circuits with `NO_PROJECT_FANOUT_FOR_RUNTIME`.
- Skills walk the source tree with `rglob`; one blocked file in `scripts/`, `references/`, or `assets/` aborts the entire skill atomically (no partial copy in canonical).
- Commands keep two distinct branches — Claude bytes-passthrough vs Gemini TOML→Markdown — and the Gemini branch scans the converted Markdown body so secrets in source `prompt = "..."` still hit Gate A.
- `_resolve_artifact_cli_scope` deliberately defaults to `project_shared` and does NOT consult `cfg.hooks.target_scope` (artifact storage is a different feature axis from settings host placement).
- `_append_gitignore_marker` is comment-marker idempotent. Pyproject-only projects (no `.git`) get a specific `git init` hint and init does not abort.
- New skip codes `privacy_blocked` / `privacy_blocked_project_shared` registered in both `Final` constants and `SkipCode` Literal.

### `enforce_write_guard` proceed-gate (B1)

Explicit `if guard.decision in ("pass", "bypassed")` proceed + `RuntimeError` on any other decision so a future privacy enum addition surfaces loudly rather than silently dropping the write (symmetric assertion per `feedback_pin_invert_symmetric_assertion.md`).

## Reviewer findings → fix mapping (E2)

| # | Finding | Fix |
|---|---|---|
| **B1** | `decision="allowed"` doesn't exist; pseudocode would silently skip writes. | Explicit `("pass","bypassed")` proceed-gate + `RuntimeError` on unknown decision. |
| **B2** | Skills tree walk needed — `scripts/*.py` is a common leak shape. | `rglob` per-file scan; one blocked file → atomic skip of the whole skill. |
| **B3** | Claude vs Gemini branches can't generic-loop. | Two explicit branches; Gemini scans converted Markdown (where source `prompt` field lands). |
| **#1** | Default `mm context init` would silently start prompting. | Gate B fires only on EXPLICIT `--scope project_shared`. |
| **#2** | `project_shared` blocked imports skipped + continued. | Hard-abort with ClickException on any blocked decision. |
| **#3** | `detect_skill_dirs` is project-only — wrong for `--scope user`. | Source via `runtime_fanout_root(...)` for the resolved scope. |
| **#4** | UnicodeDecodeError → `""` false-passes embedded ASCII secrets. | `errors="replace"` (printable ASCII preserved; `�` doesn't overlap with secret-pattern alphanumerics). |
| **#5** | pyproject-only project warns "no .git" but skipped silently. | Specific warning ("project root resolved via pyproject.toml; `.git` missing") with `git init` hint. |
| **#6** | New `SkipCode`s need both surfaces updated. | `Final` constants + `Literal` updated; web UI graceful (special-cases only `no_canonical_root`). |

## Test plan

- [x] 38 new pytest cases (`test_context_init_scope.py` + `test_context_extract_scope_kwarg.py`) cover all reviewer findings + per-scope source/destination pinning.
- [x] Full pytest: 4637 passed, 10 skipped, 0 failed.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `mypy` clean (3 pre-existing memory-migrate annotations unrelated to PR-E).
- [x] Manual smoke matrix in `/tmp/mm-e2-smoke` (subprocess `mm`, isolated `HOME`):
  - [x] #2 `--scope project_shared` no confirm — Gate B prompt + abort
  - [x] #4 `--scope project_local` — `*.local/` dirs + `.gitignore` block written
  - [x] #5 idempotent (sha256 byte-identical)
  - [x] #14 `--scope user --include agents` with leak.md — `PRIVACY_BLOCKED` + bypass hint
  - [x] #15 `--force-unsafe-import` — audit-log "redaction bypass via force_unsafe=True (... hits=1)" + raw bytes match source
  - [x] #16 `--scope project_shared --force-unsafe-import` — exit code 1 + ClickException "no force bypass available"
  - [x] #17 skill `scripts/leak.py` — atomic skip (no SKILL.md copied either)
  - [x] #19 default `mm context init` (no flag) — no prompt, project_shared dirs created (back-compat)

## Pre-merge checklist

- [ ] Wait for ADR-0011 PR-A flip (Proposed → Accepted) on/after **2026-05-23**.
- [ ] Decide whether to merge as one combined PR or split into separate E1 + E2 sub-PRs at ship-gate time.
- [ ] Re-run yesterday's PR-D dwell smoke matrix before merge.
- [ ] Codex review focus per `feedback_codex_review_no_commit.md`:
  - `_resolve_artifact_cli_scope` default ≠ `_resolve_cli_scope` (no `Mem2MemConfig`).
  - Gate B fires only on **explicit** `--scope project_shared`.
  - Per-file `enforce_write_guard` proceed-gate uses `("pass","bypassed")`; unknown decision raises `RuntimeError`.
  - Skills tree walk per-file (`rglob`) — one blocked → entire skill skipped (atomic).
  - Commands two-branch split: Claude bytes-passthrough vs Gemini TOML→Markdown; Gemini scans converted output.
  - `project_shared` destination + blocked decision (with OR without `--force-unsafe-import`) → `click.ClickException` (hard-abort), NEVER append-to-skipped + continue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
