### PR TITLE
feat(server): Add remote transport options to MCP Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`memtomem-server` direct TTY launches now exit with guidance.** Running the
+  stdio MCP server directly in a terminal prints MCP-client setup and
+  network-transport examples instead of waiting on stdin.
+
 ## [0.2.1] — 2026-05-13
 
 Patch release focused on Web UI stability and release polish after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`memtomem-server` now supports network MCP transports.** Adds
+  `--transport sse|http` plus `--host`, `--port`, `--url`, `--allowed-host`,
+  `--allowed-origin`, and `--disable-dns-rebinding-protection` for deployments
+  that need SSE or streamable HTTP instead of stdio. Treat sse/http transports
+  as trusted-network only; place an authenticated reverse proxy in front before
+  exposing publicly.
 - **`memtomem-server` direct TTY launches now exit with guidance.** Running the
   stdio MCP server directly in a terminal prints MCP-client setup and
   network-transport examples instead of waiting on stdin.

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -322,13 +322,133 @@ def _try_hold_legacy_flock(legacy_pid: Path) -> object | None:
     return legacy_fp
 
 
-def main() -> None:
+def _is_direct_stdio_terminal() -> bool:
+    """Return True when stdio mode was launched directly in a terminal."""
+    import sys
+
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _print_direct_stdio_help() -> None:
+    """Explain why bare stdio server launches exit immediately."""
+    print(
+        "\n".join(
+            [
+                "memtomem-server is an MCP stdio server.",
+                "",
+                "This command is normally launched by an MCP client over stdin/stdout.",
+                "Do not run it directly in a terminal.",
+                "",
+                "Configure your MCP client with:",
+                "  command: uvx",
+                '  args: ["--from", "memtomem", "memtomem-server"]',
+                "",
+                "Example:",
+                "  claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server",
+                "",
+                "For a manually started network server, use:",
+                "  memtomem-server --transport sse --host 127.0.0.1 --port 8000",
+                "  memtomem-server --transport http --host 127.0.0.1 --port 8000",
+                "",
+                "No MCP client is connected; exiting.",
+            ]
+        )
+    )
+
+
+def _parse_server_args(argv: list[str] | None = None):
+    """Parse ``memtomem-server`` transport options."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="memtomem-server",
+        description="Run the memtomem MCP server.",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "sse", "streamable-http", "http"),
+        default="stdio",
+        help="MCP transport to use. 'http' is an alias for 'streamable-http'.",
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host for sse/http transports.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port for sse/http transports.",
+    )
+    parser.add_argument(
+        "--mount-path",
+        default=None,
+        help="Optional mount path for SSE transport.",
+    )
+    parser.add_argument(
+        "--sse-path",
+        default="/sse",
+        help="SSE endpoint path for --transport sse.",
+    )
+    parser.add_argument(
+        "--http-path",
+        default="/mcp",
+        help="Streamable HTTP endpoint path for --transport http.",
+    )
+    return parser.parse_args(argv)
+
+
+def _normalize_transport(transport: str) -> str:
+    if transport == "http":
+        return "streamable-http"
+    return transport
+
+
+def _configure_network_transport(args) -> None:
+    mcp.settings.host = args.host
+    mcp.settings.port = args.port
+    mcp.settings.sse_path = args.sse_path
+    mcp.settings.streamable_http_path = args.http_path
+
+
+def _print_network_server_info(transport: str, args) -> None:
+    if transport == "sse":
+        path = args.sse_path
+        if args.mount_path:
+            mount = args.mount_path.rstrip("/")
+            path = f"{mount}{path}"
+    else:
+        path = args.http_path
+    print(
+        "\n".join(
+            [
+                "memtomem-server",
+                f"Transport: {transport}",
+                f"Listening: http://{args.host}:{args.port}{path}",
+                "",
+                "Press Ctrl+C to stop.",
+            ]
+        )
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
     """Run the MCP server."""
     import atexit
 
     import portalocker
 
     from memtomem._runtime_paths import ensure_runtime_dir, legacy_server_pid_path
+
+    args = _parse_server_args(argv)
+    transport = _normalize_transport(args.transport)
+    if transport == "stdio" and _is_direct_stdio_terminal():
+        _print_direct_stdio_help()
+        raise SystemExit(2)
+    if transport != "stdio":
+        _configure_network_transport(args)
+        _print_network_server_info(transport, args)
 
     # B1: bidirectional mutual exclusion during the transition window.
     # Hold the legacy flock for the process lifetime so an old (pre-#412)
@@ -446,4 +566,9 @@ def main() -> None:
             sigterm_targets.append(legacy_pid_file)
         _install_sigterm_handler(*sigterm_targets)
 
-    mcp.run()
+    if transport == "stdio":
+        mcp.run()
+    elif transport == "sse":
+        mcp.run(transport="sse", mount_path=args.mount_path)
+    else:
+        mcp.run(transport="streamable-http")

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -347,8 +347,8 @@ def _print_direct_stdio_help() -> None:
                 "  claude mcp add memtomem -s user -- uvx --from memtomem memtomem-server",
                 "",
                 "For a manually started network server, use:",
-                "  memtomem-server --transport sse --host 127.0.0.1 --port 8000",
-                "  memtomem-server --transport http --host 127.0.0.1 --port 8000",
+                "  memtomem-server --transport sse --host 127.0.0.1 --port 8000 --url http://127.0.0.1:8000/sse",
+                "  memtomem-server --transport http --host 127.0.0.1 --port 8000 --url http://127.0.0.1:8000/mcp",
                 "",
                 "No MCP client is connected; exiting.",
             ]
@@ -373,7 +373,10 @@ def _parse_server_args(argv: list[str] | None = None):
     parser.add_argument(
         "--host",
         default="127.0.0.1",
-        help="Host for sse/http transports.",
+        help=(
+            "Local host/interface to listen on for sse/http transports, usually "
+            "127.0.0.1 behind nginx or 0.0.0.0 for direct network access."
+        ),
     )
     parser.add_argument(
         "--port",
@@ -382,19 +385,30 @@ def _parse_server_args(argv: list[str] | None = None):
         help="Port for sse/http transports.",
     )
     parser.add_argument(
-        "--mount-path",
+        "--url",
         default=None,
-        help="Optional mount path for SSE transport.",
+        help=(
+            "Full MCP endpoint URL clients connect to, e.g. https://example.com/mcp. "
+            "The URL path is also used as this server's endpoint path; reverse "
+            "proxies should forward that path unchanged."
+        ),
     )
     parser.add_argument(
-        "--sse-path",
-        default="/sse",
-        help="SSE endpoint path for --transport sse.",
+        "--allowed-host",
+        action="append",
+        default=[],
+        help="Advanced: extra allowed Host header for sse/http transports. Repeatable.",
     )
     parser.add_argument(
-        "--http-path",
-        default="/mcp",
-        help="Streamable HTTP endpoint path for --transport http.",
+        "--allowed-origin",
+        action="append",
+        default=[],
+        help="Advanced: extra allowed Origin header for sse/http transports. Repeatable.",
+    )
+    parser.add_argument(
+        "--disable-dns-rebinding-protection",
+        action="store_true",
+        help="Advanced: disable MCP transport DNS rebinding protection for sse/http transports.",
     )
     return parser.parse_args(argv)
 
@@ -405,27 +419,113 @@ def _normalize_transport(transport: str) -> str:
     return transport
 
 
-def _configure_network_transport(args) -> None:
+def _default_network_url(transport: str, host: str, port: int) -> str:
+    path = "/sse" if transport == "sse" else "/mcp"
+    display_host = "127.0.0.1" if host == "0.0.0.0" else host
+    return f"http://{display_host}:{port}{path}"
+
+
+def _normalize_endpoint_url(url: str) -> str:
+    from urllib.parse import urlparse
+
+    normalized = url.rstrip("/")
+    parsed = urlparse(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise SystemExit("--url must be a full http(s) URL, e.g. https://example.com/mcp")
+    if not parsed.path or parsed.path == "/":
+        raise SystemExit("--url must include an endpoint path, e.g. https://example.com/mcp")
+    return normalized
+
+
+def _split_sse_url_path(path: str) -> tuple[str | None, str]:
+    mount, _, endpoint = path.rstrip("/").rpartition("/")
+    return (mount or None), f"/{endpoint}"
+
+
+def _origin_from_url(url: str) -> str:
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _host_patterns(host: str | None) -> list[str]:
+    if not host or host in {"0.0.0.0", "::"}:
+        return []
+    if ":" in host and not host.startswith("["):
+        return [f"[{host}]", f"[{host}]:*"]
+    return [host, f"{host}:*"]
+
+
+def _configure_network_transport(args, transport: str) -> tuple[str, str | None]:
+    from urllib.parse import urlparse
+
+    from mcp.server.transport_security import TransportSecuritySettings
+
+    public_url = _normalize_endpoint_url(
+        args.url or _default_network_url(transport, args.host, args.port)
+    )
+    parsed = urlparse(public_url)
+
     mcp.settings.host = args.host
     mcp.settings.port = args.port
-    mcp.settings.sse_path = args.sse_path
-    mcp.settings.streamable_http_path = args.http_path
-
-
-def _print_network_server_info(transport: str, args) -> None:
     if transport == "sse":
-        path = args.sse_path
-        if args.mount_path:
-            mount = args.mount_path.rstrip("/")
-            path = f"{mount}{path}"
+        mount_path, endpoint_path = _split_sse_url_path(parsed.path)
+        mcp.settings.sse_path = endpoint_path
     else:
-        path = args.http_path
+        mount_path = None
+        endpoint_path = parsed.path
+        mcp.settings.streamable_http_path = endpoint_path
+
+    if args.disable_dns_rebinding_protection:
+        mcp.settings.transport_security = TransportSecuritySettings(
+            enable_dns_rebinding_protection=False
+        )
+        return public_url, mount_path
+
+    allowed_hosts = [
+        "127.0.0.1",
+        "127.0.0.1:*",
+        "localhost",
+        "localhost:*",
+        "[::1]",
+        "[::1]:*",
+        *(_host_patterns(parsed.hostname)),
+        *(_host_patterns(args.host)),
+        *args.allowed_host,
+    ]
+    allowed_origins = [_origin_from_url(public_url), *args.allowed_origin]
+    mcp.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=list(dict.fromkeys(allowed_hosts)),
+        allowed_origins=list(dict.fromkeys(allowed_origins)),
+    )
+    return public_url, mount_path
+
+
+def _internal_network_url(args, transport: str, mount_path: str | None) -> str:
+    if transport == "sse":
+        path = f"{mount_path or ''}{mcp.settings.sse_path}"
+    else:
+        path = mcp.settings.streamable_http_path
+    return f"http://{args.host}:{args.port}{path}"
+
+
+def _print_network_server_info(
+    transport: str, args, public_url: str, mount_path: str | None
+) -> None:
+    transport_label = "http (streamable-http)" if args.transport == "http" else transport
+    internal_url = _internal_network_url(args, transport, mount_path)
     print(
         "\n".join(
             [
                 "memtomem-server",
-                f"Transport: {transport}",
-                f"Listening: http://{args.host}:{args.port}{path}",
+                f"Transport: {transport_label}",
+                f"Internal URL: {internal_url}",
+                f"Public URL:   {public_url}",
+                "",
+                "Reverse proxy note:",
+                "  Forward the public URL path unchanged to the internal URL path.",
                 "",
                 "Press Ctrl+C to stop.",
             ]
@@ -447,8 +547,10 @@ def main(argv: list[str] | None = None) -> None:
         _print_direct_stdio_help()
         raise SystemExit(2)
     if transport != "stdio":
-        _configure_network_transport(args)
-        _print_network_server_info(transport, args)
+        public_url, mount_path = _configure_network_transport(args, transport)
+        _print_network_server_info(transport, args, public_url, mount_path)
+    else:
+        mount_path = None
 
     # B1: bidirectional mutual exclusion during the transition window.
     # Hold the legacy flock for the process lifetime so an old (pre-#412)
@@ -569,6 +671,6 @@ def main(argv: list[str] | None = None) -> None:
     if transport == "stdio":
         mcp.run()
     elif transport == "sse":
-        mcp.run(transport="sse", mount_path=args.mount_path)
+        mcp.run(transport="sse", mount_path=mount_path)
     else:
         mcp.run(transport="streamable-http")

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -363,6 +363,10 @@ def _parse_server_args(argv: list[str] | None = None):
     parser = argparse.ArgumentParser(
         prog="memtomem-server",
         description="Run the memtomem MCP server.",
+        epilog=(
+            "Security: treat sse/http transports as trusted-network only; place an "
+            "authenticated reverse proxy in front before exposing publicly."
+        ),
     )
     parser.add_argument(
         "--transport",
@@ -375,7 +379,7 @@ def _parse_server_args(argv: list[str] | None = None):
         default="127.0.0.1",
         help=(
             "Local host/interface to listen on for sse/http transports, usually "
-            "127.0.0.1 behind nginx or 0.0.0.0 for direct network access."
+            "127.0.0.1 behind nginx or 0.0.0.0 for trusted direct network access."
         ),
     )
     parser.add_argument(

--- a/packages/memtomem/src/memtomem/server/__init__.py
+++ b/packages/memtomem/src/memtomem/server/__init__.py
@@ -408,7 +408,10 @@ def _parse_server_args(argv: list[str] | None = None):
     parser.add_argument(
         "--disable-dns-rebinding-protection",
         action="store_true",
-        help="Advanced: disable MCP transport DNS rebinding protection for sse/http transports.",
+        help=(
+            "Advanced/dangerous: disables DNS rebinding protection; only safe "
+            "behind an authenticated reverse proxy."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -543,6 +546,8 @@ def main(argv: list[str] | None = None) -> None:
 
     args = _parse_server_args(argv)
     transport = _normalize_transport(args.transport)
+    # These informational banners are safe on stdout: the stdio TTY guard exits
+    # before mcp.run(), and network transports do not use stdout as the MCP stream.
     if transport == "stdio" and _is_direct_stdio_terminal():
         _print_direct_stdio_help()
         raise SystemExit(2)

--- a/packages/memtomem/tests/test_server_cli.py
+++ b/packages/memtomem/tests/test_server_cli.py
@@ -8,6 +8,25 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _restore_mcp_settings():
+    from memtomem import server as server_mod
+
+    settings = server_mod.mcp.settings
+    original = {
+        "host": settings.host,
+        "port": settings.port,
+        "sse_path": settings.sse_path,
+        "streamable_http_path": settings.streamable_http_path,
+        "transport_security": settings.transport_security,
+    }
+
+    yield
+
+    for name, value in original.items():
+        setattr(settings, name, value)
+
+
 def _isolate_runtime(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -54,6 +73,7 @@ def test_stdio_direct_terminal_prints_help_and_exits(
     assert "memtomem-server is an MCP stdio server." in out
     assert "No MCP client is connected; exiting." in out
     assert "--url http://127.0.0.1:8000/mcp" in out
+    # Direct server launches should point users to MCP setup/network transports.
     assert "mm status" not in out
 
 
@@ -182,6 +202,116 @@ def test_network_url_trailing_slash_is_normalized(
     assert calls == [((), {"transport": "streamable-http"})]
 
 
+def test_disable_dns_rebinding_protection_skips_allowed_hosts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(
+            [
+                "--transport",
+                "http",
+                "--url",
+                "https://mcp.example.test/mcp",
+                "--disable-dns-rebinding-protection",
+            ]
+        )
+    finally:
+        _run_callbacks(callbacks)
+
+    security = server_mod.mcp.settings.transport_security
+    assert security.enable_dns_rebinding_protection is False
+    assert security.allowed_hosts == []
+    assert security.allowed_origins == []
+    assert calls == [((), {"transport": "streamable-http"})]
+
+
+def test_sse_transport_uses_default_endpoint_when_url_omitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(["--transport", "sse", "--host", "127.0.0.1", "--port", "8768"])
+    finally:
+        _run_callbacks(callbacks)
+
+    assert server_mod.mcp.settings.host == "127.0.0.1"
+    assert server_mod.mcp.settings.port == 8768
+    assert server_mod.mcp.settings.sse_path == "/sse"
+    assert "127.0.0.1" in server_mod.mcp.settings.transport_security.allowed_hosts
+    assert "http://127.0.0.1:8768" in server_mod.mcp.settings.transport_security.allowed_origins
+    assert calls == [((), {"transport": "sse", "mount_path": None})]
+
+
+def test_http_transport_uses_default_endpoint_when_url_omitted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(["--transport", "http", "--host", "127.0.0.1", "--port", "8769"])
+    finally:
+        _run_callbacks(callbacks)
+
+    assert server_mod.mcp.settings.host == "127.0.0.1"
+    assert server_mod.mcp.settings.port == 8769
+    assert server_mod.mcp.settings.streamable_http_path == "/mcp"
+    assert "127.0.0.1" in server_mod.mcp.settings.transport_security.allowed_hosts
+    assert "http://127.0.0.1:8769" in server_mod.mcp.settings.transport_security.allowed_origins
+    assert calls == [((), {"transport": "streamable-http"})]
+
+
+def test_default_network_url_uses_loopback_for_wildcard_host(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(["--transport", "http", "--host", "0.0.0.0", "--port", "8770"])
+    finally:
+        _run_callbacks(callbacks)
+
+    security = server_mod.mcp.settings.transport_security
+    assert server_mod.mcp.settings.host == "0.0.0.0"
+    assert server_mod.mcp.settings.port == 8770
+    assert server_mod.mcp.settings.streamable_http_path == "/mcp"
+    assert "0.0.0.0" not in security.allowed_hosts
+    assert "0.0.0.0:*" not in security.allowed_hosts
+    assert "http://127.0.0.1:8770" in security.allowed_origins
+    assert "http://0.0.0.0:8770" not in security.allowed_origins
+    assert calls == [((), {"transport": "streamable-http"})]
+
+
 def test_network_url_requires_endpoint_path() -> None:
     from memtomem import server as server_mod
 
@@ -189,3 +319,13 @@ def test_network_url_requires_endpoint_path() -> None:
         server_mod.main(["--transport", "http", "--url", "https://mcp.example.test/"])
 
     assert "must include an endpoint path" in str(exc.value)
+
+
+@pytest.mark.parametrize("url", ["file:///tmp/mcp", "127.0.0.1:8000/mcp"])
+def test_network_url_requires_full_http_url(url: str) -> None:
+    from memtomem import server as server_mod
+
+    with pytest.raises(SystemExit) as exc:
+        server_mod.main(["--transport", "http", "--url", url])
+
+    assert "must be a full http(s) URL" in str(exc.value)

--- a/packages/memtomem/tests/test_server_cli.py
+++ b/packages/memtomem/tests/test_server_cli.py
@@ -1,0 +1,149 @@
+"""CLI-facing behavior for ``memtomem-server``."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+
+def _isolate_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> list[tuple[Callable, tuple[object, ...], dict[str, object]]]:
+    import memtomem._runtime_paths as runtime_paths
+
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+    legacy_pid = tmp_path / "home" / ".memtomem" / ".server.pid"
+    callbacks: list[tuple[Callable, tuple[object, ...], dict[str, object]]] = []
+
+    monkeypatch.setattr(runtime_paths, "ensure_runtime_dir", lambda: runtime_dir)
+    monkeypatch.setattr(runtime_paths, "legacy_server_pid_path", lambda: legacy_pid)
+    monkeypatch.setattr(
+        "atexit.register",
+        lambda fn, *args, **kwargs: callbacks.append((fn, args, kwargs)) or fn,
+    )
+    return callbacks
+
+
+def _run_callbacks(callbacks: list[tuple[Callable, tuple[object, ...], dict[str, object]]]) -> None:
+    for fn, args, kwargs in reversed(callbacks):
+        fn(*args, **kwargs)
+
+
+def test_stdio_direct_terminal_prints_help_and_exits(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from memtomem import server as server_mod
+
+    monkeypatch.setattr(server_mod, "_is_direct_stdio_terminal", lambda: True)
+    monkeypatch.setattr(
+        server_mod.mcp,
+        "run",
+        lambda *args, **kwargs: pytest.fail("stdio TTY launch must not run the server"),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        server_mod.main(["--transport", "stdio"])
+
+    assert exc.value.code == 2
+    out = capsys.readouterr().out
+    assert "memtomem-server is an MCP stdio server." in out
+    assert "No MCP client is connected; exiting." in out
+    assert "mm status" not in out
+
+
+def test_stdio_pipe_runs_without_terminal_help(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_is_direct_stdio_terminal", lambda: False)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(["--transport", "stdio"])
+    finally:
+        _run_callbacks(callbacks)
+
+    assert calls == [((), {})]
+    assert "MCP stdio server" not in capsys.readouterr().out
+
+
+def test_http_transport_alias_runs_streamable_http(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(
+            [
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8765",
+                "--http-path",
+                "/custom-mcp",
+            ]
+        )
+    finally:
+        _run_callbacks(callbacks)
+
+    assert server_mod.mcp.settings.host == "127.0.0.1"
+    assert server_mod.mcp.settings.port == 8765
+    assert server_mod.mcp.settings.streamable_http_path == "/custom-mcp"
+    assert calls == [((), {"transport": "streamable-http"})]
+
+
+def test_sse_transport_passes_mount_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(
+            [
+                "--transport",
+                "sse",
+                "--host",
+                "0.0.0.0",
+                "--port",
+                "8766",
+                "--mount-path",
+                "/memtomem",
+                "--sse-path",
+                "/events",
+            ]
+        )
+    finally:
+        _run_callbacks(callbacks)
+
+    assert server_mod.mcp.settings.host == "0.0.0.0"
+    assert server_mod.mcp.settings.port == 8766
+    assert server_mod.mcp.settings.sse_path == "/events"
+    assert calls == [((), {"transport": "sse", "mount_path": "/memtomem"})]

--- a/packages/memtomem/tests/test_server_cli.py
+++ b/packages/memtomem/tests/test_server_cli.py
@@ -53,6 +53,7 @@ def test_stdio_direct_terminal_prints_help_and_exits(
     out = capsys.readouterr().out
     assert "memtomem-server is an MCP stdio server." in out
     assert "No MCP client is connected; exiting." in out
+    assert "--url http://127.0.0.1:8000/mcp" in out
     assert "mm status" not in out
 
 
@@ -100,8 +101,8 @@ def test_http_transport_alias_runs_streamable_http(
                 "127.0.0.1",
                 "--port",
                 "8765",
-                "--http-path",
-                "/custom-mcp",
+                "--url",
+                "https://mcp.example.test/custom-mcp",
             ]
         )
     finally:
@@ -110,6 +111,8 @@ def test_http_transport_alias_runs_streamable_http(
     assert server_mod.mcp.settings.host == "127.0.0.1"
     assert server_mod.mcp.settings.port == 8765
     assert server_mod.mcp.settings.streamable_http_path == "/custom-mcp"
+    assert "mcp.example.test" in server_mod.mcp.settings.transport_security.allowed_hosts
+    assert "https://mcp.example.test" in server_mod.mcp.settings.transport_security.allowed_origins
     assert calls == [((), {"transport": "streamable-http"})]
 
 
@@ -134,10 +137,8 @@ def test_sse_transport_passes_mount_path(
                 "0.0.0.0",
                 "--port",
                 "8766",
-                "--mount-path",
-                "/memtomem",
-                "--sse-path",
-                "/events",
+                "--url",
+                "https://mcp.example.test/memtomem/events",
             ]
         )
     finally:
@@ -147,3 +148,44 @@ def test_sse_transport_passes_mount_path(
     assert server_mod.mcp.settings.port == 8766
     assert server_mod.mcp.settings.sse_path == "/events"
     assert calls == [((), {"transport": "sse", "mount_path": "/memtomem"})]
+
+
+def test_network_url_trailing_slash_is_normalized(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from memtomem import server as server_mod
+
+    calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+    callbacks = _isolate_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(server_mod, "_try_hold_legacy_flock", lambda _path: None)
+    monkeypatch.setattr(server_mod, "_install_sigterm_handler", lambda *_paths: None)
+    monkeypatch.setattr(server_mod.mcp, "run", lambda *args, **kwargs: calls.append((args, kwargs)))
+
+    try:
+        server_mod.main(
+            [
+                "--transport",
+                "http",
+                "--host",
+                "127.0.0.1",
+                "--port",
+                "8767",
+                "--url",
+                "https://mcp.example.test/mcp/",
+            ]
+        )
+    finally:
+        _run_callbacks(callbacks)
+
+    assert server_mod.mcp.settings.streamable_http_path == "/mcp"
+    assert calls == [((), {"transport": "streamable-http"})]
+
+
+def test_network_url_requires_endpoint_path() -> None:
+    from memtomem import server as server_mod
+
+    with pytest.raises(SystemExit) as exc:
+        server_mod.main(["--transport", "http", "--url", "https://mcp.example.test/"])
+
+    assert "must include an endpoint path" in str(exc.value)

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -613,16 +613,20 @@ def test_server_main_acquires_portalocker_pid_lock(
     import atexit
     import pathlib
 
+    import memtomem._runtime_paths as runtime_paths
+
     from memtomem import server as server_mod
-    from memtomem._runtime_paths import server_pid_path
     from memtomem.cli._liveness import probe_pid_file
 
     tmp_home = tmp_path / "home"
     tmp_home.mkdir()
     xdg = tmp_path / "xdg_runtime"
     xdg.mkdir()
+    runtime = xdg / "memtomem"
+    runtime.mkdir()
     if os.name != "nt":
         os.chmod(xdg, 0o700)
+        os.chmod(runtime, 0o700)
 
     captured_atexit: list[tuple] = []
 
@@ -630,16 +634,21 @@ def test_server_main_acquires_portalocker_pid_lock(
     monkeypatch.setattr(server_mod.mcp, "run", lambda: None)
     monkeypatch.setattr(pathlib.Path, "home", classmethod(lambda cls: tmp_home))
     monkeypatch.setenv("XDG_RUNTIME_DIR", str(xdg))
+    monkeypatch.setenv("TMPDIR", str(xdg))
+    monkeypatch.setenv("TMP", str(xdg))
+    monkeypatch.setenv("TEMP", str(xdg))
+    monkeypatch.setattr(runtime_paths, "ensure_runtime_dir", lambda: runtime)
+    monkeypatch.setattr(runtime_paths, "server_pid_path", lambda: runtime / "server.pid")
     monkeypatch.setattr(
         atexit,
         "register",
         lambda fn, *a, **kw: captured_atexit.append((fn, a, kw)) or fn,
     )
 
-    pid_file = server_pid_path()
+    pid_file = runtime_paths.server_pid_path()
     cleanup_ran = False
     try:
-        server_mod.main()
+        server_mod.main([])
 
         assert pid_file.exists(), "main() must create the pid file"
         # Cross-platform: pid file must be non-empty. ``LockFileEx`` blocks


### PR DESCRIPTION
Added transport options to `memtomem-server` so that the MCP Server can be run remotely, in addition to the existing default `stdio` mode.

Previously, the MCP Server command ran with `stdio` by default. Since running a `stdio`-based MCP server directly in a terminal environment is not useful, `memtomem-server` now displays a guidance message and exits instead of continuing execution in that case.

Added `sse` and `http` (`streamable-http` alias) as supported `transport` options for remote MCP Server execution. Users can start a remote server by providing the `transport`, `host`, `port`, and `url` arguments.

Also updated the `-h` / `--help` text for `memtomem-server` to reflect these changes.