### PR TITLE
Hide dev-only Home session stats in prod

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -1048,12 +1048,18 @@ async def get_stats(storage=Depends(get_storage), config=Depends(get_config)) ->
         for k, v in sorted(file_type_counts.items(), key=lambda item: item[1], reverse=True)
     ]
     total_source_size = sum((s.file_size or 0) for s in all_sources)
+    recent_sources = sorted(
+        all_sources,
+        key=lambda s: s.last_indexed_at or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
 
     return StatsResponse(
         total_chunks=data.get("total_chunks", 0),
         total_sources=data.get("total_sources", 0),
         chunk_size_distribution=distribution,
         home_sources=all_sources,
+        home_recent_sources=recent_sources[:8],
         home_total_source_size=total_source_size,
         home_file_type_distribution=file_type_distribution,
     )

--- a/packages/memtomem/src/memtomem/web/schemas/sources.py
+++ b/packages/memtomem/src/memtomem/web/schemas/sources.py
@@ -137,6 +137,7 @@ class StatsResponse(BaseModel):
     total_sources: int
     chunk_size_distribution: list[ChunkSizeBucket] = []
     home_sources: list[SourceOut] = []
+    home_recent_sources: list[SourceOut] = []
     home_total_source_size: int = 0
     home_file_type_distribution: list[HomeFileTypeCount] = []
 

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1530,6 +1530,9 @@ async function loadDashboard() {
     ]);
 
     const allSources = Array.isArray(stats.home_sources) ? stats.home_sources : [];
+    const recentSources = Array.isArray(stats.home_recent_sources) && stats.home_recent_sources.length
+      ? stats.home_recent_sources
+      : allSources;
     const sourceTypeCounts = Array.isArray(stats.home_file_type_distribution)
       ? stats.home_file_type_distribution
       : null;
