### PR TITLE
Fix tier-aware Hooks sync stale response handling

### DIFF
--- a/docs/adr/0010-settings-hooks-target-scope.md
+++ b/docs/adr/0010-settings-hooks-target-scope.md
@@ -145,12 +145,12 @@ defers. The picker is gated on the future project-config ADR. This
 keeps the Web UI consistent with the CLI surface, which has only the
 per-invocation `--scope=…` flag and no persistent per-project setting.
 
-**Per-sync override from the Web UI is intentionally absent in v1.**
-Users who want a one-shot override drop to the CLI: `mm context sync
---include=settings --scope=project_local`. Adding a per-sync scope
-selector to the Web UI would require either the deferred picker (with
-its persistence implications) or a transient form state, both of which
-expand the v1 surface beyond what this ADR proposes.
+**Superseded Web note.** This ADR originally kept per-sync override out
+of the Web UI. The later Context Gateway parity change made settings
+routes accept `?target_scope=` with default `project_shared`, matching
+skills / commands / agents Web routes. CLI users still use
+`mm context sync --include=settings --scope=project_local` for a
+one-shot override.
 
 ### 4. Migration
 

--- a/docs/adr/0015-context-gateway-scope-vocabulary.md
+++ b/docs/adr/0015-context-gateway-scope-vocabulary.md
@@ -128,8 +128,9 @@ vocabulary remediates the silent-ignore-`?scope_id=` bug in
 Background; the actual route changes ship as their own follow-up
 issue (see §"Open questions").
 
