### PR TITLE
fix(web): tighten decay confirm count, privacy hint, defensive escapes

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4818,7 +4818,7 @@ async function browseSource(path, limit = 100) {
         );
         card.innerHTML = `
           <div class="chunk-card-meta">
-            <span class="badge badge-gray">${c.chunk_type.replace('_',' ')}</span>
+            <span class="badge badge-gray">${escapeHtml(c.chunk_type.replace('_', ' '))}</span>
             <span class="chunk-card-lines">lines ${c.start_line}–${c.end_line}</span>
             ${_tierBadgeHtml(c.target_scope)}
             ${c.heading_hierarchy.length ? `<span class="hierarchy-trail">${escapeHtml(c.heading_hierarchy.join(' › '))}</span>` : ''}
@@ -5932,9 +5932,14 @@ function escapeHtml(str) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
-function escapeAttr(str) { return escapeHtml(str).replace(/"/g, '&quot;'); }
+// Alias kept for caller-side intent (attribute vs body context). escapeHtml
+// already emits the full ``& < > " '`` set so a single-quoted attribute is
+// also safe — past redundant ``.replace(/"/g, ...)`` was a no-op once the
+// quote handling moved into escapeHtml.
+function escapeAttr(str) { return escapeHtml(str); }
 
 // ---------------------------------------------------------------------------
 // Search History (A)

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -755,6 +755,7 @@
           <input id="add-namespace" type="text" placeholder="default (from config)" />
           <label class="field-label" for="add-content" data-i18n="index.add_content_label">Content</label>
           <textarea id="add-content" spellcheck="false" data-i18n-placeholder="index.add_content_placeholder" placeholder="Write your memory here…"></textarea>
+          <p class="panel-help-text" data-i18n="index.add_privacy_hint">Privacy guard scans for tokens, API keys, and private keys — not email or phone numbers.</p>
           <button id="add-btn" class="btn-primary mt-10" data-i18n="index.add_btn">Add</button>
           <div id="add-msg" class="status-msg" hidden></div>
         </div>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -275,6 +275,7 @@
   "index.add_ns_placeholder": "default (from config)",
   "index.add_content_label": "Content",
   "index.add_content_placeholder": "Write your memory here…",
+  "index.add_privacy_hint": "Privacy guard scans for tokens, API keys, and private keys — not email or phone numbers.",
   "index.add_btn": "Add",
 
   "compose.privacy_warning_title": "Possible secret detected",
@@ -815,7 +816,7 @@
   "confirm.merge_dupe_keep_a_msg": "Keep A and delete B.",
   "confirm.merge_dupe_keep_b_msg": "Keep B and delete A.",
   "confirm.expire_title": "Expire Chunks",
-  "confirm.expire_msg": "Permanently delete expired chunks. This action cannot be undone.",
+  "confirm.expire_msg": "Permanently delete {count} expired chunk(s). This action cannot be undone.",
   "confirm.hooks_replace_title": "Replace hook rule",
   "confirm.hooks_replace_msg": "Replace your \"{label}\" rule with memtomem's version?",
   "confirm.hooks_sync_title": "Sync settings",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -275,6 +275,7 @@
   "index.add_ns_placeholder": "기본값 (설정에서)",
   "index.add_content_label": "내용",
   "index.add_content_placeholder": "여기에 기억을 작성하세요…",
+  "index.add_privacy_hint": "프라이버시 가드는 토큰·API 키·개인 키만 검사하며, 이메일/전화번호는 대상이 아닙니다.",
   "index.add_btn": "추가",
 
   "compose.privacy_warning_title": "비밀 정보 가능성",
@@ -815,7 +816,7 @@
   "confirm.merge_dupe_keep_a_msg": "A를 유지하고 B를 삭제합니다.",
   "confirm.merge_dupe_keep_b_msg": "B를 유지하고 A를 삭제합니다.",
   "confirm.expire_title": "청크 만료",
-  "confirm.expire_msg": "만료된 청크를 영구적으로 삭제합니다. 이 작업은 취소할 수 없습니다.",
+  "confirm.expire_msg": "만료된 청크 {count}개를 영구적으로 삭제합니다. 이 작업은 취소할 수 없습니다.",
   "confirm.hooks_replace_title": "훅 규칙 교체",
   "confirm.hooks_replace_msg": "\"{label}\" 규칙을 memtomem 버전으로 교체하시겠습니까?",
   "confirm.hooks_sync_title": "설정 동기화",

--- a/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
@@ -200,9 +200,16 @@ async function runDecayScan() {
 }
 
 async function runDecayExpire() {
+  // Pull the count from the most recent scan rendered in the result
+  // panel — the Expire button is only enabled when scan returned > 0
+  // (see ``runDecayScan``), so this is always populated when we get
+  // here. Falling back to '?' keeps the modal sensible if a future
+  // refactor breaks that invariant rather than silently dropping the
+  // count from the message.
+  const expiredCountText = qs('decay-r-expired').textContent || '?';
   const ok = await showConfirm({
     title: t('confirm.expire_title'),
-    message: t('confirm.expire_msg'),
+    message: t('confirm.expire_msg', { count: expiredCountText }),
     confirmText: t('common.expire'),
   });
   if (!ok) return;

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -1,0 +1,256 @@
+"""Regression pins for the risk-first QA audit.
+
+These tests automate the destructive-action and trust-boundary findings
+from the manual QA pass. Each ID maps to a finding in the audit doc:
+
+* **D2** — admin namespace endpoints stay off the prod surface.
+* **B2-c** — ``_require_localhost`` rejects non-loopback peers using the
+  TCP client host, not user-supplied ``X-Forwarded-For`` headers.
+* **S1 / S3** — web ``/api/search`` and ``/api/stats`` keep parameter and
+  response shapes that the MCP ``mem_search`` / ``mem_stats`` tools also
+  expose, so a refactor on either side can't silently drift them apart.
+* **B5** — chunk-card / dedup-row renderers route every user-controlled
+  field through ``escapeHtml`` or ``DOMPurify.sanitize`` before
+  ``innerHTML`` so a malicious chunk body can't execute JS in the SPA.
+
+The point is to catch a future PR that forgets the guard, not to
+re-derive it from scratch — the underlying enforcement code lives in
+``web/routes/system.py``, ``web/app.py``, and ``web/static/app.js``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.web.app import create_app
+
+
+_STATIC_DIR = Path(__file__).resolve().parent.parent / "src" / "memtomem" / "web" / "static"
+
+
+@pytest.fixture
+def prod_app():
+    application = create_app(lifespan=None, mode="prod")
+    application.state.storage = AsyncMock()
+    application.state.config = None
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.project_root = Path("/tmp/test-project")
+    return application
+
+
+@pytest.fixture
+def dev_app():
+    application = create_app(lifespan=None, mode="dev")
+    application.state.storage = AsyncMock()
+    application.state.config = None
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.project_root = Path("/tmp/test-project")
+    return application
+
+
+# ---------------------------------------------------------------------------
+# D2 — admin namespace endpoints are dev-only
+# ---------------------------------------------------------------------------
+
+
+class TestNamespaceDeleteProdGuard:
+    """Admin namespace surface (rename / delete / per-namespace info) lives
+    on ``_DEV_ONLY_ROUTERS`` because rename + delete need chunk-id stability
+    design (ADR-0005). The prod app must not mount those routes — the
+    catch-all 404 handler in ``web/app.py`` covers anything that slips."""
+
+    @pytest.mark.asyncio
+    async def test_delete_namespace_returns_404_in_prod(self, prod_app):
+        transport = ASGITransport(app=prod_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete("/api/namespaces/whatever")
+        assert resp.status_code == 404, (
+            "DELETE /api/namespaces/{ns} must not be reachable in prod mode "
+            "(admin_router lives in _DEV_ONLY_ROUTERS — see web/app.py:91-98)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_delete_namespace_reachable_in_dev(self, dev_app):
+        # Sanity counterpart so a future refactor that drops the route
+        # entirely fails this pin instead of looking like a prod fix.
+        dev_app.state.storage.delete_by_namespace = AsyncMock(return_value=0)
+        transport = ASGITransport(app=dev_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.delete("/api/namespaces/whatever")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# B2-c — localhost guard uses TCP peer, ignores X-Forwarded-For
+# ---------------------------------------------------------------------------
+
+
+class TestResetLocalhostGuard:
+    """``/api/reset`` is gated by ``_require_localhost`` which reads
+    ``request.client.host`` (the TCP peer) and rejects anything outside
+    ``{'127.0.0.1', '::1', 'localhost'}``. ``X-Forwarded-For`` is
+    intentionally NOT consulted — a reverse-proxy header injection must
+    not unlock the endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_reset_rejects_external_client(self, prod_app):
+        transport = ASGITransport(app=prod_app, client=("203.0.113.7", 12345))
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/api/reset",
+                headers={"X-Forwarded-For": "127.0.0.1"},
+            )
+        assert resp.status_code == 403, (
+            "External client must not be able to spoof localhost via "
+            "X-Forwarded-For — _require_localhost checks request.client.host"
+        )
+        assert "localhost" in resp.json().get("detail", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_reset_accepts_loopback_client(self, prod_app):
+        prod_app.state.storage.reset_all = AsyncMock(return_value={"chunks": 0})
+        # Default ASGITransport client is ('127.0.0.1', 123); CSRFGuard
+        # also runs but localhost + same-origin (Host = "test") is
+        # inside its loopback allow-list with no Origin header.
+        transport = ASGITransport(app=prod_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/reset")
+        # CSRF middleware may 403 the missing Origin/Host on a non-loopback
+        # Host like "test" — we only assert the localhost gate passed (so a
+        # 403 here, if any, is from CSRF not _require_localhost). The
+        # localhost-failure path emits a distinctive "localhost" detail.
+        if resp.status_code == 403:
+            assert "localhost" not in resp.json().get("detail", "").lower(), (
+                "reset rejected by _require_localhost on a loopback client — "
+                "the guard's allow-list lost 127.0.0.1"
+            )
+
+
+# ---------------------------------------------------------------------------
+# S1 + S3 — web/MCP shape parity for read-only surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestDualSurfaceParity:
+    """Web ``/api/search`` and ``/api/stats`` are the read-only siblings of
+    MCP ``mem_search`` / ``mem_stats``. The audit found that both surfaces
+    must accept the same parameter set so a user (or a script) can switch
+    between them without the request shape drifting. These tests pin the
+    parameter overlap at the function-signature level — adding a parameter
+    to one side is fine; dropping a shared one without updating the other
+    fails the pin."""
+
+    def test_mem_search_accepts_documented_web_params(self):
+        from memtomem.server.tools.search import mem_search
+
+        sig = inspect.signature(mem_search)
+        params = set(sig.parameters)
+        # Subset the SPA's Search tab actually sends. The MCP tool may
+        # accept more (verbose, output_format, etc.); the assertion is
+        # that nothing on this list is missing on the MCP side.
+        web_params = {
+            "query",
+            "top_k",
+            "source_filter",
+            "tag_filter",
+            "namespace",
+            "context_window",
+        }
+        missing = web_params - params
+        assert not missing, (
+            f"mem_search MCP tool dropped parameters that the web SPA "
+            f"still sends: {sorted(missing)}. Either restore them or "
+            f"update the SPA to stop sending them."
+        )
+
+    def test_mem_stats_signature_is_zero_arg(self):
+        # Pin the no-argument shape — the SPA's ``loadStats`` calls
+        # ``GET /api/stats`` with no body, and the MCP path is the same
+        # surface. A future refactor that adds a required parameter would
+        # silently break the SPA's poll loop.
+        from memtomem.server.tools.status_config import mem_stats
+
+        sig = inspect.signature(mem_stats)
+        required = [
+            name
+            for name, p in sig.parameters.items()
+            if p.default is inspect.Parameter.empty
+            and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        ]
+        assert required == [], (
+            f"mem_stats grew required parameter(s) {required}; "
+            f"web /api/stats and SPA poll loop still call it zero-arg"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B5 — chunk-card / dedup renderers escape user content before innerHTML
+# ---------------------------------------------------------------------------
+
+
+class TestChunkCardXssGuard:
+    """Source-of-truth check that the SPA escapes user-controlled fields
+    before injecting them into the chunk card / dedup row / search result
+    templates. The audit's static review confirmed coverage today; this
+    pin catches a future refactor that adds a new ``${...}`` interpolation
+    of a user-controlled field without wrapping it in ``escapeHtml``,
+    ``escapeAttr``, ``highlightText``, or ``DOMPurify.sanitize``.
+
+    The check is intentionally substring-based on the rendered template
+    block — a runtime XSS test would need a seeded LTM and a Playwright
+    page, which adds more infra than the bug surface justifies once the
+    escape helpers are in place."""
+
+    @pytest.fixture(scope="class")
+    def app_js(self) -> str:
+        return (_STATIC_DIR / "app.js").read_text(encoding="utf-8")
+
+    def test_chunk_type_label_is_escaped_in_card(self, app_js: str):
+        # Pin for F-XSS-1: the chunk_type badge inside the chunk card
+        # template (renders inside ``browseSource``) must go through
+        # escapeHtml — server enum today, but defensive.
+        snippet = '<span class="badge badge-gray">${escapeHtml(c.chunk_type'
+        assert snippet in app_js, (
+            "chunk_type badge in browseSource() chunk-card template lost "
+            "its escapeHtml wrapping — restore it (audit F-XSS-1)"
+        )
+
+    def test_escape_html_covers_single_quote(self, app_js: str):
+        # Pin for F-XSS-2: ``escapeHtml`` must escape ``'`` so a single-
+        # quoted attribute context (none today, but defensible) stays safe.
+        # The exact replacement char (``&#39;``) is documented MDN syntax.
+        assert "replace(/'/g, '&#39;')" in app_js, (
+            "escapeHtml lost its single-quote escape — restore the "
+            ".replace(/'/g, '&#39;') line (audit F-XSS-2)"
+        )
+
+    def test_dedup_row_renders_chunk_content_through_escape(self, app_js: str):
+        # Pin for the dedup row template in settings-maintenance.js —
+        # both A and B chunk previews must funnel through ``escapeHtml``
+        # before the ``truncate``-d content lands in innerHTML.
+        m_js = (_STATIC_DIR / "settings-maintenance.js").read_text(encoding="utf-8")
+        assert m_js.count('class="dedup-chunk-content">${escapeHtml(truncate(c.chunk_') >= 2, (
+            "dedup-row template stopped escaping chunk_a/chunk_b content "
+            "before injecting into innerHTML"
+        )
+
+    def test_search_result_card_renders_filename_through_escape(self, app_js: str):
+        # Search result card builds an innerHTML template that includes
+        # the source filename — must go through escapeHtml. Spot-checks
+        # the known-vulnerable axis from the audit (``fname`` came from
+        # the chunk's source path which the user controls via filenames).
+        assert 'class="result-filename">${escapeHtml(fname)}' in app_js, (
+            "search-result card stopped escaping the source filename "
+            "before injecting into innerHTML"
+        )


### PR DESCRIPTION
## Summary

Bundles the P2/P3 follow-ups from the risk-first QA audit + regression pins for the destructive-action and trust-boundary findings the audit caught (sibling of #1045).

**User-visible**

- **F-D4-1**: Decay → Expire confirm modal now shows the would-be-deleted count (`{count}` placeholder + EN/KO locale updates) so a single click can't drop more chunks than the user expected.
- **F-Privacy-2**: Compose panel (Index → New memory) gains a fine-print line clarifying the privacy guard's scope: tokens / API keys / private keys, not PII like email or phone. The dynamic in-textarea pattern warning still fires; this hint sets context up front. EN/KO key added.

**Defensive HTML escapes**

- **F-XSS-1**: `chunk_type` badge inside `browseSource()`'s chunk-card template now routes through `escapeHtml`. Server controls the enum today, but the raw `${...}` interpolation was the only unescaped user-data slot the audit grep flagged in the card layout.
- **F-XSS-2**: `escapeHtml` gains the single-quote → `&#39;` replacement so single-quoted attribute contexts stay safe by default. `escapeAttr` collapses to a thin alias since the prior `.replace(/"/g, ...)` is now a no-op after `escapeHtml` emits `&quot;`.

