### PR TITLE
fix(web): hooks v1 follow-ups (bulk promote mtime refresh, row keydown gate)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -4804,6 +4804,11 @@ function _renderMemorySourceItem(s, maxChunks) {
     browseSource(s.path);
   });
   item.addEventListener('keydown', e => {
+    // Only treat Enter/Space as a row-open when the row itself has focus.
+    // Buttons inside `.source-item-actions` (reindex / delete) need their
+    // own native activation; if we preventDefault here for descendant
+    // targets, those actions become mouse-only.
+    if (e.target !== item) return;
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); item.click(); }
   });
   return item;

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -321,6 +321,16 @@ async function _handleHooksPromoteAll(btn) {
         if (result.status === 'ok') {
           summary.saved += 1;
           if (choice.deleteOriginal) deleteQueue.push(entry);
+          // Each successful promote rewrites .memtomem/settings.json; refresh
+          // mtimes so the next iteration's freshness check doesn't abort.
+          if (_hooksLastSyncData) {
+            if (result.canonical_mtime_ns != null) {
+              _hooksLastSyncData.canonical_mtime_ns = result.canonical_mtime_ns;
+            }
+            if (result.target_mtime_ns != null) {
+              _hooksLastSyncData.target_mtime_ns = result.target_mtime_ns;
+            }
+          }
         } else if (result.status === 'conflict') {
           summary.conflicts += 1;
         } else if (result.status === 'aborted') {


### PR DESCRIPTION
## Summary

Two P2 fixes surfaced during a code-review pass on the merged hooks-v1 work (#1047). Both are small, self-contained, and JS-only.

- **`settings-hooks-watchdog.js` — bulk-promote mtime refresh.** `_handleHooksPromoteAll` now refreshes `_hooksLastSyncData.canonical_mtime_ns` / `target_mtime_ns` from each successful promote response. Without this, the freshness check on iteration 2+ compares against the mtime the file had **before** the previous promote rewrote it, and the loop aborts.
- **`app.js` — row keydown gate.** `_renderMemorySourceItem`'s row keydown handler now early-returns when `e.target !== item`. Previously the row swallowed Enter/Space, so the per-source Reindex / Delete buttons (added in #1047) had no native keyboard activation and were mouse-only.

## Test plan

- [ ] Bulk-promote a hooks setting with ≥2 conflicts queued → all rows process, none abort with a stale-mtime error.
- [ ] Tab to a Reindex / Delete button on a Sources row → press Enter → the button's action fires (not the row's open-source).
- [ ] Tab to the row itself → press Enter → row opens (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)