-**2b. Settings routes** — stay config-driven for `target_scope` (sourced
-from `config.hooks.target_scope`; no per-request override, per §4e).
+**2b. Settings routes** — originally config-driven for `target_scope`;
+superseded by the parity change in §4e. Current Web settings routes
+accept per-request `?target_scope=` with default `project_shared`.
 Affects:
 
 - `GET /context/settings` (alias `/settings-sync`,
@@ -172,11 +173,11 @@ Stays cwd-only:
 
 ### 3. Settings vs artifact `target_scope` relationship
 
-A single tier value sourced from `config.hooks.target_scope`. This ADR
-does **not** introduce a separate artifact-side `config.context.target_scope`
-field. Splitting today would risk divergence with no driving user need;
-the artifact-tier filter on list routes (per §2a) is per-request and
-does not need a config field of its own.
+The artifact-tier filter on Web routes is per-request and does not need
+a config field of its own. `config.hooks.target_scope` remains the CLI /
+config default for settings hooks, while Web settings routes now accept
+the same `?target_scope=` query parameter as the other Context Gateway
+surfaces.
 
 ### 4. Product-semantics decisions
 
@@ -263,16 +264,18 @@ revisit the locked routes.
 
 Affects: routes listed in §2d.
 
-#### 4e. Settings per-request `target_scope` override — Option A (no override)
+#### 4e. Settings per-request `target_scope` override — superseded by parity change
 
-Settings routes derive `target_scope` from `config.hooks.target_scope`
-only. They do not accept a `?target_scope=` query parameter.
+Original decision: settings routes derived `target_scope` from
+`config.hooks.target_scope` only and did not accept a `?target_scope=`
+query parameter.
 
-Rationale: settings writes touch user / project settings files that
-may sit outside the visible artifact-tier selection; mixing per-request
-and config sources would make it hard to predict which file a settings
-write lands on. Config-only keeps the existing live-config dependency
-intact.
+Superseding implementation note: the Web Context Gateway now treats
+settings like skills / commands / agents for request routing. Settings
+GET / sync / resolve routes accept `?target_scope=` with default
+`project_shared`, and the Hooks panel sends the currently selected tier.
+This keeps Overview, Sync All, and the dedicated Hooks panel pointed at
+the same tier.
 
 Affects: settings routes per §2b.
 
@@ -399,8 +402,8 @@ at ADR-draft time; grep by symbol if they drift.
   `resolve_scope_root` (project-root resolver).
 - `packages/memtomem/src/memtomem/config.py:745` — `TargetScope`
   literal.
-- `packages/memtomem/src/memtomem/web/deps.py:57` —
-  `get_hooks_target_scope` (settings-tier dependency).
+- `packages/memtomem/src/memtomem/web/routes/settings_sync.py` —
+  settings GET / sync / resolve `target_scope` query handling.
 - `packages/memtomem/src/memtomem/web/routes/context_skills.py:61` /
   `:112` / `:283` — skills list / detail / diff routes.
 - `packages/memtomem/src/memtomem/web/routes/context_commands.py:71` /

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -168,8 +168,11 @@ Add the following to `~/.claude/settings.json`:
 > `<project>/.memtomem/settings.json` regardless of tier. The three
 > values: `user` (default) → `~/.claude/settings.json`; `project_shared`
 > → `<project>/.claude/settings.json` (committed); `project_local` →
-> `<project>/.claude/settings.local.json` (gitignored). Per-invocation
-> override: `mm context sync --include=settings --scope=project_local`.
+> `<project>/.claude/settings.local.json` (gitignored). CLI
+> per-invocation override: `mm context sync --include=settings
+> --scope=project_local`. In the Web Context Gateway, the Hooks panel
+> follows the selected tier (`target_scope`) just like Skills and
+> Subagents.
 
 ```json
 {

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, Query
 
 from memtomem.privacy import scan as _privacy_scan
 from memtomem.config import TargetScope
-from memtomem.web.deps import get_hooks_target_scope, get_project_root
+from memtomem.web.deps import get_project_root
 
 try:
     import tomllib
@@ -243,7 +243,6 @@ def _error_payload(exc: BaseException, *, shape: str = "total") -> dict:
 @router.get("/context/overview")
 async def context_overview(
     project_root: Path = Depends(get_project_root),
-    scope: str = Depends(get_hooks_target_scope),
     target_scope: TargetScope = Query(
         "project_shared",
         description=(
@@ -298,7 +297,7 @@ async def context_overview(
         result["agents"] = _error_payload(exc, shape="total")
 
     try:
-        settings_diff = diff_settings(project_root, scope=scope)
+        settings_diff = diff_settings(project_root, scope=target_scope)
         statuses = [r.status for r in settings_diff.values()]
         # `total` counts only **applicable** generators (runtime installed +
         # canonical source present). `skipped` items are N/A — including them

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -6,9 +6,10 @@ import asyncio
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
+from memtomem.config import TargetScope
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
     resolve_scope_path,
@@ -20,7 +21,7 @@ from memtomem.context.settings_doctor import (
     DuplicateTier,
     detect_duplicate_tiers,
 )
-from memtomem.web.deps import get_hooks_target_scope, get_project_root
+from memtomem.web.deps import get_project_root
 from memtomem.web.routes._locks import _gateway_lock
 
 logger = logging.getLogger(__name__)
@@ -181,19 +182,22 @@ def _compare_hooks(
 @router.get("/context/settings")
 async def get_settings_sync(
     project_root: Path = Depends(get_project_root),
-    scope: str = Depends(get_hooks_target_scope),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description="Claude Code settings tier to compare against.",
+    ),
 ) -> dict:
     """Return structured settings sync status with conflict details."""
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
-    target_path = _claude_target(project_root, scope)
+    target_path = _claude_target(project_root, target_scope)
     payload = _compare_hooks(canonical_path, target_path)
     # Surface the active scope so the Web UI can render a scope-accurate
     # target label (issue #962). Without this the panel falls back to a
     # hardcoded "User-scope target:" that lies when the scope is
     # project_shared or project_local.
-    payload["target_scope"] = scope
+    payload["target_scope"] = target_scope
     payload["duplicate_tier_warnings"] = _serialize_duplicate_tiers(
-        detect_duplicate_tiers(project_root, active_scope=scope)
+        detect_duplicate_tiers(project_root, active_scope=target_scope)
     )
     return payload
 
@@ -216,7 +220,10 @@ class ApplySettingsSyncRequest(BaseModel):
 async def apply_settings_sync(
     body: ApplySettingsSyncRequest | None = None,
     project_root: Path = Depends(get_project_root),
-    scope: str = Depends(get_hooks_target_scope),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description="Claude Code settings tier to write.",
+    ),
 ) -> dict:
     """Run the full settings merge (generate_all_settings).
 
@@ -229,13 +236,13 @@ async def apply_settings_sync(
     # Detect duplicate-tier hooks BEFORE the merge so the warning
     # reflects pre-write state (ADR-0010 §4: the warning fires in the
     # user's actual workflow, not behind a separate command).
-    duplicates = detect_duplicate_tiers(project_root, active_scope=scope)
+    duplicates = detect_duplicate_tiers(project_root, active_scope=target_scope)
     try:
         async with asyncio.timeout(60):
             async with _gateway_lock:
                 results = generate_all_settings(
                     project_root,
-                    scope=scope,
+                    scope=target_scope,
                     allow_host_writes=allow_host_writes,
                 )
     except TimeoutError:
@@ -268,7 +275,10 @@ class ResolveRequest(BaseModel):
 async def resolve_conflict(
     body: ResolveRequest,
     project_root: Path = Depends(get_project_root),
-    scope: str = Depends(get_hooks_target_scope),
+    target_scope: TargetScope = Query(
+        "project_shared",
+        description="Claude Code settings tier to update.",
+    ),
 ) -> dict:
     """Resolve a single hook conflict by replacing the target's rule."""
     if body.action != "use_proposed":
@@ -277,7 +287,7 @@ async def resolve_conflict(
     label = _rule_label(body.event, body.matcher)
 
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
-    target_path = _claude_target(project_root, scope)
+    target_path = _claude_target(project_root, target_scope)
 
     try:
         async with asyncio.timeout(60):

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -144,6 +144,8 @@ function _ctxTierControls(type) {
 
 function _ctxWireTierControls() {
   document.querySelectorAll('.ctx-tier-filter button').forEach(btn => {
+    if (btn.dataset.tierWired === 'true') return;
+    btn.dataset.tierWired = 'true';
     btn.addEventListener('click', () => {
       const next = btn.dataset.scope;
       if (!next || next === _ctxTargetScope) return;
@@ -156,6 +158,8 @@ function _ctxWireTierControls() {
       const type = btn.closest('.ctx-tier-filter')?.dataset.type || '';
       if (type === 'overview') {
         loadCtxOverview();
+      } else if (type === 'hooks-sync') {
+        loadHooksSync();
       } else if (type) {
         // Tier swap is a fresh navigation intent; the prior deep-link's
         // filter/artifact target lived on the old tier and would render
@@ -989,7 +993,10 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
     //   aborted            → mtime_conflict warning    (#799)
     //   needs_confirmation → info partial + Open Settings action (#774)
     //   all ok / skipped   → sync_success
-    const settingsResp = await fetch('/api/context/settings/sync', { method: 'POST', headers });
+    const settingsResp = await fetch(
+      _ctxWithTargetScope('/api/context/settings/sync'),
+      { method: 'POST', headers },
+    );
     if (!settingsResp.ok) {
       throw new Error(await _ctxErrorMessageFromResponse(settingsResp, 'Settings sync failed'));
     }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=82" />
+  <link rel="stylesheet" href="/style.css?v=84" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1406,9 +1406,9 @@
   <script src="/settings-maintenance.js?v=2"></script>
   <script src="/settings-namespaces.js?v=6"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=6"></script>
+  <script src="/settings-hooks-watchdog.js?v=7"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=34"></script>
+  <script src="/context-gateway.js?v=35"></script>
   <script src="/path-picker.js?v=2"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -30,6 +30,30 @@ function _wdLabel(status) {
 // call and is the source of truth that the row's ``data-hook-key``
 // references.
 let _hooksRuleRegistry = [];
+let _hooksSyncSeq = 0;
+
+function _hooksCurrentTargetScope() {
+  if (typeof _ctxTargetScope === 'string') return _ctxTargetScope;
+  return 'project_shared';
+}
+
+function _hooksScopedUrl(path) {
+  if (typeof _ctxWithTargetScope === 'function') {
+    return _ctxWithTargetScope(path);
+  }
+  return path;
+}
+
+function _hooksTierControlsHtml() {
+  if (typeof _ctxTierControls !== 'function') return '';
+  return _ctxTierControls('hooks-sync');
+}
+
+function _hooksWireTierControls() {
+  if (typeof _ctxWireTierControls === 'function') {
+    _ctxWireTierControls();
+  }
+}
 
 function _renderHookRuleDetail(key, contentEl) {
   const idx = Number(key);
@@ -38,6 +62,7 @@ function _renderHookRuleDetail(key, contentEl) {
   if (!panel || !entry) return;
 
   const rule = entry.rule || {};
+  const label = entry.matcher ? `${entry.event}:${entry.matcher}` : entry.event;
   // Claude Code's rule format: top-level ``matcher`` + ``hooks`` array
   // of command entries, each with ``type`` / ``command`` / optional
   // ``timeout`` / etc. Render the union so the user can see exactly
@@ -52,7 +77,11 @@ function _renderHookRuleDetail(key, contentEl) {
       + `</div>`;
   }
 
-  let html = `<div class="hooks-rule-detail-inner">`;
+  let html = `<div class="hooks-rule-detail-header">`;
+  html += `<strong>${escapeHtml(label)}</strong>`;
+  html += `<span class="badge ${entry._bucket === 'pending' ? 'badge-warning' : 'badge-success'}">${escapeHtml(entry._bucket || '')}</span>`;
+  html += `</div>`;
+  html += `<div class="hooks-rule-detail-inner">`;
   html += _row(t('settings.hooks.detail.event'), entry.event);
   html += _row(t('settings.hooks.detail.matcher'), entry.matcher);
   for (const h of hooks) {
@@ -74,18 +103,23 @@ function _renderHookRuleDetail(key, contentEl) {
 }
 
 async function loadHooksSync() {
+  const seq = ++_hooksSyncSeq;
+  const requestedScope = _hooksCurrentTargetScope();
   const statusEl = qs('hooks-sync-status');
   const contentEl = qs('hooks-sync-content');
   panelLoading(contentEl);
-  statusEl.innerHTML = '';
+  statusEl.innerHTML = _hooksTierControlsHtml();
+  _hooksWireTierControls();
 
   try {
-    const res = await fetch('/api/settings-sync');
+    const res = await fetch(_hooksScopedUrl('/api/settings-sync'));
+    if (seq !== _hooksSyncSeq || requestedScope !== _hooksCurrentTargetScope()) return;
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.detail || `Request failed: ${res.status}`);
     }
     const data = await res.json();
+    if (seq !== _hooksSyncSeq || requestedScope !== _hooksCurrentTargetScope()) return;
 
     // Status badge
     const badges = {
@@ -115,10 +149,12 @@ async function loadHooksSync() {
     // target path is often what the user needs to inspect.
     const showTarget = !!data.target_path && data.status !== 'no_source';
     statusEl.innerHTML =
-      `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
+      _hooksTierControlsHtml()
+      + `<span class="badge ${badge.cls}">${escapeHtml(badge.text)}</span>`
       + (showTarget
         ? `<div class="hooks-status-target" data-target-scope="${escapeHtml(scope || '')}">${escapeHtml(targetLabel)} <code>${escapeHtml(data.target_path)}</code></div>`
         : '');
+    _hooksWireTierControls();
 
     // Sync Now is only meaningful when a canonical source exists. Disable
     // the button in ``no_source`` so clicking it doesn't fire a POST that
@@ -271,7 +307,7 @@ async function loadHooksSync() {
           const headers = csrf
             ? {'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf}
             : {'Content-Type': 'application/json'};
-          const r = await fetch('/api/context/settings/resolve', {
+          const r = await fetch(_hooksScopedUrl('/api/context/settings/resolve'), {
             method: 'POST',
             headers,
             body: JSON.stringify({event, matcher, action: 'use_proposed'}),
@@ -293,6 +329,7 @@ async function loadHooksSync() {
     });
 
   } catch (err) {
+    if (seq !== _hooksSyncSeq || requestedScope !== _hooksCurrentTargetScope()) return;
     contentEl.innerHTML = emptyState('', t('settings.hooks.load_failed'), err.message);
   }
 }
@@ -317,7 +354,7 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
     // ``needs_confirmation`` for the user-scope ``~/.claude/settings.json``
     // path — the same gate the CLI confirms interactively
     // (``cli/context_cmd.py:_confirm_settings_host_writes``).
-    const res = await fetch('/api/settings-sync', {
+    const res = await fetch(_hooksScopedUrl('/api/settings-sync'), {
       method: 'POST',
       headers,
       body: JSON.stringify({ allow_host_writes: true }),
@@ -449,4 +486,3 @@ async function runWatchdogNow() {
 
 qs('health-watchdog-refresh-btn')?.addEventListener('click', loadWatchdogStatus);
 qs('health-watchdog-run-btn')?.addEventListener('click', runWatchdogNow);
-

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -868,6 +868,9 @@ button:active { opacity: 0.7; }
 .badge-blue   { background: rgba(var(--accent-rgb),0.15); color: var(--accent); }
 .badge-gray   { background: rgba(123, 127, 150, 0.15); color: var(--muted); }
 .badge-yellow { background: rgba(243, 156, 18, 0.15); color: var(--yellow); }
+.badge-success { background: rgba(76, 175, 125, 0.15); color: var(--green); }
+.badge-warning { background: rgba(243, 156, 18, 0.15); color: var(--yellow); }
+.badge-muted { background: rgba(123, 127, 150, 0.15); color: var(--muted); }
 .badge-source { background: rgba(76, 175, 125, 0.15); color: var(--green); font-family: var(--mono); font-weight: 400; }
 .badge-validity { background: rgba(108, 92, 231, 0.10); color: var(--muted); font-family: var(--mono); font-weight: 400; }
 .badge-validity--expired { opacity: 0.55; text-decoration: line-through; }
@@ -2289,24 +2292,41 @@ select:focus-visible {
 .hooks-rule-row:hover { background: var(--bg); }
 .hooks-rule-row--synced { padding: 0.25rem 0.5rem; border-radius: var(--radius); }
 .hooks-rule-detail {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
   margin-top: 1rem;
-  padding: 12px;
+  padding: 18px 20px;
+  min-height: 360px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+.hooks-rule-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.hooks-rule-detail-inner {
+  min-height: 280px;
+  padding: 12px 14px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg);
 }
 .hooks-rule-detail-row {
-  display: flex;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: minmax(140px, 0.22fr) minmax(0, 1fr);
+  gap: 14px;
   align-items: baseline;
-  margin: 4px 0;
-  font-size: 0.82rem;
+  margin: 8px 0;
+  font-size: 0.86rem;
 }
 .hooks-rule-detail-label {
   color: var(--muted);
   font-weight: 600;
-  min-width: 90px;
-  flex-shrink: 0;
 }
 .hooks-rule-detail-value {
   color: var(--text);
@@ -2314,8 +2334,12 @@ select:focus-visible {
   overflow-wrap: anywhere;
 }
 .hooks-rule-detail-json {
+  width: 100%;
+  min-height: 170px;
+  box-sizing: border-box;
+  min-width: 0;
   font-family: var(--mono);
-  font-size: 0.75rem;
+  font-size: 0.78rem;
   line-height: 1.5;
   background: var(--surface);
   border: 1px solid var(--border);

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -981,7 +981,7 @@ class TestSettingsHttpLayer:
         target.write_text(json.dumps(user_authored, indent=2) + "\n", encoding="utf-8")
 
         resp = await client.post(
-            "/api/context/settings/sync",
+            "/api/context/settings/sync?target_scope=user",
             json={"allow_host_writes": True},
         )
         assert resp.status_code == 200
@@ -989,7 +989,7 @@ class TestSettingsHttpLayer:
         claude_result = next(r for r in results if r["name"] == "claude_settings")
         assert claude_result["status"] == "ok"
 
-        diff = await client.get("/api/context/settings")
+        diff = await client.get("/api/context/settings?target_scope=user")
         assert diff.status_code == 200
         diff_body = diff.json()
         assert diff_body["status"] == "in_sync"
@@ -1057,7 +1057,7 @@ class TestSettingsHttpLayer:
         monkeypatch.setattr(routes_sync_mod, "_safe_load_json", bumping_load)
 
         resp = await client.post(
-            "/api/context/settings/resolve",
+            "/api/context/settings/resolve?target_scope=user",
             json={
                 "event": "PostToolUse",
                 "matcher": "Write",
@@ -1081,8 +1081,8 @@ class TestSettingsHttpLayer:
 
     async def test_resolve_respects_target_scope(self, app, client, claude_home, tmp_path):
         """Codex blocker #2 regression pin: ``POST /settings-sync/resolve``
-        must use ``hooks.target_scope`` from ``app.state.config``, not
-        the hardcoded user-tier path. With ``target_scope="project_local"``
+        must use the request ``target_scope`` query param, not the hardcoded
+        user-tier path. With ``target_scope="project_local"``
         a resolve must mutate ``<project>/.claude/settings.local.json``
         and leave ``~/.claude/settings.json`` untouched.
 
@@ -1091,8 +1091,9 @@ class TestSettingsHttpLayer:
         and the resolve handler would have written there regardless of
         the configured scope.
         """
-        # Configure project_local scope on the live app state.
-        app.state.config.hooks.target_scope = "project_local"
+        # Configure the opposite scope on live app state as a regression
+        # guard: Web settings routes must follow the request query param.
+        app.state.config.hooks.target_scope = "user"
 
         # Seed canonical with a hook differing from the user-authored rule
         # so the route surfaces a conflict.
@@ -1126,7 +1127,7 @@ class TestSettingsHttpLayer:
         user_target.write_text(user_authored, encoding="utf-8")
 
         resp = await client.post(
-            "/api/context/settings/resolve",
+            "/api/context/settings/resolve?target_scope=project_local",
             json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
         )
         assert resp.status_code == 200, resp.text

--- a/packages/memtomem/tests/test_settings_doctor.py
+++ b/packages/memtomem/tests/test_settings_doctor.py
@@ -396,8 +396,9 @@ class TestWebDuplicateTierWarnings:
     def app(self, project_root, fake_home, monkeypatch):
         from memtomem.config import Mem2MemConfig
 
-        # Active scope = project_local so user-tier hooks count as
-        # duplicates.
+        # Web settings routes are request-scoped. Keep the env override in
+        # place as a regression guard: the route must follow
+        # ?target_scope=..., not config.hooks.target_scope.
         monkeypatch.setenv("MEMTOMEM_HOOKS__TARGET_SCOPE", "project_local")
         application = create_app(lifespan=None, mode="dev")
         application.state.project_root = project_root
@@ -419,7 +420,7 @@ class TestWebDuplicateTierWarnings:
     async def test_get_includes_empty_warnings_when_clean(self, client, project_root):
         _write_canonical(project_root, _bundled_hook())
         # No other tiers populated → empty list.
-        response = await client.get("/api/settings-sync")
+        response = await client.get("/api/settings-sync?target_scope=project_local")
         assert response.status_code == 200
         data = response.json()
         assert data["duplicate_tier_warnings"] == []
@@ -427,7 +428,7 @@ class TestWebDuplicateTierWarnings:
     async def test_get_includes_warnings_when_duplicates(self, client, project_root, fake_home):
         _write_canonical(project_root, _bundled_hook())
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
-        response = await client.get("/api/settings-sync")
+        response = await client.get("/api/settings-sync?target_scope=project_local")
         assert response.status_code == 200
         data = response.json()
         warnings = data["duplicate_tier_warnings"]
@@ -439,7 +440,7 @@ class TestWebDuplicateTierWarnings:
         _write_canonical(project_root, _bundled_hook())
         _write_settings(fake_home / ".claude" / "settings.json", _bundled_hook())
         response = await client.post(
-            "/api/settings-sync",
+            "/api/settings-sync?target_scope=project_local",
             json={"allow_host_writes": False},
         )
         assert response.status_code == 200

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -606,6 +606,37 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
         "Sync All would still POST /api/context/commands/sync in prod "
         "even though the surface is dev-only."
     )
+    assert "const chips = runtimes.map" in cg_js, (
+        "Context Gateway runtime tags must render from detected_runtimes."
+    )
+    assert "ctx-overview-runtimes" in cg_js, (
+        "Context Gateway runtime tags disappeared from the prod overview header."
+    )
+    runtime_block = cg_js[
+        cg_js.find("const runtimes = Array.isArray(data.detected_runtimes)") : cg_js.find(
+            "html += _ctxTierControls('overview')"
+        )
+    ]
+    assert "STATE.uiMode" not in runtime_block, (
+        "Context Gateway runtime tags must not be dev-mode gated; prod users "
+        "need the claude/gemini/codex detection chips too."
+    )
+    hooks_js = _read_static("settings-hooks-watchdog.js")
+    assert "_hooksScopedUrl('/api/settings-sync')" in hooks_js
+    assert "_hooksScopedUrl('/api/context/settings/resolve')" in hooks_js
+    assert "_ctxTierControls('hooks-sync')" in hooks_js
+    assert "let _hooksSyncSeq = 0;" in hooks_js
+    assert "const requestedScope = _hooksCurrentTargetScope();" in hooks_js
+    assert "seq !== _hooksSyncSeq || requestedScope !== _hooksCurrentTargetScope()" in hooks_js
+    css = _read_static("style.css")
+    assert (
+        ".badge-success" in css
+        and "background:" in css.split(".badge-success", 1)[1].split("}", 1)[0]
+    ), "Runtime tags use badge-success for detected runtimes; it must define a background."
+    assert ".badge-warning" in css and ".badge-muted" in css
+    assert ".hooks-rule-detail-header" in css and ".hooks-rule-detail-inner" in css, (
+        "Hooks per-rule detail should render as a card with a header and framed body."
+    )
     # And the locale entries themselves are pinned so a rename doesn't go
     # unnoticed by the i18n completeness check.
     en = _read_static("locales/en.json")

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -624,40 +624,29 @@ class TestSettingsSync:
         data = resp.json()
         assert data["status"] == "no_source"
         # Issue #962: response must surface ``target_scope`` so the Web
-        # UI can render a scope-accurate target label. Defaults to "user"
-        # per ADR-0010 §2.
-        assert data["target_scope"] == "user"
+        # UI can render a scope-accurate target label. Web routes default
+        # to the same project_shared tier as the other Context Gateway
+        # surfaces.
+        assert data["target_scope"] == "project_shared"
 
     async def test_target_scope_surfaces_project_shared(self, app, client: AsyncClient, tmp_path):
         """Issue #962: when the active scope is ``project_shared``, the
         GET response surfaces that value so the Web UI does not lie
         with a hardcoded ``User-scope target:`` label.
         """
-        from memtomem.web.deps import get_hooks_target_scope
-
         app.state.project_root = tmp_path
-        app.dependency_overrides[get_hooks_target_scope] = lambda: "project_shared"
-        try:
-            resp = await client.get("/api/settings-sync")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert data["target_scope"] == "project_shared"
-        finally:
-            app.dependency_overrides.pop(get_hooks_target_scope, None)
+        resp = await client.get("/api/settings-sync?target_scope=project_shared")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["target_scope"] == "project_shared"
 
     async def test_target_scope_surfaces_project_local(self, app, client: AsyncClient, tmp_path):
         """Issue #962 sibling: ``project_local`` scope round-trips too."""
-        from memtomem.web.deps import get_hooks_target_scope
-
         app.state.project_root = tmp_path
-        app.dependency_overrides[get_hooks_target_scope] = lambda: "project_local"
-        try:
-            resp = await client.get("/api/settings-sync")
-            assert resp.status_code == 200
-            data = resp.json()
-            assert data["target_scope"] == "project_local"
-        finally:
-            app.dependency_overrides.pop(get_hooks_target_scope, None)
+        resp = await client.get("/api/settings-sync?target_scope=project_local")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["target_scope"] == "project_local"
 
     async def test_in_sync(self, app, client: AsyncClient, tmp_path):
         """When hooks are identical in both files, status is in_sync."""
@@ -675,7 +664,7 @@ class TestSettingsSync:
             target.write_text(json.dumps(hooks), encoding="utf-8")
             app.state.project_root = tmp_path
 
-            resp = await client.get("/api/settings-sync")
+            resp = await client.get("/api/settings-sync?target_scope=user")
             data = resp.json()
             assert data["status"] == "in_sync"
             assert len(data["hooks"]["synced"]) == 1
@@ -706,7 +695,7 @@ class TestSettingsSync:
             )
             app.state.project_root = tmp_path
 
-            resp = await client.get("/api/settings-sync")
+            resp = await client.get("/api/settings-sync?target_scope=user")
             data = resp.json()
             assert data["status"] == "conflicts"
             assert len(data["hooks"]["conflicts"]) == 1
@@ -735,7 +724,7 @@ class TestSettingsSync:
             target.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
             app.state.project_root = tmp_path
 
-            resp = await client.get("/api/settings-sync")
+            resp = await client.get("/api/settings-sync?target_scope=user")
             data = resp.json()
             assert data["status"] == "out_of_sync"
             assert len(data["hooks"]["pending"]) == 1
@@ -776,7 +765,7 @@ class TestSettingsSync:
             )
             app.state.project_root = tmp_path
 
-            resp = await client.get("/api/settings-sync")
+            resp = await client.get("/api/settings-sync?target_scope=user")
             data = resp.json()
 
             assert data["status"] == "in_sync"  # was "conflicts" before the fix
@@ -809,7 +798,7 @@ class TestSettingsSync:
             app.state.project_root = tmp_path
 
             resp = await client.post(
-                "/api/settings-sync/resolve",
+                "/api/settings-sync/resolve?target_scope=user",
                 json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
             )
             data = resp.json()
@@ -828,7 +817,7 @@ class TestSettingsSync:
         # No .memtomem/settings.json created in tmp_path
         app.state.project_root = tmp_path
         resp = await client.post(
-            "/api/settings-sync/resolve",
+            "/api/settings-sync/resolve?target_scope=user",
             json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
         )
         assert resp.status_code == 404
@@ -838,7 +827,7 @@ class TestSettingsSync:
         """POST /resolve with invalid action returns HTTP 400."""
         app.state.project_root = tmp_path
         resp = await client.post(
-            "/api/settings-sync/resolve",
+            "/api/settings-sync/resolve?target_scope=user",
             json={"event": "PostToolUse", "matcher": "Write", "action": "bad_action"},
         )
         assert resp.status_code == 400
@@ -858,7 +847,7 @@ class TestSettingsSync:
             app.state.project_root = tmp_path
 
             resp = await client.post(
-                "/api/settings-sync/resolve",
+                "/api/settings-sync/resolve?target_scope=user",
                 json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
             )
             assert resp.status_code == 404
@@ -913,7 +902,7 @@ class TestSettingsSync:
         app.state.project_root = project
 
         resp = await client.post(
-            "/api/settings-sync",
+            "/api/settings-sync?target_scope=user",
             headers={"Content-Type": "application/json"},
         )
         assert resp.status_code == 200
@@ -942,7 +931,7 @@ class TestSettingsSync:
         app.state.project_root = project
 
         resp = await client.post(
-            "/api/settings-sync",
+            "/api/settings-sync?target_scope=user",
             json={"allow_host_writes": True},
         )
         assert resp.status_code == 200
@@ -971,7 +960,7 @@ class TestSettingsSync:
             app.state.project_root = tmp_path
 
             resp = await client.post(
-                "/api/context/settings/resolve",
+                "/api/context/settings/resolve?target_scope=user",
                 json={"event": "PostToolUse", "matcher": "Edit", "action": "use_proposed"},
             )
             data = resp.json()

--- a/packages/memtomem/tests/web/test_settings_hooks_detail.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_detail.py
@@ -89,6 +89,8 @@ def test_clicking_synced_rule_opens_detail_panel(page, mm_web_url: str) -> None:
 
     detail = page.locator("#hooks-rule-detail")
     detail.wait_for(state="visible", timeout=4_000)
+    assert detail.locator(".hooks-rule-detail-header").count() == 1
+    assert detail.locator(".hooks-rule-detail-inner").count() == 1
     text = detail.text_content() or ""
     assert "PostToolUse" in text, f"event missing from detail panel, got {text!r}"
     assert "Edit" in text, f"matcher missing from detail panel, got {text!r}"


### PR DESCRIPTION
## Summary
- thread target_scope through Hooks sync GET/POST/resolve routes and Web calls
- render tier controls and scope-specific Hooks target labels
- guard loadHooksSync responses/errors by request sequence and requested tier so stale responses cannot paint the wrong tier
- update docs, styling, and regression pins for tier-aware Hooks sync

## Tests
- uv run pytest packages/memtomem/tests/test_context_settings.py packages/memtomem/tests/test_settings_doctor.py packages/memtomem/tests/test_web_routes_extended.py packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/web/test_settings_hooks_detail.py