### PR TITLE
fix(web): keep Discovered dirs visible when filter is active

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3275,12 +3275,21 @@ function _renderMemorySourceTree(sources, list) {
       (sum, [, indexed]) => sum + indexed.reduce((s, d) => s + (sourcesByDir[d] || []).length, 0),
       0,
     ) + vendorOrphans.length;
+    // Tracked separately from ``totalFiles`` so the sub-tab badge keeps its
+    // "indexed + orphans" meaning while the empty-state guard further down
+    // can still see discovered dirs (codex review on #896: a vendor with
+    // only Discovered dirs would otherwise hit the "No matches" fallback
+    // because ``totalFiles`` is zero, hiding the section the carve-out in
+    // ``visibleCatsRaw`` just preserved).
+    const discoveredCount = visibleCats.reduce(
+      (sum, [, , discovered]) => sum + discovered.length, 0,
+    );
     const visibleIndexedCats = visibleCats.filter(([, indexed]) => indexed.length);
     const isSingleLeaf = visibleIndexedCats.length === 1
       || (visibleIndexedCats.length === 0 && visibleCats.length === 1);
     vendorPlans[provider] = {
-      visibleCats, visibleIndexedCats, isEmptyVendor, totalFiles, isSingleLeaf,
-      orphans: vendorOrphans,
+      visibleCats, visibleIndexedCats, isEmptyVendor, totalFiles, discoveredCount,
+      isSingleLeaf, orphans: vendorOrphans,
     };
 
     // Update the sub-tab badge + empty class so all three vendor tabs
