### PR TITLE
Fix Add Project picker discovery scope

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/fs.py
+++ b/packages/memtomem/src/memtomem/web/routes/fs.py
@@ -1,16 +1,19 @@
-"""Filesystem listing endpoint for the Index tab folder picker.
+"""Filesystem listing endpoint for folder pickers.
 
-Single endpoint ``GET /api/fs/list`` that powers the Browse modal next to the
-Folder-mode path input. Returns either the picker's roots view (no ``path``)
-or the subdirectories of an allow-listed directory.
+Single endpoint ``GET /api/fs/list`` powers the Browse modal next to the
+Index tab's Folder-mode path input and the Context Gateway Add Project picker.
+It returns either the picker's roots view (no ``path``) or the subdirectories
+of an allow-listed directory.
 
-The allow-list is ``~`` plus every ``config.indexing.memory_dirs`` entry. It
-is a *discoverability* boundary, not a security one — ``mm web`` is bound to
-localhost and the user can still type any path into the Index input directly.
-422 here means "this path is outside the picker's scope, close the picker
-and type it instead", not "you don't have permission". Keeping the status
-distinct from 403 lets the frontend map outside-scope replies to the
-picker-specific toast without conflating with real auth failures elsewhere.
+The default Index allow-list is ``~`` plus every ``config.indexing.memory_dirs``
+entry. ``purpose=project`` adds project-discovery roots for Context Gateway
+Add Project without widening the Index tab's existing picker scope. The
+allow-list is a *discoverability* boundary, not a security one — ``mm web`` is
+bound to localhost and the user can still type paths directly in surfaces that
+offer free-form input. 422 here means "this path is outside the picker's
+scope", not "you don't have permission". Keeping the status distinct from 403
+lets the frontend map outside-scope replies to the picker-specific toast
+without conflating with real auth failures elsewhere.
 """
 
 from __future__ import annotations
@@ -19,9 +22,10 @@ import os
 import unicodedata
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
+from memtomem.context.projects import KnownProjectsStore
 from memtomem.storage.sqlite_helpers import norm_path
 from memtomem.web.deps import get_config
 
@@ -40,18 +44,11 @@ class FsListResponse(BaseModel):
     entries: list[FsEntry]
 
 
-def _allow_list_roots(config) -> list[Path]:
-    """Return the picker's allow-list roots in display order.
+def _dedupe_roots(candidates: list[Path]) -> list[Path]:
+    """Return roots in first-seen order, normalized for comparison."""
 
