### PR TITLE
feat(status): dense-vector coverage in mem_status + /api/embedding-status

### DIFF
--- a/packages/memtomem/src/memtomem/server/tools/status_config.py
+++ b/packages/memtomem/src/memtomem/server/tools/status_config.py
@@ -107,6 +107,31 @@ async def format_status_report(app: AppContext) -> str:
     except Exception:
         logger.debug("Orphan detection failed", exc_info=True)
 
+    # Dense-vector coverage line. The hint at the end surfaces the
+    # BM25-only run case loudly: an embedder that crashed mid-init or
+    # fell back to NoopEmbedder will still index chunks into ``chunks``
+    # + ``chunks_fts`` but skip ``chunks_vec`` entirely, so semantic
+    # search returns nothing while keyword search keeps working. The
+    # check is gated on ``hasattr`` so older storage doubles that
+    # haven't grown the method don't break the report.
+    if hasattr(app.storage, "get_dense_coverage"):
+        try:
+            cov = await app.storage.get_dense_coverage()
+            total = int(cov["total"])
+            with_dense = int(cov["with_dense"])
+            if total > 0:
+                pct = round((with_dense / total) * 100, 1)
+                hint = ""
+                if with_dense == 0:
+                    hint = "  (BM25-only — dense retrieval will return nothing)"
+                elif with_dense < total:
+                    hint = "  (partial dense coverage — some chunks BM25-only)"
+                lines.append(f"Dense vectors: {with_dense}/{total} ({pct}%){hint}")
+            else:
+                lines.append("Dense vectors: 0/0")
+        except Exception:
+            logger.debug("dense coverage query failed", exc_info=True)
+
     # Immutable fields — these cannot be changed via mem_config at runtime.
     # Surfacing them here so operators are not surprised when a `mm config set`
     # on one of these paths fails silently.

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -1199,6 +1199,28 @@ class SqliteBackend(
         sources = db.execute("SELECT COUNT(DISTINCT source_file) FROM chunks").fetchone()[0]
         return {"total_chunks": total, "total_sources": sources}
 
+    async def get_dense_coverage(self) -> dict[str, int]:
+        """Return dense-vector coverage: ``{"total": N, "with_dense": M}``.
+
+        ``M < N`` when chunks were indexed before the embedder finished
+        loading (NoopEmbedder dimension==0 path, or an init-time failure
+        that fell through to BM25-only). ``M == 0`` also when
+        ``chunks_vec`` is absent — typical right after
+        ``mm embedding-reset --mode purge`` or before the first indexing
+        run creates the virtual table.
+
+        Surface used by ``/api/embedding-status`` and ``mem_status`` so
+        operators can see at a glance whether dense retrieval is going
+        to find anything before they wonder why semantic search is
+        returning only BM25-flavored results.
+        """
+        db = self._get_read_db()
+        total = db.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        with_dense = 0
+        if self._has_vec_table:
+            with_dense = db.execute("SELECT COUNT(*) FROM chunks_vec").fetchone()[0]
+        return {"total": total, "with_dense": with_dense}
+
     async def get_chunk_size_distribution(
         self,
         source_file: Path | None = None,

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -1209,6 +1209,15 @@ class SqliteBackend(
         ``mm embedding-reset --mode purge`` or before the first indexing
         run creates the virtual table.
 
+        ``with_dense`` joins ``chunks`` ⋈ ``chunks_vec`` on rowid so the
+        count tracks **retrievable** chunks only. A raw
+        ``COUNT(*) FROM chunks_vec`` would over-report when an
+        interrupted upsert or concurrent writer leaves stale vec
+        sidecars behind (orphan_gc.py already treats this state as
+        possible) — the rollup would then show ``with_dense == total``
+        even with some current chunks missing a vector, hiding the
+        BM25-only condition this telemetry exists to surface.
+
         Surface used by ``/api/embedding-status`` and ``mem_status`` so
         operators can see at a glance whether dense retrieval is going
         to find anything before they wonder why semantic search is
@@ -1218,7 +1227,10 @@ class SqliteBackend(
         total = db.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
         with_dense = 0
         if self._has_vec_table:
-            with_dense = db.execute("SELECT COUNT(*) FROM chunks_vec").fetchone()[0]
+            with_dense = db.execute(
+                "SELECT COUNT(*) FROM chunks c "
+                "INNER JOIN chunks_vec v ON v.rowid = c.rowid"
+            ).fetchone()[0]
         return {"total": total, "with_dense": with_dense}
 
     async def get_chunk_size_distribution(

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -1228,8 +1228,7 @@ class SqliteBackend(
         with_dense = 0
         if self._has_vec_table:
             with_dense = db.execute(
-                "SELECT COUNT(*) FROM chunks c "
-                "INNER JOIN chunks_vec v ON v.rowid = c.rowid"
+                "SELECT COUNT(*) FROM chunks c INNER JOIN chunks_vec v ON v.rowid = c.rowid"
             ).fetchone()[0]
         return {"total": total, "with_dense": with_dense}
 

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -57,6 +57,7 @@ from memtomem.web.schemas.config import (
     ConfigSearchOut,
     ConfigStorageOut,
     EmbeddingConfigInfo,
+    EmbeddingCoverage,
     EmbeddingResetResponse,
     EmbeddingStatusResponse,
     ModelComponent,
@@ -768,15 +769,34 @@ async def get_embedding_status(storage=Depends(get_storage)) -> EmbeddingStatusR
         else None
     )
 
+    # Dense-vector coverage so the UI can flag "BM25-only" runs without
+    # forcing the user to peek at sqlite. ``get_dense_coverage`` falls
+    # back to ``with_dense=0`` when the vec virtual table is absent, so
+    # we always have a numeric pair to render. Storage backends that
+    # don't implement the method (e.g. mocked test doubles) leave the
+    # field at ``None`` rather than 500ing this endpoint — the warning
+    # banner the field feeds is informational, not load-bearing.
+    coverage_out: EmbeddingCoverage | None = None
+    if hasattr(storage, "get_dense_coverage"):
+        try:
+            cov = await storage.get_dense_coverage()
+            total = int(cov["total"])
+            with_dense = int(cov["with_dense"])
+            pct = round((with_dense / total) * 100, 1) if total > 0 else 0.0
+            coverage_out = EmbeddingCoverage(total=total, with_dense=with_dense, percent=pct)
+        except Exception:
+            logger.debug("dense coverage query failed", exc_info=True)
+
     mismatch = getattr(storage, "embedding_mismatch", None)
     if mismatch is None:
-        return EmbeddingStatusResponse(has_mismatch=False, stored=stored_out)
+        return EmbeddingStatusResponse(has_mismatch=False, stored=stored_out, coverage=coverage_out)
     return EmbeddingStatusResponse(
         has_mismatch=True,
         dimension_mismatch=mismatch["dimension_mismatch"],
         model_mismatch=mismatch["model_mismatch"],
         stored=EmbeddingConfigInfo(**mismatch["stored"]),
         configured=EmbeddingConfigInfo(**mismatch["configured"]),
+        coverage=coverage_out,
     )
 
 

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -126,12 +126,27 @@ class EmbeddingConfigInfo(BaseModel):
     model: str
 
 
+class EmbeddingCoverage(BaseModel):
+    """Dense-vector coverage rollup for the ``chunks`` table.
+
+    ``total`` is the chunk row count; ``with_dense`` is the subset that
+    also has an embedding row in ``chunks_vec``. ``percent`` rounds to
+    one decimal. When ``total == 0`` ``percent`` is ``0.0`` so callers
+    can render the field directly without a divide-by-zero branch.
+    """
+
+    total: int
+    with_dense: int
+    percent: float
+
+
 class EmbeddingStatusResponse(BaseModel):
     has_mismatch: bool
     dimension_mismatch: bool = False
     model_mismatch: bool = False
     stored: EmbeddingConfigInfo | None = None
     configured: EmbeddingConfigInfo | None = None
+    coverage: EmbeddingCoverage | None = None
 
 
 class EmbeddingResetResponse(BaseModel):

--- a/packages/memtomem/tests/test_cli_status.py
+++ b/packages/memtomem/tests/test_cli_status.py
@@ -21,6 +21,7 @@ def _mock_components(
     source_files: list[Path] | None = None,
     stored_embedding_info: dict | None = None,
     embedding_mismatch: dict | None = None,
+    dense_coverage: dict | None = None,
 ) -> SimpleNamespace:
     """Build a minimal ``Components``-shaped mock for ``mm status`` tests.
 
@@ -31,6 +32,11 @@ def _mock_components(
     A ``SimpleNamespace`` covers all of that without dragging in the real
     ``Components`` dataclass (which would require building a SqliteBackend
     and an embedder).
+
+    ``dense_coverage`` opts in to a stubbed ``get_dense_coverage`` so the
+    report's coverage line is exercised. Leaving it ``None`` keeps the
+    attribute off the namespace — ``hasattr`` returns False and the
+    formatter skips the line, matching older storage doubles.
     """
     storage = SimpleNamespace(
         get_stats=AsyncMock(
@@ -40,6 +46,8 @@ def _mock_components(
         stored_embedding_info=stored_embedding_info,
         embedding_mismatch=embedding_mismatch,
     )
+    if dense_coverage is not None:
+        storage.get_dense_coverage = AsyncMock(return_value=dense_coverage)
     return SimpleNamespace(
         config=Mem2MemConfig(),
         storage=storage,
@@ -115,6 +123,66 @@ class TestStatusOutput:
         assert result.exit_code == 0, result.output
         assert "2 orphaned" in result.output
         assert "mem_cleanup_orphans" in result.output
+
+    def test_dense_coverage_line_emitted_full(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(
+            total_chunks=42,
+            total_sources=7,
+            dense_coverage={"total": 42, "with_dense": 42},
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "Dense vectors: 42/42 (100.0%)" in result.output
+        # Full coverage is the happy path — no hint suffix should appear.
+        assert "BM25-only" not in result.output
+        assert "partial dense coverage" not in result.output
+
+    def test_dense_coverage_line_flags_bm25_only(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The motivating failure: chunks indexed without an embedding
+        # row, so dense retrieval returns nothing while BM25 still
+        # works. The hint must be loud enough that users connect the
+        # dots without reading code.
+        comp = _mock_components(
+            total_chunks=42,
+            total_sources=7,
+            dense_coverage={"total": 42, "with_dense": 0},
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "Dense vectors: 0/42 (0.0%)" in result.output
+        assert "BM25-only" in result.output
+        assert "dense retrieval will return nothing" in result.output
+
+    def test_dense_coverage_line_flags_partial(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        comp = _mock_components(
+            total_chunks=42,
+            total_sources=7,
+            dense_coverage={"total": 42, "with_dense": 21},
+        )
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "Dense vectors: 21/42 (50.0%)" in result.output
+        assert "partial dense coverage" in result.output
+
+    def test_dense_coverage_line_skipped_when_method_missing(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # No ``dense_coverage=`` → helper omits the method on the
+        # storage namespace → formatter skips the line entirely.
+        comp = _mock_components(total_chunks=42, total_sources=7)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+        result = runner.invoke(cli, ["status"])
+        assert result.exit_code == 0, result.output
+        assert "Dense vectors:" not in result.output
 
     def test_embedding_mismatch_warning_block_emitted(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch

--- a/packages/memtomem/tests/test_storage_extended.py
+++ b/packages/memtomem/tests/test_storage_extended.py
@@ -304,6 +304,37 @@ class TestStorageExtended:
         cov = await storage.get_dense_coverage()
         assert cov == {"total": 2, "with_dense": 2}
 
+    async def test_dense_coverage_ignores_stale_vec_sidecar(self, components):
+        # Codex carry-over on #898: if ``chunks_vec`` keeps a row whose
+        # rowid no longer points at a ``chunks`` row (interrupted
+        # upsert, concurrent writer — orphan_gc.py treats this state
+        # as expected), the rollup must still report retrievable
+        # chunks. A raw ``COUNT(*) FROM chunks_vec`` would show 100%
+        # coverage while a real chunk is silently BM25-only, hiding
+        # the exact failure mode this telemetry exists to surface.
+        from memtomem.storage.sqlite_helpers import serialize_f32
+
+        storage = components.storage
+        chunk = make_chunk(content="real", embedding=_varied_embedding(0.1))
+        await storage.upsert_chunks([chunk])
+
+        # Inject a stale vec sidecar at a rowid that no ``chunks`` row
+        # owns (production source: a partial commit between the chunks
+        # delete and the chunks_vec delete in a delete-by-source path).
+        db = storage._get_db()
+        db.execute(
+            "INSERT INTO chunks_vec(rowid, embedding) VALUES (?, ?)",
+            (999999, serialize_f32(_varied_embedding(0.5))),
+        )
+        db.commit()
+
+        cov = await storage.get_dense_coverage()
+        assert cov["total"] == 1
+        # 1 retrievable chunk; the stale sidecar must not count toward
+        # ``with_dense`` — otherwise a real BM25-only chunk would be
+        # masked by an orphan row.
+        assert cov["with_dense"] == 1
+
     async def test_dense_coverage_zero_when_vec_table_dropped(self, components):
         # ``reset_embedding_meta`` drops and recreates ``chunks_vec`` but
         # leaves ``chunks`` intact, which is the production shape of the

--- a/packages/memtomem/tests/test_storage_extended.py
+++ b/packages/memtomem/tests/test_storage_extended.py
@@ -288,6 +288,38 @@ class TestStorageExtended:
         total = sum(d["count"] for d in dist)
         assert total == 1
 
+    # ---- get_dense_coverage --------------------------------------------------
+
+    async def test_dense_coverage_empty_db(self, components):
+        storage = components.storage
+        cov = await storage.get_dense_coverage()
+        assert cov == {"total": 0, "with_dense": 0}
+
+    async def test_dense_coverage_full_after_upsert(self, components):
+        storage = components.storage
+        c1 = make_chunk(content="one", embedding=_varied_embedding(0.1), source="a.md")
+        c2 = make_chunk(content="two", embedding=_varied_embedding(0.2), source="b.md")
+        await storage.upsert_chunks([c1, c2])
+
+        cov = await storage.get_dense_coverage()
+        assert cov == {"total": 2, "with_dense": 2}
+
+    async def test_dense_coverage_zero_when_vec_table_dropped(self, components):
+        # ``reset_embedding_meta`` drops and recreates ``chunks_vec`` but
+        # leaves ``chunks`` intact, which is the production shape of the
+        # BM25-only failure mode this telemetry surfaces. The new vec
+        # table is created with the requested dimension but holds no
+        # rows until something re-embeds, so coverage should land at 0/N.
+        storage = components.storage
+        chunk = make_chunk(content="before reset", embedding=_varied_embedding(0.1))
+        await storage.upsert_chunks([chunk])
+
+        await storage.reset_embedding_meta(dimension=1024, provider="onnx", model="bge-m3")
+
+        cov = await storage.get_dense_coverage()
+        assert cov["total"] == 1
+        assert cov["with_dense"] == 0
+
     # ---- reset_embedding_meta ------------------------------------------------
 
     async def test_reset_embedding_meta_changes_dimension(self, components):

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1869,6 +1869,40 @@ class TestEmbeddingStatus:
         data = resp.json()
         assert data["has_mismatch"] is False
 
+    async def test_coverage_reports_full(self, app, client: AsyncClient):
+        app.state.storage.get_dense_coverage = AsyncMock(
+            return_value={"total": 100, "with_dense": 100}
+        )
+        resp = await client.get("/api/embedding-status")
+        assert resp.status_code == 200
+        cov = resp.json()["coverage"]
+        assert cov == {"total": 100, "with_dense": 100, "percent": 100.0}
+
+    async def test_coverage_reports_bm25_only(self, app, client: AsyncClient):
+        # The motivating failure mode: chunks indexed but ``chunks_vec``
+        # never populated (embedder init crashed, NoopEmbedder fallback,
+        # etc.). The UI uses this 0% signal to flag a BM25-only run.
+        app.state.storage.get_dense_coverage = AsyncMock(
+            return_value={"total": 100, "with_dense": 0}
+        )
+        resp = await client.get("/api/embedding-status")
+        cov = resp.json()["coverage"]
+        assert cov["total"] == 100
+        assert cov["with_dense"] == 0
+        assert cov["percent"] == 0.0
+
+    async def test_coverage_partial_rounds_to_one_decimal(self, app, client: AsyncClient):
+        # 1/3 -> 33.3333… ; the schema commits to one decimal so a
+        # partial-coverage banner reads consistently.
+        app.state.storage.get_dense_coverage = AsyncMock(return_value={"total": 3, "with_dense": 1})
+        resp = await client.get("/api/embedding-status")
+        assert resp.json()["coverage"]["percent"] == 33.3
+
+    async def test_coverage_handles_empty_db(self, app, client: AsyncClient):
+        app.state.storage.get_dense_coverage = AsyncMock(return_value={"total": 0, "with_dense": 0})
+        cov = (await client.get("/api/embedding-status")).json()["coverage"]
+        assert cov == {"total": 0, "with_dense": 0, "percent": 0.0}
+
 
 # ---------------------------------------------------------------------------
 # GET /locales/*.json  (i18n files served via StaticFiles)


### PR DESCRIPTION
## Summary

When an embedder fails to initialize (ONNX model download fails,
Ollama unreachable, NoopEmbedder fallback) the indexing pipeline
quietly falls through to a BM25-only path: chunks land in `chunks` +
`chunks_fts` but never get an embedding row in `chunks_vec`. Semantic
search returns nothing while keyword search keeps working, and no
existing surface tells operators why. `mem_status` only reports
configured provider/dimension, not what's actually in the database.

This PR adds one coverage signal that both the MCP/CLI status report
and the Web UI status endpoint consume.

## What changes

- **`SqliteBackend.get_dense_coverage`** returns `{"total": N,
  "with_dense": M}`. Falls back to `with_dense=0` when `chunks_vec`
  is absent (post `embedding-reset --mode purge` or pre-first-index).
- **`GET /api/embedding-status`** grows a `coverage` field shaped
  `{total, with_dense, percent}`. `percent` rounds to one decimal
  and is `0.0` for empty databases so the SPA can render the value
  with no divide-by-zero guard.
- **`mem_status` / `mm status`** add a `Dense vectors: M/N (P%)`
  line:
  - `with_dense == 0 && total > 0` → `(BM25-only — dense retrieval
    will return nothing)` hint.
  - `0 < with_dense < total` → `(partial dense coverage — some
    chunks BM25-only)` hint.
  - Full coverage stays quiet so the happy path doesn't acquire
    noise.

Both surfaces gate the new field on `hasattr(storage,
"get_dense_coverage")`, so older test doubles (and any future
storage backend that hasn't grown the method) leave `coverage` at
`None` / omit the line rather than 500ing the endpoint.

## Scope (intentional)

Stage 1 of the embedding-coverage thread. Telemetry only — no change
to how indexing decides whether to embed. Stage 2 (separate PR) will
make the underlying init failure loud (engine-level abort instead of
silent BM25-only fallback). Splitting keeps the review surface scoped
to "expose what's there" before "change what runs."

## Test plan

- [x] `pytest tests/test_storage_extended.py` — three new tests
      covering empty DB, full coverage after upsert, and the
      reset-vec-table-then-chunks-survive shape that mirrors the
      production failure mode.
- [x] `pytest tests/test_web_routes.py::TestEmbeddingStatus` — full,
      BM25-only, partial-rounding, and empty-DB cases on the API.
- [x] `pytest tests/test_cli_status.py::TestStatusOutput` — four new
      cases for the CLI/MCP text shape (full, BM25-only with hint,
      partial with hint, skipped-when-method-missing).
- [x] `pytest tests/test_storage_extended.py tests/test_cli_status.py
      tests/test_web_routes.py -q` — 216 PASS.
- [x] `ruff check` / `ruff format --check` PASS.

## Out of scope

- The actual init-failure abort lives in a follow-up PR (Stage 2).
- No Sources tab badge UI yet — operator-facing telemetry first;
  per-chunk UI badge deferred until we see how the rollup reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
