### PR TITLE
feat(cli): parse MCP config entries during uninstall external integration probe

### DIFF
--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -26,10 +26,12 @@ Design notes:
 from __future__ import annotations
 
 import errno
+import json
 import os
 import shutil
 import sqlite3
 import sys
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -305,10 +307,39 @@ def _probe_external_integrations() -> list[_External]:
             text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        # Substring detection — first-cut, false-positive-tolerant since
-        # this is detect-and-report. LOW 7 in the plan upgrades to a
-        # parsed mcpServers.memtomem key check in a follow-up.
-        if "memtomem" in text:
+
+        # ── parsed mcpServers.memtomem key check ──────────────────────────
+        # JSON files: check ``mcpServers.memtomem`` via json.loads.
+        # Codex TOML: check ``mcp_servers.memtomem`` via tomllib (TOML uses
+        #   snake_case dotted keys resolved to nested dicts by tomllib).
+        # Unparseable files are silently skipped — uninstall is a recovery
+        #   path and must not crash on malformed configs.
+        suffix = path.suffix.lower()
+        matched = False
+
+        if suffix == ".json":
+            try:
+                data = json.loads(text)
+            except (json.JSONDecodeError, TypeError):
+                pass
+            else:
+                if isinstance(data, dict) and isinstance(data.get("mcpServers"), dict):
+                    if "memtomem" in data["mcpServers"]:
+                        matched = True
+        elif suffix == ".toml":
+            try:
+                data = tomllib.loads(text)
+            except (tomllib.TOMLDecodeError, TypeError, ValueError):
+                pass
+            else:
+                # tomllib resolves TOML dotted keys into nested dicts, e.g.
+                # ``[mcp_servers.memtomem]`` becomes ``{"mcp_servers": {"memtomem": {...}}}``
+                # and ``[mcp_servers]`` with ``memtomem = {...}`` also nests.
+                if isinstance(data, dict) and isinstance(data.get("mcp_servers"), dict):
+                    if "memtomem" in data["mcp_servers"]:
+                        matched = True
+
+        if matched:
             found.append(_External(path=path, reason="contains memtomem MCP entry"))
     return found
 

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -81,6 +81,12 @@ def home(tmp_path, monkeypatch):
 
     h = tmp_path / "home"
     h.mkdir()
+    # The external-MCP probe also checks ``Path.cwd() / ".mcp.json"`` (the
+    # project-local Claude config). Pin cwd into the tmp home so the repo's
+    # own ``.mcp.json`` doesn't leak into the probe and trip the negative
+    # "not reported" assertions — CI runs pytest from the repo root, which
+    # ships a real ``.mcp.json``.
+    monkeypatch.chdir(h)
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
     os.chmod(xdg, 0o700)  # _runtime_paths validator requires owner-only

--- a/packages/memtomem/tests/test_uninstall_cmd.py
+++ b/packages/memtomem/tests/test_uninstall_cmd.py
@@ -244,6 +244,171 @@ class TestExternalsDetectedNotModified:
         assert claude_json.read_text(encoding="utf-8") == original_text
 
 
