### PR TITLE
docs(guides): fix migrate flag shape in getting-started 3-tier note

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -445,9 +445,13 @@ Run `mm context --help` for the full fan-out matrix across editors (Claude Code,
 > git-tracked, the default for these artifacts), or `project_local`
 > (`<proj>/.memtomem/<artifact>.local/`, gitignored, draft tier — no runtime
 > fan-out). Pick the tier per write with `--scope=<tier>` on `mm context
-> init` / `sync` / `migrate`. Tier (canonical residency) is distinct from
-> the runtime **scope** the canonical fans out to under `.claude/` —
-> ADR-0016 documents the split; ADR-0011 §1 has the per-artifact table.
+> init` / `sync` / `generate`. To move an existing canonical between tiers,
+> `mm context migrate <kind> <name> --from <tier> --to <tier> --apply`
+> uses the explicit `--from` / `--to` pair instead of `--scope` (the verb
+> has two endpoints, not one). Tier (canonical residency) is distinct
+> from the runtime **scope** the canonical fans out to under `.claude/`
+> — ADR-0016 documents the split; ADR-0011 §1 has the per-artifact
+> table.
 
 ---
 


### PR DESCRIPTION
## Summary

Review-pass on commit 4de9fa7 (\"docs(3-tier): align 4 guides + ADR-0011 §1 settings row with ADR-0016 vocabulary (#868-C)\"). The new 3-tier callout at `docs/guides/getting-started.md:447-448` told users to pick the tier with \`--scope=<tier>\` on \`mm context init / sync / migrate\`. Two problems with that line:

1. **\`mm context migrate\` does NOT accept \`--scope\`** — its tier-move mode (PR-E4) uses \`--from\` / \`--to\` because the verb has two endpoints, not one (\`mm context migrate skills foo --to project_local --apply\` per ADR-0011 §PR-E shipping notes). A user following the guide hits \"no such option: --scope\".
2. **\`mm context generate\` also takes \`--scope\` but was omitted** — \`init\` / \`sync\` / \`generate\` are the three scope-aware write verbs (verified via \`--help\` on each).

## Fix

- List the correct trio (\`init\` / \`sync\` / \`generate\`) for \`--scope\`.
- Call out migrate's \`--from\` / \`--to\` shape explicitly with a concrete command so users don't have to guess.
- ADR-0011 §1 and ADR-0016 vocabulary unchanged.

## Scope check

- Grep'd the other 3 guides touched by 4de9fa7 (configuration.md, integrations/claude-code.md, mcp-clients.md) for the same conflation — none repeat it.
- ADR text (\`docs/adr/0011-canonical-artifact-scope-hierarchy.md:367\`) already documents migrate's correct \`--to <scope>\` shape, so no ADR change needed.

## Test plan

- [x] Verified \`mm context init / sync / generate --help\` all list \`--scope\`
- [x] Verified \`mm context migrate --help\` lists \`--from\` / \`--to\` only (no \`--scope\`)
- [x] Verified \`mm context memory-migrate --help\` same shape (\`--from\` / \`--to\`)
- [x] Rendered the diff and confirmed the markdown reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)