### PR TITLE
PR-E follow-up nits — N4 + D3 + N1 + D2 (apply_gate_a DRY)

### DIFF
--- a/packages/memtomem/src/memtomem/context/_gate_a.py
+++ b/packages/memtomem/src/memtomem/context/_gate_a.py
@@ -69,29 +69,32 @@ def format_project_shared_block_message(
 
 
 @dataclass(frozen=True)
-class GateAOutcome:
-    """Result of :func:`apply_gate_a` for a single content scan.
+class GateAProceed:
+    """:func:`apply_gate_a` outcome — content passed Gate A; caller should write."""
 
-    On the project_shared hard-abort path the helper raises
-    :class:`click.ClickException` directly — callers never observe a
-    ``proceed=False`` outcome with a project_shared scope.
+
+@dataclass(frozen=True)
+class GateABlocked:
+    """:func:`apply_gate_a` outcome — content was blocked at Gate A.
+
+    Only emitted for non-``project_shared`` scopes. ``project_shared``
+    block hits raise :class:`click.ClickException` inside the helper.
 
     Attributes:
-        proceed: ``True`` iff the caller should write the content.
-            ``False`` means the caller should record a skip using
-            ``code`` / ``hits_count`` / ``hint``.
-        code: ``PRIVACY_BLOCKED`` or ``PRIVACY_BLOCKED_PROJECT_SHARED``
-            when ``proceed`` is ``False``; ``None`` otherwise.
+        code: ``PRIVACY_BLOCKED`` or ``PRIVACY_BLOCKED_PROJECT_SHARED``.
         hits_count: Number of privacy pattern hits — count only, never
-            echo bytes. Zero when ``proceed`` is ``True``.
+            echo bytes.
         hint: ``" — pass --force-unsafe-import to bypass"`` for
             ``decision == "blocked"``, otherwise ``""``.
     """
 
-    proceed: bool
-    code: skip_codes.SkipCode | None
+    code: skip_codes.SkipCode
     hits_count: int
     hint: str
+
+
+# Discriminated union — callers narrow with ``isinstance(outcome, GateABlocked)``.
+GateAOutcome = GateAProceed | GateABlocked
 
 
 def apply_gate_a(
@@ -100,7 +103,7 @@ def apply_gate_a(
     src: Path,
     scope: TargetScope,
     force_unsafe_import: bool,
-    audit_context: dict[str, str],
+    audit_context: dict[str, object],
     message_kind: str,
     imported_so_far: int,
 ) -> GateAOutcome:
@@ -108,15 +111,15 @@ def apply_gate_a(
 
     Outcomes:
       * ``decision in ("pass", "bypassed")`` — return
-        :class:`GateAOutcome` with ``proceed=True``.
+        :class:`GateAProceed`.
       * ``decision in ("blocked", "blocked_project_shared")`` AND
         ``scope == "project_shared"`` — raise :class:`click.ClickException`
         via :func:`format_project_shared_block_message`. The
         ``project_shared`` ban is hard regardless of
         ``force_unsafe_import`` (ADR-0011 §5).
       * ``decision in ("blocked", "blocked_project_shared")`` AND
-        ``scope != "project_shared"`` — return :class:`GateAOutcome`
-        with ``proceed=False`` and the matching ``code`` / ``hint``.
+        ``scope != "project_shared"`` — return :class:`GateABlocked`
+        with the matching ``code`` / ``hits_count`` / ``hint``.
       * Anything else — :class:`RuntimeError` (fail-loud on enum drift).
 
     Args:
@@ -166,15 +169,10 @@ def apply_gate_a(
             else skip_codes.PRIVACY_BLOCKED
         )
         hint = " — pass --force-unsafe-import to bypass" if guard.decision == "blocked" else ""
-        return GateAOutcome(
-            proceed=False,
-            code=code,
-            hits_count=len(guard.hits),
-            hint=hint,
-        )
+        return GateABlocked(code=code, hits_count=len(guard.hits), hint=hint)
     if guard.decision not in ("pass", "bypassed"):
         # Symmetric assertion — fail-loud on unknown decision so a
         # future privacy enum addition surfaces here rather than
         # silently dropping the write.
         raise RuntimeError(f"enforce_write_guard returned unexpected decision: {guard.decision!r}")
-    return GateAOutcome(proceed=True, code=None, hits_count=0, hint="")
+    return GateAProceed()

--- a/packages/memtomem/src/memtomem/context/_gate_a.py
+++ b/packages/memtomem/src/memtomem/context/_gate_a.py
@@ -130,19 +130,33 @@ def apply_gate_a(
             ``project_shared`` ClickException only — never echoed for
             non-project_shared skips.
         scope: Destination scope.
-        force_unsafe_import: Caller's bypass flag. Only honoured for
-            ``user`` / ``project_local`` scopes.
+        force_unsafe_import: Caller's bypass flag — the value of the
+            CLI's ``--force-unsafe-import`` flag (or its MCP equivalent).
+            Forwarded to :func:`privacy.enforce_write_guard` as the
+            ``force_unsafe`` kwarg; the kept-distinct names mark the
+            "this is the import-side bypass valve" call site
+            (``project_shared`` ignores it regardless).
         audit_context: Caller-supplied dict, passed verbatim to
             :func:`privacy.enforce_write_guard`. Helper does not inject
             or rename keys (so SOC-pipeline grep on per-kind fields like
             ``agent_name`` / ``source_file`` / ``runtime`` is preserved).
+            Typed ``dict[str, object]`` to match the chokepoint signature
+            (``privacy.enforce_write_guard``); current callers pass
+            ``dict[str, str]`` literals which mypy widens at the call
+            site. Non-string values are supported by
+            :func:`privacy._sanitize_audit_value`.
         message_kind: Singular display noun for the ClickException
             ("agent" / "skill" / "command"). Distinct from the plural
             ``kind`` field that callers usually carry inside
             ``audit_context``.
         imported_so_far: Number of artifacts already imported in this
             run; passed through to the cleanup hint in the
-            ClickException message.
+            ClickException message. **Invariant**: callers must compute
+            this from a list that is appended to only AFTER ``apply_gate_a``
+            returns ``GateAProceed`` (i.e. no mid-scan mutation). A future
+            partial-copy refactor that appends to the imported list
+            inside the scan loop would silently change the cleanup-hint
+            count and must update this contract.
     """
     guard = privacy.enforce_write_guard(
         content_text,

--- a/packages/memtomem/src/memtomem/context/_gate_a.py
+++ b/packages/memtomem/src/memtomem/context/_gate_a.py
@@ -1,19 +1,34 @@
-"""ADR-0011 PR-E2 — Gate A error formatting helpers shared across extract paths.
+"""ADR-0011 PR-E2 — Gate A helpers shared across extract paths.
 
-Centralises the user-facing error message format for ``project_shared`` Gate A
-hard-abort so ``extract_agents_to_canonical``, ``extract_skills_to_canonical``,
-and ``extract_commands_to_canonical`` cannot drift on the wording. The message
-deliberately echoes only the hit count and source path — never the matched
-bytes themselves (``feedback_force_unsafe_redaction_valve_only.md`` and the
+Centralises both the user-facing error message format for
+``project_shared`` Gate A hard-abort and the proceed-gate decision logic
+so ``extract_agents_to_canonical``, ``extract_skills_to_canonical``, and
+``extract_commands_to_canonical`` cannot drift on either the wording or
+the per-decision branching. The message deliberately echoes only the hit
+count and source path — never the matched bytes themselves
+(``feedback_force_unsafe_redaction_valve_only.md`` and the
 ``RedactionHit`` docstring on the privacy module both pin the
 "never echo secrets" contract).
+
+The proceed-gate helper :func:`apply_gate_a` keeps the audit_context
+dictionary opaque — callers continue to supply their own per-kind
+field shape (``agent_name`` vs ``command_name`` vs ``skill_name``;
+``source`` vs ``source_file``; ``runtime``; etc.) — so a future
+"normalise the audit shape" refactor cannot silently break SOC-pipeline
+grep on those fields. The display-side singular noun is a separate
+``message_kind`` parameter.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
+import click
+
+from memtomem import privacy
 from memtomem.config import TargetScope
+from memtomem.context import _skip_reasons as skip_codes
 
 
 def format_project_shared_block_message(
@@ -51,3 +66,115 @@ def format_project_shared_block_message(
         f"  Retry with --scope=user or --scope=project_local, or remove the "
         f"secret from {src} first.{tail}"
     )
+
+
+@dataclass(frozen=True)
+class GateAOutcome:
+    """Result of :func:`apply_gate_a` for a single content scan.
+
+    On the project_shared hard-abort path the helper raises
+    :class:`click.ClickException` directly — callers never observe a
+    ``proceed=False`` outcome with a project_shared scope.
+
+    Attributes:
+        proceed: ``True`` iff the caller should write the content.
+            ``False`` means the caller should record a skip using
+            ``code`` / ``hits_count`` / ``hint``.
+        code: ``PRIVACY_BLOCKED`` or ``PRIVACY_BLOCKED_PROJECT_SHARED``
+            when ``proceed`` is ``False``; ``None`` otherwise.
+        hits_count: Number of privacy pattern hits — count only, never
+            echo bytes. Zero when ``proceed`` is ``True``.
+        hint: ``" — pass --force-unsafe-import to bypass"`` for
+            ``decision == "blocked"``, otherwise ``""``.
+    """
+
+    proceed: bool
+    code: skip_codes.SkipCode | None
+    hits_count: int
+    hint: str
+
+
+def apply_gate_a(
+    *,
+    content_text: str,
+    src: Path,
+    scope: TargetScope,
+    force_unsafe_import: bool,
+    audit_context: dict[str, str],
+    message_kind: str,
+    imported_so_far: int,
+) -> GateAOutcome:
+    """Run :func:`privacy.enforce_write_guard` and decide proceed / skip / abort.
+
+    Outcomes:
+      * ``decision in ("pass", "bypassed")`` — return
+        :class:`GateAOutcome` with ``proceed=True``.
+      * ``decision in ("blocked", "blocked_project_shared")`` AND
+        ``scope == "project_shared"`` — raise :class:`click.ClickException`
+        via :func:`format_project_shared_block_message`. The
+        ``project_shared`` ban is hard regardless of
+        ``force_unsafe_import`` (ADR-0011 §5).
+      * ``decision in ("blocked", "blocked_project_shared")`` AND
+        ``scope != "project_shared"`` — return :class:`GateAOutcome`
+        with ``proceed=False`` and the matching ``code`` / ``hint``.
+      * Anything else — :class:`RuntimeError` (fail-loud on enum drift).
+
+    Args:
+        content_text: Bytes-decoded content to scan. Caller decodes with
+            ``errors="replace"`` so non-UTF8 bytes cannot mask an
+            embedded ASCII secret.
+        src: The source file the content was read from. Surfaced in the
+            ``project_shared`` ClickException only — never echoed for
+            non-project_shared skips.
+        scope: Destination scope.
+        force_unsafe_import: Caller's bypass flag. Only honoured for
+            ``user`` / ``project_local`` scopes.
+        audit_context: Caller-supplied dict, passed verbatim to
+            :func:`privacy.enforce_write_guard`. Helper does not inject
+            or rename keys (so SOC-pipeline grep on per-kind fields like
+            ``agent_name`` / ``source_file`` / ``runtime`` is preserved).
+        message_kind: Singular display noun for the ClickException
+            ("agent" / "skill" / "command"). Distinct from the plural
+            ``kind`` field that callers usually carry inside
+            ``audit_context``.
+        imported_so_far: Number of artifacts already imported in this
+            run; passed through to the cleanup hint in the
+            ClickException message.
+    """
+    guard = privacy.enforce_write_guard(
+        content_text,
+        surface="cli_context_init",
+        force_unsafe=force_unsafe_import,
+        scope=scope,
+        audit_context=audit_context,
+        record_outcome=True,
+    )
+    if guard.decision in ("blocked", "blocked_project_shared"):
+        if scope == "project_shared":
+            raise click.ClickException(
+                format_project_shared_block_message(
+                    src,
+                    hits_count=len(guard.hits),
+                    scope=scope,
+                    kind=message_kind,
+                    imported_so_far=imported_so_far,
+                )
+            )
+        code: skip_codes.SkipCode = (
+            skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
+            if guard.decision == "blocked_project_shared"
+            else skip_codes.PRIVACY_BLOCKED
+        )
+        hint = " — pass --force-unsafe-import to bypass" if guard.decision == "blocked" else ""
+        return GateAOutcome(
+            proceed=False,
+            code=code,
+            hits_count=len(guard.hits),
+            hint=hint,
+        )
+    if guard.decision not in ("pass", "bypassed"):
+        # Symmetric assertion — fail-loud on unknown decision so a
+        # future privacy enum addition surfaces here rather than
+        # silently dropping the write.
+        raise RuntimeError(f"enforce_write_guard returned unexpected decision: {guard.decision!r}")
+    return GateAOutcome(proceed=True, code=None, hits_count=0, hint="")

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -27,11 +27,15 @@ Design rules:
    yet. Tests assert ``project_*`` entries are ``None``; the user
    entry returns ``~/.codex/prompts`` so a future
    ``CodexCommandsGenerator`` can land without table churn.
-5. **Codex skills user-tier path is a TBD** — Codex's own docs are
-   ambiguous between ``~/.codex/skills`` and ``~/.agents/skills``.
-   We mirror the project-scope path (``.agents/skills``) into the
-   user tier as a placeholder; revise in PR-E follow-up if the
-   Codex CLI's user-scope skill discovery is confirmed elsewhere.
+5. **Codex skills user-tier path is ``~/.agents/skills``** — verified
+   externally against the Agent Skills Open Specification (Anthropic
+   2025-12 release, OpenAI Codex adoption documented in-repo at
+   ``context/skills.py:12-13``). The user-scope path follows the same
+   spec-aligned convention as the project-scope tail
+   (``.agents/skills`` — see ``context/detector.py:34-39`` for the
+   in-repo anchor). Both paths are vendor-neutral by design so a
+   skill installed once is discovered by Claude / Gemini / Codex
+   through their respective alias resolution.
 """
 
 from __future__ import annotations
@@ -55,7 +59,7 @@ _CODEX_AGENTS_REL = Path(".codex/agents")
 
 _CLAUDE_SKILLS_REL = Path(".claude/skills")
 _GEMINI_SKILLS_REL = Path(".gemini/skills")
-_CODEX_SKILLS_REL = Path(".agents/skills")  # NOT .codex/skills — see skills.py:80
+_CODEX_SKILLS_REL = Path(".agents/skills")  # NOT .codex/skills — see skills.py module docstring
 
 _CLAUDE_COMMANDS_REL = Path(".claude/commands")
 _GEMINI_COMMANDS_REL = Path(".gemini/commands")
@@ -82,7 +86,9 @@ RUNTIME_FANOUT_TABLE: dict[tuple[ArtifactKind, str, TargetScope], Path | None] =
     ("skills", "gemini", "user"): Path("~/.gemini/skills"),
     ("skills", "gemini", "project_shared"): _GEMINI_SKILLS_REL,
     ("skills", "gemini", "project_local"): NO_FANOUT,
-    ("skills", "codex", "user"): Path("~/.agents/skills"),  # TBD per docstring rule 5
+    ("skills", "codex", "user"): Path(
+        "~/.agents/skills"
+    ),  # Agent Skills Open Spec — see docstring rule 5
     ("skills", "codex", "project_shared"): _CODEX_SKILLS_REL,
     ("skills", "codex", "project_local"): NO_FANOUT,
     # ── commands ─────────────────────────────────────────────────────

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -41,7 +41,7 @@ from typing import Any, Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._gate_a import apply_gate_a
+from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -803,7 +803,7 @@ def extract_agents_to_canonical(
                 message_kind="agent",
                 imported_so_far=len(imported),
             )
-            if not outcome.proceed:
+            if isinstance(outcome, GateABlocked):
                 skipped.append(
                     (
                         agent_name,
@@ -813,7 +813,7 @@ def extract_agents_to_canonical(
                 )
                 seen[agent_name] = runtime_label
                 continue
-            # outcome.proceed is True — write.
+            # outcome is GateAProceed — write.
             dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_bytes(dst, content_bytes)
             imported.append((dst, layout))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -38,13 +38,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
-import click
-
-from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._gate_a import format_project_shared_block_message
+from memtomem.context._gate_a import apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -782,65 +779,41 @@ def extract_agents_to_canonical(
             # ``errors="replace"`` so non-UTF8 bytes cannot mask an
             # embedded ASCII secret (the replacement char `�` does
             # not overlap with any provider-token alphanumeric pattern).
+            # Project_shared hard-abort (git-history-is-forever) is
+            # raised inside ``apply_gate_a`` — Files imported earlier in
+            # this run that passed Gate A stay (each was scanned
+            # independently).
             try:
                 content_bytes = md_file.read_bytes()
             except OSError as exc:
                 skipped.append((agent_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
                 continue
             content_text = content_bytes.decode("utf-8", errors="replace")
-            guard = privacy.enforce_write_guard(
-                content_text,
-                surface="cli_context_init",
-                force_unsafe=force_unsafe_import,
+            outcome = apply_gate_a(
+                content_text=content_text,
+                src=md_file,
                 scope=scope,
+                force_unsafe_import=force_unsafe_import,
                 audit_context={
                     "source": str(md_file),
                     "target": str(dst),
                     "kind": "agents",
                     "agent_name": agent_name,
                 },
-                record_outcome=True,
+                message_kind="agent",
+                imported_so_far=len(imported),
             )
-            if guard.decision in ("blocked", "blocked_project_shared"):
-                if scope == "project_shared":
-                    # Hard-abort: project_shared writes go into git
-                    # history and cannot be retracted from any clone or
-                    # reflog. Files imported earlier in this run that
-                    # passed Gate A stay (each was scanned independently).
-                    raise click.ClickException(
-                        format_project_shared_block_message(
-                            md_file,
-                            hits_count=len(guard.hits),
-                            scope=scope,
-                            kind="agent",
-                            imported_so_far=len(imported),
-                        )
-                    )
-                code: skip_codes.SkipCode = (
-                    skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
-                    if guard.decision == "blocked_project_shared"
-                    else skip_codes.PRIVACY_BLOCKED
-                )
-                hint = (
-                    " — pass --force-unsafe-import to bypass" if guard.decision == "blocked" else ""
-                )
+            if not outcome.proceed:
                 skipped.append(
                     (
                         agent_name,
-                        f"blocked: {len(guard.hits)} privacy pattern hit(s){hint}",
-                        code,
+                        f"blocked: {outcome.hits_count} privacy pattern hit(s){outcome.hint}",
+                        outcome.code,
                     )
                 )
                 seen[agent_name] = runtime_label
                 continue
-            if guard.decision not in ("pass", "bypassed"):
-                # Symmetric assertion — fail-loud on unknown decision so
-                # a future privacy enum addition surfaces here rather
-                # than silently dropping the write.
-                raise RuntimeError(
-                    f"enforce_write_guard returned unexpected decision: {guard.decision!r}"
-                )
-            # decision in ("pass", "bypassed") — proceed.
+            # outcome.proceed is True — write.
             dst.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_bytes(dst, content_bytes)
             imported.append((dst, layout))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -617,11 +617,13 @@ def generate_all_agents(
             # ADR-0011 PR-E: target_file may return None for scopes with no
             # fan-out by design. Default kwarg is project_shared (existing
             # behavior), which never returns None — so this branch is
-            # currently unreachable, but the assertion makes the contract
-            # explicit for E2/E3 callers that pass scope= kwargs.
-            assert out_path is not None, (
-                f"{target} target_file returned None for default project_shared scope"
-            )
+            # currently unreachable, but the explicit raise makes the
+            # contract survive `python -O` (which strips bare asserts) and
+            # gives E2/E3 callers passing scope= kwargs a fail-loud signal.
+            if out_path is None:
+                raise RuntimeError(
+                    f"{target} target_file returned None for default project_shared scope"
+                )
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
             # Race: see PR-D' for the unified write path that closes the
@@ -899,7 +901,13 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
                 continue
             expected, _ = gen.render(agent)
             target = gen.target_file(project_root, name)
-            assert target is not None  # ADR-0011 PR-E: default scope=project_shared never None
+            if target is None:
+                # ADR-0011 PR-E: default scope=project_shared never returns
+                # None from the runtime table. `python -O` survives.
+                raise RuntimeError(
+                    f"{gen_name} target_file returned None — diff over default "
+                    f"project_shared scope should never see None per ADR-0011 PR-E"
+                )
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -41,7 +41,7 @@ from typing import Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._gate_a import apply_gate_a
+from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -594,7 +594,7 @@ def extract_commands_to_canonical(
                 message_kind="command",
                 imported_so_far=len(imported),
             )
-            if not outcome.proceed:
+            if isinstance(outcome, GateABlocked):
                 skipped.append(
                     (
                         cmd_name,
@@ -662,7 +662,7 @@ def extract_commands_to_canonical(
                 message_kind="command",
                 imported_so_far=len(imported),
             )
-            if not outcome.proceed:
+            if isinstance(outcome, GateABlocked):
                 skipped.append(
                     (
                         cmd_name,

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -413,10 +413,12 @@ def generate_all_commands(
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
             out_path = gen.target_file(project_root, cmd.name)
             # ADR-0011 PR-E: target_file may return None for scopes with no
-            # fan-out (default scope=project_shared never None here).
-            assert out_path is not None, (
-                f"{target} target_file returned None for default project_shared scope"
-            )
+            # fan-out (default scope=project_shared never None here). Raise
+            # explicitly so the contract survives `python -O`.
+            if out_path is None:
+                raise RuntimeError(
+                    f"{target} target_file returned None for default project_shared scope"
+                )
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
             # Race: see PR-D' for the unified write path that closes the
@@ -771,7 +773,13 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
                 continue
             expected, _ = gen.render(cmd)
             target = gen.target_file(project_root, name)
-            assert target is not None  # ADR-0011 PR-E: default scope=project_shared never None
+            if target is None:
+                # ADR-0011 PR-E: default scope=project_shared never returns
+                # None from the runtime table. `python -O` survives.
+                raise RuntimeError(
+                    f"{gen_name} target_file returned None — diff over default "
+                    f"project_shared scope should never see None per ADR-0011 PR-E"
+                )
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -38,13 +38,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
-import click
-
-from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
-from memtomem.context._gate_a import format_project_shared_block_message
+from memtomem.context._gate_a import apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -486,72 +483,6 @@ def _resolve_command_extract_target(canonical_root: Path, cmd_name: str) -> tupl
     return dir_target, "dir"
 
 
-def _apply_command_gate_a(
-    *,
-    content_text: str,
-    src: Path,
-    dst: Path,
-    cmd_name: str,
-    scope: TargetScope,
-    runtime: str,
-    force_unsafe_import: bool,
-    imported_so_far: int,
-    skipped: list[tuple[str, str, skip_codes.SkipCode]],
-) -> bool:
-    """Apply Gate A to one command file's scanned content.
-
-    Returns ``True`` when the caller should proceed with the write,
-    ``False`` when the file was rejected and recorded into ``skipped``
-    (or, for ``project_shared`` destinations, raised as
-    :class:`click.ClickException`).
-    """
-    guard = privacy.enforce_write_guard(
-        content_text,
-        surface="cli_context_init",
-        force_unsafe=force_unsafe_import,
-        scope=scope,
-        # Mirror agents.py audit_context shape — SOC pipelines grep both
-        # ``source=`` and ``target=`` for incident triage; commands' earlier
-        # omission was a sibling-parity gap (PR #889 review D1).
-        audit_context={
-            "source": str(src),
-            "target": str(dst),
-            "kind": "commands",
-            "runtime": runtime,
-            "command_name": cmd_name,
-        },
-        record_outcome=True,
-    )
-    if guard.decision in ("blocked", "blocked_project_shared"):
-        if scope == "project_shared":
-            raise click.ClickException(
-                format_project_shared_block_message(
-                    src,
-                    hits_count=len(guard.hits),
-                    scope=scope,
-                    kind="command",
-                    imported_so_far=imported_so_far,
-                )
-            )
-        code: skip_codes.SkipCode = (
-            skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
-            if guard.decision == "blocked_project_shared"
-            else skip_codes.PRIVACY_BLOCKED
-        )
-        hint = " — pass --force-unsafe-import to bypass" if guard.decision == "blocked" else ""
-        skipped.append(
-            (
-                cmd_name,
-                f"blocked: {len(guard.hits)} privacy pattern hit(s){hint}",
-                code,
-            )
-        )
-        return False
-    if guard.decision not in ("pass", "bypassed"):
-        raise RuntimeError(f"enforce_write_guard returned unexpected decision: {guard.decision!r}")
-    return True
-
-
 def extract_commands_to_canonical(
     project_root: Path,
     overwrite: bool = False,
@@ -644,17 +575,33 @@ def extract_commands_to_canonical(
                 skipped.append((cmd_name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
                 continue
             content_text = content_bytes.decode("utf-8", errors="replace")
-            if not _apply_command_gate_a(
+            outcome = apply_gate_a(
                 content_text=content_text,
                 src=md_file,
-                dst=dst,
-                cmd_name=cmd_name,
                 scope=scope,
-                runtime="claude",
                 force_unsafe_import=force_unsafe_import,
+                # Mirror agents.py audit_context shape — SOC pipelines grep
+                # both ``source=`` and ``target=`` for incident triage;
+                # commands' earlier omission was a sibling-parity gap
+                # (PR #889 review D1).
+                audit_context={
+                    "source": str(md_file),
+                    "target": str(dst),
+                    "kind": "commands",
+                    "runtime": "claude",
+                    "command_name": cmd_name,
+                },
+                message_kind="command",
                 imported_so_far=len(imported),
-                skipped=skipped,
-            ):
+            )
+            if not outcome.proceed:
+                skipped.append(
+                    (
+                        cmd_name,
+                        f"blocked: {outcome.hits_count} privacy pattern hit(s){outcome.hint}",
+                        outcome.code,
+                    )
+                )
                 seen[cmd_name] = claude_label
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)
@@ -700,17 +647,29 @@ def extract_commands_to_canonical(
             # Scan the CONVERTED Markdown — that's what gets persisted.
             # A secret in the source `prompt = "..."` field flows into
             # the body, so this catches it without re-scanning the raw TOML.
-            if not _apply_command_gate_a(
+            outcome = apply_gate_a(
                 content_text=canonical_content,
                 src=toml_file,
-                dst=dst,
-                cmd_name=cmd_name,
                 scope=scope,
-                runtime="gemini",
                 force_unsafe_import=force_unsafe_import,
+                audit_context={
+                    "source": str(toml_file),
+                    "target": str(dst),
+                    "kind": "commands",
+                    "runtime": "gemini",
+                    "command_name": cmd_name,
+                },
+                message_kind="command",
                 imported_so_far=len(imported),
-                skipped=skipped,
-            ):
+            )
+            if not outcome.proceed:
+                skipped.append(
+                    (
+                        cmd_name,
+                        f"blocked: {outcome.hits_count} privacy pattern hit(s){outcome.hint}",
+                        outcome.code,
+                    )
+                )
                 seen[cmd_name] = gemini_label
                 continue
             dst.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -301,6 +301,16 @@ def extract_skills_to_canonical(
     ``project_shared`` destinations hard-abort via :class:`click.ClickException`
     on the first hit (with or without ``force_unsafe_import``).
 
+    Threat model — Gate A walks the source tree once and :func:`copy_skill`
+    re-reads the same files when the import proceeds; an adversarial
+    filesystem could swap bytes between the two reads (a TOCTOU window).
+    The current threat model is "accidental leak", not "adversarial
+    filesystem", so this gap is accepted: ``--force-unsafe-import`` is
+    not the path to bypass Gate A regardless, and ``project_shared``
+    hard-refuses without any bypass valve. Hardening to single-read +
+    in-memory copy is out of scope until a concrete adversarial-FS
+    threat appears.
+
     When ``only_name`` is set, every runtime entry with a different name is
     silently skipped before any validation/dedupe work.
     """

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -246,10 +246,12 @@ def generate_all_skills(
         for skill_dir in canonicals:
             dst = gen.target_dir(project_root, skill_dir.name)
             # ADR-0011 PR-E: target_dir may return None for scopes with no
-            # fan-out (default scope=project_shared never None here).
-            assert dst is not None, (
-                f"{target} target_dir returned None for default project_shared scope"
-            )
+            # fan-out (default scope=project_shared never None here). Raise
+            # explicitly so the contract survives `python -O`.
+            if dst is None:
+                raise RuntimeError(
+                    f"{target} target_dir returned None for default project_shared scope"
+                )
             copy_skill(skill_dir, dst)
             # ADR-0008 Invariant 4: per-vendor override replaces SKILL.md only.
             # Auxiliary files (scripts/, references/) stay from canonical.
@@ -498,7 +500,13 @@ def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
             else:
                 src = canonical_root / name
                 dst = gen.target_dir(project_root, name)
-                assert dst is not None  # ADR-0011 PR-E: default scope=project_shared never None
+                if dst is None:
+                    # ADR-0011 PR-E: default scope=project_shared never returns
+                    # None from the runtime table. `python -O` survives.
+                    raise RuntimeError(
+                        f"{gen_name} target_dir returned None — diff over default "
+                        f"project_shared scope should never see None per ADR-0011 PR-E"
+                    )
                 if _skill_dirs_equal(src, dst):
                     results.append((gen_name, name, "in sync"))
                 else:

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -27,7 +27,7 @@ from typing import Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
-from memtomem.context._gate_a import GateAOutcome, apply_gate_a
+from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -369,7 +369,7 @@ def extract_skills_to_canonical(
             # hard-abort path raises ClickException inside apply_gate_a;
             # the rglob loop only sees ``proceed=False`` for non-
             # project_shared scopes.
-            blocked: tuple[Path, GateAOutcome] | None = None
+            blocked: tuple[Path, GateABlocked] | None = None
             for src_file in sorted(skill_dir.rglob("*")):
                 if not src_file.is_file():
                     continue
@@ -394,7 +394,7 @@ def extract_skills_to_canonical(
                     message_kind="skill",
                     imported_so_far=len(imported),
                 )
-                if not outcome.proceed:
+                if isinstance(outcome, GateABlocked):
                     blocked = (src_file, outcome)
                     break
 

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -24,13 +24,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
-import click
-
-from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
-from memtomem.context._gate_a import format_project_shared_block_message
+from memtomem.context._gate_a import GateAOutcome, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
 from memtomem.context._runtime_targets import runtime_fanout_root
@@ -368,10 +365,11 @@ def extract_skills_to_canonical(
 
             # Gate A — walk every file in the skill tree before copying.
             # One blocked file aborts the whole skill (atomic — never
-            # leave a partial copy in canonical).
-            blocked_file: Path | None = None
-            blocked_decision: str | None = None
-            blocked_hits: int = 0
+            # leave a partial copy in canonical). The project_shared
+            # hard-abort path raises ClickException inside apply_gate_a;
+            # the rglob loop only sees ``proceed=False`` for non-
+            # project_shared scopes.
+            blocked: tuple[Path, GateAOutcome] | None = None
             for src_file in sorted(skill_dir.rglob("*")):
                 if not src_file.is_file():
                     continue
@@ -383,54 +381,33 @@ def extract_skills_to_canonical(
                     # it is real, otherwise the file passes through as
                     # a binary asset.
                     continue
-                guard = privacy.enforce_write_guard(
-                    content_text,
-                    surface="cli_context_init",
-                    force_unsafe=force_unsafe_import,
+                outcome = apply_gate_a(
+                    content_text=content_text,
+                    src=src_file,
                     scope=scope,
+                    force_unsafe_import=force_unsafe_import,
                     audit_context={
                         "source_file": str(src_file),
                         "skill_name": skill_name,
                         "kind": "skills",
                     },
-                    record_outcome=True,
+                    message_kind="skill",
+                    imported_so_far=len(imported),
                 )
-                if guard.decision in ("blocked", "blocked_project_shared"):
-                    blocked_file = src_file
-                    blocked_decision = guard.decision
-                    blocked_hits = len(guard.hits)
+                if not outcome.proceed:
+                    blocked = (src_file, outcome)
                     break
-                if guard.decision not in ("pass", "bypassed"):
-                    raise RuntimeError(
-                        f"enforce_write_guard returned unexpected decision: {guard.decision!r}"
-                    )
 
-            if blocked_file is not None:
-                if scope == "project_shared":
-                    raise click.ClickException(
-                        format_project_shared_block_message(
-                            blocked_file,
-                            hits_count=blocked_hits,
-                            scope=scope,
-                            kind="skill",
-                            imported_so_far=len(imported),
-                        )
-                    )
-                code: skip_codes.SkipCode = (
-                    skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
-                    if blocked_decision == "blocked_project_shared"
-                    else skip_codes.PRIVACY_BLOCKED
-                )
-                hint = (
-                    " — pass --force-unsafe-import to bypass"
-                    if blocked_decision == "blocked"
-                    else ""
-                )
+            if blocked is not None:
+                blocked_file, blocked_outcome = blocked
                 skipped.append(
                     (
                         skill_name,
-                        f"blocked: {blocked_file.name} hit {blocked_hits} pattern(s){hint}",
-                        code,
+                        (
+                            f"blocked: {blocked_file.name} hit "
+                            f"{blocked_outcome.hits_count} pattern(s){blocked_outcome.hint}"
+                        ),
+                        blocked_outcome.code,
                     )
                 )
                 seen[skill_name] = runtime_label

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -529,6 +529,55 @@ def test_extract_skills_per_file_walk_blocks_scripts_dir(
     assert not (home / ".memtomem" / "skills" / "myskill").exists()
 
 
+def test_extract_skills_project_shared_blocked_hard_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Skills #2 — project_shared destination + blocked → ClickException.
+
+    PR-E follow-up D2 part 2 — skills.py refactor moved Gate A through
+    apply_gate_a; the rglob loop now never observes a project_shared
+    block (the helper raises before returning). This test pins the
+    contract for the skills kind so the atomic-skill semantic is
+    preserved across the refactor.
+    """
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+
+    skill = proj / ".claude" / "skills" / "myskill"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: myskill\n---\nclean body\n", encoding="utf-8")
+    (skill / "scripts" / "leak.py").write_text(f"# uses {_AKIA_SECRET}\n", encoding="utf-8")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        extract_skills_to_canonical(proj, scope="project_shared")
+    msg = exc_info.value.message
+    assert "Gate A" in msg
+    assert "project_shared" in msg
+    # No partial copy — even SKILL.md must NOT exist in canonical.
+    assert not (proj / ".memtomem" / "skills" / "myskill").exists()
+
+
+def test_extract_skills_project_shared_force_unsafe_still_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Skills B-spec smoke #16 — --force-unsafe-import does NOT bypass project_shared."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+
+    skill = proj / ".claude" / "skills" / "myskill"
+    (skill / "scripts").mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: myskill\n---\nclean body\n", encoding="utf-8")
+    (skill / "scripts" / "leak.py").write_text(f"# uses {_AKIA_SECRET}\n", encoding="utf-8")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        extract_skills_to_canonical(proj, scope="project_shared", force_unsafe_import=True)
+    assert "no force bypass" in exc_info.value.message.lower()
+
+
 def test_extract_skills_clean_skill_copies_normally(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -709,10 +758,11 @@ def _capture_guard_audit(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict[str,
             captured["first"] = dict(audit_context)
         return WriteGuardResult("pass", [])
 
-    # Patch through both paths — agents/commands go via _gate_a; skills
-    # still goes through its inline call site (until Commit 4b lands).
+    # All three kinds (agents / skills / commands) now route through
+    # _gate_a.apply_gate_a, which dereferences ``privacy.enforce_write_guard``
+    # at call time — patching the helper module's namespace catches every
+    # caller.
     monkeypatch.setattr("memtomem.context._gate_a.privacy.enforce_write_guard", spy)
-    monkeypatch.setattr("memtomem.context.skills.privacy.enforce_write_guard", spy)
     return captured
 
 

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -743,17 +743,23 @@ def test_unknown_decision_raises_runtime_error(
 # ── D2 — audit_context shape pins (PR-E follow-up) ─────────────────────
 
 
-def _capture_guard_audit(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict[str, str]]:
+def _capture_guard_audit(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict[str, object]]:
     """Spy ``privacy.enforce_write_guard`` and capture the first call's audit_context.
 
     Returns a dict the caller can read after the extract function returns.
     The spy still has to return a real ``WriteGuardResult`` so the extract
     pipeline proceeds normally — we want the audit-context capture, not
     the proceed/block decision.
-    """
-    captured: dict[str, dict[str, str]] = {}
 
-    def spy(content_text: str, *, audit_context: dict[str, str], **kw: Any) -> WriteGuardResult:
+    Spy signature mirrors the chokepoint (``dict[str, object]``) so a
+    future producer that legitimately routes a non-string field (e.g.
+    an ``item_idx: int`` from a batch ingress surface) flows through
+    this spy without a type mismatch. Current producers all pass
+    string-only values; the assertions still pin those shapes.
+    """
+    captured: dict[str, dict[str, object]] = {}
+
+    def spy(content_text: str, *, audit_context: dict[str, object], **kw: Any) -> WriteGuardResult:
         if "first" not in captured:
             captured["first"] = dict(audit_context)
         return WriteGuardResult("pass", [])

--- a/packages/memtomem/tests/test_context_init_scope.py
+++ b/packages/memtomem/tests/test_context_init_scope.py
@@ -574,6 +574,55 @@ def test_extract_commands_gemini_toml_secret_in_prompt_blocked(
     assert skip_codes.PRIVACY_BLOCKED in codes
 
 
+def test_extract_commands_project_shared_blocked_hard_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commands #2 — project_shared destination + blocked → ClickException.
+
+    Mirrors the agents counterpart at the top of this file. PR-E follow-up
+    D2 — apply_gate_a centralised the hard-abort path; this test pins the
+    contract for the commands kind so a future helper drift cannot silently
+    let a project_shared command write through.
+    """
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+
+    runtime = proj / ".claude" / "commands"
+    runtime.mkdir(parents=True)
+    (runtime / "leak.md").write_text(
+        f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n", encoding="utf-8"
+    )
+
+    with pytest.raises(click.ClickException) as exc_info:
+        extract_commands_to_canonical(proj, scope="project_shared")
+    msg = exc_info.value.message
+    assert "Gate A" in msg
+    assert "project_shared" in msg
+    assert not (proj / ".memtomem" / "commands" / "leak.md").exists()
+
+
+def test_extract_commands_project_shared_force_unsafe_still_aborts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Commands B-spec smoke #16 — --force-unsafe-import does NOT bypass project_shared."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+
+    runtime = proj / ".claude" / "commands"
+    runtime.mkdir(parents=True)
+    (runtime / "leak.md").write_text(
+        f"---\nname: leak\n---\nuses {_AKIA_SECRET}\n", encoding="utf-8"
+    )
+
+    with pytest.raises(click.ClickException) as exc_info:
+        extract_commands_to_canonical(proj, scope="project_shared", force_unsafe_import=True)
+    assert "no force bypass" in exc_info.value.message.lower()
+
+
 def test_extract_commands_codex_not_imported(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -634,6 +683,97 @@ def test_unknown_decision_raises_runtime_error(
     def fake_guard(*a: Any, **kw: Any) -> WriteGuardResult:
         return WriteGuardResult("nonsense", [])
 
-    monkeypatch.setattr("memtomem.context.agents.privacy.enforce_write_guard", fake_guard)
+    # Gate A apply lives in _gate_a now (PR-E follow-up D2 — apply_gate_a
+    # helper). The chokepoint stayed privacy.enforce_write_guard; only
+    # the call site moved.
+    monkeypatch.setattr("memtomem.context._gate_a.privacy.enforce_write_guard", fake_guard)
     with pytest.raises(RuntimeError, match="unexpected decision"):
         extract_agents_to_canonical(proj, scope="user")
+
+
+# ── D2 — audit_context shape pins (PR-E follow-up) ─────────────────────
+
+
+def _capture_guard_audit(monkeypatch: pytest.MonkeyPatch) -> dict[str, dict[str, str]]:
+    """Spy ``privacy.enforce_write_guard`` and capture the first call's audit_context.
+
+    Returns a dict the caller can read after the extract function returns.
+    The spy still has to return a real ``WriteGuardResult`` so the extract
+    pipeline proceeds normally — we want the audit-context capture, not
+    the proceed/block decision.
+    """
+    captured: dict[str, dict[str, str]] = {}
+
+    def spy(content_text: str, *, audit_context: dict[str, str], **kw: Any) -> WriteGuardResult:
+        if "first" not in captured:
+            captured["first"] = dict(audit_context)
+        return WriteGuardResult("pass", [])
+
+    # Patch through both paths — agents/commands go via _gate_a; skills
+    # still goes through its inline call site (until Commit 4b lands).
+    monkeypatch.setattr("memtomem.context._gate_a.privacy.enforce_write_guard", spy)
+    monkeypatch.setattr("memtomem.context.skills.privacy.enforce_write_guard", spy)
+    return captured
+
+
+def test_extract_agents_audit_context_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D2 — agents audit_context keeps {source, target, kind, agent_name}.
+
+    PR #889 review carry-over D1 was a sibling-parity gap on the
+    commands' audit_context — the source/target/runtime fields were
+    missing. Pinning the per-kind shape prevents a future "let's
+    normalise audit_context" refactor from silently breaking
+    SOC-pipeline grep on per-kind fields.
+    """
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+    _seed_user_runtime_agents(home, "agt", "---\nname: agt\n---\nbody\n")
+
+    captured = _capture_guard_audit(monkeypatch)
+    extract_agents_to_canonical(proj, scope="user")
+    assert captured["first"].keys() == {"source", "target", "kind", "agent_name"}
+    assert captured["first"]["kind"] == "agents"  # plural, intentionally
+    assert captured["first"]["agent_name"] == "agt"
+
+
+def test_extract_skills_audit_context_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D2 — skills audit_context keeps {source_file, skill_name, kind}."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+    skill = home / ".claude" / "skills" / "myskill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: myskill\n---\nbody\n", encoding="utf-8")
+
+    captured = _capture_guard_audit(monkeypatch)
+    extract_skills_to_canonical(proj, scope="user")
+    assert captured["first"].keys() == {"source_file", "skill_name", "kind"}
+    assert captured["first"]["kind"] == "skills"  # plural
+    assert captured["first"]["skill_name"] == "myskill"
+
+
+def test_extract_commands_audit_context_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """D2 — commands audit_context keeps {source, target, kind, runtime, command_name}."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, str(home))
+    proj = _make_project(tmp_path)
+    runtime = home / ".claude" / "commands"
+    runtime.mkdir(parents=True)
+    (runtime / "cmd.md").write_text("---\nname: cmd\n---\nbody\n", encoding="utf-8")
+
+    captured = _capture_guard_audit(monkeypatch)
+    extract_commands_to_canonical(proj, scope="user")
+    assert captured["first"].keys() == {"source", "target", "kind", "runtime", "command_name"}
+    assert captured["first"]["kind"] == "commands"  # plural
+    assert captured["first"]["runtime"] == "claude"
+    assert captured["first"]["command_name"] == "cmd"

--- a/packages/memtomem/tests/test_context_runtime_table_none_raises.py
+++ b/packages/memtomem/tests/test_context_runtime_table_none_raises.py
@@ -1,0 +1,169 @@
+"""ADR-0011 PR-E follow-up N1 — fail-loud parity for runtime-table None.
+
+Each ``generate_all_*`` and ``diff_*`` function previously protected its
+``target_file`` / ``target_dir`` contract with a bare ``assert x is not None``
+that strips under ``python -O``. The follow-up converts those to explicit
+``if x is None: raise RuntimeError(...)`` so the contract holds regardless
+of optimization mode. These tests pin the new fail-loud behaviour by
+forcing the runtime-fanout table to return ``None`` for one generator and
+asserting ``RuntimeError`` propagates through the loop.
+
+The branches are contractually unreachable on the default
+``scope="project_shared"`` (the table never returns ``None`` for that
+tuple) — see ``feedback_pin_test_mutation_validation.md``: pin the new
+fail-loud branch with one mutation per kind so the contract isn't
+silently weaker than the comment claims.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.agents import (
+    AGENT_GENERATORS,
+    diff_agents,
+    generate_all_agents,
+)
+from memtomem.context.commands import (
+    COMMAND_GENERATORS,
+    diff_commands,
+    generate_all_commands,
+)
+from memtomem.context.skills import (
+    SKILL_GENERATORS,
+    diff_skills,
+    generate_all_skills,
+)
+
+
+def _seed_canonical_agent(project_root: Path, name: str = "foo") -> None:
+    canonical = project_root / ".memtomem" / "agents"
+    canonical.mkdir(parents=True, exist_ok=True)
+    (canonical / f"{name}.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+    # diff_agents only reaches the target_file check when the name appears
+    # in both canonical and runtime sets — seed the Claude runtime side too.
+    runtime = project_root / ".claude" / "agents"
+    runtime.mkdir(parents=True, exist_ok=True)
+    (runtime / f"{name}.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+
+
+def _seed_canonical_skill(project_root: Path, name: str = "foo") -> None:
+    skill = project_root / ".memtomem" / "skills" / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+    runtime_skill = project_root / ".claude" / "skills" / name
+    runtime_skill.mkdir(parents=True, exist_ok=True)
+    (runtime_skill / "SKILL.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+
+
+def _seed_canonical_command(project_root: Path, name: str = "foo") -> None:
+    canonical = project_root / ".memtomem" / "commands"
+    canonical.mkdir(parents=True, exist_ok=True)
+    (canonical / f"{name}.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+    runtime = project_root / ".claude" / "commands"
+    runtime.mkdir(parents=True, exist_ok=True)
+    (runtime / f"{name}.md").write_text(f"---\nname: {name}\n---\nbody\n", encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "kind, seed, runner, runtime_key, registry, attr",
+    [
+        (
+            "agents",
+            _seed_canonical_agent,
+            generate_all_agents,
+            "claude_agents",
+            AGENT_GENERATORS,
+            "target_file",
+        ),
+        (
+            "skills",
+            _seed_canonical_skill,
+            generate_all_skills,
+            "claude_skills",
+            SKILL_GENERATORS,
+            "target_dir",
+        ),
+        (
+            "commands",
+            _seed_canonical_command,
+            generate_all_commands,
+            "claude_commands",
+            COMMAND_GENERATORS,
+            "target_file",
+        ),
+    ],
+)
+def test_generate_all_runtime_table_none_raises(
+    kind: str,
+    seed,
+    runner,
+    runtime_key: str,
+    registry,
+    attr: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N1 — generate_all_<kind> raises RuntimeError when the registered
+    generator's ``target_*`` returns ``None``.
+
+    Forces ``None`` by monkeypatching the registered generator's bound
+    method, which simulates a future scope wiring where the table entry
+    legitimately becomes ``NO_FANOUT`` for the active scope.
+    """
+    seed(tmp_path)
+    gen = registry[runtime_key]
+    monkeypatch.setattr(gen, attr, lambda *args, **kwargs: None)
+
+    with pytest.raises(RuntimeError, match=r"target_(file|dir) returned None"):
+        runner(tmp_path, runtimes=[runtime_key])
+
+
+@pytest.mark.parametrize(
+    "kind, seed, runner, runtime_key, registry, attr",
+    [
+        (
+            "agents",
+            _seed_canonical_agent,
+            diff_agents,
+            "claude_agents",
+            AGENT_GENERATORS,
+            "target_file",
+        ),
+        (
+            "skills",
+            _seed_canonical_skill,
+            diff_skills,
+            "claude_skills",
+            SKILL_GENERATORS,
+            "target_dir",
+        ),
+        (
+            "commands",
+            _seed_canonical_command,
+            diff_commands,
+            "claude_commands",
+            COMMAND_GENERATORS,
+            "target_file",
+        ),
+    ],
+)
+def test_diff_runtime_table_none_raises(
+    kind: str,
+    seed,
+    runner,
+    runtime_key: str,
+    registry,
+    attr: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N1 — diff_<kind> raises RuntimeError when ``target_*`` returns ``None``."""
+    seed(tmp_path)
+    gen = registry[runtime_key]
+    monkeypatch.setattr(gen, attr, lambda *args, **kwargs: None)
+
+    with pytest.raises(RuntimeError, match=r"target_(file|dir) returned None"):
+        runner(tmp_path)


### PR DESCRIPTION
## Summary

ADR-0011 PR-E (#889, merged 2026-05-10 as `38c436e`) shipped with four reviewer-flagged carry-overs deferred by mutual "merge and go" agreement. This PR clears all four in **six commits** so the reviewer can climb small commits sequentially and the most delicate change (skills' atomic semantics) is isolated.

| Commit | Carry-over | Surface |
|---|---|---|
| `ab52659` | **N4** — Codex skills user-tier path | `_runtime_targets.py` docstring (TBD → verified citation) + line-anchor drift fix |
| `a1b03c6` | **D3** — TOCTOU window | `extract_skills_to_canonical` docstring (caller's responsibility, not `copy_skill`) |
| `e3b29d4` | **N1** — bare-assert → fail-loud raise | 6 sites in `agents.py` / `skills.py` / `commands.py` + parametrized test |
| `e871c90` | **D2 part 1** — `apply_gate_a` DRY helper | `_gate_a.py` adds helper + `agents.py` / `commands.py` refactor + 3 audit-shape pin tests + commands `project_shared` test |
| `6212319` | **D2 part 2** — skills atomic-skill | `skills.py` rglob loop uses helper; atomic semantic preserved + skills `project_shared` test |
| `64cc5b4` | mypy polish | `GateAOutcome` → discriminated union (`GateAProceed` / `GateABlocked`) for typesafe `code` narrowing |

A first-pass Codex review of the plan flagged six issues; all six are folded in. One reviewer claim (that `mm context init` is the forward path) was rebutted after a one-minute check — `cli/context_cmd.py:163/235/320` confirms `init` calls `extract_*_to_canonical` (import). Secrets in the verification smoke go in the runtime dir, not canonical.

## What changed and why

**N4 — Codex skills user-tier path verified.** External verification (Agent Skills Open Specification, Anthropic 2025-12 release adopted by OpenAI Codex) confirmed `~/.agents/skills/` is correct. The placeholder was right; only the docstring "TBD / ambiguous" wording needed upgrading to a precise citation. In-repo `skills.py:12-13` and `detector.py:34-39` are anchors for the spec/project-scope side of the convention. **No path change.**

**D3 — TOCTOU note in the right place.** Reviewer correction applied: `copy_skill` is a copy primitive without a security contract; the TOCTOU window between Gate A scan and copy lives in the *caller* (`extract_skills_to_canonical`). Note appended to that function's docstring next to the existing "Gate A walks every file" paragraph. ADR-0011 §5 untouched (its layered-gate language already covers the threat model; TOCTOU prose belongs at the call-site).

**N1 — bare-assert → fail-loud raise (6 sites).** The carry-over note quoted three line numbers (910/1184/1829); current `git grep` found six sites total — three messaged asserts in `generate_all_*` and three bare asserts in `diff_*`. All six convert to `if x is None: raise RuntimeError(...)` so the contract survives `python -O`. The branches are contractually unreachable on the default `scope="project_shared"` (defense-in-depth for a future E3/E4 wiring).

Pinned with one parametrized test per kind (`test_context_runtime_table_none_raises.py`) — both `generate_all_<kind>` and `diff_<kind>` raise `RuntimeError` when the registered generator's `target_*` returns `None`.

**D2 — `apply_gate_a` DRY helper.** The Gate A apply blocks duplicated the same six-step decision dance across three files. New helper `apply_gate_a` in `_gate_a.py`:

- Returns a discriminated union (`GateAProceed` / `GateABlocked`).
- Caller narrows with `isinstance(outcome, GateABlocked)` and reads non-optional `code` / `hits_count` / `hint`.
- Project_shared hard-abort raises `click.ClickException` *inside* the helper — callers never observe a `proceed=False` outcome with project_shared scope.
- `audit_context` is opaque (passed verbatim) so per-kind shape is preserved (`agent_name` vs `command_name` vs `skill_name`; `source` vs `source_file`; `runtime`). PR #889 review carry-over D1 was specifically about a `source/target` field omission — this helper boundary prevents a future "let's normalise audit_context" refactor from silently breaking SOC-pipeline grep.

The skills refactor (Commit 4b) keeps the rglob walk's atomic-skill semantic: a single blocked file aborts the whole skill, no partial copy.

Tests added in this PR:
- 3 audit-shape pin tests (one per kind) capturing the spy's first call and asserting key set + plural `kind` value.
- `test_extract_commands_project_shared_blocked_hard_aborts` + force-unsafe variant — mirrors the agents pair so commands hard-abort is covered by automated tests, not just dwell smoke.
- `test_extract_skills_project_shared_blocked_hard_aborts` + force-unsafe variant — same treatment for skills.
- `test_unknown_decision_raises_runtime_error` retargets `_gate_a.privacy.enforce_write_guard` (chokepoint stayed; only the call site moved).

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean.
- [x] `uv run pytest packages/memtomem/tests/ -k "context"` — 904 passed.
- [x] `uv run pytest packages/memtomem/tests/test_context_init_scope.py packages/memtomem/tests/test_context_extract_scope_kwarg.py packages/memtomem/tests/test_context_runtime_table_none_raises.py` — 86 passed (includes new tests).
- [x] `uv run mypy packages/memtomem/src` — 38 errors total (advisory; pre-existing in unrelated modules; new helper introduces 0 mypy errors after Commit 4c).
- [x] `uv run pytest packages/memtomem/tests/test_context_cli_subprocess_e2e.py` — 2 passed.
- [x] Reviewer must-fix #1 — skills + commands `project_shared` block-path now have automated tests (mirrored from agents at line 482).
- [x] Reviewer recommendation #5 — audit_context shape pinned across all three kinds (3 spy tests).

## Out of scope

- ADR-0011 §5 edits (D3 stays in `extract_skills_to_canonical` docstring).
- New ADR / RFC for the helper API (stays in `_gate_a.py` docstring).
- E3/E4 — `mm context sync --scope`, migration command. Master plan: `~/.claude/plans/delegated-wandering-lollipop.md`.
- Renaming or normalising `audit_context` keys across kinds — pinned by Commit 4a's spy tests as intentionally per-kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
