### PR TITLE
fix(web): help-toggle accessible name (#1062 F1)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -24,7 +24,7 @@
       <button id="settings-btn" class="btn-ghost btn-icon" data-i18n-title="header.settings_title" data-i18n-aria-label="header.settings_title" title="Settings" aria-label="Settings">⚙️</button>
       <button id="lang-toggle" class="btn-ghost btn-icon" data-i18n-title="header.lang_toggle_aria" data-i18n-aria-label="header.lang_toggle_aria" title="Switch language" aria-label="Switch language">EN</button>
       <button id="theme-toggle" class="btn-ghost btn-icon" data-i18n-title="header.theme_title" data-i18n-aria-label="header.theme_title" title="Toggle theme" aria-label="Toggle theme">🌙</button>
-      <button id="help-toggle" data-i18n-title="header.help_title" title="Toggle help hints (h)" aria-pressed="true">?</button>
+      <button id="help-toggle" data-i18n-title="header.help_title" data-i18n-aria-label="header.help_title" title="Toggle help hints (h)" aria-label="Toggle help hints (h)" aria-pressed="true">?</button>
     </div>
   </header>
 

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -94,6 +94,18 @@ class TestIssue1062IconButtonNames:
                 "accessible name instead of relying on the × glyph"
             )
 
+    def test_help_toggle_has_accessible_name(self, index_html: str) -> None:
+        # Regression pin for #1062 F1: help-toggle was the only header icon-only
+        # button without aria-label, relying on `title` alone — which VoiceOver
+        # does not reliably announce in form-controls rotor mode.
+        m = re.search(r'<button\b[^>]*\bid="help-toggle"[^>]*>', index_html)
+        assert m, "#help-toggle button not found"
+        tag = m.group(0)
+        assert "data-i18n-aria-label=" in tag and "aria-label=" in tag, (
+            "#help-toggle is icon-only ('?' glyph) and must expose a translated "
+            "accessible name; `title` alone is not reliably announced by VoiceOver"
+        )
+
     def test_view_toggle_updates_runtime_aria_label(self, app_js: str) -> None:
         # Bound by intrinsic anchors (the state flip line and the renderResults
         # tail call) rather than a // --- comment delimiter, so a reflow of the


### PR DESCRIPTION
## Summary

- #1062's manual VoiceOver smoke pass surfaced `help-toggle` (`index.html:27`) as the only header icon-only button without `aria-label` — it relied on `title` alone, which VoiceOver does not reliably announce in form-controls rotor mode.
- Adds `aria-label` + `data-i18n-aria-label` (reusing the existing `header.help_title` key, matching the pattern already on `settings-btn` / `lang-toggle` / `theme-toggle` two lines above).
- Pins it in `TestIssue1062IconButtonNames` (`tests/test_web_a11y.py`) so the gap can't silently re-open.

Same class of defect as #1065 just landed for the view-toggle / close buttons; closes one of the items called out on #1062.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_a11y.py::TestIssue1062IconButtonNames -v` — all 4 pass (3 existing + new)
- [x] `uv run ruff check` + `uv run ruff format --check` on the test file — clean
- [ ] Manual VoiceOver smoke (optional, for whoever picks up the remaining #1062 checklist): Cmd+F5, Tab to header `?` button, confirm VO announces "Toggle help hints (h), toggle button, pressed/not pressed" instead of just "button".

## Out of scope

The other items on #1062 (modal announcement quality, live-region timing, rotor traversal) still need a human VO pass — this PR only closes the one programmatically-discoverable gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)