### PR TITLE
docs(adr): clarify adr-feedback label is for signal sources, not the tracker

### DIFF
--- a/docs/adr/TRACKER.md
+++ b/docs/adr/TRACKER.md
@@ -45,9 +45,11 @@ When a deferred question expects qualitative contributor signal (vs. a
 crisp event trigger), maintainers can:
 
 - Comment on the tracking issue with a quote + source link + date.
-- Apply the `adr-feedback` label to any PR / issue / discussion where
-  the confusion surfaces, then copy the relevant quote to the tracking
-  issue so signals don't get lost in closed-PR review threads.
+- Apply the `adr-feedback` label to any **non-tracker** PR / issue /
+  discussion where the confusion surfaces, then copy the relevant quote
+  to the tracking issue so signals don't get lost in closed-PR review
+  threads. The tracker issue itself is the aggregation point, not a
+  signal source — do not label it.
 
 The tracking issue's body should enumerate which signal sources count
 and what the adjudication rule is (see #922 for the canonical example).


### PR DESCRIPTION
## Summary

- TRACKER.md L48 said "any PR / issue / discussion" — read in isolation it left room to apply the `adr-feedback` label to the **tracker issue itself**, even though L52-53 frames the tracker as the aggregation point (not a signal source).
- Add a `**non-tracker**` qualifier and an explicit "do not label it" sentence so `is:open label:adr-feedback` queries return only signal sources, and so a maintainer scanning the rule in isolation reaches the same conclusion the two lines together imply.

## Why

Caught in practice: while wiring up the signal channels post-#942 the `adr-feedback` label was briefly applied to #922 (the tracker for the `target_scope` → `target_tier` deferred ADR). Codex review pointed at L48-50 vs L52-53 — the label belongs on the source thread, the quote gets copied to the tracker's comments. The label has since been removed from #922; this PR pins the rule so the same misread doesn't recur.

## Scope notes

- `CONTRIBUTING.md` L51-55 already says "apply the `adr-feedback` label to **your** PR / issue" — contributor-facing wording already implies non-tracker. No change needed there.
- No code, no tests touched. One docs file, +5/-3 LOC.

## Test plan

- [x] `ruff` / `pytest` not relevant (docs-only)
- [x] Read TRACKER.md §"Signal collection" end-to-end with the new wording — internally consistent with §"Authoring rules" and §"Adding a row"

Follow-up to #942.

🤖 Generated with [Claude Code](https://claude.com/claude-code)