### PR TITLE
feat(server): add mem_context_migrate MCP wrapper (#887)

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -343,7 +343,7 @@ uses, so the output is identical. Useful as a sanity check between
 | **Data** | `mem_export`, `mem_import` |
 | **Config** | `mem_stats`, `mem_status`, `mem_config`\*, `mem_embedding_reset`\*, `mem_reset`\* |
 | **Evaluation** | `mem_eval` |
-| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, and `sync` accept `scope="project_shared\|user\|project_local"` — the canonical **tier** per ADR-0016 §2; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops) |
+| **Context** | `mem_context_detect`, `mem_context_init`, `mem_context_generate`, `mem_context_diff`, `mem_context_sync`, `mem_context_migrate` (context tools accept `include="skills,agents,commands"` for canonical artifact workflows; `init`, `generate`, `sync`, and `diff` accept `scope="project_shared\|user\|project_local"` — the canonical **tier** per ADR-0016 §2; `generate`/`sync` also accept `strict=True` to fail on sub-agent or command field drops; `migrate` takes `from_scope`/`to_scope` instead of a single `scope` because it has two endpoints, plus `apply_=True` to execute and `confirm_project_shared=True` when writing to the git-tracked tier) |
 
 \* Requires `MEMTOMEM_TOOL_MODE=full`. In `core` or `standard` mode, use `mm config` (CLI) or the Web UI Settings tab instead.
 

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -2726,7 +2726,23 @@ async def _memory_migrate_run(
     apply_: bool,
     yes: bool,
     confirm_project_shared: bool,
+    *,
+    stdout_buf: list[str] | None = None,
+    stderr_buf: list[str] | None = None,
 ) -> None:
+    """Apply or dry-run a memory-migrate plan over the resolved sources.
+
+    ``stdout_buf`` / ``stderr_buf``: when provided, every plan/summary/
+    error message that the CLI would emit via ``click.echo`` /
+    ``click.secho`` is appended to the corresponding list INSTEAD of
+    being written to the global ``sys.stdout`` / ``sys.stderr``. Used by
+    the MCP wrapper (``mem_context_migrate``) to capture per-call
+    output without ``contextlib.redirect_stdout`` — which would leak
+    output from other concurrent MCP tool calls into the migrate
+    response while this coroutine is suspended on I/O. When both
+    buffers are ``None`` (CLI default) the helper behaves exactly as
+    before.
+    """
     import shutil
     from contextlib import ExitStack
 
@@ -2739,6 +2755,24 @@ async def _memory_migrate_run(
         project_tier_registration_error,
         resolve_memory_scope_dir,
     )
+
+    # Routed emit: when capture buffers are provided (MCP path) the
+    # message is appended to the buffer ONLY; nothing touches
+    # ``sys.stdout`` / ``sys.stderr``. Default (CLI path) calls
+    # ``click.secho`` so the terminal output and color codes are
+    # preserved. Avoids the process-global ``redirect_stdout``
+    # cross-request leakage flagged by Codex on PR #926.
+    def _emit_out(msg: str, fg: str | None = None) -> None:
+        if stdout_buf is not None:
+            stdout_buf.append(msg)
+        else:
+            click.secho(msg, fg=fg)
+
+    def _emit_err(msg: str, fg: str | None = None) -> None:
+        if stderr_buf is not None:
+            stderr_buf.append(msg)
+        else:
+            click.secho(msg, fg=fg, err=True)
 
     async with cli_components() as comp:
         # Project-tier resolution. For ``from`` project tiers we walk
@@ -2860,12 +2894,11 @@ async def _memory_migrate_run(
                     record_outcome=False,
                 )
                 if guard.decision in ("blocked", "blocked_project_shared"):
