### PR TITLE
fix(web): improve Search filter removal UX

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -49,15 +49,6 @@ const STATE = {
   // (filter typing, sort change) read the active vendor without
   // hitting localStorage on the hot path.
   sourcesActiveVendor: null,
-  // Per Sources vendor/category visible source-row or folder budget. Mirrors
-  // Search's paging shape, but the data is already client-side so scrolling
-  // just expands the rendered slice by 10 units.
-  sourcesCategoryLimits: {},
-  sourcesExpandedDirs: {},
-  sourcesActiveCategoryByVendor: {},
-  sourcesBodyFilterQuery: '',
-  sourcesBodyFilterPaths: null,
-  sourcesBodyFilterPending: false,
   dedupScanActive: false,
   dedupAbortCtrl: null,
   lastTagsData: [],
@@ -2048,25 +2039,62 @@ function _buildSearchParams(topK) {
   return params;
 }
 
+function _resetSearchResultsEmpty() {
+  const list = qs('results-list');
+  const empty = qs('results-empty');
+  list.innerHTML = '';
+  hide(list);
+  hide(qs('bulk-toolbar'));
+  hide(qs('load-more-row'));
+  show(empty);
+  let emptyText = (typeof t === 'function') ? t('search.empty_text') : '';
+  if (!emptyText || emptyText === 'search.empty_text') emptyText = 'Enter a query to search';
+  empty.innerHTML = `
+    <span class="empty-state-icon">\u{1F50D}</span>
+    <span>${escapeHtml(emptyText)}</span>
+    <span class="empty-state-hint"><kbd>/</kbd> focus · <kbd>j</kbd>/<kbd>k</kbd> navigate · <kbd>p</kbd> pin · <kbd>c</kbd> copy</span>
+    <div id="recent-chips" class="recent-chips" hidden></div>
+  `;
+  STATE.lastResults = [];
+  STATE.selectedIds.clear();
+  _renderActiveFilters();
+  clearDetail();
+  if (typeof renderRecentChips === 'function') renderRecentChips();
+}
+
+function _refreshAfterFilterClear(filterKind) {
+  _updateFilterCountBadge();
+  if (!_hasSearchAxis()) {
+    _resetSearchResultsEmpty();
+    return;
+  }
+  if (filterKind === 'server') {
+    _renderActiveFilters();
+    doSearch();
+    return;
+  }
+  renderResults(STATE.lastResults);
+}
+
 function _renderActiveFilters() {
   const el = qs('active-filters');
   const chips = [];
   const ns = qs('ns-filter').value;
-  if (ns) chips.push({ label: `ns: ${ns}`, clear: () => { qs('ns-filter').value = ''; } });
+  if (ns) chips.push({ label: `ns: ${ns}`, kind: 'server', clear: () => { qs('ns-filter').value = ''; } });
   const tag = qs('tag-filter').value.trim();
-  if (tag) chips.push({ label: `tag: ${tag}`, clear: () => { qs('tag-filter').value = ''; } });
+  if (tag) chips.push({ label: `tag: ${tag}`, kind: 'server', clear: () => { qs('tag-filter').value = ''; } });
   const ct = qs('chunk-type-filter').value;
-  if (ct) chips.push({ label: `type: ${ct.replace('_', ' ')}`, clear: () => { qs('chunk-type-filter').value = ''; } });
+  if (ct) chips.push({ label: `type: ${ct.replace('_', ' ')}`, kind: 'client', clear: () => { qs('chunk-type-filter').value = ''; } });
   const sources = _getSelectedSourceFilters();
   if (sources.length) {
     const label = sources.length === 1
       ? `source: ${basename(sources[0])}`
       : `sources: ${sources.length}`;
-    chips.push({ label, clear: _clearSourceFilters });
+    chips.push({ label, kind: 'server', clear: _clearSourceFilters });
   }
   const dateLabel = _formatDateFilterLabel();
-  if (dateLabel) chips.push({ label: dateLabel, clear: _clearDateFilter });
-  if (STATE.scoreMin > 0) chips.push({ label: `score \u2265 ${STATE.scoreMin}`, clear: () => { qs('score-threshold').value = 0; STATE.scoreMin = 0; qs('score-val').textContent = '0.0'; } });
+  if (dateLabel) chips.push({ label: dateLabel, kind: 'client', clear: _clearDateFilter });
+  if (STATE.scoreMin > 0) chips.push({ label: `score \u2265 ${STATE.scoreMin}`, kind: 'client', clear: () => { qs('score-threshold').value = 0; STATE.scoreMin = 0; qs('score-val').textContent = '0.0'; } });
 
   _updateFilterCountBadge();
   if (!chips.length) { hide(el); return; }
@@ -2077,14 +2105,9 @@ function _renderActiveFilters() {
   el.querySelectorAll('.active-filter-remove').forEach(btn => {
     btn.addEventListener('click', e => {
       e.stopPropagation();
-      chips[parseInt(btn.dataset.idx)].clear();
-      _updateFilterCountBadge();
-      if (_hasSearchAxis()) {
-        renderResults(STATE.lastResults);
-        doSearch();
-      } else {
-        renderResults([]);
-      }
+      const chip = chips[parseInt(btn.dataset.idx)];
+      chip.clear();
+      _refreshAfterFilterClear(chip.kind);
     });
   });
   qs('clear-search-filters').addEventListener('click', e => {
@@ -2097,20 +2120,14 @@ function _renderActiveFilters() {
     qs('score-threshold').value = 0;
     STATE.scoreMin = 0;
     qs('score-val').textContent = '0.0';
-    _updateFilterCountBadge();
-    if (_hasSearchAxis()) {
-      renderResults(STATE.lastResults);
-      doSearch();
-    } else {
-      renderResults([]);
-    }
+    _refreshAfterFilterClear('server');
   });
   show(el);
 }
 
 // Count of currently-applied search filters. Kept in sync with the chip
-// set built by _renderActiveFilters above \u2014 same four categories so the
-// toggle-button badge and the chip row never disagree.
+// set built by _renderActiveFilters above so the toggle-button badge and
+// the chip row never disagree.
 function _countActiveFilters() {
   let n = 0;
   if (qs('ns-filter')?.value) n++;
@@ -2943,9 +2960,6 @@ qs('d-tag-save-btn').addEventListener('click', async () => {
 // ---------------------------------------------------------------------------
 
 // STATE.allSources, STATE.sourcesSortBy now in STATE
-let _sourcesBodyFilterTimer = null;
-let _sourcesBodyFilterAbort = null;
-let _sourcesBodyFilterSeq = 0;
 
 function sortSources(sources) {
   const sorted = [...sources];
@@ -2969,73 +2983,13 @@ function sortSources(sources) {
   return sorted;
 }
 
-function _sourceMatchesLocalFilter(s, q) {
-  return [
-    s.path,
-    s.title,
-    s.excerpt,
-    s.ai_summary,
-    ...((s.namespaces || [])),
-  ].some(value => String(value || '').toLowerCase().includes(q));
-}
-
-function _sourcesFilterHighlightQuery() {
-  return qs('sources-filter') ? qs('sources-filter').value.trim() : '';
-}
-
 function _getFilteredSorted() {
   const q = qs('sources-filter').value.trim().toLowerCase();
-  const bodyMatches = q && STATE.sourcesBodyFilterQuery === q && STATE.sourcesBodyFilterPaths instanceof Set
-    ? STATE.sourcesBodyFilterPaths
-    : null;
-  let filtered = q
-    ? STATE.allSources.filter(s => _sourceMatchesLocalFilter(s, q) || (bodyMatches && bodyMatches.has(s.path)))
-    : STATE.allSources;
+  let filtered = q ? STATE.allSources.filter(s => s.path.toLowerCase().includes(q)) : STATE.allSources;
   if (STATE.sourcesNsFilter) {
     filtered = filtered.filter(s => (s.namespaces || []).includes(STATE.sourcesNsFilter));
   }
   return sortSources(filtered);
-}
-
-function _scheduleSourcesBodyFilter(opts = {}) {
-  const q = qs('sources-filter').value.trim().toLowerCase();
-  if (_sourcesBodyFilterTimer) clearTimeout(_sourcesBodyFilterTimer);
-  if (!q) {
-    STATE.sourcesBodyFilterQuery = '';
-    STATE.sourcesBodyFilterPaths = null;
-    STATE.sourcesBodyFilterPending = false;
-    if (_sourcesBodyFilterAbort) _sourcesBodyFilterAbort.abort();
-    return;
-  }
-  if (STATE.sourcesBodyFilterQuery === q && STATE.sourcesBodyFilterPaths instanceof Set) return;
-  STATE.sourcesBodyFilterQuery = q;
-  STATE.sourcesBodyFilterPaths = null;
-  STATE.sourcesBodyFilterPending = true;
-  const delay = opts.immediate ? 0 : 180;
-  _sourcesBodyFilterTimer = setTimeout(() => _loadSourcesBodyMatches(q), delay);
-}
-
-async function _loadSourcesBodyMatches(q) {
-  const seq = ++_sourcesBodyFilterSeq;
-  if (_sourcesBodyFilterAbort) _sourcesBodyFilterAbort.abort();
-  _sourcesBodyFilterAbort = new AbortController();
-  try {
-    const resp = await api(
-      'GET',
-      `/api/sources/content-matches?q=${encodeURIComponent(q)}&limit=10000`,
-      undefined,
-      { signal: _sourcesBodyFilterAbort.signal },
-    );
-    if (seq !== _sourcesBodyFilterSeq || qs('sources-filter').value.trim().toLowerCase() !== q) return;
-    STATE.sourcesBodyFilterQuery = q;
-    STATE.sourcesBodyFilterPaths = new Set((resp && resp.paths) || []);
-    STATE.sourcesBodyFilterPending = false;
-    renderSourceTree(_getFilteredSorted());
-  } catch (err) {
-    if (err && err.name === 'AbortError') return;
-    STATE.sourcesBodyFilterPending = false;
-    console.warn('[sources-filter] body match lookup failed', err);
-  }
 }
 
 function _renderSourcesNsChip() {
@@ -3171,10 +3125,7 @@ function navigateToSourcesByNs(nsName) {
   activateTab('sources');
 }
 
-qs('sources-filter').addEventListener('input', () => {
-  _scheduleSourcesBodyFilter();
-  renderSourceTree(_getFilteredSorted());
-});
+qs('sources-filter').addEventListener('input', () => renderSourceTree(_getFilteredSorted()));
 
 document.querySelectorAll('.sources-sort-btn').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -3320,7 +3271,6 @@ async function loadSources() {
     STATE.sourcesLanguageDrift = (sourcesResp && sourcesResp.language_drift) || null;
     _renderSourcesNsChip();
     _renderLanguageDriftBanner(STATE.sourcesLanguageDrift);
-    _scheduleSourcesBodyFilter({ immediate: true });
     renderSourceTree(_getFilteredSorted());
   } catch (err) {
     list.innerHTML = `<div class="empty-state"><p>Error: ${escapeHtml(err.message)}</p></div>`;
@@ -3441,9 +3391,6 @@ function _renderMemorySourceTree(sources, list) {
   // matches.
   const filterActive = !!(qs('sources-filter') && qs('sources-filter').value.trim())
     || !!STATE.sourcesNsFilter;
-  const bodyFilterPending = !!(qs('sources-filter') && qs('sources-filter').value.trim())
-    && STATE.sourcesBodyFilterPending;
-  const fileSortMode = ['chunks', 'size', 'recent'].includes(STATE.sourcesSortBy);
 
   const PROVIDER_ORDER = (typeof _MEMORY_DIR_PROVIDER_ORDER !== 'undefined')
     ? _MEMORY_DIR_PROVIDER_ORDER : ['user', 'claude', 'openai'];
@@ -3453,47 +3400,8 @@ function _renderMemorySourceTree(sources, list) {
     ? _MEMORY_DIR_CATEGORY_ORDER : ['user', 'claude-memory', 'claude-plans', 'codex'];
   const CATEGORY_LABEL_KEY = (typeof _MEMORY_DIR_CATEGORY_LABEL_KEY !== 'undefined')
     ? _MEMORY_DIR_CATEGORY_LABEL_KEY : {};
-  const CATEGORY_TO_PROVIDER = {
-    'user': 'user',
-    'claude-memory': 'claude',
-    'claude-plans': 'claude',
-    'codex': 'openai',
-  };
   const PROVIDER_COLLAPSED = (typeof _MEMORY_DIR_PROVIDER_COLLAPSED !== 'undefined')
     ? _MEMORY_DIR_PROVIDER_COLLAPSED : new Set(['claude', 'openai']);
-  const CATEGORY_PAGE_SIZE = 10;
-  const CLAUDE_PROJECT_TREE_MAX_DEPTH = 2;
-  const TREE_DEFAULT_OPEN_DEPTH = 1;
-  if (!STATE.sourcesCategoryLimits || typeof STATE.sourcesCategoryLimits !== 'object') {
-    STATE.sourcesCategoryLimits = {};
-  }
-  if (!STATE.sourcesExpandedDirs || typeof STATE.sourcesExpandedDirs !== 'object') {
-    STATE.sourcesExpandedDirs = {};
-  }
-  if (!STATE.sourcesActiveCategoryByVendor || typeof STATE.sourcesActiveCategoryByVendor !== 'object') {
-    STATE.sourcesActiveCategoryByVendor = {};
-  }
-  const categoryLimitKey = (provider, cat) => `${provider}:${cat}`;
-  const getCategoryLimit = (provider, cat) => (
-    Math.max(CATEGORY_PAGE_SIZE, STATE.sourcesCategoryLimits[categoryLimitKey(provider, cat)] || CATEGORY_PAGE_SIZE)
-  );
-  const setCategoryLimit = (provider, cat, limit) => {
-    STATE.sourcesCategoryLimits[categoryLimitKey(provider, cat)] = Math.max(CATEGORY_PAGE_SIZE, limit);
-  };
-  const normalizeDirPath = (path) => String(path || '').replace(/\\/g, '/').replace(/\/+$/, '');
-  const presentationCategoryForDir = (dir, st) => {
-    const normalized = normalizeDirPath(dir);
-    if (/\/\.claude\/plans(?:\/|$)/.test(normalized)) return 'claude-plans';
-    if (/\/\.claude\/projects\/[^/]+\/memory$/.test(normalized)) return 'claude-memory';
-    return (st && CATEGORY_LABEL_KEY[st.category]) ? st.category : 'user';
-  };
-  const presentationProviderForDir = (dir, st) => {
-    const cat = presentationCategoryForDir(dir, st);
-    const providerFromCat = CATEGORY_TO_PROVIDER[cat];
-    if (providerFromCat) return providerFromCat;
-    const rawProvider = st && st.provider;
-    return PROVIDER_ORDER.includes(rawProvider) ? rawProvider : 'user';
-  };
 
   const byProvider = {};
   for (const p of PROVIDER_ORDER) byProvider[p] = { order: [], byCategory: {} };
@@ -3504,8 +3412,9 @@ function _renderMemorySourceTree(sources, list) {
   for (const k of Object.keys(sourcesByDir)) if (k) allDirs.add(k);
   for (const d of allDirs) {
     const st = statusByPath[d];
-    const cat = presentationCategoryForDir(d, st);
-    const provider = presentationProviderForDir(d, st);
+    const cat = (st && CATEGORY_LABEL_KEY[st.category]) ? st.category : 'user';
+    const rawProvider = st && st.provider;
+    const provider = byProvider[rawProvider] ? rawProvider : 'user';
     const bucket = byProvider[provider];
     if (!bucket.byCategory[cat]) {
       bucket.byCategory[cat] = [];
@@ -3601,9 +3510,12 @@ function _renderMemorySourceTree(sources, list) {
     const discoveredCount = visibleCats.reduce(
       (sum, [, , discovered]) => sum + discovered.length, 0,
     );
+    const visibleIndexedCats = visibleCats.filter(([, indexed]) => indexed.length);
+    const isSingleLeaf = visibleIndexedCats.length === 1
+      || (visibleIndexedCats.length === 0 && visibleCats.length === 1);
     vendorPlans[provider] = {
-      visibleCats, isEmptyVendor, totalFiles, discoveredCount,
-      orphans: vendorOrphans,
+      visibleCats, visibleIndexedCats, isEmptyVendor, totalFiles, discoveredCount,
+      isSingleLeaf, orphans: vendorOrphans,
     };
 
     // Update the sub-tab badge + empty class so all three vendor tabs
@@ -3668,33 +3580,14 @@ function _renderMemorySourceTree(sources, list) {
   // the NS-filter follow-through that mutates ``activeVendor`` here.
   _renderSourcesStats(activeVendor);
 
-  const dirOpenStateKey = (provider, cat, dir) => `${provider}:${cat}:${dir}`;
-  const getDirOpen = (provider, cat, dir, defaultOpen) => {
-    const key = dirOpenStateKey(provider, cat, dir);
-    return Object.prototype.hasOwnProperty.call(STATE.sourcesExpandedDirs, key)
-      ? !!STATE.sourcesExpandedDirs[key]
-      : defaultOpen;
-  };
-  const setDirOpen = (provider, cat, dir, open) => {
-    STATE.sourcesExpandedDirs[dirOpenStateKey(provider, cat, dir)] = !!open;
-  };
-  const treeOpenStateKey = (provider, cat, key) => `${provider}:${cat}:tree:${key}`;
-  const getTreeOpen = (provider, cat, key, defaultOpen = false) => {
-    const stateKey = treeOpenStateKey(provider, cat, key);
-    return Object.prototype.hasOwnProperty.call(STATE.sourcesExpandedDirs, stateKey)
-      ? !!STATE.sourcesExpandedDirs[stateKey]
-      : defaultOpen;
-  };
-  const setTreeOpen = (provider, cat, key, open) => {
-    STATE.sourcesExpandedDirs[treeOpenStateKey(provider, cat, key)] = !!open;
-  };
-
-  const renderDir = (dir, opts = {}) => _renderMemoryDirGroup(
+  // Helpers shared by the active-vendor render branches. Lifted out of
+  // the per-vendor loop because they don't close over the iteration.
+  const renderDir = (dir) => _renderMemoryDirGroup(
     dir,
     sourcesByDir[dir] || [],
     statusByPath[dir],
     maxChunks,
-    { isDefault: dir === defaultDir, ...opts },
+    { isDefault: dir === defaultDir },
   );
 
   const renderDiscoveredBlock = (dirs) => {
@@ -3746,330 +3639,13 @@ function _renderMemorySourceTree(sources, list) {
     return det;
   };
 
-  const categoryFileCount = (indexed) => (
-    indexed.reduce((sum, d) => sum + (sourcesByDir[d] || []).length, 0)
-  );
-
-  const renderCategoryNav = (cats, activeCat) => {
-    const visible = cats.filter(([, indexed, discovered]) => indexed.length || discovered.length);
-    if (visible.length <= 1) return null;
-    const nav = document.createElement('nav');
-    nav.className = 'source-category-nav';
-    nav.setAttribute(
-      'aria-label',
-      (typeof t === 'function') ? t('sources.category_nav_label') : 'Source categories',
-    );
-    for (const [cat, indexed, discovered] of visible) {
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.className = 'source-category-nav-btn';
-      if (cat === activeCat) btn.classList.add('active');
-      btn.dataset.category = cat;
-      btn.setAttribute('aria-pressed', cat === activeCat ? 'true' : 'false');
-      const label = document.createElement('span');
-      label.className = 'source-category-nav-label';
-      const key = CATEGORY_LABEL_KEY[cat] || cat;
-      label.textContent = (typeof t === 'function') ? t(key) : key;
-      btn.appendChild(label);
-      const count = document.createElement('span');
-      count.className = 'source-category-nav-count';
-      count.textContent = String(categoryFileCount(indexed));
-      btn.appendChild(count);
-      btn.addEventListener('click', () => {
-        STATE.sourcesActiveCategoryByVendor[activeVendor] = cat;
-        renderSourceTree(_getFilteredSorted());
-      });
-      nav.appendChild(btn);
-    }
-    return nav;
-  };
-
-  const sliceIndexedFiles = (indexed, limit) => {
-    const rendered = [];
-    let shown = 0;
-    for (const dir of indexed) {
-      const items = sourcesByDir[dir] || [];
-      if (!items.length) {
-        rendered.push([dir, items]);
-        continue;
-      }
-      if (shown >= limit) break;
-      const remaining = limit - shown;
-      const nextItems = items.slice(0, remaining);
-      rendered.push([dir, nextItems]);
-      shown += nextItems.length;
-    }
-    return { rendered, shown };
-  };
-
-  const sliceIndexedFolders = (indexed, limit) => {
-    const rendered = indexed.slice(0, limit).map(dir => [dir, sourcesByDir[dir] || []]);
-    return { rendered, shown: rendered.length };
-  };
-
-  const sliceIndexedFlatFiles = (indexed, limit) => {
-    const dirSet = new Set(indexed);
-    const rendered = sources
-      .filter(s => s.memory_dir && dirSet.has(s.memory_dir))
-      .slice(0, limit);
-    return { rendered, shown: rendered.length };
-  };
-
-  const splitPathSegments = (path) => String(path || '')
-    .replace(/\\/g, '/')
-    .split('/')
-    .filter(Boolean);
-
-  const commonPrefixLength = (segmentLists) => {
-    if (!segmentLists.length) return 0;
-    let len = segmentLists[0].length;
-    for (const segments of segmentLists.slice(1)) {
-      let i = 0;
-      while (i < len && i < segments.length && segments[i] === segmentLists[0][i]) i += 1;
-      len = i;
-    }
-    return len;
-  };
-
-  const claudeProjectSegments = (dir) => {
-    const match = String(dir || '').replace(/\\/g, '/').match(/\/\.claude\/projects\/([^/]+)\/memory\/?$/);
-    if (!match) return null;
-    const slug = match[1];
-    if (!slug.startsWith('-')) return null;
-    return slug.replace(/^-/, '').split('-').filter(Boolean);
-  };
-
-  const dirSegmentsForTree = (cat, dir) => {
-    const claudeSegments = cat === 'claude-memory' ? claudeProjectSegments(dir) : null;
-    if (claudeSegments && claudeSegments.length) return claudeSegments;
-    const segments = splitPathSegments(dir);
-    if (segments.length > 1 && segments[segments.length - 1] === 'memory') {
-      return segments.slice(0, -1);
-    }
-    return segments.length ? segments : [String(dir || '')];
-  };
-
-  const limitTreeSegments = (cat, segments) => {
-    if (cat !== 'claude-memory' || segments.length <= CLAUDE_PROJECT_TREE_MAX_DEPTH) return segments;
-    const head = segments.slice(0, CLAUDE_PROJECT_TREE_MAX_DEPTH - 1);
-    const tail = segments.slice(CLAUDE_PROJECT_TREE_MAX_DEPTH - 1).join('-');
-    return [...head, tail].filter(Boolean);
-  };
-
-  const shouldPreserveTopTreeSegment = (cat, segments) => {
-    if (segments.length <= 1) return false;
-    if (cat === 'claude-memory') return segments.length > CLAUDE_PROJECT_TREE_MAX_DEPTH;
-    return true;
-  };
-
-  const compactSingleChildChains = (node, joiner = '/') => {
-    for (const child of Array.from(node.children.values())) compactSingleChildChains(child, joiner);
-    if (node.preserveSelf) return;
-    while (!node.leaf && node.children.size === 1) {
-      const only = Array.from(node.children.values())[0];
-      node.label = node.label ? `${node.label}${joiner}${only.label}` : only.label;
-      node.key = only.key;
-      node.children = only.children;
-      node.leaf = only.leaf;
-      node.preserveSelf = !!only.preserveSelf;
-      if (node.preserveSelf) break;
-    }
-  };
-
-  const buildDirTree = (cat, dirs, rendered) => {
-    const allSegments = dirs.map(dir => dirSegmentsForTree(cat, dir));
-    const prefixLen = commonPrefixLength(allSegments);
-    const segmentByDir = new Map();
-    dirs.forEach((dir, idx) => {
-      let segments = allSegments[idx].slice(prefixLen);
-      if (!segments.length) segments = [allSegments[idx][allSegments[idx].length - 1] || dir];
-      const preserveTop = shouldPreserveTopTreeSegment(cat, segments);
-      segments = limitTreeSegments(cat, segments);
-      segmentByDir.set(dir, { segments, preserveTop });
-    });
-    const root = { label: '', key: '', children: new Map(), leaf: null };
-    for (const [dir, items] of rendered) {
-      const treeInfo = segmentByDir.get(dir) || { segments: [dir], preserveTop: false };
-      const { segments, preserveTop } = treeInfo;
-      let node = root;
-      let key = '';
-      segments.forEach((segment, idx) => {
-        key = key ? `${key}/${segment}` : segment;
-        if (!node.children.has(segment)) {
-          node.children.set(segment, { label: segment, key, children: new Map(), leaf: null, preserveSelf: false });
-        }
-        node = node.children.get(segment);
-        if (idx === 0 && preserveTop) node.preserveSelf = true;
-      });
-      node.leaf = { dir, items };
-    }
-    for (const child of Array.from(root.children.values())) {
-      compactSingleChildChains(child, cat === 'claude-memory' ? '-' : '/');
-    }
-    return root;
-  };
-
-  const treeKeysForDir = (cat, dirs, dir) => {
-    const allSegments = dirs.map(d => dirSegmentsForTree(cat, d));
-    const prefixLen = commonPrefixLength(allSegments);
-    const idx = dirs.indexOf(dir);
-    if (idx < 0) return [];
-    let segments = allSegments[idx].slice(prefixLen);
-    if (!segments.length) segments = [allSegments[idx][allSegments[idx].length - 1] || dir];
-    segments = limitTreeSegments(cat, segments);
-    const keys = [];
-    let key = '';
-    for (const segment of segments) {
-      key = key ? `${key}/${segment}` : segment;
-      keys.push(key);
-    }
-    return keys.slice(0, -1);
-  };
-
-  const renderDirTreeNode = (node, provider, cat, depth) => {
-    const wrap = document.createElement('div');
-    wrap.className = 'source-dir-tree-node';
-    wrap.style.setProperty('--tree-depth', String(depth));
-
-    if (node.leaf) {
-      const { dir, items } = node.leaf;
-      const pendingInDir = !!STATE.pendingActivatePath
-        && items.some(s => s.path === STATE.pendingActivatePath);
-      wrap.appendChild(_renderMemoryDirGroup(
-        dir,
-        items,
-        statusByPath[dir],
-        maxChunks,
-        {
-          isDefault: dir === defaultDir,
-          label: node.label,
-          open: getDirOpen(provider, cat, dir, pendingInDir),
-          onToggle: (open) => setDirOpen(provider, cat, dir, open),
-        },
-      ));
-    }
-
-    if (node.children.size) {
-      const details = document.createElement('details');
-      details.className = 'source-dir-tree-branch';
-      details.style.setProperty('--tree-depth', String(depth));
-      details.open = getTreeOpen(provider, cat, node.key, depth <= TREE_DEFAULT_OPEN_DEPTH);
-      details.addEventListener('toggle', () => setTreeOpen(provider, cat, node.key, details.open));
-      const summary = document.createElement('summary');
-      summary.className = 'source-dir-tree-summary';
-      const label = document.createElement('span');
-      label.className = 'source-dir-tree-label';
-      label.textContent = node.label;
-      summary.appendChild(label);
-      const count = document.createElement('span');
-      count.className = 'source-vendor-count';
-      count.textContent = String(Array.from(node.children.values()).reduce(
-        (sum, child) => sum + countTreeLeaves(child),
-        0,
-      ));
-      summary.appendChild(count);
-      details.appendChild(summary);
-      for (const child of node.children.values()) {
-        details.appendChild(renderDirTreeNode(child, provider, cat, depth + 1));
-      }
-      wrap.appendChild(details);
-    }
-    return wrap;
-  };
-
-  const countTreeLeaves = (node) => (
-    (node.leaf ? 1 : 0)
-      + Array.from(node.children.values()).reduce((sum, child) => sum + countTreeLeaves(child), 0)
-  );
-
-  const renderDirTree = (cat, dirs, rendered, provider) => {
-    const tree = buildDirTree(cat, dirs, rendered);
-    const frag = document.createDocumentFragment();
-    for (const child of tree.children.values()) {
-      frag.appendChild(renderDirTreeNode(child, provider, cat, 0));
-    }
-    return frag;
-  };
-
-  if (STATE.pendingActivatePath) {
-    const pendingSrc = (STATE.allSources || sources || []).find(s => s.path === STATE.pendingActivatePath);
-    if (pendingSrc && pendingSrc.memory_dir) {
-      const st = statusByPath[pendingSrc.memory_dir];
-      const pendingCat = presentationCategoryForDir(pendingSrc.memory_dir, st);
-      const pendingProvider = presentationProviderForDir(pendingSrc.memory_dir, st);
-      const pendingPlan = vendorPlans[pendingProvider];
-      const pendingEntry = pendingPlan && pendingPlan.visibleCats.find(([cat]) => cat === pendingCat);
-      if (pendingEntry) {
-        STATE.sourcesActiveCategoryByVendor[pendingProvider] = pendingCat;
-        const [, indexed] = pendingEntry;
-        if (indexed.length > 1) {
-          const dirIdx = indexed.indexOf(pendingSrc.memory_dir);
-          if (dirIdx >= 0) {
-            setCategoryLimit(
-              pendingProvider,
-              pendingCat,
-              Math.ceil((dirIdx + 1) / CATEGORY_PAGE_SIZE) * CATEGORY_PAGE_SIZE,
-            );
-            for (const key of treeKeysForDir(pendingCat, indexed, pendingSrc.memory_dir)) {
-              setTreeOpen(pendingProvider, pendingCat, key, true);
-            }
-            setDirOpen(pendingProvider, pendingCat, pendingSrc.memory_dir, true);
-          }
-        } else {
-          let seen = 0;
-          for (const dir of indexed) {
-            const items = sourcesByDir[dir] || [];
-            const idx = items.findIndex(s => s.path === STATE.pendingActivatePath);
-            if (idx >= 0) {
-              setCategoryLimit(
-                pendingProvider,
-                pendingCat,
-                Math.ceil((seen + idx + 1) / CATEGORY_PAGE_SIZE) * CATEGORY_PAGE_SIZE,
-              );
-              break;
-            }
-            seen += items.length;
-          }
-        }
-      }
-    }
-  }
-
-  const setupAutoCategoryMore = () => {
-    if (!list) return;
-    if (list._sourcesAutoMoreHandler) {
-      list.removeEventListener('scroll', list._sourcesAutoMoreHandler);
-    }
-    let ticking = false;
-    const handler = () => {
-      if (ticking) return;
-      ticking = true;
-      requestAnimationFrame(() => {
-        ticking = false;
-        const rows = Array.from(list.querySelectorAll('.source-category-more-row[data-auto-more="true"]'));
-        if (!rows.length) return;
-        const listRect = list.getBoundingClientRect();
-        const threshold = listRect.bottom + 48;
-        const row = rows.find(el => el.getBoundingClientRect().top <= threshold);
-        if (!row) return;
-        const cat = row.dataset.category;
-        const nextLimit = Number(row.dataset.nextLimit || 0);
-        if (!cat || !nextLimit) return;
-        setCategoryLimit(activeVendor, cat, nextLimit);
-        renderSourceTree(_getFilteredSorted());
-      });
-    };
-    list._sourcesAutoMoreHandler = handler;
-    list.addEventListener('scroll', handler, { passive: true });
-  };
-
   // Pass 2: render only the active vendor's content directly into the
   // sidebar list — the sub-tab strip carries the vendor disclosure, so
   // no per-vendor ``<details>`` wrapper is needed.
   list.innerHTML = '';
   const plan = vendorPlans[activeVendor];
 
-  if (plan.isEmptyVendor && !filterActive) {
+  if (plan.isEmptyVendor) {
     const placeholder = document.createElement('div');
     placeholder.className = 'source-vendor-placeholder';
     const msg = document.createElement('span');
@@ -4092,94 +3668,32 @@ function _renderMemorySourceTree(sources, list) {
     });
     placeholder.appendChild(cta);
     list.appendChild(placeholder);
+  } else if (plan.isSingleLeaf) {
+    const sole = plan.visibleIndexedCats[0] || plan.visibleCats[0];
+    for (const dir of sole[1]) list.appendChild(renderDir(dir));
+    const disc = renderDiscoveredBlock(sole[2]);
+    if (disc) list.appendChild(disc);
   } else {
     const products = document.createElement('div');
     products.className = 'source-vendor-products';
-    const visibleProductCount = plan.visibleCats.filter(
-      ([, indexed, discovered]) => indexed.length || discovered.length,
-    ).length;
-    const hasCategoryNav = visibleProductCount > 1;
-    const visibleCatsForMenu = plan.visibleCats.filter(
-      ([, indexed, discovered]) => indexed.length || discovered.length,
-    );
-    let activeCategory = STATE.sourcesActiveCategoryByVendor[activeVendor];
-    if (hasCategoryNav && !visibleCatsForMenu.some(([cat]) => cat === activeCategory)) {
-      activeCategory = visibleCatsForMenu[0] ? visibleCatsForMenu[0][0] : '';
-      if (activeCategory) STATE.sourcesActiveCategoryByVendor[activeVendor] = activeCategory;
-    }
-    const catsToRender = hasCategoryNav
-      ? visibleCatsForMenu.filter(([cat]) => cat === activeCategory)
-      : visibleCatsForMenu;
-    for (const [cat, indexed, discovered] of catsToRender) {
+    for (const [cat, indexed, discovered] of plan.visibleCats) {
       if (!indexed.length && !discovered.length) continue;
       const section = document.createElement('section');
       section.className = 'source-vendor-product';
       section.dataset.category = cat;
-      const totalFiles = categoryFileCount(indexed);
-      if (hasCategoryNav) {
-        section.setAttribute('tabindex', '-1');
-      } else {
-        const productHeader = document.createElement('div');
-        productHeader.className = 'source-vendor-product-header';
-        productHeader.setAttribute('tabindex', '-1');
-        const pLabel = document.createElement('span');
-        pLabel.className = 'source-vendor-product-label';
-        const pKey = CATEGORY_LABEL_KEY[cat] || cat;
-        pLabel.textContent = (typeof t === 'function') ? t(pKey) : pKey;
-        productHeader.appendChild(pLabel);
-        const pCount = document.createElement('span');
-        pCount.className = 'source-vendor-count';
-        pCount.textContent = String(totalFiles);
-        productHeader.appendChild(pCount);
-        section.appendChild(productHeader);
-      }
-      const flatFileMode = filterActive || fileSortMode;
-      const folderMode = indexed.length > 1 && !flatFileMode;
-      const limit = getCategoryLimit(activeVendor, cat);
-      const totalVisibleUnits = folderMode ? indexed.length : totalFiles;
-      const { rendered, shown } = folderMode
-        ? sliceIndexedFolders(indexed, limit)
-        : (flatFileMode ? sliceIndexedFlatFiles(indexed, limit) : sliceIndexedFiles(indexed, limit));
-      if (folderMode) {
-        section.appendChild(renderDirTree(cat, indexed, rendered, activeVendor));
-      } else if (flatFileMode) {
-        for (const s of rendered) section.appendChild(_renderMemorySourceItem(s, maxChunks));
-      } else {
-        for (const [dir, items] of rendered) {
-          if (hasCategoryNav && indexed.length === 1) {
-            for (const s of items) section.appendChild(_renderMemorySourceItem(s, maxChunks));
-          } else {
-            section.appendChild(_renderMemoryDirGroup(
-              dir,
-              items,
-              statusByPath[dir],
-              maxChunks,
-              {
-                isDefault: dir === defaultDir,
-                open: getDirOpen(activeVendor, cat, dir, true),
-                onToggle: (open) => setDirOpen(activeVendor, cat, dir, open),
-              },
-            ));
-          }
-        }
-      }
-      if (shown < totalVisibleUnits) {
-        const moreRow = document.createElement('div');
-        moreRow.className = 'source-category-more-row';
-        moreRow.dataset.autoMore = 'true';
-        moreRow.dataset.category = cat;
-        moreRow.dataset.nextLimit = String(limit + CATEGORY_PAGE_SIZE);
-        const status = document.createElement('span');
-        status.className = 'source-category-more-status';
-        status.textContent = (typeof t === 'function')
-          ? t(
-              folderMode ? 'sources.category_scroll_more_folders' : 'sources.category_scroll_more',
-              { shown, total: totalVisibleUnits },
-            )
-          : `Showing ${shown}/${totalVisibleUnits}; scroll for more`;
-        moreRow.appendChild(status);
-        section.appendChild(moreRow);
-      }
+      const productHeader = document.createElement('div');
+      productHeader.className = 'source-vendor-product-header';
+      const pLabel = document.createElement('span');
+      pLabel.className = 'source-vendor-product-label';
+      const pKey = CATEGORY_LABEL_KEY[cat] || cat;
+      pLabel.textContent = (typeof t === 'function') ? t(pKey) : pKey;
+      productHeader.appendChild(pLabel);
+      const pCount = document.createElement('span');
+      pCount.className = 'source-vendor-count';
+      pCount.textContent = String(indexed.reduce((sum, d) => sum + (sourcesByDir[d] || []).length, 0));
+      productHeader.appendChild(pCount);
+      section.appendChild(productHeader);
+      for (const dir of indexed) section.appendChild(renderDir(dir));
       const disc = renderDiscoveredBlock(discovered);
       if (disc) section.appendChild(disc);
       products.appendChild(section);
@@ -4190,13 +3704,7 @@ function _renderMemorySourceTree(sources, list) {
     // ``.source-vendor-products`` div would still ship its CSS margin
     // before the orphan block sits below.
     if (products.children.length) list.appendChild(products);
-    const categoryNav = renderCategoryNav(plan.visibleCats, activeCategory);
-    if (categoryNav) {
-      products.classList.add('source-vendor-products-with-nav');
-      list.insertBefore(categoryNav, products);
-    }
   }
-  setupAutoCategoryMore();
 
   // Append the orphan block last so indexed groups stay primary. Only
   // shows up when ``activeVendor === 'user'`` because ``plan.orphans``
@@ -4213,11 +3721,9 @@ function _renderMemorySourceTree(sources, list) {
   // other vendors do, the muted "no matches" hint sits inside the
   // panel — the populated badge on sibling tabs tells the user where
   // to look.
-  if (!filterActive && !allDirs.size && !orphanItems.length) {
+  if (!allDirs.size && !orphanItems.length) {
     list.innerHTML = '<div class="empty-state">' + emptyState('📁', 'No memory directories', 'Add one with the + Add path button') + '</div>';
-  } else if (bodyFilterPending && filterActive && !plan.totalFiles && !plan.discoveredCount) {
-    list.innerHTML = '<div class="empty-state">' + emptyState('🔎', 'Searching indexed body…') + '</div>';
-  } else if (filterActive && !plan.totalFiles && !plan.discoveredCount) {
+  } else if (filterActive && !plan.totalFiles && !plan.discoveredCount && !plan.isEmptyVendor) {
     // ``totalFiles`` only counts indexed+orphan rows; a vendor whose
     // ``visibleCats`` carries discovered dirs (the #896 carve-out) would
     // otherwise be wiped here, defeating the carry-over fix.
@@ -4290,18 +3796,15 @@ function _renderMemorySourceTree(sources, list) {
 }
 
 function _renderMemoryDirGroup(dir, items, status, maxChunks, opts) {
-  const { isDefault, label = null, open = true, onToggle = null } = opts || {};
+  const { isDefault } = opts || {};
   // ``<details>`` gives us a native chevron + auto-flip on toggle and
   // matches the vendor group's disclosure shape one level up — keeping a
   // single mental model for collapse state across the whole tree.
   const group = document.createElement('details');
   group.className = 'source-group source-group-memory';
   if (status && status.exists === false) group.classList.add('source-group-missing');
-  group.open = !!open;
+  group.open = true;
   group.dataset.dir = dir;
-  if (typeof onToggle === 'function') {
-    group.addEventListener('toggle', () => onToggle(group.open));
-  }
 
   const header = document.createElement('summary');
   header.className = 'source-group-header';
@@ -4309,7 +3812,7 @@ function _renderMemoryDirGroup(dir, items, status, maxChunks, opts) {
 
   const dirLabel = document.createElement('span');
   dirLabel.className = 'source-group-dir';
-  dirLabel.textContent = label || ((typeof shortDir === 'function') ? shortDir(dir) : dir);
+  dirLabel.textContent = (typeof shortDir === 'function') ? shortDir(dir) : dir;
   header.appendChild(dirLabel);
 
   if (isDefault) {
@@ -4412,7 +3915,7 @@ function _renderMemorySourceItem(s, maxChunks) {
   const barPct = Math.round(((s.chunk_count || 0) / maxChunks) * 100);
   const nsBadges = (s.namespaces || [])
     .filter(ns => ns !== 'default')
-    .map(ns => `<span class="badge badge-ns source-ns-badge">${highlightText(ns, _sourcesFilterHighlightQuery())}</span>`)
+    .map(ns => `<span class="badge badge-ns source-ns-badge">${escapeHtml(ns)}</span>`)
     .join('');
   // Three-tier preview: filename row1 (anchor) → title (heading
   // subtitle) → AI summary OR heuristic excerpt (body preview). When an
@@ -4421,19 +3924,18 @@ function _renderMemorySourceItem(s, maxChunks) {
   // the same slot. Title comes from the heading hierarchy regardless,
   // so a row keeps a visible label even when the body slot is empty.
   let summaryHtml = '';
-  const filterQuery = _sourcesFilterHighlightQuery();
   const titlePart = s.title
-    ? `<div class="source-item-title">${highlightText(s.title, filterQuery)}</div>`
+    ? `<div class="source-item-title">${escapeHtml(s.title)}</div>`
     : '';
   let bodyPart = '';
   if (s.ai_summary) {
     bodyPart =
       `<div class="source-item-excerpt" data-ai="true">` +
       `<span class="source-item-ai-badge" aria-hidden="true">✨</span> ` +
-      `${highlightText(s.ai_summary, filterQuery)}` +
+      `${escapeHtml(s.ai_summary)}` +
       `</div>`;
   } else if (s.excerpt) {
-    bodyPart = `<div class="source-item-excerpt">${highlightText(s.excerpt, filterQuery)}</div>`;
+    bodyPart = `<div class="source-item-excerpt">${escapeHtml(s.excerpt)}</div>`;
   }
   if (titlePart || bodyPart) {
     summaryHtml = `<div class="source-item-summary">${titlePart}${bodyPart}</div>`;
@@ -4441,7 +3943,7 @@ function _renderMemorySourceItem(s, maxChunks) {
   item.innerHTML = `
     <div class="source-item-row1">
       <span class="source-type-dot" style="background:${fileTypeColor(s.path)}"></span>
-      <span class="source-name">${highlightText(filename, filterQuery)}</span>
+      <span class="source-name">${escapeHtml(filename)}</span>
       ${nsBadges}
     </div>
     ${summaryHtml}

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -52,6 +52,35 @@ function _groupNamespaces(namespaces) {
   return { groups, ungrouped };
 }
 
+function _namespaceDropdownGroupName(nsName) {
+  if (nsName === 'default') return 'Default';
+  if (nsName.startsWith('claude-memory:') || nsName.startsWith('claude:')) return 'Claude';
+  if (nsName.startsWith('codex:') || nsName.startsWith('openai:')) return 'OpenAI';
+  if (nsName.startsWith('agent-runtime:')) return 'Agents';
+  if (nsName.includes(':')) return 'Scoped';
+  return 'User';
+}
+
+function _namespaceDropdownBuckets(namespaces) {
+  const sorted = [...namespaces].sort((a, b) => (
+    (a.namespace === 'default' ? -1 : b.namespace === 'default' ? 1 : 0)
+    || b.chunk_count - a.chunk_count
+    || a.namespace.localeCompare(b.namespace)
+  ));
+  const buckets = new Map();
+  sorted.forEach(ns => {
+    const group = _namespaceDropdownGroupName(ns.namespace);
+    if (!buckets.has(group)) buckets.set(group, []);
+    buckets.get(group).push(ns);
+  });
+  const preferred = ['Default', 'User', 'Claude', 'OpenAI', 'Agents', 'Scoped'];
+  const names = [
+    ...preferred.filter(name => buckets.has(name)),
+    ...[...buckets.keys()].filter(name => !preferred.includes(name)).sort(),
+  ];
+  return names.map(name => ({ name, members: buckets.get(name) || [] }));
+}
+
 // ---------------------------------------------------------------------------
 // Namespace filter dropdowns + Namespaces tab
 // ---------------------------------------------------------------------------
@@ -63,30 +92,33 @@ async function loadNamespaceDropdowns() {
   try {
     const data = await api('GET', '/api/namespaces');
     const namespaces = data.namespaces || [];
-    const { groups, ungrouped } = _groupNamespaces(namespaces);
+    const buckets = _namespaceDropdownBuckets(namespaces);
     ['ns-filter', 'tl-namespace', 'exp-namespace'].forEach(id => {
       const sel = document.getElementById(id);
       if (!sel) return;
       const current = sel.value;
       // Keep first option (All Namespaces), remove rest + optgroups
       while (sel.children.length > 1) sel.removeChild(sel.lastChild);
-      groups.forEach(g => {
+      buckets.forEach(bucket => {
+        if (bucket.name === 'Default') {
+          bucket.members.forEach(ns => {
+            const opt = document.createElement('option');
+            opt.value = ns.namespace;
+            opt.textContent = `${ns.namespace} (${ns.chunk_count})`;
+            sel.appendChild(opt);
+          });
+          return;
+        }
         const optgroup = document.createElement('optgroup');
-        optgroup.label = `${g.prefix} (${g.totalChunks} chunks)`;
-        g.members.forEach(ns => {
+        const totalChunks = bucket.members.reduce((s, ns) => s + ns.chunk_count, 0);
+        optgroup.label = `${bucket.name} (${totalChunks})`;
+        bucket.members.forEach(ns => {
           const opt = document.createElement('option');
           opt.value = ns.namespace;
-          const suffix = ns.namespace.slice(g.prefix.length + 1);
-          opt.textContent = `${suffix} (${ns.chunk_count})`;
+          opt.textContent = `${ns.namespace} (${ns.chunk_count})`;
           optgroup.appendChild(opt);
         });
         sel.appendChild(optgroup);
-      });
-      ungrouped.forEach(ns => {
-        const opt = document.createElement('option');
-        opt.value = ns.namespace;
-        opt.textContent = `${ns.namespace} (${ns.chunk_count})`;
-        sel.appendChild(opt);
       });
       if (current) {
         sel.value = current;
@@ -786,4 +818,3 @@ document.addEventListener('keydown', e => {
 // ═══════════════════════════════════════════════════════════════════════════
 
 // Treemap is now rendered inline in loadDashboard() — no monkey-patch needed.
-

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+describe('Search filters - add/remove UX', () => {
+  let window;
+  let document;
+  let searchUrls;
+
+  beforeEach(async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    window = dom.window;
+    document = window.document;
+    searchUrls = [];
+
+    const original = window.fetch;
+    window.fetch = async function fetchSpy(input, init) {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url && url.startsWith('/api/search')) {
+        searchUrls.push(url);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            results: [],
+            retrieval_stats: {
+              bm25_candidates: 0,
+              dense_candidates: 0,
+              fused_total: 0,
+              final_total: 0,
+            },
+          }),
+          text: async () => '{}',
+        };
+      }
+      return original(input, init);
+    };
+  });
+
+  function addSourceOption(path, selected = true) {
+    const opt = document.createElement('option');
+    opt.value = path;
+    opt.textContent = path.split('/').pop();
+    opt.selected = selected;
+    document.getElementById('source-filter').appendChild(opt);
+  }
+
+  async function flush() {
+    for (let i = 0; i < 8; i++) {
+      await new Promise(r => setTimeout(r, 0));
+    }
+  }
+
+  it('keeps active filter chips visible when filters produce zero results', () => {
+    document.getElementById('tag-filter').value = 'redis';
+    document.getElementById('date-range-preset').value = '7d';
+    addSourceOption('/repo/docs/cache.md');
+
+    window.renderResults([]);
+
+    const active = document.getElementById('active-filters');
+    expect(active.hidden).toBe(false);
+    expect(active.textContent).toContain('tag: redis');
+    expect(active.textContent).toContain('source: cache.md');
+    expect(active.textContent).toContain('date: Last 7 days');
+    expect(active.textContent).toContain('Clear all');
+    expect(document.getElementById('filter-count-badge').textContent).toBe('3');
+
+    document.getElementById('clear-search-filters').click();
+    expect(active.hidden).toBe(true);
+    expect(document.getElementById('filter-count-badge').hidden).toBe(true);
+    expect(document.getElementById('tag-filter').value).toBe('');
+    expect(document.getElementById('date-range-preset').value).toBe('');
+    expect([...document.getElementById('source-filter').selectedOptions]).toHaveLength(0);
+    expect(document.getElementById('results-empty').textContent).toContain('Enter a query to search');
+    expect(document.getElementById('results-empty').textContent).not.toContain('No results found');
+  });
+
+  it('runs source-only search from the Search tab', async () => {
+    addSourceOption('/repo/docs/cache.md');
+
+    await window.doSearch();
+    await flush();
+
+    expect(searchUrls).toHaveLength(1);
+    const params = new URL(`http://localhost${searchUrls[0]}`).searchParams;
+    expect(params.get('source_filter')).toBe('/repo/docs/cache.md');
+    expect(params.get('q')).toBeNull();
+    expect(params.get('tag_filter')).toBeNull();
+  });
+
+  it('preserves server-side filters when loading more results', async () => {
+    document.getElementById('search-input').value = 'cache';
+    document.getElementById('context-window').value = '2';
+    const ns = document.createElement('option');
+    ns.value = 'work';
+    ns.textContent = 'work';
+    document.getElementById('ns-filter').appendChild(ns);
+    document.getElementById('ns-filter').value = 'work';
+    addSourceOption('/repo/docs/cache.md');
+
+    document.getElementById('load-more-btn').dispatchEvent(new window.Event('click'));
+    await flush();
+
+    expect(searchUrls).toHaveLength(1);
+    const params = new URL(`http://localhost${searchUrls[0]}`).searchParams;
+    expect(params.get('q')).toBe('cache');
+    expect(params.get('top_k')).toBe('20');
+    expect(params.get('namespace')).toBe('work');
+    expect(params.get('context_window')).toBe('2');
+    expect(params.get('source_filter')).toBe('/repo/docs/cache.md');
+  });
+});
+
+describe('Search namespace filter list', () => {
+  it('keeps full namespace names inside stable human groups', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'settings-namespaces.js'] });
+    const { window } = dom;
+    const { document } = window;
+    const original = window.fetch;
+    window.fetch = async function fetchSpy(input, init) {
+      const url = typeof input === 'string' ? input : input?.url;
+      if (url === '/api/namespaces') {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            namespaces: [
+              { namespace: 'claude-memory:alpha', chunk_count: 3 },
+              { namespace: 'claude-memory:beta', chunk_count: 7 },
+              { namespace: 'codex:planner', chunk_count: 2 },
+              { namespace: 'work', chunk_count: 5 },
+              { namespace: 'default', chunk_count: 11 },
+            ],
+          }),
+          text: async () => '{}',
+        };
+      }
+      return original(input, init);
+    };
+
+    await window.loadNamespaceDropdowns();
+
+    const sel = document.getElementById('ns-filter');
+    expect(sel.children[1].tagName).toBe('OPTION');
+    expect(sel.children[1].textContent).toBe('default (11)');
+    const groups = [...sel.querySelectorAll('optgroup')];
+    expect(groups.map(g => g.label)).toEqual(['User (5)', 'Claude (10)', 'OpenAI (2)']);
+    expect([...groups[1].querySelectorAll('option')].map(o => o.textContent)).toEqual([
+      'claude-memory:beta (7)',
+      'claude-memory:alpha (3)',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep active Search filter chips visible when filters produce zero results.
- Include source/date filters in active chips and the filter-count badge.
- Split server-backed filter clearing from client-only filtering so removing filters does not flash stale intermediate states.
- Allow source-only Search requests and preserve namespace/source/context filters on Load More.
- Keep namespace in the main filter row, but render namespace dropdown options with full names inside stable human groups.

Closes #980.

## Tests

- `npm test -- search-filter-ux.test.mjs`
- `npm test`

## Worktree

Implemented in separate worktree `/private/tmp/memtomem-search-filter-ux` from `origin/main`, independent of #981.