### PR TITLE
test(qa-pins): add F-C4-1 embedding-reset / BM25-fallback regression pin

### DIFF
--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -12,6 +12,9 @@ from the manual QA pass. Each ID maps to a finding in the audit doc:
 * **B5** — chunk-card / dedup-row renderers route every user-controlled
   field through ``escapeHtml`` or ``DOMPurify.sanitize`` before
   ``innerHTML`` so a malicious chunk body can't execute JS in the SPA.
+* **C4 / F-C4-1** — embedding reset concurrent with search degrades to
+  BM25-only (never 503 / sqlite error) because reset is one atomic
+  transaction *and* the dense leg has a defensive exception catch.
 
 The point is to catch a future PR that forgets the guard, not to
 re-derive it from scratch — the underlying enforcement code lives in
@@ -253,4 +256,100 @@ class TestChunkCardXssGuard:
         assert 'class="result-filename">${escapeHtml(fname)}' in app_js, (
             "search-result card stopped escaping the source filename "
             "before injecting into innerHTML"
+        )
+
+
+# ---------------------------------------------------------------------------
+# F-C4-1 — embedding reset during search degrades to BM25-only, not 503
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingResetBm25Fallback:
+    """Pin for F-C4-1 [Positive] in the kind-moth QA audit.
+
+    The 2026-05-15 runtime probe showed that ``POST /api/embedding-reset``
+    issued mid-search burst never produces a 503, sqlite error, or stale
+    response — search transparently degrades to BM25-only while the dense
+    vector table is recreated. Two layered invariants make that true:
+
+    1. ``reset_embedding_meta`` (``storage/sqlite_backend.py``) is a single
+       *synchronous* transaction — ``DROP TABLE``, ``CREATE VIRTUAL TABLE``,
+       ``db.commit()`` — so a concurrent search never observes a "table
+       missing" intermediate state.
+    2. The dense leg in ``search/pipeline.py`` is wrapped in a defensive
+       ``except Exception`` that resets ``dense_results = []`` and surfaces
+       the failure via ``dense_error``; BM25 still returns hits and the
+       endpoint stays at HTTP 200.
+
+    The probe also confirmed (2) never actually fires today because (1) is
+    atomic — but (2) is the load-bearing safety net the moment reset moves
+    to background execution or grows an inter-statement ``await``. If
+    either invariant changes the F-C4-1 smoke must be re-run before merge."""
+
+    @pytest.fixture(scope="class")
+    def pipeline_src(self) -> str:
+        from memtomem.search import pipeline
+
+        return inspect.getsource(pipeline)
+
+    @pytest.fixture(scope="class")
+    def reset_body(self) -> str:
+        # Extract just the ``reset_embedding_meta`` coroutine so a future
+        # refactor that splits the transaction across helpers will trip
+        # the per-function shape checks below rather than passing on
+        # module-level coincidence.
+        from memtomem.storage.sqlite_backend import SqliteBackend
+
+        return inspect.getsource(SqliteBackend.reset_embedding_meta)
+
+    def test_dense_leg_swallows_exception_to_empty_bm25_only(self, pipeline_src: str):
+        # The hot loop: try { embed_query + dense_search } except Exception:
+        # dense_results = []; dense_error = str(exc). Substring spans the
+        # assignment so a refactor that drops the [] reset (and silently
+        # leaves last-success stale results) also trips the pin.
+        assert "except Exception as exc:" in pipeline_src, (
+            "search/pipeline.py dense leg lost its `except Exception` "
+            "catch — embedding-reset / dim-mismatch will now surface as "
+            "an HTTP 5xx instead of the BM25-only fallback documented in "
+            "the F-C4-1 runtime probe"
+        )
+        assert "dense_results = []" in pipeline_src, (
+            "search/pipeline.py dense leg stopped resetting dense_results "
+            "to [] on exception — stale prior results would leak across "
+            "queries, breaking the F-C4-1 graceful-degradation contract"
+        )
+        assert "dense_error = str(exc)" in pipeline_src, (
+            "search/pipeline.py dense leg stopped surfacing dense_error — "
+            "the /api/embedding-status diagnostic depends on it"
+        )
+
+    def test_reset_embedding_meta_is_single_atomic_transaction(self, reset_body: str):
+        # The audit invariant: DROP + meta-update + CREATE + commit all
+        # share one synchronous transaction inside reset_embedding_meta().
+        # If a refactor splits this — e.g. moves the CREATE to a worker
+        # or inserts an ``await`` between DROP and commit — search would
+        # be able to observe a missing chunks_vec table mid-reset and the
+        # F-C4-1 BM25-only smoke must be re-run before merge.
+        assert "DROP TABLE IF EXISTS chunks_vec" in reset_body, (
+            "reset_embedding_meta no longer DROPs chunks_vec — "
+            "verify the new shape against the F-C4-1 probe"
+        )
+        assert "CREATE VIRTUAL TABLE IF NOT EXISTS chunks_vec" in reset_body, (
+            "reset_embedding_meta no longer CREATEs chunks_vec — "
+            "verify the new shape against the F-C4-1 probe"
+        )
+        assert reset_body.count("db.commit()") == 1, (
+            "reset_embedding_meta lost its single-commit shape — the "
+            "F-C4-1 runtime probe relies on DROP+CREATE+commit being one "
+            "transaction so search never sees chunks_vec missing"
+        )
+        # An ``await`` *inside* the coroutine body (anywhere other than
+        # the ``async def`` signature) means a sqlite checkpoint could
+        # land mid-reset and a concurrent dense_search could observe the
+        # table absent. The current implementation has no such await.
+        body_only = reset_body.split(":\n", 1)[1] if ":\n" in reset_body else reset_body
+        assert "await " not in body_only, (
+            "reset_embedding_meta gained an `await` mid-transaction — "
+            "re-run the F-C4-1 runtime probe to confirm search still "
+            "degrades to BM25-only instead of surfacing a transient 503"
         )

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import textwrap
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -288,10 +289,18 @@ class TestEmbeddingResetBm25Fallback:
     either invariant changes the F-C4-1 smoke must be re-run before merge."""
 
     @pytest.fixture(scope="class")
-    def pipeline_src(self) -> str:
-        from memtomem.search import pipeline
+    def search_method_src(self) -> str:
+        # Scope the fixture to ``SearchPipeline.search`` specifically — the
+        # main user-facing retrieval method. The runtime probe ran against
+        # this method, so the pin must too. A module-wide AST walk (PR
+        # #1051 review round 2) passes when *any* dense_search Try in the
+        # module has the right shape, which would mask a regression here
+        # if a future helper happens to share the F-C4-1 markers.
+        from memtomem.search.pipeline import SearchPipeline
 
-        return inspect.getsource(pipeline)
+        # ``inspect.getsource`` preserves the method's 4-space class
+        # indent; dedent so ``ast.parse`` sees ``async def`` at column 0.
+        return textwrap.dedent(inspect.getsource(SearchPipeline.search))
 
     @pytest.fixture(scope="class")
     def reset_body(self) -> str:
@@ -303,21 +312,13 @@ class TestEmbeddingResetBm25Fallback:
 
         return inspect.getsource(SqliteBackend.reset_embedding_meta)
 
-    def test_dense_leg_swallows_exception_to_empty_bm25_only(self, pipeline_src: str):
-        # Locate the dense leg's Try node *specifically*, not via
-        # module-wide substring match: `pipeline.py` also contains the
-        # BM25 leg's identical-shape `except Exception as exc:` right
-        # after this block (plus a rescue-path `_dense_leg` that has its
-        # own narrower fallback), so substring assertions on the whole
-        # module pass even when this leg is narrowed (see PR #1051 review).
-        #
-        # Strategy: walk the AST, collect every Try whose body calls
-        # `dense_search`, and require that at least one matches the full
-        # F-C4-1 fallback shape — unconditional ``Exception`` handler,
-        # ``dense_results = []`` reset, and ``dense_error = str(exc)``
-        # surface. Narrowing the handler (e.g. to ``sqlite3.OperationalError``)
-        # drops the candidate out of the match set and trips the pin.
-        tree = ast.parse(pipeline_src)
+    def test_dense_leg_swallows_exception_to_empty_bm25_only(self, search_method_src: str):
+        # Find Try nodes inside ``SearchPipeline.search`` that call
+        # ``dense_search``. There should be exactly one — the main-path
+        # dense leg. Zero means the F-C4-1 structure was removed; more
+        # than one means search() grew a second dense call path and the
+        # pin needs an explicit decision on which Try to gate.
+        tree = ast.parse(search_method_src)
 
         dense_try_nodes: list[ast.Try] = []
         for node in ast.walk(tree):
@@ -336,45 +337,39 @@ class TestEmbeddingResetBm25Fallback:
                     continue
                 break
 
-        assert dense_try_nodes, (
-            "search/pipeline.py no longer has a try/except wrapping a "
-            "dense_search call — the F-C4-1 fallback structure changed; "
-            "re-run the runtime probe before relying on this pin"
+        assert len(dense_try_nodes) == 1, (
+            f"SearchPipeline.search no longer has exactly one Try wrapping "
+            f"a dense_search call (found {len(dense_try_nodes)}). The "
+            "F-C4-1 fallback structure changed; re-run the runtime probe "
+            "and update this pin to match the new shape before relying on it."
         )
 
-        def _handler_caught(handler: ast.ExceptHandler) -> str:
-            if handler.type is None:
-                return "BaseException"
-            return ast.unparse(handler.type)
+        try_node = dense_try_nodes[0]
+        assert try_node.handlers, (
+            "SearchPipeline.search dense leg lost its except handler — "
+            "any dense_search exception (incl. embedding-reset race) will "
+            "now propagate as HTTP 5xx instead of degrading to BM25-only"
+        )
+        handler = try_node.handlers[0]
+        caught = "BaseException" if handler.type is None else ast.unparse(handler.type)
+        assert caught in ("Exception", "BaseException"), (
+            f"SearchPipeline.search dense leg narrowed its handler from "
+            f"`except Exception` to `except {caught}` — embedding-reset "
+            "or dim-mismatch errors not covered by this type will now "
+            "surface as HTTP 5xx instead of the BM25-only fallback "
+            "documented in the F-C4-1 runtime probe"
+        )
 
-        diagnostics: list[str] = []
-        matches: list[ast.Try] = []
-        for try_node in dense_try_nodes:
-            if not try_node.handlers:
-                diagnostics.append(f"  - Try at line {try_node.lineno}: no handlers")
-                continue
-            handler = try_node.handlers[0]
-            caught = _handler_caught(handler)
-            body_src = "\n".join(ast.unparse(s) for s in handler.body)
-            has_empty_reset = "dense_results = []" in body_src
-            has_error_surface = "dense_error = str(exc)" in body_src
-            broadly_caught = caught in ("Exception", "BaseException")
-            if broadly_caught and has_empty_reset and has_error_surface:
-                matches.append(try_node)
-            else:
-                diagnostics.append(
-                    f"  - Try at line {try_node.lineno}: catches `{caught}`; "
-                    f"`dense_results = []`={has_empty_reset}; "
-                    f"`dense_error = str(exc)`={has_error_surface}"
-                )
-
-        assert matches, (
-            "search/pipeline.py main-path dense leg no longer matches the "
-            "F-C4-1 fallback shape (unconditional `Exception` handler, "
-            "`dense_results = []`, `dense_error = str(exc)`). "
-            "Embedding-reset / dim-mismatch may now surface as HTTP 5xx "
-            "instead of the BM25-only fallback documented in the runtime "
-            "probe. Candidates inspected:\n" + "\n".join(diagnostics)
+        handler_src = "\n".join(ast.unparse(s) for s in handler.body)
+        assert "dense_results = []" in handler_src, (
+            "SearchPipeline.search dense handler stopped resetting "
+            "`dense_results = []` — stale prior results would leak across "
+            "queries, breaking the F-C4-1 graceful-degradation contract"
+        )
+        assert "dense_error = str(exc)" in handler_src, (
+            "SearchPipeline.search dense handler stopped surfacing "
+            "`dense_error = str(exc)` — the /api/embedding-status "
+            "diagnostic depends on this string for reset-detection"
         )
 
     def test_reset_embedding_meta_is_single_atomic_transaction(self, reset_body: str):

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -23,6 +23,7 @@ re-derive it from scratch — the underlying enforcement code lives in
 
 from __future__ import annotations
 
+import ast
 import inspect
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -303,24 +304,77 @@ class TestEmbeddingResetBm25Fallback:
         return inspect.getsource(SqliteBackend.reset_embedding_meta)
 
     def test_dense_leg_swallows_exception_to_empty_bm25_only(self, pipeline_src: str):
-        # The hot loop: try { embed_query + dense_search } except Exception:
-        # dense_results = []; dense_error = str(exc). Substring spans the
-        # assignment so a refactor that drops the [] reset (and silently
-        # leaves last-success stale results) also trips the pin.
-        assert "except Exception as exc:" in pipeline_src, (
-            "search/pipeline.py dense leg lost its `except Exception` "
-            "catch — embedding-reset / dim-mismatch will now surface as "
-            "an HTTP 5xx instead of the BM25-only fallback documented in "
-            "the F-C4-1 runtime probe"
+        # Locate the dense leg's Try node *specifically*, not via
+        # module-wide substring match: `pipeline.py` also contains the
+        # BM25 leg's identical-shape `except Exception as exc:` right
+        # after this block (plus a rescue-path `_dense_leg` that has its
+        # own narrower fallback), so substring assertions on the whole
+        # module pass even when this leg is narrowed (see PR #1051 review).
+        #
+        # Strategy: walk the AST, collect every Try whose body calls
+        # `dense_search`, and require that at least one matches the full
+        # F-C4-1 fallback shape — unconditional ``Exception`` handler,
+        # ``dense_results = []`` reset, and ``dense_error = str(exc)``
+        # surface. Narrowing the handler (e.g. to ``sqlite3.OperationalError``)
+        # drops the candidate out of the match set and trips the pin.
+        tree = ast.parse(pipeline_src)
+
+        dense_try_nodes: list[ast.Try] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try):
+                continue
+            for stmt in node.body:
+                for inner in ast.walk(stmt):
+                    if (
+                        isinstance(inner, ast.Call)
+                        and isinstance(inner.func, ast.Attribute)
+                        and inner.func.attr == "dense_search"
+                    ):
+                        dense_try_nodes.append(node)
+                        break
+                else:
+                    continue
+                break
+
+        assert dense_try_nodes, (
+            "search/pipeline.py no longer has a try/except wrapping a "
+            "dense_search call — the F-C4-1 fallback structure changed; "
+            "re-run the runtime probe before relying on this pin"
         )
-        assert "dense_results = []" in pipeline_src, (
-            "search/pipeline.py dense leg stopped resetting dense_results "
-            "to [] on exception — stale prior results would leak across "
-            "queries, breaking the F-C4-1 graceful-degradation contract"
-        )
-        assert "dense_error = str(exc)" in pipeline_src, (
-            "search/pipeline.py dense leg stopped surfacing dense_error — "
-            "the /api/embedding-status diagnostic depends on it"
+
+        def _handler_caught(handler: ast.ExceptHandler) -> str:
+            if handler.type is None:
+                return "BaseException"
+            return ast.unparse(handler.type)
+
+        diagnostics: list[str] = []
+        matches: list[ast.Try] = []
+        for try_node in dense_try_nodes:
+            if not try_node.handlers:
+                diagnostics.append(f"  - Try at line {try_node.lineno}: no handlers")
+                continue
+            handler = try_node.handlers[0]
+            caught = _handler_caught(handler)
+            body_src = "\n".join(ast.unparse(s) for s in handler.body)
+            has_empty_reset = "dense_results = []" in body_src
+            has_error_surface = "dense_error = str(exc)" in body_src
+            broadly_caught = caught in ("Exception", "BaseException")
+            if broadly_caught and has_empty_reset and has_error_surface:
+                matches.append(try_node)
+            else:
+                diagnostics.append(
+                    f"  - Try at line {try_node.lineno}: catches `{caught}`; "
+                    f"`dense_results = []`={has_empty_reset}; "
+                    f"`dense_error = str(exc)`={has_error_surface}"
+                )
+
+        assert matches, (
+            "search/pipeline.py main-path dense leg no longer matches the "
+            "F-C4-1 fallback shape (unconditional `Exception` handler, "
+            "`dense_results = []`, `dense_error = str(exc)`). "
+            "Embedding-reset / dim-mismatch may now surface as HTTP 5xx "
+            "instead of the BM25-only fallback documented in the runtime "
+            "probe. Candidates inspected:\n" + "\n".join(diagnostics)
         )
 
     def test_reset_embedding_meta_is_single_atomic_transaction(self, reset_body: str):


### PR DESCRIPTION
## Summary

- Adds `TestEmbeddingResetBm25Fallback` (2 cases) to `test_qa_audit_pins.py`, pinning the two invariants behind the kind-moth QA audit's F-C4-1 [Positive] finding: embedding reset concurrent with search degrades to BM25-only, never an HTTP 5xx.
- The probe itself ran 2026-05-15 (timing table in `memtomem-web-kind-moth-findings.md` §C4); this PR is just the regression guard so a future structural change to reset or to the dense leg cannot land without the reviewer re-running the smoke.
- No source changes. Total diff: +99 lines in one test file.

## What's pinned

1. **`search/pipeline.py` dense leg has a defensive `except Exception`** that resets `dense_results = []` and surfaces `dense_error = str(exc)`. Refactor that drops the catch ⇒ embedding-reset / dim-mismatch becomes a user-visible 503.
2. **`SqliteBackend.reset_embedding_meta` is one synchronous transaction** — DROP + CREATE + single `db.commit()`, no inter-statement `await`. Refactor that splits the transaction (background worker, lock, async checkpoint) ⇒ concurrent search could observe `chunks_vec` missing.

Either pin trips ⇒ the F-C4-1 smoke (BM25-only graceful fallback) must be re-run before merge.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_qa_audit_pins.py -v` — 12/12 pass (10 prior + 2 new)
- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests/test_qa_audit_pins.py`
- [x] `uv run ruff format --check packages/memtomem/tests/test_qa_audit_pins.py`
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)