### PR TITLE
fix(web): /api/add honors memory_dirs[0] (parity with MCP mem_add)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1214,6 +1214,7 @@ async def add_memory(
     req: AddMemoryRequest,
     index_engine=Depends(get_index_engine),
     storage=Depends(get_storage),
+    config=Depends(get_config),
 ) -> AddMemoryResponse:
     from datetime import datetime, timezone
 
@@ -1239,6 +1240,16 @@ async def add_memory(
             },
         )
 
+    # Write-surface parity with MCP ``mem_add``: route the default-dated
+    # file to the configured user-tier ``memory_dirs[0]``. Before this
+    # fix the route hardcoded ``~/.memtomem/memories``, ignoring the
+    # user's configured destination and silently diverging from MCP and
+    # CLI which already honor ``memory_dirs[0]``. The historical default
+    # remains as a last-resort fallback when no dirs are configured at
+    # all (``require_configured`` already guards the common case).
+    mdirs = config.indexing.memory_dirs
+    base = Path(mdirs[0] if mdirs else "~/.memtomem/memories").expanduser().resolve()
+
     if req.file:
         raw = req.file
         if raw.startswith("/") or raw.startswith("\\") or ".." in raw:
@@ -1246,7 +1257,6 @@ async def add_memory(
                 status_code=422,
                 detail="File path must be relative and must not contain '..'",
             )
-        base = Path("~/.memtomem/memories").expanduser().resolve()
         target = (base / raw).resolve()
         if not str(target).startswith(str(base)):
             raise HTTPException(
@@ -1255,7 +1265,6 @@ async def add_memory(
             )
     else:
         date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        base = Path("~/.memtomem/memories").expanduser().resolve()
         target = (base / f"{date_str}.md").resolve()
 
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1613,6 +1613,46 @@ class TestAddMemory:
         )
         assert resp.status_code == 422
 
+    async def test_add_memory_writes_under_configured_memory_dirs_default(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # /api/add must honor ``config.indexing.memory_dirs[0]`` for the
+        # default-dated file, matching MCP ``mem_add``. Before the
+        # write-surface parity fix the route hardcoded
+        # ``~/.memtomem/memories`` and silently ignored configured dirs,
+        # which meant prod users (and this test suite under a real HOME)
+        # had their entries leak outside the configured corpus.
+        app.state.config.indexing.memory_dirs = [tmp_path]
+        resp = await client.post(
+            "/api/add",
+            json={"content": "Parity check."},
+        )
+        assert resp.status_code == 200, resp.text
+        path = Path(resp.json()["file"]).resolve()
+        assert tmp_path.resolve() in path.parents, (
+            f"daily file {path} did not land under configured memory_dirs[0] {tmp_path}"
+        )
+        legacy = Path("~/.memtomem/memories").expanduser().resolve()
+        assert legacy not in path.parents, (
+            f"daily file regressed to hardcoded {legacy} (write-surface divergence)"
+        )
+
+    async def test_add_memory_writes_under_configured_memory_dirs_explicit_file(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        # Explicit ``file=`` (relative) must also resolve under
+        # ``memory_dirs[0]``, not the legacy ``~/.memtomem/memories``.
+        app.state.config.indexing.memory_dirs = [tmp_path]
+        resp = await client.post(
+            "/api/add",
+            json={"content": "Parity check.", "file": "notes/topic.md"},
+        )
+        assert resp.status_code == 200, resp.text
+        path = Path(resp.json()["file"]).resolve()
+        assert tmp_path.resolve() in path.parents, (
+            f"explicit-file write {path} did not land under {tmp_path}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Redaction guard wire-in for the web write surfaces. The helper-level


### PR DESCRIPTION
## Summary

- `POST /api/add` hardcoded its destination base to
  `~/.memtomem/memories`, ignoring `config.indexing.memory_dirs[0]`.
  MCP `mem_add` and the CLI already resolve daily-file writes through
  the configured user-tier dir — this was a write-surface divergence
  that caused production users whose `memory_dirs[0]` was, e.g.,
  `~/memories` to have SPA-added entries silently land outside the
  configured corpus and surface as orphan ("Other (unregistered)")
  rows in the Sources tab.
- Route the base through `config.indexing.memory_dirs[0]` like the
  sibling write surfaces. The legacy path stays only as a last-resort
  fallback for the `memory_dirs == []` case (`require_configured`
  already gates the common path so the fallback effectively never
  runs in production).
- The hardcoded base also explains the test-suite leak that motivated
  this PR: `TestAddMemory` / `TestAddMemoryRedaction` exercise
  `/api/add` against a stubbed `app.state.config` whose
  `memory_dirs = [Path("/tmp/memories")]`, but the route bypassed that
  and wrote to the real user `~/.memtomem/memories/` on every suite
  run. The production parity fix resolves the test leak as a side
  effect — no defensive monkeypatch needed.

## Surface divergence (before this PR)

| Surface         | Daily-file base                       |
| --------------- | ------------------------------------- |
| MCP `mem_add`   | `config.indexing.memory_dirs[0]`      |
| CLI `mm add`    | `config.indexing.memory_dirs[0]`      |
| Web `/api/add`  | `~/.memtomem/memories` (hardcoded — bug) |

After this PR all three surfaces honor `memory_dirs[0]`.

## Repro (before fix)

1. `~/.memtomem/config.json` has `indexing.memory_dirs[0] = "~/memories"`.
2. In the SPA, Add memory → entry appended.
3. The file lands at `~/.memtomem/memories/<date>.md` instead of
   `~/memories/<date>.md`.
4. Sources tab classifies the file as **User → Other (unregistered)**
   (its parent dir is not in `memory_dirs`).

## Test plan

- [x] Two new regression pins: the default-dated write and explicit
      `file=` write both land under `memory_dirs[0]`, and neither
      legacy `~/.memtomem/memories` parent is ever the actual target.
- [x] Mutation check: reverting the fix back to the hardcoded base
      fails the default-write pin.
- [x] Existing `TestAddMemory` (5) and `TestAddMemoryRedaction` (3)
      all PASS.
- [x] Full `pytest test_web_routes.py -q` — 149 PASS.
- [x] `ruff check` / `ruff format --check` PASS.

## Out of scope

- Scope-aware tier resolution (`project_local` / `project_shared`)
  will land on the web write surface in a follow-up once ADR-0011
  PR-E settles. This PR sticks to user-tier `memory_dirs[0]` parity.
- No test-infra defensive monkeypatch — the production fix resolves
  the leak. Reopen as a follow-up if a different leak surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
