### PR TITLE
feat(scope): mm context migrate <kind> --to for scope-tier moves (PR-E4)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -50,8 +50,11 @@ from memtomem.context.install import (
 )
 from memtomem.context.migrate import (
     MigrateRow,
+    MigrateScopeResult,
+    SCOPE_MIGRATABLE_KINDS,
     classify_migrate,
     migrate_one,
+    migrate_scope,
 )
 from memtomem.context.projects import KnownProjectsStore
 from memtomem.context.lockfile import LockfileVersionError
@@ -1784,6 +1787,143 @@ def _print_migrate_preview(rows: list[MigrateRow], *, skills_section: bool) -> N
         )
 
 
+def _migrate_scope_dispatch(
+    asset_type: str,
+    name: str,
+    from_scope: str | None,
+    to_scope: str,
+    apply_: bool,
+    yes: bool,
+    confirm_project_shared: bool,
+) -> None:
+    """ADR-0011 PR-E4 scope-tier move for agents / commands / skills.
+
+    Calls :func:`memtomem.context.migrate.migrate_scope` after running the
+    project_shared confirmation gate. Click prompts and stdout writes
+    live here; the pure module stays prompt-free.
+    """
+    project_root = _find_project_root()
+
+    # Pre-flight Gate B (project_shared opt-in, mirroring memory-migrate).
+    # Apply only — dry-run reads the same plan without touching disk and
+    # is the recommended way to inspect the move before opting in.
+    if to_scope == "project_shared" and apply_ and not confirm_project_shared:
+        if yes:
+            raise click.ClickException(
+                "--to project_shared requires --confirm-project-shared. "
+                "--yes alone is not sufficient: project_shared writes go "
+                "to the git-tracked tier and require explicit opt-in."
+            )
+        if not click.confirm(
+            "\nThis will move the canonical into the git-tracked project_shared tier. Continue?",
+            default=False,
+        ):
+            raise click.Abort()
+
+    try:
+        result = migrate_scope(
+            asset_type,  # type: ignore[arg-type]
+            name,
+            from_scope=from_scope,  # type: ignore[arg-type]
+            to_scope=to_scope,  # type: ignore[arg-type]
+            project_root=project_root,
+            apply_=apply_,
+        )
+    except (FileNotFoundError, ValueError, InvalidNameError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    _print_migrate_scope_result(result, apply_=apply_)
+
+
+def _print_migrate_scope_result(result: MigrateScopeResult, *, apply_: bool) -> None:
+    """User-facing summary for one scope-tier migration.
+
+    Dry-run prints the plan + a "run with --apply" hint. Apply prints a
+    green-tick line plus any cleaned runtime fan-out paths so the user
+    sees both halves of the move (canonical + stale fan-out).
+    """
+    layout_note = " (flat layout)" if result.layout == "flat" else ""
+    click.echo(f"Plan: migrate {result.kind}/{result.name}{layout_note}")
+    click.echo(f"  from {result.from_scope}: {result.src_path}")
+    click.echo(f"  to   {result.to_scope}: {result.dst_path}")
+
+    if not apply_:
+        click.echo("\nRun with --apply to execute.")
+        click.echo(
+            f"After apply, run `mm context sync --scope {result.to_scope}` "
+            f"to refresh runtime fan-out."
+        )
+        return
+
+    click.secho(
+        f"  ✓ moved {result.kind}/{result.name}: {result.from_scope} → {result.to_scope}",
+        fg="green",
+    )
+    if result.fanout_cleaned:
+        click.echo(
+            f"  cleaned {len(result.fanout_cleaned)} stale runtime fan-out "
+            f"target(s) at scope='{result.from_scope}':"
+        )
+        for path in result.fanout_cleaned:
+            click.echo(f"    - {path}")
+    click.echo(
+        f"\nNext: run `mm context sync --scope {result.to_scope}` to "
+        f"regenerate runtime fan-out at the new tier."
+    )
+
+
+def _migrate_memory_dispatch(
+    operand: str | None,
+    from_scope: str | None,
+    to_scope: str | None,
+    apply_: bool,
+    force: bool,
+    yes: bool,
+    confirm_project_shared: bool,
+) -> None:
+    """ADR-0011 PR-E4 cross-link to ``mm context memory-migrate``.
+
+    The operand is a SOURCE PATH (not a name) since memory canonical
+    files are addressed by absolute path, not by an artifact-style name.
+    Both ``--from`` and ``--to`` are required (memory has no
+    auto-detection — paths can be ambiguous between user / project_shared
+    / project_local in nested layouts). Behaviour is byte-identical to
+    ``mm context memory-migrate`` since both call the same impl.
+    """
+    if operand is None:
+        raise click.UsageError(
+            "source path argument is required for kind=memory (operand is a path, not a name)"
+        )
+    if from_scope is None or to_scope is None:
+        raise click.UsageError("--from and --to are both required for kind=memory")
+    if force:
+        raise click.UsageError(
+            "--force does not apply to memory migration (no flat/dir layouts in this kind)"
+        )
+    if from_scope == to_scope:
+        raise click.ClickException("--from and --to must differ.")
+
+    source = Path(operand).expanduser()
+    if not source.exists():
+        raise click.ClickException(f"source path does not exist: {source}")
+    if not source.is_file():
+        raise click.ClickException(f"source path must be a file, not a directory: {source}")
+    source_resolved = source.resolve()
+
+    import asyncio
+
+    asyncio.run(
+        _memory_migrate_run(
+            source_resolved,
+            from_scope,
+            to_scope,
+            apply_,
+            yes,
+            confirm_project_shared,
+        )
+    )
+
+
 def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
     """Build the post-preview summary line."""
     counts: dict[str, int] = {s: 0 for s in _MIGRATE_GLYPH}
@@ -1808,10 +1948,32 @@ def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
 @context.command("migrate")
 @click.argument(
     "asset_type",
-    type=click.Choice(["agents", "commands", "skills"]),
+    type=click.Choice(["agents", "commands", "skills", "memory"]),
     required=False,
 )
 @click.argument("name", required=False)
+@click.option(
+    "--from",
+    "from_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    default=None,
+    help=(
+        "Explicit source scope. Required for kind=memory; auto-detected "
+        "for agents/commands/skills (pass to disambiguate when the same "
+        "name lives in multiple scopes)."
+    ),
+)
+@click.option(
+    "--to",
+    "to_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    default=None,
+    help=(
+        "Target scope tier. When set, migrate moves the artifact's "
+        "canonical between ADR-0011 tiers (PR-E4). When omitted, falls "
+        "back to the PR-D flat→dir layout migration."
+    ),
+)
 @click.option(
     "--apply",
     "apply_",
@@ -1823,7 +1985,11 @@ def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
     "--force",
     is_flag=True,
     default=False,
-    help="Migrate dirty flat files; each gets a .bak sibling. Requires --apply.",
+    help=(
+        "Flat→dir mode: migrate dirty flat files; each gets a .bak sibling. "
+        "Has no effect in scope-tier mode (--to) — destinations always "
+        "refuse on conflict in PR-E4. Requires --apply."
+    ),
 )
 @click.option(
     "--yes",
@@ -1832,33 +1998,92 @@ def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
     default=False,
     help="Skip the confirmation prompt. Requires --apply.",
 )
+@click.option(
+    "--confirm-project-shared",
+    "confirm_project_shared",
+    is_flag=True,
+    default=False,
+    help=(
+        "Required (in addition to --apply) when --to=project_shared "
+        "or kind=memory --to=project_shared, mirroring "
+        "``mm context memory-migrate``. --yes alone does not satisfy "
+        "the project_shared opt-in."
+    ),
+)
 def migrate_cmd(
     asset_type: str | None,
     name: str | None,
+    from_scope: str | None,
+    to_scope: str | None,
     apply_: bool,
     force: bool,
     yes: bool,
+    confirm_project_shared: bool,
 ) -> None:
-    """Convert flat-layout context assets to canonical directory layout.
+    """Migrate canonical context artifacts.
 
-    PR-C made the directory layout canonical for agents and commands;
-    pre-PR-C installs and reverse-imports leave behind flat files
-    (``agents/<name>.md``). This command renames each such file to
-    ``agents/<name>/agent.md`` (and the equivalent for commands) atomically
-    via ``os.replace``.
+    Two modes share this verb:
 
-    Skills are always directory layout (Agent Skills spec) and are not
-    in scope. Invoking ``migrate skills`` exits 0 with an informational
-    message rather than an error.
+    * **Flat→dir layout** (PR-D, default when ``--to`` is omitted) —
+      converts pre-PR-C ``agents/<name>.md`` to ``agents/<name>/agent.md``.
+      Skills are always directory layout (Agent Skills spec) and exit 0
+      with an informational message in this mode.
+    * **Scope-tier move** (PR-E4, when ``--to`` is set) — moves the
+      canonical between ADR-0011 tiers (``user`` /
+      ``project_shared`` / ``project_local``). Supports agents,
+      commands, skills, and memory (memory delegates to
+      ``mm context memory-migrate``'s impl with parity behaviour).
 
-    Default mode is a dry-run preview; pass ``--apply`` to execute. Dirty
-    flat files (mtime > installed_at) require ``--force`` and produce a
-    ``.bak`` sibling before mutation, mirroring ``mm context update --force``.
+    Default mode is a dry-run preview; pass ``--apply`` to execute.
     """
     if (force or yes) and not apply_:
         raise click.UsageError("--force / --yes are only valid with --apply")
     if name is not None and asset_type is None:
         raise click.UsageError("name argument requires asset_type")
+
+    # ── PR-E4 scope-mode dispatch ────────────────────────────────────
+    if asset_type == "memory":
+        _migrate_memory_dispatch(
+            name,
+            from_scope,
+            to_scope,
+            apply_,
+            force,
+            yes,
+            confirm_project_shared,
+        )
+        return
+    if to_scope is not None:
+        if asset_type is None:
+            raise click.UsageError("--to requires an asset_type")
+        if asset_type not in SCOPE_MIGRATABLE_KINDS:
+            raise click.UsageError(
+                f"--to is not supported for asset_type={asset_type!r} "
+                f"(use one of {SCOPE_MIGRATABLE_KINDS} or 'memory')"
+            )
+        if name is None:
+            raise click.UsageError("name argument is required with --to")
+        if force:
+            raise click.UsageError(
+                "--force does not apply to --to scope-tier moves "
+                "(destinations always refuse on conflict in PR-E4)"
+            )
+        _migrate_scope_dispatch(
+            asset_type,
+            name,
+            from_scope,
+            to_scope,
+            apply_,
+            yes,
+            confirm_project_shared,
+        )
+        return
+
+    # ── Flat→dir mode validation gates ───────────────────────────────
+    if from_scope is not None:
+        raise click.UsageError("--from requires --to (scope-tier mode)")
+    if confirm_project_shared:
+        raise click.UsageError("--confirm-project-shared requires --to")
 
     if asset_type == "skills":
         click.secho(

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -6,28 +6,46 @@ installs and reverse-imports left flat-layout files (``agents/<name>.md``)
 on disk. This module classifies and converts those flat assets to the
 dir layout in place.
 
+ADR-0011 PR-E4 extends the same module with :func:`migrate_scope`, which
+moves an existing canonical artifact between ADR-0011 scope tiers
+(``user`` ↔ ``project_shared`` ↔ ``project_local``). The flat→dir path
+and the scope-move path share the dry-run/apply/click-exception
+discipline; they branch on whether ``--to <scope>`` is passed at the CLI
+layer.
+
 Pure module: filesystem + lockfile only, no wiki dependency (ADR-0008
 Invariants 1 / 3). The CLI wrapper in
 :func:`memtomem.cli.context_cmd.migrate_cmd` adds the dry-run preview,
 ``--apply`` gating, and confirmation prompts.
 
-Skills are always directory layout (Agent Skills spec) and are not in
-scope here — :func:`classify_migrate` returns an empty list when invoked
-with ``asset_type="skills"`` and the CLI surfaces a friendly informational
-message rather than an error.
+Skills are always directory layout (Agent Skills spec) so flat→dir
+classification is a no-op for them — :func:`classify_migrate` returns an
+empty list when invoked with ``asset_type="skills"`` and the CLI surfaces
+a friendly informational message rather than an error. Scope-move
+(:func:`migrate_scope`) DOES support skills since their canonical can
+live at any tier per ADR-0011 §3.
 """
 
 from __future__ import annotations
 
+import contextlib
+import errno
 import logging
 import os
+import secrets
 import shutil
-from dataclasses import dataclass
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Iterator, Literal
 
+import click
+
+from memtomem.config import TargetScope
+from memtomem.context._atomic import _file_lock, _lock_path_for
 from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._runtime_targets import runtime_fanout_root
 from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
     CANONICAL_AGENT_ROOT,
@@ -39,17 +57,30 @@ from memtomem.context.commands import (
     list_canonical_commands,
 )
 from memtomem.context.lockfile import Lockfile
+from memtomem.context.privacy_scan import (
+    raise_or_collect,
+    scan_artifact_tree,
+)
+from memtomem.context.scope_resolver import (
+    ArtifactKind,
+    ContextScopeError,
+    canonical_artifact_dir,
+)
+from memtomem.context.skills import SKILL_MANIFEST
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "ASSET_DIR_FILENAMES",
     "MIGRATABLE_ASSET_TYPES",
+    "SCOPE_MIGRATABLE_KINDS",
     "MigrateResult",
     "MigrateRow",
+    "MigrateScopeResult",
     "MigrateState",
     "classify_migrate",
     "migrate_one",
+    "migrate_scope",
 ]
 
 
@@ -469,3 +500,435 @@ def _is_within(path: Path, root: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+# ── ADR-0011 PR-E4: scope-tier migration ──────────────────────────────
+
+
+SCOPE_MIGRATABLE_KINDS: tuple[ArtifactKind, ...] = ("agents", "commands", "skills")
+"""Artifact kinds supported by :func:`migrate_scope`.
+
+Memory tier moves stay in :func:`memtomem.cli.context_cmd._memory_migrate_run`
+(chunk-id-stable single-DB rename). The CLI's ``mm context migrate
+memory <src> --from --to`` wires that call through; it does not enter
+this module.
+"""
+
+
+_DIR_MANIFEST: dict[str, str] = {
+    "agents": AGENT_DIR_FILENAME,
+    "commands": COMMAND_DIR_FILENAME,
+    "skills": SKILL_MANIFEST,
+}
+
+
+@dataclass(frozen=True)
+class MigrateScopeResult:
+    """Outcome of one scope-tier migration plan or apply.
+
+    Set ``moved=False`` for dry-run results (preview only) and for
+    skipped rows. ``error`` is non-``None`` only on apply-time failures
+    that the helper recovered from (e.g. partial rollback succeeded);
+    fatal failures raise :class:`click.ClickException` and never produce
+    a ``MigrateScopeResult``.
+    """
+
+    kind: ArtifactKind
+    name: str
+    from_scope: TargetScope
+    to_scope: TargetScope
+    src_path: Path
+    dst_path: Path
+    layout: Literal["dir", "flat"]
+    moved: bool
+    fanout_cleaned: list[Path] = field(default_factory=list)
+    error: str | None = None
+
+
+@contextmanager
+def _acquire_pair_lock(path_a: Path, path_b: Path) -> Iterator[None]:
+    """Acquire two sidecar locks in deterministic sorted order.
+
+    Inverse migrations running concurrently (A: foo user→project_shared,
+    B: foo project_shared→user) would deadlock if each side acquired its
+    src lock first and dst lock second. Sorting by ``str(lock_path)``
+    forces every caller to take the same global order, eliminating the
+    cycle.
+
+    The pair is always two locks; if both arguments resolve to the same
+    sidecar (defensive — only happens when src and dst are the same file,
+    which :func:`migrate_scope` rejects upstream) the second lock is
+    skipped to avoid re-entrancy issues with portalocker on platforms
+    where ``LOCK_EX`` does not nest.
+    """
+    lock_a = _lock_path_for(path_a)
+    lock_b = _lock_path_for(path_b)
+    ordered = sorted([lock_a, lock_b], key=str)
+    if ordered[0] == ordered[1]:
+        with _file_lock(ordered[0]):
+            yield
+        return
+    with _file_lock(ordered[0]), _file_lock(ordered[1]):
+        yield
+
+
+def _stage_move(src: Path, dst_parent: Path, name_hint: str) -> tuple[Path, bool]:
+    """Move *src* into a same-fs staging entry under *dst_parent*.
+
+    Returns ``(staging_path, src_consumed)``. ``src_consumed=True`` when
+    ``os.rename`` succeeded (same-FS fast path) and the source is now
+    gone from disk. ``False`` when EXDEV forced a copy fallback; the
+    caller is responsible for removing the source after a successful
+    promote.
+
+    Cleanup discipline: on any error the staging entry is removed before
+    re-raising so callers do not have to. The src side is never touched
+    on the EXDEV fallback path until the caller signals promote success.
+    """
+    dst_parent.mkdir(parents=True, exist_ok=True)
+    suffix = f"{os.getpid()}-{secrets.token_hex(4)}"
+    staging = dst_parent / f".migrate-{name_hint}-{suffix}.tmp"
+    if staging.exists():
+        # Crashed prior run with a colliding suffix (extremely unlikely
+        # given pid+rand) — leftover is from us; safe to clear.
+        if staging.is_dir():
+            shutil.rmtree(staging)
+        else:
+            staging.unlink()
+    try:
+        os.rename(src, staging)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            # Non-EXDEV failure (permissions, missing src, etc.) — surface.
+            with contextlib.suppress(OSError):
+                if staging.exists():
+                    if staging.is_dir():
+                        shutil.rmtree(staging, ignore_errors=True)
+                    else:
+                        staging.unlink()
+            raise
+        # EXDEV fallback: copy bytes into staging without touching src.
+        try:
+            if src.is_dir():
+                shutil.copytree(src, staging)
+            else:
+                shutil.copy2(src, staging)
+        except BaseException:
+            if staging.exists():
+                if staging.is_dir():
+                    shutil.rmtree(staging, ignore_errors=True)
+                else:
+                    with contextlib.suppress(OSError):
+                        staging.unlink()
+            raise
+        return staging, False
+    return staging, True
+
+
+def _promote_move(staging: Path, dst: Path) -> None:
+    """Atomic ``os.replace(staging, dst)``; refuse if dst already exists.
+
+    Pre-condition (pinned by :func:`migrate_scope` Row 15 contract): dst
+    must not exist. Re-checking inside the lock window avoids the rare
+    race where the dry-run preview observed an empty dst but an external
+    actor created one before the apply phase took the lock.
+    """
+    if dst.exists():
+        raise FileExistsError(f"destination already exists: {dst}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(staging, dst)
+
+
+def _remove_runtime_fanout_for(
+    kind: ArtifactKind,
+    name: str,
+    scope: TargetScope,
+    project_root: Path | None,
+) -> list[Path]:
+    """Remove runtime fan-out targets for one artifact at one scope.
+
+    Best-effort cleanup invoked after a successful canonical move so the
+    pre-migration scope's runtime entries (``~/.claude/agents/foo.md``
+    etc.) do not linger as orphans. Returns the list of removed paths
+    for telemetry / verification.
+
+    Walks every known runtime (claude / gemini / codex). Tuples that
+    :func:`runtime_fanout_root` reports as ``NO_FANOUT`` are skipped
+    (project_local entries, codex commands at project tiers, etc.).
+    KeyError surfaces a programming error in the table — fail-loud.
+    """
+    removed: list[Path] = []
+    for runtime in ("claude", "gemini", "codex"):
+        try:
+            root = runtime_fanout_root(kind, runtime, scope, project_root)
+        except KeyError:
+            # Unknown (kind, runtime, scope) tuple — table gap. Skip
+            # rather than fail the migration (canonical is already
+            # moved at this point); the table is the contract source-
+            # of-truth and a missing tuple should be caught by the
+            # unit tests on _runtime_targets, not here.
+            logger.warning(
+                "fanout cleanup: no table entry for (%s, %s, %s); skipping",
+                kind,
+                runtime,
+                scope,
+            )
+            continue
+        if root is None:
+            continue
+        if kind == "skills":
+            target = root / name
+            if target.is_symlink():
+                # Defensive: never follow / rmtree a symlink — could
+                # point outside the runtime root.
+                continue
+            if target.is_dir():
+                try:
+                    shutil.rmtree(target)
+                    removed.append(target)
+                except OSError as exc:
+                    logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
+        else:
+            target = root / f"{name}.md"
+            if target.is_file():
+                try:
+                    target.unlink()
+                    removed.append(target)
+                except OSError as exc:
+                    logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
+    return removed
+
+
+def _detect_source_scope(
+    kind: ArtifactKind,
+    name: str,
+    project_root: Path,
+    explicit_from: TargetScope | None,
+) -> tuple[TargetScope, Path, Literal["dir", "flat"]]:
+    """Locate the unique scope where *name*'s canonical lives.
+
+    Uses :func:`canonical_artifact_dir` + on-disk probes (NOT
+    ``list_canonical_*`` because PR-E4 only operates on a single name:
+    listing the whole tree just to filter is wasteful, and we still want
+    to surface flat-layout legacy entries). Returns
+    ``(scope, src_path, layout)`` where ``src_path`` is the directory or
+    file to move:
+
+    - ``layout="dir"``  → ``src_path = <canonical_root> / <name>``
+      (the directory that contains the manifest file).
+    - ``layout="flat"`` → ``src_path = <canonical_root> / f"{name}.md"``
+      (a single legacy file). Skills never have flat layout.
+
+    When ``explicit_from`` is set, only that scope is checked and a miss
+    raises with a scope-specific message. Otherwise all three scopes are
+    checked and ambiguity (>1 match) raises with the candidate list so
+    the user can disambiguate via ``--from``.
+    """
+    candidates: list[tuple[TargetScope, Path, Literal["dir", "flat"]]] = []
+    scopes_to_check: tuple[TargetScope, ...]
+    if explicit_from is not None:
+        scopes_to_check = (explicit_from,)
+    else:
+        scopes_to_check = ("user", "project_shared", "project_local")
+    manifest = _DIR_MANIFEST[kind]
+    for s in scopes_to_check:
+        try:
+            root = canonical_artifact_dir(kind, s, project_root)
+        except ContextScopeError:
+            continue
+        if not root.is_dir():
+            continue
+        dir_candidate = root / name
+        if dir_candidate.is_dir() and (dir_candidate / manifest).is_file():
+            candidates.append((s, dir_candidate, "dir"))
+            continue  # dir wins over flat — same convention as list_canonical_*
+        if kind == "skills":
+            # Skills have no flat layout; probe stops here.
+            continue
+        flat_candidate = root / f"{name}.md"
+        if flat_candidate.is_file():
+            candidates.append((s, flat_candidate, "flat"))
+
+    if not candidates:
+        if explicit_from is not None:
+            raise click.ClickException(f"{kind}/{name} not found at scope='{explicit_from}'.")
+        raise click.ClickException(
+            f"{kind}/{name} not found in any scope (user / project_shared / project_local)."
+        )
+    if len(candidates) > 1:
+        listed = ", ".join(f"{s} ({p})" for s, p, _ in candidates)
+        raise click.ClickException(
+            f"{kind}/{name} exists in multiple scopes: {listed}. "
+            f"Pass --from <scope> to disambiguate."
+        )
+    return candidates[0]
+
+
+def migrate_scope(
+    kind: ArtifactKind,
+    name: str,
+    *,
+    from_scope: TargetScope | None,
+    to_scope: TargetScope,
+    project_root: Path,
+    apply_: bool,
+) -> MigrateScopeResult:
+    """Move a canonical artifact between ADR-0011 scope tiers.
+
+    Pure module entry point — no Click prompts, no stdout writes; the
+    CLI wrapper in :mod:`memtomem.cli.context_cmd` owns all user-facing
+    output. Errors raise :class:`click.ClickException` so the wrapper
+    can re-raise verbatim.
+
+    Apply sequence:
+
+    1. Auto-detect or validate ``from_scope`` via
+       :func:`_detect_source_scope`; reject same-source-as-target.
+    2. Resolve ``dst_path`` (mirrors src layout — dir or flat).
+    3. Dry-run gate — return the plan without touching disk if
+       ``apply_=False``.
+    4. Refuse on dst conflict (PR-E4 Row 15: ``--force`` does not
+       overwrite scope-tier targets; replace verb is a follow-up).
+    5. Acquire src + dst sidecar locks in sorted order
+       (:func:`_acquire_pair_lock`).
+    6. Stage src → ``<dst.parent>/.migrate-<name>-<pid>-<rand>.tmp``
+       via rename; fall back to copytree on EXDEV.
+    7. Gate A scan on staging when ``to_scope == project_shared``.
+       Block raises :class:`click.ClickException` with the standard
+       project_shared block message; rollback puts src back.
+    8. Promote staging → dst via ``os.replace``.
+    9. EXDEV cleanup (rmtree src) when the rename fell back.
+    10. Best-effort cleanup of stale src runtime fan-out targets
+        (``~/.claude/agents/<name>.md`` etc.) — outside the lock so a
+        partial cleanup failure does not roll back the canonical move.
+
+    Returns:
+        :class:`MigrateScopeResult` with ``moved=True`` on apply
+        success, ``moved=False`` on dry-run, and ``fanout_cleaned``
+        listing every runtime path removed.
+    """
+    if kind not in SCOPE_MIGRATABLE_KINDS:
+        raise click.ClickException(
+            f"unsupported kind for scope migration: {kind!r} (use one of {SCOPE_MIGRATABLE_KINDS})"
+        )
+    validate_name(name, kind=f"{kind[:-1]} name")
+    if from_scope is not None and from_scope == to_scope:
+        raise click.ClickException("--from and --to must differ.")
+
+    project_root = Path(project_root).expanduser().resolve()
+
+    src_scope, src_path, layout = _detect_source_scope(kind, name, project_root, from_scope)
+    if src_scope == to_scope:
+        raise click.ClickException(f"{kind}/{name} is already at scope='{to_scope}' (no-op).")
+
+    dst_root = canonical_artifact_dir(kind, to_scope, project_root)
+    dst_path = dst_root / name if layout == "dir" else dst_root / f"{name}.md"
+
+    # Pre-flight conflict check (also re-checked inside the lock).
+    if dst_path.exists():
+        raise click.ClickException(
+            f"destination already exists: {dst_path}. "
+            "Resolve manually or remove the existing entry first. "
+            "--force does not overwrite scope-tier targets in PR-E4 "
+            "(replace verb is a follow-up)."
+        )
+
+    if not apply_:
+        # Dry-run: compute plan, no mutation.
+        return MigrateScopeResult(
+            kind=kind,
+            name=name,
+            from_scope=src_scope,
+            to_scope=to_scope,
+            src_path=src_path,
+            dst_path=dst_path,
+            layout=layout,
+            moved=False,
+        )
+
+    # ── apply path ───────────────────────────────────────────────────
+    with _acquire_pair_lock(src_path, dst_path):
+        # Re-check dst inside the lock window — some other process could
+        # have created it between the dry-run preview and the apply
+        # phase, even with our own lock-pair held (the writer would have
+        # had to take the same lock, but check defensively).
+        if dst_path.exists():
+            raise click.ClickException(f"destination appeared during lock acquire: {dst_path}.")
+
+        staging, src_consumed = _stage_move(src_path, dst_path.parent, name_hint=name)
+
+        try:
+            # Gate A on the staged content if landing in project_shared.
+            # The scan runs against staging (the bytes about to be
+            # promoted), not against src — so any in-flight edits caught
+            # mid-rename are still scanned.
+            if to_scope == "project_shared":
+                scan = scan_artifact_tree(
+                    staging,
+                    surface="cli_context_migrate",
+                    scope=to_scope,
+                    project_root=project_root,
+                    on_blocked="fail_fast",
+                )
+                if scan.blocked:
+                    # Raise — project_shared has no force valve in PR-E4
+                    # (mirrors PR-D memory-migrate and PR-E3 sync-side).
+                    raise_or_collect(
+                        scan.blocked[0],
+                        scope=to_scope,
+                        kind=kind[:-1],
+                        artifact_name=name,
+                    )
+
+            _promote_move(staging, dst_path)
+        except BaseException:
+            # Roll back: put bytes back at src so the caller can retry
+            # without manual cleanup.
+            if src_consumed and not src_path.exists() and staging.exists():
+                # Same-FS fast path consumed src; rename staging back.
+                with contextlib.suppress(OSError):
+                    os.replace(staging, src_path)
+            # Drop staging if still present (EXDEV fallback path or the
+            # rename-back above failed).
+            if staging.exists():
+                if staging.is_dir():
+                    shutil.rmtree(staging, ignore_errors=True)
+                else:
+                    with contextlib.suppress(OSError):
+                        staging.unlink()
+            raise
+
+        # EXDEV cleanup — promoted dst now holds the bytes; src copy is
+        # stale and must be removed for the migration to be complete.
+        if not src_consumed and src_path.exists():
+            try:
+                if src_path.is_dir():
+                    shutil.rmtree(src_path)
+                else:
+                    src_path.unlink()
+            except OSError as exc:
+                # Canonical is migrated; src cleanup failed. Surface but
+                # don't roll back the canonical move (would re-create
+                # the duplicate state we just resolved). User can re-run
+                # — _detect_source_scope will then see only src and
+                # treat it as the source for a re-migrate.
+                logger.warning(
+                    "EXDEV cleanup: failed to remove stale src %s: %s",
+                    src_path,
+                    exc,
+                )
+
+    # Lock released. Cleanup stale src runtime fan-out (best-effort).
+    fanout_cleaned = _remove_runtime_fanout_for(kind, name, src_scope, project_root)
+
+    return MigrateScopeResult(
+        kind=kind,
+        name=name,
+        from_scope=src_scope,
+        to_scope=to_scope,
+        src_path=src_path,
+        dst_path=dst_path,
+        layout=layout,
+        moved=True,
+        fanout_cleaned=fanout_cleaned,
+    )

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -526,11 +526,11 @@ _DIR_MANIFEST: dict[str, str] = {
 class MigrateScopeResult:
     """Outcome of one scope-tier migration plan or apply.
 
-    Set ``moved=False`` for dry-run results (preview only) and for
-    skipped rows. ``error`` is non-``None`` only on apply-time failures
-    that the helper recovered from (e.g. partial rollback succeeded);
-    fatal failures raise :class:`click.ClickException` and never produce
-    a ``MigrateScopeResult``.
+    Set ``moved=False`` for dry-run results (preview only). Fatal
+    failures raise :class:`click.ClickException` rather than producing
+    a result — the absence of an ``error`` field is deliberate
+    (Codex review #4 fold: dataclass vs raise hybrid is harder to
+    reason about than "raise on fail, return on success").
     """
 
     kind: ArtifactKind
@@ -542,7 +542,6 @@ class MigrateScopeResult:
     layout: Literal["dir", "flat"]
     moved: bool
     fanout_cleaned: list[Path] = field(default_factory=list)
-    error: str | None = None
 
 
 @contextmanager
@@ -884,13 +883,36 @@ def migrate_scope(
         except BaseException:
             # Roll back: put bytes back at src so the caller can retry
             # without manual cleanup.
+            #
+            # Codex review #1 (P-medium): when the same-FS rename-back
+            # fails — rare, but possible if e.g. ``src_path.parent`` was
+            # rmdir'd between rename and rollback — staging is now the
+            # ONLY copy of the user's bytes. Deleting it would silently
+            # destroy user data. Track that case explicitly and preserve
+            # staging when rename-back failed; log a loud ERROR pointing
+            # to the surviving path so manual recovery is possible.
+            rename_back_failed = False
             if src_consumed and not src_path.exists() and staging.exists():
-                # Same-FS fast path consumed src; rename staging back.
-                with contextlib.suppress(OSError):
+                try:
                     os.replace(staging, src_path)
-            # Drop staging if still present (EXDEV fallback path or the
-            # rename-back above failed).
-            if staging.exists():
+                except OSError as exc:
+                    rename_back_failed = True
+                    logger.error(
+                        "migrate_scope rollback: rename-back failed (%s); "
+                        "staging at %s is the ONLY surviving copy of the "
+                        "source bytes — manual recovery required (mv it back "
+                        "to %s).",
+                        exc,
+                        staging,
+                        src_path,
+                    )
+            # Drop staging only when the bytes are safe somewhere else:
+            # - src_consumed=False (EXDEV path): src still exists with the
+            #   bytes; staging is just a copy.
+            # - src_consumed=True, rename-back succeeded: src has the bytes again.
+            # - src_consumed=True, rename-back FAILED: staging is the bytes;
+            #   leave it so the user can recover.
+            if staging.exists() and not rename_back_failed:
                 if staging.is_dir():
                     shutil.rmtree(staging, ignore_errors=True)
                 else:

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -884,35 +884,57 @@ def migrate_scope(
             # Roll back: put bytes back at src so the caller can retry
             # without manual cleanup.
             #
-            # Codex review #1 (P-medium): when the same-FS rename-back
-            # fails — rare, but possible if e.g. ``src_path.parent`` was
-            # rmdir'd between rename and rollback — staging is now the
-            # ONLY copy of the user's bytes. Deleting it would silently
-            # destroy user data. Track that case explicitly and preserve
-            # staging when rename-back failed; log a loud ERROR pointing
-            # to the surviving path so manual recovery is possible.
-            rename_back_failed = False
-            if src_consumed and not src_path.exists() and staging.exists():
+            # The cleanup rule is: staging is deleted only when we KNOW
+            # the bytes are safe elsewhere. There are exactly three safe
+            # cases; everything else preserves staging as a recovery copy
+            # and logs a loud ERROR pointing the user at it.
+            #
+            # Codex review #1 fold caught the "rename-back fails →
+            # staging gets deleted" path. Re-review then caught a
+            # subtler one: ``not src_path.exists()`` was a TOCTOU — an
+            # external writer (``mm context install``, a manual file op,
+            # any tool that does not take our sidecar lock) can recreate
+            # ``src_path`` between our ``os.rename`` and rollback. The
+            # old guard would skip rename-back (src "already there") and
+            # the cleanup branch would delete staging anyway, even
+            # though the bytes at src now belong to someone else.
+            cleanup_staging = False
+            if not src_consumed:
+                # EXDEV fallback: src was never consumed, staging is
+                # just a copy. Safe to drop.
+                cleanup_staging = True
+            elif src_path.exists():
+                # Same-FS path consumed src, but src has reappeared —
+                # not by us. Don't overwrite the new src bytes; don't
+                # delete staging either. User reconciles manually.
+                logger.error(
+                    "migrate_scope rollback: src %s reappeared during apply "
+                    "(another writer outside our lock); preserving staging "
+                    "at %s as a recovery copy — manual reconciliation "
+                    "required.",
+                    src_path,
+                    staging,
+                )
+            elif staging.exists():
+                # Same-FS path consumed src; src is gone as expected;
+                # try the rename-back. Success consumes staging (cleanup
+                # is a no-op then); failure preserves staging.
                 try:
                     os.replace(staging, src_path)
+                    cleanup_staging = True
                 except OSError as exc:
-                    rename_back_failed = True
                     logger.error(
                         "migrate_scope rollback: rename-back failed (%s); "
                         "staging at %s is the ONLY surviving copy of the "
-                        "source bytes — manual recovery required (mv it back "
-                        "to %s).",
+                        "source bytes — manual recovery required (mv it "
+                        "back to %s).",
                         exc,
                         staging,
                         src_path,
                     )
-            # Drop staging only when the bytes are safe somewhere else:
-            # - src_consumed=False (EXDEV path): src still exists with the
-            #   bytes; staging is just a copy.
-            # - src_consumed=True, rename-back succeeded: src has the bytes again.
-            # - src_consumed=True, rename-back FAILED: staging is the bytes;
-            #   leave it so the user can recover.
-            if staging.exists() and not rename_back_failed:
+            # else: src_consumed and staging is gone too — nothing to do.
+
+            if cleanup_staging and staging.exists():
                 if staging.is_dir():
                     shutil.rmtree(staging, ignore_errors=True)
                 else:

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -103,13 +103,35 @@ def scan_artifact_tree(
         audit_context: dict[str, object] = {**audit_context_base, "path": str(path)}
         try:
             text = path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, OSError):
-            # Binary asset (PNG, etc.) or transient read failure: out of
-            # scope for the regex-based pattern set. Recording as ``pass``
-            # is safe-by-default — false negatives are bounded by the
-            # pattern set's ASCII-only character classes.
+        except UnicodeDecodeError:
+            # Binary asset (PNG, etc.): out of scope for the regex-based
+            # pattern set. Recording as ``pass`` is safe-by-default —
+            # ASCII-only character classes in the pattern set cannot
+            # match non-text payloads.
             decisions.append(FileScan(path, "pass", 0))
             continue
+        except OSError as exc:
+            # Read failure (permissions, transient I/O, missing file).
+            # Pre-PR-E4 review this was conflated with UnicodeDecodeError
+            # and recorded as ``pass`` — but ``UnicodeDecodeError`` reads
+            # the bytes (regex would have nothing to match), while
+            # ``OSError`` means we never even saw the bytes. PR-E4's
+            # ``_stage_move`` can rename a ``chmod 000`` canonical file
+            # into staging without reading it, so silent-pass would have
+            # let an unreadable file containing a secret promote into
+            # ``project_shared`` with Gate A never inspecting it.
+            #
+            # Fail closed: hard-abort the scan with a scope-aware
+            # ClickException. The exception propagates through callers'
+            # rollback paths (``migrate_scope`` re-renames staging back
+            # to src; ``generate_all_skills`` removes staging in its
+            # finally block) so no half-promoted state survives.
+            raise click.ClickException(
+                f"Gate A: cannot read {path} (errno={exc.errno}); refusing to "
+                f"fan-out / migrate to scope='{scope}'. An unreadable file "
+                "cannot be scanned for secrets — fix the permission or "
+                "remove the file before re-running."
+            ) from exc
 
         guard = privacy.enforce_write_guard(
             text,

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1403,3 +1403,136 @@ def test_e4_unreadable_canonical_blocks_project_shared_promotion(scope_layout, m
     dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
     assert not (dst_root / "leak").exists()
     assert not list(dst_root.glob(".migrate-leak-*.tmp"))
+
+
+# ── PR-E4 Codex review fold #2: EXDEV + Gate A combined path ─────────
+
+
+def test_e4_exdev_then_gate_a_blocks_src_untouched(scope_layout, monkeypatch):
+    """Codex review #2 — EXDEV-fallback path must roll back cleanly when
+    Gate A then blocks. Combines two branches that Row 11 (clean EXDEV)
+    and Row 2 (same-FS Gate A block) cover separately:
+
+    1. ``os.rename`` raises EXDEV → ``_stage_move`` falls back to
+       ``copytree``, leaving src on disk and staging as a copy
+       (``src_consumed=False``).
+    2. Gate A scans staging, finds the secret, raises ClickException.
+    3. ``except BaseException`` rollback: src already exists (was never
+       renamed away), so the rename-back branch is a no-op; staging
+       (the copy) gets dropped via rmtree.
+
+    Pin: src is byte-identical to the pre-migrate state, dst absent,
+    no staging leftover, exit non-zero.
+    """
+    import errno as _errno
+    import os as os_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+    real_rename = os_mod.rename
+    raised: dict[str, bool] = {"once": False}
+
+    def fake_rename(a, b):
+        # Trigger EXDEV on the FIRST os.rename call (the src→staging
+        # step inside _stage_move). Subsequent renames (none expected
+        # in this path because Gate A blocks before _promote_move) go
+        # through.
+        if not raised["once"]:
+            raised["once"] = True
+            raise OSError(_errno.EXDEV, "Cross-device link", str(a))
+        return real_rename(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.rename", fake_rename)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    assert "Gate A" in result.output
+    assert raised["once"], "EXDEV branch should have triggered"
+
+    # POSITIVE: src untouched (EXDEV path never consumed it).
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+    # NEGATIVE: dst absent + no staging tmp leftover (rollback dropped it).
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "leak").exists()
+    assert not list(dst_root.glob(".migrate-leak-*.tmp"))
+
+
+# ── PR-E4 Codex review fold #1: rollback rename-back failure ─────────
+
+
+def test_e4_rollback_rename_back_failure_preserves_staging(scope_layout, monkeypatch, caplog):
+    """Codex review #1 — when the rollback rename-back fails, staging is
+    the only surviving copy of the user's bytes; do NOT delete it.
+
+    Setup: clean canonical at user-tier, Gate A would block (secret),
+    and ``os.replace`` is monkeypatched so the rollback's staging→src
+    rename-back call raises ``OSError``. The first ``os.replace`` in
+    the apply path is the rollback (Gate A blocks before
+    ``_promote_move`` runs).
+
+    Pin: error logged with the staging path, staging dir is NOT
+    deleted, exit non-zero. Pre-fix the cleanup branch unconditionally
+    deleted staging → user data lost.
+    """
+    import logging as _logging
+    import os as os_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+    real_replace = os_mod.replace
+    rename_back_calls: list[tuple[Path, Path]] = []
+
+    def fake_replace(a, b):
+        # The first os.replace in this path is the rollback's
+        # staging→src rename-back. Trip it once so the rollback hits the
+        # OSError branch; subsequent os.replace calls (none expected
+        # along this code path) go through.
+        if not rename_back_calls:
+            rename_back_calls.append((Path(a), Path(b)))
+            raise OSError(13, "Permission denied", str(a))
+        return real_replace(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.replace", fake_replace)
+    caplog.set_level(_logging.ERROR, logger="memtomem.context.migrate")
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    # The Gate A path raised first; rollback hit the os.replace failure.
+    assert rename_back_calls, "rollback rename-back should have been attempted"
+
+    # POSITIVE: ERROR logged pointing at the surviving staging path so
+    # the user can recover manually.
+    assert any(
+        "rename-back failed" in r.getMessage() and ".migrate-leak-" in r.getMessage()
+        for r in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+    # POSITIVE: staging dir survives (the only copy of the bytes).
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    surviving = list(dst_root.glob(".migrate-leak-*.tmp"))
+    assert len(surviving) == 1, surviving
+    # Bytes inside staging are byte-identical to the original src
+    # (it was renamed, not rewritten).
+    surviving_manifest = surviving[0] / "agent.md"
+    assert surviving_manifest.is_file()
+    assert surviving_manifest.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+
+    # NEGATIVE: src is gone (consumed by the initial os.rename); dst
+    # never landed.
+    assert not src.exists()
+    assert not (dst_root / "leak").exists()

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1350,3 +1350,56 @@ def test_e4_row17_memory_dispatch_validates_inputs(monkeypatch, tmp_path):
     )
     assert r3.exit_code != 0
     assert "must differ" in r3.output
+
+
+# ── PR-E4 review fold: unreadable canonical cannot bypass Gate A ─────
+
+
+def test_e4_unreadable_canonical_blocks_project_shared_promotion(scope_layout, monkeypatch):
+    """Pre-fold this branch passed: ``_stage_move`` renames a chmod-000
+    file into staging without reading it, then ``scan_artifact_tree``
+    treated the read failure as ``pass`` (conflated with binary), and
+    the secret-bearing file got promoted into the git-tracked
+    ``project_shared`` tier with Gate A never inspecting it.
+
+    Pin: ``OSError`` on the staging-side read raises a
+    ``ClickException``, ``migrate_scope``'s rollback puts src back, and
+    the project_shared destination stays empty. Uses a monkeypatched
+    ``Path.read_text`` to simulate the unreadable file portably — real
+    ``chmod 000`` works on POSIX but is meaningless on Windows, and the
+    monkeypatch exercises the same ``OSError`` branch in both.
+    """
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+
+    real_read_text = Path.read_text
+
+    def explode_on_staged_read(self: Path, *args: object, **kwargs: object) -> str:
+        # The scan walks staging at <dst.parent>/.migrate-leak-<pid>-<rand>.tmp/.
+        # Match by name + the staging suffix marker so unrelated reads
+        # (CLI bootstrap, config loading) are unaffected.
+        if self.name == "agent.md" and ".migrate-leak-" in str(self.parent):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", explode_on_staged_read)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    # Fail-loud message specifics — never echo the secret bytes.
+    assert "cannot read" in result.output
+    assert _SECRET_LITERAL not in result.output
+    # POSITIVE: src restored bytes-identical to the pre-migrate state.
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+    # NEGATIVE: dst absent and no staging tmp left behind.
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "leak").exists()
+    assert not list(dst_root.glob(".migrate-leak-*.tmp"))

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1536,3 +1536,78 @@ def test_e4_rollback_rename_back_failure_preserves_staging(scope_layout, monkeyp
     # never landed.
     assert not src.exists()
     assert not (dst_root / "leak").exists()
+
+
+# ── PR-E4 Codex re-review fold: src reappears via external race ──────
+
+
+def test_e4_rollback_src_reappears_preserves_staging(scope_layout, monkeypatch, caplog):
+    """Codex re-review fold — when ``src_path`` reappears during apply
+    (an external writer outside our sidecar lock — e.g.,
+    ``mm context install`` running in parallel, a user manually
+    recreating the canonical), the rollback must NOT silently delete
+    staging. The new src bytes might be unrelated to ours; staging is
+    the only verified copy of the original.
+
+    Triggered by monkeypatching ``scan_artifact_tree`` in the
+    ``migrate`` module so that BEFORE Gate A would block, the racer
+    recreates ``src_path`` with different bytes. Then Gate A blocks,
+    rollback enters the ``src_path.exists()`` branch, logs ERROR, and
+    preserves staging.
+
+    Pin (Codex re-review):
+      * src reappeared bytes are preserved verbatim — rollback does
+        not overwrite them.
+      * staging directory survives — original bytes recoverable.
+      * ERROR log includes the "reappeared" marker + both paths.
+    """
+    import logging as _logging
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+
+    from memtomem.context import migrate as migrate_mod
+
+    real_scan = migrate_mod.scan_artifact_tree
+    racer_bytes = "racer wrote different bytes\n"
+
+    def fake_scan_with_racer(*args, **kwargs):
+        # Recreate src with different bytes BEFORE the scan returns.
+        # The scan itself runs against staging — Gate A will block on
+        # the original secret. By the time rollback runs, src exists
+        # again from the racer's write.
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text(racer_bytes, encoding="utf-8")
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(migrate_mod, "scan_artifact_tree", fake_scan_with_racer)
+    caplog.set_level(_logging.ERROR, logger="memtomem.context.migrate")
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+
+    # POSITIVE: ERROR logged with the "reappeared" marker.
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("reappeared during apply" in m and ".migrate-leak-" in m for m in messages), messages
+
+    # POSITIVE: racer bytes preserved at src (not overwritten by rollback).
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == racer_bytes
+
+    # POSITIVE: staging dir survives with the ORIGINAL secret-bearing bytes.
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    surviving = list(dst_root.glob(".migrate-leak-*.tmp"))
+    assert len(surviving) == 1, surviving
+    surviving_manifest = surviving[0] / "agent.md"
+    assert surviving_manifest.is_file()
+    assert surviving_manifest.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+
+    # NEGATIVE: dst never landed.
+    assert not (dst_root / "leak").exists()

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -720,3 +720,633 @@ def test_migrate_one_keeps_unrelated_dir_contents(tmp_path: Path) -> None:
     assert sibling.stat().st_mtime == pre_sibling_mtime
     # Flat removed
     assert not flat.exists()
+
+
+# ── PR-E4: scope-tier migration (17-row smoke matrix) ────────────────
+
+
+_MANIFEST_NAME = {"agents": "agent.md", "commands": "command.md", "skills": "SKILL.md"}
+_RUNTIME_REL = {
+    "agents": {"claude": ".claude/agents", "gemini": ".gemini/agents"},
+    "commands": {"claude": ".claude/commands", "gemini": ".gemini/commands"},
+    "skills": {"claude": ".claude/skills", "gemini": ".gemini/skills"},
+}
+_AGENT_BODY_CLEAN = "---\nname: foo\ndescription: a clean test agent\n---\n\nhello world\n"
+_COMMAND_BODY_CLEAN = "---\nname: foo\ndescription: a clean test command\n---\n\nhello $ARGUMENTS\n"
+_SKILL_BODY_CLEAN = "---\nname: foo\ndescription: a clean test skill\n---\n\nhello\n"
+_BODY_CLEAN = {
+    "agents": _AGENT_BODY_CLEAN,
+    "commands": _COMMAND_BODY_CLEAN,
+    "skills": _SKILL_BODY_CLEAN,
+}
+_SECRET_LITERAL = "AKIA1234567890ABCDEF"  # AWS-key shape — caught by privacy.enforce_write_guard
+_AGENT_BODY_SECRET = "---\nname: foo\ndescription: leaks\n---\n\napi_key=" + _SECRET_LITERAL + "\n"
+
+
+@pytest.fixture
+def scope_layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Project root + monkeypatched HOME for cross-scope migration tests.
+
+    Layout:
+
+    - ``project_root`` = ``tmp_path / "proj"`` (with ``.git`` so the CLI's
+      ``_find_project_root`` walker picks it up).
+    - ``user_home`` = ``tmp_path / "home"`` — both ``HOME`` and
+      ``USERPROFILE`` are monkeypatched to this path so
+      ``canonical_artifact_dir(scope="user")`` and the user-tier runtime
+      fan-out (``~/.claude/...``) resolve under it
+      (``feedback_path_home_cross_platform.md``).
+    - cwd is set to ``project_root`` so the CLI walker terminates there.
+
+    Returns a dict the test functions index for the four useful paths.
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    user_home = tmp_path / "home"
+    user_home.mkdir()
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("USERPROFILE", str(user_home))
+    monkeypatch.chdir(project_root)
+    return {"project_root": project_root, "user_home": user_home}
+
+
+def _canonical_root_for(layout: dict[str, Path], kind: str, scope: str) -> Path:
+    """Mirror ``canonical_artifact_dir`` using the fixture paths."""
+    if scope == "user":
+        return layout["user_home"] / ".memtomem" / kind
+    if scope == "project_shared":
+        return layout["project_root"] / ".memtomem" / kind
+    if scope == "project_local":
+        return layout["project_root"] / ".memtomem" / f"{kind}.local"
+    raise ValueError(f"unknown scope: {scope}")
+
+
+def _write_canonical_dir(
+    layout: dict[str, Path], kind: str, scope: str, name: str, body: str
+) -> Path:
+    """Write a dir-layout canonical artifact and return the manifest path."""
+    root = _canonical_root_for(layout, kind, scope)
+    manifest_dir = root / name
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest = manifest_dir / _MANIFEST_NAME[kind]
+    manifest.write_text(body, encoding="utf-8")
+    return manifest
+
+
+def _runtime_fanout_path(
+    layout: dict[str, Path], kind: str, runtime: str, scope: str, name: str
+) -> Path:
+    """Compute the runtime fan-out file/dir path for a given (kind, runtime, scope, name)."""
+    rel = _RUNTIME_REL[kind][runtime]
+    if scope == "user":
+        base = layout["user_home"] / rel
+    elif scope == "project_shared":
+        base = layout["project_root"] / rel
+    else:
+        raise ValueError(f"runtime fan-out not defined for scope={scope!r}")
+    return base / name if kind == "skills" else base / f"{name}.md"
+
+
+def _seed_runtime_fanout(
+    layout: dict[str, Path], kind: str, scope: str, name: str, body: str
+) -> list[Path]:
+    """Pre-seed runtime fan-out targets so the migrate cleanup path has something to remove."""
+    seeded: list[Path] = []
+    for runtime in ("claude", "gemini"):
+        target = _runtime_fanout_path(layout, kind, runtime, scope, name)
+        if kind == "skills":
+            target.mkdir(parents=True, exist_ok=True)
+            (target / _MANIFEST_NAME[kind]).write_text(body, encoding="utf-8")
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+        seeded.append(target)
+    return seeded
+
+
+def _invoke_migrate(args: list[str]) -> object:
+    """Click runner shorthand. ``catch_exceptions=False`` lets test failures surface."""
+    return CliRunner().invoke(context_group, args, catch_exceptions=False)
+
+
+def _migrate_args(
+    kind: str,
+    name: str,
+    *,
+    from_scope: str | None,
+    to_scope: str,
+    apply_: bool = True,
+    confirm_project_shared: bool = False,
+    yes: bool = True,
+) -> list[str]:
+    args: list[str] = ["migrate", kind, name, "--to", to_scope]
+    if from_scope is not None:
+        args.extend(["--from", from_scope])
+    if apply_:
+        args.append("--apply")
+    if confirm_project_shared:
+        args.append("--confirm-project-shared")
+    if yes:
+        args.append("--yes")
+    return args
+
+
+# ── Rows 1–10: per-(kind, transition) basic moves ────────────────────
+
+
+def test_e4_row1_agents_user_to_project_shared_clean(scope_layout):
+    """Row 1: agents user→project_shared clean — canonical at dst, src removed."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert dst.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    assert not src.exists()
+    assert not src.parent.exists()
+
+
+def test_e4_row2_agents_user_to_project_shared_secret_blocks(scope_layout):
+    """Row 2: secret on the wire to project_shared — Gate A raises, src untouched."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_SECRET)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    assert "Gate A" in result.output
+    # POSITIVE: src restored
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+    # NEGATIVE: dst absent
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "foo").exists()
+    # Staging cleaned (no .migrate-foo-* leftover under dst.parent)
+    assert not list(dst_root.glob(".migrate-foo-*.tmp"))
+
+
+def test_e4_row3_agents_user_to_project_local_clean(scope_layout):
+    """Row 3: agents user→project_local clean — canonical at draft tier, src removed."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_local") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row4_agents_project_shared_to_user_clean(scope_layout):
+    """Row 4: agents project_shared→user clean — canonical at user, src removed.
+
+    Also pins runtime fan-out cleanup at the source scope: a stale
+    ``<proj>/.claude/agents/foo.md`` seeded before migrate is removed
+    afterward.
+    """
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "user") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+    # Stale fan-out removed
+    for path in seeded:
+        assert not path.exists(), f"expected stale fan-out cleaned: {path}"
+
+
+def test_e4_row5_agents_project_local_to_project_shared_clean(scope_layout):
+    """Row 5: agents project_local→project_shared clean — promote draft to shared."""
+    src = _write_canonical_dir(scope_layout, "agents", "project_local", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="project_local",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row6_agents_project_shared_to_project_local_clean(scope_layout):
+    """Row 6: agents project_shared→project_local — demote, fan-out dropped."""
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "agents", "project_local") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+    for path in seeded:
+        assert not path.exists(), f"expected stale fan-out cleaned on demote: {path}"
+
+
+def test_e4_row7_commands_user_to_project_shared_clean(scope_layout):
+    """Row 7: parallel of row 1 for commands."""
+    src = _write_canonical_dir(scope_layout, "commands", "user", "build", _COMMAND_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "commands",
+            "build",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "commands", "project_shared") / "build" / "command.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row8_commands_project_local_to_user_clean(scope_layout):
+    """Row 8: commands project_local→user clean."""
+    src = _write_canonical_dir(
+        scope_layout, "commands", "project_local", "build", _COMMAND_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args("commands", "build", from_scope="project_local", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "commands", "user") / "build" / "command.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row9_skills_user_to_project_shared_clean(scope_layout):
+    """Row 9: skills user→project_shared — canonical moves; user-tier fan-out cleaned.
+
+    Pre-seeds ``~/.claude/skills/foo/`` (user-tier fan-out per ADR-0011
+    runtime table) and verifies it is removed after migrate. ADR-0011
+    correction: skills `project_shared` IS a fan-out target (only
+    `project_local` is NO_FANOUT) — see plan review feedback.
+    """
+    src = _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "skills",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "skills", "project_shared") / "foo" / "SKILL.md"
+    assert dst.is_file()
+    assert not src.exists()
+    # User-tier fan-out cleaned (rmtree-d skill dir).
+    for path in seeded:
+        assert not path.exists(), f"expected user-tier skill fan-out cleaned: {path}"
+
+
+def test_e4_row10_skills_project_shared_to_project_local_clean(scope_layout):
+    """Row 10: skills project_shared→project_local — fan-out drops (project_local NO_FANOUT).
+
+    Project_shared skills DO fan out (``<proj>/.claude/skills/foo/``);
+    project_local skills do NOT (ADR-0011 §6 / §3). The demote must
+    remove the project-shared fan-out so the runtime stops seeing the
+    skill.
+    """
+    src = _write_canonical_dir(scope_layout, "skills", "project_shared", "foo", _SKILL_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "skills", "project_shared", "foo", _SKILL_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "skills",
+            "foo",
+            from_scope="project_shared",
+            to_scope="project_local",
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "skills", "project_local") / "foo" / "SKILL.md"
+    assert dst.is_file()
+    assert not src.exists()
+    for path in seeded:
+        assert not path.exists(), (
+            f"expected project_shared skills fan-out cleaned on demote: {path}"
+        )
+
+
+# ── Rows 11–15: edge cases ───────────────────────────────────────────
+
+
+def test_e4_row11_exdev_fallback_copytree(scope_layout, monkeypatch):
+    """Row 11: EXDEV — first ``os.rename`` raises EXDEV; staging falls back to copytree.
+
+    Monkeypatches ``os.rename`` once so the ``src → staging`` step
+    (the only ``os.rename`` call inside ``migrate_scope`` before
+    ``_promote_move``) hits EXDEV. The promote-side ``os.replace`` is
+    a different function and therefore unaffected.
+    """
+    import os as os_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    real_rename = os_mod.rename
+    raised: dict[str, bool] = {"once": False}
+
+    def fake_rename(a, b):
+        if not raised["once"]:
+            raised["once"] = True
+            import errno as _errno
+
+            raise OSError(_errno.EXDEV, "Cross-device link", str(a))
+        return real_rename(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.rename", fake_rename)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert raised["once"], "EXDEV path should have triggered"
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert dst.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    # Source cleaned up after EXDEV-fallback copy + promote.
+    assert not src.exists()
+    assert not src.parent.exists()
+
+
+def test_e4_row12_idempotent_after_migrate(scope_layout):
+    """Row 12: re-running migrate after a successful move is a clear no-op error.
+
+    The "concurrent migrate, same src" thread-race shape collapses to
+    "second invocation sees src gone" once the first invocation
+    completes. The lock-order test in
+    ``test_context_migrate_lock_order.py`` covers true concurrency.
+    """
+    _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    first = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert first.exit_code == 0, first.output
+
+    second = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert second.exit_code != 0, second.output
+    assert "not found at scope='user'" in second.output
+
+
+def test_e4_row13_inverse_migrate_lock_order_pin(scope_layout):
+    """Row 13: deterministic lock-acquire order — sorted by ``str(lock_path)``.
+
+    Asserts the contract directly via ``_acquire_pair_lock`` instead of
+    racing two threads (which is harder to make deterministic). The
+    threaded deadlock-freedom test lives in
+    ``test_context_migrate_lock_order.py``.
+    """
+    from memtomem.context._atomic import _lock_path_for
+    from memtomem.context.migrate import _acquire_pair_lock
+
+    src_dir = _canonical_root_for(scope_layout, "agents", "user") / "foo"
+    dst_dir = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo"
+    src_dir.parent.mkdir(parents=True, exist_ok=True)
+    dst_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    expected_first = min(_lock_path_for(src_dir), _lock_path_for(dst_dir), key=str)
+
+    # Smoke: the helper acquires both locks without deadlock and the
+    # sorted order is the documented contract (we do not introspect the
+    # internal sequence — taking both locks is sufficient functional
+    # evidence; the dedicated lock-order test asserts the order).
+    with _acquire_pair_lock(src_dir, dst_dir):
+        assert expected_first.parent.is_dir()  # lock parent exists
+
+
+def test_e4_row14_dry_run_no_mutation(scope_layout):
+    """Row 14: dry-run — plan reported, no disk mutation."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            apply_=False,
+            yes=False,  # --yes / --force require --apply
+            confirm_project_shared=False,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert "Plan: migrate" in result.output
+    assert "Run with --apply" in result.output
+
+    # Filesystem unchanged.
+    assert src.is_file()
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "foo").exists()
+    # No staging tmp leftover.
+    assert not list(dst_root.glob(".migrate-foo-*.tmp"))
+
+
+def test_e4_row15_dst_conflict_always_refuses(scope_layout):
+    """Row 15: dst already has same name — refuse, even with --force."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    dst_existing = _write_canonical_dir(
+        scope_layout, "agents", "project_shared", "foo", "stale dst body\n"
+    )
+
+    # With --force: --force is rejected as a usage error in scope-mode.
+    forced = _invoke_migrate(
+        [
+            "migrate",
+            "agents",
+            "foo",
+            "--from",
+            "user",
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+            "--yes",
+            "--force",
+        ]
+    )
+    assert forced.exit_code != 0, forced.output
+    assert "--force does not apply" in forced.output
+
+    # Without --force: refuses with a destination-exists message.
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    assert "destination already exists" in result.output
+
+    # Both sides preserved.
+    assert src.is_file()
+    assert dst_existing.read_text(encoding="utf-8") == "stale dst body\n"
+
+
+# ── Rows 16–17: memory cross-link delegate ───────────────────────────
+
+
+def test_e4_row16_memory_dispatch_delegates_to_memory_migrate(monkeypatch, tmp_path):
+    """Row 16: ``mm context migrate memory <src> --from --to`` delegates to memory-migrate.
+
+    Verifies dispatch parity by monkeypatching ``_memory_migrate_run``
+    and checking it gets called with the same args the public
+    ``mm context memory-migrate`` would build (path, from, to, apply,
+    yes, confirm_project_shared).
+    """
+    src = tmp_path / "rule.md"
+    src.write_text("## Rule\n\nharmless body\n", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run(source, from_scope, to_scope, apply_, yes, confirm_project_shared):
+        captured["source"] = source
+        captured["from_scope"] = from_scope
+        captured["to_scope"] = to_scope
+        captured["apply_"] = apply_
+        captured["yes"] = yes
+        captured["confirm_project_shared"] = confirm_project_shared
+
+    monkeypatch.setattr("memtomem.cli.context_cmd._memory_migrate_run", _fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke_migrate(
+        [
+            "migrate",
+            "memory",
+            str(src),
+            "--from",
+            "user",
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["source"] == src.resolve()
+    assert captured["from_scope"] == "user"
+    assert captured["to_scope"] == "project_shared"
+    assert captured["apply_"] is True
+    assert captured["confirm_project_shared"] is True
+
+
+def test_e4_row17_memory_dispatch_validates_inputs(monkeypatch, tmp_path):
+    """Row 17: memory dispatch validation — missing flags / non-existent path / same-scope.
+
+    Compresses three negative cases into one row since they share the
+    same dispatch helper:
+
+    1. Missing ``--to`` → UsageError.
+    2. Non-existent source path → ClickException.
+    3. ``--from`` == ``--to`` → ClickException.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # 1. Missing --to
+    r1 = _invoke_migrate(["migrate", "memory", "/some/path", "--from", "user"])
+    assert r1.exit_code != 0
+    assert "--from and --to are both required" in r1.output
+
+    # 2. Non-existent source
+    r2 = _invoke_migrate(
+        [
+            "migrate",
+            "memory",
+            "/this/does/not/exist.md",
+            "--from",
+            "user",
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+        ]
+    )
+    assert r2.exit_code != 0
+    assert "does not exist" in r2.output
+
+    # 3. --from == --to
+    src = tmp_path / "rule.md"
+    src.write_text("body\n", encoding="utf-8")
+    r3 = _invoke_migrate(
+        [
+            "migrate",
+            "memory",
+            str(src),
+            "--from",
+            "user",
+            "--to",
+            "user",
+            "--apply",
+        ]
+    )
+    assert r3.exit_code != 0
+    assert "must differ" in r3.output

--- a/packages/memtomem/tests/test_context_migrate_lock_order.py
+++ b/packages/memtomem/tests/test_context_migrate_lock_order.py
@@ -1,0 +1,130 @@
+"""ADR-0011 PR-E4 — deterministic lock-acquire order regression test.
+
+Pins the contract that :func:`memtomem.context.migrate._acquire_pair_lock`
+takes the two sidecar locks in ``sorted(key=str)`` order regardless of
+which path the caller passes as ``path_a`` vs ``path_b``. Without this
+ordering, two concurrent inverse migrations
+(``A: foo user→project_shared`` and ``B: foo project_shared→user``)
+would each grab their src-side lock first and deadlock waiting for the
+other's dst-side lock.
+
+Two pins:
+
+1. **Order pin** — ``_acquire_pair_lock(a, b)`` and ``_acquire_pair_lock(b, a)``
+   acquire locks in the same global sequence (verified via a tracker
+   that watches the order locks are obtained and released).
+2. **Deadlock-freedom pin** — two threads racing inverse migrations
+   complete within a generous timeout (no deadlock).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem.context._atomic import _file_lock, _lock_path_for
+from memtomem.context.migrate import _acquire_pair_lock
+
+
+def _acquire_log(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Wrap ``_file_lock`` so each acquire appends its lock_path to a shared list.
+
+    The wrapper installs at the module path ``_acquire_pair_lock`` reads
+    from (``memtomem.context.migrate._file_lock``). The original
+    ``_file_lock`` implementation is delegated to verbatim — we only
+    record the call sequence.
+    """
+    log: list[Path] = []
+    real = _file_lock
+
+    def wrapped(lock_path: Path):
+        log.append(lock_path)
+        return real(lock_path)
+
+    monkeypatch.setattr("memtomem.context.migrate._file_lock", wrapped)
+    return log
+
+
+def test_acquire_pair_lock_orders_by_str(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Order pin — both call orientations produce the same global lock sequence."""
+    a = tmp_path / "alpha"
+    b = tmp_path / "beta"
+    a.mkdir()
+    b.mkdir()
+
+    expected_first = min(_lock_path_for(a), _lock_path_for(b), key=str)
+    expected_second = max(_lock_path_for(a), _lock_path_for(b), key=str)
+
+    log_ab = _acquire_log(monkeypatch)
+    with _acquire_pair_lock(a, b):
+        pass
+    assert log_ab == [expected_first, expected_second], (
+        f"a→b orientation: got {log_ab}, expected [{expected_first}, {expected_second}]"
+    )
+
+    log_ba = _acquire_log(monkeypatch)
+    with _acquire_pair_lock(b, a):
+        pass
+    assert log_ba == [expected_first, expected_second], (
+        f"b→a orientation: got {log_ba}, expected [{expected_first}, {expected_second}]"
+    )
+
+
+def test_acquire_pair_lock_same_path_acquires_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Defensive: when both args resolve to the same lock, only one acquire."""
+    p = tmp_path / "same"
+    p.mkdir()
+    log = _acquire_log(monkeypatch)
+    with _acquire_pair_lock(p, p):
+        pass
+    assert log == [_lock_path_for(p)]
+
+
+def test_inverse_migrate_no_deadlock(tmp_path: Path):
+    """Deadlock-freedom pin — two threads racing inverse pair-locks both finish.
+
+    Sets up two paths ``alpha`` and ``beta``; thread A locks
+    ``(alpha, beta)`` while thread B locks ``(beta, alpha)``. Without
+    sorted ordering, thread A would wait on beta's lock while thread B
+    waits on alpha's, deadlocking. Sorted ordering forces both threads
+    to acquire alpha's lock first, so one finishes its critical section
+    and releases before the other proceeds.
+
+    We verify both threads complete inside a generous timeout. The hold
+    duration inside the lock is short (a 50 ms sleep) so the test
+    finishes quickly when no deadlock; under deadlock it would hit the
+    join timeout.
+    """
+    a = tmp_path / "alpha"
+    b = tmp_path / "beta"
+    a.mkdir()
+    b.mkdir()
+
+    barrier = threading.Barrier(2)
+    finished: dict[str, bool] = {"A": False, "B": False}
+
+    def thread_a():
+        barrier.wait(timeout=5)
+        with _acquire_pair_lock(a, b):
+            time.sleep(0.05)
+        finished["A"] = True
+
+    def thread_b():
+        barrier.wait(timeout=5)
+        with _acquire_pair_lock(b, a):
+            time.sleep(0.05)
+        finished["B"] = True
+
+    ta = threading.Thread(target=thread_a)
+    tb = threading.Thread(target=thread_b)
+    ta.start()
+    tb.start()
+    ta.join(timeout=5)
+    tb.join(timeout=5)
+
+    assert not ta.is_alive(), "thread A still alive — possible deadlock"
+    assert not tb.is_alive(), "thread B still alive — possible deadlock"
+    assert finished["A"] and finished["B"]

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -171,6 +171,90 @@ class TestBinaryAssetGracefulPass:
         assert result.blocked == []
 
 
+class TestUnreadableFileFailsClosed:
+    """Pre-PR-E4 review the OSError branch was conflated with
+    UnicodeDecodeError and recorded as ``pass``. PR-E4's ``_stage_move``
+    can rename a ``chmod 000`` canonical file into staging without
+    reading bytes, so silent-pass would have promoted unreadable
+    secret-bearing content into project_shared. These pins check that
+    ``OSError`` from ``read_text`` raises a scope-aware ``ClickException``
+    rather than recording a pass.
+    """
+
+    def test_oserror_raises_click_exception_project_shared(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "agent.md"
+        path.write_text(CLEAN, encoding="utf-8")
+
+        real_read_text = Path.read_text
+
+        def explode(self: Path, *args: object, **kwargs: object) -> str:
+            if self == path:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", explode)
+
+        with pytest.raises(click.ClickException) as exc_info:
+            scan_artifact_tree(path, surface="t", scope="project_shared", project_root=tmp_path)
+        msg = exc_info.value.message
+        assert "cannot read" in msg
+        assert "agent.md" in msg
+        assert "scope='project_shared'" in msg
+        # Negative — the message must NOT echo the file's content even
+        # if the file were readable mid-flight.
+        assert CLEAN.strip() not in msg
+
+    def test_oserror_raises_click_exception_user_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fail-closed posture is uniform across scopes for unreadable
+        # files. Skip-warn semantics apply to *known* pattern hits at
+        # user/project_local — an unreadable file is not a known hit,
+        # it's an unknown.
+        path = tmp_path / "agent.md"
+        path.write_text(CLEAN, encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def explode(self: Path, *args: object, **kwargs: object) -> str:
+            if self == path:
+                raise OSError(5, "Input/output error", str(self))
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", explode)
+
+        with pytest.raises(click.ClickException) as exc_info:
+            scan_artifact_tree(path, surface="t", scope="user", project_root=tmp_path)
+        assert "scope='user'" in exc_info.value.message
+
+    def test_unreadable_in_tree_walk_fails_fast(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tree walk should hard-abort on the first unreadable file and
+        # NOT continue scanning siblings — the staging tree as a whole
+        # is poisoned the moment any leaf cannot be inspected.
+        skill_root = _seed_skill(tmp_path / "foo")
+        unreadable = skill_root / "scripts" / "leak.sh"
+        real_read_text = Path.read_text
+
+        def explode(self: Path, *args: object, **kwargs: object) -> str:
+            if self == unreadable:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", explode)
+
+        with pytest.raises(click.ClickException) as exc_info:
+            scan_artifact_tree(
+                skill_root,
+                surface="t",
+                scope="project_shared",
+                project_root=tmp_path,
+            )
+        assert "leak.sh" in exc_info.value.message
+
+
 class TestRaiseOrCollect:
     def test_project_shared_raises(self) -> None:
         blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked", 1)


### PR DESCRIPTION
## Summary

ADR-0011 PR-E4 — `mm context migrate <kind> <name> --to <scope>` for scope-tier moves on agents / commands / skills, plus a hidden `migrate memory <src> --from --to` cross-link delegating to the existing `mm context memory-migrate` impl. Resolves the remediation hint that PR-E3's sync-side Gate A already emits (`mm context migrate <kind> <name> --to project_local`) — that hint now points at real behaviour.

## Status: draft, stacked on PR-E3

Base: `fix/adr-0011-pr-e3` (still pending its own dwell — see ADR-0011 §9 sequencing note: PR-E flips are gated on PR-A's `Accepted` flip after a ≥2-week, zero-P0/P1 window). This PR will retarget to `main` once PR-E3 lands.

## Why this verb (not `promote` / `demote`)

The repo already has two PR-D-era migration verbs:

- `mm context migrate <kind> <name>` — flat→dir layout normalization
- `mm context memory-migrate <src> --from --to` — memory tier moves

ADR §9 wrote up the artifact-tier surface as `promote` / `demote`, but adding those would scatter move semantics across three verbs and force per-kind grammar on users. PR-E4 instead extends `migrate` so the single verb covers both flat→dir (default when `--to` is omitted) and scope-tier moves (when `--to` is set). Memory folds in as a hidden cross-link that delegates to `_memory_migrate_run` byte-identically — the public `memory-migrate` surface stays as-is and a deprecation pass is deferred to PR-F.

## Implementation pins

- **Deterministic lock-acquire order** via `_acquire_pair_lock(a, b)` — sorts the two sidecar lock paths by `str(...)` so inverse migrations (`foo user→shared` and `foo shared→user` racing in two processes) cannot deadlock. Reuses PR-E3's `_file_lock` / `_lock_path_for` verbatim.
- **EXDEV → staging copytree fallback**: `_stage_move` first tries `os.rename(src, staging)` for the same-FS fast path; on EXDEV it falls back to `shutil.copytree` (or `copy2` for flat layout) so user-tier ↔ project-tier moves span different filesystems without tearing.
- **Gate A on staging when `to_scope == project_shared`**, reusing PR-E3's `scan_artifact_tree` + `raise_or_collect`. project_shared has no force valve here (matches `mm context memory-migrate`).
- **Stale src runtime fan-out cleanup** outside the lock — `~/.claude/...` / `<proj>/.claude/...` entries for the migrated artifact are removed so the runtime stops resolving the old tier copy. ADR-0011 §6 correction (caught in plan review): only `project_local` is `NO_FANOUT`; `project_shared` skills do fan out.
- **Row 15 (dst conflict): always refuses, regardless of `--force`**. PR-D's `--force` is preserved for flat→dir's dirty-flat `.bak` semantics; scope-tier overwrite is deferred to a future replace verb.

## 17-row smoke matrix (axes: `kind × transition × payload/edge`)

| # | kind | src→dst | edge | pin |
|---|------|---------|------|-----|
| 1 | agents | user→project_shared | clean | canonical at dst, src removed |
| 2 | agents | user→project_shared | secret | Gate A raises, src restored, staging cleaned |
| 3 | agents | user→project_local | clean | draft tier, no fan-out |
| 4 | agents | project_shared→user | clean | stale fan-out cleaned |
| 5 | agents | project_local→project_shared | clean | promote |
| 6 | agents | project_shared→project_local | clean | demote, fan-out drops |
| 7 | commands | user→project_shared | clean | row 1 parallel |
| 8 | commands | project_local→user | clean | fan-out emerges at user-tier |
| 9 | skills | user→project_shared | clean | user-tier `~/.claude/skills/foo/` cleaned |
| 10 | skills | project_shared→project_local | clean | project-shared fan-out drops (project_local NO_FANOUT) |
| 11 | edge | EXDEV monkeypatch | clean | copytree fallback |
| 12 | edge | rerun after migrate | clean | "not found at src scope" — idempotent |
| 13 | edge | sorted lock-order pin | clean | helper smoke (threaded test in separate file) |
| 14 | edge | dry-run | clean | no mutation, no staging tmp |
| 15 | edge | dst conflict | clean | refuse + non-zero, even with `--force` |
| 16 | memory | delegate dispatch | clean | `_memory_migrate_run` called byte-identically |
| 17 | memory | dispatch validation | various | missing flag / non-existent path / same-scope |

Plus `test_context_migrate_lock_order.py` (3 cases): order-by-str pin both orientations + same-path defensive + threaded inverse deadlock-freedom.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_migrate.py packages/memtomem/tests/test_context_migrate_lock_order.py -v` — 20 new + 42 PR-D rows = 62 PASS
- [x] `uv run pytest packages/memtomem/tests/ -m "not ollama"` — 4770 PASS (zero regressions)
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean
- [x] CLI smoke (dry-run) under isolated `HOME=/tmp/...` — output matches plan
- [ ] Manual EXDEV walk on a real cross-volume mount (CI uses monkeypatch)
- [ ] Manual `mm context sync --scope <to_scope>` after migrate on an isolated worktree

## Files changed

- `packages/memtomem/src/memtomem/context/migrate.py` — `+475` (`migrate_scope` + `_acquire_pair_lock` + `_stage_move` + `_promote_move` + `_remove_runtime_fanout_for` + `_detect_source_scope` + `MigrateScopeResult` + `SCOPE_MIGRATABLE_KINDS`)
- `packages/memtomem/src/memtomem/cli/context_cmd.py` — `+253` (`--from` / `--to` / `--confirm-project-shared` flags on `migrate_cmd`; `_migrate_scope_dispatch` + `_migrate_memory_dispatch` + `_print_migrate_scope_result` helpers)
- `packages/memtomem/tests/test_context_migrate.py` — `+630` (17-row smoke matrix)
- `packages/memtomem/tests/test_context_migrate_lock_order.py` — `+130` (new file: order pin + deadlock-freedom)

## Out of scope (deferred)

- `mm context promote` / `mm context demote` separate verbs — no concrete need has surfaced; if it does, a thin alias on top of `migrate --to` is the answer.
- `memory-migrate` deprecation / hidden marker / help text rewording — PR-F.
- Auto-trigger of dst fan-out generation after migrate (`generate_all_*`) — `mm context sync` is the user-driven follow-up, matching `memory-migrate`'s "move + cache invalidate; reindex is your job" philosophy.
- Scope-tier dst overwrite (Row 15) — explicit `--overwrite` or replace verb is a separate decision.
- `mm context rescan` — ADR-0011 Open Questions item 4 (deferred at the ADR level).
- Web UI scope badge / public docs — PR-F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
