### PR TITLE
feat(web): tier badges + /api/add project-tier rejection hint (#924)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from memtomem.config import TargetScope
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.agents import (
@@ -85,10 +86,17 @@ def _agent_to_dict(agent: SubAgent) -> dict:
 @router.get("/context/agents")
 async def list_agents(
     project_root: Path = Depends(resolve_scope_root),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to list. project_local is shown only "
+            "when explicitly requested."
+        ),
+    ),
 ) -> dict:
     """List canonical agents. Accepts ``?scope_id=`` like list_skills."""
-    canonicals = list_canonical_agents(project_root)
-    diffs = diff_agents(project_root)
+    canonicals = list_canonical_agents(project_root, scope=target_scope)
+    diffs = diff_agents(project_root, scope=target_scope)
 
     by_name: dict[str, list[dict]] = {}
     for runtime, agent_name, status in diffs:
@@ -102,14 +110,22 @@ async def list_agents(
         agents.append(
             {
                 "name": name,
-                "canonical_path": str(agent_path.relative_to(project_root)),
+                "canonical_path": _safe_rel(agent_path, project_root),
+                "target_scope": target_scope,
                 "runtimes": by_name.get(name, []),
             }
         )
 
     for agent_name, runtimes in by_name.items():
         if agent_name not in canonical_names:
-            agents.append({"name": agent_name, "canonical_path": None, "runtimes": runtimes})
+            agents.append(
+                {
+                    "name": agent_name,
+                    "canonical_path": None,
+                    "target_scope": target_scope,
+                    "runtimes": runtimes,
+                }
+            )
 
     return {
         "agents": agents,

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from memtomem.config import TargetScope
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.commands import (
@@ -71,10 +72,17 @@ def _safe_rel(p: Path, project_root: Path) -> str:
 @router.get("/context/commands")
 async def list_commands(
     project_root: Path = Depends(resolve_scope_root),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to list. project_local is shown only "
+            "when explicitly requested."
+        ),
+    ),
 ) -> dict:
     """List canonical commands. Accepts ``?scope_id=`` like list_skills."""
-    canonicals = list_canonical_commands(project_root)
-    diffs = diff_commands(project_root)
+    canonicals = list_canonical_commands(project_root, scope=target_scope)
+    diffs = diff_commands(project_root, scope=target_scope)
 
     by_name: dict[str, list[dict]] = {}
     for runtime, cmd_name, status in diffs:
@@ -88,14 +96,22 @@ async def list_commands(
         commands.append(
             {
                 "name": name,
-                "canonical_path": str(cmd_path.relative_to(project_root)),
+                "canonical_path": _safe_rel(cmd_path, project_root),
+                "target_scope": target_scope,
                 "runtimes": by_name.get(name, []),
             }
         )
 
     for cmd_name, runtimes in by_name.items():
         if cmd_name not in canonical_names:
-            commands.append({"name": cmd_name, "canonical_path": None, "runtimes": runtimes})
+            commands.append(
+                {
+                    "name": cmd_name,
+                    "canonical_path": None,
+                    "target_scope": target_scope,
+                    "runtimes": runtimes,
+                }
+            )
 
     return {
         "commands": commands,

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -25,6 +25,7 @@ from memtomem.context.skills import (
     generate_all_skills,
     list_canonical_skills,
 )
+from memtomem.config import TargetScope
 from memtomem.web.deps import get_project_root
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes.context_projects import resolve_scope_root
@@ -61,6 +62,13 @@ def _safe_rel(p: Path, project_root: Path) -> str:
 @router.get("/context/skills")
 async def list_skills(
     project_root: Path = Depends(resolve_scope_root),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description=(
+            "Canonical-residency tier to list. project_local is shown only "
+            "when explicitly requested."
+        ),
+    ),
 ) -> dict:
     """List canonical skills with per-runtime sync status.
 
@@ -69,8 +77,8 @@ async def list_skills(
     for that scope's root. PR2 keeps mutating endpoints (POST/PUT/DELETE/
     sync/import) on cwd only — multi-scope writes ship in PR3.
     """
-    canonicals = list_canonical_skills(project_root)
-    diffs = diff_skills(project_root)
+    canonicals = list_canonical_skills(project_root, scope=target_scope)
+    diffs = diff_skills(project_root, scope=target_scope)
 
     # Group diff tuples by skill name
     by_name: dict[str, list[dict]] = {}
@@ -82,7 +90,8 @@ async def list_skills(
         skills.append(
             {
                 "name": skill_dir.name,
-                "canonical_path": str(skill_dir.relative_to(project_root)),
+                "canonical_path": _safe_rel(skill_dir, project_root),
+                "target_scope": target_scope,
                 "runtimes": by_name.get(skill_dir.name, []),
             }
         )
@@ -95,6 +104,7 @@ async def list_skills(
                 {
                     "name": skill_name,
                     "canonical_path": None,
+                    "target_scope": target_scope,
                     "runtimes": runtimes,
                 }
             )

--- a/packages/memtomem/src/memtomem/web/routes/sources.py
+++ b/packages/memtomem/src/memtomem/web/routes/sources.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-from memtomem.config import MemoryDirKind, memory_dir_kind
+from memtomem.config import MemoryDirKind, TargetScope, classify_scope, memory_dir_kind
 from memtomem.indexing.engine import norm_dir_prefix
 from memtomem.indexing.summarizer import regenerate_for_paths
 from memtomem.storage.sqlite_helpers import norm_path
@@ -76,6 +76,18 @@ async def list_sources(
             "registered (so they don't disappear from the UI)."
         ),
     ),
+    target_scope: TargetScope | None = Query(
+        None,
+        description=(
+            "ADR-0016 §7 canonical-residency tier filter. Default (omit) "
+            "shows ``user`` + ``project_shared`` only; ``project_local`` "
+            "is hidden until explicitly requested (ADR-0015 §4a — keeps "
+            "the draft tier out of overview unless the operator opts in). "
+            "Passing one of the three literal tokens narrows the list "
+            "to that tier; passing ``project_local`` is the only way to "
+            "surface those sources."
+        ),
+    ),
     storage=Depends(get_storage),
     config=Depends(get_config),
 ) -> SourcesResponse:
@@ -111,6 +123,14 @@ async def list_sources(
         ),
         key=lambda t: -len(t[0]),
     )
+
+    # ADR-0011 / ADR-0016: pre-resolve project_memory_dirs so the
+    # per-source ``classify_scope`` lookup can refuse unregistered
+    # project-tier paths (the public API of ``classify_scope`` falls
+    # back to ``"user"`` for any path under ``.memtomem/...`` whose
+    # owning project_memory_dir was not registered, mirroring the
+    # indexer's safety net at config.py:1495-1507).
+    pmdirs = config.indexing.project_memory_dirs
 
     all_sources: list[SourceOut] = []
     for p, cnt, last_indexed_iso, ns_csv, avg_tok, min_tok, max_tok in sorted(rows):
