### PR TITLE
feat(rescan): scope-aware audit for memory and context artifacts (#934)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -3109,17 +3109,67 @@ async def _memory_migrate_run(
 
 
 # ---------------------------------------------------------------------------
-# rescan — privacy-only audit over project-root generated context files
+# rescan — privacy-only audit, scope-aware across the three-tier model
 # ---------------------------------------------------------------------------
 #
-# ADR-0011 follow-up (issue #885). The v1 target set is exactly the set
-# returned by ``detect_agent_files`` — the project-root generated files
-# (CLAUDE.md, .cursorrules, GEMINI.md, AGENTS.md, .github/copilot-
-# instructions.md). Agents / skills / commands runtime fanout (the
-# scope-tiered ``_runtime_targets.py`` table) is intentionally out of
-# scope and tracked separately.
+# ADR-0011 / ADR-0016 follow-up (issue #934). The target set is now
+# scope-dependent so a privacy audit can be run per tier without
+# leaking into unrelated worktrees that happen to share state:
+#
+# - ``--scope=user`` walks ``~/.memtomem/{agents,skills,commands}/``
+#   (canonical user tier). No project-root scanner files — those are
+#   project-rooted by definition.
+# - ``--scope=project_shared`` walks ``<root>/.memtomem/{agents,skills,
+#   commands}/`` PLUS the project-root scanner files returned by
+#   ``detect_agent_files(root)`` (CLAUDE.md, .cursorrules, GEMINI.md,
+#   AGENTS.md, .github/copilot-instructions.md). Those scanner files
+#   ARE the runtime fan-out of project_shared into the project root —
+#   dropping them would silently regress v1 coverage from issue #885.
+# - ``--scope=project_local`` walks ``<root>/.memtomem/{agents,skills,
+#   commands}.local/`` only. No scanner files: per ADR-0011 §3 /
+#   ADR-0016 §7 ``project_local`` is gitignored draft tier with NO
+#   runtime fan-out — surfacing scanner-file violations under a
+#   ``project_local`` audit would mislead the operator about the
+#   tier's actual reach.
+#
+# Project tiers require a project context (``.git`` or
+# ``pyproject.toml``); the marker check mirrors ``mm context init
+# --scope`` at lines 737-748. Symlink-escape defence: descendants
+# whose ``resolve()`` lands outside ``root.resolve()`` are dropped
+# from the project-tier scan so a stray symlink into a sibling
+# project's ``.memtomem/`` cannot pull foreign files into the
+# decisions list.
 
 _RESCAN_SCOPE_CHOICES = list(get_args(TargetScope))
+_RESCAN_ARTIFACT_KINDS: tuple[str, ...] = ("agents", "skills", "commands")
+
+
+def _rescan_targets(scope: TargetScope, project_root: Path | None) -> list[Path]:
+    """Resolve the per-scope file/directory set the rescan walks.
+
+    See the module-level comment block above the command for the full
+    per-tier specification. Non-existent paths are silently dropped —
+    rescan is an audit, not an inventory check, so a missing
+    ``agents.local/`` does not constitute a failure.
+    """
+    targets: list[Path] = []
+    if scope == "user":
+        for kind in _RESCAN_ARTIFACT_KINDS:
+            targets.append(canonical_artifact_dir(kind, "user", None))  # type: ignore[arg-type]
+    elif scope == "project_shared":
+        assert project_root is not None  # gated by caller
+        for kind in _RESCAN_ARTIFACT_KINDS:
+            targets.append(
+                canonical_artifact_dir(kind, "project_shared", project_root)  # type: ignore[arg-type]
+            )
+        targets.extend(entry.path for entry in detect_agent_files(project_root))
+    elif scope == "project_local":
+        assert project_root is not None  # gated by caller
+        for kind in _RESCAN_ARTIFACT_KINDS:
+            targets.append(
+                canonical_artifact_dir(kind, "project_local", project_root)  # type: ignore[arg-type]
+            )
+    return [t for t in targets if t.exists()]
 
 
 @context.command("rescan")
@@ -3128,9 +3178,10 @@ _RESCAN_SCOPE_CHOICES = list(get_args(TargetScope))
     type=click.Choice(_RESCAN_SCOPE_CHOICES),
     required=True,
     help=(
-        "Guard decision scope. The same artifact set is scanned regardless "
-        "of --scope; the value flows into enforce_write_guard's scope= "
-        "argument. v1 always calls with force_unsafe=False."
+        "Tier to audit. Selects BOTH the canonical artifact directories "
+        "walked AND the scope= value forwarded to enforce_write_guard. "
+        "Required — there is no implicit default so audits are explicit "
+        "and CI-readable. v1 always calls with force_unsafe=False."
     ),
 )
 @click.option(
@@ -3152,7 +3203,7 @@ def rescan_cmd(
     as_json: bool,
     quiet: bool,
 ) -> None:
-    """Re-run the privacy guard over project-root generated context files.
+    """Re-run the privacy guard over scope-tiered context artifacts.
 
     Read-only: no file is modified. The guard is invoked with
     ``record_outcome=False`` so the rescan does not double-count outcomes
@@ -3161,30 +3212,72 @@ def rescan_cmd(
 
     Exit codes: 0 if no violations, 1 if any violation found.
     """
-    root = _find_project_root()
-    detected = detect_agent_files(root)
+    # ADR-0011 / issue #934: project tiers require a real project marker
+    # so the audit can't accidentally walk a sibling worktree's tree
+    # via ``_find_project_root``'s cwd fallback.
+    project_root: Path | None
+    if scope == "user":
+        project_root = None
+    else:
+        candidate = _find_project_root()
+        has_signal = (candidate / ".git").exists() or (candidate / "pyproject.toml").exists()
+        if not has_signal:
+            raise click.ClickException(
+                f"--scope={scope} requires a project root (with .git or "
+                "pyproject.toml). Use --scope=user from outside a project, "
+                "or run from inside one."
+            )
+        project_root = candidate
+
+    targets = _rescan_targets(scope, project_root)
 
     scanned = 0
     violations: list[dict] = []
+    # Resolve once so the symlink-escape check is a cheap path-prefix
+    # equality rather than a per-file resolve()-then-resolve() pair.
+    resolved_root = project_root.resolve() if project_root is not None else None
 
-    for entry in detected:
+    for target in targets:
         result = scan_artifact_tree(
-            entry.path,
+            target,
             surface="cli_context_rescan",
             scope=scope,
-            project_root=root,
+            project_root=project_root,
             on_blocked="skip_warn",
             record_outcome=False,
         )
         for fs in result.decisions:
+            # Symlink-escape defence (project tiers only). ``rglob`` in
+            # ``scan_artifact_tree`` follows symlinks; if a descendant of
+            # ``<root>/.memtomem/...`` resolves outside ``root`` it is
+            # almost certainly a misconfigured / hostile link — drop it
+            # from the audit rather than pretend the foreign file
+            # belongs to this project. User tier is exempt because the
+            # user canonical dir lives outside any project root by
+            # design.
+            if resolved_root is not None:
+                try:
+                    resolved_fs = fs.path.resolve()
+                except OSError:
+                    # Defensive: unresolvable symlink — fail closed by
+                    # skipping rather than including. The fail-closed
+                    # contract on read errors lives in scan_artifact_tree
+                    # itself (PrivacyScanReadError); ``resolve()`` here
+                    # is purely for the project-anchor check.
+                    continue
+                if not resolved_fs.is_relative_to(resolved_root):
+                    continue
             scanned += 1
             if fs.decision == "pass":
                 continue
+            display_path = (
+                fs.path.relative_to(project_root)
+                if project_root is not None and fs.path.is_relative_to(project_root)
+                else fs.path
+            )
             violations.append(
                 {
-                    "path": str(
-                        fs.path.relative_to(root) if fs.path.is_relative_to(root) else fs.path
-                    ),
+                    "path": str(display_path),
                     "scope": scope,
                     "decision": fs.decision,
                     "hits": [

--- a/packages/memtomem/src/memtomem/cli/mem_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/mem_cmd.py
@@ -7,6 +7,12 @@ re-embedding or recreating chunks. The rescan is **privacy-only** by design:
 chunk identity, content, validity windows, and access stats are not
 touched. Quarantine / soft-delete is a v2 concern (issue #885 follow-up).
 
+Issue #934 (ADR-0011 / ADR-0016 follow-up) wires the three-tier model
+into the rescan: ``--scope=project_shared`` / ``--scope=project_local``
+require a project context (``.git`` or ``pyproject.toml`` marker) so the
+audit cannot accidentally walk chunks owned by an unrelated project in
+the same SQLite database. ``--scope=user`` stays global by design.
+
 ``mm add`` / ``mm recall`` intentionally remain top-level CLI commands —
 folding them into ``mm mem`` is a separate UX migration tracked outside
 this issue.
@@ -22,6 +28,7 @@ from typing import get_args
 import click
 
 from memtomem import privacy
+from memtomem.cli.context_cmd import _find_project_root
 from memtomem.config import TargetScope
 
 
@@ -113,12 +120,30 @@ def rescan_cmd(
     if source is not None:
         source_exact, source_prefix = _resolve_source_filter(source)
 
+    # ADR-0011 / ADR-0016 / issue #934 cross-project isolation gate.
+    # Project tiers must run from inside a real project so the audit
+    # cannot accidentally walk chunks owned by a sibling project that
+    # shares the same SQLite DB. Mirror ``mm context init --scope``'s
+    # marker check at ``cli/context_cmd.py:737-748``.
+    project_root: Path | None = None
+    if scope != "user":
+        root = _find_project_root()
+        has_signal = (root / ".git").exists() or (root / "pyproject.toml").exists()
+        if not has_signal:
+            raise click.ClickException(
+                f"--scope={scope} requires a project root (with .git or "
+                "pyproject.toml). Use --scope=user from outside a project, "
+                "or run from inside one."
+            )
+        project_root = root
+
     try:
         result = asyncio.run(
             _rescan(
                 scope=scope,
                 source_exact=source_exact,
                 source_prefix=source_prefix,
+                project_root=project_root,
             )
         )
     except click.ClickException:
@@ -166,6 +191,7 @@ async def _rescan(
     scope: TargetScope,
     source_exact: Path | None,
     source_prefix: Path | None,
+    project_root: Path | None,
 ) -> tuple[int, list[dict]]:
     from memtomem.cli._bootstrap import cli_components
 
@@ -177,6 +203,7 @@ async def _rescan(
             scope=scope,
             source_exact=source_exact,
             source_prefix=source_prefix,
+            project_root=project_root,
         ):
             scanned += 1
             guard = privacy.enforce_write_guard(

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -814,6 +814,7 @@ class SqliteBackend(
         scope: str,
         source_exact: Path | None = None,
         source_prefix: Path | None = None,
+        project_root: Path | None = None,
         batch_size: int = 500,
     ) -> AsyncIterator[ChunkAuditRow]:
         """Stream chunks in ``scope`` for a privacy audit walk.
@@ -829,14 +830,39 @@ class SqliteBackend(
         are normalised via :func:`norm_path` before the query, mirroring
         the storage layer's existing source-path equality contract used
         by :meth:`list_chunks_by_source` and friends.
+
+        ``project_root`` is the ADR-0011 / ADR-0016 / issue #934 cross-
+        project isolation gate. When ``scope`` is a project tier
+        (``project_shared`` / ``project_local``) and multiple project
+        roots share the same SQLite DB, the caller passes the current
+        project root so the audit only walks rows owned by that root.
+        ``None`` (the default) means "no project filter" — the
+        ``--scope=user`` path always passes ``None`` because the user
+        tier is global by design. Mixing ``scope='user'`` with a
+        non-None ``project_root`` is a caller bug and is rejected up
+        front; user-tier rows have ``project_root IS NULL`` in the
+        chunks table so the filter would silently elide every user row.
         """
         if source_exact is not None and source_prefix is not None:
             raise ValueError(
                 "iter_chunks_for_audit: source_exact and source_prefix are mutually exclusive"
             )
+        if scope == "user" and project_root is not None:
+            raise ValueError(
+                "iter_chunks_for_audit: project_root must be None when scope='user' "
+                "(user-tier rows have project_root IS NULL by contract)"
+            )
 
         where_parts = ["COALESCE(scope, 'user') = ?"]
         params: list[object] = [scope]
+        if project_root is not None:
+            # ADR-0011 / issue #934 cross-project isolation. ``project_root``
+            # in the chunks table is the string returned by ``norm_path``
+            # at write time, so we apply the same normalisation here to
+            # keep the equality contract byte-exact across platforms (the
+            # source-path normalisation pattern above).
+            where_parts.append("project_root = ?")
+            params.append(norm_path(project_root))
         if source_exact is not None:
             where_parts.append("source_file = ?")
             params.append(norm_path(source_exact))

--- a/packages/memtomem/tests/test_context_rescan.py
+++ b/packages/memtomem/tests/test_context_rescan.py
@@ -191,11 +191,13 @@ class TestContextRescanProjectMarkerGate:
         """User tier is global by design — no project context required.
         Point ``$HOME`` at an empty tmp dir so the test doesn't read the
         real ``~/.memtomem``. ``canonical_artifact_dir`` resolves
-        ``~/.memtomem`` via ``Path.expanduser()`` which reads ``$HOME``.
+        ``~/.memtomem`` via ``Path.expanduser()`` which reads ``$HOME``
+        on POSIX and ``$USERPROFILE`` on Windows.
         """
         home = tmp_path / "user_home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
         monkeypatch.chdir(tmp_path)
 
         result = runner.invoke(cli, ["context", "rescan", "--scope", "user"])
@@ -215,6 +217,9 @@ class TestContextRescanScopeTargetSets:
         home = tmp_path / "user_home"
         home.mkdir()
         monkeypatch.setenv("HOME", str(home))
+        # Path.expanduser() reads $USERPROFILE on Windows; HOME alone leaks
+        # to the real runner profile and the audit scans 0 files.
+        monkeypatch.setenv("USERPROFILE", str(home))
         # Seed a secret under user canonical agents at $HOME/.memtomem/.
         _write_secret_artifact(home, ".memtomem", "agents", "shared", "agent.md")
         # Also seed a project root with a CLAUDE.md secret — must NOT

--- a/packages/memtomem/tests/test_context_rescan.py
+++ b/packages/memtomem/tests/test_context_rescan.py
@@ -144,3 +144,193 @@ class TestContextRescanBehaviour:
         after = privacy.snapshot()["outcomes"]
         for key, expected in before.items():
             assert after[key] == expected, f"counter {key!r} drifted"
+
+
+# ---------------------------------------------------------------------------
+# Issue #934 — scope-aware target sets
+# ---------------------------------------------------------------------------
+
+
+def _write_secret_artifact(root: Path, *parts: str) -> Path:
+    """Scaffold a single-file artifact (e.g. flat-layout agent) with a
+    secret payload inside ``root``. Returns the file path so the test can
+    assert against it.
+    """
+    target = root.joinpath(*parts)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_SECRET_LINE)
+    return target
+
+
+class TestContextRescanProjectMarkerGate:
+    """Issue #934 / AC #2: project tiers refuse to run without a real
+    project marker so the rescan cannot accidentally walk a sibling
+    worktree via ``_find_project_root``'s cwd fallback.
+    """
+
+    def test_project_shared_refused_without_marker(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # tmp_path has neither .git nor pyproject.toml.
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "project_shared"])
+        assert result.exit_code != 0
+        assert "requires a project root" in result.output
+
+    def test_project_local_refused_without_marker(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "project_local"])
+        assert result.exit_code != 0
+        assert "requires a project root" in result.output
+
+    def test_user_scope_runs_without_marker(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """User tier is global by design — no project context required.
+        Point ``$HOME`` at an empty tmp dir so the test doesn't read the
+        real ``~/.memtomem``. ``canonical_artifact_dir`` resolves
+        ``~/.memtomem`` via ``Path.expanduser()`` which reads ``$HOME``.
+        """
+        home = tmp_path / "user_home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "user"])
+        assert result.exit_code == 0, result.output
+        assert "0 violations" in result.output
+
+
+class TestContextRescanScopeTargetSets:
+    """Issue #934 / AC #1 + AC #3: ``--scope`` selects WHICH directories
+    are walked. Each tier audits a disjoint canonical set so the rescan
+    semantics mirror the tier's actual reach.
+    """
+
+    def test_user_scope_walks_user_canonical_only(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        home = tmp_path / "user_home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        # Seed a secret under user canonical agents at $HOME/.memtomem/.
+        _write_secret_artifact(home, ".memtomem", "agents", "shared", "agent.md")
+        # Also seed a project root with a CLAUDE.md secret — must NOT
+        # be walked under --scope=user.
+        (tmp_path / "proj").mkdir()
+        proj = _make_project_root(tmp_path / "proj")
+        (proj / "CLAUDE.md").write_text(_SECRET_LINE)
+        monkeypatch.chdir(proj)
+
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "user", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        paths = {v["path"] for v in payload["violations"]}
+        assert any("agents/shared/agent.md" in p or "agents\\shared\\agent.md" in p for p in paths)
+        assert not any(p.endswith("CLAUDE.md") for p in paths)
+
+    def test_project_shared_walks_canonical_plus_scanner_files(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        root = _make_project_root(tmp_path)
+        # Canonical project_shared dir + flat-layout agent.
+        _write_secret_artifact(root, ".memtomem", "agents", "shared-agent.md")
+        # Project-root scanner file — STILL in scope for project_shared
+        # because CLAUDE.md is the runtime fan-out of project_shared.
+        (root / "CLAUDE.md").write_text(_SECRET_LINE)
+        monkeypatch.chdir(root)
+
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "project_shared", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        paths = {v["path"] for v in payload["violations"]}
+        assert any(p.endswith("CLAUDE.md") for p in paths)
+        assert any(
+            p.endswith(".memtomem/agents/shared-agent.md")
+            or p.endswith(".memtomem\\agents\\shared-agent.md")
+            for p in paths
+        )
+
+    def test_project_local_walks_local_only_no_fanout(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """ADR-0011 §3 / ADR-0016 §7: project_local has NO runtime
+        fan-out. A rescan with --scope=project_local must walk the
+        ``*.local/`` canonical dirs and ignore project-root scanner
+        files like CLAUDE.md (which belong to project_shared's reach,
+        not project_local's).
+        """
+        root = _make_project_root(tmp_path)
+        _write_secret_artifact(root, ".memtomem", "agents.local", "draft.md")
+        # Plant a secret CLAUDE.md too — must NOT be walked because
+        # project_local has no fan-out into the project root.
+        (root / "CLAUDE.md").write_text(_SECRET_LINE)
+        monkeypatch.chdir(root)
+
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "project_local", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        paths = {v["path"] for v in payload["violations"]}
+        assert any(
+            p.endswith(".memtomem/agents.local/draft.md")
+            or p.endswith(".memtomem\\agents.local\\draft.md")
+            for p in paths
+        )
+        assert not any(p.endswith("CLAUDE.md") for p in paths)
+
+
+class TestContextRescanCrossProjectIsolation:
+    """Issue #934 / AC #4: a rescan inside project A must never walk
+    files owned by project B even if B's canonical tree happens to
+    sit next to A's in the same parent.
+    """
+
+    def test_project_local_cross_project_isolation(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        (tmp_path / "proj_a").mkdir()
+        (tmp_path / "proj_b").mkdir()
+        proj_a = _make_project_root(tmp_path / "proj_a")
+        proj_b = _make_project_root(tmp_path / "proj_b")
+        _write_secret_artifact(proj_a, ".memtomem", "agents.local", "a.md")
+        _write_secret_artifact(proj_b, ".memtomem", "agents.local", "b.md")
+        monkeypatch.chdir(proj_a)
+
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "project_local", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        # proj_b's secret must never appear in the violations list.
+        for v in payload["violations"]:
+            assert "proj_b" not in v["path"], v
+            assert "b.md" != Path(v["path"]).name, v
+        # And proj_a's secret must be present.
+        assert any("a.md" == Path(v["path"]).name for v in payload["violations"])
+
+    def test_symlink_escape_is_dropped(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Defence in depth: a symlink under .memtomem/agents/ pointing
+        into a sibling project's tree is dropped from the audit so a
+        misconfigured workspace cannot smuggle foreign files into A's
+        decisions list.
+        """
+        (tmp_path / "proj_a").mkdir()
+        (tmp_path / "proj_b").mkdir()
+        proj_a = _make_project_root(tmp_path / "proj_a")
+        proj_b = _make_project_root(tmp_path / "proj_b")
+        _write_secret_artifact(proj_a, ".memtomem", "agents", "self.md")
+        _write_secret_artifact(proj_b, ".memtomem", "agents", "stranger.md")
+        # Plant the escape link inside A pointing at B's agents tree.
+        (proj_a / ".memtomem" / "agents" / "link").symlink_to(proj_b / ".memtomem" / "agents")
+        monkeypatch.chdir(proj_a)
+
+        result = runner.invoke(cli, ["context", "rescan", "--scope", "project_shared", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        # ``stranger.md`` lives in proj_b; the symlink resolves outside
+        # proj_a's root and must be skipped by the defence.
+        assert all("stranger.md" != Path(v["path"]).name for v in payload["violations"])
+        # ``self.md`` is the only legitimate violation.
+        assert any("self.md" == Path(v["path"]).name for v in payload["violations"])

--- a/packages/memtomem/tests/test_mem_rescan.py
+++ b/packages/memtomem/tests/test_mem_rescan.py
@@ -60,10 +60,15 @@ def _mock_storage(rows_by_scope: dict[str, list[ChunkAuditRow]]) -> SimpleNamesp
         scope: str,
         source_exact: Path | None = None,
         source_prefix: Path | None = None,
+        project_root: Path | None = None,
         batch_size: int = 500,
     ) -> AsyncIterator[ChunkAuditRow]:
         # Replicates the SQLite backend's exact / prefix split so the CLI's
-        # source-filter contract is exercised end-to-end.
+        # source-filter contract is exercised end-to-end. The
+        # ``project_root`` filter (issue #934) is also honoured here so the
+        # cross-project isolation case can be reproduced without spinning
+        # up a real SQLite DB — when ``project_root`` is set, only rows
+        # whose ``project_root`` matches are yielded.
         for row in rows_by_scope.get(scope, []):
             if source_exact is not None and row.source != source_exact:
                 continue
@@ -72,6 +77,8 @@ def _mock_storage(rows_by_scope: dict[str, list[ChunkAuditRow]]) -> SimpleNamesp
                     row.source.relative_to(source_prefix)
                 except ValueError:
                     continue
+            if project_root is not None and row.project_root != project_root:
+                continue
             yield row
 
     storage = SimpleNamespace(iter_chunks_for_audit=iter_chunks_for_audit)
@@ -84,6 +91,19 @@ def _patched_cli_components(comp: SimpleNamespace):
         yield comp
 
     return fake
+
+
+def _stub_project_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    """Make the issue-#934 project-marker gate believe we're inside a
+    real project rooted at ``root``.
+
+    The CLI gate calls ``_find_project_root()`` and then verifies
+    ``.git`` / ``pyproject.toml`` exists. Writing ``pyproject.toml`` on
+    disk satisfies the second half; patching the lookup satisfies the
+    first regardless of cwd, so the test does not have to manage cwd.
+    """
+    (root / "pyproject.toml").write_text("[project]\nname='fixture'\n")
+    monkeypatch.setattr("memtomem.cli.mem_cmd._find_project_root", lambda: root)
 
 
 @pytest.fixture
@@ -123,13 +143,23 @@ class TestRescanRegistration:
 class TestRescanBehaviour:
     """Privacy-only audit semantics."""
 
+    @pytest.fixture(autouse=True)
+    def _project_marker(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Issue #934: ``--scope=project_shared`` requires a project root.
+        These tests focus on the audit pipeline, not the gate, so we
+        always stub a marker. The user-scope test in this class still
+        works because the gate is short-circuited for ``--scope=user``.
+        """
+        _stub_project_root(monkeypatch, tmp_path)
+
     def test_clean_chunks_exit_zero(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        proj = str(tmp_path)
         rows = {
             "project_shared": [
-                _row("c1", "/proj/docs/a.md", _SAFE_CONTENT),
-                _row("c2", "/proj/docs/b.md", _SAFE_CONTENT),
+                _row("c1", "/proj/docs/a.md", _SAFE_CONTENT, project_root=proj),
+                _row("c2", "/proj/docs/b.md", _SAFE_CONTENT, project_root=proj),
             ]
         }
         comp = _mock_storage(rows)
@@ -141,11 +171,11 @@ class TestRescanBehaviour:
         assert "2 chunks scanned" in result.output
 
     def test_secret_chunk_exits_one(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         rows = {
             "project_shared": [
-                _row("c1", "/proj/docs/secret.md", _SECRET_CONTENT),
+                _row("c1", "/proj/docs/secret.md", _SECRET_CONTENT, project_root=str(tmp_path)),
             ]
         }
         comp = _mock_storage(rows)
@@ -160,12 +190,12 @@ class TestRescanBehaviour:
         assert "span=[" in result.output
 
     def test_secret_chunk_clean_inverse_passes(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Pin-and-invert: same fixture shape without the secret exits 0."""
         rows = {
             "project_shared": [
-                _row("c1", "/proj/docs/safe.md", _SAFE_CONTENT),
+                _row("c1", "/proj/docs/safe.md", _SAFE_CONTENT, project_root=str(tmp_path)),
             ]
         }
         comp = _mock_storage(rows)
@@ -174,10 +204,12 @@ class TestRescanBehaviour:
         result = runner.invoke(cli, ["mem", "rescan", "--scope", "project_shared"])
         assert result.exit_code == 0, result.output
 
-    def test_json_output_schema(self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_json_output_schema(
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
         rows = {
             "project_shared": [
-                _row("c1", "/proj/docs/secret.md", _SECRET_CONTENT),
+                _row("c1", "/proj/docs/secret.md", _SECRET_CONTENT, project_root=str(tmp_path)),
             ]
         }
         comp = _mock_storage(rows)
@@ -202,7 +234,7 @@ class TestRescanBehaviour:
         assert h["span_end"] > h["span_start"]
 
     def test_decision_is_blocked_not_blocked_project_shared(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """v1 calls force_unsafe=False, so project_shared secret hits return
         decision='blocked', NOT 'blocked_project_shared' (which requires
@@ -210,7 +242,7 @@ class TestRescanBehaviour:
         """
         rows = {
             "project_shared": [
-                _row("c1", "/proj/x.md", _SECRET_CONTENT),
+                _row("c1", "/proj/x.md", _SECRET_CONTENT, project_root=str(tmp_path)),
             ]
         }
         comp = _mock_storage(rows)
@@ -240,14 +272,14 @@ class TestRescanBehaviour:
         assert payload["violations"][0]["scope"] == "user"
 
     def test_no_counter_drift_with_record_outcome_false(
-        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+        self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """The CLI passes record_outcome=False, so a violating rescan must
         not bump privacy._outcomes counters. End-to-end pin.
         """
         rows = {
             "project_shared": [
-                _row("c1", "/p/x.md", _SECRET_CONTENT),
+                _row("c1", "/p/x.md", _SECRET_CONTENT, project_root=str(tmp_path)),
             ]
         }
         comp = _mock_storage(rows)
@@ -265,6 +297,10 @@ class TestRescanBehaviour:
 class TestSourceFilter:
     """`--source` cwd-relative resolution and matching contract."""
 
+    @pytest.fixture(autouse=True)
+    def _project_marker(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        _stub_project_root(monkeypatch, tmp_path)
+
     def test_source_exact_file_filter(
         self, runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -273,10 +309,11 @@ class TestSourceFilter:
         b = tmp_path / "b.md"
         a.write_text("placeholder")
         b.write_text("placeholder")
+        proj = str(tmp_path)
         rows = {
             "project_shared": [
-                _row("a-id", str(a), _SECRET_CONTENT),
-                _row("b-id", str(b), _SECRET_CONTENT),
+                _row("a-id", str(a), _SECRET_CONTENT, project_root=proj),
+                _row("b-id", str(b), _SECRET_CONTENT, project_root=proj),
             ]
         }
         comp = _mock_storage(rows)
@@ -301,10 +338,11 @@ class TestSourceFilter:
         outside = tmp_path / "y.md"
         inside.write_text("p")
         outside.write_text("p")
+        proj = str(tmp_path)
         rows = {
             "project_shared": [
-                _row("inside", str(inside), _SECRET_CONTENT),
-                _row("outside", str(outside), _SECRET_CONTENT),
+                _row("inside", str(inside), _SECRET_CONTENT, project_root=proj),
+                _row("outside", str(outside), _SECRET_CONTENT, project_root=proj),
             ]
         }
         comp = _mock_storage(rows)
@@ -339,3 +377,98 @@ class TestSourceFilter:
             ],
         )
         assert result.exit_code == 2, result.output
+
+
+class TestProjectMarkerGate:
+    """Issue #934 ADR-0011 / ADR-0016 cross-project isolation gate.
+
+    The CLI refuses ``--scope=project_shared`` / ``--scope=project_local``
+    without a real project marker (``.git`` or ``pyproject.toml``) so a
+    shared SQLite DB can't accidentally leak chunks across worktrees.
+    ``--scope=user`` is unaffected because user-tier rows are global by
+    design.
+    """
+
+    def test_project_shared_refused_without_project_marker(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # No pyproject.toml, no .git → marker check fails.
+        monkeypatch.setattr("memtomem.cli.mem_cmd._find_project_root", lambda: tmp_path)
+
+        result = runner.invoke(cli, ["mem", "rescan", "--scope", "project_shared"])
+        assert result.exit_code != 0
+        assert "requires a project root" in result.output
+        # Make sure storage was never touched — the gate runs before
+        # ``cli_components`` is opened.
+
+    def test_project_local_refused_without_project_marker(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setattr("memtomem.cli.mem_cmd._find_project_root", lambda: tmp_path)
+
+        result = runner.invoke(cli, ["mem", "rescan", "--scope", "project_local"])
+        assert result.exit_code != 0
+        assert "requires a project root" in result.output
+
+    def test_user_scope_does_not_require_project_marker(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        # No marker, no patch. User tier short-circuits the gate.
+        monkeypatch.setattr("memtomem.cli.mem_cmd._find_project_root", lambda: tmp_path)
+        comp = _mock_storage({"user": []})
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["mem", "rescan", "--scope", "user"])
+        assert result.exit_code == 0, result.output
+
+    def test_project_shared_isolated_from_other_project(
+        self,
+        runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Two ``project_shared`` chunks in one mock DB — one tagged to
+        the current project, one to a sibling. The CLI passes the
+        current project_root into the audit; the mock honours it; the
+        sibling row never appears in the output.
+        """
+        proj_a = tmp_path / "proj_a"
+        proj_b = tmp_path / "proj_b"
+        proj_a.mkdir()
+        proj_b.mkdir()
+        _stub_project_root(monkeypatch, proj_a)
+
+        rows = {
+            "project_shared": [
+                _row(
+                    "a-secret",
+                    str(proj_a / "x.md"),
+                    _SECRET_CONTENT,
+                    project_root=str(proj_a),
+                ),
+                _row(
+                    "b-secret",
+                    str(proj_b / "x.md"),
+                    _SECRET_CONTENT,
+                    project_root=str(proj_b),
+                ),
+            ]
+        }
+        comp = _mock_storage(rows)
+        monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", _patched_cli_components(comp))
+
+        result = runner.invoke(cli, ["mem", "rescan", "--scope", "project_shared", "--json"])
+        assert result.exit_code == 1, result.output
+        payload = json.loads(result.output)
+        assert payload["scanned"] == 1
+        assert payload["violations"][0]["chunk_id"] == "a-secret"
+        assert all("b-secret" not in str(v) for v in payload["violations"])

--- a/packages/memtomem/tests/test_storage_iter_chunks_for_audit.py
+++ b/packages/memtomem/tests/test_storage_iter_chunks_for_audit.py
@@ -265,3 +265,102 @@ class TestPagination:
 
         rows = await _collect(backend, scope="user", batch_size=3)
         assert len(rows) == 7
+
+
+class TestProjectRootFilter:
+    """ADR-0011 / ADR-0016 / issue #934 cross-project isolation pin.
+
+    Before this filter existed, two projects sharing a single SQLite DB
+    could both write ``scope='project_shared'`` chunks; a rescan in
+    project A would walk B's chunks too and surface false positives /
+    leak B's content into A's audit log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_project_shared_filter_excludes_other_project(self, backend, tmp_path):
+        proj_a = norm_path(tmp_path / "proj_a")
+        proj_b = norm_path(tmp_path / "proj_b")
+        a_id = _seed(
+            backend,
+            source_file=norm_path(tmp_path / "proj_a" / "doc.md"),
+            scope="project_shared",
+            project_root=proj_a,
+        )
+        _seed(
+            backend,
+            source_file=norm_path(tmp_path / "proj_b" / "doc.md"),
+            scope="project_shared",
+            project_root=proj_b,
+        )
+
+        rows = await _collect(
+            backend,
+            scope="project_shared",
+            project_root=Path(proj_a),
+        )
+        assert [r.chunk_id for r in rows] == [a_id]
+        assert rows[0].project_root == Path(proj_a)
+
+    @pytest.mark.asyncio
+    async def test_project_local_filter_excludes_other_project(self, backend, tmp_path):
+        proj_a = norm_path(tmp_path / "proj_a")
+        proj_b = norm_path(tmp_path / "proj_b")
+        a_id = _seed(
+            backend,
+            source_file=norm_path(tmp_path / "proj_a" / "local.md"),
+            scope="project_local",
+            project_root=proj_a,
+        )
+        _seed(
+            backend,
+            source_file=norm_path(tmp_path / "proj_b" / "local.md"),
+            scope="project_local",
+            project_root=proj_b,
+        )
+
+        rows = await _collect(
+            backend,
+            scope="project_local",
+            project_root=Path(proj_a),
+        )
+        assert [r.chunk_id for r in rows] == [a_id]
+
+    @pytest.mark.asyncio
+    async def test_none_project_root_walks_every_project(self, backend, tmp_path):
+        """Back-compat: callers that don't pass ``project_root`` still see
+        every row in the requested scope. Pre-#934 callers (and the v1
+        bootstrap path) rely on this — only the CLI gate-up-front pattern
+        opts into the cross-project filter.
+        """
+        proj_a = norm_path(tmp_path / "proj_a")
+        proj_b = norm_path(tmp_path / "proj_b")
+        a_id = _seed(
+            backend,
+            source_file=norm_path(tmp_path / "proj_a" / "doc.md"),
+            scope="project_shared",
+            project_root=proj_a,
+        )
+        b_id = _seed(
+            backend,
+            source_file=norm_path(tmp_path / "proj_b" / "doc.md"),
+            scope="project_shared",
+            project_root=proj_b,
+        )
+
+        rows = await _collect(backend, scope="project_shared")
+        assert {r.chunk_id for r in rows} == {a_id, b_id}
+
+    @pytest.mark.asyncio
+    async def test_user_scope_with_project_root_raises(self, backend, tmp_path):
+        """Defensive contract: user-tier rows have project_root IS NULL
+        in the chunks table, so combining ``scope='user'`` with a
+        ``project_root`` filter would silently elide every user row.
+        The storage layer rejects the mix up front so a caller bug is
+        immediately visible.
+        """
+        with pytest.raises(ValueError, match="user-tier rows have project_root IS NULL"):
+            await _collect(
+                backend,
+                scope="user",
+                project_root=tmp_path,
+            )


### PR DESCRIPTION
## Summary

ADR-0011 / ADR-0016 follow-up that closes #934 by extending `mm mem rescan` and `mm context rescan` across the three-tier model (`user`, `project_shared`, `project_local`). Both surfaces stayed at issue-#885 shape and leaked across tiers; this PR fixes the two concrete gaps:

- **`mm mem rescan` was leaking across projects.** `iter_chunks_for_audit` filtered chunks by `scope` only — with a shared SQLite DB, `--scope=project_shared` walked rows owned by every project that had ever written one. New `project_root` kwarg gates the WHERE clause; defensive raise rejects `scope='user' + project_root != None`. (AC #2)
- **`mm context rescan` covered the wrong file set.** v1 walked exactly `detect_agent_files(root)` regardless of `--scope`. The canonical agents/skills/commands directories at any tier were never scanned. The CLI now resolves a per-tier target set via `canonical_artifact_dir`:
  - `--scope=user` → `~/.memtomem/{agents,skills,commands}/`
  - `--scope=project_shared` → `<root>/.memtomem/{agents,skills,commands}/` **plus** `detect_agent_files(root)` (the runtime fan-out of project_shared)
  - `--scope=project_local` → `<root>/.memtomem/{agents,skills,commands}.local/` only (no fan-out per ADR-0011 §3 / ADR-0016 §7)

Both surfaces refuse project tiers without a `.git`/`pyproject.toml` marker, mirroring `mm context init`'s gate. `mm context rescan` also drops symlink-escape descendants on project tiers (cheap `resolve()` + `is_relative_to(root)` check) so a misconfigured workspace link cannot smuggle foreign files into the audit.

MCP parity (`mem_rescan` / `mem_context_rescan`) is **intentionally deferred** to a follow-up — rescan is a pre-commit / CI audit gate, not an agent-runtime tool.

## AC mapping (issue #934)

- **AC #1** (CLI accepts tier/scope selector) — both surfaces keep `--scope` required; help text updated to document the per-tier target set.
- **AC #2** (project-tier rescans require project context) — `.git`/`pyproject.toml` marker check, no silent cwd fallback. Mem-side `iter_chunks_for_audit` gates on `project_root` so a project-tier rescan inside the wrong tree cannot surface foreign rows.
- **AC #3** (`project_local` gitignored + no fan-out) — context rescan for `project_local` walks ONLY the canonical `*.local/` dirs; scanner files (CLAUDE.md etc.) are excluded because project_local has no runtime fan-out. `.gitignore` scaffolding already lives in `_append_gitignore_marker` on the install/migrate path; no change required here.
- **AC #4** (tests cover the four cases) — per-tier user/project_shared/project_local on both surfaces, cross-project isolation at the SQLite layer (`TestProjectRootFilter`) and CLI layer (`TestProjectMarkerGate::test_project_shared_isolated_from_other_project` + context's `TestContextRescanCrossProjectIsolation`), plus a symlink-escape pin.

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_mem_rescan.py packages/memtomem/tests/test_context_rescan.py packages/memtomem/tests/test_storage_iter_chunks_for_audit.py` — 46 passed
- [x] `uv run pytest -m "not ollama"` (full CI filter) — 4973 passed, 10 skipped
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — clean
- [x] `uv run mypy packages/memtomem/src/memtomem/{cli/mem_cmd.py,cli/context_cmd.py,storage/sqlite_backend.py}` — 3 pre-existing errors in `context_cmd.py:2812-2829` (migrate path, unrelated to this PR; verified on `origin/main`)

End-to-end smoke (run from inside a memtomem checkout):
- [ ] `uv run mm mem rescan --scope=user`
- [ ] `uv run mm mem rescan --scope=project_shared`
- [ ] `uv run mm context rescan --scope=project_local`
- [ ] `cd $HOME && uv run mm mem rescan --scope=project_shared` → refuses with "requires a project root"

🤖 Generated with [Claude Code](https://claude.com/claude-code)