+class TestProbeExternalParsedMCP:
+    """#975: parsed MCP config check avoids substring false positives."""
+
+    def _seed_state_dir(self, home: Path) -> Path:
+        state = home / ".memtomem"
+        state.mkdir()
+        (state / "config.json").write_text("{}", encoding="utf-8")
+        return state
+
+    def test_json_mcp_servers_memtomem_reported(self, home):
+        """Valid JSON with ``mcpServers.memtomem`` is still reported."""
+        self._seed_state_dir(home)
+        path = home / ".cursor" / "mcp.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"mcpServers": {"memtomem": {"command": "mm-server"}}}),
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" in result.output
+        assert "mcp.json" in result.output
+
+    def test_json_unrelated_text_not_reported(self, home):
+        """JSON that only mentions 'memtomem' in a comment/description is NOT reported."""
+        self._seed_state_dir(home)
+        path = home / ".cursor" / "mcp.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "other-server": {"command": "some-tool"},
+                    },
+                    "description": "This config works with memtomem for context",
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" not in result.output
+
+    def test_json_no_mcp_servers_key_not_reported(self, home):
+        """JSON without an ``mcpServers`` key is NOT reported even if
+        'memtomem' appears elsewhere in the config."""
+        self._seed_state_dir(home)
+        path = home / ".gemini" / "settings.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"someOtherKey": {"memtomem": "mentioned-but-not-mcp"}}),
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" not in result.output
+
+    def test_toml_mcp_servers_memtomem_reported(self, home):
+        """TOML (Codex config) with ``mcp_servers.memtomem`` is reported."""
+        import tomllib as _tl
+
+        self._seed_state_dir(home)
+        path = home / ".codex" / "config.toml"
+        path.parent.mkdir(parents=True)
+        toml_text = 'command = "mm-server"\n[mcp_servers.memtomem]\n'
+        path.write_text(toml_text, encoding="utf-8")
+        # Sanity: tomllib round-trips
+        parsed = _tl.loads(toml_text)
+        assert "mcp_servers" in parsed
+        assert "memtomem" in parsed["mcp_servers"]
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" in result.output
+        assert "config.toml" in result.output
+
+    def test_toml_unrelated_text_not_reported(self, home):
+        """TOML with 'memtomem' only in a comment or non-MCP section is NOT reported."""
+        self._seed_state_dir(home)
+        path = home / ".codex" / "config.toml"
+        path.parent.mkdir(parents=True)
+        # "memtomem" appears only in a comment and in an unrelated value
+        path.write_text(
+            "# This config used to reference memtomem\n"
+            "[unrelated]\n"
+            'note = "not about memtomem here"\n',
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        # Must NOT be reported — "memtomem" is only in comment / unrelated value,
+        # not under a parsed mcp_servers key.
+        assert "External integrations" not in result.output
+
+    def test_toml_no_mcp_servers_section_not_reported(self, home):
+        """TOML with ``memtomem = true`` at top level (not under mcp_servers)
+        is NOT reported — the parsed check only looks under ``mcp_servers``."""
+        self._seed_state_dir(home)
+        path = home / ".codex" / "config.toml"
+        path.parent.mkdir(parents=True)
+        path.write_text("memtomem = true\n", encoding="utf-8")
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" not in result.output
+
+    def test_invalid_json_ignored_no_crash(self, home):
+        """Malformed JSON must NOT crash uninstall — uninstall is a recovery path."""
+        self._seed_state_dir(home)
+        path = home / ".claude.json"
+        path.write_text("{this is not valid json //}", encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        # The substring "memtomem" isn't in the bad json, so no external is reported
+        assert "External integrations" not in result.output
+
+    def test_invalid_toml_ignored_no_crash(self, home):
+        """Malformed TOML must NOT crash uninstall — parsed check fails, no fallback."""
+        self._seed_state_dir(home)
+        path = home / ".codex" / "config.toml"
+        path.parent.mkdir(parents=True)
+        path.write_text("[mcp_servers\n  memtomem = bad\n", encoding="utf-8")
+
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        # Invalid TOML → parse fails → silently skipped. No crash, no false report.
+        assert "External integrations" not in result.output
+
+    def test_windsurf_mcp_config_json_parsed(self, home):
+        """Windsurf ``mcp_config.json`` is a JSON file and uses the parsed path."""
+        self._seed_state_dir(home)
+        path = home / ".codeium" / "windsurf" / "mcp_config.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"mcpServers": {"memtomem": {"command": "mm-server"}}}),
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" in result.output
+        assert "mcp_config.json" in result.output
+
+    def test_gemini_settings_json_parsed(self, home):
+        """Gemini ``settings.json`` uses the parsed JSON path.
+        No ``mcpServers`` key → NOT reported, even though 'memtomem' appears in text."""
+        self._seed_state_dir(home)
+        path = home / ".gemini" / "settings.json"
+        path.parent.mkdir(parents=True)
+        path.write_text(
+            json.dumps({"gemini": {"version": "1.0", "description": "uses memtomem"}}),
+            encoding="utf-8",
+        )
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" not in result.output
+
+    def test_nonexistent_files_skipped_silently(self, home):
+        """Files that don't exist are simply skipped — no error, no output."""
+        self._seed_state_dir(home)
+        # No external files created → _probe must return empty list.
+        result = CliRunner().invoke(cli, ["uninstall", "-y"])
+        assert result.exit_code == 0, result.output
+        assert "External integrations" not in result.output
+
+
 # -------------------------------------------------------------------- 8
 
 


### PR DESCRIPTION
## Summary

Replace the broad substring check in `_probe_external_integrations()` with proper JSON and TOML parsing. This prevents false positives where "memtomem" appears in comments, descriptions, or unrelated text without being an actual MCP server configuration entry.

## Root Cause

The `mm uninstall` command probes external MCP client configs (`.claude.json`, `.codex/config.toml`, `.cursor/mcp.json`, etc.) to warn the user about integrations they must clean up manually. Previously it used a naive substring match — any file containing the text "memtomem" was reported. This produced false positives from comments, descriptions, and unrelated config values.

## Fix

- **JSON files**: Parse with `json.loads`, check for `mcpServers.memtomem` key
- **TOML files** (Codex): Parse with `tomllib` (Python 3.12 stdlib), check for `mcp_servers.memtomem` key
- **Invalid/malformed files**: Silently skipped — uninstall is a recovery path and must not crash
- Removed the legacy substring fallback entirely for known formats

## Changes

| File | Change |
|------|--------|
| `packages/memtomem/src/memtomem/cli/uninstall_cmd.py` | Added `json` and `tomllib` imports; replaced substring check with parsed `mcpServers.memtomem` / `mcp_servers.memtomem` check |
| `packages/memtomem/tests/test_uninstall_cmd.py` | Added `TestProbeExternalParsedMCP` with 11 focused tests |

## Testing

- ✅ All 42 existing tests pass (2 Windows-only skipped)
- ✅ `ruff check` passes
- ✅ `ruff format` passes
- 11 new tests covering:
  - Valid JSON with `mcpServers.memtomem` → reported
  - JSON with "memtomem" only in description → NOT reported
  - JSON without `mcpServers` key → NOT reported
  - Valid TOML with `mcp_servers.memtomem` → reported
  - TOML with "memtomem" only in comments → NOT reported
  - TOML without `mcp_servers` section → NOT reported
  - Invalid JSON → no crash
  - Invalid TOML → no crash
  - Windsurf `mcp_config.json` → parsed path
  - Gemini `settings.json` (no `mcpServers`) → NOT reported
  - No external files → no output

Fixes #975