### PR TITLE
fix(config): coerce all_index_roots() to Path so /api/reindex stops 500ing

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -310,8 +310,14 @@ class IndexingConfig(BaseSettings):
         view, auto-discover migration); functional consumers that need
         to act on every indexable file go through this helper instead so
         a future scope addition does not fork the consumers.
+
+        Entries are coerced to ``Path`` to honour the declared return
+        type even when raw ``str`` values slipped past Pydantic via the
+        non-validating ``setattr`` path in ``load_config_overrides`` —
+        otherwise ``reindex_all`` blew up calling ``.expanduser()`` on
+        the unwrapped JSON strings.
         """
-        return list(self.memory_dirs) + list(self.project_memory_dirs)
+        return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
 
 class DecayConfig(BaseSettings):

--- a/packages/memtomem/tests/test_all_index_roots.py
+++ b/packages/memtomem/tests/test_all_index_roots.py
@@ -59,12 +59,21 @@ class TestAllIndexRootsHelper:
         # ``~/.memtomem/config.json``. The helper MUST normalise these
         # to ``Path`` to match the declared return type — otherwise the
         # web ``/api/reindex`` route 500s on ``str.expanduser()``.
+        #
+        # ``object.__setattr__`` mirrors the exact path
+        # ``load_config_overrides`` takes (Pydantic ``setattr`` without
+        # ``validate_assignment``) and avoids ``# type: ignore`` noise.
         cfg = IndexingConfig(memory_dirs=[], project_memory_dirs=[])
-        cfg.memory_dirs = ["~/u1", "~/u2"]  # type: ignore[assignment]
-        cfg.project_memory_dirs = ["~/p1"]  # type: ignore[assignment]
+        object.__setattr__(cfg, "memory_dirs", ["/u1", "/u2"])
+        object.__setattr__(cfg, "project_memory_dirs", ["/p1"])
         roots = cfg.all_index_roots()
         assert all(isinstance(r, Path) for r in roots)
-        assert roots == [Path("~/u1"), Path("~/u2"), Path("~/p1")]
+        assert roots == [Path("/u1"), Path("/u2"), Path("/p1")]
+        # ``.expanduser()`` is the next caller's contract; round-trip
+        # through it to document that the wrapped Path is filesystem-
+        # usable (the original bug surfaced exactly because callers
+        # could not invoke this on a ``str``).
+        assert [r.expanduser() for r in roots] == [Path("/u1"), Path("/u2"), Path("/p1")]
 
 
 class TestConsumerRegressionPin:

--- a/packages/memtomem/tests/test_all_index_roots.py
+++ b/packages/memtomem/tests/test_all_index_roots.py
@@ -53,6 +53,19 @@ class TestAllIndexRootsHelper:
         assert Path("/leak") not in cfg.memory_dirs
         assert Path("/leak") not in cfg.project_memory_dirs
 
+    def test_helper_coerces_str_entries_to_path(self):
+        # ``load_config_overrides`` uses ``setattr`` without validation,
+        # so ``memory_dirs`` can hold raw ``str`` values straight off
+        # ``~/.memtomem/config.json``. The helper MUST normalise these
+        # to ``Path`` to match the declared return type — otherwise the
+        # web ``/api/reindex`` route 500s on ``str.expanduser()``.
+        cfg = IndexingConfig(memory_dirs=[], project_memory_dirs=[])
+        cfg.memory_dirs = ["~/u1", "~/u2"]  # type: ignore[assignment]
+        cfg.project_memory_dirs = ["~/p1"]  # type: ignore[assignment]
+        roots = cfg.all_index_roots()
+        assert all(isinstance(r, Path) for r in roots)
+        assert roots == [Path("~/u1"), Path("~/u2"), Path("~/p1")]
+
 
 class TestConsumerRegressionPin:
     """Architectural guard — direct ``.memory_dirs`` access is restricted.

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -102,7 +102,11 @@ class FakeConfig:
         summary_max_tokens = 256
 
         def all_index_roots(self):
-            return list(self.memory_dirs) + list(self.project_memory_dirs)
+            # Mirror ``IndexingConfig.all_index_roots`` — coerce each
+            # entry to ``Path`` so the helper honours its declared
+            # return type even when a test (or
+            # ``load_config_overrides``) assigns raw ``str`` values.
+            return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
     class _Decay:
         enabled = False
