### PR TITLE
fix(web): cold-load deep link routes to target leaf (#1070)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1326,7 +1326,20 @@ function activateTab(tabName, opts = {}) {
     switchSettingsSection(start || 'config');
   }
   if (tabName === 'context-gateway') {
-    let start = opts.sectionOverride || STATE.lastSettingsSection;
+    let start = opts.sectionOverride;
+    // #1070: prefer the deep-link ``?section=`` over remembered state so a
+    // cold-loaded share-URL routes to the target leaf instead of landing on
+    // Overview. ``sectionOverride`` (set by ``switchSettingsSection``'s
+    // re-entry hop) still wins so an in-page click is not overridden by a
+    // stale URL param. ``_ctxParseDeepLink`` is declared at module scope in
+    // ``context-gateway.js`` and is on ``window`` by the time the
+    // DOMContentLoaded handler fires ``activateTab`` — fall back gracefully
+    // if it isn't (e.g., script-load ordering regression).
+    if (!start && typeof _ctxParseDeepLink === 'function') {
+      const link = _ctxParseDeepLink();
+      if (link && GATEWAY_SECTIONS.has(link.section)) start = link.section;
+    }
+    if (!start) start = STATE.lastSettingsSection;
     if (!start) {
       try { start = localStorage.getItem(LAST_SECTION_KEY); } catch {}
     }

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1403,7 +1403,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=117"></script>
+  <script src="/app.js?v=118"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -1216,6 +1216,50 @@ def test_deep_link_banner_reset_restores_full_list(page, mm_web_url: str) -> Non
     assert "filter=" not in href, f"reset must strip filter param: {href}"
 
 
+def test_deep_link_cold_load_routes_to_target_section(page, mm_web_url: str) -> None:
+    """#1070: cold-loading ``?section=ctx-skills&filter=...#context-gateway``
+    must route to the target leaf, not Overview.
+
+    Previously, ``activateTab('context-gateway')`` consulted only
+    ``opts.sectionOverride`` → ``STATE.lastSettingsSection`` → localStorage
+    → ``ctx-overview``. The query-string was ignored on cold load, so the
+    share-URL landed on Overview and ``_ctxApplyDeepLinkToContainer``
+    never had a target list to filter. The previous deep-link specs in
+    this file all cheated past this by explicitly calling
+    ``activateTab('settings')`` + ``switchSettingsSection('ctx-skills')``
+    after the goto — this spec deliberately does NOT, so it exercises the
+    cold-load routing the issue actually reports.
+    """
+    install_default_stubs(page)
+    _stub_projects(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
+    _stub_skills(page, _CWD_SKILLS_THREE)
+
+    page.goto(
+        f"{mm_web_url}/?section=ctx-skills&filter=missing_canonical#context-gateway"
+    )
+    # Wait for cold-load routing to land on ctx-skills and the deep-link
+    # banner to render. The banner is the same wait-handle the existing
+    # specs use because both filter- and missing-link modes paint one.
+    page.wait_for_function(
+        "() => document.querySelector('#settings-ctx-skills.active') !== null"
+        " && document.querySelector('#ctx-skills-list .ctx-deep-link-banner') !== null",
+        timeout=5_000,
+    )
+
+    # Positive: the target section is the active one.
+    assert page.locator("#settings-ctx-skills.active").count() == 1, (
+        "cold-loaded ?section=ctx-skills must activate the Skills section"
+    )
+    # Negative: Overview is not the active section — pin the regression
+    # shape (``activeSections: ['settings-ctx-overview']`` per the issue).
+    assert page.locator("#settings-ctx-overview.active").count() == 0, (
+        "cold-loaded deep-link must not land on Overview (regression pin for #1070)"
+    )
+    # And the filter banner is present, proving the deep-link payload
+    # reached ``_ctxApplyDeepLinkToContainer`` after routing.
+    assert page.locator("#ctx-skills-list .ctx-deep-link-banner").count() == 1
+
+
 # Empty-list skills payload used by the #956 tier-aware empty-hint tests.
 # ``scanned_dirs`` is present so the project-tier branch's ``{scan_dirs}``
 # token interpolates with a real value (the user-tier branch ignores it).

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -1234,9 +1234,7 @@ def test_deep_link_cold_load_routes_to_target_section(page, mm_web_url: str) -> 
     _stub_projects(page, _CWD_PROJECTS_WITH_NON_CWD_MISSING)
     _stub_skills(page, _CWD_SKILLS_THREE)
 
-    page.goto(
-        f"{mm_web_url}/?section=ctx-skills&filter=missing_canonical#context-gateway"
-    )
+    page.goto(f"{mm_web_url}/?section=ctx-skills&filter=missing_canonical#context-gateway")
     # Wait for cold-load routing to land on ctx-skills and the deep-link
     # banner to render. The banner is the same wait-handle the existing
     # specs use because both filter- and missing-link modes paint one.


### PR DESCRIPTION
## Summary

- Closes #1070. `activateTab('context-gateway')` now reads `_ctxParseDeepLink()` and prefers `link.section` (when it's in `GATEWAY_SECTIONS`) over `STATE.lastSettingsSection` / localStorage, so a cold-loaded `?section=ctx-skills&filter=missing_canonical#context-gateway` routes to Skills instead of Overview.
- `opts.sectionOverride` still wins so the `switchSettingsSection` re-entry hop (in-page click → tab change) isn't displaced by a stale URL param.
- New Playwright spec `test_deep_link_cold_load_routes_to_target_section` bare-`goto`s the repro URL with no manual `activateTab` / `switchSettingsSection` shortcut, asserts `#settings-ctx-skills.active` + the deep-link banner, and pins a negative on `#settings-ctx-overview.active` to catch the regression shape from the issue.
- `app.js?v=117 → v=118` per the static-asset cache-bust rule.

## Test plan

- [ ] `uv run pytest packages/memtomem/tests/web/test_context_gateway_lists.py -k deep_link -m browser` (incl. new cold-load spec)
- [ ] Manual: `uv run mm web`, open `http://127.0.0.1:8080/?section=ctx-skills&filter=missing_canonical#context-gateway` in a fresh browser profile, confirm the page lands on Skills with the filter banner instead of Overview
- [ ] Manual: with `localStorage.memtomem_last_settings` set to `'ctx-agents'`, the same URL still routes to Skills (deep-link wins over remembered state)
- [ ] Manual: in-page Overview → tile click still threads through `sectionOverride` (no regression on the existing happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
