### PR TITLE
docs: fix "good first issue" label spelling in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ Labels that affect triage:
   — exempt from the stale sweep.
 - `needs-cla` — the CLA workflow has not yet recorded a signature; merge is
   blocked until the workflow re-checks (see CLA section below).
-- `good-first-issue` — scoped to ≤3 files and no public API changes; check
+- `good first issue` — scoped to ≤3 files and no public API changes; check
   the comments for an existing claim before starting work.
 
 If your PR is time-sensitive (security, regression on `main`, release


### PR DESCRIPTION
## Summary

Fixes #974

`CONTRIBUTING.md` listed the label for newcomer-friendly issues as `good-first-issue` (hyphenated), but the repository actually uses GitHub's standard label name `good first issue` (with spaces). This mismatch could confuse first-time contributors searching for labeled issues in the GitHub UI.

## Root Cause

Line 169 of `CONTRIBUTING.md` used the hyphenated form `good-first-issue` instead of the repository's actual label name. The repository label was verified via the GitHub API and confirmed as `good first issue` with the description "Good for newcomers".

## Fix

Changed the documented label name from `good-first-issue` to `good first issue` on line 169. The surrounding criteria text ("scoped to ≤3 files and no public API changes; check the comments for an existing claim before starting work") was preserved unchanged.

## Changes

- `CONTRIBUTING.md`: Updated label reference from hyphenated to space-separated form (`+1 -1` lines)

## Testing

- **Exact label match**: `gh api repos/memtomem/memtomem/labels` confirms the label is `good first issue` ✅
- **No stale references**: `rg -n "good-first-issue" CONTRIBUTING.md README.md docs .github` after fix returns zero matches ✅
- **Other labels unaffected**: No other label references in the file were modified ✅