### PR TITLE
fix(web): skip-to-main link + #main landmark (#1053 PR #5)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=87" />
+  <link rel="stylesheet" href="/style.css?v=88" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -58,7 +58,7 @@
     <button id="tabbtn-settings" class="tab-btn" role="tab" aria-controls="tab-settings" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="settings" data-i18n="nav.more">More</button>
   </nav>
 
-  <main id="main">
+  <main id="main" tabindex="-1">
   <!-- ===== HOME TAB ===== -->
   <div id="tab-home" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-home" hidden>
     <div class="home-layout">

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=86" />
+  <link rel="stylesheet" href="/style.css?v=87" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,10 +6,11 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=85" />
+  <link rel="stylesheet" href="/style.css?v=86" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
+  <a class="skip-link" href="#main" data-i18n="nav.skip_to_main">Skip to main content</a>
   <header>
     <h1>memtomem</h1>
     <div class="header-info-bar">
@@ -57,6 +58,7 @@
     <button id="tabbtn-settings" class="tab-btn" role="tab" aria-controls="tab-settings" aria-selected="false" tabindex="-1" data-ui-tier="prod" data-tab="settings" data-i18n="nav.more">More</button>
   </nav>
 
+  <main id="main">
   <!-- ===== HOME TAB ===== -->
   <div id="tab-home" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-home" hidden>
     <div class="home-layout">
@@ -1228,6 +1230,7 @@
     <div id="tl-list" class="timeline-list" hidden></div>
     <div id="tl-msg" class="status-msg" hidden></div>
   </div>
+  </main>
 
 
   <!-- Expand Modal (I2) -->

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -7,6 +7,7 @@
   "nav.tags": "Tags",
   "nav.timeline": "Timeline",
   "nav.more": "More",
+  "nav.skip_to_main": "Skip to main content",
 
   "header.stat_chunks": "— chunks",
   "header.stat_sources": "— sources",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -7,6 +7,7 @@
   "nav.tags": "태그",
   "nav.timeline": "타임라인",
   "nav.more": "더보기",
+  "nav.skip_to_main": "본문으로 건너뛰기",
 
   "header.stat_chunks": "— 청크",
   "header.stat_sources": "— 소스",

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -38,6 +38,29 @@
 html { font-size: 14px; height: 100%; overflow: hidden; }
 body { background: var(--bg); color: var(--text); font-family: var(--font); height: 100%; overflow: hidden; display: flex; flex-direction: column; }
 
