### PR TITLE
fix(dedup): default mem_dedup_merge to dry_run=True for safety parity

### DIFF
--- a/packages/memtomem/src/memtomem/search/dedup.py
+++ b/packages/memtomem/src/memtomem/search/dedup.py
@@ -60,11 +60,17 @@ class DedupScanner:
 
         return candidates[:limit]
 
-    async def merge(self, keep_id: UUID, delete_ids: list[UUID]) -> int:
+    async def merge(self, keep_id: UUID, delete_ids: list[UUID], dry_run: bool = False) -> int:
         """Merge duplicate chunks: keep *keep_id*, delete *delete_ids*.
 
         The tags of all deleted chunks are unioned into the kept chunk.
-        Returns the number of chunks actually deleted.
+        Returns the number of chunks that were (or would be) deleted.
+
+        When ``dry_run`` is True, no writes are performed: neither the
+        tag-merge upsert on ``keep_id`` nor the deletion of ``delete_ids``.
+        The return value is the count of ``delete_ids`` that resolve to
+        existing chunks — the same value the non-dry path's
+        ``storage.delete_chunks`` would return.
         """
         if not delete_ids:
             return 0
@@ -83,6 +89,9 @@ class DedupScanner:
             del_chunk = chunks_map.get(del_id)
             if del_chunk is not None:
                 merged_tags.update(del_chunk.metadata.tags)
+
+        if dry_run:
+            return sum(1 for d in delete_ids if d in chunks_map)
 
         # Update keep chunk if tags changed
         if merged_tags != set(keep_chunk.metadata.tags):

