### PR TITLE
feat(context): annotate project_local drafts in mm context status (#923)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1502,7 +1502,14 @@ _STATUS_GLYPH: dict[str, tuple[str, str]] = {
     "dirty": ("✗", "yellow"),
     "missing": ("!", "red"),
     "stale-pin": ("⚠", "red"),
+    "local-draft": ("·", "magenta"),
 }
+
+# ADR-0011 §3 / ADR-0016 §7: project_local agents / commands / skills never
+# reach a runtime fan-out path. The annotation flags the row inline so a
+# reader of ``mm context status`` understands the entry is a draft tier with
+# no Claude Code (or other agent) discovery path.
+_PROJECT_LOCAL_ANNOTATION = "(draft, no fan-out)"
 
 
 @context.command("status")
@@ -1528,33 +1535,61 @@ def status_cmd() -> None:
         click.secho(f"  ✗ lock.json: {lockfile_error}", fg="red", err=True)
 
     # Header — counts + wiki HEAD (or "wiki not present" annotation).
+    # Lockfile-tracked installs (project_shared) drive the "installed"
+    # count; project_local rows are surfaced separately so the header
+    # word ("installed") stays accurate for both groups.
+    installed_count = sum(1 for r in rows if r.tier != "project_local")
+    draft_count = sum(1 for r in rows if r.tier == "project_local")
+    draft_suffix = f" (+ {draft_count} local draft{'s' if draft_count != 1 else ''})" if draft_count else ""
     if wiki_head is None:
         wiki_root = wiki.root
         click.echo(
-            f".memtomem/ — {len(rows)} asset(s) installed — "
+            f".memtomem/ — {installed_count} asset(s) installed{draft_suffix} — "
             f"wiki not present at {wiki_root}; pin reachability not checked"
         )
     else:
-        click.echo(f".memtomem/ — {len(rows)} asset(s) installed — wiki HEAD {wiki_head[:12]}")
+        click.echo(
+            f".memtomem/ — {installed_count} asset(s) installed{draft_suffix} — "
+            f"wiki HEAD {wiki_head[:12]}"
+        )
 
     if not rows and lockfile_error is None:
         click.echo("\nNo wiki assets installed in this project.")
         return
 
-    # Sectioned by asset type, preserving iter_entries() order
-    # (alphabetical: agents → commands → skills, names alpha within).
+    # Sectioned by asset type, preserving classify_status() order
+    # (alphabetical: agents → commands → skills, names alpha within,
+    # project_shared rows before project_local rows on a name collision).
     last_type: str | None = None
-    summary: dict[str, int] = {"ok": 0, "behind": 0, "dirty": 0, "missing": 0, "stale-pin": 0}
+    summary: dict[str, int] = {
+        "ok": 0,
+        "behind": 0,
+        "dirty": 0,
+        "missing": 0,
+        "stale-pin": 0,
+        "local-draft": 0,
+    }
     for row in rows:
         if row.asset_type != last_type:
             click.secho(f"\n{row.asset_type}", fg="cyan")
             last_type = row.asset_type
         glyph, color = _STATUS_GLYPH[row.state]
-        installed_date = row.installed_at[:10] if row.installed_at else "—"
-        line = (
-            f"  {glyph}  {row.name:24s}  {(row.pin_commit or '?')[:12]}  installed {installed_date}"
-        )
-        if row.reason:
+        # Local-draft rows have no lockfile metadata — render the
+        # pin and installed-at columns as dashes rather than the
+        # "?"/"—" placeholders the lockfile-tracked branches use, so
+        # the visual distinction is obvious to a reader scanning the
+        # column.
+        if row.tier == "project_local":
+            line = f"  {glyph}  {row.name:24s}  {'—':<12}  {'(no install record)':<23}"
+        else:
+            installed_date = row.installed_at[:10] if row.installed_at else "—"
+            line = (
+                f"  {glyph}  {row.name:24s}  "
+                f"{(row.pin_commit or '?')[:12]}  installed {installed_date}"
+            )
+        if row.tier == "project_local":
+            line += f"  {_PROJECT_LOCAL_ANNOTATION}"
+        elif row.reason:
             line += f"  ({row.reason})"
         click.secho(line, fg=color)
         summary[row.state] += 1
