### PR TITLE
feat(web): promote Context Gateway to a top-level main tab (#962)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1185,7 +1185,20 @@ function activateTab(tabName, opts = {}) {
     if (!start) {
       try { start = localStorage.getItem(LAST_SECTION_KEY); } catch {}
     }
+    // Gateway-tab sections live under ``#tab-context-gateway`` now; if the
+    // last-section memory points at one of them, fall back to a settings-tab
+    // section so activating Settings does not silently re-route the user
+    // back to Gateway via the redirect below.
+    if (GATEWAY_SECTIONS.has(start)) start = 'config';
     switchSettingsSection(start || 'config');
+  }
+  if (tabName === 'context-gateway') {
+    let start = opts.sectionOverride || STATE.lastSettingsSection;
+    if (!start) {
+      try { start = localStorage.getItem(LAST_SECTION_KEY); } catch {}
+    }
+    if (!GATEWAY_SECTIONS.has(start)) start = 'ctx-overview';
+    switchSettingsSection(start);
   }
   if (['search', 'timeline'].includes(tabName)) loadNamespaceDropdowns();
 }
@@ -1197,6 +1210,14 @@ const LAST_SECTION_KEY = 'memtomem_last_settings';
 const DEFAULT_NAV_COLLAPSED = { general: false, integrations: false, runtime: true, data: true };
 // Deep-link redirects for renamed/removed sections.
 const LEGACY_SECTION_MAP = { 'harness-watchdog': 'harness-health' };
