### PR TITLE
feat(server): MCP parity for context init + scoped generate/sync

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -335,7 +335,7 @@ uses, so the output is identical. Useful as a sanity check between
 | **Data** | `mem_export`, `mem_import` |
 | **Config** | `mem_stats`, `mem_status`, `mem_config`\*, `mem_embedding_reset`\*, `mem_reset`\* |
 | **Evaluation** | `mem_eval` |
-| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init` and `sync` accept `scope="project_shared\|user\|project_local"`; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
+| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, and `sync` accept `scope="project_shared\|user\|project_local"`; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -335,7 +335,7 @@ uses, so the output is identical. Useful as a sanity check between
 | **Data** | `mem_export`, `mem_import` |
 | **Config** | `mem_stats`, `mem_status`, `mem_config`\*, `mem_embedding_reset`\*, `mem_reset`\* |
 | **Evaluation** | `mem_eval` |
-| **Context** | `mem_context_detect`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (each accepts `include="skills,agents,commands"` to fan out `.memtomem/{skills,agents,commands}/` to Claude/Gemini/Codex runtimes; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
+| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init` and `sync` accept `scope="project_shared\|user\|project_local"`; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -126,6 +126,7 @@ from memtomem.server.tools.policy import (
 )  # noqa: E402, F401
 from memtomem.server.tools.context import (
     mem_context_detect,
+    mem_context_init,
     mem_context_generate,
     mem_context_diff,
     mem_context_sync,

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import click
+
 from memtomem.config import TargetScope
 from memtomem.server import mcp
 from memtomem.server.context import CtxType
@@ -128,7 +130,11 @@ async def mem_context_init(
     artifact_scope = _resolve_artifact_mcp_scope(scope)
     has_project_signal = (root / ".git").exists() or (root / "pyproject.toml").exists()
 
-    if artifact_scope != "user" and not has_project_signal:
+    # EXPLICIT scope=project_* requires a real project context, mirroring
+    # the CLI gate at cli/context_cmd.py:744. Implicit default (no scope=)
+    # preserves pre-PR-E2 backward compatibility — falls through to the
+    # warning + seed-here path below, the same way the CLI does.
+    if scope_explicit and artifact_scope != "user" and not has_project_signal:
         return (
             f"--scope={artifact_scope} requires a project root "
             "(with .git or pyproject.toml). Use scope='user' from outside a project."
@@ -231,6 +237,11 @@ async def mem_context_init(
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
+        except click.ClickException as exc:
+            # apply_gate_a hard-aborts project_shared privacy hits via
+            # click.ClickException (_gate_a.py:171). Surface its message
+            # so MCP callers see the actionable block, not "internal error".
+            return f"privacy block: {exc.message}"
         results.append(f"Imported skills: {len(skill_result.imported)}")
         for path in skill_result.imported:
             results.append(f"  {path.name}")
@@ -247,6 +258,8 @@ async def mem_context_init(
             )
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
+        except click.ClickException as exc:
+            return f"privacy block: {exc.message}"
         results.append(f"Imported sub-agents: {len(agent_result.imported)}")
         for path, layout in agent_result.imported:
             results.append(f"  {canonical_agent_name(path, layout)}")
@@ -262,6 +275,8 @@ async def mem_context_init(
                 force_unsafe_import=force_unsafe_import,
             )
         except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
+        except click.ClickException as exc:
             return f"privacy block: {exc.message}"
         results.append(f"Imported commands: {len(command_result.imported)}")
         for path, layout in command_result.imported:

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -84,6 +84,7 @@ def _parse_include(include: str) -> set[str]:
 async def mem_context_init(
     include: str = "",
     overwrite: bool = False,
+    overwrite_context_md: bool = False,
     scope: str = "",
     confirm_project_shared: bool = False,
     force_unsafe_import: bool = False,
@@ -97,7 +98,14 @@ async def mem_context_init(
             ``settings`` is accepted for parity with other context tools
             but has no init-time import action.
         overwrite: Overwrite existing canonical entries during runtime
-            import.
+            import. Does **not** govern ``.memtomem/context.md`` rewrite
+            — see ``overwrite_context_md``.
+        overwrite_context_md: Allow rewriting an existing
+            ``.memtomem/context.md`` from detected agent files. Kept
+            separate from ``overwrite`` so artifact-import refresh cannot
+            silently clobber hand-edited project memory. Mirrors the
+            CLI's separate confirmation prompt at
+            ``cli/context_cmd.py:789-798`` (which defaults to "No").
         scope: Artifact storage scope: ``project_shared`` (default),
             ``user``, or ``project_local``.
         confirm_project_shared: Required when ``scope="project_shared"``
@@ -158,8 +166,11 @@ async def mem_context_init(
     write_context_md = has_project_signal and not artifact_only_scope
     ctx_path = root / CONTEXT_FILENAME
 
-    if write_context_md and ctx_path.exists() and not overwrite:
-        results.append(f"skipped {CONTEXT_FILENAME} rewrite (already exists)")
+    if write_context_md and ctx_path.exists() and not overwrite_context_md:
+        results.append(
+            f"skipped {CONTEXT_FILENAME} rewrite (already exists; "
+            "pass overwrite_context_md=True to replace)"
+        )
         write_context_md = False
 
     if write_context_md:

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -422,7 +422,6 @@ async def mem_context_generate(
     inc = _parse_include(include)
     root = _find_project_root()
     artifact_scope = _resolve_artifact_mcp_scope(scope)
-    settings_scope = _resolve_mcp_scope(scope.strip() or None)
     ctx_path = root / CONTEXT_FILENAME
 
     results: list[str] = []
@@ -507,6 +506,11 @@ async def mem_context_generate(
     if "settings" in inc:
         from memtomem.context.settings import generate_all_settings
 
+        # Resolve settings scope lazily: _resolve_mcp_scope builds
+        # Mem2MemConfig and applies env/file overrides, which can fail
+        # on unrelated misconfiguration. Artifact-only callers must not
+        # pay that cost or see that failure.
+        settings_scope = _resolve_mcp_scope(scope.strip() or None)
         settings_results = generate_all_settings(
             root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
@@ -667,7 +671,6 @@ async def mem_context_sync(
     inc = _parse_include(include)
     root = _find_project_root()
     artifact_scope = _resolve_artifact_mcp_scope(scope)
-    settings_scope = _resolve_mcp_scope(scope.strip() or None)
     ctx_path = root / CONTEXT_FILENAME
 
     results: list[str] = []
@@ -758,6 +761,11 @@ async def mem_context_sync(
     if "settings" in inc:
         from memtomem.context.settings import generate_all_settings
 
+        # Resolve settings scope lazily (see mem_context_generate note):
+        # _resolve_mcp_scope builds Mem2MemConfig and applies env/file
+        # overrides — artifact-only callers must not pay that cost or
+        # see that failure.
+        settings_scope = _resolve_mcp_scope(scope.strip() or None)
         settings_results = generate_all_settings(
             root, scope=settings_scope, allow_host_writes=allow_host_writes
         )

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -385,6 +385,7 @@ async def mem_context_generate(
     agent: str = "all",
     include: str = "",
     strict: bool = False,
+    scope: str = "",
     allow_host_writes: bool = False,
     ctx: CtxType = None,
 ) -> str:
@@ -396,6 +397,11 @@ async def mem_context_generate(
             (``skills``, ``agents``, ``commands``, ``settings``).
         strict: Promote dropped-field warnings to errors when converting
             sub-agents or slash commands.
+        scope: ADR-0011 canonical artifact tier for skills / agents /
+            commands fan-out: ``project_shared`` (default), ``user``, or
+            ``project_local``. The same value is also forwarded as the
+            ADR-0010 host-write target-scope override for ``settings``
+            (mirrors the CLI at ``cli/context_cmd.py:963-987``).
         allow_host_writes: When ``include="settings"`` writes a settings
             file outside the project root (today only
             ``~/.claude/settings.json``), refuse with a
@@ -415,6 +421,8 @@ async def mem_context_generate(
 
     inc = _parse_include(include)
     root = _find_project_root()
+    artifact_scope = _resolve_artifact_mcp_scope(scope)
+    settings_scope = _resolve_mcp_scope(scope.strip() or None)
     ctx_path = root / CONTEXT_FILENAME
 
     results: list[str] = []
@@ -442,7 +450,7 @@ async def mem_context_generate(
 
     if "skills" in inc:
         try:
-            skill_result = generate_all_skills(root)
+            skill_result = generate_all_skills(root, scope=artifact_scope)
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
         if skill_result.generated:
@@ -456,7 +464,7 @@ async def mem_context_generate(
 
     if "agents" in inc:
         try:
-            agent_result = generate_all_agents(root, strict=strict)
+            agent_result = generate_all_agents(root, strict=strict, scope=artifact_scope)
         except StrictDropError as exc:
             return f"strict error: {exc}"
         except PrivacyScanError as exc:
@@ -477,7 +485,7 @@ async def mem_context_generate(
 
     if "commands" in inc:
         try:
-            command_result = generate_all_commands(root, strict=strict)
+            command_result = generate_all_commands(root, strict=strict, scope=artifact_scope)
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
         except PrivacyScanError as exc:
@@ -500,7 +508,7 @@ async def mem_context_generate(
         from memtomem.context.settings import generate_all_settings
 
         settings_results = generate_all_settings(
-            root, scope=_resolve_mcp_scope(), allow_host_writes=allow_host_writes
+            root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
         for sname, sr in settings_results.items():
             if sr.status == "ok":

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1,10 +1,11 @@
-"""Tools: context_detect, context_generate, context_sync, context_diff."""
+"""Tools: context_detect, context_init, context_generate, context_sync, context_diff."""
 
 from __future__ import annotations
 
 import asyncio
 from pathlib import Path
 
+from memtomem.config import TargetScope
 from memtomem.server import mcp
 from memtomem.server.context import CtxType
 from memtomem.server.error_handler import tool_handler
@@ -12,6 +13,7 @@ from memtomem.server.tool_registry import register
 
 # Known --include values (mirrors cli.context_cmd._KNOWN_INCLUDES).
 _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "settings"})
+_KNOWN_ARTIFACT_SCOPES: frozenset[str] = frozenset({"user", "project_shared", "project_local"})
 
 
 def _find_project_root() -> Path:
@@ -24,21 +26,39 @@ def _find_project_root() -> Path:
     return Path.cwd()
 
 
-def _resolve_mcp_scope() -> str:
+def _resolve_mcp_scope(override: str | None = None) -> str:
     """Return the resolved ``hooks.target_scope`` for an MCP tool call.
 
-    Builds a fresh ``Mem2MemConfig`` and applies user-level overrides
-    with ``migrate=False`` — scope resolution is read-only, and the
-    same MCP tool dispatcher is shared by read-only entry points
-    (mem_context_detect, mem_context_diff) where a disk-write side
-    effect would be wrong (see ``feedback_doctor_no_migration_loader``).
+    A per-call override wins. Otherwise this builds a fresh config and
+    applies user-level overrides with ``migrate=False``. Scope
+    resolution is read-only, and the same MCP tool dispatcher is shared
+    by read-only entry points (mem_context_detect, mem_context_diff)
+    where a disk-write side effect would be wrong.
     """
     from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
 
+    if override is not None:
+        if override not in _KNOWN_ARTIFACT_SCOPES:
+            raise ValueError(
+                f"Unknown scope value '{override}'. Supported: {sorted(_KNOWN_ARTIFACT_SCOPES)}"
+            )
+        return override
     cfg = Mem2MemConfig()
     load_config_d(cfg, quiet=True)
     load_config_overrides(cfg, migrate=False)
     return cfg.hooks.target_scope
+
+
+def _resolve_artifact_mcp_scope(scope: str | None) -> TargetScope:
+    """Resolve the ADR-0011 artifact scope axis for MCP context tools."""
+    if scope is None or not scope.strip():
+        return "project_shared"
+    scope = scope.strip()
+    if scope not in _KNOWN_ARTIFACT_SCOPES:
+        raise ValueError(
+            f"Unknown scope value '{scope}'. Supported: {sorted(_KNOWN_ARTIFACT_SCOPES)}"
+        )
+    return scope  # type: ignore[return-value]
 
 
 def _parse_include(include: str) -> set[str]:
@@ -54,6 +74,206 @@ def _parse_include(include: str) -> set[str]:
             )
         values.add(token)
     return values
+
+
+@mcp.tool()
+@tool_handler
+@register("context")
+async def mem_context_init(
+    include: str = "",
+    overwrite: bool = False,
+    scope: str = "",
+    confirm_project_shared: bool = False,
+    force_unsafe_import: bool = False,
+    ctx: CtxType = None,
+) -> str:
+    """Seed canonical context artifact directories.
+
+    Args:
+        include: Comma-separated runtime artifact kinds to import into
+            canonical storage (``skills``, ``agents``, ``commands``).
+            ``settings`` is accepted for parity with other context tools
+            but has no init-time import action.
+        overwrite: Overwrite existing canonical entries during runtime
+            import.
+        scope: Artifact storage scope: ``project_shared`` (default),
+            ``user``, or ``project_local``.
+        confirm_project_shared: Required when ``scope="project_shared"``
+            is explicitly supplied; MCP cannot prompt interactively, so a
+            missing confirmation returns a ``needs confirmation`` message.
+        force_unsafe_import: Bypass Gate A on existing runtime files for
+            ``user`` / ``project_local`` imports. ``project_shared`` still
+            hard-refuses unsafe imports.
+    """
+    from memtomem.context import _skip_reasons as skip_codes
+    from memtomem.context.agents import (
+        canonical_agent_name,
+        extract_agents_to_canonical,
+    )
+    from memtomem.context.commands import extract_commands_to_canonical
+    from memtomem.context.detector import detect_agent_files
+    from memtomem.context.generator import extract_sections_from_agent_file
+    from memtomem.context.parser import CONTEXT_FILENAME, sections_to_markdown
+    from memtomem.context.privacy_scan import PrivacyScanError
+    from memtomem.context.scope_resolver import canonical_artifact_dir
+    from memtomem.context.skills import extract_skills_to_canonical
+
+    # Reuse the CLI helper so the marker text and idempotency stay pinned
+    # to one implementation.
+    from memtomem.cli.context_cmd import _append_gitignore_marker
+
+    inc = _parse_include(include)
+    root = _find_project_root()
+    scope_explicit = bool(scope.strip())
+    artifact_scope = _resolve_artifact_mcp_scope(scope)
+    has_project_signal = (root / ".git").exists() or (root / "pyproject.toml").exists()
+
+    if artifact_scope != "user" and not has_project_signal:
+        return (
+            f"--scope={artifact_scope} requires a project root "
+            "(with .git or pyproject.toml). Use scope='user' from outside a project."
+        )
+
+    if scope_explicit and artifact_scope == "project_shared" and not confirm_project_shared:
+        return (
+            "needs confirmation: scope='project_shared' writes to git-tracked "
+            f"{root / '.memtomem'}. Re-call with confirm_project_shared=True to proceed."
+        )
+
+    results: list[str] = []
+
+    if not scope_explicit and not has_project_signal:
+        results.append(
+            f"warning: no .git or pyproject.toml in {root} — creating .memtomem/ here. "
+            "Use scope='user' for cross-project artifacts."
+        )
+
+    artifact_only_scope = scope_explicit and artifact_scope in ("user", "project_local")
+    write_context_md = has_project_signal and not artifact_only_scope
+    ctx_path = root / CONTEXT_FILENAME
+
+    if write_context_md and ctx_path.exists() and not overwrite:
+        results.append(f"skipped {CONTEXT_FILENAME} rewrite (already exists)")
+        write_context_md = False
+
+    if write_context_md:
+        files = detect_agent_files(root)
+        if not files:
+            results.append("No agent files found. Creating empty context template.")
+            sections: dict[str, str] = {
+                "Project": "- Name: \n- Language: \n- Package manager: ",
+                "Commands": "- Build: \n- Test: \n- Lint: ",
+                "Architecture": "",
+                "Rules": "",
+                "Style": "",
+            }
+        else:
+            best = max(files, key=lambda f: f.size)
+            results.append(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
+            content = await asyncio.to_thread(best.path.read_text, encoding="utf-8")
+            sections = extract_sections_from_agent_file(content)
+            for f in files:
+                if f.path == best.path:
+                    continue
+                other_content = await asyncio.to_thread(f.path.read_text, encoding="utf-8")
+                other_sections = extract_sections_from_agent_file(other_content)
+                for key, val in other_sections.items():
+                    if key not in sections and val.strip():
+                        sections[key] = val
+
+        ctx_path.parent.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(
+            ctx_path.write_text,
+            sections_to_markdown(sections),
+            encoding="utf-8",
+        )
+        results.append(f"Created {CONTEXT_FILENAME}")
+        results.append(f"  Sections: {', '.join(sections.keys())}")
+
+    for kind in ("agents", "skills", "commands"):
+        d = canonical_artifact_dir(kind, artifact_scope, root)
+        d.mkdir(parents=True, exist_ok=True)
+        results.append(f"Created {d}")
+
+    if artifact_scope == "project_local":
+        wrote, msg = _append_gitignore_marker(root)
+        if wrote:
+            results.append("Appended .gitignore marker for project_local artifacts")
+        elif msg == "already_present":
+            results.append(".gitignore marker already present")
+        elif msg == "no_git_repo_pyproject_only":
+            results.append(
+                "warning: project root resolved via pyproject.toml but .git is missing; "
+                ".gitignore not appended"
+            )
+        elif msg == "no_project_signal":
+            results.append("warning: no project signal; .gitignore append skipped")
+
+    def _skip_line(name: str, reason: str, code: str | None) -> str:
+        prefix = (
+            "blocked"
+            if code
+            in (
+                skip_codes.PRIVACY_BLOCKED,
+                skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED,
+            )
+            else "skipped"
+        )
+        return f"  {prefix} {name}: {reason}"
+
+    if "skills" in inc:
+        try:
+            skill_result = extract_skills_to_canonical(
+                root,
+                overwrite=overwrite,
+                scope=artifact_scope,
+                force_unsafe_import=force_unsafe_import,
+            )
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
+        results.append(f"Imported skills: {len(skill_result.imported)}")
+        for path in skill_result.imported:
+            results.append(f"  {path.name}")
+        for name, reason, code in skill_result.skipped:
+            results.append(_skip_line(name, reason, code))
+
+    if "agents" in inc:
+        try:
+            agent_result = extract_agents_to_canonical(
+                root,
+                overwrite=overwrite,
+                scope=artifact_scope,
+                force_unsafe_import=force_unsafe_import,
+            )
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
+        results.append(f"Imported sub-agents: {len(agent_result.imported)}")
+        for path, layout in agent_result.imported:
+            results.append(f"  {canonical_agent_name(path, layout)}")
+        for name, reason, code in agent_result.skipped:
+            results.append(_skip_line(name, reason, code))
+
+    if "commands" in inc:
+        try:
+            command_result = extract_commands_to_canonical(
+                root,
+                overwrite=overwrite,
+                scope=artifact_scope,
+                force_unsafe_import=force_unsafe_import,
+            )
+        except PrivacyScanError as exc:
+            return f"privacy block: {exc.message}"
+        results.append(f"Imported commands: {len(command_result.imported)}")
+        for path, layout in command_result.imported:
+            display = path.parent.name if layout == "dir" else path.stem
+            results.append(f"  {display}")
+        for name, reason, code in command_result.skipped:
+            results.append(_skip_line(name, reason, code))
+
+    if "settings" in inc:
+        results.append("settings: no init-time import action")
+
+    return "Initialized:\n" + "\n".join(results)
 
 
 @mcp.tool()
@@ -387,6 +607,7 @@ async def mem_context_diff(
 async def mem_context_sync(
     include: str = "",
     strict: bool = False,
+    scope: str = "",
     allow_host_writes: bool = False,
     ctx: CtxType = None,
 ) -> str:
@@ -397,6 +618,11 @@ async def mem_context_sync(
     and ``.memtomem/settings.json`` to their runtime targets (Claude Code,
     Gemini CLI, Codex CLI).  ``strict=True`` turns dropped sub-agent /
     command fields into errors.
+
+    ``scope`` selects the ADR-0011 canonical artifact tier for
+    ``skills``, ``agents``, and ``commands``: ``project_shared``
+    (default), ``user``, or ``project_local``. For ``settings`` the same
+    value is treated as the ADR-0010 host-write target-scope override.
 
     ``allow_host_writes`` defaults to ``False``: when ``include="settings"``
     would write to a file outside the project root (today only
@@ -417,6 +643,8 @@ async def mem_context_sync(
 
     inc = _parse_include(include)
     root = _find_project_root()
+    artifact_scope = _resolve_artifact_mcp_scope(scope)
+    settings_scope = _resolve_mcp_scope(scope.strip() or None)
     ctx_path = root / CONTEXT_FILENAME
 
     results: list[str] = []
@@ -447,7 +675,7 @@ async def mem_context_sync(
 
     if "skills" in inc:
         try:
-            skill_result = generate_all_skills(root)
+            skill_result = generate_all_skills(root, scope=artifact_scope)
         except PrivacyScanError as exc:
             return f"privacy block: {exc.message}"
         if skill_result.generated:
@@ -462,7 +690,7 @@ async def mem_context_sync(
 
     if "agents" in inc:
         try:
-            agent_result = generate_all_agents(root, strict=strict)
+            agent_result = generate_all_agents(root, strict=strict, scope=artifact_scope)
         except StrictDropError as exc:
             return f"strict error: {exc}"
         except PrivacyScanError as exc:
@@ -484,7 +712,7 @@ async def mem_context_sync(
 
     if "commands" in inc:
         try:
-            command_result = generate_all_commands(root, strict=strict)
+            command_result = generate_all_commands(root, strict=strict, scope=artifact_scope)
         except CommandStrictDropError as exc:
             return f"strict error: {exc}"
         except PrivacyScanError as exc:
@@ -508,7 +736,7 @@ async def mem_context_sync(
         from memtomem.context.settings import generate_all_settings
 
         settings_results = generate_all_settings(
-            root, scope=_resolve_mcp_scope(), allow_host_writes=allow_host_writes
+            root, scope=settings_scope, allow_host_writes=allow_host_writes
         )
         for sname, sr in settings_results.items():
             if sr.status == "ok":

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -1,0 +1,75 @@
+"""MCP parity pins for ADR-0011 context init/sync scope handling."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.server.tools.context import mem_context_init, mem_context_sync
+
+from .helpers import set_home
+
+
+def _make_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    monkeypatch.chdir(project)
+    return project
+
+
+def _clean_agent_body(name: str) -> str:
+    return f"---\nname: {name}\ndescription: example\n---\nbody\n"
+
+
+@pytest.mark.anyio
+async def test_mem_context_init_scope_user_seeds_user_dirs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _make_project(tmp_path, monkeypatch)
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+
+    out = await mem_context_init(scope="user")
+
+    assert out.startswith("Initialized:")
+    for kind in ("agents", "skills", "commands"):
+        assert (home / ".memtomem" / kind).is_dir()
+        assert not (project / ".memtomem" / kind).exists()
+    assert not (project / ".memtomem" / "context.md").exists()
+
+
+@pytest.mark.anyio
+async def test_mem_context_init_project_shared_requires_confirmation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _make_project(tmp_path, monkeypatch)
+    set_home(monkeypatch, tmp_path / "home")
+
+    out = await mem_context_init(scope="project_shared")
+
+    assert out.startswith("needs confirmation:")
+    assert not (project / ".memtomem" / "agents").exists()
+
+
+@pytest.mark.anyio
+async def test_mem_context_sync_scope_user_reads_user_canonical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = _make_project(tmp_path, monkeypatch)
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    canonical = canonical_artifact_dir("agents", "user", project)
+    canonical.mkdir(parents=True)
+    (canonical / "ok.md").write_text(_clean_agent_body("ok"), encoding="utf-8")
+
+    out = await mem_context_sync(include="agents", scope="user")
+
+    assert "Sub-agent fan-out:" in out
+    assert (home / ".claude" / "agents" / "ok.md").is_file()
+    assert not (project / ".claude" / "agents" / "ok.md").exists()

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -1,4 +1,4 @@
-"""MCP parity pins for ADR-0011 context init/sync scope handling."""
+"""MCP parity pins for ADR-0011 context init/generate/sync scope handling."""
 
 from __future__ import annotations
 
@@ -7,7 +7,11 @@ from pathlib import Path
 import pytest
 
 from memtomem.context.scope_resolver import canonical_artifact_dir
-from memtomem.server.tools.context import mem_context_init, mem_context_sync
+from memtomem.server.tools.context import (
+    mem_context_generate,
+    mem_context_init,
+    mem_context_sync,
+)
 
 from .helpers import set_home
 
@@ -97,6 +101,36 @@ async def test_mem_context_init_implicit_outside_project_warns_and_seeds(
     assert "warning: no .git or pyproject.toml" in out
     for kind in ("agents", "skills", "commands"):
         assert (bare / ".memtomem" / kind).is_dir()
+
+
+@pytest.mark.anyio
+async def test_mem_context_generate_scope_user_reads_user_canonical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``mem_context_generate(scope="user")`` must fan out from the
+    ``user`` canonical tier — the CLI ``mm context generate --scope=user``
+    already does this (see ``cli/context_cmd.py:963-987``). Without
+    ``scope=`` the default ``project_shared`` tier is read, so a
+    user-scope canonical agent is invisible.
+    """
+    project = _make_project(tmp_path, monkeypatch)
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    user_canonical = canonical_artifact_dir("agents", "user", project)
+    user_canonical.mkdir(parents=True)
+    (user_canonical / "scoped.md").write_text(_clean_agent_body("scoped"), encoding="utf-8")
+
+    # Default (no scope=) reads project_shared and finds nothing — pins the
+    # bug that motivated this fix.
+    default_out = await mem_context_generate(include="agents")
+    assert "Sub-agent fan-out:" not in default_out
+    assert not (home / ".claude" / "agents" / "scoped.md").exists()
+
+    # scope="user" picks up the user-tier canonical.
+    scoped_out = await mem_context_generate(include="agents", scope="user")
+    assert "Sub-agent fan-out:" in scoped_out
+    assert (home / ".claude" / "agents" / "scoped.md").is_file()
 
 
 @pytest.mark.anyio

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -191,6 +191,36 @@ async def test_mem_context_sync_artifact_only_skips_settings_scope_resolve(
 
 
 @pytest.mark.anyio
+async def test_mem_context_init_overwrite_does_not_clobber_context_md(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``overwrite=True`` is for artifact imports only — it must NOT
+    rewrite an existing ``.memtomem/context.md``. The CLI keeps
+    context.md rewrite behind a separate confirmation prompt
+    (``cli/context_cmd.py:789-798``) that defaults to "No"; the MCP
+    surface mirrors that with the explicit ``overwrite_context_md``
+    flag (default False).
+    """
+    project = _make_project(tmp_path, monkeypatch)
+    set_home(monkeypatch, tmp_path / "home")
+
+    ctx_path = project / ".memtomem" / "context.md"
+    ctx_path.parent.mkdir(parents=True)
+    handcrafted = "# hand-edited\n\nimportant project memory\n"
+    ctx_path.write_text(handcrafted, encoding="utf-8")
+
+    # overwrite=True targets artifact imports only — context.md is preserved.
+    out = await mem_context_init(include="agents", overwrite=True)
+    assert "skipped" in out and "context.md rewrite" in out
+    assert ctx_path.read_text(encoding="utf-8") == handcrafted
+
+    # Explicit overwrite_context_md=True is required to replace it.
+    out = await mem_context_init(overwrite_context_md=True)
+    assert ctx_path.read_text(encoding="utf-8") != handcrafted
+
+
+@pytest.mark.anyio
 async def test_mem_context_init_project_shared_privacy_block_surfaces(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -134,6 +134,63 @@ async def test_mem_context_generate_scope_user_reads_user_canonical(
 
 
 @pytest.mark.anyio
+async def test_mem_context_generate_artifact_only_skips_settings_scope_resolve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Artifact-only generate must not eagerly resolve the settings scope.
+
+    ``_resolve_mcp_scope`` builds ``Mem2MemConfig`` and applies env/file
+    overrides — if an unrelated override is broken, the whole call would
+    fail before touching artifacts. Pin: monkeypatch the helper to raise,
+    then call generate with ``include="agents"``; the artifact path must
+    still complete.
+    """
+    project = _make_project(tmp_path, monkeypatch)
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    canonical = canonical_artifact_dir("agents", "user", project)
+    canonical.mkdir(parents=True)
+    (canonical / "ok.md").write_text(_clean_agent_body("ok"), encoding="utf-8")
+
+    from memtomem.server.tools import context as context_mod
+
+    def _boom(*_a: object, **_kw: object) -> str:
+        raise RuntimeError("settings scope resolver poisoned for test")
+
+    monkeypatch.setattr(context_mod, "_resolve_mcp_scope", _boom)
+
+    out = await mem_context_generate(include="agents", scope="user")
+    assert "Sub-agent fan-out:" in out
+    assert (home / ".claude" / "agents" / "ok.md").is_file()
+
+
+@pytest.mark.anyio
+async def test_mem_context_sync_artifact_only_skips_settings_scope_resolve(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same regression pin as ``mem_context_generate`` but for ``mem_context_sync``."""
+    project = _make_project(tmp_path, monkeypatch)
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    canonical = canonical_artifact_dir("agents", "user", project)
+    canonical.mkdir(parents=True)
+    (canonical / "ok.md").write_text(_clean_agent_body("ok"), encoding="utf-8")
+
+    from memtomem.server.tools import context as context_mod
+
+    def _boom(*_a: object, **_kw: object) -> str:
+        raise RuntimeError("settings scope resolver poisoned for test")
+
+    monkeypatch.setattr(context_mod, "_resolve_mcp_scope", _boom)
+
+    out = await mem_context_sync(include="agents", scope="user")
+    assert "Sub-agent fan-out:" in out
+    assert (home / ".claude" / "agents" / "ok.md").is_file()
+
+
+@pytest.mark.anyio
 async def test_mem_context_init_project_shared_privacy_block_surfaces(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/packages/memtomem/tests/test_server_tools_context_scope.py
+++ b/packages/memtomem/tests/test_server_tools_context_scope.py
@@ -73,3 +73,59 @@ async def test_mem_context_sync_scope_user_reads_user_canonical(
     assert "Sub-agent fan-out:" in out
     assert (home / ".claude" / "agents" / "ok.md").is_file()
     assert not (project / ".claude" / "agents" / "ok.md").exists()
+
+
+@pytest.mark.anyio
+async def test_mem_context_init_implicit_outside_project_warns_and_seeds(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Implicit init (no scope=) from outside a project must keep pre-PR-E2
+    back-compat — warn + seed .memtomem/ here, not return an error.
+
+    Mirrors the CLI gate at ``cli/context_cmd.py:744`` which only refuses
+    when ``scope_explicit`` is true.
+    """
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    monkeypatch.chdir(bare)
+    set_home(monkeypatch, tmp_path / "home")
+
+    out = await mem_context_init()
+
+    assert out.startswith("Initialized:")
+    assert "warning: no .git or pyproject.toml" in out
+    for kind in ("agents", "skills", "commands"):
+        assert (bare / ".memtomem" / kind).is_dir()
+
+
+@pytest.mark.anyio
+async def test_mem_context_init_project_shared_privacy_block_surfaces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """project_shared Gate A hard-aborts via click.ClickException
+    (apply_gate_a in _gate_a.py:171). The MCP handler must catch it and
+    surface a ``privacy block:`` message rather than letting it fall
+    through to tool_handler as ``internal error``.
+    """
+    project = _make_project(tmp_path, monkeypatch)
+    set_home(monkeypatch, tmp_path / "home")
+
+    leaky_agent = project / ".claude" / "agents"
+    leaky_agent.mkdir(parents=True)
+    (leaky_agent / "leak.md").write_text(
+        "---\nname: leak\ndescription: leak\n---\nuses AKIAIOSFODNN7EXAMPLE\n",
+        encoding="utf-8",
+    )
+
+    out = await mem_context_init(
+        include="agents",
+        scope="project_shared",
+        confirm_project_shared=True,
+    )
+
+    assert out.startswith("privacy block:")
+    assert "Gate A" in out
+    assert "internal error" not in out.lower()
+    assert not (project / ".memtomem" / "agents" / "leak.md").exists()


### PR DESCRIPTION
## Summary

- Adds `mem_context_init` MCP tool and threads `scope=` through `mem_context_generate` / `mem_context_sync`, closing the MCP-side parity gap for ADR-0011 PR-E that issue #887 tracked.
- Honors the CLI invariants: implicit-default back-compat outside projects, separate `confirm_project_shared` gate, Gate A privacy-block surfacing, lazy settings-scope resolution, and separate `overwrite_context_md` from artifact-import `overwrite`.
- Out of scope: `mm context promote` / `demote` MCP parity. Those CLI subcommands never shipped; PR-E consolidated the scope move path into `mm context migrate --to`. #887 stays open as the tracker for future MCP exposure of migrate if requested.

## Changes

- **`mem_context_init`**: new MCP tool registered through `@register("context")` and `@mcp.tool()`. Mirrors `mm context init` with `scope=`, non-interactive `confirm_project_shared=True`, canonical dir seeding, project-local `.gitignore` handling, optional runtime import, and Gate A privacy-block translation.
- **`mem_context_generate`**: gains `scope=` for skills/agents/commands fan-out. The same value is reused as the ADR-0010 host-write target-scope override when `include="settings"` is present.
- **`mem_context_sync`**: same scope handling as `generate`.
- **Lazy settings-scope resolution**: `_resolve_mcp_scope` now runs only inside the settings branch, so artifact-only and project-memory-only calls cannot fail on unrelated settings config.
- **Docs**: updates `docs/guides/mcp-clients.md` for the new tool and `scope=` args.
- **Tests**: adds `packages/memtomem/tests/test_server_tools_context_scope.py` covering init scope seeding, project_shared confirmation, implicit-default outside projects, privacy-block surfacing, scoped generate/sync, lazy settings-scope resolution, and context.md overwrite separation.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_server_tools_context_scope.py packages/memtomem/tests/test_server_tools_context_settings_gate.py packages/memtomem/tests/test_sync_privacy_block_surfaces.py packages/memtomem/tests/test_tool_registration.py packages/memtomem/tests/test_docs_guards.py packages/memtomem/tests/test_context_init_scope.py` — 70/70 green locally
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/server/tools/context.py` — advisory clean
- [ ] CI green on `feat/887-mcp-context-init-sync-parity`

## Out of scope

- `mm context promote` / `demote` MCP parity. ADR-0011 originally listed these as PR-E deliverables, but they were consolidated into `mm context migrate --to` in the shipped CLI. MCP exposure of migrate is a separate follow-up if a caller requests it.
- Web UI scope badges — PR-F territory, separate from MCP.

Refs #887
