### PR TITLE
Make Home namespace chart identifiable and actionable

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1785,6 +1785,40 @@ function _renderChunkDist(distribution) {
 }
 
 // G. Namespace Summary
+function _formatHomeNsLabel(nsName) {
+  const raw = String(nsName || '');
+  if (raw.length <= 28) return raw;
+
+  const autoMatch = raw.match(/^([a-z]+):-(.+)$/);
+  if (autoMatch) {
+    const provider = autoMatch[1];
+    const parts = autoMatch[2].split('-').filter(Boolean);
+    const tail = parts.slice(-2).join('/');
+    if (tail) return `${provider}: .../${tail}`;
+  }
+
+  return `${raw.slice(0, 12)}...${raw.slice(-14)}`;
+}
+
+function _homeNsActionLabel(nsName, chunkCount) {
+  const count = Number(chunkCount || 0);
+  return `Open Sources filtered to namespace ${nsName}, ${count.toLocaleString()} chunk${count === 1 ? '' : 's'}`;
+}
+
+function _bindHomeNsChartActions(chart) {
+  chart.querySelectorAll('[data-home-ns]').forEach(el => {
+    el.addEventListener('click', () => {
+      navigateToSourcesByNs(el.dataset.homeNs);
+    });
+  });
+  chart.querySelectorAll('[data-home-ns-more]').forEach(el => {
+    el.addEventListener('click', () => {
+      activateTab('settings');
+      switchSettingsSection('namespaces');
+    });
+  });
+}
+
 function _renderNsChart(namespaces) {
   const chart = qs('home-ns-chart');
   if (!namespaces.length) {
@@ -1792,25 +1826,37 @@ function _renderNsChart(namespaces) {
     return;
   }
 
-  const sorted = [...namespaces].sort((a, b) => b.chunk_count - a.chunk_count).slice(0, 6);
+  const allSorted = [...namespaces].sort((a, b) => b.chunk_count - a.chunk_count);
+  const sorted = allSorted.slice(0, 6);
+  const hiddenCount = Math.max(0, allSorted.length - sorted.length);
   const max = sorted[0]?.chunk_count || 1;
   const palette = ['var(--accent)', 'var(--green)', '#e0a800', '#a29bfe', '#e17055', '#00cec9'];
 
   chart.innerHTML = sorted.map((ns, i) => {
     const pct = Math.round((ns.chunk_count / max) * 100);
     const color = ns.color || palette[i % palette.length];
-    // ``.home-bar-label`` is CSS-clipped at 120px with text-overflow:ellipsis,
-    // which hides the tail of long auto-namespaces like
-    // ``claude:-Users-...-projectname``. The row-level ``title`` makes the
-    // full string visible on hover so users can identify which namespace is
-    // selected.
-    const fullNs = escapeHtml(ns.namespace);
-    return `<div class="home-bar-row" title="${fullNs}">
-      <span class="home-bar-label">${fullNs}</span>
-      <div class="home-bar-track"><div class="home-bar-fill" style="width:${pct}%;background:${color}"></div></div>
-      <span class="home-bar-count">${ns.chunk_count.toLocaleString()}</span>
+    const nsName = String(ns.namespace || '');
+    const fullNs = escapeHtml(nsName);
+    const shortNs = escapeHtml(_formatHomeNsLabel(nsName));
+    const nsAttr = escapeAttr(nsName);
+    const actionLabel = escapeAttr(_homeNsActionLabel(nsName, ns.chunk_count));
+    return `<div class="home-bar-row home-ns-row">
+      <button class="home-ns-open" type="button" data-home-ns="${nsAttr}" aria-label="${actionLabel}">
+        <span class="home-bar-label" title="${escapeAttr(nsName)}">${shortNs}</span>
+        <span class="home-bar-track" aria-hidden="true"><span class="home-bar-fill" style="width:${pct}%;background:${color}"></span></span>
+        <span class="home-bar-count">${ns.chunk_count.toLocaleString()}</span>
+        <span class="home-ns-action">Sources</span>
+      </button>
+      <details class="home-ns-detail">
+        <summary aria-label="Show full namespace ${escapeAttr(nsName)}">Full</summary>
+        <span>${fullNs}</span>
+      </details>
     </div>`;
-  }).join('');
+  }).join('') + (hiddenCount
+    ? `<button class="home-ns-more" type="button" data-home-ns-more="true">+ ${hiddenCount.toLocaleString()} more in Namespaces</button>`
+    : '');
+
+  _bindHomeNsChartActions(chart);
 }
 
 // E. Recent Sources — color dot + 2-row layout
@@ -5671,7 +5717,7 @@ function escapeHtml(str) {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
 }
-function escapeAttr(str) { return String(str).replace(/"/g, '&quot;'); }
+function escapeAttr(str) { return escapeHtml(str).replace(/"/g, '&quot;'); }
 
 // ---------------------------------------------------------------------------
 // Search History (A)

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -517,7 +517,9 @@ _renderNsChart = function(namespaces) {
     return;
   }
 
-  const sorted = [...namespaces].sort((a, b) => b.chunk_count - a.chunk_count).slice(0, 8);
+  const allSorted = [...namespaces].sort((a, b) => b.chunk_count - a.chunk_count);
+  const sorted = allSorted.slice(0, 6);
+  const hiddenCount = Math.max(0, allSorted.length - sorted.length);
   const total = sorted.reduce((s, ns) => s + ns.chunk_count, 0);
   const palette = ['#6c8fff', '#4caf7d', '#e0a800', '#a29bfe', '#e17055', '#00cec9', '#fd79a8', '#636e72'];
 
@@ -543,6 +545,9 @@ _renderNsChart = function(namespaces) {
     .attr('fill', (d, i) => d.data.color || palette[i % palette.length])
     .attr('stroke', 'var(--surface)')
     .attr('stroke-width', 2)
+    .attr('tabindex', 0)
+    .attr('role', 'button')
+    .attr('aria-label', d => _homeNsActionLabel(d.data.namespace, d.data.chunk_count))
     .style('cursor', 'pointer')
     .on('mouseover', function(event, d) {
       d3.select(this).attr('opacity', 0.8);
@@ -554,6 +559,12 @@ _renderNsChart = function(namespaces) {
     })
     .on('click', (event, d) => {
       navigateToSourcesByNs(d.data.namespace);
+    })
+    .on('keydown', (event, d) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        navigateToSourcesByNs(d.data.namespace);
+      }
     });
 
   const centerText = g.append('text')
@@ -565,9 +576,26 @@ _renderNsChart = function(namespaces) {
   legend.className = 'ns-legend-row';
   legend.innerHTML = sorted.map((ns, i) => {
     const c = ns.color || palette[i % palette.length];
-    return `<span class="ns-legend-item"><span class="ns-legend-dot" style="background:${c}"></span>${escapeHtml(truncate(ns.namespace, 18))} ${ns.chunk_count}</span>`;
-  }).join('');
+    const nsName = String(ns.namespace || '');
+    const nsAttr = escapeAttr(nsName);
+    const label = escapeHtml(_formatHomeNsLabel(nsName));
+    const actionLabel = escapeAttr(_homeNsActionLabel(nsName, ns.chunk_count));
+    return `<div class="ns-legend-item">
+      <button class="ns-legend-action" type="button" data-home-ns="${nsAttr}" aria-label="${actionLabel}">
+        <span class="ns-legend-dot" style="background:${c}"></span>
+        <span class="ns-legend-label" title="${nsAttr}">${label}</span>
+        <span class="ns-legend-count">${ns.chunk_count.toLocaleString()}</span>
+      </button>
+      <details class="home-ns-detail ns-legend-detail">
+        <summary aria-label="Show full namespace ${nsAttr}">Full</summary>
+        <span>${escapeHtml(nsName)}</span>
+      </details>
+    </div>`;
+  }).join('') + (hiddenCount
+    ? `<button class="home-ns-more" type="button" data-home-ns-more="true">+ ${hiddenCount.toLocaleString()} more in Namespaces</button>`
+    : '');
   chart.appendChild(legend);
+  _bindHomeNsChartActions(chart);
 };
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2543,6 +2543,23 @@ select:focus-visible {
 .home-chart-card { min-width: 0; }
 .home-bar-chart { display: flex; flex-direction: column; gap: 6px; }
 .home-bar-row { display: flex; align-items: center; gap: 8px; font-size: 0.75rem; }
+.home-ns-row { align-items: flex-start; gap: 6px; }
+.home-ns-open {
+  appearance: none; border: 0; background: transparent; color: inherit;
+  display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0;
+  padding: 2px; margin: -2px; border-radius: 4px; cursor: pointer;
+  font: inherit; text-align: left;
+}
+.home-ns-open:hover .home-bar-label,
+.home-ns-open:focus-visible .home-bar-label,
+.ns-legend-action:hover .ns-legend-label,
+.ns-legend-action:focus-visible .ns-legend-label { color: var(--accent); }
+.home-ns-open:focus-visible,
+.ns-legend-action:focus-visible,
+.home-ns-more:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .home-bar-label {
   font-family: var(--mono); color: var(--text);
   width: min(120px, 36vw); max-width: 120px;
@@ -2553,6 +2570,29 @@ select:focus-visible {
 .home-bar-count {
   font-family: var(--mono); color: var(--muted); font-size: 0.68rem;
   min-width: 40px; max-width: 60px; text-align: right; flex-shrink: 0; white-space: nowrap;
+}
+.home-ns-action {
+  color: var(--accent); font-size: 0.66rem; font-weight: 600; flex-shrink: 0;
+}
+.home-ns-detail {
+  color: var(--muted); font-size: 0.66rem; line-height: 1.35; min-width: 34px;
+}
+.home-ns-detail summary {
+  cursor: pointer; list-style: none; color: var(--muted); white-space: nowrap;
+}
+.home-ns-detail summary::-webkit-details-marker { display: none; }
+.home-ns-detail[open] {
+  flex-basis: 100%;
+  margin-left: 2px;
+  overflow-wrap: anywhere;
+}
+.home-ns-detail[open] summary {
+  margin-bottom: 2px;
+  color: var(--accent);
+}
+.home-ns-more {
+  appearance: none; border: 0; background: transparent; color: var(--accent);
+  align-self: flex-start; padding: 2px 0; font-size: 0.72rem; cursor: pointer;
 }
 .muted-sm { color: var(--muted); font-size: 0.72rem; }
 
@@ -3220,8 +3260,20 @@ select:focus-visible {
   display: flex; flex-wrap: wrap; gap: 6px 12px; padding: 6px 0 0;
   font-size: 0.72rem; color: var(--muted); font-family: var(--mono);
 }
-.ns-legend-item { display: flex; align-items: center; gap: 4px; }
+.ns-legend-item { display: flex; align-items: center; gap: 4px; min-width: 0; }
+.ns-legend-action {
+  appearance: none; border: 0; background: transparent; color: inherit;
+  display: flex; align-items: center; gap: 4px; max-width: 100%;
+  padding: 2px; margin: -2px; border-radius: 4px; cursor: pointer;
+  font: inherit;
+}
 .ns-legend-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+.ns-legend-label {
+  color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  max-width: 150px;
+}
+.ns-legend-count { color: var(--muted); flex-shrink: 0; }
+.ns-legend-detail { flex-shrink: 0; }
 
 
 /* ═══════════════════════════════════════════════════════════════

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -151,3 +151,35 @@ describe('Search namespace filter list', () => {
     ]);
   });
 });
+
+describe('Home namespace summary chart', () => {
+  it('makes long namespaces identifiable and actionable', async () => {
+    const dom = await bootApp({ scripts: ['i18n.js', 'app.js'] });
+    const { window } = dom;
+    const { document } = window;
+
+    const longNs = 'claude:-Users-pdstudio-Work-agent-harness-memtomem';
+    window._renderNsChart([
+      { namespace: longNs, chunk_count: 42 },
+      { namespace: 'work', chunk_count: 12 },
+      { namespace: 'default', chunk_count: 8 },
+      { namespace: 'codex:-Users-pdstudio-Work-other-project', chunk_count: 7 },
+      { namespace: 'notes', chunk_count: 6 },
+      { namespace: 'archive', chunk_count: 5 },
+      { namespace: 'hidden', chunk_count: 4 },
+    ]);
+
+    const chart = document.getElementById('home-ns-chart');
+    const firstAction = chart.querySelector('[data-home-ns]');
+    expect(firstAction.textContent).toContain('claude: .../harness/memtomem');
+    expect(firstAction.getAttribute('aria-label')).toContain(longNs);
+    expect(firstAction.getAttribute('aria-label')).toContain('42 chunks');
+    expect(chart.querySelector('.home-ns-detail span').textContent).toBe(longNs);
+    expect(chart.querySelector('.home-ns-more').textContent).toContain('+ 1 more');
+
+    firstAction.click();
+
+    expect(window.STATE.sourcesNsFilter).toBe(longNs);
+    expect(document.querySelector('.tab-btn[data-tab="sources"]').classList.contains('active')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add readable short labels, accessible full-name disclosure, and Sources actions to Home namespace chart rows.
- Show a `+ N more` Namespaces link when the chart hides namespaces beyond the top six.
- Apply the same action and accessibility behavior to the D3 namespace donut override.
- Cover the fallback Home chart path with a JS unit test.

Closes #988.

## Tests

- `git diff --check`
- `npx vitest run search-filter-ux.test.mjs -t "Home namespace summary chart"`

Note: `npm test -- search-filter-ux.test.mjs` still has an existing failure in `Search filters - add/remove UX`: it expects “Enter a query to search” after clearing filters, while current main behavior renders “No results found”.