@@ -165,6 +185,26 @@ async def list_sources(
             if kind == "general" and source_kind == "memory":
                 continue
 
+        # ADR-0016 §7: path-classify the source's canonical-residency
+        # tier. ``classify_scope`` returns ``"user"`` for any path that
+        # is not under a registered project_memory_dir (including
+        # otherwise project-shaped paths whose owning dir was not
+        # registered) — matches the indexer's persisted scope so the
+        # badge agrees with the chunk's stored ``meta.scope``.
+        source_scope, _src_project_root = classify_scope(p, pmdirs)
+
+        # ADR-0015 §4a project_local default-hidden rule. When the
+        # caller passes ``?target_scope=`` we narrow to exactly that
+        # tier (the only way to surface ``project_local`` sources).
+        # When omitted, ``project_local`` rows fall out — keeps the
+        # draft tier out of overview / list views unless the operator
+        # explicitly asks for it.
+        if target_scope is None:
+            if source_scope == "project_local":
+                continue
+        elif source_scope != target_scope:
+            continue
+
         path_str = str(p)
         hh, first_content = summaries.get(path_str, ([], ""))
         title, excerpt = _derive_summary(hh, first_content)
@@ -185,6 +225,7 @@ async def list_sources(
                 max_tokens=max_tok,
                 memory_dir=memory_dir_str,
                 kind=source_kind,
+                target_scope=source_scope,
                 title=title,
                 excerpt=excerpt,
                 ai_summary=ai_summary_text,

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1232,6 +1232,7 @@ async def uploads_usage() -> UploadUsageResponse:
 @router.post("/add", response_model=AddMemoryResponse, dependencies=[Depends(require_configured)])
 async def add_memory(
     req: AddMemoryRequest,
+    request: Request,
     index_engine=Depends(get_index_engine),
     storage=Depends(get_storage),
     config=Depends(get_config),
@@ -1240,15 +1241,57 @@ async def add_memory(
 
     from memtomem import privacy
 
+    # ADR-0011 §5 Gate B (PR-F slice 4): project_shared writes go to git;
+    # require an explicit ``confirm_project_shared=true`` so the SPA
+    # cannot silently commit PII to a tracked tier through a default-bool
+    # oversight. Mirrors the MCP ``mem_add`` gate at
+    # ``memory_crud.py:204`` and the Web parallel on the chunks DELETE
+    # path at ``chunks.py:157``. project_local is NOT Gate B-gated —
+    # only the canonical-residency tier choice + ADR-0011 §3's
+    # zero-fan-out rule applies. The 4xx body carries the CLI hint /
+    # docs link so the SPA renders "rejected, here's the equivalent
+    # invocation" without rewriting the prose client-side.
+    if req.scope == "project_shared" and not req.confirm_project_shared:
+        logger.info(
+            "web add_memory rejected project_shared write without confirmation",
+            extra={"file": req.file, "namespace": req.namespace},
+        )
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "detail": "blocked_project_shared",
+                "surface": "web_api_add",
+                "scope": req.scope,
+                "message": (
+                    "scope='project_shared' writes to a git-tracked directory. "
+                    "Re-submit with confirm_project_shared=true to proceed."
+                ),
+                "cli_hint": "mm mem add --scope project_shared",
+                "docs_url": (
+                    "https://github.com/memtomem/memtomem/blob/main/docs/adr/"
+                    "0011-canonical-artifact-scope-hierarchy.md"
+                ),
+            },
+        )
+
     # Trust-boundary redaction guard. Mirrors MCP ``mem_add`` so the
     # same secret patterns block writes regardless of which surface
     # the agent or user came in through. ``force_unsafe`` is opt-in
-    # via the SPA's confirm-and-retry UX after the first 403.
+    # via the SPA's confirm-and-retry UX after the first 403. Threading
+    # ``scope`` here makes Gate A's hard-refusal of ``force_unsafe=True``
+    # on project_shared writes fire on the Web path too (ADR-0011 PR-D
+    # round 7 parity — same fix as the chunks PATCH path at
+    # ``chunks.py:73-86``).
     guard = privacy.enforce_write_guard(
         req.content,
         surface="web_api_add",
         force_unsafe=req.force_unsafe,
-        audit_context={"namespace": req.namespace, "file": req.file},
+        scope=req.scope,
+        audit_context={
+            "namespace": req.namespace,
+            "file": req.file,
+            "scope": req.scope,
+        },
     )
     if guard.decision == "blocked":
         raise HTTPException(
@@ -1257,6 +1300,21 @@ async def add_memory(
                 "detail": "redaction_blocked",
                 "hits": len(guard.hits),
                 "surface": "web_api_add",
+            },
+        )
+    if guard.decision == "blocked_project_shared":
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "detail": "blocked_project_shared",
+                "hits": len(guard.hits),
+                "surface": "web_api_add",
+                "message": (
+                    "force_unsafe is not permitted on scope='project_shared' "
+                    "writes (git history is forever). Re-submit with "
+                    "scope='project_local' or scope='user' to bypass, or "
+                    "hand-edit the canonical file."
+                ),
             },
         )
 
@@ -1268,7 +1326,52 @@ async def add_memory(
     # remains as a last-resort fallback when no dirs are configured at
     # all (``require_configured`` already guards the common case).
     mdirs = config.indexing.memory_dirs
-    base = Path(mdirs[0] if mdirs else "~/.memtomem/memories").expanduser().resolve()
+    user_base = Path(mdirs[0] if mdirs else "~/.memtomem/memories").expanduser().resolve()
+
+    # ADR-0011 §4 PR-F slice 4: resolve the canonical-residency base
+    # directory per tier. User tier stays on ``memory_dirs[0]`` for
+    # back-compat. Project tiers route through ``resolve_memory_scope_dir``
+    # against the server's project root so writes land in
+    # ``<proj>/.memtomem/memories[/.local]/`` — the same path the MCP
+    # ``mem_add(scope=...)`` flow uses. Refuses unregistered project-tier
+    # dirs upfront so the row's persisted scope cannot diverge from what
+    # the read surface / watcher can actually see.
+    if req.scope == "user":
+        base = user_base
+    else:
+        from memtomem.memory_scope import (
+            MemoryScopeError,
+            is_project_tier_registered,
+            project_tier_registration_error,
+            resolve_memory_scope_dir,
+        )
+        from memtomem.server.tools.search import _resolve_project_context_from_dirs
+
+        # ADR-0011 PR-F parity with MCP ``mem_add`` (memory_crud.py:285
+        # via search.py:73-96): resolve the *registered* project root
+        # containing the server's cwd rather than using ``cwd`` itself.
+        # ``app.state.project_root`` was set to ``Path.cwd()`` in the
+        # lifespan; if the server is launched from a subdirectory of a
+        # registered project, the raw cwd has no ``.memtomem/memories``
+        # tree, so ``resolve_memory_scope_dir`` would land on the wrong
+        # directory and ``is_project_tier_registered`` would 422 — while
+        # MCP correctly writes under the project root. Falls back to
+        # the lifespan cwd only if no registered tier covers the cwd
+        # (the 422 below then surfaces the operator-actionable
+        # "register your project_memory_dirs first" error).
+        pmdirs = config.indexing.project_memory_dirs
+        project_root = _resolve_project_context_from_dirs(pmdirs)
+        if project_root is None:
+            project_root = Path(request.app.state.project_root)
+        try:
+            base = resolve_memory_scope_dir(req.scope, project_root, user_base=user_base)
+        except MemoryScopeError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        if not is_project_tier_registered(base, pmdirs):
+            raise HTTPException(
+                status_code=422,
+                detail=project_tier_registration_error(base, req.scope),
+            )
 
     if req.file:
         raw = req.file

--- a/packages/memtomem/src/memtomem/web/schemas/core.py
+++ b/packages/memtomem/src/memtomem/web/schemas/core.py
@@ -24,6 +24,13 @@ class ChunkOut(BaseModel):
     # surfaces a badge with ∞ sentinel for the unbounded side.
     valid_from_unix: int | None = None
     valid_to_unix: int | None = None
+    # ADR-0016 §7 canonical-residency tier. Always one of the three
+    # literal tokens ``user`` / ``project_shared`` / ``project_local``
+    # — no display aliases (the SPA renders the token verbatim per the
+    # PR-F badge contract). Mirrors ``ChunkMetadata.scope`` in
+    # ``memtomem/models.py``; missing on legacy chunks defaults to
+    # ``user`` via ``chunk_to_out``.
+    target_scope: str = "user"
 
 
 class ContextInfoOut(BaseModel):
@@ -72,6 +79,7 @@ def chunk_to_out(chunk) -> ChunkOut:
         updated_at=chunk.updated_at,
         valid_from_unix=meta.valid_from_unix,
         valid_to_unix=meta.valid_to_unix,
+        target_scope=meta.scope or "user",
     )
 
 

--- a/packages/memtomem/src/memtomem/web/schemas/memory.py
+++ b/packages/memtomem/src/memtomem/web/schemas/memory.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
+
+from memtomem.config import TargetScope
 
 
 class AddMemoryRequest(BaseModel):
@@ -16,6 +20,15 @@ class AddMemoryRequest(BaseModel):
     # surfaces the matched-pattern count and asks the user to confirm
     # before retrying with this flag set.
     force_unsafe: bool = False
