### PR TITLE
feat(context): surface project_root + detected_runtimes on overview dashboard

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -112,6 +112,47 @@ def _redact_message(message: str) -> str:
     return redacted
 
 
+def _compute_detected_runtimes(project_root: Path) -> list[dict[str, object]]:
+    """Probe each known runtime for any on-disk fan-out surface.
+
+    Returns one entry per runtime in :data:`KNOWN_RUNTIMES` with an
+    ``available`` flag that is the OR across:
+      * top-level agent file (``CLAUDE.md`` / ``GEMINI.md`` / ``AGENTS.md``),
+      * project-scope skill dir (``.claude/skills`` etc.),
+      * project-scope sub-agent dir (``.claude/agents`` etc.),
+      * project-scope command dir (``.claude/commands`` etc., Codex omitted).
+
+    The aggregate "any surface" semantics matches the dashboard chip strip
+    described in #830 — undetected-but-known runtimes still appear so the
+    user can see they exist on the runway, just greyed out.
+
+    Aggregate ``registered_roots`` shape is deferred until ADR-0009 (#829);
+    this endpoint stays single-project until that policy lands.
+    """
+    from memtomem.context._runtime_targets import KNOWN_RUNTIMES
+    from memtomem.context.detector import (
+        AGENT_DIRS,
+        AGENT_FILES,
+        COMMAND_DIRS,
+        SKILL_DIRS,
+    )
+
+    out: list[dict[str, object]] = []
+    for rt in KNOWN_RUNTIMES:
+        probes: list[bool] = []
+        for rel in AGENT_FILES.get(rt, []):
+            probes.append((project_root / rel).exists())
+        for rel in SKILL_DIRS.get(f"{rt}_skills", []):
+            probes.append((project_root / rel).is_dir())
+        for rel in AGENT_DIRS.get(f"{rt}_agents", []):
+            probes.append((project_root / rel).is_dir())
+        cmd = COMMAND_DIRS.get(f"{rt}_commands")
+        if cmd is not None:
+            probes.append((project_root / cmd[0]).is_dir())
+        out.append({"name": rt, "available": any(probes)})
+    return out
+
+
 def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
     """Build the per-surface error envelope.
 
@@ -232,4 +273,15 @@ async def context_overview(
         logger.exception("diff_settings failed")
         result["settings"] = _error_payload(exc, shape="status")
 
-    return {"target_scope": target_scope, **result}
+    try:
+        detected_runtimes = _compute_detected_runtimes(project_root)
+    except Exception:
+        logger.exception("_compute_detected_runtimes failed")
+        detected_runtimes = []
+
+    return {
+        "target_scope": target_scope,
+        "project_root": str(project_root),
+        "detected_runtimes": detected_runtimes,
+        **result,
+    }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -173,7 +173,38 @@ function _renderCtxOverview(data) {
     { key: 'settings', label: t('settings.hooks.title'),        section: 'hooks-sync' },
   ];
 
-  let html = _ctxTierControls('overview');
+  // Issues #830/#831: surface project root and detected runtimes so a "0 skills"
+  // tile isn't ambiguous between "empty project" and "wrong root". Defensive
+  // readers — older _ctxOverviewCache payloads (pre-add) replay through this
+  // path on langchange and would otherwise blow up.
+  const runtimes = Array.isArray(data.detected_runtimes) ? data.detected_runtimes : [];
+  const projectRoot = typeof data.project_root === 'string' ? data.project_root : '';
+  const undetectedTitle = escapeHtml(t('settings.ctx.runtime_undetected_tooltip'));
+  const chips = runtimes.map(rt => {
+    const available = !!rt.available;
+    const cls = available ? 'badge badge-success' : 'badge badge-gray';
+    const title = available ? '' : ` title="${undetectedTitle}"`;
+    const name = escapeHtml(rt.name || '');
+    return `<span class="${cls}"${title} data-runtime="${name}">${name}</span>`;
+  }).join('');
+
+  // Inline ``t()`` text rather than ``data-i18n`` attrs: the langchange
+  // listener applies ``I18N.applyDOM`` first and then re-renders this
+  // panel, so any ``data-i18n`` attr written *during* the re-render would
+  // miss the translation pass and stay on its EN fallback. Tile labels in
+  // this same render path use the same inline-``t()`` convention for the
+  // same ordering reason.
+  let html = `<div class="ctx-overview-header">
+      <div class="ctx-overview-root">
+        <span class="ctx-overview-root-label">${escapeHtml(t('settings.ctx.project_root_label'))}</span>
+        <code class="ctx-overview-root-path">${escapeHtml(projectRoot)}</code>
+      </div>
+      <div class="ctx-overview-runtimes">
+        <span class="ctx-overview-runtimes-label">${escapeHtml(t('settings.ctx.runtimes_label'))}</span>
+        ${chips}
+      </div>
+    </div>`;
+  html += _ctxTierControls('overview');
   html += '<div class="ctx-overview-grid">';
   for (const typ of types) {
       if (typ.devOnly && STATE.uiMode !== 'dev') continue;

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -284,6 +284,9 @@
   "settings.nav.reset_sub": "Delete all data",
 
   "settings.ctx.overview_title": "Context Gateway",
+  "settings.ctx.project_root_label": "Project",
+  "settings.ctx.runtimes_label": "Runtimes",
+  "settings.ctx.runtime_undetected_tooltip": "Not detected in this project",
   "settings.ctx.refresh": "Refresh",
   "settings.ctx.sync_all": "Sync All",
   "settings.ctx.sync": "Sync",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -284,6 +284,9 @@
   "settings.nav.reset_sub": "전체 데이터 삭제",
 
   "settings.ctx.overview_title": "컨텍스트 게이트웨이",
+  "settings.ctx.project_root_label": "프로젝트",
+  "settings.ctx.runtimes_label": "런타임",
+  "settings.ctx.runtime_undetected_tooltip": "이 프로젝트에서 감지되지 않음",
   "settings.ctx.refresh": "새로고침",
   "settings.ctx.sync_all": "전체 동기화",
   "settings.ctx.sync": "동기화",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3137,6 +3137,11 @@ body.help-hidden #help-toggle { opacity: 0.5; }
   color: white;
 }
 
+.ctx-overview-header { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-bottom: 12px; font-size: 0.85rem; color: var(--muted); }
+.ctx-overview-root, .ctx-overview-runtimes { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ctx-overview-root-label, .ctx-overview-runtimes-label { font-weight: 600; color: var(--text); }
+.ctx-overview-root-path { font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace); font-size: 0.78rem; background: var(--surface); padding: 2px 6px; border: 1px solid var(--border); border-radius: 4px; color: var(--text); word-break: break-all; }
+
 .ctx-overview-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; }
 .ctx-overview-stat { text-align: center; padding: 20px 16px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); cursor: pointer; transition: border-color 0.15s; }
 .ctx-overview-stat:hover { border-color: var(--accent); }

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -90,6 +90,40 @@ class TestOverview:
         assert data["skills"]["total"] >= 1
 
     @pytest.mark.anyio
+    async def test_overview_exposes_project_root(self, client: AsyncClient, tmp_path: Path):
+        r = await client.get("/api/context/overview")
+        data = r.json()
+        assert data["project_root"] == str(tmp_path)
+
+    @pytest.mark.anyio
+    async def test_overview_detected_runtimes_shape(self, client: AsyncClient):
+        r = await client.get("/api/context/overview")
+        data = r.json()
+        runtimes = data["detected_runtimes"]
+        assert isinstance(runtimes, list)
+        # One entry per ``KNOWN_RUNTIMES``; greyed chips for absent runtimes
+        # are part of the contract — the frontend renders them as undetected.
+        names = [r["name"] for r in runtimes]
+        assert names == ["claude", "gemini", "codex"]
+        for entry in runtimes:
+            assert isinstance(entry["available"], bool)
+
+    @pytest.mark.anyio
+    async def test_overview_detected_runtimes_flags_present_surfaces(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        # CLAUDE.md (top-level agent file) → claude detected
+        (tmp_path / "CLAUDE.md").write_text("# x\n", encoding="utf-8")
+        # .gemini/skills/foo/SKILL.md → gemini detected via skill dir
+        gem_skill = tmp_path / ".gemini" / "skills" / "foo"
+        gem_skill.mkdir(parents=True)
+        (gem_skill / SKILL_MANIFEST).write_text("# g\n", encoding="utf-8")
+
+        r = await client.get("/api/context/overview")
+        runtimes = {r["name"]: r["available"] for r in r.json()["detected_runtimes"]}
+        assert runtimes == {"claude": True, "gemini": True, "codex": False}
+
+    @pytest.mark.anyio
     async def test_project_local_overview_visible_only_with_explicit_target_scope(
         self, client: AsyncClient, tmp_path: Path
     ):

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -218,6 +218,132 @@ def test_langchange_rerenders_card_label_text(page, mm_web_url: str) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# Header (issues #830 / #831): project_root path + detected_runtimes chip strip.
+# ---------------------------------------------------------------------------
+
+_OVERVIEW_WITH_HEADER = {
+    **_HEALTHY_OVERVIEW,
+    "project_root": "/tmp/example-project",
+    "detected_runtimes": [
+        {"name": "claude", "available": True},
+        {"name": "gemini", "available": False},
+        {"name": "codex", "available": False},
+    ],
+}
+
+
+def test_overview_header_renders_project_root_and_runtime_chips(page, mm_web_url: str) -> None:
+    """#830/#831 pin: the overview panel header surfaces the registered
+    project root path and a per-runtime chip strip, with detected runtimes
+    rendered as ``badge-success`` and undetected as ``badge-gray``.
+
+    Undetected chips also carry the
+    ``settings.ctx.runtime_undetected_tooltip`` ``title`` attribute so the
+    "why is this greyed out" question is one hover away on desktop and
+    discoverable via screen reader on assistive tech.
+    """
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_OVERVIEW_WITH_HEADER),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    root_text = (
+        page.locator("#ctx-overview-content .ctx-overview-root-path").text_content() or ""
+    ).strip()
+    assert root_text == "/tmp/example-project", (
+        f"header must render the stubbed project_root; got {root_text!r}"
+    )
+
+    chips = page.locator("#ctx-overview-content .ctx-overview-runtimes [data-runtime]")
+    assert chips.count() == 3, (
+        f"chip strip must include all KNOWN_RUNTIMES (greyed when undetected); got {chips.count()}"
+    )
+
+    claude_chip = page.locator(
+        "#ctx-overview-content .ctx-overview-runtimes [data-runtime='claude']"
+    )
+    claude_classes = (claude_chip.get_attribute("class") or "").split()
+    assert "badge-success" in claude_classes, (
+        f"detected runtime chip must be badge-success; got {claude_classes!r}"
+    )
+
+    gemini_chip = page.locator(
+        "#ctx-overview-content .ctx-overview-runtimes [data-runtime='gemini']"
+    )
+    gemini_classes = (gemini_chip.get_attribute("class") or "").split()
+    assert "badge-gray" in gemini_classes, (
+        f"undetected runtime chip must be badge-gray; got {gemini_classes!r}"
+    )
+    # Tooltip pin: undetected chip exposes a ``title`` attribute so hover
+    # reveals why it's greyed; the i18n key path is what makes this
+    # translatable (EN/KO parity is enforced by ``test_i18n.py``).
+    assert gemini_chip.get_attribute("title"), (
+        "undetected chip must carry a title attribute (runtime_undetected_tooltip)"
+    )
+
+
+def test_overview_header_labels_translate_on_langchange(page, mm_web_url: str) -> None:
+    """The header labels use ``data-i18n`` attrs so ``I18N.applyDOM`` (which
+    only walks data-attributes) handles the EN→KO swap without needing the
+    inline-text re-render path. Cross-pinned with #825: no refetch on toggle.
+
+    The chip names themselves are proper nouns (claude/gemini/codex) and
+    must NOT translate — pinning their text after the toggle guards against
+    a future "translate runtime names too" footgun.
+    """
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_OVERVIEW_WITH_HEADER),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    root_label = page.locator("#ctx-overview-content .ctx-overview-root-label")
+    pre = (root_label.text_content() or "").strip()
+    assert pre == "Project", f"default (EN) header label should be 'Project'; got {pre!r}"
+
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
+    page.wait_for_function(
+        "() => {"
+        "  const el = document.querySelector("
+        "    '#ctx-overview-content .ctx-overview-root-label');"
+        "  return el && el.textContent.trim() === '프로젝트';"
+        "}",
+        timeout=3_000,
+    )
+
+    runtimes_label = (
+        page.locator("#ctx-overview-content .ctx-overview-runtimes-label").text_content() or ""
+    ).strip()
+    assert runtimes_label == "런타임", (
+        f"runtimes label must translate to KO; got {runtimes_label!r}"
+    )
+
+    # Chip names stay as raw runtime identifiers — proper nouns, not labels.
+    claude_text = (
+        page.locator(
+            "#ctx-overview-content .ctx-overview-runtimes [data-runtime='claude']"
+        ).text_content()
+        or ""
+    ).strip()
+    assert claude_text == "claude", (
+        f"runtime chip text must stay as the raw identifier on lang toggle; got {claude_text!r}"
+    )
+
+
 def test_langchange_uses_cache_no_spinner_flash(page, mm_web_url: str) -> None:
     """#825 pin: lang toggle on a healthy mounted dashboard must re-render
     from ``_ctxOverviewCache`` directly — no refetch and, crucially, no


