### PR TITLE
refactor(context): extract shared atomic-file sync engine for agents+commands (#900)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ BUG_REPORT.md
 main.py
 scripts/
 .agents-dev/
+# dev-trio plugin: per-run Codex/Gemini reviewer transcripts. Contain local
+# paths, session metadata, prompts, and reviewer output — never commit.
+.dev-trio/
 
 # Experimental plugins kept private until promoted
 packages/memtomem-openclaw-plugin/

--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -1,0 +1,365 @@
+"""Shared atomic-file artifact sync engine (issue #900).
+
+Agents and commands share the same six-stage lifecycle — enumerate canonical →
+resolve runtime fan-out target → drop/strict policy → per-vendor override →
+sync-side Gate A privacy → atomic write → return summary — implemented today
+as two near-identical copies in :mod:`memtomem.context.agents` and
+:mod:`memtomem.context.commands`. This module is the extraction: a single
+``sync_atomic_artifact`` engine parametrized by an :class:`AtomicSyncAdapter`
+that plugs in the per-artifact callables (list_canonical / parse / generators).
+
+Behavior is byte-for-byte identical to the pre-extraction implementations.
+The TOCTOU-close (read canonical bytes once, scan and parse from the captured
+buffer; same for override bytes) is preserved. The Phase-1-raises-early
+``project_shared`` atomicity is preserved — no partial fan-out can land on
+disk for the all-or-nothing scope. The strict-drop partial-write boundary
+pinned by ``test_strict_drop_preserves_earlier_writes`` (#908) is preserved:
+Phase 2 ``StrictDropError`` fires mid-loop, earlier writes remain.
+
+Skills are intentionally out of scope here — their staging-dir promotion
+shape is different enough that forcing it into this engine would cost more
+than it saves. See :mod:`memtomem.context.skills`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, Literal, Protocol, TypeVar
+
+from memtomem.config import TargetScope
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import override as _override
+from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._names import GENERATOR_VENDOR, Layout
+from memtomem.context.privacy_scan import raise_or_collect, scan_text_content
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+# Contravariant alias used only by ``AtomicGenerator``: the protocol only
+# *consumes* the parsed item (in ``render(item)``), never produces it, so
+# mypy expects a contravariant marker. ``AtomicSyncAdapter`` keeps using
+# invariant ``T`` — it owns both the parse function (produces T) and the
+# generators mapping (consumes T).
+T_contra = TypeVar("T_contra", contravariant=True)
+
+
+class StrictDropError(ValueError):
+    """Engine-level strict-drop error.
+
+    :mod:`memtomem.context.agents` and :mod:`memtomem.context.commands`
+    each subclass this so their public ``StrictDropError`` stays a
+    distinct class (``agents.StrictDropError is not commands.StrictDropError``)
+    — an ``except agents.StrictDropError`` block does NOT catch a commands
+    raise. The engine raises ``adapter.strict_drop_error_type`` which each
+    adapter sets to its own subclass.
+    """
+
+
+# Valid severity levels for the ``on_drop`` parameter.
+ON_DROP_LEVELS = ("ignore", "warn", "error")
+
+
+@dataclass
+class AtomicSyncResult:
+    """Engine-level result shape for atomic-file sync (agents + commands).
+
+    :mod:`memtomem.context.agents` and :mod:`memtomem.context.commands`
+    each subclass this so their public ``AgentSyncResult`` /
+    ``CommandSyncResult`` stay distinct classes (matching the
+    pre-extraction API surface). The engine constructs results via
+    ``adapter.result_type`` so each adapter binds its own subclass.
+    """
+
+    generated: list[tuple[str, Path]]  # (runtime, target_file)
+    dropped: list[tuple[str, str, list[str]]]  # (runtime, item_name, dropped_fields)
+    # (runtime_or_item, human_reason, reason_code) — see :mod:`memtomem.context._skip_reasons`.
+    skipped: list[tuple[str, str, skip_codes.SkipCode]]
+
+
+class AtomicGenerator(Protocol[T_contra]):
+    """Per-runtime generator protocol — exactly what AGENT_GENERATORS /
+    COMMAND_GENERATORS values already implement (``target_file`` returns
+    ``None`` for ``NO_FANOUT`` runtime/scope tuples, see
+    ``_runtime_targets.RUNTIME_FANOUT_TABLE``).
+    """
+
+    def target_file(self, project_root: Path, name: str, *, scope: TargetScope) -> Path | None: ...
+
+    def render(self, item: T_contra) -> tuple[str, list[str]]: ...
+
+
+@dataclass(frozen=True)
+class AtomicSyncAdapter(Generic[T]):
+    """Per-artifact plug-in points for :func:`sync_atomic_artifact`.
+
+    Each callable is the exact function the original agents.py / commands.py
+    used; the adapter just bundles them so the engine stays artifact-
+    agnostic.
+
+    Args:
+        kind: Discriminator passed through to ``raise_or_collect`` and used
+            in the ``StrictDropError`` message. Must match the literal the
+            privacy scan layer expects (``"agent"`` or ``"command"``).
+        artifact_label: Plural form passed to ``_override.resolve`` as the
+            second positional argument (``"agents"`` or ``"commands"``).
+            Also appears in the ``NO_CANONICAL_ROOT`` skip reason.
+        list_canonical: ``list_canonical_agents`` / ``list_canonical_commands``
+            — returns ``[(path, layout), ...]`` for the canonical root at
+            the requested scope.
+        parse_canonical_text: ``_parse_canonical_agent_text`` /
+            ``_parse_canonical_command_text`` — raises
+            ``parse_error_type`` on malformed input.
+        parse_error_type: ``AgentParseError`` / ``CommandParseError`` —
+            the concrete exception class ``parse_canonical_text`` raises.
+        name_of: Extracts the artifact name from a parsed item
+            (``lambda a: a.name`` for SubAgent / SlashCommand).
+        generators: ``AGENT_GENERATORS`` / ``COMMAND_GENERATORS`` —
+            runtime-key → generator mapping.
+    """
+
+    kind: Literal["agent", "command"]
+    artifact_label: str
+    list_canonical: Callable[..., list[tuple[Path, Layout]]]
+    parse_canonical_text: Callable[..., T]
+    parse_error_type: type[Exception]
+    name_of: Callable[[T], str]
+    generators: Mapping[str, AtomicGenerator[T]]
+    # The engine constructs results via ``result_type`` and raises
+    # ``strict_drop_error_type`` so each artifact module's public class
+    # identity is preserved (``AgentSyncResult is not CommandSyncResult``,
+    # ``agents.StrictDropError is not commands.StrictDropError`` — Codex
+    # review on #900 flagged the aliased-class regression). Default to the
+    # shared engine types so adapters that don't care don't have to opt in.
+    result_type: type[AtomicSyncResult] = AtomicSyncResult
+    strict_drop_error_type: type[StrictDropError] = StrictDropError
+    # Logger used for ``on_drop="warn"`` messages. Defaults to the engine
+    # module's logger; each adapter passes its own so warnings continue to
+    # appear under ``memtomem.context.agents`` / ``memtomem.context.commands``
+    # for log filters that historically targeted those names.
+    logger: logging.Logger = logger
+
+
+def sync_atomic_artifact(
+    adapter: AtomicSyncAdapter[T],
+    project_root: Path,
+    runtimes: list[str] | None = None,
+    strict: bool = False,
+    on_drop: str = "ignore",
+    *,
+    scope: TargetScope = "project_shared",
+) -> AtomicSyncResult:
+    """Fan out every canonical artifact to the requested runtimes (atomic-file shape).
+
+    Args:
+        adapter: Per-artifact plug-in points. See :class:`AtomicSyncAdapter`.
+        project_root: Project root containing ``.memtomem/<artifact_label>/``.
+        runtimes: List of generator names. ``None`` means all registered
+            generators in ``adapter.generators``.
+        on_drop: Severity when fields are dropped during conversion.
+            ``"ignore"`` (default) — silently record in ``result.dropped``.
+            ``"warn"``  — log a warning per dropped-field set.
+            ``"error"`` — raise :class:`StrictDropError` immediately.
+        strict: Legacy alias for ``on_drop="error"``. If both are supplied,
+            ``on_drop`` takes precedence unless it is still the default.
+        scope: ADR-0011 PR-E3 — selects canonical root and runtime fan-out
+            destination. Default ``project_shared`` preserves pre-PR-E3
+            behavior.
+
+    Returns:
+        :class:`AtomicSyncResult` carrying ``generated``, ``dropped``, and
+        ``skipped`` tuples.
+
+    Raises:
+        click.ClickException: Phase 1 Gate A block under ``scope=project_shared``
+            — surfaced via :func:`raise_or_collect`. No filesystem mutation
+            has happened at this point (all-or-nothing atomicity).
+        StrictDropError: Phase 2, when ``on_drop="error"`` (or legacy
+            ``strict=True``) and a render would drop fields. Earlier writes
+            in pending order have already landed on disk — this is the
+            intentional partial-write boundary pinned by
+            ``test_strict_drop_preserves_earlier_writes`` (#908).
+    """
+    # Resolve legacy ``strict`` flag.
+    effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
+
+    generated: list[tuple[str, Path]] = []
+    dropped: list[tuple[str, str, list[str]]] = []
+    skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
+
+    canonicals = adapter.list_canonical(project_root, scope=scope)
+    if not canonicals:
+        return adapter.result_type(
+            generated=[],
+            dropped=[],
+            skipped=[
+                (
+                    "<all>",
+                    f"no canonical {adapter.artifact_label}",
+                    skip_codes.NO_CANONICAL_ROOT,
+                )
+            ],
+        )
+
+    targets = runtimes if runtimes is not None else list(adapter.generators.keys())
+
+    # ── Phase 1: parse + scan every (target, item) pair — pure read pass. ──
+    # No filesystem mutation happens here. For ``scope='project_shared'``
+    # the first Gate A hit raises immediately via :func:`raise_or_collect`,
+    # so Phase 2 never starts and no partial runtime fan-out can land on
+    # disk (#895 P2 review #5). For user / project_local scopes, blocks
+    # collect into ``skipped`` as before.
+    #
+    # ``pending`` is a list of write descriptors: one per (target, item)
+    # pair that passed every gate. Each entry carries the immutable
+    # snapshot Phase 2 needs (parsed item + override bytes that already
+    # passed Gate A) so the write loop never re-reads canonical from
+    # disk and the scan→write TOCTOU window stays closed.
+    pending: list[tuple[str, str, AtomicGenerator[T], T, Path, bytes | None]] = []
+
+    for target in targets:
+        gen = adapter.generators.get(target)
+        if gen is None:
+            skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
+            continue
+        for item_path, layout in canonicals:
+            # PR-E3 Codex review fold: read canonical bytes ONCE and use
+            # the captured buffer for both Gate A scan AND parse, closing
+            # the scan→write TOCTOU window. A concurrent edit between
+            # scan and parse would otherwise let an attacker present
+            # clean bytes to scan and unsafe bytes to render.
+            try:
+                item_bytes = item_path.read_bytes()
+            except OSError as exc:
+                skipped.append((item_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
+                continue
+            item_text = item_bytes.decode("utf-8", errors="replace")
+            try:
+                item = adapter.parse_canonical_text(item_text, source=item_path, layout=layout)
+            except adapter.parse_error_type as exc:
+                skipped.append((item_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
+                continue
+            name = adapter.name_of(item)
+            # ADR-0011 PR-E (#891): resolve the runtime target BEFORE render
+            # + dropped-field handling. ``None`` means NO_FANOUT per
+            # ``_runtime_targets.RUNTIME_FANOUT_TABLE``; emit a typed skip
+            # without invoking ``render`` so a strict caller doesn't raise
+            # ``StrictDropError`` for a runtime that has no fan-out by
+            # design (the fail-quiet contract).
+            out_path = gen.target_file(project_root, name, scope=scope)
+            if out_path is None:
+                skipped.append(
+                    (
+                        name,
+                        f"no fan-out for runtime {target} at this scope",
+                        skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
+                    )
+                )
+                continue
+            # ADR-0011 PR-E3 Gate A — scan the IN-MEMORY canonical bytes
+            # (same buffer the parse used). project_shared block raises
+            # PrivacyBlockedError; user/project_local block emits
+            # PRIVACY_BLOCKED skip and continues to next runtime.
+            file_scan = scan_text_content(
+                item_text,
+                source_path=item_path,
+                surface="cli_context_sync",
+                scope=scope,
+                project_root=project_root,
+            )
+            if file_scan.decision in ("blocked", "blocked_project_shared"):
+                code, reason = raise_or_collect(
+                    file_scan,
+                    scope=scope,
+                    kind=adapter.kind,
+                    artifact_name=name,
+                )
+                skipped.append((name, reason, code))
+                continue
+            # Resolve per-vendor override and scan its bytes — read once,
+            # scan once, hand the bytes to Phase 2. Same TOCTOU close as
+            # canonical above.
+            vendor = GENERATOR_VENDOR.get(target)
+            override_bytes: bytes | None = None
+            if vendor is not None:
+                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
+                # to override resolution. Same-tier-only lookup (narrow→broad
+                # is intentionally NOT used for default sync per ADR §4).
+                override_path = _override.resolve(
+                    project_root,
+                    adapter.artifact_label,
+                    name,
+                    vendor,
+                    scope=scope,
+                )
+                if override_path is not None:
+                    try:
+                        override_bytes = override_path.read_bytes()
+                    except OSError as exc:
+                        skipped.append(
+                            (
+                                name,
+                                f"override unreadable: {exc}",
+                                skip_codes.PARSE_ERROR,
+                            )
+                        )
+                        continue
+                    override_text = override_bytes.decode("utf-8", errors="replace")
+                    file_scan = scan_text_content(
+                        override_text,
+                        source_path=override_path,
+                        surface="cli_context_sync",
+                        scope=scope,
+                        project_root=project_root,
+                    )
+                    if file_scan.decision in ("blocked", "blocked_project_shared"):
+                        code, reason = raise_or_collect(
+                            file_scan,
+                            scope=scope,
+                            kind=adapter.kind,
+                            artifact_name=name,
+                        )
+                        skipped.append((name, reason, code))
+                        continue
+            pending.append((target, name, gen, item, out_path, override_bytes))
+
+    # ── Phase 2: render + atomic write every pending pair. ──
+    # By construction Phase 1 raised on any project_shared privacy block,
+    # so reaching this loop means every queued write is clean. The only
+    # remaining mid-loop raise is StrictDropError, which is opt-in
+    # (``on_drop="error"`` or legacy ``strict=True``) and is an unrelated
+    # atomicity boundary — pre-existing behavior pinned by
+    # ``test_strict_drop_preserves_earlier_writes`` (#908).
+    for target, name, gen, item, out_path, override_bytes in pending:
+        content, dropped_fields = gen.render(item)
+        if dropped_fields:
+            if effective_drop == "error":
+                raise adapter.strict_drop_error_type(
+                    f"strict mode: {target} would drop {dropped_fields} from '{name}'"
+                )
+            if effective_drop == "warn":
+                adapter.logger.warning("%s dropped %s from '%s'", target, dropped_fields, name)
+        atomic_write_text(out_path, content)
+        # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
+        # Use the SAME captured buffer that passed Gate A — never
+        # re-read from disk (would re-open the TOCTOU window).
+        if override_bytes is not None:
+            atomic_write_bytes(out_path, override_bytes)
+        generated.append((target, out_path))
+        if dropped_fields:
+            dropped.append((target, name, dropped_fields))
+
+    return adapter.result_type(generated=generated, dropped=dropped, skipped=skipped)
+
+
+__all__ = [
+    "AtomicGenerator",
+    "AtomicSyncAdapter",
+    "AtomicSyncResult",
+    "ON_DROP_LEVELS",
+    "StrictDropError",
+    "sync_atomic_artifact",
+]

--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -174,9 +174,12 @@ def sync_atomic_artifact(
         ``skipped`` tuples.
 
     Raises:
-        click.ClickException: Phase 1 Gate A block under ``scope=project_shared``
-            — surfaced via :func:`raise_or_collect`. No filesystem mutation
-            has happened at this point (all-or-nothing atomicity).
+        PrivacyBlockedError: Phase 1 Gate A block under ``scope=project_shared``
+            — raised by :func:`raise_or_collect`. No filesystem mutation
+            has happened at this point (all-or-nothing atomicity). Surfaces
+            translate at the boundary (CLI → ``click.ClickException``,
+            MCP → tool error, web → HTTP 422); the engine itself does not
+            import ``click``.
         StrictDropError: Phase 2, when ``on_drop="error"`` (or legacy
             ``strict=True``) and a render would drop fields. Earlier writes
             in pending order have already landed on disk — this is the

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -36,18 +36,20 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context import override as _override
-from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
+from memtomem.context._atomic import atomic_write_bytes
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
+from memtomem.context._names import InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
-from memtomem.context.privacy_scan import (
-    raise_or_collect,
-    scan_text_content,
+from memtomem.context._sync_atomic import (
+    ON_DROP_LEVELS,
+    AtomicSyncAdapter,
+    AtomicSyncResult,
+    StrictDropError as _EngineStrictDropError,
+    sync_atomic_artifact,
 )
 from memtomem.context.scope_resolver import canonical_artifact_dir
 
@@ -587,12 +589,23 @@ _register(CodexAgentsGenerator())
 # ── Fan-out: canonical → runtimes ───────────────────────────────────
 
 
+# Sister subclass (issue #900): inherits the engine's result shape but
+# stays a distinct class so ``AgentSyncResult is CommandSyncResult`` is
+# False and ``type(result).__name__ == "AgentSyncResult"`` matches the
+# pre-extraction API. External callers consume it by attribute access
+# (``.generated``, ``.dropped``, ``.skipped``) — those attributes come
+# from the parent dataclass.
 @dataclass
-class AgentSyncResult:
-    generated: list[tuple[str, Path]]  # (runtime, target_file)
-    dropped: list[tuple[str, str, list[str]]]  # (runtime, agent_name, dropped_fields)
-    # (runtime_or_agent, human_reason, reason_code) — see :mod:`memtomem.context._skip_reasons`.
-    skipped: list[tuple[str, str, skip_codes.SkipCode]]
+class AgentSyncResult(AtomicSyncResult):
+    """Module-specific result subclass — see :class:`AtomicSyncResult`."""
+
+
+# Sister subclass for the same reason — ``agents.StrictDropError is
+# commands.StrictDropError`` stays False so an ``except StrictDropError``
+# block imported from ``memtomem.context.agents`` only catches the
+# agents-flavored raise.
+class StrictDropError(_EngineStrictDropError):
+    """Module-specific strict-drop error — see :class:`_EngineStrictDropError`."""
 
 
 @dataclass
@@ -611,12 +624,24 @@ class ExtractResult:
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = field(default_factory=list)
 
 
-class StrictDropError(ValueError):
-    """Raised under ``strict=True`` / ``on_drop="error"`` when a conversion would drop fields."""
-
-
-# Valid severity levels for the ``on_drop`` parameter.
-ON_DROP_LEVELS = ("ignore", "warn", "error")
+# Issue #900 extraction: the previously per-module ``generate_all_agents``
+# body is now :func:`memtomem.context._sync_atomic.sync_atomic_artifact`.
+# The adapter below bundles the agent-specific callables the engine plugs
+# into. Behavior is byte-for-byte identical (TOCTOU close on canonical and
+# override bytes, Phase 1 raise-early atomicity for ``project_shared``,
+# Phase 2 strict-drop partial-write boundary pinned by #908).
+_AGENT_ADAPTER: AtomicSyncAdapter[SubAgent] = AtomicSyncAdapter(
+    kind="agent",
+    artifact_label="agents",
+    list_canonical=list_canonical_agents,
+    parse_canonical_text=_parse_canonical_agent_text,
+    parse_error_type=AgentParseError,
+    name_of=lambda a: a.name,
+    generators=AGENT_GENERATORS,
+    result_type=AgentSyncResult,
+    strict_drop_error_type=StrictDropError,
+    logger=logger,
+)
 
 
 def generate_all_agents(
@@ -629,6 +654,10 @@ def generate_all_agents(
 ) -> AgentSyncResult:
     """Fan out every canonical sub-agent to the requested runtimes.
 
+    Thin wrapper that binds the agent-specific adapter and delegates to
+    :func:`memtomem.context._sync_atomic.sync_atomic_artifact` — see that
+    function for the full Phase 1 / Phase 2 contract.
+
     Args:
         on_drop: Severity when fields are dropped during conversion.
             ``"ignore"`` (default) — silently record in ``result.dropped``.
@@ -640,160 +669,21 @@ def generate_all_agents(
             fan-out destination. Default ``project_shared`` preserves
             pre-PR-E3 behavior.
     """
-    # Resolve legacy ``strict`` flag.
-    effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
-
-    generated: list[tuple[str, Path]] = []
-    dropped: list[tuple[str, str, list[str]]] = []
-    skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
-
-    canonicals = list_canonical_agents(project_root, scope=scope)
-    if not canonicals:
-        return AgentSyncResult(
-            generated=[],
-            dropped=[],
-            skipped=[("<all>", "no canonical agents", skip_codes.NO_CANONICAL_ROOT)],
-        )
-
-    targets = runtimes if runtimes is not None else list(AGENT_GENERATORS.keys())
-
-    # ── Phase 1: parse + scan every (target, agent) pair — pure read pass. ──
-    # No filesystem mutation happens here. For ``scope='project_shared'``
-    # the first Gate A hit raises immediately via :func:`raise_or_collect`,
-    # so Phase 2 never starts and no partial runtime fan-out can land on
-    # disk (#895 P2 review #5). For user / project_local scopes, blocks
-    # collect into ``skipped`` as before.
-    #
-    # ``pending`` is a list of write descriptors: one per (target, agent)
-    # pair that passed every gate. Each entry carries the immutable
-    # snapshot Phase 2 needs (parsed agent + override bytes that already
-    # passed Gate A) so the write loop never re-reads canonical from
-    # disk and the scan→write TOCTOU window stays closed.
-    pending: list[tuple[str, str, AgentGenerator, SubAgent, Path, bytes | None]] = []
-
-    for target in targets:
-        gen = AGENT_GENERATORS.get(target)
-        if gen is None:
-            skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
-            continue
-        for agent_path, layout in canonicals:
-            # PR-E3 Codex review fold: read canonical bytes ONCE and use
-            # the captured buffer for both Gate A scan AND parse, closing
-            # the scan→write TOCTOU window. A concurrent edit between
-            # scan and parse would otherwise let an attacker present
-            # clean bytes to scan and unsafe bytes to render.
-            try:
-                agent_bytes = agent_path.read_bytes()
-            except OSError as exc:
-                skipped.append((agent_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
-                continue
-            agent_text = agent_bytes.decode("utf-8", errors="replace")
-            try:
-                agent = _parse_canonical_agent_text(agent_text, source=agent_path, layout=layout)
-            except AgentParseError as exc:
-                skipped.append((agent_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
-                continue
-            # ADR-0011 PR-E (#891): resolve the runtime target BEFORE render
-            # + dropped-field handling. ``None`` means NO_FANOUT per
-            # ``_runtime_targets.RUNTIME_FANOUT_TABLE``; emit a typed skip
-            # without invoking ``render`` so a strict caller doesn't raise
-            # ``StrictDropError`` for a runtime that has no fan-out by
-            # design (the fail-quiet contract).
-            out_path = gen.target_file(project_root, agent.name, scope=scope)
-            if out_path is None:
-                skipped.append(
-                    (
-                        agent.name,
-                        f"no fan-out for runtime {target} at this scope",
-                        skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
-                    )
-                )
-                continue
-            # ADR-0011 PR-E3 Gate A — scan the IN-MEMORY canonical bytes
-            # (same buffer the parse used). project_shared block raises
-            # PrivacyBlockedError; user/project_local block emits
-            # PRIVACY_BLOCKED skip and continues to next runtime.
-            file_scan = scan_text_content(
-                agent_text,
-                source_path=agent_path,
-                surface="cli_context_sync",
-                scope=scope,
-                project_root=project_root,
-            )
-            if file_scan.decision in ("blocked", "blocked_project_shared"):
-                code, reason = raise_or_collect(
-                    file_scan,
-                    scope=scope,
-                    kind="agent",
-                    artifact_name=agent.name,
-                )
-                skipped.append((agent.name, reason, code))
-                continue
-            # Resolve per-vendor override and scan its bytes — read once,
-            # scan once, hand the bytes to Phase 2. Same TOCTOU close as
-            # canonical above.
-            vendor = GENERATOR_VENDOR.get(target)
-            override_bytes: bytes | None = None
-            if vendor is not None:
-                # ADR-0011 PR-E3: thread the resolved sync ``scope`` through
-                # to override resolution. Same-tier-only lookup (narrow→broad
-                # is intentionally NOT used for default sync per ADR §4).
-                override_path = _override.resolve(
-                    project_root, "agents", agent.name, vendor, scope=scope
-                )
-                if override_path is not None:
-                    try:
-                        override_bytes = override_path.read_bytes()
-                    except OSError as exc:
-                        skipped.append(
-                            (agent.name, f"override unreadable: {exc}", skip_codes.PARSE_ERROR)
-                        )
-                        continue
-                    override_text = override_bytes.decode("utf-8", errors="replace")
-                    file_scan = scan_text_content(
-                        override_text,
-                        source_path=override_path,
-                        surface="cli_context_sync",
-                        scope=scope,
-                        project_root=project_root,
-                    )
-                    if file_scan.decision in ("blocked", "blocked_project_shared"):
-                        code, reason = raise_or_collect(
-                            file_scan,
-                            scope=scope,
-                            kind="agent",
-                            artifact_name=agent.name,
-                        )
-                        skipped.append((agent.name, reason, code))
-                        continue
-            pending.append((target, agent.name, gen, agent, out_path, override_bytes))
-
-    # ── Phase 2: render + atomic write every pending pair. ──
-    # By construction Phase 1 raised on any project_shared privacy block,
-    # so reaching this loop means every queued write is clean. The only
-    # remaining mid-loop raise is StrictDropError, which is opt-in
-    # (``on_drop="error"`` or legacy ``strict=True``) and is an unrelated
-    # atomicity boundary — pre-existing behavior.
-    for target, _name, gen, agent, out_path, override_bytes in pending:
-        content, dropped_fields = gen.render(agent)
-        if dropped_fields:
-            if effective_drop == "error":
-                raise StrictDropError(
-                    f"strict mode: {target} would drop {dropped_fields} from '{agent.name}'"
-                )
-            if effective_drop == "warn":
-                logger.warning("%s dropped %s from '%s'", target, dropped_fields, agent.name)
-        atomic_write_text(out_path, content)
-        # ADR-0008 Invariant 4: per-vendor override replaces the runtime file.
-        # Use the SAME captured buffer that passed Gate A — never
-        # re-read from disk (would re-open the TOCTOU window).
-        if override_bytes is not None:
-            atomic_write_bytes(out_path, override_bytes)
-        generated.append((target, out_path))
-        if dropped_fields:
-            dropped.append((target, agent.name, dropped_fields))
-
-    return AgentSyncResult(generated=generated, dropped=dropped, skipped=skipped)
+    # Runtime type matches AgentSyncResult because _AGENT_ADAPTER's
+    # ``result_type`` is AgentSyncResult; mypy can't infer that through the
+    # engine's AtomicSyncResult signature, so cast to preserve the public
+    # type annotation.
+    return cast(
+        "AgentSyncResult",
+        sync_atomic_artifact(
+            _AGENT_ADAPTER,
+            project_root,
+            runtimes,
+            strict=strict,
+            on_drop=on_drop,
+            scope=scope,
+        ),
+    )
 
 
 # ── Reverse: runtime → canonical ────────────────────────────────────

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -36,18 +36,19 @@ import re
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast
 
 from memtomem.context import _skip_reasons as skip_codes
-from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
+from memtomem.context._names import InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
-from memtomem.context.privacy_scan import (
-    raise_or_collect,
-    scan_text_content,
+from memtomem.context._sync_atomic import (
+    AtomicSyncAdapter,
+    AtomicSyncResult,
+    StrictDropError as _EngineStrictDropError,
+    sync_atomic_artifact,
 )
 from memtomem.context.agents import (
     _FRONT_MATTER_RE,
@@ -392,12 +393,16 @@ _register(GeminiCommandsGenerator())
 # ── Fan-out: canonical → runtimes ───────────────────────────────────
 
 
+# Sister subclass (issue #900) — see the matching comment in
+# :mod:`memtomem.context.agents`. Distinct class so identity stays
+# module-specific (``AgentSyncResult is not CommandSyncResult``).
 @dataclass
-class CommandSyncResult:
-    generated: list[tuple[str, Path]]  # (runtime, target_file)
-    dropped: list[tuple[str, str, list[str]]]  # (runtime, command_name, dropped_fields)
-    # (runtime_or_command, human_reason, reason_code) — see :mod:`memtomem.context._skip_reasons`.
-    skipped: list[tuple[str, str, skip_codes.SkipCode]]
+class CommandSyncResult(AtomicSyncResult):
+    """Module-specific result subclass — see :class:`AtomicSyncResult`."""
+
+
+class StrictDropError(_EngineStrictDropError):
+    """Module-specific strict-drop error — see :class:`_EngineStrictDropError`."""
 
 
 @dataclass
@@ -414,8 +419,20 @@ class ExtractResult:
     skipped: list[tuple[str, str, skip_codes.SkipCode]] = field(default_factory=list)
 
 
-class StrictDropError(ValueError):
-    """Raised under ``strict=True`` / ``on_drop="error"`` when a conversion would drop fields."""
+# Issue #900 extraction — see the matching adapter in
+# :mod:`memtomem.context.agents` for the design rationale.
+_COMMAND_ADAPTER: AtomicSyncAdapter[SlashCommand] = AtomicSyncAdapter(
+    kind="command",
+    artifact_label="commands",
+    list_canonical=list_canonical_commands,
+    parse_canonical_text=_parse_canonical_command_text,
+    parse_error_type=CommandParseError,
+    name_of=lambda c: c.name,
+    generators=COMMAND_GENERATORS,
+    result_type=CommandSyncResult,
+    strict_drop_error_type=StrictDropError,
+    logger=logger,
+)
 
 
 def generate_all_commands(
@@ -428,6 +445,10 @@ def generate_all_commands(
 ) -> CommandSyncResult:
     """Fan out every canonical command to the requested runtimes.
 
+    Thin wrapper that binds the command-specific adapter and delegates to
+    :func:`memtomem.context._sync_atomic.sync_atomic_artifact` — see that
+    function for the full Phase 1 / Phase 2 contract.
+
     Args:
         on_drop: Severity when fields are dropped during conversion.
             ``"ignore"`` (default) — silently record in ``result.dropped``.
@@ -439,139 +460,18 @@ def generate_all_commands(
             fan-out destination. Default ``project_shared`` preserves
             pre-PR-E3 behavior.
     """
-    effective_drop = on_drop if on_drop != "ignore" or not strict else "error"
-
-    generated: list[tuple[str, Path]] = []
-    dropped: list[tuple[str, str, list[str]]] = []
-    skipped: list[tuple[str, str, skip_codes.SkipCode]] = []
-
-    canonicals = list_canonical_commands(project_root, scope=scope)
-    if not canonicals:
-        return CommandSyncResult(
-            generated=[],
-            dropped=[],
-            skipped=[("<all>", "no canonical commands", skip_codes.NO_CANONICAL_ROOT)],
-        )
-
-    targets = runtimes if runtimes is not None else list(COMMAND_GENERATORS.keys())
-
-    # ── Phase 1: parse + scan every (target, command) pair — pure read pass. ──
-    # See agents.py for the rationale (project_shared atomicity, ADR §5).
-    # The first project_shared Gate A hit raises immediately via
-    # :func:`raise_or_collect`, so no partial runtime fan-out can land
-    # on disk (#895 P2 review #5).
-    pending: list[tuple[str, CommandGenerator, SlashCommand, Path, bytes | None]] = []
-
-    for target in targets:
-        gen = COMMAND_GENERATORS.get(target)
-        if gen is None:
-            skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
-            continue
-        for cmd_path, layout in canonicals:
-            # PR-E3 Codex review fold: read canonical bytes ONCE and use
-            # the captured buffer for both Gate A scan AND parse, closing
-            # the scan→write TOCTOU window (mirror of agents.py logic).
-            try:
-                cmd_bytes = cmd_path.read_bytes()
-            except OSError as exc:
-                skipped.append((cmd_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
-                continue
-            cmd_text = cmd_bytes.decode("utf-8", errors="replace")
-            try:
-                cmd = _parse_canonical_command_text(cmd_text, source=cmd_path, layout=layout)
-            except CommandParseError as exc:
-                skipped.append((cmd_path.name, f"parse error: {exc}", skip_codes.PARSE_ERROR))
-                continue
-            # ADR-0011 PR-E (#891): resolve the runtime target BEFORE render
-            # + dropped-field handling. ``None`` means NO_FANOUT per
-            # ``_runtime_targets.RUNTIME_FANOUT_TABLE``; emit a typed skip
-            # without invoking ``render`` so a strict caller doesn't raise
-            # ``StrictDropError`` for a runtime that has no fan-out by
-            # design (the fail-quiet contract).
-            out_path = gen.target_file(project_root, cmd.name, scope=scope)
-            if out_path is None:
-                skipped.append(
-                    (
-                        cmd.name,
-                        f"no fan-out for runtime {target} at this scope",
-                        skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME,
-                    )
-                )
-                continue
-            # ADR-0011 PR-E3 Gate A — scan the IN-MEMORY canonical bytes
-            # (same buffer the parse used). Mirrors the agents.py flow.
-            file_scan = scan_text_content(
-                cmd_text,
-                source_path=cmd_path,
-                surface="cli_context_sync",
-                scope=scope,
-                project_root=project_root,
-            )
-            if file_scan.decision in ("blocked", "blocked_project_shared"):
-                code, reason = raise_or_collect(
-                    file_scan,
-                    scope=scope,
-                    kind="command",
-                    artifact_name=cmd.name,
-                )
-                skipped.append((cmd.name, reason, code))
-                continue
-            # Resolve per-vendor override and scan its bytes — read once,
-            # scan once, hand the bytes to Phase 2.
-            vendor = GENERATOR_VENDOR.get(target)
-            override_bytes: bytes | None = None
-            if vendor is not None:
-                override_path = _override.resolve(
-                    project_root, "commands", cmd.name, vendor, scope=scope
-                )
-                if override_path is not None:
-                    try:
-                        override_bytes = override_path.read_bytes()
-                    except OSError as exc:
-                        skipped.append(
-                            (cmd.name, f"override unreadable: {exc}", skip_codes.PARSE_ERROR)
-                        )
-                        continue
-                    override_text = override_bytes.decode("utf-8", errors="replace")
-                    file_scan = scan_text_content(
-                        override_text,
-                        source_path=override_path,
-                        surface="cli_context_sync",
-                        scope=scope,
-                        project_root=project_root,
-                    )
-                    if file_scan.decision in ("blocked", "blocked_project_shared"):
-                        code, reason = raise_or_collect(
-                            file_scan,
-                            scope=scope,
-                            kind="command",
-                            artifact_name=cmd.name,
-                        )
-                        skipped.append((cmd.name, reason, code))
-                        continue
-            pending.append((target, gen, cmd, out_path, override_bytes))
-
-    # ── Phase 2: render + atomic write every pending pair. ──
-    # By construction Phase 1 raised on any project_shared block, so
-    # every queued write here is clean.
-    for target, gen, cmd, out_path, override_bytes in pending:
-        content, dropped_fields = gen.render(cmd)
-        if dropped_fields:
-            if effective_drop == "error":
-                raise StrictDropError(
-                    f"strict mode: {target} would drop {dropped_fields} from '{cmd.name}'"
-                )
-            if effective_drop == "warn":
-                logger.warning("%s dropped %s from '%s'", target, dropped_fields, cmd.name)
-        atomic_write_text(out_path, content)
-        # Use the SAME captured override buffer that passed Gate A.
-        if override_bytes is not None:
-            atomic_write_bytes(out_path, override_bytes)
-        generated.append((target, out_path))
-        if dropped_fields:
-            dropped.append((target, cmd.name, dropped_fields))
-
-    return CommandSyncResult(generated=generated, dropped=dropped, skipped=skipped)
+    # See note on the matching ``cast`` in agents.py.
+    return cast(
+        "CommandSyncResult",
+        sync_atomic_artifact(
+            _COMMAND_ADAPTER,
+            project_root,
+            runtimes,
+            strict=strict,
+            on_drop=on_drop,
+            scope=scope,
+        ),
+    )
 
 
 # ── Reverse: runtime → canonical ────────────────────────────────────

--- a/packages/memtomem/tests/test_sync_atomic_engine.py
+++ b/packages/memtomem/tests/test_sync_atomic_engine.py
@@ -190,9 +190,7 @@ class TestUnreadableSource:
     def test_emits_parse_error_skip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """OSError on canonical read → PARSE_ERROR skip with ``unreadable:`` reason."""
         _seed_canonical(tmp_path, "alpha", "clean\n", scope="project_local")
-        unreadable = _seed_canonical(
-            tmp_path, "beta", "would be clean\n", scope="project_local"
-        )
+        unreadable = _seed_canonical(tmp_path, "beta", "would be clean\n", scope="project_local")
 
         original_read_bytes = Path.read_bytes
 
@@ -400,3 +398,21 @@ def test_empty_canonical_root_returns_no_canonical_skip(tmp_path: Path) -> None:
     assert name == "<all>"
     assert code == skip_codes.NO_CANONICAL_ROOT
     assert "no canonical agents" in reason
+
+
+def test_strict_drop_errors_are_sister_subclasses() -> None:
+    """``agents.StrictDropError`` and ``commands.StrictDropError`` must stay distinct.
+
+    The engine raises through ``adapter.strict_drop_error_type``; each module's
+    wrapper binds its own subclass. If someone "simplifies" the adapter back to
+    an engine-default base, ``except agents.StrictDropError`` would accidentally
+    catch a commands raise (and vice versa) — existing tests pinning
+    ``pytest.raises(<module>.StrictDropError)`` would still pass because they
+    each import their own catch class. This guards that adapter regression.
+    """
+    from memtomem.context.agents import StrictDropError as AgentsStrictDrop
+    from memtomem.context.commands import StrictDropError as CommandsStrictDrop
+
+    assert AgentsStrictDrop is not CommandsStrictDrop
+    assert not issubclass(AgentsStrictDrop, CommandsStrictDrop)
+    assert not issubclass(CommandsStrictDrop, AgentsStrictDrop)

--- a/packages/memtomem/tests/test_sync_atomic_engine.py
+++ b/packages/memtomem/tests/test_sync_atomic_engine.py
@@ -1,0 +1,402 @@
+"""Service-level tests for ``sync_atomic_artifact`` (issue #900).
+
+Exercises the shared engine through a minimal stub adapter so each failure
+mode is asserted ONCE at the engine layer instead of once per artifact in
+``test_context_agents.py`` / ``test_context_commands.py``. Per the issue's
+acceptance criteria, new tests cover: privacy block, unreadable source,
+``NO_PROJECT_FANOUT_FOR_RUNTIME``, unknown runtime, strict drop, and
+override bytes.
+
+The stub adapter uses ``artifact_label="agents"`` so the override resolver
+(:func:`memtomem.context.override.resolve`) finds the override format in
+``OVERRIDE_FORMATS[("agents", "<vendor>")]`` for the override-bytes tests.
+Canonical files live at ``<project_root>/.memtomem/agents/<name>.txt`` —
+the stub's ``list_canonical`` reads .txt files so they bypass the real
+markdown parser entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context._sync_atomic import (
+    AtomicSyncAdapter,
+    AtomicSyncResult,
+    StrictDropError,
+    sync_atomic_artifact,
+)
+from memtomem.context.privacy_scan import PrivacyBlockedError
+
+# Trip the same privacy pattern existing scope/privacy tests use.
+SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+# ── Minimal stub adapter ─────────────────────────────────────────────
+
+
+@dataclass
+class StubItem:
+    name: str
+    body: str
+
+
+class StubParseError(ValueError):
+    """Raised by the stub parser on malformed text."""
+
+
+def _canonical_root(project_root: Path, scope: str) -> Path:
+    """Scope-aware canonical root — mirrors ``canonical_artifact_dir("agents", ...)``."""
+    if scope == "project_local":
+        return project_root / ".memtomem" / "agents.local"
+    if scope == "user":
+        return project_root / ".memtomem-user" / "agents"
+    return project_root / ".memtomem" / "agents"
+
+
+def _stub_list_canonical(
+    project_root: Path, *, scope: Any = "project_shared"
+) -> list[tuple[Path, str]]:
+    """Read all ``.txt`` files at the scope-appropriate canonical root."""
+    root = _canonical_root(project_root, scope)
+    if not root.exists():
+        return []
+    return [(p, "flat") for p in sorted(root.glob("*.txt"))]
+
+
+def _stub_parse_text(text: str, *, source: Path, layout: Any = "flat") -> StubItem:
+    if text.startswith("BROKEN:"):
+        raise StubParseError(f"unparseable preamble in {source.name}")
+    return StubItem(name=source.stem, body=text)
+
+
+class StubGenerator:
+    """Per-runtime generator that mirrors the AGENT_GENERATORS contract.
+
+    ``target_subdir`` controls where the fan-out lands. Set ``no_fanout=True``
+    to simulate a ``RUNTIME_FANOUT_TABLE`` ``None`` entry (engine should emit
+    ``NO_PROJECT_FANOUT_FOR_RUNTIME``).
+
+    ``drops_for`` decides per-item whether ``render`` reports dropped fields.
+    Default ``None`` → never drops. Pass a callable to drop conditionally;
+    pass a list to drop the same fields for every item (back-compat shape).
+    """
+
+    def __init__(
+        self,
+        target_subdir: str,
+        *,
+        no_fanout: bool = False,
+        drops_for: Any = None,
+    ) -> None:
+        self.target_subdir = target_subdir
+        self.no_fanout = no_fanout
+        # Normalize: None → no-op, list → constant, callable → as-is.
+        if drops_for is None:
+            self._drops_for = lambda _item: []
+        elif callable(drops_for):
+            self._drops_for = drops_for
+        else:
+            self._drops_for = lambda _item, _d=list(drops_for): list(_d)
+
+    def target_file(
+        self, project_root: Path, name: str, *, scope: Any = "project_shared"
+    ) -> Path | None:
+        if self.no_fanout:
+            return None
+        return project_root / self.target_subdir / f"{name}.txt"
+
+    def render(self, item: StubItem) -> tuple[str, list[str]]:
+        return item.body, self._drops_for(item)
+
+
+def _make_adapter(generators: dict[str, StubGenerator]) -> AtomicSyncAdapter[StubItem]:
+    """Bundle the stub callables behind the engine's adapter contract."""
+    return AtomicSyncAdapter(
+        kind="agent",
+        artifact_label="agents",
+        list_canonical=_stub_list_canonical,
+        parse_canonical_text=_stub_parse_text,
+        parse_error_type=StubParseError,
+        name_of=lambda item: item.name,
+        generators=generators,
+    )
+
+
+def _seed_canonical(tmp_path: Path, name: str, body: str, *, scope: str = "project_shared") -> Path:
+    """Write a canonical .txt at the scope-appropriate root."""
+    root = _canonical_root(tmp_path, scope)
+    root.mkdir(parents=True, exist_ok=True)
+    p = root / f"{name}.txt"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ── 1. Privacy block ──────────────────────────────────────────────────
+
+
+class TestPrivacyBlock:
+    def test_project_shared_raises_before_phase2(self, tmp_path: Path) -> None:
+        """Phase 1 Gate A hits a secret → raise BEFORE any write lands on disk.
+
+        Mirrors the all-or-nothing atomicity contract in
+        :func:`memtomem.context._sync_atomic.sync_atomic_artifact`. The
+        engine raises :class:`PrivacyBlockedError` directly; surface
+        layers (CLI / MCP / Web) translate that into their own error
+        types (``click.ClickException``, HTTP 422, MCP tool error).
+        """
+        _seed_canonical(tmp_path, "alpha", "clean body\n")
+        _seed_canonical(tmp_path, "leaky", f"body with {SECRET}\n")
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out")})
+
+        with pytest.raises(PrivacyBlockedError):
+            sync_atomic_artifact(adapter, tmp_path, scope="project_shared")
+
+        # No partial fan-out should have landed on disk — Phase 1 raise
+        # fires before Phase 2 ever opens a write.
+        out_dir = tmp_path / ".stub-out"
+        if out_dir.exists():
+            assert list(out_dir.iterdir()) == []
+
+    def test_project_local_collects_skip(self, tmp_path: Path) -> None:
+        """``project_local`` scope: privacy block emits skip, other artifacts proceed."""
+        _seed_canonical(tmp_path, "alpha", "clean body\n", scope="project_local")
+        _seed_canonical(tmp_path, "leaky", f"body with {SECRET}\n", scope="project_local")
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out")})
+
+        result = sync_atomic_artifact(adapter, tmp_path, scope="project_local")
+
+        assert isinstance(result, AtomicSyncResult)
+        gen_names = {name for _, p in result.generated for name in [p.stem]}
+        assert "alpha" in gen_names
+        assert "leaky" not in gen_names
+        skip_names = {name for name, _, _ in result.skipped}
+        assert "leaky" in skip_names
+        block_codes = {code for _, _, code in result.skipped}
+        assert (
+            skip_codes.PRIVACY_BLOCKED in block_codes
+            or skip_codes.PRIVACY_BLOCKED_PROJECT_SHARED in block_codes
+        )
+
+
+# ── 2. Unreadable source ──────────────────────────────────────────────
+
+
+class TestUnreadableSource:
+    def test_emits_parse_error_skip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError on canonical read → PARSE_ERROR skip with ``unreadable:`` reason."""
+        _seed_canonical(tmp_path, "alpha", "clean\n", scope="project_local")
+        unreadable = _seed_canonical(
+            tmp_path, "beta", "would be clean\n", scope="project_local"
+        )
+
+        original_read_bytes = Path.read_bytes
+
+        def fake_read_bytes(self: Path) -> bytes:
+            if self == unreadable:
+                raise OSError("EACCES: permission denied")
+            return original_read_bytes(self)
+
+        monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out")})
+        result = sync_atomic_artifact(adapter, tmp_path, scope="project_local")
+
+        # alpha succeeds, beta is skipped with PARSE_ERROR + "unreadable:" reason.
+        assert any(p.stem == "alpha" for _, p in result.generated)
+        beta_skips = [s for s in result.skipped if s[0] == "beta.txt"]
+        assert len(beta_skips) == 1
+        _, reason, code = beta_skips[0]
+        assert code == skip_codes.PARSE_ERROR
+        assert reason.startswith("unreadable:")
+
+
+# ── 3. Unknown runtime ────────────────────────────────────────────────
+
+
+class TestUnknownRuntime:
+    def test_unknown_runtime_skipped(self, tmp_path: Path) -> None:
+        """Caller passes a runtime name not in ``adapter.generators`` → UNKNOWN_RUNTIME skip."""
+        _seed_canonical(tmp_path, "alpha", "clean\n", scope="project_local")
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out")})
+
+        result = sync_atomic_artifact(
+            adapter, tmp_path, runtimes=["stub_rt", "nope"], scope="project_local"
+        )
+
+        assert ("nope", "unknown runtime", skip_codes.UNKNOWN_RUNTIME) in result.skipped
+        # The known runtime still ran.
+        assert any(name == "stub_rt" for name, _ in result.generated)
+
+
+# ── 4. NO_PROJECT_FANOUT_FOR_RUNTIME ──────────────────────────────────
+
+
+class TestNoProjectFanout:
+    def test_target_file_returns_none_emits_skip(self, tmp_path: Path) -> None:
+        """Generator returns ``None`` from ``target_file`` → NO_PROJECT_FANOUT_FOR_RUNTIME skip.
+
+        Mirrors the ``RUNTIME_FANOUT_TABLE`` contract: a (runtime, scope)
+        tuple that has no fan-out by design emits a typed skip rather
+        than raising.
+        """
+        _seed_canonical(tmp_path, "alpha", "clean\n", scope="project_local")
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out", no_fanout=True)})
+
+        result = sync_atomic_artifact(adapter, tmp_path, scope="project_local")
+
+        assert result.generated == []
+        no_fanout_skips = [
+            s for s in result.skipped if s[2] == skip_codes.NO_PROJECT_FANOUT_FOR_RUNTIME
+        ]
+        assert len(no_fanout_skips) == 1
+        name, reason, _ = no_fanout_skips[0]
+        assert name == "alpha"
+        assert "no fan-out for runtime stub_rt" in reason
+
+
+# ── 5. Strict drop partial-write boundary ─────────────────────────────
+
+
+class TestStrictDrop:
+    def test_raises_after_earlier_writes(self, tmp_path: Path) -> None:
+        """Engine-level mirror of #908's pin for issue #900.
+
+        Phase 2 raises StrictDropError on the first dropping canonical, but
+        canonicals iterated earlier in sorted-name order have already been
+        written. No mkstemp temp file remains for the failing write.
+        """
+        # Canonicals iterate sorted by Path: alpha-minimal < beta-full.
+        _seed_canonical(tmp_path, "alpha-minimal", "alpha body\n", scope="project_local")
+        _seed_canonical(tmp_path, "beta-full", "beta body\n", scope="project_local")
+
+        # The stub generator drops ``["tools"]`` ONLY for beta-full; render
+        # is invoked in Phase 2 sorted order, so alpha-minimal renders
+        # cleanly and lands on disk, then beta-full's render triggers the
+        # raise. This is the partial-write boundary pinned by #908.
+        adapter = _make_adapter(
+            {
+                "stub_rt": StubGenerator(
+                    ".stub-out",
+                    drops_for=lambda item: ["tools"] if item.name == "beta-full" else [],
+                )
+            }
+        )
+
+        with pytest.raises(StrictDropError):
+            sync_atomic_artifact(adapter, tmp_path, on_drop="error", scope="project_local")
+
+        out_dir = tmp_path / ".stub-out"
+        # alpha-minimal landed before the raise.
+        assert (out_dir / "alpha-minimal.txt").is_file()
+        # beta-full did NOT land — and no mkstemp temp file was left
+        # behind (atomic_write_text uses prefix=f".{path.name}.").
+        assert not (out_dir / "beta-full.txt").exists()
+        assert list(out_dir.glob(".beta-full.txt.*.tmp")) == []
+
+    def test_legacy_strict_flag_promotes_to_error(self, tmp_path: Path) -> None:
+        """``strict=True`` is equivalent to ``on_drop="error"`` when on_drop is default."""
+        _seed_canonical(tmp_path, "alpha", "body\n", scope="project_local")
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out", drops_for=["something"])})
+
+        with pytest.raises(StrictDropError):
+            sync_atomic_artifact(adapter, tmp_path, strict=True, scope="project_local")
+
+    def test_on_drop_warn_logs_but_writes(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``on_drop="warn"`` logs the drop but still writes the file."""
+        _seed_canonical(tmp_path, "alpha", "body\n", scope="project_local")
+        adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out", drops_for=["lost"])})
+
+        with caplog.at_level("WARNING", logger="memtomem.context._sync_atomic"):
+            result = sync_atomic_artifact(adapter, tmp_path, on_drop="warn", scope="project_local")
+
+        assert (tmp_path / ".stub-out" / "alpha.txt").is_file()
+        assert any("dropped" in r.message for r in caplog.records)
+        assert result.dropped == [("stub_rt", "alpha", ["lost"])]
+
+
+# ── 6. Override bytes ─────────────────────────────────────────────────
+
+
+def _seed_override(
+    tmp_path: Path,
+    name: str,
+    vendor: str,
+    body: str,
+    *,
+    scope: str = "project_shared",
+    ext: str = "md",
+) -> Path:
+    """Write an override file at the scope-appropriate layout.
+
+    Layout: ``<canonical_artifact_dir("agents", scope, project_root)>/
+    <name>/overrides/<vendor>.<ext>``
+    """
+    override_dir = _canonical_root(tmp_path, scope) / name / "overrides"
+    override_dir.mkdir(parents=True, exist_ok=True)
+    p = override_dir / f"{vendor}.{ext}"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+class TestOverrideBytes:
+    def test_override_bytes_replace_render_output(self, tmp_path: Path) -> None:
+        """Render emits canonical body; override bytes overwrite the final file.
+
+        Phase 2: atomic_write_text(canonical) → atomic_write_bytes(override).
+        Final file contents == override bytes, not render output.
+        """
+        _seed_canonical(tmp_path, "alpha", "canonical body\n", scope="project_local")
+        _seed_override(tmp_path, "alpha", "claude", "OVERRIDDEN\n", scope="project_local")
+
+        adapter = _make_adapter({"claude_agents": StubGenerator(".stub-out")})
+
+        result = sync_atomic_artifact(adapter, tmp_path, scope="project_local")
+
+        assert len(result.generated) == 1
+        out_file = tmp_path / ".stub-out" / "alpha.txt"
+        assert out_file.read_text(encoding="utf-8") == "OVERRIDDEN\n"
+
+    def test_override_secret_raises_under_project_shared(self, tmp_path: Path) -> None:
+        """Override bytes carrying a secret trip Gate A in Phase 1.
+
+        Closes the override-bytes TOCTOU: the bytes that get scanned are
+        the same bytes Phase 2 promotes. Override is read ONCE.
+        """
+        _seed_canonical(tmp_path, "alpha", "canonical body (clean)\n")
+        _seed_override(tmp_path, "alpha", "claude", f"override body with {SECRET}\n")
+
+        adapter = _make_adapter({"claude_agents": StubGenerator(".stub-out")})
+
+        with pytest.raises(PrivacyBlockedError):
+            sync_atomic_artifact(adapter, tmp_path, scope="project_shared")
+
+        # Even though canonical was clean and target dir is set, no file
+        # should have landed — Phase 1 raise fires before any write.
+        out_dir = tmp_path / ".stub-out"
+        if out_dir.exists():
+            assert list(out_dir.iterdir()) == []
+
+
+# ── Sanity: empty canonical root ──────────────────────────────────────
+
+
+def test_empty_canonical_root_returns_no_canonical_skip(tmp_path: Path) -> None:
+    """Empty canonical → single ``NO_CANONICAL_ROOT`` skip, empty generated."""
+    adapter = _make_adapter({"stub_rt": StubGenerator(".stub-out")})
+
+    result = sync_atomic_artifact(adapter, tmp_path, scope="project_local")
+
+    assert result.generated == []
+    assert result.dropped == []
+    assert len(result.skipped) == 1
+    name, reason, code = result.skipped[0]
+    assert name == "<all>"
+    assert code == skip_codes.NO_CANONICAL_ROOT
+    assert "no canonical agents" in reason


### PR DESCRIPTION
## Summary

- Extracts the duplicated body of `generate_all_agents` + `generate_all_commands` (~98% identical) into a single `sync_atomic_artifact(adapter, ...)` engine in `memtomem/context/_sync_atomic.py`. Each module becomes a ~12-line wrapper that binds an `AtomicSyncAdapter`.
- Behavior preserved byte-for-byte: TOCTOU close on canonical+override bytes, Phase-1-raise-early `project_shared` atomicity, strict-drop partial-write boundary (pinned by #908 / d2cb843).
- Skills (`skills.py`) intentionally out of scope per the issue — its staging-dir promotion shape (directory promotion, ExitStack of locks, aux files) is genuinely different and single-caller, not worth abstracting yet.

## Class identity preserved (Codex review fold)

`AgentSyncResult` and `CommandSyncResult` are **sister subclasses** of the engine `AtomicSyncResult` base, not aliases. Same for `StrictDropError`. The adapter carries `result_type`, `strict_drop_error_type`, and `logger` fields, and the engine constructs/raises/logs through them, so:

- `AgentSyncResult is not CommandSyncResult` (was: distinct classes) ✓
- `agents.StrictDropError is not commands.StrictDropError` (was: distinct classes) ✓
- `on_drop="warn"` messages still log under `memtomem.context.agents` / `memtomem.context.commands` (not the new engine module), so existing log filters keep working.

## What this enables

A single place to evolve privacy semantics, skip codes, strict-drop policy, override-bytes flow, and result shape for the atomic-file artifact pipelines. The duplication that previously forced every change to land twice is gone.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — clean
- [x] `uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/context/{_sync_atomic,agents,commands}.py` — clean
- [x] `uv run pytest -m "not ollama" packages/memtomem` — **4902 passed, 10 skipped**
- [x] Targeted regression: `TestStrictMode` (including the #908 d2cb843 partial-write pin), `test_sync_privacy_block_surfaces`, `test_context_sync_scope`, `test_context_runtime_table_none_skips`, `test_context_override` — all green
- [x] 11 new service-level tests in `test_sync_atomic_engine.py` exercise the six failure modes the issue enumerates (privacy block × 2 scopes, unreadable source, unknown runtime, NO_PROJECT_FANOUT, strict-drop partial-write, override-bytes replace + privacy) through a minimal stub adapter — failure modes asserted once at the engine layer
- [x] Runtime sanity: confirmed `AgentSyncResult.__name__ == "AgentSyncResult"`, `agents.StrictDropError` does not catch `commands.StrictDropError`, warning logs route to historical per-module loggers
- [x] Reviewed by Codex twice: round 1 returned NEEDS-FIX (2 Majors on class+logger identity), round 2 returned **SHIP** after fixes — no Blockers / Majors / Minors

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)