### PR TITLE
feat(context): rename target_scope to target_tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Added
 
+- **`target_tier` canonical identifier (ADR-0017).** Context Gateway and
+  Sources Web routes now accept `?target_tier=` and include `target_tier`
+  response fields. `hooks.target_tier` is the canonical config field; legacy
+  `hooks.target_scope`, `?target_scope=`, response `target_scope`, and the
+  `TargetScope` import remain compatibility aliases.
 - **Web tier badges + `/api/add` project-tier rejection hint (ADR-0011
   PR-F Web/docs slice, #929).** Memory sources/chunks and context
   Skills/Commands/Subagents list rows now carry literal tier badges
   (`user`, `project_shared`, `project_local`) per ADR-0016. Web list
-  routes accept `?target_scope=` for canonical tier selection and keep
+  routes accept `?target_tier=` for canonical tier selection and keep
   `project_local` hidden by default unless explicitly requested; context
   rows in `project_local` annotate the draft/no-runtime-fan-out behavior
   inline. `POST /api/add` now rejects unconfirmed

--- a/docs/adr/0015-context-gateway-scope-vocabulary.md
+++ b/docs/adr/0015-context-gateway-scope-vocabulary.md
@@ -2,6 +2,10 @@
 
 **Status:** Accepted
 **Date:** 2026-05-11
+**Superseded in part:** ADR-0017 (Accepted 2026-05-12) renames the
+canonical tier identifier from `target_scope` to `target_tier` while keeping
+`target_scope` as a compatibility alias. This ADR remains the historical
+record for the `project_scope_id` vs canonical-tier split.
 **Context:** Issue #901 surfaced that the Context Gateway Web layer uses
 "scope" for two unrelated dimensions — a per-request project-root selector
 (`?scope_id=`) and the canonical artifact tier

--- a/docs/adr/0016-three-tier-canonical-context-store.md
+++ b/docs/adr/0016-three-tier-canonical-context-store.md
@@ -2,6 +2,9 @@
 
 **Status:** Accepted
 **Date:** 2026-05-11
+**Superseded in part:** ADR-0017 (Accepted 2026-05-12) resolves the deferred
+identifier question by making `target_tier` canonical and keeping
+`target_scope` as a compatibility alias.
 **Context:** Epic issue #868 (`Tiered context gateway v2`) calls for a
 "uniform tiered model for the entire context gateway." Most of that
 model already exists in tree as three separate ADRs that landed on
@@ -444,12 +447,9 @@ not block ADR acceptance.
   CLI list tier filter copy, migration tooling polish, detail/diff/
   rendered-route alignment, tier-switching write affordances, and the
   eventual `target_scope` → `target_tier` decision.
-- **`target_scope` → `target_tier` rename ADR.** Whether to
-  author one, and when. Default posture: wait until the PR-F follow-up
-  polish settles and a concrete contributor signal exists ("the field name
-  confused me when reading X"). If no signal emerges within 3
-  months, file an ADR concluding the rename is not worth the
-  churn and close the question.
+- **`target_scope` → `target_tier` rename ADR.** Resolved by ADR-0017
+  (Accepted 2026-05-12): `target_tier` is canonical, and
+  `target_scope` remains a compatibility alias.
 - **ADR-0001 §1 formal amendment.** Whether the cross-references
   in ADR-0011 §7 and ADR-0016 §9 are sufficient, or whether a
   separate amendment ADR is warranted. Default posture: skip

--- a/docs/adr/0017-target-tier-identifier-rename.md
+++ b/docs/adr/0017-target-tier-identifier-rename.md
@@ -1,0 +1,102 @@
+# ADR-0017: Rename target_scope identifiers to target_tier
+
+**Status:** Accepted
+**Date:** 2026-05-12
+**Context:** ADR-0016 accepted the "tier" vocabulary while deferring the
+implementation-level `target_scope` -> `target_tier` rename. The deferred
+question was tracked in #922 and ADR-0016's open questions. The project is
+still early enough in the tiered Context Gateway rollout that the public
+surface can move without a long-lived second vocabulary, provided existing
+configs and clients keep working through a compatibility window.
+
+## Decision
+
+Use `target_tier` as the canonical identifier for the canonical-residency
+tier axis.
+
+The canonical tier values remain unchanged:
+
+- `user`
+- `project_shared`
+- `project_local`
+
+The rename applies to:
+
+- `hooks.target_tier` in config objects and persisted `config.json`
+- `?target_tier=` on Web context/source routes
+- `target_tier` response fields on Web rows and overview payloads
+- the Python type name `TargetTier`
+
+`target_scope` stays as a deprecated compatibility alias:
+
+- config loading accepts `hooks.target_scope`
+- `mm config set/unset hooks.target_scope` maps to `hooks.target_tier`
+- Web routes accept `?target_scope=`
+- Web responses temporarily include both `target_tier` and `target_scope`
+- `TargetScope` remains importable as an alias for `TargetTier`
+
+This ADR does not rename the memory/search `scope` axis, CLI `--scope`
+flags, MCP `scope=` arguments, or internal function parameters that pass the
+tier value into existing helpers named `scope`. Those names cover broader
+compatibility surfaces and are not part of the confusing `target_scope`
+identifier called out by ADR-0016.
+
+## Compatibility
+
+The compatibility rule is one-way: new writes use `target_tier`; old reads
+continue to work.
+
+When a legacy config file contains:
+
+```json
+{"hooks": {"target_scope": "project_local"}}
+```
+
+loading resolves it as `hooks.target_tier == "project_local"`. The next
+normal config save writes:
+
+```json
+{"hooks": {"target_tier": "project_local"}}
+```
+
+Web clients should send `?target_tier=` and read `target_tier`. Existing
+clients using `?target_scope=` or reading `target_scope` keep working during
+the compatibility window.
+
+When a client sends **both** `?target_tier=` and the deprecated
+`?target_scope=` on the same request, the canonical `target_tier` wins. The
+deprecated alias is the fallback for callers that have not been renamed yet;
+letting it pre-empt the canonical query would invert the rename. (The same
+precedence rule applies symmetrically to env vars: `MEMTOMEM_HOOKS__TARGET_TIER`
+wins over `MEMTOMEM_HOOKS__TARGET_SCOPE` when both are set, via Pydantic's
+`AliasChoices` ordering.)
+
+The compatibility window has no calendar deadline. Removal of the
+`target_scope` aliases (env/persisted key, query param, response field,
+`TargetScope` import) is tracked as a single deferred row in
+`docs/adr/TRACKER.md` under ADR-0017, with the trigger criteria listed there.
+
+## Consequences
+
+- New code and docs have a single spelling for the tier axis.
+- ADR-0015 and ADR-0016 remain historical records for why the old spelling
+  existed, but their identifier guidance is superseded by this ADR.
+- #922's decision question is answered by this ADR. The separate issue-body
+  cleanup can remain a follow-up.
+
+## Considered
+
+- **No rename.** Rejected. ADR-0016 already made "tier" the conceptual term,
+  and leaving new APIs on `target_scope` would keep the original ambiguity.
+- **Hard break with no aliases.** Rejected. Config files, Web clients, and
+  tests already use the old spelling; accepting aliases is low risk and makes
+  the rollout reversible if a missed client appears.
+- **Rename every `scope` parameter.** Rejected. Many `scope` names refer to
+  memory visibility, project-root selection, or helper-local tier values.
+  Broad churn would obscure the actual public rename and risk regressions.
+
+## References
+
+- ADR-0015: Context Gateway scope vocabulary
+- ADR-0016: Three-tier canonical context store
+- #922: target_scope -> target_tier decision tracker

--- a/docs/adr/TRACKER.md
+++ b/docs/adr/TRACKER.md
@@ -23,7 +23,7 @@ pointer so a maintainer can scan due dates without opening each ADR.
 
 | ADR | Deferred question | Trigger / deadline | Tracking issue | Next review |
 |-----|-------------------|--------------------|----------------|-------------|
-| 0016 §"Open questions" §2 | `target_scope` → `target_tier` identifier rename | "the field name confused me when reading X" non-author signal ≥1 / **2026-08-11** (3-month window from ADR merge) | [#922](https://github.com/memtomem/memtomem/issues/922) | 2026-08-11 |
+| 0017 §"Compatibility" | Remove `target_scope` compatibility aliases (`hooks.target_scope` env/persisted key, `?target_scope=` query param, response `target_scope` field, `TargetScope` import) | No external clients still send `?target_scope=` for two consecutive minor releases (audit via access logs / contributor reports) OR a v1 breaking-release window opens | (none — tracked in ADR) | 2026-08-12 |
 | 0012 §"Shape A" | Cross-DB memory migration — team onboarding export | Onboarding flow blocked on `scope`/`project_root` serialization OR gate plumbing on import (full criteria in ADR §"Shape A — Trigger criteria") | [#911](https://github.com/memtomem/memtomem/issues/911) | (event-driven) |
 | 0012 §"Shape B" | Cross-DB memory migration — project archive | User reports `~/.memtomem/memtomem.db` size pain that existing compaction / orphan-GC remedies do not solve (full criteria in ADR §"Shape B — Trigger criteria") | [#911](https://github.com/memtomem/memtomem/issues/911) | (event-driven) |
 | 0007 §"Trigger criteria" | PR-C: Namespace rename / bulk delete prod exposure (PR-A/B already shipped) | "≥ 2 prod user reports" along the rename/bulk-delete axis OR namespace rules surfacing in the onboarding flow | (none — tracked in ADR) | (event-driven) |

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -162,7 +162,7 @@ You can automate memtomem using Claude Code's hooks system.
 Add the following to `~/.claude/settings.json`:
 
 > **Tier** (ADR-0010 §3; ADR-0016 §2 settings special-case): for
-> settings, the `hooks.target_scope` tier selects the **runtime fan-out
+> settings, the `hooks.target_tier` tier selects the **runtime fan-out
 > target** under `~/.claude/` or `<project>/.claude/`, not a canonical
 > residency — settings have one canonical file at
 > `<project>/.memtomem/settings.json` regardless of tier. The three

--- a/packages/memtomem/src/memtomem/cli/config_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/config_cmd.py
@@ -24,6 +24,13 @@ def config() -> None:
     """View or modify memtomem configuration."""
 
 
+def _canonical_config_key(key: str) -> str:
+    """Map deprecated config keys to their canonical spelling."""
+    if key == "hooks.target_scope":
+        return "hooks.target_tier"
+    return key
+
+
 @config.command("show")
 @click.option("--format", "fmt", type=click.Choice(["table", "json"]), default="table")
 @click.option("--json", "as_json", is_flag=True, help="Shortcut for --format json.")
@@ -65,6 +72,8 @@ def config_set(key: str, value: str) -> None:
     """Set a config field (e.g., 'search.default_top_k 20'). Persists to ~/.memtomem/config.json."""
     from memtomem.config import Mem2MemConfig, load_config_overrides, save_config_overrides
 
+    requested_key = key
+    key = _canonical_config_key(key)
     parts = key.split(".", 1)
     if len(parts) != 2:
         click.echo(click.style("Key must be section.field (e.g., search.default_top_k)", fg="red"))
@@ -91,7 +100,8 @@ def config_set(key: str, value: str) -> None:
     setattr(section_obj, field_name, coerced)
 
     save_config_overrides(cfg)
-    click.echo(f"{key}: {old_val} -> {coerced}")
+    label = key if requested_key == key else f"{requested_key} ({key})"
+    click.echo(f"{label}: {old_val} -> {coerced}")
 
     # Rebuild FTS index when tokenizer changes (matches Web UI / MCP behaviour)
     if key == "search.tokenizer":
@@ -118,6 +128,7 @@ def _canonical_unset_keys() -> set[str]:
     """
     canonical = {f"{sec}.{f}" for sec, fs in MUTABLE_FIELDS.items() for f in fs}
     canonical |= {f"{sec}.{f}" for sec, fs in _EXTRA_MUTATION_FIELDS.items() for f in fs}
+    canonical.add("hooks.target_scope")
     return canonical
 
 
@@ -178,31 +189,44 @@ def config_unset(keys: tuple[str, ...]) -> None:
     any_skip = False
 
     for key in keys:
-        if key not in canonical:
+        requested_key = key
+        key = _canonical_config_key(key)
+        if requested_key not in canonical and key not in canonical:
             any_skip = True
-            suggestion = _suggest_key(key, canonical)
+            suggestion = _suggest_key(requested_key, canonical)
             if suggestion is not None:
                 lines.append(
                     click.style(
-                        f"Skipped {key}: not set (did you mean '{suggestion}'?)",
+                        f"Skipped {requested_key}: not set (did you mean '{suggestion}'?)",
                         fg="yellow",
                     )
                 )
             else:
-                lines.append(click.style(f"Skipped {key}: not set", fg="yellow"))
+                lines.append(click.style(f"Skipped {requested_key}: not set", fg="yellow"))
             continue
 
         section, field = key.split(".", 1)
         section_data = existing.get(section)
-        if isinstance(section_data, dict) and field in section_data:
-            section_data.pop(field)
+        legacy_field = "target_scope" if key == "hooks.target_tier" else field
+        if isinstance(section_data, dict) and (
+            field in section_data or legacy_field in section_data
+        ):
+            # ADR-0017: a legacy-only config.json (only ``target_scope`` present,
+            # ``target_tier`` absent) enters this branch via ``legacy_field in
+            # section_data``. The canonical pop must tolerate a missing field
+            # so unset works on un-migrated installs instead of raising
+            # KeyError.
+            section_data.pop(field, None)
+            section_data.pop(legacy_field, None)
             if not section_data:
                 existing.pop(section, None)
-            lines.append(f"Removed: {key}")
+            label = key if requested_key == key else f"{requested_key} ({key})"
+            lines.append(f"Removed: {label}")
             if field in _EXTRA_MUTATION_FIELDS.get(section, set()):
                 removed_extra_mutation = True
         else:
-            lines.append(f"Unset: {key} (already at default)")
+            label = key if requested_key == key else f"{requested_key} ({key})"
+            lines.append(f"Unset: {label} (already at default)")
 
     if existing:
         _relativize_config_paths_in_place(existing)

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -441,7 +441,7 @@ def _print_commands_diff(root: Path, *, scope: TargetScope = "project_shared") -
 
 
 def _resolve_cli_scope(override: str | None) -> str:
-    """Return the resolved ``hooks.target_scope`` for a CLI invocation.
+    """Return the resolved ``hooks.target_tier`` for a CLI invocation.
 
     Per-invocation ``--scope`` flag wins; otherwise build a fresh
     ``Mem2MemConfig`` and apply the user-level config + env overrides.
@@ -455,17 +455,17 @@ def _resolve_cli_scope(override: str | None) -> str:
     cfg = Mem2MemConfig()
     load_config_d(cfg, quiet=True)
     load_config_overrides(cfg, migrate=False)
-    return cfg.hooks.target_scope
+    return cfg.hooks.target_tier
 
 
 def _resolve_artifact_cli_scope(scope_flag: str | None) -> TargetScope:
     """Resolve ``--scope`` for non-memory artifact CLI commands (ADR-0011 PR-E2).
 
     Unlike :func:`_resolve_cli_scope` this does NOT consult
-    ``cfg.hooks.target_scope``: artifact storage location is a different
+    ``cfg.hooks.target_tier``: artifact storage location is a different
     feature axis from settings host placement. Leaning on the hooks
     default would silently flip the artifact target whenever a user
-    pinned ``hooks.target_scope = "user"`` for unrelated reasons (e.g.
+    pinned ``hooks.target_tier = "user"`` for unrelated reasons (e.g.
     Cursor-style settings layout), which Codex flagged as a
     ``_resolve_cli_scope`` default-leak risk in PR-E1 review. The
     artifact-side default is fixed at ``"project_shared"`` to match the
@@ -612,7 +612,7 @@ _SCOPE_OPTION = click.option(
     type=click.Choice(list(get_args(TargetScope))),
     default=None,
     help=(
-        "Override hooks.target_scope for this invocation only "
+        "Override hooks.target_tier for this invocation only "
         "(user / project_shared / project_local). "
         "Host-write confirmation is computed against the resolved scope, "
         "so --scope=project_local skips the prompt (writes stay in-project)."
@@ -958,7 +958,7 @@ def generate_cmd(
     # ADR-0011 PR-E3: resolve the canonical-artifact scope once and thread
     # it through the three include helpers. Defaults to ``project_shared``
     # via ``_resolve_artifact_cli_scope`` (NOT ``_resolve_cli_scope``,
-    # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
+    # which leaks ``cfg.hooks.target_tier`` into the artifact axis —
     # ADR-0011 PR-E1 Codex review trip-wire).
     artifact_scope = _resolve_artifact_cli_scope(scope_flag)
 
@@ -977,7 +977,7 @@ def generate_cmd(
     if "settings" in inc:
         click.echo("")
         # Settings has its own (separate from artifact) scope axis — see
-        # ADR-0010. ``_resolve_cli_scope`` consults ``cfg.hooks.target_scope``;
+        # ADR-0010. ``_resolve_cli_scope`` consults ``cfg.hooks.target_tier``;
         # this is intentional for settings and intentionally NOT used for
         # artifacts above.
         scope = _resolve_cli_scope(scope_flag)
@@ -1113,7 +1113,7 @@ def sync_cmd(
     # ADR-0011 PR-E3: resolve the canonical-artifact scope once and thread
     # it through the three include helpers. Defaults to ``project_shared``
     # via ``_resolve_artifact_cli_scope`` (NOT ``_resolve_cli_scope``,
-    # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
+    # which leaks ``cfg.hooks.target_tier`` into the artifact axis —
     # ADR-0011 PR-E1 Codex review trip-wire).
     artifact_scope = _resolve_artifact_cli_scope(scope_flag)
 
@@ -1132,7 +1132,7 @@ def sync_cmd(
     if "settings" in inc:
         click.echo("")
         # Settings has its own (separate from artifact) scope axis — see
-        # ADR-0010. ``_resolve_cli_scope`` consults ``cfg.hooks.target_scope``;
+        # ADR-0010. ``_resolve_cli_scope`` consults ``cfg.hooks.target_tier``;
         # this is intentional for settings and intentionally NOT used for
         # artifacts above.
         scope = _resolve_cli_scope(scope_flag)

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -957,7 +957,7 @@ def _step_settings(state: dict) -> None:
         # necessarily persisted, so we hardcode the v1 default scope here
         # (ADR-0010 §3) instead of loading config — loading would mask
         # the wizard's own write. Users can flip the scope post-install
-        # via ``mm config set hooks.target_scope …`` and re-run sync.
+        # via ``mm config set hooks.target_tier …`` and re-run sync.
         results = generate_all_settings(project_root, scope="user")
         for name, r in results.items():
             if r.status == "ok":

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Annotated, Literal, cast, get_args
 
-from pydantic import Field, ValidationInfo, field_validator, model_validator
+from pydantic import AliasChoices, Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from memtomem.constants import default_system_prefixes
@@ -742,20 +742,35 @@ class SessionSummaryConfig(BaseSettings):
         return v
 
 
-TargetScope = Literal["user", "project_shared", "project_local"]
+TargetTier = Literal["user", "project_shared", "project_local"]
+# Back-compat alias: older code and third-party callers may still import
+# TargetScope while the public vocabulary moves to target_tier.
+TargetScope = TargetTier
 
 
 class HooksConfig(BaseSettings):
-    """Settings-hooks fan-out scope (ADR-0010 §3).
+    """Settings-hooks fan-out tier (ADR-0010 §3).
 
-    ``target_scope`` selects where memtomem-managed Claude Code hooks land:
+    ``target_tier`` selects where memtomem-managed Claude Code hooks land:
     user-tier (``~/.claude/settings.json``), project-shared
     (``<project>/.claude/settings.json``), or project-local
     (``<project>/.claude/settings.local.json``). v1 default is ``user`` for
     zero behavior change; the default-flip trigger lives in ADR-0010 §5.
     """
 
-    target_scope: TargetScope = "user"
+    target_tier: TargetTier = Field(
+        "user",
+        validation_alias=AliasChoices("target_tier", "target_scope"),
+    )
+
+    @property
+    def target_scope(self) -> TargetTier:
+        """Deprecated alias for config files and callers not yet renamed."""
+        return self.target_tier
+
+    @target_scope.setter
+    def target_scope(self, value: TargetTier) -> None:
+        self.target_tier = value
 
 
 class ContextGatewayConfig(BaseSettings):
@@ -880,7 +895,7 @@ MUTABLE_FIELDS: dict[str, set[str]] = {
     # instance is cached on startup), so only the pool-sizing knobs are
     # runtime-mutable.
     "rerank": {"enabled", "oversample", "min_pool", "max_pool"},
-    "hooks": {"target_scope"},
+    "hooks": {"target_tier"},
 }
 
 FIELD_CONSTRAINTS: dict[str, dict] = {
@@ -920,7 +935,10 @@ FIELD_CONSTRAINTS: dict[str, dict] = {
     "rerank.oversample": {"type": float, "min": 0.1, "max": 10.0},
     "rerank.min_pool": {"type": int, "min": 1, "max": 1000},
     "rerank.max_pool": {"type": int, "min": 1, "max": 1000},
-    "hooks.target_scope": {"type": str, "allowed": set(get_args(TargetScope))},
+    "hooks.target_tier": {"type": str, "allowed": set(get_args(TargetTier))},
+    # Deprecated read path for config.json/config.d fragments written before
+    # the target_scope -> target_tier rename.
+    "hooks.target_scope": {"type": str, "allowed": set(get_args(TargetTier))},
 }
 
 
@@ -1052,6 +1070,47 @@ def _override_path() -> Path:
     return _CONFIG_OVERRIDE_PATH.expanduser()
 
 
+# ADR-0017: legacy `target_scope` field renamed to `target_tier`. Both env var
+# names map to the same value via `AliasChoices` on construct, so the
+# persisted-config loaders must treat either env name as a precedence signal —
+# otherwise a user who sets `MEMTOMEM_HOOKS__TARGET_TIER` on a not-yet-migrated
+# `config.json`/`config.d` install would silently see the persisted legacy
+# value clobber their env-selected tier.
+#
+# Both directions are listed deliberately:
+#
+# - ``("hooks", "target_tier"): ("target_scope",)`` — covers a config that
+#   has been migrated to ``target_tier`` (loader iterates ``key="target_tier"``
+#   and must also notice the legacy env name).
+# - ``("hooks", "target_scope"): ("target_tier",)`` — covers a config that
+#   still persists the legacy ``target_scope`` key. The loader iterates
+#   ``key="target_scope"``, so symmetric lookup is needed for the canonical
+#   env name to also pre-empt the legacy persisted value. Without this entry
+#   a user who set ``MEMTOMEM_HOOKS__TARGET_TIER`` and still has a legacy
+#   ``config.json`` would see the file's ``target_scope`` clobber the env.
+#
+# One alias pair today; the helper scales when future field renames need the
+# same treatment.
+_LEGACY_FIELD_ALIASES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("hooks", "target_tier"): ("target_scope",),
+    ("hooks", "target_scope"): ("target_tier",),
+}
+
+
+def _env_aliases_for_field(section_name: str, field: str) -> list[str]:
+    """All `MEMTOMEM_<SECTION>__<FIELD>` env names that bind to (section, field).
+
+    Returned list always starts with the literal `MEMTOMEM_<SECTION>__<FIELD>`
+    derived from the caller's argument names, followed by legacy aliases (if
+    any). Loaders check membership in `os.environ` against the full list and
+    skip the persisted entry if any alias is set — matching the precedence
+    behaviour of `AliasChoices` at construct time.
+    """
+    base = f"MEMTOMEM_{section_name.upper()}__{field.upper()}"
+    aliases = _LEGACY_FIELD_ALIASES.get((section_name, field), ())
+    return [base, *(f"MEMTOMEM_{section_name.upper()}__{a.upper()}" for a in aliases)]
+
+
 def load_config_overrides(config: Mem2MemConfig, *, migrate: bool = True) -> None:
     """Apply persisted overrides from ~/.memtomem/config.json (if exists).
 
@@ -1086,14 +1145,15 @@ def load_config_overrides(config: Mem2MemConfig, *, migrate: bool = True) -> Non
             continue
         for key, value in updates.items():
             if hasattr(section_obj, key):
-                env_var = f"MEMTOMEM_{section_name.upper()}__{key.upper()}"
-                if env_var in os.environ:
+                env_vars = _env_aliases_for_field(section_name, key)
+                env_hits = [v for v in env_vars if v in os.environ]
+                if env_hits:
                     _log.debug(
                         "Skipping %s.%s from %s: %s is set in environment (env wins)",
                         section_name,
                         key,
                         path,
-                        env_var,
+                        ", ".join(env_hits),
                     )
                     continue
                 full_key = f"{section_name}.{key}"
@@ -1250,14 +1310,15 @@ def load_config_d(config: Mem2MemConfig, *, quiet: bool = False) -> None:
             for key, value in updates.items():
                 if not hasattr(section_obj, key):
                     continue
-                env_var = f"MEMTOMEM_{section_name.upper()}__{key.upper()}"
-                if env_var in os.environ:
+                env_vars = _env_aliases_for_field(section_name, key)
+                env_hits = [v for v in env_vars if v in os.environ]
+                if env_hits:
                     _log.debug(
                         "Skipping %s.%s from %s: %s is set (env wins)",
                         section_name,
                         key,
                         path,
-                        env_var,
+                        ", ".join(env_hits),
                     )
                     continue
                 strategy = _merge_strategy_for(section_cls, key)
@@ -1935,6 +1996,8 @@ def save_config_overrides(
         section_data: dict[str, object] = existing.get(section_name, {})
         if not isinstance(section_data, dict):
             section_data = {}
+        if section_name == "hooks":
+            section_data.pop("target_scope", None)
 
         for key in keys:
             live_val = getattr(live_section, key, None)

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -249,11 +249,11 @@ def detect_settings_files(project_root: Path, scope: str) -> list[DetectedFile]:
 def detect_all(project_root: Path, scope: str = "user") -> list[DetectedFile]:
     """Return project-memory files, skill dirs, sub-agents, commands, and settings.
 
-    *scope* is the resolved ``hooks.target_scope`` (ADR-0010 §3); see
+    *scope* is the resolved ``hooks.target_tier`` (ADR-0010 §3); see
     :func:`detect_settings_files` for why it's relevant. Defaults to
     ``"user"`` so external consumers of this public function don't see
     a breaking signature change in v1 — the value matches the default
-    of ``hooks.target_scope`` (ADR-0010 §2).
+    of ``hooks.target_tier`` (ADR-0010 §2).
     """
     return (
         detect_agent_files(project_root)

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -53,7 +53,7 @@ _MALFORMED = object()
 
 
 def resolve_scope_path(project_root: Path, scope: str) -> Path:
-    """Resolve ``hooks.target_scope`` to the runtime settings file path.
+    """Resolve ``hooks.target_tier`` to the runtime settings file path.
 
     Single source of truth for the ADR-0010 §3 path math; shared by
     :class:`ClaudeSettingsGenerator`, the Web ``_claude_target`` helper,
@@ -67,7 +67,7 @@ def resolve_scope_path(project_root: Path, scope: str) -> Path:
         return project_root / ".claude" / "settings.json"
     if scope == "project_local":
         return project_root / ".claude" / "settings.local.json"
-    raise ValueError(f"Unknown target_scope: {scope!r}")
+    raise ValueError(f"Unknown target_tier: {scope!r}")
 
 
 # ── Protocol + Result ───────────────────────────────────────────────
@@ -240,7 +240,7 @@ def host_write_targets(project_root: Path, *, scope: str) -> list[Path]:
     ``mm context sync --include=settings`` from a worktree must not silently
     edit the real home directory.
 
-    *scope* is the resolved ``hooks.target_scope`` (per ADR-0010 §3); it
+    *scope* is the resolved ``hooks.target_tier`` (per ADR-0010 §3); it
     determines which tier each generator's ``target_file`` resolves to.
     Project-tier scopes (``project_shared`` / ``project_local``) yield an
     empty list because writes stay inside the project root.
@@ -301,7 +301,7 @@ def generate_all_settings(
 ) -> dict[str, SettingsSyncResult]:
     """Fan out ``.memtomem/settings.json`` to registered runtimes.
 
-    *scope* is the resolved ``hooks.target_scope`` (per ADR-0010 §3) and
+    *scope* is the resolved ``hooks.target_tier`` (per ADR-0010 §3) and
     is required keyword-only — every caller (CLI, MCP, Web) is expected
     to resolve it from its own config layer rather than have this
     function lazy-load ``Mem2MemConfig`` (which would trigger the
@@ -402,7 +402,7 @@ def diff_settings(
 ) -> dict[str, SettingsSyncResult]:
     """Dry-run: compute what :func:`generate_all_settings` would do.
 
-    *scope* is the resolved ``hooks.target_scope`` (ADR-0010 §3); see
+    *scope* is the resolved ``hooks.target_tier`` (ADR-0010 §3); see
     :func:`generate_all_settings` for the rationale on why callers pass
     this in rather than having it lazy-loaded here.
     """

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -29,7 +29,7 @@ def _find_project_root() -> Path:
 
 
 def _resolve_mcp_scope(override: str | None = None) -> str:
-    """Return the resolved ``hooks.target_scope`` for an MCP tool call.
+    """Return the resolved ``hooks.target_tier`` for an MCP tool call.
 
     A per-call override wins. Otherwise this builds a fresh config and
     applies user-level overrides with ``migrate=False``. Scope
@@ -48,7 +48,7 @@ def _resolve_mcp_scope(override: str | None = None) -> str:
     cfg = Mem2MemConfig()
     load_config_d(cfg, quiet=True)
     load_config_overrides(cfg, migrate=False)
-    return cfg.hooks.target_scope
+    return cfg.hooks.target_tier
 
 
 def _resolve_artifact_mcp_scope(scope: str | None) -> TargetScope:

--- a/packages/memtomem/src/memtomem/web/deps.py
+++ b/packages/memtomem/src/memtomem/web/deps.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 
-from fastapi import HTTPException, Request
+from fastapi import HTTPException, Query, Request
+
+from memtomem.config import TargetTier
 
 from memtomem.storage.sqlite_helpers import norm_path
 
@@ -54,15 +56,67 @@ def get_project_root(request: Request) -> Path:
     return request.app.state.project_root
 
 
-def get_hooks_target_scope(request: Request) -> str:
-    """Return ``hooks.target_scope`` from the live ``app.state.config``.
+def get_hooks_target_tier(request: Request) -> str:
+    """Return ``hooks.target_tier`` from the live ``app.state.config``.
 
     ``hot_reload.py`` swaps ``app.state.config`` atomically on
     ``config.json`` edits, so handlers depending on this Depends
-    automatically pick up scope changes without a server restart
+    automatically pick up tier changes without a server restart
     (mirrors :func:`get_config`).
     """
-    return request.app.state.config.hooks.target_scope
+    return request.app.state.config.hooks.target_tier
+
+
+def get_hooks_target_scope(request: Request) -> str:
+    """Deprecated alias for callers not yet renamed."""
+    return get_hooks_target_tier(request)
+
+
+# ADR-0017: when a client sends BOTH ``?target_tier=`` and the deprecated
+# ``?target_scope=``, the canonical name wins. The legacy alias is only the
+# fallback for clients that haven't been renamed yet — letting it pre-empt the
+# canonical query would invert the rename and let the deprecated surface
+# silently override the new one. The default for ``target_tier`` is sentinel
+# (``None`` for the optional helper, or ``"project_shared"`` for the required
+# one materialized only when neither query was sent), so a bare
+# ``?target_scope=...`` still routes to the legacy value as expected.
+def get_query_target_tier(
+    target_tier: TargetTier | None = Query(
+        None,
+        description=(
+            "Canonical-residency tier to use. project_local is shown only "
+            "when explicitly requested. Defaults to project_shared when "
+            "neither this nor the deprecated target_scope alias is sent."
+        ),
+    ),
+    target_scope: TargetTier | None = Query(
+        None,
+        deprecated=True,
+        description="Deprecated alias for target_tier; ignored when target_tier is sent.",
+    ),
+) -> TargetTier:
+    if target_tier is not None:
+        return target_tier
+    if target_scope is not None:
+        return target_scope
+    return "project_shared"
+
+
+def get_optional_query_target_tier(
+    target_tier: TargetTier | None = Query(
+        None,
+        description=(
+            "Canonical-residency tier filter. Omit to show user and "
+            "project_shared while hiding project_local."
+        ),
+    ),
+    target_scope: TargetTier | None = Query(
+        None,
+        deprecated=True,
+        description="Deprecated alias for target_tier; ignored when target_tier is sent.",
+    ),
+) -> TargetTier | None:
+    return target_tier if target_tier is not None else target_scope
 
 
 def require_configured() -> None:

--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from memtomem.config import TargetScope
+from memtomem.config import TargetTier
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.agents import (
@@ -28,7 +28,7 @@ from memtomem.context.agents import (
 )
 from memtomem.context.detector import AGENT_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.deps import get_project_root
+from memtomem.web.deps import get_project_root, get_query_target_tier
 from memtomem.web.routes.context_projects import resolve_scope_root
 from memtomem.web.routes._locks import _gateway_lock
 
@@ -48,14 +48,14 @@ _ALL_OPTIONAL_FIELDS = ("tools", "model", "skills", "isolation", "kind", "temper
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 
-def _agents_root(project_root: Path, *, scope: TargetScope = "project_shared") -> Path:
+def _agents_root(project_root: Path, *, scope: TargetTier = "project_shared") -> Path:
     from memtomem.context.scope_resolver import canonical_artifact_dir
 
     return canonical_artifact_dir("agents", scope, project_root)
 
 
 def _canonical_agent_path(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
+    project_root: Path, raw_name: str, *, scope: TargetTier = "project_shared"
 ) -> Path:
     """Validate the name via core and return the canonical agent path.
 
@@ -69,24 +69,24 @@ def _canonical_agent_path(
 
 
 def _resolve_existing_agent(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
+    project_root: Path, raw_name: str, *, scope: TargetTier = "project_shared"
 ):
     name = validate_name(raw_name, kind="agent")
     return name, resolve_canonical_agent(project_root, name, scope=scope)
 
 
-def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
+def _reject_non_shared_write(target_tier: TargetTier, action: str) -> None:
     """Reject writes on non-``project_shared`` tiers with HTTP 400.
 
     See context_skills.py:_reject_non_shared_write for the rationale.
     Mirrored here so each route file stays self-contained.
     """
-    if target_scope != "project_shared":
+    if target_tier != "project_shared":
         raise HTTPException(
             status_code=400,
             detail=(
                 f"{action} is supported only on project_shared in this release; "
-                f"got target_scope={target_scope!r}."
+                f"got target_tier={target_tier!r}."
             ),
         )
 
@@ -110,17 +110,11 @@ def _agent_to_dict(agent: SubAgent) -> dict:
 @router.get("/context/agents")
 async def list_agents(
     project_root: Path = Depends(resolve_scope_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description=(
-            "Canonical-residency tier to list. project_local is shown only "
-            "when explicitly requested."
-        ),
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """List canonical agents. Accepts ``?scope_id=`` like list_skills."""
-    canonicals = list_canonical_agents(project_root, scope=target_scope)
-    diffs = diff_agents(project_root, scope=target_scope)
+    canonicals = list_canonical_agents(project_root, scope=target_tier)
+    diffs = diff_agents(project_root, scope=target_tier)
 
     by_name: dict[str, list[dict]] = {}
     for runtime, agent_name, status in diffs:
@@ -135,7 +129,8 @@ async def list_agents(
             {
                 "name": name,
                 "canonical_path": _safe_rel(agent_path, project_root),
-                "target_scope": target_scope,
+                "target_tier": target_tier,
+                "target_scope": target_tier,
                 "runtimes": by_name.get(name, []),
             }
         )
@@ -146,7 +141,8 @@ async def list_agents(
                 {
                     "name": agent_name,
                     "canonical_path": None,
-                    "target_scope": target_scope,
+                    "target_tier": target_tier,
+                    "target_scope": target_tier,
                     "runtimes": runtimes,
                 }
             )
@@ -165,12 +161,9 @@ async def list_agents(
 async def read_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to read from (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
+    name, resolved = _resolve_existing_agent(project_root, name, scope=target_tier)
     if resolved is None:
         raise KeyError(name)
     agent_path, layout = resolved
@@ -197,12 +190,9 @@ async def read_agent(
 async def rendered_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to render (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> JSONResponse:
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
+    name, resolved = _resolve_existing_agent(project_root, name, scope=target_tier)
     if resolved is None:
         raise KeyError(name)
     agent_path, layout = resolved
@@ -213,7 +203,7 @@ async def rendered_agent(
     except AgentParseError as exc:
         return JSONResponse(status_code=422, content={"detail": f"Parse error: {exc}"})
 
-    diffs = diff_agents(project_root, scope=target_scope)
+    diffs = diff_agents(project_root, scope=target_tier)
     status_map: dict[tuple[str, str], str] = {(rt, n): s for rt, n, s in diffs}
 
     runtimes = []
@@ -258,20 +248,17 @@ class AgentCreateRequest(BaseModel):
 async def create_agent(
     body: AgentCreateRequest,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to create in. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Create agent")
+    _reject_non_shared_write(target_tier, "Create agent")
     name = validate_name(body.name, kind="agent")
 
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                if resolve_canonical_agent(project_root, name, scope=target_scope) is not None:
+                if resolve_canonical_agent(project_root, name, scope=target_tier) is not None:
                     raise HTTPException(409, detail=f"Agent '{name}' already exists")
-                agent_path = _canonical_agent_path(project_root, name, scope=target_scope)
+                agent_path = _canonical_agent_path(project_root, name, scope=target_tier)
                 atomic_write_text(agent_path, body.content)
     except TimeoutError:
         raise HTTPException(503, "Agent create timed out — another sync may be in progress")
@@ -297,13 +284,10 @@ async def update_agent(
     name: str,
     body: AgentUpdateRequest,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to update. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> JSONResponse:
-    _reject_non_shared_write(target_scope, "Update agent")
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Update agent")
+    name, resolved = _resolve_existing_agent(project_root, name, scope=target_tier)
     if resolved is None:
         raise KeyError(name)
     agent_path, _layout = resolved
@@ -358,13 +342,10 @@ async def delete_agent(
     name: str,
     cascade: bool = Query(False),
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to delete from. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Delete agent")
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Delete agent")
+    name, resolved = _resolve_existing_agent(project_root, name, scope=target_tier)
 
     try:
         async with asyncio.timeout(60):
@@ -407,12 +388,9 @@ async def delete_agent(
 async def diff_agent(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to diff against runtime fan-out (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    name, resolved = _resolve_existing_agent(project_root, name, scope=target_scope)
+    name, resolved = _resolve_existing_agent(project_root, name, scope=target_tier)
 
     canonical_content = None
     if resolved is not None:
@@ -458,12 +436,9 @@ class SyncRequest(BaseModel):
 async def sync_agents(
     body: SyncRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to fan out. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Sync agents")
+    _reject_non_shared_write(target_tier, "Sync agents")
     on_drop = body.on_drop if body else "warn"
     try:
         async with asyncio.timeout(60):
@@ -504,12 +479,9 @@ class ImportRequest(BaseModel):
 async def import_agents(
     body: ImportRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Import agents")
+    _reject_non_shared_write(target_tier, "Import agents")
     overwrite = body.overwrite if body else False
     try:
         async with asyncio.timeout(60):
@@ -539,10 +511,7 @@ async def import_agent(
     name: str,
     body: ImportRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Import a single runtime agent into ``.memtomem/agents/``.
 
@@ -551,7 +520,7 @@ async def import_agent(
     import would silently report 0 imported, which is the wrong shape of
     feedback for "you clicked a specific item that doesn't exist").
     """
-    _reject_non_shared_write(target_scope, "Import agent")
+    _reject_non_shared_write(target_tier, "Import agent")
     try:
         validate_name(name, kind="agent name")
     except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from memtomem.config import TargetScope
+from memtomem.config import TargetTier
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.commands import (
@@ -27,7 +27,7 @@ from memtomem.context.commands import (
 )
 from memtomem.context.detector import COMMAND_DIRS
 from memtomem.context.privacy_scan import PrivacyScanError
-from memtomem.web.deps import get_project_root
+from memtomem.web.deps import get_project_root, get_query_target_tier
 from memtomem.web.routes.context_projects import resolve_scope_root
 from memtomem.web.routes._locks import _gateway_lock
 
@@ -44,14 +44,14 @@ router = APIRouter(tags=["context-commands"])
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 
-def _commands_root(project_root: Path, *, scope: TargetScope = "project_shared") -> Path:
+def _commands_root(project_root: Path, *, scope: TargetTier = "project_shared") -> Path:
     from memtomem.context.scope_resolver import canonical_artifact_dir
 
     return canonical_artifact_dir("commands", scope, project_root)
 
 
 def _canonical_command_path(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
+    project_root: Path, raw_name: str, *, scope: TargetTier = "project_shared"
 ) -> Path:
     """Validate the name via core and return the canonical command path.
 
@@ -62,24 +62,24 @@ def _canonical_command_path(
 
 
 def _resolve_existing_command(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
+    project_root: Path, raw_name: str, *, scope: TargetTier = "project_shared"
 ):
     name = validate_name(raw_name, kind="command")
     return name, resolve_canonical_command(project_root, name, scope=scope)
 
 
-def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
+def _reject_non_shared_write(target_tier: TargetTier, action: str) -> None:
     """Reject writes on non-``project_shared`` tiers with HTTP 400.
 
     See context_skills.py:_reject_non_shared_write for the rationale.
     Mirrored here so each route file stays self-contained.
     """
-    if target_scope != "project_shared":
+    if target_tier != "project_shared":
         raise HTTPException(
             status_code=400,
             detail=(
                 f"{action} is supported only on project_shared in this release; "
-                f"got target_scope={target_scope!r}."
+                f"got target_tier={target_tier!r}."
             ),
         )
 
@@ -97,17 +97,11 @@ def _safe_rel(p: Path, project_root: Path) -> str:
 @router.get("/context/commands")
 async def list_commands(
     project_root: Path = Depends(resolve_scope_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description=(
-            "Canonical-residency tier to list. project_local is shown only "
-            "when explicitly requested."
-        ),
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """List canonical commands. Accepts ``?scope_id=`` like list_skills."""
-    canonicals = list_canonical_commands(project_root, scope=target_scope)
-    diffs = diff_commands(project_root, scope=target_scope)
+    canonicals = list_canonical_commands(project_root, scope=target_tier)
+    diffs = diff_commands(project_root, scope=target_tier)
 
     by_name: dict[str, list[dict]] = {}
     for runtime, cmd_name, status in diffs:
@@ -122,7 +116,8 @@ async def list_commands(
             {
                 "name": name,
                 "canonical_path": _safe_rel(cmd_path, project_root),
-                "target_scope": target_scope,
+                "target_tier": target_tier,
+                "target_scope": target_tier,
                 "runtimes": by_name.get(name, []),
             }
         )
@@ -133,7 +128,8 @@ async def list_commands(
                 {
                     "name": cmd_name,
                     "canonical_path": None,
-                    "target_scope": target_scope,
+                    "target_tier": target_tier,
+                    "target_scope": target_tier,
                     "runtimes": runtimes,
                 }
             )
@@ -152,12 +148,9 @@ async def list_commands(
 async def read_command(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to read from (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
+    name, resolved = _resolve_existing_command(project_root, name, scope=target_tier)
     if resolved is None:
         raise KeyError(name)
     cmd_path, layout = resolved
@@ -194,12 +187,9 @@ _ALL_OPTIONAL_FIELDS = ("argument-hint", "allowed-tools", "model")
 async def rendered_command(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to render (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> JSONResponse:
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
+    name, resolved = _resolve_existing_command(project_root, name, scope=target_tier)
     if resolved is None:
         raise KeyError(name)
     cmd_path, layout = resolved
@@ -211,7 +201,7 @@ async def rendered_command(
         return JSONResponse(status_code=422, content={"detail": f"Parse error: {exc}"})
 
     runtimes = []
-    diffs = diff_commands(project_root, scope=target_scope)
+    diffs = diff_commands(project_root, scope=target_tier)
     status_map: dict[tuple[str, str], str] = {(rt, n): s for rt, n, s in diffs}
     # ``field_map[field][runtime] = bool`` — True when the runtime keeps the
     # field, False when it drops it. Mirrors ``context_agents.rendered_agent``
@@ -255,20 +245,17 @@ class CommandCreateRequest(BaseModel):
 async def create_command(
     body: CommandCreateRequest,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to create in. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Create command")
+    _reject_non_shared_write(target_tier, "Create command")
     name = validate_name(body.name, kind="command")
 
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
-                if resolve_canonical_command(project_root, name, scope=target_scope) is not None:
+                if resolve_canonical_command(project_root, name, scope=target_tier) is not None:
                     raise HTTPException(409, detail=f"Command '{name}' already exists")
-                cmd_path = _canonical_command_path(project_root, name, scope=target_scope)
+                cmd_path = _canonical_command_path(project_root, name, scope=target_tier)
                 atomic_write_text(cmd_path, body.content)
     except TimeoutError:
         raise HTTPException(503, "Command create timed out — another sync may be in progress")
@@ -294,13 +281,10 @@ async def update_command(
     name: str,
     body: CommandUpdateRequest,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to update. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> JSONResponse:
-    _reject_non_shared_write(target_scope, "Update command")
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Update command")
+    name, resolved = _resolve_existing_command(project_root, name, scope=target_tier)
     if resolved is None:
         raise KeyError(name)
     cmd_path, _layout = resolved
@@ -348,13 +332,10 @@ async def delete_command(
     name: str,
     cascade: bool = Query(False),
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to delete from. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Delete command")
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Delete command")
+    name, resolved = _resolve_existing_command(project_root, name, scope=target_tier)
 
     try:
         async with asyncio.timeout(60):
@@ -397,12 +378,9 @@ async def delete_command(
 async def diff_command(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to diff against runtime fan-out (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    name, resolved = _resolve_existing_command(project_root, name, scope=target_scope)
+    name, resolved = _resolve_existing_command(project_root, name, scope=target_tier)
 
     canonical_content = None
     if resolved is not None:
@@ -450,12 +428,9 @@ class SyncRequest(BaseModel):
 async def sync_commands(
     body: SyncRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to fan out. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Sync commands")
+    _reject_non_shared_write(target_tier, "Sync commands")
     on_drop = body.on_drop if body else "warn"
     try:
         async with asyncio.timeout(60):
@@ -491,12 +466,9 @@ class ImportRequest(BaseModel):
 async def import_commands(
     body: ImportRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
-    _reject_non_shared_write(target_scope, "Import commands")
+    _reject_non_shared_write(target_tier, "Import commands")
     overwrite = body.overwrite if body else False
     try:
         async with asyncio.timeout(60):
@@ -526,10 +498,7 @@ async def import_command(
     name: str,
     body: ImportRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Import a single runtime command into ``.memtomem/commands/``.
 
@@ -538,7 +507,7 @@ async def import_command(
     import would silently report 0 imported, which is the wrong shape of
     feedback for "you clicked a specific item that doesn't exist").
     """
-    _reject_non_shared_write(target_scope, "Import command")
+    _reject_non_shared_write(target_tier, "Import command")
     try:
         validate_name(name, kind="command name")
     except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -6,11 +6,11 @@ import json
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends
 
 from memtomem.privacy import scan as _privacy_scan
-from memtomem.config import TargetScope
-from memtomem.web.deps import get_hooks_target_scope, get_project_root
+from memtomem.config import TargetTier
+from memtomem.web.deps import get_hooks_target_tier, get_project_root, get_query_target_tier
 
 try:
     import tomllib
@@ -130,14 +130,8 @@ def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
 @router.get("/context/overview")
 async def context_overview(
     project_root: Path = Depends(get_project_root),
-    scope: str = Depends(get_hooks_target_scope),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description=(
-            "Canonical-residency tier to summarize. project_local is shown only "
-            "when explicitly requested."
-        ),
-    ),
+    scope: str = Depends(get_hooks_target_tier),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Aggregate sync status across skills, commands, agents, and settings."""
     from memtomem.context.agents import canonical_agent_name, diff_agents, list_canonical_agents
@@ -153,8 +147,8 @@ async def context_overview(
 
     try:
         result["skills"] = _count_context_statuses(
-            diff_skills(project_root, scope=target_scope),
-            {p.name for p in list_canonical_skills(project_root, scope=target_scope)},
+            diff_skills(project_root, scope=target_tier),
+            {p.name for p in list_canonical_skills(project_root, scope=target_tier)},
         )
     except Exception as exc:
         logger.exception("diff_skills failed")
@@ -162,10 +156,10 @@ async def context_overview(
 
     try:
         result["commands"] = _count_context_statuses(
-            diff_commands(project_root, scope=target_scope),
+            diff_commands(project_root, scope=target_tier),
             {
                 canonical_command_name(p, layout)
-                for p, layout in list_canonical_commands(project_root, scope=target_scope)
+                for p, layout in list_canonical_commands(project_root, scope=target_tier)
             },
         )
     except Exception as exc:
@@ -174,10 +168,10 @@ async def context_overview(
 
     try:
         result["agents"] = _count_context_statuses(
-            diff_agents(project_root, scope=target_scope),
+            diff_agents(project_root, scope=target_tier),
             {
                 canonical_agent_name(p, layout)
-                for p, layout in list_canonical_agents(project_root, scope=target_scope)
+                for p, layout in list_canonical_agents(project_root, scope=target_tier)
             },
         )
     except Exception as exc:
@@ -232,4 +226,9 @@ async def context_overview(
         logger.exception("diff_settings failed")
         result["settings"] = _error_payload(exc, shape="status")
 
-    return {"target_scope": target_scope, "project_root": str(project_root), **result}
+    return {
+        "target_tier": target_tier,
+        "target_scope": target_tier,
+        "project_root": str(project_root),
+        **result,
+    }

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from memtomem.context.agents import canonical_agent_name, diff_agents, list_canonical_agents
@@ -37,7 +37,8 @@ from memtomem.context.projects import (
     has_runtime_marker,
 )
 from memtomem.context.skills import diff_skills, list_canonical_skills
-from memtomem.config import TargetScope
+from memtomem.config import TargetTier
+from memtomem.web.deps import get_query_target_tier
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,7 @@ def resolve_scope_root(
 # ── GET /context/projects ────────────────────────────────────────────────
 
 
-def _counts_for(root: Path, *, target_scope: TargetScope) -> dict[str, int]:
+def _counts_for(root: Path, *, target_tier: TargetTier) -> dict[str, int]:
     """Per-type unique-name counts for a project root.
 
     Mirrors the union the existing ``list_*`` routes render: canonical files
@@ -113,22 +114,22 @@ def _counts_for(root: Path, *, target_scope: TargetScope) -> dict[str, int]:
     """
     counts: dict[str, int] = {}
     try:
-        names = {name for _runtime, name, _status in diff_skills(root, scope=target_scope)}
-        names.update(p.name for p in list_canonical_skills(root, scope=target_scope))
+        names = {name for _runtime, name, _status in diff_skills(root, scope=target_tier)}
+        names.update(p.name for p in list_canonical_skills(root, scope=target_tier))
         counts["skills"] = len(names)
     except Exception:
         logger.warning("counts: skills failed for %s", root, exc_info=True)
         counts["skills"] = 0
 
     try:
-        names = {name for _runtime, name, _status in diff_commands(root, scope=target_scope)}
+        names = {name for _runtime, name, _status in diff_commands(root, scope=target_tier)}
         # ``list_canonical_commands`` returns ``list[tuple[Path, Layout]]``
         # since ADR-0008 PR-C (#624) added directory layout. Name extraction
         # MUST be layout-aware: under directory layout the manifest is
         # ``<name>/command.md`` so ``p.stem == "command"`` collapses every
         # draft to a single ``"command"`` row, undercounting the actual
         # inventory and polluting the union with a phantom name. Especially
-        # acute for ``target_scope=project_local`` where ``diff_commands``
+        # acute for ``target_tier=project_local`` where ``diff_commands``
         # returns nothing (no runtime fan-out — ADR-0011 §3 / ADR-0016 §7)
         # so the canonical count is the only contributor (review P2 on
         # PR #940). Use ``canonical_command_name`` — the single source of
@@ -136,7 +137,7 @@ def _counts_for(root: Path, *, target_scope: TargetScope) -> dict[str, int]:
         # ``canonical_agent_name`` below.
         names.update(
             canonical_command_name(p, layout)
-            for p, layout in list_canonical_commands(root, scope=target_scope)
+            for p, layout in list_canonical_commands(root, scope=target_tier)
         )
         counts["commands"] = len(names)
     except Exception:
@@ -144,14 +145,14 @@ def _counts_for(root: Path, *, target_scope: TargetScope) -> dict[str, int]:
         counts["commands"] = 0
 
     try:
-        names = {name for _runtime, name, _status in diff_agents(root, scope=target_scope)}
+        names = {name for _runtime, name, _status in diff_agents(root, scope=target_tier)}
         # Same layout-aware extraction as commands above — directory-layout
         # agents at ``<name>/agent.md`` collapse to a phantom ``"agent"``
         # name under ``p.stem``. ``canonical_agent_name`` is the agent-side
         # mirror of ``canonical_command_name``.
         names.update(
             canonical_agent_name(p, layout)
-            for p, layout in list_canonical_agents(root, scope=target_scope)
+            for p, layout in list_canonical_agents(root, scope=target_tier)
         )
         counts["agents"] = len(names)
     except Exception:
@@ -161,7 +162,7 @@ def _counts_for(root: Path, *, target_scope: TargetScope) -> dict[str, int]:
     return counts
 
 
-def _scope_to_dict(scope: ProjectScope, *, with_counts: bool, target_scope: TargetScope) -> dict:
+def _scope_to_dict(scope: ProjectScope, *, with_counts: bool, target_tier: TargetTier) -> dict:
     return {
         "scope_id": scope.scope_id,
         "label": scope.label,
@@ -171,7 +172,7 @@ def _scope_to_dict(scope: ProjectScope, *, with_counts: bool, target_scope: Targ
         "missing": scope.missing,
         "experimental": scope.experimental,
         "counts": (
-            _counts_for(scope.root, target_scope=target_scope)
+            _counts_for(scope.root, target_tier=target_tier)
             if (with_counts and scope.root is not None and not scope.missing)
             else {"skills": 0, "commands": 0, "agents": 0}
         ),
@@ -181,13 +182,7 @@ def _scope_to_dict(scope: ProjectScope, *, with_counts: bool, target_scope: Targ
 @router.get("/context/projects")
 async def list_projects(
     request: Request,
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description=(
-            "Canonical-residency tier for per-project counts. project_local "
-            "is counted only when explicitly requested."
-        ),
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Enumerate discovered project scopes with per-type item counts.
 
@@ -198,8 +193,9 @@ async def list_projects(
     """
     scopes = _discover_for(request)
     return {
-        "target_scope": target_scope,
-        "scopes": [_scope_to_dict(s, with_counts=True, target_scope=target_scope) for s in scopes],
+        "target_tier": target_tier,
+        "target_scope": target_tier,
+        "scopes": [_scope_to_dict(s, with_counts=True, target_tier=target_tier) for s in scopes],
     }
 
 

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -25,8 +25,8 @@ from memtomem.context.skills import (
     generate_all_skills,
     list_canonical_skills,
 )
-from memtomem.config import TargetScope
-from memtomem.web.deps import get_project_root
+from memtomem.config import TargetTier
+from memtomem.web.deps import get_project_root, get_query_target_tier
 from memtomem.web.routes._locks import _gateway_lock
 from memtomem.web.routes.context_projects import resolve_scope_root
 
@@ -44,7 +44,7 @@ router = APIRouter(tags=["context-skills"])
 
 
 def _canonical_skill_dir(
-    project_root: Path, raw_name: str, *, scope: TargetScope = "project_shared"
+    project_root: Path, raw_name: str, *, scope: TargetTier = "project_shared"
 ) -> Path:
     """Validate the name via core and return the canonical skill directory.
 
@@ -55,7 +55,7 @@ def _canonical_skill_dir(
     return canonical_skills_root(project_root, scope=scope) / name
 
 
-def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
+def _reject_non_shared_write(target_tier: TargetTier, action: str) -> None:
     """Reject writes on non-``project_shared`` tiers with HTTP 400.
 
     Reads honor every tier (the canonical content differs per scope), but
@@ -68,12 +68,12 @@ def _reject_non_shared_write(target_scope: TargetScope, action: str) -> None:
     flagged ("mutates a same-named project_shared artifact while the UI is
     showing a user/local row").
     """
-    if target_scope != "project_shared":
+    if target_tier != "project_shared":
         raise HTTPException(
             status_code=400,
             detail=(
                 f"{action} is supported only on project_shared in this release; "
-                f"got target_scope={target_scope!r}."
+                f"got target_tier={target_tier!r}."
             ),
         )
 
@@ -91,13 +91,7 @@ def _safe_rel(p: Path, project_root: Path) -> str:
 @router.get("/context/skills")
 async def list_skills(
     project_root: Path = Depends(resolve_scope_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description=(
-            "Canonical-residency tier to list. project_local is shown only "
-            "when explicitly requested."
-        ),
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """List canonical skills with per-runtime sync status.
 
@@ -106,8 +100,8 @@ async def list_skills(
     for that scope's root. PR2 keeps mutating endpoints (POST/PUT/DELETE/
     sync/import) on cwd only — multi-scope writes ship in PR3.
     """
-    canonicals = list_canonical_skills(project_root, scope=target_scope)
-    diffs = diff_skills(project_root, scope=target_scope)
+    canonicals = list_canonical_skills(project_root, scope=target_tier)
+    diffs = diff_skills(project_root, scope=target_tier)
 
     # Group diff tuples by skill name
     by_name: dict[str, list[dict]] = {}
@@ -120,7 +114,8 @@ async def list_skills(
             {
                 "name": skill_dir.name,
                 "canonical_path": _safe_rel(skill_dir, project_root),
-                "target_scope": target_scope,
+                "target_tier": target_tier,
+                "target_scope": target_tier,
                 "runtimes": by_name.get(skill_dir.name, []),
             }
         )
@@ -133,7 +128,8 @@ async def list_skills(
                 {
                     "name": skill_name,
                     "canonical_path": None,
-                    "target_scope": target_scope,
+                    "target_tier": target_tier,
+                    "target_scope": target_tier,
                     "runtimes": runtimes,
                 }
             )
@@ -152,13 +148,10 @@ async def list_skills(
 async def read_skill(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to read from (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Read a canonical skill's SKILL.md content and list auxiliary files."""
-    skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
+    skill_dir = _canonical_skill_dir(project_root, name, scope=target_tier)
 
     manifest = skill_dir / SKILL_MANIFEST
     if not manifest.is_file():
@@ -194,14 +187,11 @@ class SkillCreateRequest(BaseModel):
 async def create_skill(
     body: SkillCreateRequest,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to create in. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Create a new canonical skill."""
-    _reject_non_shared_write(target_scope, "Create skill")
-    skill_dir = _canonical_skill_dir(project_root, body.name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Create skill")
+    skill_dir = _canonical_skill_dir(project_root, body.name, scope=target_tier)
 
     try:
         async with asyncio.timeout(60):
@@ -235,14 +225,11 @@ async def update_skill(
     name: str,
     body: SkillUpdateRequest,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to update. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> JSONResponse:
     """Update a canonical skill's SKILL.md (mtime-guarded, atomic, locked)."""
-    _reject_non_shared_write(target_scope, "Update skill")
-    skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Update skill")
+    skill_dir = _canonical_skill_dir(project_root, name, scope=target_tier)
     manifest = skill_dir / SKILL_MANIFEST
     if not manifest.is_file():
         raise KeyError(name)
@@ -290,17 +277,14 @@ async def delete_skill(
     name: str,
     cascade: bool = Query(False),
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to delete from. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Delete a canonical skill, optionally cascading to runtime copies.
 
     Idempotent: missing canonical directory returns ``deleted: []``.
     """
-    _reject_non_shared_write(target_scope, "Delete skill")
-    skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
+    _reject_non_shared_write(target_tier, "Delete skill")
+    skill_dir = _canonical_skill_dir(project_root, name, scope=target_tier)
 
     try:
         async with asyncio.timeout(60):
@@ -342,13 +326,10 @@ async def delete_skill(
 async def diff_skill(
     name: str,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to diff against runtime fan-out (ADR-0016).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Per-runtime diff for a single skill (returns text content if out of sync)."""
-    skill_dir = _canonical_skill_dir(project_root, name, scope=target_scope)
+    skill_dir = _canonical_skill_dir(project_root, name, scope=target_tier)
 
     canonical_manifest = skill_dir / SKILL_MANIFEST
     canonical_content = None
@@ -397,17 +378,10 @@ async def diff_skill(
 @router.post("/context/skills/sync")
 async def sync_skills(
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description=(
-            "Canonical-residency tier to fan out. Non-shared rejected — "
-            "project_local has no runtime fan-out per ADR-0011 §3, and user-tier "
-            "sync is deferred to a follow-up (#940)."
-        ),
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Fan out canonical skills to all runtimes."""
-    _reject_non_shared_write(target_scope, "Sync skills")
+    _reject_non_shared_write(target_tier, "Sync skills")
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
@@ -439,13 +413,10 @@ class ImportRequest(BaseModel):
 async def import_skills(
     body: ImportRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Import runtime skills into canonical .memtomem/skills/."""
-    _reject_non_shared_write(target_scope, "Import skills")
+    _reject_non_shared_write(target_tier, "Import skills")
     overwrite = body.overwrite if body else False
     try:
         async with asyncio.timeout(60):
@@ -472,10 +443,7 @@ async def import_skill(
     name: str,
     body: ImportRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    target_scope: TargetScope = Query(
-        "project_shared",
-        description="Canonical-residency tier to import into. Non-shared rejected (#940).",
-    ),
+    target_tier: TargetTier = Depends(get_query_target_tier),
 ) -> dict:
     """Import a single runtime skill into ``.memtomem/skills/``.
 
@@ -484,7 +452,7 @@ async def import_skill(
     section import would silently report 0 imported, which is the wrong
     shape of feedback for "you clicked a specific item that doesn't exist").
     """
-    _reject_non_shared_write(target_scope, "Import skill")
+    _reject_non_shared_write(target_tier, "Import skill")
     try:
         validate_name(name, kind="skill name")
     except InvalidNameError as exc:

--- a/packages/memtomem/src/memtomem/web/routes/sources.py
+++ b/packages/memtomem/src/memtomem/web/routes/sources.py
@@ -8,11 +8,16 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
-from memtomem.config import MemoryDirKind, TargetScope, classify_scope, memory_dir_kind
+from memtomem.config import MemoryDirKind, TargetTier, classify_scope, memory_dir_kind
 from memtomem.indexing.engine import norm_dir_prefix
 from memtomem.indexing.summarizer import regenerate_for_paths
 from memtomem.storage.sqlite_helpers import norm_path
-from memtomem.web.deps import get_config, get_storage, require_indexed_source
+from memtomem.web.deps import (
+    get_config,
+    get_optional_query_target_tier,
+    get_storage,
+    require_indexed_source,
+)
 from memtomem.web.schemas.core import DeleteResponse
 from memtomem.web.schemas.sources import (
     ChunkSizeBucket,
@@ -76,18 +81,7 @@ async def list_sources(
             "registered (so they don't disappear from the UI)."
         ),
     ),
-    target_scope: TargetScope | None = Query(
-        None,
-        description=(
-            "ADR-0016 §7 canonical-residency tier filter. Default (omit) "
-            "shows ``user`` + ``project_shared`` only; ``project_local`` "
-            "is hidden until explicitly requested (ADR-0015 §4a — keeps "
-            "the draft tier out of overview unless the operator opts in). "
-            "Passing one of the three literal tokens narrows the list "
-            "to that tier; passing ``project_local`` is the only way to "
-            "surface those sources."
-        ),
-    ),
+    target_tier: TargetTier | None = Depends(get_optional_query_target_tier),
     storage=Depends(get_storage),
     config=Depends(get_config),
 ) -> SourcesResponse:
@@ -194,15 +188,16 @@ async def list_sources(
         source_scope, _src_project_root = classify_scope(p, pmdirs)
 
         # ADR-0015 §4a project_local default-hidden rule. When the
-        # caller passes ``?target_scope=`` we narrow to exactly that
+        # caller passes ``?target_tier=`` (or deprecated ``?target_scope=``)
+        # we narrow to exactly that
         # tier (the only way to surface ``project_local`` sources).
         # When omitted, ``project_local`` rows fall out — keeps the
         # draft tier out of overview / list views unless the operator
         # explicitly asks for it.
-        if target_scope is None:
+        if target_tier is None:
             if source_scope == "project_local":
                 continue
-        elif source_scope != target_scope:
+        elif source_scope != target_tier:
             continue
 
         path_str = str(p)
@@ -225,6 +220,7 @@ async def list_sources(
                 max_tokens=max_tok,
                 memory_dir=memory_dir_str,
                 kind=source_kind,
+                target_tier=source_scope,
                 target_scope=source_scope,
                 title=title,
                 excerpt=excerpt,

--- a/packages/memtomem/src/memtomem/web/schemas/core.py
+++ b/packages/memtomem/src/memtomem/web/schemas/core.py
@@ -30,6 +30,9 @@ class ChunkOut(BaseModel):
     # PR-F badge contract). Mirrors ``ChunkMetadata.scope`` in
     # ``memtomem/models.py``; missing on legacy chunks defaults to
     # ``user`` via ``chunk_to_out``.
+    target_tier: str = "user"
+    # Deprecated response alias kept for existing clients during the
+    # target_scope -> target_tier rename.
     target_scope: str = "user"
 
 
@@ -79,6 +82,7 @@ def chunk_to_out(chunk) -> ChunkOut:
         updated_at=chunk.updated_at,
         valid_from_unix=meta.valid_from_unix,
         valid_to_unix=meta.valid_to_unix,
+        target_tier=meta.scope or "user",
         target_scope=meta.scope or "user",
     )
 

--- a/packages/memtomem/src/memtomem/web/schemas/sources.py
+++ b/packages/memtomem/src/memtomem/web/schemas/sources.py
@@ -33,8 +33,12 @@ class SourceOut(BaseModel):
     # path-classified via :func:`memtomem.config.classify_scope`. Always
     # one of ``user`` / ``project_shared`` / ``project_local``. The
     # SPA renders this verbatim as a per-row tier badge; the route also
-    # supports ``?target_scope=`` filtering (project_local hidden by
+    # supports ``?target_tier=`` filtering (deprecated ``?target_scope=``
+    # remains accepted; project_local hidden by
     # default per ADR-0015 §4a).
+    target_tier: str = "user"
+    # Deprecated response alias kept for existing clients during the
+    # target_scope -> target_tier rename.
     target_scope: str = "user"
     # Heuristic preview derived at read-time from the first indexed chunk:
     # ``title`` is the file's first heading (``#`` markers stripped) and

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -629,12 +629,12 @@ function _formatValidityDate(unix) {
 // project_local context artifacts (agents / skills / commands) per
 // ADR-0011 §3 — memory rows skip the annotation because project_local
 // memory still fans out via memory's own contract.
-function _tierBadgeHtml(targetScope, { isContextRow = false } = {}) {
-  if (!targetScope || targetScope === 'user') return '';
-  if (targetScope !== 'project_shared' && targetScope !== 'project_local') return '';
-  const cls = `badge badge-tier badge-tier--${targetScope}`;
-  const badge = ` <span class="${cls}" data-tier="${targetScope}">${targetScope}</span>`;
-  if (isContextRow && targetScope === 'project_local') {
+function _tierBadgeHtml(targetTier, { isContextRow = false } = {}) {
+  if (!targetTier || targetTier === 'user') return '';
+  if (targetTier !== 'project_shared' && targetTier !== 'project_local') return '';
+  const cls = `badge badge-tier badge-tier--${targetTier}`;
+  const badge = ` <span class="${cls}" data-tier="${targetTier}">${targetTier}</span>`;
+  if (isContextRow && targetTier === 'project_local') {
     return `${badge}<span class="tier-fanout-annotation">(no runtime fan-out)</span>`;
   }
   return badge;
@@ -2120,7 +2120,7 @@ function _buildResultItem(r) {
   // non-default tiers (project_shared / project_local) earn pixels.
   // The token is rendered verbatim per the PR-F display-alias-free
   // contract pinned in the Tiered Context Gateway v2 memory.
-  const tierBadge = _tierBadgeHtml(r.chunk.target_scope);
+  const tierBadge = _tierBadgeHtml(r.chunk.target_tier || r.chunk.target_scope);
   const validityBadge = _validityBadgeHtml(r.chunk.valid_from_unix, r.chunk.valid_to_unix);
   const scorePct = STATE.maxResultScore > 0 ? Math.round((r.score / STATE.maxResultScore) * 100) : 0;
   const barColor = scorePct > 70 ? 'var(--green)' : scorePct > 40 ? 'var(--accent)' : 'var(--muted)';
@@ -3917,7 +3917,7 @@ async function browseSource(path, limit = 100) {
           <div class="chunk-card-meta">
             <span class="badge badge-gray">${c.chunk_type.replace('_',' ')}</span>
             <span class="chunk-card-lines">lines ${c.start_line}–${c.end_line}</span>
-            ${_tierBadgeHtml(c.target_scope)}
+            ${_tierBadgeHtml(c.target_tier || c.target_scope)}
             ${c.heading_hierarchy.length ? `<span class="hierarchy-trail">${escapeHtml(c.heading_hierarchy.join(' › '))}</span>` : ''}
             <div class="chunk-card-actions">
               <button class="btn-ghost btn-xs card-copy-btn" title="Copy content">Copy</button>

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -132,24 +132,24 @@ let _ctxOverviewSeq = 0;
 // review P2 / #825). Cleared on fetch errors so the next call falls
 // back to a fresh fetch path.
 let _ctxOverviewCache = null;
-let _ctxTargetScope = 'project_shared';
+let _ctxTargetTier = 'project_shared';
 
-function _ctxTargetScopeParam() {
-  if (_ctxTargetScope === 'project_shared') return '';
-  return `target_scope=${encodeURIComponent(_ctxTargetScope)}`;
+function _ctxTargetTierParam() {
+  if (_ctxTargetTier === 'project_shared') return '';
+  return `target_tier=${encodeURIComponent(_ctxTargetTier)}`;
 }
 
-function _ctxWithTargetScope(url) {
-  const param = _ctxTargetScopeParam();
+function _ctxWithTargetTier(url) {
+  const param = _ctxTargetTierParam();
   if (!param) return url;
   return `${url}${url.includes('?') ? '&' : '?'}${param}`;
 }
 
 function _ctxTierControls(type) {
   return `<div class="ctx-tier-filter" data-type="${escapeHtml(type)}" role="group" aria-label="${escapeHtml(t('settings.ctx.tier_filter'))}">
-    <button type="button" data-scope="user" class="${_ctxTargetScope === 'user' ? 'active' : ''}">user</button>
-    <button type="button" data-scope="project_shared" class="${_ctxTargetScope === 'project_shared' ? 'active' : ''}">project_shared</button>
-    <button type="button" data-scope="project_local" class="${_ctxTargetScope === 'project_local' ? 'active' : ''}">project_local</button>
+    <button type="button" data-scope="user" class="${_ctxTargetTier === 'user' ? 'active' : ''}">user</button>
+    <button type="button" data-scope="project_shared" class="${_ctxTargetTier === 'project_shared' ? 'active' : ''}">project_shared</button>
+    <button type="button" data-scope="project_local" class="${_ctxTargetTier === 'project_local' ? 'active' : ''}">project_local</button>
   </div>`;
 }
 
@@ -157,8 +157,8 @@ function _ctxWireTierControls() {
   document.querySelectorAll('.ctx-tier-filter button').forEach(btn => {
     btn.addEventListener('click', () => {
       const next = btn.dataset.scope;
-      if (!next || next === _ctxTargetScope) return;
-      _ctxTargetScope = next;
+      if (!next || next === _ctxTargetTier) return;
+      _ctxTargetTier = next;
       const type = btn.closest('.ctx-tier-filter')?.dataset.type || '';
       if (type === 'overview') {
         loadCtxOverview();
@@ -293,7 +293,7 @@ function _renderCtxOverview(data) {
   // stays as a fallback for users who don't hover (mobile, keyboard).
   const syncAllBtn = document.getElementById('ctx-sync-all-btn');
   if (syncAllBtn) {
-    if (_ctxTargetScope === 'project_local') {
+    if (_ctxTargetTier === 'project_local') {
       // project_local has no runtime fan-out (ADR-0011 §3 / ADR-0016 §7),
       // so the Sync All button is disabled in this tier. We deliberately
       // do NOT ``return`` here — falling through lets the overview-card
@@ -351,7 +351,7 @@ async function loadCtxOverview() {
   const el = qs('ctx-overview-content');
   panelLoading(el);
   try {
-    const res = await fetch(_ctxWithTargetScope('/api/context/overview'));
+    const res = await fetch(_ctxWithTargetTier('/api/context/overview'));
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Failed to load overview');
     const data = await res.json();
     if (seq !== _ctxOverviewSeq) return;
@@ -414,7 +414,7 @@ window.addEventListener('langchange', () => {
     // hover text to the wrong copy for project_local. User-tier writes
     // hit the server's HTTP 400 reject path (#940 r3), so they don't
     // need a special tooltip — the click toast covers that case.
-    btn.title = _ctxTargetScope === 'project_local'
+    btn.title = _ctxTargetTier === 'project_local'
       ? t('settings.ctx.project_local_no_fanout_tooltip')
       : t('settings.ctx.sync_all_disabled_tooltip');
   }
@@ -569,7 +569,7 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
       : ['skills', 'agents'];
     for (const typ of types) {
       const resp = await fetch(
-        _ctxWithTargetScope(`/api/context/${typ}/sync`),
+        _ctxWithTargetTier(`/api/context/${typ}/sync`),
         { method: 'POST', headers },
       );
       if (!resp.ok) {
@@ -767,7 +767,8 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
     // because the list response carries the per-runtime statuses;
     // ``loadCtxDetail`` would otherwise need a second fetch.
     const outOfSync = (item.runtimes || []).some(r => r.status === 'out of sync');
-    const tierBadge = _tierBadgeHtml(item.target_scope, { isContextRow: true });
+    const itemTier = item.target_tier || item.target_scope;
+    const tierBadge = _tierBadgeHtml(itemTier, { isContextRow: true });
     html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}">
       <div class="ctx-card-header">
         <div>
@@ -785,7 +786,7 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
   panelLoading(container);
   try {
     const params = new URLSearchParams();
-    if (_ctxTargetScope !== 'project_shared') params.set('target_scope', _ctxTargetScope);
+    if (_ctxTargetTier !== 'project_shared') params.set('target_tier', _ctxTargetTier);
     if (!_ctxScopeIsServerCwd(scope)) params.set('scope_id', scope.scope_id);
     const query = params.toString();
     const res = await fetch(`/api/context/${type}${query ? `?${query}` : ''}`);
@@ -800,7 +801,7 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
     if (seq !== _ctxListSeq[type]) return;
     const items = data[type] || [];
     // Cards on the cwd scope are clickable across all tiers — the detail /
-    // rendered / diff / edit / delete endpoints now accept ``target_scope=``
+    // rendered / diff / edit / delete endpoints now accept ``target_tier=``
     // (#940 r3), so a click on a project_local draft opens the project_local
     // canonical, not a same-named project_shared one. Writes on non-shared
     // tiers are rejected at the server with HTTP 400 (the route's
@@ -861,9 +862,9 @@ function _ctxRefreshSectionState(type, cwdItems, scannedDirs) {
   const sectionEl = document.getElementById(`settings-ctx-${type}`);
   if (sectionEl) {
     sectionEl.dataset.canonicalCount = String(
-      _ctxTargetScope === 'project_local' ? 0 : canonicalCount,
+      _ctxTargetTier === 'project_local' ? 0 : canonicalCount,
     );
-    if (_ctxTargetScope === 'project_local') {
+    if (_ctxTargetTier === 'project_local') {
       sectionEl.dataset.noFanout = 'true';
     } else {
       delete sectionEl.dataset.noFanout;
@@ -906,7 +907,7 @@ async function loadCtxList(type) {
   }
 
   try {
-    const res = await fetch(_ctxWithTargetScope('/api/context/projects'));
+    const res = await fetch(_ctxWithTargetTier('/api/context/projects'));
     if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Failed to load projects');
     const data = await res.json();
     if (seq !== _ctxListSeq[type]) return;
@@ -1031,7 +1032,7 @@ async function _ctxFetchFresh(type, name) {
   // on transport / decode failure (toast already shown).
   try {
     const res = await fetch(
-      _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}`),
+      _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}`),
     );
     if (!res.ok) {
       showToast(t('toast.request_failed'), 'error');
@@ -1128,7 +1129,7 @@ async function _ctxHandleConflict(type, name, userBuffer, staleMtimeNs, detailEl
   if (choice === 'force') {
     try {
       const r2 = await fetch(
-        _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}`),
+        _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}`),
         {
           method: 'PUT',
           headers,
@@ -1185,7 +1186,7 @@ async function loadCtxDetail(type, name, opts = {}) {
 
   try {
     const res = await fetch(
-      _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}`),
+      _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}`),
     );
     if (res.status === 404) {
       if (seq !== _ctxDetailSeq[type]) return;
@@ -1322,7 +1323,7 @@ async function loadCtxDetail(type, name, opts = {}) {
           ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
           : { 'Content-Type': 'application/json' };
         const r = await fetch(
-          _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}`),
+          _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}`),
           {
             method: 'PUT',
             headers,
@@ -1379,7 +1380,7 @@ async function loadCtxDetail(type, name, opts = {}) {
       try {
         const csrf = await ensureCsrfToken();
         const r = await fetch(
-          _ctxWithTargetScope(
+          _ctxWithTargetTier(
             `/api/context/${type}/${encodeURIComponent(name)}?cascade=${cascade}`,
           ),
           { method: 'DELETE', headers: csrf ? { 'X-Memtomem-CSRF': csrf } : {} },
@@ -1445,7 +1446,7 @@ async function _ctxFetchFieldMap(type, name) {
   // the field map is supplementary.
   try {
     const res = await fetch(
-      _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}/rendered`),
+      _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}/rendered`),
     );
     if (!res.ok) return null;
     const data = await res.json();
@@ -1466,7 +1467,7 @@ async function _ctxLoadDiff(type, name, detailEl) {
     // would fail the whole pane on a /rendered hiccup; the explicit
     // fail-soft inside ``_ctxFetchFieldMap`` is what we want here.
     const diffPromise = fetch(
-      _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}/diff`),
+      _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}/diff`),
     );
     const fieldMapPromise = _CTX_FIELD_MAP_TYPES.has(type)
       ? _ctxFetchFieldMap(type, name)
@@ -1531,7 +1532,7 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
 
   try {
     const res = await fetch(
-      _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}/diff`),
+      _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}/diff`),
     );
     if (!res.ok) {
       throw new Error((await res.json().catch(() => ({}))).detail || `Failed to load ${name}`);
@@ -1577,7 +1578,7 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
       btnLoading(btn, true);
       try {
         const r = await fetch(
-          _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}/import`),
+          _ctxWithTargetTier(`/api/context/${type}/${encodeURIComponent(name)}/import`),
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -1642,7 +1643,7 @@ document.querySelectorAll('.ctx-sync-btn').forEach(btn => {
         ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
         : { 'Content-Type': 'application/json' };
       const r = await fetch(
-        _ctxWithTargetScope(`/api/context/${type}/sync`),
+        _ctxWithTargetTier(`/api/context/${type}/sync`),
         { method: 'POST', headers },
       );
       if (!r.ok) {
@@ -1699,7 +1700,7 @@ document.querySelectorAll('.ctx-import-btn').forEach(btn => {
     const overwrite = !!(result.extras && result.extras.overwrite);
     btnLoading(btn, true);
     try {
-      const r = await fetch(_ctxWithTargetScope(`/api/context/${type}/import`), {
+      const r = await fetch(_ctxWithTargetTier(`/api/context/${type}/import`), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ overwrite }),
@@ -1768,7 +1769,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
       const submitBtn = form.querySelector('.ctx-create-submit');
       btnLoading(submitBtn, true);
       try {
-        const r = await fetch(_ctxWithTargetScope(`/api/context/${type}`), {
+        const r = await fetch(_ctxWithTargetTier(`/api/context/${type}`), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: nameInput, content }),

--- a/packages/memtomem/tests/test_cli.py
+++ b/packages/memtomem/tests/test_cli.py
@@ -1001,6 +1001,71 @@ class TestConfigUnset:
         load_config_overrides(fresh)
         assert fresh.mmr.enabled is True
 
+    def test_unset_hooks_target_scope_with_only_legacy_persisted(
+        self, isolated, runner: CliRunner
+    ) -> None:
+        """ADR-0017 legacy unset: a config.json that still carries only the
+        legacy ``hooks.target_scope`` (no canonical ``target_tier`` yet) must
+        unset cleanly. Pre-fix the canonical pop raised ``KeyError`` because
+        the branch entered via ``legacy_field in section_data`` but then
+        called ``section_data.pop(field)`` for the missing canonical field.
+
+        Covers both legacy and canonical request spellings — both routes go
+        through ``_canonical_config_key`` and the same pop branch.
+        """
+        import json as _json
+
+        for request_key in ("hooks.target_scope", "hooks.target_tier"):
+            isolated["config_file"].write_text(
+                _json.dumps({"hooks": {"target_scope": "project_local"}}),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(cli, ["config", "unset", request_key])
+            assert result.exit_code == 0, (
+                f"unset({request_key!r}) on legacy-only config must succeed; "
+                f"got exit={result.exit_code}, output={result.output!r}"
+            )
+            assert "Removed" in result.output, (
+                f"unset({request_key!r}) must report removal; output={result.output!r}"
+            )
+            # Both forms wipe the legacy entry; the section is dropped when
+            # empty, matching the existing ``test_unset_removes_empty_section``
+            # behaviour.
+            assert not isolated["config_file"].exists() or "hooks" not in _json.loads(
+                isolated["config_file"].read_text(encoding="utf-8")
+            ), "legacy hooks.target_scope must be removed from config.json"
+
+    def test_set_hooks_target_scope_legacy_spelling_persists_as_target_tier(
+        self, isolated, runner: CliRunner
+    ) -> None:
+        """ADR-0017 legacy set: ``mm config set hooks.target_scope <v>`` is
+        equivalent to ``mm config set hooks.target_tier <v>`` and persists
+        under the canonical key. Sister test to the legacy-unset case above —
+        pins the full set-then-load round-trip end-to-end so the
+        ``_canonical_config_key`` mapping + property setter chain stay wired.
+        """
+        import json as _json
+
+        result = runner.invoke(cli, ["config", "set", "hooks.target_scope", "project_local"])
+        assert result.exit_code == 0, (
+            f"legacy set must succeed; got exit={result.exit_code}, output={result.output!r}"
+        )
+        # Echo line shows the requested key with the canonical spelling in
+        # parentheses so the operator sees the rename in passing.
+        assert "hooks.target_scope" in result.output
+        assert "hooks.target_tier" in result.output
+
+        persisted = _json.loads(isolated["config_file"].read_text(encoding="utf-8"))
+        assert persisted["hooks"] == {"target_tier": "project_local"}, (
+            f"legacy set must persist under the canonical target_tier key, got {persisted!r}"
+        )
+
+        fresh = Mem2MemConfig()
+        load_config_overrides(fresh)
+        assert fresh.hooks.target_tier == "project_local"
+        assert fresh.hooks.target_scope == "project_local"
+
     def test_atomic_write_preserves_original_on_failure(self, tmp_path, monkeypatch):
         import os as _os
 

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -15,7 +15,12 @@ from pathlib import Path
 import pytest
 
 from memtomem import config as _cfg
-from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+from memtomem.config import (
+    Mem2MemConfig,
+    load_config_d,
+    load_config_overrides,
+    save_config_overrides,
+)
 
 from .helpers import set_home
 
@@ -121,6 +126,103 @@ def test_env_and_config_coexist_on_different_fields(
     load_config_overrides(cfg)
     assert Path(cfg.storage.sqlite_path).as_posix() == "/from/env.db"
     assert cfg.embedding.model == "from-config"
+
+
+def test_hooks_target_scope_legacy_key_loads_and_saves_as_target_tier(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    override_path.write_text(
+        json.dumps({"hooks": {"target_scope": "project_local"}}), encoding="utf-8"
+    )
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert cfg.hooks.target_tier == "project_local"
+    assert cfg.hooks.target_scope == "project_local"
+
+    save_config_overrides(cfg)
+    persisted = json.loads(override_path.read_text(encoding="utf-8"))
+    assert persisted["hooks"] == {"target_tier": "project_local"}
+
+
+def test_hooks_target_tier_env_wins_over_legacy_config_json(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_TIER", "project_shared")
+    override_path.write_text(
+        json.dumps({"hooks": {"target_scope": "project_local"}}), encoding="utf-8"
+    )
+
+    cfg = Mem2MemConfig()
+    load_config_overrides(cfg)
+    assert cfg.hooks.target_tier == "project_shared"
+
+
+def test_hooks_target_tier_env_wins_over_legacy_config_d(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_TIER", "project_shared")
+    (config_d_dir / "hooks.json").write_text(
+        json.dumps({"hooks": {"target_scope": "project_local"}}), encoding="utf-8"
+    )
+
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert cfg.hooks.target_tier == "project_shared"
+
+
+def test_legacy_env_target_scope_wins_over_canonical_persisted_target_tier(
+    override_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ADR-0017 symmetric env precedence: a user who pinned the legacy
+    ``MEMTOMEM_HOOKS__TARGET_SCOPE`` env var must keep it even after their
+    ``config.json`` has been migrated to the canonical ``target_tier`` key.
+
+    Pre-fix, the loader derived ``env_var = "MEMTOMEM_HOOKS__TARGET_TIER"``
+    from the canonical persisted key only; a user still pinning the legacy
+    env name went undetected and the persisted target_tier value clobbered
+    the env-bound choice via direct ``setattr``. The fix enumerates both
+    env aliases per field.
+    """
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "user")
+    override_path.write_text(
+        json.dumps({"hooks": {"target_tier": "project_shared"}}), encoding="utf-8"
+    )
+
+    cfg = Mem2MemConfig()
+    assert cfg.hooks.target_tier == "user", (
+        "AliasChoices should populate target_tier from the legacy env name on construct"
+    )
+    load_config_overrides(cfg)
+    assert cfg.hooks.target_tier == "user", (
+        "Legacy MEMTOMEM_HOOKS__TARGET_SCOPE must continue to pre-empt a "
+        "canonical target_tier in config.json (env-wins precedence symmetric "
+        "with the canonical env name)"
+    )
+
+
+def test_legacy_env_target_scope_wins_over_canonical_config_d_target_tier(
+    config_d_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """config.d half of the symmetric env-precedence pin (see the override_path
+    sibling above). Fragment-loader path goes through the same
+    ``_env_aliases_for_field`` helper so the fix lands once and covers both."""
+    _clear_all_memtomem_env(monkeypatch)
+    monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "user")
+    (config_d_dir / "hooks.json").write_text(
+        json.dumps({"hooks": {"target_tier": "project_shared"}}), encoding="utf-8"
+    )
+
+    cfg = Mem2MemConfig()
+    load_config_d(cfg)
+    assert cfg.hooks.target_tier == "user", (
+        "Legacy MEMTOMEM_HOOKS__TARGET_SCOPE must pre-empt a canonical "
+        "target_tier coming from a config.d fragment too"
+    )
 
 
 def test_regression_pr247_mcp_json_env_block(

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -1030,6 +1030,14 @@ class TestSources:
         assert len(rows_shared) == 1
         assert rows_shared[0]["target_scope"] == "project_shared"
 
+        resp_shared_tier = await client.get(
+            "/api/sources", params={"target_tier": "project_shared"}
+        )
+        rows_shared_tier = resp_shared_tier.json()["sources"]
+        assert len(rows_shared_tier) == 1
+        assert rows_shared_tier[0]["target_tier"] == "project_shared"
+        assert rows_shared_tier[0]["target_scope"] == "project_shared"
+
     async def test_invalid_target_scope_returns_422(self, client: AsyncClient):
         """Literal validation refuses unknown tier tokens at the query
         layer too — same guardrail as ``/api/add``."""

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -113,6 +113,48 @@ class TestOverview:
         assert data["skills"]["total"] == 1
         assert data["skills"]["local_draft"] == 1
 
+    @pytest.mark.anyio
+    async def test_project_local_overview_accepts_target_tier_alias(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        local = tmp_path / ".memtomem" / "skills.local" / "draft"
+        local.mkdir(parents=True)
+        (local / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+
+        r = await client.get("/api/context/overview", params={"target_tier": "project_local"})
+        data = r.json()
+        assert r.status_code == 200
+        assert data["target_tier"] == "project_local"
+        assert data["target_scope"] == "project_local"
+        assert data["skills"]["total"] == 1
+
+    @pytest.mark.anyio
+    async def test_target_tier_wins_when_both_query_params_sent(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """ADR-0017 precedence: when a client sends BOTH ``?target_tier=`` and
+        the deprecated ``?target_scope=``, the canonical name wins. The legacy
+        alias is the fallback for un-renamed callers; letting it pre-empt the
+        canonical query would invert the rename. Pinned here against the
+        overview endpoint — the same dep (``get_query_target_tier``) covers
+        every Web context route.
+        """
+        local = tmp_path / ".memtomem" / "skills.local" / "draft"
+        local.mkdir(parents=True)
+        (local / SKILL_MANIFEST).write_text("# Draft\n", encoding="utf-8")
+
+        # target_tier=project_local + (deprecated) target_scope=project_shared
+        # → canonical wins → response reflects project_local + skill counted.
+        r = await client.get(
+            "/api/context/overview",
+            params={"target_tier": "project_local", "target_scope": "project_shared"},
+        )
+        data = r.json()
+        assert r.status_code == 200
+        assert data["target_tier"] == "project_local"
+        assert data["target_scope"] == "project_local"
+        assert data["skills"]["total"] == 1
+
 
 class TestSettingsCountShape:
     """Q-PR3 Visual-1 pins for the new ``settings`` count envelope.

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -259,7 +259,7 @@ def test_context_list_card_renders_project_local_tier_badge_with_annotation(
                 {
                     "name": "draft-skill",
                     "canonical_path": ".memtomem/skills.local/draft-skill",
-                    "target_scope": "project_local",
+                    "target_tier": "project_local",
                     "runtimes": [],
                 }
             ],
@@ -276,19 +276,19 @@ def test_context_list_card_renders_project_local_tier_badge_with_annotation(
     assert card_name.locator(".badge-tier--project_local").count() == 1
 
 
-def test_context_list_non_shared_tier_click_threads_target_scope(page, mm_web_url: str) -> None:
-    """Card click on a non-shared tier hits ``?target_scope=...`` (P1 #940 r3).
+def test_context_list_non_shared_tier_click_threads_target_tier(page, mm_web_url: str) -> None:
+    """Card click on a non-shared tier hits ``?target_tier=...`` (P1 #940 r3).
 
-    Item-level routes now accept ``target_scope`` (skills/agents/commands
+    Item-level routes now accept ``target_tier`` (skills/agents/commands
     read/diff/rendered honor every tier; create/update/delete/sync/import
     reject non-shared with HTTP 400 via ``_reject_non_shared_write``). This
     pins the round-trip: a click on a project_local card MUST fire
-    ``GET /api/context/skills/draft-skill?target_scope=project_local`` so the
+    ``GET /api/context/skills/draft-skill?target_tier=project_local`` so the
     backend opens the project_local canonical (not the same-name shared one).
     """
     install_default_stubs(page)
     # The shared ``_stub_*`` helpers register patterns without trailing ``**``
-    # so they miss URLs that carry ``?target_scope=...``. This test triggers
+    # so they miss URLs that carry ``?target_tier=...``. This test triggers
     # a tier switch which adds that query string, so register wider patterns
     # locally; last-route-wins puts these ahead of the catch-all.
     _skills_payload = {
@@ -296,7 +296,7 @@ def test_context_list_non_shared_tier_click_threads_target_scope(page, mm_web_ur
             {
                 "name": "draft-skill",
                 "canonical_path": ".memtomem/skills.local/draft-skill",
-                "target_scope": "project_local",
+                "target_tier": "project_local",
                 "runtimes": [],
             }
         ],
@@ -359,15 +359,15 @@ def test_context_list_non_shared_tier_click_threads_target_scope(page, mm_web_ur
         timeout=500,
     )
     # The card MUST be clickable on non-shared tiers — readonly-card workaround
-    # is gone now that routes honor target_scope.
+    # is gone now that routes honor target_tier.
     card_classes = card.get_attribute("class") or ""
     assert "ctx-card--readonly" not in card_classes, (
         f"non-shared-tier card should be clickable now (#940 r3), got class={card_classes!r}"
     )
     # The detail fetch fires with the tier appended.
     assert len(detail_calls) == 1, f"expected 1 detail call, got {detail_calls}"
-    assert "target_scope=project_local" in detail_calls[0], (
-        f"detail URL should carry target_scope=project_local, got {detail_calls[0]}"
+    assert "target_tier=project_local" in detail_calls[0], (
+        f"detail URL should carry target_tier=project_local, got {detail_calls[0]}"
     )
 
 


### PR DESCRIPTION
## Summary
- Add ADR-0017 accepting target_scope -> target_tier and update the ADR tracker/docs pointers
- Make hooks.target_tier, ?target_tier=, TargetTier, and target_tier response fields canonical
- Keep hooks.target_scope, ?target_scope=, TargetScope, and response target_scope as compatibility aliases

## Tests
- uv run pytest packages/memtomem/tests/test_web_routes_context.py packages/memtomem/tests/test_web_routes.py packages/memtomem/tests/test_config_overrides.py packages/memtomem/tests/test_cli.py::TestConfigUnset packages/memtomem/tests/test_docs_guards.py packages/memtomem/tests/web/test_context_gateway_lists.py -q
- uv run ruff check [focused Python files]
- node --check packages/memtomem/src/memtomem/web/static/app.js
- node --check packages/memtomem/src/memtomem/web/static/context-gateway.js