### PR TITLE
fix(web): honor reduced-motion preference

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -167,6 +167,13 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
   50%      { opacity: 0.55; }
 }
 @media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
   .indexing-pill { animation: none; }
 }
 .header-actions .btn-icon {

--- a/packages/memtomem/tests/web/test_reduced_motion_css.py
+++ b/packages/memtomem/tests/web/test_reduced_motion_css.py
@@ -1,0 +1,30 @@
+"""Static regression pins for reduced-motion CSS coverage."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_STATIC_DIR = Path(__file__).resolve().parents[2] / "src" / "memtomem" / "web" / "static"
+
+
+def test_reduced_motion_media_block_has_wildcard_sweep() -> None:
+    css = (_STATIC_DIR / "style.css").read_text(encoding="utf-8")
+    media = re.search(
+        r"@media\s*\(\s*prefers-reduced-motion\s*:\s*reduce\s*\)\s*\{(?P<body>.*?)\n\}",
+        css,
+        re.S,
+    )
+    assert media is not None, "style.css must define a prefers-reduced-motion: reduce block"
+
+    body = media.group("body")
+    wildcard = re.search(r"\*,\s*\*::before,\s*\*::after\s*\{(?P<body>.*?)\}", body, re.S)
+    assert wildcard is not None, (
+        "reduced-motion block must include a near-wildcard selector so new "
+        "transitions and animations inherit reduced motion coverage"
+    )
+
+    wildcard_body = wildcard.group("body")
+    assert "transition-duration: 0.01ms !important" in wildcard_body
+    assert "animation-duration: 0.01ms !important" in wildcard_body


### PR DESCRIPTION
Fixes #1063.

## Summary
- broaden the existing reduced-motion media query with a wildcard sweep for animations/transitions
- keep the indexing pill animation disabled explicitly
- add a static regression pin under tests/web for the wildcard reduced-motion selector

## Verification
- uv run pytest packages/memtomem/tests/web/test_reduced_motion_css.py
- uv run ruff check packages/memtomem/tests/web/test_reduced_motion_css.py packages/memtomem/src
- uv run ruff format --check packages/memtomem/tests/web/test_reduced_motion_css.py packages/memtomem/src
- uv run pytest -m "not ollama"