-    Order is ``~`` first, then ``config.indexing.memory_dirs`` in config
-    order. Duplicates (same NFC-normalized resolved path) are dropped on
-    first occurrence so the response stays stable when ``~`` itself is also
-    listed in ``memory_dirs``.
-    """
     seen: set[str] = set()
     out: list[Path] = []
-    candidates: list[Path] = [Path.home()]
-    candidates.extend(Path(d).expanduser() for d in config.indexing.memory_dirs)
     for cand in candidates:
         key = norm_path(cand)
         if key in seen:
@@ -59,6 +56,57 @@ def _allow_list_roots(config) -> list[Path]:
         seen.add(key)
         out.append(Path(key))
     return out
+
+
+def _index_allow_list_roots(config) -> list[Path]:
+    """Return the Index picker's allow-list roots in display order.
+
+    Order is ``~`` first, then ``config.indexing.memory_dirs`` in config
+    order. Duplicates (same NFC-normalized resolved path) are dropped on
+    first occurrence so the response stays stable when ``~`` itself is also
+    listed in ``memory_dirs``.
+    """
+    candidates: list[Path] = [Path.home()]
+    candidates.extend(Path(d).expanduser() for d in config.indexing.memory_dirs)
+    return _dedupe_roots(candidates)
+
+
+def _known_project_parent_roots(config) -> list[Path]:
+    cg = getattr(config, "context_gateway", None)
+    known_projects_path = getattr(cg, "known_projects_path", None)
+    if known_projects_path is None:
+        return []
+
+    roots: list[Path] = []
+    for entry in KnownProjectsStore(Path(known_projects_path).expanduser()).load():
+        roots.append(entry.root.expanduser().parent)
+    return roots
+
+
+def _project_allow_list_roots(request: Request, config) -> list[Path]:
+    """Return wider project-discovery roots for Context Gateway Add Project.
+
+    This extends, rather than replaces, the Index roots so Home and configured
+    memory dirs remain visible. Adding the server cwd's parent lets users pick
+    sibling worktrees/projects without making the picker browse from ``/``.
+    Known-project parents keep previously registered project families
+    discoverable after restart.
+    """
+    candidates = _index_allow_list_roots(config)
+    project_root = Path(getattr(request.app.state, "project_root", Path.cwd())).expanduser()
+    project_parent = project_root.parent
+    if project_parent != project_root and project_parent != Path(project_parent.anchor):
+        candidates.append(project_parent)
+    candidates.extend(_known_project_parent_roots(config))
+    return _dedupe_roots(candidates)
+
+
+def _allow_list_roots(request: Request, config, purpose: str) -> list[Path]:
+    if purpose == "index":
+        return _index_allow_list_roots(config)
+    if purpose == "project":
+        return _project_allow_list_roots(request, config)
+    raise HTTPException(status_code=400, detail="invalid_picker_purpose")
 
 
 def _display_name(p: Path) -> str:
@@ -105,10 +153,15 @@ def _inside_any_root(target: Path, roots: list[Path]) -> bool:
 
 @router.get("/list", response_model=FsListResponse)
 async def list_directory(
+    request: Request,
     path: str | None = Query(None),
+    purpose: str = Query(
+        "index",
+        description="Picker purpose: index keeps the legacy memory-dir scope; project widens discovery for Add Project.",
+    ),
     config=Depends(get_config),
 ) -> FsListResponse:
-    roots = _allow_list_roots(config)
+    roots = _allow_list_roots(request, config, purpose)
 
     if not path:
         return FsListResponse(

--- a/packages/memtomem/src/memtomem/web/routes/fs.py
+++ b/packages/memtomem/src/memtomem/web/routes/fs.py
@@ -79,7 +79,13 @@ def _known_project_parent_roots(config) -> list[Path]:
 
     roots: list[Path] = []
     for entry in KnownProjectsStore(Path(known_projects_path).expanduser()).load():
-        roots.append(entry.root.expanduser().parent)
+        parent = entry.root.expanduser().parent
+        # Same filesystem-root guard as _project_allow_list_roots: a known
+        # project registered at ``/foo`` would otherwise add ``/`` to the
+        # picker's discovery roots, bypassing the protection used for the
+        # server cwd's parent a few lines below.
+        if parent != Path(parent.anchor):
+            roots.append(parent)
     return roots
 
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -2776,7 +2776,7 @@ document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
       }
     };
     if (window.PathPicker && typeof window.PathPicker.open === 'function') {
-      window.PathPicker.open({ onSelect });
+      window.PathPicker.open({ purpose: 'project', onSelect });
       return;
     }
     const raw = window.prompt(

--- a/packages/memtomem/src/memtomem/web/static/path-picker.js
+++ b/packages/memtomem/src/memtomem/web/static/path-picker.js
@@ -7,11 +7,13 @@
  * allow-list (memory_dirs + ~); going outside requires closing the modal
  * and typing the path manually — the input itself stays free-form.
  *
- * Also exposes ``window.PathPicker.open({ onSelect })`` for other
- * surfaces (Context Gateway "Add Project") so they can reuse the
- * modal instead of falling back to ``window.prompt``. ``onSelect`` is
- * invoked with the selected absolute path; ``close`` is called by the
- * picker itself once the callback returns.
+ * Also exposes ``window.PathPicker.open({ purpose, onSelect })`` for
+ * other surfaces (Context Gateway "Add Project") so they can reuse
+ * the modal instead of falling back to ``window.prompt``. ``purpose``
+ * is forwarded to /api/fs/list so each surface can use an appropriate
+ * discovery scope. ``onSelect`` is invoked with the selected absolute
+ * path; ``close`` is called by the picker itself once the callback
+ * returns.
  */
 'use strict';
 
@@ -23,6 +25,7 @@
   // previous invocation can't fire when the picker is reopened by the
   // default Index-tab path.
   let onSelectCb = null;
+  let pickerPurpose = 'index';
 
   function modal() { return qs('path-picker-modal'); }
   function listEl() { return qs('path-picker-list'); }
@@ -41,7 +44,11 @@
   }
 
   async function _fetchList(path) {
-    const url = path ? `/api/fs/list?path=${encodeURIComponent(path)}` : '/api/fs/list';
+    const params = new URLSearchParams();
+    if (path) params.set('path', path);
+    if (pickerPurpose && pickerPurpose !== 'index') params.set('purpose', pickerPurpose);
+    const query = params.toString();
+    const url = `/api/fs/list${query ? `?${query}` : ''}`;
     let resp;
     try {
       resp = await fetch(url);
@@ -178,6 +185,7 @@
 
   function open(opts) {
     onSelectCb = (opts && typeof opts.onSelect === 'function') ? opts.onSelect : null;
+    pickerPurpose = (opts && opts.purpose) || 'index';
     modal().hidden = false;
     document.addEventListener('keydown', _onKey, true);
     modal().addEventListener('click', _onBackdrop);
@@ -192,6 +200,7 @@
     currentPath = null;
     currentEntries = [];
     onSelectCb = null;
+    pickerPurpose = 'index';
     listEl().textContent = '';
     crumbEl().textContent = '';
     emptyEl().hidden = true;

--- a/packages/memtomem/tests-js/path-picker-purpose.test.mjs
+++ b/packages/memtomem/tests-js/path-picker-purpose.test.mjs
@@ -1,0 +1,98 @@
+/* Regression guards for purpose-scoped folder picker discovery (#1015). */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+function jsonResponse(body, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+async function waitFor(predicate) {
+  for (let i = 0; i < 20; i += 1) {
+    if (predicate()) return;
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+describe('PathPicker purpose', () => {
+  it('keeps the default picker request on the legacy index scope', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js'],
+    });
+    const { window } = dom;
+    const requests = [];
+    window.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      requests.push(url);
+      if (url.startsWith('/api/fs/list')) {
+        return jsonResponse({ path: null, parent: null, is_root: true, entries: [] });
+      }
+      return jsonResponse({});
+    };
+
+    window.PathPicker.open();
+
+    await waitFor(() => requests.includes('/api/fs/list'));
+  });
+
+  it('passes project purpose through to fs/list', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js'],
+    });
+    const { window } = dom;
+    const requests = [];
+    window.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      requests.push(url);
+      if (url === '/api/fs/list?purpose=project') {
+        return jsonResponse({
+          path: null,
+          parent: null,
+          is_root: true,
+          entries: [{ name: 'project-a', path: '/tmp/project-a' }],
+        });
+      }
+      if (url.startsWith('/api/fs/list')) {
+        return jsonResponse({ path: '/tmp/project-a', parent: '/tmp', is_root: false, entries: [] });
+      }
+      return jsonResponse({});
+    };
+
+    window.PathPicker.open({ purpose: 'project' });
+
+    await waitFor(() => window.document.querySelector('#path-picker-list li'));
+    window.document.querySelector('#path-picker-list li').dispatchEvent(
+      new window.Event('click', { bubbles: true }),
+    );
+    await waitFor(() => requests.includes('/api/fs/list?path=%2Ftmp%2Fproject-a&purpose=project'));
+  });
+});
+
+describe('Context Gateway Add Project picker', () => {
+  it('opens PathPicker with project purpose', async () => {
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    let optsSeen = null;
+    window.PathPicker = {
+      open: (opts) => {
+        optsSeen = opts;
+      },
+    };
+
+    window.document
+      .querySelector('.ctx-add-project-btn[data-type="skills"]')
+      .dispatchEvent(new window.Event('click', { bubbles: true }));
+
+    expect(optsSeen).toBeTruthy();
+    expect(optsSeen.purpose).toBe('project');
+    expect(typeof optsSeen.onSelect).toBe('function');
+  });
+});

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -8,6 +8,7 @@ full component initialization (embedding provider, SQLite, etc.).
 from __future__ import annotations
 
 import asyncio
+import json
 import unicodedata
 import uuid
 from dataclasses import dataclass
@@ -3819,6 +3820,45 @@ class TestFsList:
 
         scoped = await client.get(f"/api/fs/list?path={known_project}&purpose=project")
         assert scoped.status_code == 200, scoped.text
+
+    async def test_project_purpose_drops_known_project_at_filesystem_root(
+        self,
+        app,
+        client: AsyncClient,
+        fs_tree,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A known project registered at a top-level dir must not widen to ``/``.
+
+        ``_project_allow_list_roots`` guards the server cwd's parent against
+        collapsing to the filesystem anchor; ``_known_project_parent_roots``
+        needs the same guard so a stale ``/foo`` entry can't sidestep it.
+        """
+        memdir = fs_tree["memdir"]
+        known_projects_path = tmp_path / "known_projects.json"
+
+        anchor = Path(Path(memdir).anchor)
+        top_level = anchor / "memtomem-test-top-level"
+        # Bypass KnownProjectsStore.add so the test never has to create or
+        # touch a real top-level directory.
+        known_projects_path.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "projects": [{"root": str(top_level), "added_at": "2026-01-01T00:00:00Z"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        app.state.config.context_gateway = SimpleNamespace(known_projects_path=known_projects_path)
+        set_home(monkeypatch, fs_tree["home"])
+        self._wire_memory_dirs(app, [memdir], monkeypatch)
+
+        roots = await client.get("/api/fs/list?purpose=project")
+        assert roots.status_code == 200, roots.text
+        root_paths = {Path(e["path"]) for e in roots.json()["entries"]}
+        assert anchor not in root_paths
 
     async def test_project_purpose_still_excludes_symlink_out(
         self,

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -13,11 +13,13 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from memtomem.context.projects import KnownProjectsStore
 from memtomem.models import Chunk, ChunkMetadata, IndexingStats, SearchResult
 from memtomem.search.pipeline import RetrievalStats
 from memtomem.web.app import create_app
@@ -3758,6 +3760,89 @@ class TestFsList:
         resp = await client.get(f"/api/fs/list?path={outside}")
         assert resp.status_code == 422, resp.text
         assert resp.json()["detail"] == "outside_picker_scope"
+
+    async def test_project_purpose_adds_project_root_parent_without_changing_default(
+        self,
+        app,
+        client: AsyncClient,
+        fs_tree,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Add Project can discover sibling project folders outside memory_dirs.
+
+        The default picker still rejects the same path, preserving the Index
+        tab's memory-dir scope. ``purpose=project`` adds the server project
+        root's parent, which is enough for the user to choose sibling checkouts
+        without browsing from filesystem root.
+        """
+        memdir = fs_tree["memdir"]
+        outside = fs_tree["outside"]
+        project_root = outside / "server-cwd"
+        project_root.mkdir()
+        app.state.project_root = project_root
+        set_home(monkeypatch, fs_tree["home"])
+        self._wire_memory_dirs(app, [memdir], monkeypatch)
+
+        default = await client.get(f"/api/fs/list?path={outside / 'target'}")
+        assert default.status_code == 422, default.text
+
+        roots = await client.get("/api/fs/list?purpose=project")
+        assert roots.status_code == 200, roots.text
+        root_paths = [Path(e["path"]) for e in roots.json()["entries"]]
+        assert Path(unicodedata.normalize("NFC", str(outside.resolve()))) in root_paths
+
+        scoped = await client.get(f"/api/fs/list?path={outside / 'target'}&purpose=project")
+        assert scoped.status_code == 200, scoped.text
+        assert scoped.json()["path"] == unicodedata.normalize("NFC", str(outside / "target"))
+
+    async def test_project_purpose_adds_known_project_parents(
+        self,
+        app,
+        client: AsyncClient,
+        fs_tree,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        memdir = fs_tree["memdir"]
+        known_parent = tmp_path / "known-family"
+        known_project = known_parent / "project-a"
+        known_project.mkdir(parents=True)
+        known_projects_path = tmp_path / "known_projects.json"
+        KnownProjectsStore(known_projects_path).add(known_project)
+        app.state.config.context_gateway = SimpleNamespace(known_projects_path=known_projects_path)
+        set_home(monkeypatch, fs_tree["home"])
+        self._wire_memory_dirs(app, [memdir], monkeypatch)
+
+        default = await client.get(f"/api/fs/list?path={known_project}")
+        assert default.status_code == 422, default.text
+
+        scoped = await client.get(f"/api/fs/list?path={known_project}&purpose=project")
+        assert scoped.status_code == 200, scoped.text
+
+    async def test_project_purpose_still_excludes_symlink_out(
+        self,
+        app,
+        client: AsyncClient,
+        fs_tree,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        memdir = fs_tree["memdir"]
+        set_home(monkeypatch, fs_tree["home"])
+        self._wire_memory_dirs(app, [memdir], monkeypatch)
+
+        resp = await client.get(f"/api/fs/list?path={memdir}&purpose=project")
+        assert resp.status_code == 200, resp.text
+        names = [e["name"] for e in resp.json()["entries"]]
+        assert "ln_outside" not in names
+
+    async def test_invalid_picker_purpose_400(
+        self,
+        client: AsyncClient,
+    ):
+        resp = await client.get("/api/fs/list?purpose=everything")
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "invalid_picker_purpose"
 
     async def test_nonexistent_404(
         self,


### PR DESCRIPTION
## Summary

- Add `purpose=project` to `/api/fs/list` so Context Gateway Add Project can discover project folders beyond `memory_dirs` without changing the Index picker default.
- Thread `PathPicker.open({ purpose })` through to `/api/fs/list` and use `purpose: 'project'` from the Context Gateway Add Project button.
- Cover default-vs-project picker roots, known-project parents, symlink-out filtering, and JS purpose forwarding.

Closes #1015

## Tests

- `uv run pytest packages/memtomem/tests/test_web_routes.py`
- `npm test -- --cache=false`
- `uv run ruff check packages/memtomem/src/memtomem/web/routes/fs.py packages/memtomem/tests/test_web_routes.py`