### PR TITLE
test(server): pin Windows pid-content regression via stat().st_size

### DIFF
--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -642,13 +642,26 @@ def test_server_main_acquires_portalocker_pid_lock(
         server_mod.main()
 
         assert pid_file.exists(), "main() must create the pid file"
+        # Cross-platform: pid file must be non-empty. ``LockFileEx`` blocks
+        # *content* reads from other handles on Windows (#819), but file
+        # metadata via ``stat`` is unaffected — so a regression where
+        # ``main()`` creates and locks an empty pid file would still trip
+        # this assertion on Windows. ``probe_pid_file`` (and uninstall /
+        # status diagnostics) call ``read_text().strip()`` on the file when
+        # it isn't currently locked, so an empty pid file would surface as
+        # ``int("")`` → ``pid=None`` in ``ServerState`` — degraded UX even
+        # though liveness still works.
+        assert pid_file.stat().st_size > 0, (
+            "pid file must not be empty — main() must write its pid before "
+            "returning, on every platform"
+        )
         # POSIX-only: read pid-file content via a fresh handle. Windows
         # ``LockFileEx`` blocks reads from other handles, so this would
         # raise ``PermissionError`` (#819). The lock-owning handle lives
         # in ``main()``'s closure (``_lock_fp``) and isn't reachable from
-        # here. The cross-platform ``probe_pid_file`` assertion below is
-        # the load-bearing check; the content read is just additional
-        # POSIX-side coverage.
+        # here. The cross-platform ``stat().st_size`` check above pins the
+        # "non-empty" half of the contract; the exact-pid check below is
+        # additional POSIX-side coverage that the value is *this* process.
         if os.name != "nt":
             assert pid_file.read_text().strip() == str(os.getpid()), (
                 "pid file must contain this process's pid"


### PR DESCRIPTION
## Summary

Addresses a P2 review comment on the post-#819 server test:

> [P2] Keep Windows pid-content regression pinned — When this test runs on Windows, this guard skips the only assertion that ``main()`` wrote ``os.getpid()`` into ``server.pid``. That behavior is still required there because ``probe_pid_file`` reads the pid text for uninstall/status diagnostics; a Windows-only regression that creates and locks an empty pid file would now pass this cross-platform regression test.

The fix: add a ``pid_file.stat().st_size > 0`` assertion *before* the POSIX-only ``read_text().strip() == str(os.getpid())`` check. ``stat`` queries directory metadata and is unaffected by ``LockFileEx``, so it runs on every platform and pins the "non-empty" half of the contract that the platform skip removed.

## Why ``stat`` instead of removing the platform skip

``LockFileEx`` legitimately blocks content reads from a separate handle on Windows (#819) — that's why ``probe_pid_file`` itself catches ``OSError`` at the read site and falls back to ``pid=None`` during the live-server case. We can't read content from the test, but we *can* check size.

## What the new assertion catches

- ``main()`` calls ``_lock_fp.seek(0); _lock_fp.truncate(); _lock_fp.write(str(os.getpid())); _lock_fp.flush()`` (``server/__init__.py:407-410``).
- A regression that drops the ``write`` or otherwise leaves the file empty would still pass the existing cross-platform check, but ``probe_pid_file`` / ``mm uninstall`` / ``mm status`` would surface ``pid=None`` to users.
- ``stat().st_size > 0`` catches that regression on every platform.

## Test plan

- [x] ``uv run pytest packages/memtomem/tests/test_server_sigterm.py::test_server_main_acquires_portalocker_pid_lock`` — PASS
- [x] ``uv run pytest packages/memtomem/tests/test_server_sigterm.py`` — 11 passed, 1 skipped (existing platform-conditional skip)
- [x] ``ruff check`` + ``format --check`` clean

Refs the #818 / #819 / #820 portalocker cluster.