### PR TITLE
feat(web): last-sync freshness indicator on context-gateway dashboard (#832)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -112,6 +112,78 @@ def _redact_message(message: str) -> str:
     return redacted
 
 
+def _compute_last_synced_at(project_root: Path, target_scope: TargetScope) -> str | None:
+    """Return ISO8601 UTC timestamp of the most recently touched canonical artifact.
+
+    ADR-0009 §1.c: the dashboard freshness indicator is sourced from
+    **canonical-source mtime** rather than a persisted sync-event log —
+    cheapest option, matches Health Report semantics, avoids a new
+    write path. The cost is that the timestamp doesn't disambiguate
+    "edits" from "explicit syncs"; the ADR accepts this for the v1
+    "5 min ago" surface.
+
+    Aggregates across skills + commands + agents canonical files for the
+    requested ``target_scope`` (so a tier switch on the dashboard refreshes
+    the freshness signal alongside the per-tile counts). Settings is
+    intentionally excluded — its additive merge has no canonical-residency
+    that maps to "what would Sync All push," so its mtime would muddle the
+    freshness reading rather than sharpen it.
+
+    Returns ``None`` when no canonical files exist in the requested scope —
+    a fresh / empty project legitimately has no last-sync, and the
+    dashboard suppresses the line in that case (clearer than rendering
+    epoch-zero or "never").
+    """
+    from memtomem.context.agents import list_canonical_agents
+    from memtomem.context.commands import list_canonical_commands
+    from memtomem.context.skills import SKILL_MANIFEST, list_canonical_skills
+
+    latest: float | None = None
+
+    def _bump(path: Path) -> None:
+        nonlocal latest
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            return
+        if latest is None or mtime > latest:
+            latest = mtime
+
+    try:
+        for skill_dir in list_canonical_skills(project_root, scope=target_scope):
+            # ``list_canonical_skills`` returns the skill directory; the
+            # mtime that tracks "last sync" is the manifest file written by
+            # ``sync_skills`` / extract. The directory's own mtime advances
+            # on any auxiliary-file write too, which would over-trigger.
+            _bump(skill_dir / SKILL_MANIFEST)
+    except Exception:
+        logger.exception("list_canonical_skills failed during last_synced_at")
+
+    try:
+        for path, _layout in list_canonical_commands(project_root, scope=target_scope):
+            # ``list_canonical_commands`` returns the manifest file path
+            # directly (flat: ``<name>.md``; dir: ``<name>/command.md``).
+            _bump(path)
+    except Exception:
+        logger.exception("list_canonical_commands failed during last_synced_at")
+
+    try:
+        for path, _layout in list_canonical_agents(project_root, scope=target_scope):
+            _bump(path)
+    except Exception:
+        logger.exception("list_canonical_agents failed during last_synced_at")
+
+    if latest is None:
+        return None
+
+    # ISO8601 UTC with a trailing ``Z`` — matches the audit-catalog freshness
+    # surface and avoids the ``+00:00`` representation that confuses naive
+    # JS ``new Date(...)`` parsing across older browsers.
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(latest, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _compute_detected_runtimes(project_root: Path) -> list[dict[str, object]]:
     """Probe each known runtime for any on-disk fan-out surface.
 
@@ -279,9 +351,16 @@ async def context_overview(
         logger.exception("_compute_detected_runtimes failed")
         detected_runtimes = []
 
+    try:
+        last_synced_at = _compute_last_synced_at(project_root, target_scope)
+    except Exception:
+        logger.exception("_compute_last_synced_at failed")
+        last_synced_at = None
+
     return {
         "target_scope": target_scope,
         "project_root": str(project_root),
         "detected_runtimes": detected_runtimes,
+        "last_synced_at": last_synced_at,
         **result,
     }

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -415,6 +415,27 @@ function _renderCtxOverview(data) {
     return `<span class="${cls}"${title} data-runtime="${name}">${name}</span>`;
   }).join('');
 
+  // Issue #832 / ADR-0009 §1.c: surface "Last sync: 5 min ago" sourced from
+  // canonical-source mtime. Suppress the line when the backend returns null
+  // (fresh / empty project — no canonical files yet); rendering "Last sync:
+  // never" or epoch-zero would be more confusing than silent absence. The
+  // raw ISO timestamp is exposed via ``title=`` on the row for the
+  // copy/diagnose case (mtime drift, timezone weirdness) — the relative
+  // form alone hides the absolute value that's sometimes what the user
+  // actually needs.
+  const lastSyncedAt = typeof data.last_synced_at === 'string' && data.last_synced_at
+    ? data.last_synced_at
+    : '';
+  let lastSyncHtml = '';
+  if (lastSyncedAt) {
+    const rel = escapeHtml(relativeTime(lastSyncedAt));
+    const iso = escapeHtml(lastSyncedAt);
+    lastSyncHtml = `<div class="ctx-overview-last-sync" title="${iso}">
+        <span class="ctx-overview-last-sync-label">${escapeHtml(t('settings.ctx.last_synced_label'))}</span>
+        <span class="ctx-overview-last-sync-value" data-iso="${iso}">${rel}</span>
+      </div>`;
+  }
+
   // Inline ``t()`` text rather than ``data-i18n`` attrs: the langchange
   // listener applies ``I18N.applyDOM`` first and then re-renders this
   // panel, so any ``data-i18n`` attr written *during* the re-render would
@@ -430,6 +451,7 @@ function _renderCtxOverview(data) {
         <span class="ctx-overview-runtimes-label">${escapeHtml(t('settings.ctx.runtimes_label'))}</span>
         ${chips}
       </div>
+      ${lastSyncHtml}
     </div>`;
   html += _ctxTierControls('overview');
   html += '<div class="ctx-overview-grid">';

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -286,6 +286,7 @@
   "settings.ctx.overview_title": "Context Gateway",
   "settings.ctx.project_root_label": "Project",
   "settings.ctx.runtimes_label": "Runtimes",
+  "settings.ctx.last_synced_label": "Last sync",
   "settings.ctx.runtime_undetected_tooltip": "Not detected in this project",
   "settings.ctx.refresh": "Refresh",
   "settings.ctx.sync_all": "Sync All",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -286,6 +286,7 @@
   "settings.ctx.overview_title": "컨텍스트 게이트웨이",
   "settings.ctx.project_root_label": "프로젝트",
   "settings.ctx.runtimes_label": "런타임",
+  "settings.ctx.last_synced_label": "마지막 동기화",
   "settings.ctx.runtime_undetected_tooltip": "이 프로젝트에서 감지되지 않음",
   "settings.ctx.refresh": "새로고침",
   "settings.ctx.sync_all": "전체 동기화",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3138,9 +3138,10 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 }
 
 .ctx-overview-header { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; margin-bottom: 12px; font-size: 0.85rem; color: var(--muted); }
-.ctx-overview-root, .ctx-overview-runtimes { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.ctx-overview-root-label, .ctx-overview-runtimes-label { font-weight: 600; color: var(--text); }
+.ctx-overview-root, .ctx-overview-runtimes, .ctx-overview-last-sync { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ctx-overview-root-label, .ctx-overview-runtimes-label, .ctx-overview-last-sync-label { font-weight: 600; color: var(--text); }
 .ctx-overview-root-path { font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace); font-size: 0.78rem; background: var(--surface); padding: 2px 6px; border: 1px solid var(--border); border-radius: 4px; color: var(--text); word-break: break-all; }
+.ctx-overview-last-sync-value { font-variant-numeric: tabular-nums; }
 
 .ctx-overview-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; }
 .ctx-overview-stat { text-align: center; padding: 20px 16px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); cursor: pointer; transition: border-color 0.15s; }

--- a/packages/memtomem/tests/test_web_routes_context.py
+++ b/packages/memtomem/tests/test_web_routes_context.py
@@ -145,6 +145,82 @@ class TestOverview:
         assert data["skills"]["total"] == 1
         assert data["skills"]["local_draft"] == 1
 
+    # ----- Issue #832 / ADR-0009 §1.c — last-sync freshness -----
+
+    @pytest.mark.anyio
+    async def test_overview_last_synced_at_null_on_empty_project(self, client: AsyncClient):
+        """A fresh / empty project has no canonical artifacts, so
+        ``last_synced_at`` must be JSON-null rather than an epoch-zero
+        string or a present-time fallback. The frontend uses null to
+        suppress the "Last sync" header line entirely (clearer than
+        rendering "Last sync: 56 years ago").
+        """
+        r = await client.get("/api/context/overview")
+        data = r.json()
+        # Key must be PRESENT in the response shape (even when null) so
+        # older clients don't have to feature-detect — the dashboard
+        # always reads ``data.last_synced_at`` with a string-type guard.
+        assert "last_synced_at" in data
+        assert data["last_synced_at"] is None
+
+    @pytest.mark.anyio
+    async def test_overview_last_synced_at_reflects_canonical_mtime(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """ADR-0009 §1.c: ``last_synced_at`` is derived from the canonical
+        SKILL.md / command / agent file mtime — not a persisted log. A
+        single skill drop yields its manifest mtime, formatted as
+        ISO8601 UTC with a trailing ``Z`` (no ``+00:00`` ambiguity).
+        """
+        import re
+
+        skill_dir = _make_skill(tmp_path, "code-review")
+        manifest = skill_dir / SKILL_MANIFEST
+        # Pin mtime explicitly so the assertion isn't time-of-test fragile.
+        target_epoch = 1715000000.0  # 2024-05-06T12:53:20Z UTC
+        os.utime(manifest, (target_epoch, target_epoch))
+
+        r = await client.get("/api/context/overview")
+        data = r.json()
+        ts = data["last_synced_at"]
+        assert isinstance(ts, str)
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", ts), (
+            f"last_synced_at must be ISO8601 UTC with trailing Z; got {ts!r}"
+        )
+        # The exact pinned timestamp — confirms the helper read the
+        # manifest mtime rather than directory mtime or current time.
+        assert ts == "2024-05-06T12:53:20Z", (
+            f"last_synced_at must equal the pinned SKILL.md mtime; got {ts!r}"
+        )
+
+    @pytest.mark.anyio
+    async def test_overview_last_synced_at_returns_max_across_surfaces(
+        self, client: AsyncClient, tmp_path: Path
+    ):
+        """When canonical artifacts exist across multiple surfaces
+        (skills + agents), the freshness indicator must reflect the
+        most-recent mtime — the user reads "Last sync: 5 min ago"
+        as "something in the dashboard scope was synced 5 min ago,"
+        not "the oldest of all the things."
+        """
+        older_skill = _make_skill(tmp_path, "older")
+        os.utime(older_skill / SKILL_MANIFEST, (1700000000.0, 1700000000.0))
+
+        # Drop a canonical agent file via the flat layout so the helper's
+        # list_canonical_agents branch is exercised end-to-end.
+        agents_dir = tmp_path / ".memtomem" / "agents"
+        agents_dir.mkdir(parents=True)
+        newer_agent = agents_dir / "fresh.md"
+        newer_agent.write_text("---\nname: fresh\ndescription: x\n---\n# fresh\n", encoding="utf-8")
+        newer_epoch = 1720000000.0  # 2024-07-03T09:46:40Z UTC
+        os.utime(newer_agent, (newer_epoch, newer_epoch))
+
+        r = await client.get("/api/context/overview")
+        ts = r.json()["last_synced_at"]
+        assert ts == "2024-07-03T09:46:40Z", (
+            f"last_synced_at must be max(skill_mtime, agent_mtime); got {ts!r}"
+        )
+
 
 class TestSettingsCountShape:
     """Q-PR3 Visual-1 pins for the new ``settings`` count envelope.

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -1010,3 +1010,106 @@ def test_pointer_absent_on_in_sync_tile(page, mm_web_url: str) -> None:
         "either — the dashboard 'glance' property requires the block to "
         "be entirely absent, not just empty"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #832 — ADR-0009 §1.c last-sync freshness indicator.
+# ---------------------------------------------------------------------------
+#
+# The dashboard header surfaces "Last sync: <relative>" with the full ISO
+# timestamp on hover. Source: canonical-source mtime (ADR §1.c). Null on
+# empty project — the line is suppressed so the user doesn't see
+# "Last sync: 56 years ago" on a fresh install (epoch-zero fallthrough).
+
+
+def _build_iso(seconds_ago: int) -> str:
+    """Return an ISO8601 UTC string ``seconds_ago`` ago. Uses ``Z`` trailer
+    to match the backend (avoiding the ``+00:00`` ambiguity that some
+    browsers parse inconsistently).
+    """
+    import datetime as _dt
+
+    return (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(seconds=seconds_ago)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+
+def test_overview_last_sync_renders_relative_text_and_iso_tooltip(page, mm_web_url: str) -> None:
+    """ADR-0009 §1.c pin: header surfaces ``last_synced_at`` as a relative
+    string ("5m ago") with the full ISO timestamp exposed via ``title=`` on
+    the row container. The raw ISO is also reflected on the value span's
+    ``data-iso`` attribute so screen-reader / scraping consumers don't have
+    to parse the localized relative form.
+    """
+    install_default_stubs(page)
+    iso = _build_iso(seconds_ago=300)  # ~5 minutes ago
+    payload = {
+        **_OVERVIEW_WITH_HEADER,
+        "last_synced_at": iso,
+    }
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    row = page.locator("#ctx-overview-content .ctx-overview-last-sync")
+    assert row.count() == 1, (
+        f"freshness row must render when last_synced_at is set; got {row.count()}"
+    )
+    # ``title`` carries the unredacted ISO for the diagnose case.
+    assert row.get_attribute("title") == iso, (
+        f"freshness row title= must carry the raw ISO; got {row.get_attribute('title')!r}"
+    )
+    value = row.locator(".ctx-overview-last-sync-value")
+    assert value.get_attribute("data-iso") == iso, (
+        f"value span must mirror the raw ISO on data-iso for non-tooltip "
+        f"consumers; got {value.get_attribute('data-iso')!r}"
+    )
+    # Relative formatter routes through ``t('time.relative.*')``; for ~5
+    # minutes ago we expect the minutes-ago branch in EN ("5m ago").
+    text = (value.text_content() or "").strip()
+    assert text.endswith("m ago"), (
+        f"~300s ago must render via the minutes_ago branch of relativeTime(); got {text!r}"
+    )
+
+
+def test_overview_last_sync_absent_when_null(page, mm_web_url: str) -> None:
+    """Negative pin (``feedback_pin_invert_symmetric_assertion.md``
+    symmetric): a fresh project returns ``last_synced_at: null`` and the
+    dashboard must suppress the row entirely — both the wrapper and any
+    inner element. Rendering "Last sync: never" or an epoch-zero relative
+    ("56 years ago") would mislead the user about empty-project state.
+    """
+    install_default_stubs(page)
+    payload = {
+        **_OVERVIEW_WITH_HEADER,
+        "last_synced_at": None,
+    }
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    assert page.locator("#ctx-overview-content .ctx-overview-last-sync").count() == 0, (
+        "null last_synced_at must suppress the entire row wrapper"
+    )
+    # The label key must NOT bleed into the header via some other path
+    # (e.g. a label rendered without a value). Cross-locale-safe: search
+    # by the data-i18n attribute name in case the locale flips around test
+    # execution.
+    header_text = page.locator("#ctx-overview-content .ctx-overview-header").text_content() or ""
+    assert "Last sync" not in header_text, (
+        f"label must not leak into header when value is null; got: {header_text!r}"
+    )


### PR DESCRIPTION
## Summary

- Adds the **Last sync** header row on the Context Gateway dashboard, implementing ADR-0009 §1.c (Info-3 of 5).
- Sourced from **canonical-source mtime** — SKILL.md / command / agent files under `.memtomem/`, aggregated across surfaces for the active `target_scope`. No persisted event log, no new write path.
- Backend emits `last_synced_at` as an ISO8601 UTC string (trailing `Z`) on `/api/context/overview`, or `null` when the project is empty.

## Design notes

- **Settings excluded.** Its additive merge into `~/.claude/settings.json` has no canonical-residency that maps to "what would Sync All push" — including its mtime would muddle the freshness reading rather than sharpen it.
- **Why mtime over a persisted sync-event log** (ADR §1.c last paragraph): mtime reuses existing artifacts; the loss is that the timestamp doesn't disambiguate "edits" from "explicit syncs," which the ADR accepts for a v1 "5 min ago" glance.
- **Null suppression.** When no canonical artifacts exist, the row is entirely absent rather than rendering "Last sync: never" or an epoch-zero relative ("56 years ago"). Silent absence is the clearer signal for a fresh project.
- **Row anatomy.**
  - `title="<full ISO>"` on the wrapper — diagnose case (timezone weirdness, mtime drift).
  - `data-iso="<full ISO>"` on the value span — scrape / screen-reader.
  - Relative text via the existing `relativeTime()` helper (already routes through `t('time.relative.*')`, so EN/KO parity comes for free).

## Test plan

- [x] **Backend** (`tests/test_web_routes_context.py`) — 3 new specs:
  - `test_overview_last_synced_at_null_on_empty_project` — null when no canonical exists; key is still present in the response shape.
  - `test_overview_last_synced_at_reflects_canonical_mtime` — pinned SKILL.md mtime round-trips through the helper as the expected ISO8601-UTC string.
  - `test_overview_last_synced_at_returns_max_across_surfaces` — skills + agents with different mtimes; helper returns the max.
- [x] **Browser** (`tests/web/test_context_gateway_overview.py`) — 2 new specs:
  - `test_overview_last_sync_renders_relative_text_and_iso_tooltip` — row renders with `title=<ISO>` + `data-iso=<ISO>` + relative text ending in `"m ago"` for a ~5-min-old stub.
  - `test_overview_last_sync_absent_when_null` — negative-symmetric pin: `null` suppresses the wrapper AND the label, with cross-locale-safe header text inspection.

Lint clean (ruff check + format). Standalone test runs:
- `tests/test_web_routes_context.py` — 93 pass
- `tests/test_i18n.py` — 44 pass
- `tests/web/test_context_gateway_*.py` — 37 pass

Closes #832.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)