@@ -1562,7 +1597,7 @@ def status_cmd() -> None:
     if rows:
         parts = [
             f"{summary[k]} {k}"
-            for k in ("ok", "behind", "dirty", "missing", "stale-pin")
+            for k in ("ok", "behind", "dirty", "missing", "stale-pin", "local-draft")
             if summary[k] > 0
         ]
         if parts:

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1540,7 +1540,9 @@ def status_cmd() -> None:
     # word ("installed") stays accurate for both groups.
     installed_count = sum(1 for r in rows if r.tier != "project_local")
     draft_count = sum(1 for r in rows if r.tier == "project_local")
-    draft_suffix = f" (+ {draft_count} local draft{'s' if draft_count != 1 else ''})" if draft_count else ""
+    draft_suffix = (
+        f" (+ {draft_count} local draft{'s' if draft_count != 1 else ''})" if draft_count else ""
+    )
     if wiki_head is None:
         wiki_root = wiki.root
         click.echo(

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -205,10 +205,19 @@ def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
     """Yield ``StatusRow``s for every valid project_local draft on disk.
 
     Walks ``<proj>/.memtomem/{agents,commands,skills}.local/`` and emits
-    one row per ``<name>/`` subdirectory whose kind-specific manifest
-    file is present (``agent.md`` / ``command.md`` / ``SKILL.md``). The
-    presence of the manifest is the same validity probe migrate uses
-    to recognise a directory-layout artifact (``migrate._detect_source_scope``).
+    one row per valid artifact. Both layouts that ``migrate._detect_source_scope``
+    accepts are recognised:
+
+    - **Directory layout** (all three kinds): ``<root>/<name>/`` containing
+      the kind-specific manifest file (``agent.md`` / ``command.md`` /
+      ``SKILL.md``). The manifest presence is the validity probe.
+    - **Flat layout** (agents and commands only; skills are dir-only by
+      design — see ``migrate._detect_source_scope``): ``<root>/<name>.md``
+      as a single file. ``<name>`` is the file stem.
+
+    When the same name exists in both layouts at the same tier the
+    directory wins (mirrors migrate's ``continue`` after a dir match),
+    so flat siblings of a directory artifact are silently shadowed.
 
     Emitted rows carry ``tier="project_local"``, ``state="local-draft"``,
     and empty ``pin_commit``/``installed_at`` — project_local artifacts
@@ -226,18 +235,43 @@ def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
         if not local_root.is_dir():
             continue
         manifest = _LOCAL_DRAFT_MANIFEST[asset_type]
+        seen_names: set[str] = set()
+
         for entry in sorted(local_root.iterdir(), key=lambda p: p.name):
             if not entry.is_dir():
                 continue
             if not (entry / manifest).is_file():
                 # Skip directories that don't satisfy the kind's
                 # manifest contract — same convention as migrate's
-                # source-scope probe. A future flat-layout sweep would
-                # add a sibling check here.
+                # source-scope probe.
                 continue
+            seen_names.add(entry.name)
             yield StatusRow(
                 asset_type=asset_type,  # type: ignore[arg-type]
                 name=entry.name,
+                pin_commit="",
+                installed_at="",
+                state="local-draft",
+                dirty_file_count=0,
+                reason=None,
+                tier="project_local",
+            )
+
+        if asset_type == "skills":
+            # Skills have no flat layout (migrate._detect_source_scope:792).
+            continue
+        for entry in sorted(local_root.iterdir(), key=lambda p: p.name):
+            if not entry.is_file() or entry.suffix != ".md":
+                continue
+            name = entry.stem
+            if name in seen_names:
+                # Dir-layout wins on collision (same convention as
+                # migrate._detect_source_scope's `continue` after a
+                # dir match).
+                continue
+            yield StatusRow(
+                asset_type=asset_type,  # type: ignore[arg-type]
+                name=name,
                 pin_commit="",
                 installed_at="",
                 state="local-draft",

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -29,8 +29,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from memtomem.config import TargetScope
+from memtomem.context.agents import AGENT_DIR_FILENAME
+from memtomem.context.commands import COMMAND_DIR_FILENAME
 from memtomem.context.dirty import is_asset_dirty
 from memtomem.context.lockfile import Lockfile, LockfileVersionError
+from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.skills import SKILL_MANIFEST
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
 
 __all__ = [
@@ -40,7 +45,13 @@ __all__ = [
 ]
 
 
-StatusState = Literal["ok", "behind", "dirty", "missing", "stale-pin"]
+StatusState = Literal["ok", "behind", "dirty", "missing", "stale-pin", "local-draft"]
+
+_LOCAL_DRAFT_MANIFEST: dict[str, str] = {
+    "agents": AGENT_DIR_FILENAME,
+    "commands": COMMAND_DIR_FILENAME,
+    "skills": SKILL_MANIFEST,
+}
 
 
 @dataclass(frozen=True)
@@ -58,6 +69,14 @@ class StatusRow:
     parens after the row. Common contents: ``"N file(s) modified
     locally"`` for dirty, ``"dest missing"`` for missing, ``"pin <abbr>
     not reachable"`` / ``"wiki not present"`` for stale-pin.
+
+    ``tier`` distinguishes lockfile-tracked installs (``project_shared``)
+    from locally-authored drafts discovered by walking
+    ``<proj>/.memtomem/<artifact>.local/`` (``project_local``). The CLI
+    appends ``(draft, no fan-out)`` after project_local rows per ADR-0011
+    §3 / ADR-0016 §7. ``user`` tier is reserved for a future scan;
+    today's `mm context install` only writes project_shared, so no
+    ``user``-tier rows are produced.
     """
 
     asset_type: Literal["skills", "agents", "commands"]
@@ -67,6 +86,7 @@ class StatusRow:
     state: StatusState
     dirty_file_count: int
     reason: str | None
+    tier: TargetScope = "project_shared"
 
 
 def classify_status(
@@ -159,12 +179,72 @@ def classify_status(
                 state=state,
                 dirty_file_count=dirty_count,
                 reason=reason,
+                tier="project_shared",
             )
         )
 
-    # iter_entries yields alphabetical (agents → commands → skills);
-    # rows preserve that order — see Lockfile.iter_entries docstring.
+    rows.extend(_scan_project_local_drafts(project_root_path))
+
+    # Final order: alphabetical by (asset_type, name); within a name,
+    # project_shared (lockfile-tracked install) renders before
+    # project_local (locally-authored draft). A name colliding across
+    # tiers therefore produces two adjacent rows under the same section
+    # header, shared first.
+    rows.sort(key=lambda r: (r.asset_type, r.name, _TIER_RENDER_ORDER[r.tier]))
     return wiki_head, rows
+
+
+_TIER_RENDER_ORDER: dict[str, int] = {
+    "user": 0,
+    "project_shared": 1,
+    "project_local": 2,
+}
+
+
+def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
+    """Yield ``StatusRow``s for every valid project_local draft on disk.
+
+    Walks ``<proj>/.memtomem/{agents,commands,skills}.local/`` and emits
+    one row per ``<name>/`` subdirectory whose kind-specific manifest
+    file is present (``agent.md`` / ``command.md`` / ``SKILL.md``). The
+    presence of the manifest is the same validity probe migrate uses
+    to recognise a directory-layout artifact (``migrate._detect_source_scope``).
+
+    Emitted rows carry ``tier="project_local"``, ``state="local-draft"``,
+    and empty ``pin_commit``/``installed_at`` — project_local artifacts
+    are not currently tracked in the lockfile (install path is
+    project_shared-only today; locally-authored drafts never enter
+    ``lock.json``). The CLI render layer appends ``(draft, no fan-out)``
+    to these rows per ADR-0011 §3 / ADR-0016 §7.
+    """
+    for asset_type in ("agents", "commands", "skills"):
+        local_root = canonical_artifact_dir(
+            asset_type,  # type: ignore[arg-type]
+            "project_local",
+            project_root,
+        )
+        if not local_root.is_dir():
+            continue
+        manifest = _LOCAL_DRAFT_MANIFEST[asset_type]
+        for entry in sorted(local_root.iterdir(), key=lambda p: p.name):
+            if not entry.is_dir():
+                continue
+            if not (entry / manifest).is_file():
+                # Skip directories that don't satisfy the kind's
+                # manifest contract — same convention as migrate's
+                # source-scope probe. A future flat-layout sweep would
+                # add a sibling check here.
+                continue
+            yield StatusRow(
+                asset_type=asset_type,  # type: ignore[arg-type]
+                name=entry.name,
+                pin_commit="",
+                installed_at="",
+                state="local-draft",
+                dirty_file_count=0,
+                reason=None,
+                tier="project_local",
+            )
 
 
 def load_with_recovery(project_root: Path | str) -> tuple[dict, str | None]:

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -437,6 +437,74 @@ def test_classify_status_absent_local_dirs_do_not_crash(wiki_root: Path, tmp_pat
     assert rows == []
 
 
+def _seed_local_flat_draft(project: Path, asset_type: str, name: str) -> None:
+    """Create a flat-layout draft ``<proj>/.memtomem/<asset_type>.local/<name>.md``.
+
+    Flat layout is the legacy single-file shape for agents and commands
+    (skills have always been dir-only). Used by tests covering the
+    flat-layout side of the project_local scan.
+    """
+    local_root = project / ".memtomem" / f"{asset_type}.local"
+    local_root.mkdir(parents=True, exist_ok=True)
+    (local_root / f"{name}.md").write_bytes(b"# flat draft\n")
+
+
+def test_classify_status_scans_flat_layout_agents_and_commands(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """Flat-layout drafts at ``.local/<name>.md`` are emitted for agents and commands.
+
+    Mirrors migrate._detect_source_scope's dual-layout recognition. Skills
+    are dir-only and covered by the sibling skip test.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_local_flat_draft(tmp_path, "agents", "flat-agent")
+    _seed_local_flat_draft(tmp_path, "commands", "flat-cmd")
+
+    _, rows = classify_status(tmp_path)
+
+    by_kind = {(r.asset_type, r.name): r for r in rows}
+    assert ("agents", "flat-agent") in by_kind
+    assert ("commands", "flat-cmd") in by_kind
+    for row in (by_kind["agents", "flat-agent"], by_kind["commands", "flat-cmd"]):
+        assert row.tier == "project_local"
+        assert row.state == "local-draft"
+
+
+def test_classify_status_skills_flat_layout_is_not_recognised(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """A ``.md`` at the top of ``skills.local/`` is NOT emitted — skills are dir-only.
+
+    Pins parity with migrate._detect_source_scope's ``if kind == "skills":
+    continue`` after the dir probe (migrate.py:792).
+    """
+    _initialized_wiki(wiki_root)
+    _seed_local_flat_draft(tmp_path, "skills", "bogus-flat-skill")
+
+    _, rows = classify_status(tmp_path)
+
+    assert rows == []
+
+
+def test_classify_status_dir_layout_shadows_flat_sibling(wiki_root: Path, tmp_path: Path) -> None:
+    """When a name has both dir and flat layout in the same .local/, dir wins.
+
+    Mirrors the ``continue`` in migrate._detect_source_scope after a
+    successful dir match — the flat sibling is silently shadowed to
+    avoid a duplicate row.
+    """
+    _initialized_wiki(wiki_root)
+    _seed_local_draft(tmp_path, "agents", "twin", "agent.md")
+    _seed_local_flat_draft(tmp_path, "agents", "twin")
+
+    _, rows = classify_status(tmp_path)
+
+    twin_rows = [r for r in rows if r.asset_type == "agents" and r.name == "twin"]
+    assert len(twin_rows) == 1
+    assert twin_rows[0].tier == "project_local"
+
+
 def test_classify_status_shows_both_rows_on_name_collision(wiki_root: Path, tmp_path: Path) -> None:
     """Same name in lock.json and .local/ → two rows, project_shared before project_local."""
     _initialized_wiki(wiki_root)

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -369,6 +369,125 @@ def test_cli_status_wiki_absent_renders_with_annotation(
     assert "foo" in result.output
 
 
+# ── project_local draft scan tests (#923) ────────────────────────────────
+
+
+def _seed_local_draft(project: Path, asset_type: str, name: str, manifest: str) -> None:
+    """Create ``<proj>/.memtomem/<asset_type>.local/<name>/<manifest>``.
+
+    Matches the canonical-side path scope_resolver.canonical_artifact_dir
+    resolves for ``project_local``. The manifest file is what
+    classify_status's draft scanner uses to confirm the dir is a real
+    artifact (same probe migrate uses).
+    """
+    draft_dir = project / ".memtomem" / f"{asset_type}.local" / name
+    draft_dir.mkdir(parents=True)
+    (draft_dir / manifest).write_bytes(b"# draft\n")
+
+
+def test_classify_status_scans_project_local_drafts(wiki_root: Path, tmp_path: Path) -> None:
+    """All three artifact kinds produce project_local rows from real on-disk dirs."""
+    _initialized_wiki(wiki_root)
+    _seed_local_draft(tmp_path, "agents", "draft-agent", "agent.md")
+    _seed_local_draft(tmp_path, "commands", "draft-cmd", "command.md")
+    _seed_local_draft(tmp_path, "skills", "draft-skill", "SKILL.md")
+
+    _, rows = classify_status(tmp_path)
+
+    by_kind = {(r.asset_type, r.name): r for r in rows}
+    assert ("agents", "draft-agent") in by_kind
+    assert ("commands", "draft-cmd") in by_kind
+    assert ("skills", "draft-skill") in by_kind
+    for row in (
+        by_kind["agents", "draft-agent"],
+        by_kind["commands", "draft-cmd"],
+        by_kind["skills", "draft-skill"],
+    ):
+        assert row.tier == "project_local"
+        assert row.state == "local-draft"
+        assert row.pin_commit == ""
+        assert row.installed_at == ""
+        assert row.reason is None
+
+
+def test_classify_status_skips_directories_missing_kind_manifest(
+    wiki_root: Path, tmp_path: Path
+) -> None:
+    """A directory under ``agents.local/`` without ``agent.md`` is NOT emitted.
+
+    Mirrors migrate._detect_source_scope's contract: a directory only
+    counts as an artifact when its kind-specific manifest is present.
+    """
+    _initialized_wiki(wiki_root)
+    bogus = tmp_path / ".memtomem" / "agents.local" / "no-manifest-here"
+    bogus.mkdir(parents=True)
+    (bogus / "README.md").write_bytes(b"# not the manifest\n")
+
+    _, rows = classify_status(tmp_path)
+
+    assert rows == []
+
+
+def test_classify_status_absent_local_dirs_do_not_crash(wiki_root: Path, tmp_path: Path) -> None:
+    """No ``.local/`` directories on disk → scanner yields nothing, no error."""
+    _initialized_wiki(wiki_root)
+
+    _, rows = classify_status(tmp_path)
+
+    assert rows == []
+
+
+def test_classify_status_shows_both_rows_on_name_collision(wiki_root: Path, tmp_path: Path) -> None:
+    """Same name in lock.json and .local/ → two rows, project_shared before project_local."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"v1\n"}, pin)
+    _seed_local_draft(tmp_path, "skills", "foo", "SKILL.md")
+
+    _, rows = classify_status(tmp_path)
+
+    foo_rows = [r for r in rows if r.asset_type == "skills" and r.name == "foo"]
+    assert len(foo_rows) == 2
+    assert foo_rows[0].tier == "project_shared"
+    assert foo_rows[0].state == "ok"
+    assert foo_rows[1].tier == "project_local"
+    assert foo_rows[1].state == "local-draft"
+
+
+def test_cli_status_renders_draft_no_fanout_annotation(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """CLI output for a project_local row carries the exact ``(draft, no fan-out)`` string."""
+    _initialized_wiki(wiki_root)
+    _seed_local_draft(tmp_path, "agents", "draft-only", "agent.md")
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["status"])
+
+    assert result.exit_code == 0
+    assert "draft-only" in result.output
+    assert "(draft, no fan-out)" in result.output
+    assert "1 local-draft" in result.output
+
+
+def test_cli_status_no_annotation_on_project_shared_rows(
+    wiki_root: Path, tmp_path: Path, monkeypatch
+) -> None:
+    """The annotation is absent for lockfile-tracked (project_shared) rows."""
+    _initialized_wiki(wiki_root)
+    pin = _seed_wiki_skill(wiki_root, "shared-skill", {"SKILL.md": b"v1\n"})
+    _setup_installed_at_pin(tmp_path, "skills", "shared-skill", {"SKILL.md": b"v1\n"}, pin)
+
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["status"])
+
+    assert result.exit_code == 0
+    assert "shared-skill" in result.output
+    assert "(draft, no fan-out)" not in result.output
+
+
 # ── unused-fixture helpers (silence ruff F401) ───────────────────────────
 
 _ = pytest  # keep pytest import alive if no test uses it directly
@@ -387,3 +506,7 @@ def test_status_row_dataclass_shape() -> None:
     )
     assert row.asset_type == "skills"
     assert row.dirty_file_count == 0
+    # New tier field defaults to project_shared so existing call sites
+    # (and the lockfile-walk branch in classify_status) remain valid
+    # without explicit tier= updates.
+    assert row.tier == "project_shared"


### PR DESCRIPTION
## Summary

- Implements ADR-0011 §3 / ADR-0016 §7 inline `(draft, no fan-out)` annotation for project_local agent / command / skill rows in `mm context status`.
- Adds a `tier: TargetScope` field to `StatusRow` and a new `local-draft` state; `classify_status` scans `<proj>/.memtomem/{agents,commands,skills}.local/` for valid manifest directories alongside the lockfile walk.

## Stale-verb note about #923's body

The issue body says `mm context list`. The actual extant verb is `mm context status` — `list` is a pre-consolidation name and there is no such subcommand today (`mm context --help`). The "Out of scope: `--scope <tier>` already exists on `mm context list`" bullet in the issue is also inaccurate: `mm context install` is project_shared-only and accepts no `--scope` flag.

I treated the issue's user-visible intent as authoritative (annotate project_local rows in the row-per-asset listing surface) and mapped it onto `mm context status`, which is structurally the listing command (row-per-asset, sectioned by kind, walks lock.json today). No rename of the verb is in scope here.

## Why a tier-aware scan, not an annotation-only patch

`mm context install` currently writes only to `<proj>/.memtomem/<asset_type>/<name>` (the project_shared canonical) and `lock.json` carries no tier field. A pure annotation patch would emit zero `(draft, no fan-out)` rows from real installs because lockfile-tracked entries are always project_shared today.

To make the annotation actually visible end-to-end, this PR scans `<proj>/.memtomem/{agents,commands,skills}.local/` directly and emits un-pinned rows tagged `tier="project_local"` / `state="local-draft"`. The validity probe (kind-specific manifest file present) matches `migrate._detect_source_scope`'s contract.

**This intentionally does not extend the lockfile schema; project_local status rows are discovered from canonical draft directories because install is project_shared-only today.** A future PR that teaches install to write project_local can write a `tier` field into lock.json and layer onto the same `StatusRow.tier` shape without schema churn.

## What changed

- `packages/memtomem/src/memtomem/context/status.py`
  - `StatusRow` gains `tier: TargetScope` (default `project_shared`).
  - `StatusState` gains `"local-draft"`.
  - New `_scan_project_local_drafts` walks `.local/` dirs and yields project_local rows.
  - `classify_status` merges lockfile + draft rows; final sort by `(asset_type, name, tier_order)` so name collisions render shared → local.
- `packages/memtomem/src/memtomem/cli/context_cmd.py`
  - `_STATUS_GLYPH["local-draft"] = ("·", "magenta")`.
  - Render branch for `tier == "project_local"`: dashes in pin / installed-at columns + `(draft, no fan-out)` appended inline.
  - Header count splits installed (lockfile) and local-draft so "N asset(s) installed" stays accurate; drafts surface as "(+ M local draft(s))".
- `packages/memtomem/tests/test_context_status.py`
  - 6 new tests: real-filesystem scan (all 3 kinds), missing-manifest skip, absent `.local` no-crash, name-collision two-row order, CLI annotation present for project_local, CLI annotation absent for project_shared.

## Acceptance per #923

- [x] `mm context status` annotates every `project_local` agent / skill / command row with `(draft, no fan-out)` inline.
- [x] `user` and `project_shared` rows are unchanged (existing 15 tests + 5 CLI tests still pass; new test pins absence).
- [x] Test pins the exact annotation format (string-match assertion on `"(draft, no fan-out)"`).
- [x] Memory `mm mem list` is untouched — out of scope per issue.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_context_status.py packages/memtomem/tests/test_cli_status.py` — 26 passed
- [x] `uv run pytest packages/memtomem/tests/ -k "context or status"` — 1058 passed
- [x] `uv run ruff check packages/memtomem/src` — clean
- [x] `uv run ruff format --check packages/memtomem/src` — clean
- [x] Smoke: created `.memtomem/agents.local/my-draft-agent/agent.md` in a temp project, ran `mm context status`, confirmed annotation + glyph + summary.

## References

- ADR-0011 §3 — project_local for agents/skills/commands is a draft tier with no fan-out.
- ADR-0011 §"Consequences" — `(draft, no fan-out)` CLI annotation called out explicitly.
- ADR-0016 §7 — CLI user-facing names + `project_local` annotation requirement.
- Issue #923 — sub-issue B of #868 epic (Tiered Context Gateway v2).

Closes #923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)