### PR TITLE
docs(cli): repoint #886 self-references to ADR-0012 / #911 (#886)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2638,7 +2638,7 @@ def memory_migrate_cmd(
     ``enforce_write_guard``; secret hits reject the migration with no
     force bypass — git history would carry them forever (ADR-0011 §5).
 
-    Cross-DB migration is deferred to a follow-up issue (see #886).
+    Cross-DB migration is deferred; see ADR-0012 / #911.
     """
     if from_scope == to_scope:
         raise click.ClickException("--from and --to must differ.")
@@ -2842,8 +2842,8 @@ async def _memory_migrate_run(
             click.echo(f"  chunks affected: {entry['affected']}")
             # ``N preserved, 0 dropped`` for single-DB chunk-id-stable
             # rename: chunks.id never changes so the entire chunk_links
-            # neighborhood survives untouched. Cross-DB migration (#886
-            # follow-up) is where ``dropped`` could become non-zero.
+            # neighborhood survives untouched. Cross-DB migration (#911,
+            # deferred per ADR-0012) is where ``dropped`` could become non-zero.
             click.echo(f"  chunk_links lineage: {entry['lineage']} preserved, 0 dropped")
 
         if is_batch:


### PR DESCRIPTION
## Summary

After #912 (lineage regression test + glob input + computed display) and #913 (ADR-0012 deferring cross-DB rename via #911), two comments in `_memory_migrate_run` still pointed at #886 itself as the cross-DB follow-up target. Since #886 is the v1 baseline and #911 / ADR-0012 is where cross-DB lives, the in-code pointer is circular — a reader who follows the docstring lands back on the closed v1 umbrella with no signal that the deferral RFC exists.

This PR repoints both:

- `memory_migrate_cmd` docstring → `Cross-DB migration is deferred; see ADR-0012 / #911.` (visible in `mm context memory-migrate --help`).
- Inline comment above the `chunk_links lineage` echo → `Cross-DB migration (#911, deferred per ADR-0012) is where ``dropped`` could become non-zero.`

Comment-only. No behavior delta. Other `#886` references (CHANGELOG, ADR-0012, test docstrings, `sqlite_backend.py:1385` context anchor) describe the work that landed *under* #886 and stay correct.

This is the last residual on #886; once this merges to `main`, #886 will be closed referencing the merge commit + the #912 / #913 trail.

## Test plan

- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run mm context memory-migrate --help` — confirmed the new docstring renders the exact wording `Cross-DB migration is deferred; see ADR-0012 / #911.` and no longer self-references #886
- [x] `uv run pytest packages/memtomem/tests/test_context_memory_migrate.py -v` — 18 passed (no behavior delta expected from a comment-only edit)

Refs #886, #911, ADR-0012, #912, #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)