### PR TITLE
fix(indexing): abort when embedder dim=0 with a real model name

### DIFF
--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -568,6 +568,7 @@ class IndexEngine:
             skipped_chunks=result["skipped"],
             deleted_chunks=result["deleted"],
             duration_ms=duration,
+            errors=tuple(result.get("errors", ())),
             new_chunk_ids=tuple(result.get("new_chunk_ids", ())),
         )
 
@@ -844,7 +845,32 @@ class IndexEngine:
             )
 
         # Embed BEFORE any deletion — if embedding fails, DB stays untouched.
-        # Skip embedding entirely when using the noop provider (BM25-only mode).
+        # Refuse to silently produce BM25-only chunks when the configured
+        # embedder reports dimension=0. NoopEmbedder ("none" provider) is
+        # the explicit BM25-only opt-in and bypasses this guard;
+        # anything else with dim=0 is a misconfigured embedder (init
+        # failed, fastembed download timed out, etc.) and was previously
+        # papered over by the silent skip — chunks landed in ``chunks`` +
+        # ``chunks_fts`` while ``chunks_vec`` stayed empty, leaving
+        # semantic search returning nothing with no audit trail.
+        if diff_result.to_upsert and self._embedder.dimension == 0:
+            model = getattr(self._embedder, "model_name", "?")
+            if model != "none":
+                msg = (
+                    f"Embedder reports dimension=0 but model={model!r} — "
+                    "configured provider failed to initialize. Refusing "
+                    "to index BM25-only chunks; fix the embedder config "
+                    'or set embedding.provider="none" for intentional '
+                    "BM25-only mode."
+                )
+                logger.error("%s file=%s chunks=%d", msg, file_path, len(diff_result.to_upsert))
+                return {
+                    "total": len(new_chunks),
+                    "indexed": 0,
+                    "skipped": len(new_chunks),
+                    "deleted": 0,
+                    "errors": [msg],
+                }
         if diff_result.to_upsert and self._embedder.dimension > 0:
             texts = [c.retrieval_content for c in diff_result.to_upsert]
             # Threshold gate lives here, not inside the embedder, so callers

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -2011,6 +2011,66 @@ class TestIndexFile:
             f"got {stats.deleted_chunks}"
         )
 
+    async def test_dim_zero_with_real_model_aborts(self, components, memory_dir):
+        """Misconfigured embedder (dim=0, non-noop model) must abort instead
+        of silently producing BM25-only chunks.
+
+        Production scenario: ONNX/Ollama provider's init throws on the
+        first call but downstream code never propagates the exception,
+        so the engine sees an embedder reporting ``dimension == 0`` even
+        though config asked for a real model. Without this guard the
+        chunks land in ``chunks`` + ``chunks_fts`` while ``chunks_vec``
+        stays empty, and the user gets BM25-only retrieval with no log
+        line explaining why.
+        """
+        md_path = memory_dir / "abort.md"
+        md_path.write_text(
+            "# Abort\n\nShould not be indexed under misconfigured embedder.\n",
+            encoding="utf-8",
+        )
+
+        misconfigured = AsyncMock()
+        misconfigured.dimension = 0
+        misconfigured.model_name = "bge-m3"  # not the "none" opt-in
+        components.index_engine._embedder = misconfigured
+
+        stats = await components.index_engine.index_file(md_path)
+
+        # IndexingStats normalises per-file dicts; the engine reports
+        # zero indexed and surfaces the abort message in errors.
+        assert stats.indexed_chunks == 0
+        assert stats.skipped_chunks > 0
+        assert stats.errors, "abort must populate IndexingStats.errors"
+        joined = " ".join(stats.errors)
+        assert "dimension=0" in joined
+        assert "bge-m3" in joined
+        assert "BM25-only" in joined
+
+        # And nothing should have actually landed in storage — the abort
+        # is upstream of the transaction so chunks + chunks_vec stay
+        # consistent (both empty for this file).
+        chunks_after = await components.storage.list_chunks_by_source(md_path)
+        assert chunks_after == []
+
+    async def test_dim_zero_with_noop_provider_indexes_silently(self, components, memory_dir):
+        """``embedding.provider == "none"`` is the explicit BM25-only path
+        and must continue to index normally — the abort only fires for
+        unintended dim=0 from a real-model embedder.
+        """
+        md_path = memory_dir / "noop.md"
+        md_path.write_text("# Noop\n\nIntentional BM25-only.\n", encoding="utf-8")
+
+        from memtomem.embedding.noop import NoopEmbedder
+
+        components.index_engine._embedder = NoopEmbedder()
+
+        stats = await components.index_engine.index_file(md_path)
+
+        assert stats.indexed_chunks > 0, stats.errors
+        assert not stats.errors
+        chunks_after = await components.storage.list_chunks_by_source(md_path)
+        assert len(chunks_after) >= 1
+
 
 # ===========================================================================
 # 8. index_path — directory indexing


