### PR TITLE
fix(retry): validate max_delay before sleeping

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/retry.py
+++ b/packages/memtomem/src/memtomem/embedding/retry.py
@@ -46,6 +46,8 @@ def with_retry(
         raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
     if base_delay < 0:
         raise ValueError(f"base_delay must be >= 0, got {base_delay}")
+    if max_delay < 0:
+        raise ValueError(f"max_delay must be >= 0, got {max_delay}")
 
     def decorator(func):
         @wraps(func)


### PR DESCRIPTION
## Summary

Fixes #1035

`with_retry()` accepted negative `max_delay` values, allowing `asyncio.sleep()` to be called with a negative delay at runtime.

## Root Cause

In `packages/memtomem/src/memtomem/embedding/retry.py`, the `with_retry()` decorator validates `max_attempts` (line 45) and `base_delay` (line 47) but has no validation for `max_delay` (line 37). A negative `max_delay` would cause `min(base_delay * (2**attempt), max_delay)` to produce a negative value, which is then passed directly to `asyncio.sleep()` on line 73.

## Fix

Added `max_delay >= 0` validation at line 49, following the same pattern as the existing `base_delay` check. Raises `ValueError` with a message that names the parameter.

## Changes

- `packages/memtomem/src/memtomem/embedding/retry.py`: 2 lines added (`+2 -0`)

## Testing

- `with_retry(max_delay=-1)`: raises `ValueError` with message containing `max_delay` ✅
- `with_retry(max_delay=16.0)`: no exception raised ✅
- `with_retry(max_delay=0)`: no exception raised (valid edge case) ✅
- Existing `with_retry` tests: unaffected ✅