### PR TITLE
Fix pending chunk highlight retry

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -39,9 +39,10 @@ const STATE = {
   // rendering the chunk list. Set by ``_navigateToSource`` when the
   // caller knows the specific chunk (e.g. Timeline → Source jump);
   // empty string means "source-level only, no chunk highlight".
-  // Cleared on consume in ``browseSource`` so a later same-source
-  // browse (e.g. Load All) doesn't re-flash an old target.
+  // Preserved across a same-source miss so a larger follow-up fetch
+  // (e.g. Load All / future pagination) can retry the highlight.
   pendingActivateChunkId: '',
+  pendingActivateChunkSourcePath: '',
   // Active Sources vendor sub-tab (one of ``user`` / ``claude`` /
   // ``openai``). Lazily populated from localStorage on first render so
   // the value survives reloads. Keeping it on STATE means re-renders
@@ -1894,6 +1895,7 @@ function _navigateToSource(path, chunkId = '') {
   //      the exact chunk), ``browseSource`` scrolls + expands + flashes
   //      that card after the source's chunk list renders.
   STATE.pendingActivateChunkId = chunkId || '';
+  STATE.pendingActivateChunkSourcePath = chunkId ? path : '';
   const src = (STATE.allSources || []).find(s => s.path === path);
   const status = src && src.memory_dir
     ? (STATE.memoryStatusByPath || {})[src.memory_dir]
@@ -3863,6 +3865,7 @@ function _renderMemorySourceItem(s, maxChunks) {
     // UUIDs), but it would silently no-op the next ``browseSource`` flash
     // path until something else clears it. PR #676 review follow-up.
     STATE.pendingActivateChunkId = '';
+    STATE.pendingActivateChunkSourcePath = '';
     document.querySelectorAll('.source-item').forEach(el => el.classList.remove('active'));
     item.classList.add('active');
     browseSource(s.path);
@@ -4053,15 +4056,14 @@ async function browseSource(path, limit = 100) {
 
     // Consume ``pendingActivateChunkId`` (set by ``_navigateToSource``
     // when the caller — e.g. Timeline — knows the specific chunk).
-    // Done after appendChild so the card is in the DOM. Cleared
-    // unconditionally so a later same-source browse (Load All, manual
-    // re-click) doesn't re-flash an old target. The accordion-expand
-    // listener attaches in the next rAF, so we run inside one too — but
-    // we don't depend on the listener: we set the ``expanded`` class
-    // directly when the card is collapsible.
-    if (STATE.pendingActivateChunkId) {
+    // Done after appendChild so the card is in the DOM. On a miss, keep
+    // the target for this same source so a larger follow-up fetch can
+    // retry. The accordion-expand listener attaches in the next rAF, so
+    // we run inside one too — but we don't depend on the listener: we set
+    // the ``expanded`` class directly when the card is collapsible.
+    const pendingChunkPath = STATE.pendingActivateChunkSourcePath || path;
+    if (STATE.pendingActivateChunkId && pendingChunkPath === path) {
       const targetId = STATE.pendingActivateChunkId;
-      STATE.pendingActivateChunkId = '';
       requestAnimationFrame(() => {
         const card = content.querySelector(
           `.chunk-card[data-chunk-id="${CSS.escape(String(targetId))}"]`,
@@ -4078,6 +4080,8 @@ async function browseSource(path, limit = 100) {
           }
           return;
         }
+        STATE.pendingActivateChunkId = '';
+        STATE.pendingActivateChunkSourcePath = '';
         card.scrollIntoView({ behavior: 'smooth', block: 'center' });
         const contentDiv = card.querySelector('.chunk-card-content');
         if (contentDiv && card.classList.contains('chunk-card-collapsible')) {

--- a/packages/memtomem/tests-js/pending-activate-chunk-retry.test.mjs
+++ b/packages/memtomem/tests-js/pending-activate-chunk-retry.test.mjs
@@ -1,0 +1,133 @@
+/* Regression guards for Timeline -> Source chunk activation.
+ *
+ * Issue #680: a target chunk beyond the first fetch used to clear
+ * ``STATE.pendingActivateChunkId`` on the initial miss, so a later Load All
+ * / pagination fetch had nothing left to retry.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function chunk(id) {
+  return {
+    id,
+    chunk_type: 'paragraph',
+    start_line: 1,
+    end_line: 2,
+    heading_hierarchy: [],
+    content: `content for ${id}`,
+  };
+}
+
+async function nextFrame(window) {
+  await new Promise(resolve => window.requestAnimationFrame(resolve));
+}
+
+describe('browseSource pending chunk activation retry', () => {
+  let window;
+  let document;
+  let toasts;
+  let requests;
+
+  beforeEach(async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    window = dom.window;
+    document = window.document;
+    toasts = [];
+    requests = [];
+
+    window.CSS = window.CSS || {};
+    window.CSS.escape = window.CSS.escape || (value => String(value).replace(/"/g, '\\"'));
+    window.Element.prototype.scrollIntoView = function scrollIntoViewSpy() {
+      this.dataset.scrolled = 'true';
+    };
+    window.showToast = (msg, level) => {
+      toasts.push({ msg, level });
+    };
+  });
+
+  function stubChunksByLimit(responsesByLimit) {
+    const originalFetch = window.fetch;
+    window.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url && url.startsWith('/api/chunks')) {
+        const parsed = new URL(url, 'http://localhost');
+        const limit = Number(parsed.searchParams.get('limit'));
+        requests.push({ source: parsed.searchParams.get('source'), limit });
+        const chunks = responsesByLimit[limit] || [];
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ chunks, total: Math.max(501, chunks.length) }),
+          text: async () => '{}',
+        };
+      }
+      return originalFetch(input, init);
+    };
+  }
+
+  it('keeps the pending chunk id after a same-source miss and clears it after retry success', async () => {
+    const sourcePath = '/notes/large.md';
+    const targetId = 'target-501';
+    stubChunksByLimit({
+      100: [chunk('first-visible')],
+      500: [chunk('first-visible'), chunk(targetId)],
+    });
+    Object.assign(window.STATE, {
+      pendingActivateChunkId: targetId,
+      pendingActivateChunkSourcePath: sourcePath,
+    });
+
+    await window.browseSource(sourcePath, 100);
+    await nextFrame(window);
+
+    expect(window.STATE.pendingActivateChunkId).toBe(targetId);
+    expect(window.STATE.pendingActivateChunkSourcePath).toBe(sourcePath);
+    expect(toasts.some(toast => toast.level === 'info')).toBe(true);
+
+    await window.browseSource(sourcePath, 500);
+    await nextFrame(window);
+
+    const card = document.querySelector(`.chunk-card[data-chunk-id="${targetId}"]`);
+    expect(card).not.toBeNull();
+    expect(card?.dataset.scrolled).toBe('true');
+    expect(card?.classList.contains('tl-target-flash')).toBe(true);
+    expect(window.STATE.pendingActivateChunkId).toBe('');
+    expect(window.STATE.pendingActivateChunkSourcePath).toBe('');
+    expect(requests.map(req => req.limit)).toEqual([100, 500]);
+  });
+
+  it('does not consume a pending chunk target while browsing another source', async () => {
+    stubChunksByLimit({ 100: [chunk('target-501')] });
+    Object.assign(window.STATE, {
+      pendingActivateChunkId: 'target-501',
+      pendingActivateChunkSourcePath: '/notes/large.md',
+    });
+
+    await window.browseSource('/notes/other.md', 100);
+    await nextFrame(window);
+
+    expect(window.STATE.pendingActivateChunkId).toBe('target-501');
+    expect(window.STATE.pendingActivateChunkSourcePath).toBe('/notes/large.md');
+    expect(toasts).toEqual([]);
+  });
+
+  it('manual source item click clears a stale pending chunk target', () => {
+    Object.assign(window.STATE, {
+      pendingActivateChunkId: 'target-501',
+      pendingActivateChunkSourcePath: '/notes/large.md',
+    });
+    stubChunksByLimit({ 100: [chunk('other')] });
+
+    const item = window._renderMemorySourceItem(
+      { path: '/notes/other.md', chunk_count: 1, namespaces: [] },
+      1,
+    );
+    document.body.appendChild(item);
+
+    item.click();
+
+    expect(window.STATE.pendingActivateChunkId).toBe('');
+    expect(window.STATE.pendingActivateChunkSourcePath).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- preserve pending Timeline chunk highlight IDs across same-source misses so Load All can retry
- track the owning source path to avoid cross-source consumption
- add Vitest coverage for retry, path scoping, and manual source pivot clearing

## Tests
- npm test -- pending-activate-chunk-retry.test.mjs
- npm test

Fixes #680