### PR DESCRIPTION
## Summary

Stage 2 of the embedding-coverage thread (#898 was Stage 1 telemetry).

`IndexEngine._index_file` previously had a single `dimension > 0`
gate around the embedding call. When the gate was false the engine
silently dropped to a BM25-only path: chunks landed in `chunks` +
`chunks_fts` while `chunks_vec` stayed empty, with no log line
explaining why semantic search would return nothing afterwards.

The gate was originally meant for the explicit BM25-only mode
(`embedding.provider == "none"` → `NoopEmbedder` reports `dim=0`)
but also caught the misconfigured-embedder case as collateral
damage: an ONNX / Ollama provider whose init crashed could end up
returning `dim=0` and the engine would happily index BM25-only
chunks under what the user thought was a dense-enabled corpus.

## What changes

- **Split the two `dim=0` cases by `model_name`.** `NoopEmbedder` is
  the sentinel `"none"` model and keeps the silent skip — intentional
  BM25-only mode is unchanged. Any other embedder reporting `dim=0`
  now aborts with an explicit error message that flows back through
  the same return shape `IndexingStats` already exposes for the
  embedding-failure path.
- **`return` happens before the delete/upsert transaction**, so
  storage stays consistent (chunks + chunks_vec both untouched for
  this file).
- **Drive-by fix:** the single-file `index_file` return path was
  dropping `result["errors"]` on the floor. The embedding-failure
  path already populated `errors=[...]` but
  `IndexingStats(..., new_chunk_ids=...)` omitted `errors=` so the
  message never made it past the engine. Plumb it through too so the
  new abort message (and any pre-existing embedding-failure message)
  propagates to the caller — without this the new abort would log
  but its message would still be invisible to callers reading
  `IndexingStats.errors`.

## Test plan

- [x] `test_dim_zero_with_real_model_aborts` — abort when an embedder
      with `dimension=0` but `model_name="bge-m3"` (or any non-noop
      model) is asked to index. Asserts zero chunks landed in
      storage and that the error message names both the model and
      the BM25-only failure mode so users can grep for it.
- [x] `test_dim_zero_with_noop_provider_indexes_silently` — keeps
      the explicit BM25-only opt-in path working. NoopEmbedder
      (`model_name == "none"`) indexes normally with empty errors.
- [x] Mutation check: dropping the new gate (force the abort
      condition to `False`) fails the abort test, confirming the
      guard isn't being short-circuited elsewhere.
- [x] `pytest tests/test_indexing_engine.py -q` — 148 PASS
      (including the wider suite that already exercises NoopEmbedder
      paths under `bm25_only_components`).
- [x] `ruff check` / `ruff format --check` PASS.

## Out of scope

- Per-chunk dense/BM25 badge UI — deferred until coverage telemetry
  from #898 lands and we see how the rollup signal reads in
  practice.
- Recovery flow (e.g., `mm reindex --force` after an embedder fix)
  — orthogonal; the abort already leaves storage consistent so
  re-running indexing after fixing the embedder picks up the same
  set as a fresh run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
