### PR TITLE
fix(web): aria-live=polite on #results-list (#1053 PR #4)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -292,7 +292,7 @@
           <span class="empty-state-hint"><kbd>/</kbd> focus · <kbd>j</kbd>/<kbd>k</kbd> navigate · <kbd>p</kbd> pin · <kbd>c</kbd> copy</span>
           <div id="recent-chips" class="recent-chips" hidden></div>
         </div>
-        <div id="results-list" hidden></div>
+        <div id="results-list" aria-live="polite" hidden></div>
         <div id="load-more-row" class="load-more-row" hidden>
           <button id="load-more-btn" class="btn-ghost" data-i18n="search.load_more">Load More</button>
         </div>

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -592,9 +592,6 @@ _ICON_ONLY_BUTTONS = (
 # assertion passes, pytest reports XPASS as a failure and forces the developer
 # to drop the marker rather than leave a permanent expected-failure that
 # silently re-RED'd later.
-_A11Y_XFAIL_PR4 = pytest.mark.xfail(
-    strict=True, reason="A11Y-2.1 — pending fix in issue #1053 PR #4"
-)
 _A11Y_XFAIL_PR5 = pytest.mark.xfail(
     strict=True, reason="A11Y-1.1 — pending fix in issue #1053 PR #5"
 )
@@ -732,7 +729,6 @@ class TestA11yLiveRegionsPreserved:
         assert 'aria-live="polite"' in opening_tag, 'toast-container lost its aria-live="polite"'
 
 
-@_A11Y_XFAIL_PR4
 class TestA11yResultsLiveRegion:
     """A11Y-2.1 — ``renderResults()`` rewrites the results list every time
     a search returns; SR users get no notification of the count change.


### PR DESCRIPTION
## Summary

- Adds \`aria-live=\"polite\"\` to \`#results-list\` so SR users hear when \`renderResults()\` rewrites the list after a search. The A11Y-2.1 audit row explicitly endorsed placing the attribute on either the list or an adjacent summary node; this repo only has \`#results-list\`, so it lands there.
- Drops the \`_A11Y_XFAIL_PR4\` marker from \`TestA11yResultsLiveRegion\` — the pin already encodes the contract.

## Test plan

- [x] \`uv run pytest packages/memtomem/tests/test_qa_audit_pins.py::TestA11yResultsLiveRegion -v\` — PASSED
- [x] \`uv run ruff check\` + \`format --check\` — clean

Closes the PR #4 row in #1053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)