@@ -2529,6 +2533,62 @@ class TestIndex:
         assert data["indexed_chunks"] == 0
         assert len(data["errors"]) == 1
         assert "fastembed" in data["errors"][0]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/reindex — "Reindex all" bulk route
+# ---------------------------------------------------------------------------
+
+
+class TestReindexAll:
+    """End-to-end pin for ``POST /api/reindex``.
+
+    The single-dir ``trigger_index`` route wraps ``Path(req.path)``
+    defensively, so it survives a ``memory_dirs`` field that holds raw
+    ``str`` (the shape ``load_config_overrides`` actually produces on
+    disk-config load). ``reindex_all`` iterates ``all_index_roots()``
+    and calls ``.expanduser()`` directly — without the helper-side
+    coercion this PR adds, the route 500s on the first entry. Lock
+    that contract here so a future "simplify" of ``all_index_roots()``
+    can't silently re-introduce the regression.
+    """
+
+    async def test_reindex_all_with_path_dirs_returns_200(self, app, client: AsyncClient, tmp_path):
+        target = tmp_path / "memdir"
+        target.mkdir()
+        app.state.config.indexing.memory_dirs = [target]
+        app.state.config.indexing.project_memory_dirs = []
+
+        resp = await client.post("/api/reindex")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["errors"] == []
+        assert len(data["results"]) == 1
+        assert data["results"][0]["path"] == str(target)
+
+    async def test_reindex_all_with_str_dirs_returns_200(self, app, client: AsyncClient, tmp_path):
+        """Regression: ``memory_dirs`` loaded from ``~/.memtomem/config.json``
+        comes in as ``list[str]`` because ``load_config_overrides`` writes
+        the JSON-decoded value via ``setattr`` without Pydantic validation.
+        ``all_index_roots()`` MUST coerce these to ``Path`` — otherwise the
+        bulk route 500s on ``str.expanduser()`` (single-dir ``/api/index``
+        is unaffected because it wraps ``Path(req.path)`` at the boundary).
+        """
+        target = tmp_path / "memdir"
+        target.mkdir()
+        # Deliberately store raw strings — mirrors what
+        # ``load_config_overrides`` produces.
+        app.state.config.indexing.memory_dirs = [str(target)]
+        app.state.config.indexing.project_memory_dirs = []
+
+        resp = await client.post("/api/reindex")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["errors"] == []
+        assert len(data["results"]) == 1
+        assert data["results"][0]["path"] == str(target)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -91,7 +91,11 @@ class FakeConfig:
         structured_chunk_mode = "original"
 
         def all_index_roots(self):
-            return list(self.memory_dirs) + list(self.project_memory_dirs)
+            # Mirror ``IndexingConfig.all_index_roots`` — coerce each
+            # entry to ``Path`` so the helper honours its declared
+            # return type even when a test (or
+            # ``load_config_overrides``) assigns raw ``str`` values.
+            return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
     class _Decay:
         enabled = False


### PR DESCRIPTION
## Summary
- `Reindex all` (POST `/api/reindex`) was failing with `500 Internal server error`. Root cause: `config.indexing.memory_dirs` is declared `list[Path]` but `load_config_overrides` writes the JSON-loaded values via `setattr` without Pydantic validation, so entries stayed as raw `str`. `reindex_all` iterates `all_index_roots()` and calls `.expanduser()` directly → `AttributeError: 'str' object has no attribute 'expanduser'`. Single-dir `/api/index` survived because `trigger_index` defensively wraps `Path(req.path)`.
- Fix at the helper that already calls itself the "single source of truth" for index roots: coerce each entry to `Path` in `all_index_roots()`. Every other consumer either re-wraps `Path(d)` (no-op after the fix) or accepts `str | Path` already, so behaviour is unchanged elsewhere.
- Regression pin asserts the helper hands back `Path` instances even when `memory_dirs` is mutated via the same `setattr` path `load_config_overrides` takes.

## Test plan
- [x] `uv run pytest packages/memtomem/tests/test_all_index_roots.py` — 8 passed (incl. new `test_helper_coerces_str_entries_to_path`)
- [x] `uv run ruff check` + `ruff format --check` on changed files — clean
- [x] In-process repro against the user's live `~/.memtomem/config.json` (15 index roots, all raw-string entries): every root reindexes without exception
- [ ] Restart `mm web` and click **Reindex all** in the Sources tab — confirm toast `reindex_complete` instead of `reindex_failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)