### PR TITLE
sec(web): fold codex review — thread CSRF in 5 missed SPA mutators (PR #958 follow-up)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,9 @@ every unsafe-method request to `/api/**` (POST / PUT / PATCH / DELETE) is
 gated by a single middleware that checks three things at once:
 
 1. **CSRF token** — `X-Memtomem-CSRF` must match the per-process token in
-   `app.state.csrf_token`. The SPA fetches it via `GET /api/session` on
-   load; the token rotates on every restart and is never persisted.
+   `app.state.csrf_token`. The SPA fetches it via `GET /api/session`
+   lazily on the first unsafe-method request (cached for the page
+   lifetime); the token rotates on every restart and is never persisted.
 2. **Origin / Referer** — when present, must resolve to a loopback host
    or an operator-supplied `--trusted-origin` entry. Defends drive-by
    tabs whose Origin reveals the attacker domain.

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1673,7 +1673,7 @@ function _ctxRenderConflictBanner(detailEl, userBuffer, freshContent) {
   banner.hidden = false;
 }
 
-async function _ctxHandleConflict(type, name, userBuffer, staleMtimeNs, detailEl, headers) {
+async function _ctxHandleConflict(type, name, userBuffer, staleMtimeNs, detailEl) {
   // ``staleMtimeNs`` is the mtime_ns the user's first Save was already
   // racing against — i.e. what they thought disk was. We thread it
   // through to the force PUT body so the server-side WARNING log
@@ -1702,6 +1702,10 @@ async function _ctxHandleConflict(type, name, userBuffer, staleMtimeNs, detailEl
   }
   if (choice === 'force') {
     try {
+      const csrf = await ensureCsrfToken();
+      const headers = csrf
+        ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
+        : { 'Content-Type': 'application/json' };
       const r2 = await fetch(
         _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}`),
         {
@@ -1905,7 +1909,7 @@ async function loadCtxDetail(type, name, opts = {}) {
           },
         );
         if (r.status === 409) {
-          await _ctxHandleConflict(type, name, content, mtime_ns, detailEl, headers);
+          await _ctxHandleConflict(type, name, content, mtime_ns, detailEl);
           return;
         }
         if (!r.ok) {

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -2156,11 +2156,15 @@ async function _ctxLoadRuntimeOnlyDetail(type, name, detailEl, opts = {}) {
       const btn = detailEl.querySelector('.ctx-runtime-only-import');
       btnLoading(btn, true);
       try {
+        const csrf = await ensureCsrfToken();
+        const headers = csrf
+          ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
+          : { 'Content-Type': 'application/json' };
         const r = await fetch(
           _ctxWithTargetScope(`/api/context/${type}/${encodeURIComponent(name)}/import`),
           {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers,
             body: JSON.stringify({}),
           },
         );
@@ -2283,9 +2287,13 @@ document.querySelectorAll('.ctx-import-btn').forEach(btn => {
     const overwrite = !!(result.extras && result.extras.overwrite);
     btnLoading(btn, true);
     try {
+      const csrf = await ensureCsrfToken();
+      const headers = csrf
+        ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
+        : { 'Content-Type': 'application/json' };
       const r = await fetch(_ctxWithTargetScope(`/api/context/${type}/import`), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ overwrite }),
       });
       if (!r.ok) {
@@ -2352,9 +2360,13 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
       const submitBtn = form.querySelector('.ctx-create-submit');
       btnLoading(submitBtn, true);
       try {
+        const csrf = await ensureCsrfToken();
+        const headers = csrf
+          ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
+          : { 'Content-Type': 'application/json' };
         const r = await fetch(_ctxWithTargetScope(`/api/context/${type}`), {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers,
           body: JSON.stringify({ name: nameInput, content }),
         });
         if (!r.ok) {
@@ -2391,9 +2403,13 @@ document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
       if (!root) return;
       btnLoading(btn, true);
       try {
+        const csrf = await ensureCsrfToken();
+        const headers = csrf
+          ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
+          : { 'Content-Type': 'application/json' };
         const r = await fetch('/api/context/known-projects', {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers,
           body: JSON.stringify({ root }),
         });
         if (!r.ok) {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1390,7 +1390,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=6"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=33"></script>
+  <script src="/context-gateway.js?v=34"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1388,9 +1388,9 @@
   <script src="/settings-maintenance.js?v=2"></script>
   <script src="/settings-namespaces.js?v=6"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=5"></script>
+  <script src="/settings-hooks-watchdog.js?v=6"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=32"></script>
+  <script src="/context-gateway.js?v=33"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -128,9 +128,13 @@ async function loadHooksSync() {
         if (!ok) return;
         btnLoading(btn, true);
         try {
+          const csrf = await ensureCsrfToken();
+          const headers = csrf
+            ? {'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf}
+            : {'Content-Type': 'application/json'};
           const r = await fetch('/api/context/settings/resolve', {
             method: 'POST',
-            headers: {'Content-Type': 'application/json'},
+            headers,
             body: JSON.stringify({event, matcher, action: 'use_proposed'}),
           });
           if (!r.ok) {

--- a/packages/memtomem/tests/test_web_csrf_middleware.py
+++ b/packages/memtomem/tests/test_web_csrf_middleware.py
@@ -308,10 +308,13 @@ def test_env_override_unknown_values_keep_enforce(
 
 
 def test_production_create_app_enforces_csrf_without_token(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, caplog_csrf
 ) -> None:
     """``create_app`` wires the middleware in enforce mode by default;
-    an unsafe ``/api/...`` request without the token returns 403."""
+    an unsafe ``/api/...`` request without the token returns 403, and
+    the observe log proves the 403 came from the **token** check (not
+    a host/origin fallback that would also 403 the same request).
+    """
     from memtomem.web.app import create_app
 
     monkeypatch.delenv("MEMTOMEM_WEB__CSRF_ENFORCE", raising=False)
@@ -321,11 +324,23 @@ def test_production_create_app_enforces_csrf_without_token(
     )
 
     client = TestClient(app)
-    # Any unsafe /api path triggers the middleware before route lookup;
-    # a non-existent /api path is fine — the gate runs first.
-    res = client.post("/api/csrf-production-pin")
+    # Send loopback Host + Origin so the host/origin checks pass — this
+    # isolates the 403 to the token check. Otherwise TestClient's default
+    # ``Host: testserver`` would 403 the request via ``host_ok=False`` even
+    # if token validation were silently bypassed.
+    res = client.post(
+        "/api/csrf-production-pin",
+        headers={"Host": "127.0.0.1:8080", "Origin": "http://127.0.0.1:8080"},
+    )
     assert res.status_code == 403, (
         "Production-posture create_app should 403 unsafe /api requests "
         "without a CSRF token. The autouse conftest fixture must not be "
         "leaking into this test."
     )
+    events = _parse_observe(caplog_csrf.records)
+    assert len(events) == 1, f"expected one observe event, got {events}"
+    ev = events[0]
+    assert ev["token_ok"] == "False", "403 must be attributable to the token check"
+    assert ev["host_ok"] == "True", "loopback host must pass the host check"
+    assert ev["origin_ok"] == "True", "loopback origin must pass the origin check"
+    assert ev["would_block"] == "True"

--- a/packages/memtomem/tests/test_web_csrf_middleware.py
+++ b/packages/memtomem/tests/test_web_csrf_middleware.py
@@ -291,3 +291,41 @@ def test_env_override_unknown_values_keep_enforce(
     Only the explicit disable tokens turn it off."""
     monkeypatch.setenv("MEMTOMEM_WEB__CSRF_ENFORCE", on_value)
     assert resolve_csrf_enforce_from_env() is True
+
+
+# ---------------------------------------------------------------------------
+# Production-posture end-to-end pin
+# ---------------------------------------------------------------------------
+#
+# The autouse fixture in ``conftest.py`` defaults the rest of the suite to
+# observe-only so route-unit tests don't have to thread a token. That
+# fixture hides exactly the regression class flagged in PR #958 code
+# review — an SPA mutator bypassing ``ensureCsrfToken()`` would still go
+# green. This test bypasses the fixture by clearing the env explicitly,
+# builds the *real* app via ``create_app``, and asserts the middleware
+# returns 403 for an unsafe ``/api/...`` request without a token. It is
+# the canonical "does the production wiring actually enforce" pin.
+
+
+def test_production_create_app_enforces_csrf_without_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``create_app`` wires the middleware in enforce mode by default;
+    an unsafe ``/api/...`` request without the token returns 403."""
+    from memtomem.web.app import create_app
+
+    monkeypatch.delenv("MEMTOMEM_WEB__CSRF_ENFORCE", raising=False)
+    app = create_app(lifespan=None, mode="prod")
+    assert app.state.csrf_enforce is True, (
+        "create_app must default to enforce mode when MEMTOMEM_WEB__CSRF_ENFORCE is unset"
+    )
+
+    client = TestClient(app)
+    # Any unsafe /api path triggers the middleware before route lookup;
+    # a non-existent /api path is fine — the gate runs first.
+    res = client.post("/api/csrf-production-pin")
+    assert res.status_code == 403, (
+        "Production-posture create_app should 403 unsafe /api requests "
+        "without a CSRF token. The autouse conftest fixture must not be "
+        "leaking into this test."
+    )

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -348,39 +348,60 @@ def test_redaction_classification_covers_every_unsafe_route() -> None:
 # unsafe-method ``fetch(...)`` in the SPA must thread the CSRF token, so
 # the gate doesn't 403 a legitimate user-initiated write.
 #
-# Regression history: PR1 (#793) and the first PR2 commit each shipped
-# with a handful of mutators that bypassed ``ensureCsrfToken()`` — code
-# review caught them, but a code-side guard prevents recurrence.
+# Regression history: PR1 (#793), the first PR2 commit, and the first
+# PR2 review-fold each leaked sites that bypassed ``ensureCsrfToken()``.
+# This guard prevents recurrence. Each unsafe ``fetch(...)`` must be
+# classifiable into one of three safe shapes:
 #
-# The check targets the exact bug shape: an unsafe ``fetch(...)`` whose
-# ``headers:`` value is an inline ``{...}`` object literal lacking
-# ``X-Memtomem-CSRF``. Threaded callsites use ``headers`` as a bare
-# identifier (the convention here is ``const csrf = await
-# ensureCsrfToken(); const headers = csrf ? { ..., 'X-Memtomem-CSRF':
-# csrf } : { ... }; fetch(URL, { method, headers })``); those pass
-# because we trust the convention. Calls without any ``headers:`` key
-# (e.g. ``FormData`` POSTs where the browser sets the boundary
-# automatically) are out of scope — they should still thread the token
-# via a one-off explicit headers map, and a follow-up assertion below
-# pins ``ensureCsrfToken()`` proximity for those.
+# A. **Inline literal with token** — ``headers: { ..., 'X-Memtomem-CSRF':
+#    csrf }`` directly in the fetch options.
+# B. **Variable threading** — ``headers`` as a bare identifier, with a
+#    ``const headers = csrf ? {..., 'X-Memtomem-CSRF': csrf} : {...}``
+#    binding from an ``ensureCsrfToken()`` call in the same function (we
+#    check a 4000-char lookback, which covers every handler in the
+#    codebase).
+# C. **Param threading** — the enclosing function takes ``headers`` as a
+#    parameter and the caller threads it. These are listed explicitly in
+#    ``_CSRF_FETCH_EXEMPT`` with the caller cited, since the regex can't
+#    chase across functions.
+#
+# Anything else fails:
+# * Inline literal *without* the token.
+# * No ``headers`` key on an unsafe ``fetch(...)`` whose method isn't
+#   ``GET``/``HEAD``/``OPTIONS``.
+# * ``headers`` identifier with no ``ensureCsrfToken()`` in lookback and
+#   no entry in the exempt list.
 
 _FETCH_LINE_RE = re.compile(r"\bfetch\(")
 _UNSAFE_METHOD_RE = re.compile(r"method:\s*['\"](POST|PUT|PATCH|DELETE)['\"]")
 _INLINE_HEADERS_LITERAL_RE = re.compile(r"headers:\s*\{([^}]*)\}", re.DOTALL)
+_HEADERS_KEY_RE = re.compile(r"\bheaders\b\s*[:,}]")
 _CSRF_HEADER_RE = re.compile(r"X-Memtomem-CSRF", re.IGNORECASE)
+_ENSURE_CSRF_RE = re.compile(r"\bensureCsrfToken\s*\(")
 
 # Vendored libraries (Swagger UI, etc.) don't observe our CSRF contract
 # and don't reach our routes via unsafe methods at runtime — skip them.
 _STATIC_SKIP_DIRS = frozenset({"vendor"})
 
+# Sites whose threading is via function parameter, so the regex's
+# 4000-char lookback can't see ``ensureCsrfToken()`` (it's in the caller).
+# Each entry MUST cite the caller line where the token *is* threaded.
+_CSRF_FETCH_EXEMPT: dict[tuple[str, int], str] = {
+    ("context-gateway.js", 1705): (
+        "headers threaded via _ctxHandleConflict's function parameter; "
+        "caller at context-gateway.js:1908 calls ensureCsrfToken() and "
+        "passes the resulting headers map into the conflict-resolution flow"
+    ),
+}
 
-def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str]]:
-    """Return ``(file, line, window)`` for every unsafe-method ``fetch(``.
 
-    The window extends 800 chars forward from ``fetch(``, wide enough to
-    cover the multi-line option-object shape used in the codebase.
+def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str, int]]:
+    """Return ``(file, line, window, start_offset)`` for each unsafe ``fetch(``.
+
+    The window extends 800 chars forward from the ``fetch(`` token; the
+    start offset is preserved so the caller can do a lookback scan.
     """
-    sites: list[tuple[Path, int, str]] = []
+    sites: list[tuple[Path, int, str, int]] = []
     for path in sorted(STATIC_DIR.rglob("*.js")):
         if any(part in _STATIC_SKIP_DIRS for part in path.parts):
             continue
@@ -391,43 +412,92 @@ def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str]]:
             if not _UNSAFE_METHOD_RE.search(window):
                 continue
             line_no = text.count("\n", 0, start) + 1
-            sites.append((path, line_no, window))
+            sites.append((path, line_no, window, start))
     return sites
 
 
-def test_spa_unsafe_fetch_inline_headers_thread_csrf_token() -> None:
-    """Unsafe ``fetch(...)`` calls with an inline ``headers: {...}`` literal
-    must include ``X-Memtomem-CSRF``.
+def _classify_site(path: Path, window: str, start: int) -> tuple[str, str | None]:
+    """Return ``(verdict, reason)`` where verdict is one of ``"pass"`` or
+    a failure shorthand. Used by the test below to produce specific
+    error messages instead of a single "missing token" blob.
+    """
+    # Shape A: inline literal with X-Memtomem-CSRF.
+    inline = _INLINE_HEADERS_LITERAL_RE.search(window)
+    if inline:
+        if _CSRF_HEADER_RE.search(inline.group(1)):
+            return ("pass", None)
+        return ("inline-literal-missing-csrf", "headers: {...} without X-Memtomem-CSRF")
 
-    This catches the regression shape Codex flagged on PR #958: a copied
-    ``headers: { 'Content-Type': 'application/json' }`` literal without
-    the token. Callsites that pass headers via a bare identifier (the
-    threaded-variable convention) are not constrained here — see the
-    convention notes above the test.
+    # Shape B/C require headers to be referenced at all. If the unsafe
+    # fetch options omit the ``headers`` key entirely (e.g. a copied
+    # ``fetch(url, { method: 'POST', body })`` shape), the gate will
+    # 403 the request in production.
+    if not _HEADERS_KEY_RE.search(window):
+        return (
+            "no-headers-on-unsafe-fetch",
+            "unsafe fetch options omit the `headers` key entirely",
+        )
+
+    # Shape A also covers ``X-Memtomem-CSRF`` appearing outside the
+    # `headers: {...}` literal — e.g. inlined into a ternary expression
+    # that the literal regex didn't match.
+    if _CSRF_HEADER_RE.search(window):
+        return ("pass", None)
+
+    # Shape B: bare identifier `headers` — needs ensureCsrfToken() in scope.
+    text = path.read_text(encoding="utf-8")
+    lookback = text[max(0, start - 4000) : start]
+    if _ENSURE_CSRF_RE.search(lookback):
+        return ("pass", None)
+
+    return (
+        "headers-var-without-ensure-csrf",
+        "`headers` identifier passed to unsafe fetch, but no "
+        "`ensureCsrfToken()` call in the preceding ~100 lines",
+    )
+
+
+def test_spa_unsafe_fetch_threads_csrf_token() -> None:
+    """Every unsafe-method ``fetch(...)`` in the SPA threads the CSRF
+    token via one of the three safe shapes. Failures cite the specific
+    shape so the developer knows what to change.
     """
     sites = _iter_unsafe_fetch_sites()
     assert sites, "static/*.js sweep found no unsafe-method fetch sites"
 
-    missing: list[str] = []
-    for path, line_no, window in sites:
-        m = _INLINE_HEADERS_LITERAL_RE.search(window)
-        if not m:
-            continue  # headers passed as identifier or via FormData
-        headers_body = m.group(1)
-        if _CSRF_HEADER_RE.search(headers_body):
+    failures: list[str] = []
+    for path, line_no, window, start in sites:
+        if (path.name, line_no) in _CSRF_FETCH_EXEMPT:
+            continue
+        verdict, reason = _classify_site(path, window, start)
+        if verdict == "pass":
             continue
         rel = path.relative_to(STATIC_DIR.parent.parent.parent.parent)
-        missing.append(f"{rel}:{line_no}")
+        failures.append(f"{rel}:{line_no} — {verdict}: {reason}")
 
-    if missing:
+    if failures:
         pytest.fail(
-            "Unsafe-method fetch() calls with inline ``headers: {...}`` "
-            "literal missing ``X-Memtomem-CSRF``. Replace the inline "
-            "literal with the threaded pattern:\n"
-            "    const csrf = await ensureCsrfToken();\n"
-            "    const headers = csrf\n"
-            "      ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }\n"
-            "      : { 'Content-Type': 'application/json' };\n"
-            "    fetch(URL, { method, headers, body });\n\nOffending sites:\n  - "
-            + "\n  - ".join(missing)
+            "Unsafe-method fetch() sites without CSRF threading.\n\n"
+            "Safe shapes (one must apply):\n"
+            "  A. Inline literal: `headers: { ..., 'X-Memtomem-CSRF': csrf }`.\n"
+            "  B. Variable threading: `const csrf = await ensureCsrfToken();\n"
+            "     const headers = csrf ? { ..., 'X-Memtomem-CSRF': csrf } : {...};\n"
+            "     fetch(URL, { method, headers })`.\n"
+            "  C. Param threading: enclosing function takes `headers` as a parameter;\n"
+            "     add the site to `_CSRF_FETCH_EXEMPT` citing the caller.\n\n"
+            "Offending sites:\n  - " + "\n  - ".join(failures)
+        )
+
+
+def test_spa_csrf_fetch_exempt_entries_are_live() -> None:
+    """Each `_CSRF_FETCH_EXEMPT` entry references an actual unsafe fetch
+    site. Catches drift if a site is renamed/removed but the exemption
+    is left behind."""
+    live = {(p.name, line) for p, line, _, _ in _iter_unsafe_fetch_sites()}
+    stale = sorted(set(_CSRF_FETCH_EXEMPT) - live)
+    if stale:
+        pytest.fail(
+            "Stale entries in _CSRF_FETCH_EXEMPT (file no longer has an "
+            "unsafe fetch at that line):\n  - "
+            + "\n  - ".join(f"{name}:{lineno}" for name, lineno in stale)
         )

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -345,62 +345,245 @@ def test_redaction_classification_covers_every_unsafe_route() -> None:
 #
 # Backend coverage above guarantees every unsafe handler is *gated* by the
 # middleware. This complementary test pins the opposite direction: every
-# unsafe-method ``fetch(...)`` in the SPA must thread the CSRF token, so
+# ``/api/...`` ``fetch(...)`` in the SPA must thread the CSRF token, so
 # the gate doesn't 403 a legitimate user-initiated write.
 #
-# Regression history: PR1 (#793), the first PR2 commit, and the first
-# PR2 review-fold each leaked sites that bypassed ``ensureCsrfToken()``.
-# This guard prevents recurrence. Each unsafe ``fetch(...)`` must be
-# classifiable into one of three safe shapes:
+# Regression history: PR1 (#793), PR #958, and two review-folds of #961
+# each leaked sites that bypassed the token. This guard is the
+# "stop-the-bleeding" check.
 #
-# A. **Inline literal with token** — ``headers: { ..., 'X-Memtomem-CSRF':
-#    csrf }`` directly in the fetch options.
-# B. **Variable threading** — ``headers`` as a bare identifier, with a
-#    ``const headers = csrf ? {..., 'X-Memtomem-CSRF': csrf} : {...}``
-#    binding from an ``ensureCsrfToken()`` call in the same function (we
-#    check a 4000-char lookback, which covers every handler in the
-#    codebase).
-# C. **Param threading** — the enclosing function takes ``headers`` as a
-#    parameter and the caller threads it. These are listed explicitly in
-#    ``_CSRF_FETCH_EXEMPT`` with the caller cited, since the regex can't
-#    chase across functions.
+# Design notes (informed by Codex review of `c5897b5`):
 #
-# Anything else fails:
-# * Inline literal *without* the token.
-# * No ``headers`` key on an unsafe ``fetch(...)`` whose method isn't
-#   ``GET``/``HEAD``/``OPTIONS``.
-# * ``headers`` identifier with no ``ensureCsrfToken()`` in lookback and
-#   no entry in the exempt list.
+# 1. **Statically-classify every /api fetch.** We list each fetch as
+#    "safe method" (GET/HEAD/OPTIONS), "unsafe method with literal", or
+#    "method not statically inferable". The third class fails — a
+#    ``fetch(url, opts)`` or ``fetch(url, { method })`` shape would hide
+#    an unsafe write from the test otherwise. The codebase's convention
+#    is inline literal methods; the test enforces it.
+#
+# 2. **Token must live INSIDE the headers value.** A comment, debug
+#    string, or unrelated literal that contains the substring
+#    ``X-Memtomem-CSRF`` anywhere in the 800-char fetch window must not
+#    cause a pass. Two valid shapes:
+#
+#    * **Inline-literal** — ``headers: { ..., 'X-Memtomem-CSRF': csrf }``.
+#    * **Variable threading** — ``headers`` as a bare identifier passed
+#      to fetch, *backed by a local* ``const headers = ... 'X-Memtomem-CSRF'
+#      ...`` binding in the preceding ~100 lines.
+#
+# 3. **No free-form exempt list.** The "function-parameter threading"
+#    shape (used by ``_ctxHandleConflict`` in earlier revisions) was
+#    refactored to self-thread (call ``ensureCsrfToken()`` inside its
+#    own scope) so this test never has to chase across functions —
+#    keeping the regex contract tight.
 
 _FETCH_LINE_RE = re.compile(r"\bfetch\(")
-_UNSAFE_METHOD_RE = re.compile(r"method:\s*['\"](POST|PUT|PATCH|DELETE)['\"]")
-_INLINE_HEADERS_LITERAL_RE = re.compile(r"headers:\s*\{([^}]*)\}", re.DOTALL)
-_HEADERS_KEY_RE = re.compile(r"\bheaders\b\s*[:,}]")
+_METHOD_LITERAL_RE = re.compile(r"method:\s*['\"](GET|HEAD|OPTIONS|POST|PUT|PATCH|DELETE)['\"]")
+_HEADERS_KEY_RE = re.compile(r"\bheaders\s*:")
+_HEADERS_SHORTHAND_RE = re.compile(r"[\{,]\s*headers\s*[,}\n]")
+_IDENT_ONLY_RE = re.compile(r"^[A-Za-z_$][\w$]*$")
 _CSRF_HEADER_RE = re.compile(r"X-Memtomem-CSRF", re.IGNORECASE)
-_ENSURE_CSRF_RE = re.compile(r"\bensureCsrfToken\s*\(")
 
-# Vendored libraries (Swagger UI, etc.) don't observe our CSRF contract
-# and don't reach our routes via unsafe methods at runtime — skip them.
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+_UNSAFE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+# Vendored libraries (Swagger UI, etc.) don't observe our CSRF contract.
 _STATIC_SKIP_DIRS = frozenset({"vendor"})
 
-# Sites whose threading is via function parameter, so the regex's
-# 4000-char lookback can't see ``ensureCsrfToken()`` (it's in the caller).
-# Each entry MUST cite the caller line where the token *is* threaded.
-_CSRF_FETCH_EXEMPT: dict[tuple[str, int], str] = {
-    ("context-gateway.js", 1705): (
-        "headers threaded via _ctxHandleConflict's function parameter; "
-        "caller at context-gateway.js:1908 calls ensureCsrfToken() and "
-        "passes the resulting headers map into the conflict-resolution flow"
-    ),
-}
 
+def _scan_fetch_args(window: str) -> tuple[str, str]:
+    """Return ``(first_arg_text, second_arg_shape)`` by scanning the
+    fetch call's argument list with awareness of strings, template
+    literals, and nested braces/parens.
 
-def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str, int]]:
-    """Return ``(file, line, window, start_offset)`` for each unsafe ``fetch(``.
-
-    The window extends 800 chars forward from the ``fetch(`` token; the
-    start offset is preserved so the caller can do a lookback scan.
+    ``second_arg_shape`` is one of:
+    * ``"none"`` — no second argument; JS fetch defaults to GET.
+    * ``"inline"`` — second argument starts with ``{`` (inline options
+      literal); ``method`` is statically discoverable if present.
+    * ``"identifier"`` — second argument starts with an identifier or
+      anything that isn't ``{``; the method can't be statically
+      determined and the site fails open.
     """
+    # The window starts at ``f`` of ``fetch(``. Move past the open paren.
+    if not window.startswith("fetch("):
+        return ("", "none")
+    i = len("fetch(")
+    depth_paren = 1
+    depth_brace = 0
+    depth_bracket = 0
+    in_string: str | None = None
+    in_template = False
+    in_template_expr = 0  # nested ${} inside a template literal
+    first_arg_start = i
+    while i < len(window):
+        c = window[i]
+        if in_string is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == in_string:
+                in_string = None
+            i += 1
+            continue
+        if in_template:
+            if c == "\\":
+                i += 2
+                continue
+            if c == "`" and in_template_expr == 0:
+                in_template = False
+            elif c == "$" and i + 1 < len(window) and window[i + 1] == "{":
+                in_template_expr += 1
+                i += 2
+                continue
+            elif c == "}" and in_template_expr > 0:
+                in_template_expr -= 1
+            i += 1
+            continue
+        if c == "'" or c == '"':
+            in_string = c
+        elif c == "`":
+            in_template = True
+        elif c == "(":
+            depth_paren += 1
+        elif c == ")":
+            depth_paren -= 1
+            if depth_paren == 0:
+                return (window[first_arg_start:i], "none")
+        elif c == "{":
+            depth_brace += 1
+        elif c == "}":
+            depth_brace -= 1
+        elif c == "[":
+            depth_bracket += 1
+        elif c == "]":
+            depth_bracket -= 1
+        elif c == "," and depth_paren == 1 and depth_brace == 0 and depth_bracket == 0:
+            first_arg = window[first_arg_start:i]
+            j = i + 1
+            while j < len(window) and window[j].isspace():
+                j += 1
+            if j >= len(window) or window[j] == ")":
+                return (first_arg, "none")
+            return (first_arg, "inline" if window[j] == "{" else "identifier")
+        i += 1
+    # Unterminated — treat as unknown so the test fails loudly.
+    return (window[first_arg_start:], "identifier")
+
+
+def _is_api_fetch(window: str) -> bool:
+    """Does this fetch call target ``/api/...``?"""
+    first_arg, _ = _scan_fetch_args(window)
+    return "/api/" in first_arg
+
+
+def _extract_methods(window: str) -> list[str]:
+    """All HTTP methods statically inferable from inline ``method: '...'``
+    literals inside the fetch window."""
+    return [m.group(1).upper() for m in _METHOD_LITERAL_RE.finditer(window)]
+
+
+def _extract_headers_value(window: str) -> str | None:
+    """Find ``headers:`` in the fetch options literal and return the
+    value expression as raw text, scanning at brace/paren/bracket depth
+    0 until the next ``,`` or ``}`` outside strings/templates. Returns
+    None if no ``headers:`` key is present.
+
+    The shorthand ``{ method, headers }`` (i.e. ``headers`` without an
+    explicit ``:`` value) returns the identifier ``"headers"`` so the
+    caller can route it through the local-binding check.
+    """
+    m = _HEADERS_KEY_RE.search(window)
+    if m is None:
+        sh = _HEADERS_SHORTHAND_RE.search(window)
+        if sh is not None:
+            return "headers"
+        return None
+    i = m.end()
+    while i < len(window) and window[i].isspace():
+        i += 1
+    start = i
+    depth_paren = depth_brace = depth_bracket = 0
+    in_string: str | None = None
+    in_template = False
+    in_template_expr = 0
+    while i < len(window):
+        c = window[i]
+        if in_string is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == in_string:
+                in_string = None
+            i += 1
+            continue
+        if in_template:
+            if c == "\\":
+                i += 2
+                continue
+            if c == "`" and in_template_expr == 0:
+                in_template = False
+            elif c == "$" and i + 1 < len(window) and window[i + 1] == "{":
+                in_template_expr += 1
+                i += 2
+                continue
+            elif c == "}" and in_template_expr > 0:
+                in_template_expr -= 1
+            i += 1
+            continue
+        if c == "'" or c == '"':
+            in_string = c
+        elif c == "`":
+            in_template = True
+        elif c == "(":
+            depth_paren += 1
+        elif c == ")":
+            depth_paren -= 1
+            if depth_paren < 0:
+                # Fell out of the fetch options object.
+                return window[start:i].strip()
+        elif c == "{":
+            depth_brace += 1
+        elif c == "}":
+            if depth_brace == 0:
+                return window[start:i].strip()
+            depth_brace -= 1
+        elif c == "[":
+            depth_bracket += 1
+        elif c == "]":
+            depth_bracket -= 1
+        elif c == "," and depth_paren == 0 and depth_brace == 0 and depth_bracket == 0:
+            return window[start:i].strip()
+        i += 1
+    return window[start:].strip()
+
+
+def _has_local_binding_with_csrf(text: str, fetch_start: int, ident: str) -> bool:
+    """True iff a ``const|let|var <ident> = <RHS containing X-Memtomem-CSRF>``
+    binding appears in the ~100-line lookback.
+
+    The check is tied to the **exact identifier** passed to fetch — so a
+    fetch shaped ``headers: _hdr4`` only passes when there's a local
+    ``const _hdr4 = ...'X-Memtomem-CSRF'...`` binding, not when some
+    unrelated ``const headers = ...`` happens to live nearby. This is
+    the binding-tracing pin Codex requested in round 3.
+    """
+    if not _IDENT_ONLY_RE.match(ident):
+        return False
+    lookback = text[max(0, fetch_start - 4000) : fetch_start]
+    binding_re = re.compile(
+        r"\b(?:const|let|var)\s+" + re.escape(ident) + r"\s*=\s*(.+?)(?:;|\n\n)",
+        re.DOTALL,
+    )
+    for m in binding_re.finditer(lookback):
+        rhs = m.group(1)
+        if _CSRF_HEADER_RE.search(rhs):
+            return True
+    return False
+
+
+def _iter_api_fetch_sites() -> list[tuple[Path, int, str, int]]:
+    """Return ``(file, line, window, start_offset)`` for each ``/api/...``
+    fetch call (safe or unsafe)."""
     sites: list[tuple[Path, int, str, int]] = []
     for path in sorted(STATIC_DIR.rglob("*.js")):
         if any(part in _STATIC_SKIP_DIRS for part in path.parts):
@@ -409,7 +592,7 @@ def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str, int]]:
         for line_match in _FETCH_LINE_RE.finditer(text):
             start = line_match.start()
             window = text[start : start + 800]
-            if not _UNSAFE_METHOD_RE.search(window):
+            if not _is_api_fetch(window):
                 continue
             line_no = text.count("\n", 0, start) + 1
             sites.append((path, line_no, window, start))
@@ -418,57 +601,77 @@ def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str, int]]:
 
 def _classify_site(path: Path, window: str, start: int) -> tuple[str, str | None]:
     """Return ``(verdict, reason)`` where verdict is one of ``"pass"`` or
-    a failure shorthand. Used by the test below to produce specific
-    error messages instead of a single "missing token" blob.
+    a failure shorthand naming the specific bug shape.
     """
-    # Shape A: inline literal with X-Memtomem-CSRF.
-    inline = _INLINE_HEADERS_LITERAL_RE.search(window)
-    if inline:
-        if _CSRF_HEADER_RE.search(inline.group(1)):
-            return ("pass", None)
-        return ("inline-literal-missing-csrf", "headers: {...} without X-Memtomem-CSRF")
+    _first_arg, second_arg_shape = _scan_fetch_args(window)
+    if second_arg_shape == "identifier":
+        return (
+            "method-not-inferable",
+            "fetch's second argument is an identifier — the method can't "
+            "be classified statically. Inline the options literal at the "
+            "callsite so the CSRF guard test can see the method.",
+        )
 
-    # Shape B/C require headers to be referenced at all. If the unsafe
-    # fetch options omit the ``headers`` key entirely (e.g. a copied
-    # ``fetch(url, { method: 'POST', body })`` shape), the gate will
-    # 403 the request in production.
-    if not _HEADERS_KEY_RE.search(window):
+    methods = _extract_methods(window)
+    if not methods:
+        # No inline ``method:`` AND options is either absent or an inline
+        # literal — JS fetch defaults to GET, which is safe.
+        return ("pass", None)
+    unsafe = [m for m in methods if m in _UNSAFE_METHODS]
+    if not unsafe:
+        return ("pass", None)  # safe-method fetch
+
+    headers_value = _extract_headers_value(window)
+    if headers_value is None:
         return (
             "no-headers-on-unsafe-fetch",
             "unsafe fetch options omit the `headers` key entirely",
         )
 
-    # Shape A also covers ``X-Memtomem-CSRF`` appearing outside the
-    # `headers: {...}` literal — e.g. inlined into a ternary expression
-    # that the literal regex didn't match.
-    if _CSRF_HEADER_RE.search(window):
+    # Shape A: the headers value text contains 'X-Memtomem-CSRF' — either
+    # an inline literal, a ternary like ``csrf ? {...CSRF...} : {...}``,
+    # or any expression that includes the header name. Covers the
+    # canonical inline-literal case and the conditional-headers shape.
+    if _CSRF_HEADER_RE.search(headers_value):
         return ("pass", None)
 
-    # Shape B: bare identifier `headers` — needs ensureCsrfToken() in scope.
-    text = path.read_text(encoding="utf-8")
-    lookback = text[max(0, start - 4000) : start]
-    if _ENSURE_CSRF_RE.search(lookback):
-        return ("pass", None)
+    # Shape B: the headers value is a bare identifier — must be backed
+    # by a local ``const|let|var <that-identifier> = ... 'X-Memtomem-CSRF'
+    # ...`` binding. The binding name is matched against the literal
+    # identifier passed to fetch, so an unrelated ``const headers = ...``
+    # binding elsewhere doesn't accidentally rescue a fetch shaped
+    # ``headers: someOtherVar``.
+    if _IDENT_ONLY_RE.match(headers_value):
+        text = path.read_text(encoding="utf-8")
+        if _has_local_binding_with_csrf(text, start, headers_value):
+            return ("pass", None)
+        return (
+            "headers-var-without-csrf-binding",
+            f"`headers: {headers_value}` passed to unsafe fetch, but no "
+            f"local `const {headers_value} = ...'X-Memtomem-CSRF'...` "
+            "binding in the preceding ~100 lines",
+        )
 
     return (
-        "headers-var-without-ensure-csrf",
-        "`headers` identifier passed to unsafe fetch, but no "
-        "`ensureCsrfToken()` call in the preceding ~100 lines",
+        "headers-expression-missing-csrf",
+        f"`headers:` value (`{headers_value[:80]}`) is not a bare "
+        "identifier and does not contain 'X-Memtomem-CSRF'",
     )
 
 
-def test_spa_unsafe_fetch_threads_csrf_token() -> None:
-    """Every unsafe-method ``fetch(...)`` in the SPA threads the CSRF
-    token via one of the three safe shapes. Failures cite the specific
-    shape so the developer knows what to change.
+def test_spa_api_fetch_threads_csrf_token() -> None:
+    """Every SPA ``/api/...`` fetch is either a safe-method read or
+    threads the CSRF token via the local-binding convention.
+
+    Shape-specific failure verdicts make it obvious what to change:
+    ``method-not-inferable``, ``inline-literal-missing-csrf``,
+    ``no-headers-on-unsafe-fetch``, ``headers-var-without-csrf-binding``.
     """
-    sites = _iter_unsafe_fetch_sites()
-    assert sites, "static/*.js sweep found no unsafe-method fetch sites"
+    sites = _iter_api_fetch_sites()
+    assert sites, "static/*.js sweep found no /api/... fetch sites"
 
     failures: list[str] = []
     for path, line_no, window, start in sites:
-        if (path.name, line_no) in _CSRF_FETCH_EXEMPT:
-            continue
         verdict, reason = _classify_site(path, window, start)
         if verdict == "pass":
             continue
@@ -477,27 +680,15 @@ def test_spa_unsafe_fetch_threads_csrf_token() -> None:
 
     if failures:
         pytest.fail(
-            "Unsafe-method fetch() sites without CSRF threading.\n\n"
+            "Unsafe /api fetch() sites without CSRF threading.\n\n"
             "Safe shapes (one must apply):\n"
             "  A. Inline literal: `headers: { ..., 'X-Memtomem-CSRF': csrf }`.\n"
-            "  B. Variable threading: `const csrf = await ensureCsrfToken();\n"
-            "     const headers = csrf ? { ..., 'X-Memtomem-CSRF': csrf } : {...};\n"
-            "     fetch(URL, { method, headers })`.\n"
-            "  C. Param threading: enclosing function takes `headers` as a parameter;\n"
-            "     add the site to `_CSRF_FETCH_EXEMPT` citing the caller.\n\n"
+            "  B. Variable threading with a local binding:\n"
+            "       const csrf = await ensureCsrfToken();\n"
+            "       const headers = csrf\n"
+            "         ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }\n"
+            "         : { 'Content-Type': 'application/json' };\n"
+            "       fetch(URL, { method: 'POST', headers });\n"
+            "  C. Safe-method (GET/HEAD/OPTIONS) — no threading required.\n\n"
             "Offending sites:\n  - " + "\n  - ".join(failures)
-        )
-
-
-def test_spa_csrf_fetch_exempt_entries_are_live() -> None:
-    """Each `_CSRF_FETCH_EXEMPT` entry references an actual unsafe fetch
-    site. Catches drift if a site is renamed/removed but the exemption
-    is left behind."""
-    live = {(p.name, line) for p, line, _, _ in _iter_unsafe_fetch_sites()}
-    stale = sorted(set(_CSRF_FETCH_EXEMPT) - live)
-    if stale:
-        pytest.fail(
-            "Stale entries in _CSRF_FETCH_EXEMPT (file no longer has an "
-            "unsafe fetch at that line):\n  - "
-            + "\n  - ".join(f"{name}:{lineno}" for name, lineno in stale)
         )

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -27,11 +27,13 @@ Pattern lineage: ``feedback_ast_architectural_guard_pattern.md``
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 import pytest
 
 ROUTES_DIR = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" / "routes"
+STATIC_DIR = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" / "static"
 
 _UNSAFE_DECORATOR_METHODS = frozenset({"post", "patch", "put", "delete"})
 
@@ -337,3 +339,95 @@ def test_redaction_classification_covers_every_unsafe_route() -> None:
                 "(route was renamed or removed):\n  - " + "\n  - ".join(stale)
             )
         pytest.fail("\n\n".join(msg))
+
+
+# --- SPA-side CSRF threading invariant -------------------------------------
+#
+# Backend coverage above guarantees every unsafe handler is *gated* by the
+# middleware. This complementary test pins the opposite direction: every
+# unsafe-method ``fetch(...)`` in the SPA must thread the CSRF token, so
+# the gate doesn't 403 a legitimate user-initiated write.
+#
+# Regression history: PR1 (#793) and the first PR2 commit each shipped
+# with a handful of mutators that bypassed ``ensureCsrfToken()`` — code
+# review caught them, but a code-side guard prevents recurrence.
+#
+# The check targets the exact bug shape: an unsafe ``fetch(...)`` whose
+# ``headers:`` value is an inline ``{...}`` object literal lacking
+# ``X-Memtomem-CSRF``. Threaded callsites use ``headers`` as a bare
+# identifier (the convention here is ``const csrf = await
+# ensureCsrfToken(); const headers = csrf ? { ..., 'X-Memtomem-CSRF':
+# csrf } : { ... }; fetch(URL, { method, headers })``); those pass
+# because we trust the convention. Calls without any ``headers:`` key
+# (e.g. ``FormData`` POSTs where the browser sets the boundary
+# automatically) are out of scope — they should still thread the token
+# via a one-off explicit headers map, and a follow-up assertion below
+# pins ``ensureCsrfToken()`` proximity for those.
+
+_FETCH_LINE_RE = re.compile(r"\bfetch\(")
+_UNSAFE_METHOD_RE = re.compile(r"method:\s*['\"](POST|PUT|PATCH|DELETE)['\"]")
+_INLINE_HEADERS_LITERAL_RE = re.compile(r"headers:\s*\{([^}]*)\}", re.DOTALL)
+_CSRF_HEADER_RE = re.compile(r"X-Memtomem-CSRF", re.IGNORECASE)
+
+# Vendored libraries (Swagger UI, etc.) don't observe our CSRF contract
+# and don't reach our routes via unsafe methods at runtime — skip them.
+_STATIC_SKIP_DIRS = frozenset({"vendor"})
+
+
+def _iter_unsafe_fetch_sites() -> list[tuple[Path, int, str]]:
+    """Return ``(file, line, window)`` for every unsafe-method ``fetch(``.
+
+    The window extends 800 chars forward from ``fetch(``, wide enough to
+    cover the multi-line option-object shape used in the codebase.
+    """
+    sites: list[tuple[Path, int, str]] = []
+    for path in sorted(STATIC_DIR.rglob("*.js")):
+        if any(part in _STATIC_SKIP_DIRS for part in path.parts):
+            continue
+        text = path.read_text(encoding="utf-8")
+        for line_match in _FETCH_LINE_RE.finditer(text):
+            start = line_match.start()
+            window = text[start : start + 800]
+            if not _UNSAFE_METHOD_RE.search(window):
+                continue
+            line_no = text.count("\n", 0, start) + 1
+            sites.append((path, line_no, window))
+    return sites
+
+
+def test_spa_unsafe_fetch_inline_headers_thread_csrf_token() -> None:
+    """Unsafe ``fetch(...)`` calls with an inline ``headers: {...}`` literal
+    must include ``X-Memtomem-CSRF``.
+
+    This catches the regression shape Codex flagged on PR #958: a copied
+    ``headers: { 'Content-Type': 'application/json' }`` literal without
+    the token. Callsites that pass headers via a bare identifier (the
+    threaded-variable convention) are not constrained here — see the
+    convention notes above the test.
+    """
+    sites = _iter_unsafe_fetch_sites()
+    assert sites, "static/*.js sweep found no unsafe-method fetch sites"
+
+    missing: list[str] = []
+    for path, line_no, window in sites:
+        m = _INLINE_HEADERS_LITERAL_RE.search(window)
+        if not m:
+            continue  # headers passed as identifier or via FormData
+        headers_body = m.group(1)
+        if _CSRF_HEADER_RE.search(headers_body):
+            continue
+        rel = path.relative_to(STATIC_DIR.parent.parent.parent.parent)
+        missing.append(f"{rel}:{line_no}")
+
+    if missing:
+        pytest.fail(
+            "Unsafe-method fetch() calls with inline ``headers: {...}`` "
+            "literal missing ``X-Memtomem-CSRF``. Replace the inline "
+            "literal with the threaded pattern:\n"
+            "    const csrf = await ensureCsrfToken();\n"
+            "    const headers = csrf\n"
+            "      ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }\n"
+            "      : { 'Content-Type': 'application/json' };\n"
+            "    fetch(URL, { method, headers, body });\n\nOffending sites:\n  - "
+            + "\n  - ".join(missing)
+        )


### PR DESCRIPTION
Follow-up to PR #958 (which merged the CSRF/Origin/Host enforcement flip). Codex review of the merged commit flagged a class of regression the merged PR missed.

## Summary

PR #958 flipped `csrf_enforce` to `True` by default but four SPA mutators were still issuing unsafe `fetch(...)` without `X-Memtomem-CSRF` — those flows would 403 in production. Adding an AST-style guard test caught a fifth site neither I nor Codex spotted in the manual sweep.

## The 5 missed callsites

| File | Line | Route | Flow |
|---|---|---|---|
| `context-gateway.js` | 2286 | `POST /api/context/{type}/import` | bulk import |
| `context-gateway.js` | 2355 | `POST /api/context/{type}` | create artifact |
| `context-gateway.js` | 2394 | `POST /api/context/known-projects` | add project (path-picker callback) |
| `context-gateway.js` | 2159 | `POST /api/context/{type}/{name}/import` | runtime-only single-item import *(found by new test, not by Codex)* |
| `settings-hooks-watchdog.js` | 131 | `POST /api/context/settings/resolve` | hook conflict resolve |

All five now follow the established pattern: `const csrf = await ensureCsrfToken(); const headers = csrf ? {...,'X-Memtomem-CSRF':csrf} : {...}; fetch(URL, { method, headers, body })`.

## Regression guard

`tests/test_web_invariants_registry.py` gains `test_spa_unsafe_fetch_inline_headers_thread_csrf_token`. It scans `web/static/**/*.js` for unsafe-method `fetch(...)` calls and rejects any that pass `headers: {...}` as an inline literal without `X-Memtomem-CSRF`. Bare-identifier `headers` references (the threaded-variable convention) are trusted — this scoping keeps the check resistant to false positives from the long-handler patterns elsewhere in `context-gateway.js`.

## Autouse-fixture blind-spot pin

`tests/conftest.py`'s autouse `MEMTOMEM_WEB__CSRF_ENFORCE=0` fixture (added in PR #958) defaults route-unit tests to observe-only for ergonomics. Codex correctly noted this hides exactly the regression class fixed here. `test_production_create_app_enforces_csrf_without_token` in `test_web_csrf_middleware.py` explicitly clears the env, builds via `create_app()`, and asserts the middleware returns 403 for an unsafe `/api/...` request — pinning the production wiring end-to-end.

## Also

- Cache-bust bumps for the two edited SPA files (`context-gateway.js` v32→v33, `settings-hooks-watchdog.js` v5→v6).
- SECURITY.md wording fix: SPA fetches `/api/session` lazily on first unsafe-method request, not "on load" (Codex Minor).

## Test plan

- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/test_web_csrf_middleware.py packages/memtomem/tests/test_web_invariants_registry.py` → 30/30 ✅
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/ -k 'web'` → 759/759 ✅
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/` → 5037 passed, 10 skipped ✅
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests` → All checks passed ✅
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests` → 463 files already formatted ✅

References: #787, #958.