### PR TITLE
test(context): pin strict-drop partial-write boundary for #900 refactor

### DIFF
--- a/packages/memtomem/tests/test_context_agents.py
+++ b/packages/memtomem/tests/test_context_agents.py
@@ -277,6 +277,34 @@ class TestStrictMode:
         )
         assert len(result.generated) == 2
 
+    def test_strict_drop_preserves_earlier_writes(self, tmp_path):
+        # Pre-existing partial-write boundary documented on issue #900:
+        # Phase 2 raises StrictDropError for the first dropping canonical,
+        # but earlier canonicals in pending order have already been written.
+        # Canonicals iterate in sorted-name order (list_canonical_agents),
+        # so "alpha-minimal" is processed before "beta-full".
+        _make_canonical_agent(
+            tmp_path,
+            "alpha-minimal",
+            SAMPLE_MINIMAL_AGENT.replace("helper", "alpha-minimal"),
+        )
+        _make_canonical_agent(
+            tmp_path,
+            "beta-full",
+            SAMPLE_FULL_AGENT.replace("code-reviewer", "beta-full"),
+        )
+
+        with pytest.raises(StrictDropError):
+            generate_all_agents(tmp_path, runtimes=["claude_agents"], on_drop="error")
+
+        runtime_dir = tmp_path / ".claude" / "agents"
+        assert (runtime_dir / "alpha-minimal.md").is_file()
+        assert not (runtime_dir / "beta-full.md").exists()
+        # atomic_write_* uses tempfile.mkstemp with prefix=f".{path.name}.";
+        # since the raise fires before atomic_write_text for beta-full,
+        # no temp file should exist for it.
+        assert list(runtime_dir.glob(".beta-full.md.*.tmp")) == []
+
 
 class TestExtractAgentsToCanonical:
     def test_imports_claude_agent(self, tmp_path):

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -206,6 +206,28 @@ class TestStrictMode:
         result = generate_all_commands(tmp_path, strict=True)
         assert len(result.generated) == 2
 
+    def test_strict_drop_preserves_earlier_writes(self, tmp_path):
+        # Pre-existing partial-write boundary documented on issue #900:
+        # Phase 2 raises StrictDropError for the first dropping canonical,
+        # but earlier canonicals in pending order have already been written.
+        # Canonicals iterate in sorted-name order (list_canonical_commands),
+        # so "alpha-minimal" is processed before "beta-full". gemini_commands
+        # is used because claude_commands supports the full command schema
+        # and never drops fields.
+        _make_canonical_command(tmp_path, "alpha-minimal", SAMPLE_MINIMAL_COMMAND)
+        _make_canonical_command(tmp_path, "beta-full", SAMPLE_FULL_COMMAND)
+
+        with pytest.raises(StrictDropError):
+            generate_all_commands(tmp_path, runtimes=["gemini_commands"], on_drop="error")
+
+        runtime_dir = tmp_path / ".gemini" / "commands"
+        assert (runtime_dir / "alpha-minimal.toml").is_file()
+        assert not (runtime_dir / "beta-full.toml").exists()
+        # atomic_write_* uses tempfile.mkstemp with prefix=f".{path.name}.";
+        # since the raise fires before atomic_write_text for beta-full,
+        # no temp file should exist for it.
+        assert list(runtime_dir.glob(".beta-full.toml.*.tmp")) == []
+
 
 class TestExtractCommandsToCanonical:
     def test_imports_claude_command(self, tmp_path):


### PR DESCRIPTION
## Summary

- Add `test_strict_drop_preserves_earlier_writes` to both `TestStrictMode` classes (`test_context_agents.py`, `test_context_commands.py`).
- Lock in the pre-existing partial-write boundary in `generate_all_agents` / `generate_all_commands` Phase 2: when `on_drop="error"` hits a dropping canonical, earlier canonicals in the pending list have already been written to disk by `atomic_write_text`.
- Behavior-preserving — no production code changes. Two test files only.

## Why now

Issue #900 plans to extract the artifact sync flow into a shared service. The [behavior-inventory comment](https://github.com/memtomem/memtomem/issues/900#issuecomment-4419280062-anchor) on #900 calls out this `StrictDropError` mid-Phase-2 raise as a real, intended atomicity boundary distinct from the all-or-nothing `project_shared` privacy-block contract. Without a pinning test, a refactor that adds full-batch atomicity to the strict-drop path would silently change observable behavior. These tests catch that.

The new tests use the existing fixtures and `SAMPLE_*` constants in each file; canonicals are processed in sorted-name order (`list_canonical_agents` / `list_canonical_commands`), so `alpha-minimal` is guaranteed to be written before the raise on `beta-full`.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_agents.py::TestStrictMode packages/memtomem/tests/test_context_commands.py::TestStrictMode -v` — 6/6 pass.
- [x] `uv run pytest packages/memtomem/tests/test_context_agents.py packages/memtomem/tests/test_context_commands.py -q` — 119/119 pass (no regression in surrounding suites).
- [x] `uv run ruff check` + `ruff format --check` on the two test files — clean.

Refs #900