### PR TITLE
fix(web): layout-aware artifact name for /api/context/projects counts

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from memtomem.context._names import Layout
 from memtomem.context.agents import diff_agents, list_canonical_agents
 from memtomem.context.commands import diff_commands, list_canonical_commands
 from memtomem.context.projects import (
@@ -93,6 +94,21 @@ def resolve_scope_root(
 # ── GET /context/projects ────────────────────────────────────────────────
 
 
+def _canonical_artifact_name(path: Path, layout: Layout) -> str:
+    """Return the artifact name for a ``(Path, Layout)`` pair.
+
+    Flat layout: ``<root>/<name>.md`` — the file stem IS the artifact name.
+    Dir layout: ``<root>/<name>/{command,agent}.md`` — the file stem is
+    always the manifest filename (``"command"`` / ``"agent"``), so
+    multiple drafts would collapse to one entry in a name-keyed count.
+    Fall back to the parent directory name for dir layout so each draft
+    contributes a distinct entry — observed shape: two drafts at
+    ``commands/deploy/command.md`` and ``commands/ship/command.md``
+    should yield two distinct counted names, not one ``"command"``.
+    """
+    return path.parent.name if layout == "dir" else path.stem
+
+
 def _counts_for(root: Path) -> dict[str, int]:
     """Per-type unique-name counts for a project root.
 
@@ -118,10 +134,16 @@ def _counts_for(root: Path) -> dict[str, int]:
     try:
         names = {name for _runtime, name, _status in diff_commands(root)}
         # ``list_canonical_commands`` returns ``list[tuple[Path, Layout]]``
-        # since ADR-0008 PR-C (#624) added directory layout. Unpack the
-        # tuple — ``p.stem`` on the raw tuple raised AttributeError and
-        # the blanket ``except Exception`` below silently zeroed the count.
-        names.update(p.stem for p, _layout in list_canonical_commands(root))
+        # since ADR-0008 PR-C (#624) added directory layout. Name
+        # extraction must be layout-aware (review on PR for #934
+        # follow-up): ``p.stem`` is ``"command"`` for every dir-layout
+        # entry, so multiple drafts collapsed into one counted name and
+        # surfaced a phantom ``"command"`` row that masked the real
+        # canonical names. ``_canonical_artifact_name`` returns the
+        # parent directory name for dir layout, the file stem for flat.
+        names.update(
+            _canonical_artifact_name(p, layout) for p, layout in list_canonical_commands(root)
+        )
         counts["commands"] = len(names)
     except Exception:
         logger.warning("counts: commands failed for %s", root, exc_info=True)
@@ -129,9 +151,13 @@ def _counts_for(root: Path) -> dict[str, int]:
 
     try:
         names = {name for _runtime, name, _status in diff_agents(root)}
-        # Same tuple-unpack as commands above; ``list_canonical_agents``
-        # also returns ``list[tuple[Path, Layout]]`` post PR-C.
-        names.update(p.stem for p, _layout in list_canonical_agents(root))
+        # Same layout-aware extraction as commands above;
+        # ``list_canonical_agents`` returns the same tuple shape with the
+        # same manifest-name collapse (every dir entry has p.stem ==
+        # "agent").
+        names.update(
+            _canonical_artifact_name(p, layout) for p, layout in list_canonical_agents(root)
+        )
         counts["agents"] = len(names)
     except Exception:
         logger.warning("counts: agents failed for %s", root, exc_info=True)

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -123,6 +123,71 @@ async def test_get_projects_counts_directory_layout_commands_agents(client, cwd_
 
 
 @pytest.mark.asyncio
+async def test_get_projects_counts_multiple_dir_layout_drafts(client, cwd_root: Path) -> None:
+    """Multiple directory-layout drafts must NOT collapse into one count.
+
+    Review-pass on the #934 follow-up surfaced that
+    ``list_canonical_{commands,agents}`` returns ``(Path, Layout)`` with
+    the Path pointing at the manifest file — so under directory layout
+    ``p.stem`` is always ``"command"`` / ``"agent"`` and every draft
+    folds into the same name-keyed entry. Two real drafts at
+    ``commands/deploy/command.md`` and ``commands/ship/command.md``
+    would have counted as one ``"command"`` row, masking the actual
+    inventory in the UI's count badges.
+
+    The fix uses the parent directory name for dir-layout entries.
+    Asserting **exact** counts here (not ``>=``) pins the no-collapse
+    contract — pre-fix the assertion would have read 1 instead of 2.
+    """
+    for name in ("deploy", "ship"):
+        cmd_dir = cwd_root / ".memtomem" / "commands" / name
+        cmd_dir.mkdir(parents=True)
+        (cmd_dir / "command.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    for name in ("reviewer", "summarizer"):
+        agent_dir = cwd_root / ".memtomem" / "agents" / name
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "agent.md").write_text(f"# {name}\n", encoding="utf-8")
+
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    counts = resp.json()["scopes"][0]["counts"]
+    assert counts["commands"] == 2, (
+        f"two dir-layout commands must count as 2 distinct names, "
+        f"not collapse to 1 via p.stem='command' (got {counts})"
+    )
+    assert counts["agents"] == 2, (
+        f"two dir-layout agents must count as 2 distinct names, "
+        f"not collapse to 1 via p.stem='agent' (got {counts})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_projects_counts_flat_and_dir_layout_mix(client, cwd_root: Path) -> None:
+    """Flat-layout drafts still count by file stem.
+
+    Pin-and-invert: the layout-aware extractor must keep using ``p.stem``
+    for flat layout — switching wholesale to ``p.parent.name`` would
+    collapse every flat-layout artifact under ``commands/`` /
+    ``agents/`` into the canonical-root name.
+    """
+    cmd_root = cwd_root / ".memtomem" / "commands"
+    cmd_root.mkdir(parents=True)
+    # Flat layout: <root>/commands/<name>.md
+    (cmd_root / "build.md").write_text("# build\n", encoding="utf-8")
+    # Dir layout: <root>/commands/<name>/command.md
+    (cmd_root / "deploy").mkdir()
+    (cmd_root / "deploy" / "command.md").write_text("# deploy\n", encoding="utf-8")
+
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    counts = resp.json()["scopes"][0]["counts"]
+    assert counts["commands"] == 2, (
+        f"flat 'build' + dir 'deploy' must count as 2, not collapse (got {counts})"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_projects_after_add(client, tmp_path: Path) -> None:
     other = tmp_path / "inflearn"
     other.mkdir()


### PR DESCRIPTION
## Summary

Review-pass on the #934 follow-up flagged a dir-layout name collapse in `_counts_for` (`web/routes/context_projects.py:124, 134`).

\`list_canonical_{commands,agents}\` returns \`list[tuple[Path, Layout]]\` (since ADR-0008 PR-C / #624). The path points at the manifest file:

- Flat layout → \`<root>/<name>.md\` (\`p.stem == name\` ✓)
- Dir layout → \`<root>/<name>/{command,agent}.md\` (\`p.stem == \"command\"\` or \`\"agent\"\` — **always** the same, so multiple drafts fold into one entry)

Pre-fix: two real drafts at \`commands/deploy/command.md\` + \`commands/ship/command.md\` counted as **1**, not 2; the count badge in the multi-project UI also surfaced a phantom \`\"command\"\` / \`\"agent\"\` row when unioned with \`diff_*\` runtime names.

Fix: small helper \`_canonical_artifact_name(path, layout)\` returns \`path.parent.name\` for dir layout, \`path.stem\` for flat. Skills already used \`p.name\` on the directory path and are unaffected.

## Why \"project_local\" appeared in the review note

The bug exists today for any scope using dir layout — the reviewer's framing (\`?target_scope=project_local\`) anticipates the query-param wiring that would also exercise \`commands.local/\` and \`agents.local/\`. That wiring is separate work; this PR ships the underlying name-extraction fix that any future per-tier consumer (and today's project_shared default) needs.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/test_web_routes_context_projects.py\` — 16 passed (2 new)
- [x] \`uv run pytest packages/memtomem/tests/test_web_routes_context_projects.py packages/memtomem/tests/web/test_context_gateway_lists.py\` — 27 passed (slice covering the routes + UI list rendering)
- [x] \`uv run ruff check packages/memtomem/src packages/memtomem/tests\` — clean
- [x] \`uv run ruff format --check packages/memtomem/src packages/memtomem/tests\` — clean
- [x] **Mutation-tested** the new asserts: stashed the source change → \`test_get_projects_counts_multiple_dir_layout_drafts\` reads commands==1 (should be 2), \`test_get_projects_counts_flat_and_dir_layout_mix\` reads commands==3 (should be 2 — the residual phantom \`\"command\"\` name pollutes the union).

## Test additions

- \`test_get_projects_counts_multiple_dir_layout_drafts\` — two dir-layout drafts each for commands/agents, exact \`== 2\` count assertion.
- \`test_get_projects_counts_flat_and_dir_layout_mix\` — pin-and-invert that the layout-aware extractor still uses \`p.stem\` for flat layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)