### PR TITLE
fix: harden FTS5 query tokenization

### DIFF
--- a/packages/memtomem/src/memtomem/storage/fts_tokenizer.py
+++ b/packages/memtomem/src/memtomem/storage/fts_tokenizer.py
@@ -14,8 +14,10 @@ import re
 
 _log = logging.getLogger(__name__)
 
-# FTS5 special characters that must not appear in prefix-match tokens
-_FTS5_SPECIAL_RE = re.compile(r'[*"()\-+^:]')
+# FTS5 barewords are intentionally narrow. Quote any query token containing
+# punctuation so paths, URLs, YAML, code spans, and future FTS5 operators stay
+# literal instead of being parsed as query syntax.
+_FTS5_SPECIAL_RE = re.compile(r"[^\w]", re.UNICODE)
 
 # Active tokenizer backend: "unicode61" or "kiwipiepy"
 _active_tokenizer: str = "unicode61"
@@ -98,7 +100,7 @@ def tokenize_for_fts(
     if _active_tokenizer == "kiwipiepy":
         tokens = _kiwi_tokenize(text)
         if for_query:
-            parts = [t + "*" for t in tokens if not _FTS5_SPECIAL_RE.search(t)]
+            parts = [_format_query_token(t) for t in tokens]
             joiner = " OR " if use_or else " "
             return joiner.join(parts)
         return " ".join(tokens)
@@ -117,12 +119,14 @@ def _apply_prefix_wildcard(text: str, *, use_or: bool = False) -> str:
     """
     parts: list[str] = []
     for word in text.split():
-        if _FTS5_SPECIAL_RE.search(word):
-            # Quote the word so FTS5 treats it as a literal phrase
-            safe = word.replace('"', '""')
-            if safe:
-                parts.append(f'"{safe}"')
-        else:
-            parts.append(word + "*")
+        parts.append(_format_query_token(word))
     joiner = " OR " if use_or else " "
     return joiner.join(parts)
+
+
+def _format_query_token(word: str) -> str:
+    """Return one FTS5-safe query token."""
+    if _FTS5_SPECIAL_RE.search(word):
+        safe = word.replace('"', '""')
+        return f'"{safe}"'
+    return word + "*"

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2343,17 +2343,19 @@ function renderResults(results, retrievalStats) {
   let funnelHtml = '';
   if (retrievalStats) {
     const s = retrievalStats;
-    const bm25Warn = s.bm25_error ? ` <span class="badge badge-yellow" title="${escapeHtml(s.bm25_error)}">!</span>` : '';
+    const bm25Warn = s.bm25_error
+      ? `<span class="badge badge-yellow retrieval-warning" title="${escapeHtml(s.bm25_error)}" role="status" aria-label="Keyword search degraded: ${escapeHtml(s.bm25_error)}">Keyword degraded</span>`
+      : '';
     funnelHtml = `<div class="results-funnel">
       <span class="help-tip" data-help="BM25: keyword matching. Dense: semantic embedding similarity. RRF: reciprocal rank fusion merges both. Final: after reranking and filters." tabindex="0" role="img" aria-label="BM25: keyword matching. Dense: semantic embedding similarity. RRF: reciprocal rank fusion merges both. Final: after reranking and filters.">i</span>
-      <span class="funnel-stage"><span class="funnel-stage-label">BM25${bm25Warn}</span> <span class="funnel-stage-count">${s.bm25_candidates}</span></span>
+      <span class="funnel-stage"><span class="funnel-stage-label">BM25</span> <span class="funnel-stage-count">${s.bm25_candidates}</span></span>
       <span class="funnel-arrow">+</span>
       <span class="funnel-stage"><span class="funnel-stage-label">Dense</span> <span class="funnel-stage-count">${s.dense_candidates}</span></span>
       <span class="funnel-arrow">\u2192</span>
       <span class="funnel-stage"><span class="funnel-stage-label">RRF</span> <span class="funnel-stage-count">${s.fused_total}</span></span>
       <span class="funnel-arrow">\u2192</span>
       <span class="funnel-stage"><span class="funnel-stage-label">Final</span> <span class="funnel-stage-count">${s.final_total}</span></span>
-    </div>`;
+    </div>${bm25Warn}`;
     // Cache retrieval stats for score detail computation
     STATE.lastRetrievalStats = s;
   }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -867,6 +867,7 @@ button:active { opacity: 0.7; }
 .badge { display: inline-block; border-radius: 4px; padding: 2px 8px; font-size: 0.72rem; font-weight: 600; }
 .badge-blue   { background: rgba(var(--accent-rgb),0.15); color: var(--accent); }
 .badge-gray   { background: rgba(123, 127, 150, 0.15); color: var(--muted); }
+.badge-yellow { background: rgba(243, 156, 18, 0.15); color: var(--yellow); }
 .badge-source { background: rgba(76, 175, 125, 0.15); color: var(--green); font-family: var(--mono); font-weight: 400; }
 .badge-validity { background: rgba(108, 92, 231, 0.10); color: var(--muted); font-family: var(--mono); font-weight: 400; }
 .badge-validity--expired { opacity: 0.55; text-decoration: line-through; }

--- a/packages/memtomem/tests/test_fts_tokenizer.py
+++ b/packages/memtomem/tests/test_fts_tokenizer.py
@@ -1,0 +1,78 @@
+"""Regression tests for FTS5 query tokenization."""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from memtomem.storage.fts_tokenizer import _FTS5_SPECIAL_RE, tokenize_for_fts
+
+
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("https://example.com/path", '"https://example.com/path"'),
+        ("file.name.ext", '"file.name.ext"'),
+        ("a/b/c", '"a/b/c"'),
+        (r"dir\\file.md", r'"dir\\file.md"'),
+        ("<tag>", '"<tag>"'),
+        ("word~3", '"word~3"'),
+        ("`foo.bar()`", '"`foo.bar()`"'),
+        ("---\nkey: value", '"---" "key:" value*'),
+    ],
+)
+def test_query_tokens_with_punctuation_are_quoted(query: str, expected: str) -> None:
+    assert tokenize_for_fts(query, for_query=True) == expected
+
+
+def test_plain_words_still_get_prefix_wildcards() -> None:
+    assert tokenize_for_fts("hello world", for_query=True) == "hello* world*"
+
+
+def test_or_queries_preserve_safe_quoting() -> None:
+    assert (
+        tokenize_for_fts("file.name.ext a/b/c", for_query=True, use_or=True)
+        == '"file.name.ext" OR "a/b/c"'
+    )
+
+
+@pytest.mark.parametrize("char", list('."()/\\<>~`[]{}!,;?@#$%&=|'))
+def test_ascii_punctuation_is_not_treated_as_bareword(char: str) -> None:
+    assert _FTS5_SPECIAL_RE.search(f"a{char}b")
+
+
+def test_punctuation_queries_do_not_raise_fts5_syntax_errors() -> None:
+    db = sqlite3.connect(":memory:")
+    try:
+        db.execute("CREATE VIRTUAL TABLE chunks_fts USING fts5(content)")
+    except sqlite3.OperationalError as exc:
+        pytest.skip(f"sqlite FTS5 unavailable: {exc}")
+
+    db.execute(
+        "INSERT INTO chunks_fts(content) VALUES (?)",
+        (
+            "---\n"
+            "key: value\n"
+            "https://example.com/path file.name.ext a/b/c dir/file.md "
+            "`foo.bar()` <tag> word~3",
+        ),
+    )
+
+    queries = [
+        "---\nkey: value",
+        "https://example.com/path",
+        "file.name.ext",
+        "a/b/c",
+        "dir/file.md",
+        "`foo.bar()`",
+        "<tag>",
+        "word~3",
+    ]
+    for query in queries:
+        fts_query = tokenize_for_fts(query, for_query=True)
+        rows = db.execute(
+            "SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ?",
+            (fts_query,),
+        ).fetchall()
+        assert rows == [(1,)]


### PR DESCRIPTION
## Summary

- Quote punctuation-bearing FTS5 query tokens so URLs, paths, dotted filenames, YAML/frontmatter, code spans, angle brackets, and tilde tokens stay literal.
- Keep plain barewords on prefix wildcard matching.
- Surface BM25 degradation in the Web results summary as a visible `Keyword degraded` badge.
- Add tokenizer and live SQLite FTS5 MATCH regression coverage.

Fixes #697.
Part of #702.

## Verification

- `uv run pytest packages/memtomem/tests/test_fts_tokenizer.py packages/memtomem/tests/test_usability_fixes.py::TestFTS5HyphenQuoting`
- `uv run pytest packages/memtomem/tests/test_pipeline.py`
- `uv run ruff check packages/memtomem/src/memtomem/storage/fts_tokenizer.py packages/memtomem/tests/test_fts_tokenizer.py`
- `node --check packages/memtomem/src/memtomem/web/static/app.js`