### PR TITLE
fix(web): aria-label on residual icon-only buttons (#1062 sweep)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -160,7 +160,7 @@
   <div id="tab-search" class="tab-panel active" role="tabpanel" aria-labelledby="tabbtn-search">
     <div class="tab-help-bar" id="help-search" role="status" hidden>
       <span class="tab-help-bar-text" data-i18n="search.help">Semantic search across indexed memories. Filters: tag, namespace, type, score. Pipeline: BM25 (keyword) + Dense (semantic) → RRF fusion.</span>
-      <button class="tab-help-bar-dismiss" data-help-tab="search">✕</button>
+      <button class="tab-help-bar-dismiss" data-help-tab="search" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div class="search-bar">
       <button id="filter-toggle" class="btn-ghost btn-icon has-tip" data-i18n-title="search.filter_toggle_title" title="Show/hide tag, type, sort and other filters" aria-controls="search-filters" aria-expanded="false"><span data-i18n="search.filter_toggle">▾ Filters</span><span id="filter-count-badge" class="filter-count-badge" hidden></span></button>
@@ -177,7 +177,7 @@
         <div id="search-history-dropdown" class="search-history-dropdown" hidden></div>
       </div>
       <button id="search-btn" class="btn-primary has-tip" data-i18n-title="search.search_btn_title" title="Run semantic search (Enter)" data-i18n="search.search_btn">Search</button>
-      <button id="save-star-btn" class="btn-ghost btn-icon has-tip" data-i18n-title="search.save_title" title="Save current search">☆</button>
+      <button id="save-star-btn" class="btn-ghost btn-icon has-tip" data-i18n-title="search.save_title" data-i18n-aria-label="search.save_title" title="Save current search" aria-label="Save current search">☆</button>
       <button id="group-toggle" class="btn-ghost btn-icon has-tip" data-i18n-title="search.group_title" data-i18n-aria-label="search.group_title" title="Group results by source file" aria-label="Group results by source file">⊟</button>
       <button id="view-toggle" class="btn-ghost btn-icon has-tip" title="Switch to list view" aria-label="Switch to list view">☰</button>
     </div>
@@ -252,7 +252,7 @@
         <div class="saved-wrap">
           <select id="saved-queries-select"><option value="">— Load saved —</option></select>
           <button id="save-query-btn" class="btn-ghost btn-xs" title="Save current search">Save</button>
-          <button id="delete-query-btn" class="btn-ghost btn-xs" title="Delete selected">✕</button>
+          <button id="delete-query-btn" class="btn-ghost btn-xs" data-i18n-title="search.delete_query_aria" data-i18n-aria-label="search.delete_query_aria" title="Delete saved search" aria-label="Delete saved search">✕</button>
         </div>
       </div>
       <div class="adv-row">
@@ -329,9 +329,9 @@
               <span id="d-lines" class="lines-info"></span>
             </div>
             <div class="source-nav">
-              <button id="d-prev-btn" class="btn-ghost btn-xs" title="Previous chunk in source" disabled>◀</button>
+              <button id="d-prev-btn" class="btn-ghost btn-xs" data-i18n-title="search.prev_title" data-i18n-aria-label="search.prev_title" title="Previous chunk in source" aria-label="Previous chunk in source" disabled>◀</button>
               <span id="d-source-pos" class="source-pos"></span>
-              <button id="d-next-btn" class="btn-ghost btn-xs" title="Next chunk in source" disabled>▶</button>
+              <button id="d-next-btn" class="btn-ghost btn-xs" data-i18n-title="search.next_title" data-i18n-aria-label="search.next_title" title="Next chunk in source" aria-label="Next chunk in source" disabled>▶</button>
             </div>
           </div>
 
@@ -391,7 +391,7 @@
           <div id="history-panel" hidden>
             <div class="similar-header">
               <span class="editor-label" data-i18n="search.history_header">Edit History</span>
-              <button id="history-close-btn" class="btn-ghost btn-xs">✕</button>
+              <button id="history-close-btn" class="btn-ghost btn-xs" data-i18n-title="search.history_close_aria" data-i18n-aria-label="search.history_close_aria" title="Close edit history panel" aria-label="Close edit history panel">✕</button>
             </div>
             <div id="history-list"></div>
           </div>
@@ -416,7 +416,7 @@
   <div id="tab-sources" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-sources" hidden>
     <div class="tab-help-bar" id="help-sources" role="status" hidden>
       <span class="tab-help-bar-text" data-i18n="sources.help">Indexed source files. Click a file to browse chunks. Drag the divider to resize. Sort by name, chunks, size, or recency.</span>
-      <button class="tab-help-bar-dismiss" data-help-tab="sources">✕</button>
+      <button class="tab-help-bar-dismiss" data-help-tab="sources" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div id="sources-view" class="sources-view" role="region" aria-labelledby="tabbtn-sources">
       <div class="sources-layout">
@@ -661,7 +661,7 @@
   <div id="tab-index" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-index" hidden>
     <div class="tab-help-bar" id="help-index" role="status" hidden>
       <span class="tab-help-bar-text" data-i18n="index.help">Three ways to add memories to memtomem.</span>
-      <button class="tab-help-bar-dismiss" data-help-tab="index">✕</button>
+      <button class="tab-help-bar-dismiss" data-help-tab="index" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div class="index-mode-toggle" role="tablist" data-i18n-aria-label="index.mode_aria" aria-label="Index mode">
       <button id="index-mode-folder" class="btn-ghost btn-active"
@@ -1109,7 +1109,7 @@
   <div id="tab-tags" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-tags" hidden>
     <div class="tab-help-bar" id="help-tags" role="status" hidden>
       <span class="tab-help-bar-text" data-i18n="tags.help">Tag cloud sized by frequency. Click a tag to filter search. Auto-Tag analyzes content to suggest tags for untagged chunks.</span>
-      <button class="tab-help-bar-dismiss" data-help-tab="tags">✕</button>
+      <button class="tab-help-bar-dismiss" data-help-tab="tags" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div class="tags-layout">
       <div class="tags-left card">
@@ -1182,7 +1182,7 @@
   <div id="tab-timeline" class="tab-panel" role="tabpanel" aria-labelledby="tabbtn-timeline" hidden>
     <div class="tab-help-bar" id="help-timeline" role="status" hidden>
       <span class="tab-help-bar-text" data-i18n="timeline.help">Activity timeline of indexed chunks. Heatmap shows daily activity. Toggle Chunks/Files view.</span>
-      <button class="tab-help-bar-dismiss" data-help-tab="timeline">✕</button>
+      <button class="tab-help-bar-dismiss" data-help-tab="timeline" data-i18n-title="common.dismiss_help" data-i18n-aria-label="common.dismiss_help" title="Dismiss help" aria-label="Dismiss help">✕</button>
     </div>
     <div class="timeline-controls">
       <div class="date-range-picker">

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -177,7 +177,7 @@
         <div id="search-history-dropdown" class="search-history-dropdown" hidden></div>
       </div>
       <button id="search-btn" class="btn-primary has-tip" data-i18n-title="search.search_btn_title" title="Run semantic search (Enter)" data-i18n="search.search_btn">Search</button>
-      <button id="save-star-btn" class="btn-ghost btn-icon has-tip" data-i18n-title="search.save_title" data-i18n-aria-label="search.save_title" title="Save current search" aria-label="Save current search">☆</button>
+      <button id="save-star-btn" class="btn-ghost btn-icon has-tip" title="Save current search" aria-label="Save current search">☆</button>
       <button id="group-toggle" class="btn-ghost btn-icon has-tip" data-i18n-title="search.group_title" data-i18n-aria-label="search.group_title" title="Group results by source file" aria-label="Group results by source file">⊟</button>
       <button id="view-toggle" class="btn-ghost btn-icon has-tip" title="Switch to list view" aria-label="Switch to list view">☰</button>
     </div>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -112,6 +112,7 @@
   "search.search_btn": "Search",
   "search.search_btn_title": "Run semantic search (Enter)",
   "search.save_title": "Save current search",
+  "search.unsave_title": "Remove from saved searches",
   "search.delete_query_aria": "Delete saved search",
   "search.group_title": "Group results by source file",
   "search.view_title": "Switch between card and compact list view",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -112,6 +112,7 @@
   "search.search_btn": "Search",
   "search.search_btn_title": "Run semantic search (Enter)",
   "search.save_title": "Save current search",
+  "search.delete_query_aria": "Delete saved search",
   "search.group_title": "Group results by source file",
   "search.view_title": "Switch between card and compact list view",
   "search.view_card_title": "Switch to card view",
@@ -198,6 +199,7 @@
   "search.source_chunks_header": "Chunks in Same Source",
   "search.source_chunks_close_aria": "Close source chunks panel",
   "search.history_header": "Edit History",
+  "search.history_close_aria": "Close edit history panel",
   "search.related_header": "Related Chunks",
   "search.drop_msg": "📥 Drop files to index",
   "search.prev_title": "Previous chunk in source",
@@ -733,6 +735,7 @@
   "common.merge": "Merge",
   "common.expire": "Expire",
   "common.sync": "Sync",
+  "common.dismiss_help": "Dismiss help",
   "common.file_chunk_progress": "{file} — {done}/{total} chunks",
 
   "time.relative.just_now": "just now",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -112,6 +112,7 @@
   "search.search_btn": "검색",
   "search.search_btn_title": "시맨틱 검색 실행 (Enter)",
   "search.save_title": "현재 검색 저장",
+  "search.unsave_title": "저장된 검색에서 제거",
   "search.delete_query_aria": "저장된 검색 삭제",
   "search.group_title": "소스 파일별로 결과 그룹화",
   "search.view_title": "카드/목록 보기 전환",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -112,6 +112,7 @@
   "search.search_btn": "검색",
   "search.search_btn_title": "시맨틱 검색 실행 (Enter)",
   "search.save_title": "현재 검색 저장",
+  "search.delete_query_aria": "저장된 검색 삭제",
   "search.group_title": "소스 파일별로 결과 그룹화",
   "search.view_title": "카드/목록 보기 전환",
   "search.view_card_title": "카드 보기로 전환",
@@ -198,6 +199,7 @@
   "search.source_chunks_header": "같은 소스의 청크",
   "search.source_chunks_close_aria": "소스 청크 패널 닫기",
   "search.history_header": "편집 기록",
+  "search.history_close_aria": "편집 기록 패널 닫기",
   "search.related_header": "관련 청크",
   "search.drop_msg": "📥 파일을 드롭하여 인덱스",
   "search.prev_title": "소스의 이전 청크",
@@ -733,6 +735,7 @@
   "common.merge": "병합",
   "common.expire": "만료",
   "common.sync": "동기화",
+  "common.dismiss_help": "도움말 닫기",
   "common.file_chunk_progress": "{file} — {done}/{total} 청크",
 
   "time.relative.just_now": "방금",

--- a/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-namespaces.js
@@ -352,18 +352,33 @@ async function deleteNamespace(name) {
 // Phase 1a: Saved Searches — Star button + history dropdown integration
 // ═══════════════════════════════════════════════════════════════════════════
 
+// JS owns #save-star-btn's title/aria-label because the label is
+// state-dependent (the next action — Save vs Remove — flips with the glyph).
+// The HTML element therefore has no data-i18n-title / data-i18n-aria-label:
+// applyDOM() would otherwise reset both attributes to search.save_title on
+// every langchange, silently announcing "Save current search" while the
+// button is in the starred (unsave) state. Mirrors the #view-toggle pattern.
+function _syncSaveStar() {
+  const btn = qs('save-star-btn');
+  if (!btn) return;
+  const q = qs('search-input').value.trim();
+  const isSaved = q.length > 0 && _getSavedQueries().some(s => s.query === q);
+  const label = isSaved ? t('search.unsave_title') : t('search.save_title');
+  btn.textContent = isSaved ? '★' : '☆';
+  btn.classList.toggle('starred', isSaved);
+  btn.title = label;
+  btn.setAttribute('aria-label', label);
+}
+
 qs('save-star-btn').addEventListener('click', () => {
   const q = qs('search-input').value.trim();
   if (!q) { showToast(t('toast.enter_query'), 'error'); return; }
   const list = _getSavedQueries();
   const exists = list.some(s => s.query === q);
   if (exists) {
-    // Unsave
     const idx = list.findIndex(s => s.query === q);
     list.splice(idx, 1);
     _setSavedQueries(list);
-    qs('save-star-btn').textContent = '☆';
-    qs('save-star-btn').classList.remove('starred');
     showToast(t('toast.search_removed'), 'info');
   } else {
     const name = q.length > 40 ? q.slice(0, 40) + '…' : q;
@@ -372,22 +387,15 @@ qs('save-star-btn').addEventListener('click', () => {
     const topK = parseInt(qs('top-k').value, 10);
     list.push({ name, query: q, namespace: nsFilter, tags: tf, topK, ts: new Date().toISOString() });
     _setSavedQueries(list);
-    qs('save-star-btn').textContent = '★';
-    qs('save-star-btn').classList.add('starred');
     showToast(t('toast.query_saved', { name }), 'success');
   }
+  _syncSaveStar();
   _renderSavedSelect();
   _renderSavedBar();
 });
 
-// Update star button state when search input changes
-qs('search-input').addEventListener('input', () => {
-  const q = qs('search-input').value.trim();
-  const list = _getSavedQueries();
-  const isSaved = list.some(s => s.query === q);
-  qs('save-star-btn').textContent = isSaved ? '★' : '☆';
-  qs('save-star-btn').classList.toggle('starred', isSaved);
-});
+qs('search-input').addEventListener('input', _syncSaveStar);
+window.addEventListener('langchange', _syncSaveStar);
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Phase 1b: Related Chunks — auto-load on detail view

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -109,8 +109,6 @@ class TestIssue1062IconButtonNames:
     @pytest.mark.parametrize(
         "button_id",
         [
-            # ☆ — toolbar save-search trigger
-            "save-star-btn",
             # ✕ — saved-search delete
             "delete-query-btn",
             # ◀ / ▶ — chunk navigation in detail pane
@@ -126,12 +124,59 @@ class TestIssue1062IconButtonNames:
         # Sweep follow-up to #1062 F1/#1065/#1066: the remaining icon-only
         # <button id=...> elements either relied on `title` alone or had no
         # accessible name at all. Same defect class as help-toggle (#1066).
+        #
+        # Excludes #save-star-btn — that button's label is state-dependent
+        # (Save vs Remove) and is JS-owned; see
+        # ``test_save_star_label_survives_langchange`` below.
         m = re.search(rf'<button\b[^>]*\bid="{re.escape(button_id)}"[^>]*>', index_html)
         assert m, f"#{button_id} button not found"
         tag = m.group(0)
         assert "data-i18n-aria-label=" in tag and "aria-label=" in tag, (
             f"#{button_id} is icon-only and must expose a translated accessible "
             "name; `title` alone is not reliably announced by VoiceOver"
+        )
+
+    def test_save_star_label_survives_langchange(self, index_html: str, app_js: str) -> None:
+        # The save-star button is a toggle: ☆ → click saves the current query,
+        # ★ → click *removes* it. A static aria-label="Save current search"
+        # would announce the wrong action in the starred state — exactly the
+        # bug flagged in PR review on #1068. So JS owns the label per-state and
+        # the HTML must not declare data-i18n hooks that applyDOM() would
+        # clobber back to search.save_title on every langchange. Mirrors the
+        # view-toggle pattern.
+        m = re.search(r'<button\b[^>]*\bid="save-star-btn"[^>]*>', index_html)
+        assert m, "#save-star-btn button not found"
+        tag = m.group(0)
+        assert "data-i18n-title" not in tag, (
+            "#save-star-btn must not declare data-i18n-title — applyDOM() "
+            "would clobber the state-dependent label written by _syncSaveStar()"
+        )
+        assert "data-i18n-aria-label" not in tag, (
+            "#save-star-btn must not declare data-i18n-aria-label — applyDOM() "
+            "would clobber the state-dependent label written by _syncSaveStar()"
+        )
+        # The settings-namespaces.js module owns this button; the fixture is
+        # app.js so search there is correct only if we read the right file.
+        ns_js = (_STATIC_DIR / "settings-namespaces.js").read_text(encoding="utf-8")
+        assert "function _syncSaveStar" in ns_js, (
+            "_syncSaveStar helper must exist so click and langchange go through "
+            "one label-writing code path"
+        )
+        # Click handler must delegate (not duplicate textContent/aria writes
+        # inline — that was the original bug shape).
+        click_start = ns_js.index("qs('save-star-btn').addEventListener('click'")
+        click_end = ns_js.index("\n});", click_start)
+        click_block = ns_js[click_start:click_end]
+        assert "_syncSaveStar()" in click_block, (
+            "save-star click handler must call _syncSaveStar so the per-state "
+            "label is written by the shared helper, not inline"
+        )
+        assert re.search(
+            r"window\.addEventListener\(\s*['\"]langchange['\"]\s*,\s*_syncSaveStar\s*\)",
+            ns_js,
+        ), (
+            "_syncSaveStar must be registered as a langchange listener so the "
+            "per-state label is re-translated when the user switches locale"
         )
 
     def test_tab_help_bar_dismiss_buttons_have_accessible_names(self, index_html: str) -> None:

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -106,6 +106,53 @@ class TestIssue1062IconButtonNames:
             "accessible name; `title` alone is not reliably announced by VoiceOver"
         )
 
+    @pytest.mark.parametrize(
+        "button_id",
+        [
+            # ☆ — toolbar save-search trigger
+            "save-star-btn",
+            # ✕ — saved-search delete
+            "delete-query-btn",
+            # ◀ / ▶ — chunk navigation in detail pane
+            "d-prev-btn",
+            "d-next-btn",
+            # ✕ — edit-history panel close (had no title OR aria-label)
+            "history-close-btn",
+        ],
+    )
+    def test_residual_icon_buttons_have_accessible_names(
+        self, index_html: str, button_id: str
+    ) -> None:
+        # Sweep follow-up to #1062 F1/#1065/#1066: the remaining icon-only
+        # <button id=...> elements either relied on `title` alone or had no
+        # accessible name at all. Same defect class as help-toggle (#1066).
+        m = re.search(rf'<button\b[^>]*\bid="{re.escape(button_id)}"[^>]*>', index_html)
+        assert m, f"#{button_id} button not found"
+        tag = m.group(0)
+        assert "data-i18n-aria-label=" in tag and "aria-label=" in tag, (
+            f"#{button_id} is icon-only and must expose a translated accessible "
+            "name; `title` alone is not reliably announced by VoiceOver"
+        )
+
+    def test_tab_help_bar_dismiss_buttons_have_accessible_names(self, index_html: str) -> None:
+        # The ✕ dismiss button on each tab's help bar (search, sources, index,
+        # tags, timeline) is a class, not an id — sweep all instances and pin
+        # that each one carries the shared `common.dismiss_help` aria-label.
+        # Five instances exist today; if a new tab grows a help bar without a
+        # name, this test fails.
+        matches = re.findall(r'<button\b[^>]*\bclass="tab-help-bar-dismiss"[^>]*>', index_html)
+        assert len(matches) >= 5, (
+            f"expected ≥5 tab-help-bar-dismiss buttons, found {len(matches)}; "
+            "if a tab was removed, lower the count — if added, ensure it has "
+            "the aria-label below"
+        )
+        for tag in matches:
+            assert 'data-i18n-aria-label="common.dismiss_help"' in tag and "aria-label=" in tag, (
+                "every .tab-help-bar-dismiss button must declare "
+                'data-i18n-aria-label="common.dismiss_help" + aria-label; '
+                f"found a bare instance: {tag}"
+            )
+
     def test_view_toggle_updates_runtime_aria_label(self, app_js: str) -> None:
         # Bound by intrinsic anchors (the state flip line and the renderResults
         # tail call) rather than a // --- comment delimiter, so a reflow of the


### PR DESCRIPTION
## Summary

Static sweep follow-up to #1062 after #1066 landed. Found 10 icon-only `<button>` instances across 6 ids/classes that still relied on `title` alone or had no accessible name at all — same defect class as #1065 / #1066.

| Selector | Before | After |
|---|---|---|
| `#save-star-btn` ☆ | `data-i18n-title` only | + `data-i18n-aria-label="search.save_title"` (reuse) |
| `#delete-query-btn` ✕ | `title="Delete selected"` hardcoded | + new `search.delete_query_aria` |
| `#d-prev-btn` ◀ / `#d-next-btn` ▶ | `title=...` hardcoded | + `data-i18n-aria-label="search.prev_title"` / `next_title` (reuse) |
| `#history-close-btn` ✕ | **nothing** — no title, no label | + new `search.history_close_aria` |
| `.tab-help-bar-dismiss` ✕ (×5) | **nothing** | + new `common.dismiss_help` |

Three new locale keys added with both en and ko translations; existing keys reused where possible.

## Pinning

Extends `TestIssue1062IconButtonNames`:
- Parametrized test over the five fixed id'd buttons
- Class-sweep over every `.tab-help-bar-dismiss` so a new tab can't ship a help bar without a name

## Out of scope

Static sweep only — covers what's grep-discoverable. The non-static items on #1062 (announcement quality, rotor traversal as heard, live-region timing, modal context cues) still need a human VoiceOver session.

Text-input accessible names are also out of scope here. The 6 inputs originally flagged on #1062 were handled in earlier PRs; broader placeholder-only inputs (sources-filter, index-path, dedup/decay numerics, etc.) are a separate judgment call.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_a11y.py -v` — 23 pass (10 in `TestIssue1062IconButtonNames`)
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py -v` — 47 pass (locale parity intact)
- [x] `uv run ruff check` + `uv run ruff format --check` on changed files — clean
- [x] Both locale JSONs parse
- [ ] Manual VoiceOver smoke on the 6 button types (left for whoever picks up the remaining #1062 checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)