### PR TITLE
chore(web): polish Home Quick Actions helper + regression pin

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -2133,7 +2133,7 @@ qs('home-search-input').addEventListener('keydown', e => {
 });
 
 // F. Quick Actions
-function _quickActionToast(key, focusTarget) {
+function showQuickActionToast(key, focusTarget) {
   showToast(t(key), 'info');
   if (focusTarget) {
     requestAnimationFrame(() => qs(focusTarget)?.focus());
@@ -2143,30 +2143,30 @@ function _quickActionToast(key, focusTarget) {
 qs('home-search-btn').addEventListener('click', () => {
   activateTab('search');
   qs('search-input').focus();
-  _quickActionToast('toast.quick_action.open_search');
+  showQuickActionToast('toast.quick_action.open_search');
 });
 qs('home-index-btn').addEventListener('click', () => {
   activateTab('index');
-  _quickActionToast('toast.quick_action.open_index', 'index-path');
+  showQuickActionToast('toast.quick_action.open_index', 'index-path');
 });
 qs('home-reindex-btn').addEventListener('click', () => {
   activateTab('index');
   qs('index-force').checked = true;
-  _quickActionToast('toast.quick_action.reindex_ready', 'index-path');
+  showQuickActionToast('toast.quick_action.reindex_ready', 'index-path');
 });
 qs('home-export-btn').addEventListener('click', () => {
   activateTab('settings');
   switchSettingsSection('export');
-  _quickActionToast('toast.quick_action.open_export', 'exp-preview-btn');
+  showQuickActionToast('toast.quick_action.open_export', 'exp-preview-btn');
 });
 qs('home-dedup-btn').addEventListener('click', () => {
   activateTab('settings');
   switchSettingsSection('dedup');
-  _quickActionToast('toast.quick_action.open_dedup', 'dedup-scan-btn');
+  showQuickActionToast('toast.quick_action.open_dedup', 'dedup-scan-btn');
 });
 qs('home-tags-btn').addEventListener('click', () => {
   activateTab('tags');
-  _quickActionToast('toast.quick_action.open_tags', 'tags-search');
+  showQuickActionToast('toast.quick_action.open_tags', 'tags-search');
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -376,6 +376,8 @@ class TestNoHardcodedStrings:
             for action in ids:
                 label = locale[f"home.action.{action}"]
                 title = locale[f"home.action.{action}_title"]
+                # Emoji-prefix guard: leading char must be word/space or a Hangul
+                # syllable. Rejects 🔍/📥/🧹/… that drifted in pre-#989.
                 if re.match(r"^[^\w\s가-힣]", label):
                     bad.append(f"  {locale_name}: home.action.{action} still starts with an icon")
                 if locale_name == "en" and action in {"reindex", "dedup"}:
@@ -389,6 +391,10 @@ class TestNoHardcodedStrings:
         assert en["home.action.dedup"] == "Open Dedup Scan"
         assert "switchSettingsSection('export')" in js
         assert "switchSettingsSection('dedup')" in js
+        # Negative pin: the pre-#989 brittle `.settings-nav-btn?.click()` poke
+        # must not return — `switchSettingsSection(...)` is the public router.
+        assert '.settings-nav-btn[data-section="export"]\')?.click()' not in js
+        assert '.settings-nav-btn[data-section="dedup"]\')?.click()' not in js
         for key in [
             "toast.quick_action.open_search",
             "toast.quick_action.open_index",


### PR DESCRIPTION
## Summary

Follow-up polish for #1010 (already merged) addressing the three review notes that landed in the PR-review pass:

- Rename `_quickActionToast` → `showQuickActionToast` in `app.js`. The `_FOO` prefix in this file is reserved for module-private constants/regex (`_UNSAFE_METHODS`, `_HELP_VISIBLE_KEY`, `_UPLOAD_REDACTION_BLOCKED_RE`); function helpers in the Home view use plain names (`renderHomeStorage`, `switchSettingsSection`).
- Tighten `test_home_quick_actions_describe_navigation_flow`: add two negative-pin asserts that the pre-#989 brittle `.settings-nav-btn[data-section="export"|"dedup"]?.click()` DOM-poke does not return. Without these, a regression could re-pass the existing positive `switchSettingsSection(...)` asserts while silently reintroducing the original bug shape.
- Comment the leading-icon regex so a future reader knows it is the "no emoji prefix" guard from #989.

No behavior change.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 47 passed
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/tests/test_i18n.py`