### PR TITLE
fix(web): focus trap + restore + aria-modal across modals (#1053 PR #2)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -526,6 +526,86 @@ async function uploadFilesWithRedactionRetry(formData) {
 function qs(id) { return document.getElementById(id); }
 function show(el)  { if (el) { el.hidden = false; el.style.display = ''; } }
 function hide(el)  { if (el) el.hidden = true; }
+
+// ---------------------------------------------------------------------------
+// Modal accessibility (A11Y-1.2 / 1.5 / 3.2 — issue #1053 PR #2)
+// ---------------------------------------------------------------------------
+
+// Top-of-stack = most-recently-opened modal. Stacking happens today:
+// settings-modal can have a maintenance showConfirm dialog on top of it
+// (audit row A11Y-3.3). Inert state is derived from this stack each
+// transition, never from a per-open snapshot — so closing the inner modal
+// recomputes inert correctly and leaves the outer modal's background still
+// inerted.
+const _ACTIVE_MODALS = [];
+const _MODAL_CLOSERS = new Map(); // HTMLElement -> () => void
+
+function _recomputeBackgroundInert() {
+  const active = new Set(_ACTIVE_MODALS);
+  const hasAny = _ACTIVE_MODALS.length > 0;
+  Array.from(document.body.children).forEach(el => {
+    if (!hasAny || active.has(el)) el.removeAttribute('inert');
+    else el.setAttribute('inert', '');
+  });
+}
+
+// openModalA11y(modal, { focusables })
+//   - captures the trigger (document.activeElement) for focus restoration
+//   - pushes modal onto _ACTIVE_MODALS and recomputes background inert
+//   - when ``focusables`` is a function, installs a capture-phase keydown
+//     trap that cycles Tab/Shift+Tab through the returned list
+// Returns a release() closure the caller MUST invoke from its close path;
+// release() is idempotent so double-call (ESC + close-btn race) is safe.
+function openModalA11y(modal, { focusables = null } = {}) {
+  const previouslyFocused = document.activeElement;
+  _ACTIVE_MODALS.push(modal);
+  _recomputeBackgroundInert();
+
+  let onKey = null;
+  if (typeof focusables === 'function') {
+    onKey = (e) => {
+      if (modal.hidden || e.key !== 'Tab') return;
+      const f = focusables();
+      if (!f.length) return;
+      e.preventDefault();
+      const idx = f.indexOf(document.activeElement);
+      f[(idx + (e.shiftKey ? -1 : 1) + f.length) % f.length].focus();
+    };
+    document.addEventListener('keydown', onKey, true);
+  }
+
+  let released = false;
+  return function releaseA11y() {
+    if (released) return;
+    released = true;
+    const idx = _ACTIVE_MODALS.indexOf(modal);
+    if (idx !== -1) _ACTIVE_MODALS.splice(idx, 1);
+    _recomputeBackgroundInert();
+    if (onKey) document.removeEventListener('keydown', onKey, true);
+    if (
+      previouslyFocused
+      && document.contains(previouslyFocused)
+      && typeof previouslyFocused.focus === 'function'
+    ) {
+      previouslyFocused.focus();
+    }
+  };
+}
+
+function registerModalCloser(modal, closeFn) { _MODAL_CLOSERS.set(modal, closeFn); }
+// Falls back to hide() when no closer is registered so the ESC dispatcher
+// stays correct for any modal-overlay not yet migrated.
+function closeModal(modal) {
+  const fn = _MODAL_CLOSERS.get(modal);
+  if (fn) fn(); else hide(modal);
+}
+
+// Expose helpers on window so path-picker.js / context-gateway.js /
+// settings-namespaces.js can use them without import wiring (matches the
+// existing window.showConfirm / window.PathPicker style).
+window.openModalA11y = openModalA11y;
+window.registerModalCloser = registerModalCloser;
+window.closeModal = closeModal;
 function setMsg(el, text, isErr) {
   if (!el) return;
   el.textContent = text;
@@ -1078,11 +1158,22 @@ function showConfirm({
 
     show(modal);
     const focusables = [qs('confirm-cancel-btn'), qs('confirm-ok-btn')];
+    // openModalA11y must run AFTER show() so previouslyFocused captures the
+    // trigger (not confirm-ok-btn after focus() below). The Tab trap inside
+    // showConfirm at onKey() below already handles Tab cycling — pass
+    // focusables: null so the helper only adds restore + inert.
+    const releaseA11y = openModalA11y(modal);
     focusables[1].focus();
+    // Register a closer so the generic ESC dispatcher (line ~6119) routes
+    // through cleanup() and the release() runs — without this, ESC on a
+    // confirm modal would hide() the DOM but leak inert + lose focus.
+    registerModalCloser(modal, () => cleanup(false));
 
     function cleanup(ok) {
       const extraChecked = extraOption && ok ? extraCheckbox.checked : false;
       hide(modal);
+      releaseA11y();
+      _MODAL_CLOSERS.delete(modal);
       // Always reset the checkbox row so a later non-extra confirm
       // doesn't inherit the previous label / checked state.
       extraRow.hidden = true;
@@ -6110,13 +6201,13 @@ document.addEventListener('keydown', e => {
     const confirmModal = qs('confirm-modal');
     if (confirmModal && !confirmModal.hidden) return; // handled by showConfirm's own listener
     const srcPreview = qs('source-preview-modal');
-    if (srcPreview && !srcPreview.hidden) { hide(srcPreview); return; }
+    if (srcPreview && !srcPreview.hidden) { closeModal(srcPreview); return; }
     const expandModal = qs('expand-modal');
-    if (expandModal && !expandModal.hidden) { hide(expandModal); return; }
+    if (expandModal && !expandModal.hidden) { closeModal(expandModal); return; }
     const settingsModal = qs('settings-modal');
-    if (settingsModal && !settingsModal.hidden) { hide(settingsModal); return; }
+    if (settingsModal && !settingsModal.hidden) { closeModal(settingsModal); return; }
     const modal = qs('shortcuts-modal');
-    if (modal && !modal.hidden) { hide(modal); return; }
+    if (modal && !modal.hidden) { closeModal(modal); return; }
     const dropdown = qs('search-history-dropdown');
     if (dropdown && !dropdown.hidden) { hide(dropdown); return; }
     const similar = qs('similar-panel');
@@ -6141,7 +6232,7 @@ document.addEventListener('keydown', e => {
   if (e.key === '?') {
     e.preventDefault();
     const modal = qs('shortcuts-modal');
-    modal.hidden ? show(modal) : hide(modal);
+    if (modal.hidden) openShortcutsModal(); else closeShortcutsModal();
     return;
   }
 
@@ -6415,17 +6506,31 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 });
 
-qs('settings-btn').addEventListener('click', () => {
+let _settingsRelease = null;
+function openSettingsModal() {
+  const modal = qs('settings-modal');
   const s = _loadSettings();
   qs('settings-default-tab').value = s.defaultTab;
-  // Show current server config top-k (or UI value as fallback)
   const curTopK = STATE.serverConfig?.search?.default_top_k || STATE.currentTopK || 10;
   qs('settings-default-topk').value = String(curTopK);
-  show(qs('settings-modal'));
-});
-qs('settings-close-btn').addEventListener('click', () => hide(qs('settings-modal')));
+  show(modal);
+  _settingsRelease = openModalA11y(modal, {
+    focusables: () => Array.from(
+      modal.querySelectorAll('input, select, button, [tabindex="0"]')
+    ).filter(el => !el.disabled && el.offsetParent !== null),
+  });
+}
+function closeSettingsModal() {
+  hide(qs('settings-modal'));
+  if (_settingsRelease) { _settingsRelease(); _settingsRelease = null; }
+}
+window.openSettingsModal = openSettingsModal;
+registerModalCloser(qs('settings-modal'), closeSettingsModal);
+
+qs('settings-btn').addEventListener('click', openSettingsModal);
+qs('settings-close-btn').addEventListener('click', closeSettingsModal);
 qs('settings-modal').addEventListener('click', e => {
-  if (e.target === qs('settings-modal')) hide(qs('settings-modal'));
+  if (e.target === qs('settings-modal')) closeSettingsModal();
 });
 qs('settings-save-btn').addEventListener('click', async () => {
   localStorage.setItem('m2m-default-tab', qs('settings-default-tab').value);
@@ -6440,7 +6545,7 @@ qs('settings-save-btn').addEventListener('click', async () => {
     console.warn('Failed to persist top-k to server config:', e);
   }
   showToast(t('toast.settings_saved'), 'success');
-  hide(qs('settings-modal'));
+  closeSettingsModal();
 });
 qs('settings-reset-btn').addEventListener('click', () => {
   localStorage.removeItem('m2m-default-tab');
@@ -6451,9 +6556,25 @@ qs('settings-reset-btn').addEventListener('click', () => {
   showToast(t('toast.settings_reset'), 'info');
 });
 
-qs('shortcuts-close-btn').addEventListener('click', () => hide(qs('shortcuts-modal')));
+let _shortcutsRelease = null;
+function openShortcutsModal() {
+  const modal = qs('shortcuts-modal');
+  show(modal);
+  _shortcutsRelease = openModalA11y(modal, {
+    focusables: () => [qs('shortcuts-close-btn')],
+  });
+}
+function closeShortcutsModal() {
+  hide(qs('shortcuts-modal'));
+  if (_shortcutsRelease) { _shortcutsRelease(); _shortcutsRelease = null; }
+}
+window.openShortcutsModal = openShortcutsModal;
+window.closeShortcutsModal = closeShortcutsModal;
+registerModalCloser(qs('shortcuts-modal'), closeShortcutsModal);
+
+qs('shortcuts-close-btn').addEventListener('click', closeShortcutsModal);
 qs('shortcuts-modal').addEventListener('click', e => {
-  if (e.target === qs('shortcuts-modal')) hide(qs('shortcuts-modal'));
+  if (e.target === qs('shortcuts-modal')) closeShortcutsModal();
 });
 
 // ---------------------------------------------------------------------------
@@ -6578,7 +6699,9 @@ qs('view-toggle').addEventListener('click', () => {
 // Expand Detail (I2)
 // ---------------------------------------------------------------------------
 
-qs('d-expand-btn').addEventListener('click', () => {
+let _expandRelease = null;
+function openExpandModal() {
+  const modal = qs('expand-modal');
   qs('expand-modal-title').textContent = qs('d-file').textContent || 'Content';
   const pre = qs('expand-content');
   pre.textContent = '';
@@ -6589,17 +6712,42 @@ qs('d-expand-btn').addEventListener('click', () => {
   code.textContent = qs('d-editor').value;
   pre.appendChild(code);
   if (lang && window.Prism) Prism.highlightElement(code);
-  show(qs('expand-modal'));
-});
+  show(modal);
+  _expandRelease = openModalA11y(modal, {
+    focusables: () => [qs('expand-close-btn')],
+  });
+}
+function closeExpandModal() {
+  hide(qs('expand-modal'));
+  if (_expandRelease) { _expandRelease(); _expandRelease = null; }
+}
+window.openExpandModal = openExpandModal;
+registerModalCloser(qs('expand-modal'), closeExpandModal);
 
-qs('expand-close-btn').addEventListener('click', () => hide(qs('expand-modal')));
+qs('d-expand-btn').addEventListener('click', openExpandModal);
+qs('expand-close-btn').addEventListener('click', closeExpandModal);
 qs('expand-modal').addEventListener('click', e => {
-  if (e.target === qs('expand-modal')) hide(qs('expand-modal'));
+  if (e.target === qs('expand-modal')) closeExpandModal();
 });
 
 // ---------------------------------------------------------------------------
 // Source Preview Modal — full document view with chunk highlight
 // ---------------------------------------------------------------------------
+
+let _sourcePreviewRelease = null;
+function openSourcePreviewModal() {
+  const modal = qs('source-preview-modal');
+  show(modal);
+  _sourcePreviewRelease = openModalA11y(modal, {
+    focusables: () => [qs('source-preview-close')],
+  });
+}
+function closeSourcePreviewModal() {
+  hide(qs('source-preview-modal'));
+  if (_sourcePreviewRelease) { _sourcePreviewRelease(); _sourcePreviewRelease = null; }
+}
+window.openSourcePreviewModal = openSourcePreviewModal;
+registerModalCloser(qs('source-preview-modal'), closeSourcePreviewModal);
 
 async function openSourcePreview(sourcePath, highlightStart, highlightEnd) {
   const modal = qs('source-preview-modal');
@@ -6611,7 +6759,7 @@ async function openSourcePreview(sourcePath, highlightStart, highlightEnd) {
   title.title = sourcePath;
   info.textContent = 'Loading…';
   body.innerHTML = '<div class="loading-panel"><div class="spinner-panel"></div></div>';
-  show(modal);
+  openSourcePreviewModal();
 
   try {
     const data = await api('GET', `/api/sources/content?path=${encodeURIComponent(sourcePath)}`);
@@ -6654,9 +6802,9 @@ async function openSourcePreview(sourcePath, highlightStart, highlightEnd) {
   }
 }
 
-qs('source-preview-close').addEventListener('click', () => hide(qs('source-preview-modal')));
+qs('source-preview-close').addEventListener('click', closeSourcePreviewModal);
 qs('source-preview-modal').addEventListener('click', e => {
-  if (e.target === qs('source-preview-modal')) hide(qs('source-preview-modal'));
+  if (e.target === qs('source-preview-modal')) closeSourcePreviewModal();
 });
 
 // Make d-file clickable to open source preview

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1852,6 +1852,10 @@ function _ctxResolveConflict(userBuffer, freshContent) {
     const diffBtn = qs('ctx-conflict-diff-btn');
     const forceBtn = qs('ctx-conflict-force-btn');
     show(modal);
+    const releaseA11y = window.openModalA11y(modal, {
+      focusables: () => [reloadBtn, diffBtn, forceBtn],
+    });
+    window.registerModalCloser(modal, () => cleanup(null));
     // Focus the safest choice. Force-save is destructive (overwrites the
     // other writer's edits) and the modal exists precisely to make that
     // choice explicit — auto-focusing the danger button would let a
@@ -1861,6 +1865,7 @@ function _ctxResolveConflict(userBuffer, freshContent) {
 
     function cleanup(choice) {
       hide(modal);
+      releaseA11y();
       modal.removeEventListener('click', onBackdrop);
       document.removeEventListener('keydown', onKey, true);
       reloadBtn.onclick = null;
@@ -1879,6 +1884,11 @@ function _ctxResolveConflict(userBuffer, freshContent) {
     forceBtn.onclick = () => cleanup('force');
   });
 }
+
+// Test/dev entry point — production callers use ``_ctxResolveConflict``
+// with real user/disk buffers. The no-arg shim is what the A11Y Playwright
+// pins drive so they don't need to set up a full edit-conflict scenario.
+window.openCtxConflictModal = () => _ctxResolveConflict('', '');
 
 function _ctxRenderConflictBanner(detailEl, userBuffer, freshContent) {
   // Inline diff inside the edit pane, above the textarea. Diff orientation

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1231,7 +1231,7 @@
 
 
   <!-- Expand Modal (I2) -->
-  <div id="expand-modal" class="modal-overlay" hidden>
+  <div id="expand-modal" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="expand-modal-title">
     <div class="modal-inner expand-modal-inner">
       <div class="modal-header">
         <span id="expand-modal-title" class="modal-title"></span>
@@ -1242,7 +1242,7 @@
   </div>
 
   <!-- Source Preview Modal -->
-  <div id="source-preview-modal" class="modal-overlay" hidden>
+  <div id="source-preview-modal" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="source-preview-title">
     <div class="modal-inner source-preview-inner">
       <div class="modal-header">
         <span id="source-preview-title" class="modal-title"></span>
@@ -1256,10 +1256,10 @@
   </div>
 
   <!-- Settings Modal -->
-  <div id="settings-modal" class="modal-overlay" hidden>
+  <div id="settings-modal" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="settings-title">
     <div class="modal-inner">
       <div class="modal-header">
-        <span class="modal-title" data-i18n="modal.settings_title">Settings</span>
+        <span id="settings-title" class="modal-title" data-i18n="modal.settings_title">Settings</span>
         <button id="settings-close-btn" class="btn-ghost">✕</button>
       </div>
       <div class="settings-form">
@@ -1294,10 +1294,10 @@
   </div>
 
   <!-- Keyboard Shortcuts Modal -->
-  <div id="shortcuts-modal" class="modal-overlay" hidden>
+  <div id="shortcuts-modal" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">
     <div class="modal-inner">
       <div class="modal-header">
-        <span class="modal-title" data-i18n="modal.shortcuts_title">Keyboard Shortcuts</span>
+        <span id="shortcuts-title" class="modal-title" data-i18n="modal.shortcuts_title">Keyboard Shortcuts</span>
         <button id="shortcuts-close-btn" class="btn-ghost">✕</button>
       </div>
       <table class="shortcuts-table">
@@ -1320,7 +1320,7 @@
   </div>
 
   <!-- Command Palette (Cmd+K) -->
-  <div id="cmd-palette" class="modal-overlay" hidden>
+  <div id="cmd-palette" class="modal-overlay" hidden role="dialog" aria-modal="true" data-i18n-aria-label="modal.cmd_palette_aria_label">
     <div class="cmd-palette-inner">
       <input id="cmd-input" type="text" class="cmd-input" data-i18n-placeholder="modal.cmd_placeholder" placeholder="Type a command…" autocomplete="off" spellcheck="false" />
       <div id="cmd-list" class="cmd-list"></div>
@@ -1331,7 +1331,7 @@
   <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="false"></div>
 
   <!-- Confirm Dialog (A3) -->
-  <div id="confirm-modal" class="modal-overlay" hidden>
+  <div id="confirm-modal" class="modal-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="confirm-title">
     <div class="modal-inner confirm-dialog">
       <div class="modal-header">
         <span id="confirm-title" class="modal-title"></span>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -700,6 +700,7 @@
   "modal.cancel_btn": "Cancel",
   "modal.delete_btn": "Delete",
   "modal.cmd_placeholder": "Type a command…",
+  "modal.cmd_palette_aria_label": "Command palette",
 
   "shortcut.focus_search": "Focus search input",
   "shortcut.navigate": "Navigate results (next / prev)",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -700,6 +700,7 @@
   "modal.cancel_btn": "취소",
   "modal.delete_btn": "삭제",
   "modal.cmd_placeholder": "명령어 입력…",
+  "modal.cmd_palette_aria_label": "명령 팔레트",
 
   "shortcut.focus_search": "검색 입력창 포커스",
   "shortcut.navigate": "결과 탐색 (다음 / 이전)",

--- a/packages/memtomem/src/memtomem/web/static/path-picker.js
+++ b/packages/memtomem/src/memtomem/web/static/path-picker.js
@@ -183,10 +183,16 @@
     (firstItem || cancelBtn()).focus();
   }
 
+  let _releaseA11y = null;
+
   function open(opts) {
     onSelectCb = (opts && typeof opts.onSelect === 'function') ? opts.onSelect : null;
     pickerPurpose = (opts && opts.purpose) || 'index';
     modal().hidden = false;
+    // Path-picker owns its own Tab trap (dynamic focusables across breadcrumbs
+    // + list items); pass focusables: null so the helper only adds restore +
+    // inert without installing a redundant trap.
+    _releaseA11y = window.openModalA11y(modal());
     document.addEventListener('keydown', _onKey, true);
     modal().addEventListener('click', _onBackdrop);
     selectBtn().disabled = true;
@@ -195,6 +201,7 @@
 
   function close() {
     modal().hidden = true;
+    if (_releaseA11y) { _releaseA11y(); _releaseA11y = null; }
     document.removeEventListener('keydown', _onKey, true);
     modal().removeEventListener('click', _onBackdrop);
     currentPath = null;
@@ -265,6 +272,7 @@
     if (browseBtn) browseBtn.addEventListener('click', () => open());
     if (cancelBtn()) cancelBtn().addEventListener('click', close);
     if (selectBtn()) selectBtn().addEventListener('click', commit);
+    if (window.registerModalCloser) window.registerModalCloser(modal(), close);
   }
 
   if (document.readyState === 'loading') {

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -623,7 +623,7 @@ function _buildCommands() {
   const actions = [
     { icon: '🔍', label: 'Focus Search', action: () => { activateTab('search'); qs('search-input').focus(); }, hint: '/' },
     { icon: '🌗', label: 'Toggle Theme', action: () => qs('theme-toggle').click() },
-    { icon: '⌨', label: 'Keyboard Shortcuts', action: () => show(qs('shortcuts-modal')), hint: '?' },
+    { icon: '⌨', label: 'Keyboard Shortcuts', action: () => window.openShortcutsModal(), hint: '?' },
   ];
 
   // Dynamic: recent sources
@@ -639,12 +639,18 @@ function _buildCommands() {
   ];
 }
 
+let _cmdPaletteRelease = null;
 function _openCmdPalette() {
   STATE.cmdPaletteOpen = true;
   const modal = qs('cmd-palette');
   const input = qs('cmd-input');
-  const list = qs('cmd-list');
   show(modal);
+  // cmd-palette navigates items with ArrowUp/Down (cmd-input keydown). The
+  // helper Tab-trap is here only to prevent Tab leaking to background — a
+  // single-focusable cycle just refocuses the input, which is what we want.
+  _cmdPaletteRelease = window.openModalA11y(modal, {
+    focusables: () => [qs('cmd-input')],
+  });
   input.value = '';
   input.focus();
   _renderCmdList('');
@@ -653,7 +659,11 @@ function _openCmdPalette() {
 function _closeCmdPalette() {
   STATE.cmdPaletteOpen = false;
   hide(qs('cmd-palette'));
+  if (_cmdPaletteRelease) { _cmdPaletteRelease(); _cmdPaletteRelease = null; }
 }
+
+window.openCmdPalette = _openCmdPalette;
+window.registerModalCloser(qs('cmd-palette'), _closeCmdPalette);
 
 function _renderCmdList(filter) {
   const list = qs('cmd-list');

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -592,9 +592,6 @@ _ICON_ONLY_BUTTONS = (
 # assertion passes, pytest reports XPASS as a failure and forces the developer
 # to drop the marker rather than leave a permanent expected-failure that
 # silently re-RED'd later.
-_A11Y_XFAIL_PR2 = pytest.mark.xfail(
-    strict=True, reason="A11Y-3.4 — pending fix in issue #1053 PR #2"
-)
 _A11Y_XFAIL_PR3 = pytest.mark.xfail(
     strict=True, reason="A11Y-3.1 — pending modal manager in issue #1053 PR #3"
 )
@@ -660,36 +657,27 @@ class TestA11yOrphanInputLabels:
 
 # Every modal-overlay container. ``role="dialog"`` + ``aria-modal="true"``
 # is the minimum SR contract — VoiceOver / NVDA use it to scope navigation
-# and stop announcing background landmarks. Two modals already declare both
-# attributes today; the remaining six get the PR #2 xfail marker so the
-# regression guard stays GREEN on the fixed ones.
-_MODALS_ALREADY_PINNED = frozenset({"ctx-conflict-modal", "path-picker-modal"})
-
-_MODAL_PARAMS = [
-    pytest.param(
-        modal_id,
-        marks=[] if modal_id in _MODALS_ALREADY_PINNED else [_A11Y_XFAIL_PR2],
-        id=modal_id,
-    )
-    for modal_id in (
-        "expand-modal",
-        "source-preview-modal",
-        "settings-modal",
-        "shortcuts-modal",
-        "cmd-palette",
-        "confirm-modal",
-        "ctx-conflict-modal",
-        "path-picker-modal",
-    )
-]
+# and stop announcing background landmarks. All 8 modals declare both
+# attributes after PR #2 (#1053); this class is now a permanent regression
+# guard against the attributes being dropped.
+_MODAL_IDS = (
+    "expand-modal",
+    "source-preview-modal",
+    "settings-modal",
+    "shortcuts-modal",
+    "cmd-palette",
+    "confirm-modal",
+    "ctx-conflict-modal",
+    "path-picker-modal",
+)
 
 
 class TestA11yModalAriaModal:
     """A11Y-3.4 — every ``.modal-overlay`` must declare itself as a dialog
-    so AT scope into it. ``ctx-conflict-modal`` and ``path-picker-modal``
-    already pass; the other six are the RED rows this pin tracks."""
+    so AT scope into it. All 8 modals carry ``role="dialog"`` +
+    ``aria-modal="true"`` after PR #2; this guards against regression."""
 
-    @pytest.mark.parametrize("modal_id", _MODAL_PARAMS)
+    @pytest.mark.parametrize("modal_id", _MODAL_IDS)
     def test_modal_declares_dialog_role(self, index_html: str, modal_id: str):
         block = _modal_block(index_html, modal_id)
         assert 'role="dialog"' in block, (
@@ -697,7 +685,7 @@ class TestA11yModalAriaModal:
             f"opening tag (A11Y-3.4, issue #1053)"
         )
 
-    @pytest.mark.parametrize("modal_id", _MODAL_PARAMS)
+    @pytest.mark.parametrize("modal_id", _MODAL_IDS)
     def test_modal_declares_aria_modal(self, index_html: str, modal_id: str):
         block = _modal_block(index_html, modal_id)
         assert 'aria-modal="true"' in block, (

--- a/packages/memtomem/tests/web/test_a11y_focus.py
+++ b/packages/memtomem/tests/web/test_a11y_focus.py
@@ -1,19 +1,17 @@
-"""A11Y-3.1 — global shortcut gate when a modal is active (issue #1053).
+"""A11Y modal behaviour pins — Playwright lane (issue #1053).
 
-The bug today: ``settings-namespaces.js:747`` registers a window-level
-keydown listener for ``Cmd/Ctrl+K`` that checks only
-``STATE.cmdPaletteOpen``. When ``confirm-modal`` is up, Ctrl+K still opens
-the command palette on top of it, stealing focus and dismissing the
-confirm gate visually.
+PR #2 adds Tab trap + focus restoration + background ``inert`` to the 8
+``.modal-overlay`` elements (``TestA11yModalFocusTrap`` /
+``TestA11yModalFocusRestore`` / ``TestA11yBackgroundInert`` /
+``TestA11yStackedModalInertSurvives``).
 
-The fix introduces a modal manager (``modal-manager.js``) that tracks
-which ``.modal-overlay`` elements are open, and the keydown listener
-gates on ``STATE.activeModals.size > 0`` (and the ``?`` / ``Cmd+,``
-listeners gain the same gate).
+PR #3 adds a modal manager + global-shortcut gate
+(``test_ctrl_k_blocked_while_confirm_modal_active``).
 
-This test is RED until the manager + gate land. It boots the SPA, opens
-a confirm modal the way the rest of the app does (``showConfirm()``),
-presses Ctrl+K, and asserts the palette stays hidden.
+Every test pin here is marked ``xfail(strict=True)`` so it self-removes
+the moment the relevant fix lands: the test xpasses, pytest reports it as
+a failure, and the dev drops the marker rather than leaving a stale
+expected-failure that could silently re-RED later.
 """
 
 from __future__ import annotations
@@ -25,10 +23,207 @@ from .conftest import install_default_stubs
 pytestmark = pytest.mark.browser
 
 
-# ``strict=True`` so the marker self-removes once the modal manager + gate
-# land in issue #1053 PR #3: the test xpasses, pytest reports it as a
-# failure, and the dev drops the marker rather than leaving a stale
-# expected-failure that could silently re-RED later.
+_A11Y_XFAIL_PR2 = pytest.mark.xfail(
+    strict=True,
+    reason="A11Y-1.2/1.5/3.2 — pending focus trap + restore + inert in issue #1053 PR #2",
+)
+
+
+# PR #2 installs Tab trapping on these six modals. ``confirm-modal`` and
+# ``path-picker-modal`` already trap Tab via their own custom listeners
+# (dynamic focusable computation) and are exercised only by the restore +
+# inert pins below.
+_TRAP_MODALS = (
+    "expand-modal",
+    "source-preview-modal",
+    "settings-modal",
+    "shortcuts-modal",
+    "cmd-palette",
+    "ctx-conflict-modal",
+)
+
+# Every modal must capture its trigger on open and restore focus on close,
+# and must inert background body-level siblings while it's up.
+_ALL_MODALS = (
+    "expand-modal",
+    "source-preview-modal",
+    "settings-modal",
+    "shortcuts-modal",
+    "cmd-palette",
+    "confirm-modal",
+    "ctx-conflict-modal",
+    "path-picker-modal",
+)
+
+
+def _open_modal_js(modal_id: str) -> str:
+    """JS expression that opens ``modal_id``.
+
+    Most modals route through a ``window.openXModal()`` wrapper that PR #2
+    introduces — pre-fix the wrapper is undefined and the evaluate throws,
+    which the strict xfail expects. ``confirm-modal`` (``window.showConfirm``)
+    and ``path-picker-modal`` (``window.PathPicker.open``) already have a
+    public open path; for those the helper just adds restore + inert.
+    """
+    if modal_id == "confirm-modal":
+        return (
+            "void window.showConfirm({title: 'a11y probe', message: 'x', "
+            "confirmText: 'OK', cancelText: 'Cancel'})"
+        )
+    if modal_id == "path-picker-modal":
+        return "window.PathPicker.open()"
+    # Per-modal wrappers exposed on window by PR #2.
+    wrapper = {
+        "expand-modal": "openExpandModal",
+        "source-preview-modal": "openSourcePreviewModal",
+        "settings-modal": "openSettingsModal",
+        "shortcuts-modal": "openShortcutsModal",
+        "cmd-palette": "openCmdPalette",
+        "ctx-conflict-modal": "openCtxConflictModal",
+    }[modal_id]
+    return f"window.{wrapper}()"
+
+
+def _goto_with_stubs(mm_web_url: str, page) -> None:
+    install_default_stubs(page)
+    page.goto(mm_web_url)
+    # All 8 modal-overlay nodes are in the static HTML — wait on one as a
+    # cheap "SPA boot finished" gate. ``confirm-modal`` is always present.
+    page.wait_for_selector("#confirm-modal", state="attached")
+
+
+class TestA11yModalFocusTrap:
+    """A11Y-1.2 — Tab cycles inside the modal, never escapes to background."""
+
+    @_A11Y_XFAIL_PR2
+    @pytest.mark.parametrize("modal_id", _TRAP_MODALS)
+    def test_tab_stays_inside_modal(self, mm_web_url, page, modal_id):
+        _goto_with_stubs(mm_web_url, page)
+        page.evaluate(_open_modal_js(modal_id))
+        page.wait_for_selector(f"#{modal_id}:not([hidden])", timeout=2_000)
+        # Press Tab enough times to wrap any reasonable focusable list (the
+        # widest modal — settings — has ~6 controls). 12 Tabs comfortably
+        # covers the cycle; an untrapped modal leaks focus to background
+        # within the first few presses.
+        for _ in range(12):
+            page.keyboard.press("Tab")
+            inside = page.evaluate(
+                f"document.getElementById('{modal_id}').contains(document.activeElement)"
+            )
+            assert inside, (
+                f"focus left #{modal_id} during Tab cycling — install a "
+                f"focus trap (A11Y-1.2, issue #1053)"
+            )
+
+
+class TestA11yModalFocusRestore:
+    """A11Y-1.5 — closing a modal returns focus to the element that opened it."""
+
+    @_A11Y_XFAIL_PR2
+    @pytest.mark.parametrize("modal_id", _ALL_MODALS)
+    def test_focus_returns_to_trigger(self, mm_web_url, page, modal_id):
+        _goto_with_stubs(mm_web_url, page)
+        # Use ``settings-btn`` as a stable trigger surrogate for every modal.
+        # The helper captures ``document.activeElement`` at open time, so
+        # focus restoration is trigger-agnostic; the test only needs a known,
+        # always-present focusable element.
+        page.evaluate("document.getElementById('settings-btn').focus()")
+        page.evaluate(_open_modal_js(modal_id))
+        page.wait_for_selector(f"#{modal_id}:not([hidden])", timeout=2_000)
+        page.keyboard.press("Escape")
+        page.wait_for_selector(f"#{modal_id}[hidden]", timeout=2_000)
+        active_id = page.evaluate("document.activeElement && document.activeElement.id")
+        assert active_id == "settings-btn", (
+            f"closing #{modal_id} did not restore focus to its trigger "
+            f"(got '{active_id}') — capture previouslyFocused on open and "
+            f"focus() it on close (A11Y-1.5, issue #1053)"
+        )
+
+
+class TestA11yBackgroundInert:
+    """A11Y-3.2 — body-level siblings get ``inert`` while a modal is open."""
+
+    @_A11Y_XFAIL_PR2
+    @pytest.mark.parametrize("modal_id", _ALL_MODALS)
+    def test_background_inerts_while_open(self, mm_web_url, page, modal_id):
+        _goto_with_stubs(mm_web_url, page)
+        page.evaluate(_open_modal_js(modal_id))
+        page.wait_for_selector(f"#{modal_id}:not([hidden])", timeout=2_000)
+        # ``<header>`` is the first body-level element (index.html:13) and is
+        # not a modal — it must be inerted while any modal is up so SR + Tab
+        # cannot escape into background chrome.
+        header_inert_open = page.evaluate(
+            "document.querySelector('body > header').hasAttribute('inert')"
+        )
+        assert header_inert_open, (
+            f"<header> not inerted while #{modal_id} was open — apply "
+            f"inert to body-level siblings (A11Y-3.2, issue #1053)"
+        )
+        page.keyboard.press("Escape")
+        page.wait_for_selector(f"#{modal_id}[hidden]", timeout=2_000)
+        header_inert_closed = page.evaluate(
+            "document.querySelector('body > header').hasAttribute('inert')"
+        )
+        assert not header_inert_closed, (
+            f"<header> remained inert after #{modal_id} closed — release "
+            f"inert when the modal stack empties (A11Y-3.2, issue #1053)"
+        )
+
+
+class TestA11yStackedModalInertSurvives:
+    """A11Y-3.2 / A11Y-3.3 stack regression — closing a nested modal must NOT
+    un-inert the outer modal's background.
+
+    Today's audit flagged settings → maintenance ``showConfirm`` as a real
+    stacking case (`a11y-1-2-3-audit-pass-dreamy-mccarthy.md` A11Y-3.3). A
+    naive per-open snapshot of "siblings to inert" un-inerts the background
+    when the inner modal closes because the outer modal was in the inner
+    modal's snapshot. The refcount-based ``_recomputeBackgroundInert()``
+    fixes this — this single test is the only thing standing between us and
+    a silent regression there.
+    """
+
+    @_A11Y_XFAIL_PR2
+    def test_inner_close_keeps_outer_background_inert(self, mm_web_url, page):
+        _goto_with_stubs(mm_web_url, page)
+        page.evaluate("document.getElementById('settings-btn').focus()")
+        # Open outer: settings-modal.
+        page.evaluate(_open_modal_js("settings-modal"))
+        page.wait_for_selector("#settings-modal:not([hidden])", timeout=2_000)
+        # Open inner on top: confirm-modal via showConfirm.
+        page.evaluate(_open_modal_js("confirm-modal"))
+        page.wait_for_selector("#confirm-modal:not([hidden])", timeout=2_000)
+        # Close inner by clicking OK (Escape would also fire, but OK is the
+        # least-ambiguous close path through cleanup()).
+        page.click("#confirm-ok-btn")
+        page.wait_for_selector("#confirm-modal[hidden]", timeout=2_000)
+        # Settings is still open; therefore <header> must STILL be inert
+        # (the refcount design holds) and settings-modal itself must NOT be
+        # inert (a snapshot-based design would have un-inerted it).
+        header_still_inert = page.evaluate(
+            "document.querySelector('body > header').hasAttribute('inert')"
+        )
+        assert header_still_inert, (
+            "closing the inner confirm-modal un-inerted the outer "
+            "settings-modal's background — _recomputeBackgroundInert() "
+            "must derive inert state from the active-modal stack, not "
+            "per-open snapshots (A11Y-3.2/3.3, issue #1053)"
+        )
+        settings_not_inert = page.evaluate(
+            "!document.getElementById('settings-modal').hasAttribute('inert')"
+        )
+        assert settings_not_inert, (
+            "settings-modal itself became inert after the nested confirm "
+            "closed — the active modal must never be inert (A11Y-3.2, "
+            "issue #1053)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PR #3 pin — kept here as the original tenant of this file.
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.xfail(strict=True, reason="A11Y-3.1 — pending modal manager in issue #1053 PR #3")
 def test_ctrl_k_blocked_while_confirm_modal_active(mm_web_url, page):
     install_default_stubs(page)

--- a/packages/memtomem/tests/web/test_a11y_focus.py
+++ b/packages/memtomem/tests/web/test_a11y_focus.py
@@ -23,12 +23,6 @@ from .conftest import install_default_stubs
 pytestmark = pytest.mark.browser
 
 
-_A11Y_XFAIL_PR2 = pytest.mark.xfail(
-    strict=True,
-    reason="A11Y-1.2/1.5/3.2 — pending focus trap + restore + inert in issue #1053 PR #2",
-)
-
-
 # PR #2 installs Tab trapping on these six modals. ``confirm-modal`` and
 # ``path-picker-modal`` already trap Tab via their own custom listeners
 # (dynamic focusable computation) and are exercised only by the restore +
@@ -101,7 +95,6 @@ def _goto_with_stubs(mm_web_url: str, page) -> None:
 class TestA11yModalFocusTrap:
     """A11Y-1.2 — Tab cycles inside the modal, never escapes to background."""
 
-    @_A11Y_XFAIL_PR2
     @pytest.mark.parametrize("modal_id", _TRAP_MODALS)
     def test_tab_stays_inside_modal(self, mm_web_url, page, modal_id):
         _goto_with_stubs(mm_web_url, page)
@@ -125,7 +118,6 @@ class TestA11yModalFocusTrap:
 class TestA11yModalFocusRestore:
     """A11Y-1.5 — closing a modal returns focus to the element that opened it."""
 
-    @_A11Y_XFAIL_PR2
     @pytest.mark.parametrize("modal_id", _ALL_MODALS)
     def test_focus_returns_to_trigger(self, mm_web_url, page, modal_id):
         _goto_with_stubs(mm_web_url, page)
@@ -149,7 +141,6 @@ class TestA11yModalFocusRestore:
 class TestA11yBackgroundInert:
     """A11Y-3.2 — body-level siblings get ``inert`` while a modal is open."""
 
-    @_A11Y_XFAIL_PR2
     @pytest.mark.parametrize("modal_id", _ALL_MODALS)
     def test_background_inerts_while_open(self, mm_web_url, page, modal_id):
         _goto_with_stubs(mm_web_url, page)
@@ -189,7 +180,6 @@ class TestA11yStackedModalInertSurvives:
     a silent regression there.
     """
 
-    @_A11Y_XFAIL_PR2
     def test_inner_close_keeps_outer_background_inert(self, mm_web_url, page):
         _goto_with_stubs(mm_web_url, page)
         page.evaluate("document.getElementById('settings-btn').focus()")

--- a/packages/memtomem/tests/web/test_a11y_focus.py
+++ b/packages/memtomem/tests/web/test_a11y_focus.py
@@ -59,6 +59,12 @@ _ALL_MODALS = (
 def _open_modal_js(modal_id: str) -> str:
     """JS expression that opens ``modal_id``.
 
+    Every expression is ``void``-prefixed: Playwright's ``page.evaluate``
+    awaits returned Promises by default, and the modal openers that resolve
+    only on close (``showConfirm``, ``_ctxResolveConflict``) would hang the
+    test until the modal is dismissed. ``void`` discards the return value
+    so the call returns immediately while the modal stays open.
+
     Most modals route through a ``window.openXModal()`` wrapper that PR #2
     introduces — pre-fix the wrapper is undefined and the evaluate throws,
     which the strict xfail expects. ``confirm-modal`` (``window.showConfirm``)
@@ -71,7 +77,7 @@ def _open_modal_js(modal_id: str) -> str:
             "confirmText: 'OK', cancelText: 'Cancel'})"
         )
     if modal_id == "path-picker-modal":
-        return "window.PathPicker.open()"
+        return "void window.PathPicker.open()"
     # Per-modal wrappers exposed on window by PR #2.
     wrapper = {
         "expand-modal": "openExpandModal",
@@ -81,7 +87,7 @@ def _open_modal_js(modal_id: str) -> str:
         "cmd-palette": "openCmdPalette",
         "ctx-conflict-modal": "openCtxConflictModal",
     }[modal_id]
-    return f"window.{wrapper}()"
+    return f"void window.{wrapper}()"
 
 
 def _goto_with_stubs(mm_web_url: str, page) -> None:
@@ -131,7 +137,7 @@ class TestA11yModalFocusRestore:
         page.evaluate(_open_modal_js(modal_id))
         page.wait_for_selector(f"#{modal_id}:not([hidden])", timeout=2_000)
         page.keyboard.press("Escape")
-        page.wait_for_selector(f"#{modal_id}[hidden]", timeout=2_000)
+        page.wait_for_selector(f"#{modal_id}", state="hidden", timeout=2_000)
         active_id = page.evaluate("document.activeElement && document.activeElement.id")
         assert active_id == "settings-btn", (
             f"closing #{modal_id} did not restore focus to its trigger "
@@ -160,7 +166,7 @@ class TestA11yBackgroundInert:
             f"inert to body-level siblings (A11Y-3.2, issue #1053)"
         )
         page.keyboard.press("Escape")
-        page.wait_for_selector(f"#{modal_id}[hidden]", timeout=2_000)
+        page.wait_for_selector(f"#{modal_id}", state="hidden", timeout=2_000)
         header_inert_closed = page.evaluate(
             "document.querySelector('body > header').hasAttribute('inert')"
         )
@@ -196,7 +202,7 @@ class TestA11yStackedModalInertSurvives:
         # Close inner by clicking OK (Escape would also fire, but OK is the
         # least-ambiguous close path through cleanup()).
         page.click("#confirm-ok-btn")
-        page.wait_for_selector("#confirm-modal[hidden]", timeout=2_000)
+        page.wait_for_selector("#confirm-modal", state="hidden", timeout=2_000)
         # Settings is still open; therefore <header> must STILL be inert
         # (the refcount design holds) and settings-modal itself must NOT be
         # inert (a snapshot-based design would have un-inerted it).


### PR DESCRIPTION
## Summary

Closes A11Y-1.2 / 1.5 / 3.2 / 3.4 from the dreamy-mccarthy audit (issue #1053). Second of five fix PRs queued there, after PR #1055 (icon-button + input labels).

- Installs `openModalA11y(modal, { focusables })` in `app.js` — a single stack-aware helper that captures the trigger, manages background `inert` from a `_ACTIVE_MODALS` stack, and (optionally) traps Tab. Returns an idempotent `release()` closure.
- Routes every `.modal-overlay` open/close through per-modal `openX/closeX` wrappers + a `closeModal(el)` dispatcher; the generic ESC handler (`app.js:6107-6125`) and the `?`-key opener now go through these. `confirm-modal` and `path-picker-modal` keep their existing custom Tab traps (dynamic focusables) — the helper just adds restore + inert there. The other 6 modals get full helper trap wiring.
- Adds `role="dialog" aria-modal="true"` to the 6 modals that lacked them; adds `id="settings-title"` / `id="shortcuts-title"` so `aria-labelledby` resolves; `cmd-palette` gets `data-i18n-aria-label="modal.cmd_palette_aria_label"` with EN/KO parity.

The stack matters: settings → maintenance `showConfirm` nests today, and a naive per-open snapshot would un-inert the outer background when the inner closes. `_recomputeBackgroundInert()` derives inert state from the active stack each transition — guarded by `TestA11yStackedModalInertSurvives`.

## Pin lifecycle (RED → fix → flip in one PR)

| Commit | Effect |
|--------|--------|
| `a3c1d6f` | RED — adds 24 strict-xfail Playwright pins (4 new classes) |
| `fab6316` | Fix — helper + wrappers + raw show/hide replaced + HTML attrs + i18n key |
| `5792822` | Flip — `_A11Y_XFAIL_PR2` constant + decorators removed from both pin files |

Net: 23 new Playwright pins land GREEN + the 12 existing `TestA11yModalAriaModal` substring pins flip GREEN. 1 Playwright pin (`test_ctrl_k_blocked_while_confirm_modal_active`) stays xfailed by design — that's PR #3's scope.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_qa_audit_pins.py::TestA11yModalAriaModal -v` — 16/16 green
- [x] `uv run pytest packages/memtomem/tests/web/test_a11y_focus.py -v` — 23/23 green + 1 xfailed (PR #3)
- [x] `uv run pytest -k "a11y or A11y" -v` — 56 green, 1 xfailed (PR #3)
- [x] `uv run ruff check packages/memtomem/src` + `format --check` — clean
- [ ] Manual smoke (recommended before merge):
  - [ ] Open expand-modal → Tab cycles inside → ESC restores focus to trigger
  - [ ] VoiceOver: open settings-modal → swipe-right rotor does not announce background landmarks
  - [ ] Open settings → maintenance `showConfirm` on top → OK confirm → settings still interactive, header still inert
  - [ ] Open confirm-modal → Cmd+K still opens palette (PR #3 will gate this; out of scope here)

## Files touched

| File | Change |
|------|--------|
| `static/app.js` | helper + 4 per-modal wrappers + ESC dispatch swap + `?` key opener |
| `static/context-gateway.js` | ctx-conflict-modal helper wiring + `window.openCtxConflictModal` test entry |
| `static/path-picker.js` | open/close: restore + inert (existing trap untouched) |
| `static/settings-namespaces.js` | cmd-palette helper wiring + line 626 shortcuts opener routes through `window.openShortcutsModal()` |
| `static/index.html` | `role`/`aria-modal`/`aria-labelledby` on 6 modals; new title ids |
| `static/locales/{en,ko}.json` | `modal.cmd_palette_aria_label` key |
| `tests/test_qa_audit_pins.py` | flip 12 substring pins + drop `_A11Y_XFAIL_PR2` |
| `tests/web/test_a11y_focus.py` | 4 new Playwright pin classes (added RED, then flipped) |

## Refs

- Audit plan: `~/.claude/plans/a11y-1-2-3-audit-pass-dreamy-mccarthy.md` (PR scope at line 93)
- Issue #1053, RED-pin PR #1054 (`59793ec`), preceding fix PR #1055 (`0b411fd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)