### PR TITLE
fix(web): tier-aware overview header copy (#952)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -406,6 +406,19 @@ function _renderCtxOverview(data) {
   // path on langchange and would otherwise blow up.
   const runtimes = Array.isArray(data.detected_runtimes) ? data.detected_runtimes : [];
   const projectRoot = typeof data.project_root === 'string' ? data.project_root : '';
+  // #952: ``Project: <root>`` is misleading on ``user`` tier — user-scope
+  // canonicals live under ``~/.memtomem/`` (host-global), not the cwd.
+  // Branch the header label + path on ``target_scope`` so the heading
+  // matches the tier the counts are computed against. Defensive default
+  // ``project_shared`` matches the route's query-param default.
+  const targetScope = typeof data.target_scope === 'string' ? data.target_scope : 'project_shared';
+  const isUserTier = targetScope === 'user';
+  const rootLabel = isUserTier
+    ? t('settings.ctx.user_canonical_label')
+    : t('settings.ctx.project_root_label');
+  const rootPath = isUserTier
+    ? t('settings.ctx.user_canonical_path')
+    : projectRoot;
   const undetectedTitle = escapeHtml(t('settings.ctx.runtime_undetected_tooltip'));
   const chips = runtimes.map(rt => {
     const available = !!rt.available;
@@ -443,9 +456,9 @@ function _renderCtxOverview(data) {
   // this same render path use the same inline-``t()`` convention for the
   // same ordering reason.
   let html = `<div class="ctx-overview-header">
-      <div class="ctx-overview-root">
-        <span class="ctx-overview-root-label">${escapeHtml(t('settings.ctx.project_root_label'))}</span>
-        <code class="ctx-overview-root-path">${escapeHtml(projectRoot)}</code>
+      <div class="ctx-overview-root" data-target-scope="${escapeHtml(targetScope)}">
+        <span class="ctx-overview-root-label">${escapeHtml(rootLabel)}</span>
+        <code class="ctx-overview-root-path">${escapeHtml(rootPath)}</code>
       </div>
       <div class="ctx-overview-runtimes">
         <span class="ctx-overview-runtimes-label">${escapeHtml(t('settings.ctx.runtimes_label'))}</span>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -285,6 +285,8 @@
 
   "settings.ctx.overview_title": "Context Gateway",
   "settings.ctx.project_root_label": "Project",
+  "settings.ctx.user_canonical_label": "User canonical",
+  "settings.ctx.user_canonical_path": "~/.memtomem/",
   "settings.ctx.runtimes_label": "Runtimes",
   "settings.ctx.last_synced_label": "Last sync",
   "settings.ctx.runtime_undetected_tooltip": "Not detected in this project",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -285,6 +285,8 @@
 
   "settings.ctx.overview_title": "컨텍스트 게이트웨이",
   "settings.ctx.project_root_label": "프로젝트",
+  "settings.ctx.user_canonical_label": "사용자 canonical",
+  "settings.ctx.user_canonical_path": "~/.memtomem/",
   "settings.ctx.runtimes_label": "런타임",
   "settings.ctx.last_synced_label": "마지막 동기화",
   "settings.ctx.runtime_undetected_tooltip": "이 프로젝트에서 감지되지 않음",

--- a/packages/memtomem/tests/web/test_context_gateway_overview.py
+++ b/packages/memtomem/tests/web/test_context_gateway_overview.py
@@ -344,6 +344,80 @@ def test_overview_header_labels_translate_on_langchange(page, mm_web_url: str) -
     )
 
 
+# ---------------------------------------------------------------------------
+# Tier-aware header (#952): user-tier swap from "Project: <root>" to
+# "User canonical: ~/.memtomem/" — project_root would mislead on user tier
+# since user-scope canonicals are host-global, not cwd-scoped.
+# ---------------------------------------------------------------------------
+
+_OVERVIEW_USER_TIER = {
+    **_HEALTHY_OVERVIEW,
+    "target_scope": "user",
+    "project_root": "/tmp/example-project",
+    "detected_runtimes": [
+        {"name": "claude", "available": True},
+    ],
+}
+
+
+def test_overview_header_user_tier_shows_user_canonical_label(page, mm_web_url: str) -> None:
+    """#952 pin: when ``target_scope=user`` the header must swap from
+    ``Project: <root>`` to ``User canonical: ~/.memtomem/``. User-scope
+    canonicals live under ``~/.memtomem/`` (host-global), so the
+    ``Project:`` framing was misleading on this tier.
+
+    Four pins:
+
+    * positive — label text matches the new ``user_canonical_label`` key
+    * positive — path text matches the new ``user_canonical_path`` key
+    * tier attr — ``data-target-scope="user"`` on ``.ctx-overview-root``
+      so CSS / selector-based tests can pin tier state without parsing
+      visible text (mirrors PR #945's ``data-write-blocked`` shape)
+    * negative — ``project_root`` from the payload must NOT render
+      (defense against a future regression that drops the tier branch
+      but keeps the payload field around).
+    """
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_OVERVIEW_USER_TIER),
+        ),
+    )
+    page.goto(mm_web_url)
+    _open_context_gateway(page)
+
+    root_label = (
+        page.locator("#ctx-overview-content .ctx-overview-root-label").text_content() or ""
+    ).strip()
+    assert root_label == "User canonical", (
+        f"user-tier header label must read 'User canonical'; got {root_label!r}"
+    )
+
+    root_path = (
+        page.locator("#ctx-overview-content .ctx-overview-root-path").text_content() or ""
+    ).strip()
+    assert root_path == "~/.memtomem/", (
+        f"user-tier header path must read '~/.memtomem/'; got {root_path!r}"
+    )
+
+    root_block = page.locator("#ctx-overview-content .ctx-overview-root")
+    assert root_block.get_attribute("data-target-scope") == "user", (
+        "user-tier header must mark .ctx-overview-root with data-target-scope=user "
+        "(mirrors data-write-blocked from PR #945)"
+    )
+
+    # Negative: project_root from the payload must not leak into the rendered
+    # path. The field is still in the response (route doesn't strip it on
+    # user tier), but the renderer must ignore it on this tier.
+    full_header = page.locator("#ctx-overview-content .ctx-overview-header").text_content() or ""
+    assert "/tmp/example-project" not in full_header, (
+        f"user-tier header must not leak project_root path; got {full_header!r}"
+    )
+
+
 def test_langchange_uses_cache_no_spinner_flash(page, mm_web_url: str) -> None:
     """#825 pin: lang toggle on a healthy mounted dashboard must re-render
     from ``_ctxOverviewCache`` directly — no refetch and, crucially, no


### PR DESCRIPTION
## Summary

- PR #947 added an unconditional `Project: <project_root>` header to the Context Gateway overview panel. Correct on project tiers; misleading on `user` tier where canonicals live under `~/.memtomem/` (host-global), not the cwd.
- Branch `_renderCtxOverview` on `data.target_scope`: user → `User canonical: ~/.memtomem/`, otherwise unchanged.
- Two new i18n keys (`settings.ctx.user_canonical_label` + `settings.ctx.user_canonical_path`). KO keeps `canonical` untransliterated to match existing locale style. Path string is shared across locales (filesystem path).
- Add `data-target-scope="<scope>"` to `.ctx-overview-root` so selectors can pin tier state without parsing text — mirrors PR #945's `data-write-blocked` shape.
- Server-side wire shape unchanged; the response already exposes `target_scope` (#940). Counts were already tier-correct — this is a read-side copy fix.

Closes #952.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_context_gateway_overview.py` — 17 passed (new `test_overview_header_user_tier_shows_user_canonical_label` + 16 regression pins on project-tier header + tile rendering).
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 44 passed (structural parity tests pick up the new keys automatically; no `{param}` placeholders so `test_placeholder_parity` is a no-op for them).
- [x] `uv run pytest packages/memtomem/tests/web/` — 70 passed (full browser suite, no cross-test fallout).
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` + `ruff format --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)