### PR TITLE
fix(context): typed PARSE_ERROR skip for unreadable skill canonical/override

### DIFF
--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -355,7 +355,17 @@ def generate_all_skills(
                 for lock_path in sorted({_lock_path_for(dst) for _, _, _, dst in work}, key=str):
                     stack.enter_context(_file_lock(lock_path))
                 for target, _gen, skill_dir, dst in work:
-                    staging = _stage_skill(skill_dir, dst)
+                    # Unreadable canonical: typed PARSE_ERROR skip rather than
+                    # an exception bubbling up — symmetric with agents.py /
+                    # commands.py read_bytes failure handling. Privacy block
+                    # is the only failure that still aborts the batch.
+                    try:
+                        staging = _stage_skill(skill_dir, dst)
+                    except OSError as exc:
+                        skipped.append(
+                            (skill_dir.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR)
+                        )
+                        continue
                     staged.append((target, staging, dst))
 
                     vendor = GENERATOR_VENDOR.get(target)
@@ -364,10 +374,23 @@ def generate_all_skills(
                             project_root, "skills", skill_dir.name, vendor, scope=scope
                         )
                         if override_path is not None:
-                            atomic_write_bytes(
-                                staging / SKILL_MANIFEST,
-                                override_path.read_bytes(),
-                            )
+                            try:
+                                override_bytes = override_path.read_bytes()
+                            except OSError as exc:
+                                skipped.append(
+                                    (
+                                        skill_dir.name,
+                                        f"override unreadable: {exc}",
+                                        skip_codes.PARSE_ERROR,
+                                    )
+                                )
+                                # Drop this pair from the promote queue and
+                                # clean its orphaned staging tree. The pop
+                                # targets the entry we just appended.
+                                staged.pop()
+                                shutil.rmtree(staging, ignore_errors=True)
+                                continue
+                            atomic_write_bytes(staging / SKILL_MANIFEST, override_bytes)
 
                     scan = scan_artifact_tree(
                         staging,
@@ -441,7 +464,14 @@ def generate_all_skills(
             # recreate ``dst`` between the move-aside and the rename-in,
             # leaving the rollback path with no clean dst to restore.
             with _file_lock(_lock_path_for(dst)):
-                staging = _stage_skill(skill_dir, dst)
+                # Unreadable canonical: typed PARSE_ERROR skip rather than
+                # an exception bubbling up — symmetric with agents.py /
+                # commands.py read_bytes failure handling.
+                try:
+                    staging = _stage_skill(skill_dir, dst)
+                except OSError as exc:
+                    skipped.append((skill_dir.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                    continue
                 promoted = False
                 try:
                     # 2. Override apply (BEFORE scan — scan must see the bytes
@@ -452,10 +482,20 @@ def generate_all_skills(
                             project_root, "skills", skill_dir.name, vendor, scope=scope
                         )
                         if override_path is not None:
-                            atomic_write_bytes(
-                                staging / SKILL_MANIFEST,
-                                override_path.read_bytes(),
-                            )
+                            try:
+                                override_bytes = override_path.read_bytes()
+                            except OSError as exc:
+                                skipped.append(
+                                    (
+                                        skill_dir.name,
+                                        f"override unreadable: {exc}",
+                                        skip_codes.PARSE_ERROR,
+                                    )
+                                )
+                                # promoted stays False; finally clause rmtrees
+                                # the staging tree.
+                                continue
+                            atomic_write_bytes(staging / SKILL_MANIFEST, override_bytes)
                     # 3. Scan.
                     scan = scan_artifact_tree(
                         staging,

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -152,6 +152,121 @@ class TestGenerateAllSkills:
         assert "codex_skills" in SKILL_GENERATORS
 
 
+class TestUnreadableSources:
+    """OSError on canonical stage or override read becomes a typed
+    ``PARSE_ERROR`` skip, mirroring ``agents.py`` / ``commands.py``
+    ``read_bytes`` failure handling. Per-item skip rather than batch abort
+    — only privacy blocks escalate to a raise (#900 inventory matrix gap)."""
+
+    def test_unreadable_canonical_is_typed_skip_and_keeps_batch_running(
+        self, tmp_path, monkeypatch
+    ):
+        # Two canonicals — "alpha" healthy, "broken" simulates an OSError
+        # from _stage_skill (e.g. unreadable file inside the canonical tree).
+        _make_canonical_skill(tmp_path, "alpha")
+        _make_canonical_skill(tmp_path, "broken")
+
+        from memtomem.context import skills as skills_module
+
+        real_stage = skills_module._stage_skill
+
+        def fake_stage(src, dst):
+            if src.name == "broken":
+                raise PermissionError("permission denied")
+            return real_stage(src, dst)
+
+        monkeypatch.setattr(skills_module, "_stage_skill", fake_stage)
+
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"])
+
+        # alpha promoted, broken typed-skipped, batch not aborted.
+        assert ("claude_skills", tmp_path / ".claude/skills/alpha") in result.generated
+        assert (tmp_path / ".claude/skills/alpha/SKILL.md").is_file()
+        assert not (tmp_path / ".claude/skills/broken").exists()
+        assert any(
+            entry[0] == "broken"
+            and entry[1].startswith("unreadable:")
+            and entry[2] == "parse_error"
+            for entry in result.skipped
+        )
+        # No orphaned staging tree under the runtime fan-out parent.
+        assert list((tmp_path / ".claude/skills").glob(".staging-*.tmp")) == []
+
+    def test_unreadable_override_is_typed_skip_and_keeps_batch_running(self, tmp_path, monkeypatch):
+        # Two skills — "alpha" healthy, "withoverride" has a resolved override
+        # whose bytes cannot be read (resolve returns a Path; read_bytes raises).
+        _make_canonical_skill(tmp_path, "alpha")
+        _make_canonical_skill(tmp_path, "withoverride")
+
+        from memtomem.context import skills as skills_module
+
+        real_resolve = skills_module._override.resolve
+        broken_override = tmp_path / "no-such-dir" / "override.md"
+
+        def fake_resolve(project_root, kind, name, vendor, *, scope=None):
+            if name == "withoverride":
+                return broken_override
+            return real_resolve(project_root, kind, name, vendor, scope=scope)
+
+        monkeypatch.setattr(skills_module._override, "resolve", fake_resolve)
+
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"])
+
+        # alpha promoted, withoverride typed-skipped, no orphaned staging.
+        assert ("claude_skills", tmp_path / ".claude/skills/alpha") in result.generated
+        assert (tmp_path / ".claude/skills/alpha/SKILL.md").is_file()
+        assert not (tmp_path / ".claude/skills/withoverride").exists()
+        assert any(
+            entry[0] == "withoverride"
+            and entry[1].startswith("override unreadable:")
+            and entry[2] == "parse_error"
+            for entry in result.skipped
+        )
+        assert list((tmp_path / ".claude/skills").glob(".staging-*.tmp")) == []
+
+    def test_unreadable_canonical_in_user_scope_is_typed_skip(self, tmp_path, monkeypatch):
+        # Exercises the non-project_shared (per-pair) path. Layout parallels
+        # the project_shared canonical test but with scope="user", which
+        # routes through canonical_skills_root → ~/.memtomem/skills/.
+        from memtomem.context import skills as skills_module
+        from memtomem.context.skills import canonical_skills_root
+
+        from .helpers import set_home
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        set_home(monkeypatch, fake_home)
+
+        user_root = canonical_skills_root(tmp_path, scope="user")
+        user_root.mkdir(parents=True, exist_ok=True)
+        for name in ("alpha", "broken"):
+            skill = user_root / name
+            skill.mkdir()
+            (skill / "SKILL.md").write_text(SAMPLE_SKILL_MD, encoding="utf-8")
+
+        real_stage = skills_module._stage_skill
+
+        def fake_stage(src, dst):
+            if src.name == "broken":
+                raise PermissionError("permission denied")
+            return real_stage(src, dst)
+
+        monkeypatch.setattr(skills_module, "_stage_skill", fake_stage)
+
+        result = generate_all_skills(tmp_path, runtimes=["claude_skills"], scope="user")
+
+        # alpha promoted under ~/.claude/skills; broken typed-skipped.
+        claude_user_dir = fake_home / ".claude/skills"
+        assert (claude_user_dir / "alpha/SKILL.md").is_file()
+        assert not (claude_user_dir / "broken").exists()
+        assert any(
+            entry[0] == "broken"
+            and entry[1].startswith("unreadable:")
+            and entry[2] == "parse_error"
+            for entry in result.skipped
+        )
+
+
 class TestDetectSkillDirs:
     def test_detects_claude_skills(self, tmp_path):
         skill = tmp_path / ".claude/skills/a"


### PR DESCRIPTION
## Summary

- Closes the only remaining gap in the #900 behavior-inventory failure matrix: skills now emit a typed `PARSE_ERROR` skip when canonical or per-vendor override bytes are unreadable, matching `agents.py` / `commands.py` (`agents.py:688/748`, `commands.py:477/532`).
- Applied symmetrically to both code paths in `generate_all_skills`:
  - **project_shared batch path** — `_stage_skill` OSError and override `read_bytes()` OSError are caught; the offending pair is skipped and (on override failure after a successful stage) the orphaned staging tree is rmtreed. Privacy block remains the only failure that escalates to a raise.
  - **per-pair path (user / project_local)** — same try/except wrappers; existing `promoted = False` + `finally` cleanup handles the staging tree on override failure.

## Response shape change

This **is** a behavior change at the API boundary, intentionally:

- **Before**: unreadable canonical or override bytes raise `OSError` / `ClickException` out of `generate_all_skills`. CLI surfaces a traceback; Web routes return a non-200.
- **After**: the same condition lands in `SkillSyncResult.skipped` as `(skill_name, "unreadable: {exc}" | "override unreadable: {exc}", "parse_error")`.

This brings `SkillSyncResult` into structural parity with `AgentSyncResult` / `CommandSyncResult`, which is the same call-site contract used by the CLI, MCP, and Web layers. Documented in the #900 inventory's failure-mode matrix as a deliberate symmetry fix.

## Why now / #900 dependency

PR #908 pinned the strict-drop partial-write boundary; this PR closes the second of the two `#900`-inventory cleanup items that don't depend on the #901 §4 scope-vocabulary decisions. Both PRs land before the #900 service extraction so the eventual shared service inherits a uniform failure-mode contract across artifacts.

## Test plan

- [x] New `TestUnreadableSources` class in `test_context_skills.py` covers:
  - project_shared canonical OSError → healthy skill still generates; broken one yields typed skip; no orphaned `.staging-*.tmp` tree
  - project_shared override OSError → same shape with `"override unreadable"` reason prefix
  - user-scope canonical OSError (per-pair path) → typed skip; HOME redirected via existing `tests.helpers.set_home`
- [x] `uv run pytest packages/memtomem/tests/test_context_skills.py` — 34/34 pass
- [x] `uv run pytest -m "not ollama"` across `test_context_{skills,skills_staging,override,override_per_scope,sync_scope,atomic,generate_warnings,install,install_all,status,rescan,runtime_table_none_skips}.py` — 160/160 pass
- [x] `uv run ruff check` + `ruff format --check` on the two changed files — clean

Refs #900