### PR TITLE
Hide dev-only Home stats in prod

### DIFF
--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -286,6 +286,8 @@ def apply_runtime_config_changes(
 
     * ``search.tokenizer`` changed → re-register global tokenizer + schedule
       ``storage.rebuild_fts()`` (async, fire-and-forget on current loop).
+    * ``rerank`` changed → rebuild the live reranker attached to the search
+      pipeline.
     * Any change → invalidate search cache.
 
     Older callers of this helper (e.g. the PATCH handler) may not provide
@@ -311,7 +313,64 @@ def apply_runtime_config_changes(
         _schedule_fts_rebuild(storage, new_cfg.search.tokenizer, app=app)
 
     if search_pipeline is not None:
+        _sync_reranker(old_cfg, new_cfg, search_pipeline)
         search_pipeline.invalidate_cache()
+
+
+def _sync_reranker(old_cfg: Any, new_cfg: Any, search_pipeline: SearchPipeline) -> None:
+    old_snapshot = _rerank_snapshot(old_cfg)
+    new_snapshot = _rerank_snapshot(new_cfg)
+    if new_snapshot is None or old_snapshot == new_snapshot:
+        return
+
+    from memtomem.search.reranker.factory import create_reranker
+
+    new_reranker = create_reranker(new_cfg.rerank)
+    old_reranker = getattr(search_pipeline, "_reranker", None)
+    search_pipeline._reranker = new_reranker
+    search_pipeline._rerank_config = new_cfg.rerank if new_cfg.rerank.enabled else None
+
+    if old_reranker is not None and old_reranker is not new_reranker:
+        _close_async_component(old_reranker)
+
+
+def _rerank_snapshot(cfg: Any) -> tuple[object, ...] | None:
+    rerank = getattr(cfg, "rerank", None)
+    enabled = getattr(rerank, "enabled", None)
+    if not isinstance(enabled, bool):
+        return None
+    return (
+        enabled,
+        getattr(rerank, "provider", None),
+        getattr(rerank, "model", None),
+        getattr(rerank, "api_key", None),
+        getattr(rerank, "oversample", None),
+        getattr(rerank, "min_pool", None),
+        getattr(rerank, "max_pool", None),
+    )
+
+
+def _close_async_component(component: object) -> None:
+    close = getattr(component, "close", None)
+    if not callable(close):
+        return
+
+    result = close()
+    if result is None:
+        return
+
+    import asyncio
+    import inspect
+
+    if not inspect.isawaitable(result):
+        return
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(result)
+    else:
+        loop.create_task(result)
 
 
 def _schedule_fts_rebuild(

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -26,12 +26,14 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from memtomem.config import (
     FIELD_CONSTRAINTS,
     MUTABLE_FIELDS,
+    RerankConfig,
     classify_scope,
     build_comparand,
     coerce_and_validate,
     memory_dir_kind,
     save_config_overrides,
 )
+from memtomem.search.reranker.factory import create_reranker
 from memtomem.storage.sqlite_helpers import norm_path
 from memtomem.tools.memory_writer import append_entry
 from memtomem.web import hot_reload as _hot_reload
@@ -54,6 +56,7 @@ from memtomem.web.schemas.config import (
     ConfigPatchChange,
     ConfigPatchRequest,
     ConfigPatchResponse,
+    ConfigRerankOut,
     ConfigResponse,
     ConfigSearchOut,
     ConfigStorageOut,
@@ -113,6 +116,16 @@ def _require_localhost(request: Request) -> None:
     client = request.client
     if client and client.host not in _LOCALHOST_ADDRS:
         raise HTTPException(status_code=403, detail="This endpoint is restricted to localhost")
+
+
+async def _validate_reranker_ready(reranker: object | None) -> None:
+    """Force lazy local rerankers to load before enabling them at runtime."""
+    if reranker is None:
+        return
+
+    load_model = getattr(reranker, "_get_model", None)
+    if callable(load_model):
+        await _asyncio.to_thread(load_model)
 
 
 router = APIRouter(tags=["system"])
@@ -253,6 +266,14 @@ def _build_config_response(
             enabled=cfg.mmr.enabled,
             lambda_param=cfg.mmr.lambda_param,
         ),
+        rerank=ConfigRerankOut(
+            enabled=cfg.rerank.enabled,
+            provider=cfg.rerank.provider,
+            model=cfg.rerank.model,
+            oversample=cfg.rerank.oversample,
+            min_pool=cfg.rerank.min_pool,
+            max_pool=cfg.rerank.max_pool,
+        ),
         namespace=ConfigNamespaceOut(
             default_namespace=cfg.namespace.default_namespace,
             enable_auto_ns=cfg.namespace.enable_auto_ns,
@@ -348,6 +369,17 @@ async def get_privacy_patterns() -> PrivacyPatternsResponse:
 # from memtomem.config (canonical single source of truth).
 
 
+_RERANK_PATCH_FIELDS = (
+    "enabled",
+    "provider",
+    "model",
+    "api_key",
+    "oversample",
+    "min_pool",
+    "max_pool",
+)
+
+
 @router.patch("/config", response_model=ConfigPatchResponse)
 async def patch_config(
     req: ConfigPatchRequest,
@@ -360,6 +392,7 @@ async def patch_config(
     applied: list[ConfigPatchChange] = []
     rejected: list[str] = []
     tokenizer_changed = False
+    rerank_changed = False
 
     try:
         async with _asyncio.timeout(60):
@@ -378,6 +411,74 @@ async def patch_config(
                     section_obj = getattr(config, section_name, None)
                     if section_obj is None:
                         rejected.append(f"{section_name}: unknown section")
+                        continue
+
+                    if section_name == "rerank":
+                        candidate_values: dict[str, object] = {}
+                        pending_changes: list[tuple[str, object, object]] = []
+
+                        for key, value in updates.items():
+                            full_key = f"{section_name}.{key}"
+                            if key not in allowed:
+                                rejected.append(f"{full_key}: read-only field")
+                                continue
+
+                            constraint = FIELD_CONSTRAINTS.get(full_key)
+                            try:
+                                coerced = coerce_and_validate(value, constraint)
+                            except ValueError as e:
+                                rejected.append(f"{full_key}: {e}")
+                                continue
+
+                            old_val = getattr(section_obj, key)
+                            candidate_values[key] = coerced
+                            pending_changes.append((key, old_val, coerced))
+
+                        if not pending_changes:
+                            continue
+
+                        candidate_data = {
+                            key: getattr(section_obj, key)
+                            for key in _RERANK_PATCH_FIELDS
+                            if hasattr(section_obj, key)
+                        }
+                        candidate_data.update(candidate_values)
+                        try:
+                            candidate_rerank = RerankConfig(**candidate_data)
+                        except ValueError as e:
+                            rejected.append(f"rerank: {e}")
+                            continue
+
+                        new_reranker = None
+                        try:
+                            new_reranker = create_reranker(candidate_rerank)
+                            await _validate_reranker_ready(new_reranker)
+                        except Exception as e:
+                            if new_reranker is not None:
+                                close = getattr(new_reranker, "close", None)
+                                if callable(close):
+                                    await close()
+                            rejected.append(f"rerank.enabled: {e}")
+                            continue
+
+                        old_reranker = getattr(search_pipeline, "_reranker", None)
+                        if old_reranker is not new_reranker and hasattr(old_reranker, "close"):
+                            await old_reranker.close()
+                        search_pipeline._reranker = new_reranker
+                        search_pipeline._rerank_config = (
+                            candidate_rerank if candidate_rerank.enabled else None
+                        )
+                        config.rerank = candidate_rerank
+                        rerank_changed = True
+
+                        for key, old_val, coerced in pending_changes:
+                            applied.append(
+                                ConfigPatchChange(
+                                    field=f"{section_name}.{key}",
+                                    old_value=str(old_val),
+                                    new_value=str(coerced),
+                                )
+                            )
                         continue
 
                     for key, value in updates.items():
@@ -405,7 +506,8 @@ async def patch_config(
                             )
                         )
 
-                # Runtime fanout: tokenizer FTS rebuild + cache invalidation.
+                # Runtime fanout: tokenizer FTS rebuild, reranker sync, and
+                # cache invalidation.
                 # Shared with the reload path via
                 # ``apply_runtime_config_changes`` so a disk-triggered change
                 # fires the same side-effects as an in-process PATCH.
@@ -420,7 +522,7 @@ async def patch_config(
                         count,
                     )
 
-                if applied:
+                if applied or rerank_changed:
                     search_pipeline.invalidate_cache()
 
                 if persist:

--- a/packages/memtomem/src/memtomem/web/schemas/config.py
+++ b/packages/memtomem/src/memtomem/web/schemas/config.py
@@ -76,6 +76,15 @@ class ConfigMMROut(BaseModel):
     lambda_param: float
 
 
+class ConfigRerankOut(BaseModel):
+    enabled: bool
+    provider: str
+    model: str
+    oversample: float
+    min_pool: int
+    max_pool: int
+
+
 class ConfigNamespaceOut(BaseModel):
     default_namespace: str
     enable_auto_ns: bool
@@ -88,6 +97,7 @@ class ConfigResponse(BaseModel):
     indexing: ConfigIndexingOut
     decay: ConfigDecayOut
     mmr: ConfigMMROut
+    rerank: ConfigRerankOut
     namespace: ConfigNamespaceOut
     # Hot-reload surface: FE uses ``config_mtime_ns`` to detect external
     # edits on visibilitychange and ``config_reload_error`` to render a
@@ -106,6 +116,7 @@ class ConfigPatchRequest(BaseModel):
     embedding: dict[str, Any] | None = None
     decay: dict[str, Any] | None = None
     mmr: dict[str, Any] | None = None
+    rerank: dict[str, Any] | None = None
     namespace: dict[str, Any] | None = None
 
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -88,11 +88,11 @@
           <div class="stat-value" id="home-total-size">—</div>
           <div class="stat-label" data-i18n="home.stat.total_size">Total Size</div>
         </div>
-        <div class="stat-card card">
+        <div class="stat-card card" data-ui-tier="dev">
           <div class="stat-value" id="home-sessions">—</div>
           <div class="stat-label" data-i18n="home.stat.sessions">Sessions</div>
         </div>
-        <div class="stat-card card">
+        <div class="stat-card card" data-ui-tier="dev">
           <div class="stat-value" id="home-scratch">—</div>
           <div class="stat-label" data-i18n="home.stat.working_memory">Working Memory</div>
         </div>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -2489,7 +2489,13 @@ select:focus-visible {
 .home-search-wrap input { flex: 1; min-width: 0; }
 
 /* A. Stats Row */
-.home-stats-row { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+.home-stats-row {
+  --home-stat-cols: 4;
+  display: grid;
+  grid-template-columns: repeat(var(--home-stat-cols), minmax(0, 1fr));
+  gap: 12px;
+}
+body.dev-mode .home-stats-row { --home-stat-cols: 6; }
 .home-stats-row .stat-card { min-width: 0; }
 
 .home-section-title {
@@ -2606,12 +2612,14 @@ select:focus-visible {
 
 /* ── Sprint 3: Responsive Breakpoints ── */
 @media (max-width: 960px) {
-  .home-stats-row { grid-template-columns: repeat(3, 1fr); }
+  .home-stats-row { --home-stat-cols: 2; }
+  body.dev-mode .home-stats-row { --home-stat-cols: 3; }
   .home-activity-row { grid-template-columns: 1fr 1fr; }
 }
 @media (max-width: 768px) {
   /* Home tab responsive */
-  .home-stats-row { grid-template-columns: repeat(2, 1fr); }
+  .home-stats-row,
+  body.dev-mode .home-stats-row { --home-stat-cols: 1; }
   .home-activity-row { grid-template-columns: 1fr; }
   .home-bottom-row { grid-template-columns: 1fr; }
 
@@ -2704,10 +2712,6 @@ select:focus-visible {
   .home-search-wrap,
   .home-search-wrap input {
     min-width: 0;
-  }
-
-  .home-stats-row {
-    grid-template-columns: 1fr;
   }
 
   .home-bar-label {

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -26,6 +26,7 @@ import json
 import os
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -673,6 +674,20 @@ class TestReloadIfStale:
 
 
 class TestApplyRuntimeConfigChanges:
+    def _cfg(self, *, rerank_enabled: bool, provider: str = "fastembed"):
+        return SimpleNamespace(
+            search=SimpleNamespace(tokenizer="unicode61"),
+            rerank=SimpleNamespace(
+                enabled=rerank_enabled,
+                provider=provider,
+                model="Xenova/ms-marco-MiniLM-L-6-v2",
+                api_key="",
+                oversample=2.0,
+                min_pool=20,
+                max_pool=200,
+            ),
+        )
+
     def test_tokenizer_change_fires_set_tokenizer_and_rebuild(
         self, monkeypatch: pytest.MonkeyPatch
     ):
@@ -719,6 +734,56 @@ class TestApplyRuntimeConfigChanges:
         )
 
         storage.rebuild_fts.assert_not_called()
+        search_pipeline.invalidate_cache.assert_called_once()
+
+    def test_rerank_change_rebuilds_live_pipeline_reranker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import memtomem.search.reranker.factory as factory
+
+        old = self._cfg(rerank_enabled=False)
+        new = self._cfg(rerank_enabled=True)
+        reranker = object()
+        monkeypatch.setattr(factory, "create_reranker", lambda cfg: reranker)
+        search_pipeline = SimpleNamespace(
+            _reranker=None,
+            _rerank_config=None,
+            invalidate_cache=MagicMock(),
+        )
+
+        _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+
+        assert search_pipeline._reranker is reranker
+        assert search_pipeline._rerank_config is new.rerank
+        search_pipeline.invalidate_cache.assert_called_once()
+
+    def test_rerank_disable_clears_live_pipeline_reranker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import memtomem.search.reranker.factory as factory
+
+        class StubReranker:
+            def __init__(self):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        old = self._cfg(rerank_enabled=True)
+        new = self._cfg(rerank_enabled=False)
+        old_reranker = StubReranker()
+        monkeypatch.setattr(factory, "create_reranker", lambda cfg: None)
+        search_pipeline = SimpleNamespace(
+            _reranker=old_reranker,
+            _rerank_config=old.rerank,
+            invalidate_cache=MagicMock(),
+        )
+
+        _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+
+        assert search_pipeline._reranker is None
+        assert search_pipeline._rerank_config is None
+        assert old_reranker.closed is True
         search_pipeline.invalidate_cache.assert_called_once()
 
 

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -326,6 +326,37 @@ def test_html_settings_nav_btns_all_carry_ui_tier_attr() -> None:
         assert "data-ui-tier=" in tag, f"settings-nav-btn missing data-ui-tier: {tag[:120]}"
 
 
+def test_home_harness_stat_cards_are_dev_tier() -> None:
+    """Sessions and Working Memory depend on dev-only routers.
+
+    The JS already gates their API fetches, but the cards themselves must
+    carry the same tier marker so prod mode hides the empty counters.
+    """
+    html = _read_static("index.html")
+    for element_id in ("home-sessions", "home-scratch"):
+        match = re.search(
+            rf'<div[^>]*class="stat-card card"[^>]*>[\s\S]*?id="{element_id}"',
+            html,
+        )
+        assert match is not None, f"{element_id} stat card missing from Home markup"
+        assert 'data-ui-tier="dev"' in match.group(0), (
+            f"{element_id} stat card must be dev-tier so prod hides it"
+        )
+
+
+def test_home_stat_grid_sizes_match_ui_mode() -> None:
+    """Home stat cards are 4-up in prod and 6-up in dev."""
+    css = _read_static("style.css")
+    assert "--home-stat-cols: 4" in css, "prod Home stat grid must default to 4 columns"
+    assert re.search(
+        r"body\.dev-mode\s+\.home-stats-row\s*\{\s*--home-stat-cols:\s*6;",
+        css,
+    ), "dev Home stat grid must expand to 6 columns"
+    assert "repeat(var(--home-stat-cols), minmax(0, 1fr))" in css, (
+        "Home stat grid must size from the ui-mode column variable"
+    )
+
+
 def test_ctx_overview_has_landing_modifier_for_group_dashboard() -> None:
     """ctx-overview is the Agent Integrations group's dashboard card and must
     carry the ``settings-nav-btn--landing`` modifier so CSS gives it visual

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -109,6 +109,14 @@ class FakeConfig:
         enabled = False
         lambda_param = 0.7
 
+    class _Rerank:
+        enabled = False
+        provider = "fastembed"
+        model = "Xenova/ms-marco-MiniLM-L-6-v2"
+        oversample = 2.0
+        min_pool = 20
+        max_pool = 200
+
     class _Namespace:
         default_namespace = "default"
         enable_auto_ns = False
@@ -119,6 +127,7 @@ class FakeConfig:
     indexing = _Indexing()
     decay = _Decay()
     mmr = _MMR()
+    rerank = _Rerank()
     namespace = _Namespace()
 
 
@@ -188,6 +197,8 @@ def app():
     rstats = RetrievalStats(bm25_candidates=10, dense_candidates=10, fused_total=1, final_total=1)
     search_pipeline.search = AsyncMock(return_value=([result], rstats))
     search_pipeline.invalidate_cache = MagicMock()
+    search_pipeline._reranker = None
+    search_pipeline._rerank_config = None
 
     # -- index engine mock --
     index_engine = AsyncMock()
@@ -384,6 +395,14 @@ class TestConfig:
         assert "indexing" in data
         assert "decay" in data
         assert "mmr" in data
+        assert data["rerank"] == {
+            "enabled": False,
+            "provider": "fastembed",
+            "model": "Xenova/ms-marco-MiniLM-L-6-v2",
+            "oversample": 2.0,
+            "min_pool": 20,
+            "max_pool": 200,
+        }
         assert "namespace" in data
         assert data["indexing"]["exclude_patterns"] == []
 
@@ -425,6 +444,7 @@ class TestConfig:
             "indexing",
             "decay",
             "mmr",
+            "rerank",
             "namespace",
         }
         # Comparand values come through, not app.state.config values.
@@ -451,6 +471,100 @@ class TestConfig:
 
         assert resp.status_code == 200
         assert resp.json()["search"]["default_top_k"] == 7
+
+    async def test_patch_rerank_runtime_fields(self, app, client: AsyncClient):
+        """The Web config card can edit rerank runtime knobs but not restart knobs."""
+        with (
+            patch("memtomem.web.routes.system.save_config_overrides"),
+            patch(
+                "memtomem.web.routes.system._validate_reranker_ready",
+                new_callable=AsyncMock,
+            ),
+        ):
+            resp = await client.patch(
+                "/api/config",
+                json={"rerank": {"enabled": True, "oversample": 3.0, "provider": "cohere"}},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert any(c["field"] == "rerank.enabled" for c in data["applied"])
+        assert any(c["field"] == "rerank.oversample" for c in data["applied"])
+        assert "rerank.provider: read-only field" in data["rejected"]
+        assert app.state.config.rerank.enabled is True
+        assert app.state.config.rerank.oversample == 3.0
+        assert app.state.config.rerank.provider == "fastembed"
+        assert app.state.search_pipeline._reranker is not None
+        assert app.state.search_pipeline._rerank_config is app.state.config.rerank
+
+    async def test_patch_rerank_rejects_lazy_load_failure(self, app, client: AsyncClient):
+        """Runtime enabling must fail if the lazy reranker cannot load."""
+
+        class BrokenReranker:
+            def __init__(self):
+                self.closed = False
+
+            def _get_model(self):
+                raise ImportError("fastembed is required")
+
+            async def close(self):
+                self.closed = True
+
+        reranker = BrokenReranker()
+
+        with (
+            patch("memtomem.web.routes.system.create_reranker", return_value=reranker),
+            patch("memtomem.web.routes.system.save_config_overrides"),
+        ):
+            resp = await client.patch("/api/config", json={"rerank": {"enabled": True}})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["applied"] == []
+        assert "rerank.enabled: fastembed is required" in data["rejected"]
+        assert app.state.config.rerank.enabled is False
+        assert app.state.search_pipeline._reranker is None
+        assert app.state.search_pipeline._rerank_config is None
+        assert reranker.closed is True
+
+    async def test_patch_rerank_disable_syncs_pipeline(self, app, client: AsyncClient):
+        class StubReranker:
+            def __init__(self):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+        reranker = StubReranker()
+        app.state.config.rerank.enabled = True
+        app.state.search_pipeline._reranker = reranker
+        app.state.search_pipeline._rerank_config = app.state.config.rerank
+
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.patch("/api/config", json={"rerank": {"enabled": False}})
+
+        assert resp.status_code == 200
+        assert resp.json()["rejected"] == []
+        assert app.state.config.rerank.enabled is False
+        assert app.state.search_pipeline._reranker is None
+        assert app.state.search_pipeline._rerank_config is None
+        assert reranker.closed is True
+
+    async def test_patch_rerank_rejects_invalid_pool_bounds(self, app, client: AsyncClient):
+        with patch("memtomem.web.routes.system.save_config_overrides"):
+            resp = await client.patch(
+                "/api/config",
+                json={"rerank": {"min_pool": 500, "max_pool": 20}},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["applied"] == []
+        assert any("rerank.max_pool" in r for r in data["rejected"])
+        assert app.state.config.rerank.min_pool == 20
+        assert app.state.config.rerank.max_pool == 200
+        assert app.state.search_pipeline._reranker is None
+        assert app.state.search_pipeline._rerank_config is None
 
     async def test_patch_exclude_patterns_accepts_valid(self, app, client: AsyncClient):
         with patch("memtomem.web.routes.system.save_config_overrides"):

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.1.36"
+version = "0.2.0"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- hide the Home Sessions and Working Memory stat cards in prod mode
- resize the Home stats grid to 4 columns in prod and 6 columns in dev
- add static regression coverage for the card tier and grid sizing

## Tests
- uv run pytest packages/memtomem/tests/test_web_mode.py -q