+    # ADR-0011 Gate B / ADR-0016 §7: explicit tier selection for the
+    # canonical residency of this write. Defaults to ``user`` so the
+    # existing SPA flow (which does not yet send the field) keeps writing
+    # to the user-tier ``memory_dirs[0]``. Project tiers require explicit
+    # opt-in from the caller; ``project_shared`` additionally requires
+    # ``confirm_project_shared=True`` (Gate B confirm — mirrors the MCP
+    # ``mem_add`` kwarg and the chunks.py PATCH/DELETE confirm pattern).
+    scope: TargetScope = "user"
+    confirm_project_shared: bool = False
 
 
 class RedactionBlockedResponse(BaseModel):
@@ -27,6 +40,27 @@ class RedactionBlockedResponse(BaseModel):
     detail: str = "redaction_blocked"
     hits: int
     surface: str
+
+
+class ProjectTierBlockedResponse(BaseModel):
+    """Body shape returned with HTTP 403 when ``/api/add`` is rejected
+    for a ``scope='project_shared'`` write without an explicit
+    ``confirm_project_shared=true`` (ADR-0011 §5 Gate B — Web-side
+    parallel of the MCP ``confirm_project_shared`` kwarg).
+
+    ``cli_hint`` names the equivalent CLI invocation so the SPA can
+    surface "rejected — to proceed, either retry with confirm or run
+    this command" without rewriting the message client-side. ``docs_url``
+    points at the canonical-residency ADR; ADR-0011 §1's settings-row
+    cleanup landed in PR #925 so the link target is stable.
+    """
+
+    detail: Literal["blocked_project_shared"] = "blocked_project_shared"
+    surface: str
+    scope: TargetScope
+    message: str
+    cli_hint: str
+    docs_url: str
 
 
 class AddMemoryResponse(BaseModel):

--- a/packages/memtomem/src/memtomem/web/schemas/sources.py
+++ b/packages/memtomem/src/memtomem/web/schemas/sources.py
@@ -29,6 +29,13 @@ class SourceOut(BaseModel):
     # for orphans (no owning dir to classify). Drives the Sources page's
     # Memory / General sub-toggle.
     kind: MemoryDirKind | None = None
+    # ADR-0016 §7 canonical-residency tier of the source itself,
+    # path-classified via :func:`memtomem.config.classify_scope`. Always
+    # one of ``user`` / ``project_shared`` / ``project_local``. The
+    # SPA renders this verbatim as a per-row tier badge; the route also
+    # supports ``?target_scope=`` filtering (project_local hidden by
+    # default per ADR-0015 §4a).
+    target_scope: str = "user"
     # Heuristic preview derived at read-time from the first indexed chunk:
     # ``title`` is the file's first heading (``#`` markers stripped) and
     # ``excerpt`` is up to ~200 chars of the first section's body. Both

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -248,6 +248,40 @@ class RedactionBlockedError extends Error {
   }
 }
 