### PR DESCRIPTION
## Summary

Add two read-only additive fields to `/api/context/overview` and surface them in the Context Gateway dashboard panel header:

- **`project_root: str`** — the project root the server is currently operating against (from `app.state.project_root`). Single-project semantics; aggregate `registered_roots` shape stays deferred pending ADR-0009 (#829).
- **`detected_runtimes: list[{name, available}]`** — one entry per `KNOWN_RUNTIMES` (`claude`, `gemini`, `codex`). `available` is the OR across per-surface probes (top-level agent file, skill dir, sub-agent dir, command dir). Undetected runtimes still appear in the response so the dashboard can render them as greyed chips — issue #830's prescribed shape.

The frontend renders both inside `#ctx-overview-content` (the overview panel header, NOT the global page header), so a `0 skills` tile now disambiguates "empty project" from "wrong root", and a CLAUDE-only project still shows that Gemini/Codex are part of the runway.

Closes #830.
Closes #831.

## Why this shape

- **`{name, available}` over `list[str]`**: greying out chips for known-but-undetected runtimes is the dashboard UX win — `list[str]` would force the frontend to recompute that diff against a hard-coded JS copy of `KNOWN_RUNTIMES`, duplicating server truth.
- **`project_root` is `str(app.state.project_root)`**, not a walked-up `.git`/`pyproject.toml` root: the dashboard should reflect what the server is actually operating against, which is what fan-out writes use.
- **Inline `t()` for header labels** rather than `data-i18n` attrs: the existing langchange listener runs `I18N.applyDOM` *before* re-rendering this panel from `_ctxOverviewCache`, so attribute-driven keys would render against EN fallback text on every toggle. Same ordering reason as the existing tile labels.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_routes_context.py -m "not ollama"` — 90 passed (3 new tests in `TestOverview`)
- [x] `uv run pytest packages/memtomem/tests/web/test_context_gateway_overview.py -m "not ollama"` — 9 passed (2 new browser tests for header rendering + langchange)
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 44 passed (en/ko parity holds)
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests && uv run ruff format --check packages/memtomem/src packages/memtomem/tests` — all checks passed
- [x] Manual smoke: curl `/api/context/overview` returns the new fields; browser shows path + chip strip in the Context Gateway panel header; EN/KO toggle translates labels but keeps runtime IDs raw.

## Out of scope

- Aggregate `registered_roots` shape (#831 follow-up — gated on ADR-0009 / #829)
- Per-runtime "last sync" timestamps (#832~ Info-3)
- MCP parity (`mem_context_overview` is a dashboard view, not an audit verb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)