### PR TITLE
fix(web): modal-aware global shortcut gate (#1053 PR #3)

### DIFF
--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -310,8 +310,14 @@ class IndexingConfig(BaseSettings):
         view, auto-discover migration); functional consumers that need
         to act on every indexable file go through this helper instead so
         a future scope addition does not fork the consumers.
+
+        Entries are coerced to ``Path`` to honour the declared return
+        type even when raw ``str`` values slipped past Pydantic via the
+        non-validating ``setattr`` path in ``load_config_overrides`` —
+        otherwise ``reindex_all`` blew up calling ``.expanduser()`` on
+        the unwrapped JSON strings.
         """
-        return list(self.memory_dirs) + list(self.project_memory_dirs)
+        return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
 
 class DecayConfig(BaseSettings):

--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -606,6 +606,28 @@ function closeModal(modal) {
 window.openModalA11y = openModalA11y;
 window.registerModalCloser = registerModalCloser;
 window.closeModal = closeModal;
+
+// openModal(el, opts) — show + a11y in one call. The single open path that
+// keeps _ACTIVE_MODALS accurate; every modal-overlay opener should funnel
+// through here so window.isAnyModalOpen() reflects every overlay on screen
+// and the global shortcut gate (A11Y-3.1) can trust it. Returns the release
+// closure the caller must invoke on close (idempotent, so double-call is
+// safe — e.g. Esc + close-btn race).
+window.openModal = function (el, opts = {}) {
+  show(el);
+  return openModalA11y(el, opts);
+};
+
+// A11Y-3.1 gate primitives. Both shortcut listeners (app.js bare keys,
+// settings-namespaces.js Cmd+K / tab numbers) consult these to decide
+// whether a keypress should fire or defer to whatever modal is on top.
+// isTopModal() lets the gate preserve toggle-close semantics (?, Cmd+K)
+// for the modal that owns the top of the stack — anything underneath
+// keeps full focus, so a stray ? while the settings modal is up cannot
+// pop the shortcuts modal on top of it.
+window.isAnyModalOpen = () => _ACTIVE_MODALS.length > 0;
+window.isTopModal = (el) => _ACTIVE_MODALS.length > 0
+  && _ACTIVE_MODALS[_ACTIVE_MODALS.length - 1] === el;
 function setMsg(el, text, isErr) {
   if (!el) return;
   el.textContent = text;
@@ -6215,6 +6237,19 @@ document.addEventListener('keydown', e => {
     const sourceChunks = qs('source-chunks-panel');
     if (sourceChunks && !sourceChunks.hidden) { hide(sourceChunks); return; }
     if (qs('detail-view') && !qs('detail-view').hidden) { clearDetail(); return; }
+    return;
+  }
+
+  // A11Y-3.1: every non-Esc bare-key shortcut below (?, /, h, j/k, p, c)
+  // is suspended while any modal is on screen. The one exception is ? as a
+  // toggle-close when the shortcuts modal owns the top of the stack — the
+  // bare-key UX that opened it should also dismiss it. Other modals on top
+  // keep ? entirely (otherwise it could pop the shortcuts modal over them).
+  if (window.isAnyModalOpen()) {
+    if (e.key === '?' && window.isTopModal(qs('shortcuts-modal'))) {
+      e.preventDefault();
+      closeShortcutsModal();
+    }
     return;
   }
 

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1845,17 +1845,18 @@ function _ctxResolveConflict(userBuffer, freshContent) {
   // Opens the 3-button modal and resolves to 'reload' | 'force' | 'diff'
   // — or null if dismissed via Escape / backdrop click.
   return new Promise(resolve => {
-    const modal = qs('ctx-conflict-modal');
+    const modalEl = qs('ctx-conflict-modal');
     qs('ctx-conflict-yours').textContent = userBuffer;
     qs('ctx-conflict-theirs').textContent = freshContent;
     const reloadBtn = qs('ctx-conflict-reload-btn');
     const diffBtn = qs('ctx-conflict-diff-btn');
     const forceBtn = qs('ctx-conflict-force-btn');
-    show(modal);
-    const releaseA11y = window.openModalA11y(modal, {
+    // window.openModal funnels through openModalA11y so the conflict modal
+    // joins _ACTIVE_MODALS and the global shortcut gate (A11Y-3.1) sees it.
+    const releaseA11y = window.openModal(modalEl, {
       focusables: () => [reloadBtn, diffBtn, forceBtn],
     });
-    window.registerModalCloser(modal, () => cleanup(null));
+    window.registerModalCloser(modalEl, () => cleanup(null));
     // Focus the safest choice. Force-save is destructive (overwrites the
     // other writer's edits) and the modal exists precisely to make that
     // choice explicit — auto-focusing the danger button would let a
@@ -1864,20 +1865,20 @@ function _ctxResolveConflict(userBuffer, freshContent) {
     reloadBtn.focus();
 
     function cleanup(choice) {
-      hide(modal);
+      hide(modalEl);
       releaseA11y();
-      modal.removeEventListener('click', onBackdrop);
+      modalEl.removeEventListener('click', onBackdrop);
       document.removeEventListener('keydown', onKey, true);
       reloadBtn.onclick = null;
       diffBtn.onclick = null;
       forceBtn.onclick = null;
       resolve(choice);
     }
-    function onBackdrop(e) { if (e.target === modal) cleanup(null); }
+    function onBackdrop(e) { if (e.target === modalEl) cleanup(null); }
     function onKey(e) {
       if (e.key === 'Escape') { e.stopPropagation(); cleanup(null); }
     }
-    modal.addEventListener('click', onBackdrop);
+    modalEl.addEventListener('click', onBackdrop);
     document.addEventListener('keydown', onKey, true);
     reloadBtn.onclick = () => cleanup('reload');
     diffBtn.onclick = () => cleanup('diff');

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1400,16 +1400,16 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=116"></script>
+  <script src="/app.js?v=117"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=2"></script>
-  <script src="/settings-namespaces.js?v=6"></script>
+  <script src="/settings-namespaces.js?v=7"></script>
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=36"></script>
-  <script src="/path-picker.js?v=2"></script>
+  <script src="/context-gateway.js?v=37"></script>
+  <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1405,7 +1405,7 @@
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=2"></script>
-  <script src="/settings-namespaces.js?v=7"></script>
+  <script src="/settings-namespaces.js?v=8"></script>
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>

--- a/packages/memtomem/src/memtomem/web/static/path-picker.js
+++ b/packages/memtomem/src/memtomem/web/static/path-picker.js
@@ -188,11 +188,10 @@
   function open(opts) {
     onSelectCb = (opts && typeof opts.onSelect === 'function') ? opts.onSelect : null;
     pickerPurpose = (opts && opts.purpose) || 'index';
-    modal().hidden = false;
     // Path-picker owns its own Tab trap (dynamic focusables across breadcrumbs
-    // + list items); pass focusables: null so the helper only adds restore +
-    // inert without installing a redundant trap.
-    _releaseA11y = window.openModalA11y(modal());
+    // + list items); openModal forwards opts.focusables=null so the helper
+    // only adds restore + inert without installing a redundant trap.
+    _releaseA11y = window.openModal(modal());
     document.addEventListener('keydown', _onKey, true);
     modal().addEventListener('click', _onBackdrop);
     selectBtn().disabled = true;
@@ -200,7 +199,7 @@
   }
 
   function close() {
-    modal().hidden = true;
+    hide(modal());
     if (_releaseA11y) { _releaseA11y(); _releaseA11y = null; }
     document.removeEventListener('keydown', _onKey, true);
     modal().removeEventListener('click', _onBackdrop);

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -763,10 +763,13 @@ document.addEventListener('keydown', e => {
   // overlay on top of an already-open one. Esc lives in app.js / the
   // cmd-palette's own listener — never gated here.
   if (window.isAnyModalOpen()) {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'k'
-        && window.isTopModal(qs('cmd-palette'))) {
+    // Cmd/Ctrl+K is a modifier shortcut some browsers map to address-bar
+    // focus; always swallow it while a modal is up so the default can't
+    // escape the focus trap. When the palette owns the top, also toggle
+    // it closed — preserves the bare-key dismissal that opened it.
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
       e.preventDefault();
-      _closeCmdPalette();
+      if (window.isTopModal(qs('cmd-palette'))) _closeCmdPalette();
     }
     return;
   }

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -755,11 +755,26 @@ qs('cmd-palette').addEventListener('click', e => {
 // Extend existing keydown handler — we add a new listener that fires before
 // We need to intercept certain keys
 document.addEventListener('keydown', e => {
-  // Cmd+K / Ctrl+K: Command Palette
+  // A11Y-3.1: when any modal-overlay is on screen the only global shortcut
+  // that fires from this listener is Cmd+K-as-close — and only when the
+  // command palette itself owns the top of the stack. Everything else
+  // (Cmd+K open, tab numbers 1–7, Enter, Backspace, g-then-_) defers to
+  // the modal's own key handlers so a stray hotkey can't pop a second
+  // overlay on top of an already-open one. Esc lives in app.js / the
+  // cmd-palette's own listener — never gated here.
+  if (window.isAnyModalOpen()) {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k'
+        && window.isTopModal(qs('cmd-palette'))) {
+      e.preventDefault();
+      _closeCmdPalette();
+    }
+    return;
+  }
+
+  // Cmd+K / Ctrl+K: Command Palette (close-while-open is handled above)
   if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
     e.preventDefault();
-    if (STATE.cmdPaletteOpen) _closeCmdPalette();
-    else _openCmdPalette();
+    _openCmdPalette();
     return;
   }
 

--- a/packages/memtomem/tests/test_all_index_roots.py
+++ b/packages/memtomem/tests/test_all_index_roots.py
@@ -59,12 +59,21 @@ class TestAllIndexRootsHelper:
         # ``~/.memtomem/config.json``. The helper MUST normalise these
         # to ``Path`` to match the declared return type — otherwise the
         # web ``/api/reindex`` route 500s on ``str.expanduser()``.
+        #
+        # ``object.__setattr__`` mirrors the exact path
+        # ``load_config_overrides`` takes (Pydantic ``setattr`` without
+        # ``validate_assignment``) and avoids ``# type: ignore`` noise.
         cfg = IndexingConfig(memory_dirs=[], project_memory_dirs=[])
-        cfg.memory_dirs = ["~/u1", "~/u2"]  # type: ignore[assignment]
-        cfg.project_memory_dirs = ["~/p1"]  # type: ignore[assignment]
+        object.__setattr__(cfg, "memory_dirs", ["/u1", "/u2"])
+        object.__setattr__(cfg, "project_memory_dirs", ["/p1"])
         roots = cfg.all_index_roots()
         assert all(isinstance(r, Path) for r in roots)
-        assert roots == [Path("~/u1"), Path("~/u2"), Path("~/p1")]
+        assert roots == [Path("/u1"), Path("/u2"), Path("/p1")]
+        # ``.expanduser()`` is the next caller's contract; round-trip
+        # through it to document that the wrapped Path is filesystem-
+        # usable (the original bug surfaced exactly because callers
+        # could not invoke this on a ``str``).
+        assert [r.expanduser() for r in roots] == [Path("/u1"), Path("/u2"), Path("/p1")]
 
 
 class TestConsumerRegressionPin:

--- a/packages/memtomem/tests/test_all_index_roots.py
+++ b/packages/memtomem/tests/test_all_index_roots.py
@@ -53,6 +53,19 @@ class TestAllIndexRootsHelper:
         assert Path("/leak") not in cfg.memory_dirs
         assert Path("/leak") not in cfg.project_memory_dirs
 
+    def test_helper_coerces_str_entries_to_path(self):
+        # ``load_config_overrides`` uses ``setattr`` without validation,
+        # so ``memory_dirs`` can hold raw ``str`` values straight off
+        # ``~/.memtomem/config.json``. The helper MUST normalise these
+        # to ``Path`` to match the declared return type — otherwise the
+        # web ``/api/reindex`` route 500s on ``str.expanduser()``.
+        cfg = IndexingConfig(memory_dirs=[], project_memory_dirs=[])
+        cfg.memory_dirs = ["~/u1", "~/u2"]  # type: ignore[assignment]
+        cfg.project_memory_dirs = ["~/p1"]  # type: ignore[assignment]
+        roots = cfg.all_index_roots()
+        assert all(isinstance(r, Path) for r in roots)
+        assert roots == [Path("~/u1"), Path("~/u2"), Path("~/p1")]
+
 
 class TestConsumerRegressionPin:
     """Architectural guard — direct ``.memory_dirs`` access is restricted.

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -592,9 +592,6 @@ _ICON_ONLY_BUTTONS = (
 # assertion passes, pytest reports XPASS as a failure and forces the developer
 # to drop the marker rather than leave a permanent expected-failure that
 # silently re-RED'd later.
-_A11Y_XFAIL_PR3 = pytest.mark.xfail(
-    strict=True, reason="A11Y-3.1 — pending modal manager in issue #1053 PR #3"
-)
 _A11Y_XFAIL_PR4 = pytest.mark.xfail(
     strict=True, reason="A11Y-2.1 — pending fix in issue #1053 PR #4"
 )
@@ -783,19 +780,18 @@ class TestSkipLinkPresent:
         assert 'id="main"' in index_html, 'no element with id="main" to be the skip-link target'
 
 
-@_A11Y_XFAIL_PR3
 class TestA11yModalToggleAntipattern:
-    """A11Y-3 enforcement — once the modal manager lands, every modal
-    open/close path must funnel through ``openModal(el)`` / ``closeModal(el)``
-    so the active-modal set stays accurate and the global shortcut gate
-    works. Direct ``modal().hidden = false/true`` or ``show(qs('X-modal'))``
-    on a ``.modal-overlay`` element re-introduces the bug at A11Y-3.1.
+    """A11Y-3 enforcement — every modal open path must funnel through
+    ``window.openModal(el)`` / ``window.closeModal(el)`` (or call
+    ``openModalA11y`` directly) so ``_ACTIVE_MODALS`` stays accurate and
+    the global shortcut gate (A11Y-3.1) keeps working. Direct
+    ``modal().hidden = false/true`` or ``show(qs('X-modal'))`` on a
+    ``.modal-overlay`` element bypasses the stack and re-introduces the
+    bug.
 
     The pin is intentionally narrow — it only fires on the two known modal
     files (``path-picker.js``, ``context-gateway.js``) plus any future
-    file that toggles ``modal().hidden``. ``app.js`` ``show()/hide()``
-    calls are still allowed because they go through the modal-manager
-    wrapper once the fix lands.
+    file that toggles ``modal().hidden`` directly.
     """
 
     def test_path_picker_uses_modal_manager(self):

--- a/packages/memtomem/tests/test_web_routes.py
+++ b/packages/memtomem/tests/test_web_routes.py
@@ -102,7 +102,11 @@ class FakeConfig:
         summary_max_tokens = 256
 
         def all_index_roots(self):
-            return list(self.memory_dirs) + list(self.project_memory_dirs)
+            # Mirror ``IndexingConfig.all_index_roots`` — coerce each
+            # entry to ``Path`` so the helper honours its declared
+            # return type even when a test (or
+            # ``load_config_overrides``) assigns raw ``str`` values.
+            return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
     class _Decay:
         enabled = False
@@ -2529,6 +2533,62 @@ class TestIndex:
         assert data["indexed_chunks"] == 0
         assert len(data["errors"]) == 1
         assert "fastembed" in data["errors"][0]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/reindex — "Reindex all" bulk route
+# ---------------------------------------------------------------------------
+
+
+class TestReindexAll:
+    """End-to-end pin for ``POST /api/reindex``.
+
+    The single-dir ``trigger_index`` route wraps ``Path(req.path)``
+    defensively, so it survives a ``memory_dirs`` field that holds raw
+    ``str`` (the shape ``load_config_overrides`` actually produces on
+    disk-config load). ``reindex_all`` iterates ``all_index_roots()``
+    and calls ``.expanduser()`` directly — without the helper-side
+    coercion this PR adds, the route 500s on the first entry. Lock
+    that contract here so a future "simplify" of ``all_index_roots()``
+    can't silently re-introduce the regression.
+    """
+
+    async def test_reindex_all_with_path_dirs_returns_200(self, app, client: AsyncClient, tmp_path):
+        target = tmp_path / "memdir"
+        target.mkdir()
+        app.state.config.indexing.memory_dirs = [target]
+        app.state.config.indexing.project_memory_dirs = []
+
+        resp = await client.post("/api/reindex")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["errors"] == []
+        assert len(data["results"]) == 1
+        assert data["results"][0]["path"] == str(target)
+
+    async def test_reindex_all_with_str_dirs_returns_200(self, app, client: AsyncClient, tmp_path):
+        """Regression: ``memory_dirs`` loaded from ``~/.memtomem/config.json``
+        comes in as ``list[str]`` because ``load_config_overrides`` writes
+        the JSON-decoded value via ``setattr`` without Pydantic validation.
+        ``all_index_roots()`` MUST coerce these to ``Path`` — otherwise the
+        bulk route 500s on ``str.expanduser()`` (single-dir ``/api/index``
+        is unaffected because it wraps ``Path(req.path)`` at the boundary).
+        """
+        target = tmp_path / "memdir"
+        target.mkdir()
+        # Deliberately store raw strings — mirrors what
+        # ``load_config_overrides`` produces.
+        app.state.config.indexing.memory_dirs = [str(target)]
+        app.state.config.indexing.project_memory_dirs = []
+
+        resp = await client.post("/api/reindex")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["ok"] is True
+        assert data["errors"] == []
+        assert len(data["results"]) == 1
+        assert data["results"][0]["path"] == str(target)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -91,7 +91,11 @@ class FakeConfig:
         structured_chunk_mode = "original"
 
         def all_index_roots(self):
-            return list(self.memory_dirs) + list(self.project_memory_dirs)
+            # Mirror ``IndexingConfig.all_index_roots`` — coerce each
+            # entry to ``Path`` so the helper honours its declared
+            # return type even when a test (or
+            # ``load_config_overrides``) assigns raw ``str`` values.
+            return [Path(d) for d in (*self.memory_dirs, *self.project_memory_dirs)]
 
     class _Decay:
         enabled = False

--- a/packages/memtomem/tests/web/test_a11y_focus.py
+++ b/packages/memtomem/tests/web/test_a11y_focus.py
@@ -1,17 +1,20 @@
 """A11Y modal behaviour pins — Playwright lane (issue #1053).
 
-PR #2 adds Tab trap + focus restoration + background ``inert`` to the 8
+PR #2 added Tab trap + focus restoration + background ``inert`` to the 8
 ``.modal-overlay`` elements (``TestA11yModalFocusTrap`` /
 ``TestA11yModalFocusRestore`` / ``TestA11yBackgroundInert`` /
 ``TestA11yStackedModalInertSurvives``).
 
-PR #3 adds a modal manager + global-shortcut gate
-(``test_ctrl_k_blocked_while_confirm_modal_active``).
+PR #3 added the modal manager (``window.openModal`` /
+``window.isAnyModalOpen`` / ``window.isTopModal``) and the global-shortcut
+gate (``TestA11yShortcutGate``). With the gate live, the bare global
+shortcuts (``Cmd+K`` / ``?`` / ``/`` / ``h`` / ``j`` / ``k``) cannot pop
+another overlay on top of one already on screen; ``?`` and ``Cmd+K``
+remain toggle-closes when their own modal owns the top of the stack.
 
-Every test pin here is marked ``xfail(strict=True)`` so it self-removes
-the moment the relevant fix lands: the test xpasses, pytest reports it as
-a failure, and the dev drops the marker rather than leaving a stale
-expected-failure that could silently re-RED later.
+xfail markers in this file are ``strict=True`` so a fix that turns a RED
+pin green forces the dev to remove the marker rather than leaving a
+silent expected-failure that could re-RED later.
 """
 
 from __future__ import annotations
@@ -216,43 +219,111 @@ class TestA11yStackedModalInertSurvives:
 
 
 # ---------------------------------------------------------------------------
-# PR #3 pin — kept here as the original tenant of this file.
+# PR #3 — A11Y-3.1 modal-aware global shortcut gate.
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="A11Y-3.1 — pending modal manager in issue #1053 PR #3")
-def test_ctrl_k_blocked_while_confirm_modal_active(mm_web_url, page):
-    install_default_stubs(page)
-    page.goto(mm_web_url)
-    page.wait_for_selector("#confirm-modal", state="attached")
-    page.wait_for_selector("#cmd-palette", state="attached")
+def _open_confirm_modal_keep_open(page) -> None:
+    """Open ``confirm-modal`` and return without dismissing it.
 
-    # ``showConfirm`` returns a Promise that only resolves on OK/Cancel.
-    # Playwright's ``page.evaluate`` awaits Promises by default, so calling
-    # it directly would hang until the modal is dismissed — but the whole
-    # point of this test is to keep the modal open while pressing Ctrl+K.
-    # ``void`` discards the returned Promise so the evaluate call returns
-    # immediately while ``showConfirm`` runs to first render in the
-    # background.
+    ``showConfirm`` returns a Promise that resolves on OK/Cancel.
+    Playwright's ``page.evaluate`` awaits returned Promises by default,
+    so calling it directly would hang the test until the modal is
+    dismissed — the whole point of these probes is to keep the modal up
+    while we drive the shortcut. ``void`` discards the Promise so the
+    evaluate returns immediately while the modal stays on screen.
+    """
     page.evaluate(
         "void window.showConfirm({"
         "title: 'A11Y gate probe', "
-        "message: 'open modal to probe the Cmd+K gate', "
+        "message: 'open modal to probe the shortcut gate', "
         "confirmText: 'OK', cancelText: 'Cancel'"
         "})"
     )
     page.wait_for_selector("#confirm-modal:not([hidden])", timeout=2_000)
 
-    # If the gate is in place, Ctrl+K is swallowed (preventDefault) and
-    # the palette stays hidden. Without the gate, the palette opens on
-    # top of the confirm modal — the bug at A11Y-3.1.
-    page.keyboard.press("Control+k")
 
-    cmd_palette_hidden = page.evaluate("document.getElementById('cmd-palette').hidden")
-    assert cmd_palette_hidden, (
-        "cmd-palette opened while confirm-modal was active — Ctrl+K must "
-        "be gated when any modal-overlay is on screen (A11Y-3.1, "
-        "issue #1053). Check the modal manager wiring in "
-        "static/modal-manager.js + the keydown listener at "
-        "settings-namespaces.js:747"
-    )
+class TestA11yShortcutGate:
+    """A11Y-3.1 — bare global shortcuts must not pop another overlay on
+    top of one already open.
+
+    Coverage map (per shortcut, gated-when-modal-open is the core claim):
+
+    * ``Cmd+K`` — opening shortcut for the command palette. Must not open
+      a second overlay; preserved as toggle-close when the palette itself
+      owns the top of the stack.
+    * ``?`` — opening shortcut for the shortcuts modal. Same contract:
+      blocked otherwise, toggle-close-while-on-top preserved.
+    * ``/`` / ``h`` / ``j`` / ``k`` — focus / help / list-navigation
+      shortcuts. None of these should fire while a modal is up; ``j``/
+      ``k`` in particular would steal focus from a modal's inner list.
+
+    Each test follows the same shape: open a known modal (``confirm-modal``
+    for the no-op gates, the target modal itself for toggle-close tests),
+    press the key, assert the gated overlay's state.
+    """
+
+    def test_ctrl_k_blocked_while_confirm_modal_active(self, mm_web_url, page):
+        _goto_with_stubs(mm_web_url, page)
+        page.wait_for_selector("#cmd-palette", state="attached")
+        _open_confirm_modal_keep_open(page)
+        page.keyboard.press("Control+k")
+        cmd_palette_hidden = page.evaluate("document.getElementById('cmd-palette').hidden")
+        assert cmd_palette_hidden, (
+            "cmd-palette opened while confirm-modal was active — Cmd/Ctrl+K "
+            "must be gated when any modal-overlay is on screen "
+            "(A11Y-3.1, issue #1053). Check the modal-open guard in "
+            "settings-namespaces.js's keydown listener."
+        )
+
+    def test_question_mark_blocked_while_confirm_modal_active(self, mm_web_url, page):
+        _goto_with_stubs(mm_web_url, page)
+        page.wait_for_selector("#shortcuts-modal", state="attached")
+        _open_confirm_modal_keep_open(page)
+        page.keyboard.press("?")
+        shortcuts_hidden = page.evaluate("document.getElementById('shortcuts-modal').hidden")
+        assert shortcuts_hidden, (
+            "shortcuts-modal opened while confirm-modal was active — ``?`` "
+            "must be gated when any modal-overlay is on screen "
+            "(A11Y-3.1, issue #1053). Check the modal-open guard in "
+            "app.js's keydown listener."
+        )
+
+    @pytest.mark.parametrize("key", ["/", "h", "j", "k"])
+    def test_bare_keys_blocked_while_modal_active(self, mm_web_url, page, key):
+        # ``/`` would focus + select the search input (focus theft);
+        # ``h`` toggles the help panel; ``j``/``k`` move the results
+        # selection. None should fire while a modal traps focus.
+        _goto_with_stubs(mm_web_url, page)
+        _open_confirm_modal_keep_open(page)
+        # Capture state before the keypress so we can prove nothing
+        # changed (we can't easily probe every side-effect, so we focus
+        # on the most visible one: active element stays inside the modal).
+        page.keyboard.press(key)
+        inside_modal = page.evaluate(
+            "document.getElementById('confirm-modal').contains(document.activeElement)"
+        )
+        assert inside_modal, (
+            f"pressing '{key}' while confirm-modal was active moved focus "
+            f"outside the modal — bare-key shortcuts must defer to the "
+            f"open modal (A11Y-3.1, issue #1053)."
+        )
+
+    def test_ctrl_k_still_closes_palette_when_palette_is_top(self, mm_web_url, page):
+        # When the palette itself owns the top of the stack, Cmd+K must
+        # still toggle it closed — the gate's preserved toggle path.
+        _goto_with_stubs(mm_web_url, page)
+        page.wait_for_selector("#cmd-palette", state="attached")
+        page.evaluate("void window.openCmdPalette()")
+        page.wait_for_selector("#cmd-palette:not([hidden])", timeout=2_000)
+        page.keyboard.press("Control+k")
+        page.wait_for_selector("#cmd-palette", state="hidden", timeout=2_000)
+
+    def test_question_mark_still_closes_shortcuts_when_shortcuts_is_top(self, mm_web_url, page):
+        # Same contract for ``?`` against shortcuts-modal.
+        _goto_with_stubs(mm_web_url, page)
+        page.wait_for_selector("#shortcuts-modal", state="attached")
+        page.evaluate("void window.openShortcutsModal()")
+        page.wait_for_selector("#shortcuts-modal:not([hidden])", timeout=2_000)
+        page.keyboard.press("?")
+        page.wait_for_selector("#shortcuts-modal", state="hidden", timeout=2_000)

--- a/packages/memtomem/tests/web/test_a11y_focus.py
+++ b/packages/memtomem/tests/web/test_a11y_focus.py
@@ -309,6 +309,34 @@ class TestA11yShortcutGate:
             f"open modal (A11Y-3.1, issue #1053)."
         )
 
+    def test_ctrl_k_default_prevented_while_modal_active(self, mm_web_url, page):
+        # Pandas-Studio review (PR #1059): the gate must also call
+        # preventDefault() on blocked Cmd/Ctrl+K, not just early-return.
+        # Some browsers map Cmd/Ctrl+K to address-bar / search focus; if
+        # the default fires, focus escapes the trapped modal even though
+        # the cmd-palette stays hidden. Probe e.defaultPrevented from a
+        # bubble-phase listener — by the time it fires, every capture
+        # handler (including the gate) has run.
+        _goto_with_stubs(mm_web_url, page)
+        _open_confirm_modal_keep_open(page)
+        page.evaluate(
+            "window.__lastCtrlKPrevented = null;"
+            "window.addEventListener('keydown', e => {"
+            "  if (e.key === 'k' && (e.ctrlKey || e.metaKey)) {"
+            "    window.__lastCtrlKPrevented = e.defaultPrevented;"
+            "  }"
+            "}, false);"
+        )
+        page.keyboard.press("Control+k")
+        prevented = page.evaluate("window.__lastCtrlKPrevented")
+        assert prevented is True, (
+            "Ctrl+K's browser default leaked through while a modal was "
+            "open — the gate in settings-namespaces.js must call "
+            "preventDefault() on the blocked Cmd/Ctrl+K path so it can't "
+            "focus the address bar and steal focus from the modal "
+            "(A11Y-3.1, issue #1053)"
+        )
+
     def test_ctrl_k_still_closes_palette_when_palette_is_top(self, mm_web_url, page):
         # When the palette itself owns the top of the stack, Cmd+K must
         # still toggle it closed — the gate's preserved toggle path.


### PR DESCRIPTION
## Summary

- Adds a modal-stack-aware gate to both global keydown listeners so bare
  shortcuts (`Cmd+K`, `?`, `/`, `h`, `j`, `k`) cannot pop a second
  overlay on top of one already open — the A11Y-3.1 bug the PR #1 audit
  flagged. `?` and `Cmd+K` are preserved as toggle-closes when their own
  modal owns the top of the stack, so the bare-key UX that opened the
  overlay can also dismiss it.
- Introduces `window.openModal(el, opts)` as the single open path that
  funnels through `openModalA11y`, plus `window.isAnyModalOpen()` /
  `window.isTopModal(el)` as the gate's single source of truth.
- Migrates `path-picker.js` and `context-gateway._ctxResolveConflict` to
  the new wrapper so every overlay actually joins `_ACTIVE_MODALS` (the
  `TestA11yModalToggleAntipattern` pin from the audit).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_a11y_focus.py::TestA11yShortcutGate -v`
      — all 8 gate scenarios pass (`Cmd+K`/`?` blocked while
      `confirm-modal` open; `/`/`h`/`j`/`k` blocked; `Cmd+K`/`?`
      still toggle-close their own modal when it owns the top)
- [x] `uv run pytest packages/memtomem/tests/test_qa_audit_pins.py::TestA11yModalToggleAntipattern -v`
      — both `path-picker` and `_ctxResolveConflict` migration pins pass
      now that the xfail marker is gone
- [x] `uv run ruff check packages/memtomem/{src,tests}` +
      `ruff format --check` — clean
- [x] Full `pytest packages/memtomem/tests/web/test_a11y_focus.py
      packages/memtomem/tests/test_qa_audit_pins.py` — 78 passed, 2
      xfailed (PR4 + PR5 markers, untouched). 4 pre-existing async-loop
      failures in `TestNamespaceDeleteProdGuard` /
      `TestResetLocalhostGuard` reproduce on baseline when these files
      are collected alongside the Playwright tests — unrelated to this
      change.

Closes the PR #3 row in #1053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)