### PR TITLE
fix(web): async hot-reload reranker lazy load

### DIFF
--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -353,13 +353,13 @@ async def _sync_reranker(
                 await asyncio.to_thread(load_model)
             except Exception:
                 logger.exception("Hot-reloaded reranker failed to load; keeping previous instance")
-                await _close_component_safely(new_reranker)
+                await _close_reranker_safely(new_reranker)
                 return
 
     if app is not None and _rerank_snapshot(getattr(app.state, "config", None)) != new_snapshot:
         logger.info("Skipping stale hot-reloaded reranker install; config changed while loading")
         if new_reranker is not None:
-            await _close_component_safely(new_reranker)
+            await _close_reranker_safely(new_reranker)
         return
 
     old_reranker = getattr(search_pipeline, "_reranker", None)
@@ -367,7 +367,7 @@ async def _sync_reranker(
     search_pipeline._rerank_config = new_cfg.rerank if new_cfg.rerank.enabled else None
 
     if old_reranker is not None and old_reranker is not new_reranker:
-        await _close_component_safely(old_reranker)
+        await _close_reranker_safely(old_reranker)
 
 
 def _rerank_snapshot(cfg: Any) -> tuple[object, ...] | None:
@@ -386,8 +386,14 @@ def _rerank_snapshot(cfg: Any) -> tuple[object, ...] | None:
     )
 
 
-async def _close_component_safely(component: object) -> None:
-    close = getattr(component, "close", None)
+async def _close_reranker_safely(reranker: object) -> None:
+    """Close a reranker, tolerating sync/async/missing close + errors.
+
+    Shared between the disk hot-reload path (this module) and the PATCH
+    handler in ``web/routes/system.py`` so a flaky teardown never turns
+    a clean "rejected"/"accepted" reply into a 500.
+    """
+    close = getattr(reranker, "close", None)
     if not callable(close):
         return
 
@@ -397,7 +403,6 @@ async def _close_component_safely(component: object) -> None:
             await result
     except Exception:
         logger.exception("Error while closing replaced reranker")
-        return
 
 
 def _schedule_fts_rebuild(

--- a/packages/memtomem/src/memtomem/web/hot_reload.py
+++ b/packages/memtomem/src/memtomem/web/hot_reload.py
@@ -34,6 +34,8 @@ else is private.
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -181,7 +183,7 @@ def _build_fresh_config() -> Mem2MemConfig:
     return cfg
 
 
-def reload_if_stale(
+async def reload_if_stale(
     app: FastAPI,
     *,
     storage: SqliteBackend | None = None,
@@ -200,13 +202,14 @@ def reload_if_stale(
     should pass them through so a disk-triggered tokenizer change still
     propagates.
 
-    Note: FTS rebuild is fire-and-forget scheduled on the running event loop
-    when invoked from an async context, so sync GET callers aren't blocked.
-    Callers in a lock-free read context should still see the Settings swap
-    immediately; the rebuild catches up out-of-band. The rebuild runs
-    concurrently with any writer inside ``_config_lock``: it touches the
-    FTS5 virtual table, not the ``config.json`` file, so there is no file-
-    level race with ``save_config_overrides``.
+    Note: runtime fanout is async so local reranker lazy loads can move to
+    a worker thread instead of blocking the request event loop. FTS rebuild
+    remains fire-and-forget scheduled on the running event loop; callers in
+    a lock-free read context should still see the Settings swap immediately
+    while the rebuild catches up out-of-band. The rebuild runs concurrently
+    with any writer inside ``_config_lock``: it touches the FTS5 virtual
+    table, not the ``config.json`` file, so there is no file-level race with
+    ``save_config_overrides``.
     """
     sig = current_signature()
     last = _get_last_signature(app)
@@ -261,7 +264,7 @@ def reload_if_stale(
     _set_reload_error(app, None)
 
     if old_cfg is not None and (storage is not None or search_pipeline is not None):
-        apply_runtime_config_changes(
+        await apply_runtime_config_changes(
             old_cfg, new_cfg, storage=storage, search_pipeline=search_pipeline, app=app
         )
 
@@ -274,7 +277,7 @@ def reload_if_stale(
 # ---------------------------------------------------------------------------
 
 
-def apply_runtime_config_changes(
+async def apply_runtime_config_changes(
     old_cfg: Any,
     new_cfg: Any,
     *,
@@ -290,16 +293,15 @@ def apply_runtime_config_changes(
       pipeline.
     * Any change → invalidate search cache.
 
-    Older callers of this helper (e.g. the PATCH handler) may not provide
+    Some callers of this helper (e.g. focused tests) may not provide
     ``storage`` / ``search_pipeline`` (rare), in which case the matching
-    fanout step is skipped. This keeps the helper usable in unit tests and
-    from non-web callers.
+    fanout step is skipped.
 
     ``app`` is optional: when provided, the FTS rebuild is tracked on
     ``app.state.fts_rebuild_task`` so back-to-back tokenizer changes coalesce
     (issue #278) instead of spawning overlapping rebuilds. When omitted, the
     rebuild is fire-and-forget without coalescing — preserved for non-web
-    callers and legacy unit tests.
+    callers and focused unit tests.
     """
     try:
         tokenizer_changed = old_cfg.search.tokenizer != new_cfg.search.tokenizer
@@ -313,11 +315,17 @@ def apply_runtime_config_changes(
         _schedule_fts_rebuild(storage, new_cfg.search.tokenizer, app=app)
 
     if search_pipeline is not None:
-        _sync_reranker(old_cfg, new_cfg, search_pipeline)
+        await _sync_reranker(old_cfg, new_cfg, search_pipeline, app=app)
         search_pipeline.invalidate_cache()
 
 
-def _sync_reranker(old_cfg: Any, new_cfg: Any, search_pipeline: SearchPipeline) -> None:
+async def _sync_reranker(
+    old_cfg: Any,
+    new_cfg: Any,
+    search_pipeline: SearchPipeline,
+    *,
+    app: FastAPI | None = None,
+) -> None:
     old_snapshot = _rerank_snapshot(old_cfg)
     new_snapshot = _rerank_snapshot(new_cfg)
     if new_snapshot is None or old_snapshot == new_snapshot:
@@ -342,18 +350,24 @@ def _sync_reranker(old_cfg: Any, new_cfg: Any, search_pipeline: SearchPipeline) 
         load_model = getattr(new_reranker, "_get_model", None)
         if callable(load_model):
             try:
-                load_model()
+                await asyncio.to_thread(load_model)
             except Exception:
                 logger.exception("Hot-reloaded reranker failed to load; keeping previous instance")
-                _close_async_component(new_reranker)
+                await _close_component_safely(new_reranker)
                 return
+
+    if app is not None and _rerank_snapshot(getattr(app.state, "config", None)) != new_snapshot:
+        logger.info("Skipping stale hot-reloaded reranker install; config changed while loading")
+        if new_reranker is not None:
+            await _close_component_safely(new_reranker)
+        return
 
     old_reranker = getattr(search_pipeline, "_reranker", None)
     search_pipeline._reranker = new_reranker
     search_pipeline._rerank_config = new_cfg.rerank if new_cfg.rerank.enabled else None
 
     if old_reranker is not None and old_reranker is not new_reranker:
-        _close_async_component(old_reranker)
+        await _close_component_safely(old_reranker)
 
 
 def _rerank_snapshot(cfg: Any) -> tuple[object, ...] | None:
@@ -372,45 +386,18 @@ def _rerank_snapshot(cfg: Any) -> tuple[object, ...] | None:
     )
 
 
-def _close_async_component(component: object) -> None:
+async def _close_component_safely(component: object) -> None:
     close = getattr(component, "close", None)
     if not callable(close):
         return
 
-    result = close()
-    if result is None:
-        return
-
-    import asyncio
-    import inspect
-
-    # Narrow to ``Coroutine`` (not just ``Awaitable``) because that's what
-    # ``asyncio.run`` / ``loop.create_task`` accept. In practice every
-    # reranker ``close()`` we wrap is ``async def`` so returns a coroutine.
-    if not inspect.iscoroutine(result):
-        return
-
     try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        try:
-            asyncio.run(result)
-        except Exception:
-            logger.exception("Error while closing replaced reranker")
+        result = close()
+        if inspect.isawaitable(result):
+            await result
+    except Exception:
+        logger.exception("Error while closing replaced reranker")
         return
-
-    task: asyncio.Task[Any] = loop.create_task(result)
-    task.add_done_callback(_log_close_task_exception)
-
-
-def _log_close_task_exception(task: Any) -> None:
-    # Fire-and-forget close tasks must not leak "Task exception was never
-    # retrieved" warnings — surface the failure with a useful stack instead.
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc is not None:
-        logger.error("Error while closing replaced reranker", exc_info=exc)
 
 
 def _schedule_fts_rebuild(

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -13,7 +13,6 @@ on the read side at ``memtomem.indexing.engine.memory_dir_stats``.
 from __future__ import annotations
 
 import asyncio as _asyncio
-import inspect
 import json
 import logging
 import os
@@ -133,24 +132,6 @@ async def _validate_reranker_ready(reranker: object | None) -> None:
     load_model = getattr(reranker, "_get_model", None)
     if callable(load_model):
         await _asyncio.to_thread(load_model)
-
-
-async def _close_reranker_safely(reranker: object) -> None:
-    """Close a reranker, tolerating sync/async/missing close + errors.
-
-    The route holds ``_config_lock`` across this, so swallowing close-time
-    exceptions keeps a clean "rejected"/"accepted" reply from turning
-    into a 500 when the old/new instance has a flaky teardown.
-    """
-    close = getattr(reranker, "close", None)
-    if not callable(close):
-        return
-    try:
-        result = close()
-        if inspect.isawaitable(result):
-            await result
-    except Exception:
-        logger.exception("Error while closing reranker")
 
 
 router = APIRouter(tags=["system"])
@@ -480,13 +461,13 @@ async def patch_config(
                             await _validate_reranker_ready(new_reranker)
                         except Exception as e:
                             if new_reranker is not None:
-                                await _close_reranker_safely(new_reranker)
+                                await _hot_reload._close_reranker_safely(new_reranker)
                             rejected.append(f"rerank.enabled: {e}")
                             continue
 
                         old_reranker = getattr(search_pipeline, "_reranker", None)
                         if old_reranker is not None and old_reranker is not new_reranker:
-                            await _close_reranker_safely(old_reranker)
+                            await _hot_reload._close_reranker_safely(old_reranker)
                         search_pipeline._reranker = new_reranker
                         search_pipeline._rerank_config = (
                             candidate_rerank if candidate_rerank.enabled else None

--- a/packages/memtomem/src/memtomem/web/routes/system.py
+++ b/packages/memtomem/src/memtomem/web/routes/system.py
@@ -315,7 +315,7 @@ async def get_config_endpoint(request: Request) -> ConfigResponse:
     # keeps the common GET path cheap while still catching CLI-side edits.
     app = request.app
     try:
-        _hot_reload.reload_if_stale(
+        await _hot_reload.reload_if_stale(
             app,
             storage=getattr(app.state, "storage", None),
             search_pipeline=getattr(app.state, "search_pipeline", None),
@@ -425,7 +425,7 @@ async def patch_config(
                 # Re-read from disk before merging so a concurrent CLI edit
                 # is preserved. If disk is broken, refuse rather than
                 # overwrite it.
-                _hot_reload.reload_if_stale(
+                await _hot_reload.reload_if_stale(
                     request.app, storage=storage, search_pipeline=search_pipeline
                 )
                 _check_reload_block(request)
@@ -572,7 +572,7 @@ async def save_config(
     try:
         async with _asyncio.timeout(60):
             async with _config_lock:
-                _hot_reload.reload_if_stale(
+                await _hot_reload.reload_if_stale(
                     request.app, storage=storage, search_pipeline=search_pipeline
                 )
                 _check_reload_block(request)
@@ -617,7 +617,7 @@ async def add_memory_dir(
     try:
         async with _asyncio.timeout(60):
             async with _config_lock:
-                _hot_reload.reload_if_stale(
+                await _hot_reload.reload_if_stale(
                     request.app, storage=storage, search_pipeline=search_pipeline
                 )
                 _check_reload_block(request)
@@ -700,7 +700,7 @@ async def remove_memory_dir(
     try:
         async with _asyncio.timeout(60):
             async with _config_lock:
-                _hot_reload.reload_if_stale(
+                await _hot_reload.reload_if_stale(
                     request.app, storage=storage, search_pipeline=search_pipeline
                 )
                 _check_reload_block(request)

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
@@ -470,7 +471,7 @@ async def test_concurrent_patches_are_serialised_by_lock(
 # ---------------------------------------------------------------------------
 
 
-def test_reload_if_stale_cas_yields_to_concurrent_writer_bump(
+async def test_reload_if_stale_cas_yields_to_concurrent_writer_bump(
     home: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """Issue #268: the lock-free reader path had a race where its trailing
@@ -525,7 +526,7 @@ def test_reload_if_stale_cas_yields_to_concurrent_writer_bump(
 
     monkeypatch.setattr(_hot_reload, "_build_fresh_config", build_and_interleave_writer)
 
-    swapped = _hot_reload.reload_if_stale(app)
+    swapped = await _hot_reload.reload_if_stale(app)
 
     # CAS must have fired: no swap happened.
     assert swapped is False
@@ -543,7 +544,7 @@ def test_reload_if_stale_cas_yields_to_concurrent_writer_bump(
 # ---------------------------------------------------------------------------
 
 
-def test_reload_if_stale_error_branch_cas_yields_to_concurrent_writer_bump(
+async def test_reload_if_stale_error_branch_cas_yields_to_concurrent_writer_bump(
     home: Path, monkeypatch: pytest.MonkeyPatch
 ):
     """Issue #273: the lock-free reader's *error* branch had the same
@@ -591,7 +592,7 @@ def test_reload_if_stale_error_branch_cas_yields_to_concurrent_writer_bump(
 
     monkeypatch.setattr(_hot_reload, "_build_fresh_config", build_and_interleave_writer_then_raise)
 
-    swapped = _hot_reload.reload_if_stale(app)
+    swapped = await _hot_reload.reload_if_stale(app)
 
     # Error branch fires but CAS guard leaves writer's signature intact.
     assert swapped is False
@@ -634,15 +635,15 @@ class TestSignature:
 
 
 class TestReloadIfStale:
-    def test_no_change_returns_false(self, home: Path):
+    async def test_no_change_returns_false(self, home: Path):
         app = create_app(lifespan=None, mode="dev")
         app.state.config = _hot_reload._build_fresh_config()
         app.state.config_signature = _hot_reload.current_signature()
         app.state.last_reload_error = None
 
-        assert _hot_reload.reload_if_stale(app) is False
+        assert await _hot_reload.reload_if_stale(app) is False
 
-    def test_change_swaps_config(self, home: Path):
+    async def test_change_swaps_config(self, home: Path):
         app = create_app(lifespan=None, mode="dev")
         _write_config(home, {"mmr": {"enabled": False}})
         app.state.config = _hot_reload._build_fresh_config()
@@ -651,10 +652,10 @@ class TestReloadIfStale:
         assert app.state.config.mmr.enabled is False
 
         _write_config(home, {"mmr": {"enabled": True}})
-        assert _hot_reload.reload_if_stale(app) is True
+        assert await _hot_reload.reload_if_stale(app) is True
         assert app.state.config.mmr.enabled is True
 
-    def test_broken_disk_keeps_old_config(self, home: Path):
+    async def test_broken_disk_keeps_old_config(self, home: Path):
         app = create_app(lifespan=None, mode="dev")
         _write_config(home, {"mmr": {"enabled": False}})
         app.state.config = _hot_reload._build_fresh_config()
@@ -666,7 +667,7 @@ class TestReloadIfStale:
         cfg_path.write_text('{"search":', encoding="utf-8")
         _bump_mtime(cfg_path)
 
-        assert _hot_reload.reload_if_stale(app) is False
+        assert await _hot_reload.reload_if_stale(app) is False
         assert app.state.config is old
         err = _hot_reload.get_reload_error(app)
         assert err is not None
@@ -688,7 +689,7 @@ class TestApplyRuntimeConfigChanges:
             ),
         )
 
-    def test_tokenizer_change_fires_set_tokenizer_and_rebuild(
+    async def test_tokenizer_change_fires_set_tokenizer_and_rebuild(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         set_tokenizer_calls: list[str] = []
@@ -706,20 +707,17 @@ class TestApplyRuntimeConfigChanges:
         storage.rebuild_fts = AsyncMock(return_value=5)
         search_pipeline = MagicMock()
 
-        async def _run():
-            _hot_reload.apply_runtime_config_changes(
-                old, new, storage=storage, search_pipeline=search_pipeline
-            )
-            # Give the scheduled rebuild a chance to run.
-            await asyncio.sleep(0)
-            await asyncio.sleep(0)
-
-        asyncio.run(_run())
+        await _hot_reload.apply_runtime_config_changes(
+            old, new, storage=storage, search_pipeline=search_pipeline
+        )
+        # Give the scheduled rebuild a chance to run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
         assert set_tokenizer_calls == ["kiwi"]
         search_pipeline.invalidate_cache.assert_called_once()
 
-    def test_no_tokenizer_change_skips_fts_rebuild(self):
+    async def test_no_tokenizer_change_skips_fts_rebuild(self):
         old = MagicMock()
         old.search.tokenizer = "unicode61"
         new = MagicMock()
@@ -729,14 +727,16 @@ class TestApplyRuntimeConfigChanges:
         storage.rebuild_fts = AsyncMock(return_value=0)
         search_pipeline = MagicMock()
 
-        _hot_reload.apply_runtime_config_changes(
+        await _hot_reload.apply_runtime_config_changes(
             old, new, storage=storage, search_pipeline=search_pipeline
         )
 
         storage.rebuild_fts.assert_not_called()
         search_pipeline.invalidate_cache.assert_called_once()
 
-    def test_rerank_change_rebuilds_live_pipeline_reranker(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_rerank_change_rebuilds_live_pipeline_reranker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         import memtomem.search.reranker.factory as factory
 
         old = self._cfg(rerank_enabled=False)
@@ -749,13 +749,15 @@ class TestApplyRuntimeConfigChanges:
             invalidate_cache=MagicMock(),
         )
 
-        _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+        await _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
 
         assert search_pipeline._reranker is reranker
         assert search_pipeline._rerank_config is new.rerank
         search_pipeline.invalidate_cache.assert_called_once()
 
-    def test_rerank_disable_clears_live_pipeline_reranker(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_rerank_disable_clears_live_pipeline_reranker(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         import memtomem.search.reranker.factory as factory
 
         class StubReranker:
@@ -775,14 +777,14 @@ class TestApplyRuntimeConfigChanges:
             invalidate_cache=MagicMock(),
         )
 
-        _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+        await _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
 
         assert search_pipeline._reranker is None
         assert search_pipeline._rerank_config is None
         assert old_reranker.closed is True
         search_pipeline.invalidate_cache.assert_called_once()
 
-    def test_rerank_disk_edit_lazy_load_failure_keeps_previous(
+    async def test_rerank_disk_edit_lazy_load_failure_keeps_previous(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         """Disk hot-reload mirrors the PATCH path: a reranker that can't
@@ -818,13 +820,15 @@ class TestApplyRuntimeConfigChanges:
             invalidate_cache=MagicMock(),
         )
 
-        _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+        await _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
 
         assert search_pipeline._reranker is previous
         assert previous.closed is False
         search_pipeline.invalidate_cache.assert_called_once()
 
-    def test_rerank_disk_edit_factory_failure_keeps_previous(self, monkeypatch: pytest.MonkeyPatch):
+    async def test_rerank_disk_edit_factory_failure_keeps_previous(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """A factory that raises mid-disk-reload leaves state untouched."""
         import memtomem.search.reranker.factory as factory
 
@@ -849,11 +853,37 @@ class TestApplyRuntimeConfigChanges:
             invalidate_cache=MagicMock(),
         )
 
-        _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+        await _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
 
         assert search_pipeline._reranker is previous
         assert previous.closed is False
         search_pipeline.invalidate_cache.assert_called_once()
+
+    async def test_rerank_disk_edit_lazy_load_runs_off_event_loop_thread(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import memtomem.search.reranker.factory as factory
+
+        class LazyReranker:
+            def _get_model(self):
+                load_thread_ids.append(threading.get_ident())
+                return object()
+
+        load_thread_ids: list[int] = []
+        old = self._cfg(rerank_enabled=False)
+        new = self._cfg(rerank_enabled=True)
+        monkeypatch.setattr(factory, "create_reranker", lambda cfg: LazyReranker())
+        search_pipeline = SimpleNamespace(
+            _reranker=None,
+            _rerank_config=None,
+            invalidate_cache=MagicMock(),
+        )
+
+        event_loop_thread_id = threading.get_ident()
+        await _hot_reload.apply_runtime_config_changes(old, new, search_pipeline=search_pipeline)
+
+        assert load_thread_ids
+        assert load_thread_ids[0] != event_loop_thread_id
 
 
 class TestScheduleFtsRebuildCoalescing:

--- a/packages/memtomem/tests/test_web_hot_reload.py
+++ b/packages/memtomem/tests/test_web_hot_reload.py
@@ -885,6 +885,54 @@ class TestApplyRuntimeConfigChanges:
         assert load_thread_ids
         assert load_thread_ids[0] != event_loop_thread_id
 
+    async def test_rerank_disk_edit_drops_stale_install_if_config_drifts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """While ``_get_model`` runs on a worker thread, a concurrent
+        PATCH can overwrite ``app.state.config``. When the disk-side load
+        returns, its candidate snapshot is no longer current — the guard
+        at ``_sync_reranker`` must discard the loaded instance (and
+        ``close()`` it) instead of clobbering the live pipeline.
+        """
+        import memtomem.search.reranker.factory as factory
+
+        app = create_app(lifespan=None, mode="dev")
+        old = self._cfg(rerank_enabled=False)
+        new = self._cfg(rerank_enabled=True)
+        drifted = self._cfg(rerank_enabled=True, provider="other-provider")
+        app.state.config = new
+
+        class DriftingReranker:
+            def __init__(self):
+                self.closed = False
+
+            def _get_model(self):
+                # Simulate a concurrent PATCH landing during the
+                # ``asyncio.to_thread`` window — by the time the load
+                # completes, ``app.state.config`` no longer matches the
+                # snapshot the disk reload captured.
+                app.state.config = drifted
+
+            async def close(self):
+                self.closed = True
+
+        loaded = DriftingReranker()
+        monkeypatch.setattr(factory, "create_reranker", lambda cfg: loaded)
+        previous = SimpleNamespace()
+        search_pipeline = SimpleNamespace(
+            _reranker=previous,
+            _rerank_config=None,
+            invalidate_cache=MagicMock(),
+        )
+
+        await _hot_reload.apply_runtime_config_changes(
+            old, new, search_pipeline=search_pipeline, app=app
+        )
+
+        assert search_pipeline._reranker is previous
+        assert loaded.closed is True
+        search_pipeline.invalidate_cache.assert_called_once()
+
 
 class TestScheduleFtsRebuildCoalescing:
     """Singleton + coalescing for back-to-back tokenizer changes (issue #278).


### PR DESCRIPTION
## Summary

- make disk hot-reload runtime fanout async so reranker lazy model loads can run off the event loop
- await hot-reload from system routes and safely close replaced/rejected rerankers
- add regression coverage proving disk-edit lazy load runs on a worker thread

Fixes #1012

## Tests

- uv run ruff check packages/memtomem/src/memtomem/web/hot_reload.py packages/memtomem/src/memtomem/web/routes/system.py packages/memtomem/tests/test_web_hot_reload.py
- uv run pytest packages/memtomem/tests/test_web_hot_reload.py
- uv run pytest packages/memtomem/tests/test_web_routes.py