### PR TITLE
fix(web): polish Hooks panel no_source state (#962 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -439,6 +439,7 @@
   "settings.hooks.title": "Hooks",
   "settings.hooks.sync_now": "Sync Now",
   "settings.hooks.sync_now_tooltip": "Apply .memtomem/settings.json hook config to the active runtime",
+  "settings.hooks.sync_now_disabled_no_source": "No .memtomem/settings.json to sync — create it first via `mm init`.",
   "settings.hooks.sync_now_aria": "Sync hooks to active runtime",
   "settings.hooks.in_sync": "All hooks are in sync",
   "settings.hooks.conflicts": "conflicts found",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -439,6 +439,7 @@
   "settings.hooks.title": "훅",
   "settings.hooks.sync_now": "지금 동기화",
   "settings.hooks.sync_now_tooltip": ".memtomem/settings.json 의 훅 설정을 활성 런타임에 적용합니다",
+  "settings.hooks.sync_now_disabled_no_source": "동기화할 .memtomem/settings.json 이 없습니다 — `mm init` 으로 먼저 생성하세요.",
   "settings.hooks.sync_now_aria": "활성 런타임으로 훅 동기화",
   "settings.hooks.in_sync": "모든 훅이 동기화됨",
   "settings.hooks.conflicts": "개 충돌 발견",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -107,11 +107,35 @@ async function loadHooksSync() {
     const targetLabel = translated && translated !== scopeKey
       ? translated
       : t('settings.hooks.target_label');
+    // In ``no_source`` state the canonical file does not exist, so the
+    // target path is irrelevant — the badge already names the condition
+    // ("No .memtomem/settings.json found"). Suppress the target line so
+    // the empty-state hint doesn't compete with a leftover scope label
+    // (PR D follow-up). ``error`` state still shows it because the
+    // target path is often what the user needs to inspect.
+    const showTarget = !!data.target_path && data.status !== 'no_source';
     statusEl.innerHTML =
       `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
-      + (data.target_path
+      + (showTarget
         ? `<div class="hooks-status-target" data-target-scope="${escapeHtml(scope || '')}">${escapeHtml(targetLabel)} <code>${escapeHtml(data.target_path)}</code></div>`
         : '');
+
+    // Sync Now is only meaningful when a canonical source exists. Disable
+    // the button in ``no_source`` so clicking it doesn't fire a POST that
+    // can never succeed; restore the enabled state on the other branches
+    // since every ``loadHooksSync`` call ends here.
+    const syncBtn = document.getElementById('hooks-sync-btn');
+    if (syncBtn) {
+      const isNoSource = data.status === 'no_source';
+      syncBtn.disabled = isNoSource;
+      if (isNoSource) {
+        syncBtn.setAttribute('data-no-source', 'true');
+        syncBtn.title = t('settings.hooks.sync_now_disabled_no_source');
+      } else {
+        syncBtn.removeAttribute('data-no-source');
+        syncBtn.title = t('settings.hooks.sync_now_tooltip');
+      }
+    }
 
     if (data.status === 'no_source' || data.status === 'error') {
       // Status badge above already names the condition — keep the body to

--- a/packages/memtomem/tests/web/test_settings_hooks_no_source.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_no_source.py
@@ -1,0 +1,155 @@
+"""Browser tests for the Hooks panel ``no_source`` state polish (PR D).
+
+Pre-fix the panel rendered (1) the ``User-scope target:`` line — even
+though the canonical file does not exist — and (2) left Sync Now
+enabled, inviting a click that the server would reject. The badge
+already names the condition ("No .memtomem/settings.json found"), so
+the target line is misleading clutter and the button is a footgun.
+
+Tests pin the post-fix behavior:
+
+* The target line is NOT rendered in ``no_source`` state.
+* Sync Now is ``disabled`` with the no-source tooltip.
+* The empty-state hint still renders under the badge so the user has
+  an actionable next step (run ``mm init``).
+* Symmetric positive pin: in other states (``in_sync`` / ``out_of_sync``)
+  the target line shows and the button is enabled.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+
+_NO_SOURCE_GET = {
+    "status": "no_source",
+    "target_path": "/fake/home/.claude/settings.json",
+    "target_scope": "user",
+    "hooks": {"pending": [], "conflicts": [], "synced": []},
+    "canonical_path": "/fake/project/.memtomem/settings.json",
+    "duplicate_tier_warnings": [],
+}
+
+_IN_SYNC_GET = {
+    "status": "in_sync",
+    "target_path": "/fake/home/.claude/settings.json",
+    "target_scope": "user",
+    "hooks": {
+        "pending": [],
+        "conflicts": [],
+        "synced": [
+            {
+                "event": "PreToolUse",
+                "matcher": "Bash",
+                "rule": {"hooks": [{"type": "command", "command": "echo hi"}]},
+            }
+        ],
+    },
+    "duplicate_tier_warnings": [],
+}
+
+
+def _stub_settings_sync(page, payload: dict) -> None:
+    page.route(
+        "**/api/settings-sync",
+        lambda r: (
+            r.fulfill(status=200, content_type="application/json", body=json.dumps(payload))
+            if r.request.method == "GET"
+            else r.fulfill(status=200, content_type="application/json", body="{}")
+        ),
+    )
+
+
+def _open_hooks_sync(page) -> None:
+    page.evaluate("() => activateTab('context-gateway')")
+    page.evaluate("() => switchSettingsSection('hooks-sync')")
+    # Wait until the badge mounts — the rest of the assertions depend on
+    # ``loadHooksSync`` having run.
+    page.wait_for_function(
+        "() => {"
+        "  const badge = document.querySelector('#hooks-sync-status .badge');"
+        "  return badge && (badge.textContent || '').trim().length > 0;"
+        "}",
+        timeout=5_000,
+    )
+
+
+def test_no_source_state_suppresses_target_line(page, mm_web_url: str) -> None:
+    """``no_source`` state must not render ``hooks-status-target`` —
+    the canonical file does not exist so the target path is irrelevant
+    clutter. The badge ("No .memtomem/settings.json found") already
+    names the condition.
+    """
+    install_default_stubs(page)
+    _stub_settings_sync(page, _NO_SOURCE_GET)
+
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    target = page.locator("#hooks-sync-status .hooks-status-target")
+    assert target.count() == 0, (
+        f"no_source state must not render the target line; got {target.count()} occurrence(s)"
+    )
+
+    # The empty-state hint still renders so the user has an actionable
+    # next step (``mm init``). Pin the hint copy as a positive check
+    # that the rest of the empty-state path didn't regress.
+    content = page.locator("#hooks-sync-content").text_content() or ""
+    assert "mm init" in content, (
+        f"no_source hint must guide the user to ``mm init``; got {content!r}"
+    )
+
+
+def test_no_source_state_disables_sync_now_button(page, mm_web_url: str) -> None:
+    """Sync Now must be ``disabled`` in ``no_source`` so a click can't
+    fire a POST that the server can never satisfy. The disabled tooltip
+    explains the gate.
+    """
+    install_default_stubs(page)
+    _stub_settings_sync(page, _NO_SOURCE_GET)
+
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    btn = page.locator("#hooks-sync-btn")
+    btn.wait_for(state="attached", timeout=4_000)
+    assert btn.is_disabled(), "Sync Now button must be disabled when status=no_source"
+    no_source_attr = btn.get_attribute("data-no-source")
+    assert no_source_attr == "true", (
+        f"data-no-source attribute must pin the gate, got {no_source_attr!r}"
+    )
+    title = btn.get_attribute("title") or ""
+    assert "mm init" in title or "create" in title.lower(), (
+        f"Disabled tooltip must hint at the remedy, got {title!r}"
+    )
+
+
+def test_in_sync_state_restores_target_line_and_enabled_button(page, mm_web_url: str) -> None:
+    """Symmetric positive pin: once a canonical exists, the target line
+    is back and Sync Now is enabled. Catches a regression where the
+    disable / suppress branches accidentally apply to every state.
+    """
+    install_default_stubs(page)
+    _stub_settings_sync(page, _IN_SYNC_GET)
+
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    target = page.locator("#hooks-sync-status .hooks-status-target")
+    target.wait_for(state="attached", timeout=4_000)
+    assert "User-scope target:" in (target.text_content() or ""), (
+        "in_sync state must render the User-scope target line"
+    )
+
+    btn = page.locator("#hooks-sync-btn")
+    assert not btn.is_disabled(), "Sync Now button must be enabled when a canonical exists"
+    no_source_attr = btn.get_attribute("data-no-source")
+    assert no_source_attr is None, (
+        f"data-no-source attribute must be cleared in non-no_source states, got {no_source_attr!r}"
+    )


### PR DESCRIPTION
## Summary

Follow-up to the #962 thread (PRs #966 / #967 / #968 all merged). Manual review of the Hooks panel in its empty / first-run shape surfaced two pieces of leftover clutter in the ``no_source`` state:

- ``User-scope target: /Users/.../.claude/settings.json`` rendered even though no canonical exists, competing with the empty-state hint for visual attention. The badge already says \"No .memtomem/settings.json found\".
- Sync Now stayed enabled, which invites a click that the server can never satisfy (returns no-op at best, error toast at worst).

## Changes

- ``settings-hooks-watchdog.js``:
  - Gate the ``hooks-status-target`` line on ``data.status !== 'no_source'`` (still rendered for ``error`` so users can inspect the malformed path).
  - Set ``syncBtn.disabled`` + ``data-no-source`` + a tooltip pointing at ``mm init`` when ``no_source``. Every other state restores ``disabled=false`` + clears the attribute + restores the original tooltip, so transitioning OUT of ``no_source`` doesn't leave the button stuck.
- New i18n key ``settings.hooks.sync_now_disabled_no_source`` (EN + KO).

## Tests

- ``tests/web/test_settings_hooks_no_source.py`` (new, 3 cases):
  - ``no_source`` → target line absent + ``mm init`` hint visible
  - ``no_source`` → Sync Now disabled with ``data-no-source=true`` + ``mm init`` in tooltip
  - ``in_sync`` (positive symmetric pin) → target line back, button enabled, no stale ``data-no-source`` attribute
- 59 hooks-related browser tests + i18n parity all pass locally
- ``ruff check && ruff format --check`` clean

## Test plan

- [x] ``uv run pytest packages/memtomem/tests/web/test_settings_hooks_*.py packages/memtomem/tests/test_i18n.py`` → 59 passed
- [x] Format + lint clean
- [ ] Manual: open the Hooks panel without a ``.memtomem/settings.json`` in cwd, confirm the target line is gone and Sync Now is dimmed with the disabled tooltip

## Notes

- The Hooks panel now lives under the top-level Gateway tab post-#967; existing fixtures in this PR navigate via ``activateTab('context-gateway')`` → ``switchSettingsSection('hooks-sync')`` to match the new container.
- Scope: ``no_source`` only. ``error`` state intentionally keeps the target line because the path is often the diagnostic clue the user needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)