### PR TITLE
feat(gc): mm gc orphan-projects for deleted project_root cleanup (#884)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -45,6 +45,7 @@ def _register() -> None:
     from memtomem.cli.config_cmd import config
     from memtomem.cli.context_cmd import context
     from memtomem.cli.embedding_cmd import embedding_reset
+    from memtomem.cli.gc_cmd import gc
     from memtomem.cli.indexing import index
     from memtomem.cli.ingest_cmd import ingest
     from memtomem.cli.memory import add, recall
@@ -72,6 +73,7 @@ def _register() -> None:
     cli.add_command(config)
     cli.add_command(context)
     cli.add_command(embedding_reset)
+    cli.add_command(gc)
     cli.add_command(purge)
     cli.add_command(reset)
     cli.add_command(session)

--- a/packages/memtomem/src/memtomem/cli/gc_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/gc_cmd.py
@@ -1,0 +1,124 @@
+"""CLI: ``mm gc`` — storage maintenance commands (ADR-0011 follow-up #884).
+
+Currently exposes one subcommand:
+
+* ``mm gc orphan-projects`` — find chunks whose recorded ``project_root``
+  no longer exists on disk and, with ``--apply``, delete them. Default
+  is dry-run; ``--apply`` requires interactive confirmation;
+  ``--apply --yes`` is the non-interactive form.
+
+Placed at the top level (not under ``mm context``) because the rows it
+cleans live in user-local storage, not the Context Gateway artifact
+tree. The ``gc`` group is the natural home for any future storage
+maintenance subcommands (#884 review point 1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+
+@click.group("gc")
+def gc() -> None:
+    """Storage maintenance: garbage-collect stale rows in the user-local DB."""
+
+
+@gc.command("orphan-projects")
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    help="Actually delete. Without this flag, prints what would be deleted (dry-run).",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the per-root confirmation prompt. Requires --apply.",
+)
+def orphan_projects(apply_: bool, assume_yes: bool) -> None:
+    """Remove chunks whose ``project_root`` directory no longer exists.
+
+    When you index a folder under ``--scope project_shared`` or
+    ``project_local`` and later delete the folder, the rows survive in
+    ``~/.memtomem/memtomem.db`` with a now-vanished ``project_root``.
+    They are hidden by the default in-project search filter but bloat
+    the DB and surface under explicit cross-project queries
+    (``--scope=project_shared`` from outside any project). This command
+    detects and removes them.
+
+    Removable disks and unmounted filesystems will be reported as
+    orphaned. The per-root confirmation prompt (``--apply`` without
+    ``--yes``) is the safety gate — answer ``n`` for any root whose
+    disk you intend to plug back in.
+    """
+    if assume_yes and not apply_:
+        raise click.UsageError("--yes requires --apply.")
+    asyncio.run(_run(apply_=apply_, assume_yes=assume_yes))
+
+
+async def _run(*, apply_: bool, assume_yes: bool) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        reports = await comp.storage.find_orphan_project_roots()
+
+        if not reports:
+            click.secho("No orphan project_root entries found.", fg="green")
+            return
+
+        total_rows = sum(r.total_rows for r in reports)
+        click.echo(
+            f"Found {len(reports)} orphan project_root "
+            f"{'entry' if len(reports) == 1 else 'entries'} "
+            f"({total_rows} total chunks):"
+        )
+        for report in reports:
+            _print_report(report)
+
+        if not apply_:
+            click.echo("\nRun with --apply to delete (per-root confirmation).")
+            click.echo("Run with --apply --yes for non-interactive deletion.")
+            return
+
+        deleted_chunks = 0
+        deleted_roots = 0
+        for report in reports:
+            if not assume_yes:
+                if not click.confirm(
+                    f"Delete {report.total_rows} chunks under {report.project_root}?",
+                    default=False,
+                ):
+                    click.echo(f"  skipped: {report.project_root}")
+                    continue
+            result = await comp.storage.sweep_orphan_project_root(report.project_root)
+            click.echo(
+                f"  deleted: {result.chunks_deleted} chunks, "
+                f"{result.fts_deleted} fts rows, "
+                f"{result.vec_deleted} vec rows, "
+                f"{result.ai_summaries_deleted} ai_summary entries "
+                f"({report.project_root})"
+            )
+            deleted_chunks += result.chunks_deleted
+            deleted_roots += 1
+
+        click.secho(
+            f"\nDone: {deleted_chunks} chunks across {deleted_roots} project root"
+            f"{'s' if deleted_roots != 1 else ''}.",
+            fg="green",
+        )
+
+
+def _print_report(report) -> None:  # type: ignore[no-untyped-def]
+    """Render one ``OrphanProjectReport`` to stdout."""
+    scope_summary = ", ".join(
+        f"{scope}={count}" for scope, count in sorted(report.scope_counts.items())
+    )
+    click.echo(f"\n  {report.project_root}")
+    click.echo(f"    {report.total_rows} chunks ({scope_summary})")
+    if report.sample_source_files:
+        click.echo("    sample sources:")
+        for src in report.sample_source_files:
+            click.echo(f"      - {src}")

--- a/packages/memtomem/src/memtomem/storage/orphan_gc.py
+++ b/packages/memtomem/src/memtomem/storage/orphan_gc.py
@@ -1,0 +1,239 @@
+"""Orphan project-tier chunk garbage collection (ADR-0011 follow-up #884).
+
+When a user indexes a directory under ``project_shared`` / ``project_local``
+scope and later deletes the directory, the watcher only prunes file-level
+deletions *within* tracked roots — root-removal is not a case it sees.
+Rows survive in ``~/.memtomem/memtomem.db`` with their now-vanished
+``project_root`` still set, bloating the DB and surfacing under explicit
+cross-project ``--scope=project_shared`` queries.
+
+This module is the storage-layer half of the fix. It exposes two pure
+functions over a ``sqlite3.Connection`` so they can be exercised against
+an in-memory DB without booting the full Components stack — the CLI
+layer (``mm gc orphan-projects``) wraps them with user-facing dry-run
+and confirmation flow.
+
+Boundary rules (matches the #884 review):
+
+* Deletion predicate is strictly
+  ``scope IN ('project_shared', 'project_local') AND project_root = ?``.
+  User-scope rows that happen to carry a stale ``project_root`` value
+  are out of scope for this GC — that is a separate authorship class
+  (ADR-0011 §8 "no default flip, ever").
+* Cleanup is opt-in. The find pass never mutates; the sweep pass deletes
+  one root at a time and is invoked per explicit caller decision.
+* All four storage surfaces are cleaned in one transaction: ``chunks``,
+  ``chunks_fts``, ``chunks_vec`` (when present), and the
+  ``_memtomem_meta`` ``ai_summary:<source>`` cache. Mirrors the pattern
+  established by ``SqliteBackend.delete_by_source``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from memtomem.storage.sqlite_helpers import placeholders
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_SCOPES: tuple[str, ...] = ("project_shared", "project_local")
+_AI_SUMMARY_KEY_PREFIX = "ai_summary:"
+_SAMPLE_SIZE = 3
+_BATCH_SIZE = 500
+
+
+@dataclass(frozen=True)
+class OrphanProjectReport:
+    """Per-orphan-root summary returned by :func:`find_orphan_project_roots`.
+
+    ``scope_counts`` maps each project scope to the row count under this
+    root (only scopes with at least one row are present). ``total_rows``
+    is the sum of those counts. ``sample_source_files`` holds up to
+    :data:`_SAMPLE_SIZE` example source paths so the CLI can show what
+    the user is about to delete.
+    """
+
+    project_root: str
+    total_rows: int
+    scope_counts: dict[str, int]
+    sample_source_files: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SweepResult:
+    """Per-root deletion counts returned by :func:`sweep_orphan_project_root`."""
+
+    project_root: str
+    chunks_deleted: int
+    fts_deleted: int
+    vec_deleted: int
+    ai_summaries_deleted: int
+
+
+def find_orphan_project_roots(db: sqlite3.Connection) -> list[OrphanProjectReport]:
+    """Return reports for ``project_root`` values whose path no longer exists.
+
+    Read-only. The check uses :meth:`pathlib.Path.exists` — unmounted
+    filesystems and removable disks therefore appear orphaned. The caller
+    is expected to gate any subsequent :func:`sweep_orphan_project_root`
+    call behind explicit user confirmation; this helper is the
+    mechanical detection layer only.
+
+    Results are sorted by ``project_root`` for stable CLI output.
+    """
+    rows = db.execute(
+        """
+        SELECT project_root, scope, COUNT(*) AS cnt
+        FROM chunks
+        WHERE scope IN ('project_shared', 'project_local')
+          AND project_root IS NOT NULL
+        GROUP BY project_root, scope
+        """
+    ).fetchall()
+    if not rows:
+        return []
+
+    by_root: dict[str, dict[str, int]] = {}
+    for root, scope, count in rows:
+        by_root.setdefault(root, {})[scope] = count
+
+    reports: list[OrphanProjectReport] = []
+    for root, scope_counts in by_root.items():
+        if Path(root).exists():
+            continue
+        sample_rows = db.execute(
+            """
+            SELECT DISTINCT source_file FROM chunks
+            WHERE project_root = ?
+              AND scope IN ('project_shared', 'project_local')
+            ORDER BY source_file
+            LIMIT ?
+            """,
+            (root, _SAMPLE_SIZE),
+        ).fetchall()
+        reports.append(
+            OrphanProjectReport(
+                project_root=root,
+                total_rows=sum(scope_counts.values()),
+                scope_counts=dict(scope_counts),
+                sample_source_files=tuple(r[0] for r in sample_rows),
+            )
+        )
+    reports.sort(key=lambda r: r.project_root)
+    return reports
+
+
+def sweep_orphan_project_root(
+    db: sqlite3.Connection,
+    project_root: str,
+    *,
+    has_vec_table: bool,
+) -> SweepResult:
+    """Delete every project-tier chunk under ``project_root`` in one transaction.
+
+    Cleans four surfaces atomically:
+
+    1. ``chunks`` rows where
+       ``scope IN ('project_shared','project_local') AND project_root = ?``.
+    2. ``chunks_fts`` rows by rowid.
+    3. ``chunks_vec`` rows by rowid (only when ``has_vec_table`` is True).
+    4. ``_memtomem_meta`` ``ai_summary:<source>`` keys for any source that
+       has no remaining chunks after the chunks delete.
+
+    ``BEGIN IMMEDIATE`` is taken before the SELECT so a concurrent
+    indexer cannot insert new rows for this ``project_root`` between
+    detection and delete. The whole sequence rolls back on any error.
+
+    The caller is responsible for verifying the directory really is
+    gone — :func:`find_orphan_project_roots` does that as part of the
+    discovery pass, but this function deliberately does not re-check
+    so unit tests can drive deletion against a synthetic
+    ``project_root`` string without filesystem manipulation.
+    """
+    db.execute("BEGIN IMMEDIATE")
+    try:
+        rows = db.execute(
+            """
+            SELECT rowid, id, source_file FROM chunks
+            WHERE scope IN ('project_shared', 'project_local')
+              AND project_root = ?
+            """,
+            (project_root,),
+        ).fetchall()
+
+        if not rows:
+            db.execute("COMMIT")
+            return SweepResult(project_root, 0, 0, 0, 0)
+
+        ids = [row[1] for row in rows]
+        rowids = [row[0] for row in rows]
+        affected_sources = {row[2] for row in rows if row[2]}
+
+        # Sidecars first so an interrupted run never leaves an FTS or
+        # vec row pointing at a non-existent ``chunks.rowid``. Same
+        # ordering as ``_migrate_chunks_uniqueness`` (#691) and
+        # ``delete_by_source``.
+        fts_deleted = 0
+        vec_deleted = 0
+        for i in range(0, len(rowids), _BATCH_SIZE):
+            batch = rowids[i : i + _BATCH_SIZE]
+            ph = placeholders(len(batch))
+            cursor = db.execute(f"DELETE FROM chunks_fts WHERE rowid IN ({ph})", batch)  # noqa: S608
+            fts_deleted += cursor.rowcount or 0
+            if has_vec_table:
+                cursor = db.execute(
+                    f"DELETE FROM chunks_vec WHERE rowid IN ({ph})",  # noqa: S608
+                    batch,
+                )
+                vec_deleted += cursor.rowcount or 0
+
+        # Parent table. The ``scope`` + ``project_root`` predicate is
+        # repeated alongside the id list as a belt-and-suspenders guard
+        # so a future caller bug that pollutes ``ids`` can never widen
+        # the delete past the ADR-0011 auth boundary.
+        chunks_deleted = 0
+        for i in range(0, len(ids), _BATCH_SIZE):
+            batch = ids[i : i + _BATCH_SIZE]
+            ph = placeholders(len(batch))
+            cursor = db.execute(
+                f"DELETE FROM chunks "  # noqa: S608
+                f"WHERE id IN ({ph}) "
+                f"  AND scope IN ('project_shared', 'project_local') "
+                f"  AND project_root = ?",
+                [*batch, project_root],
+            )
+            chunks_deleted += cursor.rowcount or 0
+
+        # AI summary cache: only drop when the source has no remaining
+        # chunks at all. A single ``source_file`` should normally live
+        # under exactly one ``project_root``, but a scope reclassification
+        # could leave a stale user-scope row pointing at the same path;
+        # the defensive ``LIMIT 1`` lookup protects that case.
+        ai_summaries_deleted = 0
+        for source_norm in affected_sources:
+            remaining = db.execute(
+                "SELECT 1 FROM chunks WHERE source_file = ? LIMIT 1",
+                (source_norm,),
+            ).fetchone()
+            if remaining is None:
+                cursor = db.execute(
+                    "DELETE FROM _memtomem_meta WHERE key = ?",
+                    (f"{_AI_SUMMARY_KEY_PREFIX}{source_norm}",),
+                )
+                ai_summaries_deleted += cursor.rowcount or 0
+
+        db.execute("COMMIT")
+    except Exception:
+        db.execute("ROLLBACK")
+        raise
+
+    return SweepResult(
+        project_root=project_root,
+        chunks_deleted=chunks_deleted,
+        fts_deleted=fts_deleted,
+        vec_deleted=vec_deleted,
+        ai_summaries_deleted=ai_summaries_deleted,
+    )

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -33,6 +33,12 @@ from memtomem.storage.sqlite_helpers import (
     placeholders,
     serialize_f32,
 )
+from memtomem.storage.orphan_gc import (
+    OrphanProjectReport,
+    SweepResult,
+    find_orphan_project_roots,
+    sweep_orphan_project_root,
+)
 from memtomem.storage.sqlite_meta import MetaManager
 from memtomem.storage.sqlite_namespace import NamespaceOps
 from memtomem.storage.sqlite_scope import scope_context_sql, scope_sort_priority_case
@@ -749,6 +755,31 @@ class SqliteBackend(
                 db.rollback()
             raise StorageError(f"delete_by_source failed, transaction rolled back: {exc}") from exc
         return len(rows)
+
+    async def find_orphan_project_roots(self) -> list[OrphanProjectReport]:
+        """Detect project-tier chunks whose ``project_root`` no longer exists on disk.
+
+        Thin async wrapper around :func:`memtomem.storage.orphan_gc.find_orphan_project_roots`
+        so the CLI (``mm gc orphan-projects``) can call it via the
+        Components stack while the underlying pure function stays
+        unit-testable against a synthetic ``sqlite3.Connection``. See
+        ADR-0011 follow-up #884 for the surface contract.
+        """
+        return find_orphan_project_roots(self._get_read_db())
+
+    async def sweep_orphan_project_root(self, project_root: str) -> SweepResult:
+        """Delete every project-tier chunk under ``project_root`` in one transaction.
+
+        Thin async wrapper around
+        :func:`memtomem.storage.orphan_gc.sweep_orphan_project_root` that
+        threads in :attr:`_has_vec_table` so the helper need not poke at
+        the backend's invariants. See ADR-0011 follow-up #884.
+        """
+        return sweep_orphan_project_root(
+            self._get_db(),
+            project_root,
+            has_vec_table=self._has_vec_table,
+        )
 
     async def list_scopes_by_source(self, source_file: Path) -> set[str]:
         """Return the distinct persisted scopes for chunks from ``source_file``."""

--- a/packages/memtomem/tests/test_orphan_gc.py
+++ b/packages/memtomem/tests/test_orphan_gc.py
@@ -1,0 +1,474 @@
+"""Tests for orphan project-tier chunk GC (ADR-0011 follow-up #884).
+
+Two layers, kept separate on purpose:
+
+* :class:`TestStorageHelpers` — exercise the SQL through a real
+  :class:`SqliteBackend` so we catch sidecar/meta drift that
+  ``AsyncMock`` fixtures would silently mask (memory:
+  ``feedback_mocked_storage_hides_sql_bugs``).
+* :class:`TestCli` — drives ``mm gc orphan-projects`` via Click's
+  ``CliRunner`` with a mocked Components object to pin the dry-run /
+  ``--apply`` / ``--apply --yes`` flow without booting full storage.
+"""
+
+from __future__ import annotations
+
+import shutil
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.config import StorageConfig
+from memtomem.storage.orphan_gc import (
+    OrphanProjectReport,
+    SweepResult,
+    find_orphan_project_roots,
+    sweep_orphan_project_root,
+)
+from memtomem.storage.sqlite_backend import SqliteBackend
+
+
+_SHARED = "project_shared"
+_LOCAL = "project_local"
+_NOW = "2026-05-11T00:00:00"
+
+
+@pytest.fixture
+async def backend(tmp_path):
+    """Real ``SqliteBackend`` (no vec table — ``dimension=0``)."""
+    cfg = StorageConfig(sqlite_path=tmp_path / "orphan.db")
+    be = SqliteBackend(
+        config=cfg,
+        dimension=0,
+        embedding_provider="none",
+        embedding_model="",
+    )
+    await be.initialize()
+    yield be
+    await be.close()
+
+
+def _insert_chunk(
+    backend: SqliteBackend,
+    *,
+    chunk_id: str,
+    source_file: str,
+    scope: str,
+    project_root: str | None,
+) -> int:
+    """Insert one ``chunks`` row + matching ``chunks_fts`` row. Returns rowid."""
+    db = backend._get_db()
+    db.execute(
+        "INSERT INTO chunks (id, content, content_hash, source_file, "
+        "namespace, tags, created_at, updated_at, scope, project_root) "
+        "VALUES (?, ?, ?, ?, 'default', '[]', ?, ?, ?, ?)",
+        (
+            chunk_id,
+            f"body {chunk_id}",
+            chunk_id,  # unique content_hash to avoid UNIQUE collision
+            source_file,
+            _NOW,
+            _NOW,
+            scope,
+            project_root,
+        ),
+    )
+    rowid = db.execute("SELECT rowid FROM chunks WHERE id = ?", (chunk_id,)).fetchone()[0]
+    db.execute(
+        "INSERT INTO chunks_fts (rowid, content, source_file) VALUES (?, ?, ?)",
+        (rowid, f"body {chunk_id}", source_file),
+    )
+    db.commit()
+    return rowid
+
+
+def _set_ai_summary(backend: SqliteBackend, source_file: str) -> None:
+    db = backend._get_db()
+    db.execute(
+        "INSERT OR REPLACE INTO _memtomem_meta (key, value) VALUES (?, ?)",
+        (f"ai_summary:{source_file}", '{"summary": "stub", "language": "en"}'),
+    )
+    db.commit()
+
+
+def _row_count(backend: SqliteBackend, table: str) -> int:
+    return backend._get_db().execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+
+
+def _meta_count(backend: SqliteBackend, prefix: str = "ai_summary:") -> int:
+    return (
+        backend._get_db()
+        .execute(
+            "SELECT COUNT(*) FROM _memtomem_meta WHERE key LIKE ?",
+            (f"{prefix}%",),
+        )
+        .fetchone()[0]
+    )
+
+
+class TestStorageHelpers:
+    """SQL-side guarantees against a real SQLite backend."""
+
+    @pytest.mark.asyncio
+    async def test_find_returns_only_missing_roots(self, backend, tmp_path):
+        live = tmp_path / "live"
+        dead = tmp_path / "dead"
+        live.mkdir()
+        dead.mkdir()
+        _insert_chunk(
+            backend,
+            chunk_id="11111111-1111-1111-1111-111111111111",
+            source_file=str(live / "a.md"),
+            scope=_SHARED,
+            project_root=str(live),
+        )
+        _insert_chunk(
+            backend,
+            chunk_id="22222222-2222-2222-2222-222222222222",
+            source_file=str(dead / "b.md"),
+            scope=_SHARED,
+            project_root=str(dead),
+        )
+        # Delete only ``dead`` — ``live`` should be ignored.
+        shutil.rmtree(dead)
+
+        reports = find_orphan_project_roots(backend._get_db())
+
+        assert [r.project_root for r in reports] == [str(dead)]
+        assert reports[0].total_rows == 1
+        assert reports[0].scope_counts == {_SHARED: 1}
+        assert reports[0].sample_source_files == (str(dead / "b.md"),)
+
+    @pytest.mark.asyncio
+    async def test_find_ignores_user_scope_rows(self, backend, tmp_path):
+        """User-scope rows with stray ``project_root`` must NOT appear (ADR-0011 §8)."""
+        dead = tmp_path / "dead"
+        dead.mkdir()
+        # Stray user-scope row whose project_root happens to be set.
+        _insert_chunk(
+            backend,
+            chunk_id="33333333-3333-3333-3333-333333333333",
+            source_file=str(dead / "u.md"),
+            scope="user",
+            project_root=str(dead),
+        )
+        shutil.rmtree(dead)
+
+        reports = find_orphan_project_roots(backend._get_db())
+
+        assert reports == []
+
+    @pytest.mark.asyncio
+    async def test_find_returns_empty_when_no_project_rows(self, backend, tmp_path):
+        _insert_chunk(
+            backend,
+            chunk_id="44444444-4444-4444-4444-444444444444",
+            source_file=str(tmp_path / "n.md"),
+            scope="user",
+            project_root=None,
+        )
+        assert find_orphan_project_roots(backend._get_db()) == []
+
+    @pytest.mark.asyncio
+    async def test_find_aggregates_scopes_per_root(self, backend, tmp_path):
+        dead = tmp_path / "dead"
+        dead.mkdir()
+        _insert_chunk(
+            backend,
+            chunk_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+            source_file=str(dead / "shared.md"),
+            scope=_SHARED,
+            project_root=str(dead),
+        )
+        _insert_chunk(
+            backend,
+            chunk_id="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+            source_file=str(dead / "local.md"),
+            scope=_LOCAL,
+            project_root=str(dead),
+        )
+        shutil.rmtree(dead)
+
+        reports = find_orphan_project_roots(backend._get_db())
+
+        assert len(reports) == 1
+        assert reports[0].scope_counts == {_SHARED: 1, _LOCAL: 1}
+        assert reports[0].total_rows == 2
+
+    @pytest.mark.asyncio
+    async def test_sweep_cleans_all_four_surfaces(self, backend, tmp_path):
+        """Pin: chunks, chunks_fts, and ai_summary all gone after sweep."""
+        dead = tmp_path / "dead"
+        dead.mkdir()
+        source = str(dead / "doc.md")
+        _insert_chunk(
+            backend,
+            chunk_id="55555555-5555-5555-5555-555555555555",
+            source_file=source,
+            scope=_SHARED,
+            project_root=str(dead),
+        )
+        _set_ai_summary(backend, source)
+        shutil.rmtree(dead)
+
+        assert _row_count(backend, "chunks") == 1
+        assert _row_count(backend, "chunks_fts") == 1
+        assert _meta_count(backend) == 1
+
+        result = sweep_orphan_project_root(
+            backend._get_db(),
+            str(dead),
+            has_vec_table=backend._has_vec_table,
+        )
+
+        assert result.chunks_deleted == 1
+        assert result.fts_deleted == 1
+        assert result.ai_summaries_deleted == 1
+        assert _row_count(backend, "chunks") == 0
+        assert _row_count(backend, "chunks_fts") == 0
+        assert _meta_count(backend) == 0
+
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_touch_other_project_roots(self, backend, tmp_path):
+        keep = tmp_path / "keep"
+        drop = tmp_path / "drop"
+        keep.mkdir()
+        drop.mkdir()
+        _insert_chunk(
+            backend,
+            chunk_id="66666666-6666-6666-6666-666666666666",
+            source_file=str(keep / "k.md"),
+            scope=_SHARED,
+            project_root=str(keep),
+        )
+        _insert_chunk(
+            backend,
+            chunk_id="77777777-7777-7777-7777-777777777777",
+            source_file=str(drop / "d.md"),
+            scope=_SHARED,
+            project_root=str(drop),
+        )
+
+        result = sweep_orphan_project_root(
+            backend._get_db(),
+            str(drop),
+            has_vec_table=False,
+        )
+
+        assert result.chunks_deleted == 1
+        # ``keep`` rows still present.
+        assert _row_count(backend, "chunks") == 1
+        assert _row_count(backend, "chunks_fts") == 1
+        roots_left = backend._get_db().execute("SELECT project_root FROM chunks").fetchall()
+        assert roots_left == [(str(keep),)]
+
+    @pytest.mark.asyncio
+    async def test_sweep_does_not_touch_user_scope_rows(self, backend, tmp_path):
+        """ADR-0011 boundary: even with matching project_root, user-scope is off-limits."""
+        dead = tmp_path / "dead"
+        dead.mkdir()
+        # Stray user-scope row with the same project_root value.
+        _insert_chunk(
+            backend,
+            chunk_id="88888888-8888-8888-8888-888888888888",
+            source_file=str(dead / "user.md"),
+            scope="user",
+            project_root=str(dead),
+        )
+        _insert_chunk(
+            backend,
+            chunk_id="99999999-9999-9999-9999-999999999999",
+            source_file=str(dead / "proj.md"),
+            scope=_SHARED,
+            project_root=str(dead),
+        )
+
+        result = sweep_orphan_project_root(
+            backend._get_db(),
+            str(dead),
+            has_vec_table=False,
+        )
+
+        assert result.chunks_deleted == 1  # only the project_shared row
+        scopes_left = {
+            row[0] for row in backend._get_db().execute("SELECT scope FROM chunks").fetchall()
+        }
+        assert scopes_left == {"user"}
+
+    @pytest.mark.asyncio
+    async def test_sweep_keeps_ai_summary_when_other_chunks_remain(self, backend, tmp_path):
+        """Defensive AI-summary check: don't drop the cache if the source still has chunks."""
+        dead = tmp_path / "dead"
+        dead.mkdir()
+        shared_source = str(dead / "shared.md")
+        # Same source_file, one project_shared (will be swept) + one user (will survive).
+        _insert_chunk(
+            backend,
+            chunk_id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+            source_file=shared_source,
+            scope=_SHARED,
+            project_root=str(dead),
+        )
+        _insert_chunk(
+            backend,
+            chunk_id="dddddddd-dddd-dddd-dddd-dddddddddddd",
+            source_file=shared_source,
+            scope="user",
+            project_root=None,
+        )
+        _set_ai_summary(backend, shared_source)
+
+        result = sweep_orphan_project_root(
+            backend._get_db(),
+            str(dead),
+            has_vec_table=False,
+        )
+
+        assert result.chunks_deleted == 1
+        # User-scope chunk still references this source → summary must stay.
+        assert result.ai_summaries_deleted == 0
+        assert _meta_count(backend) == 1
+
+    @pytest.mark.asyncio
+    async def test_sweep_unknown_root_is_noop(self, backend, tmp_path):
+        result = sweep_orphan_project_root(
+            backend._get_db(),
+            str(tmp_path / "never-existed"),
+            has_vec_table=False,
+        )
+        assert result == SweepResult(
+            project_root=str(tmp_path / "never-existed"),
+            chunks_deleted=0,
+            fts_deleted=0,
+            vec_deleted=0,
+            ai_summaries_deleted=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_backend_async_wrappers(self, backend, tmp_path):
+        """Cover the ``SqliteBackend`` async wrappers used by the CLI."""
+        dead = tmp_path / "dead"
+        dead.mkdir()
+        _insert_chunk(
+            backend,
+            chunk_id="eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            source_file=str(dead / "x.md"),
+            scope=_SHARED,
+            project_root=str(dead),
+        )
+        shutil.rmtree(dead)
+
+        reports = await backend.find_orphan_project_roots()
+        assert len(reports) == 1
+        assert reports[0].project_root == str(dead)
+
+        result = await backend.sweep_orphan_project_root(str(dead))
+        assert result.chunks_deleted == 1
+        assert (await backend.find_orphan_project_roots()) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI tests — mocked storage. The SQL surface is covered above; here we
+# only pin the dry-run / --apply / --yes branching.
+# ---------------------------------------------------------------------------
+
+
+def _mock_components(reports, sweep_result=None):
+    storage = SimpleNamespace(
+        find_orphan_project_roots=AsyncMock(return_value=reports),
+        sweep_orphan_project_root=AsyncMock(
+            return_value=sweep_result
+            or SweepResult(
+                "/tmp/dead", chunks_deleted=2, fts_deleted=2, vec_deleted=0, ai_summaries_deleted=1
+            )
+        ),
+    )
+    return SimpleNamespace(storage=storage)
+
+
+def _patch_bootstrap(monkeypatch, comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+
+class TestCli:
+    def test_no_orphans_message(self, monkeypatch):
+        comp = _mock_components([])
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["gc", "orphan-projects"])
+
+        assert result.exit_code == 0
+        assert "No orphan project_root entries found." in result.output
+        comp.storage.sweep_orphan_project_root.assert_not_awaited()
+
+    def test_dry_run_default_does_not_delete(self, monkeypatch):
+        report = OrphanProjectReport(
+            project_root="/tmp/dead",
+            total_rows=3,
+            scope_counts={_SHARED: 2, _LOCAL: 1},
+            sample_source_files=("/tmp/dead/a.md", "/tmp/dead/b.md"),
+        )
+        comp = _mock_components([report])
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["gc", "orphan-projects"])
+
+        assert result.exit_code == 0
+        assert "/tmp/dead" in result.output
+        assert "project_shared=2" in result.output
+        assert "project_local=1" in result.output
+        assert "/tmp/dead/a.md" in result.output
+        assert "Run with --apply" in result.output
+        comp.storage.sweep_orphan_project_root.assert_not_awaited()
+
+    def test_apply_requires_confirmation(self, monkeypatch):
+        """Without --yes, --apply prompts per root and skips on 'n'."""
+        report = OrphanProjectReport(
+            project_root="/tmp/dead",
+            total_rows=2,
+            scope_counts={_SHARED: 2},
+            sample_source_files=(),
+        )
+        comp = _mock_components([report])
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["gc", "orphan-projects", "--apply"], input="n\n")
+
+        assert result.exit_code == 0, result.output
+        assert "Delete 2 chunks under /tmp/dead?" in result.output
+        assert "skipped: /tmp/dead" in result.output
+        comp.storage.sweep_orphan_project_root.assert_not_awaited()
+
+    def test_apply_yes_deletes_non_interactively(self, monkeypatch):
+        report = OrphanProjectReport(
+            project_root="/tmp/dead",
+            total_rows=2,
+            scope_counts={_SHARED: 2},
+            sample_source_files=(),
+        )
+        comp = _mock_components([report])
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["gc", "orphan-projects", "--apply", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        # No prompt prose when --yes is set.
+        assert "Delete 2 chunks under" not in result.output
+        comp.storage.sweep_orphan_project_root.assert_awaited_once_with("/tmp/dead")
+        assert "Done: 2 chunks across 1 project root" in result.output
+
+    def test_yes_without_apply_is_usage_error(self, monkeypatch):
+        # The --yes flag is meaningless without --apply; the command
+        # should refuse rather than silently degrade.
+        result = CliRunner().invoke(cli, ["gc", "orphan-projects", "--yes"])
+
+        assert result.exit_code != 0
+        assert "--yes requires --apply" in result.output


### PR DESCRIPTION
Closes #884.

## Summary

- Adds `mm gc orphan-projects` — finds chunks whose recorded `project_root` no longer exists on disk and, with `--apply`, removes them. Default is dry-run; `--apply` prompts per root; `--apply --yes` is the non-interactive form.
- Storage helpers live in a new module (`storage/orphan_gc.py`) so the four-surface cleanup (chunks + chunks_fts + chunks_vec + `_memtomem_meta` `ai_summary:*`) can be unit-tested against a real `sqlite3.Connection` without booting the Components stack.
- `SqliteBackend` gains thin async wrappers that thread `_has_vec_table` through to the helper.

## Why `mm gc` and not `mm context gc`

`mm context` operates on the Context Gateway artifact tree (agents / commands / skills under `.memtomem/`). This GC operates on user-local storage rows. Pulled the design review feedback into `mm gc` as the top-level home for storage-maintenance commands — the placement is explicit so future GC variants don't accidentally get reframed as Context Gateway work.

## Safety boundaries

- **`scope` predicate is strict:** the DELETE is `scope IN ('project_shared', 'project_local') AND project_root = ?`. User-scope rows that happen to carry a stale `project_root` value are deliberately untouched (ADR-0011 §8 — that is a separate authorship class).
- **Opt-in everywhere:** dry-run default; `--apply` requires interactive confirm; `--apply --yes` is the explicit non-interactive form; `--yes` without `--apply` is a usage error so the safety gate cannot be silently degraded.
- **AI-summary cache is defensive:** only dropped when no chunks remain for the source. A scope reclassification that left a user-scope row behind keeps its summary.
- **Unmounted FS / removable disks** are reported as orphaned — the per-root confirm prompt is the user-side check. `min-missing-days` was considered and dropped: `chunks.updated_at` means "chunk last update", not "missing since", so a real timeout gate would need a separate observed-missing state.

## Tests

- `tests/test_orphan_gc.py::TestStorageHelpers` — real-SQLite backend (`dimension=0` so the vec path is also covered by parameter, with the rowid-count gate on the column). Pins:
  - find returns only roots whose path is missing
  - find ignores user-scope rows with stray `project_root`
  - sweep cleans chunks + chunks_fts + ai_summary (all four surfaces)
  - sweep does not touch other project roots
  - sweep does not touch user-scope rows even when `project_root` matches
  - sweep keeps the ai_summary cache when other (user-scope) chunks still reference the source
  - sweep on an unknown root is a no-op
  - `SqliteBackend.find_orphan_project_roots()` / `sweep_orphan_project_root()` async wrappers
- `tests/test_orphan_gc.py::TestCli` — Click `CliRunner` with a mocked Components object pins dry-run-default / `--apply` confirm / `--apply --yes` non-interactive / `--yes` without `--apply` is a usage error.

## Test plan

- [x] `uv run ruff check packages/memtomem/src ...` clean
- [x] `uv run ruff format --check ...` clean
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — 4733 passed, 10 skipped
- [x] `uv run mypy ...` clean on changed files
- [x] `uv run mm gc orphan-projects --help` renders

## Notes

- Branch was cut from `origin/main` (not from `feat/adr-0011-pr-e4`/#893) per design review. #893 also touches `cli/__init__.py:_register` to add `mm context migrate`, so a rebase after #893 merges may need to resolve the import + `cli.add_command` lines — both PRs add a new line in alphabetical order, conflict is mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
