### PR TITLE
sec(web): flip CSRF / Origin / Host guard to enforce (#787 stage 2)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,6 +21,43 @@ Please report security issues via [GitHub private advisory](https://github.com/m
 - **Path traversal protection**: All file access endpoints validate against indexed sources; symlinked files are rejected
 - **Error masking**: Filesystem paths are stripped from error responses
 
+#### CSRF / Origin / Host guard (RFC #787)
+
+`mm web` ships an unauthenticated SPA on the loopback interface. CORS is a
+browser readability boundary, not a write boundary — a malicious tab can
+issue CORS-simple `POST` requests against `http://127.0.0.1:<port>` and the
+handler still runs even if the response is unreadable. To close that gap,
+every unsafe-method request to `/api/**` (POST / PUT / PATCH / DELETE) is
+gated by a single middleware that checks three things at once:
+
+1. **CSRF token** — `X-Memtomem-CSRF` must match the per-process token in
+   `app.state.csrf_token`. The SPA fetches it via `GET /api/session` on
+   load; the token rotates on every restart and is never persisted.
+2. **Origin / Referer** — when present, must resolve to a loopback host
+   or an operator-supplied `--trusted-origin` entry. Defends drive-by
+   tabs whose Origin reveals the attacker domain.
+3. **Host header** — must be a loopback hostname or an operator-supplied
+   `--trusted-host` entry. Defends DNS rebinding, where the socket peer
+   is `127.0.0.1` but the browser's URL bar (and the `Host:` header) is
+   attacker-controlled.
+
+Failures return `403` with a JSON `{"detail": "..."}` body and a
+structured `web.csrf.observe` log record for after-the-fact auditing.
+
+**Operator surface:**
+
+- `--allow-remote-ui` — required when `--host` is non-loopback. Startup
+  refuses without it; the unauthenticated SPA must not be exposed to
+  the network by accident.
+- `--trusted-origin <host>` (repeatable) — extends the Origin/Referer
+  allow-list. Pair with `--allow-remote-ui`.
+- `--trusted-host <host>` (repeatable) — extends the Host-header
+  allow-list. Pair with `--allow-remote-ui`.
+- `MEMTOMEM_WEB__CSRF_ENFORCE` — emergency rollback to observe-only.
+  Set to `0` / `false` / `no` / `off` to keep the structured log line
+  but skip the 403. Any other value (including unset and typos) keeps
+  enforcement on.
+
 ### URL Fetching (`mem_fetch`)
 
 - **SSRF protection**: Private/reserved IP ranges blocked (10.x, 172.16-31.x, 192.168.x, 169.254.x, localhost, ::1)

--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -61,11 +61,10 @@ _LOOPBACK_BINDS = {"127.0.0.1", "::1", "localhost"}
 @click.option(
     "--allow-remote-ui",
     is_flag=True,
-    help="Acknowledge that --host is exposing the Web UI off-loopback. RFC #787 "
-    "stage 1 (this release) only logs the observation; stage 2 will refuse to "
-    "start without this flag when --host is non-loopback. Pair with "
-    "--trusted-origin / --trusted-host so the eventual enforcement layer has "
-    "an explicit allow-list to read.",
+    help="Acknowledge that --host is exposing the Web UI off-loopback. "
+    "Required when --host is non-loopback (RFC #787) — startup refuses "
+    "otherwise. Pair with --trusted-origin / --trusted-host so the CSRF / "
+    "Origin / Host allow-list has explicit entries for the remote shape.",
 )
 @click.option(
     "--trusted-origin",
@@ -134,21 +133,21 @@ def web(
 
     import asyncio
 
-    click.echo(f"Starting memtomem Web UI at http://{host}:{port} (mode={resolved_mode})")
-
     bind_is_loopback = host in _LOOPBACK_BINDS
     if not bind_is_loopback and not allow_remote_ui:
-        # PR1 (log-only) doesn't refuse to start — that's PR2's flip per
-        # RFC #787 stage 2. But emit a loud warning so an operator who
-        # ran `--host 0.0.0.0` for a screen-share knows the upcoming
-        # release will gate it on `--allow-remote-ui`.
-        click.secho(
-            f"Warning: --host {host} exposes the Web UI off-loopback. RFC #787 "
-            "stage 2 will require --allow-remote-ui (with --trusted-origin / "
-            "--trusted-host) for non-loopback binds. See "
-            "https://github.com/memtomem/memtomem/issues/787 .",
-            fg="yellow",
+        # Refuse to start: a non-loopback bind exposes the unauthenticated
+        # Web UI to anyone who can reach the host on this port. RFC #787
+        # requires explicit acknowledgement via --allow-remote-ui, paired
+        # with --trusted-origin / --trusted-host so the CSRF allow-list
+        # has the remote shape's entries.
+        raise click.UsageError(
+            f"--host {host} exposes the Web UI off-loopback. Pass "
+            "--allow-remote-ui to acknowledge, paired with --trusted-origin "
+            "and --trusted-host so the CSRF/Origin/Host allow-list covers "
+            "the remote shape. See https://github.com/memtomem/memtomem/issues/787 ."
         )
+
+    click.echo(f"Starting memtomem Web UI at http://{host}:{port} (mode={resolved_mode})")
 
     async def after_started(server: uvicorn.Server, timeout: float) -> None:
         if not open_browser:

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -56,6 +56,13 @@ WebMode = Literal["prod", "dev"]
 _VALID_WEB_MODES: frozenset[str] = frozenset(get_args(WebMode))
 _WEB_MODE_ENV = "MEMTOMEM_WEB__MODE"
 
+# CSRF enforcement default flipped to True in RFC #787 stage 2. The env var
+# is an emergency-rollback hatch — set to ``0``/``false``/``no``/``off`` to
+# fall back to observe-only without a code change. Anything else (including
+# unset) keeps the default-on behavior.
+_CSRF_ENFORCE_ENV = "MEMTOMEM_WEB__CSRF_ENFORCE"
+_CSRF_ENFORCE_DISABLED: frozenset[str] = frozenset({"0", "false", "no", "off"})
+
 # Routers that define the polished surface shipped to `uv tool install` users.
 # `_DEV_ONLY_ROUTERS` is the opt-in extension mounted only when
 # ``mode == "dev"`` — those pages have rougher UX, narrower audiences, or
@@ -89,6 +96,18 @@ _DEV_ONLY_ROUTERS: list[ModuleType] = [
     evaluation,
     watchdog,
 ]
+
+
+def resolve_csrf_enforce_from_env() -> bool:
+    """Return whether the CSRF/Origin/Host guard runs in enforce or observe.
+
+    Default-on: missing or unrecognized values keep enforcement enabled. Only
+    the explicit disable tokens in ``_CSRF_ENFORCE_DISABLED`` turn it off, so
+    a typo (``MEMTOMEM_WEB__CSRF_ENFORCE=ture``) fails safe rather than
+    silently dropping the gate.
+    """
+    raw = os.environ.get(_CSRF_ENFORCE_ENV, "").strip().lower()
+    return raw not in _CSRF_ENFORCE_DISABLED
 
 
 def resolve_web_mode_from_env(*, strict: bool = False) -> WebMode:
@@ -149,18 +168,20 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
     )
     app.state.web_mode = mode
 
-    # Per-process CSRF token (RFC #787 stage 1, log-only). Generated
-    # fresh on every ``create_app`` so token rotation is just a restart;
-    # never persisted. ``GET /api/session`` exposes this to the SPA, and
-    # ``CSRFGuardMiddleware`` checks ``X-Memtomem-CSRF`` against it on
-    # unsafe ``/api/*`` requests. Operator allow-lists default to empty
-    # — populated by the ``mm web`` CLI when ``--trusted-host`` /
-    # ``--trusted-origin`` are passed alongside ``--allow-remote-ui``.
+    # Per-process CSRF token (RFC #787). Generated fresh on every
+    # ``create_app`` so token rotation is just a restart; never persisted.
+    # ``GET /api/session`` exposes this to the SPA, and ``CSRFGuardMiddleware``
+    # checks ``X-Memtomem-CSRF`` against it on unsafe ``/api/*`` requests.
+    # Operator allow-lists default to empty — populated by the ``mm web`` CLI
+    # when ``--trusted-host`` / ``--trusted-origin`` are passed alongside
+    # ``--allow-remote-ui``.
     app.state.csrf_token = secrets.token_urlsafe(32)
     app.state.csrf_trusted_hosts = frozenset()
     app.state.csrf_trusted_origins = frozenset()
-    # Stage-1 default: observe-only. PR2 will flip via env toggle.
-    app.state.csrf_enforce = False
+    # Stage-2 default: enforce. Setting ``MEMTOMEM_WEB__CSRF_ENFORCE`` to one
+    # of ``0`` / ``false`` / ``no`` / ``off`` falls back to observe-only for
+    # emergency rollback without a code change.
+    app.state.csrf_enforce = resolve_csrf_enforce_from_env()
 
     # Hand-rolled instead of ``fastapi.openapi.docs.get_swagger_ui_html``
     # for two reasons that combine on the same page:
@@ -223,14 +244,12 @@ def create_app(lifespan=None, mode: WebMode = "prod") -> FastAPI:
         allow_headers=["Content-Type", "Accept"],
     )
 
-    # CSRF / Origin / Host guard (RFC #787 stage 1, log-only).
+    # CSRF / Origin / Host guard (RFC #787).
     #
     # Order with SecurityHeaders matters: ``add_middleware`` stacks last-added
     # outermost on the request path. We want CSRFGuard *inside*
-    # SecurityHeaders so a 403 from the gate (PR2 enforcement flip) still
-    # picks up nosniff / frame-options / CSP on its way back to the client.
-    # PR1 never returns 403, but the wiring is the same as PR2 — fewer moving
-    # parts at the flip.
+    # SecurityHeaders so a 403 from the gate still picks up nosniff /
+    # frame-options / CSP on its way back to the client.
     app.add_middleware(CSRFGuardMiddleware)
 
     class SecurityHeadersMiddleware(BaseHTTPMiddleware):

--- a/packages/memtomem/src/memtomem/web/middleware/csrf.py
+++ b/packages/memtomem/src/memtomem/web/middleware/csrf.py
@@ -1,8 +1,8 @@
 """CSRF / Origin / Host guard middleware for the local Web UI.
 
-Implements the log-only first stage of RFC #787. Three concerns gated at
-one place so the AST registry test in
-``tests/test_web_invariants_registry.py`` sees a single seam:
+Implements RFC #787. Three concerns gated at one place so the AST
+registry test in ``tests/test_web_invariants_registry.py`` sees a single
+seam:
 
 1. ``X-Memtomem-CSRF`` header must match the per-process token in
    ``app.state.csrf_token``. The SPA fetches the token from
@@ -14,12 +14,14 @@ one place so the AST registry test in
    — defends DNS rebinding, where the socket peer is ``127.0.0.1`` but
    the browser's URL bar (and the ``Host:`` header) is attacker-controlled.
 
-Stage 1 (this PR) only **observes** — every check emits a structured
-``web.csrf.observe`` log record carrying the four decision flags
-(``token_ok``, ``origin_ok``, ``host_ok``, ``would_block``) and the
-request shape (method, path) so an operator can grep production logs
-before flipping to enforcement. Stage 2 (RFC PR2) flips ``would_block``
-to a real 403 plus a ``MEMTOMEM_WEB__CSRF_ENFORCE`` env rollback toggle.
+Every gated request also emits a structured ``web.csrf.observe`` log
+record carrying the four decision flags (``token_ok``, ``origin_ok``,
+``host_ok``, ``would_block``) and the request shape (method, path), so
+an operator can audit refusals after the fact. Enforcement is governed
+by ``app.state.csrf_enforce`` (default ``True`` in production via
+``resolve_csrf_enforce_from_env``); setting
+``MEMTOMEM_WEB__CSRF_ENFORCE`` to one of ``0`` / ``false`` / ``no`` /
+``off`` falls back to observe-only for emergency rollback.
 
 Invariants:
 
@@ -100,8 +102,9 @@ class CSRFGuardMiddleware(BaseHTTPMiddleware):
       operator opted in via ``--trusted-host``. May be empty.
     * ``app.state.csrf_trusted_origins`` — set of extra hostnames the
       operator opted in via ``--trusted-origin``. May be empty.
-    * ``app.state.csrf_enforce`` — bool. PR1 leaves this ``False`` so the
-      middleware only observes; PR2 will flip it via env toggle.
+    * ``app.state.csrf_enforce`` — bool. Defaults to ``True`` in production;
+      set ``MEMTOMEM_WEB__CSRF_ENFORCE=0`` for emergency rollback to
+      observe-only.
     """
 
     async def dispatch(self, request: Request, call_next) -> Response:

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -131,6 +131,24 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_browser)
 
 
+@pytest.fixture(autouse=True)
+def _csrf_observe_only_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default CSRF enforcement to OFF for the test suite.
+
+    Production defaults to enforce. Most route tests build TestClients
+    via ``create_app`` and exercise route logic, not the middleware —
+    threading the per-process token + a loopback Host/Origin into every
+    request would be churn for zero security value. The middleware is
+    exhaustively tested in ``tests/test_web_csrf_middleware.py``.
+
+    Tests that need to exercise the production posture either build their
+    own FastAPI app and flip ``app.state.csrf_enforce = True``, or use
+    ``monkeypatch.setenv("MEMTOMEM_WEB__CSRF_ENFORCE", ...)`` directly —
+    both override this autouse default cleanly.
+    """
+    monkeypatch.setenv("MEMTOMEM_WEB__CSRF_ENFORCE", "0")
+
+
 @pytest.fixture
 async def components(tmp_path):
     """Create components with a temporary DB for isolated testing."""

--- a/packages/memtomem/tests/test_web_cli.py
+++ b/packages/memtomem/tests/test_web_cli.py
@@ -314,3 +314,53 @@ def test_web_cli_flag_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     assert exit_code == 0, output
     assert mode == "prod"
+
+
+# ---------------------------------------------------------------------------
+# --host non-loopback refusal (RFC #787 stage 2)
+# ---------------------------------------------------------------------------
+
+
+def test_web_non_loopback_host_without_acknowledgement_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`mm web --host 0.0.0.0` without `--allow-remote-ui` must refuse to
+    start. The Web UI is unauthenticated; binding off-loopback by accident
+    silently exposes it to the local network."""
+    monkeypatch.delenv("MEMTOMEM_WEB__MODE", raising=False)
+    runner = CliRunner()
+    with patch("memtomem.cli.web._missing_web_deps", return_value=None):
+        result = runner.invoke(web, ["--host", "0.0.0.0", "--port", "9999"])
+    assert result.exit_code != 0
+    assert "--allow-remote-ui" in result.output
+    # Refusal must happen before the "Starting..." banner — otherwise an
+    # operator might think the server came up.
+    assert "Starting memtomem Web UI" not in result.output
+
+
+def test_web_loopback_host_does_not_require_acknowledgement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default loopback bind needs no acknowledgement flag — the whole
+    point of the gate is that off-loopback is the exceptional case."""
+    monkeypatch.delenv("MEMTOMEM_WEB__MODE", raising=False)
+    exit_code, output, _mode = _run_web_capturing_mode(
+        ["--host", "127.0.0.1", "--port", "9999"], monkeypatch=monkeypatch
+    )
+    assert exit_code == 0, output
+    assert "--allow-remote-ui" not in output
+
+
+def test_web_non_loopback_host_with_acknowledgement_proceeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--allow-remote-ui` unblocks the off-loopback bind. The CSRF
+    allow-list stays empty unless paired with `--trusted-*` flags, so the
+    middleware will still refuse cross-origin writes — that's the point."""
+    monkeypatch.delenv("MEMTOMEM_WEB__MODE", raising=False)
+    exit_code, output, _mode = _run_web_capturing_mode(
+        ["--host", "0.0.0.0", "--port", "9999", "--allow-remote-ui"],
+        monkeypatch=monkeypatch,
+    )
+    assert exit_code == 0, output
+    assert "Starting memtomem Web UI" in output

--- a/packages/memtomem/tests/test_web_csrf_middleware.py
+++ b/packages/memtomem/tests/test_web_csrf_middleware.py
@@ -1,23 +1,18 @@
-"""TestClient pins for ``CSRFGuardMiddleware`` (RFC #787 stage 1).
+"""TestClient pins for ``CSRFGuardMiddleware`` (RFC #787).
 
-Stage 1 is observe-only: the middleware emits a structured log line for
-every gated request but never returns 403. The test suite locks both
-sides of that contract — pass-through behavior AND the observe events —
-so:
+The middleware always emits a structured ``web.csrf.observe`` log line
+per gated request. Whether a would-block decision becomes a real 403 is
+governed by ``app.state.csrf_enforce``:
 
-* PR2's flip to enforcement is a one-line change in
-  ``app.state.csrf_enforce`` plus a copy-paste of the negative cases
-  here with the assertion direction inverted.
-* A regression that *adds* a 403 in stage 1 fails immediately (would
-  break a non-CSRF caller, e.g. an MCP-only smoke that happens to ride
-  the FastAPI app).
-
-The tests build their own minimal FastAPI app rather than importing
-``create_app`` because the production factory pulls in storage /
-embedder / file-watcher dependencies — none of which the middleware
-itself touches. Mirroring the shape of the real wiring (token in
-``app.state.csrf_token``, etc.) keeps the tests honest without paying
-the boot cost.
+* In production (``create_app`` default), this is ``True`` — the gate
+  enforces. ``MEMTOMEM_WEB__CSRF_ENFORCE`` ∈ {0, false, no, off} falls
+  back to observe-only for emergency rollback.
+* These tests build their own minimal FastAPI app rather than importing
+  ``create_app`` because the production factory pulls in storage /
+  embedder / file-watcher dependencies — none of which the middleware
+  itself touches. Mirroring the shape of the real wiring (token in
+  ``app.state.csrf_token``, etc.) keeps the tests honest without paying
+  the boot cost.
 """
 
 from __future__ import annotations
@@ -29,6 +24,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from memtomem.web.app import resolve_csrf_enforce_from_env
 from memtomem.web.middleware.csrf import CSRFGuardMiddleware
 
 _OBSERVE_RE = re.compile(
@@ -38,12 +34,17 @@ _OBSERVE_RE = re.compile(
 )
 
 
-def _build_app() -> FastAPI:
+def _build_app(*, enforce: bool = True) -> FastAPI:
+    """Build a minimal FastAPI app wired with the CSRF middleware.
+
+    ``enforce`` defaults to ``True`` to mirror the production default.
+    Pass ``enforce=False`` to exercise the observe-only rollback path.
+    """
     app = FastAPI()
     app.state.csrf_token = "test-token-abc"
     app.state.csrf_trusted_hosts = frozenset()
     app.state.csrf_trusted_origins = frozenset()
-    app.state.csrf_enforce = False
+    app.state.csrf_enforce = enforce
     app.add_middleware(CSRFGuardMiddleware)
 
     @app.get("/api/ping")
@@ -95,12 +96,13 @@ def test_get_does_not_emit_observe_event(caplog_csrf) -> None:
     assert _parse_observe(caplog_csrf.records) == []
 
 
-def test_post_without_token_emits_would_block(caplog_csrf) -> None:
-    """No CSRF header → ``token_ok=False, would_block=True``,
-    but request still succeeds in observe-only mode."""
+def test_post_without_token_returns_403(caplog_csrf) -> None:
+    """No CSRF header → ``token_ok=False``; enforce mode returns 403."""
     client = TestClient(_build_app())
     res = client.post("/api/echo")
-    assert res.status_code == 200, "stage 1 must not block"
+    assert res.status_code == 403
+    body = res.json()
+    assert "CSRF" in body["detail"] or "csrf" in body["detail"].lower()
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1
     ev = events[0]
@@ -110,26 +112,26 @@ def test_post_without_token_emits_would_block(caplog_csrf) -> None:
     assert ev["would_block"] == "True"
 
 
-def test_post_with_wrong_token_emits_would_block(caplog_csrf) -> None:
+def test_post_with_wrong_token_returns_403(caplog_csrf) -> None:
     client = TestClient(_build_app())
     res = client.post("/api/echo", headers={"X-Memtomem-CSRF": "wrong"})
-    assert res.status_code == 200
+    assert res.status_code == 403
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1
     assert events[0]["token_ok"] == "False"
     assert events[0]["would_block"] == "True"
 
 
-def test_post_with_right_token_passes_token_check(caplog_csrf) -> None:
+def test_post_with_right_token_but_non_loopback_host_returns_403(caplog_csrf) -> None:
+    """Default TestClient sends ``Host: testserver`` — non-loopback. A
+    valid token isn't enough; the Host check still has to pass."""
     client = TestClient(_build_app())
     res = client.post("/api/echo", headers={"X-Memtomem-CSRF": "test-token-abc"})
-    assert res.status_code == 200
+    assert res.status_code == 403
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1
     ev = events[0]
     assert ev["token_ok"] == "True"
-    # Default TestClient sends Host: testserver — non-loopback. So
-    # host_ok=False and would_block=True even with a valid token.
     assert ev["host_ok"] == "False"
     assert ev["would_block"] == "True"
 
@@ -154,7 +156,7 @@ def test_post_with_right_token_and_loopback_host_passes_all(caplog_csrf) -> None
     assert ev["would_block"] == "False"
 
 
-def test_post_with_right_token_but_attacker_origin_emits_would_block(caplog_csrf) -> None:
+def test_post_with_right_token_but_attacker_origin_returns_403(caplog_csrf) -> None:
     client = TestClient(_build_app())
     res = client.post(
         "/api/echo",
@@ -164,7 +166,7 @@ def test_post_with_right_token_but_attacker_origin_emits_would_block(caplog_csrf
             "Origin": "https://evil.example.com",
         },
     )
-    assert res.status_code == 200
+    assert res.status_code == 403
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1
     ev = events[0]
@@ -172,12 +174,12 @@ def test_post_with_right_token_but_attacker_origin_emits_would_block(caplog_csrf
     assert ev["would_block"] == "True"
 
 
-def test_delete_without_token_emits_would_block(caplog_csrf) -> None:
+def test_delete_without_token_returns_403(caplog_csrf) -> None:
     """DELETE — the ``<form>``-impossible method that ``fetch`` can
     still issue — is gated identically to POST."""
     client = TestClient(_build_app())
     res = client.delete("/api/thing/42")
-    assert res.status_code == 200
+    assert res.status_code == 403
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1
     assert events[0]["method"] == "DELETE"
@@ -200,26 +202,27 @@ def test_session_bootstrap_post_is_token_exempt(caplog_csrf) -> None:
         "/api/session/echo",
         headers={"Host": "127.0.0.1:8080", "Origin": "http://127.0.0.1:8080"},
     )
-    assert res.status_code == 200
+    # /api/session/echo is *not* the bootstrap path, so token is still
+    # required — and missing — so enforce mode 403s.
+    assert res.status_code == 403
     events = _parse_observe(caplog_csrf.records)
     assert len(events) == 1
-    # ``/api/session/echo`` is *not* the bootstrap path, so token still
-    # required — and missing — would_block stays True.
     assert events[0]["token_ok"] == "False"
     assert events[0]["would_block"] == "True"
 
 
-def test_enforce_mode_returns_403(caplog_csrf) -> None:
-    """When ``app.state.csrf_enforce`` is True, the gate returns 403.
-    PR1 leaves the default at False; this test pins the wiring so PR2's
-    flip is a default-only change."""
-    app = _build_app()
-    app.state.csrf_enforce = True
-    client = TestClient(app)
+def test_observe_mode_passes_through_with_log_line(caplog_csrf) -> None:
+    """Emergency rollback path: ``csrf_enforce=False`` makes the gate
+    observe-only — would-block decisions reach the handler with a
+    structured log line for an operator to grep."""
+    client = TestClient(_build_app(enforce=False))
     res = client.post("/api/echo")
-    assert res.status_code == 403
-    body = res.json()
-    assert "CSRF" in body["detail"] or "csrf" in body["detail"].lower()
+    assert res.status_code == 200, "observe mode must not block"
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["token_ok"] == "False"
+    assert ev["would_block"] == "True"
 
 
 def test_trusted_host_allow_list_unblocks_host_check(caplog_csrf) -> None:
@@ -248,7 +251,7 @@ def test_non_api_paths_pass_through_without_observe(caplog_csrf) -> None:
     app.state.csrf_token = "t"
     app.state.csrf_trusted_hosts = frozenset()
     app.state.csrf_trusted_origins = frozenset()
-    app.state.csrf_enforce = False
+    app.state.csrf_enforce = True
     app.add_middleware(CSRFGuardMiddleware)
 
     @app.post("/some/other/path")
@@ -259,3 +262,32 @@ def test_non_api_paths_pass_through_without_observe(caplog_csrf) -> None:
     res = client.post("/some/other/path")
     assert res.status_code == 200
     assert _parse_observe(caplog_csrf.records) == []
+
+
+# ---------------------------------------------------------------------------
+# MEMTOMEM_WEB__CSRF_ENFORCE env override
+# ---------------------------------------------------------------------------
+
+
+def test_env_override_default_is_enforce(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing env var → enforce-on. Default-safe."""
+    monkeypatch.delenv("MEMTOMEM_WEB__CSRF_ENFORCE", raising=False)
+    assert resolve_csrf_enforce_from_env() is True
+
+
+@pytest.mark.parametrize("disable_value", ["0", "false", "FALSE", "no", "off", " False "])
+def test_env_override_disable_tokens(monkeypatch: pytest.MonkeyPatch, disable_value: str) -> None:
+    """Explicit disable tokens fall back to observe-only. Whitespace and
+    case variants normalize."""
+    monkeypatch.setenv("MEMTOMEM_WEB__CSRF_ENFORCE", disable_value)
+    assert resolve_csrf_enforce_from_env() is False
+
+
+@pytest.mark.parametrize("on_value", ["1", "true", "yes", "on", "ture", "anything-else"])
+def test_env_override_unknown_values_keep_enforce(
+    monkeypatch: pytest.MonkeyPatch, on_value: str
+) -> None:
+    """A typo'd or unrecognized value fails safe: enforce stays on.
+    Only the explicit disable tokens turn it off."""
+    monkeypatch.setenv("MEMTOMEM_WEB__CSRF_ENFORCE", on_value)
+    assert resolve_csrf_enforce_from_env() is True

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -80,6 +80,10 @@ def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 @pytest.fixture
 def app(home: Path):
     application = create_app(lifespan=None, mode="dev")
+    # `home` clears all MEMTOMEM_* env vars for pydantic-settings hermeticity,
+    # which also wipes the conftest's autouse `MEMTOMEM_WEB__CSRF_ENFORCE=0`.
+    # Hot-reload tests don't thread CSRF tokens, so set the flag directly.
+    application.state.csrf_enforce = False
 
     # Minimal component mocks — hot-reload path doesn't touch storage/embedder
     # in the read-through case, but some write handlers pass them through.


### PR DESCRIPTION
## Summary

Closes the second half of RFC #787. PR #793 shipped the CSRF / Origin / Host middleware in **observe-only** mode — a structured `web.csrf.observe` log line on every gated `/api/**` write but no 403. This PR flips the production default to **enforce** and seals the remaining surfaces from the RFC's locked-in decision summary.

## What changes

- **`app.state.csrf_enforce`** now defaults to `True` via the new
  `resolve_csrf_enforce_from_env()` helper. `MEMTOMEM_WEB__CSRF_ENFORCE`
  is the emergency-rollback hatch — `0` / `false` / `no` / `off` falls
  back to observe-only without a code change. Unknown / typo'd values
  keep enforcement on (fail-safe).
- **`mm web --host <non-loopback>` refuses to start** without
  `--allow-remote-ui` (was a yellow warning in stage 1). Pair with
  `--trusted-origin` / `--trusted-host` to populate the allow-lists for
  the remote shape.
- **`SECURITY.md`** gains a CSRF / Origin / Host guard subsection
  covering the threat model and the four operator levers.
- **`tests/test_web_csrf_middleware.py`** is re-baselined: `_build_app`
  default mirrors production (`enforce=True`), negative cases assert
  `403`, and a new observe-only test covers the rollback path.
  Parametrized env-override tests pin the disable-token set (case +
  whitespace tolerant) and the fail-safe behavior for unknown values.
- **`tests/conftest.py`** gains one autouse fixture
  (`_csrf_observe_only_default`) that sets `MEMTOMEM_WEB__CSRF_ENFORCE=0`
  per test. The 249 route-test TestClients exercise route logic, not the
  middleware — threading a per-process token on every request would be
  churn for zero security value (the middleware itself is exhaustively
  tested in its own file).
- **`tests/test_web_hot_reload.py`**'s `app` fixture wipes all `MEMTOMEM_*`
  vars for pydantic-settings hermeticity, so it explicitly sets
  `csrf_enforce = False` to mirror the conftest default.

## Operator surface (post-flip)

| Lever | Effect |
|---|---|
| `--allow-remote-ui` | Required when `--host` is non-loopback. Startup refuses without it. |
| `--trusted-origin <host>` (repeatable) | Extends the Origin/Referer allow-list. Loopback is always trusted. |
| `--trusted-host <host>` (repeatable) | Extends the Host-header allow-list. Defends DNS rebinding. |
| `MEMTOMEM_WEB__CSRF_ENFORCE` ∈ {`0`,`false`,`no`,`off`} | Emergency rollback to observe-only. Anything else keeps enforce on. |

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_web_csrf_middleware.py packages/memtomem/tests/test_web_cli.py packages/memtomem/tests/test_web_invariants_registry.py` → 50/50 ✅
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/ -k 'web'` → 754/754 ✅
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/` → 5032 passed, 10 skipped ✅
- [x] `uv run ruff check packages/memtomem/src` → All checks passed ✅
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` → 463 files already formatted ✅

Closes #787.