-                    click.secho(
+                    _emit_err(
                         f"  ✗ Gate A: {src.name} matches {len(guard.hits)} privacy "
                         f"pattern(s); migration to scope='{to_scope}' rejected. "
                         "git history is forever — no force bypass available.",
                         fg="red",
-                        err=True,
                     )
                     raise click.exceptions.Exit(1)
 
@@ -2873,26 +2906,26 @@ async def _memory_migrate_run(
 
         is_batch = len(plan) > 1
         for entry in plan:
-            click.echo(f"Plan: migrate {entry['source'].name}")
-            click.echo(f"  from {from_scope}: {entry['source']}")
-            click.echo(f"  to   {to_scope}: {entry['target']}")
-            click.echo(f"  chunks affected: {entry['affected']}")
+            _emit_out(f"Plan: migrate {entry['source'].name}")
+            _emit_out(f"  from {from_scope}: {entry['source']}")
+            _emit_out(f"  to   {to_scope}: {entry['target']}")
+            _emit_out(f"  chunks affected: {entry['affected']}")
             # ``N preserved, 0 dropped`` for single-DB chunk-id-stable
             # rename: chunks.id never changes so the entire chunk_links
             # neighborhood survives untouched. Cross-DB migration (#911,
             # deferred per ADR-0012) is where ``dropped`` could become non-zero.
-            click.echo(f"  chunk_links lineage: {entry['lineage']} preserved, 0 dropped")
+            _emit_out(f"  chunk_links lineage: {entry['lineage']} preserved, 0 dropped")
 
         if is_batch:
             total_chunks = sum(int(e["affected"]) for e in plan)
             total_lineage = sum(int(e["lineage"]) for e in plan)
-            click.echo(
+            _emit_out(
                 f"\nTotal: {len(plan)} files, {total_chunks} chunks affected, "
                 f"{total_lineage} chunk_links preserved"
             )
 
         if not apply_:
-            click.echo("\nRun with --apply to execute.")
+            _emit_out("\nRun with --apply to execute.")
             return
 
         # ADR-0011 PR-D review round 10 (M2): require an explicit
@@ -2982,22 +3015,20 @@ async def _memory_migrate_run(
                     if guard.decision in ("blocked", "blocked_project_shared"):
                         n_done = len(completed)
                         n_total = len(plan)
-                        click.secho(
+                        _emit_err(
                             f"  ✗ Gate A: {src.name} matches {len(guard.hits)} "
                             f"privacy pattern(s) at apply time (content changed "
                             "since pre-flight); migration to "
                             f"scope='{to_scope}' rejected. git history is "
                             "forever — no force bypass available.",
                             fg="red",
-                            err=True,
                         )
                         if is_batch:
-                            click.secho(
+                            _emit_err(
                                 f"  {n_done} of {n_total} migrated before this "
                                 f"file; remaining {n_total - n_done - 1} "
                                 "file(s) untouched.",
                                 fg="red",
-                                err=True,
                             )
                         raise click.exceptions.Exit(1)
 
@@ -3031,33 +3062,30 @@ async def _memory_migrate_run(
                         # how many earlier files are already migrated
                         # before they go inspect the divergent
                         # source/target pair.
-                        click.secho(
+                        _emit_err(
                             f"  ✗ DB update failed AND filesystem rollback "
                             f"failed for {src.name}; source/target may diverge. "
                             "Inspect both paths.",
                             fg="red",
-                            err=True,
                         )
                         if is_batch:
-                            click.secho(
+                            _emit_err(
                                 f"  Batch state: {n_done} of {n_total} migrated "
                                 f"before file {i}; remaining "
                                 f"{n_total - n_done - 1} file(s) untouched.",
                                 fg="red",
-                                err=True,
                             )
                         raise click.ClickException(
                             f"DB update failed AND filesystem rollback failed: "
                             f"db_error={exc!r}; rollback_error={revert_exc!r}"
                         ) from exc
                     if is_batch:
-                        click.secho(
+                        _emit_err(
                             f"  ✗ DB update failed on file {i} of {n_total} "
                             f"({src.name}); reverted that file. {n_done} of "
                             f"{n_total} migrated; remaining "
                             f"{n_total - n_done - 1} file(s) untouched.",
                             fg="red",
-                            err=True,
                         )
                     raise click.ClickException(
                         f"DB update failed; filesystem move reverted: {exc}"
@@ -3067,14 +3095,14 @@ async def _memory_migrate_run(
         comp.search_pipeline.invalidate_cache()
         if is_batch:
             total_rows = sum(c[2] for c in completed)
-            click.secho(
+            _emit_out(
                 f"  ✓ moved {len(completed)} files → {to_scope} tier; "
                 f"{total_rows} chunk row(s) updated.",
                 fg="green",
             )
         else:
             src, _tgt, updated = completed[0]
-            click.secho(
+            _emit_out(
                 f"  ✓ moved {src.name} → {to_scope} tier; {updated} chunk row(s) updated.",
                 fg="green",
             )

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -130,6 +130,7 @@ from memtomem.server.tools.context import (
     mem_context_generate,
     mem_context_diff,
     mem_context_sync,
+    mem_context_migrate,
 )  # noqa: E402, F401
 from memtomem.server.tools.ingest import mem_ingest  # noqa: E402, F401  — no @mcp.tool; import triggers @register("ingest") for mem_do routing
 from memtomem.server.tools.watchdog import mem_watchdog  # noqa: E402, F401

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -873,9 +873,6 @@ async def mem_context_migrate(
     force bypass — git history is forever (ADR-0011 §5). Rejections
     surface as ``privacy block: ...`` in the returned text.
     """
-    import contextlib
-    import io
-
     from memtomem.cli.context_cmd import (
         _memory_migrate_run,
         _resolve_memory_migrate_sources,
@@ -907,55 +904,62 @@ async def mem_context_migrate(
     except click.ClickException as exc:
         return f"error: {exc.message}"
 
-    # ``_memory_migrate_run`` uses ``click.echo``/``click.secho`` for all
-    # user-facing output (plan listing, apply summary). Capture stdout +
-    # stderr so the MCP wrapper returns a single text payload, the same
-    # way a CLI invocation would render. Gate A privacy blocks emit to
-    # stderr via ``err=True`` then ``raise click.exceptions.Exit(1)``;
-    # we translate that into the ``privacy block:`` shape the other
-    # context tools use.
-    stdout_buf = io.StringIO()
-    stderr_buf = io.StringIO()
+    # Per-call output buffers passed into ``_memory_migrate_run``.
+    # We deliberately do NOT use ``contextlib.redirect_stdout`` /
+    # ``redirect_stderr``: both swap ``sys.stdout`` / ``sys.stderr``
+    # process-globally for the duration of the ``with`` block, and the
+    # block awaits the heavy helper. While this coroutine is suspended
+    # on I/O, any other concurrent MCP tool call that prints (or that
+    # internally ``click.echo``s) would land in our buffer — and our
+    # output would land in theirs. Routing through per-call lists keeps
+    # each call's output strictly local; the helper falls back to its
+    # original ``click.secho`` behaviour when both buffers are ``None``
+    # (CLI path). Codex review-pass on PR #926.
+    stdout_lines: list[str] = []
+    stderr_lines: list[str] = []
     try:
-        with (
-            contextlib.redirect_stdout(stdout_buf),
-            contextlib.redirect_stderr(stderr_buf),
-        ):
-            await _memory_migrate_run(
-                sources,
-                from_scope,
-                to_scope,
-                apply_,
-                # ``yes=True`` because the MCP wrapper has already
-                # gated Gate B above via the explicit
-                # ``confirm_project_shared`` argument. ``yes`` only
-                # suppresses the ``click.confirm`` prompt that the CLI
-                # falls through to when ``confirm_project_shared`` is
-                # missing — irrelevant for MCP, which has no TTY.
-                yes=True,
-                confirm_project_shared=confirm_project_shared,
-            )
+        await _memory_migrate_run(
+            sources,
+            from_scope,
+            to_scope,
+            apply_,
+            # ``yes=True`` because the MCP wrapper has already gated
+            # Gate B above via the explicit ``confirm_project_shared``
+            # argument. ``yes`` only suppresses the ``click.confirm``
+            # prompt that the CLI falls through to when
+            # ``confirm_project_shared`` is missing — irrelevant for
+            # MCP, which has no TTY.
+            yes=True,
+            confirm_project_shared=confirm_project_shared,
+            stdout_buf=stdout_lines,
+            stderr_buf=stderr_lines,
+        )
     except PrivacyScanError as exc:
         return f"privacy block: {exc.message}"
     except click.exceptions.Exit:
-        # Gate A privacy block — the helper printed the rejection text
-        # to stderr before exiting. Surface as a privacy block so the
-        # MCP caller can branch on the prefix.
-        stderr_text = stderr_buf.getvalue().strip()
+        # Gate A privacy block — the helper recorded the rejection text
+        # in ``stderr_lines`` before exiting. Surface as a privacy
+        # block so the MCP caller can branch on the prefix.
+        stderr_text = "\n".join(stderr_lines).strip()
         if "Gate A:" in stderr_text:
             return f"privacy block: {stderr_text}"
         return f"error: {stderr_text or 'migration exited unexpectedly'}"
     except click.ClickException as exc:
+        # Mid-batch failures (DB UPDATE failed, double-failure path)
+        # record per-file partial-progress lines in ``stderr_lines``
+        # BEFORE raising ``ClickException``. Append those so the MCP
+        # caller sees the K-of-N batch state, not just the bare error
+        # message — Codex flagged this on PR #926.
+        stderr_tail = "\n".join(stderr_lines).strip()
+        if stderr_tail:
+            return f"error: {exc.message}\n{stderr_tail}"
         return f"error: {exc.message}"
 
-    output = stdout_buf.getvalue()
-    # Apply-time success line is emitted via ``click.secho(... fg='green')``
-    # which is not on stderr; the buffer already contains it. stderr is
-    # only populated for refusals / failures — append it if non-empty
-    # so the MCP caller doesn't lose the partial-progress message after
-    # a mid-batch failure that did not raise (no such path exists today,
-    # but the helper may grow one).
-    stderr_tail = stderr_buf.getvalue().strip()
+    stdout_text = "\n".join(stdout_lines).rstrip()
+    # Helper paths that reach here without raising have nothing in
+    # ``stderr_lines`` today; defensively concatenate so a future
+    # warning-but-don't-raise path is not silently dropped.
+    stderr_tail = "\n".join(stderr_lines).strip()
     if stderr_tail:
-        output = f"{output.rstrip()}\n{stderr_tail}"
-    return output.rstrip() or "Nothing to migrate."
+        stdout_text = f"{stdout_text}\n{stderr_tail}" if stdout_text else stderr_tail
+    return stdout_text or "Nothing to migrate."

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -1,4 +1,4 @@
-"""Tools: context_detect, context_init, context_generate, context_sync, context_diff."""
+"""Tools: context_detect, context_init, context_generate, context_sync, context_diff, context_migrate."""
 
 from __future__ import annotations
 
@@ -817,3 +817,145 @@ async def mem_context_sync(
                 results.append(f"  {sr.status} {sname}: {sr.reason}")
 
     return "Synced:\n" + "\n".join(results) if results else "Nothing to sync."
+
+
+_KNOWN_MEMORY_SCOPES: frozenset[str] = frozenset({"user", "project_shared", "project_local"})
+
+
+@mcp.tool()
+@tool_handler
+@register("context")
+async def mem_context_migrate(
+    source: str,
+    from_scope: str,
+    to_scope: str,
+    apply_: bool = False,
+    confirm_project_shared: bool = False,
+    ctx: CtxType = None,
+) -> str:
+    """Move markdown memory file(s) between ADR-0011 memory scope tiers.
+
+    Mirrors the CLI ``mm context memory-migrate <SOURCE> --from <scope>
+    --to <scope> [--apply] [--confirm-project-shared]``
+    (``cli/context_cmd.py:2574-2659``). Chunk-id-stable single-DB rename:
+    the source file moves on disk to the target tier's canonical
+    directory and the ``chunks`` table is UPDATEd in place via
+    ``update_chunks_scope_for_source`` so chunk UUIDs and the
+    ``chunk_links`` lineage are preserved. No re-index is triggered.
+
+    Cross-DB migration is out of scope — deferred per ADR-0012 / #911.
+
+    Args:
+        source: Single existing markdown file path OR a glob pattern
+            (e.g. ``"~/.memtomem/memories/**/*.md"``). For globs the
+            pre-flight pass (privacy scan + lockfile probe) runs over
+            every match before any FS move; on per-file DB failure
+            mid-batch, that file's FS move is reverted, the remaining
+            files are left untouched, and the call exits with the
+            partial-progress message in the returned text.
+        from_scope: Source memory tier — ``user``, ``project_shared``,
+            or ``project_local``.
+        to_scope: Target memory tier (same vocabulary). Must differ
+            from ``from_scope``.
+        apply_: Execute the migration. Default ``False`` returns a
+            dry-run preview (the same plan output the CLI shows above
+            its "Run with --apply to execute." footer).
+        confirm_project_shared: Required when ``to_scope="project_shared"``;
+            MCP cannot prompt interactively, so a missing confirmation
+            returns a ``needs confirmation`` message instead of touching
+            disk. Mirrors ``mem_context_init`` / ``mem_context_generate``
+            project_shared gating.
+
+    Privacy: when ``to_scope="project_shared"`` the file content is
+    re-scanned by ``privacy.enforce_write_guard`` both at pre-flight and
+    at apply time (the latter catches in-flight edits during the
+    confirmation window). Secret hits reject the migration with no
+    force bypass — git history is forever (ADR-0011 §5). Rejections
+    surface as ``privacy block: ...`` in the returned text.
+    """
+    import contextlib
+    import io
+
+    from memtomem.cli.context_cmd import (
+        _memory_migrate_run,
+        _resolve_memory_migrate_sources,
+    )
+    from memtomem.context.privacy_scan import PrivacyScanError
+
+    # Scope vocabulary validation up-front so callers get a clean error
+    # instead of a downstream MemoryScopeError stringification.
+    for label, value in (("from_scope", from_scope), ("to_scope", to_scope)):
+        if value not in _KNOWN_MEMORY_SCOPES:
+            return f"error: Unknown {label}='{value}'. Supported: {sorted(_KNOWN_MEMORY_SCOPES)}"
+
+    if from_scope == to_scope:
+        return "error: --from and --to must differ."
+
+    # Gate B: project_shared writes go to the git-tracked memory tier.
+    # MCP has no interactive prompt, so refuse early and tell the caller
+    # how to opt in. Mirrors mem_context_init project_shared gating at
+    # ``tools/context.py:151-155``.
+    if to_scope == "project_shared" and not confirm_project_shared:
+        return (
+            "needs confirmation: to_scope='project_shared' writes to the "
+            "git-tracked memory tier. Re-call with confirm_project_shared=True "
+            "to proceed."
+        )
+
+    try:
+        sources = _resolve_memory_migrate_sources(source)
+    except click.ClickException as exc:
+        return f"error: {exc.message}"
+
+    # ``_memory_migrate_run`` uses ``click.echo``/``click.secho`` for all
+    # user-facing output (plan listing, apply summary). Capture stdout +
+    # stderr so the MCP wrapper returns a single text payload, the same
+    # way a CLI invocation would render. Gate A privacy blocks emit to
+    # stderr via ``err=True`` then ``raise click.exceptions.Exit(1)``;
+    # we translate that into the ``privacy block:`` shape the other
+    # context tools use.
+    stdout_buf = io.StringIO()
+    stderr_buf = io.StringIO()
+    try:
+        with (
+            contextlib.redirect_stdout(stdout_buf),
+            contextlib.redirect_stderr(stderr_buf),
+        ):
+            await _memory_migrate_run(
+                sources,
+                from_scope,
+                to_scope,
+                apply_,
+                # ``yes=True`` because the MCP wrapper has already
+                # gated Gate B above via the explicit
+                # ``confirm_project_shared`` argument. ``yes`` only
+                # suppresses the ``click.confirm`` prompt that the CLI
+                # falls through to when ``confirm_project_shared`` is
+                # missing — irrelevant for MCP, which has no TTY.
+                yes=True,
+                confirm_project_shared=confirm_project_shared,
+            )
+    except PrivacyScanError as exc:
+        return f"privacy block: {exc.message}"
+    except click.exceptions.Exit:
+        # Gate A privacy block — the helper printed the rejection text
+        # to stderr before exiting. Surface as a privacy block so the
+        # MCP caller can branch on the prefix.
+        stderr_text = stderr_buf.getvalue().strip()
+        if "Gate A:" in stderr_text:
+            return f"privacy block: {stderr_text}"
+        return f"error: {stderr_text or 'migration exited unexpectedly'}"
+    except click.ClickException as exc:
+        return f"error: {exc.message}"
+
+    output = stdout_buf.getvalue()
+    # Apply-time success line is emitted via ``click.secho(... fg='green')``
+    # which is not on stderr; the buffer already contains it. stderr is
+    # only populated for refusals / failures — append it if non-empty
+    # so the MCP caller doesn't lose the partial-progress message after
+    # a mid-batch failure that did not raise (no such path exists today,
+    # but the helper may grow one).
+    stderr_tail = stderr_buf.getvalue().strip()
+    if stderr_tail:
+        output = f"{output.rstrip()}\n{stderr_tail}"
+    return output.rstrip() or "Nothing to migrate."

--- a/packages/memtomem/tests/test_server_tools_context_migrate.py
+++ b/packages/memtomem/tests/test_server_tools_context_migrate.py
@@ -101,25 +101,45 @@ def _stub_components(layout):
 
 
 @pytest.mark.anyio
-async def test_mem_context_migrate_unknown_from_scope_rejected_without_helper(
+@pytest.mark.parametrize(
+    ("from_scope", "to_scope", "expected_label"),
+    [
+        ("bogus", "user", "from_scope='bogus'"),
+        ("user", "bogus", "to_scope='bogus'"),
+    ],
+)
+async def test_mem_context_migrate_unknown_scope_rejected_without_helper(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    from_scope: str,
+    to_scope: str,
+    expected_label: str,
 ) -> None:
-    """Bogus ``from_scope`` must return a clean error string without
-    spinning up ``cli_components``. Otherwise the helper raises a
-    ``MemoryScopeError`` wrapped in ``ClickException`` deeper in, which
-    works but pays the bootstrap cost for a vocabulary typo.
+    """Bogus ``from_scope`` / ``to_scope`` must return a clean error string
+    without spinning up ``cli_components``. Both axes are validated
+    against the same {user, project_shared, project_local} vocabulary so
+    the helper never sees an invalid scope.
     """
     src = tmp_path / "rule.md"
     src.write_text("body", encoding="utf-8")
 
+    # Sentinel pins that the helper is never reached.
+    invoked = []
+
+    async def _sentinel(*args, **kwargs):  # noqa: ANN001
+        invoked.append((args, kwargs))
+
+    monkeypatch.setattr("memtomem.cli.context_cmd._memory_migrate_run", _sentinel)
+
     out = await mem_context_migrate(
         source=str(src),
-        from_scope="bogus",
-        to_scope="user",
+        from_scope=from_scope,
+        to_scope=to_scope,
     )
     assert out.startswith("error:")
-    assert "Unknown from_scope='bogus'" in out
+    assert expected_label in out
+    assert "Unknown" in out
+    assert invoked == []
 
 
 @pytest.mark.anyio
@@ -307,3 +327,62 @@ async def test_mem_context_migrate_no_glob_match_returns_clean_error(
     )
     assert out.startswith("error:")
     assert "No .md files matched" in out
+
+
+# ---------------------------------------------------------------------------
+# 7) Mid-batch DB failure — partial-progress stderr surfaces in the error.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_mid_batch_db_failure_includes_partial_progress(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_project_layout,
+) -> None:
+    """``_memory_migrate_run`` raises ``ClickException`` for a DB UPDATE
+    failure but emits partial-progress lines ("DB update failed on
+    file N of M; reverted that file. K of M migrated; remaining ...")
+    to stderr BEFORE raising. The MCP wrapper must include that stderr
+    tail in the returned error so the caller learns the K-of-N batch
+    state — bare ``error: {exc.message}`` is insufficient. Codex
+    flagged this on PR #926.
+    """
+    layout = fake_project_layout
+    # Two clean sources so the helper enters batch mode (is_batch=True)
+    # and emits the per-file failure narration. layout["src"] is the
+    # first one (rule.md).
+    src2 = layout["user_tier"] / "second.md"
+    src2.write_text("## Second\n\nharmless body.\n", encoding="utf-8")
+
+    comp = _stub_components(layout)
+    # First file UPDATE succeeds, second raises — the helper reverts the
+    # second file's FS move and emits "DB update failed on file 2 of 2".
+    update_calls = {"n": 0}
+
+    async def _flaky_update(*_a, **_kw):
+        update_calls["n"] += 1
+        if update_calls["n"] == 2:
+            raise RuntimeError("simulated DB failure on file 2")
+        return 2
+
+    comp.storage.update_chunks_scope_for_source = _flaky_update
+    _patch_cli_components(monkeypatch, comp)
+    monkeypatch.chdir(layout["project_root"])
+
+    out = await mem_context_migrate(
+        source=str(layout["user_tier"] / "*.md"),
+        from_scope="user",
+        to_scope="project_local",
+        apply_=True,
+    )
+    assert out.startswith("error:")
+    # Bare ClickException message is present.
+    assert "DB update failed" in out
+    # AND the partial-progress narration that lived only in stderr
+    # before this fix.
+    assert "DB update failed on file 2 of 2" in out
+    assert "remaining" in out
+    # File 1 actually migrated; file 2's move was reverted.
+    assert (layout["proj_local"] / "rule.md").exists()
+    assert not (layout["proj_local"] / "second.md").exists()
+    assert src2.exists()

--- a/packages/memtomem/tests/test_server_tools_context_migrate.py
+++ b/packages/memtomem/tests/test_server_tools_context_migrate.py
@@ -1,0 +1,309 @@
+"""MCP parity pins for ``mem_context_migrate`` wrapping the CLI
+``mm context memory-migrate`` verb.
+
+Closes the second half of #887. The underlying migration semantics
+(chunk-id-stable rename, glob, lockfile, compensation) are pinned by
+``test_context_memory_migrate.py``; this file pins only the MCP-shape
+contract:
+
+1. Vocabulary validation rejects unknown scope values without touching
+   the helper.
+2. ``from_scope == to_scope`` short-circuits at the wrapper.
+3. ``to_scope='project_shared'`` without ``confirm_project_shared=True``
+   short-circuits at the wrapper — the heavy helper is never invoked.
+4. ``to_scope='project_shared'`` with confirm + a secret in the source
+   surfaces as a ``privacy block:`` string (the CLI's
+   ``click.exceptions.Exit`` translated for MCP).
+5. Dry-run captures the plan output via ``click.echo`` redirection and
+   returns it as a string; the DB UPDATE is never called.
+6. ``apply_=True`` against a non-project_shared target calls the
+   helper end-to-end and returns the success summary.
+
+Reuses the AsyncMock-based ``cli_components`` patching from
+``test_context_memory_migrate.py`` to avoid spinning up a real storage
+backend for the wrapper contract tests.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from memtomem import privacy
+from memtomem.server.tools.context import mem_context_migrate
+
+
+_SECRET = "api_key=AKIA1234567890ABCDEF"
+
+
+@pytest.fixture(autouse=True)
+def _reset_counters():
+    privacy.reset_for_tests()
+    yield
+    privacy.reset_for_tests()
+
+
+@pytest.fixture
+def fake_project_layout(tmp_path: Path):
+    project_root = tmp_path / "proj"
+    proj_shared = project_root / ".memtomem" / "memories"
+    proj_local = project_root / ".memtomem" / "memories.local"
+    proj_shared.mkdir(parents=True)
+    proj_local.mkdir(parents=True)
+    (project_root / ".git").mkdir()
+
+    user_tier = tmp_path / "user_home" / ".memtomem" / "memories"
+    user_tier.mkdir(parents=True)
+    src = user_tier / "rule.md"
+    src.write_text("## Rule\n\nharmless team rule body.\n", encoding="utf-8")
+    return {
+        "project_root": project_root,
+        "proj_shared": proj_shared,
+        "proj_local": proj_local,
+        "user_tier": user_tier,
+        "src": src,
+    }
+
+
+def _patch_cli_components(monkeypatch: pytest.MonkeyPatch, comp) -> None:
+    """Replace ``cli_components`` with a no-op context yielding ``comp``."""
+
+    @asynccontextmanager
+    async def _fake():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _fake)
+
+
+def _stub_components(layout):
+    comp = AsyncMock()
+    comp.config.indexing.memory_dirs = [layout["user_tier"]]
+    # Register both project tiers so the ``is_project_tier_registered``
+    # guard accepts moves to either project_shared or project_local.
+    comp.config.indexing.project_memory_dirs = [
+        layout["proj_shared"],
+        layout["proj_local"],
+    ]
+    comp.storage = AsyncMock()
+    comp.storage.count_chunks_by_source = AsyncMock(return_value=2)
+    comp.storage.count_chunk_links_for_source = AsyncMock(return_value=0)
+    comp.storage.update_chunks_scope_for_source = AsyncMock(return_value=2)
+    comp.search_pipeline = AsyncMock()
+    return comp
+
+
+# ---------------------------------------------------------------------------
+# 1) Vocabulary + from==to validation — refuse before touching the helper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_unknown_from_scope_rejected_without_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Bogus ``from_scope`` must return a clean error string without
+    spinning up ``cli_components``. Otherwise the helper raises a
+    ``MemoryScopeError`` wrapped in ``ClickException`` deeper in, which
+    works but pays the bootstrap cost for a vocabulary typo.
+    """
+    src = tmp_path / "rule.md"
+    src.write_text("body", encoding="utf-8")
+
+    out = await mem_context_migrate(
+        source=str(src),
+        from_scope="bogus",
+        to_scope="user",
+    )
+    assert out.startswith("error:")
+    assert "Unknown from_scope='bogus'" in out
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_from_equals_to_rejected(
+    tmp_path: Path,
+) -> None:
+    src = tmp_path / "rule.md"
+    src.write_text("body", encoding="utf-8")
+
+    out = await mem_context_migrate(
+        source=str(src),
+        from_scope="user",
+        to_scope="user",
+    )
+    assert out == "error: --from and --to must differ."
+
+
+# ---------------------------------------------------------------------------
+# 2) project_shared Gate B — short-circuit at the wrapper.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_project_shared_requires_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_project_layout,
+) -> None:
+    """``to_scope='project_shared'`` without ``confirm_project_shared=True``
+    must short-circuit at the MCP wrapper. The heavy helper
+    (``_memory_migrate_run``) must NOT be invoked — assert via a sentinel
+    that records calls.
+    """
+    layout = fake_project_layout
+    invoked = []
+
+    async def _sentinel(*args, **kwargs):  # noqa: ANN001
+        invoked.append((args, kwargs))
+
+    monkeypatch.setattr("memtomem.cli.context_cmd._memory_migrate_run", _sentinel)
+
+    out = await mem_context_migrate(
+        source=str(layout["src"]),
+        from_scope="user",
+        to_scope="project_shared",
+    )
+    assert out.startswith("needs confirmation:")
+    assert "confirm_project_shared=True" in out
+    assert invoked == []
+    # Source untouched.
+    assert layout["src"].exists()
+    assert not (layout["proj_shared"] / "rule.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# 3) Gate A privacy block — translate click.exceptions.Exit to "privacy block:".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_project_shared_privacy_block_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_project_layout,
+) -> None:
+    """A secret in the source rejects the migration with no force bypass
+    (ADR-0011 §5). The underlying helper emits to stderr via ``click.secho``
+    then raises ``click.exceptions.Exit(1)``; the MCP wrapper must
+    translate that into the ``privacy block:`` shape so callers can
+    branch on the prefix the same way they do for
+    ``mem_context_init`` / ``mem_context_generate``.
+    """
+    layout = fake_project_layout
+    src = layout["src"]
+    src.write_text(f"## Token\n\n{_SECRET}\n", encoding="utf-8")
+
+    comp = _stub_components(layout)
+    comp.storage.count_chunks_by_source = AsyncMock(return_value=1)
+    _patch_cli_components(monkeypatch, comp)
+    monkeypatch.chdir(layout["project_root"])
+
+    out = await mem_context_migrate(
+        source=str(src),
+        from_scope="user",
+        to_scope="project_shared",
+        apply_=True,
+        confirm_project_shared=True,
+    )
+    assert out.startswith("privacy block:")
+    assert "Gate A" in out
+    assert "git history is forever" in out
+    # Source untouched on Gate A rejection.
+    assert src.exists()
+    comp.storage.update_chunks_scope_for_source.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4) Dry-run — capture click.echo plan output, no DB UPDATE.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_dry_run_returns_plan_and_does_not_mutate(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_project_layout,
+) -> None:
+    layout = fake_project_layout
+    src = layout["src"]
+
+    comp = _stub_components(layout)
+    _patch_cli_components(monkeypatch, comp)
+    monkeypatch.chdir(layout["project_root"])
+
+    out = await mem_context_migrate(
+        source=str(src),
+        from_scope="user",
+        to_scope="project_local",
+    )
+    # Plan listing from click.echo arrived through stdout capture.
+    assert "Plan: migrate rule.md" in out
+    assert "chunks affected: 2" in out
+    assert "Run with --apply" in out
+    # Dry-run never calls the DB UPDATE.
+    comp.storage.update_chunks_scope_for_source.assert_not_called()
+    # File never moved.
+    assert src.exists()
+    assert not (layout["proj_local"] / "rule.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# 5) Apply path — non-project_shared, clean content, success summary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_apply_user_to_project_local_calls_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_project_layout,
+) -> None:
+    """End-to-end happy path through the wrapper: clean source, non-
+    project_shared target (so no Gate B prompt), ``apply_=True``. Asserts
+    the helper's DB UPDATE was called once and the success line is in
+    the captured stdout.
+    """
+    layout = fake_project_layout
+    src = layout["src"]
+
+    comp = _stub_components(layout)
+    _patch_cli_components(monkeypatch, comp)
+    monkeypatch.chdir(layout["project_root"])
+
+    out = await mem_context_migrate(
+        source=str(src),
+        from_scope="user",
+        to_scope="project_local",
+        apply_=True,
+    )
+    # The wrapper captures both stdout and stderr; the success secho
+    # ("✓ moved ...") goes to stdout.
+    assert "moved rule.md" in out
+    assert "project_local tier" in out
+    comp.storage.update_chunks_scope_for_source.assert_awaited_once()
+    # File actually moved on disk.
+    assert not src.exists()
+    assert (layout["proj_local"] / "rule.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# 6) Source-resolution error — bad glob surfaces as "error: ...".
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mem_context_migrate_no_glob_match_returns_clean_error(
+    tmp_path: Path,
+) -> None:
+    """A typo'd glob would normally raise ``ClickException`` inside the
+    resolver; the wrapper must translate that to an ``error:`` string
+    rather than letting the exception bubble through ``tool_handler`` as
+    ``internal error``.
+    """
+    bogus_glob = str(tmp_path / "does-not-exist" / "**" / "*.md")
+    out = await mem_context_migrate(
+        source=bogus_glob,
+        from_scope="user",
+        to_scope="project_local",
+    )
+    assert out.startswith("error:")
+    assert "No .md files matched" in out

--- a/packages/memtomem/tests/test_server_tools_context_migrate.py
+++ b/packages/memtomem/tests/test_server_tools_context_migrate.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -91,7 +91,11 @@ def _stub_components(layout):
     comp.storage.count_chunks_by_source = AsyncMock(return_value=2)
     comp.storage.count_chunk_links_for_source = AsyncMock(return_value=0)
     comp.storage.update_chunks_scope_for_source = AsyncMock(return_value=2)
-    comp.search_pipeline = AsyncMock()
+    # ``invalidate_cache`` is called synchronously in production
+    # (``cli/context_cmd.py`` post-apply step); using ``AsyncMock`` here
+    # would leave an unawaited coroutine and fail under
+    # ``pytest -W error``. A plain ``Mock`` keeps it sync.
+    comp.search_pipeline = Mock()
     return comp
 
 


### PR DESCRIPTION
## Summary

Closes the second half of #887 — the first half (`mem_context_diff` scope=) lands in #920. Wraps the existing CLI verb `mm context memory-migrate` so MCP callers can move markdown memory files between ADR-0011 memory scope tiers.

## Surface

```python
async def mem_context_migrate(
    source: str,                            # single file path or glob
    from_scope: str,                        # user | project_shared | project_local
    to_scope: str,                          # same vocabulary, must differ
    apply_: bool = False,                   # dry-run unless True
    confirm_project_shared: bool = False,   # required when to_scope='project_shared'
    ctx: CtxType = None,
) -> str
```

## Design notes

- **Dual-scope signature** — migrate is the one verb where source and target tiers differ. Both are validated up-front against the `{user, project_shared, project_local}` vocabulary; bogus values short-circuit before paying the `cli_components` bootstrap cost.
- **`--yes` does not survive the port** — it only suppresses the `click.confirm` prompt that the CLI falls through to when `--confirm-project-shared` is missing. MCP has no TTY, so there is nothing to suppress. Per gotcha #5 from `feedback_cli_mcp_parity_gotchas.md`, each CLI confirm gets its own MCP flag — here that's `confirm_project_shared`.
- **Gate A privacy translation** — `_memory_migrate_run` raises `click.exceptions.Exit(1)` with the rejection text on stderr for project_shared secret hits. The wrapper captures both streams via `redirect_stdout` / `redirect_stderr` and translates `Exit` into the `privacy block:` shape that `mem_context_init` / `mem_context_generate` already use, so MCP callers can branch on the same prefix across all context tools.
- **Cross-DB migration is out of scope** — deferred per ADR-0012 / #911.

## Tests

`packages/memtomem/tests/test_server_tools_context_migrate.py` pins the MCP-shape contract only:

1. Unknown `from_scope` returns `error: Unknown from_scope=...` without invoking the helper
2. `from == to` returns `error: --from and --to must differ.`
3. `to_scope='project_shared'` without `confirm_project_shared=True` returns `needs confirmation:` — helper never called
4. project_shared with confirm + secret content → `privacy block:` (Gate A translation)
5. Dry-run returns the plan via captured `click.echo`; no DB UPDATE
6. Apply against `project_local` calls the helper end-to-end; file moves, DB UPDATE awaited once
7. No-glob-match returns `error: No .md files matched ...`

The underlying chunk-id-stable rename / lockfile / compensation semantics are already pinned by `test_context_memory_migrate.py` — this PR does not re-cover them.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_server_tools_context_migrate.py` — 7 passed
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/ -k "context_memory_migrate or test_server_tools_context"` — 38 passed (no regression in adjacent migrate / wrapper paths)
- [x] `uv run ruff check` + `uv run ruff format --check` on modified files — clean

## Follow-up

After this merges with #920, issue #887 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)