@@ -3488,7 +3497,10 @@ function _renderMemorySourceTree(sources, list) {
   // to look.
   if (!allDirs.size && !orphanItems.length) {
     list.innerHTML = '<div class="empty-state">' + emptyState('📁', 'No memory directories', 'Add one with the + Add path button') + '</div>';
-  } else if (filterActive && !plan.totalFiles && !plan.isEmptyVendor) {
+  } else if (filterActive && !plan.totalFiles && !plan.discoveredCount && !plan.isEmptyVendor) {
+    // ``totalFiles`` only counts indexed+orphan rows; a vendor whose
+    // ``visibleCats`` carries discovered dirs (the #896 carve-out) would
+    // otherwise be wiped here, defeating the carry-over fix.
     list.innerHTML = '<div class="empty-state">' + emptyState('🔍', 'No matches for that filter') + '</div>';
   }
 

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -3242,9 +3242,14 @@ function _renderMemorySourceTree(sources, list) {
     const bucket = byProvider[provider];
 
     const categoriesAll = CATEGORY_ORDER.filter(c => bucket.byCategory[c]);
+    // Filter narrows indexed dirs (chunks>0) by source matches, but always
+    // keeps "Discovered" dirs (chunks=0 && files>0) regardless of filter
+    // state — without this branch, any NS/path filter ever set on the page
+    // makes all Discovered dirs vanish at once (the original ``Claude (0)``
+    // guard was scoped to indexed-empty rows, not Discovered ones).
     const visibleCatsRaw = filterActive
       ? categoriesAll
-          .map(cat => [cat, bucket.byCategory[cat].filter(d => (sourcesByDir[d] || []).length > 0)])
+          .map(cat => [cat, bucket.byCategory[cat].filter(d => (sourcesByDir[d] || []).length > 0 || isDiscovered(d))])
           .filter(([, dirs]) => dirs.length > 0)
       : categoriesAll.map(cat => [cat, bucket.byCategory[cat]]);
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1381,7 +1381,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=113"></script>
+  <script src="/app.js?v=114"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1381,7 +1381,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=112"></script>
+  <script src="/app.js?v=113"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=11"></script>
   <script src="/settings-maintenance.js?v=2"></script>

--- a/packages/memtomem/tests/test_web_sources_tree.py
+++ b/packages/memtomem/tests/test_web_sources_tree.py
@@ -44,3 +44,27 @@ def test_is_discovered_predicate_shape() -> None:
     assert "return chunks === 0 && files > 0;" in js, (
         "isDiscovered predicate shape changed — update the filterActive pin too"
     )
+
+
+def test_empty_state_guard_respects_discovered_dirs() -> None:
+    """Codex carry-over on #896: the filterActive carve-out keeps
+    Discovered dirs in ``visibleCats``, but the later empty-state guard
+    used to wipe the whole panel when ``totalFiles == 0`` — discovered-
+    only vendors fell through to "No matches for that filter." The
+    fix counts Discovered dirs separately and lets the guard see them.
+    """
+    js = _read_app_js()
+    # Plan must carry discoveredCount alongside totalFiles so the empty-
+    # state check can distinguish "no indexed matches but Discovered dirs
+    # still to show" from "really nothing to show."
+    assert "discoveredCount" in js, (
+        "plan.discoveredCount field missing — empty-state guard cannot tell "
+        "indexed-empty from truly-empty vendors"
+    )
+    # The empty-state guard itself must consult discoveredCount, otherwise
+    # vendors with only Discovered dirs hit the "No matches" fallback that
+    # replaces the section the #896 carve-out just preserved.
+    assert "!plan.discoveredCount" in js, (
+        "empty-state guard still trips on discovered-only vendors — "
+        "discoveredCount must be part of the !totalFiles fallback condition"
+    )

--- a/packages/memtomem/tests/test_web_sources_tree.py
+++ b/packages/memtomem/tests/test_web_sources_tree.py
@@ -1,0 +1,46 @@
+"""JS source-grep pins for the Sources tab vendor tree.
+
+No JS runtime in the suite, so we lock the small set of branches that
+fan-out determines whether each ``memory_dir`` renders. Two pieces of
+behaviour we don't want to regress:
+
+* Filter state (path filter input OR ``STATE.sourcesNsFilter``) must NOT
+  hide "Discovered" dirs (chunks=0, files>0). The original ``Claude (0)``
+  filter guard was meant to drop *indexed-empty* dirs only; without a
+  Discovered carve-out the same guard makes 30+ dirs vanish the moment
+  any filter is set.
+* The ``isDiscovered`` predicate stays defined as ``chunks === 0 &&
+  files > 0`` so the grep above remains meaningful.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_STATIC = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" / "static"
+
+
+def _read_app_js() -> str:
+    return (_STATIC / "app.js").read_text(encoding="utf-8")
+
+
+def test_filter_keeps_discovered_dirs_visible() -> None:
+    js = _read_app_js()
+    # The filterActive branch in _renderMemorySourceTree must keep
+    # Discovered dirs in addition to dirs with matching sources.
+    # Any future refactor that drops the ``|| isDiscovered(d)`` half of
+    # this predicate hides 30+ chunkless dirs the moment a filter is set.
+    needle = "filter(d => (sourcesByDir[d] || []).length > 0 || isDiscovered(d))"
+    assert needle in js, (
+        "filterActive branch lost its Discovered carve-out — dirs with "
+        "chunks=0 will vanish whenever any filter is active"
+    )
+
+
+def test_is_discovered_predicate_shape() -> None:
+    js = _read_app_js()
+    # Lock the predicate so the grep above keeps catching regressions.
+    # If this expression ever moves to a helper, update both pins together.
+    assert "return chunks === 0 && files > 0;" in js, (
+        "isDiscovered predicate shape changed — update the filterActive pin too"
+    )


### PR DESCRIPTION
## Summary

- The Sources tab's `_renderMemorySourceTree` hides all Discovered dirs
  (chunks=0, files>0) whenever `filterActive` is true. For a user with
  30+ auto-discovered `~/.claude/projects/*/memory` entries, setting the
  path-filter input or clicking an NS card (which sets
  `STATE.sourcesNsFilter`) collapses the entire vendor down to the one
  indexed dir.
- The original `Claude (0)` guard was scoped to indexed-empty rows, not
  Discovered ones. Restore the Discovered carve-out so the filter only
  narrows indexed dirs; Discovered dirs always render alongside.
- Follow-up commit (codex review): the later empty-state guard tripped
  on `!plan.totalFiles` too, so a discovered-only vendor or a filter
  with zero indexed matches still got replaced with "No matches."
  Track `plan.discoveredCount` separately and gate the fallback on
  it so the carve-out survives the empty-state check.

## Files

- `app.js:3245-3253` — filter predicate gains `|| isDiscovered(d)`.
- `app.js:3270-3290` — `plan.discoveredCount` field; empty-state guard
  consults it alongside `totalFiles` and `isEmptyVendor`. `totalFiles`
  keeps its "indexed + orphans" shape so the sub-tab badge meaning is
  unchanged.
- `index.html` — `app.js` cache-bust bumped `v=112 → v=114`.
- `tests/test_web_sources_tree.py` — new JS source-grep file with three
  pins (carve-out, `isDiscovered` predicate shape, empty-state guard).

## Repro (before fix)

1. Config with one user-tier dir plus many auto-discovered
   `~/.claude/projects/*/memory` dirs (chunks=0, files>0).
2. Open Sources → Claude sub-tab. Discovered group lists every project
   dir.
3. Index a single dir (or click an NS card so
   `STATE.sourcesNsFilter` is set).
4. All other Discovered dirs vanish — only the indexed one remains.

After fix: Discovered dirs stay visible regardless of filter state,
and a vendor with *only* Discovered dirs no longer falls through to
the "No matches for that filter" placeholder.

## Test plan

- [x] `pytest packages/memtomem/tests/test_web_sources_tree.py` — 3 PASS.
- [x] Mutation check: dropping `|| isDiscovered(d)` from the filter
      predicate fails the carve-out pin; dropping `!plan.discoveredCount`
      from the empty-state guard fails the new follow-up pin
      (per `feedback_pin_test_mutation_validation.md`).
- [x] `ruff check` / `ruff format --check` PASS.
- [ ] Manual UI smoke (`uv run mm web` → Claude sub-tab → type into
      filter input, click NS card): Discovered list stays populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
