### PR TITLE
fix(lint): remove unused noqa directives from source tree

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -427,7 +427,7 @@ def _step_embedding(state: dict) -> None:
         provider = "onnx"
         _onnx_available = False
         try:
-            import fastembed  # noqa: F401
+            import fastembed
 
             _onnx_available = True
         except ImportError:
@@ -898,7 +898,7 @@ def _step_language(state: dict) -> None:
 
     if tokenizer == "kiwipiepy":
         try:
-            import kiwipiepy  # noqa: F401
+            import kiwipiepy
 
             click.secho("  kiwipiepy is installed.", fg="green")
         except ImportError:

--- a/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/uninstall_cmd.py
@@ -38,7 +38,7 @@ import click
 
 from memtomem._runtime_paths import runtime_dir, server_pid_path
 from memtomem.cli._liveness import check_server_liveness as _check_server_liveness
-from memtomem.cli._liveness import probe_pid_file as _probe_pid_file  # noqa: F401  (test seam)
+from memtomem.cli._liveness import probe_pid_file as _probe_pid_file
 from memtomem.cli.init_cmd import RuntimeProfile, _runtime_profile
 
 _DEFAULT_STATE_DIR = Path.home() / ".memtomem"
@@ -123,7 +123,7 @@ def _load_config_safely() -> tuple[Path, str | None]:
         load_config_overrides(cfg)
         db_path = Path(cfg.storage.sqlite_path).expanduser()
         return db_path, None
-    except Exception as exc:  # noqa: BLE001 — uninstall must never abort on config
+    except Exception as exc:
         return _DEFAULT_STATE_DIR / _DEFAULT_DB_NAME, f"{type(exc).__name__}: {exc}"
 
 

--- a/packages/memtomem/src/memtomem/cli/web.py
+++ b/packages/memtomem/src/memtomem/cli/web.py
@@ -150,7 +150,7 @@ def _web_pid_lock(port: int) -> Iterator[None]:
     from memtomem._runtime_paths import ensure_runtime_dir
 
     pid_file = ensure_runtime_dir() / "web.pid"
-    lock_fp = open(pid_file, "a+")  # noqa: SIM115
+    lock_fp = open(pid_file, "a+")
     try:
         portalocker.lock(lock_fp, portalocker.LOCK_EX | portalocker.LOCK_NB)
     except (portalocker.LockException, BlockingIOError, OSError) as exc:

--- a/packages/memtomem/src/memtomem/embedding/readiness.py
+++ b/packages/memtomem/src/memtomem/embedding/readiness.py
@@ -29,7 +29,7 @@ from pathlib import Path
 
 # Re-exported for backwards compatibility with the readiness endpoint
 # import site. Source of truth is ``embedding/aliases.py``.