+// ADR-0011 §5 Gate B — project_shared writes without an explicit
+// ``confirm_project_shared=true`` return HTTP 403 with the structured
+// payload defined by ``ProjectTierBlockedResponse``. The SPA preserves
+// ``cli_hint`` + ``docs_url`` on the error object so the caller can
+// surface "rejected, here's the equivalent CLI invocation" without
+// rewriting the prose client-side (the localized title + body live in
+// the locale files; the hint / link come from the server so they stay
+// in lockstep with the back-end vocabulary).
+class ProjectTierBlockedError extends Error {
+  constructor({ surface, scope, message, cli_hint, docs_url }) {
+    super(message || 'blocked_project_shared');
+    this.name = 'ProjectTierBlockedError';
+    this.surface = surface;
+    this.scope = scope;
+    this.cliHint = cli_hint;
+    this.docsUrl = docs_url;
+  }
+}
+
+// Shared formatter for the project-tier rejection toast. Returns the
+// multi-line string both ``addMemoryFromCompose``'s catch-arm and the
+// Playwright spec build off the same code path — without this helper
+// the test would silently pass even if the production catch-arm
+// stopped showing one of the actionable fields (Codex review #924).
+// Both ``cliHint`` and ``docsUrl`` are optional because the Gate A
+// hard-refusal for ``force_unsafe=true`` on project_shared reuses
+// the ``blocked_project_shared`` discriminant without those fields.
+function formatProjectTierBlockedToast(err) {
+  const lines = [err.message];
+  if (err.cliHint) lines.push(`$ ${err.cliHint}`);
+  if (err.docsUrl) lines.push(err.docsUrl);
+  return lines.join('\n');
+}
+
 async function api(method, path, body, opts = {}) {
   if (typeof opts !== 'object' || Array.isArray(opts)) opts = {};
   const fetchOpts = { method, headers: { 'Content-Type': 'application/json' } };
@@ -269,6 +303,19 @@ async function api(method, path, body, opts = {}) {
       throw new RedactionBlockedError({
         hits: err.detail.hits,
         surface: err.detail.surface,
+      });
+    }
+    if (
+      res.status === 403 &&
+      err && typeof err.detail === 'object' && err.detail !== null &&
+      err.detail.detail === 'blocked_project_shared'
+    ) {
+      throw new ProjectTierBlockedError({
+        surface: err.detail.surface,
+        scope: err.detail.scope,
+        message: err.detail.message,
+        cli_hint: err.detail.cli_hint,
+        docs_url: err.detail.docs_url,
       });
     }
     // Harden against ``[object Object]`` when ``detail`` is itself a dict
@@ -573,6 +620,26 @@ function _formatValidityDate(unix) {
 // without a window so the caller can ${validityBadge} unconditionally.
 // Uses _formatValidityDate which produces strict ISO date strings —
 // no XSS surface in the interpolated content.
+// ADR-0016 §7 canonical-residency tier badge for memory rows. Returns
+// "" for the user tier (the default — keeps the common case visually
+// quiet) and a token-literal span for ``project_shared`` /
+// ``project_local``. The three tokens are rendered verbatim (no
+// display aliases — pinned by the Tiered Context Gateway v2 contract).
+// ``isContextRow`` adds the ``(no runtime fan-out)`` annotation for
+// project_local context artifacts (agents / skills / commands) per
+// ADR-0011 §3 — memory rows skip the annotation because project_local
+// memory still fans out via memory's own contract.
+function _tierBadgeHtml(targetScope, { isContextRow = false } = {}) {
+  if (!targetScope || targetScope === 'user') return '';
+  if (targetScope !== 'project_shared' && targetScope !== 'project_local') return '';
+  const cls = `badge badge-tier badge-tier--${targetScope}`;
+  const badge = ` <span class="${cls}" data-tier="${targetScope}">${targetScope}</span>`;
+  if (isContextRow && targetScope === 'project_local') {
+    return `${badge}<span class="tier-fanout-annotation">(no runtime fan-out)</span>`;
+  }
+  return badge;
+}
+
 function _validityBadgeHtml(validFromUnix, validToUnix) {
   const hasWindow = validFromUnix !== null && validFromUnix !== undefined
     || validToUnix !== null && validToUnix !== undefined;
@@ -2044,6 +2111,12 @@ function _buildResultItem(r) {
   item.setAttribute('aria-label', ariaParts.join(', '));
   const nsBadge = r.chunk.namespace && r.chunk.namespace !== 'default'
     ? ` <span class="badge badge-ns">${escapeHtml(r.chunk.namespace)}</span>` : '';
+  // ADR-0016 §7 canonical-residency tier badge. Default-omit for the
+  // user tier so the common case stays visually quiet — only the
+  // non-default tiers (project_shared / project_local) earn pixels.
+  // The token is rendered verbatim per the PR-F display-alias-free
+  // contract pinned in the Tiered Context Gateway v2 memory.
+  const tierBadge = _tierBadgeHtml(r.chunk.target_scope);
   const validityBadge = _validityBadgeHtml(r.chunk.valid_from_unix, r.chunk.valid_to_unix);
   const scorePct = STATE.maxResultScore > 0 ? Math.round((r.score / STATE.maxResultScore) * 100) : 0;
   const barColor = scorePct > 70 ? 'var(--green)' : scorePct > 40 ? 'var(--accent)' : 'var(--muted)';
@@ -2056,7 +2129,7 @@ function _buildResultItem(r) {
       <span class="result-filename">${escapeHtml(fname)}</span>
       <span class="score-badge">${r.score.toFixed(3)}</span>
       <span class="badge badge-retrieval badge-retrieval--${escapeAttr(r.source)}">${escapeHtml(r.source)}</span>
-      ${nsBadge}${validityBadge}
+      ${nsBadge}${tierBadge}${validityBadge}
     </div>
     <div class="result-item-meta">${escapeHtml(dir)} \u00b7 #${r.rank} \u00b7 ${escapeHtml(age)}</div>
     <div class="result-score-bar"><div class="result-score-fill" style="width:${scorePct}%;background:${barColor}"></div></div>
@@ -3840,6 +3913,7 @@ async function browseSource(path, limit = 100) {
           <div class="chunk-card-meta">
             <span class="badge badge-gray">${c.chunk_type.replace('_',' ')}</span>
             <span class="chunk-card-lines">lines ${c.start_line}–${c.end_line}</span>
+            ${_tierBadgeHtml(c.target_scope)}
             ${c.heading_hierarchy.length ? `<span class="hierarchy-trail">${escapeHtml(c.heading_hierarchy.join(' › '))}</span>` : ''}
             <div class="chunk-card-actions">
               <button class="btn-ghost btn-xs card-copy-btn" title="Copy content">Copy</button>
@@ -4261,7 +4335,15 @@ qs('add-btn').addEventListener('click', async () => {
     _markDataStale();
     loadStats();
   } catch (err) {
-    showToast(t('toast.save_failed', { error: err.message }), 'error');
+    if (err && err.name === 'ProjectTierBlockedError') {
+      // Render the rejection message + literal CLI hint via the shared
+      // formatter so the Playwright spec exercises the same code path
+      // (today's compose form doesn't expose a tier picker so this
+      // catch-arm is dev-tools / API-only — see #924 PR description).
+      showToast(formatProjectTierBlockedToast(err), 'error');
+    } else {
+      showToast(t('toast.save_failed', { error: err.message }), 'error');
+    }
   } finally {
     btnLoading(btn, false);
   }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -672,10 +672,11 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
     // because the list response carries the per-runtime statuses;
     // ``loadCtxDetail`` would otherwise need a second fetch.
     const outOfSync = (item.runtimes || []).some(r => r.status === 'out of sync');
+    const tierBadge = _tierBadgeHtml(item.target_scope, { isContextRow: true });
     html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}">
       <div class="ctx-card-header">
         <div>
-          <div class="ctx-card-name">${escapeHtml(item.name)}</div>
+          <div class="ctx-card-name">${escapeHtml(item.name)}${tierBadge}</div>
           ${item.canonical_path ? `<div class="ctx-card-path">${escapeHtml(item.canonical_path)}</div>` : '<div class="ctx-card-path text-muted">(runtime only)</div>'}
         </div>
         ${renderRuntimeBadges(item.runtimes)}

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2603,6 +2603,18 @@ select:focus-visible {
 .badge-retrieval--dense   { background: rgba(116, 185, 255, 0.15); color: #5ba4f5; }
 .badge-retrieval--reranked{ background: rgba(232, 67, 147, 0.15); color: #e84393; }
 
+/* ── Canonical-residency tier badges (ADR-0016 §7) ──
+ * Three literal tokens rendered as-is — no display aliases
+ * (project memory "Tiered Context Gateway v2" pins this contract).
+ * Colors track the trust axis: user (cool, low risk),
+ * project_shared (warm, git-tracked), project_local (neutral, draft).
+ */
+.badge-tier { font-family: var(--mono); font-size: 0.65rem; letter-spacing: 0.02em; }
+.badge-tier--user           { background: rgba(116, 185, 255, 0.15); color: #5ba4f5; }
+.badge-tier--project_shared { background: rgba(253, 203, 110, 0.18); color: #e0a800; }
+.badge-tier--project_local  { background: rgba(123, 127, 150, 0.18); color: var(--muted); }
+.tier-fanout-annotation { font-size: 0.65rem; color: var(--muted); margin-left: 4px; font-style: italic; }
+
 /* ── Namespaces Tab ── */
 .ns-layout { display: flex; flex-direction: column; gap: 16px; padding: 20px; overflow-y: auto; }
 .ns-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -908,6 +908,134 @@ class TestSources:
         data = resp.json()
         assert data["language_drift"] is None
 
+    # ---- canonical-residency tier (ADR-0016 §7 — #924) ----------------------
+    #
+    # Sources surface a per-row ``target_scope`` so the SPA can render a
+    # tier badge without rebuilding the classification client-side. The
+    # route also honors ``?target_scope=`` — omitting it hides
+    # ``project_local`` rows per ADR-0015 §4a.
+
+    async def test_user_tier_default_when_path_outside_project_dirs(self, app, client: AsyncClient):
+        """Any source path that isn't under a registered
+        ``project_memory_dir`` classifies as ``user`` — same fallback the
+        indexer applies at config.py:1495-1507. Default fixture's
+        ``/tmp/test.md`` lives outside the project memory tree, so the
+        badge token must be the user-tier default."""
+        resp = await client.get("/api/sources")
+        src = resp.json()["sources"][0]
+        assert src["target_scope"] == "user"
+
+    async def test_project_shared_tier_classified_from_path(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        """A source under a registered ``project_memory_dirs`` shared
+        directory classifies as ``project_shared``. Pin the
+        path-pattern resolution end-to-end so a regression in
+        ``classify_scope`` (or in the route's wire-up) surfaces here
+        rather than as a silently-wrong tier badge."""
+        proj_root = tmp_path / "proj"
+        shared_dir = proj_root / ".memtomem" / "memories"
+        shared_dir.mkdir(parents=True)
+        source = shared_dir / "note.md"
+        source.touch()
+
+        app.state.config.indexing.memory_dirs = []
+        app.state.config.indexing.project_memory_dirs = [shared_dir]
+        app.state.storage.get_source_files_with_counts.return_value = [
+            (source, 2, "2026-04-29T10:00:00", "default", 100, 50, 200),
+        ]
+
+        resp = await client.get("/api/sources")
+        src = resp.json()["sources"][0]
+        assert src["target_scope"] == "project_shared"
+
+    async def test_project_local_hidden_by_default(self, app, client: AsyncClient, tmp_path: Path):
+        """ADR-0015 §4a — ``project_local`` sources are hidden in
+        overview / list views unless explicitly requested. Pin the
+        default-omit behavior; the only way to surface this tier is
+        ``?target_scope=project_local``.
+        """
+        proj_root = tmp_path / "proj"
+        local_dir = proj_root / ".memtomem" / "memories.local"
+        local_dir.mkdir(parents=True)
+        source = local_dir / "draft.md"
+        source.touch()
+
+        app.state.config.indexing.memory_dirs = []
+        app.state.config.indexing.project_memory_dirs = [local_dir]
+        app.state.storage.get_source_files_with_counts.return_value = [
+            (source, 1, "2026-04-29T10:00:00", "default", 100, 50, 200),
+        ]
+
+        resp = await client.get("/api/sources")
+        assert resp.json()["total"] == 0, (
+            "project_local sources must be hidden when ?target_scope= is omitted"
+        )
+
+    async def test_project_local_visible_with_explicit_filter(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        """Symmetric pin against the default-hidden case — passing
+        ``?target_scope=project_local`` is the only way to surface
+        these rows. Without this test the previous case could pass
+        vacuously even if the filter never actually narrowed to the
+        local tier."""
+        proj_root = tmp_path / "proj"
+        local_dir = proj_root / ".memtomem" / "memories.local"
+        local_dir.mkdir(parents=True)
+        source = local_dir / "draft.md"
+        source.touch()
+
+        app.state.config.indexing.memory_dirs = []
+        app.state.config.indexing.project_memory_dirs = [local_dir]
+        app.state.storage.get_source_files_with_counts.return_value = [
+            (source, 1, "2026-04-29T10:00:00", "default", 100, 50, 200),
+        ]
+
+        resp = await client.get("/api/sources", params={"target_scope": "project_local"})
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["sources"][0]["target_scope"] == "project_local"
+
+    async def test_target_scope_filter_narrows_to_one_tier(
+        self, app, client: AsyncClient, tmp_path: Path
+    ):
+        """``?target_scope=user`` excludes a registered project_shared
+        source even though it would otherwise pass the default filter.
+        Pins that the filter is *narrow-to-one* (not *omit-only-local*)."""
+        proj_root = tmp_path / "proj"
+        shared_dir = proj_root / ".memtomem" / "memories"
+        shared_dir.mkdir(parents=True)
+        shared_src = shared_dir / "note.md"
+        shared_src.touch()
+        user_src = tmp_path / "user.md"
+        user_src.touch()
+
+        app.state.config.indexing.memory_dirs = [tmp_path]
+        app.state.config.indexing.project_memory_dirs = [shared_dir]
+        app.state.storage.get_source_files_with_counts.return_value = [
+            (shared_src, 2, "2026-04-29T10:00:00", "default", 100, 50, 200),
+            (user_src, 1, "2026-04-29T10:00:00", "default", 100, 50, 200),
+        ]
+
+        resp_user = await client.get("/api/sources", params={"target_scope": "user"})
+        rows = resp_user.json()["sources"]
+        assert len(rows) == 1
+        assert rows[0]["target_scope"] == "user"
+
+        # Symmetric narrow: ``project_shared`` excludes the user-tier row.
+        resp_shared = await client.get("/api/sources", params={"target_scope": "project_shared"})
+        rows_shared = resp_shared.json()["sources"]
+        assert len(rows_shared) == 1
+        assert rows_shared[0]["target_scope"] == "project_shared"
+
+    async def test_invalid_target_scope_returns_422(self, client: AsyncClient):
+        """Literal validation refuses unknown tier tokens at the query
+        layer too — same guardrail as ``/api/add``."""
+        resp = await client.get("/api/sources", params={"target_scope": "draft"})
+        assert resp.status_code == 422
+
     # ---- regenerate endpoints ----------------------------------------------
 
     async def test_regenerate_summaries_rejected_when_disabled(self, app, client: AsyncClient):
@@ -996,6 +1124,69 @@ class TestChunksList:
         app.state.storage.get_all_source_files.return_value = [Path("/tmp/other.md")]
         resp = await client.get("/api/chunks", params={"source": "/tmp/test.md"})
         assert resp.status_code == 403
+
+    async def test_chunk_out_carries_target_scope_from_meta(self, app, client: AsyncClient):
+        """ADR-0016 §7 — ``ChunkOut.target_scope`` is sourced from
+        ``ChunkMetadata.scope`` so the SPA's tier badge always agrees
+        with the canonical-residency tier persisted in storage. Pin
+        all three literal tokens; rendering relies on them verbatim
+        (no display aliases — pinned by the Tiered Context Gateway v2
+        memory)."""
+        from memtomem.models import Chunk, ChunkMetadata
+
+        def _chunk_with_scope(scope: str) -> Chunk:
+            return Chunk(
+                content=f"content for {scope}",
+                metadata=ChunkMetadata(
+                    source_file=Path("/tmp/test.md"),
+                    heading_hierarchy=("Overview",),
+                    tags=(),
+                    namespace="default",
+                    start_line=1,
+                    end_line=2,
+                    scope=scope,
+                ),
+                id=CHUNK_ID,
+                content_hash="h",
+                embedding=[0.1] * 768,
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+
+        for token in ("user", "project_shared", "project_local"):
+            app.state.storage.list_chunks_by_source.return_value = [_chunk_with_scope(token)]
+            resp = await client.get("/api/chunks", params={"source": "/tmp/test.md"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["chunks"][0]["target_scope"] == token, (
+                f"target_scope on ChunkOut did not echo meta.scope={token!r}"
+            )
+
+    async def test_chunk_out_target_scope_defaults_to_user(self, app, client: AsyncClient):
+        """Legacy chunks whose persisted ``scope`` is an empty string fall
+        back to the user-tier badge. Pins the ``chunk_to_out`` fallback
+        so a partially-migrated DB doesn't produce empty-string badges."""
+        from memtomem.models import Chunk, ChunkMetadata
+
+        legacy = Chunk(
+            content="legacy",
+            metadata=ChunkMetadata(
+                source_file=Path("/tmp/test.md"),
+                heading_hierarchy=(),
+                tags=(),
+                namespace="default",
+                start_line=1,
+                end_line=2,
+                scope="",  # legacy empty-string row
+            ),
+            id=CHUNK_ID,
+            content_hash="h",
+            embedding=[0.1] * 768,
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        app.state.storage.list_chunks_by_source.return_value = [legacy]
+        resp = await client.get("/api/chunks", params={"source": "/tmp/test.md"})
+        assert resp.json()["chunks"][0]["target_scope"] == "user"
 
 
 # ---------------------------------------------------------------------------
@@ -1716,6 +1907,212 @@ class TestAddMemoryRedaction:
         snap = privacy.snapshot()["by_tool"]["web_api_add"]
         assert snap["pass"] == 1
         assert snap["blocked"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/add — project-tier (ADR-0011 §5 Gate B / ADR-0016 §7) — #924
+#
+# Mirror the MCP ``mem_add`` Gate B at ``memory_crud.py:204`` and the Web
+# parallel on the chunks DELETE path at ``chunks.py:157``. project_shared
+# writes via ``/api/add`` require an explicit ``confirm_project_shared=true``;
+# the 4xx payload carries the CLI hint + docs URL so the SPA renders
+# "rejected, here's the equivalent invocation" without rewriting the prose.
+# ---------------------------------------------------------------------------
+
+
+class TestAddMemoryProjectTier:
+    async def test_invalid_scope_returns_422(self, client: AsyncClient):
+        """Pydantic Literal validation rejects unknown tier tokens.
+
+        Cheap guardrail: the API only accepts the three canonical tokens —
+        any typo (e.g. ``user_local``) lands a 422 before the route runs,
+        so a misspelled tier can't silently fall back to user-tier writes.
+        """
+        resp = await client.post(
+            "/api/add",
+            json={"content": "x", "scope": "user_local"},
+        )
+        assert resp.status_code == 422, resp.text
+
+    async def test_project_shared_without_confirm_returns_403_with_hint(self, client: AsyncClient):
+        """Gate B fires before the redaction guard runs. The 4xx body must
+        carry the literal CLI hint + docs URL so the SPA can render the
+        rejection without rebuilding the prose client-side.
+        """
+        resp = await client.post(
+            "/api/add",
+            json={"content": "Plain prose.", "scope": "project_shared"},
+        )
+        assert resp.status_code == 403, resp.text
+        body = resp.json()
+        # FastAPI wraps the raised ``detail`` dict under ``detail`` again
+        # (mirrors the redaction-error nesting at line 1685 above).
+        detail = body.get("detail") if isinstance(body.get("detail"), dict) else body
+        assert detail["detail"] == "blocked_project_shared"
+        assert detail["surface"] == "web_api_add"
+        assert detail["scope"] == "project_shared"
+        assert "confirm_project_shared" in detail["message"]
+        assert detail["cli_hint"] == "mm mem add --scope project_shared"
+        # Docs URL must point at the canonical-residency ADR — pin the
+        # filename so a re-org of the ADR tree gets caught here rather
+        # than producing a silently dead link in production toasts.
+        assert "0011-canonical-artifact-scope-hierarchy" in detail["docs_url"]
+
+    async def test_project_shared_confirm_required_even_with_clean_content(
+        self, client: AsyncClient
+    ):
+        """The redaction guard would normally let plain prose through;
+        Gate B must still refuse without confirm. Pins that the gates
+        compose in the right order (Gate B → redaction, not the other
+        way around) so a clean payload can't sneak past Gate B.
+        """
+        resp = await client.post(
+            "/api/add",
+            json={"content": "Plain prose, no secrets.", "scope": "project_shared"},
+        )
+        assert resp.status_code == 403
+        # Critically, the 4xx must be the project-tier shape, not
+        # the redaction shape — the latter would mean Gate B never ran.
+        detail = resp.json().get("detail", {})
+        assert detail.get("detail") == "blocked_project_shared", (
+            f"expected Gate B 4xx shape, got: {detail!r}"
+        )
+
+    async def test_project_local_bypasses_gate_b(self, app, client: AsyncClient, tmp_path):
+        """ADR-0011 §3: project_local does NOT require confirm_project_shared
+        — it's the draft tier (zero-to-one fan-out for non-memory artifacts;
+        memory still fans out per its own contract). Only project_shared
+        is git-tracked and gate-B-confirmed.
+        """
+        # Register the project_local tier so the route's
+        # ``is_project_tier_registered`` check passes. Mirrors the
+        # ``mm context memory-migrate`` registration guard the MCP add
+        # path enforces at memory_crud.py:296-300.
+        proj_root = tmp_path / "proj"
+        local_dir = proj_root / ".memtomem" / "memories.local"
+        local_dir.mkdir(parents=True)
+        app.state.project_root = proj_root
+        app.state.config.indexing.memory_dirs = [tmp_path / "user_mem"]
+        (tmp_path / "user_mem").mkdir()
+        app.state.config.indexing.project_memory_dirs = [local_dir]
+
+        resp = await client.post(
+            "/api/add",
+            json={"content": "Draft note.", "scope": "project_local"},
+        )
+        assert resp.status_code == 200, resp.text
+        path = Path(resp.json()["file"]).resolve()
+        assert local_dir.resolve() in path.parents, (
+            f"project_local write landed at {path}, expected under {local_dir}"
+        )
+
+    async def test_project_shared_with_confirm_routes_to_shared_dir(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """With ``confirm_project_shared=true`` the write proceeds and
+        the resolved path lands under ``<proj>/.memtomem/memories``.
+        Pins write-surface parity with the MCP ``mem_add`` shared-tier
+        routing at memory_crud.py:286-289.
+        """
+        proj_root = tmp_path / "proj"
+        shared_dir = proj_root / ".memtomem" / "memories"
+        shared_dir.mkdir(parents=True)
+        app.state.project_root = proj_root
+        app.state.config.indexing.memory_dirs = [tmp_path / "user_mem"]
+        (tmp_path / "user_mem").mkdir()
+        app.state.config.indexing.project_memory_dirs = [shared_dir]
+
+        resp = await client.post(
+            "/api/add",
+            json={
+                "content": "Team note.",
+                "scope": "project_shared",
+                "confirm_project_shared": True,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        path = Path(resp.json()["file"]).resolve()
+        assert shared_dir.resolve() in path.parents, (
+            f"project_shared write landed at {path}, expected under {shared_dir}"
+        )
+
+    async def test_project_shared_resolves_via_registered_root_not_raw_cwd(
+        self, app, client: AsyncClient, tmp_path, monkeypatch
+    ):
+        """ADR-0011 PR-F parity with MCP ``mem_add`` (memory_crud.py:285
+        via search.py:73-96): when the server runs from a subdirectory
+        of a registered project, ``scope=project_shared`` must resolve
+        against the registered project root, not the raw cwd. Without
+        ``_resolve_project_context_from_dirs`` wiring, the route would
+        land on ``<cwd>/.memtomem/memories`` (which doesn't exist /
+        isn't registered) and 422 the operator — while MCP correctly
+        writes under ``<project_root>/.memtomem/memories``. Codex
+        review #924 Major finding.
+        """
+        proj_root = tmp_path / "proj"
+        subdir = proj_root / "src" / "deep"
+        subdir.mkdir(parents=True)
+        shared_dir = proj_root / ".memtomem" / "memories"
+        shared_dir.mkdir(parents=True)
+
+        # Simulate "server launched from a subdirectory of a project".
+        # The MCP path resolves project_root from cwd via
+        # ``_resolve_project_context_from_dirs`` — pin that the Web
+        # path now uses the same resolver, so a cwd inside the project
+        # finds its way to the registered root regardless of where on
+        # the tree the process was started.
+        monkeypatch.chdir(subdir)
+        # ``app.state.project_root`` stays at the (now-wrong) subdir
+        # value the lifespan would have captured if it ran here. The
+        # fix is that the route now ignores it in favor of the
+        # registered-root resolver; if a regression reverts to using
+        # ``app.state.project_root`` raw, this test fails because
+        # ``<subdir>/.memtomem/memories`` is unregistered.
+        app.state.project_root = subdir
+        app.state.config.indexing.memory_dirs = [tmp_path / "user_mem"]
+        (tmp_path / "user_mem").mkdir()
+        app.state.config.indexing.project_memory_dirs = [shared_dir]
+
+        resp = await client.post(
+            "/api/add",
+            json={
+                "content": "Team note from a subdirectory.",
+                "scope": "project_shared",
+                "confirm_project_shared": True,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        path = Path(resp.json()["file"]).resolve()
+        assert shared_dir.resolve() in path.parents, (
+            f"project_shared write from subdir landed at {path}, "
+            f"expected under registered root {shared_dir}"
+        )
+
+    async def test_project_tier_unregistered_returns_422(self, app, client: AsyncClient, tmp_path):
+        """Refuse if the resolved project-tier dir isn't in
+        ``project_memory_dirs`` — otherwise the row's persisted scope
+        would flip to ``project_shared`` but the read surface / watcher
+        couldn't see it. Mirrors the MCP gate at
+        ``memory_crud.py:296-300``.
+        """
+        proj_root = tmp_path / "proj"
+        proj_root.mkdir()
+        app.state.project_root = proj_root
+        app.state.config.indexing.memory_dirs = [tmp_path / "user_mem"]
+        (tmp_path / "user_mem").mkdir()
+        # Intentionally leave project_memory_dirs empty so the registration
+        # check refuses the write.
+        app.state.config.indexing.project_memory_dirs = []
+
+        resp = await client.post(
+            "/api/add",
+            json={
+                "content": "x",
+                "scope": "project_shared",
+                "confirm_project_shared": True,
+            },
+        )
+        assert resp.status_code == 422, resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1158,9 +1158,7 @@ class TestListAgents:
         rows = r.json()["agents"]
         names = [a["name"] for a in rows]
         assert "reviewer" in names
-        assert {a["target_scope"] for a in rows if a["name"] == "reviewer"} == {
-            "project_shared"
-        }
+        assert {a["target_scope"] for a in rows if a["name"] == "reviewer"} == {"project_shared"}
 
     @pytest.mark.anyio
     async def test_project_local_visible_only_with_explicit_target_scope(

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -498,6 +498,32 @@ class TestListSkills:
         names = [s["name"] for s in data["skills"]]
         assert "alpha" in names
         assert "beta" in names
+        assert {s["target_scope"] for s in data["skills"]} == {"project_shared"}
+
+    @pytest.mark.anyio
+    async def test_project_local_visible_only_with_explicit_target_scope(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        local = tmp_path / ".memtomem" / "skills.local" / "draft"
+        local.mkdir(parents=True)
+        (local / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+
+        default = await client.get("/api/context/skills")
+        assert all(s["name"] != "draft" for s in default.json()["skills"])
+
+        explicit = await client.get(
+            "/api/context/skills",
+            params={"target_scope": "project_local"},
+        )
+        data = explicit.json()
+        assert explicit.status_code == 200, explicit.text
+        assert data["skills"][0]["name"] == "draft"
+        assert data["skills"][0]["target_scope"] == "project_local"
+
+    @pytest.mark.anyio
+    async def test_invalid_target_scope_returns_422(self, client: AsyncClient):
+        r = await client.get("/api/context/skills", params={"target_scope": "draft"})
+        assert r.status_code == 422
 
     @pytest.mark.anyio
     async def test_includes_runtime_status(self, client: AsyncClient, tmp_path: Path):
@@ -877,8 +903,30 @@ class TestListCommands:
     async def test_with_items(self, client: AsyncClient, tmp_path: Path):
         _make_command(tmp_path, "review")
         r = await client.get("/api/context/commands")
-        names = [c["name"] for c in r.json()["commands"]]
+        rows = r.json()["commands"]
+        names = [c["name"] for c in rows]
         assert "review" in names
+        assert {c["target_scope"] for c in rows if c["name"] == "review"} == {"project_shared"}
+
+    @pytest.mark.anyio
+    async def test_project_local_visible_only_with_explicit_target_scope(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        local_dir = tmp_path / ".memtomem" / "commands.local"
+        local_dir.mkdir(parents=True)
+        (local_dir / "draft.md").write_text(_CMD_CONTENT, encoding="utf-8")
+
+        default = await client.get("/api/context/commands")
+        assert all(c["name"] != "draft" for c in default.json()["commands"])
+
+        explicit = await client.get(
+            "/api/context/commands",
+            params={"target_scope": "project_local"},
+        )
+        rows = explicit.json()["commands"]
+        assert explicit.status_code == 200, explicit.text
+        assert rows[0]["name"] == "draft"
+        assert rows[0]["target_scope"] == "project_local"
 
 
 class TestReadCommand:
@@ -1107,8 +1155,32 @@ class TestListAgents:
     async def test_with_items(self, client: AsyncClient, tmp_path: Path):
         _make_agent(tmp_path, "reviewer")
         r = await client.get("/api/context/agents")
-        names = [a["name"] for a in r.json()["agents"]]
+        rows = r.json()["agents"]
+        names = [a["name"] for a in rows]
         assert "reviewer" in names
+        assert {a["target_scope"] for a in rows if a["name"] == "reviewer"} == {
+            "project_shared"
+        }
+
+    @pytest.mark.anyio
+    async def test_project_local_visible_only_with_explicit_target_scope(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        local_dir = tmp_path / ".memtomem" / "agents.local"
+        local_dir.mkdir(parents=True)
+        (local_dir / "draft.md").write_text(_AGENT_CONTENT, encoding="utf-8")
+
+        default = await client.get("/api/context/agents")
+        assert all(a["name"] != "draft" for a in default.json()["agents"])
+
+        explicit = await client.get(
+            "/api/context/agents",
+            params={"target_scope": "project_local"},
+        )
+        rows = explicit.json()["agents"]
+        assert explicit.status_code == 200, explicit.text
+        assert rows[0]["name"] == "draft"
+        assert rows[0]["target_scope"] == "project_local"
 
 
 class TestReadAgent:

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -265,6 +265,38 @@ def test_q_pr4_langchange_rerenders_runtime_badge_label(page, mm_web_url: str) -
     assert "In sync" not in post_text, f"EN 'In sync' must not survive KO toggle: {post_text!r}"
 
 
+def test_context_list_card_renders_project_local_tier_badge_with_annotation(
+    page, mm_web_url: str
+) -> None:
+    """Context artifact cards render the literal tier token and the
+    project_local zero-runtime-fan-out annotation inline with the name.
+    """
+    _install_default_stubs(page)
+    _stub_projects(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
+    _stub_skills(
+        page,
+        {
+            "skills": [
+                {
+                    "name": "draft-skill",
+                    "canonical_path": ".memtomem/skills.local/draft-skill",
+                    "target_scope": "project_local",
+                    "runtimes": [],
+                }
+            ],
+            "scanned_dirs": [],
+        },
+    )
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    card_name = page.locator("#ctx-skills-list .ctx-card-name").first
+    text = card_name.text_content() or ""
+    assert "project_local" in text
+    assert "no runtime fan-out" in text
+    assert card_name.locator(".badge-tier--project_local").count() == 1
+
+
 def test_q_pr4_langchange_rerenders_runtime_only_banner(page, mm_web_url: str) -> None:
     """``_ctxRefreshSectionState`` writes the runtime-only banner via
     ``textContent`` (not innerHTML), but the staleness mechanism is the

--- a/packages/memtomem/tests/web/test_project_tier_rejection_hint.py
+++ b/packages/memtomem/tests/web/test_project_tier_rejection_hint.py
@@ -1,0 +1,296 @@
+"""Browser tests for the ADR-0011 §5 Gate B rejection-hint flow on
+``POST /api/add`` (issue #924 — PR-F slice 4).
+
+The route signals a project-tier rejection with::
+
+    HTTP 403
+    {"detail": {"detail": "blocked_project_shared",
+                "surface": "web_api_add",
+                "scope": "project_shared",
+                "message": "scope='project_shared' writes...",
+                "cli_hint": "mm mem add --scope project_shared",
+                "docs_url": "https://github.com/.../0011-...md"}}
+
+The SPA must parse this nested shape (mirroring the redaction-blocked
+parser at ``api()``) and surface the CLI hint + docs URL via the toast
+so an operator who hits this path via dev-tools / API client sees the
+equivalent invocation rather than an opaque "save failed" error.
+
+These specs pin the wire-level contract — they stub ``/api/add`` and
+fire the request through ``page.evaluate`` (the compose form doesn't
+currently expose a tier picker, so a UI-driven path would never reach
+this code; the dev-tools / API-only path is what we test). When a
+future tier-picker UI ships, the assertions on toast contents stay
+valid.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.browser
+
+
+def _install_default_stubs(page) -> None:
+    """Mirror the catch-all stub pattern from ``test_redaction_blocked_retry``.
+
+    ``page.route`` is last-registered-wins so the catch-all goes first
+    and the spec-specific ``/api/add`` override goes last.
+    """
+
+    def _ok(route, payload):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        )
+
+    page.route("**/api/**", lambda r: _ok(r, {}))
+    page.route("**/api/system/ui-mode", lambda r: _ok(r, {"mode": "prod"}))
+    page.route("**/api/system/model-readiness", lambda r: _ok(r, {"ready": True}))
+    page.route("**/api/sources", lambda r: _ok(r, {"sources": []}))
+    page.route("**/api/namespaces", lambda r: _ok(r, {"namespaces": []}))
+    page.route("**/api/stats", lambda r: _ok(r, {}))
+    page.route("**/api/privacy/patterns", lambda r: _ok(r, {"patterns": []}))
+
+
+def test_api_add_403_blocked_project_shared_surfaces_cli_hint_and_docs(
+    page, mm_web_url: str
+) -> None:
+    """``POST /api/add`` 403 with ``blocked_project_shared`` shape →
+    error toast carries both the rejection prose and the literal
+    ``mm mem add --scope project_shared`` CLI hint + docs URL, so the
+    operator can copy/paste the equivalent invocation.
+
+    Fires the request through ``page.evaluate`` (the compose form
+    doesn't expose a tier picker today, so dev-tools is the realistic
+    caller). When a tier-picker UI ships this spec stays valid — the
+    toast contract is independent of the trigger surface.
+    """
+    _install_default_stubs(page)
+
+    def _add_handler(route):
+        # Mirror the FastAPI-nested ``{detail: {detail: ...}}`` shape the
+        # backend actually produces (system.py raises ``HTTPException``
+        # with a structured ``detail`` dict).
+        route.fulfill(
+            status=403,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "detail": {
+                        "detail": "blocked_project_shared",
+                        "surface": "web_api_add",
+                        "scope": "project_shared",
+                        "message": (
+                            "scope='project_shared' writes to a git-tracked "
+                            "directory. Re-submit with confirm_project_shared=true."
+                        ),
+                        "cli_hint": "mm mem add --scope project_shared",
+                        "docs_url": (
+                            "https://github.com/memtomem/memtomem/blob/main/docs/adr/"
+                            "0011-canonical-artifact-scope-hierarchy.md"
+                        ),
+                    }
+                }
+            ),
+        )
+
+    page.route("**/api/add", _add_handler)
+
+    page.goto(mm_web_url)
+
+    # Drive the request from the page's JS context so the error path
+    # exercises ``api()`` → ``ProjectTierBlockedError`` → catch-arm
+    # toast. ``addMemoryFromCompose`` is the SPA's submit handler; we
+    # invoke its inner ``apiWithRedactionRetry`` path directly through
+    # the global API helper since the compose form has no tier picker.
+    page.evaluate(
+        """
+        (async () => {
+          try {
+            await window.api('POST', '/api/add', {
+              content: 'team note',
+              scope: 'project_shared',
+            });
+          } catch (err) {
+            // Drive the actual production formatter — same code path
+            // ``addMemoryFromCompose``'s catch-arm uses. Without this
+            // shared helper the test would silently pass even if the
+            // catch-arm stopped showing cliHint / docsUrl (Codex #924
+            // review-pass).
+            if (err && err.name === 'ProjectTierBlockedError') {
+              window.showToast(window.formatProjectTierBlockedToast(err), 'error');
+            } else {
+              window.showToast('unexpected error: ' + err.message, 'error');
+            }
+          }
+        })()
+        """
+    )
+
+    # Toast must render with the literal CLI hint and docs URL. The
+    # rejection prose is intentionally not pinned word-for-word — the
+    # server-side message can evolve; the actionable pieces (CLI hint
+    # + docs URL) are the contract.
+    toast = page.wait_for_selector("#toast-container .toast", timeout=2_000)
+    text = toast.text_content() or ""
+    assert "mm mem add --scope project_shared" in text, f"toast missing CLI hint: {text!r}"
+    assert "0011-canonical-artifact-scope-hierarchy" in text, f"toast missing docs URL: {text!r}"
+
+
+def test_api_add_403_blocked_project_shared_is_not_redaction_error(page, mm_web_url: str) -> None:
+    """Symmetric guardrail — the project-tier 4xx path must NOT trigger
+    the redaction confirm dialog. Without strict ``detail.detail``
+    discrimination in ``api()``, a future regression that catches both
+    error classes through the same branch would silently re-issue the
+    request with ``force_unsafe=true`` (which is exactly what Gate B
+    is designed to prevent for project_shared writes).
+    """
+    _install_default_stubs(page)
+
+    page.route(
+        "**/api/add",
+        lambda route: route.fulfill(
+            status=403,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "detail": {
+                        "detail": "blocked_project_shared",
+                        "surface": "web_api_add",
+                        "scope": "project_shared",
+                        "message": "scope='project_shared' write rejected",
+                        "cli_hint": "mm mem add --scope project_shared",
+                        "docs_url": "https://example.com/adr-0011",
+                    }
+                }
+            ),
+        ),
+    )
+
+    page.goto(mm_web_url)
+
+    err_name = page.evaluate(
+        """
+        (async () => {
+          try {
+            await window.api('POST', '/api/add', {
+              content: 'x',
+              scope: 'project_shared',
+            });
+            return 'no-error';
+          } catch (err) {
+            return err && err.name ? err.name : 'unknown';
+          }
+        })()
+        """
+    )
+    assert err_name == "ProjectTierBlockedError", (
+        f"expected ProjectTierBlockedError, got {err_name!r}"
+    )
+
+    # The redaction confirm dialog must stay hidden — its presence would
+    # indicate the project-tier 4xx was misclassified as a redaction
+    # block.
+    assert page.locator("#confirm-modal").get_attribute("hidden") is not None, (
+        "redaction confirm dialog must not appear for project-tier 4xx"
+    )
+
+
+def test_format_project_tier_blocked_toast_omits_cli_line_when_hint_absent(
+    page, mm_web_url: str
+) -> None:
+    """The Gate A force-unsafe-on-project_shared 4xx reuses the
+    ``blocked_project_shared`` discriminant but does NOT carry
+    ``cli_hint`` / ``docs_url`` (there's no actionable CLI form for
+    "your write was redaction-blocked on a git-tracked tier"). Pin
+    that the shared formatter omits the ``$ undefined`` line and the
+    URL line cleanly when those fields are absent — Codex review #924
+    Major finding, the original direct interpolation would have
+    leaked ``$ undefined`` into the toast.
+    """
+    _install_default_stubs(page)
+    page.goto(mm_web_url)
+
+    rendered = page.evaluate(
+        """
+        () => {
+          // Duck-typed error mirrors what api() builds when the 4xx
+          // omits cli_hint / docs_url (Gate A force-unsafe path).
+          // The class itself isn't exported on ``window`` because
+          // ``class`` declarations don't attach automatically the way
+          // top-level ``function`` declarations do — that's why this
+          // test uses a plain Error with name + fields rather than
+          // ``new ProjectTierBlockedError(...)``. The formatter only
+          // reads ``.message`` / ``.cliHint`` / ``.docsUrl`` so duck
+          // typing is sufficient.
+          const err = Object.assign(
+            new Error('force_unsafe rejected on project_shared'),
+            { name: 'ProjectTierBlockedError' }
+          );
+          return window.formatProjectTierBlockedToast(err);
+        }
+        """
+    )
+    assert rendered == "force_unsafe rejected on project_shared", (
+        f"formatter must omit empty cli/docs lines, got: {rendered!r}"
+    )
+    # Pin the literal that the original bug would have produced — any
+    # regression that drops the truthiness guard re-introduces it.
+    assert "undefined" not in rendered
+    assert "$ " not in rendered
+
+
+def test_tier_badge_html_helper_renders_project_tier_tokens_verbatim(page, mm_web_url: str) -> None:
+    """Pin the ADR-0016 §7 "no display alias" contract on the SPA helper.
+
+    ``_tierBadgeHtml`` is the single render path for the canonical-residency
+    tier badge — the three tokens are rendered verbatim. The user tier
+    is suppressed (returns empty string) so the common case stays
+    visually quiet; ``project_shared`` and ``project_local`` get their
+    own tier classes; ``project_local`` rows on context surfaces carry
+    the inline ``(no runtime fan-out)`` annotation per ADR-0011 §3.
+    """
+    _install_default_stubs(page)
+    page.goto(mm_web_url)
+
+    user_badge = page.evaluate("window._tierBadgeHtml('user')")
+    assert user_badge == "", (
+        "user-tier badge must render as empty string so the common case stays quiet"
+    )
+
+    shared_badge = page.evaluate("window._tierBadgeHtml('project_shared')")
+    assert "project_shared" in shared_badge
+    assert "badge-tier--project_shared" in shared_badge
+    # Display-alias guardrail: the literal token must appear without
+    # any of the historical aliases (Personal / Team / Local Draft) the
+    # Tiered Context Gateway v2 memory explicitly forbids.
+    for alias in ("Personal", "Team", "Local Draft"):
+        assert alias not in shared_badge, (
+            f"badge HTML must not contain display alias {alias!r}: {shared_badge!r}"
+        )
+
+    local_badge = page.evaluate("window._tierBadgeHtml('project_local')")
+    assert "project_local" in local_badge
+    assert "badge-tier--project_local" in local_badge
+    # Memory rows don't carry the fan-out annotation (project_local
+    # memory still fans out via memory's own contract per ADR-0011 §3).
+    assert "no runtime fan-out" not in local_badge
+
+    # Context rows DO carry the annotation when project_local — ADR-0011
+    # §3 zero-fan-out rule for agents/skills/commands.
+    local_ctx_badge = page.evaluate(
+        "window._tierBadgeHtml('project_local', { isContextRow: true })"
+    )
+    assert "no runtime fan-out" in local_ctx_badge, (
+        f"context-row project_local badge missing fan-out annotation: {local_ctx_badge!r}"
+    )
+
+    # Unknown tokens render as empty string — defense against a
+    # malformed server response that would otherwise inject arbitrary
+    # text into the badge slot.
+    bogus = page.evaluate("window._tierBadgeHtml('draft')")
+    assert bogus == "", f"unknown tier token must render empty: {bogus!r}"


### PR DESCRIPTION
## Summary
- Web slice of ADR-0011 PR-F (#868-A): tier badges on memory + context list views, and `/api/add` project-tier rejection hint mirroring the MCP Gate B confirm. Both slices share `/api` + the SPA badge renderer, so they ship together.
- `target_scope` flows through chunk + source + context-list schemas verbatim per ADR-0016 §7 (no display aliases — the SPA renders the literal token). `/api/sources` and the context agents/skills/commands list routes accept `?target_scope=` and hide `project_local` by default (ADR-0015 §4a); `project_local` context rows render the `(no runtime fan-out)` annotation inline (ADR-0011 §3).
- `POST /api/add` returns `403 detail=blocked_project_shared` with `cli_hint` + `docs_url` when `scope=project_shared` lands without `confirm_project_shared=true` (mirrors `mem_add` MCP Gate B). Threads `scope` into `enforce_write_guard` so Gate A's `force_unsafe × project_shared` hard-refusal fires on Web too (PR-D round 7 parity). Project-tier base dirs resolve via `resolve_memory_scope_dir`; unregistered project tiers are 422'd upfront so a row's persisted scope cannot diverge from what the watcher can see.

Out of scope per #924 deferral: tier-switching dropdown / write affordances, detail/diff/rendered-route alignment.

Closes #924. Sub-issue of #868.

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_web_routes.py packages/memtomem/tests/test_web_routes_context.py packages/memtomem/tests/web/test_context_gateway_lists.py packages/memtomem/tests/web/test_project_tier_rejection_hint.py -q` → 260 passed locally
- [x] `uv run ruff check` on touched Python files
- [x] `node --check packages/memtomem/src/memtomem/web/static/context-gateway.js`
- [x] `git diff --check`
- [ ] CI: full pytest + ruff + mypy on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)