### PR TITLE
docs(3-tier): align 4 guides + ADR-0011 §1 settings row with ADR-0016 (#868-C)

### DIFF
--- a/docs/adr/0011-canonical-artifact-scope-hierarchy.md
+++ b/docs/adr/0011-canonical-artifact-scope-hierarchy.md
@@ -118,7 +118,15 @@ The canonical / runtime layout per scope per artifact type:
 | **agents**   | `~/.memtomem/agents/<name>.md`                | `<proj>/.memtomem/agents/<name>.md`              | `<proj>/.memtomem/agents.local/<name>.md`                | user → `~/.claude/agents/`; project_shared → `<proj>/.claude/agents/`; project_local → no fan-out |
 | **skills**   | `~/.memtomem/skills/<name>/SKILL.md`          | `<proj>/.memtomem/skills/<name>/SKILL.md`        | `<proj>/.memtomem/skills.local/<name>/SKILL.md`          | user → `~/.claude/skills/<name>/`; project_shared → `<proj>/.claude/skills/<name>/`; project_local → no fan-out |
 | **commands** | `~/.memtomem/commands/<name>.md`              | `<proj>/.memtomem/commands/<name>.md`            | `<proj>/.memtomem/commands.local/<name>.md`              | user → `~/.claude/commands/`; project_shared → `<proj>/.claude/commands/`; project_local → no fan-out |
-| **settings** (ADR-0010, included for completeness) | `~/.claude/settings.json` | `<proj>/.claude/settings.json`                   | `<proj>/.claude/settings.local.json`                     | settings have no canonical/runtime split — they ARE the runtime |
+| **settings** (ADR-0010, special case per ADR-0016 §2) | `<proj>/.memtomem/settings.json` (canonical is single regardless of tier) | ↑ same | ↑ same | `user` → `~/.claude/settings.json`; `project_shared` → `<proj>/.claude/settings.json`; `project_local` → `<proj>/.claude/settings.local.json` |
+
+Settings inverts the tier ↔ residency mapping the other rows share: per
+ADR-0016 §2, the `target_scope` axis on settings hooks selects the
+**runtime fan-out target**, not the canonical residency (the canonical
+is `<proj>/.memtomem/settings.json` by ADR-0010 §Background, regardless
+of the configured `target_scope`). The other four artifacts in this
+table couple canonical residency and runtime fan-out through
+`RUNTIME_FANOUT_TABLE`; settings is the documented exception.
 
 ### 2. v1 defaults preserve current behavior, zero behavior change for existing installs
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -778,16 +778,18 @@ Tab classification changes over time — run `mm web --dev` to see the full surf
 ## Context Gateway
 
 Settings for the multi-project context UI (Skills, Custom Commands, and
-Subagents) that ships with `mm web`. The discovery surface enumerates every scope
-the gateway knows about — the server's current working directory, any
-project roots registered via the Web UI, and (opt-in) decoded paths
-from `~/.claude/projects/`.
+Subagents) that ships with `mm web`. The discovery surface enumerates every
+project root the gateway knows about — the server's current working
+directory, any roots registered via the Web UI, and (opt-in) decoded paths
+from `~/.claude/projects/`. These project roots populate `project_shared`
+and `project_local` tier entries; the `user` tier (per ADR-0011 §1) is a
+separate axis gated by `USER_TIER_ENABLED` below.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `MEMTOMEM_CONTEXT_GATEWAY__KNOWN_PROJECTS_PATH` | `~/.memtomem/known_projects.json` | Where the Web UI persists "Add Project" registrations. The Sources, Skills, Custom Commands, and Subagents tabs render one collapsible group per registered scope. |
-| `MEMTOMEM_CONTEXT_GATEWAY__EXPERIMENTAL_CLAUDE_PROJECTS_SCAN` | `false` | When `true`, the gateway also reverse-decodes `~/.claude/projects/<encoded>` directory names into project roots and surfaces them as discovered scopes. Off by default — the encoding is fragile around dash-containing paths, so this stays gated behind explicit consent. |
-| `MEMTOMEM_CONTEXT_GATEWAY__USER_TIER_ENABLED` | `false` | Forward-compat flag for the user-scope artifact surface. While `false`, user-tier entries are hidden from discovery responses entirely. |
+| `MEMTOMEM_CONTEXT_GATEWAY__KNOWN_PROJECTS_PATH` | `~/.memtomem/known_projects.json` | Where the Web UI persists "Add Project" registrations. The Sources, Skills, Custom Commands, and Subagents tabs render one collapsible group per registered project root. |
+| `MEMTOMEM_CONTEXT_GATEWAY__EXPERIMENTAL_CLAUDE_PROJECTS_SCAN` | `false` | When `true`, the gateway also reverse-decodes `~/.claude/projects/<encoded>` directory names into project roots and surfaces them as discovered roots. Off by default — the encoding is fragile around dash-containing paths, so this stays gated behind explicit consent. |
+| `MEMTOMEM_CONTEXT_GATEWAY__USER_TIER_ENABLED` | `false` | Forward-compat flag for the `user`-tier canonical artifact surface (ADR-0011 §1; canonical lives under `~/.memtomem/<artifact>/`). While `false`, `user`-tier entries are hidden from discovery responses entirely. |
 
 ## Querying and Modifying at Runtime
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -439,6 +439,16 @@ Run `mm context --help` for the full fan-out matrix across editors (Claude Code,
 
 > Cursor, OpenAI Codex, and GitHub Copilot generators concatenate the `Rules` and `Style` sections from `context.md` into a single block — `mm context generate` warns on stderr when both are populated. `context.md` remains the source of truth; edit there, not in the generated files.
 
+> **Where do canonical files live? (3-tier model)** memtomem stores
+> canonical agents / skills / commands under one of three **tiers**: `user`
+> (`~/.memtomem/<artifact>/`), `project_shared` (`<proj>/.memtomem/<artifact>/`,
+> git-tracked, the default for these artifacts), or `project_local`
+> (`<proj>/.memtomem/<artifact>.local/`, gitignored, draft tier — no runtime
+> fan-out). Pick the tier per write with `--scope=<tier>` on `mm context
+> init` / `sync` / `migrate`. Tier (canonical residency) is distinct from
+> the runtime **scope** the canonical fans out to under `.claude/` —
+> ADR-0016 documents the split; ADR-0011 §1 has the per-artifact table.
+
 ---
 
 ## Optional: STM Proxy — Proactive Memory Surfacing

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -161,13 +161,15 @@ mem_index(path="~/notes", recursive=True)
 You can automate memtomem using Claude Code's hooks system.
 Add the following to `~/.claude/settings.json`:
 
-> **Scope** (ADR-0010 §3): the path memtomem writes to is controlled by
-> the `hooks.target_scope` config field (default: `user` →
-> `~/.claude/settings.json`). Set `hooks.target_scope = project_shared`
-> to land hooks at `<project>/.claude/settings.json` (committed) or
-> `project_local` for `<project>/.claude/settings.local.json`
-> (gitignored). Per-invocation override: `mm context sync
-> --include=settings --scope=project_local`.
+> **Tier** (ADR-0010 §3; ADR-0016 §2 settings special-case): for
+> settings, the `hooks.target_scope` tier selects the **runtime fan-out
+> target** under `~/.claude/` or `<project>/.claude/`, not a canonical
+> residency — settings have one canonical file at
+> `<project>/.memtomem/settings.json` regardless of tier. The three
+> values: `user` (default) → `~/.claude/settings.json`; `project_shared`
+> → `<project>/.claude/settings.json` (committed); `project_local` →
+> `<project>/.claude/settings.local.json` (gitignored). Per-invocation
+> override: `mm context sync --include=settings --scope=project_local`.
 
 ```json
 {

--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -35,6 +35,14 @@ Precedence is `local > project > user`, so a `local` entry can override
 a shared team `project` server when you need to test with personal
 credentials.
 
+> **Different axis from memtomem's canonical tier.** The `-s local /
+> -s project / -s user` flag above selects where Claude Code records
+> the MCP server entry; memtomem's own canonical artifacts (agents,
+> skills, commands, memory) carry an independent `user / project_shared
+> / project_local` **tier** (ADR-0016) chosen per write via `mm context
+> ... --scope=<tier>`. Keeping the two axes separate is intentional —
+> server registration and canonical residency are unrelated decisions.
+
 ### Add via command (`local` / `user`)
 
 ```bash
@@ -335,7 +343,7 @@ uses, so the output is identical. Useful as a sanity check between
 | **Data** | `mem_export`, `mem_import` |
 | **Config** | `mem_stats`, `mem_status`, `mem_config`\*, `mem_embedding_reset`\*, `mem_reset`\* |
 | **Evaluation** | `mem_eval` |
-| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, and `sync` accept `scope="project_shared\|user\|project_local"`; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
+| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, and `sync` accept `scope="project_shared\|user\|project_local"` — the canonical **tier** per ADR-0016 §2; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 


### PR DESCRIPTION
## Summary

ADR-0016 (umbrella, 2026-05-11) pinned `tier` ↔ `runtime scope` as separate dimensions across the context gateway, but the public guides predated it and the ADR-0011 §1 settings row directly contradicted ADR-0010 §Background. This PR is the docs-only follow-up flagged in ADR-0016 §"Open questions" → "ADR-0011 §1 settings row cleanup", filed as issue #921 (#868-C).

## Edits

- **`docs/adr/0011-canonical-artifact-scope-hierarchy.md` §1** — settings row now lists the single canonical (`<proj>/.memtomem/settings.json`); moves `~/.claude/*` paths into the runtime-fan-out column; new paragraph cites ADR-0016 §2's settings-special-case framing.
- **`docs/guides/getting-started.md`** — short "3-tier model" callout after the `mm context sync` block. Introduces `--scope=<tier>` and links ADR-0016 / ADR-0011 §1.
- **`docs/guides/configuration.md`** — Context Gateway intro disambiguates "project root" (discovery axis) from "tier" (residency axis); `USER_TIER_ENABLED` row reframed in ADR-0016 vocabulary and pins canonical path under `~/.memtomem/<artifact>/`.
- **`docs/guides/mcp-clients.md`** — `-s local|project|user` Claude Code MCP install-scope callout disambiguated from memtomem's `user|project_shared|project_local` canonical tier; Context tool row clarifies `scope=` is the canonical tier per ADR-0016 §2.
- **`docs/guides/integrations/claude-code.md`** — hooks-tier callout updated: `hooks.target_scope` selects the runtime fan-out target, not canonical residency (settings canonical is single).

## Out of scope (per issue body)

- No ADR vocabulary changes (settled in 0010/0011/0015/0016).
- No `target_scope` → `target_tier` rename (filed as #868-D, 3-month wait-for-signal posture).
- `cursor.md` and `claude-desktop.md` carry no tier content — nothing to refresh.

## Acceptance (issue #921)

- [x] All 4 target guides reference the 3-tier model consistently and use ADR-0016's tier vs. runtime-scope split.
- [x] ADR-0011 §1 settings row corrected so canonical and runtime paths are no longer conflated.
- [x] Swept `docs/guides/integrations/*` — no vocabulary/path drift outside the claude-code hooks block (already in scope).
- [x] Snapshot-diff reviewed; no `mm context init` flag changes accidentally introduced.

## Test plan

- [x] Docs-only — no `.py` files touched, so ruff / pytest / mypy are unaffected.
- [x] `grep -rn "settings have no canonical/runtime split" docs/ packages/` — zero remaining matches.
- [x] No tests reference the §1 row contents (only schema-rollback docstrings; structurally unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)