**Regression pins** (new `tests/test_qa_audit_pins.py`, 10 cases)

- **D2** — admin namespace endpoints stay 404 in prod mode (mounted only on `_DEV_ONLY_ROUTERS` in `web/app.py`).
- **B2-c** — `POST /api/reset` rejects non-loopback ASGI clients even with a forged `X-Forwarded-For: 127.0.0.1` header.
- **S1 + S3** — `mem_search` keeps the parameter set the SPA actually sends; `mem_stats` stays zero-arg so the SPA's poll loop doesn't drift.
- **B5** — chunk_type badge, dedup-row chunk previews, search-result filename, and `escapeHtml`'s single-quote escape are all string-pinned so a future `\${...}` interpolation that drops the wrapper fails the pin instead of shipping an XSS surface.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_qa_audit_pins.py` — 10 new pins pass
- [x] `uv run pytest packages/memtomem/tests/ -k 'decay or compose or i18n or xss or escape or privacy'` — 184 pass (covers `confirm.expire_msg` placeholder parity, redacted JS pattern wiring, etc.)
- [x] `cd packages/memtomem/tests-js && npm test` (vitest + jsdom) — 48 pass
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src` — 250 files clean
- [x] `uv run pytest -m "not ollama" packages/memtomem/tests/` — 5179 pass; 13 local environmental flakes (12 in `test_web_cli.py` because the dev `mm web` server is currently running on this machine, and 1 test-ordering flake that passes in isolation), all unrelated to the changes here

🤖 Generated with [Claude Code](https://claude.com/claude-code)