### PR TITLE
fix(web): resolve dir-layout agents/commands in context gateway detail routes (#899)

### DIFF
--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -253,6 +253,40 @@ def parse_canonical_agent(path: Path, *, layout: Layout = "flat") -> SubAgent:
     return _parse_canonical_agent_text(content, source=path, layout=layout)
 
 
+def _resolve_agent_under_root(canonical_root: Path, agent_name: str) -> tuple[Path, Layout] | None:
+    dir_target = canonical_root / agent_name / AGENT_DIR_FILENAME
+    flat_target = canonical_root / f"{agent_name}.md"
+    has_dir = dir_target.is_file()
+    has_flat = flat_target.is_file()
+    if has_dir and has_flat:
+        logger.warning(
+            "agents/%s: reverse-sync updates dir layout (%s/agent.md); the flat "
+            "file (%s.md) is now silently divergent. Remove it or run "
+            "`mm context migrate` (PR-D).",
+            agent_name,
+            agent_name,
+            agent_name,
+        )
+        return dir_target, "dir"
+    if has_dir:
+        return dir_target, "dir"
+    if has_flat:
+        return flat_target, "flat"
+    return None
+
+
+def resolve_canonical_agent(project_root: Path, name: str) -> tuple[Path, Layout] | None:
+    """Return the canonical ``(path, layout)`` for ``name`` if it exists.
+
+    Directory layout wins when both the legacy flat file and ADR-0008
+    directory layout are present. Name validation is intentionally left to
+    callers so existing 400 behavior remains at the route/CLI boundary.
+    """
+    return _resolve_agent_under_root(
+        canonical_artifact_dir("agents", "project_shared", project_root), name
+    )
+
+
 def list_canonical_agents(
     project_root: Path,
     *,
@@ -774,25 +808,10 @@ def _resolve_agent_extract_target(canonical_root: Path, agent_name: str) -> tupl
       flat only     → flat (preserve existing layout; PR-C does not migrate)
       neither       → dir (ADR-0008 layout for new agents)
     """
-    dir_target = canonical_root / agent_name / AGENT_DIR_FILENAME
-    flat_target = canonical_root / f"{agent_name}.md"
-    has_dir = dir_target.is_file()
-    has_flat = flat_target.is_file()
-    if has_dir and has_flat:
-        logger.warning(
-            "agents/%s: reverse-sync updates dir layout (%s/agent.md); the flat "
-            "file (%s.md) is now silently divergent. Remove it or run "
-            "`mm context migrate` (PR-D).",
-            agent_name,
-            agent_name,
-            agent_name,
-        )
-        return dir_target, "dir"
-    if has_dir:
-        return dir_target, "dir"
-    if has_flat:
-        return flat_target, "flat"
-    return dir_target, "dir"
+    resolved = _resolve_agent_under_root(canonical_root, agent_name)
+    if resolved is not None:
+        return resolved
+    return canonical_root / agent_name / AGENT_DIR_FILENAME, "dir"
 
 
 def extract_agents_to_canonical(
@@ -1055,4 +1074,5 @@ __all__ = [
     "generate_all_agents",
     "list_canonical_agents",
     "parse_canonical_agent",
+    "resolve_canonical_agent",
 ]

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -172,6 +172,40 @@ def parse_canonical_command(path: Path, *, layout: Layout = "flat") -> SlashComm
     return _parse_canonical_command_text(content, source=path, layout=layout)
 
 
+def _resolve_command_under_root(canonical_root: Path, cmd_name: str) -> tuple[Path, Layout] | None:
+    dir_target = canonical_root / cmd_name / COMMAND_DIR_FILENAME
+    flat_target = canonical_root / f"{cmd_name}.md"
+    has_dir = dir_target.is_file()
+    has_flat = flat_target.is_file()
+    if has_dir and has_flat:
+        logger.warning(
+            "commands/%s: reverse-sync updates dir layout (%s/command.md); the "
+            "flat file (%s.md) is now silently divergent. Remove it or run "
+            "`mm context migrate` (PR-D).",
+            cmd_name,
+            cmd_name,
+            cmd_name,
+        )
+        return dir_target, "dir"
+    if has_dir:
+        return dir_target, "dir"
+    if has_flat:
+        return flat_target, "flat"
+    return None
+
+
+def resolve_canonical_command(project_root: Path, name: str) -> tuple[Path, Layout] | None:
+    """Return the canonical ``(path, layout)`` for ``name`` if it exists.
+
+    Directory layout wins when both the legacy flat file and ADR-0008
+    directory layout are present. Name validation is intentionally left to
+    callers so existing 400 behavior remains at the route/CLI boundary.
+    """
+    return _resolve_command_under_root(
+        canonical_artifact_dir("commands", "project_shared", project_root), name
+    )
+
+
 def list_canonical_commands(
     project_root: Path,
     *,
@@ -565,25 +599,10 @@ def _resolve_command_extract_target(canonical_root: Path, cmd_name: str) -> tupl
     dir+flat both → dir wins (silent flat divergence WARNed);
     dir only → dir; flat only → flat (preserve); neither → dir (ADR layout).
     """
-    dir_target = canonical_root / cmd_name / COMMAND_DIR_FILENAME
-    flat_target = canonical_root / f"{cmd_name}.md"
-    has_dir = dir_target.is_file()
-    has_flat = flat_target.is_file()
-    if has_dir and has_flat:
-        logger.warning(
-            "commands/%s: reverse-sync updates dir layout (%s/command.md); the "
-            "flat file (%s.md) is now silently divergent. Remove it or run "
-            "`mm context migrate` (PR-D).",
-            cmd_name,
-            cmd_name,
-            cmd_name,
-        )
-        return dir_target, "dir"
-    if has_dir:
-        return dir_target, "dir"
-    if has_flat:
-        return flat_target, "flat"
-    return dir_target, "dir"
+    resolved = _resolve_command_under_root(canonical_root, cmd_name)
+    if resolved is not None:
+        return resolved
+    return canonical_root / cmd_name / COMMAND_DIR_FILENAME, "dir"
 
 
 def extract_commands_to_canonical(
@@ -881,4 +900,5 @@ __all__ = [
     "generate_all_commands",
     "list_canonical_commands",
     "parse_canonical_command",
+    "resolve_canonical_command",
 ]

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -23,6 +23,7 @@ from memtomem.context.agents import (
     generate_all_agents,
     list_canonical_agents,
     parse_canonical_agent,
+    resolve_canonical_agent,
 )
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
@@ -58,6 +59,11 @@ def _canonical_agent_path(project_root: Path, raw_name: str) -> Path:
     """
     name = validate_name(raw_name, kind="agent")
     return _agents_root(project_root) / f"{name}.md"
+
+
+def _resolve_existing_agent(project_root: Path, raw_name: str):
+    name = validate_name(raw_name, kind="agent")
+    return name, resolve_canonical_agent(project_root, name)
 
 
 def _agent_to_dict(agent: SubAgent) -> dict:
@@ -120,9 +126,10 @@ async def read_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    agent_path = _canonical_agent_path(project_root, name)
-    if not agent_path.is_file():
+    name, resolved = _resolve_existing_agent(project_root, name)
+    if resolved is None:
         raise KeyError(name)
+    agent_path, layout = resolved
 
     content = agent_path.read_text(encoding="utf-8")
     # mtime_ns is serialized as a string because JavaScript Number cannot
@@ -131,7 +138,7 @@ async def read_agent(
 
     fields: dict = {}
     try:
-        parsed = parse_canonical_agent(agent_path)
+        parsed = parse_canonical_agent(agent_path, layout=layout)
         fields = _agent_to_dict(parsed)
     except AgentParseError:
         pass
@@ -147,13 +154,14 @@ async def rendered_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
 ) -> JSONResponse:
-    agent_path = _canonical_agent_path(project_root, name)
-    if not agent_path.is_file():
+    name, resolved = _resolve_existing_agent(project_root, name)
+    if resolved is None:
         raise KeyError(name)
+    agent_path, layout = resolved
 
     content = agent_path.read_text(encoding="utf-8")
     try:
-        parsed = parse_canonical_agent(agent_path)
+        parsed = parse_canonical_agent(agent_path, layout=layout)
     except AgentParseError as exc:
         return JSONResponse(status_code=422, content={"detail": f"Parse error: {exc}"})
 
@@ -203,17 +211,18 @@ async def create_agent(
     body: AgentCreateRequest,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    agent_path = _canonical_agent_path(project_root, body.name)
+    name = validate_name(body.name, kind="agent")
 
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                if agent_path.exists():
-                    raise ValueError(f"Agent '{body.name}' already exists")
+                if resolve_canonical_agent(project_root, name) is not None:
+                    raise HTTPException(409, detail=f"Agent '{name}' already exists")
+                agent_path = _canonical_agent_path(project_root, name)
                 atomic_write_text(agent_path, body.content)
     except TimeoutError:
         raise HTTPException(503, "Agent create timed out — another sync may be in progress")
-    return {"name": body.name, "canonical_path": str(agent_path.relative_to(project_root))}
+    return {"name": name, "canonical_path": str(agent_path.relative_to(project_root))}
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -236,9 +245,10 @@ async def update_agent(
     body: AgentUpdateRequest,
     project_root: Path = Depends(get_project_root),
 ) -> JSONResponse:
-    agent_path = _canonical_agent_path(project_root, name)
-    if not agent_path.is_file():
+    name, resolved = _resolve_existing_agent(project_root, name)
+    if resolved is None:
         raise KeyError(name)
+    agent_path, _layout = resolved
 
     try:
         body_mtime_ns = int(body.mtime_ns)
@@ -291,7 +301,7 @@ async def delete_agent(
     cascade: bool = Query(False),
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    agent_path = _canonical_agent_path(project_root, name)
+    name, resolved = _resolve_existing_agent(project_root, name)
 
     try:
         async with asyncio.timeout(60):
@@ -299,7 +309,8 @@ async def delete_agent(
                 removed: list[str] = []
                 skipped: list[dict[str, str]] = []
 
-                if agent_path.is_file():
+                if resolved is not None:
+                    agent_path, _layout = resolved
                     try:
                         agent_path.unlink()
                         removed.append(_safe_rel(agent_path, project_root))
@@ -334,10 +345,11 @@ async def diff_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    agent_path = _canonical_agent_path(project_root, name)
+    name, resolved = _resolve_existing_agent(project_root, name)
 
     canonical_content = None
-    if agent_path.is_file():
+    if resolved is not None:
+        agent_path, _layout = resolved
         canonical_content = agent_path.read_text(encoding="utf-8")
 
     runtimes = []

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -22,6 +22,7 @@ from memtomem.context.commands import (
     generate_all_commands,
     list_canonical_commands,
     parse_canonical_command,
+    resolve_canonical_command,
 )
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
@@ -50,6 +51,11 @@ def _canonical_command_path(project_root: Path, raw_name: str) -> Path:
     """Validate the name via core and return the canonical command path."""
     name = validate_name(raw_name, kind="command")
     return _commands_root(project_root) / f"{name}.md"
+
+
+def _resolve_existing_command(project_root: Path, raw_name: str):
+    name = validate_name(raw_name, kind="command")
+    return name, resolve_canonical_command(project_root, name)
 
 
 def _safe_rel(p: Path, project_root: Path) -> str:
@@ -106,9 +112,10 @@ async def read_command(
     name: str,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    cmd_path = _canonical_command_path(project_root, name)
-    if not cmd_path.is_file():
+    name, resolved = _resolve_existing_command(project_root, name)
+    if resolved is None:
         raise KeyError(name)
+    cmd_path, layout = resolved
 
     content = cmd_path.read_text(encoding="utf-8")
     # mtime_ns serialized as string (JS bigint-unsafe).
@@ -116,7 +123,7 @@ async def read_command(
 
     fields: dict = {}
     try:
-        parsed = parse_canonical_command(cmd_path)
+        parsed = parse_canonical_command(cmd_path, layout=layout)
         fields = {
             "description": parsed.description,
             "argument_hint": parsed.argument_hint,
@@ -143,13 +150,14 @@ async def rendered_command(
     name: str,
     project_root: Path = Depends(get_project_root),
 ) -> JSONResponse:
-    cmd_path = _canonical_command_path(project_root, name)
-    if not cmd_path.is_file():
+    name, resolved = _resolve_existing_command(project_root, name)
+    if resolved is None:
         raise KeyError(name)
+    cmd_path, layout = resolved
 
     content = cmd_path.read_text(encoding="utf-8")
     try:
-        parsed = parse_canonical_command(cmd_path)
+        parsed = parse_canonical_command(cmd_path, layout=layout)
     except CommandParseError as exc:
         return JSONResponse(status_code=422, content={"detail": f"Parse error: {exc}"})
 
@@ -199,17 +207,18 @@ async def create_command(
     body: CommandCreateRequest,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    cmd_path = _canonical_command_path(project_root, body.name)
+    name = validate_name(body.name, kind="command")
 
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                if cmd_path.exists():
-                    raise ValueError(f"Command '{body.name}' already exists")
+                if resolve_canonical_command(project_root, name) is not None:
+                    raise HTTPException(409, detail=f"Command '{name}' already exists")
+                cmd_path = _canonical_command_path(project_root, name)
                 atomic_write_text(cmd_path, body.content)
     except TimeoutError:
         raise HTTPException(503, "Command create timed out — another sync may be in progress")
-    return {"name": body.name, "canonical_path": str(cmd_path.relative_to(project_root))}
+    return {"name": name, "canonical_path": str(cmd_path.relative_to(project_root))}
 
 
 # ── Update ───────────────────────────────────────────────────────────────
@@ -232,9 +241,10 @@ async def update_command(
     body: CommandUpdateRequest,
     project_root: Path = Depends(get_project_root),
 ) -> JSONResponse:
-    cmd_path = _canonical_command_path(project_root, name)
-    if not cmd_path.is_file():
+    name, resolved = _resolve_existing_command(project_root, name)
+    if resolved is None:
         raise KeyError(name)
+    cmd_path, _layout = resolved
 
     try:
         body_mtime_ns = int(body.mtime_ns)
@@ -280,7 +290,7 @@ async def delete_command(
     cascade: bool = Query(False),
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    cmd_path = _canonical_command_path(project_root, name)
+    name, resolved = _resolve_existing_command(project_root, name)
 
     try:
         async with asyncio.timeout(60):
@@ -288,7 +298,8 @@ async def delete_command(
                 removed: list[str] = []
                 skipped: list[dict[str, str]] = []
 
-                if cmd_path.is_file():
+                if resolved is not None:
+                    cmd_path, _layout = resolved
                     try:
                         cmd_path.unlink()
                         removed.append(_safe_rel(cmd_path, project_root))
@@ -323,10 +334,11 @@ async def diff_command(
     name: str,
     project_root: Path = Depends(get_project_root),
 ) -> dict:
-    cmd_path = _canonical_command_path(project_root, name)
+    name, resolved = _resolve_existing_command(project_root, name)
 
     canonical_content = None
-    if cmd_path.is_file():
+    if resolved is not None:
+        cmd_path, _layout = resolved
         canonical_content = cmd_path.read_text(encoding="utf-8")
 
     runtimes = []

--- a/packages/memtomem/tests/test_web_routes_context_mutators.py
+++ b/packages/memtomem/tests/test_web_routes_context_mutators.py
@@ -535,3 +535,173 @@ async def test_DELETE_existing_removes_canonical(
     data = r.json()
     assert len(data["deleted"]) == 1
     assert not adapter["manifest"](gateway_root, "bye").exists()
+
+
+# ---------------------------------------------------------------------------
+# ADR-0008 directory-layout agents / commands (issue #899)
+# ---------------------------------------------------------------------------
+
+
+def _make_canonical_agent_dir(root: Path, name: str, content: str | None = None) -> Path:
+    path = root / ".memtomem" / "agents" / name / "agent.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content if content is not None else _agent_content(name), encoding="utf-8")
+    return path
+
+
+def _make_canonical_command_dir(root: Path, name: str, content: str | None = None) -> Path:
+    path = root / ".memtomem" / "commands" / name / "command.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content if content is not None else _command_content(), encoding="utf-8")
+    return path
+
+
+DIR_LAYOUT_MATRIX = [
+    pytest.param(
+        {
+            "type": "agents",
+            "list_url": "/api/context/agents",
+            "detail": lambda n: f"/api/context/agents/{n}",
+            "rendered": lambda n: f"/api/context/agents/{n}/rendered",
+            "diff": lambda n: f"/api/context/agents/{n}/diff",
+            "create_body": lambda n: {"name": n, "content": _agent_content(n)},
+            "flat_manifest": lambda root, n: root / ".memtomem" / "agents" / f"{n}.md",
+            "make_flat": _make_canonical_agent,
+            "make_dir": _make_canonical_agent_dir,
+            "dir_body": lambda n: _agent_content(n).replace("Body", "DIR BODY"),
+            "flat_body": lambda n: _agent_content(n).replace("Body", "FLAT BODY"),
+            "warn_fragment": "agents/both: reverse-sync updates dir layout",
+        },
+        id="agents-dir-layout",
+    ),
+    pytest.param(
+        {
+            "type": "commands",
+            "list_url": "/api/context/commands",
+            "detail": lambda n: f"/api/context/commands/{n}",
+            "rendered": lambda n: f"/api/context/commands/{n}/rendered",
+            "diff": lambda n: f"/api/context/commands/{n}/diff",
+            "create_body": lambda n: {"name": n, "content": _command_content()},
+            "flat_manifest": lambda root, n: root / ".memtomem" / "commands" / f"{n}.md",
+            "make_flat": _make_canonical_command,
+            "make_dir": _make_canonical_command_dir,
+            "dir_body": lambda n: _command_content().replace("Body", "DIR BODY"),
+            "flat_body": lambda n: _command_content().replace("Body", "FLAT BODY"),
+            "warn_fragment": "commands/both: reverse-sync updates dir layout",
+        },
+        id="commands-dir-layout",
+    ),
+]
+
+
+@pytest.mark.parametrize("adapter", DIR_LAYOUT_MATRIX)
+@pytest.mark.anyio
+async def test_dir_layout_detail_and_rendered_routes_return_200(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    adapter["make_dir"](gateway_root, "dir-item")
+
+    detail = await client.get(adapter["detail"]("dir-item"))
+    assert detail.status_code == 200, (adapter["type"], detail.text)
+    assert "Body" in detail.json()["content"]
+
+    rendered = await client.get(adapter["rendered"]("dir-item"))
+    assert rendered.status_code == 200, (adapter["type"], rendered.text)
+
+
+@pytest.mark.parametrize("adapter", DIR_LAYOUT_MATRIX)
+@pytest.mark.anyio
+async def test_dir_layout_update_uses_dir_file_and_preserves_mtime_409(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    target = adapter["make_dir"](gateway_root, "dir-cas")
+    read = await client.get(adapter["detail"]("dir-cas"))
+    mtime_ns = read.json()["mtime_ns"]
+
+    update = await client.put(
+        adapter["detail"]("dir-cas"),
+        json={"content": "UPDATED\n", "mtime_ns": mtime_ns},
+    )
+    assert update.status_code == 200, (adapter["type"], update.text)
+    assert target.read_text(encoding="utf-8") == "UPDATED\n"
+
+    stale = await client.put(
+        adapter["detail"]("dir-cas"),
+        json={"content": "STALE\n", "mtime_ns": mtime_ns},
+    )
+    assert stale.status_code == 409
+    assert stale.json()["status"] == "aborted"
+    assert target.read_text(encoding="utf-8") == "UPDATED\n"
+
+
+@pytest.mark.parametrize("adapter", DIR_LAYOUT_MATRIX)
+@pytest.mark.anyio
+async def test_dir_layout_delete_removes_dir_file_only(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    target = adapter["make_dir"](gateway_root, "dir-delete")
+
+    r = await client.delete(adapter["detail"]("dir-delete"))
+    assert r.status_code == 200, (adapter["type"], r.text)
+    assert not target.exists()
+    assert target.parent.is_dir()
+
+
+@pytest.mark.parametrize("adapter", DIR_LAYOUT_MATRIX)
+@pytest.mark.anyio
+async def test_dir_layout_diff_returns_200(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    adapter["make_dir"](gateway_root, "dir-diff")
+
+    r = await client.get(adapter["diff"]("dir-diff"))
+    assert r.status_code == 200, (adapter["type"], r.text)
+    assert r.json()["canonical_content"] is not None
+
+
+@pytest.mark.parametrize("adapter", DIR_LAYOUT_MATRIX)
+@pytest.mark.anyio
+async def test_POST_rejects_existing_flat_or_dir_layout_without_shadowing(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+):
+    adapter["make_dir"](gateway_root, "dir-exists")
+    dir_resp = await client.post(adapter["list_url"], json=adapter["create_body"]("dir-exists"))
+    assert dir_resp.status_code == 409, (adapter["type"], dir_resp.text)
+    assert not adapter["flat_manifest"](gateway_root, "dir-exists").exists()
+
+    adapter["make_flat"](gateway_root, "flat-exists")
+    flat_resp = await client.post(adapter["list_url"], json=adapter["create_body"]("flat-exists"))
+    assert flat_resp.status_code == 409, (adapter["type"], flat_resp.text)
+
+
+@pytest.mark.parametrize("adapter", DIR_LAYOUT_MATRIX)
+@pytest.mark.anyio
+async def test_both_layouts_detail_prefers_dir_and_warns(
+    adapter: dict,
+    client: AsyncClient,
+    gateway_root: Path,
+    caplog: pytest.LogCaptureFixture,
+):
+    adapter["make_flat"](gateway_root, "both")
+    adapter["flat_manifest"](gateway_root, "both").write_text(
+        adapter["flat_body"]("both"), encoding="utf-8"
+    )
+    adapter["make_dir"](gateway_root, "both", adapter["dir_body"]("both"))
+
+    with caplog.at_level(logging.WARNING):
+        r = await client.get(adapter["detail"]("both"))
+
+    assert r.status_code == 200, (adapter["type"], r.text)
+    assert "DIR BODY" in r.json()["content"]
+    assert "FLAT BODY" not in r.json()["content"]
+    assert adapter["warn_fragment"] in caplog.text


### PR DESCRIPTION
## Summary

- Web Context Gateway detail/action routes (`read`, `rendered`, `update`, `delete`, `diff`) for agents and commands resolved only the flat canonical path (`.memtomem/agents/<name>.md`), so items listed under the ADR-0008 directory layout (`.memtomem/agents/<name>/agent.md`) 404'd on open. Now they use a shared resolver that mirrors `list_canonical_agents()` / `list_canonical_commands()` precedence (directory wins when both exist).
- The `create` POST handler had the same root cause: it only checked the flat path, so POSTing a name that already existed under the directory layout silently created a `<name>.md` shadow. Same resolver is now used to reject with 409 if either layout already exists; new files still write flat (not a default change — that belongs to a separate ADR).
- The truth table already lived in the private reverse-sync resolvers (`_resolve_agent_extract_target` / `_resolve_command_extract_target`); they now delegate to the new public `resolve_canonical_agent` / `resolve_canonical_command` so the rule lives in one place.

Out of scope (linked from #899): layout migration (ADR-0008 PR-D) and changing the create default to directory layout.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_routes_context_mutators.py` — 81 passed
- [x] `pytest test_web_routes_context_mutators.py test_context_agents_bc_layout.py test_context_commands_bc_layout.py` — 100 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests/test_web_routes_context_mutators.py`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests/test_web_routes_context_mutators.py`
- [ ] Manual: create `.memtomem/agents/foo/agent.md`, `mm web`, verify `GET /api/context/agents/foo` returns 200 (was 404) and `POST /api/context/agents {"name":"foo",...}` returns 409 (was 200 with silent shadow).

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)