### PR TITLE
feat(web): tier-aware empty hint in context-gateway list (#956)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1121,14 +1121,26 @@ function _ctxScopeCount(scope, type) {
 
 function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable }) {
   if (!items.length) {
-    const canonical = `.memtomem/${type}`;
-    // Same fallback as the runtime-only banner (line 732) so the hint stays
-    // grammatical when no scan dirs are reported (fresh project / no runtimes).
-    const scanList = (scannedDirs || []).join(', ') || `.${type}/`;
-    const hint = t('settings.ctx.empty_hint')
+    // Branch the hint on the active tier (#956): user canonical lives at
+    // ``~/.memtomem/<type>`` and is shared across all projects, so the
+    // project-tier copy ("within this project", import-from-scan-dirs)
+    // is wrong on ``?target_scope=user``. ``_ctxTargetScope`` is the
+    // canonical client-side read — same source used by sibling tier-aware
+    // code (``_ctxRefreshSectionState``, ``langchange`` listener).
+    // ``project_local`` stays on the project-tier key by design: issue
+    // #956 explicitly scopes "preserve current project-tier wording".
+    const isUser = _ctxTargetScope === 'user';
+    const canonical = isUser ? `~/.memtomem/${type}` : `.memtomem/${type}`;
+    const hintKey = isUser ? 'settings.ctx.empty_hint_user' : 'settings.ctx.empty_hint';
+    let hint = t(hintKey)
       .replace(/\{type\}/g, type)
-      .replace('{canonical}', canonical)
-      .replace('{scan_dirs}', scanList);
+      .replace('{canonical}', canonical);
+    if (!isUser) {
+      // Same fallback as the runtime-only banner so the hint stays
+      // grammatical when no scan dirs are reported (fresh project / no runtimes).
+      const scanList = (scannedDirs || []).join(', ') || `.${type}/`;
+      hint = hint.replace('{scan_dirs}', scanList);
+    }
     return emptyState(
       '',
       t('settings.ctx.no_artifacts').replace('{type}', type),

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1389,7 +1389,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=5"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=31"></script>
+  <script src="/context-gateway.js?v=32"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -350,6 +350,7 @@
   "settings.ctx.no_artifacts": "No {type} found",
   "settings.ctx.no_artifacts_hint": "Create one or import from existing runtimes.",
   "settings.ctx.empty_hint": "Place {type} under {canonical}/<name>/ then click Sync, or click Import to pull existing {type} from {scan_dirs} within this project.",
+  "settings.ctx.empty_hint_user": "Place {type} under {canonical}/<name>/ then click Sync. User canonical is shared across all projects.",
   "settings.ctx.import_no_runtimes": "No runtime {type} found in {root}. Scanned: {scan_dirs}.",
   "settings.ctx.sync_empty_canonical": "No canonical {type} under {canonical}. Create one first.",
   "settings.ctx.runtime_only_banner": "{count} {type} found in {scan_dirs}; none imported yet. Click Import to canonicalize.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -350,6 +350,7 @@
   "settings.ctx.no_artifacts": "{type} 없음",
   "settings.ctx.no_artifacts_hint": "새로 만들거나 기존 런타임에서 가져올 수 있습니다.",
   "settings.ctx.empty_hint": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르거나, 이 프로젝트의 {scan_dirs} 에서 기존 {type} 폴더를 가져오기로 불러올 수 있습니다.",
+  "settings.ctx.empty_hint_user": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르세요. 사용자 canonical 은 모든 프로젝트에서 공유됩니다.",
   "settings.ctx.import_no_runtimes": "{root} 에서 런타임 {type} 폴더를 찾지 못했습니다. 스캔한 경로: {scan_dirs}.",
   "settings.ctx.sync_empty_canonical": "{canonical} 아래에 canonical {type} 폴더가 없습니다. 먼저 하나 만들어 주세요.",
   "settings.ctx.runtime_only_banner": "{scan_dirs} 에서 {type} {count}개를 발견했지만 아직 가져오지 않았습니다. 가져오기를 눌러 canonical 로 만드세요.",

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -1243,9 +1243,7 @@ def test_q956_empty_hint_user_tier_paths_to_user_canonical(page, mm_web_url: str
         timeout=3_000,
     )
     page.wait_for_selector("#ctx-skills-list .empty-state", timeout=5_000)
-    hint = (
-        page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
-    )
+    hint = page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
     assert "~/.memtomem/skills" in hint, (
         f"user-tier empty hint should reference ~/.memtomem/skills: {hint!r}"
     )
@@ -1267,9 +1265,7 @@ def test_q956_empty_hint_project_tier_preserves_existing_copy(page, mm_web_url: 
     _open_skills_list(page)
 
     page.wait_for_selector("#ctx-skills-list .empty-state", timeout=5_000)
-    hint = (
-        page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
-    )
+    hint = page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
     assert ".memtomem/skills" in hint, (
         f"project-tier empty hint should reference .memtomem/skills: {hint!r}"
     )
@@ -1308,9 +1304,7 @@ def test_q956_empty_hint_user_tier_ko_locale(page, mm_web_url: str) -> None:
         "}",
         timeout=3_000,
     )
-    hint = (
-        page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
-    )
+    hint = page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
     assert "사용자 canonical" in hint, (
         f"KO user-tier empty hint should contain '사용자 canonical': {hint!r}"
     )

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -1173,3 +1173,147 @@ def test_deep_link_banner_reset_restores_full_list(page, mm_web_url: str) -> Non
     href = page.evaluate("() => window.location.href")
     assert "artifact=" not in href, f"reset must strip artifact param: {href}"
     assert "filter=" not in href, f"reset must strip filter param: {href}"
+
+
+# Empty-list skills payload used by the #956 tier-aware empty-hint tests.
+# ``scanned_dirs`` is present so the project-tier branch's ``{scan_dirs}``
+# token interpolates with a real value (the user-tier branch ignores it).
+_CWD_SKILLS_EMPTY = {
+    "skills": [],
+    "scanned_dirs": ["/srv/cwd/.claude/skills/"],
+}
+
+
+def _stub_projects_wide(page, payload):
+    """Register a wider catch-all for ``/api/context/projects`` that also
+    matches ``?target_scope=...``. ``loadCtxList`` builds the projects URL
+    via ``_ctxWithTargetScope`` which appends the tier query string on
+    non-shared tiers, so the narrow ``**/api/context/projects`` pattern
+    misses the refetch after a tier swap and the catch-all empty body
+    leaves the list panel in the "No project scopes" branch.
+    """
+    page.route(
+        "**/api/context/projects**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        ),
+    )
+
+
+def _stub_skills_wide(page, payload):
+    """Register a wider catch-all for ``/api/context/skills`` that also
+    matches ``?target_scope=...``. Mirrors the inline pattern used by
+    ``test_context_list_non_shared_tier_click_threads_target_scope``.
+    """
+    page.route(
+        "**/api/context/skills**",
+        lambda r: r.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(payload),
+        ),
+    )
+
+
+def test_q956_empty_hint_user_tier_paths_to_user_canonical(page, mm_web_url: str) -> None:
+    """``_ctxRenderItemsHtml`` empty-state branches on ``_ctxTargetScope``
+    (#956). On the user tier the canonical lives at ``~/.memtomem/<type>``
+    and is shared across all projects, so the project-tier copy ("within
+    this project" / import-from-scan-dirs) is wrong.
+
+    Click the user tier button to trigger the refetch + re-render, then
+    pin the user-tier empty-hint copy and the negative on the project
+    framing.
+    """
+    install_default_stubs(page)
+    _stub_projects_wide(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
+    _stub_skills_wide(page, _CWD_SKILLS_EMPTY)
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    page.locator("#ctx-skills-list .ctx-tier-filter button[data-scope='user']").click()
+    page.wait_for_function(
+        "() => {"
+        "  const b = document.querySelector("
+        "    '#ctx-skills-list .ctx-tier-filter button[data-scope=\"user\"]');"
+        "  return b && b.classList.contains('active');"
+        "}",
+        timeout=3_000,
+    )
+    page.wait_for_selector("#ctx-skills-list .empty-state", timeout=5_000)
+    hint = (
+        page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
+    )
+    assert "~/.memtomem/skills" in hint, (
+        f"user-tier empty hint should reference ~/.memtomem/skills: {hint!r}"
+    )
+    assert "within this project" not in hint, (
+        f"user-tier empty hint must not say 'within this project': {hint!r}"
+    )
+
+
+def test_q956_empty_hint_project_tier_preserves_existing_copy(page, mm_web_url: str) -> None:
+    """Regression pin for the project-tier (default ``project_shared``)
+    empty hint: the ``.memtomem/<type>`` canonical token and "within this
+    project" phrase must remain (#956 issue body: preserve project-tier
+    wording).
+    """
+    install_default_stubs(page)
+    _stub_projects_wide(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
+    _stub_skills_wide(page, _CWD_SKILLS_EMPTY)
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    page.wait_for_selector("#ctx-skills-list .empty-state", timeout=5_000)
+    hint = (
+        page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
+    )
+    assert ".memtomem/skills" in hint, (
+        f"project-tier empty hint should reference .memtomem/skills: {hint!r}"
+    )
+    assert "within this project" in hint, (
+        f"project-tier empty hint should retain 'within this project': {hint!r}"
+    )
+
+
+def test_q956_empty_hint_user_tier_ko_locale(page, mm_web_url: str) -> None:
+    """Korean copy for the user-tier empty hint (#956): contains the
+    ``사용자 canonical`` phrase (the technical-term carve-out keeps
+    ``canonical`` un-Koreanized, matching CLI/ADR vocabulary) and drops
+    the ``이 프로젝트의`` project framing.
+    """
+    install_default_stubs(page)
+    _stub_projects_wide(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
+    _stub_skills_wide(page, _CWD_SKILLS_EMPTY)
+    page.goto(mm_web_url)
+    _open_skills_list(page)
+
+    page.locator("#ctx-skills-list .ctx-tier-filter button[data-scope='user']").click()
+    page.wait_for_function(
+        "() => {"
+        "  const b = document.querySelector("
+        "    '#ctx-skills-list .ctx-tier-filter button[data-scope=\"user\"]');"
+        "  return b && b.classList.contains('active');"
+        "}",
+        timeout=3_000,
+    )
+    page.evaluate("async () => { await I18N.setLang('ko'); }")
+    page.wait_for_function(
+        "() => {"
+        "  const el = document.querySelector("
+        "    '#ctx-skills-list .empty-state .empty-state-hint');"
+        "  return el && el.textContent.includes('사용자 canonical');"
+        "}",
+        timeout=3_000,
+    )
+    hint = (
+        page.locator("#ctx-skills-list .empty-state .empty-state-hint").text_content() or ""
+    )
+    assert "사용자 canonical" in hint, (
+        f"KO user-tier empty hint should contain '사용자 canonical': {hint!r}"
+    )
+    assert "이 프로젝트의" not in hint, (
+        f"KO user-tier empty hint must not say '이 프로젝트의': {hint!r}"
+    )


### PR DESCRIPTION
## Summary

- `_ctxRenderItemsHtml` empty-state now branches on `_ctxTargetScope`: user tier gets `~/.memtomem/<type>` canonical + "shared across all projects" copy via new `settings.ctx.empty_hint_user`; project tiers keep the existing `empty_hint` wording (issue body explicitly scopes "preserve project-tier wording").
- `{scan_dirs}` interpolation is gated to the project branch so it can't leak into the user copy.
- Locales: new `settings.ctx.empty_hint_user` in `en.json` + `ko.json`. Korean copy keeps `canonical` un-Koreanized per the technical-term carve-out (matches CLI/ADR vocabulary).
- Cache-bust: `context-gateway.js?v=31` → `v=32` so partial-cache returning users pick up the new key.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_context_gateway_lists.py -m "not ollama"` — 63 passed (3 new + 60 existing)
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -m "not ollama"` — 44 passed (no key drift between `en.json` and `ko.json`)
- [ ] Manual: toggle context-gateway tier to `user` on a fresh project with no canonical user artifacts; confirm empty hint shows `~/.memtomem/skills` and no "within this project" phrase; toggle back to `project_shared`, confirm unchanged.

## Out of scope

- `project_local` tier-specific copy (issue scope: preserve project-tier wording — `project_shared` and `project_local` share the existing key by design).
- Overview-tile empty hints — already tier-correct via separate `empty_tile_hint_*` keys; the recent PR #955 covered the overview header.

Closes #956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)