### PR TITLE
refactor(web): extract shared chunk_progress throttle helper (#659)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4831,12 +4831,10 @@ async function runIndexStream() {
   }
   let _sseFailCount = 0;
   const _SSE_MAX_FAILS = 3;
-  // Throttle ``chunk_progress`` DOM writes — a 250-chunk file at batch_size=64
-  // emits ~4 events; a 2000-chunk pathological case would emit ~32. 100ms gap
-  // covers both without making the human eye work. The final tick (done==total)
-  // bypasses this so the user actually sees "(N/N)" land before the file row
-  // is replaced by the next file.
-  let _lastChunkRender = 0;
+  const _chunkProgress = makeChunkProgressRenderer({
+    targetEl: fileEl,
+    formatKey: 'common.file_chunk_progress',
+  });
 
   es.onmessage = (e) => {
     let event;
@@ -4855,20 +4853,11 @@ async function runIndexStream() {
     }
     _sseFailCount = 0;
     if (event.type === 'chunk_progress') {
-      const now = (typeof performance !== 'undefined' && performance.now)
-        ? performance.now() : Date.now();
-      const isFinal = event.chunks_done >= event.chunks_total;
-      if (!isFinal && now - _lastChunkRender < 100) return;
-      _lastChunkRender = now;
-      fileEl.textContent = t('index.file_chunk_progress', {
-        file: basename(event.file),
-        done: event.chunks_done,
-        total: event.chunks_total,
-      });
+      _chunkProgress.onChunk(event);
       return;
     }
     if (event.type === 'progress') {
-      _lastChunkRender = 0;  // reset on file boundary so first chunk of next file renders immediately
+      _chunkProgress.onProgressBoundary();
       const pct = event.files_total > 0
         ? Math.round((event.files_done / event.files_total) * 100) : 0;
       barEl.style.width = pct + '%';

--- a/packages/memtomem/src/memtomem/web/static/chunk-progress.js
+++ b/packages/memtomem/src/memtomem/web/static/chunk-progress.js
@@ -1,0 +1,55 @@
+/* memtomem chunk-progress renderer — shared throttle helper (#659)
+ *
+ * Extracted from ``runIndexStream`` (app.js) and ``mdReindexOne``
+ * (sources-memory-dirs.js) once the rule-of-three threshold was met
+ * (#659 deferral lifted). Both call-sites consume ``chunk_progress``
+ * SSE events from ``/api/index/stream`` and share the same shape:
+ *
+ *   - 100ms gap on intermediate ticks — a 250-chunk file at
+ *     batch_size=64 emits ~4 events; a 2000-chunk pathological case
+ *     ~32. The throttle keeps mid-file DOM writes off the layout
+ *     hot path.
+ *   - Final-tick bypass (``done >= total``) so the user actually
+ *     sees ``(N/N)`` before the next file boundary overwrites the
+ *     slot.
+ *   - Reset on ``progress`` event boundary so the first chunk of
+ *     the next file renders immediately.
+ *
+ * Depends on globals ``t`` (i18n.js) and ``basename`` (app.js) at
+ * call time. Load order in index.html: i18n.js → app.js →
+ * chunk-progress.js → sources-memory-dirs.js.
+ */
+'use strict';
+
+(function () {
+  // ``onChunk`` returns true when the DOM was written, false on a
+  // throttle skip or detached target — callers can flip ancillary
+  // state (e.g. a "label currently shows chunk text" flag, see
+  // ``_metaIsChunkLabel`` in sources-memory-dirs.js) only on truthy
+  // returns.
+  function makeChunkProgressRenderer({ targetEl, formatKey }) {
+    let lastRender = 0;
+    return {
+      onChunk(event) {
+        if (!targetEl || !targetEl.isConnected) return false;
+        const now = (typeof performance !== 'undefined' && performance.now)
+          ? performance.now() : Date.now();
+        const isFinal = event.chunks_done >= event.chunks_total;
+        if (!isFinal && now - lastRender < 100) return false;
+        lastRender = now;
+        targetEl.textContent = t(formatKey, {
+          file: basename(event.file),
+          done: event.chunks_done,
+          total: event.chunks_total,
+        });
+        return true;
+      },
+      onProgressBoundary() { lastRender = 0; },
+      onCleanup() { lastRender = 0; },
+    };
+  }
+
+  if (typeof window !== 'undefined') {
+    window.makeChunkProgressRenderer = makeChunkProgressRenderer;
+  }
+})();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1381,9 +1381,10 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=115"></script>
+  <script src="/app.js?v=116"></script>
+  <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=9"></script>
-  <script src="/sources-memory-dirs.js?v=11"></script>
+  <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=2"></script>
   <script src="/settings-namespaces.js?v=6"></script>
   <script src="/settings-harness.js?v=2"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -192,7 +192,6 @@
   "index.browse_btn": "📁 Browse",
   "index.browse_aria": "Open folder picker",
   "index.progress_label": "0 / 0 files",
-  "index.file_chunk_progress": "{file} — {done}/{total} chunks",
   "index.indicator": "⏳ Indexing…",
   "index.result.files": "Files scanned",
   "index.result.chunks": "Total chunks",
@@ -616,6 +615,7 @@
   "common.merge": "Merge",
   "common.expire": "Expire",
   "common.sync": "Sync",
+  "common.file_chunk_progress": "{file} — {done}/{total} chunks",
 
   "time.relative.just_now": "just now",
   "time.relative.minutes_ago": "{m}m ago",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -192,7 +192,6 @@
   "index.browse_btn": "📁 둘러보기",
   "index.browse_aria": "폴더 선택 창 열기",
   "index.progress_label": "0 / 0 파일",
-  "index.file_chunk_progress": "{file} — {done}/{total} 청크",
   "index.indicator": "⏳ 인덱싱 중…",
   "index.result.files": "스캔된 파일",
   "index.result.chunks": "전체 청크",
@@ -616,6 +615,7 @@
   "common.merge": "병합",
   "common.expire": "만료",
   "common.sync": "동기화",
+  "common.file_chunk_progress": "{file} — {done}/{total} 청크",
 
   "time.relative.just_now": "방금",
   "time.relative.minutes_ago": "{m}분 전",

--- a/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
+++ b/packages/memtomem/src/memtomem/web/static/sources-memory-dirs.js
@@ -1114,10 +1114,13 @@ async function mdReindexOne(path, btn) {
   const _item = btn ? btn.closest('.source-group') : null;
   const metaEl = _item ? _item.querySelector('.source-group-stats') : null;
   const _origMeta = metaEl ? metaEl.textContent : '';
-  // Throttle state — function-local so two concurrent reindex clicks
-  // (one per dir) don't share each other's clocks. Mirrors the
+  // Function-local renderer so two concurrent reindex clicks (one per
+  // dir) don't share each other's throttle clocks. Mirrors the
   // ``runIndexStream`` closure scope in ``app.js``.
-  let _lastChunkRender = 0;
+  const _chunkProgress = makeChunkProgressRenderer({
+    targetEl: metaEl,
+    formatKey: 'common.file_chunk_progress',
+  });
   let _metaIsChunkLabel = false;
   showToast(t('toast.memory_dir.reindex_started', { path }), 'info');
 
@@ -1172,7 +1175,7 @@ async function mdReindexOne(path, btn) {
       // meta row stuck on "CHANGELOG.md — 250/250" through the rest
       // of the run. The flag avoids a sub-100ms flash on big→big
       // transitions because the next ``chunk_progress`` overwrites.
-      _lastChunkRender = 0;
+      _chunkProgress.onProgressBoundary();
       if (metaEl && _metaIsChunkLabel) {
         metaEl.textContent = _origMeta;
         _metaIsChunkLabel = false;
@@ -1181,23 +1184,9 @@ async function mdReindexOne(path, btn) {
         btn.textContent = `${event.files_done}/${event.files_total}`;
       }
     } else if (event.type === 'chunk_progress') {
-      // Mirrors ``app.js:runIndexStream`` — 100ms throttle on
-      // intermediate ticks, final tick (done >= total) bypasses so
-      // ``(N/N)`` lands before the next file boundary. ``isConnected``
-      // guards against late events arriving after ``loadSources()``
-      // detached the row (silent no-op today, but cheap insurance).
-      if (!metaEl || !metaEl.isConnected) return;
-      const now = (typeof performance !== 'undefined' && performance.now)
-        ? performance.now() : Date.now();
-      const isFinal = event.chunks_done >= event.chunks_total;
-      if (!isFinal && now - _lastChunkRender < 100) return;
-      _lastChunkRender = now;
-      metaEl.textContent = t('index.file_chunk_progress', {
-        file: basename(event.file),
-        done: event.chunks_done,
-        total: event.chunks_total,
-      });
-      _metaIsChunkLabel = true;
+      if (_chunkProgress.onChunk(event)) {
+        _metaIsChunkLabel = true;
+      }
     } else if (event.type === 'complete') {
       _completed = true;
       es.close();


### PR DESCRIPTION
## Summary

- New `chunk-progress.js` helper: `makeChunkProgressRenderer({ targetEl, formatKey })` → `{ onChunk, onProgressBoundary, onCleanup }`. Owns the 100ms throttle, the final-tick bypass (`done >= total`), the file-boundary reset, and the `isConnected` guard.
- Migrate `runIndexStream` (app.js) and `mdReindexOne` (sources-memory-dirs.js) verbatim onto the helper. `onChunk` returns a boolean so the memory-dirs caller flips `_metaIsChunkLabel` only on actual renders (matches the pre-refactor early-return-on-throttle-skip).
- Rename i18n key `index.file_chunk_progress` → `common.file_chunk_progress` (en + ko in the same commit, parity tests cover it). Old key removed in the same PR.
- Wire the helper script tag between `app.js` and `sources-memory-dirs.js`; bump `app.js?v=115→116` and `sources-memory-dirs.js?v=11→12`.

## Why now

Two call-sites was the rule-of-three danger zone, but the shape stabilized across PR #653 (Index tab) and PR #658 (Memory Dirs reindex) with no daylight between them. Lifting the helper now keeps the next caller — wizard `_seed_with_progress` or CLI streaming — from having to re-derive the empirical 100ms constant and the final-tick bypass.

## Behavior preservation

- `app.js` path: helper inherits `isConnected` guard, but `fileEl` is a stable DOM node throughout `runIndexStream` so this is a no-op safety check, not a behavior change.
- `sources-memory-dirs.js` path: `_metaIsChunkLabel` previously only set on the post-throttle-render branch; the new `if (onChunk(event)) _metaIsChunkLabel = true` preserves that exact gate via the boolean return.
- `onProgressBoundary` is a direct rename of `_lastChunkRender = 0`.

## Test plan

- [x] `uv run ruff check packages/memtomem/src` — clean
- [x] `uv run ruff format --check packages/memtomem/src` — clean
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -q` — 44 passed (key-parity rename pinned)
- [x] `uv run pytest packages/memtomem/tests -m "not ollama" -q` — 5019 passed, 10 skipped
- [ ] Manual: Index tab on a >250-chunk file — observe `(N/total)` ticks at ~100ms cadence, final `(N/N)` lands before file boundary.
- [ ] Manual: Memory Dirs reindex on a dir with a big file followed by small files — meta badge restores after big file, doesn't get stuck.

Closes #659.