+/* A11Y-1.1 — skip-to-main link. Kept visually off-screen until focused so
+   keyboard users can jump past the header chrome (~6 Tabs today) on the
+   very first Tab from page load. On focus it pins to top-left at a high
+   z-index so it sits over banners + nav. */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 8px;
+  z-index: 10000;
+  padding: 8px 16px;
+  background: var(--surface);
+  color: var(--text);
+  border: 2px solid var(--accent);
+  border-radius: var(--radius);
+  font-weight: 600;
+  text-decoration: none;
+}
+.skip-link:focus {
+  top: 8px;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* ── Header ── */
 /* Embedding mismatch banner */
 .embedding-mismatch-banner {

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -38,6 +38,20 @@
 html { font-size: 14px; height: 100%; overflow: hidden; }
 body { background: var(--bg); color: var(--text); font-family: var(--font); height: 100%; overflow: hidden; display: flex; flex-direction: column; }
 
+/* A11Y-1.1 — the <main id="main"> wrapper sits between <body> (column flex,
+   overflow hidden) and the .tab-panel children which rely on flex: 1 +
+   min-height: 0 for a definite remaining-viewport height. Without this
+   rule <main> is display: block and breaks the sizing chain — active
+   tabs lose their bounded scroll region and overflow gets clipped by
+   body's overflow: hidden. Mirror body's column flex behavior so <main>
+   stays transparent to the layout. */
+#main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
 /* A11Y-1.1 — skip-to-main link. Kept visually off-screen until focused so
    keyboard users can jump past the header chrome (~6 Tabs today) on the
    very first Tab from page load. On focus it pins to top-left at a high

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -51,6 +51,17 @@ body { background: var(--bg); color: var(--text); font-family: var(--font); heig
   display: flex;
   flex-direction: column;
 }
+/* <main tabindex="-1"> is programmatically focusable so activating the
+   skip-link actually moves keyboard focus (Chromium/Firefox don't move
+   focus to a non-focusable target — they only scroll). Suppress the
+   mouse-style focus ring; show a subtle one on :focus-visible so
+   keyboard activation has a brief visual confirmation before the next
+   Tab lands on the active panel's first focusable. */
+#main:focus { outline: none; }
+#main:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* A11Y-1.1 — skip-to-main link. Kept visually off-screen until focused so
    keyboard users can jump past the header chrome (~6 Tabs today) on the

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -774,13 +774,26 @@ class TestSkipLinkPresent:
         # clipped by ``html/body { overflow: hidden }``. Pin the four
         # declarations so a future CSS cleanup can't silently
         # re-introduce the scroll regression.
+        #
+        # Regex over substring search: ``#main {`` would miss
+        # ``#main\n{`` (formatter-dependent) and ``flex: 1`` in plain
+        # ``in block`` would silently pass on ``flex: 1.5``. The
+        # word-boundaries make both robust to CSS reflow.
+        import re
+
         css = (_STATIC_DIR / "style.css").read_text(encoding="utf-8")
-        start = css.find("#main {")
-        assert start != -1, "#main { ... } rule missing from style.css"
-        block = css[start : css.find("}", start) + 1]
-        for prop in ("flex: 1", "min-height: 0", "display: flex", "flex-direction: column"):
-            assert prop in block, (
-                f"#main is missing `{prop}` — without it the <main> wrapper "
+        m = re.search(r"^\s*#main\s*\{([^}]*)\}", css, re.M)
+        assert m is not None, "#main { ... } rule missing from style.css"
+        block = m.group(1)
+        required = (
+            (r"\bflex\s*:\s*1\s*;", "flex: 1"),
+            (r"\bmin-height\s*:\s*0\s*;", "min-height: 0"),
+            (r"\bdisplay\s*:\s*flex\s*;", "display: flex"),
+            (r"\bflex-direction\s*:\s*column\s*;", "flex-direction: column"),
+        )
+        for pattern, label in required:
+            assert re.search(pattern, block), (
+                f"#main is missing `{label}` — without it the <main> wrapper "
                 f"breaks the .tab-panel flex sizing chain "
                 f"(A11Y-1.1, issue #1053, PR #1061 P1 review)"
             )

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -765,6 +765,26 @@ class TestSkipLinkPresent:
         # And there has to actually be a main landmark to jump to.
         assert 'id="main"' in index_html, 'no element with id="main" to be the skip-link target'
 
+    def test_main_landmark_preserves_tab_flex_layout(self):
+        # PR #1061 review (P1): wrapping the .tab-panel children in a
+        # <main id="main"> only works if main itself is a column flex
+        # container with flex: 1 + min-height: 0. Otherwise the panels
+        # — which use ``flex: 1; min-height: 0`` on their parent — lose
+        # their definite remaining-viewport height and overflow gets
+        # clipped by ``html/body { overflow: hidden }``. Pin the four
+        # declarations so a future CSS cleanup can't silently
+        # re-introduce the scroll regression.
+        css = (_STATIC_DIR / "style.css").read_text(encoding="utf-8")
+        start = css.find("#main {")
+        assert start != -1, "#main { ... } rule missing from style.css"
+        block = css[start : css.find("}", start) + 1]
+        for prop in ("flex: 1", "min-height: 0", "display: flex", "flex-direction: column"):
+            assert prop in block, (
+                f"#main is missing `{prop}` — without it the <main> wrapper "
+                f"breaks the .tab-panel flex sizing chain "
+                f"(A11Y-1.1, issue #1053, PR #1061 P1 review)"
+            )
+
 
 class TestA11yModalToggleAntipattern:
     """A11Y-3 enforcement — every modal open path must funnel through

--- a/packages/memtomem/tests/test_qa_audit_pins.py
+++ b/packages/memtomem/tests/test_qa_audit_pins.py
@@ -588,15 +588,6 @@ _ICON_ONLY_BUTTONS = (
 )
 
 
-# ``strict=True`` so the marker self-removes when the fix PR lands: once the
-# assertion passes, pytest reports XPASS as a failure and forces the developer
-# to drop the marker rather than leave a permanent expected-failure that
-# silently re-RED'd later.
-_A11Y_XFAIL_PR5 = pytest.mark.xfail(
-    strict=True, reason="A11Y-1.1 — pending fix in issue #1053 PR #5"
-)
-
-
 class TestA11yIconButtonNames:
     """A11Y-2.3 — icon-only buttons in the header / panel chrome must carry
     an explicit accessible name. ``aria-label`` (static) or
@@ -754,7 +745,6 @@ class TestA11yResultsLiveRegion:
         )
 
 
-@_A11Y_XFAIL_PR5
 class TestSkipLinkPresent:
     """A11Y-1.1 — first focusable element in the document should be a
     skip-to-main anchor so keyboard users bypass the header chrome (~6

--- a/packages/memtomem/tests/web/test_a11y_focus.py
+++ b/packages/memtomem/tests/web/test_a11y_focus.py
@@ -355,3 +355,44 @@ class TestA11yShortcutGate:
         page.wait_for_selector("#shortcuts-modal:not([hidden])", timeout=2_000)
         page.keyboard.press("?")
         page.wait_for_selector("#shortcuts-modal", state="hidden", timeout=2_000)
+
+
+# ---------------------------------------------------------------------------
+# PR #5 — A11Y-1.1 skip-to-main runtime focus behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestA11ySkipLinkRuntimeFocus:
+    """A11Y-1.1 runtime — the DOM contract pin in
+    ``test_qa_audit_pins.TestSkipLinkPresent`` proves the link + landmark
+    exist, but Chromium/Firefox only move keyboard focus to a hash-link
+    target if that target is focusable (anchor with href, button, input,
+    or any element carrying tabindex). Without ``tabindex="-1"`` on
+    ``<main>`` the link scrolls but focus stays on the now-off-screen
+    skip-link itself, and the next Tab cycles back into the header
+    chrome — defeating the affordance. Pin the runtime so the regression
+    can't slip back."""
+
+    def test_activating_skip_link_moves_focus_into_main(self, mm_web_url, page):
+        _goto_with_stubs(mm_web_url, page)
+        # The skip link is the first tabbable in document order — one
+        # Tab from initial state should land on it.
+        page.keyboard.press("Tab")
+        on_skip = page.evaluate(
+            "document.activeElement && document.activeElement.classList.contains('skip-link')"
+        )
+        assert on_skip, (
+            "first Tab from initial state did not land on the .skip-link — "
+            "ensure the skip-link <a> is the first tabbable child of <body>"
+        )
+        # Enter activates the anchor; href='#main' should focus <main>.
+        page.keyboard.press("Enter")
+        inside_main = page.evaluate(
+            "document.getElementById('main').contains(document.activeElement)"
+        )
+        assert inside_main, (
+            "activating the skip link did not move keyboard focus into "
+            "<main> — add tabindex='-1' to <main id='main'> so it can "
+            "receive programmatic focus from hash-link activation "
+            "(A11Y-1.1, issue #1053, PR #1061 P1 review)"
+        )


### PR DESCRIPTION
## Summary

- Adds a visually-hidden `.skip-link` as the first focusable child of `<body>` so the very first Tab from page load lands a "Skip to main content" affordance — keyboard users no longer have to step through ~6 header chrome controls + the tab nav to reach the active tab content.
- Wraps the seven tab panels in `<main id="main">` as the anchor target and primary content landmark. The `<nav>` tab strip stays outside `<main>` so it remains its own landmark; the skip jumps past header + nav both.
- Skip-link copy lives under `nav.skip_to_main` in en + ko.
- Drops the `_A11Y_XFAIL_PR5` marker on `TestSkipLinkPresent`.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_qa_audit_pins.py::TestSkipLinkPresent -v` — PASSED
- [x] `uv run pytest packages/memtomem/tests/web/test_a11y_focus.py::TestA11yBackgroundInert packages/memtomem/tests/web/test_a11y_focus.py::TestA11yStackedModalInertSurvives -v` — 9/9 PASSED (verifying `_recomputeBackgroundInert` still inerts `<main>` as a body child)
- [x] `uv run ruff check` + `format --check` — clean

Closes the PR #5 row in #1053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)