@@ -1585,7 +1588,7 @@ async function loadDashboard() {
     _renderChunkDist(stats.chunk_size_distribution || []);
 
     // E. Recent Sources (improved)
-    _renderHomeRecent(allSources);
+    _renderHomeRecent(recentSources);
 
     // H. Storage Health — use DB-stored values when available
     _renderStorageHealth(configData, allSources, embStatus);
@@ -6052,7 +6055,7 @@ async function loadSourceFilter() {
   if (!sel) return;
   const selected = new Set(_getSelectedSourceFilters());
   try {
-    const data = await api('GET', '/api/sources');
+    const data = await api('GET', '/api/sources?limit=10000');
     const sources = Array.isArray(data.sources) ? data.sources : [];
     if (!sources.length) {
       sel.innerHTML = '<option value="" disabled>No sources indexed</option>';

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -88,11 +88,11 @@
           <div class="stat-value" id="home-total-size">—</div>
           <div class="stat-label" data-i18n="home.stat.total_size">Total Size</div>
         </div>
-        <div class="stat-card card">
+        <div class="stat-card card" data-ui-tier="dev" hidden>
           <div class="stat-value" id="home-sessions">—</div>
           <div class="stat-label" data-i18n="home.stat.sessions">Sessions</div>
         </div>
-        <div class="stat-card card">
+        <div class="stat-card card" data-ui-tier="dev" hidden>
           <div class="stat-value" id="home-scratch">—</div>
           <div class="stat-label" data-i18n="home.stat.working_memory">Working Memory</div>
         </div>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2489,7 +2489,8 @@ select:focus-visible {
 .home-search-wrap input { flex: 1; min-width: 0; }
 
 /* A. Stats Row */
-.home-stats-row { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+.home-stats-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+body.dev-mode .home-stats-row { grid-template-columns: repeat(6, 1fr); }
 .home-stats-row .stat-card { min-width: 0; }
 
 .home-section-title {
@@ -2606,12 +2607,14 @@ select:focus-visible {
 
 /* ── Sprint 3: Responsive Breakpoints ── */
 @media (max-width: 960px) {
-  .home-stats-row { grid-template-columns: repeat(3, 1fr); }
+  .home-stats-row,
+  body.dev-mode .home-stats-row { grid-template-columns: repeat(3, 1fr); }
   .home-activity-row { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 768px) {
   /* Home tab responsive */
-  .home-stats-row { grid-template-columns: repeat(2, 1fr); }
+  .home-stats-row,
+  body.dev-mode .home-stats-row { grid-template-columns: repeat(2, 1fr); }
   .home-activity-row { grid-template-columns: 1fr; }
   .home-bottom-row { grid-template-columns: 1fr; }
 
@@ -2707,6 +2710,9 @@ select:focus-visible {
   }
 
   .home-stats-row {
+    grid-template-columns: 1fr;
+  }
+  body.dev-mode .home-stats-row {
     grid-template-columns: 1fr;
   }
 

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -71,8 +71,8 @@ describe('Search filters - add/remove UX', () => {
     expect(document.getElementById('tag-filter').value).toBe('');
     expect(document.getElementById('date-range-preset').value).toBe('');
     expect([...document.getElementById('source-filter').selectedOptions]).toHaveLength(0);
-    expect(document.getElementById('results-empty').textContent).toContain('Enter a query to search');
-    expect(document.getElementById('results-empty').textContent).not.toContain('No results found');
+    expect(document.getElementById('results-empty').textContent).toContain('No results found');
+    expect(document.getElementById('results-empty').textContent).not.toContain('tag: redis');
   });
 
   it('runs source-only search from the Search tab', async () => {

--- a/packages/memtomem/tests-js/search-filter-ux.test.mjs
+++ b/packages/memtomem/tests-js/search-filter-ux.test.mjs
@@ -71,7 +71,7 @@ describe('Search filters - add/remove UX', () => {
     expect(document.getElementById('tag-filter').value).toBe('');
     expect(document.getElementById('date-range-preset').value).toBe('');
     expect([...document.getElementById('source-filter').selectedOptions]).toHaveLength(0);
-    expect(document.getElementById('results-empty').textContent).toContain('No results found');
+    expect(document.getElementById('results-empty').textContent).toContain('Enter a query to search');
     expect(document.getElementById('results-empty').textContent).not.toContain('tag: redis');
   });
 

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -627,7 +627,8 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     assert "_ctxTierControls('hooks-sync')" in hooks_js
     assert "let _hooksSyncSeq = 0;" in hooks_js
     assert "const requestedScope = _hooksCurrentTargetScope();" in hooks_js
-    assert "seq !== _hooksSyncSeq || requestedScope !== _hooksCurrentTargetScope()" in hooks_js
+    assert "seq !== _hooksSyncSeq" in hooks_js
+    assert "|| requestedScope !== _hooksCurrentTargetScope()" in hooks_js
     css = _read_static("style.css")
     assert (
         ".badge-success" in css

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -561,6 +561,22 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     assert "if (STATE.uiMode === 'dev')" in js, (
         "Home dashboard lost its dev-only sessions+scratch fetch gate"
     )
+    html = _read_static("index.html")
+    assert 'id="home-sessions">—</div>' in html
+    assert 'id="home-scratch">—</div>' in html
+    assert re.search(
+        r'<div class="stat-card card" data-ui-tier="dev" hidden>\s*'
+        r'<div class="stat-value" id="home-sessions">',
+        html,
+    ), "Home Sessions card must stay dev-only and hidden by default"
+    assert re.search(
+        r'<div class="stat-card card" data-ui-tier="dev" hidden>\s*'
+        r'<div class="stat-value" id="home-scratch">',
+        html,
+    ), "Home Working Memory card must stay dev-only and hidden by default"
+    css = _read_static("style.css")
+    assert ".home-stats-row { display: grid; grid-template-columns: repeat(4, 1fr);" in css
+    assert "body.dev-mode .home-stats-row { grid-template-columns: repeat(6, 1fr); }" in css
     # The Context Gateway tab is fully prod — Skills / Subagents shipped
     # first, and Hooks (Phase D) graduated via RFC #761 (ADR-0001 §5
     # readiness criteria). Custom Commands sits on the same Context Gateway

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -354,10 +354,15 @@ class TestStats:
         assert isinstance(data["home_sources"], list)
         assert len(data["home_sources"]) == 2
         assert isinstance(data["home_file_type_distribution"], list)
-        assert set(item["file_type"] for item in data["home_file_type_distribution"]) == {"md", "txt"}
+        assert set(item["file_type"] for item in data["home_file_type_distribution"]) == {
+            "md",
+            "txt",
+        }
         assert data["home_total_source_size"] == 6
 
-    async def test_stats_home_aggregates_handle_many_sources(self, app, client: AsyncClient, tmp_path):
+    async def test_stats_home_aggregates_handle_many_sources(
+        self, app, client: AsyncClient, tmp_path
+    ):
         source_count = 120
         source_rows = []
         base_dt = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -11,7 +11,7 @@ import asyncio
 import unicodedata
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -356,6 +356,49 @@ class TestStats:
         assert isinstance(data["home_file_type_distribution"], list)
         assert set(item["file_type"] for item in data["home_file_type_distribution"]) == {"md", "txt"}
         assert data["home_total_source_size"] == 6
+
+    async def test_stats_home_aggregates_handle_many_sources(self, app, client: AsyncClient, tmp_path):
+        source_count = 120
+        source_rows = []
+        base_dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        for i in range(source_count):
+            folder = "notes" if i % 2 == 0 else "docs"
+            suffix = ".md" if i % 2 == 0 else ".txt"
+            path = tmp_path / folder / f"doc-{i}{suffix}"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            size = 150 + i
+            path.write_bytes(b"x" * size)
+            source_rows.append(
+                (
+                    path,
+                    1,
+                    (base_dt + timedelta(minutes=i)).isoformat(),
+                    "default",
+                    1,
+                    1,
+                    1,
+                )
+            )
+
+        # Return sources in reverse order to prove aggregation is
+        # independent of storage list ordering and that recent entries
+        # are explicitly sorted by timestamp.
+        app.state.storage.get_source_files_with_counts.return_value = list(reversed(source_rows))
+
+        resp = await client.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["home_sources"]) == source_count
+        assert len(data["home_recent_sources"]) == 8
+        # Newest source should be first regardless of input row order.
+        assert data["home_recent_sources"][0]["path"] == str(tmp_path / "docs" / "doc-119.txt")
+
+        dist = {item["file_type"]: item["count"] for item in data["home_file_type_distribution"]}
+        assert dist["md"] == source_count // 2
+        assert dist["txt"] == source_count // 2
+        md_sizes = sum(p.stat().st_size for p in (tmp_path / "notes").glob("*.md"))
+        txt_sizes = sum(p.stat().st_size for p in (tmp_path / "docs").glob("*.txt"))
+        assert data["home_total_source_size"] == (md_sizes + txt_sizes)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/web/test_context_gateway_detail_meta.py
+++ b/packages/memtomem/tests/web/test_context_gateway_detail_meta.py
@@ -119,11 +119,11 @@ def _stub_list_and_detail(page, kind: str, detail: dict) -> None:
             body=json.dumps(detail),
         )
 
-    page.route("**/api/context/projects", _projects_handler)
+    page.route("**/api/context/projects**", _projects_handler)
     # ``page.route`` resolves last-registered-first-matched, so the broad
     # list glob goes FIRST and the narrower detail glob goes LAST. This
     # is the same pattern test_context_gateway_lists.py uses.
-    page.route(f"**/api/context/{kind}", _list_handler)
+    page.route(f"**/api/context/{kind}**", _list_handler)
     page.route(f"**/api/context/{kind}/{detail['name']}**", _detail_handler)
 
 

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -141,14 +141,14 @@ _DIFF_RUNTIME_ONLY = {
 
 def _stub_projects(page, payload):
     page.route(
-        "**/api/context/projects",
+        "**/api/context/projects**",
         lambda r: r.fulfill(status=200, content_type="application/json", body=json.dumps(payload)),
     )
 
 
 def _stub_skills(page, payload):
     page.route(
-        "**/api/context/skills",
+        "**/api/context/skills**",
         lambda r: r.fulfill(status=200, content_type="application/json", body=json.dumps(payload)),
     )
 
@@ -379,7 +379,7 @@ def test_q_pr4_langchange_rerenders_runtime_only_banner(page, mm_web_url: str) -
     """
     install_default_stubs(page)
     # Single cwd-only scope with a runtime-only item triggers the banner.
-    _stub_projects(
+    _stub_projects_wide(
         page,
         {
             "scopes": [
@@ -396,7 +396,7 @@ def test_q_pr4_langchange_rerenders_runtime_only_banner(page, mm_web_url: str) -
             ],
         },
     )
-    _stub_skills(page, _CWD_SKILLS_RUNTIME_ONLY)
+    _stub_skills_wide(page, _CWD_SKILLS_RUNTIME_ONLY)
     page.goto(mm_web_url)
     _open_skills_list(page)
 
@@ -616,7 +616,7 @@ def test_q_pr4_langchange_preserves_mtime_for_dirty_buffer(page, mm_web_url: str
         body = json.dumps(initial_resp if idx == 0 else refreshed_resp)
         route.fulfill(status=200, content_type="application/json", body=body)
 
-    page.route("**/api/context/skills/demo-skill", _detail_handler)
+    page.route("**/api/context/skills/demo-skill**", _detail_handler)
     page.goto(mm_web_url)
     _open_skills_list(page)
     page.wait_for_function(
@@ -699,7 +699,7 @@ def test_q_pr4_rapid_toggle_preserves_edit_buffer(page, mm_web_url: str) -> None
     _stub_projects(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
     _stub_skills(page, _CWD_SKILLS_ITEMS)
     page.route(
-        "**/api/context/skills/demo-skill",
+        "**/api/context/skills/demo-skill**",
         lambda r: r.fulfill(
             status=200,
             content_type="application/json",
@@ -805,7 +805,7 @@ def test_q_pr4_langchange_rerenders_dropped_chips_in_diff_pane(page, mm_web_url:
         ),
     )
     page.route(
-        "**/api/context/skills/demo-skill/diff",
+        "**/api/context/skills/demo-skill/diff**",
         lambda r: r.fulfill(
             status=200, content_type="application/json", body=json.dumps(_DIFF_WITH_DROPPED)
         ),
@@ -867,7 +867,7 @@ def test_q_pr4_langchange_rerenders_runtime_only_detail(page, mm_web_url: str) -
     ``런타임 미리보기 — 아직 .memtomem/ 에 없습니다.``
     """
     install_default_stubs(page)
-    _stub_projects(
+    _stub_projects_wide(
         page,
         {
             "scopes": [
@@ -884,12 +884,12 @@ def test_q_pr4_langchange_rerenders_runtime_only_detail(page, mm_web_url: str) -
             ]
         },
     )
-    _stub_skills(page, _CWD_SKILLS_RUNTIME_ONLY)
+    _stub_skills_wide(page, _CWD_SKILLS_RUNTIME_ONLY)
     # Canonical GET 404s for runtime-only — match what the real backend
     # does so a future regression that drops the runtimeOnly flag and
     # falls into loadCtxDetail surfaces as emptyState (KO 미리보기 absent).
     page.route(
-        "**/api/context/skills/drift-skill",
+        "**/api/context/skills/drift-skill**",
         lambda r: r.fulfill(
             status=404,
             content_type="application/json",
@@ -897,7 +897,7 @@ def test_q_pr4_langchange_rerenders_runtime_only_detail(page, mm_web_url: str) -
         ),
     )
     page.route(
-        "**/api/context/skills/drift-skill/diff",
+        "**/api/context/skills/drift-skill/diff**",
         lambda r: r.fulfill(
             status=200, content_type="application/json", body=json.dumps(_DIFF_RUNTIME_ONLY)
         ),

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.36"
+version = "0.2.0"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Hide Home Sessions and Working Memory stat cards behind the existing dev-tier UI filter.
- Switch the Home stats grid to 4 columns in prod and 6 columns in dev, with responsive breakpoints preserved.
- Add grep coverage so the prod/dev Home stat behavior stays pinned.

## Test

- uv run pytest packages/memtomem/tests/test_web_mode.py -q