-from memtomem.embedding.aliases import approx_size_mb as approx_size_mb  # noqa: F401
+from memtomem.embedding.aliases import approx_size_mb as approx_size_mb
 
 
 def model_snapshot_present(cache_dir: Path, model_id: str) -> bool:

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E402, F401
 """MCP server package — facade and tool registration.
 
 All public symbols are re-exported here for backward compatibility:
@@ -59,17 +58,17 @@ from memtomem import __version__ as _memtomem_version
 mcp._mcp_server.version = _memtomem_version
 
 # ── Register ALL tools (decorators bind to `mcp` on import) ───────────
-from memtomem.server.tools.ask import mem_ask  # noqa: E402, F401
-from memtomem.server.tools.indexing import mem_index  # noqa: E402, F401
-from memtomem.server.tools.memory_crud import (  # noqa: E402, F401
+from memtomem.server.tools.ask import mem_ask
+from memtomem.server.tools.indexing import mem_index
+from memtomem.server.tools.memory_crud import (
     mem_add,
     mem_add_redaction_stats,
     mem_batch_add,
     mem_delete,
     mem_edit,
 )
-from memtomem.server.tools.recall import mem_recall  # noqa: E402, F401
-from memtomem.server.tools.search import mem_search, mem_expand  # noqa: E402, F401
+from memtomem.server.tools.recall import mem_recall
+from memtomem.server.tools.search import mem_search, mem_expand
 from memtomem.server.tools.status_config import (
     mem_config,
     mem_embedding_reset,
@@ -77,7 +76,7 @@ from memtomem.server.tools.status_config import (
     mem_stats,
     mem_status,
     mem_version,
-)  # noqa: E402, F401
+)
 from memtomem.server.tools.namespace import (
     mem_ns_assign,
     mem_ns_list,
@@ -86,44 +85,44 @@ from memtomem.server.tools.namespace import (
     mem_ns_get,
     mem_ns_rename,
     mem_ns_update,
-)  # noqa: E402, F401
+)
 from memtomem.server.tools.dedup_decay import (
     mem_cleanup_orphans,
     mem_dedup_scan,
     mem_dedup_merge,
     mem_decay_scan,
     mem_decay_expire,
-)  # noqa: E402, F401
-from memtomem.server.tools.export_import import mem_export, mem_import  # noqa: E402, F401
-from memtomem.server.tools.auto_tag import mem_auto_tag  # noqa: E402, F401
-from memtomem.server.tools.browse import mem_list, mem_read  # noqa: E402, F401
+)
+from memtomem.server.tools.export_import import mem_export, mem_import
+from memtomem.server.tools.auto_tag import mem_auto_tag
+from memtomem.server.tools.browse import mem_list, mem_read
 from memtomem.server.tools.tag_management import (
     mem_tag_list,
     mem_tag_rename,
     mem_tag_delete,
     mem_tag_merge,
-)  # noqa: E402, F401
-from memtomem.server.tools.url_index import mem_fetch  # noqa: E402, F401
-from memtomem.server.tools.cross_ref import mem_link, mem_unlink, mem_related  # noqa: E402, F401
-from memtomem.server.tools.session import mem_session_start, mem_session_end, mem_session_list  # noqa: E402, F401
-from memtomem.server.tools.scratch import mem_scratch_set, mem_scratch_get, mem_scratch_promote  # noqa: E402, F401
-from memtomem.server.tools.procedure import mem_procedure_save, mem_procedure_list  # noqa: E402, F401
-from memtomem.server.tools.multi_agent import mem_agent_register, mem_agent_search, mem_agent_share  # noqa: E402, F401
-from memtomem.server.tools.evaluation import mem_eval  # noqa: E402, F401
-from memtomem.server.tools.consolidation import mem_consolidate, mem_consolidate_apply  # noqa: E402, F401
-from memtomem.server.tools.reflection import mem_reflect, mem_reflect_save  # noqa: E402, F401
-from memtomem.server.tools.search_history import mem_search_history, mem_search_suggest  # noqa: E402, F401
-from memtomem.server.tools.conflict import mem_conflict_check  # noqa: E402, F401
-from memtomem.server.tools.importance import mem_importance_scan  # noqa: E402, F401
-from memtomem.server.tools.importers import mem_import_notion, mem_import_obsidian  # noqa: E402, F401
-from memtomem.server.tools.entity import mem_entity_scan, mem_entity_search  # noqa: E402, F401
-from memtomem.server.tools.temporal import mem_timeline, mem_activity  # noqa: E402, F401
+)
+from memtomem.server.tools.url_index import mem_fetch
+from memtomem.server.tools.cross_ref import mem_link, mem_unlink, mem_related
+from memtomem.server.tools.session import mem_session_start, mem_session_end, mem_session_list
+from memtomem.server.tools.scratch import mem_scratch_set, mem_scratch_get, mem_scratch_promote
+from memtomem.server.tools.procedure import mem_procedure_save, mem_procedure_list
+from memtomem.server.tools.multi_agent import mem_agent_register, mem_agent_search, mem_agent_share
+from memtomem.server.tools.evaluation import mem_eval
+from memtomem.server.tools.consolidation import mem_consolidate, mem_consolidate_apply
+from memtomem.server.tools.reflection import mem_reflect, mem_reflect_save
+from memtomem.server.tools.search_history import mem_search_history, mem_search_suggest
+from memtomem.server.tools.conflict import mem_conflict_check
+from memtomem.server.tools.importance import mem_importance_scan
+from memtomem.server.tools.importers import mem_import_notion, mem_import_obsidian
+from memtomem.server.tools.entity import mem_entity_scan, mem_entity_search
+from memtomem.server.tools.temporal import mem_timeline, mem_activity
 from memtomem.server.tools.policy import (
     mem_policy_add,
     mem_policy_list,
     mem_policy_delete,
     mem_policy_run,
-)  # noqa: E402, F401
+)
 from memtomem.server.tools.context import (
     mem_context_detect,
     mem_context_init,
@@ -131,17 +130,17 @@ from memtomem.server.tools.context import (
     mem_context_diff,
     mem_context_sync,
     mem_context_migrate,
-)  # noqa: E402, F401
-from memtomem.server.tools.ingest import mem_ingest  # noqa: E402, F401  — no @mcp.tool; import triggers @register("ingest") for mem_do routing
-from memtomem.server.tools.watchdog import mem_watchdog  # noqa: E402, F401
-from memtomem.server.tools.schedule import (  # noqa: E402, F401
+)
+from memtomem.server.tools.ingest import mem_ingest
+from memtomem.server.tools.watchdog import mem_watchdog
+from memtomem.server.tools.schedule import (
     mem_schedule_delete,
     mem_schedule_list,
     mem_schedule_register,
     mem_schedule_run_now,
 )
-from memtomem.server.tools.meta import mem_do  # noqa: E402, F401
-import memtomem.server.resources  # noqa: E402, F401  — register MCP resources
+from memtomem.server.tools.meta import mem_do
+import memtomem.server.resources
 
 # ── Tool mode: core | standard | full ─────────────────────────────────
 # Set MEMTOMEM_TOOL_MODE env var to control which tools are exposed.
@@ -384,7 +383,7 @@ def main() -> None:
     # ``MsvcrtLocker`` backend calls ``msvcrt.locking``, which the C runtime
     # rejects on read-only handles with ``EACCES``. ``cli/_liveness.py`` uses
     # ``"rb+"`` for the same reason. Don't simplify this to ``"w"``.
-    _lock_fp = open(pid_file, "a+")  # noqa: SIM115
+    _lock_fp = open(pid_file, "a+")
     try:
         portalocker.lock(_lock_fp, portalocker.LOCK_EX | portalocker.LOCK_NB)
     except (portalocker.LockException, BlockingIOError, OSError):

--- a/packages/memtomem/src/memtomem/storage/orphan_gc.py
+++ b/packages/memtomem/src/memtomem/storage/orphan_gc.py
@@ -181,11 +181,11 @@ def sweep_orphan_project_root(
         for i in range(0, len(rowids), _BATCH_SIZE):
             batch = rowids[i : i + _BATCH_SIZE]
             ph = placeholders(len(batch))
-            cursor = db.execute(f"DELETE FROM chunks_fts WHERE rowid IN ({ph})", batch)  # noqa: S608
+            cursor = db.execute(f"DELETE FROM chunks_fts WHERE rowid IN ({ph})", batch)
             fts_deleted += cursor.rowcount or 0
             if has_vec_table:
                 cursor = db.execute(
-                    f"DELETE FROM chunks_vec WHERE rowid IN ({ph})",  # noqa: S608
+                    f"DELETE FROM chunks_vec WHERE rowid IN ({ph})",
                     batch,
                 )
                 vec_deleted += cursor.rowcount or 0
@@ -199,7 +199,7 @@ def sweep_orphan_project_root(
             batch = ids[i : i + _BATCH_SIZE]
             ph = placeholders(len(batch))
             cursor = db.execute(
-                f"DELETE FROM chunks "  # noqa: S608
+                f"DELETE FROM chunks "
                 f"WHERE id IN ({ph}) "
                 f"  AND scope IN ('project_shared', 'project_local') "
                 f"  AND project_root = ?",

--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -380,8 +380,8 @@ class SqliteBackend(
                     "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (tbl,)
                 ).fetchone()
                 if exists:
-                    count = db.execute(f"SELECT COUNT(*) FROM [{tbl}]").fetchone()[0]  # noqa: S608
-                    db.execute(f"DELETE FROM [{tbl}]")  # noqa: S608
+                    count = db.execute(f"SELECT COUNT(*) FROM [{tbl}]").fetchone()[0]
+                    db.execute(f"DELETE FROM [{tbl}]")
                     deleted[tbl] = count
 
             # Core content tables

--- a/packages/memtomem/src/memtomem/web/schemas/__init__.py
+++ b/packages/memtomem/src/memtomem/web/schemas/__init__.py
@@ -1,13 +1,13 @@
 """Pydantic request/response schemas for Web UI API."""
 
-from memtomem.web.schemas.core import *  # noqa: F401,F403
-from memtomem.web.schemas.search import *  # noqa: F401,F403
-from memtomem.web.schemas.sources import *  # noqa: F401,F403
-from memtomem.web.schemas.memory import *  # noqa: F401,F403
-from memtomem.web.schemas.config import *  # noqa: F401,F403
-from memtomem.web.schemas.tags import *  # noqa: F401,F403
-from memtomem.web.schemas.dedup import *  # noqa: F401,F403
-from memtomem.web.schemas.decay import *  # noqa: F401,F403
-from memtomem.web.schemas.namespaces import *  # noqa: F401,F403
-from memtomem.web.schemas.sessions import *  # noqa: F401,F403
-from memtomem.web.schemas.scratch import *  # noqa: F401,F403
+from memtomem.web.schemas.core import *
+from memtomem.web.schemas.search import *
+from memtomem.web.schemas.sources import *
+from memtomem.web.schemas.memory import *
+from memtomem.web.schemas.config import *
+from memtomem.web.schemas.tags import *
+from memtomem.web.schemas.dedup import *
+from memtomem.web.schemas.decay import *
+from memtomem.web.schemas.namespaces import *
+from memtomem.web.schemas.sessions import *
+from memtomem.web.schemas.scratch import *


### PR DESCRIPTION
## Summary

Fixes #1033

Source files in `packages/memtomem/src/` contained 58 unused `# noqa` directives, primarily for `E402` and `F401` rules that are not enabled in the project's ruff configuration.

## Root Cause

`ruff check --select RUF100 packages/memtomem/src/` reported 58 unused `noqa` directives across the source tree. The main concentration was in `server/__init__.py` where imports had `# noqa: E402, F401` annotations that weren't suppressing any active rules.

## Fix

Ran `ruff check --select RUF100 --fix packages/memtomem/src/` to automatically remove all unused directives.

## Changes

- `packages/memtomem/src/`: 58 unused noqa directives removed across source files

## Testing

- `ruff check --select RUF100 packages/memtomem/src/`: zero findings ✅
- Existing ruff checks: no regressions ✅
- Source tree only (test tree handled separately in #1042) ✅