### PR TITLE
feat(web): surface detected runtime chip strip on overview (#830)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -112,6 +112,47 @@ def _redact_message(message: str) -> str:
     return redacted
 
 
+def _detected_runtimes(project_root: Path, scope: str) -> list[dict]:
+    """OR-aggregate runtime availability across the four declared surfaces.
+
+    Per ADR-0009 §1 the dashboard chip strip emits one entry per declared
+    runtime root with an aggregate ``available`` flag that is ``True`` when
+    *any* surface (skills / sub-agents / commands / settings) resolves a
+    target on disk. The universe of declared runtimes is the union of
+    suffix-stripped keys across ``detector.SKILL_DIRS`` / ``AGENT_DIRS`` /
+    ``COMMAND_DIRS`` and ``SETTINGS_GENERATORS``. Skill / agent / command
+    availability is directory-probe based (the registry protocols expose
+    only ``target_dir()`` / ``target_file()``); settings availability uses
+    the generator's ``is_available()`` (the protocol exposes that one
+    method because user-scope ``~/.claude/`` cannot be discovered by a
+    project-root walk).
+    """
+    from memtomem.context import detector
+    from memtomem.context.settings import SETTINGS_GENERATORS
+
+    universe: set[str] = set()
+    for key in detector.SKILL_DIRS:
+        universe.add(key.removesuffix("_skills"))
+    for key in detector.AGENT_DIRS:
+        universe.add(key.removesuffix("_agents"))
+    for key in detector.COMMAND_DIRS:
+        universe.add(key.removesuffix("_commands"))
+    for name in SETTINGS_GENERATORS:
+        universe.add(name.removesuffix("_settings"))
+
+    detected: set[str] = set()
+    for d in detector.detect_skill_dirs(project_root):
+        detected.add(d.agent.removesuffix("_skills"))
+    for d in detector.detect_agent_dirs(project_root):
+        detected.add(d.agent.removesuffix("_agents"))
+    for d in detector.detect_command_dirs(project_root):
+        detected.add(d.agent.removesuffix("_commands"))
+    for d in detector.detect_settings_files(project_root, scope):
+        detected.add(d.agent.removesuffix("_settings"))
+
+    return [{"name": name, "available": name in detected} for name in sorted(universe)]
+
+
 def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
     """Build the per-surface error envelope.
 
@@ -232,4 +273,15 @@ async def context_overview(
         logger.exception("diff_settings failed")
         result["settings"] = _error_payload(exc, shape="status")
 
-    return {"target_scope": target_scope, **result}
+    # detected_runtimes is independent of ``target_scope`` (its surfaces are
+    # detected per ADR-0009 §1) but uses the resolved hooks scope for the
+    # settings probe so ``detect_settings_files`` walks the same tier that
+    # ``diff_settings`` did above. Failures here must not collapse the four
+    # tile envelopes — a permission glitch on one detector path would leave
+    # the chip strip empty, but the rest of the dashboard stays usable.
+    try:
+        runtimes = _detected_runtimes(project_root, scope)
+    except Exception:
+        logger.exception("detect_runtimes failed")
+        runtimes = []
+    return {"target_scope": target_scope, **result, "detected_runtimes": runtimes}

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -49,6 +49,26 @@ function _ctxBadge(status) {
   return `<span class="ctx-runtime-badge ${cls}">${escapeHtml(_ctxStatusText(status))}</span>`;
 }
 
+// Dashboard chip strip (ADR-0009 §1 / #830). Distinct from
+// ``renderRuntimeBadges`` below — that one is per-(runtime, status) for the
+// leaf list pages; this one is per-runtime (aggregate availability) for the
+// dashboard header. The two share the ``.ctx-runtime-badge`` palette but
+// not the data shape: ``runtimes`` here is ``[{name, available}]`` from
+// ``/api/context/overview``'s ``detected_runtimes`` field (ADR-0009 §5).
+function renderDetectedRuntimes(runtimes) {
+  if (!runtimes || !runtimes.length) return '';
+  const chips = runtimes.map(r => {
+    const cls = r.available
+      ? 'ctx-runtime-badge--sync'
+      : 'ctx-runtime-badge--missing';
+    return `<span class="ctx-runtime-badge ${cls}" data-available="${r.available ? 'true' : 'false'}">${escapeHtml(r.name)}</span>`;
+  }).join('');
+  return `<div class="ctx-detected-runtimes" role="group" aria-label="${escapeHtml(t('settings.ctx.detected_runtimes_label'))}">
+    <span class="ctx-detected-runtimes-label">${escapeHtml(t('settings.ctx.detected_runtimes_label'))}</span>
+    <div class="ctx-runtime-badges">${chips}</div>
+  </div>`;
+}
+
 function renderRuntimeBadges(runtimes) {
   if (!runtimes || !runtimes.length) return '';
   return '<div class="ctx-runtime-badges">' +
@@ -174,6 +194,11 @@ function _renderCtxOverview(data) {
   ];
 
   let html = _ctxTierControls('overview');
+  // ADR-0009 §1 / #830 — chip strip above the 4-tile grid. ``data`` is the
+  // cached ``/api/context/overview`` payload (langchange re-render path
+  // reuses ``_ctxOverviewCache``), so the strip rebuilds from the same
+  // shape on every render — locale changes flow through ``t()`` naturally.
+  html += renderDetectedRuntimes(data.detected_runtimes);
   html += '<div class="ctx-overview-grid">';
   for (const typ of types) {
       if (typ.devOnly && STATE.uiMode !== 'dev') continue;

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -355,6 +355,7 @@
   "settings.ctx.field_map": "Field Map",
   "settings.ctx.auxiliary_files": "Auxiliary files",
   "settings.ctx.overview_desc": "Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.",
+  "settings.ctx.detected_runtimes_label": "Detected runtimes",
   "settings.ctx.refresh_tooltip": "Refresh detected Claude Code / Codex runtime status",
   "settings.ctx.refresh_aria": "Refresh detected runtime status",
   "settings.ctx.sync_all_tooltip": "Push canonical memtomem artifacts to all detected runtimes",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -355,6 +355,7 @@
   "settings.ctx.field_map": "필드 맵",
   "settings.ctx.auxiliary_files": "보조 파일",
   "settings.ctx.overview_desc": "memtomem 의 에이전트 런타임 아티팩트를 Claude Code, Codex 등 감지된 런타임으로 동기화합니다.",
+  "settings.ctx.detected_runtimes_label": "감지된 런타임",
   "settings.ctx.refresh_tooltip": "감지된 Claude Code · Codex 런타임 상태를 새로고침합니다",
   "settings.ctx.refresh_aria": "감지된 런타임 상태 새로고침",
   "settings.ctx.sync_all_tooltip": "memtomem 정본 아티팩트를 감지된 모든 런타임으로 push 합니다",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3219,6 +3219,24 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 }
 .ctx-runtime-badge--error { background: rgba(224, 90, 90, 0.15); color: var(--danger); }
 
+/* Dashboard detected-runtimes chip strip (ADR-0009 §1 / #830). Sits above
+   the 4-tile overview grid. Reuses the ``.ctx-runtime-badge`` palette
+   (sync for available, missing for declared-but-undetected). */
+.ctx-detected-runtimes {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 6px 0 10px;
+}
+.ctx-detected-runtimes-label {
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.ctx-runtime-badge[data-available="false"] { opacity: 0.6; }
+
 /* Import-first state: when the cwd's canonical count is zero, demote the
    Sync button (no-op until canonicals exist) and promote Import to the
    primary affordance. The data attribute is wired by _ctxRefreshSectionState

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -1492,3 +1492,127 @@ class TestCommandTargetScopePlumbing:
             json={"content": "# x\n", "mtime_ns": "0"},
         )
         assert r.status_code == 400
+
+
+class TestDetectedRuntimes:
+    """ADR-0009 §1 / #830 — chip strip on the dashboard header.
+
+    ``/api/context/overview`` now carries ``detected_runtimes`` — an
+    OR-aggregate per declared runtime root across four detection surfaces
+    (skills / sub-agents / commands / settings). The runtime universe is
+    the union of suffix-stripped keys from ``SKILL_DIRS`` / ``AGENT_DIRS``
+    / ``COMMAND_DIRS`` / ``SETTINGS_GENERATORS``.
+
+    Tests pin HOME *and* USERPROFILE to a clean temp dir so the runner's
+    own ``~/.claude/`` doesn't leak into the assertions — POSIX reads
+    HOME, Windows reads USERPROFILE for ``Path.home()`` /
+    ``Path.expanduser()`` (see ``feedback_windows_expanduser``).
+    """
+
+    @pytest.fixture
+    def clean_home(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("USERPROFILE", str(home))
+        return home
+
+    @pytest.mark.anyio
+    async def test_field_present_and_universe_covered(self, client: AsyncClient, clean_home: Path):
+        """Universe pin: detected_runtimes lists every declared runtime
+        root from the four surfaces, sorted, with ``available`` flag."""
+        r = await client.get("/api/context/overview")
+        data = r.json()
+        assert "detected_runtimes" in data
+        names = [e["name"] for e in data["detected_runtimes"]]
+        assert names == sorted(names), f"must be sorted; got {names}"
+        # All known runtime roots must appear (claude/gemini/codex are
+        # declared across at least one of the four surfaces today).
+        assert {"claude", "gemini", "codex"} <= set(names), (
+            f"declared runtime universe regressed; got {names}"
+        )
+        # Every entry has the documented shape.
+        for entry in data["detected_runtimes"]:
+            assert set(entry.keys()) == {"name", "available"}, entry
+            assert isinstance(entry["available"], bool), entry
+
+    @pytest.mark.anyio
+    async def test_empty_project_all_unavailable(self, client: AsyncClient, clean_home: Path):
+        """Negative pin: a fresh project with a clean ``$HOME`` has no
+        runtimes detected. Catches a regression where availability
+        latches True without any on-disk evidence."""
+        r = await client.get("/api/context/overview")
+        for entry in r.json()["detected_runtimes"]:
+            assert entry["available"] is False, (
+                f"empty project must not flag {entry['name']} available; got {entry}"
+            )
+
+    @pytest.mark.anyio
+    async def test_skill_surface_alone_flips_available(
+        self, client: AsyncClient, tmp_path: Path, clean_home: Path
+    ):
+        """A single ``.claude/skills/<name>/SKILL.md`` is enough to flip
+        claude → available, even with no settings dir and no command /
+        sub-agent dirs. Pins the OR-of-surfaces semantics."""
+        skill = tmp_path / ".claude" / "skills" / "code-review"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# x\n", encoding="utf-8")
+
+        r = await client.get("/api/context/overview")
+        flags = {e["name"]: e["available"] for e in r.json()["detected_runtimes"]}
+        assert flags["claude"] is True, flags
+        # Sibling runtimes stay False — no overlap with claude's skills dir.
+        assert flags["gemini"] is False, flags
+        assert flags["codex"] is False, flags
+
+    @pytest.mark.anyio
+    async def test_settings_is_available_alone_flips_claude(
+        self, client: AsyncClient, clean_home: Path
+    ):
+        """Per ADR-0009 §1, settings detection routes through the
+        generator's ``is_available()`` — not a directory probe. A bare
+        ``~/.claude/`` directory (no settings file) is enough for the
+        ``ClaudeSettingsGenerator`` to report available, which OR-folds
+        into ``claude: True``."""
+        (clean_home / ".claude").mkdir()
+
+        r = await client.get("/api/context/overview")
+        flags = {e["name"]: e["available"] for e in r.json()["detected_runtimes"]}
+        assert flags["claude"] is True, flags
+
+    @pytest.mark.anyio
+    async def test_empty_skill_root_does_not_flip(
+        self, client: AsyncClient, tmp_path: Path, clean_home: Path
+    ):
+        """Directory-probe surfaces require an actual artifact, not just
+        an empty parent dir. Use ``gemini`` — it has skill / agent /
+        command surfaces but no registered settings generator, so the
+        bare ``.gemini/skills/`` cannot mask the directory-probe gate
+        by routing through ``is_available()`` (which is what happens
+        with claude — its settings generator flips True on a bare
+        ``<project>/.claude/`` directory, by design)."""
+        (tmp_path / ".gemini" / "skills").mkdir(parents=True)
+        r = await client.get("/api/context/overview")
+        flags = {e["name"]: e["available"] for e in r.json()["detected_runtimes"]}
+        assert flags["gemini"] is False, flags
+
+    @pytest.mark.anyio
+    async def test_field_survives_detection_failure(
+        self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch, clean_home: Path
+    ):
+        """A detector raising must not collapse the rest of the overview
+        envelope. The endpoint returns ``detected_runtimes: []`` and the
+        four tile envelopes stay intact (errors there are surface-scoped,
+        not whole-response-scoped)."""
+
+        def _boom(*_a, **_kw):
+            raise PermissionError("denied")
+
+        monkeypatch.setattr("memtomem.context.detector.detect_skill_dirs", _boom)
+        r = await client.get("/api/context/overview")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["detected_runtimes"] == []
+        # Tile envelopes still computed.
+        assert "skills" in data and "commands" in data
+        assert "agents" in data and "settings" in data

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -101,6 +101,87 @@ _HEALTHY_OVERVIEW = {
 }
 
 
+_OVERVIEW_WITH_RUNTIMES = {
+    **_HEALTHY_OVERVIEW,
+    # Mixed detection state: claude on, gemini off, codex on. The chip
+    # strip must render one chip per runtime with the right class.
+    "detected_runtimes": [
+        {"name": "claude", "available": True},
+        {"name": "codex", "available": True},
+        {"name": "gemini", "available": False},
+    ],
+}
+
+
+def test_detected_runtimes_chip_strip_renders_per_runtime(page, mm_web_url: str) -> None:
+    """ADR-0009 §1 / #830 — the dashboard renders a chip strip above the
+    4-tile grid. One chip per declared runtime; ``available=true`` chips
+    use ``ctx-runtime-badge--sync``, ``available=false`` chips use
+    ``ctx-runtime-badge--missing`` with an opacity fade. Negative-pin the
+    inverse class assignment so a class-swap regression surfaces."""
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_OVERVIEW_WITH_RUNTIMES),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    strip = page.locator("#ctx-overview-content .ctx-detected-runtimes")
+    strip.wait_for(state="attached", timeout=3_000)
+    label = (strip.locator(".ctx-detected-runtimes-label").text_content() or "").strip()
+    assert label == "Detected runtimes", f"label mismatch: {label!r}"
+
+    chips = strip.locator(".ctx-runtime-badge")
+    assert chips.count() == 3, f"expected 3 chips, got {chips.count()}"
+
+    def _chip_info(name: str) -> tuple[str, str]:
+        chip = strip.locator(f".ctx-runtime-badge:has-text('{name}')")
+        return (
+            (chip.get_attribute("class") or ""),
+            (chip.get_attribute("data-available") or ""),
+        )
+
+    claude_cls, claude_avail = _chip_info("claude")
+    codex_cls, codex_avail = _chip_info("codex")
+    gemini_cls, gemini_avail = _chip_info("gemini")
+
+    assert "ctx-runtime-badge--sync" in claude_cls, claude_cls
+    assert claude_avail == "true", claude_avail
+    assert "ctx-runtime-badge--sync" in codex_cls, codex_cls
+    assert codex_avail == "true", codex_avail
+    assert "ctx-runtime-badge--missing" in gemini_cls, gemini_cls
+    assert gemini_avail == "false", gemini_avail
+
+    # Negative pin: an available chip must not carry the missing class
+    # (and vice versa) — catches a swap that would tint claude grey.
+    assert "ctx-runtime-badge--missing" not in claude_cls, claude_cls
+    assert "ctx-runtime-badge--sync" not in gemini_cls, gemini_cls
+
+
+def test_detected_runtimes_strip_absent_when_field_missing(page, mm_web_url: str) -> None:
+    """Backwards-compat pin: an older response shape with no
+    ``detected_runtimes`` field must not crash the render — the strip is
+    simply not emitted. Catches a regression where the chip block became
+    mandatory and forced ``undefined.length`` on legacy payloads."""
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_HEALTHY_OVERVIEW)
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    strip = page.locator("#ctx-overview-content .ctx-detected-runtimes")
+    assert strip.count() == 0, "chip strip must not render when field is missing"
+
+
 def test_zero_total_renders_empty_badge_not_green_synced(page, mm_web_url: str) -> None:
     """Bug-2 pin: ``total === 0`` on a count tile must render the ``Empty``
     badge (``settings.ctx.badge_empty``) with ``badge-gray``, never the


### PR DESCRIPTION
## Summary

- Resolves #830 (Info-1, unblocked by ADR-0009 acceptance in #946).
- Adds `detected_runtimes: list[{name, available}]` to `/api/context/overview`; aggregation is OR across the four declared surfaces (skills / sub-agents / commands / settings) per ADR-0009 §1, reusing the existing detector functions in `memtomem/context/detector.py` rather than introducing a parallel path.
- Renders a chip strip above the 4-tile grid on the Context Gateway dashboard. Reuses the existing `.ctx-runtime-badge--sync` / `--missing` palette plus a `data-available` attribute that drives a small opacity fade on declared-but-undetected chips.
- New i18n key `settings.ctx.detected_runtimes_label` added to both `en.json` and `ko.json` (KO/EN parity per issue spec); runtime names themselves are proper nouns and stay un-localized.

## Why the OR-of-surfaces asymmetry

Per ADR-0009 §1 the settings surface routes through `SettingsGenerator.is_available()` while skill / agent / command surfaces are directory-probe based — the latter registry protocols expose only `target_dir()` / `target_file()` and have no uniform `is_available()` method. The aggregate flag is `True` when *any* surface resolves a target on disk, which is what lets a project with bare `~/.claude/` (no canonical artifacts) still flag claude as detected via the settings surface.

## Test plan

- [x] Backend pytest sweep (`uv run pytest -m "not ollama and not browser"`) — 4946 passed.
- [x] New backend tests in `TestDetectedRuntimes`:
  - universe-membership + sort + shape invariant
  - empty project + clean HOME → all `available=False`
  - skill surface alone flips claude → True
  - settings `is_available()` alone flips claude → True (bare `~/.claude/` is enough)
  - empty `.gemini/skills/` does NOT flip gemini (directory-probe guard; gemini has no settings generator so the gate isn't masked)
  - detector failure → `detected_runtimes: []`, tile envelopes still computed
- [x] Browser tests added:
  - chip strip class assignment per `available` flag (positive + symmetric-negative)
  - backwards-compat: missing `detected_runtimes` field → strip not emitted, render does not crash
- [x] `uv run ruff check packages/memtomem/src` ✅, `uv run ruff format --check` ✅
- [ ] Required CI lanes (macOS first) — to confirm post-push

## Out of scope

This PR ships **Info-1 only**. Info-2 (#831, project root indicator) and Info-3 (#832, last-sync freshness) also land on the overview response per ADR-0009 §5 but are intentionally separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)