+// Sections that now live under the top-level Context Gateway tab (#962).
+// ``switchSettingsSection`` routes these to ``#tab-context-gateway`` so
+// every legacy caller — overview tile clicks, Sync All "open settings"
+// CTA, settings-namespaces.js Quick Links — auto-redirects without
+// per-call-site updates.
+const GATEWAY_SECTIONS = new Set([
+  'ctx-overview', 'ctx-skills', 'ctx-commands', 'ctx-agents', 'hooks-sync',
+]);
 
 function loadNavCollapseState() {
   try {
@@ -1250,6 +1271,18 @@ function ensureActiveGroupExpanded(section) {
 
 function switchSettingsSection(sectionName) {
   sectionName = LEGACY_SECTION_MAP[sectionName] || sectionName;
+  // Gateway-tab sections live under ``#tab-context-gateway`` (#962). If
+  // the user is currently on a different main tab, hop into the Gateway
+  // tab first; activateTab will re-enter this function via the
+  // ``sectionOverride`` argument. Guard prevents the infinite recursion
+  // that would otherwise fire when called from activateTab itself.
+  if (GATEWAY_SECTIONS.has(sectionName)) {
+    const currentMainTab = document.querySelector('.tab-btn.active');
+    if (!currentMainTab || currentMainTab.dataset.tab !== 'context-gateway') {
+      activateTab('context-gateway', { sectionOverride: sectionName });
+      return;
+    }
+  }
   // In prod mode, redirect dev-only sections to the first visible one.
   const targetBtn = document.querySelector(
     `.settings-nav-btn[data-section="${sectionName}"]`,

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -804,8 +804,16 @@ window.addEventListener('langchange', () => {
   // ``loadCtxList``) is re-rendered by the ``loadCtxList`` re-issue
   // below — no separate handling needed.
   _ctxRefreshWriteBlockedState();
+  // Gateway sections now live under ``#tab-context-gateway`` (#962). Keep
+  // the legacy ``#tab-settings`` check as a fallback so a partial revert
+  // doesn't silently disable the langchange re-render — drop it once the
+  // sections live only under the Gateway tab.
+  const gatewayTab = document.getElementById('tab-context-gateway');
   const settingsTab = document.getElementById('tab-settings');
-  if (!settingsTab || !settingsTab.classList.contains('active')) return;
+  const hostActive =
+    (gatewayTab && gatewayTab.classList.contains('active'))
+    || (settingsTab && settingsTab.classList.contains('active'));
+  if (!hostActive) return;
 
   const overviewSection = document.getElementById('settings-ctx-overview');
   if (overviewSection && overviewSection.classList.contains('active')) {

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1307,7 +1307,7 @@
           <tr><td><kbd>c</kbd></td><td data-i18n="shortcut.copy">Copy selected chunk content</td></tr>
           <tr><td><kbd>Enter</kbd></td><td data-i18n="shortcut.open_detail">Open selected result detail</td></tr>
           <tr><td><kbd>Backspace</kbd></td><td data-i18n="shortcut.back">Back to results list from detail</td></tr>
-          <tr><td><kbd>1</kbd>–<kbd>7</kbd></td><td data-i18n="shortcut.switch_tabs">Switch tabs (Home=1 … More=7)</td></tr>
+          <tr><td><kbd>1</kbd>–<kbd>8</kbd></td><td data-i18n="shortcut.switch_tabs">Switch tabs (Home=1 … More=8)</td></tr>
           <tr><td><kbd>⌘K</kbd></td><td data-i18n="shortcut.cmd_palette">Command palette</td></tr>
           <tr><td><kbd>g</kbd> <kbd>s</kbd></td><td data-i18n="shortcut.go_sources">Go to Sources</td></tr>
           <tr><td><kbd>Esc</kbd></td><td data-i18n="shortcut.close">Close panel, dropdown, or modal</td></tr>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -50,6 +50,7 @@
     <button id="tabbtn-home" class="tab-btn" role="tab" aria-controls="tab-home" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="home" data-i18n="nav.home">Home</button>
     <button id="tabbtn-search" class="tab-btn active" role="tab" aria-controls="tab-search" aria-selected="true" tabindex="0" data-ui-tier="prod" data-tab="search" data-i18n="nav.search">Search</button>
     <button id="tabbtn-sources" class="tab-btn" role="tab" aria-controls="tab-sources" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="sources" data-i18n="nav.sources">Sources</button>
+    <button id="tabbtn-context-gateway" class="tab-btn" role="tab" aria-controls="tab-context-gateway" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="context-gateway" data-i18n="nav.context_gateway">Gateway</button>
     <button id="tabbtn-index" class="tab-btn" role="tab" aria-controls="tab-index" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="index" data-i18n="nav.index">Index</button>
     <button id="tabbtn-tags" class="tab-btn" role="tab" aria-controls="tab-tags" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="tags" data-i18n="nav.tags">Tags</button>
     <button id="tabbtn-timeline" class="tab-btn" role="tab" aria-controls="tab-timeline" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="timeline" data-i18n="nav.timeline">Timeline</button>
@@ -478,6 +479,182 @@
     </div>
   </div>
 
+  <!-- ===== CONTEXT GATEWAY TAB =====
+       Promoted from a Settings sub-section to a top-level tab in #962. The
+       sidebar reuses ``.settings-nav-btn`` / ``.settings-section`` classes so
+       ``switchSettingsSection`` resolves the panels via existing selectors
+       (``#settings-${name}``) regardless of which top-level tab hosts them.
+       ``activateTab('context-gateway')`` is the entry point; falling through
+       ``switchSettingsSection('ctx-*'/'hooks-sync')`` auto-redirects here. -->
+  <div id="tab-context-gateway" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-context-gateway" hidden>
+    <div class="settings-layout">
+      <div class="settings-nav" role="tablist">
+        <button class="settings-nav-group" type="button" data-group="integrations" aria-expanded="true">
+          <span class="nav-group-caret" aria-hidden="true">▾</span>
+          <span data-i18n="settings.nav.integrations">Agent Integrations</span>
+        </button>
+        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+          <span class="nav-icon" aria-hidden="true">🔄</span>
+          <span class="nav-labels">
+            <span class="nav-label" data-i18n="settings.nav.ctx_overview">Context Gateway</span>
+            <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Sync overview</span>
+          </span>
+        </button>
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
+          <span class="nav-icon" aria-hidden="true">🧩</span>
+          <span class="nav-labels">
+            <span class="nav-label" data-i18n="settings.nav.ctx_skills">Skills</span>
+            <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Reusable workflows</span>
+          </span>
+        </button>
+        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
+          <span class="nav-icon" aria-hidden="true">⌘</span>
+          <span class="nav-labels">
+            <span class="nav-label" data-i18n="settings.nav.ctx_commands">Custom Commands</span>
+            <span class="nav-sub" data-i18n="settings.nav.ctx_commands_sub">Legacy .claude/commands/</span>
+          </span>
+        </button>
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
+          <span class="nav-icon" aria-hidden="true">🤖</span>
+          <span class="nav-labels">
+            <span class="nav-label" data-i18n="settings.nav.ctx_agents">Subagents</span>
+            <span class="nav-sub" data-i18n="settings.nav.ctx_agents_sub">Specialized agents</span>
+          </span>
+        </button>
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
+          <span class="nav-icon" aria-hidden="true">📎</span>
+          <span class="nav-labels">
+            <span class="nav-label" data-i18n="settings.nav.hooks_sync">Hooks</span>
+            <span class="nav-sub" data-i18n="settings.nav.hooks_sync_sub">Lifecycle hooks</span>
+          </span>
+        </button>
+      </div>
+      <div class="settings-content">
+
+        <!-- Context Gateway: Overview -->
+        <div class="settings-section active" id="settings-ctx-overview">
+          <p class="settings-section-desc" data-i18n="settings.ctx.overview_desc">Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.</p>
+          <div class="ctx-header">
+            <h2 data-i18n="settings.ctx.overview_title">Context Gateway</h2>
+            <div>
+              <button id="ctx-refresh-btn" class="btn-ghost"
+                      data-i18n="settings.ctx.refresh"
+                      data-i18n-title="settings.ctx.refresh_tooltip"
+                      data-i18n-aria-label="settings.ctx.refresh_aria">Refresh</button>
+              <button id="ctx-sync-all-btn" class="btn-primary"
+                      data-i18n="settings.ctx.sync_all"
+                      data-i18n-title="settings.ctx.sync_all_tooltip"
+                      data-i18n-aria-label="settings.ctx.sync_all_aria">Sync All</button>
+            </div>
+          </div>
+          <div id="ctx-overview-content"></div>
+        </div>
+
+        <!-- Context Gateway: Skills -->
+        <div class="settings-section" id="settings-ctx-skills">
+          <p class="settings-section-desc" data-i18n="settings.ctx.skills_desc">Reusable workflows shared across Claude Code, Codex, and other detected runtimes.</p>
+          <div class="ctx-header">
+            <h2 data-i18n="settings.ctx.skills_title">Skills</h2>
+            <div>
+              <button class="btn-ghost ctx-add-project-btn" data-type="skills"
+                      data-i18n="settings.ctx.add_project"
+                      data-i18n-title="settings.ctx.skills_add_project_tooltip"
+                      data-i18n-aria-label="settings.ctx.skills_add_project_aria">Add Project</button>
+              <button class="btn-ghost ctx-create-btn" data-type="skills"
+                      data-i18n="settings.ctx.create"
+                      data-i18n-title="settings.ctx.skills_create_tooltip"
+                      data-i18n-aria-label="settings.ctx.skills_create_aria">Create</button>
+              <button class="btn-ghost ctx-import-btn" data-type="skills"
+                      data-i18n="settings.ctx.import"
+                      data-i18n-title="settings.ctx.skills_import_tooltip"
+                      data-i18n-aria-label="settings.ctx.skills_import_aria">Import</button>
+              <button class="btn-primary ctx-sync-btn" data-type="skills"
+                      data-i18n="settings.ctx.sync"
+                      data-i18n-title="settings.ctx.skills_sync_tooltip"
+                      data-i18n-aria-label="settings.ctx.skills_sync_aria">Sync</button>
+            </div>
+          </div>
+          <div id="ctx-skills-status"></div>
+          <div id="ctx-skills-list"></div>
+          <div id="ctx-skills-detail" hidden></div>
+        </div>
+
+        <!-- Context Gateway: Commands -->
+        <div class="settings-section" id="settings-ctx-commands">
+          <p class="settings-section-desc" data-i18n="settings.ctx.commands_desc">Project-scoped slash commands kept in .claude/commands/, synced to detected runtimes.</p>
+          <div class="ctx-header">
+            <h2 data-i18n="settings.ctx.commands_title">Custom Commands</h2>
+            <div>
+              <button class="btn-ghost ctx-add-project-btn" data-type="commands"
+                      data-i18n="settings.ctx.add_project"
+                      data-i18n-title="settings.ctx.commands_add_project_tooltip"
+                      data-i18n-aria-label="settings.ctx.commands_add_project_aria">Add Project</button>
+              <button class="btn-ghost ctx-create-btn" data-type="commands"
+                      data-i18n="settings.ctx.create"
+                      data-i18n-title="settings.ctx.commands_create_tooltip"
+                      data-i18n-aria-label="settings.ctx.commands_create_aria">Create</button>
+              <button class="btn-ghost ctx-import-btn" data-type="commands"
+                      data-i18n="settings.ctx.import"
+                      data-i18n-title="settings.ctx.commands_import_tooltip"
+                      data-i18n-aria-label="settings.ctx.commands_import_aria">Import</button>
+              <button class="btn-primary ctx-sync-btn" data-type="commands"
+                      data-i18n="settings.ctx.sync"
+                      data-i18n-title="settings.ctx.commands_sync_tooltip"
+                      data-i18n-aria-label="settings.ctx.commands_sync_aria">Sync</button>
+            </div>
+          </div>
+          <div id="ctx-commands-status"></div>
+          <div id="ctx-commands-list"></div>
+          <div id="ctx-commands-detail" hidden></div>
+        </div>
+
+        <!-- Context Gateway: Agents -->
+        <div class="settings-section" id="settings-ctx-agents">
+          <p class="settings-section-desc" data-i18n="settings.ctx.agents_desc">Specialized subagents shared across Claude Code, Codex, and other detected runtimes.</p>
+          <div class="ctx-header">
+            <h2 data-i18n="settings.ctx.agents_title">Subagents</h2>
+            <div>
+              <button class="btn-ghost ctx-add-project-btn" data-type="agents"
+                      data-i18n="settings.ctx.add_project"
+                      data-i18n-title="settings.ctx.agents_add_project_tooltip"
+                      data-i18n-aria-label="settings.ctx.agents_add_project_aria">Add Project</button>
+              <button class="btn-ghost ctx-create-btn" data-type="agents"
+                      data-i18n="settings.ctx.create"
+                      data-i18n-title="settings.ctx.agents_create_tooltip"
+                      data-i18n-aria-label="settings.ctx.agents_create_aria">Create</button>
+              <button class="btn-ghost ctx-import-btn" data-type="agents"
+                      data-i18n="settings.ctx.import"
+                      data-i18n-title="settings.ctx.agents_import_tooltip"
+                      data-i18n-aria-label="settings.ctx.agents_import_aria">Import</button>
+              <button class="btn-primary ctx-sync-btn" data-type="agents"
+                      data-i18n="settings.ctx.sync"
+                      data-i18n-title="settings.ctx.agents_sync_tooltip"
+                      data-i18n-aria-label="settings.ctx.agents_sync_aria">Sync</button>
+            </div>
+          </div>
+          <div id="ctx-agents-status"></div>
+          <div id="ctx-agents-list"></div>
+          <div id="ctx-agents-detail" hidden></div>
+        </div>
+
+        <!-- Hooks Sync section -->
+        <div class="settings-section" id="settings-hooks-sync">
+          <p class="settings-section-desc" data-i18n="settings.hooks.desc">Lifecycle hooks defined in .memtomem/settings.json, applied to the active runtime.</p>
+          <div class="hooks-sync-header">
+            <h2 data-i18n="settings.hooks.title">Hooks</h2>
+            <button id="hooks-sync-btn" class="btn-primary"
+                    data-i18n="settings.hooks.sync_now"
+                    data-i18n-title="settings.hooks.sync_now_tooltip"
+                    data-i18n-aria-label="settings.hooks.sync_now_aria">Sync Now</button>
+          </div>
+          <div id="hooks-sync-status"></div>
+          <div id="hooks-sync-content"></div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
   <!-- ===== INDEX TAB ===== -->
   <div id="tab-index" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-index" hidden>
     <div class="tab-help-bar" id="help-index" role="status" hidden>
@@ -608,46 +785,6 @@
           </span>
         </button>
 
-        <button class="settings-nav-group" type="button" data-group="integrations" aria-expanded="true">
-          <span class="nav-group-caret" aria-hidden="true">▾</span>
-          <span data-i18n="settings.nav.integrations">Agent Integrations</span>
-        </button>
-        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
-          <span class="nav-icon" aria-hidden="true">🔄</span>
-          <span class="nav-labels">
-            <span class="nav-label" data-i18n="settings.nav.ctx_overview">Context Gateway</span>
-            <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Sync overview</span>
-          </span>
-        </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-skills" data-group="integrations" role="tab" aria-selected="false">
-          <span class="nav-icon" aria-hidden="true">🧩</span>
-          <span class="nav-labels">
-            <span class="nav-label" data-i18n="settings.nav.ctx_skills">Skills</span>
-            <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Reusable workflows</span>
-          </span>
-        </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
-          <span class="nav-icon" aria-hidden="true">⌘</span>
-          <span class="nav-labels">
-            <span class="nav-label" data-i18n="settings.nav.ctx_commands">Custom Commands</span>
-            <span class="nav-sub" data-i18n="settings.nav.ctx_commands_sub">Legacy .claude/commands/</span>
-          </span>
-        </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-agents" data-group="integrations" role="tab" aria-selected="false">
-          <span class="nav-icon" aria-hidden="true">🤖</span>
-          <span class="nav-labels">
-            <span class="nav-label" data-i18n="settings.nav.ctx_agents">Subagents</span>
-            <span class="nav-sub" data-i18n="settings.nav.ctx_agents_sub">Specialized agents</span>
-          </span>
-        </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="hooks-sync" data-group="integrations" role="tab" aria-selected="false">
-          <span class="nav-icon" aria-hidden="true">📎</span>
-          <span class="nav-labels">
-            <span class="nav-label" data-i18n="settings.nav.hooks_sync">Hooks</span>
-            <span class="nav-sub" data-i18n="settings.nav.hooks_sync_sub">Lifecycle hooks</span>
-          </span>
-        </button>
-
         <button class="settings-nav-group" type="button" data-ui-tier="dev" data-group="runtime" aria-expanded="false">
           <span class="nav-group-caret" aria-hidden="true">▸</span>
           <span data-i18n="settings.nav.runtime">Runtime</span>
@@ -754,126 +891,6 @@
           </div>
         </div>
 
-
-        <!-- Hooks Sync section -->
-        <div class="settings-section" id="settings-hooks-sync">
-          <p class="settings-section-desc" data-i18n="settings.hooks.desc">Lifecycle hooks defined in .memtomem/settings.json, applied to the active runtime.</p>
-          <div class="hooks-sync-header">
-            <h2 data-i18n="settings.hooks.title">Hooks</h2>
-            <button id="hooks-sync-btn" class="btn-primary"
-                    data-i18n="settings.hooks.sync_now"
-                    data-i18n-title="settings.hooks.sync_now_tooltip"
-                    data-i18n-aria-label="settings.hooks.sync_now_aria">Sync Now</button>
-          </div>
-          <div id="hooks-sync-status"></div>
-          <div id="hooks-sync-content"></div>
-        </div>
-
-        <!-- Context Gateway: Overview -->
-        <div class="settings-section" id="settings-ctx-overview">
-          <p class="settings-section-desc" data-i18n="settings.ctx.overview_desc">Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.</p>
-          <div class="ctx-header">
-            <h2 data-i18n="settings.ctx.overview_title">Context Gateway</h2>
-            <div>
-              <button id="ctx-refresh-btn" class="btn-ghost"
-                      data-i18n="settings.ctx.refresh"
-                      data-i18n-title="settings.ctx.refresh_tooltip"
-                      data-i18n-aria-label="settings.ctx.refresh_aria">Refresh</button>
-              <button id="ctx-sync-all-btn" class="btn-primary"
-                      data-i18n="settings.ctx.sync_all"
-                      data-i18n-title="settings.ctx.sync_all_tooltip"
-                      data-i18n-aria-label="settings.ctx.sync_all_aria">Sync All</button>
-            </div>
-          </div>
-          <div id="ctx-overview-content"></div>
-        </div>
-
-        <!-- Context Gateway: Skills -->
-        <div class="settings-section" id="settings-ctx-skills">
-          <p class="settings-section-desc" data-i18n="settings.ctx.skills_desc">Reusable workflows shared across Claude Code, Codex, and other detected runtimes.</p>
-          <div class="ctx-header">
-            <h2 data-i18n="settings.ctx.skills_title">Skills</h2>
-            <div>
-              <button class="btn-ghost ctx-add-project-btn" data-type="skills"
-                      data-i18n="settings.ctx.add_project"
-                      data-i18n-title="settings.ctx.skills_add_project_tooltip"
-                      data-i18n-aria-label="settings.ctx.skills_add_project_aria">Add Project</button>
-              <button class="btn-ghost ctx-create-btn" data-type="skills"
-                      data-i18n="settings.ctx.create"
-                      data-i18n-title="settings.ctx.skills_create_tooltip"
-                      data-i18n-aria-label="settings.ctx.skills_create_aria">Create</button>
-              <button class="btn-ghost ctx-import-btn" data-type="skills"
-                      data-i18n="settings.ctx.import"
-                      data-i18n-title="settings.ctx.skills_import_tooltip"
-                      data-i18n-aria-label="settings.ctx.skills_import_aria">Import</button>
-              <button class="btn-primary ctx-sync-btn" data-type="skills"
-                      data-i18n="settings.ctx.sync"
-                      data-i18n-title="settings.ctx.skills_sync_tooltip"
-                      data-i18n-aria-label="settings.ctx.skills_sync_aria">Sync</button>
-            </div>
-          </div>
-          <div id="ctx-skills-status"></div>
-          <div id="ctx-skills-list"></div>
-          <div id="ctx-skills-detail" hidden></div>
-        </div>
-
-        <!-- Context Gateway: Commands -->
-        <div class="settings-section" id="settings-ctx-commands">
-          <p class="settings-section-desc" data-i18n="settings.ctx.commands_desc">Project-scoped slash commands kept in .claude/commands/, synced to detected runtimes.</p>
-          <div class="ctx-header">
-            <h2 data-i18n="settings.ctx.commands_title">Custom Commands</h2>
-            <div>
-              <button class="btn-ghost ctx-add-project-btn" data-type="commands"
-                      data-i18n="settings.ctx.add_project"
-                      data-i18n-title="settings.ctx.commands_add_project_tooltip"
-                      data-i18n-aria-label="settings.ctx.commands_add_project_aria">Add Project</button>
-              <button class="btn-ghost ctx-create-btn" data-type="commands"
-                      data-i18n="settings.ctx.create"
-                      data-i18n-title="settings.ctx.commands_create_tooltip"
-                      data-i18n-aria-label="settings.ctx.commands_create_aria">Create</button>
-              <button class="btn-ghost ctx-import-btn" data-type="commands"
-                      data-i18n="settings.ctx.import"
-                      data-i18n-title="settings.ctx.commands_import_tooltip"
-                      data-i18n-aria-label="settings.ctx.commands_import_aria">Import</button>
-              <button class="btn-primary ctx-sync-btn" data-type="commands"
-                      data-i18n="settings.ctx.sync"
-                      data-i18n-title="settings.ctx.commands_sync_tooltip"
-                      data-i18n-aria-label="settings.ctx.commands_sync_aria">Sync</button>
-            </div>
-          </div>
-          <div id="ctx-commands-status"></div>
-          <div id="ctx-commands-list"></div>
-          <div id="ctx-commands-detail" hidden></div>
-        </div>
-
-        <!-- Context Gateway: Agents -->
-        <div class="settings-section" id="settings-ctx-agents">
-          <p class="settings-section-desc" data-i18n="settings.ctx.agents_desc">Specialized subagents shared across Claude Code, Codex, and other detected runtimes.</p>
-          <div class="ctx-header">
-            <h2 data-i18n="settings.ctx.agents_title">Subagents</h2>
-            <div>
-              <button class="btn-ghost ctx-add-project-btn" data-type="agents"
-                      data-i18n="settings.ctx.add_project"
-                      data-i18n-title="settings.ctx.agents_add_project_tooltip"
-                      data-i18n-aria-label="settings.ctx.agents_add_project_aria">Add Project</button>
-              <button class="btn-ghost ctx-create-btn" data-type="agents"
-                      data-i18n="settings.ctx.create"
-                      data-i18n-title="settings.ctx.agents_create_tooltip"
-                      data-i18n-aria-label="settings.ctx.agents_create_aria">Create</button>
-              <button class="btn-ghost ctx-import-btn" data-type="agents"
-                      data-i18n="settings.ctx.import"
-                      data-i18n-title="settings.ctx.agents_import_tooltip"
-                      data-i18n-aria-label="settings.ctx.agents_import_aria">Import</button>
-              <button class="btn-primary ctx-sync-btn" data-type="agents"
-                      data-i18n="settings.ctx.sync"
-                      data-i18n-title="settings.ctx.agents_sync_tooltip"
-                      data-i18n-aria-label="settings.ctx.agents_sync_aria">Sync</button>
-            </div>
-          </div>
-          <div id="ctx-agents-status"></div>
-          <div id="ctx-agents-list"></div>
-          <div id="ctx-agents-detail" hidden></div>
-        </div>
 
         <!-- Dedup section -->
         <div class="settings-section" id="settings-dedup">

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1268,6 +1268,7 @@
             <option value="home">Home</option>
             <option value="search">Search</option>
             <option value="sources">Sources</option>
+            <option value="context-gateway">Gateway</option>
             <option value="index">Index</option>
             <option value="tags">Tags</option>
             <option value="timeline">Timeline</option>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -603,7 +603,7 @@
   "shortcut.copy": "Copy selected chunk content",
   "shortcut.open_detail": "Open selected result detail",
   "shortcut.back": "Back to results list from detail",
-  "shortcut.switch_tabs": "Switch tabs (Home=1 … More=7)",
+  "shortcut.switch_tabs": "Switch tabs (Home=1 … More=8)",
   "shortcut.cmd_palette": "Command palette",
   "shortcut.go_sources": "Go to Sources",
   "shortcut.close": "Close panel, dropdown, or modal",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -2,6 +2,7 @@
   "nav.home": "Home",
   "nav.search": "Search",
   "nav.sources": "Sources",
+  "nav.context_gateway": "Gateway",
   "nav.index": "Index",
   "nav.tags": "Tags",
   "nav.timeline": "Timeline",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -603,7 +603,7 @@
   "shortcut.copy": "선택한 청크 내용 복사",
   "shortcut.open_detail": "선택한 결과 상세 보기",
   "shortcut.back": "상세에서 결과 목록으로 돌아가기",
-  "shortcut.switch_tabs": "탭 전환 (홈=1 … 더보기=7)",
+  "shortcut.switch_tabs": "탭 전환 (홈=1 … 더보기=8)",
   "shortcut.cmd_palette": "명령 팔레트",
   "shortcut.go_sources": "소스로 이동",
   "shortcut.close": "패널, 드롭다운 또는 모달 닫기",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -2,6 +2,7 @@
   "nav.home": "홈",
   "nav.search": "검색",
   "nav.sources": "소스",
+  "nav.context_gateway": "게이트웨이",
   "nav.index": "인덱스",
   "nav.tags": "태그",
   "nav.timeline": "타임라인",

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -8,6 +8,7 @@ Python ``_PROD_ROUTERS`` / ``_DEV_ONLY_ROUTERS`` lists.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -411,6 +412,49 @@ def test_gateway_main_tab_button_exists() -> None:
     assert sources_idx < gateway_idx < index_idx, (
         "Gateway tab button must sit between Sources and Index in the main nav"
     )
+
+
+def test_shortcut_switch_tabs_copy_matches_tab_count() -> None:
+    """#962 review P3 fold: the keyboard-shortcuts help row claims
+    digits 1-N map to the main tabs. The Gateway tab promotion
+    bumped N from 7 to 8 (Home/Search/Sources/Gateway/Index/Tags/
+    Timeline/More). Pin both the digit range row and the per-locale
+    ``shortcut.switch_tabs`` copy so a future tab add/remove can't
+    silently leave a stale digit there.
+    """
+    html = _read_static("index.html")
+    en = json.loads(_read_static("locales/en.json"))
+    ko = json.loads(_read_static("locales/ko.json"))
+
+    # Count the main-nav tab buttons. The shortcut row's digit range
+    # must match the visible tab count so users never see a
+    # number that doesn't actually activate anything.
+    main_tab_buttons = re.findall(
+        r'<button[^>]*class="tab-btn[^"]*"[^>]*data-tab="([^"]+)"',
+        html,
+    )
+    assert len(main_tab_buttons) == 8, (
+        f"Expected 8 top-level tabs after #962 Gateway promotion; got "
+        f"{len(main_tab_buttons)}: {main_tab_buttons}"
+    )
+
+    # Help row literal (rendered fallback before i18n applies).
+    row = re.search(
+        r"<kbd>1</kbd>[^<]*<kbd>([0-9]+)</kbd>",
+        html,
+    )
+    assert row is not None, "shortcut help row missing in markup"
+    assert row.group(1) == "8", (
+        f"Help row digit range must end at 8 (one per top-level tab); "
+        f"got: <kbd>1</kbd>-<kbd>{row.group(1)}</kbd>"
+    )
+
+    for locale_name, locale in (("en", en), ("ko", ko)):
+        copy = locale.get("shortcut.switch_tabs", "")
+        assert "8" in copy and "7" not in copy, (
+            f"{locale_name}.json shortcut.switch_tabs must mention the new "
+            f"tab count of 8 (and not retain the stale 7); got: {copy!r}"
+        )
 
 
 def test_gateway_appears_in_default_tab_selector() -> None:

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -328,7 +328,13 @@ def test_html_settings_nav_btns_all_carry_ui_tier_attr() -> None:
 def test_ctx_overview_has_landing_modifier_for_group_dashboard() -> None:
     """ctx-overview is the Agent Integrations group's dashboard card and must
     carry the ``settings-nav-btn--landing`` modifier so CSS gives it visual
-    hierarchy distinct from the leaf rows."""
+    hierarchy distinct from the leaf rows.
+
+    Post-#962 the Agent Integrations sidebar lives under the top-level
+    ``#tab-context-gateway`` panel rather than nested in Settings. The
+    landing-modifier contract moves with the button — assert both the
+    class and the new tab ancestry.
+    """
     html = _read_static("index.html")
     overview_btn = re.search(r'<button[^>]*data-section="ctx-overview"[^>]*>', html)
     assert overview_btn is not None, "ctx-overview button not found in markup"
@@ -337,13 +343,31 @@ def test_ctx_overview_has_landing_modifier_for_group_dashboard() -> None:
         "(group dashboard, not a leaf); "
         f"got: {overview_btn.group(0)[:200]}"
     )
+    # Anchor the button inside the new Gateway tab. ``#tab-context-gateway``
+    # comes BEFORE the ctx-overview match site if the move was applied
+    # correctly; a regression that re-nests the Gateway under Settings
+    # would put ``#tab-settings`` between them.
+    head = html[: overview_btn.start()]
+    gateway_idx = head.rfind('id="tab-context-gateway"')
+    settings_idx = head.rfind('id="tab-settings"')
+    assert gateway_idx >= 0, (
+        "ctx-overview button is not under #tab-context-gateway — promotion regressed (#962)."
+    )
+    assert gateway_idx > settings_idx, (
+        "ctx-overview must live under #tab-context-gateway, but its closest"
+        " ancestor tab id is #tab-settings — restructure regressed (#962)."
+    )
 
 
 def test_other_integration_leaves_lack_landing_modifier() -> None:
     """Symmetric negative pin: only ctx-overview is the landing card. The
     other Agent Integrations leaves (Skills / Custom Commands / Subagents /
     Hooks) must not carry the ``--landing`` modifier, otherwise the visual
-    hierarchy collapses again."""
+    hierarchy collapses again.
+
+    Also pins that each leaf lives under ``#tab-context-gateway`` so a
+    partial revert doesn't silently leave the section back under Settings.
+    """
     html = _read_static("index.html")
     for section in ("ctx-skills", "ctx-commands", "ctx-agents", "hooks-sync"):
         tag = re.search(rf'<button[^>]*data-section="{section}"[^>]*>', html)
@@ -352,6 +376,64 @@ def test_other_integration_leaves_lack_landing_modifier() -> None:
             f"{section} must NOT carry --landing modifier "
             "(reserved for ctx-overview only); "
             f"got: {tag.group(0)[:200]}"
+        )
+        head = html[: tag.start()]
+        gateway_idx = head.rfind('id="tab-context-gateway"')
+        settings_idx = head.rfind('id="tab-settings"')
+        assert gateway_idx > settings_idx, (
+            f"{section} must live under #tab-context-gateway post-#962, not #tab-settings."
+        )
+
+
+def test_gateway_main_tab_button_exists() -> None:
+    """#962: Context Gateway is promoted to a top-level tab. The button
+    sits between Sources and Index in the main nav and uses the
+    ``data-tab="context-gateway"`` hash-driven activation contract.
+    """
+    html = _read_static("index.html")
+    btn = re.search(
+        r'<button[^>]*id="tabbtn-context-gateway"[^>]*>',
+        html,
+    )
+    assert btn is not None, "tabbtn-context-gateway button missing"
+    tag = btn.group(0)
+    assert 'data-tab="context-gateway"' in tag, (
+        f"tabbtn-context-gateway must use data-tab='context-gateway', got: {tag}"
+    )
+    assert 'data-i18n="nav.context_gateway"' in tag, (
+        f"tabbtn-context-gateway must use nav.context_gateway i18n key, got: {tag}"
+    )
+    # Positional check — the button must be after Sources and before Index
+    # so it sits visually next to the related Sources/Index lane.
+    sources_idx = html.find('id="tabbtn-sources"')
+    gateway_idx = html.find('id="tabbtn-context-gateway"')
+    index_idx = html.find('id="tabbtn-index"')
+    assert sources_idx < gateway_idx < index_idx, (
+        "Gateway tab button must sit between Sources and Index in the main nav"
+    )
+
+
+def test_settings_sidebar_no_longer_holds_gateway_buttons() -> None:
+    """#962 negative pin: after the promotion, none of the Gateway
+    sections may still be reachable from the Settings sidebar. A
+    regression that left a stale settings-nav-btn under ``#tab-settings``
+    would re-create the duplicate-entry confusion the move was meant to
+    eliminate.
+    """
+    html = _read_static("index.html")
+    settings_open = html.find('id="tab-settings"')
+    settings_close = html.find('id="tab-context-gateway"')
+    # Settings tab ends before Gateway tab begins (Settings is below in
+    # the file — this guards against the layout being flipped). Use
+    # rfind to locate the actual Settings panel close instead.
+    if settings_close < settings_open:
+        # Layout where Gateway sits above Settings — fall back to a
+        # bounded slice around Settings only.
+        settings_close = len(html)
+    settings_slice = html[settings_open:settings_close]
+    for section in ("ctx-overview", "ctx-skills", "ctx-commands", "ctx-agents", "hooks-sync"):
+        assert f'data-section="{section}"' not in settings_slice, (
+            f"Settings sidebar must not retain {section} button after #962 Gateway promotion."
         )
 
 

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -413,6 +413,26 @@ def test_gateway_main_tab_button_exists() -> None:
     )
 
 
+def test_gateway_appears_in_default_tab_selector() -> None:
+    """#962 review P3 fold: the Settings modal's ``#settings-default-tab``
+    dropdown must include the new Gateway tab so users can pick it as
+    their landing tab. Without this entry the Gateway is a top-level
+    tab the user can navigate to but never default to.
+    """
+    html = _read_static("index.html")
+    select_match = re.search(
+        r'<select[^>]*id="settings-default-tab"[^>]*>(.*?)</select>',
+        html,
+        re.DOTALL,
+    )
+    assert select_match is not None, "#settings-default-tab select missing"
+    select_body = select_match.group(1)
+    assert 'value="context-gateway"' in select_body, (
+        "#settings-default-tab must offer context-gateway as a selectable "
+        f"default; got: {select_body!r}"
+    )
+
+
 def test_settings_sidebar_no_longer_holds_gateway_buttons() -> None:
     """#962 negative pin: after the promotion, none of the Gateway
     sections may still be reachable from the Settings sidebar. A

--- a/packages/memtomem/tests/web/test_context_gateway_main_tab.py
+++ b/packages/memtomem/tests/web/test_context_gateway_main_tab.py
@@ -1,0 +1,114 @@
+"""Browser tests for the Context Gateway top-level tab (#962).
+
+The Gateway was promoted from a Settings sub-section to a top-level tab.
+Pin three pieces of behavior so a partial revert can't silently re-nest
+the Gateway under Settings without breaking these tests:
+
+* Clicking ``#tabbtn-context-gateway`` lands the user on ``#tab-context-gateway``
+  with ``ctx-overview`` as the default active section.
+* ``switchSettingsSection('ctx-skills')`` (legacy caller pattern from
+  e.g. ``settings-namespaces.js`` quick links) auto-redirects into the
+  new Gateway tab — no per-call-site fix needed.
+* The Settings tab no longer surfaces the moved sections in its sidebar
+  (test_web_mode.py covers this on the markup side; this is the
+  runtime symmetry pin).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+
+def test_main_tab_button_activates_gateway_panel(page, mm_web_url: str) -> None:
+    """Click on the new top-level Gateway button → ``#tab-context-gateway``
+    becomes active and the default section ``ctx-overview`` populates.
+    """
+    install_default_stubs(page)
+
+    page.goto(mm_web_url)
+    page.locator("#tabbtn-context-gateway").click()
+    page.wait_for_function(
+        "() => {"
+        "  const tab = document.getElementById('tab-context-gateway');"
+        "  return tab && tab.classList.contains('active') && !tab.hidden;"
+        "}",
+        timeout=4_000,
+    )
+
+    # Default landing section is ctx-overview.
+    active_section = page.evaluate(
+        "() => {"
+        "  const sections = document.querySelectorAll("
+        "    '#tab-context-gateway .settings-section');"
+        "  for (const s of sections) {"
+        "    if (s.classList.contains('active')) return s.id;"
+        "  }"
+        "  return null;"
+        "}"
+    )
+    assert active_section == "settings-ctx-overview", (
+        f"Default Gateway sub-section must be ctx-overview, got {active_section!r}"
+    )
+
+
+def test_switch_settings_section_to_ctx_skills_auto_redirects(page, mm_web_url: str) -> None:
+    """Legacy callers like ``settings-namespaces.js`` invoke
+    ``switchSettingsSection('ctx-skills')`` to jump to a Gateway section.
+    Post-#962 that call must auto-redirect into the new Gateway tab so
+    no per-call-site update is needed.
+    """
+    install_default_stubs(page)
+
+    page.goto(mm_web_url)
+    page.evaluate("() => switchSettingsSection('ctx-skills')")
+
+    page.wait_for_function(
+        "() => {"
+        "  const tab = document.getElementById('tab-context-gateway');"
+        "  if (!tab || !tab.classList.contains('active')) return false;"
+        "  const section = document.getElementById('settings-ctx-skills');"
+        "  return section && section.classList.contains('active');"
+        "}",
+        timeout=4_000,
+    )
+
+
+def test_settings_tab_no_longer_lists_gateway_sections_in_sidebar(page, mm_web_url: str) -> None:
+    """Symmetric runtime pin for the test_web_mode.py markup check —
+    when Settings is the active tab, none of the moved sections should
+    be reachable from the Settings sidebar (i.e. their nav buttons live
+    elsewhere now).
+    """
+    install_default_stubs(page)
+
+    page.goto(mm_web_url)
+    page.evaluate("() => activateTab('settings')")
+    page.wait_for_function(
+        "() => {"
+        "  const tab = document.getElementById('tab-settings');"
+        "  return tab && tab.classList.contains('active');"
+        "}",
+        timeout=4_000,
+    )
+
+    moved_sections = (
+        "ctx-overview",
+        "ctx-skills",
+        "ctx-commands",
+        "ctx-agents",
+        "hooks-sync",
+    )
+    for section in moved_sections:
+        count = page.evaluate(
+            f"() => document.querySelectorAll("
+            f"'#tab-settings .settings-nav-btn[data-section=\"{section}\"]'"
+            f").length"
+        )
+        assert count == 0, (
+            f"Settings sidebar must not retain a nav button for {section!r} "
+            f"after the Gateway promotion (#962); found {count} button(s)."
+        )


### PR DESCRIPTION
## Summary

Sibling PR to #966 — also part of the #962 thread. Manual Context Gateway testing showed the Gateway is buried under `Settings → Agent Integrations`, which costs an extra click and lets users wander into unrelated settings while diagnosing sync issues. Promote it to a top-level tab next to Search and Sources.

## Approach — restructure, don't duplicate

- Move `ctx-overview / ctx-skills / ctx-commands / ctx-agents / hooks-sync` sections from `#tab-settings` into a new `#tab-context-gateway` panel
- Keep existing ids (`settings-ctx-*`) and CSS classes (`.settings-nav-btn` / `.settings-section`) so `switchSettingsSection`'s DOM selectors resolve panels unchanged regardless of which tab hosts them
- A new `GATEWAY_SECTIONS` set is the routing pivot:
  - `activateTab('context-gateway')` restores the user's last gateway section (or falls back to `ctx-overview`)
  - `switchSettingsSection('ctx-*' | 'hooks-sync')` auto-redirects into the Gateway tab via `activateTab` with a `sectionOverride` arg
  - `activateTab('settings')` recognizes that the last section may be a gateway one and falls back to `config` so users don't get bounced back to Gateway by the redirect
  - `context-gateway.js`'s `langchange` listener now considers both `#tab-context-gateway` and `#tab-settings` as valid hosts (legacy fallback so a partial revert can't silently kill re-render)

Hooks moves with the Gateway tab — both the issue body's framing and the overview tile already treat Hooks as part of the Gateway flow.

## Tests

- `test_web_mode.py`: `ctx-overview` keeps the `--landing` modifier AND now lives under `#tab-context-gateway`. Symmetric pin on the leaves. New positive pin on the main-tab button presence + position. New negative pin that the Settings sidebar no longer surfaces gateway sections.
- `test_context_gateway_main_tab.py` (new browser test, 3 cases):
  - Clicking the main tab button lands on `ctx-overview` by default
  - Legacy `switchSettingsSection('ctx-skills')` auto-redirects to the Gateway tab
  - The Settings tab runtime no longer holds gateway nav buttons
- All 58 existing browser tests touching the gateway/hooks panels continue to pass (fixture redirect handles the move transparently)

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_context_gateway_*.py packages/memtomem/tests/web/test_settings_hooks_*.py` — 58 passed
- [x] `uv run pytest packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/test_i18n.py` — 81 passed
- [x] `uv run ruff check && uv run ruff format --check` clean
- [ ] Manual: click the new Gateway tab, navigate through all 5 sub-sections, verify deep-link `?section=skills&filter=out_of_sync#context-gateway` resolves

## Notes for reviewers

- The `style="display:flex;..."` inline header on the hooks-sync section is intentionally unchanged in this PR — sibling PR #966 lifts that into a CSS class, and rebasing here cleanly resolves to PR #966's form
- Sibling PR #966 is the four-part Hooks UI fix from the same #962 thread; they're orthogonal and can land in either order
- Sub-issue spec for a future cleanup: rename the `settings-ctx-*` ids to `ctx-*` so the Settings/Gateway separation is also evident in DOM ids. Deferred to keep this PR's diff focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)