--- a/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
+++ b/packages/memtomem/src/memtomem/server/tools/dedup_decay.py
@@ -62,15 +62,22 @@ async def mem_dedup_scan(
 async def mem_dedup_merge(
     keep_id: str,
     delete_ids: list[str],
+    dry_run: bool = True,
     ctx: CtxType = None,
 ) -> str:
     """Merge duplicate chunks: keep keep_id, delete delete_ids.
 
     Tags from deleted chunks are merged into the kept chunk.
 
+    Defaults to dry_run=True for safety -- set dry_run=False to actually
+    delete. Mirrors the safety-first defaults on mem_decay_expire and
+    mem_cleanup_orphans so a wrong UUID in a maintenance script can't
+    silently destroy data on first call.
+
     Args:
         keep_id: UUID of the chunk to keep
         delete_ids: UUIDs of chunks to delete
+        dry_run: If True (default), preview without making any changes.
     """
     app = await _get_app_initialized(ctx)
     if app.dedup_scanner is None:
@@ -81,9 +88,14 @@ async def mem_dedup_merge(
     except ValueError as exc:
         return f"Invalid UUID: {exc}"
 
-    deleted = await app.dedup_scanner.merge(keep_uuid, delete_uuids)
+    would_or_did = await app.dedup_scanner.merge(keep_uuid, delete_uuids, dry_run=dry_run)
+    if dry_run:
+        return (
+            f"Merge preview (dry-run): {would_or_did} chunks would be deleted, "
+            f"keep_id={keep_id}\n(no changes -- re-run with dry_run=False to apply)"
+        )
     app.search_pipeline.invalidate_cache()
-    return f"Merge complete: {deleted} chunks deleted, keep_id={keep_id}"
+    return f"Merge complete: {would_or_did} chunks deleted, keep_id={keep_id}"
 
 
 @mcp.tool()

--- a/packages/memtomem/tests/test_dedup.py
+++ b/packages/memtomem/tests/test_dedup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from uuid import UUID
 
 import pytest
 
@@ -36,6 +37,24 @@ class _FakeStorage:
 
     async def list_chunks_by_source(self, source: Path, limit: int) -> list[Chunk]:
         return self._chunks[:limit]
+
+    async def get_chunks_batch(self, ids: list[UUID]) -> dict[UUID, Chunk]:
+        by_id = {c.id: c for c in self._chunks}
+        return {i: by_id[i] for i in ids if i in by_id}
+
+    async def upsert_chunks(self, chunks: list[Chunk]) -> None:
+        by_id = {c.id: i for i, c in enumerate(self._chunks)}
+        for c in chunks:
+            if c.id in by_id:
+                self._chunks[by_id[c.id]] = c
+            else:
+                self._chunks.append(c)
+
+    async def delete_chunks(self, ids: list[UUID]) -> int:
+        target = set(ids)
+        before = len(self._chunks)
+        self._chunks[:] = [c for c in self._chunks if c.id not in target]
+        return before - len(self._chunks)
 
     async def dense_search(
         self,
@@ -230,3 +249,92 @@ class TestOrdering:
         # 0.99 pair should come before 0.93 pair.
         assert result[0].score == pytest.approx(0.99)
         assert result[1].score == pytest.approx(0.93)
+
+
+class TestMergeDryRun:
+    """``DedupScanner.merge`` safety-default parity with decay/cleanup tools.
+
+    The MCP wrapper ``mem_dedup_merge`` defaults ``dry_run=True`` so a
+    wrong UUID in a maintenance script can't silently destroy data on
+    first call, mirroring ``mem_decay_expire`` and ``mem_cleanup_orphans``.
+    The scanner-side default stays ``False`` because the web route
+    (``POST /api/dedup/merge``) calls through after the user has already
+    confirmed against a visible scan preview — the safety gate lives at
+    the MCP layer for the no-preview path.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_count_without_deleting(self, scanner_factory):
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        keep = _mk("identical text", created_at=t0)
+        dup_a = _mk("identical text", created_at=t0 + timedelta(minutes=1))
+        dup_b = _mk("identical text", created_at=t0 + timedelta(minutes=2))
+        scanner, storage, _ = scanner_factory([keep, dup_a, dup_b])
+
+        would_delete = await scanner.merge(keep.id, [dup_a.id, dup_b.id], dry_run=True)
+
+        assert would_delete == 2
+        # Storage still holds all three chunks.
+        assert {c.id for c in storage._chunks} == {keep.id, dup_a.id, dup_b.id}
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips_tag_merge_upsert(self, scanner_factory):
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        keep = Chunk(
+            content="x",
+            metadata=ChunkMetadata(source_file=Path("/s.md"), tags=("a",)),
+            embedding=[],
+            created_at=t0,
+        )
+        dup = Chunk(
+            content="x",
+            metadata=ChunkMetadata(source_file=Path("/s.md"), tags=("b",)),
+            embedding=[],
+            created_at=t0 + timedelta(minutes=1),
+        )
+        scanner, storage, _ = scanner_factory([keep, dup])
+
+        await scanner.merge(keep.id, [dup.id], dry_run=True)
+
+        # keep_chunk's tags are unchanged — no upsert happened.
+        kept = next(c for c in storage._chunks if c.id == keep.id)
+        assert kept.metadata.tags == ("a",)
+
+    @pytest.mark.asyncio
+    async def test_apply_deletes_and_merges_tags(self, scanner_factory):
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        keep = Chunk(
+            content="x",
+            metadata=ChunkMetadata(source_file=Path("/s.md"), tags=("a",)),
+            embedding=[],
+            created_at=t0,
+        )
+        dup = Chunk(
+            content="x",
+            metadata=ChunkMetadata(source_file=Path("/s.md"), tags=("b",)),
+            embedding=[],
+            created_at=t0 + timedelta(minutes=1),
+        )
+        scanner, storage, _ = scanner_factory([keep, dup])
+
+        deleted = await scanner.merge(keep.id, [dup.id], dry_run=False)
+
+        assert deleted == 1
+        assert {c.id for c in storage._chunks} == {keep.id}
+        kept = storage._chunks[0]
+        assert kept.metadata.tags == ("a", "b")
+
+    @pytest.mark.asyncio
+    async def test_default_apply_path_unchanged(self, scanner_factory):
+        # Web route at ``POST /api/dedup/merge`` calls
+        # ``scanner.merge(keep, deletes)`` without the new ``dry_run`` kwarg.
+        # Pin the default behavior so that path stays write-through.
+        t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        keep = _mk("dup", created_at=t0)
+        dup = _mk("dup", created_at=t0 + timedelta(minutes=1))
+        scanner, storage, _ = scanner_factory([keep, dup])
+
+        deleted = await scanner.merge(keep.id, [dup.id])
+
+        assert deleted == 1
+        assert {c.id for c in storage._chunks} == {keep.id}

--- a/packages/memtomem/tests/test_usability_fixes.py
+++ b/packages/memtomem/tests/test_usability_fixes.py
@@ -296,3 +296,25 @@ class TestCleanupOrphans:
     def test_cleanup_orphans_has_dry_run(self):
         info = ACTIONS["cleanup_orphans"]
         assert "dry_run" in info.params
+
+
+# ── dedup_merge safety-default parity ────────────────────────────────────
+
+
+class TestDedupMerge:
+    """Pin the ``dry_run`` safety default on the MCP wrapper.
+
+    ``mem_decay_expire`` and ``mem_cleanup_orphans`` both default to
+    ``dry_run=True`` so a typo in a maintenance script can't silently
+    destroy data on first call. ``mem_dedup_merge`` joined that contract
+    after F-D3-1; this test pins it so a future signature change can't
+    silently regress the safety default.
+    """
+
+    def test_dedup_merge_registered(self):
+        assert "dedup_merge" in ACTIONS
+        assert ACTIONS["dedup_merge"].category == "maintenance"
+
+    def test_dedup_merge_has_dry_run(self):
+        info = ACTIONS["dedup_merge"]
+        assert "dry_run" in info.params


### PR DESCRIPTION
## Summary

- `mem_decay_expire` and `mem_cleanup_orphans` both default to `dry_run=True` so a typo in a maintenance script can't silently destroy data on first call. `mem_dedup_merge` was the odd one out — calling it with the wrong `keep_id`/`delete_ids` hard-deleted immediately.
- Web `POST /api/dedup/merge` is unaffected: the SPA shows a side-by-side scan preview before the confirm modal, so the safety gate lives in the UI there. The gap was the no-preview MCP/automation surface.
- Threads `dry_run` through `DedupScanner.merge` with a `False` default so the existing web call site stays write-through. The MCP wrapper (`mem_dedup_merge`) flips its default to `True`.

Found while running a risk-first QA pass against the destructive-action surface (web UI + MCP).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_dedup.py` — 11 pass (4 new `TestMergeDryRun` cases + 7 existing scan tests)
- [x] `uv run pytest packages/memtomem/tests/test_usability_fixes.py::TestDedupMerge` — 2 new registry-pin tests pass alongside the existing `TestCleanupOrphans` parity assertion
- [x] `uv run pytest packages/memtomem/tests/test_web_routes_extended.py -k 'dedup or decay'` — 5 pass (web route signature unchanged)
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/` — 5174 pass / 10 skip / 1 unrelated chromium playwright flake (`test_resolve_aborted_envelope_keeps_card_and_emits_error_toast`, passes in isolation)
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`
- [x] `uv run mypy packages/memtomem/src/memtomem/search/dedup.py packages/memtomem/src/memtomem/server/tools/dedup_decay.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)