### PR TITLE
feat(scope): ADR-0011 PR-E3 + PR-E4 retarget to main (#893 recovery)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,36 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   serialization (#836). Inbound links from `README.md`,
   `docs/guides/getting-started.md`, and
   `docs/guides/configuration.md` (Moving `config.json` between machines).
+- **`mm context sync --scope=...` + canonical-side Gate A + skills
+  staging-dir-first scan (ADR-0011 PR-E3).** ``mm context sync`` (and
+  ``mm context generate``) thread the resolved canonical-artifact
+  scope through the three include surfaces (``--include=agents`` /
+  ``--include=skills`` / ``--include=commands``); the helpers in turn
+  call ``generate_all_*`` with the new ``scope=`` kwarg. The default
+  remains ``project_shared`` so pre-PR-E3 invocations are
+  byte-identical. ``--scope user`` reads ``~/.memtomem/{agents,
+  skills,commands}/`` and fans out to ``~/.{claude,gemini,codex}/...``;
+  ``--scope project_local`` short-circuits to
+  ``NO_PROJECT_FANOUT_FOR_RUNTIME`` skips per runtime (ADR §3 — the
+  draft tier has no runtime equivalent). New
+  ``context/privacy_scan.py`` runs ``enforce_write_guard`` per file
+  (sync direction; ``force_unsafe`` is hardcoded ``False`` per ADR §5
+  — sync has no escape valve, unlike init's
+  ``--force-unsafe-import``). ``project_shared`` hits raise
+  :class:`click.ClickException` with a remediation hint pointing at
+  ``mm context migrate`` (PR-E4); ``user`` / ``project_local`` hits
+  emit ``PRIVACY_BLOCKED`` skips. Skills fan-out now uses a
+  staging-dir-first flow (``_stage_skill`` builds at
+  ``dst.parent/.staging-…tmp`` for same-fs atomic
+  :func:`os.replace`; vendor SKILL.md override applies BEFORE the
+  scan so the scan walks the bytes that will actually be promoted;
+  ``_promote_staging`` swaps with rollback). Skill auxiliary files
+  (``scripts/``, ``references/``, ``assets/``) stay byte-equal to
+  canonical even when an override is staged for ``SKILL.md`` —
+  ``test_override_only_touches_skill_md_not_scripts`` invariant
+  preserved. Web routes pass explicit ``scope="project_shared"`` to
+  preserve current behavior; PR-F (UI badges) replaces with
+  request-driven scope.
 - **`mm context init --scope=...` + Gate A/B for canonical artifact
   seeding (ADR-0011 PR-E2).** ``mm context init`` (no flag) keeps the
   pre-PR-E2 failure-mode shape — same context.md path, no Gate B

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -1074,28 +1074,40 @@ mm context init --scope project_shared --confirm-project-shared       # Gate B: 
 mm context init --include=agents --scope user --force-unsafe-import   # bypass Gate A on existing leaks
 mm context generate --agent all        # generate all agent files
 mm context diff                        # check sync status
-mm context sync                        # sync context.md → agent files
+mm context sync                        # sync context.md → agent files (project_shared default)
+mm context sync --scope user           # fan out from ~/.memtomem/... → ~/.{claude,gemini,codex}/...
+mm context sync --include=skills --scope project_local   # NO_FANOUT skip (no runtime per ADR §3)
 mm context generate --include=settings # merge hooks → ~/.claude/settings.json
 mm context diff --include=settings     # check hook sync status
 # Note: cursor / codex / copilot fold ## Rules + ## Style into a single block;
 # `generate` warns on stderr when both sections are populated. context.md is
 # the source of truth — edit there, not in generated files.
 #
-# `--scope` semantics (ADR-0011 PR-E2):
-#   user            → seeds ~/.memtomem/{agents,skills,commands}/; imports from
-#                     ~/.claude/agents, ~/.gemini/agents, ~/.claude/skills, etc.
+# `--scope` semantics (ADR-0011 PR-E2 init / PR-E3 sync):
+#   user            → seeds ~/.memtomem/{agents,skills,commands}/; init imports from
+#                     ~/.claude/agents, ~/.gemini/agents, ~/.claude/skills, etc.;
+#                     sync fans canonical out to those same runtime roots.
 #   project_shared  → seeds <proj>/.memtomem/{agents,skills,commands}/; imports
 #                     from <proj>/.claude/agents etc.; git-tracked. Requires
-#                     --confirm-project-shared when --scope is explicit.
+#                     --confirm-project-shared when --scope is explicit on init.
 #   project_local   → seeds <proj>/.memtomem/{agents,skills,commands}.local/;
 #                     auto-appends .memtomem/*.local/ + .memtomem/.staging/ to
 #                     <proj>/.gitignore (idempotent). No runtime fan-out
-#                     by design (ADR §3) — nothing to import.
+#                     by design (ADR §3) — nothing to import or sync.
 #
-# Gate A on `--include=...` import path: every source file is re-scanned
+# Gate A on `init --include=...` import path: every source file is re-scanned
 # for secrets via enforce_write_guard. user / project_local destinations
 # can bypass with --force-unsafe-import (audit-logged); project_shared
 # destinations hard-refuse on any hit (no force bypass available).
+#
+# Gate A on `sync` write path (PR-E3): same per-file scan, but sync has NO
+# escape valve — `--force-unsafe-import` is init-only (ADR §5). user /
+# project_local destinations skip-and-warn on hits with PRIVACY_BLOCKED;
+# project_shared destinations raise ClickException with a remediation hint
+# pointing at `mm context migrate` (PR-E4) for moving the artifact to a
+# writable tier first. Skills fan-out uses staging-dir-first scan + atomic
+# os.replace promote so a blocked sync leaves the existing dst tree
+# unchanged.
 
 # Sessions & activity
 mm session start                                              # start a tracked session

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -49,6 +49,7 @@ from memtomem.context.install import (
     update_skill,
 )
 from memtomem.context.migrate import (
+    MigratePartialError,
     MigrateRow,
     MigrateScopeResult,
     SCOPE_MIGRATABLE_KINDS,
@@ -1840,6 +1841,13 @@ def _migrate_scope_dispatch(
     except (FileNotFoundError, ValueError, InvalidNameError) as exc:
         raise click.ClickException(str(exc)) from exc
     except PrivacyScanError as exc:
+        raise click.ClickException(exc.message) from exc
+    except MigratePartialError as exc:
+        # Fan-out cleanup never ran (raise short-circuited), and the
+        # "Next: run sync ..." hint at the bottom of
+        # _print_migrate_scope_result is skipped because we exit before
+        # the result rendering — the user sees only the recovery hint
+        # embedded in exc.message.
         raise click.ClickException(exc.message) from exc
 
     _print_migrate_scope_result(result, apply_=apply_)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1844,6 +1844,37 @@ def _migrate_scope_dispatch(
 
     _print_migrate_scope_result(result, apply_=apply_)
 
+    # ADR-0011 project_local contract: ``.memtomem/*.local/`` and the
+    # staging dir must be gitignored. ``mm context init --scope
+    # project_local`` already appends the marker, but a user can land
+    # on project_local for the first time via ``mm context migrate
+    # <kind> <name> --to project_local --apply`` without ever running
+    # init — without this call the new local-draft tier shows up in
+    # ``git status`` and risks being committed by accident
+    # (#895 P2 review #3 fold).
+    if apply_ and to_scope == "project_local":
+        wrote, msg = _append_gitignore_marker(project_root)
+        if wrote:
+            click.secho(
+                "  Appended .gitignore marker (.memtomem/*.local/, .memtomem/.staging/)",
+                fg="green",
+            )
+        elif msg == "no_git_repo_pyproject_only":
+            click.secho(
+                "  warning: project root resolved via pyproject.toml but `.git` "
+                "missing — .gitignore not appended. Run `git init` first to "
+                "git-protect the local tier.",
+                fg="yellow",
+            )
+        elif msg == "no_project_signal":
+            click.secho(
+                "  warning: no .git and no pyproject.toml in project root — "
+                ".gitignore append skipped.",
+                fg="yellow",
+            )
+        # ``already_present`` is silent — the marker is already there,
+        # the user does not need a redundant green tick on every migrate.
+
 
 def _print_migrate_scope_result(result: MigrateScopeResult, *, apply_: bool) -> None:
     """User-facing summary for one scope-tier migration.

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -190,15 +190,28 @@ def _print_skills_init(
         click.secho(f"    skipped {name}: {reason}", fg=color)
 
 
-def _print_skills_generate(root: Path) -> None:
-    result = generate_all_skills(root)
+def _print_skills_generate(
+    root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> None:
+    result = generate_all_skills(root, scope=scope)
     if result.generated:
         click.secho(f"  Skills fan-out: {len(result.generated)}", fg="green")
         for runtime, path in result.generated:
             rel = path.relative_to(root) if path.is_relative_to(root) else path
             click.echo(f"    {runtime:15s}  {rel}")
-    for runtime, reason, _code in result.skipped:
-        click.secho(f"  skipped {runtime}: {reason}", fg="yellow")
+    for runtime, reason, code in result.skipped:
+        color = (
+            "red"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "yellow"
+        )
+        click.secho(f"  skipped {runtime}: {reason}", fg=color)
 
 
 def _print_skills_diff(root: Path) -> None:
@@ -262,9 +275,15 @@ def _print_agents_init(
         click.secho(f"    skipped {name}: {reason}", fg=color)
 
 
-def _print_agents_generate(root: Path, strict: bool, on_drop: str = "ignore") -> None:
+def _print_agents_generate(
+    root: Path,
+    strict: bool,
+    on_drop: str = "ignore",
+    *,
+    scope: TargetScope = "project_shared",
+) -> None:
     try:
-        result = generate_all_agents(root, strict=strict, on_drop=on_drop)
+        result = generate_all_agents(root, strict=strict, on_drop=on_drop, scope=scope)
     except StrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort()
@@ -277,8 +296,17 @@ def _print_agents_generate(root: Path, strict: bool, on_drop: str = "ignore") ->
             except ValueError:
                 rel = path
             click.echo(f"    {runtime:15s}  {rel}")
-    for runtime, reason, _code in result.skipped:
-        click.secho(f"  skipped {runtime}: {reason}", fg="yellow")
+    for runtime, reason, code in result.skipped:
+        color = (
+            "red"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "yellow"
+        )
+        click.secho(f"  skipped {runtime}: {reason}", fg=color)
     for runtime, agent_name, dropped in result.dropped:
         click.secho(
             f"  {runtime} dropped {dropped} from '{agent_name}'",
@@ -348,9 +376,15 @@ def _print_commands_init(
         click.secho(f"    skipped {name}: {reason}", fg=color)
 
 
-def _print_commands_generate(root: Path, strict: bool, on_drop: str = "ignore") -> None:
+def _print_commands_generate(
+    root: Path,
+    strict: bool,
+    on_drop: str = "ignore",
+    *,
+    scope: TargetScope = "project_shared",
+) -> None:
     try:
-        result = generate_all_commands(root, strict=strict, on_drop=on_drop)
+        result = generate_all_commands(root, strict=strict, on_drop=on_drop, scope=scope)
     except CommandStrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort() from exc
@@ -363,8 +397,17 @@ def _print_commands_generate(root: Path, strict: bool, on_drop: str = "ignore") 
             except ValueError:
                 rel = path
             click.echo(f"    {runtime:17s}  {rel}")
-    for runtime, reason, _code in result.skipped:
-        click.secho(f"  skipped {runtime}: {reason}", fg="yellow")
+    for runtime, reason, code in result.skipped:
+        color = (
+            "red"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "yellow"
+        )
+        click.secho(f"  skipped {runtime}: {reason}", fg=color)
     for runtime, cmd_name, dropped in result.dropped:
         click.secho(
             f"  {runtime} dropped {dropped} from '{cmd_name}'",
@@ -900,20 +943,31 @@ def generate_cmd(
     else:
         click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
+    # ADR-0011 PR-E3: resolve the canonical-artifact scope once and thread
+    # it through the three include helpers. Defaults to ``project_shared``
+    # via ``_resolve_artifact_cli_scope`` (NOT ``_resolve_cli_scope``,
+    # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
+    # ADR-0011 PR-E1 Codex review trip-wire).
+    artifact_scope = _resolve_artifact_cli_scope(scope_flag)
+
     if "skills" in inc:
         click.echo("")
-        _print_skills_generate(root)
+        _print_skills_generate(root, scope=artifact_scope)
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_generate(root, strict=strict, on_drop=on_drop)
+        _print_agents_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_generate(root, strict=strict, on_drop=on_drop)
+        _print_commands_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
 
     if "settings" in inc:
         click.echo("")
+        # Settings has its own (separate from artifact) scope axis — see
+        # ADR-0010. ``_resolve_cli_scope`` consults ``cfg.hooks.target_scope``;
+        # this is intentional for settings and intentionally NOT used for
+        # artifacts above.
         scope = _resolve_cli_scope(scope_flag)
         if _confirm_settings_host_writes(root, scope=scope, yes=yes):
             _print_settings_generate(root, scope=scope, allow_host_writes=True)
@@ -1033,20 +1087,31 @@ def sync_cmd(
     else:
         click.secho(f"  ({CONTEXT_FILENAME} missing — skipping project memory)", fg="yellow")
 
+    # ADR-0011 PR-E3: resolve the canonical-artifact scope once and thread
+    # it through the three include helpers. Defaults to ``project_shared``
+    # via ``_resolve_artifact_cli_scope`` (NOT ``_resolve_cli_scope``,
+    # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
+    # ADR-0011 PR-E1 Codex review trip-wire).
+    artifact_scope = _resolve_artifact_cli_scope(scope_flag)
+
     if "skills" in inc:
         click.echo("")
-        _print_skills_generate(root)
+        _print_skills_generate(root, scope=artifact_scope)
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_generate(root, strict=strict, on_drop=on_drop)
+        _print_agents_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_generate(root, strict=strict, on_drop=on_drop)
+        _print_commands_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
 
     if "settings" in inc:
         click.echo("")
+        # Settings has its own (separate from artifact) scope axis — see
+        # ADR-0010. ``_resolve_cli_scope`` consults ``cfg.hooks.target_scope``;
+        # this is intentional for settings and intentionally NOT used for
+        # artifacts above.
         scope = _resolve_cli_scope(scope_flag)
         if _confirm_settings_host_writes(root, scope=scope, yes=yes):
             _print_settings_generate(root, scope=scope, allow_host_writes=True)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -64,6 +64,7 @@ from memtomem.context.generator import (
     extract_sections_from_agent_file,
 )
 from memtomem.context.parser import CONTEXT_FILENAME, parse_context, sections_to_markdown
+from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.context.settings import (
     diff_settings,
     generate_all_settings,
@@ -198,7 +199,10 @@ def _print_skills_generate(
     *,
     scope: TargetScope = "project_shared",
 ) -> None:
-    result = generate_all_skills(root, scope=scope)
+    try:
+        result = generate_all_skills(root, scope=scope)
+    except PrivacyScanError as exc:
+        raise click.ClickException(exc.message) from exc
     if result.generated:
         click.secho(f"  Skills fan-out: {len(result.generated)}", fg="green")
         for runtime, path in result.generated:
@@ -290,6 +294,8 @@ def _print_agents_generate(
     except StrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort()
+    except PrivacyScanError as exc:
+        raise click.ClickException(exc.message) from exc
 
     if result.generated:
         click.secho(f"  Sub-agent fan-out: {len(result.generated)}", fg="green")
@@ -391,6 +397,8 @@ def _print_commands_generate(
     except CommandStrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort() from exc
+    except PrivacyScanError as exc:
+        raise click.ClickException(exc.message) from exc
 
     if result.generated:
         click.secho(f"  Command fan-out: {len(result.generated)}", fg="green")
@@ -1831,6 +1839,8 @@ def _migrate_scope_dispatch(
         )
     except (FileNotFoundError, ValueError, InvalidNameError) as exc:
         raise click.ClickException(str(exc)) from exc
+    except PrivacyScanError as exc:
+        raise click.ClickException(exc.message) from exc
 
     _print_migrate_scope_result(result, apply_=apply_)
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -50,8 +50,11 @@ from memtomem.context.install import (
 )
 from memtomem.context.migrate import (
     MigrateRow,
+    MigrateScopeResult,
+    SCOPE_MIGRATABLE_KINDS,
     classify_migrate,
     migrate_one,
+    migrate_scope,
 )
 from memtomem.context.projects import KnownProjectsStore
 from memtomem.context.lockfile import LockfileVersionError
@@ -1784,6 +1787,143 @@ def _print_migrate_preview(rows: list[MigrateRow], *, skills_section: bool) -> N
         )
 
 
+def _migrate_scope_dispatch(
+    asset_type: str,
+    name: str,
+    from_scope: str | None,
+    to_scope: str,
+    apply_: bool,
+    yes: bool,
+    confirm_project_shared: bool,
+) -> None:
+    """ADR-0011 PR-E4 scope-tier move for agents / commands / skills.
+
+    Calls :func:`memtomem.context.migrate.migrate_scope` after running the
+    project_shared confirmation gate. Click prompts and stdout writes
+    live here; the pure module stays prompt-free.
+    """
+    project_root = _find_project_root()
+
+    # Pre-flight Gate B (project_shared opt-in, mirroring memory-migrate).
+    # Apply only — dry-run reads the same plan without touching disk and
+    # is the recommended way to inspect the move before opting in.
+    if to_scope == "project_shared" and apply_ and not confirm_project_shared:
+        if yes:
+            raise click.ClickException(
+                "--to project_shared requires --confirm-project-shared. "
+                "--yes alone is not sufficient: project_shared writes go "
+                "to the git-tracked tier and require explicit opt-in."
+            )
+        if not click.confirm(
+            "\nThis will move the canonical into the git-tracked project_shared tier. Continue?",
+            default=False,
+        ):
+            raise click.Abort()
+
+    try:
+        result = migrate_scope(
+            asset_type,  # type: ignore[arg-type]
+            name,
+            from_scope=from_scope,  # type: ignore[arg-type]
+            to_scope=to_scope,  # type: ignore[arg-type]
+            project_root=project_root,
+            apply_=apply_,
+        )
+    except (FileNotFoundError, ValueError, InvalidNameError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    _print_migrate_scope_result(result, apply_=apply_)
+
+
+def _print_migrate_scope_result(result: MigrateScopeResult, *, apply_: bool) -> None:
+    """User-facing summary for one scope-tier migration.
+
+    Dry-run prints the plan + a "run with --apply" hint. Apply prints a
+    green-tick line plus any cleaned runtime fan-out paths so the user
+    sees both halves of the move (canonical + stale fan-out).
+    """
+    layout_note = " (flat layout)" if result.layout == "flat" else ""
+    click.echo(f"Plan: migrate {result.kind}/{result.name}{layout_note}")
+    click.echo(f"  from {result.from_scope}: {result.src_path}")
+    click.echo(f"  to   {result.to_scope}: {result.dst_path}")
+
+    if not apply_:
+        click.echo("\nRun with --apply to execute.")
+        click.echo(
+            f"After apply, run `mm context sync --scope {result.to_scope}` "
+            f"to refresh runtime fan-out."
+        )
+        return
+
+    click.secho(
+        f"  ✓ moved {result.kind}/{result.name}: {result.from_scope} → {result.to_scope}",
+        fg="green",
+    )
+    if result.fanout_cleaned:
+        click.echo(
+            f"  cleaned {len(result.fanout_cleaned)} stale runtime fan-out "
+            f"target(s) at scope='{result.from_scope}':"
+        )
+        for path in result.fanout_cleaned:
+            click.echo(f"    - {path}")
+    click.echo(
+        f"\nNext: run `mm context sync --scope {result.to_scope}` to "
+        f"regenerate runtime fan-out at the new tier."
+    )
+
+
+def _migrate_memory_dispatch(
+    operand: str | None,
+    from_scope: str | None,
+    to_scope: str | None,
+    apply_: bool,
+    force: bool,
+    yes: bool,
+    confirm_project_shared: bool,
+) -> None:
+    """ADR-0011 PR-E4 cross-link to ``mm context memory-migrate``.
+
+    The operand is a SOURCE PATH (not a name) since memory canonical
+    files are addressed by absolute path, not by an artifact-style name.
+    Both ``--from`` and ``--to`` are required (memory has no
+    auto-detection — paths can be ambiguous between user / project_shared
+    / project_local in nested layouts). Behaviour is byte-identical to
+    ``mm context memory-migrate`` since both call the same impl.
+    """
+    if operand is None:
+        raise click.UsageError(
+            "source path argument is required for kind=memory (operand is a path, not a name)"
+        )
+    if from_scope is None or to_scope is None:
+        raise click.UsageError("--from and --to are both required for kind=memory")
+    if force:
+        raise click.UsageError(
+            "--force does not apply to memory migration (no flat/dir layouts in this kind)"
+        )
+    if from_scope == to_scope:
+        raise click.ClickException("--from and --to must differ.")
+
+    source = Path(operand).expanduser()
+    if not source.exists():
+        raise click.ClickException(f"source path does not exist: {source}")
+    if not source.is_file():
+        raise click.ClickException(f"source path must be a file, not a directory: {source}")
+    source_resolved = source.resolve()
+
+    import asyncio
+
+    asyncio.run(
+        _memory_migrate_run(
+            source_resolved,
+            from_scope,
+            to_scope,
+            apply_,
+            yes,
+            confirm_project_shared,
+        )
+    )
+
+
 def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
     """Build the post-preview summary line."""
     counts: dict[str, int] = {s: 0 for s in _MIGRATE_GLYPH}
@@ -1808,10 +1948,32 @@ def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
 @context.command("migrate")
 @click.argument(
     "asset_type",
-    type=click.Choice(["agents", "commands", "skills"]),
+    type=click.Choice(["agents", "commands", "skills", "memory"]),
     required=False,
 )
 @click.argument("name", required=False)
+@click.option(
+    "--from",
+    "from_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    default=None,
+    help=(
+        "Explicit source scope. Required for kind=memory; auto-detected "
+        "for agents/commands/skills (pass to disambiguate when the same "
+        "name lives in multiple scopes)."
+    ),
+)
+@click.option(
+    "--to",
+    "to_scope",
+    type=click.Choice(list(get_args(TargetScope))),
+    default=None,
+    help=(
+        "Target scope tier. When set, migrate moves the artifact's "
+        "canonical between ADR-0011 tiers (PR-E4). When omitted, falls "
+        "back to the PR-D flat→dir layout migration."
+    ),
+)
 @click.option(
     "--apply",
     "apply_",
@@ -1823,7 +1985,11 @@ def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
     "--force",
     is_flag=True,
     default=False,
-    help="Migrate dirty flat files; each gets a .bak sibling. Requires --apply.",
+    help=(
+        "Flat→dir mode: migrate dirty flat files; each gets a .bak sibling. "
+        "Has no effect in scope-tier mode (--to) — destinations always "
+        "refuse on conflict in PR-E4. Requires --apply."
+    ),
 )
 @click.option(
     "--yes",
@@ -1832,33 +1998,92 @@ def _summarize_migrate_rows(rows: list[MigrateRow]) -> str:
     default=False,
     help="Skip the confirmation prompt. Requires --apply.",
 )
+@click.option(
+    "--confirm-project-shared",
+    "confirm_project_shared",
+    is_flag=True,
+    default=False,
+    help=(
+        "Required (in addition to --apply) when --to=project_shared "
+        "or kind=memory --to=project_shared, mirroring "
+        "``mm context memory-migrate``. --yes alone does not satisfy "
+        "the project_shared opt-in."
+    ),
+)
 def migrate_cmd(
     asset_type: str | None,
     name: str | None,
+    from_scope: str | None,
+    to_scope: str | None,
     apply_: bool,
     force: bool,
     yes: bool,
+    confirm_project_shared: bool,
 ) -> None:
-    """Convert flat-layout context assets to canonical directory layout.
+    """Migrate canonical context artifacts.
 
-    PR-C made the directory layout canonical for agents and commands;
-    pre-PR-C installs and reverse-imports leave behind flat files
-    (``agents/<name>.md``). This command renames each such file to
-    ``agents/<name>/agent.md`` (and the equivalent for commands) atomically
-    via ``os.replace``.
+    Two modes share this verb:
 
-    Skills are always directory layout (Agent Skills spec) and are not
-    in scope. Invoking ``migrate skills`` exits 0 with an informational
-    message rather than an error.
+    * **Flat→dir layout** (PR-D, default when ``--to`` is omitted) —
+      converts pre-PR-C ``agents/<name>.md`` to ``agents/<name>/agent.md``.
+      Skills are always directory layout (Agent Skills spec) and exit 0
+      with an informational message in this mode.
+    * **Scope-tier move** (PR-E4, when ``--to`` is set) — moves the
+      canonical between ADR-0011 tiers (``user`` /
+      ``project_shared`` / ``project_local``). Supports agents,
+      commands, skills, and memory (memory delegates to
+      ``mm context memory-migrate``'s impl with parity behaviour).
 
-    Default mode is a dry-run preview; pass ``--apply`` to execute. Dirty
-    flat files (mtime > installed_at) require ``--force`` and produce a
-    ``.bak`` sibling before mutation, mirroring ``mm context update --force``.
+    Default mode is a dry-run preview; pass ``--apply`` to execute.
     """
     if (force or yes) and not apply_:
         raise click.UsageError("--force / --yes are only valid with --apply")
     if name is not None and asset_type is None:
         raise click.UsageError("name argument requires asset_type")
+
+    # ── PR-E4 scope-mode dispatch ────────────────────────────────────
+    if asset_type == "memory":
+        _migrate_memory_dispatch(
+            name,
+            from_scope,
+            to_scope,
+            apply_,
+            force,
+            yes,
+            confirm_project_shared,
+        )
+        return
+    if to_scope is not None:
+        if asset_type is None:
+            raise click.UsageError("--to requires an asset_type")
+        if asset_type not in SCOPE_MIGRATABLE_KINDS:
+            raise click.UsageError(
+                f"--to is not supported for asset_type={asset_type!r} "
+                f"(use one of {SCOPE_MIGRATABLE_KINDS} or 'memory')"
+            )
+        if name is None:
+            raise click.UsageError("name argument is required with --to")
+        if force:
+            raise click.UsageError(
+                "--force does not apply to --to scope-tier moves "
+                "(destinations always refuse on conflict in PR-E4)"
+            )
+        _migrate_scope_dispatch(
+            asset_type,
+            name,
+            from_scope,
+            to_scope,
+            apply_,
+            yes,
+            confirm_project_shared,
+        )
+        return
+
+    # ── Flat→dir mode validation gates ───────────────────────────────
+    if from_scope is not None:
+        raise click.UsageError("--from requires --to (scope-tier mode)")
+    if confirm_project_shared:
+        raise click.UsageError("--confirm-project-shared requires --to")
 
     if asset_type == "skills":
         click.secho(

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -156,3 +156,47 @@ def runtime_fanout_root(
             "requires project_root for a project-tier scope."
         )
     return (project_root / entry).resolve()
+
+
+def runtime_artifact_names(
+    artifact: ArtifactKind,
+    runtime: str,
+    project_root: Path | None,
+    scope: TargetScope,
+    *,
+    file_suffix: str | None = None,
+    dir_manifest: str | None = None,
+) -> set[str]:
+    """Return artifact names present under the runtime fan-out root.
+
+    Replaces the per-module helpers ``_runtime_agent_names`` /
+    ``_runtime_command_names`` and the inline runtime-listing in
+    ``diff_skills`` (ADR-0011 PR-E3 cleanup item #4 — collapses three
+    implementations onto one source of truth so the
+    ``RUNTIME_FANOUT_TABLE`` shape is the only place a runtime root is
+    spelled out).
+
+    Pass exactly one of:
+
+    * ``file_suffix`` (e.g. ``".md"`` / ``".toml"``) — return the
+      ``stem`` of every regular file matching the suffix. Used for
+      agents and commands fan-out where each artifact is one file.
+    * ``dir_manifest`` (e.g. ``"SKILL.md"``) — return the ``name`` of
+      every directory containing the named manifest file. Used for
+      skills where each artifact is a directory tree.
+
+    Returns the empty set when the table entry is ``NO_FANOUT`` or
+    when the resolved root does not yet exist on disk (caller treats
+    "no runtime listing" the same as "table says no fan-out").
+    """
+    if (file_suffix is None) == (dir_manifest is None):
+        raise ValueError(
+            "runtime_artifact_names requires exactly one of file_suffix= or dir_manifest=."
+        )
+    root = runtime_fanout_root(artifact, runtime, scope, project_root)
+    if root is None or not root.is_dir():
+        return set()
+    if file_suffix is not None:
+        return {p.stem for p in root.iterdir() if p.is_file() and p.suffix == file_suffix}
+    assert dir_manifest is not None  # mypy narrow
+    return {p.name for p in root.iterdir() if p.is_dir() and (p / dir_manifest).is_file()}

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -47,7 +47,7 @@ from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, 
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context.privacy_scan import (
     raise_or_collect,
-    scan_artifact_tree,
+    scan_text_content,
 )
 from memtomem.context.scope_resolver import canonical_artifact_dir
 
@@ -195,36 +195,37 @@ _KNOWN_AGENT_KEYS = frozenset(
 )
 
 
-def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
-    """Parse a canonical agent file into a :class:`SubAgent`.
-
-    ``layout`` selects the default-name fallback when the frontmatter omits
-    ``name``: ``"flat"`` (legacy ``agents/<name>.md``) uses ``path.stem``;
-    ``"dir"`` (ADR-0008 ``agents/<name>/agent.md``) uses
-    ``path.parent.name``. Callers normally get ``layout`` from
-    :func:`list_canonical_agents`.
+def _parse_canonical_agent_text(
+    content: str,
+    *,
+    source: Path,
+    layout: Layout = "flat",
+) -> SubAgent:
+    """Parse already-loaded canonical agent text. Used by both the path-based
+    :func:`parse_canonical_agent` (for backwards compat) and the sync flow
+    that captures bytes once to close the scan→write TOCTOU window
+    (PR-E3 Codex review fold).
     """
-    content = path.read_text(encoding="utf-8")
     # Normalize CRLF → LF so ``_FRONT_MATTER_RE`` (which anchors on ``\n``) matches
     # files authored on Windows or by editors that emit CRLF.
     content = content.replace("\r\n", "\n")
     m = _FRONT_MATTER_RE.match(content)
     if not m:
-        raise AgentParseError(f"missing YAML frontmatter: {path}")
+        raise AgentParseError(f"missing YAML frontmatter: {source}")
     frontmatter = _parse_flat_yaml(m.group(1))
 
     unknown = sorted(set(frontmatter) - _KNOWN_AGENT_KEYS)
     if unknown:
-        logger.warning("unknown frontmatter keys %s in %s (ignored)", unknown, path)
+        logger.warning("unknown frontmatter keys %s in %s (ignored)", unknown, source)
 
     body = content[m.end() :].lstrip("\n").rstrip() + "\n"
 
-    default_name = path.parent.name if layout == "dir" else path.stem
+    default_name = source.parent.name if layout == "dir" else source.stem
     name = frontmatter.get("name") or default_name
     try:
         name = validate_name(str(name), kind="agent name")
     except InvalidNameError as exc:
-        raise AgentParseError(f"{exc} (source: {path})") from exc
+        raise AgentParseError(f"{exc} (source: {source})") from exc
     description = frontmatter.get("description") or ""
     return SubAgent(
         name=name,
@@ -237,6 +238,19 @@ def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
         kind=(str(frontmatter["kind"]) if frontmatter.get("kind") else None),
         temperature=_coerce_float(frontmatter.get("temperature")),
     )
+
+
+def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
+    """Parse a canonical agent file into a :class:`SubAgent`.
+
+    ``layout`` selects the default-name fallback when the frontmatter omits
+    ``name``: ``"flat"`` (legacy ``agents/<name>.md``) uses ``path.stem``;
+    ``"dir"`` (ADR-0008 ``agents/<name>/agent.md``) uses
+    ``path.parent.name``. Callers normally get ``layout`` from
+    :func:`list_canonical_agents`.
+    """
+    content = path.read_text(encoding="utf-8")
+    return _parse_canonical_agent_text(content, source=path, layout=layout)
 
 
 def list_canonical_agents(
@@ -614,8 +628,19 @@ def generate_all_agents(
             skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
             continue
         for agent_path, layout in canonicals:
+            # PR-E3 Codex review fold: read canonical bytes ONCE and use
+            # the captured buffer for both Gate A scan AND parse, closing
+            # the scan→write TOCTOU window. A concurrent edit between
+            # scan and parse would otherwise let an attacker present
+            # clean bytes to scan and unsafe bytes to render.
             try:
-                agent = parse_canonical_agent(agent_path, layout=layout)
+                agent_bytes = agent_path.read_bytes()
+            except OSError as exc:
+                skipped.append((agent_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                continue
+            agent_text = agent_bytes.decode("utf-8", errors="replace")
+            try:
+                agent = _parse_canonical_agent_text(agent_text, source=agent_path, layout=layout)
             except AgentParseError as exc:
                 skipped.append((agent_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
                 continue
@@ -635,35 +660,31 @@ def generate_all_agents(
                     )
                 )
                 continue
-            # ADR-0011 PR-E3 Gate A — scan canonical bytes BEFORE render.
-            # project_shared block raises ClickException; user/project_local
-            # block emits PRIVACY_BLOCKED skip and continues to next runtime.
-            # Scan-before-render also keeps strict=true semantics correct:
-            # a NO_FANOUT runtime never reaches render (#892 P2 fold), and
-            # a privacy-blocked canonical never reaches render either, so
-            # render+drop handling only runs for clean fan-outs.
-            scan = scan_artifact_tree(
-                agent_path,
+            # ADR-0011 PR-E3 Gate A — scan the IN-MEMORY canonical bytes
+            # (same buffer the parse used). project_shared block raises
+            # ClickException; user/project_local block emits
+            # PRIVACY_BLOCKED skip and continues to next runtime.
+            file_scan = scan_text_content(
+                agent_text,
+                source_path=agent_path,
                 surface="cli_context_sync",
                 scope=scope,
                 project_root=project_root,
-                on_blocked="fail_fast",
             )
-            if scan.blocked:
+            if file_scan.decision in ("blocked", "blocked_project_shared"):
                 code, reason = raise_or_collect(
-                    scan.blocked[0],
+                    file_scan,
                     scope=scope,
                     kind="agent",
                     artifact_name=agent.name,
                 )
                 skipped.append((agent.name, reason, code))
                 continue
-            # Resolve per-vendor override (single-tier scope) and scan its
-            # bytes — the override path replaces the rendered canonical
-            # before write, so unscanned-override would silently bypass
-            # Gate A.
+            # Resolve per-vendor override and scan its bytes — read once,
+            # scan once, write the same buffer. Same TOCTOU close as
+            # canonical above.
             vendor = GENERATOR_VENDOR.get(target)
-            override_path: Path | None = None
+            override_bytes: bytes | None = None
             if vendor is not None:
                 # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
                 # to override resolution. Same-tier-only lookup (narrow→broad
@@ -672,16 +693,24 @@ def generate_all_agents(
                     project_root, "agents", agent.name, vendor, scope=scope
                 )
                 if override_path is not None:
-                    scan_override = scan_artifact_tree(
-                        override_path,
+                    try:
+                        override_bytes = override_path.read_bytes()
+                    except OSError as exc:
+                        skipped.append(
+                            (agent.name, f"override unreadable: {exc}", skip_codes.PARSE_ERROR)
+                        )
+                        continue
+                    override_text = override_bytes.decode("utf-8", errors="replace")
+                    file_scan = scan_text_content(
+                        override_text,
+                        source_path=override_path,
                         surface="cli_context_sync",
                         scope=scope,
                         project_root=project_root,
-                        on_blocked="fail_fast",
                     )
-                    if scan_override.blocked:
+                    if file_scan.decision in ("blocked", "blocked_project_shared"):
                         code, reason = raise_or_collect(
-                            scan_override.blocked[0],
+                            file_scan,
                             scope=scope,
                             kind="agent",
                             artifact_name=agent.name,
@@ -698,10 +727,10 @@ def generate_all_agents(
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
-            # Both canonical and override bytes have already passed Gate A
-            # above; the write below is unconditional once we reach here.
-            if override_path is not None:
-                atomic_write_bytes(out_path, override_path.read_bytes())
+            # Use the SAME captured buffer that passed Gate A — never
+            # re-read from disk (would re-open the TOCTOU window).
+            if override_bytes is not None:
+                atomic_write_bytes(out_path, override_bytes)
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, agent.name, dropped_fields))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -44,7 +44,7 @@ from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
-from memtomem.context._runtime_targets import runtime_fanout_root
+from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
@@ -235,7 +235,11 @@ def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
     )
 
 
-def list_canonical_agents(project_root: Path) -> list[tuple[Path, Layout]]:
+def list_canonical_agents(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[Path, Layout]]:
     """Enumerate canonical agents in both flat and directory layouts.
 
     Flat layout (legacy): ``agents/<name>.md``. Directory layout (ADR-0008
@@ -243,8 +247,12 @@ def list_canonical_agents(project_root: Path) -> list[tuple[Path, Layout]]:
     the directory layout wins and a WARNING is logged so the silent flat
     file is visible. ``mm context migrate`` (PR-D) is the supported way
     to consolidate.
+
+    ADR-0011 PR-E3: ``scope`` selects the canonical root via
+    :func:`canonical_artifact_dir` (default ``project_shared`` preserves
+    pre-PR-E3 behavior of reading ``<project_root>/.memtomem/agents``).
     """
-    root = project_root / CANONICAL_AGENT_ROOT
+    root = canonical_artifact_dir("agents", scope, project_root)
     if not root.is_dir():
         return []
 
@@ -564,6 +572,8 @@ def generate_all_agents(
     runtimes: list[str] | None = None,
     strict: bool = False,
     on_drop: str = "ignore",
+    *,
+    scope: TargetScope = "project_shared",
 ) -> AgentSyncResult:
     """Fan out every canonical sub-agent to the requested runtimes.
 
@@ -574,6 +584,9 @@ def generate_all_agents(
             ``"error"`` — raise :class:`StrictDropError` immediately.
         strict: Legacy alias for ``on_drop="error"``. If *both* are supplied,
             ``on_drop`` takes precedence unless it is still the default.
+        scope: ADR-0011 PR-E3 — selects canonical root and runtime
+            fan-out destination. Default ``project_shared`` preserves
+            pre-PR-E3 behavior.
     """
     # Resolve legacy ``strict`` flag.
     effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
@@ -582,7 +595,7 @@ def generate_all_agents(
     dropped: list[tuple[str, str, list[str]]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
 
-    canonicals = list_canonical_agents(project_root)
+    canonicals = list_canonical_agents(project_root, scope=scope)
     if not canonicals:
         return AgentSyncResult(
             generated=[],
@@ -608,7 +621,7 @@ def generate_all_agents(
             # without invoking ``render`` so a strict caller doesn't raise
             # ``StrictDropError`` for a runtime that has no fan-out by
             # design (the fail-quiet contract).
-            out_path = gen.target_file(project_root, agent.name)
+            out_path = gen.target_file(project_root, agent.name, scope=scope)
             if out_path is None:
                 skipped.append(
                     (
@@ -632,13 +645,13 @@ def generate_all_agents(
             # canonical→override window. Same pattern as skills.py:213-220.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
-                # ADR-0011 PR-E: pin scope=project_shared so default fan-out
-                # never picks up a draft project_local override (narrow→broad
-                # is intended for explicit cross-tier reads, not the default
-                # project_shared sync surface). E3 will thread the resolved
-                # scope through when sync becomes scope-aware.
+                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
+                # to override resolution. Same-tier override wins (narrow);
+                # broader-tier override is consulted only when the same-tier
+                # is absent. ``scope`` defaults to ``project_shared`` so the
+                # pre-PR-E3 sync surface keeps the prior behavior.
                 override_path = _override.resolve(
-                    project_root, "agents", agent.name, vendor, scope="project_shared"
+                    project_root, "agents", agent.name, vendor, scope=scope
                 )
                 if override_path is not None:
                     atomic_write_bytes(out_path, override_path.read_bytes())
@@ -830,46 +843,67 @@ def extract_agents_to_canonical(
 # ── Diff: canonical ↔ runtimes ──────────────────────────────────────
 
 
+# Per-runtime file suffix for agents fan-out. Used by ``diff_agents`` to
+# delegate to ``runtime_artifact_names``. Kept inline (rather than on each
+# generator) because (a) the suffix is a property of the on-disk format, not
+# of the runtime conversion, and (b) it's referenced from one site only.
+_AGENT_RUNTIME_SUFFIX: dict[str, str] = {
+    "claude": ".md",
+    "gemini": ".md",
+    "codex": ".toml",
+}
+
+
 def _runtime_agent_names(gen_name: str, project_root: Path) -> set[str]:
-    if gen_name == "codex_agents":
-        runtime_root = project_root / ".codex/agents"
-        suffix = ".toml"
-    elif gen_name == "claude_agents":
-        runtime_root = project_root / ".claude/agents"
-        suffix = ".md"
-    elif gen_name == "gemini_agents":
-        runtime_root = project_root / ".gemini/agents"
-        suffix = ".md"
-    else:
+    """Thin wrapper around :func:`runtime_artifact_names` for back-compat.
+
+    Pre-PR-E3 callers and tests pass ``gen_name`` (e.g. ``"claude_agents"``)
+    and an implicit ``project_shared`` scope. New callers should consume
+    :func:`runtime_artifact_names` directly with explicit scope.
+    """
+    runtime = gen_name.split("_", 1)[0]
+    suffix = _AGENT_RUNTIME_SUFFIX.get(runtime)
+    if suffix is None:
         return set()
-    if not runtime_root.is_dir():
-        return set()
-    return {p.stem for p in runtime_root.iterdir() if p.is_file() and p.suffix == suffix}
+    return runtime_artifact_names(
+        "agents", runtime, project_root, "project_shared", file_suffix=suffix
+    )
 
 
-def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
+def diff_agents(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[str, str, str]]:
     """Compare canonical agents against every registered runtime.
 
     Returns a list of ``(runtime, agent_name, status)`` where status is one of
     ``"in sync"``, ``"out of sync"``, ``"missing target"``, ``"missing canonical"``,
     ``"parse error"``.
+
+    ADR-0011 PR-E3: ``scope`` selects both the canonical source and the
+    runtime fan-out roots. Default ``project_shared`` preserves
+    pre-PR-E3 behavior.
     """
     results: list[tuple[str, str, str]] = []
     canonical_index = {
         path.parent.name if layout == "dir" else path.stem: (path, layout)
-        for path, layout in list_canonical_agents(project_root)
+        for path, layout in list_canonical_agents(project_root, scope=scope)
     }
     canonical_names = set(canonical_index)
 
     for gen_name, gen in AGENT_GENERATORS.items():
-        # ADR-0011 PR-E (#891): probe NO_FANOUT for this runtime+scope. The
-        # table lookup ignores the artifact name, so a fixed probe name is
-        # safe. When None, the runtime has no fan-out by design — skip the
-        # whole runtime so canonical-only entries don't surface as
-        # ``missing target`` (the realistic NO_FANOUT shape).
-        if gen.target_file(project_root, "__probe_891__") is None:
+        # ADR-0011 PR-E3 cleanup item #1: query the table directly via
+        # ``runtime_fanout_root``. Earlier code probed with a fixed agent
+        # name (``__probe_891__``) which leaked the table-shape assumption
+        # into the call shape — call-shape fragility, not name-independence.
+        runtime = gen_name.split("_", 1)[0]
+        if runtime_fanout_root("agents", runtime, scope, project_root) is None:
             continue
-        runtime_names = _runtime_agent_names(gen_name, project_root)
+        suffix = _AGENT_RUNTIME_SUFFIX.get(runtime, ".md")
+        runtime_names = runtime_artifact_names(
+            "agents", runtime, project_root, scope, file_suffix=suffix
+        )
         for name in sorted(canonical_names | runtime_names):
             if name in canonical_names and name not in runtime_names:
                 results.append((gen_name, name, "missing target"))
@@ -885,14 +919,12 @@ def diff_agents(project_root: Path) -> list[tuple[str, str, str]]:
                 results.append((gen_name, name, "parse error"))
                 continue
             expected, _ = gen.render(agent)
-            target = gen.target_file(project_root, name)
-            # The upstream NO_FANOUT probe already filters out runtimes
-            # whose ``RUNTIME_FANOUT_TABLE`` entry is ``None``, so this
-            # branch is only reachable if the table lookup is per-name
-            # (which today's table is not). Keep the skip as a defensive
-            # silent fallback so the contract holds regardless.
-            if target is None:
-                continue
+            # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
+            # above guarantees this runtime+scope has a fan-out root, so
+            # ``gen.target_file`` cannot return ``None`` for any name.
+            # Earlier defensive ``if target is None: continue`` removed.
+            target = gen.target_file(project_root, name, scope=scope)
+            assert target is not None  # narrowed by upstream NO_FANOUT guard
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -45,6 +45,10 @@ from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
+from memtomem.context.privacy_scan import (
+    raise_or_collect,
+    scan_artifact_tree,
+)
 from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
@@ -631,6 +635,59 @@ def generate_all_agents(
                     )
                 )
                 continue
+            # ADR-0011 PR-E3 Gate A — scan canonical bytes BEFORE render.
+            # project_shared block raises ClickException; user/project_local
+            # block emits PRIVACY_BLOCKED skip and continues to next runtime.
+            # Scan-before-render also keeps strict=true semantics correct:
+            # a NO_FANOUT runtime never reaches render (#892 P2 fold), and
+            # a privacy-blocked canonical never reaches render either, so
+            # render+drop handling only runs for clean fan-outs.
+            scan = scan_artifact_tree(
+                agent_path,
+                surface="cli_context_sync",
+                scope=scope,
+                project_root=project_root,
+                on_blocked="fail_fast",
+            )
+            if scan.blocked:
+                code, reason = raise_or_collect(
+                    scan.blocked[0],
+                    scope=scope,
+                    kind="agent",
+                    artifact_name=agent.name,
+                )
+                skipped.append((agent.name, reason, code))
+                continue
+            # Resolve per-vendor override (single-tier scope) and scan its
+            # bytes — the override path replaces the rendered canonical
+            # before write, so unscanned-override would silently bypass
+            # Gate A.
+            vendor = GENERATOR_VENDOR.get(target)
+            override_path: Path | None = None
+            if vendor is not None:
+                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
+                # to override resolution. Same-tier-only lookup (narrow→broad
+                # is intentionally NOT used for default sync per ADR §4).
+                override_path = _override.resolve(
+                    project_root, "agents", agent.name, vendor, scope=scope
+                )
+                if override_path is not None:
+                    scan_override = scan_artifact_tree(
+                        override_path,
+                        surface="cli_context_sync",
+                        scope=scope,
+                        project_root=project_root,
+                        on_blocked="fail_fast",
+                    )
+                    if scan_override.blocked:
+                        code, reason = raise_or_collect(
+                            scan_override.blocked[0],
+                            scope=scope,
+                            kind="agent",
+                            artifact_name=agent.name,
+                        )
+                        skipped.append((agent.name, reason, code))
+                        continue
             content, dropped_fields = gen.render(agent)
             if dropped_fields:
                 if effective_drop == "error":
@@ -641,20 +698,10 @@ def generate_all_agents(
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
             atomic_write_text(out_path, content)
             # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
-            # Race: see PR-D' for the unified write path that closes the
-            # canonical→override window. Same pattern as skills.py:213-220.
-            vendor = GENERATOR_VENDOR.get(target)
-            if vendor is not None:
-                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
-                # to override resolution. Same-tier override wins (narrow);
-                # broader-tier override is consulted only when the same-tier
-                # is absent. ``scope`` defaults to ``project_shared`` so the
-                # pre-PR-E3 sync surface keeps the prior behavior.
-                override_path = _override.resolve(
-                    project_root, "agents", agent.name, vendor, scope=scope
-                )
-                if override_path is not None:
-                    atomic_write_bytes(out_path, override_path.read_bytes())
+            # Both canonical and override bytes have already passed Gate A
+            # above; the write below is unconditional once we reach here.
+            if override_path is not None:
+                atomic_write_bytes(out_path, override_path.read_bytes())
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, agent.name, dropped_fields))

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -622,6 +622,21 @@ def generate_all_agents(
         )
 
     targets = runtimes if runtimes is not None else list(AGENT_GENERATORS.keys())
+
+    # ── Phase 1: parse + scan every (target, agent) pair — pure read pass. ──
+    # No filesystem mutation happens here. For ``scope='project_shared'``
+    # the first Gate A hit raises immediately via :func:`raise_or_collect`,
+    # so Phase 2 never starts and no partial runtime fan-out can land on
+    # disk (#895 P2 review #5). For user / project_local scopes, blocks
+    # collect into ``skipped`` as before.
+    #
+    # ``pending`` is a list of write descriptors: one per (target, agent)
+    # pair that passed every gate. Each entry carries the immutable
+    # snapshot Phase 2 needs (parsed agent + override bytes that already
+    # passed Gate A) so the write loop never re-reads canonical from
+    # disk and the scan→write TOCTOU window stays closed.
+    pending: list[tuple[str, str, AgentGenerator, SubAgent, Path, bytes | None]] = []
+
     for target in targets:
         gen = AGENT_GENERATORS.get(target)
         if gen is None:
@@ -662,7 +677,7 @@ def generate_all_agents(
                 continue
             # ADR-0011 PR-E3 Gate A — scan the IN-MEMORY canonical bytes
             # (same buffer the parse used). project_shared block raises
-            # ClickException; user/project_local block emits
+            # PrivacyBlockedError; user/project_local block emits
             # PRIVACY_BLOCKED skip and continues to next runtime.
             file_scan = scan_text_content(
                 agent_text,
@@ -681,7 +696,7 @@ def generate_all_agents(
                 skipped.append((agent.name, reason, code))
                 continue
             # Resolve per-vendor override and scan its bytes — read once,
-            # scan once, write the same buffer. Same TOCTOU close as
+            # scan once, hand the bytes to Phase 2. Same TOCTOU close as
             # canonical above.
             vendor = GENERATOR_VENDOR.get(target)
             override_bytes: bytes | None = None
@@ -717,23 +732,32 @@ def generate_all_agents(
                         )
                         skipped.append((agent.name, reason, code))
                         continue
-            content, dropped_fields = gen.render(agent)
-            if dropped_fields:
-                if effective_drop == "error":
-                    raise StrictDropError(
-                        f"strict mode: {target} would drop {dropped_fields} from '{agent.name}'"
-                    )
-                if effective_drop == "warn":
-                    logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
-            atomic_write_text(out_path, content)
-            # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
-            # Use the SAME captured buffer that passed Gate A — never
-            # re-read from disk (would re-open the TOCTOU window).
-            if override_bytes is not None:
-                atomic_write_bytes(out_path, override_bytes)
-            generated.append((target, out_path))
-            if dropped_fields:
-                dropped.append((target, agent.name, dropped_fields))
+            pending.append((target, agent.name, gen, agent, out_path, override_bytes))
+
+    # ── Phase 2: render + atomic write every pending pair. ──
+    # By construction Phase 1 raised on any project_shared privacy block,
+    # so reaching this loop means every queued write is clean. The only
+    # remaining mid-loop raise is StrictDropError, which is opt-in
+    # (``on_drop="error"`` or legacy ``strict=True``) and is an unrelated
+    # atomicity boundary — pre-existing behavior.
+    for target, _name, gen, agent, out_path, override_bytes in pending:
+        content, dropped_fields = gen.render(agent)
+        if dropped_fields:
+            if effective_drop == "error":
+                raise StrictDropError(
+                    f"strict mode: {target} would drop {dropped_fields} from '{agent.name}'"
+                )
+            if effective_drop == "warn":
+                logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
+        atomic_write_text(out_path, content)
+        # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
+        # Use the SAME captured buffer that passed Gate A — never
+        # re-read from disk (would re-open the TOCTOU window).
+        if override_bytes is not None:
+            atomic_write_bytes(out_path, override_bytes)
+        generated.append((target, out_path))
+        if dropped_fields:
+            dropped.append((target, agent.name, dropped_fields))
 
     return AgentSyncResult(generated=generated, dropped=dropped, skipped=skipped)
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -45,6 +45,10 @@ from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
+from memtomem.context.privacy_scan import (
+    raise_or_collect,
+    scan_artifact_tree,
+)
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
@@ -429,6 +433,52 @@ def generate_all_commands(
                     )
                 )
                 continue
+            # ADR-0011 PR-E3 Gate A — scan canonical command bytes BEFORE
+            # render. Mirrors the agents.py flow; project_shared raises,
+            # user/project_local skip-warns. See agents.py block-comment
+            # for the strict=true ordering rationale.
+            scan = scan_artifact_tree(
+                cmd_path,
+                surface="cli_context_sync",
+                scope=scope,
+                project_root=project_root,
+                on_blocked="fail_fast",
+            )
+            if scan.blocked:
+                code, reason = raise_or_collect(
+                    scan.blocked[0],
+                    scope=scope,
+                    kind="command",
+                    artifact_name=cmd.name,
+                )
+                skipped.append((cmd.name, reason, code))
+                continue
+            # Resolve per-vendor override and scan its bytes — override
+            # replaces canonical at write time so unscanned-override
+            # would silently bypass Gate A.
+            vendor = GENERATOR_VENDOR.get(target)
+            override_path: Path | None = None
+            if vendor is not None:
+                override_path = _override.resolve(
+                    project_root, "commands", cmd.name, vendor, scope=scope
+                )
+                if override_path is not None:
+                    scan_override = scan_artifact_tree(
+                        override_path,
+                        surface="cli_context_sync",
+                        scope=scope,
+                        project_root=project_root,
+                        on_blocked="fail_fast",
+                    )
+                    if scan_override.blocked:
+                        code, reason = raise_or_collect(
+                            scan_override.blocked[0],
+                            scope=scope,
+                            kind="command",
+                            artifact_name=cmd.name,
+                        )
+                        skipped.append((cmd.name, reason, code))
+                        continue
             content, dropped_fields = gen.render(cmd)
             if dropped_fields:
                 if effective_drop == "error":
@@ -438,19 +488,9 @@ def generate_all_commands(
                 if effective_drop == "warn":
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
             atomic_write_text(out_path, content)
-            # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
-            # Race: see PR-D' for the unified write path that closes the
-            # canonical→override window. Same pattern as skills.py:213-220.
-            vendor = GENERATOR_VENDOR.get(target)
-            if vendor is not None:
-                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
-                # to override resolution (same-tier-only lookup; see
-                # agents.py for the mirrored rationale).
-                override_path = _override.resolve(
-                    project_root, "commands", cmd.name, vendor, scope=scope
-                )
-                if override_path is not None:
-                    atomic_write_bytes(out_path, override_path.read_bytes())
+            # Both canonical and override bytes have passed Gate A above.
+            if override_path is not None:
+                atomic_write_bytes(out_path, override_path.read_bytes())
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, cmd.name, dropped_fields))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -420,6 +420,14 @@ def generate_all_commands(
         )
 
     targets = runtimes if runtimes is not None else list(COMMAND_GENERATORS.keys())
+
+    # ── Phase 1: parse + scan every (target, command) pair — pure read pass. ──
+    # See agents.py for the rationale (project_shared atomicity, ADR §5).
+    # The first project_shared Gate A hit raises immediately via
+    # :func:`raise_or_collect`, so no partial runtime fan-out can land
+    # on disk (#895 P2 review #5).
+    pending: list[tuple[str, CommandGenerator, SlashCommand, Path, bytes | None]] = []
+
     for target in targets:
         gen = COMMAND_GENERATORS.get(target)
         if gen is None:
@@ -475,7 +483,7 @@ def generate_all_commands(
                 skipped.append((cmd.name, reason, code))
                 continue
             # Resolve per-vendor override and scan its bytes — read once,
-            # scan once, write the same buffer.
+            # scan once, hand the bytes to Phase 2.
             vendor = GENERATOR_VENDOR.get(target)
             override_bytes: bytes | None = None
             if vendor is not None:
@@ -507,21 +515,27 @@ def generate_all_commands(
                         )
                         skipped.append((cmd.name, reason, code))
                         continue
-            content, dropped_fields = gen.render(cmd)
-            if dropped_fields:
-                if effective_drop == "error":
-                    raise StrictDropError(
-                        f"strict mode: {target} would drop {dropped_fields} from '{cmd.name}'"
-                    )
-                if effective_drop == "warn":
-                    logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
-            atomic_write_text(out_path, content)
-            # Use the SAME captured override buffer that passed Gate A.
-            if override_bytes is not None:
-                atomic_write_bytes(out_path, override_bytes)
-            generated.append((target, out_path))
-            if dropped_fields:
-                dropped.append((target, cmd.name, dropped_fields))
+            pending.append((target, gen, cmd, out_path, override_bytes))
+
+    # ── Phase 2: render + atomic write every pending pair. ──
+    # By construction Phase 1 raised on any project_shared block, so
+    # every queued write here is clean.
+    for target, gen, cmd, out_path, override_bytes in pending:
+        content, dropped_fields = gen.render(cmd)
+        if dropped_fields:
+            if effective_drop == "error":
+                raise StrictDropError(
+                    f"strict mode: {target} would drop {dropped_fields} from '{cmd.name}'"
+                )
+            if effective_drop == "warn":
+                logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
+        atomic_write_text(out_path, content)
+        # Use the SAME captured override buffer that passed Gate A.
+        if override_bytes is not None:
+            atomic_write_bytes(out_path, override_bytes)
+        generated.append((target, out_path))
+        if dropped_fields:
+            dropped.append((target, cmd.name, dropped_fields))
 
     return CommandSyncResult(generated=generated, dropped=dropped, skipped=skipped)
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -47,7 +47,7 @@ from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, 
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context.privacy_scan import (
     raise_or_collect,
-    scan_artifact_tree,
+    scan_text_content,
 )
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
@@ -92,17 +92,19 @@ class CommandParseError(ValueError):
     """Raised when a canonical command file cannot be parsed."""
 
 
-def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashCommand:
-    """Parse a canonical command file into a :class:`SlashCommand`.
-
-    ``layout`` selects the default-name fallback when the frontmatter omits
-    ``name``: ``"flat"`` (legacy ``commands/<name>.md``) uses ``path.stem``;
-    ``"dir"`` (ADR-0008 ``commands/<name>/command.md``) uses
-    ``path.parent.name``.
+def _parse_canonical_command_text(
+    content: str,
+    *,
+    source: Path,
+    layout: Layout = "flat",
+) -> SlashCommand:
+    """Parse already-loaded canonical command text. Used by both the path-based
+    :func:`parse_canonical_command` (back-compat) and the sync flow that
+    captures bytes once to close the scan→write TOCTOU window
+    (PR-E3 Codex review fold).
     """
-    default_name = path.parent.name if layout == "dir" else path.stem
+    default_name = source.parent.name if layout == "dir" else source.stem
 
-    content = path.read_text(encoding="utf-8")
     # Share agents.py's CRLF normalization — the shared ``_FRONT_MATTER_RE``
     # anchors on ``\n`` only, so a CRLF file would otherwise parse as "no
     # frontmatter" and silently fall through to the filename-based default.
@@ -115,7 +117,7 @@ def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashComm
         try:
             stem = validate_name(default_name, kind="command name")
         except InvalidNameError as exc:
-            raise CommandParseError(f"{exc} (source: {path})") from exc
+            raise CommandParseError(f"{exc} (source: {source})") from exc
         return SlashCommand(name=stem, description="", body=body)
 
     frontmatter = _parse_flat_yaml(m.group(1))
@@ -125,7 +127,7 @@ def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashComm
     try:
         name = validate_name(name, kind="command name")
     except InvalidNameError as exc:
-        raise CommandParseError(f"{exc} (source: {path})") from exc
+        raise CommandParseError(f"{exc} (source: {source})") from exc
     description = str(frontmatter.get("description") or "")
     argument_hint_raw = frontmatter.get("argument-hint") or frontmatter.get("argument_hint")
     allowed_tools_raw = frontmatter.get("allowed-tools") or frontmatter.get("allowed_tools")
@@ -156,6 +158,18 @@ def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashComm
         allowed_tools=allowed_tools,
         model=(str(frontmatter["model"]) if frontmatter.get("model") else None),
     )
+
+
+def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashCommand:
+    """Parse a canonical command file into a :class:`SlashCommand`.
+
+    ``layout`` selects the default-name fallback when the frontmatter omits
+    ``name``: ``"flat"`` (legacy ``commands/<name>.md``) uses ``path.stem``;
+    ``"dir"`` (ADR-0008 ``commands/<name>/command.md``) uses
+    ``path.parent.name``.
+    """
+    content = path.read_text(encoding="utf-8")
+    return _parse_canonical_command_text(content, source=path, layout=layout)
 
 
 def list_canonical_commands(
@@ -412,8 +426,17 @@ def generate_all_commands(
             skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
             continue
         for cmd_path, layout in canonicals:
+            # PR-E3 Codex review fold: read canonical bytes ONCE and use
+            # the captured buffer for both Gate A scan AND parse, closing
+            # the scan→write TOCTOU window (mirror of agents.py logic).
             try:
-                cmd = parse_canonical_command(cmd_path, layout=layout)
+                cmd_bytes = cmd_path.read_bytes()
+            except OSError as exc:
+                skipped.append((cmd_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                continue
+            cmd_text = cmd_bytes.decode("utf-8", errors="replace")
+            try:
+                cmd = _parse_canonical_command_text(cmd_text, source=cmd_path, layout=layout)
             except CommandParseError as exc:
                 skipped.append((cmd_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
                 continue
@@ -433,46 +456,51 @@ def generate_all_commands(
                     )
                 )
                 continue
-            # ADR-0011 PR-E3 Gate A — scan canonical command bytes BEFORE
-            # render. Mirrors the agents.py flow; project_shared raises,
-            # user/project_local skip-warns. See agents.py block-comment
-            # for the strict=true ordering rationale.
-            scan = scan_artifact_tree(
-                cmd_path,
+            # ADR-0011 PR-E3 Gate A — scan the IN-MEMORY canonical bytes
+            # (same buffer the parse used). Mirrors the agents.py flow.
+            file_scan = scan_text_content(
+                cmd_text,
+                source_path=cmd_path,
                 surface="cli_context_sync",
                 scope=scope,
                 project_root=project_root,
-                on_blocked="fail_fast",
             )
-            if scan.blocked:
+            if file_scan.decision in ("blocked", "blocked_project_shared"):
                 code, reason = raise_or_collect(
-                    scan.blocked[0],
+                    file_scan,
                     scope=scope,
                     kind="command",
                     artifact_name=cmd.name,
                 )
                 skipped.append((cmd.name, reason, code))
                 continue
-            # Resolve per-vendor override and scan its bytes — override
-            # replaces canonical at write time so unscanned-override
-            # would silently bypass Gate A.
+            # Resolve per-vendor override and scan its bytes — read once,
+            # scan once, write the same buffer.
             vendor = GENERATOR_VENDOR.get(target)
-            override_path: Path | None = None
+            override_bytes: bytes | None = None
             if vendor is not None:
                 override_path = _override.resolve(
                     project_root, "commands", cmd.name, vendor, scope=scope
                 )
                 if override_path is not None:
-                    scan_override = scan_artifact_tree(
-                        override_path,
+                    try:
+                        override_bytes = override_path.read_bytes()
+                    except OSError as exc:
+                        skipped.append(
+                            (cmd.name, f"override unreadable: {exc}", skip_codes.PARSE_ERROR)
+                        )
+                        continue
+                    override_text = override_bytes.decode("utf-8", errors="replace")
+                    file_scan = scan_text_content(
+                        override_text,
+                        source_path=override_path,
                         surface="cli_context_sync",
                         scope=scope,
                         project_root=project_root,
-                        on_blocked="fail_fast",
                     )
-                    if scan_override.blocked:
+                    if file_scan.decision in ("blocked", "blocked_project_shared"):
                         code, reason = raise_or_collect(
-                            scan_override.blocked[0],
+                            file_scan,
                             scope=scope,
                             kind="command",
                             artifact_name=cmd.name,
@@ -488,9 +516,9 @@ def generate_all_commands(
                 if effective_drop == "warn":
                     logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
             atomic_write_text(out_path, content)
-            # Both canonical and override bytes have passed Gate A above.
-            if override_path is not None:
-                atomic_write_bytes(out_path, override_path.read_bytes())
+            # Use the SAME captured override buffer that passed Gate A.
+            if override_bytes is not None:
+                atomic_write_bytes(out_path, override_bytes)
             generated.append((target, out_path))
             if dropped_fields:
                 dropped.append((target, cmd.name, dropped_fields))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -44,7 +44,7 @@ from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
-from memtomem.context._runtime_targets import runtime_fanout_root
+from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
     _parse_flat_yaml,
@@ -154,15 +154,23 @@ def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashComm
     )
 
 
-def list_canonical_commands(project_root: Path) -> list[tuple[Path, Layout]]:
+def list_canonical_commands(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[Path, Layout]]:
     """Enumerate canonical commands in both flat and directory layouts.
 
     Flat layout (legacy): ``commands/<name>.md``. Directory layout (ADR-0008
     PR-C+): ``commands/<name>/command.md``. When the same name has both
     forms, the directory layout wins and a WARNING is logged so the silent
     flat file is visible.
+
+    ADR-0011 PR-E3: ``scope`` selects the canonical root via
+    :func:`canonical_artifact_dir` (default ``project_shared`` preserves
+    pre-PR-E3 behavior).
     """
-    root = project_root / CANONICAL_COMMAND_ROOT
+    root = canonical_artifact_dir("commands", scope, project_root)
     if not root.is_dir():
         return []
 
@@ -363,6 +371,8 @@ def generate_all_commands(
     runtimes: list[str] | None = None,
     strict: bool = False,
     on_drop: str = "ignore",
+    *,
+    scope: TargetScope = "project_shared",
 ) -> CommandSyncResult:
     """Fan out every canonical command to the requested runtimes.
 
@@ -373,6 +383,9 @@ def generate_all_commands(
             ``"error"`` — raise :class:`StrictDropError` immediately.
         strict: Legacy alias for ``on_drop="error"``. If *both* are supplied,
             ``on_drop`` takes precedence unless it is still the default.
+        scope: ADR-0011 PR-E3 — selects canonical root and runtime
+            fan-out destination. Default ``project_shared`` preserves
+            pre-PR-E3 behavior.
     """
     effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
 
@@ -380,7 +393,7 @@ def generate_all_commands(
     dropped: list[tuple[str, str, list[str]]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
 
-    canonicals = list_canonical_commands(project_root)
+    canonicals = list_canonical_commands(project_root, scope=scope)
     if not canonicals:
         return CommandSyncResult(
             generated=[],
@@ -406,7 +419,7 @@ def generate_all_commands(
             # without invoking ``render`` so a strict caller doesn't raise
             # ``StrictDropError`` for a runtime that has no fan-out by
             # design (the fail-quiet contract).
-            out_path = gen.target_file(project_root, cmd.name)
+            out_path = gen.target_file(project_root, cmd.name, scope=scope)
             if out_path is None:
                 skipped.append(
                     (
@@ -430,11 +443,11 @@ def generate_all_commands(
             # canonical→override window. Same pattern as skills.py:213-220.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
-                # ADR-0011 PR-E: pin scope=project_shared (see agents.py for
-                # the same rationale — default sync must not see draft
-                # project_local overrides).
+                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
+                # to override resolution (same-tier-only lookup; see
+                # agents.py for the mirrored rationale).
                 override_path = _override.resolve(
-                    project_root, "commands", cmd.name, vendor, scope="project_shared"
+                    project_root, "commands", cmd.name, vendor, scope=scope
                 )
                 if override_path is not None:
                     atomic_write_bytes(out_path, override_path.read_bytes())
@@ -692,44 +705,51 @@ def extract_commands_to_canonical(
 # ── Diff: canonical ↔ runtimes ──────────────────────────────────────
 
 
-def _runtime_command_names(gen_name: str, project_root: Path) -> set[str]:
-    """Return the set of command ``stem`` names present on disk for a runtime."""
-    if gen_name == "claude_commands":
-        runtime_root = project_root / ".claude/commands"
-        suffix = ".md"
-    elif gen_name == "gemini_commands":
-        runtime_root = project_root / ".gemini/commands"
-        suffix = ".toml"
-    else:
-        return set()
-    if not runtime_root.is_dir():
-        return set()
-    return {p.stem for p in runtime_root.iterdir() if p.is_file() and p.suffix == suffix}
+# Per-runtime file suffix for commands fan-out. Used by ``diff_commands``
+# to delegate to ``runtime_artifact_names``.
+_COMMAND_RUNTIME_SUFFIX: dict[str, str] = {
+    "claude": ".md",
+    "gemini": ".toml",
+    # Codex: project-tier has no fan-out (RUNTIME_FANOUT_TABLE returns None);
+    # user-tier prompts use ``.md`` per Codex docs.
+    "codex": ".md",
+}
 
 
-def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
+def diff_commands(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[str, str, str]]:
     """Compare canonical commands against every registered runtime.
 
     Returns ``(runtime, command_name, status)`` where status is one of
     ``"in sync"``, ``"out of sync"``, ``"missing target"``,
     ``"missing canonical"``, or ``"parse error"``.
+
+    ADR-0011 PR-E3: ``scope`` selects both the canonical source and the
+    runtime fan-out roots. Default ``project_shared`` preserves
+    pre-PR-E3 behavior.
     """
     results: list[tuple[str, str, str]] = []
     canonical_index = {
         path.parent.name if layout == "dir" else path.stem: (path, layout)
-        for path, layout in list_canonical_commands(project_root)
+        for path, layout in list_canonical_commands(project_root, scope=scope)
     }
     canonical_names = set(canonical_index)
 
     for gen_name, gen in COMMAND_GENERATORS.items():
-        # ADR-0011 PR-E (#891): probe NO_FANOUT for this runtime+scope. The
-        # table lookup ignores the artifact name, so a fixed probe name is
-        # safe. When None, the runtime has no fan-out by design — skip the
-        # whole runtime so canonical-only entries don't surface as
-        # ``missing target`` (the realistic NO_FANOUT shape).
-        if gen.target_file(project_root, "__probe_891__") is None:
+        # ADR-0011 PR-E3 cleanup item #1: query the table directly via
+        # ``runtime_fanout_root``. Earlier code probed with a fixed command
+        # name (``__probe_891__``) which leaked the table-shape assumption
+        # into the call shape — call-shape fragility, not name-independence.
+        runtime = gen_name.split("_", 1)[0]
+        if runtime_fanout_root("commands", runtime, scope, project_root) is None:
             continue
-        runtime_names = _runtime_command_names(gen_name, project_root)
+        suffix = _COMMAND_RUNTIME_SUFFIX.get(runtime, ".md")
+        runtime_names = runtime_artifact_names(
+            "commands", runtime, project_root, scope, file_suffix=suffix
+        )
 
         for name in sorted(canonical_names | runtime_names):
             if name in canonical_names and name not in runtime_names:
@@ -746,14 +766,12 @@ def diff_commands(project_root: Path) -> list[tuple[str, str, str]]:
                 results.append((gen_name, name, "parse error"))
                 continue
             expected, _ = gen.render(cmd)
-            target = gen.target_file(project_root, name)
-            # The upstream NO_FANOUT probe already filters out runtimes
-            # whose ``RUNTIME_FANOUT_TABLE`` entry is ``None``, so this
-            # branch is only reachable if the table lookup is per-name
-            # (which today's table is not). Keep the skip as a defensive
-            # silent fallback so the contract holds regardless.
-            if target is None:
-                continue
+            # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
+            # above guarantees this runtime+scope has a fan-out root, so
+            # ``gen.target_file`` cannot return ``None`` for any name.
+            # Earlier defensive ``if target is None: continue`` removed.
+            target = gen.target_file(project_root, name, scope=scope)
+            assert target is not None  # narrowed by upstream NO_FANOUT guard
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -638,6 +638,20 @@ def _promote_move(staging: Path, dst: Path) -> None:
     os.replace(staging, dst)
 
 
+# Per-(kind, runtime) file suffix for non-skill fan-out cleanup. Source of
+# truth lives next to the generators (``commands._COMMAND_RUNTIME_SUFFIX``
+# / ``agents._AGENT_RUNTIME_SUFFIX``), but importing those introduces a
+# circular-import risk at module load time and would also re-couple
+# migrate.py to internal names. Mirror them verbatim here — a regression
+# guard (``test_e4_runtime_suffix_parity_with_generators``) pins the
+# two-way agreement so a future runtime addition cannot drift the cleanup
+# silently.
+_NON_SKILL_FANOUT_SUFFIX: dict[ArtifactKind, dict[str, str]] = {
+    "agents": {"claude": ".md", "gemini": ".md", "codex": ".toml"},
+    "commands": {"claude": ".md", "gemini": ".toml", "codex": ".md"},
+}
+
+
 def _remove_runtime_fanout_for(
     kind: ArtifactKind,
     name: str,
@@ -647,14 +661,21 @@ def _remove_runtime_fanout_for(
     """Remove runtime fan-out targets for one artifact at one scope.
 
     Best-effort cleanup invoked after a successful canonical move so the
-    pre-migration scope's runtime entries (``~/.claude/agents/foo.md``
-    etc.) do not linger as orphans. Returns the list of removed paths
-    for telemetry / verification.
+    pre-migration scope's runtime entries (``~/.claude/agents/foo.md``,
+    ``~/.gemini/commands/foo.toml``, ``~/.codex/agents/foo.toml`` etc.)
+    do not linger as orphans. Returns the list of removed paths for
+    telemetry / verification.
 
     Walks every known runtime (claude / gemini / codex). Tuples that
     :func:`runtime_fanout_root` reports as ``NO_FANOUT`` are skipped
     (project_local entries, codex commands at project tiers, etc.).
     KeyError surfaces a programming error in the table — fail-loud.
+
+    Per-runtime suffix: agents/codex and commands/gemini write
+    ``.toml``, the other non-skill pairs write ``.md``. The cleanup
+    must use the same suffix the generator used at sync time or the
+    stale artifact survives and the runtime can still discover and
+    invoke the moved-away command/agent (#895 P2 review #2).
     """
     removed: list[Path] = []
     for runtime in ("claude", "gemini", "codex"):
@@ -688,7 +709,8 @@ def _remove_runtime_fanout_for(
                 except OSError as exc:
                     logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
         else:
-            target = root / f"{name}.md"
+            suffix = _NON_SKILL_FANOUT_SUFFIX[kind].get(runtime, ".md")
+            target = root / f"{name}{suffix}"
             if target.is_file():
                 try:
                     target.unlink()

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -6,28 +6,46 @@ installs and reverse-imports left flat-layout files (``agents/<name>.md``)
 on disk. This module classifies and converts those flat assets to the
 dir layout in place.
 
+ADR-0011 PR-E4 extends the same module with :func:`migrate_scope`, which
+moves an existing canonical artifact between ADR-0011 scope tiers
+(``user`` ↔ ``project_shared`` ↔ ``project_local``). The flat→dir path
+and the scope-move path share the dry-run/apply/click-exception
+discipline; they branch on whether ``--to <scope>`` is passed at the CLI
+layer.
+
 Pure module: filesystem + lockfile only, no wiki dependency (ADR-0008
 Invariants 1 / 3). The CLI wrapper in
 :func:`memtomem.cli.context_cmd.migrate_cmd` adds the dry-run preview,
 ``--apply`` gating, and confirmation prompts.
 
-Skills are always directory layout (Agent Skills spec) and are not in
-scope here — :func:`classify_migrate` returns an empty list when invoked
-with ``asset_type="skills"`` and the CLI surfaces a friendly informational
-message rather than an error.
+Skills are always directory layout (Agent Skills spec) so flat→dir
+classification is a no-op for them — :func:`classify_migrate` returns an
+empty list when invoked with ``asset_type="skills"`` and the CLI surfaces
+a friendly informational message rather than an error. Scope-move
+(:func:`migrate_scope`) DOES support skills since their canonical can
+live at any tier per ADR-0011 §3.
 """
 
 from __future__ import annotations
 
+import contextlib
+import errno
 import logging
 import os
+import secrets
 import shutil
-from dataclasses import dataclass
+from contextlib import contextmanager
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Iterator, Literal
 
+import click
+
+from memtomem.config import TargetScope
+from memtomem.context._atomic import _file_lock, _lock_path_for
 from memtomem.context._names import InvalidNameError, validate_name
+from memtomem.context._runtime_targets import runtime_fanout_root
 from memtomem.context.agents import (
     AGENT_DIR_FILENAME,
     CANONICAL_AGENT_ROOT,
@@ -39,17 +57,30 @@ from memtomem.context.commands import (
     list_canonical_commands,
 )
 from memtomem.context.lockfile import Lockfile
+from memtomem.context.privacy_scan import (
+    raise_or_collect,
+    scan_artifact_tree,
+)
+from memtomem.context.scope_resolver import (
+    ArtifactKind,
+    ContextScopeError,
+    canonical_artifact_dir,
+)
+from memtomem.context.skills import SKILL_MANIFEST
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
     "ASSET_DIR_FILENAMES",
     "MIGRATABLE_ASSET_TYPES",
+    "SCOPE_MIGRATABLE_KINDS",
     "MigrateResult",
     "MigrateRow",
+    "MigrateScopeResult",
     "MigrateState",
     "classify_migrate",
     "migrate_one",
+    "migrate_scope",
 ]
 
 
@@ -469,3 +500,479 @@ def _is_within(path: Path, root: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+# ── ADR-0011 PR-E4: scope-tier migration ──────────────────────────────
+
+
+SCOPE_MIGRATABLE_KINDS: tuple[ArtifactKind, ...] = ("agents", "commands", "skills")
+"""Artifact kinds supported by :func:`migrate_scope`.
+
+Memory tier moves stay in :func:`memtomem.cli.context_cmd._memory_migrate_run`
+(chunk-id-stable single-DB rename). The CLI's ``mm context migrate
+memory <src> --from --to`` wires that call through; it does not enter
+this module.
+"""
+
+
+_DIR_MANIFEST: dict[str, str] = {
+    "agents": AGENT_DIR_FILENAME,
+    "commands": COMMAND_DIR_FILENAME,
+    "skills": SKILL_MANIFEST,
+}
+
+
+@dataclass(frozen=True)
+class MigrateScopeResult:
+    """Outcome of one scope-tier migration plan or apply.
+
+    Set ``moved=False`` for dry-run results (preview only). Fatal
+    failures raise :class:`click.ClickException` rather than producing
+    a result — the absence of an ``error`` field is deliberate
+    (Codex review #4 fold: dataclass vs raise hybrid is harder to
+    reason about than "raise on fail, return on success").
+    """
+
+    kind: ArtifactKind
+    name: str
+    from_scope: TargetScope
+    to_scope: TargetScope
+    src_path: Path
+    dst_path: Path
+    layout: Literal["dir", "flat"]
+    moved: bool
+    fanout_cleaned: list[Path] = field(default_factory=list)
+
+
+@contextmanager
+def _acquire_pair_lock(path_a: Path, path_b: Path) -> Iterator[None]:
+    """Acquire two sidecar locks in deterministic sorted order.
+
+    Inverse migrations running concurrently (A: foo user→project_shared,
+    B: foo project_shared→user) would deadlock if each side acquired its
+    src lock first and dst lock second. Sorting by ``str(lock_path)``
+    forces every caller to take the same global order, eliminating the
+    cycle.
+
+    The pair is always two locks; if both arguments resolve to the same
+    sidecar (defensive — only happens when src and dst are the same file,
+    which :func:`migrate_scope` rejects upstream) the second lock is
+    skipped to avoid re-entrancy issues with portalocker on platforms
+    where ``LOCK_EX`` does not nest.
+    """
+    lock_a = _lock_path_for(path_a)
+    lock_b = _lock_path_for(path_b)
+    ordered = sorted([lock_a, lock_b], key=str)
+    if ordered[0] == ordered[1]:
+        with _file_lock(ordered[0]):
+            yield
+        return
+    with _file_lock(ordered[0]), _file_lock(ordered[1]):
+        yield
+
+
+def _stage_move(src: Path, dst_parent: Path, name_hint: str) -> tuple[Path, bool]:
+    """Move *src* into a same-fs staging entry under *dst_parent*.
+
+    Returns ``(staging_path, src_consumed)``. ``src_consumed=True`` when
+    ``os.rename`` succeeded (same-FS fast path) and the source is now
+    gone from disk. ``False`` when EXDEV forced a copy fallback; the
+    caller is responsible for removing the source after a successful
+    promote.
+
+    Cleanup discipline: on any error the staging entry is removed before
+    re-raising so callers do not have to. The src side is never touched
+    on the EXDEV fallback path until the caller signals promote success.
+    """
+    dst_parent.mkdir(parents=True, exist_ok=True)
+    suffix = f"{os.getpid()}-{secrets.token_hex(4)}"
+    staging = dst_parent / f".migrate-{name_hint}-{suffix}.tmp"
+    if staging.exists():
+        # Crashed prior run with a colliding suffix (extremely unlikely
+        # given pid+rand) — leftover is from us; safe to clear.
+        if staging.is_dir():
+            shutil.rmtree(staging)
+        else:
+            staging.unlink()
+    try:
+        os.rename(src, staging)
+    except OSError as exc:
+        if exc.errno != errno.EXDEV:
+            # Non-EXDEV failure (permissions, missing src, etc.) — surface.
+            with contextlib.suppress(OSError):
+                if staging.exists():
+                    if staging.is_dir():
+                        shutil.rmtree(staging, ignore_errors=True)
+                    else:
+                        staging.unlink()
+            raise
+        # EXDEV fallback: copy bytes into staging without touching src.
+        try:
+            if src.is_dir():
+                shutil.copytree(src, staging)
+            else:
+                shutil.copy2(src, staging)
+        except BaseException:
+            if staging.exists():
+                if staging.is_dir():
+                    shutil.rmtree(staging, ignore_errors=True)
+                else:
+                    with contextlib.suppress(OSError):
+                        staging.unlink()
+            raise
+        return staging, False
+    return staging, True
+
+
+def _promote_move(staging: Path, dst: Path) -> None:
+    """Atomic ``os.replace(staging, dst)``; refuse if dst already exists.
+
+    Pre-condition (pinned by :func:`migrate_scope` Row 15 contract): dst
+    must not exist. Re-checking inside the lock window avoids the rare
+    race where the dry-run preview observed an empty dst but an external
+    actor created one before the apply phase took the lock.
+    """
+    if dst.exists():
+        raise FileExistsError(f"destination already exists: {dst}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    os.replace(staging, dst)
+
+
+def _remove_runtime_fanout_for(
+    kind: ArtifactKind,
+    name: str,
+    scope: TargetScope,
+    project_root: Path | None,
+) -> list[Path]:
+    """Remove runtime fan-out targets for one artifact at one scope.
+
+    Best-effort cleanup invoked after a successful canonical move so the
+    pre-migration scope's runtime entries (``~/.claude/agents/foo.md``
+    etc.) do not linger as orphans. Returns the list of removed paths
+    for telemetry / verification.
+
+    Walks every known runtime (claude / gemini / codex). Tuples that
+    :func:`runtime_fanout_root` reports as ``NO_FANOUT`` are skipped
+    (project_local entries, codex commands at project tiers, etc.).
+    KeyError surfaces a programming error in the table — fail-loud.
+    """
+    removed: list[Path] = []
+    for runtime in ("claude", "gemini", "codex"):
+        try:
+            root = runtime_fanout_root(kind, runtime, scope, project_root)
+        except KeyError:
+            # Unknown (kind, runtime, scope) tuple — table gap. Skip
+            # rather than fail the migration (canonical is already
+            # moved at this point); the table is the contract source-
+            # of-truth and a missing tuple should be caught by the
+            # unit tests on _runtime_targets, not here.
+            logger.warning(
+                "fanout cleanup: no table entry for (%s, %s, %s); skipping",
+                kind,
+                runtime,
+                scope,
+            )
+            continue
+        if root is None:
+            continue
+        if kind == "skills":
+            target = root / name
+            if target.is_symlink():
+                # Defensive: never follow / rmtree a symlink — could
+                # point outside the runtime root.
+                continue
+            if target.is_dir():
+                try:
+                    shutil.rmtree(target)
+                    removed.append(target)
+                except OSError as exc:
+                    logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
+        else:
+            target = root / f"{name}.md"
+            if target.is_file():
+                try:
+                    target.unlink()
+                    removed.append(target)
+                except OSError as exc:
+                    logger.warning("fanout cleanup: failed to remove %s: %s", target, exc)
+    return removed
+
+
+def _detect_source_scope(
+    kind: ArtifactKind,
+    name: str,
+    project_root: Path,
+    explicit_from: TargetScope | None,
+) -> tuple[TargetScope, Path, Literal["dir", "flat"]]:
+    """Locate the unique scope where *name*'s canonical lives.
+
+    Uses :func:`canonical_artifact_dir` + on-disk probes (NOT
+    ``list_canonical_*`` because PR-E4 only operates on a single name:
+    listing the whole tree just to filter is wasteful, and we still want
+    to surface flat-layout legacy entries). Returns
+    ``(scope, src_path, layout)`` where ``src_path`` is the directory or
+    file to move:
+
+    - ``layout="dir"``  → ``src_path = <canonical_root> / <name>``
+      (the directory that contains the manifest file).
+    - ``layout="flat"`` → ``src_path = <canonical_root> / f"{name}.md"``
+      (a single legacy file). Skills never have flat layout.
+
+    When ``explicit_from`` is set, only that scope is checked and a miss
+    raises with a scope-specific message. Otherwise all three scopes are
+    checked and ambiguity (>1 match) raises with the candidate list so
+    the user can disambiguate via ``--from``.
+    """
+    candidates: list[tuple[TargetScope, Path, Literal["dir", "flat"]]] = []
+    scopes_to_check: tuple[TargetScope, ...]
+    if explicit_from is not None:
+        scopes_to_check = (explicit_from,)
+    else:
+        scopes_to_check = ("user", "project_shared", "project_local")
+    manifest = _DIR_MANIFEST[kind]
+    for s in scopes_to_check:
+        try:
+            root = canonical_artifact_dir(kind, s, project_root)
+        except ContextScopeError:
+            continue
+        if not root.is_dir():
+            continue
+        dir_candidate = root / name
+        if dir_candidate.is_dir() and (dir_candidate / manifest).is_file():
+            candidates.append((s, dir_candidate, "dir"))
+            continue  # dir wins over flat — same convention as list_canonical_*
+        if kind == "skills":
+            # Skills have no flat layout; probe stops here.
+            continue
+        flat_candidate = root / f"{name}.md"
+        if flat_candidate.is_file():
+            candidates.append((s, flat_candidate, "flat"))
+
+    if not candidates:
+        if explicit_from is not None:
+            raise click.ClickException(f"{kind}/{name} not found at scope='{explicit_from}'.")
+        raise click.ClickException(
+            f"{kind}/{name} not found in any scope (user / project_shared / project_local)."
+        )
+    if len(candidates) > 1:
+        listed = ", ".join(f"{s} ({p})" for s, p, _ in candidates)
+        raise click.ClickException(
+            f"{kind}/{name} exists in multiple scopes: {listed}. "
+            f"Pass --from <scope> to disambiguate."
+        )
+    return candidates[0]
+
+
+def migrate_scope(
+    kind: ArtifactKind,
+    name: str,
+    *,
+    from_scope: TargetScope | None,
+    to_scope: TargetScope,
+    project_root: Path,
+    apply_: bool,
+) -> MigrateScopeResult:
+    """Move a canonical artifact between ADR-0011 scope tiers.
+
+    Pure module entry point — no Click prompts, no stdout writes; the
+    CLI wrapper in :mod:`memtomem.cli.context_cmd` owns all user-facing
+    output. Errors raise :class:`click.ClickException` so the wrapper
+    can re-raise verbatim.
+
+    Apply sequence:
+
+    1. Auto-detect or validate ``from_scope`` via
+       :func:`_detect_source_scope`; reject same-source-as-target.
+    2. Resolve ``dst_path`` (mirrors src layout — dir or flat).
+    3. Dry-run gate — return the plan without touching disk if
+       ``apply_=False``.
+    4. Refuse on dst conflict (PR-E4 Row 15: ``--force`` does not
+       overwrite scope-tier targets; replace verb is a follow-up).
+    5. Acquire src + dst sidecar locks in sorted order
+       (:func:`_acquire_pair_lock`).
+    6. Stage src → ``<dst.parent>/.migrate-<name>-<pid>-<rand>.tmp``
+       via rename; fall back to copytree on EXDEV.
+    7. Gate A scan on staging when ``to_scope == project_shared``.
+       Block raises :class:`click.ClickException` with the standard
+       project_shared block message; rollback puts src back.
+    8. Promote staging → dst via ``os.replace``.
+    9. EXDEV cleanup (rmtree src) when the rename fell back.
+    10. Best-effort cleanup of stale src runtime fan-out targets
+        (``~/.claude/agents/<name>.md`` etc.) — outside the lock so a
+        partial cleanup failure does not roll back the canonical move.
+
+    Returns:
+        :class:`MigrateScopeResult` with ``moved=True`` on apply
+        success, ``moved=False`` on dry-run, and ``fanout_cleaned``
+        listing every runtime path removed.
+    """
+    if kind not in SCOPE_MIGRATABLE_KINDS:
+        raise click.ClickException(
+            f"unsupported kind for scope migration: {kind!r} (use one of {SCOPE_MIGRATABLE_KINDS})"
+        )
+    validate_name(name, kind=f"{kind[:-1]} name")
+    if from_scope is not None and from_scope == to_scope:
+        raise click.ClickException("--from and --to must differ.")
+
+    project_root = Path(project_root).expanduser().resolve()
+
+    src_scope, src_path, layout = _detect_source_scope(kind, name, project_root, from_scope)
+    if src_scope == to_scope:
+        raise click.ClickException(f"{kind}/{name} is already at scope='{to_scope}' (no-op).")
+
+    dst_root = canonical_artifact_dir(kind, to_scope, project_root)
+    dst_path = dst_root / name if layout == "dir" else dst_root / f"{name}.md"
+
+    # Pre-flight conflict check (also re-checked inside the lock).
+    if dst_path.exists():
+        raise click.ClickException(
+            f"destination already exists: {dst_path}. "
+            "Resolve manually or remove the existing entry first. "
+            "--force does not overwrite scope-tier targets in PR-E4 "
+            "(replace verb is a follow-up)."
+        )
+
+    if not apply_:
+        # Dry-run: compute plan, no mutation.
+        return MigrateScopeResult(
+            kind=kind,
+            name=name,
+            from_scope=src_scope,
+            to_scope=to_scope,
+            src_path=src_path,
+            dst_path=dst_path,
+            layout=layout,
+            moved=False,
+        )
+
+    # ── apply path ───────────────────────────────────────────────────
+    with _acquire_pair_lock(src_path, dst_path):
+        # Re-check dst inside the lock window — some other process could
+        # have created it between the dry-run preview and the apply
+        # phase, even with our own lock-pair held (the writer would have
+        # had to take the same lock, but check defensively).
+        if dst_path.exists():
+            raise click.ClickException(f"destination appeared during lock acquire: {dst_path}.")
+
+        staging, src_consumed = _stage_move(src_path, dst_path.parent, name_hint=name)
+
+        try:
+            # Gate A on the staged content if landing in project_shared.
+            # The scan runs against staging (the bytes about to be
+            # promoted), not against src — so any in-flight edits caught
+            # mid-rename are still scanned.
+            if to_scope == "project_shared":
+                scan = scan_artifact_tree(
+                    staging,
+                    surface="cli_context_migrate",
+                    scope=to_scope,
+                    project_root=project_root,
+                    on_blocked="fail_fast",
+                )
+                if scan.blocked:
+                    # Raise — project_shared has no force valve in PR-E4
+                    # (mirrors PR-D memory-migrate and PR-E3 sync-side).
+                    raise_or_collect(
+                        scan.blocked[0],
+                        scope=to_scope,
+                        kind=kind[:-1],
+                        artifact_name=name,
+                    )
+
+            _promote_move(staging, dst_path)
+        except BaseException:
+            # Roll back: put bytes back at src so the caller can retry
+            # without manual cleanup.
+            #
+            # The cleanup rule is: staging is deleted only when we KNOW
+            # the bytes are safe elsewhere. There are exactly three safe
+            # cases; everything else preserves staging as a recovery copy
+            # and logs a loud ERROR pointing the user at it.
+            #
+            # Codex review #1 fold caught the "rename-back fails →
+            # staging gets deleted" path. Re-review then caught a
+            # subtler one: ``not src_path.exists()`` was a TOCTOU — an
+            # external writer (``mm context install``, a manual file op,
+            # any tool that does not take our sidecar lock) can recreate
+            # ``src_path`` between our ``os.rename`` and rollback. The
+            # old guard would skip rename-back (src "already there") and
+            # the cleanup branch would delete staging anyway, even
+            # though the bytes at src now belong to someone else.
+            cleanup_staging = False
+            if not src_consumed:
+                # EXDEV fallback: src was never consumed, staging is
+                # just a copy. Safe to drop.
+                cleanup_staging = True
+            elif src_path.exists():
+                # Same-FS path consumed src, but src has reappeared —
+                # not by us. Don't overwrite the new src bytes; don't
+                # delete staging either. User reconciles manually.
+                logger.error(
+                    "migrate_scope rollback: src %s reappeared during apply "
+                    "(another writer outside our lock); preserving staging "
+                    "at %s as a recovery copy — manual reconciliation "
+                    "required.",
+                    src_path,
+                    staging,
+                )
+            elif staging.exists():
+                # Same-FS path consumed src; src is gone as expected;
+                # try the rename-back. Success consumes staging (cleanup
+                # is a no-op then); failure preserves staging.
+                try:
+                    os.replace(staging, src_path)
+                    cleanup_staging = True
+                except OSError as exc:
+                    logger.error(
+                        "migrate_scope rollback: rename-back failed (%s); "
+                        "staging at %s is the ONLY surviving copy of the "
+                        "source bytes — manual recovery required (mv it "
+                        "back to %s).",
+                        exc,
+                        staging,
+                        src_path,
+                    )
+            # else: src_consumed and staging is gone too — nothing to do.
+
+            if cleanup_staging and staging.exists():
+                if staging.is_dir():
+                    shutil.rmtree(staging, ignore_errors=True)
+                else:
+                    with contextlib.suppress(OSError):
+                        staging.unlink()
+            raise
+
+        # EXDEV cleanup — promoted dst now holds the bytes; src copy is
+        # stale and must be removed for the migration to be complete.
+        if not src_consumed and src_path.exists():
+            try:
+                if src_path.is_dir():
+                    shutil.rmtree(src_path)
+                else:
+                    src_path.unlink()
+            except OSError as exc:
+                # Canonical is migrated; src cleanup failed. Surface but
+                # don't roll back the canonical move (would re-create
+                # the duplicate state we just resolved). User can re-run
+                # — _detect_source_scope will then see only src and
+                # treat it as the source for a re-migrate.
+                logger.warning(
+                    "EXDEV cleanup: failed to remove stale src %s: %s",
+                    src_path,
+                    exc,
+                )
+
+    # Lock released. Cleanup stale src runtime fan-out (best-effort).
+    fanout_cleaned = _remove_runtime_fanout_for(kind, name, src_scope, project_root)
+
+    return MigrateScopeResult(
+        kind=kind,
+        name=name,
+        from_scope=src_scope,
+        to_scope=to_scope,
+        src_path=src_path,
+        dst_path=dst_path,
+        layout=layout,
+        moved=True,
+        fanout_cleaned=fanout_cleaned,
+    )

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -73,6 +73,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "ASSET_DIR_FILENAMES",
     "MIGRATABLE_ASSET_TYPES",
+    "MigratePartialError",
     "SCOPE_MIGRATABLE_KINDS",
     "MigrateResult",
     "MigrateRow",
@@ -82,6 +83,30 @@ __all__ = [
     "migrate_one",
     "migrate_scope",
 ]
+
+
+class MigratePartialError(Exception):
+    """Raised when a scope-tier migrate cannot be cleanly completed.
+
+    Specifically raised by the EXDEV-fallback path when the canonical
+    has been copied to ``dst`` but the original ``src`` cannot be
+    removed (permissions, open file handle, etc.). Both canonicals
+    are now on disk; the next ``mm context sync`` at the source
+    scope would recreate runtime fan-out at the old tier from the
+    stale ``src``, producing duplicate-scope ambiguity that
+    ``_detect_source_scope`` cannot resolve (#895 P2 review #5).
+
+    The error carries both paths so the caller (CLI / web / MCP)
+    can surface a remediation hint pointing at the file the user
+    needs to remove manually. Translation to surface-native errors
+    follows the same pattern as :class:`PrivacyScanError`.
+    """
+
+    def __init__(self, message: str, *, src_path: Path, dst_path: Path) -> None:
+        super().__init__(message)
+        self.message = message
+        self.src_path = src_path
+        self.dst_path = dst_path
 
 
 MigrateState = Literal[
@@ -973,16 +998,31 @@ def migrate_scope(
                 else:
                     src_path.unlink()
             except OSError as exc:
-                # Canonical is migrated; src cleanup failed. Surface but
-                # don't roll back the canonical move (would re-create
-                # the duplicate state we just resolved). User can re-run
-                # — _detect_source_scope will then see only src and
-                # treat it as the source for a re-migrate.
-                logger.warning(
+                # Canonical is at dst but src cleanup failed — both
+                # canonicals are on disk. Rolling back dst would just
+                # restore the duplicate state we just resolved (and the
+                # bytes at src are presumably the same — copy succeeded).
+                # Instead, surface as a hard error so the caller does
+                # NOT report "moved" and does NOT proceed to fan-out
+                # cleanup. Without this fail-loud, the next
+                # ``mm context sync`` at src_scope would recreate runtime
+                # fan-out from the stale src (#895 P2 review #5).
+                logger.error(
                     "EXDEV cleanup: failed to remove stale src %s: %s",
                     src_path,
                     exc,
                 )
+                raise MigratePartialError(
+                    f"Migrate {kind}/{name}: canonical copied to {dst_path} but "
+                    f"failed to remove stale source at {src_path} (errno={exc.errno}). "
+                    f"Both canonicals now exist on disk. Remove {src_path} manually, "
+                    f"then run `mm context sync --scope {to_scope}` to refresh "
+                    f"runtime fan-out at the new tier. Until then, do NOT run "
+                    f"`mm context sync --scope {src_scope}` — it would recreate "
+                    f"runtime fan-out from the stale source.",
+                    src_path=src_path,
+                    dst_path=dst_path,
+                ) from exc
 
     # Lock released. Cleanup stale src runtime fan-out (best-effort).
     fanout_cleaned = _remove_runtime_fanout_for(kind, name, src_scope, project_root)

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -127,10 +127,13 @@ def scan_artifact_tree(
     Args:
         src: Either a single file (agents/commands canonical entry) or a
             directory tree (skill staging directory). When a directory,
-            every regular file under it is scanned in sorted order; binary
-            files (``UnicodeDecodeError`` on UTF-8 decode) are recorded
-            with ``decision="pass"`` since the regex-based pattern set
-            cannot match non-text payloads.
+            every regular file under it is scanned in sorted order.
+            Bytes are decoded with ``errors="replace"`` (mirrors the
+            import side, ``_gate_a.gate_a_text_content``) so an ASCII
+            secret embedded in an otherwise-undecodable blob still
+            blocks — replacement chars (U+FFFD) cannot themselves
+            match the ASCII-only regex pattern set, so this does not
+            create false positives on benign binary assets.
         surface: Audit-log surface tag — typically ``"cli_context_sync"``.
             Used by :func:`enforce_write_guard` to attribute the outcome
             to the calling code path.
@@ -161,14 +164,16 @@ def scan_artifact_tree(
     for path in files:
         audit_context: dict[str, object] = {**audit_context_base, "path": str(path)}
         try:
-            text = path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            # Binary asset (PNG, etc.): out of scope for the regex-based
-            # pattern set. Recording as ``pass`` is safe-by-default —
-            # ASCII-only character classes in the pattern set cannot
-            # match non-text payloads.
-            decisions.append(FileScan(path, "pass", 0))
-            continue
+            # Decode with ``errors="replace"`` so non-UTF8 bytes cannot
+            # mask an embedded ASCII secret. A binary blob that happens
+            # to carry ``AKIA...`` / ``sk-...`` bytes between
+            # undecodable garbage would otherwise short-circuit to
+            # ``pass`` (#895 P1 review #4); the regex pattern set is
+            # ASCII-only so individual replacement characters (U+FFFD)
+            # cannot themselves match, and ASCII byte values survive
+            # the decode unchanged. Mirrors the import-side contract
+            # documented in ``_gate_a.gate_a_text_content``.
+            text = path.read_bytes().decode("utf-8", errors="replace")
         except OSError as exc:
             # Read failure (permissions, transient I/O, missing file).
             # Pre-PR-E4 review this was conflated with UnicodeDecodeError

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -273,18 +273,26 @@ def format_scan_block_message(
         scope: Destination scope. Always ``"project_shared"`` in
             practice; other scopes never invoke this helper.
         kind: Singular display noun ("agent" / "skill" / "command").
+            Used as-is in the prose; pluralised to "<kind>s" inside
+            the embedded ``mm context migrate`` command because that
+            CLI only accepts the plural choices ``agents`` /
+            ``commands`` / ``skills`` / ``memory`` (#895 P2 review #3
+            — the pre-fix hint produced ``mm context migrate agent ...``
+            and tripped Click's invalid-choice error when users
+            followed the remediation).
         artifact_name: The artifact's canonical name when known (e.g.
             "leak"). Used in the remediation hint —
-            ``mm context migrate <kind> <artifact_name> ...``. ``None``
+            ``mm context migrate <kind>s <artifact_name> ...``. ``None``
             falls back to a generic hint.
 
     Returns:
         Multi-line string carried by :class:`PrivacyBlockedError`.
     """
+    cli_kind = f"{kind}s"  # singular → plural for the migrate CLI choice
     target_hint = (
-        f"mm context migrate {kind} {artifact_name} --to project_local"
+        f"mm context migrate {cli_kind} {artifact_name} --to project_local"
         if artifact_name is not None
-        else f"mm context migrate {kind} <name> --to project_local"
+        else f"mm context migrate {cli_kind} <name> --to project_local"
     )
     return (
         f"Gate A: {blocked.path.name} contains {blocked.hits_count} privacy "

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -129,6 +129,49 @@ def scan_artifact_tree(
     return ScanResult(decisions=decisions, blocked=blocked)
 
 
+def scan_text_content(
+    text: str,
+    *,
+    source_path: Path,
+    surface: str,
+    scope: TargetScope,
+    project_root: Path | None,
+) -> FileScan:
+    """Scan an already-loaded content string against :func:`enforce_write_guard`.
+
+    Distinct from :func:`scan_artifact_tree` (which opens the path
+    itself): callers that have already read the bytes pass the in-memory
+    text here and use the SAME bytes for the downstream parse / write.
+    Closes the scan→read TOCTOU window flagged by Codex review on the
+    PR-E3 commit (concurrent edit between scan and write would otherwise
+    let unscanned bytes fan out).
+
+    ``force_unsafe`` is hardcoded ``False`` per ADR §5 (sync has no
+    escape valve regardless of scope).
+
+    Returns a :class:`FileScan` with the path attribution preserved for
+    downstream messaging; caller branches on
+    ``decision in ("blocked", "blocked_project_shared")`` and feeds the
+    result through :func:`raise_or_collect`.
+    """
+    audit_context: dict[str, object] = {
+        "kind": "sync",
+        "scope": scope,
+        "path": str(source_path),
+    }
+    if project_root is not None:
+        audit_context["project_root"] = str(project_root)
+    guard = privacy.enforce_write_guard(
+        text,
+        surface=surface,
+        force_unsafe=False,
+        scope=scope,
+        audit_context=audit_context,
+        record_outcome=True,
+    )
+    return FileScan(source_path, guard.decision, len(guard.hits))
+
+
 def format_scan_block_message(
     blocked: FileScan,
     *,

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -23,11 +23,70 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal, NamedTuple
 
-import click
-
 from memtomem import privacy
 from memtomem.config import TargetScope
 from memtomem.context import _skip_reasons as skip_codes
+
+
+class PrivacyScanError(Exception):
+    """Umbrella for sync-side privacy scan failures across surfaces.
+
+    Surfaced as a plain ``Exception`` (not ``click.ClickException``)
+    so non-CLI callers — web routes, MCP context tool — can catch and
+    render in their native error shape (HTTP 422, structured tool
+    response) instead of falling through to the generic 500 handler.
+    The CLI sub-commands wrap their generator calls to translate this
+    back into ``click.ClickException``.
+
+    Concrete subclasses pin which scan stage failed; the message is
+    pre-formatted and safe to surface to the user.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class PrivacyBlockedError(PrivacyScanError):
+    """Raised by :func:`raise_or_collect` for ``project_shared`` privacy hits.
+
+    Carries the formatted user-facing message plus the structured
+    ``FileScan`` and scope context so non-CLI surfaces can render
+    their own error shape. ADR-0011 §5: ``project_shared`` has no
+    force-bypass valve — every caller must hard-refuse.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        blocked: "FileScan",
+        scope: TargetScope,
+        kind: str,
+        artifact_name: str | None,
+    ) -> None:
+        super().__init__(message)
+        self.blocked = blocked
+        self.scope = scope
+        self.kind = kind
+        self.artifact_name = artifact_name
+
+
+class PrivacyScanReadError(PrivacyScanError):
+    """Raised when a file cannot be read during the scan walk.
+
+    Fail-closed counterpart to :class:`PrivacyBlockedError`: an
+    unreadable file cannot be inspected for secrets, so the only
+    safe move is to abort the sync. Migration callers re-rename
+    staging back to ``src``; sync callers remove staging in their
+    ``finally`` block.
+    """
+
+    def __init__(self, message: str, *, path: Path, scope: TargetScope) -> None:
+        super().__init__(message)
+        self.path = path
+        self.scope = scope
+
 
 OnBlocked = Literal["fail_fast", "skip_warn"]
 
@@ -78,7 +137,7 @@ def scan_artifact_tree(
         scope: Destination scope. Determines block-vs-skip semantics
             via the caller's policy (this function only emits
             decisions; the caller branches on
-            ``project_shared`` → :class:`click.ClickException` vs
+            ``project_shared`` → :class:`PrivacyBlockedError` vs
             ``user``/``project_local`` → skip-and-warn).
         project_root: Forwarded to :func:`enforce_write_guard` audit
             context only (privacy itself does not need it). May be
@@ -121,16 +180,18 @@ def scan_artifact_tree(
             # let an unreadable file containing a secret promote into
             # ``project_shared`` with Gate A never inspecting it.
             #
-            # Fail closed: hard-abort the scan with a scope-aware
-            # ClickException. The exception propagates through callers'
+            # Fail closed: hard-abort the scan with a
+            # :class:`PrivacyScanReadError`. The exception propagates through callers'
             # rollback paths (``migrate_scope`` re-renames staging back
             # to src; ``generate_all_skills`` removes staging in its
             # finally block) so no half-promoted state survives.
-            raise click.ClickException(
+            raise PrivacyScanReadError(
                 f"Gate A: cannot read {path} (errno={exc.errno}); refusing to "
                 f"fan-out / migrate to scope='{scope}'. An unreadable file "
                 "cannot be scanned for secrets — fix the permission or "
-                "remove the file before re-running."
+                "remove the file before re-running.",
+                path=path,
+                scope=scope,
             ) from exc
 
         guard = privacy.enforce_write_guard(
@@ -201,7 +262,7 @@ def format_scan_block_message(
     kind: str,
     artifact_name: str | None = None,
 ) -> str:
-    """User-facing :class:`click.ClickException` message for project_shared sync block.
+    """User-facing message body for project_shared sync block.
 
     Mirrors :func:`memtomem.context._gate_a.format_project_shared_block_message`
     but with sync-side wording and ``mm context migrate`` remediation hint.
@@ -218,7 +279,7 @@ def format_scan_block_message(
             falls back to a generic hint.
 
     Returns:
-        Multi-line string suitable for ``raise click.ClickException(...)``.
+        Multi-line string carried by :class:`PrivacyBlockedError`.
     """
     target_hint = (
         f"mm context migrate {kind} {artifact_name} --to project_local"
@@ -246,13 +307,22 @@ def raise_or_collect(
     """Branch on ``scope``: raise for project_shared, return skip tuple otherwise.
 
     Helper to keep the per-call-site branch concise. ``project_shared``
-    always raises :class:`click.ClickException`; ``user`` /
+    always raises :class:`PrivacyBlockedError`; ``user`` /
     ``project_local`` return ``(code, reason)`` for the caller to append
-    to its ``skipped`` list.
+    to its ``skipped`` list. Each calling surface owns the translation
+    (CLI → :class:`click.ClickException`, web → HTTP 422, MCP →
+    structured tool error) so deep generators stay surface-agnostic.
     """
     if scope == "project_shared":
-        raise click.ClickException(
-            format_scan_block_message(blocked, scope=scope, kind=kind, artifact_name=artifact_name)
+        message = format_scan_block_message(
+            blocked, scope=scope, kind=kind, artifact_name=artifact_name
+        )
+        raise PrivacyBlockedError(
+            message,
+            blocked=blocked,
+            scope=scope,
+            kind=kind,
+            artifact_name=artifact_name,
         )
     code: skip_codes.SkipCode = (
         skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -103,13 +103,35 @@ def scan_artifact_tree(
         audit_context: dict[str, object] = {**audit_context_base, "path": str(path)}
         try:
             text = path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, OSError):
-            # Binary asset (PNG, etc.) or transient read failure: out of
-            # scope for the regex-based pattern set. Recording as ``pass``
-            # is safe-by-default — false negatives are bounded by the
-            # pattern set's ASCII-only character classes.
+        except UnicodeDecodeError:
+            # Binary asset (PNG, etc.): out of scope for the regex-based
+            # pattern set. Recording as ``pass`` is safe-by-default —
+            # ASCII-only character classes in the pattern set cannot
+            # match non-text payloads.
             decisions.append(FileScan(path, "pass", 0))
             continue
+        except OSError as exc:
+            # Read failure (permissions, transient I/O, missing file).
+            # Pre-PR-E4 review this was conflated with UnicodeDecodeError
+            # and recorded as ``pass`` — but ``UnicodeDecodeError`` reads
+            # the bytes (regex would have nothing to match), while
+            # ``OSError`` means we never even saw the bytes. PR-E4's
+            # ``_stage_move`` can rename a ``chmod 000`` canonical file
+            # into staging without reading it, so silent-pass would have
+            # let an unreadable file containing a secret promote into
+            # ``project_shared`` with Gate A never inspecting it.
+            #
+            # Fail closed: hard-abort the scan with a scope-aware
+            # ClickException. The exception propagates through callers'
+            # rollback paths (``migrate_scope`` re-renames staging back
+            # to src; ``generate_all_skills`` removes staging in its
+            # finally block) so no half-promoted state survives.
+            raise click.ClickException(
+                f"Gate A: cannot read {path} (errno={exc.errno}); refusing to "
+                f"fan-out / migrate to scope='{scope}'. An unreadable file "
+                "cannot be scanned for secrets — fix the permission or "
+                "remove the file before re-running."
+            ) from exc
 
         guard = privacy.enforce_write_guard(
             text,

--- a/packages/memtomem/src/memtomem/context/privacy_scan.py
+++ b/packages/memtomem/src/memtomem/context/privacy_scan.py
@@ -1,0 +1,198 @@
+"""ADR-0011 PR-E3 — canonical → runtime sync-side privacy scan.
+
+Sibling of :mod:`memtomem.context._gate_a` (the runtime → canonical
+import-side gate). Both share :func:`memtomem.privacy.enforce_write_guard`
+underneath, but the two surfaces differ on:
+
+* ``surface=`` string — ``"cli_context_sync"`` vs ``"cli_context_init"``.
+* ``force_unsafe`` valve — sync has none (ADR §5: canonical → runtime
+  fan-out is a write-amplifying loop, so a single bypass-flagged content
+  would propagate to every registered runtime; the ADR explicitly
+  reserves ``--force-unsafe-import`` for the import direction only).
+* Block-message wording — "fan-out … rejected" vs "import … rejected"
+  with a remediation hint that points at ``mm context migrate`` (the
+  cross-tier move command landing in PR-E4) instead of "retry with a
+  different ``--scope``".
+
+A future PR can fold both surfaces onto a single ``gate_a.py`` once the
+divergence stabilises (see PR-E3 plan §2d Implementer-side note 9).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+import click
+
+from memtomem import privacy
+from memtomem.config import TargetScope
+from memtomem.context import _skip_reasons as skip_codes
+
+OnBlocked = Literal["fail_fast", "skip_warn"]
+
+
+class FileScan(NamedTuple):
+    """Per-file scan result (one entry per visited file in a tree walk)."""
+
+    path: Path
+    decision: str  # "pass" | "blocked" | "blocked_project_shared" | "bypassed"
+    hits_count: int
+
+
+class ScanResult(NamedTuple):
+    """Aggregate result of :func:`scan_artifact_tree`.
+
+    ``decisions`` is the full per-file list (every visited file, including
+    passes — useful for telemetry). ``blocked`` is the convenience
+    subset for callers that only need the failure list.
+    """
+
+    decisions: list[FileScan]
+    blocked: list[FileScan]
+
+
+def scan_artifact_tree(
+    src: Path,
+    *,
+    surface: str,
+    scope: TargetScope,
+    project_root: Path | None,
+    on_blocked: OnBlocked = "fail_fast",
+) -> ScanResult:
+    """Walk ``src`` (file or directory) and run :func:`enforce_write_guard` per file.
+
+    Sync-side privacy gate. ``force_unsafe`` is hardcoded ``False`` —
+    sync has no escape valve regardless of ``scope`` (ADR §5).
+
+    Args:
+        src: Either a single file (agents/commands canonical entry) or a
+            directory tree (skill staging directory). When a directory,
+            every regular file under it is scanned in sorted order; binary
+            files (``UnicodeDecodeError`` on UTF-8 decode) are recorded
+            with ``decision="pass"`` since the regex-based pattern set
+            cannot match non-text payloads.
+        surface: Audit-log surface tag — typically ``"cli_context_sync"``.
+            Used by :func:`enforce_write_guard` to attribute the outcome
+            to the calling code path.
+        scope: Destination scope. Determines block-vs-skip semantics
+            via the caller's policy (this function only emits
+            decisions; the caller branches on
+            ``project_shared`` → :class:`click.ClickException` vs
+            ``user``/``project_local`` → skip-and-warn).
+        project_root: Forwarded to :func:`enforce_write_guard` audit
+            context only (privacy itself does not need it). May be
+            ``None`` for ``scope="user"``.
+        on_blocked: ``"fail_fast"`` returns immediately on the first
+            blocked file (subsequent files are NOT scanned — useful when
+            the caller will raise). ``"skip_warn"`` continues through
+            all files and collects the full block list.
+
+    Returns:
+        :class:`ScanResult` with the per-file ``decisions`` list and the
+        ``blocked`` convenience subset. Callers branch on
+        ``result.blocked`` and ``scope`` to decide raise-vs-skip.
+    """
+    files = [src] if src.is_file() else sorted(p for p in src.rglob("*") if p.is_file())
+    decisions: list[FileScan] = []
+    audit_context_base: dict[str, object] = {"kind": "sync", "scope": scope}
+    if project_root is not None:
+        audit_context_base["project_root"] = str(project_root)
+
+    for path in files:
+        audit_context: dict[str, object] = {**audit_context_base, "path": str(path)}
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            # Binary asset (PNG, etc.) or transient read failure: out of
+            # scope for the regex-based pattern set. Recording as ``pass``
+            # is safe-by-default — false negatives are bounded by the
+            # pattern set's ASCII-only character classes.
+            decisions.append(FileScan(path, "pass", 0))
+            continue
+
+        guard = privacy.enforce_write_guard(
+            text,
+            surface=surface,
+            force_unsafe=False,
+            scope=scope,
+            audit_context=audit_context,
+            record_outcome=True,
+        )
+        scan = FileScan(path, guard.decision, len(guard.hits))
+        decisions.append(scan)
+
+        if guard.decision in ("blocked", "blocked_project_shared") and on_blocked == "fail_fast":
+            return ScanResult(decisions=decisions, blocked=[scan])
+
+    blocked = [d for d in decisions if d.decision in ("blocked", "blocked_project_shared")]
+    return ScanResult(decisions=decisions, blocked=blocked)
+
+
+def format_scan_block_message(
+    blocked: FileScan,
+    *,
+    scope: TargetScope,
+    kind: str,
+    artifact_name: str | None = None,
+) -> str:
+    """User-facing :class:`click.ClickException` message for project_shared sync block.
+
+    Mirrors :func:`memtomem.context._gate_a.format_project_shared_block_message`
+    but with sync-side wording and ``mm context migrate`` remediation hint.
+
+    Args:
+        blocked: First :class:`FileScan` from
+            :attr:`ScanResult.blocked` (caller fail-fasts on first hit).
+        scope: Destination scope. Always ``"project_shared"`` in
+            practice; other scopes never invoke this helper.
+        kind: Singular display noun ("agent" / "skill" / "command").
+        artifact_name: The artifact's canonical name when known (e.g.
+            "leak"). Used in the remediation hint —
+            ``mm context migrate <kind> <artifact_name> ...``. ``None``
+            falls back to a generic hint.
+
+    Returns:
+        Multi-line string suitable for ``raise click.ClickException(...)``.
+    """
+    target_hint = (
+        f"mm context migrate {kind} {artifact_name} --to project_local"
+        if artifact_name is not None
+        else f"mm context migrate {kind} <name> --to project_local"
+    )
+    return (
+        f"Gate A: {blocked.path.name} contains {blocked.hits_count} privacy "
+        f"pattern hit(s); fan-out to scope='{scope}' rejected. git history "
+        f"is forever — no force bypass available for project_shared "
+        f"(ADR-0011 §5).\n"
+        f"  Move the {kind} to a writable tier first:\n"
+        f"    {target_hint}\n"
+        f"  Or remove the secret from {blocked.path} before re-running sync."
+    )
+
+
+def raise_or_collect(
+    blocked: FileScan,
+    *,
+    scope: TargetScope,
+    kind: str,
+    artifact_name: str | None = None,
+) -> tuple[skip_codes.SkipCode, str]:
+    """Branch on ``scope``: raise for project_shared, return skip tuple otherwise.
+
+    Helper to keep the per-call-site branch concise. ``project_shared``
+    always raises :class:`click.ClickException`; ``user`` /
+    ``project_local`` return ``(code, reason)`` for the caller to append
+    to its ``skipped`` list.
+    """
+    if scope == "project_shared":
+        raise click.ClickException(
+            format_scan_block_message(blocked, scope=scope, kind=kind, artifact_name=artifact_name)
+        )
+    code: skip_codes.SkipCode = (
+        skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
+        if blocked.decision == "blocked_project_shared"
+        else skip_codes.PRIVACY_BLOCKED
+    )
+    reason = f"privacy blocked at {blocked.path.name} ({blocked.hits_count} pattern hit(s))"
+    return code, reason

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -22,6 +22,7 @@ import logging
 import os
 import secrets
 import shutil
+from contextlib import ExitStack
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -323,6 +324,76 @@ def generate_all_skills(
         )
 
     targets = runtimes if runtimes is not None else list(SKILL_GENERATORS.keys())
+
+    # ``project_shared`` is a hard-refusal surface: if any skill or
+    # runtime override fails Gate A, no runtime fan-out should be
+    # promoted. Hold all destination locks, stage+scan every final tree,
+    # then promote only after the full batch passes.
+    if scope == "project_shared":
+        work: list[tuple[str, SkillGenerator, Path, Path]] = []
+        for target in targets:
+            gen = SKILL_GENERATORS.get(target)
+            if gen is None:
+                skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
+                continue
+            for skill_dir in canonicals:
+                dst = gen.target_dir(project_root, skill_dir.name, scope=scope)
+                if dst is None:
+                    skipped.append(
+                        (
+                            skill_dir.name,
+                            f"no fan-out for runtime {target} at this scope",
+                            skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+                        )
+                    )
+                    continue
+                work.append((target, gen, skill_dir, dst))
+
+        staged: list[tuple[str, Path, Path]] = []
+        try:
+            with ExitStack() as stack:
+                for lock_path in sorted({_lock_path_for(dst) for _, _, _, dst in work}, key=str):
+                    stack.enter_context(_file_lock(lock_path))
+                for target, _gen, skill_dir, dst in work:
+                    staging = _stage_skill(skill_dir, dst)
+                    staged.append((target, staging, dst))
+
+                    vendor = GENERATOR_VENDOR.get(target)
+                    if vendor is not None:
+                        override_path = _override.resolve(
+                            project_root, "skills", skill_dir.name, vendor, scope=scope
+                        )
+                        if override_path is not None:
+                            atomic_write_bytes(
+                                staging / SKILL_MANIFEST,
+                                override_path.read_bytes(),
+                            )
+
+                    scan = scan_artifact_tree(
+                        staging,
+                        surface="cli_context_sync",
+                        scope=scope,
+                        project_root=project_root,
+                        on_blocked="fail_fast",
+                    )
+                    if scan.blocked:
+                        raise_or_collect(
+                            scan.blocked[0],
+                            scope=scope,
+                            kind="skill",
+                            artifact_name=skill_dir.name,
+                        )
+
+                for target, staging, dst in staged:
+                    _promote_staging(staging, dst)
+                    generated.append((target, dst))
+        finally:
+            for _target, staging, _dst in staged:
+                if staging.exists():
+                    shutil.rmtree(staging, ignore_errors=True)
+
+        return SkillSyncResult(generated=generated, skipped=skipped)
+
     for target in targets:
         gen = SKILL_GENERATORS.get(target)
         if gen is None:

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -19,6 +19,8 @@ frontmatter rewriting without touching callers.
 from __future__ import annotations
 
 import logging
+import os
+import secrets
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -31,6 +33,10 @@ from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
+from memtomem.context.privacy_scan import (
+    raise_or_collect,
+    scan_artifact_tree,
+)
 from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
@@ -178,37 +184,83 @@ def list_canonical_skills(
 # ── Copy primitive ────────────────────────────────────────────────────
 
 
-def copy_skill(src: Path, dst: Path) -> None:
-    """Mirror a skill directory from ``src`` to ``dst``.
+def _stage_skill(src: Path, dst: Path) -> Path:
+    """Mirror ``src`` into a same-fs staging directory under ``dst.parent``.
 
-    ``src`` MUST contain ``SKILL.md``. If ``dst`` already exists and looks like
-    a skill directory (has its own ``SKILL.md``) it is replaced wholesale so
-    that removed files on the source side propagate. If ``dst`` exists but
-    does NOT look like a skill directory, the copy aborts with ``IsADirectoryError``
-    to avoid clobbering something the user put there by hand.
+    Picks ``dst.parent / .staging-<dst.name>-<pid>-<rand>.tmp`` so the
+    eventual promote-step (:func:`_promote_staging`) is a same-fs atomic
+    rename via :func:`os.replace`. Caller is responsible for cleanup on
+    failure (either by promoting into ``dst`` or by ``shutil.rmtree``-ing
+    the staging path).
 
-    Individual files are written atomically via
-    :func:`memtomem.context._atomic.atomic_write_bytes` so a crash mid-copy
-    leaves each file either fully-written or absent, never truncated.
-    Directory-level atomicity (the rmtree+mkdir window) is out of scope here.
+    ``src`` MUST contain ``SKILL.md``. ``dst.parent`` is created if it
+    does not yet exist.
     """
     manifest = src / SKILL_MANIFEST
     if not manifest.is_file():
         raise FileNotFoundError(f"source skill missing {SKILL_MANIFEST}: {src}")
 
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    suffix = f"{os.getpid()}-{secrets.token_hex(3)}"
+    staging = dst.parent / f".staging-{dst.name}-{suffix}.tmp"
+    if staging.exists():
+        # Crashed prior run — collision is unlikely (pid+rand) but if it
+        # happens, the leftover tree is from us; safe to remove.
+        shutil.rmtree(staging)
+    staging.mkdir()
+    copy_tree_atomic(src, staging)
+    return staging
+
+
+def _promote_staging(staging: Path, dst: Path) -> None:
+    """Atomic-replace ``dst`` with ``staging`` (same-fs precondition).
+
+    Cross-platform via :func:`os.replace`. When ``dst`` already exists,
+    moves it aside first then renames staging into place; rolls back on
+    any failure during the swap window (``feedback_stage_before_mutation_revert.md``).
+    """
     if dst.exists():
         if not dst.is_dir():
             raise NotADirectoryError(f"target exists and is not a directory: {dst}")
         if not (dst / SKILL_MANIFEST).is_file() and any(dst.iterdir()):
-            # Non-empty directory that is NOT a skill — refuse to overwrite.
             raise IsADirectoryError(
                 f"refusing to overwrite non-skill directory: {dst} "
                 f"(add a SKILL.md or remove the directory first)"
             )
-        shutil.rmtree(dst)
+        # Move-aside name uses the same {pid}-{rand} discipline as staging
+        # so concurrent runs (different pids) cannot collide.
+        suffix = f"{os.getpid()}-{secrets.token_hex(3)}"
+        old = dst.parent / f".old-{dst.name}-{suffix}.tmp"
+        os.replace(dst, old)
+        try:
+            os.replace(staging, dst)
+        except BaseException:
+            # Roll back: put the original tree back.
+            os.replace(old, dst)
+            raise
+        shutil.rmtree(old, ignore_errors=True)
+    else:
+        os.replace(staging, dst)
 
-    dst.mkdir(parents=True)
-    copy_tree_atomic(src, dst)
+
+def copy_skill(src: Path, dst: Path) -> None:
+    """Mirror a skill directory from ``src`` to ``dst`` via staging-then-promote.
+
+    Thin wrapper kept for callers that don't care about the staging step
+    (no privacy scan, no override merge — pure file copy). E3
+    sync-side flow uses :func:`_stage_skill` + :func:`_promote_staging`
+    directly so it can scan + override-apply between the two halves.
+
+    Individual files are written atomically via
+    :func:`memtomem.context._atomic.atomic_write_bytes`. Directory-level
+    atomicity is now provided by the staging+promote pair.
+    """
+    staging = _stage_skill(src, dst)
+    try:
+        _promote_staging(staging, dst)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
 
 
 # ── Fan-out: canonical → runtimes ─────────────────────────────────────
@@ -277,23 +329,67 @@ def generate_all_skills(
                     )
                 )
                 continue
-            copy_skill(skill_dir, dst)
-            # ADR-0008 Invariant 4: per-vendor override replaces SKILL.md only.
-            # Auxiliary files (scripts/, references/) stay from canonical.
-            vendor = GENERATOR_VENDOR.get(target)
-            if vendor is not None:
-                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
-                # to override resolution (same-tier-only lookup — narrow→broad
-                # is intentionally NOT used for default sync per ADR §4).
-                override_path = _override.resolve(
-                    project_root, "skills", skill_dir.name, vendor, scope=scope
-                )
-                if override_path is not None:
-                    atomic_write_bytes(
-                        dst / SKILL_MANIFEST,
-                        override_path.read_bytes(),
+            # ADR-0011 PR-E3 staging-dir-first scan flow:
+            #   1. _stage_skill — mirror canonical bytes into a same-fs
+            #      staging dir under dst.parent.
+            #   2. Apply vendor SKILL.md override IF any (per-scope, single-
+            #      tier lookup). Auxiliary files (scripts/, references/,
+            #      assets/) stay from canonical — preserves the
+            #      ``test_override_only_touches_skill_md_not_scripts``
+            #      invariant.
+            #   3. scan_artifact_tree — privacy walk against the FINAL
+            #      bytes (canonical + applied override). project_shared
+            #      block raises ClickException; user/project_local block
+            #      collects a skip.
+            #   4. On pass — _promote_staging atomic-replaces dst with
+            #      staging via os.replace (same-fs).
+            #   5. On block or any exception — finally clause removes
+            #      the staging tree without touching dst.
+            staging = _stage_skill(skill_dir, dst)
+            promoted = False
+            try:
+                # 2. Override apply (BEFORE scan — scan must see the bytes
+                # that will be promoted).
+                vendor = GENERATOR_VENDOR.get(target)
+                if vendor is not None:
+                    override_path = _override.resolve(
+                        project_root, "skills", skill_dir.name, vendor, scope=scope
                     )
-            generated.append((target, dst))
+                    if override_path is not None:
+                        atomic_write_bytes(
+                            staging / SKILL_MANIFEST,
+                            override_path.read_bytes(),
+                        )
+                # 3. Scan.
+                scan = scan_artifact_tree(
+                    staging,
+                    surface="cli_context_sync",
+                    scope=scope,
+                    project_root=project_root,
+                    on_blocked="fail_fast",
+                )
+                if scan.blocked:
+                    # raise_or_collect raises ClickException for project_shared;
+                    # otherwise returns (code, reason) and falls through to
+                    # the skip append.
+                    code, reason = raise_or_collect(
+                        scan.blocked[0],
+                        scope=scope,
+                        kind="skill",
+                        artifact_name=skill_dir.name,
+                    )
+                    skipped.append((skill_dir.name, reason, code))
+                else:
+                    # 4. Promote — atomic os.replace into dst.
+                    _promote_staging(staging, dst)
+                    promoted = True
+                    generated.append((target, dst))
+            finally:
+                # 5. Cleanup. Promote consumes staging via rename, so we
+                # only remove it when something else (block/exception)
+                # left it behind.
+                if not promoted and staging.exists():
+                    shutil.rmtree(staging, ignore_errors=True)
 
     return SkillSyncResult(generated=generated, skipped=skipped)
 

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -28,7 +28,12 @@ from typing import Protocol
 
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
-from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
+from memtomem.context._atomic import (
+    _file_lock,
+    _lock_path_for,
+    atomic_write_bytes,
+    copy_tree_atomic,
+)
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
@@ -208,7 +213,16 @@ def _stage_skill(src: Path, dst: Path) -> Path:
         # happens, the leftover tree is from us; safe to remove.
         shutil.rmtree(staging)
     staging.mkdir()
-    copy_tree_atomic(src, staging)
+    # Codex review fold: if ``copy_tree_atomic`` raises after partial
+    # copy, the caller would never see ``staging`` (no return value),
+    # leaving an unscanned partial tree under the runtime fan-out root.
+    # Clean up here before re-raising so Gate A's staging-dir-first
+    # contract holds even on copy failure.
+    try:
+        copy_tree_atomic(src, staging)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        raise
     return staging
 
 
@@ -333,8 +347,10 @@ def generate_all_skills(
             #   1. _stage_skill — mirror canonical bytes into a same-fs
             #      staging dir under dst.parent.
             #   2. Apply vendor SKILL.md override IF any (per-scope, single-
-            #      tier lookup). Auxiliary files (scripts/, references/,
-            #      assets/) stay from canonical — preserves the
+            #      tier lookup) — read override bytes ONCE and reuse them
+            #      so the scan sees the exact bytes that get promoted.
+            #      Auxiliary files (scripts/, references/, assets/) stay
+            #      from canonical — preserves the
             #      ``test_override_only_touches_skill_md_not_scripts``
             #      invariant.
             #   3. scan_artifact_tree — privacy walk against the FINAL
@@ -345,51 +361,60 @@ def generate_all_skills(
             #      staging via os.replace (same-fs).
             #   5. On block or any exception — finally clause removes
             #      the staging tree without touching dst.
-            staging = _stage_skill(skill_dir, dst)
-            promoted = False
-            try:
-                # 2. Override apply (BEFORE scan — scan must see the bytes
-                # that will be promoted).
-                vendor = GENERATOR_VENDOR.get(target)
-                if vendor is not None:
-                    override_path = _override.resolve(
-                        project_root, "skills", skill_dir.name, vendor, scope=scope
-                    )
-                    if override_path is not None:
-                        atomic_write_bytes(
-                            staging / SKILL_MANIFEST,
-                            override_path.read_bytes(),
+            #
+            # Concurrency (PR-E3 Codex review fold): the entire
+            # stage+scan+promote sequence runs inside a sidecar flock at
+            # ``_lock_path_for(dst)`` so two parallel ``mm context sync``
+            # invocations cannot interleave their dst→old→staging→dst
+            # swaps. Without the lock, a second invocation could
+            # recreate ``dst`` between the move-aside and the rename-in,
+            # leaving the rollback path with no clean dst to restore.
+            with _file_lock(_lock_path_for(dst)):
+                staging = _stage_skill(skill_dir, dst)
+                promoted = False
+                try:
+                    # 2. Override apply (BEFORE scan — scan must see the bytes
+                    # that will be promoted).
+                    vendor = GENERATOR_VENDOR.get(target)
+                    if vendor is not None:
+                        override_path = _override.resolve(
+                            project_root, "skills", skill_dir.name, vendor, scope=scope
                         )
-                # 3. Scan.
-                scan = scan_artifact_tree(
-                    staging,
-                    surface="cli_context_sync",
-                    scope=scope,
-                    project_root=project_root,
-                    on_blocked="fail_fast",
-                )
-                if scan.blocked:
-                    # raise_or_collect raises ClickException for project_shared;
-                    # otherwise returns (code, reason) and falls through to
-                    # the skip append.
-                    code, reason = raise_or_collect(
-                        scan.blocked[0],
+                        if override_path is not None:
+                            atomic_write_bytes(
+                                staging / SKILL_MANIFEST,
+                                override_path.read_bytes(),
+                            )
+                    # 3. Scan.
+                    scan = scan_artifact_tree(
+                        staging,
+                        surface="cli_context_sync",
                         scope=scope,
-                        kind="skill",
-                        artifact_name=skill_dir.name,
+                        project_root=project_root,
+                        on_blocked="fail_fast",
                     )
-                    skipped.append((skill_dir.name, reason, code))
-                else:
-                    # 4. Promote — atomic os.replace into dst.
-                    _promote_staging(staging, dst)
-                    promoted = True
-                    generated.append((target, dst))
-            finally:
-                # 5. Cleanup. Promote consumes staging via rename, so we
-                # only remove it when something else (block/exception)
-                # left it behind.
-                if not promoted and staging.exists():
-                    shutil.rmtree(staging, ignore_errors=True)
+                    if scan.blocked:
+                        # raise_or_collect raises ClickException for project_shared;
+                        # otherwise returns (code, reason) and falls through to
+                        # the skip append.
+                        code, reason = raise_or_collect(
+                            scan.blocked[0],
+                            scope=scope,
+                            kind="skill",
+                            artifact_name=skill_dir.name,
+                        )
+                        skipped.append((skill_dir.name, reason, code))
+                    else:
+                        # 4. Promote — atomic os.replace into dst.
+                        _promote_staging(staging, dst)
+                        promoted = True
+                        generated.append((target, dst))
+                finally:
+                    # 5. Cleanup. Promote consumes staging via rename, so we
+                    # only remove it when something else (block/exception)
+                    # left it behind.
+                    if not promoted and staging.exists():
+                        shutil.rmtree(staging, ignore_errors=True)
 
     return SkillSyncResult(generated=generated, skipped=skipped)
 

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -30,7 +30,7 @@ from memtomem.context._atomic import atomic_write_bytes, copy_tree_atomic
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
 from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, validate_name
-from memtomem.context._runtime_targets import runtime_fanout_root
+from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context.scope_resolver import canonical_artifact_dir
 
 logger = logging.getLogger(__name__)
@@ -129,11 +129,25 @@ _register(CodexSkillsGenerator())
 # ── Canonical helpers ─────────────────────────────────────────────────
 
 
-def canonical_skills_root(project_root: Path) -> Path:
-    return project_root / CANONICAL_SKILL_ROOT
+def canonical_skills_root(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> Path:
+    """Return the canonical skills root for ``scope`` (default ``project_shared``).
+
+    Pre-PR-E3 callers (no scope kwarg) keep the old behavior of
+    ``<project_root>/.memtomem/skills`` because that's exactly
+    :func:`canonical_artifact_dir` for ``scope="project_shared"``.
+    """
+    return canonical_artifact_dir("skills", scope, project_root)
 
 
-def list_canonical_skills(project_root: Path) -> list[Path]:
+def list_canonical_skills(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[Path]:
     """Return canonical skill directories sorted by name.
 
     A sub-directory only counts as a skill if it contains ``SKILL.md``. This
@@ -142,8 +156,11 @@ def list_canonical_skills(project_root: Path) -> list[Path]:
 
     Skill directory names are validated; entries that fail
     :func:`memtomem.context._names.validate_name` are skipped with a warning.
+
+    ADR-0011 PR-E3: ``scope`` selects the canonical root via
+    :func:`canonical_skills_root`.
     """
-    root = canonical_skills_root(project_root)
+    root = canonical_skills_root(project_root, scope=scope)
     if not root.is_dir():
         return []
     skills: list[Path] = []
@@ -216,6 +233,8 @@ class SkillSyncResult:
 def generate_all_skills(
     project_root: Path,
     runtimes: list[str] | None = None,
+    *,
+    scope: TargetScope = "project_shared",
 ) -> SkillSyncResult:
     """Fan out every canonical skill to the requested runtime targets.
 
@@ -223,11 +242,14 @@ def generate_all_skills(
         project_root: project root containing ``.memtomem/skills/``.
         runtimes: list of generator names. ``None`` means all registered
             runtimes (currently ``claude_skills`` + ``gemini_skills``).
+        scope: ADR-0011 PR-E3 — selects canonical root and runtime
+            fan-out destination. Default ``project_shared`` preserves
+            pre-PR-E3 behavior.
     """
     generated: list[tuple[str, Path]] = []
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
 
-    canonicals = list_canonical_skills(project_root)
+    canonicals = list_canonical_skills(project_root, scope=scope)
     if not canonicals:
         return SkillSyncResult(
             generated=generated,
@@ -241,12 +263,11 @@ def generate_all_skills(
             skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
             continue
         for skill_dir in canonicals:
-            dst = gen.target_dir(project_root, skill_dir.name)
+            dst = gen.target_dir(project_root, skill_dir.name, scope=scope)
             # ADR-0011 PR-E (#891): None means NO_FANOUT per
             # ``_runtime_targets.RUNTIME_FANOUT_TABLE``. Emit a typed skip
-            # so E3 scope wiring sees graceful behavior. Today's default
-            # scope=project_shared never reaches this branch for registered
-            # generators; the table is the contract source-of-truth.
+            # so E3 scope wiring sees graceful behavior. The table is the
+            # contract source-of-truth.
             if dst is None:
                 skipped.append(
                     (
@@ -261,11 +282,11 @@ def generate_all_skills(
             # Auxiliary files (scripts/, references/) stay from canonical.
             vendor = GENERATOR_VENDOR.get(target)
             if vendor is not None:
-                # ADR-0011 PR-E: pin scope=project_shared (see agents.py for
-                # the same rationale — default sync must not see draft
-                # project_local overrides).
+                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
+                # to override resolution (same-tier-only lookup — narrow→broad
+                # is intentionally NOT used for default sync per ADR §4).
                 override_path = _override.resolve(
-                    project_root, "skills", skill_dir.name, vendor, scope="project_shared"
+                    project_root, "skills", skill_dir.name, vendor, scope=scope
                 )
                 if override_path is not None:
                     atomic_write_bytes(
@@ -453,7 +474,11 @@ def _skill_dirs_equal(a: Path, b: Path) -> bool:
     return True
 
 
-def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
+def diff_skills(
+    project_root: Path,
+    *,
+    scope: TargetScope = "project_shared",
+) -> list[tuple[str, str, str]]:
     """Compare canonical skills against every registered runtime.
 
     Returns a sorted list of ``(runtime, skill_name, status)`` tuples where
@@ -463,25 +488,25 @@ def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
     * ``"out of sync"`` — both sides exist but differ.
     * ``"missing target"`` — canonical has it, runtime does not.
     * ``"missing canonical"`` — runtime has it, canonical does not.
+
+    ADR-0011 PR-E3: ``scope`` selects both the canonical root and the
+    runtime fan-out roots (default ``project_shared``).
     """
     results: list[tuple[str, str, str]] = []
-    canonical_root = canonical_skills_root(project_root)
-    canonical_names = {p.name for p in list_canonical_skills(project_root)}
+    canonical_root = canonical_skills_root(project_root, scope=scope)
+    canonical_names = {p.name for p in list_canonical_skills(project_root, scope=scope)}
 
     for gen_name, gen in SKILL_GENERATORS.items():
-        # ADR-0011 PR-E (#891): probe NO_FANOUT for this runtime+scope. The
-        # table lookup ignores the artifact name, so a fixed probe name is
-        # safe. When None, the runtime has no fan-out by design — skip the
-        # whole runtime so canonical-only entries don't surface as
-        # ``missing target`` (the realistic NO_FANOUT shape).
-        if gen.target_dir(project_root, "__probe_891__") is None:
+        # ADR-0011 PR-E3 cleanup item #1: query the table directly via
+        # ``runtime_fanout_root``. Earlier code probed with a fixed skill
+        # name (``__probe_891__``) which leaked the table-shape assumption
+        # into the call shape — call-shape fragility, not name-independence.
+        runtime = gen_name.split("_", 1)[0]
+        if runtime_fanout_root("skills", runtime, scope, project_root) is None:
             continue
-        runtime_root = project_root / gen.output_root
-        runtime_names: set[str] = set()
-        if runtime_root.is_dir():
-            for entry in runtime_root.iterdir():
-                if entry.is_dir() and (entry / SKILL_MANIFEST).is_file():
-                    runtime_names.add(entry.name)
+        runtime_names = runtime_artifact_names(
+            "skills", runtime, project_root, scope, dir_manifest=SKILL_MANIFEST
+        )
 
         for name in sorted(canonical_names | runtime_names):
             if name in canonical_names and name not in runtime_names:
@@ -490,14 +515,12 @@ def diff_skills(project_root: Path) -> list[tuple[str, str, str]]:
                 results.append((gen_name, name, "missing canonical"))
             else:
                 src = canonical_root / name
-                dst = gen.target_dir(project_root, name)
-                # The upstream NO_FANOUT probe already filters out runtimes
-                # whose ``RUNTIME_FANOUT_TABLE`` entry is ``None``, so this
-                # branch is only reachable if the table lookup is per-name
-                # (which today's table is not). Keep the skip as a defensive
-                # silent fallback so the contract holds regardless.
-                if dst is None:
-                    continue
+                # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
+                # above guarantees this runtime+scope has a fan-out root, so
+                # ``gen.target_dir`` cannot return ``None`` for any name.
+                # Earlier defensive ``if dst is None: continue`` removed.
+                dst = gen.target_dir(project_root, name, scope=scope)
+                assert dst is not None  # narrowed by upstream NO_FANOUT guard
                 if _skill_dirs_equal(src, dst):
                     results.append((gen_name, name, "in sync"))
                 else:

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -175,6 +175,7 @@ async def mem_context_generate(
     )
     from memtomem.context.generator import GENERATORS
     from memtomem.context.parser import CONTEXT_FILENAME, parse_context
+    from memtomem.context.privacy_scan import PrivacyScanError
     from memtomem.context.skills import generate_all_skills
 
     inc = _parse_include(include)
@@ -205,7 +206,10 @@ async def mem_context_generate(
         results.append(f"({CONTEXT_FILENAME} missing — skipping project memory)")
 
     if "skills" in inc:
-        skill_result = generate_all_skills(root)
+        try:
+            skill_result = generate_all_skills(root)
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
         if skill_result.generated:
             results.append("")
             results.append(f"Skills fan-out: {len(skill_result.generated)}")
@@ -220,6 +224,8 @@ async def mem_context_generate(
             agent_result = generate_all_agents(root, strict=strict)
         except StrictDropError as exc:
             return f"strict error: {exc}"
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
         if agent_result.generated:
             results.append("")
             results.append(f"Sub-agent fan-out: {len(agent_result.generated)}")
@@ -239,6 +245,8 @@ async def mem_context_generate(
             command_result = generate_all_commands(root, strict=strict)
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
         if command_result.generated:
             results.append("")
             results.append(f"Command fan-out: {len(command_result.generated)}")
@@ -404,6 +412,7 @@ async def mem_context_sync(
     from memtomem.context.detector import detect_agent_files
     from memtomem.context.generator import GENERATORS
     from memtomem.context.parser import CONTEXT_FILENAME, parse_context
+    from memtomem.context.privacy_scan import PrivacyScanError
     from memtomem.context.skills import generate_all_skills
 
     inc = _parse_include(include)
@@ -437,7 +446,10 @@ async def mem_context_sync(
         results.append(f"({CONTEXT_FILENAME} missing — skipping project memory)")
 
     if "skills" in inc:
-        skill_result = generate_all_skills(root)
+        try:
+            skill_result = generate_all_skills(root)
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
         if skill_result.generated:
             if results:
                 results.append("")
@@ -453,6 +465,8 @@ async def mem_context_sync(
             agent_result = generate_all_agents(root, strict=strict)
         except StrictDropError as exc:
             return f"strict error: {exc}"
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
         if agent_result.generated:
             if results:
                 results.append("")
@@ -473,6 +487,8 @@ async def mem_context_sync(
             command_result = generate_all_commands(root, strict=strict)
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
         if command_result.generated:
             if results:
                 results.append("")

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -25,6 +25,7 @@ from memtomem.context.agents import (
     parse_canonical_agent,
 )
 from memtomem.context.detector import AGENT_DIRS
+from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.web.deps import get_project_root
 from memtomem.web.routes.context_projects import resolve_scope_root
 from memtomem.web.routes._locks import _gateway_lock
@@ -386,6 +387,12 @@ async def sync_agents(
                 result = generate_all_agents(project_root, on_drop=on_drop)
     except TimeoutError:
         raise HTTPException(503, "Agents sync timed out — another sync may be in progress")
+    except PrivacyScanError as exc:
+        # 422 Unprocessable Entity — request is well-formed but the canonical
+        # bytes violate the project_shared privacy gate. ADR-0011 §5: no
+        # bypass valve, so the user must remove the secret or migrate the
+        # artifact to a writable tier (the message body explains how).
+        raise HTTPException(422, exc.message) from exc
 
     return {
         "generated": [

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -24,6 +24,7 @@ from memtomem.context.commands import (
     parse_canonical_command,
 )
 from memtomem.context.detector import COMMAND_DIRS
+from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.web.deps import get_project_root
 from memtomem.web.routes.context_projects import resolve_scope_root
 from memtomem.web.routes._locks import _gateway_lock
@@ -377,6 +378,8 @@ async def sync_commands(
                 result = generate_all_commands(project_root, on_drop=on_drop)
     except TimeoutError:
         raise HTTPException(503, "Commands sync timed out — another sync may be in progress")
+    except PrivacyScanError as exc:
+        raise HTTPException(422, exc.message) from exc
     return {
         "generated": [
             {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in result.generated

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.detector import SKILL_DIRS
+from memtomem.context.privacy_scan import PrivacyScanError
 from memtomem.context.skills import (
     CANONICAL_SKILL_ROOT,
     SKILL_GENERATORS,
@@ -342,6 +343,8 @@ async def sync_skills(
                 result = generate_all_skills(project_root)
     except TimeoutError:
         raise HTTPException(503, "Skills sync timed out — another sync may be in progress")
+    except PrivacyScanError as exc:
+        raise HTTPException(422, exc.message) from exc
     return {
         "generated": [
             {"runtime": rt, "path": _safe_rel(p, project_root)} for rt, p in result.generated

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -718,6 +718,20 @@ function _indexingTryStart() {
   if (indicator) show(indicator);
   return true;
 }
+async function _indexingTryStartOrRefresh() {
+  if (!STATE.indexing) return _indexingTryStart();
+  try {
+    const r = await api('GET', '/api/indexing/active');
+    if (!r || !r.active) {
+      _indexingEnd();
+      return _indexingTryStart();
+    }
+  } catch (err) {
+    console.warn('[indexing-active preflight]', err);
+  }
+  showToast(t('toast.indexing_in_progress'), 'info');
+  return false;
+}
 function _indexingEnd() {
   STATE.indexing = false;
   const indicator = qs('indexing-indicator');
@@ -4673,7 +4687,7 @@ async function runAutoTag() {
 async function runIndexStream() {
   const path     = qs('index-path').value.trim();
   if (!path) { setMsg(qs('index-msg'), 'Please enter a path to index.', true); return; }
-  if (!_indexingTryStart()) return;
+  if (!(await _indexingTryStartOrRefresh())) return;
   const recursive = qs('index-recursive').checked;
   const force     = qs('index-force').checked;
   const namespace = qs('index-namespace').value.trim();

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -1091,7 +1091,11 @@ async function mdOpenOne(path, btn) {
 // ``progress`` events the Index tab already consumes and surfaces them as a
 // live ``done/total`` counter on the reindex button itself.
 async function mdReindexOne(path, btn) {
-  if (typeof _indexingTryStart === 'function' && !_indexingTryStart()) return;
+  if (typeof _indexingTryStartOrRefresh === 'function') {
+    if (!(await _indexingTryStartOrRefresh())) return;
+  } else if (typeof _indexingTryStart === 'function' && !_indexingTryStart()) {
+    return;
+  }
   if (btn) btnLoading(btn, true);
   // Cache the original button label so we can restore it after the run —
   // ``btnLoading`` only toggles disabled+spinner, it doesn't snapshot text.
@@ -1229,7 +1233,11 @@ async function mdReindexOne(path, btn) {
 }
 
 async function mdReindexAll(btn) {
-  if (typeof _indexingTryStart === 'function' && !_indexingTryStart()) return;
+  if (typeof _indexingTryStartOrRefresh === 'function') {
+    if (!(await _indexingTryStartOrRefresh())) return;
+  } else if (typeof _indexingTryStart === 'function' && !_indexingTryStart()) {
+    return;
+  }
   if (btn) btnLoading(btn, true);
   try {
     const resp = await api('POST', '/api/reindex', undefined, { timeout: 300_000 });

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -727,8 +727,19 @@ def test_migrate_one_keeps_unrelated_dir_contents(tmp_path: Path) -> None:
 
 _MANIFEST_NAME = {"agents": "agent.md", "commands": "command.md", "skills": "SKILL.md"}
 _RUNTIME_REL = {
-    "agents": {"claude": ".claude/agents", "gemini": ".gemini/agents"},
-    "commands": {"claude": ".claude/commands", "gemini": ".gemini/commands"},
+    "agents": {
+        "claude": ".claude/agents",
+        "gemini": ".gemini/agents",
+        "codex": ".codex/agents",
+    },
+    "commands": {
+        "claude": ".claude/commands",
+        "gemini": ".gemini/commands",
+        # Codex has no project-tier commands fan-out (RUNTIME_FANOUT_TABLE
+        # returns NO_FANOUT for project_shared/local), but the key exists
+        # so the user-tier path can still seed for the codex regression.
+        "codex": ".codex/prompts",
+    },
     "skills": {"claude": ".claude/skills", "gemini": ".gemini/skills"},
 }
 _AGENT_BODY_CLEAN = "---\nname: foo\ndescription: a clean test agent\n---\n\nhello world\n"
@@ -794,6 +805,17 @@ def _write_canonical_dir(
     return manifest
 
 
+# Per-(kind, runtime) file suffix for non-skill runtime artifacts.
+# Mirrors the production table in
+# ``memtomem.context.migrate._NON_SKILL_FANOUT_SUFFIX`` so the test
+# helpers seed the same on-disk shape the production generators write.
+# Parity is locked by ``test_e4_runtime_suffix_parity_with_generators``.
+_RUNTIME_SUFFIX: dict[str, dict[str, str]] = {
+    "agents": {"claude": ".md", "gemini": ".md", "codex": ".toml"},
+    "commands": {"claude": ".md", "gemini": ".toml", "codex": ".md"},
+}
+
+
 def _runtime_fanout_path(
     layout: dict[str, Path], kind: str, runtime: str, scope: str, name: str
 ) -> Path:
@@ -805,15 +827,24 @@ def _runtime_fanout_path(
         base = layout["project_root"] / rel
     else:
         raise ValueError(f"runtime fan-out not defined for scope={scope!r}")
-    return base / name if kind == "skills" else base / f"{name}.md"
+    if kind == "skills":
+        return base / name
+    suffix = _RUNTIME_SUFFIX[kind].get(runtime, ".md")
+    return base / f"{name}{suffix}"
 
 
 def _seed_runtime_fanout(
-    layout: dict[str, Path], kind: str, scope: str, name: str, body: str
+    layout: dict[str, Path],
+    kind: str,
+    scope: str,
+    name: str,
+    body: str,
+    *,
+    runtimes: tuple[str, ...] = ("claude", "gemini"),
 ) -> list[Path]:
     """Pre-seed runtime fan-out targets so the migrate cleanup path has something to remove."""
     seeded: list[Path] = []
-    for runtime in ("claude", "gemini"):
+    for runtime in runtimes:
         target = _runtime_fanout_path(layout, kind, runtime, scope, name)
         if kind == "skills":
             target.mkdir(parents=True, exist_ok=True)
@@ -1611,3 +1642,101 @@ def test_e4_rollback_src_reappears_preserves_staging(scope_layout, monkeypatch, 
 
     # NEGATIVE: dst never landed.
     assert not (dst_root / "leak").exists()
+
+
+# ── #895 P2 review #2: per-runtime fan-out suffix cleanup ────────────
+
+
+def test_e4_runtime_suffix_parity_with_generators():
+    """Pin: migrate's cleanup suffix table matches the generator tables.
+
+    A future runtime addition that writes a new file format must update
+    both the generator's per-runtime suffix dict AND the cleanup table
+    in :mod:`memtomem.context.migrate`. This test fails immediately if
+    they drift, preventing a repeat of the Gemini-commands ``.toml``
+    leak (#895 P2 review #2) where the cleanup hardcoded ``.md`` and
+    silently orphaned ``.gemini/commands/<name>.toml`` after a scope
+    move.
+    """
+    from memtomem.context.agents import _AGENT_RUNTIME_SUFFIX
+    from memtomem.context.commands import _COMMAND_RUNTIME_SUFFIX
+    from memtomem.context.migrate import _NON_SKILL_FANOUT_SUFFIX
+
+    assert _NON_SKILL_FANOUT_SUFFIX["agents"] == _AGENT_RUNTIME_SUFFIX
+    assert _NON_SKILL_FANOUT_SUFFIX["commands"] == _COMMAND_RUNTIME_SUFFIX
+
+
+def test_e4_gemini_commands_toml_cleanup_on_migrate(scope_layout):
+    """#895 P2 review #2: ``mm context migrate commands foo --from
+    project_shared --to user`` must remove ``.gemini/commands/foo.toml``,
+    not leave it as an orphan after the canonical move.
+
+    Pre-fix, the cleanup probed ``.gemini/commands/foo.md`` (always
+    absent because Gemini writes TOML), so the ``.toml`` survived and
+    Gemini could still discover/run the moved-away command at the old
+    scope.
+    """
+    src = _write_canonical_dir(
+        scope_layout, "commands", "project_shared", "foo", _COMMAND_BODY_CLEAN
+    )
+    # Seed both runtimes at the source scope — claude with .md (the
+    # existing test path), gemini with .toml (the regression target).
+    seeded_claude = _seed_runtime_fanout(
+        scope_layout,
+        "commands",
+        "project_shared",
+        "foo",
+        _COMMAND_BODY_CLEAN,
+        runtimes=("claude",),
+    )
+    seeded_gemini = _seed_runtime_fanout(
+        scope_layout,
+        "commands",
+        "project_shared",
+        "foo",
+        _COMMAND_BODY_CLEAN,
+        runtimes=("gemini",),
+    )
+    # Sanity: the seed actually placed a ``.toml`` for gemini.
+    assert seeded_gemini[0].suffix == ".toml", seeded_gemini
+
+    result = _invoke_migrate(
+        _migrate_args("commands", "foo", from_scope="project_shared", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "commands", "user") / "foo" / "command.md"
+    assert dst.is_file()
+    assert not src.exists()
+    # POSITIVE pins: BOTH runtimes' stale fan-out cleaned, not just claude.
+    for path in seeded_claude + seeded_gemini:
+        assert not path.exists(), f"expected stale fan-out cleaned: {path}"
+
+
+def test_e4_codex_agents_toml_cleanup_on_migrate(scope_layout):
+    """Sibling regression: codex agents write ``.toml`` too. The migrate
+    cleanup must use the right suffix so a project_shared→user move
+    does not leave ``<proj>/.codex/agents/foo.toml`` behind. Adjacent
+    bug to the gemini-commands case — same fix table covers both.
+    """
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    seeded_codex = _seed_runtime_fanout(
+        scope_layout,
+        "agents",
+        "project_shared",
+        "foo",
+        _AGENT_BODY_CLEAN,
+        runtimes=("codex",),
+    )
+    assert seeded_codex[0].suffix == ".toml", seeded_codex
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "user") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+    for path in seeded_codex:
+        assert not path.exists(), f"expected stale codex fan-out cleaned: {path}"

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1713,6 +1713,105 @@ def test_e4_gemini_commands_toml_cleanup_on_migrate(scope_layout):
         assert not path.exists(), f"expected stale fan-out cleaned: {path}"
 
 
+def test_e4_migrate_to_project_local_appends_gitignore_marker(scope_layout):
+    """#895 P2 review #3: ``--to project_local --apply`` must append the
+    project_local block to ``.gitignore`` so the new local-draft tier
+    is not visible to ``git status``.
+
+    Pre-fix, only ``mm context init --scope project_local`` appended the
+    marker; users who landed on project_local first via migrate ended up
+    with ``.memtomem/agents.local/foo/`` tracked by git.
+    """
+    from memtomem.cli.context_cmd import _GITIGNORE_MARKER, _GITIGNORE_PATTERNS
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    gi = scope_layout["project_root"] / ".gitignore"
+    assert not gi.exists()  # baseline — no marker yet
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_local") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+    # POSITIVE pins: marker + both glob patterns now on disk.
+    text = gi.read_text(encoding="utf-8")
+    assert _GITIGNORE_MARKER in text
+    for pat in _GITIGNORE_PATTERNS:
+        assert pat in text
+
+
+def test_e4_migrate_to_project_local_gitignore_is_idempotent(scope_layout):
+    """Second migrate to project_local with an existing marker must NOT
+    duplicate the block. Mirrors the ``mm context init`` idempotency
+    guarantee — the marker comment line is the dedup key.
+    """
+    from memtomem.cli.context_cmd import _GITIGNORE_MARKER
+
+    # Pre-seed the marker as ``init`` would have done.
+    gi = scope_layout["project_root"] / ".gitignore"
+    gi.write_text(f"# pre-existing user content\n\n{_GITIGNORE_MARKER}\n.memtomem/*.local/\n")
+    before = gi.read_text(encoding="utf-8")
+
+    _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    after = gi.read_text(encoding="utf-8")
+    # Single occurrence of the marker — no duplicate block appended.
+    assert after.count(_GITIGNORE_MARKER) == 1
+    assert after == before  # byte-identical
+
+
+def test_e4_migrate_to_project_shared_does_not_touch_gitignore(scope_layout):
+    """Negative pin: a migrate landing in ``project_shared`` (the
+    git-tracked tier) must NOT append the project_local block. The
+    marker semantic is "this scope is gitignored" — appending on the
+    wrong scope would mislead future readers of ``.gitignore``.
+    """
+    _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    gi = scope_layout["project_root"] / ".gitignore"
+    assert not gi.exists()
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    # NEGATIVE: .gitignore was never created.
+    assert not gi.exists()
+
+
+def test_e4_migrate_dry_run_does_not_touch_gitignore(scope_layout):
+    """Dry-run preview must not mutate ``.gitignore`` either — the
+    contract is "no on-disk writes without ``--apply``".
+    """
+    _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    gi = scope_layout["project_root"] / ".gitignore"
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_local",
+            apply_=False,
+            yes=False,  # ``--yes`` is rejected without ``--apply``
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert not gi.exists()
+
+
 def test_e4_codex_agents_toml_cleanup_on_migrate(scope_layout):
     """Sibling regression: codex agents write ``.toml`` too. The migrate
     cleanup must use the right suffix so a project_shared→user move

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -720,3 +720,894 @@ def test_migrate_one_keeps_unrelated_dir_contents(tmp_path: Path) -> None:
     assert sibling.stat().st_mtime == pre_sibling_mtime
     # Flat removed
     assert not flat.exists()
+
+
+# ── PR-E4: scope-tier migration (17-row smoke matrix) ────────────────
+
+
+_MANIFEST_NAME = {"agents": "agent.md", "commands": "command.md", "skills": "SKILL.md"}
+_RUNTIME_REL = {
+    "agents": {"claude": ".claude/agents", "gemini": ".gemini/agents"},
+    "commands": {"claude": ".claude/commands", "gemini": ".gemini/commands"},
+    "skills": {"claude": ".claude/skills", "gemini": ".gemini/skills"},
+}
+_AGENT_BODY_CLEAN = "---\nname: foo\ndescription: a clean test agent\n---\n\nhello world\n"
+_COMMAND_BODY_CLEAN = "---\nname: foo\ndescription: a clean test command\n---\n\nhello $ARGUMENTS\n"
+_SKILL_BODY_CLEAN = "---\nname: foo\ndescription: a clean test skill\n---\n\nhello\n"
+_BODY_CLEAN = {
+    "agents": _AGENT_BODY_CLEAN,
+    "commands": _COMMAND_BODY_CLEAN,
+    "skills": _SKILL_BODY_CLEAN,
+}
+_SECRET_LITERAL = "AKIA1234567890ABCDEF"  # AWS-key shape — caught by privacy.enforce_write_guard
+_AGENT_BODY_SECRET = "---\nname: foo\ndescription: leaks\n---\n\napi_key=" + _SECRET_LITERAL + "\n"
+
+
+@pytest.fixture
+def scope_layout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Project root + monkeypatched HOME for cross-scope migration tests.
+
+    Layout:
+
+    - ``project_root`` = ``tmp_path / "proj"`` (with ``.git`` so the CLI's
+      ``_find_project_root`` walker picks it up).
+    - ``user_home`` = ``tmp_path / "home"`` — both ``HOME`` and
+      ``USERPROFILE`` are monkeypatched to this path so
+      ``canonical_artifact_dir(scope="user")`` and the user-tier runtime
+      fan-out (``~/.claude/...``) resolve under it
+      (``feedback_path_home_cross_platform.md``).
+    - cwd is set to ``project_root`` so the CLI walker terminates there.
+
+    Returns a dict the test functions index for the four useful paths.
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / ".git").mkdir()
+    user_home = tmp_path / "home"
+    user_home.mkdir()
+    monkeypatch.setenv("HOME", str(user_home))
+    monkeypatch.setenv("USERPROFILE", str(user_home))
+    monkeypatch.chdir(project_root)
+    return {"project_root": project_root, "user_home": user_home}
+
+
+def _canonical_root_for(layout: dict[str, Path], kind: str, scope: str) -> Path:
+    """Mirror ``canonical_artifact_dir`` using the fixture paths."""
+    if scope == "user":
+        return layout["user_home"] / ".memtomem" / kind
+    if scope == "project_shared":
+        return layout["project_root"] / ".memtomem" / kind
+    if scope == "project_local":
+        return layout["project_root"] / ".memtomem" / f"{kind}.local"
+    raise ValueError(f"unknown scope: {scope}")
+
+
+def _write_canonical_dir(
+    layout: dict[str, Path], kind: str, scope: str, name: str, body: str
+) -> Path:
+    """Write a dir-layout canonical artifact and return the manifest path."""
+    root = _canonical_root_for(layout, kind, scope)
+    manifest_dir = root / name
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    manifest = manifest_dir / _MANIFEST_NAME[kind]
+    manifest.write_text(body, encoding="utf-8")
+    return manifest
+
+
+def _runtime_fanout_path(
+    layout: dict[str, Path], kind: str, runtime: str, scope: str, name: str
+) -> Path:
+    """Compute the runtime fan-out file/dir path for a given (kind, runtime, scope, name)."""
+    rel = _RUNTIME_REL[kind][runtime]
+    if scope == "user":
+        base = layout["user_home"] / rel
+    elif scope == "project_shared":
+        base = layout["project_root"] / rel
+    else:
+        raise ValueError(f"runtime fan-out not defined for scope={scope!r}")
+    return base / name if kind == "skills" else base / f"{name}.md"
+
+
+def _seed_runtime_fanout(
+    layout: dict[str, Path], kind: str, scope: str, name: str, body: str
+) -> list[Path]:
+    """Pre-seed runtime fan-out targets so the migrate cleanup path has something to remove."""
+    seeded: list[Path] = []
+    for runtime in ("claude", "gemini"):
+        target = _runtime_fanout_path(layout, kind, runtime, scope, name)
+        if kind == "skills":
+            target.mkdir(parents=True, exist_ok=True)
+            (target / _MANIFEST_NAME[kind]).write_text(body, encoding="utf-8")
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(body, encoding="utf-8")
+        seeded.append(target)
+    return seeded
+
+
+def _invoke_migrate(args: list[str]) -> object:
+    """Click runner shorthand. ``catch_exceptions=False`` lets test failures surface."""
+    return CliRunner().invoke(context_group, args, catch_exceptions=False)
+
+
+def _migrate_args(
+    kind: str,
+    name: str,
+    *,
+    from_scope: str | None,
+    to_scope: str,
+    apply_: bool = True,
+    confirm_project_shared: bool = False,
+    yes: bool = True,
+) -> list[str]:
+    args: list[str] = ["migrate", kind, name, "--to", to_scope]
+    if from_scope is not None:
+        args.extend(["--from", from_scope])
+    if apply_:
+        args.append("--apply")
+    if confirm_project_shared:
+        args.append("--confirm-project-shared")
+    if yes:
+        args.append("--yes")
+    return args
+
+
+# ── Rows 1–10: per-(kind, transition) basic moves ────────────────────
+
+
+def test_e4_row1_agents_user_to_project_shared_clean(scope_layout):
+    """Row 1: agents user→project_shared clean — canonical at dst, src removed."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert dst.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    assert not src.exists()
+    assert not src.parent.exists()
+
+
+def test_e4_row2_agents_user_to_project_shared_secret_blocks(scope_layout):
+    """Row 2: secret on the wire to project_shared — Gate A raises, src untouched."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_SECRET)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    assert "Gate A" in result.output
+    # POSITIVE: src restored
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+    # NEGATIVE: dst absent
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "foo").exists()
+    # Staging cleaned (no .migrate-foo-* leftover under dst.parent)
+    assert not list(dst_root.glob(".migrate-foo-*.tmp"))
+
+
+def test_e4_row3_agents_user_to_project_local_clean(scope_layout):
+    """Row 3: agents user→project_local clean — canonical at draft tier, src removed."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="user", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_local") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row4_agents_project_shared_to_user_clean(scope_layout):
+    """Row 4: agents project_shared→user clean — canonical at user, src removed.
+
+    Also pins runtime fan-out cleanup at the source scope: a stale
+    ``<proj>/.claude/agents/foo.md`` seeded before migrate is removed
+    afterward.
+    """
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "agents", "user") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+    # Stale fan-out removed
+    for path in seeded:
+        assert not path.exists(), f"expected stale fan-out cleaned: {path}"
+
+
+def test_e4_row5_agents_project_local_to_project_shared_clean(scope_layout):
+    """Row 5: agents project_local→project_shared clean — promote draft to shared."""
+    src = _write_canonical_dir(scope_layout, "agents", "project_local", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="project_local",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row6_agents_project_shared_to_project_local_clean(scope_layout):
+    """Row 6: agents project_shared→project_local — demote, fan-out dropped."""
+    src = _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args("agents", "foo", from_scope="project_shared", to_scope="project_local")
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "agents", "project_local") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert not src.exists()
+    for path in seeded:
+        assert not path.exists(), f"expected stale fan-out cleaned on demote: {path}"
+
+
+def test_e4_row7_commands_user_to_project_shared_clean(scope_layout):
+    """Row 7: parallel of row 1 for commands."""
+    src = _write_canonical_dir(scope_layout, "commands", "user", "build", _COMMAND_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "commands",
+            "build",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "commands", "project_shared") / "build" / "command.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row8_commands_project_local_to_user_clean(scope_layout):
+    """Row 8: commands project_local→user clean."""
+    src = _write_canonical_dir(
+        scope_layout, "commands", "project_local", "build", _COMMAND_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args("commands", "build", from_scope="project_local", to_scope="user")
+    )
+    assert result.exit_code == 0, result.output
+    dst = _canonical_root_for(scope_layout, "commands", "user") / "build" / "command.md"
+    assert dst.is_file()
+    assert not src.exists()
+
+
+def test_e4_row9_skills_user_to_project_shared_clean(scope_layout):
+    """Row 9: skills user→project_shared — canonical moves; user-tier fan-out cleaned.
+
+    Pre-seeds ``~/.claude/skills/foo/`` (user-tier fan-out per ADR-0011
+    runtime table) and verifies it is removed after migrate. ADR-0011
+    correction: skills `project_shared` IS a fan-out target (only
+    `project_local` is NO_FANOUT) — see plan review feedback.
+    """
+    src = _write_canonical_dir(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(scope_layout, "skills", "user", "foo", _SKILL_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "skills",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "skills", "project_shared") / "foo" / "SKILL.md"
+    assert dst.is_file()
+    assert not src.exists()
+    # User-tier fan-out cleaned (rmtree-d skill dir).
+    for path in seeded:
+        assert not path.exists(), f"expected user-tier skill fan-out cleaned: {path}"
+
+
+def test_e4_row10_skills_project_shared_to_project_local_clean(scope_layout):
+    """Row 10: skills project_shared→project_local — fan-out drops (project_local NO_FANOUT).
+
+    Project_shared skills DO fan out (``<proj>/.claude/skills/foo/``);
+    project_local skills do NOT (ADR-0011 §6 / §3). The demote must
+    remove the project-shared fan-out so the runtime stops seeing the
+    skill.
+    """
+    src = _write_canonical_dir(scope_layout, "skills", "project_shared", "foo", _SKILL_BODY_CLEAN)
+    seeded = _seed_runtime_fanout(
+        scope_layout, "skills", "project_shared", "foo", _SKILL_BODY_CLEAN
+    )
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "skills",
+            "foo",
+            from_scope="project_shared",
+            to_scope="project_local",
+        )
+    )
+    assert result.exit_code == 0, result.output
+
+    dst = _canonical_root_for(scope_layout, "skills", "project_local") / "foo" / "SKILL.md"
+    assert dst.is_file()
+    assert not src.exists()
+    for path in seeded:
+        assert not path.exists(), (
+            f"expected project_shared skills fan-out cleaned on demote: {path}"
+        )
+
+
+# ── Rows 11–15: edge cases ───────────────────────────────────────────
+
+
+def test_e4_row11_exdev_fallback_copytree(scope_layout, monkeypatch):
+    """Row 11: EXDEV — first ``os.rename`` raises EXDEV; staging falls back to copytree.
+
+    Monkeypatches ``os.rename`` once so the ``src → staging`` step
+    (the only ``os.rename`` call inside ``migrate_scope`` before
+    ``_promote_move``) hits EXDEV. The promote-side ``os.replace`` is
+    a different function and therefore unaffected.
+    """
+    import os as os_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    real_rename = os_mod.rename
+    raised: dict[str, bool] = {"once": False}
+
+    def fake_rename(a, b):
+        if not raised["once"]:
+            raised["once"] = True
+            import errno as _errno
+
+            raise OSError(_errno.EXDEV, "Cross-device link", str(a))
+        return real_rename(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.rename", fake_rename)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert raised["once"], "EXDEV path should have triggered"
+
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+    assert dst.read_text(encoding="utf-8") == _AGENT_BODY_CLEAN
+    # Source cleaned up after EXDEV-fallback copy + promote.
+    assert not src.exists()
+    assert not src.parent.exists()
+
+
+def test_e4_row12_idempotent_after_migrate(scope_layout):
+    """Row 12: re-running migrate after a successful move is a clear no-op error.
+
+    The "concurrent migrate, same src" thread-race shape collapses to
+    "second invocation sees src gone" once the first invocation
+    completes. The lock-order test in
+    ``test_context_migrate_lock_order.py`` covers true concurrency.
+    """
+    _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    first = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert first.exit_code == 0, first.output
+
+    second = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert second.exit_code != 0, second.output
+    assert "not found at scope='user'" in second.output
+
+
+def test_e4_row13_inverse_migrate_lock_order_pin(scope_layout):
+    """Row 13: deterministic lock-acquire order — sorted by ``str(lock_path)``.
+
+    Asserts the contract directly via ``_acquire_pair_lock`` instead of
+    racing two threads (which is harder to make deterministic). The
+    threaded deadlock-freedom test lives in
+    ``test_context_migrate_lock_order.py``.
+    """
+    from memtomem.context._atomic import _lock_path_for
+    from memtomem.context.migrate import _acquire_pair_lock
+
+    src_dir = _canonical_root_for(scope_layout, "agents", "user") / "foo"
+    dst_dir = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo"
+    src_dir.parent.mkdir(parents=True, exist_ok=True)
+    dst_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    expected_first = min(_lock_path_for(src_dir), _lock_path_for(dst_dir), key=str)
+
+    # Smoke: the helper acquires both locks without deadlock and the
+    # sorted order is the documented contract (we do not introspect the
+    # internal sequence — taking both locks is sufficient functional
+    # evidence; the dedicated lock-order test asserts the order).
+    with _acquire_pair_lock(src_dir, dst_dir):
+        assert expected_first.parent.is_dir()  # lock parent exists
+
+
+def test_e4_row14_dry_run_no_mutation(scope_layout):
+    """Row 14: dry-run — plan reported, no disk mutation."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            apply_=False,
+            yes=False,  # --yes / --force require --apply
+            confirm_project_shared=False,
+        )
+    )
+    assert result.exit_code == 0, result.output
+    assert "Plan: migrate" in result.output
+    assert "Run with --apply" in result.output
+
+    # Filesystem unchanged.
+    assert src.is_file()
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "foo").exists()
+    # No staging tmp leftover.
+    assert not list(dst_root.glob(".migrate-foo-*.tmp"))
+
+
+def test_e4_row15_dst_conflict_always_refuses(scope_layout):
+    """Row 15: dst already has same name — refuse, even with --force."""
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    dst_existing = _write_canonical_dir(
+        scope_layout, "agents", "project_shared", "foo", "stale dst body\n"
+    )
+
+    # With --force: --force is rejected as a usage error in scope-mode.
+    forced = _invoke_migrate(
+        [
+            "migrate",
+            "agents",
+            "foo",
+            "--from",
+            "user",
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+            "--yes",
+            "--force",
+        ]
+    )
+    assert forced.exit_code != 0, forced.output
+    assert "--force does not apply" in forced.output
+
+    # Without --force: refuses with a destination-exists message.
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    assert "destination already exists" in result.output
+
+    # Both sides preserved.
+    assert src.is_file()
+    assert dst_existing.read_text(encoding="utf-8") == "stale dst body\n"
+
+
+# ── Rows 16–17: memory cross-link delegate ───────────────────────────
+
+
+def test_e4_row16_memory_dispatch_delegates_to_memory_migrate(monkeypatch, tmp_path):
+    """Row 16: ``mm context migrate memory <src> --from --to`` delegates to memory-migrate.
+
+    Verifies dispatch parity by monkeypatching ``_memory_migrate_run``
+    and checking it gets called with the same args the public
+    ``mm context memory-migrate`` would build (path, from, to, apply,
+    yes, confirm_project_shared).
+    """
+    src = tmp_path / "rule.md"
+    src.write_text("## Rule\n\nharmless body\n", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    async def _fake_run(source, from_scope, to_scope, apply_, yes, confirm_project_shared):
+        captured["source"] = source
+        captured["from_scope"] = from_scope
+        captured["to_scope"] = to_scope
+        captured["apply_"] = apply_
+        captured["yes"] = yes
+        captured["confirm_project_shared"] = confirm_project_shared
+
+    monkeypatch.setattr("memtomem.cli.context_cmd._memory_migrate_run", _fake_run)
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke_migrate(
+        [
+            "migrate",
+            "memory",
+            str(src),
+            "--from",
+            "user",
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["source"] == src.resolve()
+    assert captured["from_scope"] == "user"
+    assert captured["to_scope"] == "project_shared"
+    assert captured["apply_"] is True
+    assert captured["confirm_project_shared"] is True
+
+
+def test_e4_row17_memory_dispatch_validates_inputs(monkeypatch, tmp_path):
+    """Row 17: memory dispatch validation — missing flags / non-existent path / same-scope.
+
+    Compresses three negative cases into one row since they share the
+    same dispatch helper:
+
+    1. Missing ``--to`` → UsageError.
+    2. Non-existent source path → ClickException.
+    3. ``--from`` == ``--to`` → ClickException.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # 1. Missing --to
+    r1 = _invoke_migrate(["migrate", "memory", "/some/path", "--from", "user"])
+    assert r1.exit_code != 0
+    assert "--from and --to are both required" in r1.output
+
+    # 2. Non-existent source
+    r2 = _invoke_migrate(
+        [
+            "migrate",
+            "memory",
+            "/this/does/not/exist.md",
+            "--from",
+            "user",
+            "--to",
+            "project_shared",
+            "--apply",
+            "--confirm-project-shared",
+        ]
+    )
+    assert r2.exit_code != 0
+    assert "does not exist" in r2.output
+
+    # 3. --from == --to
+    src = tmp_path / "rule.md"
+    src.write_text("body\n", encoding="utf-8")
+    r3 = _invoke_migrate(
+        [
+            "migrate",
+            "memory",
+            str(src),
+            "--from",
+            "user",
+            "--to",
+            "user",
+            "--apply",
+        ]
+    )
+    assert r3.exit_code != 0
+    assert "must differ" in r3.output
+
+
+# ── PR-E4 review fold: unreadable canonical cannot bypass Gate A ─────
+
+
+def test_e4_unreadable_canonical_blocks_project_shared_promotion(scope_layout, monkeypatch):
+    """Pre-fold this branch passed: ``_stage_move`` renames a chmod-000
+    file into staging without reading it, then ``scan_artifact_tree``
+    treated the read failure as ``pass`` (conflated with binary), and
+    the secret-bearing file got promoted into the git-tracked
+    ``project_shared`` tier with Gate A never inspecting it.
+
+    Pin: ``OSError`` on the staging-side read raises a
+    ``ClickException``, ``migrate_scope``'s rollback puts src back, and
+    the project_shared destination stays empty. Uses a monkeypatched
+    ``Path.read_text`` to simulate the unreadable file portably — real
+    ``chmod 000`` works on POSIX but is meaningless on Windows, and the
+    monkeypatch exercises the same ``OSError`` branch in both.
+    """
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+
+    real_read_text = Path.read_text
+
+    def explode_on_staged_read(self: Path, *args: object, **kwargs: object) -> str:
+        # The scan walks staging at <dst.parent>/.migrate-leak-<pid>-<rand>.tmp/.
+        # Match by name + the staging suffix marker so unrelated reads
+        # (CLI bootstrap, config loading) are unaffected.
+        if self.name == "agent.md" and ".migrate-leak-" in str(self.parent):
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", explode_on_staged_read)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    # Fail-loud message specifics — never echo the secret bytes.
+    assert "cannot read" in result.output
+    assert _SECRET_LITERAL not in result.output
+    # POSITIVE: src restored bytes-identical to the pre-migrate state.
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+    # NEGATIVE: dst absent and no staging tmp left behind.
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "leak").exists()
+    assert not list(dst_root.glob(".migrate-leak-*.tmp"))
+
+
+# ── PR-E4 Codex review fold #2: EXDEV + Gate A combined path ─────────
+
+
+def test_e4_exdev_then_gate_a_blocks_src_untouched(scope_layout, monkeypatch):
+    """Codex review #2 — EXDEV-fallback path must roll back cleanly when
+    Gate A then blocks. Combines two branches that Row 11 (clean EXDEV)
+    and Row 2 (same-FS Gate A block) cover separately:
+
+    1. ``os.rename`` raises EXDEV → ``_stage_move`` falls back to
+       ``copytree``, leaving src on disk and staging as a copy
+       (``src_consumed=False``).
+    2. Gate A scans staging, finds the secret, raises ClickException.
+    3. ``except BaseException`` rollback: src already exists (was never
+       renamed away), so the rename-back branch is a no-op; staging
+       (the copy) gets dropped via rmtree.
+
+    Pin: src is byte-identical to the pre-migrate state, dst absent,
+    no staging leftover, exit non-zero.
+    """
+    import errno as _errno
+    import os as os_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+    real_rename = os_mod.rename
+    raised: dict[str, bool] = {"once": False}
+
+    def fake_rename(a, b):
+        # Trigger EXDEV on the FIRST os.rename call (the src→staging
+        # step inside _stage_move). Subsequent renames (none expected
+        # in this path because Gate A blocks before _promote_move) go
+        # through.
+        if not raised["once"]:
+            raised["once"] = True
+            raise OSError(_errno.EXDEV, "Cross-device link", str(a))
+        return real_rename(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.rename", fake_rename)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    assert "Gate A" in result.output
+    assert raised["once"], "EXDEV branch should have triggered"
+
+    # POSITIVE: src untouched (EXDEV path never consumed it).
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+    # NEGATIVE: dst absent + no staging tmp leftover (rollback dropped it).
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    assert not (dst_root / "leak").exists()
+    assert not list(dst_root.glob(".migrate-leak-*.tmp"))
+
+
+# ── PR-E4 Codex review fold #1: rollback rename-back failure ─────────
+
+
+def test_e4_rollback_rename_back_failure_preserves_staging(scope_layout, monkeypatch, caplog):
+    """Codex review #1 — when the rollback rename-back fails, staging is
+    the only surviving copy of the user's bytes; do NOT delete it.
+
+    Setup: clean canonical at user-tier, Gate A would block (secret),
+    and ``os.replace`` is monkeypatched so the rollback's staging→src
+    rename-back call raises ``OSError``. The first ``os.replace`` in
+    the apply path is the rollback (Gate A blocks before
+    ``_promote_move`` runs).
+
+    Pin: error logged with the staging path, staging dir is NOT
+    deleted, exit non-zero. Pre-fix the cleanup branch unconditionally
+    deleted staging → user data lost.
+    """
+    import logging as _logging
+    import os as os_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+    real_replace = os_mod.replace
+    rename_back_calls: list[tuple[Path, Path]] = []
+
+    def fake_replace(a, b):
+        # The first os.replace in this path is the rollback's
+        # staging→src rename-back. Trip it once so the rollback hits the
+        # OSError branch; subsequent os.replace calls (none expected
+        # along this code path) go through.
+        if not rename_back_calls:
+            rename_back_calls.append((Path(a), Path(b)))
+            raise OSError(13, "Permission denied", str(a))
+        return real_replace(a, b)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.replace", fake_replace)
+    caplog.set_level(_logging.ERROR, logger="memtomem.context.migrate")
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+    # The Gate A path raised first; rollback hit the os.replace failure.
+    assert rename_back_calls, "rollback rename-back should have been attempted"
+
+    # POSITIVE: ERROR logged pointing at the surviving staging path so
+    # the user can recover manually.
+    assert any(
+        "rename-back failed" in r.getMessage() and ".migrate-leak-" in r.getMessage()
+        for r in caplog.records
+    ), [r.getMessage() for r in caplog.records]
+
+    # POSITIVE: staging dir survives (the only copy of the bytes).
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    surviving = list(dst_root.glob(".migrate-leak-*.tmp"))
+    assert len(surviving) == 1, surviving
+    # Bytes inside staging are byte-identical to the original src
+    # (it was renamed, not rewritten).
+    surviving_manifest = surviving[0] / "agent.md"
+    assert surviving_manifest.is_file()
+    assert surviving_manifest.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+
+    # NEGATIVE: src is gone (consumed by the initial os.rename); dst
+    # never landed.
+    assert not src.exists()
+    assert not (dst_root / "leak").exists()
+
+
+# ── PR-E4 Codex re-review fold: src reappears via external race ──────
+
+
+def test_e4_rollback_src_reappears_preserves_staging(scope_layout, monkeypatch, caplog):
+    """Codex re-review fold — when ``src_path`` reappears during apply
+    (an external writer outside our sidecar lock — e.g.,
+    ``mm context install`` running in parallel, a user manually
+    recreating the canonical), the rollback must NOT silently delete
+    staging. The new src bytes might be unrelated to ours; staging is
+    the only verified copy of the original.
+
+    Triggered by monkeypatching ``scan_artifact_tree`` in the
+    ``migrate`` module so that BEFORE Gate A would block, the racer
+    recreates ``src_path`` with different bytes. Then Gate A blocks,
+    rollback enters the ``src_path.exists()`` branch, logs ERROR, and
+    preserves staging.
+
+    Pin (Codex re-review):
+      * src reappeared bytes are preserved verbatim — rollback does
+        not overwrite them.
+      * staging directory survives — original bytes recoverable.
+      * ERROR log includes the "reappeared" marker + both paths.
+    """
+    import logging as _logging
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
+
+    from memtomem.context import migrate as migrate_mod
+
+    real_scan = migrate_mod.scan_artifact_tree
+    racer_bytes = "racer wrote different bytes\n"
+
+    def fake_scan_with_racer(*args, **kwargs):
+        # Recreate src with different bytes BEFORE the scan returns.
+        # The scan itself runs against staging — Gate A will block on
+        # the original secret. By the time rollback runs, src exists
+        # again from the racer's write.
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text(racer_bytes, encoding="utf-8")
+        return real_scan(*args, **kwargs)
+
+    monkeypatch.setattr(migrate_mod, "scan_artifact_tree", fake_scan_with_racer)
+    caplog.set_level(_logging.ERROR, logger="memtomem.context.migrate")
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "leak",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+    assert result.exit_code != 0, result.output
+
+    # POSITIVE: ERROR logged with the "reappeared" marker.
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("reappeared during apply" in m and ".migrate-leak-" in m for m in messages), messages
+
+    # POSITIVE: racer bytes preserved at src (not overwritten by rollback).
+    assert src.is_file()
+    assert src.read_text(encoding="utf-8") == racer_bytes
+
+    # POSITIVE: staging dir survives with the ORIGINAL secret-bearing bytes.
+    dst_root = _canonical_root_for(scope_layout, "agents", "project_shared")
+    surviving = list(dst_root.glob(".migrate-leak-*.tmp"))
+    assert len(surviving) == 1, surviving
+    surviving_manifest = surviving[0] / "agent.md"
+    assert surviving_manifest.is_file()
+    assert surviving_manifest.read_text(encoding="utf-8") == _AGENT_BODY_SECRET
+
+    # NEGATIVE: dst never landed.
+    assert not (dst_root / "leak").exists()

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1839,3 +1839,143 @@ def test_e4_codex_agents_toml_cleanup_on_migrate(scope_layout):
     assert not src.exists()
     for path in seeded_codex:
         assert not path.exists(), f"expected stale codex fan-out cleaned: {path}"
+
+
+# ── #895 P2 review #5: EXDEV cleanup failure must not report success ─
+
+
+def test_e4_exdev_src_cleanup_failure_raises_partial_error(scope_layout, monkeypatch):
+    """#895 P2 review #5: when the EXDEV fallback successfully copies
+    src→dst but fails to remove src (e.g. ``shutil.rmtree`` raises
+    OSError on the src cleanup), the migrate MUST raise
+    ``MigratePartialError`` rather than logging a warning and
+    returning ``moved=True``.
+
+    Pre-fix end state on failure: both src and dst canonicals on disk,
+    src_scope's runtime fan-out cleaned (it thought the move succeeded),
+    so the next ``mm context sync --scope <src_scope>`` recreates fan-out
+    at the OLD tier from the stale src. The autodetect sees two
+    canonicals and the user has no remediation hint.
+    """
+    import errno as _errno
+    import os as os_mod
+    import shutil as shutil_mod
+
+    src = _write_canonical_dir(scope_layout, "agents", "user", "foo", _AGENT_BODY_CLEAN)
+    real_rename = os_mod.rename
+    rename_state: dict[str, int] = {"calls": 0}
+
+    def fake_rename(a, b):
+        # EXDEV on the FIRST os.rename (the src→staging step). The
+        # second os.rename (staging→dst) is allowed through so the
+        # copy lands at dst.
+        rename_state["calls"] += 1
+        if rename_state["calls"] == 1:
+            raise OSError(_errno.EXDEV, "Cross-device link", str(a))
+        return real_rename(a, b)
+
+    real_rmtree = shutil_mod.rmtree
+
+    def fake_rmtree(path, *args, **kwargs):
+        # Refuse to remove the EXDEV-leftover src dir. Everything else
+        # (staging cleanup paths, runtime fan-out cleanup) still works.
+        if str(path) == str(src.parent):
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr("memtomem.context.migrate.os.rename", fake_rename)
+    monkeypatch.setattr("memtomem.context.migrate.shutil.rmtree", fake_rmtree)
+
+    result = _invoke_migrate(
+        _migrate_args(
+            "agents",
+            "foo",
+            from_scope="user",
+            to_scope="project_shared",
+            confirm_project_shared=True,
+        )
+    )
+
+    # POSITIVE: exit non-zero with a clear partial-failure message.
+    assert result.exit_code != 0, result.output
+    assert "canonical copied to" in result.output
+    assert "failed to remove stale source" in result.output
+    assert "Remove" in result.output and "manually" in result.output
+    # Recovery hint must steer the user away from the dangerous
+    # ``mm context sync --scope <src_scope>`` re-run.
+    assert "do NOT run" in result.output
+
+    # POSITIVE: both src and dst exist (the documented bad state).
+    # The error is the loud signal — the user must clean src manually.
+    assert src.is_file()
+    dst = _canonical_root_for(scope_layout, "agents", "project_shared") / "foo" / "agent.md"
+    assert dst.is_file()
+
+
+# ── #895 P2 review #5: project_shared atomicity — no partial fan-out ─
+
+
+def test_e4_project_shared_blocked_override_leaves_no_partial_fanout_agents(scope_layout):
+    """#895 P2 review #5: when ``scope='project_shared'`` and a later
+    runtime's vendor override contains a privacy hit, the earlier
+    runtimes' writes must NOT have already landed on disk.
+
+    Pre-fix the outer loop wrote claude/foo.md, then gemini's override
+    scan raised, leaving partial fan-out. Post-fix the scan runs in
+    Phase 1 over every (target, agent) pair before any write, so the
+    first block raises with disk untouched.
+    """
+    # Clean canonical at project_shared.
+    _write_canonical_dir(scope_layout, "agents", "project_shared", "foo", _AGENT_BODY_CLEAN)
+    # Override for the SECOND runtime in AGENT_GENERATORS iteration order
+    # (gemini) carries the secret. Layout per ADR-0008 + override.py:
+    # ``.memtomem/agents/foo/overrides/gemini.md``.
+    overrides_dir = scope_layout["project_root"] / ".memtomem" / "agents" / "foo" / "overrides"
+    overrides_dir.mkdir(parents=True, exist_ok=True)
+    (overrides_dir / "gemini.md").write_text(_AGENT_BODY_SECRET, encoding="utf-8")
+
+    # Drive the same sync the CLI invokes. CliRunner indirection isn't
+    # required — generate_all_agents is the boundary where the bug lives.
+    from memtomem.context.agents import generate_all_agents
+    from memtomem.context.privacy_scan import PrivacyBlockedError
+
+    with pytest.raises(PrivacyBlockedError):
+        generate_all_agents(scope_layout["project_root"], scope="project_shared")
+
+    # POSITIVE pins: NEITHER runtime's fan-out target exists on disk.
+    # Pre-fix, claude/foo.md (first runtime) would be present.
+    claude_fanout = scope_layout["project_root"] / ".claude" / "agents" / "foo.md"
+    gemini_fanout = scope_layout["project_root"] / ".gemini" / "agents" / "foo.md"
+    assert not claude_fanout.exists(), (
+        "Phase 1 must catch the blocked override before Phase 2 writes "
+        "claude_agents — partial fan-out violates ADR §5 atomicity."
+    )
+    assert not gemini_fanout.exists()
+
+
+def test_e4_project_shared_blocked_override_leaves_no_partial_fanout_commands(scope_layout):
+    """Sibling of the agents test — same atomicity contract for commands.
+    Gemini commands ship as TOML so the override file uses ``.toml``
+    (see ``OVERRIDE_FORMATS[("commands", "gemini")]``).
+    """
+    _write_canonical_dir(scope_layout, "commands", "project_shared", "foo", _COMMAND_BODY_CLEAN)
+    overrides_dir = scope_layout["project_root"] / ".memtomem" / "commands" / "foo" / "overrides"
+    overrides_dir.mkdir(parents=True, exist_ok=True)
+    (overrides_dir / "gemini.toml").write_text(
+        f'prompt = "leaks {_SECRET_LITERAL}"\ndescription = "leak"\n',
+        encoding="utf-8",
+    )
+
+    from memtomem.context.commands import generate_all_commands
+    from memtomem.context.privacy_scan import PrivacyBlockedError
+
+    with pytest.raises(PrivacyBlockedError):
+        generate_all_commands(scope_layout["project_root"], scope="project_shared")
+
+    claude_fanout = scope_layout["project_root"] / ".claude" / "commands" / "foo.md"
+    gemini_fanout = scope_layout["project_root"] / ".gemini" / "commands" / "foo.toml"
+    assert not claude_fanout.exists(), (
+        "Phase 1 must catch the blocked override before Phase 2 writes "
+        "claude_commands — partial fan-out violates ADR §5 atomicity."
+    )
+    assert not gemini_fanout.exists()

--- a/packages/memtomem/tests/test_context_migrate.py
+++ b/packages/memtomem/tests/test_context_migrate.py
@@ -1402,17 +1402,17 @@ def test_e4_unreadable_canonical_blocks_project_shared_promotion(scope_layout, m
     """
     src = _write_canonical_dir(scope_layout, "agents", "user", "leak", _AGENT_BODY_SECRET)
 
-    real_read_text = Path.read_text
+    real_read_bytes = Path.read_bytes
 
-    def explode_on_staged_read(self: Path, *args: object, **kwargs: object) -> str:
+    def explode_on_staged_read(self: Path, *args: object, **kwargs: object) -> bytes:
         # The scan walks staging at <dst.parent>/.migrate-leak-<pid>-<rand>.tmp/.
         # Match by name + the staging suffix marker so unrelated reads
         # (CLI bootstrap, config loading) are unaffected.
         if self.name == "agent.md" and ".migrate-leak-" in str(self.parent):
             raise PermissionError(13, "Permission denied", str(self))
-        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+        return real_read_bytes(self, *args, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(Path, "read_text", explode_on_staged_read)
+    monkeypatch.setattr(Path, "read_bytes", explode_on_staged_read)
 
     result = _invoke_migrate(
         _migrate_args(

--- a/packages/memtomem/tests/test_context_migrate_lock_order.py
+++ b/packages/memtomem/tests/test_context_migrate_lock_order.py
@@ -1,0 +1,130 @@
+"""ADR-0011 PR-E4 — deterministic lock-acquire order regression test.
+
+Pins the contract that :func:`memtomem.context.migrate._acquire_pair_lock`
+takes the two sidecar locks in ``sorted(key=str)`` order regardless of
+which path the caller passes as ``path_a`` vs ``path_b``. Without this
+ordering, two concurrent inverse migrations
+(``A: foo user→project_shared`` and ``B: foo project_shared→user``)
+would each grab their src-side lock first and deadlock waiting for the
+other's dst-side lock.
+
+Two pins:
+
+1. **Order pin** — ``_acquire_pair_lock(a, b)`` and ``_acquire_pair_lock(b, a)``
+   acquire locks in the same global sequence (verified via a tracker
+   that watches the order locks are obtained and released).
+2. **Deadlock-freedom pin** — two threads racing inverse migrations
+   complete within a generous timeout (no deadlock).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from memtomem.context._atomic import _file_lock, _lock_path_for
+from memtomem.context.migrate import _acquire_pair_lock
+
+
+def _acquire_log(monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Wrap ``_file_lock`` so each acquire appends its lock_path to a shared list.
+
+    The wrapper installs at the module path ``_acquire_pair_lock`` reads
+    from (``memtomem.context.migrate._file_lock``). The original
+    ``_file_lock`` implementation is delegated to verbatim — we only
+    record the call sequence.
+    """
+    log: list[Path] = []
+    real = _file_lock
+
+    def wrapped(lock_path: Path):
+        log.append(lock_path)
+        return real(lock_path)
+
+    monkeypatch.setattr("memtomem.context.migrate._file_lock", wrapped)
+    return log
+
+
+def test_acquire_pair_lock_orders_by_str(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Order pin — both call orientations produce the same global lock sequence."""
+    a = tmp_path / "alpha"
+    b = tmp_path / "beta"
+    a.mkdir()
+    b.mkdir()
+
+    expected_first = min(_lock_path_for(a), _lock_path_for(b), key=str)
+    expected_second = max(_lock_path_for(a), _lock_path_for(b), key=str)
+
+    log_ab = _acquire_log(monkeypatch)
+    with _acquire_pair_lock(a, b):
+        pass
+    assert log_ab == [expected_first, expected_second], (
+        f"a→b orientation: got {log_ab}, expected [{expected_first}, {expected_second}]"
+    )
+
+    log_ba = _acquire_log(monkeypatch)
+    with _acquire_pair_lock(b, a):
+        pass
+    assert log_ba == [expected_first, expected_second], (
+        f"b→a orientation: got {log_ba}, expected [{expected_first}, {expected_second}]"
+    )
+
+
+def test_acquire_pair_lock_same_path_acquires_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Defensive: when both args resolve to the same lock, only one acquire."""
+    p = tmp_path / "same"
+    p.mkdir()
+    log = _acquire_log(monkeypatch)
+    with _acquire_pair_lock(p, p):
+        pass
+    assert log == [_lock_path_for(p)]
+
+
+def test_inverse_migrate_no_deadlock(tmp_path: Path):
+    """Deadlock-freedom pin — two threads racing inverse pair-locks both finish.
+
+    Sets up two paths ``alpha`` and ``beta``; thread A locks
+    ``(alpha, beta)`` while thread B locks ``(beta, alpha)``. Without
+    sorted ordering, thread A would wait on beta's lock while thread B
+    waits on alpha's, deadlocking. Sorted ordering forces both threads
+    to acquire alpha's lock first, so one finishes its critical section
+    and releases before the other proceeds.
+
+    We verify both threads complete inside a generous timeout. The hold
+    duration inside the lock is short (a 50 ms sleep) so the test
+    finishes quickly when no deadlock; under deadlock it would hit the
+    join timeout.
+    """
+    a = tmp_path / "alpha"
+    b = tmp_path / "beta"
+    a.mkdir()
+    b.mkdir()
+
+    barrier = threading.Barrier(2)
+    finished: dict[str, bool] = {"A": False, "B": False}
+
+    def thread_a():
+        barrier.wait(timeout=5)
+        with _acquire_pair_lock(a, b):
+            time.sleep(0.05)
+        finished["A"] = True
+
+    def thread_b():
+        barrier.wait(timeout=5)
+        with _acquire_pair_lock(b, a):
+            time.sleep(0.05)
+        finished["B"] = True
+
+    ta = threading.Thread(target=thread_a)
+    tb = threading.Thread(target=thread_b)
+    ta.start()
+    tb.start()
+    ta.join(timeout=5)
+    tb.join(timeout=5)
+
+    assert not ta.is_alive(), "thread A still alive — possible deadlock"
+    assert not tb.is_alive(), "thread B still alive — possible deadlock"
+    assert finished["A"] and finished["B"]

--- a/packages/memtomem/tests/test_context_runtime_table_none_skips.py
+++ b/packages/memtomem/tests/test_context_runtime_table_none_skips.py
@@ -68,6 +68,7 @@ from pathlib import Path
 import pytest
 
 from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context._runtime_targets import RUNTIME_FANOUT_TABLE
 from memtomem.context.agents import (
     AGENT_GENERATORS,
     diff_agents,
@@ -244,10 +245,20 @@ def test_diff_runtime_table_none_emits_zero_rows(
     ``diff_*`` has no skip channel (its return type is ``list[tuple[str,
     str, str]]``), so a NO_FANOUT runtime+scope contributes zero rows.
     Other registered runtimes still appear in the result.
+
+    PR-E3 cleanup item #1 update: ``diff_*`` now queries
+    ``RUNTIME_FANOUT_TABLE`` directly (no ``__probe_891__`` proxy on
+    ``gen.target_*``). Tests monkeypatch the table itself — that is the
+    contract surface the cleanup made authoritative.
     """
+    del registry, attr  # parametrize legacy fields — pre-PR-E3 proxy targets
     seed(tmp_path, name="foo")
-    gen = registry[runtime_key]
-    monkeypatch.setattr(gen, attr, lambda *args, **kwargs: None)
+    runtime_canonical = runtime_key.split("_", 1)[0]  # "claude_agents" -> "claude"
+    monkeypatch.setitem(
+        RUNTIME_FANOUT_TABLE,
+        (kind, runtime_canonical, "project_shared"),
+        None,
+    )
 
     rows = runner(tmp_path)
 
@@ -298,23 +309,31 @@ def test_diff_runtime_no_fanout_canonical_only_emits_zero_rows(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """#891 (Codex review fold) — diff_<kind> emits zero rows when the
-    runtime side is absent and ``target_*`` returns ``None``.
+    runtime side is absent and the table returns ``None``.
 
     This is the realistic NO_FANOUT shape: when ``RUNTIME_FANOUT_TABLE``
     returns ``None`` for a runtime+scope (e.g. ``project_local``), the
     runtime side typically does NOT exist on disk. Without the upstream
-    probe, the diff loop reaches the ``"missing target"`` branch (canonical
-    in, runtime not) BEFORE the new ``target_*`` None check, so canonical
-    entries leak as ``("<runtime>", "<name>", "missing target")`` rows
-    instead of being silently skipped.
+    NO_FANOUT guard, the diff loop reaches the ``"missing target"`` branch
+    (canonical in, runtime not) BEFORE the per-name target lookup, so
+    canonical entries leak as ``("<runtime>", "<name>", "missing target")``
+    rows instead of being silently skipped.
 
-    Codex review of the initial #891 diff caught this gap. The fix probes
-    ``gen.target_*(project_root, "__probe_891__")`` at the top of each
-    per-runtime loop and ``continue`` s when ``None``.
+    Codex review of the initial #891 diff caught this gap. The original
+    fix probed ``gen.target_*(project_root, "__probe_891__")`` at the
+    top of each per-runtime loop. PR-E3 cleanup item #1 replaces that
+    name-shaped probe with a direct ``runtime_fanout_root`` query —
+    table-direct is the contract source-of-truth — so this test now
+    monkeypatches the table itself.
     """
+    del registry, attr  # parametrize legacy fields — pre-PR-E3 proxy targets
     seed(tmp_path, name="foo", with_runtime=False)
-    gen = registry[runtime_key]
-    monkeypatch.setattr(gen, attr, lambda *args, **kwargs: None)
+    runtime_canonical = runtime_key.split("_", 1)[0]
+    monkeypatch.setitem(
+        RUNTIME_FANOUT_TABLE,
+        (kind, runtime_canonical, "project_shared"),
+        None,
+    )
 
     rows = runner(tmp_path)
 

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -243,10 +243,11 @@ class TestGenerateAllSkillsStagingFlow:
         dst.mkdir(parents=True)
         sentinel_path = dst / SKILL_MANIFEST
         sentinel_path.write_text("PRE-EXISTING\n", encoding="utf-8")
-        # project_shared → ClickException raised.
-        import click
+        # project_shared → PrivacyBlockedError raised (Click-free so
+        # non-CLI surfaces can translate; #895 P2 review fold).
+        from memtomem.context.privacy_scan import PrivacyBlockedError
 
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyBlockedError) as exc_info:
             generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="project_shared")
         assert "Gate A" in exc_info.value.message
         assert "leak.sh" in exc_info.value.message

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -1,0 +1,328 @@
+"""ADR-0011 PR-E3 — skills staging-dir-first scan + atomic promote.
+
+Contract pins for the new ``_stage_skill`` + ``_promote_staging`` pair
+that replaced the inline ``shutil.rmtree(dst); copy_tree_atomic`` in
+``copy_skill``:
+
+* Same-fs precondition — staging lives at ``dst.parent / .staging-…tmp``
+  so :func:`os.replace` is atomic.
+* Promote happy path — ``dst`` ends up byte-equal to staging; the
+  staging path no longer exists post-promote.
+* Block + cleanup — when ``scan_artifact_tree`` blocks, the staging
+  tree is removed and any pre-existing ``dst`` content is unchanged.
+* Override-only-touches-SKILL.md invariant
+  (``test_context_override.py:317``) preserved through the new flow:
+  ``scripts/`` etc. stay byte-equal to canonical even when an override
+  is staged for ``SKILL.md``.
+* Mid-promote rollback — staging promotes atomically; an ``os.replace``
+  failure on the second swap restores the previous ``dst`` tree.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.skills import (
+    SKILL_GENERATORS,
+    SKILL_MANIFEST,
+    _promote_staging,
+    _stage_skill,
+    canonical_skills_root,
+    copy_skill,
+    generate_all_skills,
+)
+
+from .helpers import set_home
+
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _seed_canonical_skill(
+    project_root: Path,
+    name: str = "foo",
+    *,
+    scope: str = "project_shared",
+    skill_md: str = "---\nname: foo\n---\nbody\n",
+    extras: dict[str, str] | None = None,
+) -> Path:
+    """Seed a canonical skill at the requested ``scope`` location.
+
+    ``scope="project_shared"`` (default) seeds at
+    ``<project_root>/.memtomem/skills/<name>``. ``scope="user"`` requires
+    the caller to have already overridden HOME to a tmp dir so that
+    ``canonical_artifact_dir("skills", "user", project_root)`` resolves
+    to a tmp path (never the real ``~/.memtomem``).
+    """
+    canonical = canonical_artifact_dir("skills", scope, project_root)  # type: ignore[arg-type]
+    skill_dir = canonical / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / SKILL_MANIFEST).write_text(skill_md, encoding="utf-8")
+    if extras:
+        for rel, content in extras.items():
+            p = skill_dir / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+    return skill_dir
+
+
+class TestStageSkill:
+    def test_staging_under_dst_parent_same_fs(self, tmp_path: Path) -> None:
+        src = _seed_canonical_skill(tmp_path, name="foo")
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        staging = _stage_skill(src, dst)
+        # Same-fs invariant: staging lives in dst.parent (so os.replace
+        # is atomic, not a fall-back copy+delete).
+        assert staging.parent == dst.parent
+        assert staging.exists()
+        assert staging.name.startswith(f".staging-{dst.name}-")
+        assert staging.name.endswith(".tmp")
+        # Staging contains the canonical bytes byte-equal.
+        assert (staging / SKILL_MANIFEST).read_bytes() == (src / SKILL_MANIFEST).read_bytes()
+
+    def test_staging_includes_aux_files(self, tmp_path: Path) -> None:
+        src = _seed_canonical_skill(
+            tmp_path,
+            name="foo",
+            extras={"scripts/run.sh": "#!/bin/bash\necho hi\n"},
+        )
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        staging = _stage_skill(src, dst)
+        assert (staging / "scripts" / "run.sh").read_bytes() == (
+            src / "scripts" / "run.sh"
+        ).read_bytes()
+
+
+class TestPromoteStaging:
+    def test_promote_consumes_staging(self, tmp_path: Path) -> None:
+        src = _seed_canonical_skill(tmp_path, name="foo")
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        staging = _stage_skill(src, dst)
+        # Sanity: dst doesn't exist before promote.
+        assert not dst.exists()
+        _promote_staging(staging, dst)
+        # Negative marker: staging path is gone (consumed by os.replace).
+        assert not staging.exists()
+        # Positive marker: dst contents byte-equal to canonical.
+        assert (dst / SKILL_MANIFEST).read_bytes() == (src / SKILL_MANIFEST).read_bytes()
+
+    def test_promote_replaces_existing_skill_dst(self, tmp_path: Path) -> None:
+        src = _seed_canonical_skill(
+            tmp_path,
+            name="foo",
+            skill_md="---\nname: foo\n---\nNEW BODY\n",
+        )
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        # Pre-existing dst with old SKILL.md
+        dst.mkdir(parents=True)
+        (dst / SKILL_MANIFEST).write_text("---\nname: foo\n---\nold body\n", encoding="utf-8")
+        staging = _stage_skill(src, dst)
+        _promote_staging(staging, dst)
+        assert (dst / SKILL_MANIFEST).read_text(encoding="utf-8") == (
+            "---\nname: foo\n---\nNEW BODY\n"
+        )
+        # No leftover .old- or .staging- directories.
+        leftovers = [
+            p.name for p in dst.parent.iterdir() if p.name.startswith((".old-", ".staging-"))
+        ]
+        assert leftovers == []
+
+    def test_promote_refuses_nonempty_non_skill_dst(self, tmp_path: Path) -> None:
+        src = _seed_canonical_skill(tmp_path, name="foo")
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        dst.mkdir(parents=True)
+        (dst / "user_data.txt").write_text("user file\n", encoding="utf-8")
+        staging = _stage_skill(src, dst)
+        with pytest.raises(IsADirectoryError):
+            _promote_staging(staging, dst)
+        # Staging not cleaned up by _promote_staging — caller's responsibility.
+        # Pre-existing dst contents preserved.
+        assert (dst / "user_data.txt").read_text(encoding="utf-8") == "user file\n"
+
+    def test_rollback_restores_dst_on_inner_replace_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the second os.replace (staging → dst) to fail; rollback
+        # must restore the previous dst tree byte-for-byte.
+        src = _seed_canonical_skill(tmp_path, name="foo")
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        dst.mkdir(parents=True)
+        (dst / SKILL_MANIFEST).write_text("ORIGINAL CONTENT\n", encoding="utf-8")
+        staging = _stage_skill(src, dst)
+
+        original_replace = os.replace
+        call_count = {"n": 0}
+
+        def fail_second_replace(a, b):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise OSError("forced second-replace failure")
+            return original_replace(a, b)
+
+        monkeypatch.setattr(os, "replace", fail_second_replace)
+        with pytest.raises(OSError, match="forced second-replace failure"):
+            _promote_staging(staging, dst)
+        # Negative marker: dst was rolled back to ORIGINAL CONTENT.
+        assert (dst / SKILL_MANIFEST).read_text(encoding="utf-8") == "ORIGINAL CONTENT\n"
+
+
+class TestCopySkillBackCompat:
+    def test_copy_skill_still_works(self, tmp_path: Path) -> None:
+        # ``copy_skill`` is now a thin wrapper around stage+promote.
+        # Pin the public-API contract that it still mirrors src → dst.
+        src = _seed_canonical_skill(tmp_path, name="foo")
+        dst = tmp_path / ".claude" / "skills" / "foo"
+        copy_skill(src, dst)
+        assert (dst / SKILL_MANIFEST).read_bytes() == (src / SKILL_MANIFEST).read_bytes()
+
+
+class TestGenerateAllSkillsStagingFlow:
+    def test_clean_canonical_promotes(self, tmp_path: Path) -> None:
+        _seed_canonical_skill(tmp_path, name="hello")
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"])
+        # Positive: generated entry present.
+        runtimes = [r for r, _ in result.generated]
+        assert "claude_skills" in runtimes
+        gen = SKILL_GENERATORS["claude_skills"]
+        target = gen.target_dir(tmp_path, "hello")
+        assert target is not None
+        # Negative: no leftover staging in dst.parent.
+        leftovers = [
+            p.name for p in target.parent.iterdir() if p.name.startswith((".staging-", ".old-"))
+        ]
+        assert leftovers == []
+
+    def test_secret_in_scripts_blocks_user_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # User-scope canonical lives under HOME — isolate.
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_canonical_skill(
+            tmp_path,
+            name="leak",
+            scope="user",
+            extras={"scripts/leak.sh": f"#!/bin/bash\necho {SECRET}\n"},
+        )
+        # User-scope runtime fan-out target lives under HOME too —
+        # pre-create with sentinel content; blocked sync must NOT
+        # overwrite it.
+        gen = SKILL_GENERATORS["claude_skills"]
+        dst = gen.target_dir(tmp_path, "leak", scope="user")
+        assert dst is not None
+        dst.mkdir(parents=True)
+        sentinel_path = dst / SKILL_MANIFEST
+        sentinel_path.write_text("PRE-EXISTING\n", encoding="utf-8")
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="user")
+        # Positive: skip emitted with PRIVACY_BLOCKED code.
+        privacy_skips = [s for s in result.skipped if s[2] == skip_codes.PRIVACY_BLOCKED]
+        assert len(privacy_skips) == 1, result.skipped
+        assert privacy_skips[0][0] == "leak"
+        # Negative: dst contents UNTOUCHED.
+        assert sentinel_path.read_text(encoding="utf-8") == "PRE-EXISTING\n"
+        # Negative: no orphan staging dir under dst.parent.
+        leftovers = [
+            p.name for p in dst.parent.iterdir() if p.name.startswith((".staging-", ".old-"))
+        ]
+        assert leftovers == [], leftovers
+
+    def test_secret_in_scripts_raises_project_shared(self, tmp_path: Path) -> None:
+        _seed_canonical_skill(
+            tmp_path,
+            name="leak",
+            extras={"scripts/leak.sh": f"#!/bin/bash\necho {SECRET}\n"},
+        )
+        gen = SKILL_GENERATORS["claude_skills"]
+        dst = gen.target_dir(tmp_path, "leak")
+        assert dst is not None
+        # Pre-create with sentinel.
+        dst.mkdir(parents=True)
+        sentinel_path = dst / SKILL_MANIFEST
+        sentinel_path.write_text("PRE-EXISTING\n", encoding="utf-8")
+        # project_shared → ClickException raised.
+        import click
+
+        with pytest.raises(click.ClickException) as exc_info:
+            generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="project_shared")
+        assert "Gate A" in exc_info.value.message
+        assert "leak.sh" in exc_info.value.message
+        # Negative: dst untouched.
+        assert sentinel_path.read_text(encoding="utf-8") == "PRE-EXISTING\n"
+        # Negative: no orphan staging.
+        leftovers = [
+            p.name for p in dst.parent.iterdir() if p.name.startswith((".staging-", ".old-"))
+        ]
+        assert leftovers == []
+
+
+class TestOverridePreservation:
+    def test_override_only_touches_skill_md_through_staging(self, tmp_path: Path) -> None:
+        # Mirror ``test_context_override.py:317`` against the new
+        # staging+promote flow. The override file replaces SKILL.md in
+        # staging BEFORE the scan; auxiliary files (scripts/) stay from
+        # canonical's copy_tree_atomic. Post-promote, dst has the
+        # override SKILL.md AND the canonical scripts/.
+        _seed_canonical_skill(
+            tmp_path,
+            name="foo",
+            skill_md="---\nname: foo\n---\ncanonical body\n",
+            extras={"scripts/run.sh": "#!/bin/bash\necho canonical\n"},
+        )
+        # Canonical-side override file at <canonical>/foo/overrides/claude.md.
+        canonical = canonical_skills_root(tmp_path)
+        override_dir = canonical / "foo" / "overrides"
+        override_dir.mkdir(parents=True)
+        (override_dir / "claude.md").write_text(
+            "---\nname: foo\n---\nclaude only\n", encoding="utf-8"
+        )
+
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"])
+        # generation succeeded
+        assert any(r == "claude_skills" for r, _ in result.generated)
+        gen = SKILL_GENERATORS["claude_skills"]
+        target = gen.target_dir(tmp_path, "foo")
+        assert target is not None
+        # SKILL.md is the override.
+        assert (target / SKILL_MANIFEST).read_text(encoding="utf-8") == (
+            "---\nname: foo\n---\nclaude only\n"
+        )
+        # scripts/ comes from canonical (untouched by override).
+        assert (target / "scripts" / "run.sh").read_text(encoding="utf-8") == (
+            "#!/bin/bash\necho canonical\n"
+        )
+
+    def test_secret_in_override_blocks_before_promote(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Pin: override bytes are scanned (since they replace the
+        # canonical SKILL.md before write). A clean canonical + dirty
+        # override must still block. Use scope=user with HOME isolation
+        # so the block path emits a skip (project_shared raises).
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_canonical_skill(
+            tmp_path,
+            name="foo",
+            scope="user",
+            skill_md="---\nname: foo\n---\nclean canonical\n",
+        )
+        canonical = canonical_skills_root(tmp_path, scope="user")
+        override_dir = canonical / "foo" / "overrides"
+        override_dir.mkdir(parents=True)
+        (override_dir / "claude.md").write_text(
+            f"---\nname: foo\n---\nleaked: {SECRET}\n", encoding="utf-8"
+        )
+        gen = SKILL_GENERATORS["claude_skills"]
+        dst = gen.target_dir(tmp_path, "foo", scope="user")
+        assert dst is not None
+
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="user")
+        # Positive: skip emitted.
+        privacy_skips = [s for s in result.skipped if s[2] == skip_codes.PRIVACY_BLOCKED]
+        assert len(privacy_skips) == 1, result.skipped
+        # Negative: dst not created.
+        assert not dst.exists()

--- a/packages/memtomem/tests/test_context_skills_staging.py
+++ b/packages/memtomem/tests/test_context_skills_staging.py
@@ -259,6 +259,35 @@ class TestGenerateAllSkillsStagingFlow:
         ]
         assert leftovers == []
 
+    def test_project_shared_block_later_skill_leaves_no_partial_fanout(
+        self, tmp_path: Path
+    ) -> None:
+        # #895 follow-up: project_shared is an all-or-nothing privacy
+        # surface. A clean earlier skill must not be promoted before a
+        # later skill fails Gate A.
+        _seed_canonical_skill(tmp_path, name="clean")
+        _seed_canonical_skill(
+            tmp_path,
+            name="leak",
+            extras={"scripts/leak.sh": f"#!/bin/bash\necho {SECRET}\n"},
+        )
+        gen = SKILL_GENERATORS["claude_skills"]
+        clean_dst = gen.target_dir(tmp_path, "clean")
+        leak_dst = gen.target_dir(tmp_path, "leak")
+        assert clean_dst is not None
+        assert leak_dst is not None
+
+        from memtomem.context.privacy_scan import PrivacyBlockedError
+
+        with pytest.raises(PrivacyBlockedError):
+            generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="project_shared")
+
+        assert not clean_dst.exists()
+        assert not leak_dst.exists()
+        assert not [
+            p.name for p in clean_dst.parent.iterdir() if p.name.startswith((".staging-", ".old-"))
+        ]
+
 
 class TestOverridePreservation:
     def test_override_only_touches_skill_md_through_staging(self, tmp_path: Path) -> None:

--- a/packages/memtomem/tests/test_context_sync_scope.py
+++ b/packages/memtomem/tests/test_context_sync_scope.py
@@ -20,10 +20,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import click
 import pytest
 
 from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context.privacy_scan import PrivacyBlockedError
 from memtomem.context.agents import (
     AGENT_GENERATORS,
     diff_agents,
@@ -88,7 +88,7 @@ class TestAgentsSyncScopeMatrix:
         )
         gen = AGENT_GENERATORS["claude_agents"]
         dst = gen.target_file(tmp_path, "leak", scope="project_shared")
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyBlockedError) as exc_info:
             generate_all_agents(tmp_path, runtimes=["claude_agents"], scope="project_shared")
         assert "Gate A" in exc_info.value.message
         assert "leak" in exc_info.value.message
@@ -145,7 +145,7 @@ class TestCommandsSyncScopeMatrix:
         )
         gen = COMMAND_GENERATORS["claude_commands"]
         dst = gen.target_file(tmp_path, "leak", scope="project_shared")
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyBlockedError) as exc_info:
             generate_all_commands(tmp_path, runtimes=["claude_commands"], scope="project_shared")
         assert "Gate A" in exc_info.value.message
         assert dst is not None

--- a/packages/memtomem/tests/test_context_sync_scope.py
+++ b/packages/memtomem/tests/test_context_sync_scope.py
@@ -1,0 +1,212 @@
+"""ADR-0011 PR-E3 — sync --scope thread-through end-to-end.
+
+Pins the per-scope behavior of ``generate_all_agents`` /
+``generate_all_commands`` (the canonical → runtime fan-out surface) at
+each of the three scopes:
+
+* ``project_shared`` — Gate A fail-fast hard-refusal on first secret.
+* ``user`` — Gate A skip-and-warn (no force_unsafe valve in sync).
+* ``project_local`` — every runtime emits ``NO_PROJECT_FANOUT_FOR_RUNTIME``
+  per :data:`RUNTIME_FANOUT_TABLE` (ADR §3 — gitignored draft tier has
+  no runtime equivalent).
+
+Skills are exercised in ``test_context_skills_staging.py``; this file
+covers the agents + commands code paths and the project_local
+NO_FANOUT contract that applies uniformly across all three artifact
+kinds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context.agents import (
+    AGENT_GENERATORS,
+    diff_agents,
+    generate_all_agents,
+)
+from memtomem.context.commands import (
+    COMMAND_GENERATORS,
+    diff_commands,
+    generate_all_commands,
+)
+from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.skills import diff_skills
+
+from .helpers import set_home
+
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+def _clean_agent_body(name: str) -> str:
+    return f"---\nname: {name}\ndescription: example\n---\nbody\n"
+
+
+def _clean_command_body() -> str:
+    return "---\ndescription: example\n---\nbody\n"
+
+
+def _seed_agent(
+    project_root: Path,
+    name: str,
+    *,
+    scope: str,
+    body: str,
+) -> Path:
+    canonical = canonical_artifact_dir("agents", scope, project_root)  # type: ignore[arg-type]
+    canonical.mkdir(parents=True, exist_ok=True)
+    path = canonical / f"{name}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _seed_command(
+    project_root: Path,
+    name: str,
+    *,
+    scope: str,
+    body: str,
+) -> Path:
+    canonical = canonical_artifact_dir("commands", scope, project_root)  # type: ignore[arg-type]
+    canonical.mkdir(parents=True, exist_ok=True)
+    path = canonical / f"{name}.md"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestAgentsSyncScopeMatrix:
+    def test_project_shared_secret_raises(self, tmp_path: Path) -> None:
+        _seed_agent(
+            tmp_path,
+            "leak",
+            scope="project_shared",
+            body=f"---\nname: leak\n---\nuses {SECRET}\n",
+        )
+        gen = AGENT_GENERATORS["claude_agents"]
+        dst = gen.target_file(tmp_path, "leak", scope="project_shared")
+        with pytest.raises(click.ClickException) as exc_info:
+            generate_all_agents(tmp_path, runtimes=["claude_agents"], scope="project_shared")
+        assert "Gate A" in exc_info.value.message
+        assert "leak" in exc_info.value.message
+        # Negative pin: dst NOT created.
+        assert dst is not None
+        assert not dst.exists()
+
+    def test_user_secret_skips(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_agent(
+            tmp_path,
+            "leak",
+            scope="user",
+            body=f"---\nname: leak\n---\nuses {SECRET}\n",
+        )
+        # Add a clean agent to verify "other agents fan out OK".
+        _seed_agent(tmp_path, "ok", scope="user", body=_clean_agent_body("ok"))
+        gen = AGENT_GENERATORS["claude_agents"]
+        dst_leak = gen.target_file(tmp_path, "leak", scope="user")
+        dst_ok = gen.target_file(tmp_path, "ok", scope="user")
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], scope="user")
+        # Positive: skip emitted with PRIVACY_BLOCKED code.
+        privacy_skips = [s for s in result.skipped if s[2] == skip_codes.PRIVACY_BLOCKED]
+        assert len(privacy_skips) == 1, result.skipped
+        assert privacy_skips[0][0] == "leak"
+        # Positive: clean agent fanned out.
+        names_generated = [path.stem for _runtime, path in result.generated]
+        assert "ok" in names_generated
+        # Negative: leaked agent not on disk.
+        assert dst_leak is not None
+        assert not dst_leak.exists()
+        # Positive: clean agent on disk.
+        assert dst_ok is not None
+        assert dst_ok.exists()
+
+    def test_project_local_emits_no_fanout(self, tmp_path: Path) -> None:
+        _seed_agent(tmp_path, "ok", scope="project_local", body=_clean_agent_body("ok"))
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], scope="project_local")
+        # Positive: NO_PROJECT_FANOUT_FOR_RUNTIME emitted.
+        no_fanout = [s for s in result.skipped if s[2] == skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME]
+        assert len(no_fanout) == 1, result.skipped
+        # Negative: nothing generated.
+        assert result.generated == []
+
+
+class TestCommandsSyncScopeMatrix:
+    def test_project_shared_secret_raises(self, tmp_path: Path) -> None:
+        _seed_command(
+            tmp_path,
+            "leak",
+            scope="project_shared",
+            body=f"---\ndescription: leak\n---\nuses {SECRET}\n",
+        )
+        gen = COMMAND_GENERATORS["claude_commands"]
+        dst = gen.target_file(tmp_path, "leak", scope="project_shared")
+        with pytest.raises(click.ClickException) as exc_info:
+            generate_all_commands(tmp_path, runtimes=["claude_commands"], scope="project_shared")
+        assert "Gate A" in exc_info.value.message
+        assert dst is not None
+        assert not dst.exists()
+
+    def test_user_secret_skips(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = tmp_path / "home"
+        set_home(monkeypatch, str(home))
+        _seed_command(
+            tmp_path,
+            "leak",
+            scope="user",
+            body=f"---\ndescription: leak\n---\nuses {SECRET}\n",
+        )
+        _seed_command(tmp_path, "ok", scope="user", body=_clean_command_body())
+        result = generate_all_commands(tmp_path, runtimes=["claude_commands"], scope="user")
+        privacy_skips = [s for s in result.skipped if s[2] == skip_codes.PRIVACY_BLOCKED]
+        assert len(privacy_skips) == 1, result.skipped
+        names_generated = [path.stem for _runtime, path in result.generated]
+        assert "ok" in names_generated
+        assert "leak" not in names_generated
+
+
+class TestDiffScopeProjectLocal:
+    """diff_* at scope=project_local emits zero rows for every runtime."""
+
+    def test_diff_agents_project_local(self, tmp_path: Path) -> None:
+        _seed_agent(tmp_path, "ok", scope="project_local", body=_clean_agent_body("ok"))
+        rows = diff_agents(tmp_path, scope="project_local")
+        # All registered agents runtimes return None for project_local
+        # per RUNTIME_FANOUT_TABLE → upstream NO_FANOUT guard short-
+        # circuits → empty result.
+        assert rows == []
+
+    def test_diff_commands_project_local(self, tmp_path: Path) -> None:
+        _seed_command(tmp_path, "ok", scope="project_local", body=_clean_command_body())
+        rows = diff_commands(tmp_path, scope="project_local")
+        assert rows == []
+
+    def test_diff_skills_project_local(self, tmp_path: Path) -> None:
+        # Seed a project_local skill canonical.
+        canonical = canonical_artifact_dir("skills", "project_local", tmp_path)
+        skill_dir = canonical / "ok"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("---\nname: ok\n---\nbody\n", encoding="utf-8")
+        rows = diff_skills(tmp_path, scope="project_local")
+        assert rows == []
+
+
+class TestDefaultScopePreservation:
+    """Sync at the default scope (no --scope) reads project_shared canonical."""
+
+    def test_default_kwarg_matches_explicit_project_shared(self, tmp_path: Path) -> None:
+        _seed_agent(tmp_path, "ok", scope="project_shared", body=_clean_agent_body("ok"))
+        # No scope= kwarg.
+        result_default = generate_all_agents(tmp_path, runtimes=["claude_agents"])
+        # Explicit project_shared — must produce the same generated set.
+        # Re-seed in a fresh tree because generated state is on-disk.
+        result_explicit = generate_all_agents(
+            tmp_path, runtimes=["claude_agents"], scope="project_shared"
+        )
+        names_default = [p.stem for _r, p in result_default.generated]
+        names_explicit = [p.stem for _r, p in result_explicit.generated]
+        assert names_default == names_explicit

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -12,20 +12,28 @@ the sync-side :mod:`memtomem.context.privacy_scan` module. Pins:
 * Binary asset (``UnicodeDecodeError``) → ``decision="pass"`` (no false
   positive against the regex pattern set).
 * ``raise_or_collect`` branch: ``project_shared`` raises
-  :class:`click.ClickException`, others return a typed skip tuple.
+  :class:`PrivacyBlockedError`, others return a typed skip tuple.
+* Unreadable file: ``OSError`` raises :class:`PrivacyScanReadError`
+  (umbrella :class:`PrivacyScanError`). The CLI translates these to
+  ``click.ClickException`` at the boundary; web/MCP surfaces catch
+  the umbrella class and render their native error shape — pinning
+  the domain class here keeps the deeper module Click-free (see
+  #895 P2 review).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
 
-import click
 import pytest
 
 from memtomem import privacy
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context.privacy_scan import (
     FileScan,
+    PrivacyBlockedError,
+    PrivacyScanError,
+    PrivacyScanReadError,
     raise_or_collect,
     scan_artifact_tree,
 )
@@ -177,11 +185,13 @@ class TestUnreadableFileFailsClosed:
     can rename a ``chmod 000`` canonical file into staging without
     reading bytes, so silent-pass would have promoted unreadable
     secret-bearing content into project_shared. These pins check that
-    ``OSError`` from ``read_text`` raises a scope-aware ``ClickException``
-    rather than recording a pass.
+    ``OSError`` from ``read_text`` raises a scope-aware
+    :class:`PrivacyScanReadError` rather than recording a pass — and
+    that the umbrella :class:`PrivacyScanError` catches it for non-CLI
+    surface translation.
     """
 
-    def test_oserror_raises_click_exception_project_shared(
+    def test_oserror_raises_scan_read_error_project_shared(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         path = tmp_path / "agent.md"
@@ -196,17 +206,22 @@ class TestUnreadableFileFailsClosed:
 
         monkeypatch.setattr(Path, "read_text", explode)
 
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyScanReadError) as exc_info:
             scan_artifact_tree(path, surface="t", scope="project_shared", project_root=tmp_path)
+        # Umbrella class must catch — non-CLI surfaces (web, MCP) rely
+        # on this for their HTTP 422 / tool-error translation.
+        assert isinstance(exc_info.value, PrivacyScanError)
         msg = exc_info.value.message
         assert "cannot read" in msg
         assert "agent.md" in msg
         assert "scope='project_shared'" in msg
+        assert exc_info.value.path == path
+        assert exc_info.value.scope == "project_shared"
         # Negative — the message must NOT echo the file's content even
         # if the file were readable mid-flight.
         assert CLEAN.strip() not in msg
 
-    def test_oserror_raises_click_exception_user_scope(
+    def test_oserror_raises_scan_read_error_user_scope(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Fail-closed posture is uniform across scopes for unreadable
@@ -224,7 +239,7 @@ class TestUnreadableFileFailsClosed:
 
         monkeypatch.setattr(Path, "read_text", explode)
 
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyScanReadError) as exc_info:
             scan_artifact_tree(path, surface="t", scope="user", project_root=tmp_path)
         assert "scope='user'" in exc_info.value.message
 
@@ -245,7 +260,7 @@ class TestUnreadableFileFailsClosed:
 
         monkeypatch.setattr(Path, "read_text", explode)
 
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyScanReadError) as exc_info:
             scan_artifact_tree(
                 skill_root,
                 surface="t",
@@ -258,8 +273,21 @@ class TestUnreadableFileFailsClosed:
 class TestRaiseOrCollect:
     def test_project_shared_raises(self) -> None:
         blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked", 1)
-        with pytest.raises(click.ClickException) as exc_info:
+        with pytest.raises(PrivacyBlockedError) as exc_info:
             raise_or_collect(blocked, scope="project_shared", kind="agent", artifact_name="foo")
+        # Umbrella class — non-CLI surfaces catch this for translation.
+        assert isinstance(exc_info.value, PrivacyScanError)
+        # Click coupling removed: the raise must not be a ``click.ClickException``
+        # so the web/MCP generic exception handlers don't turn it into a 500.
+        import click as _click
+
+        assert not isinstance(exc_info.value, _click.ClickException)
+        # Structured fields are populated so non-CLI surfaces can build
+        # their own error shape without re-parsing the message.
+        assert exc_info.value.scope == "project_shared"
+        assert exc_info.value.kind == "agent"
+        assert exc_info.value.artifact_name == "foo"
+        assert exc_info.value.blocked == blocked
         msg = exc_info.value.message
         assert "Gate A" in msg
         assert "agent.md" in msg

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -292,8 +292,13 @@ class TestRaiseOrCollect:
         assert "Gate A" in msg
         assert "agent.md" in msg
         assert "1 privacy pattern hit" in msg
-        # Remediation hint mentions migrate + project_local.
-        assert "mm context migrate agent foo" in msg
+        # Remediation hint mentions migrate + project_local. Plural
+        # "agents" (not "agent") because the migrate CLI only accepts
+        # the plural asset-type choices (#895 P2 review #3 fold —
+        # the pre-fix hint embedded the singular and tripped Click's
+        # invalid-choice error when users followed the remediation).
+        assert "mm context migrate agents foo" in msg
+        assert "mm context migrate agent foo" not in msg
         assert "--to project_local" in msg
         # Positive contract: the wording is "fan-out", not "import"
         # (parallel to apply_gate_a's import-side wording).

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -171,6 +171,90 @@ class TestBinaryAssetGracefulPass:
         assert result.blocked == []
 
 
+class TestUnreadableFileFailsClosed:
+    """Pre-PR-E4 review the OSError branch was conflated with
+    UnicodeDecodeError and recorded as ``pass``. PR-E4's ``_stage_move``
+    can rename a ``chmod 000`` canonical file into staging without
+    reading bytes, so silent-pass would have promoted unreadable
+    secret-bearing content into project_shared. These pins check that
+    ``OSError`` from ``read_text`` raises a scope-aware ``ClickException``
+    rather than recording a pass.
+    """
+
+    def test_oserror_raises_click_exception_project_shared(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "agent.md"
+        path.write_text(CLEAN, encoding="utf-8")
+
+        real_read_text = Path.read_text
+
+        def explode(self: Path, *args: object, **kwargs: object) -> str:
+            if self == path:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", explode)
+
+        with pytest.raises(click.ClickException) as exc_info:
+            scan_artifact_tree(path, surface="t", scope="project_shared", project_root=tmp_path)
+        msg = exc_info.value.message
+        assert "cannot read" in msg
+        assert "agent.md" in msg
+        assert "scope='project_shared'" in msg
+        # Negative — the message must NOT echo the file's content even
+        # if the file were readable mid-flight.
+        assert CLEAN.strip() not in msg
+
+    def test_oserror_raises_click_exception_user_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fail-closed posture is uniform across scopes for unreadable
+        # files. Skip-warn semantics apply to *known* pattern hits at
+        # user/project_local — an unreadable file is not a known hit,
+        # it's an unknown.
+        path = tmp_path / "agent.md"
+        path.write_text(CLEAN, encoding="utf-8")
+        real_read_text = Path.read_text
+
+        def explode(self: Path, *args: object, **kwargs: object) -> str:
+            if self == path:
+                raise OSError(5, "Input/output error", str(self))
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", explode)
+
+        with pytest.raises(click.ClickException) as exc_info:
+            scan_artifact_tree(path, surface="t", scope="user", project_root=tmp_path)
+        assert "scope='user'" in exc_info.value.message
+
+    def test_unreadable_in_tree_walk_fails_fast(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tree walk should hard-abort on the first unreadable file and
+        # NOT continue scanning siblings — the staging tree as a whole
+        # is poisoned the moment any leaf cannot be inspected.
+        skill_root = _seed_skill(tmp_path / "foo")
+        unreadable = skill_root / "scripts" / "leak.sh"
+        real_read_text = Path.read_text
+
+        def explode(self: Path, *args: object, **kwargs: object) -> str:
+            if self == unreadable:
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(Path, "read_text", explode)
+
+        with pytest.raises(click.ClickException) as exc_info:
+            scan_artifact_tree(
+                skill_root,
+                surface="t",
+                scope="project_shared",
+                project_root=tmp_path,
+            )
+        assert "leak.sh" in exc_info.value.message
+
+
 class TestRaiseOrCollect:
     def test_project_shared_raises(self) -> None:
         blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked", 1)

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -9,8 +9,13 @@ the sync-side :mod:`memtomem.context.privacy_scan` module. Pins:
   — must use the real ``AKIA...`` fixture, not generic placeholders).
 * ``on_blocked="fail_fast"`` short-circuits at first hit.
 * ``on_blocked="skip_warn"`` collects every block.
-* Binary asset (``UnicodeDecodeError``) → ``decision="pass"`` (no false
-  positive against the regex pattern set).
+* Non-UTF8 file with NO embedded secret bytes → ``decision="pass"``
+  (replacement chars cannot synthesise a match the raw bytes did not
+  contain).
+* Non-UTF8 file WITH embedded ASCII secret bytes →
+  ``decision="blocked"`` (#895 P1 review #4: ``errors="replace"``
+  decode preserves ASCII byte values so a generated blob carrying
+  ``AKIA...`` between undecodable garbage cannot bypass Gate A).
 * ``raise_or_collect`` branch: ``project_shared`` raises
   :class:`PrivacyBlockedError`, others return a typed skip tuple.
 * Unreadable file: ``OSError`` raises :class:`PrivacyScanReadError`
@@ -162,21 +167,51 @@ class TestOnBlockedDispatch:
         assert len(result.decisions) == 3
 
 
-class TestBinaryAssetGracefulPass:
-    def test_png_bytes_pass_without_false_positive(self, tmp_path: Path) -> None:
-        # Embed an "AKIA..." pattern inside arbitrary binary bytes —
-        # UnicodeDecodeError on UTF-8 decode → decision="pass" path.
-        # This also pins the failure mode: if read_text were upgraded to
-        # decode with errors="replace", the secret would leak through and
-        # this test would catch it.
+class TestNonUtf8FileScan:
+    """Pre-PR-E4 review, the sync-side scan short-circuited every
+    ``UnicodeDecodeError`` to ``decision="pass"`` with the rationale
+    "ASCII-only patterns cannot match non-text payloads" — which was
+    wrong: ASCII patterns *do* match ASCII byte values embedded in a
+    non-UTF8 file, the import-side gate had already moved to
+    ``errors="replace"`` for exactly this reason, and a generated blob
+    carrying ``AKIA...`` between undecodable garbage could promote
+    into ``project_shared`` without Gate A ever inspecting it
+    (#895 P1 review #4).
+
+    These pins lock the corrected behavior: the bytes are decoded with
+    ``errors="replace"`` and run through ``enforce_write_guard``.
+    Replacement characters (U+FFFD) cannot themselves match the
+    regex pattern set (the patterns target specific ASCII shapes,
+    not arbitrary code points), so a benign binary blob still
+    passes; a blob with an embedded ASCII secret now blocks.
+    """
+
+    def test_clean_non_utf8_blob_still_passes(self, tmp_path: Path) -> None:
+        # Random binary noise with no ASCII secret bytes — must not
+        # synthesise a false positive on the embedded U+FFFD chars.
         path = tmp_path / "logo.png"
-        path.write_bytes(b"\x89PNG\r\n\x1a\n" + SECRET.encode() + b"\xff\xfe\x00")
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\xff\xfe\x00" * 200)
         result = scan_artifact_tree(
             path, surface="t", scope="project_shared", project_root=tmp_path
         )
         assert len(result.decisions) == 1
         assert result.decisions[0].decision == "pass"
         assert result.blocked == []
+
+    def test_non_utf8_blob_with_ascii_secret_is_blocked(self, tmp_path: Path) -> None:
+        # AKIA bytes embedded between non-UTF8 garbage — pre-fix this
+        # produced ``pass``, letting the bytes promote into project_shared
+        # via skill staging fan-out without Gate A inspection. Post-fix:
+        # blocked.
+        path = tmp_path / "generated.bin"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + SECRET.encode() + b"\xff\xfe\x00")
+        result = scan_artifact_tree(
+            path, surface="t", scope="project_shared", project_root=tmp_path
+        )
+        assert len(result.decisions) == 1
+        assert result.decisions[0].decision in ("blocked", "blocked_project_shared")
+        assert len(result.blocked) == 1
+        assert result.blocked[0].hits_count >= 1
 
 
 class TestUnreadableFileFailsClosed:
@@ -197,14 +232,14 @@ class TestUnreadableFileFailsClosed:
         path = tmp_path / "agent.md"
         path.write_text(CLEAN, encoding="utf-8")
 
-        real_read_text = Path.read_text
+        real_read_bytes = Path.read_bytes
 
-        def explode(self: Path, *args: object, **kwargs: object) -> str:
+        def explode(self: Path, *args: object, **kwargs: object) -> bytes:
             if self == path:
                 raise PermissionError(13, "Permission denied", str(self))
-            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+            return real_read_bytes(self, *args, **kwargs)  # type: ignore[arg-type]
 
-        monkeypatch.setattr(Path, "read_text", explode)
+        monkeypatch.setattr(Path, "read_bytes", explode)
 
         with pytest.raises(PrivacyScanReadError) as exc_info:
             scan_artifact_tree(path, surface="t", scope="project_shared", project_root=tmp_path)
@@ -230,14 +265,14 @@ class TestUnreadableFileFailsClosed:
         # it's an unknown.
         path = tmp_path / "agent.md"
         path.write_text(CLEAN, encoding="utf-8")
-        real_read_text = Path.read_text
+        real_read_bytes = Path.read_bytes
 
-        def explode(self: Path, *args: object, **kwargs: object) -> str:
+        def explode(self: Path, *args: object, **kwargs: object) -> bytes:
             if self == path:
                 raise OSError(5, "Input/output error", str(self))
-            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+            return real_read_bytes(self, *args, **kwargs)  # type: ignore[arg-type]
 
-        monkeypatch.setattr(Path, "read_text", explode)
+        monkeypatch.setattr(Path, "read_bytes", explode)
 
         with pytest.raises(PrivacyScanReadError) as exc_info:
             scan_artifact_tree(path, surface="t", scope="user", project_root=tmp_path)
@@ -251,14 +286,14 @@ class TestUnreadableFileFailsClosed:
         # is poisoned the moment any leaf cannot be inspected.
         skill_root = _seed_skill(tmp_path / "foo")
         unreadable = skill_root / "scripts" / "leak.sh"
-        real_read_text = Path.read_text
+        real_read_bytes = Path.read_bytes
 
-        def explode(self: Path, *args: object, **kwargs: object) -> str:
+        def explode(self: Path, *args: object, **kwargs: object) -> bytes:
             if self == unreadable:
                 raise PermissionError(13, "Permission denied", str(self))
-            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+            return real_read_bytes(self, *args, **kwargs)  # type: ignore[arg-type]
 
-        monkeypatch.setattr(Path, "read_text", explode)
+        monkeypatch.setattr(Path, "read_bytes", explode)
 
         with pytest.raises(PrivacyScanReadError) as exc_info:
             scan_artifact_tree(

--- a/packages/memtomem/tests/test_privacy_scan.py
+++ b/packages/memtomem/tests/test_privacy_scan.py
@@ -1,0 +1,220 @@
+"""ADR-0011 PR-E3 — sync-side privacy scan (canonical → runtime fan-out).
+
+Mirrors :mod:`test_privacy_scope_gate` (the import-side gate) but for
+the sync-side :mod:`memtomem.context.privacy_scan` module. Pins:
+
+* Single-file scan: secret hit → ``decision="blocked"``.
+* Tree walk: secret in ``scripts/leak.sh`` → blocked even when
+  ``SKILL.md`` is clean (``feedback_force_unsafe_redaction_valve_only.md``
+  — must use the real ``AKIA...`` fixture, not generic placeholders).
+* ``on_blocked="fail_fast"`` short-circuits at first hit.
+* ``on_blocked="skip_warn"`` collects every block.
+* Binary asset (``UnicodeDecodeError``) → ``decision="pass"`` (no false
+  positive against the regex pattern set).
+* ``raise_or_collect`` branch: ``project_shared`` raises
+  :class:`click.ClickException`, others return a typed skip tuple.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+
+from memtomem import privacy
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context.privacy_scan import (
+    FileScan,
+    raise_or_collect,
+    scan_artifact_tree,
+)
+
+# AKIA fixture per feedback_force_unsafe_redaction_valve_only.md — clean
+# strings would let force_unsafe=False scans pass and produce a false
+# negative on every block-related assertion.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+CLEAN = "this is just regular prose, no secrets here\n"
+
+
+@pytest.fixture(autouse=True)
+def _reset_privacy_counters():
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+def _seed_skill(skill_root: Path, *, leak_in: str | None = None) -> Path:
+    """Create a skill tree under ``skill_root``. ``leak_in`` is the
+    relative path that gets the AKIA secret (``"SKILL.md"``,
+    ``"scripts/leak.sh"``, etc.). ``None`` → all files clean."""
+    skill_root.mkdir(parents=True, exist_ok=True)
+    files = {
+        "SKILL.md": "---\nname: foo\n---\nbody\n",
+        "scripts/leak.sh": "#!/bin/bash\necho hello\n",
+        "references/notes.md": "see README\n",
+    }
+    if leak_in is not None:
+        files[leak_in] = files.get(leak_in, "") + SECRET + "\n"
+    for rel, content in files.items():
+        path = skill_root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return skill_root
+
+
+class TestSingleFileScan:
+    def test_clean_file_passes(self, tmp_path: Path) -> None:
+        path = tmp_path / "agent.md"
+        path.write_text(CLEAN, encoding="utf-8")
+        result = scan_artifact_tree(path, surface="t", scope="user", project_root=tmp_path)
+        assert len(result.decisions) == 1
+        assert result.decisions[0].decision == "pass"
+        assert result.blocked == []
+
+    def test_secret_in_file_blocked_user(self, tmp_path: Path) -> None:
+        path = tmp_path / "agent.md"
+        path.write_text(f"---\nname: foo\n---\n{SECRET}\n", encoding="utf-8")
+        result = scan_artifact_tree(path, surface="t", scope="user", project_root=tmp_path)
+        # Positive marker: at least one blocked entry referencing the file.
+        assert len(result.blocked) == 1
+        blocked = result.blocked[0]
+        assert blocked.path == path
+        assert blocked.decision == "blocked"
+        assert blocked.hits_count >= 1
+
+    def test_secret_in_file_blocked_project_shared_no_force(self, tmp_path: Path) -> None:
+        # force_unsafe is hardcoded False in scan_artifact_tree (ADR §5),
+        # so project_shared with a hit produces "blocked" (not
+        # "blocked_project_shared" — that only fires with force_unsafe=True).
+        path = tmp_path / "agent.md"
+        path.write_text(f"{SECRET}\n", encoding="utf-8")
+        result = scan_artifact_tree(
+            path, surface="t", scope="project_shared", project_root=tmp_path
+        )
+        assert len(result.blocked) == 1
+        assert result.blocked[0].decision == "blocked"
+
+
+class TestTreeWalk:
+    def test_secret_in_scripts_blocked(self, tmp_path: Path) -> None:
+        # The realistic skill leak: secret in scripts/leak.sh while
+        # SKILL.md is clean. Tree walk must catch it (regression of the
+        # pre-PR-E3 behavior where only SKILL.md was scanned).
+        skill = _seed_skill(tmp_path / "foo", leak_in="scripts/leak.sh")
+        result = scan_artifact_tree(
+            skill, surface="t", scope="project_shared", project_root=tmp_path
+        )
+        assert len(result.blocked) == 1, result.blocked
+        assert result.blocked[0].path == skill / "scripts/leak.sh"
+
+    def test_clean_skill_passes(self, tmp_path: Path) -> None:
+        skill = _seed_skill(tmp_path / "foo", leak_in=None)
+        result = scan_artifact_tree(
+            skill, surface="t", scope="project_shared", project_root=tmp_path
+        )
+        assert result.blocked == []
+        # All three files visited and all passed.
+        assert len(result.decisions) == 3
+        assert all(d.decision == "pass" for d in result.decisions)
+
+
+class TestOnBlockedDispatch:
+    def test_fail_fast_returns_at_first_hit(self, tmp_path: Path) -> None:
+        # Two leaks — fail_fast must return after the first.
+        skill = _seed_skill(tmp_path / "foo", leak_in="scripts/leak.sh")
+        # Add a second leak in references/.
+        (skill / "references" / "notes.md").write_text(f"see README\n{SECRET}\n", encoding="utf-8")
+        result = scan_artifact_tree(
+            skill,
+            surface="t",
+            scope="project_shared",
+            project_root=tmp_path,
+            on_blocked="fail_fast",
+        )
+        # fail_fast: blocked has exactly 1 entry. decisions cap at the
+        # number of files scanned BEFORE the abort (sorted iteration is
+        # deterministic per Path.rglob).
+        assert len(result.blocked) == 1
+        assert len(result.decisions) <= 3
+
+    def test_skip_warn_collects_all(self, tmp_path: Path) -> None:
+        skill = _seed_skill(tmp_path / "foo", leak_in="scripts/leak.sh")
+        (skill / "references" / "notes.md").write_text(f"see README\n{SECRET}\n", encoding="utf-8")
+        result = scan_artifact_tree(
+            skill,
+            surface="t",
+            scope="user",
+            project_root=tmp_path,
+            on_blocked="skip_warn",
+        )
+        # skip_warn: every leaked file appears in blocked.
+        assert len(result.blocked) == 2, result.blocked
+        # decisions visits all files (3 total).
+        assert len(result.decisions) == 3
+
+
+class TestBinaryAssetGracefulPass:
+    def test_png_bytes_pass_without_false_positive(self, tmp_path: Path) -> None:
+        # Embed an "AKIA..." pattern inside arbitrary binary bytes —
+        # UnicodeDecodeError on UTF-8 decode → decision="pass" path.
+        # This also pins the failure mode: if read_text were upgraded to
+        # decode with errors="replace", the secret would leak through and
+        # this test would catch it.
+        path = tmp_path / "logo.png"
+        path.write_bytes(b"\x89PNG\r\n\x1a\n" + SECRET.encode() + b"\xff\xfe\x00")
+        result = scan_artifact_tree(
+            path, surface="t", scope="project_shared", project_root=tmp_path
+        )
+        assert len(result.decisions) == 1
+        assert result.decisions[0].decision == "pass"
+        assert result.blocked == []
+
+
+class TestRaiseOrCollect:
+    def test_project_shared_raises(self) -> None:
+        blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked", 1)
+        with pytest.raises(click.ClickException) as exc_info:
+            raise_or_collect(blocked, scope="project_shared", kind="agent", artifact_name="foo")
+        msg = exc_info.value.message
+        assert "Gate A" in msg
+        assert "agent.md" in msg
+        assert "1 privacy pattern hit" in msg
+        # Remediation hint mentions migrate + project_local.
+        assert "mm context migrate agent foo" in msg
+        assert "--to project_local" in msg
+        # Positive contract: the wording is "fan-out", not "import"
+        # (parallel to apply_gate_a's import-side wording).
+        assert "fan-out to scope='project_shared' rejected" in msg
+
+    def test_user_returns_skip_tuple(self) -> None:
+        blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked", 2)
+        code, reason = raise_or_collect(blocked, scope="user", kind="agent", artifact_name="foo")
+        assert code == skip_codes.PRIVACY_BLOCKED
+        assert "agent.md" in reason
+        assert "2 pattern hit" in reason
+
+    def test_project_local_returns_skip_tuple(self) -> None:
+        blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked", 1)
+        code, reason = raise_or_collect(
+            blocked, scope="project_local", kind="agent", artifact_name="foo"
+        )
+        assert code == skip_codes.PRIVACY_BLOCKED
+        # Negative marker: never raised for non-project_shared.
+        assert reason  # non-empty
+
+    def test_blocked_project_shared_decision_maps_to_distinct_code(self) -> None:
+        # Should never happen in sync (force_unsafe=False), but the
+        # mapping is verified so a future regression in
+        # scan_artifact_tree's force_unsafe defaulting cannot silently
+        # pick the wrong code.
+        blocked = FileScan(Path("/tmp/foo/agent.md"), "blocked_project_shared", 1)
+        code, _reason = raise_or_collect(blocked, scope="user", kind="agent", artifact_name="foo")
+        assert code == skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED
+
+
+# Audit-log shape (scope marker / kind=sync field) is exercised inside
+# ``test_privacy_scope_gate.py`` against the underlying
+# ``enforce_write_guard``. ``scan_artifact_tree`` is a thin wrapper that
+# forwards to that helper; a duplicated audit-log assertion here would
+# only re-pin behavior already locked elsewhere.

--- a/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
+++ b/packages/memtomem/tests/test_sync_privacy_block_surfaces.py
@@ -1,0 +1,142 @@
+"""Regression pins for #895 P2 review fold — surface-level translation of
+``PrivacyBlockedError`` in non-CLI sync paths.
+
+Pre-fold, ``raise_or_collect`` raised ``click.ClickException`` directly
+from generic generator code; the CLI auto-handled the message but the
+web routes and MCP context tool both fell through to their generic
+exception handlers and turned a user-actionable privacy block into a
+500 "Internal server error".
+
+These tests pin:
+
+* Web ``/api/context/{agents,commands,skills}/sync`` translates the
+  block into HTTP 422 with the formatted user message in the body.
+* MCP ``mem_context_generate`` / ``mem_context_sync`` returns a
+  ``"privacy block: ..."`` string instead of letting the exception
+  propagate to the tool harness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from memtomem.context.privacy_scan import FileScan, PrivacyBlockedError
+
+
+_FAKE_BLOCKED = FileScan(Path("/tmp/p/.memtomem/agents/leak.md"), "blocked", 1)
+_FAKE_MSG = "Gate A: leak.md contains 1 privacy pattern hit(s); fan-out rejected."
+
+
+def _raise_privacy_block(*args, **kwargs):
+    raise PrivacyBlockedError(
+        _FAKE_MSG,
+        blocked=_FAKE_BLOCKED,
+        scope="project_shared",
+        kind="agent",
+        artifact_name="leak",
+    )
+
+
+def _build_app_with(router) -> FastAPI:
+    """Minimal FastAPI app + ``get_project_root`` override.
+
+    Mirrors ``test_web_csrf_middleware.py`` — boot the production
+    factory pulls in storage/embedder which the sync route does not
+    actually need. The dependency override is enough to satisfy
+    ``project_root`` injection without touching the file system.
+    """
+    from memtomem.web.deps import get_project_root
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_project_root] = lambda: Path("/tmp/p")
+    return app
+
+
+class TestWebSyncTranslatesTo422:
+    def test_agents_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.web.routes import context_agents
+
+        monkeypatch.setattr(context_agents, "generate_all_agents", _raise_privacy_block)
+        client = TestClient(_build_app_with(context_agents.router))
+
+        res = client.post("/context/agents/sync", json={})
+
+        assert res.status_code == 422, res.text
+        # FastAPI's default HTTPException renders as ``{"detail": "..."}``;
+        # the formatted message must round-trip so the UI can surface it.
+        assert _FAKE_MSG in res.json()["detail"]
+
+    def test_commands_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.web.routes import context_commands
+
+        monkeypatch.setattr(context_commands, "generate_all_commands", _raise_privacy_block)
+        client = TestClient(_build_app_with(context_commands.router))
+
+        res = client.post("/context/commands/sync", json={})
+
+        assert res.status_code == 422, res.text
+        assert _FAKE_MSG in res.json()["detail"]
+
+    def test_skills_sync_returns_422(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from memtomem.web.routes import context_skills
+
+        monkeypatch.setattr(context_skills, "generate_all_skills", _raise_privacy_block)
+        client = TestClient(_build_app_with(context_skills.router))
+
+        res = client.post("/context/skills/sync")
+
+        assert res.status_code == 422, res.text
+        assert _FAKE_MSG in res.json()["detail"]
+
+
+class TestMcpContextToolTranslates:
+    """The MCP context tool returns a string body; on privacy block it must
+    return a ``"privacy block: ..."`` prefix instead of raising into the
+    tool harness. Lazy imports inside the tool body pick up the
+    monkeypatched generator at call time.
+    """
+
+    def _setup_project(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        # ``_find_project_root`` walks up for a ``.git`` parent — give it one.
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        monkeypatch.chdir(project)
+        return project
+
+    @pytest.mark.anyio
+    async def test_generate_tool_skills_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.context import skills as ctx_skills
+        from memtomem.server.tools.context import mem_context_generate
+
+        self._setup_project(tmp_path, monkeypatch)
+        monkeypatch.setattr(ctx_skills, "generate_all_skills", _raise_privacy_block)
+
+        result = await mem_context_generate(include="skills")
+
+        assert isinstance(result, str)
+        assert result.startswith("privacy block:"), result
+        assert _FAKE_MSG in result
+
+    @pytest.mark.anyio
+    async def test_sync_tool_agents_block(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from memtomem.context import agents as ctx_agents
+        from memtomem.server.tools.context import mem_context_sync
+
+        self._setup_project(tmp_path, monkeypatch)
+        monkeypatch.setattr(ctx_agents, "generate_all_agents", _raise_privacy_block)
+
+        result = await mem_context_sync(include="agents")
+
+        assert isinstance(result, str)
+        assert result.startswith("privacy block:"), result
+        assert _FAKE_MSG in result

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -468,6 +468,23 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     assert '"toast.dev_only_section"' in ko
 
 
+def test_indexing_guard_rechecks_server_before_blocking_retry() -> None:
+    """A stale client-side indexing flag must not permanently block retry.
+
+    Source-tab SSE failures can leave users looking at a model-readiness error
+    banner while the server is already idle. The next reindex click should
+    confirm ``/api/indexing/active`` before showing "already in progress".
+    """
+    app_js = _read_static("app.js")
+    sources_js = _read_static("sources-memory-dirs.js")
+
+    assert "async function _indexingTryStartOrRefresh()" in app_js
+    assert "api('GET', '/api/indexing/active')" in app_js
+    assert "_indexingEnd();\n      return _indexingTryStart();" in app_js
+    assert "await _indexingTryStartOrRefresh()" in app_js
+    assert sources_js.count("await _indexingTryStartOrRefresh()") >= 2
+
+
 def test_html_main_tabs_all_stay_prod() -> None:
     """Main top-nav tabs (Home / Search / Sources / Index / Tags / Timeline /
     Settings) should all be prod today. Flipping a main tab to dev would be

--- a/packages/memtomem/tests/web/test_sources_reindex_retry.py
+++ b/packages/memtomem/tests/web/test_sources_reindex_retry.py
@@ -47,9 +47,7 @@ def _install_default_stubs(page) -> None:
     )
 
 
-def test_sources_reindex_retries_when_local_indexing_flag_is_stale(
-    page, mm_web_url: str
-) -> None:
+def test_sources_reindex_retries_when_local_indexing_flag_is_stale(page, mm_web_url: str) -> None:
     """Stale client ``STATE.indexing`` must not block a new Sources reindex.
 
     The server reports idle via ``/api/indexing/active``; ``mdReindexOne`` must
@@ -97,4 +95,3 @@ def test_sources_reindex_retries_when_local_indexing_flag_is_stale(
     assert "path=%2Ftmp%2Fmemories" in constructed["eventSourceUrl"]
     assert constructed["stateIndexing"] is True
     assert constructed["buttonDisabled"] is True
-

--- a/packages/memtomem/tests/web/test_sources_reindex_retry.py
+++ b/packages/memtomem/tests/web/test_sources_reindex_retry.py
@@ -1,0 +1,100 @@
+"""Browser regression tests for Sources-tab reindex retry state.
+
+The reported flow is: Sources tab reindex hits a model-load failure, the
+model-readiness banner says "Model failed to load", and later reindex attempts
+do not start. The backend active counter already has Python coverage; this
+spec pins the client-side retry bridge that rechecks server truth before
+honouring a stale ``STATE.indexing`` flag.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _ok(route, payload) -> None:
+    route.fulfill(status=200, content_type="application/json", body=json.dumps(payload))
+
+
+def _install_default_stubs(page) -> None:
+    page.route("**/api/**", lambda r: _ok(r, {}))
+    page.route("**/api/system/ui-mode", lambda r: _ok(r, {"mode": "prod"}))
+    page.route("**/api/system/model-readiness", lambda r: _ok(r, {"ready": True}))
+    page.route("**/api/sources?**", lambda r: _ok(r, {"sources": []}))
+    page.route("**/api/stats", lambda r: _ok(r, {}))
+    page.route(
+        "**/api/memory-dirs/status",
+        lambda r: _ok(
+            r,
+            {
+                "dirs": [
+                    {
+                        "path": "/tmp/memories",
+                        "exists": True,
+                        "file_count": 1,
+                        "source_file_count": 0,
+                        "chunk_count": 0,
+                        "category": "user",
+                        "provider": "user",
+                    }
+                ]
+            },
+        ),
+    )
+
+
+def test_sources_reindex_retries_when_local_indexing_flag_is_stale(
+    page, mm_web_url: str
+) -> None:
+    """Stale client ``STATE.indexing`` must not block a new Sources reindex.
+
+    The server reports idle via ``/api/indexing/active``; ``mdReindexOne`` must
+    clear the local flag and proceed far enough to construct the SSE stream.
+    """
+    _install_default_stubs(page)
+    page.route("**/api/indexing/active", lambda r: _ok(r, {"active": False}))
+    page.goto(mm_web_url)
+
+    constructed = page.evaluate(
+        """async () => {
+          let eventSourceUrl = '';
+          class FakeEventSource {
+            constructor(url) {
+              eventSourceUrl = String(url);
+              this.onmessage = null;
+              this.onerror = null;
+            }
+            close() {}
+          }
+          window.EventSource = FakeEventSource;
+          STATE.indexing = true;
+
+          const group = document.createElement('details');
+          group.className = 'source-group';
+          const meta = document.createElement('span');
+          meta.className = 'source-group-stats';
+          meta.textContent = '1/1 files, 0 chunks';
+          group.appendChild(meta);
+          const btn = document.createElement('button');
+          btn.textContent = 'Index';
+          group.appendChild(btn);
+          document.body.appendChild(group);
+
+          await mdReindexOne('/tmp/memories', btn);
+          return {
+            eventSourceUrl,
+            stateIndexing: STATE.indexing,
+            buttonDisabled: btn.disabled,
+          };
+        }"""
+    )
+
+    assert constructed["eventSourceUrl"].startswith("/api/index/stream?")
+    assert "path=%2Ftmp%2Fmemories" in constructed["eventSourceUrl"]
+    assert constructed["stateIndexing"] is True
+    assert constructed["buttonDisabled"] is True
+


### PR DESCRIPTION
## Why this exists

PR #893 ("feat(scope): mm context migrate <kind> --to for scope-tier moves (PR-E4)") was opened against base `fix/adr-0011-pr-e3` instead of `main` — a leftover from an earlier stacked PR plan. It was admin-merged in good faith, but the squash only updated the PR-E3 feature branch, not `main`. The merge commit `0ca52ac` is unreachable from any branch tip on `main`.

This PR is the recovery: it re-targets the full PR-E3 + PR-E4 stack to `main`. No new code — everything here has either been reviewed in #893 (Codex SHIP) or sat on the PR-E3 branch awaiting promotion.

## Bundled commits (4)

- `9b47ba0` prep: normalize scope plumbing for E3
- `ee09c43` feat(scope): mm context sync --scope + canonical-side Gate A
- `aa94d26` fix(scope): close scan/write TOCTOU + lock skills stage→promote
- `0ca52ac` feat(scope): mm context migrate `<kind>` --to for scope-tier moves (PR-E4) (`#893` squash)

Splitting back into two PRs (E3 then E4) is possible but adds zero signal — E4 builds on E3's plumbing and they were always intended to land together. Single bundle keeps the recovery atomic.

## Scope summary

15 files, +3614 / −246. Touches:

- `cli/context_cmd.py` — wires `mm context sync --scope` and `mm context migrate <kind> --to`.
- `context/migrate.py`, `context/agents.py`, `context/commands.py`, `context/skills.py` — scope-tier move logic, stage→promote locking, TOCTOU close.
- `context/privacy_scan.py` (new) — fail-closed scan tree.
- `context/_runtime_targets.py` (new) — scope plumbing helper.
- `docs/guides/reference.md` — flag docs.
- Tests: `test_context_migrate.py` (+891), `test_context_migrate_lock_order.py` (new +130), `test_context_skills_staging.py` (new +328), `test_context_sync_scope.py` (new +212), `test_privacy_scan.py` (new +304), and `test_context_runtime_table_none_skips.py` follow-ups.

## Test plan

- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — full suite green at branch tip (verified during the original #893 cycle; will re-verify in CI on this PR).
- [x] `uv run ruff check` / `ruff format --check` — clean.
- [x] `uv run mypy` — clean on touched files.

## Notes

- The `fix/adr-0011-pr-e3` branch will be deleted on merge so the recovery state isn't ambiguous afterwards.
- #893's CI history is preserved in the closed PR; this PR re-runs CI against `main` as the actual base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
