### PR TITLE
refactor(retry): share RateLimitError + promote parse_retry_after

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/openai.py
+++ b/packages/memtomem/src/memtomem/embedding/openai.py
@@ -9,18 +9,10 @@ from typing import Sequence
 import httpx
 
 from memtomem.config import EmbeddingConfig
-from memtomem.embedding.retry import _parse_retry_after, with_retry
+from memtomem.embedding.retry import RateLimitError, parse_retry_after, with_retry
 from memtomem.errors import EmbeddingError
 
 logger = logging.getLogger(__name__)
-
-
-class _RateLimitError(Exception):
-    """Raised on HTTP 429 to trigger retry via with_retry decorator."""
-
-    def __init__(self, retry_after: float | None = None) -> None:
-        self.retry_after = retry_after
-        super().__init__(f"Rate limited (retry_after={retry_after})")
 
 
 class OpenAIEmbedder:
@@ -57,7 +49,7 @@ class OpenAIEmbedder:
     @with_retry(
         max_attempts=4,
         base_delay=1.0,
-        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException, _RateLimitError),
+        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException, RateLimitError),
     )
     async def _embed_batch_with_retry(self, batch: list[str]) -> list[list[float]]:
         """Send a single batch to OpenAI with retry on transient errors and 429."""
@@ -67,8 +59,8 @@ class OpenAIEmbedder:
             json={"input": batch, "model": self._config.model},
         )
         if resp.status_code == 429:
-            ra_val = _parse_retry_after(resp.headers.get("retry-after"))
-            raise _RateLimitError(retry_after=ra_val)
+            ra_val = parse_retry_after(resp.headers.get("retry-after"))
+            raise RateLimitError(retry_after=ra_val)
         resp.raise_for_status()
         data = resp.json()["data"]
         data.sort(key=lambda x: x["index"])
@@ -124,7 +116,7 @@ class OpenAIEmbedder:
             raise EmbeddingError(
                 f"OpenAI embedding request timed out. The API may be overloaded. Error: {exc}"
             ) from exc
-        except _RateLimitError as exc:
+        except RateLimitError as exc:
             raise EmbeddingError(
                 "OpenAI API rate limit exceeded after retries. "
                 "Please wait before retrying or upgrade your plan."

--- a/packages/memtomem/src/memtomem/embedding/retry.py
+++ b/packages/memtomem/src/memtomem/embedding/retry.py
@@ -10,7 +10,19 @@ from functools import wraps
 logger = logging.getLogger(__name__)
 
 
-def _parse_retry_after(value: str | None) -> float | None:
+class RateLimitError(Exception):
+    """Raised on HTTP 429 to trigger retry via with_retry decorator.
+
+    The optional retry_after attribute is honored by with_retry when set:
+    the loop sleeps for max(exponential_delay, retry_after).
+    """
+
+    def __init__(self, retry_after: float | None = None) -> None:
+        self.retry_after = retry_after
+        super().__init__(f"Rate limited (retry_after={retry_after})")
+
+
+def parse_retry_after(value: str | None) -> float | None:
     """Parse a Retry-After header value (seconds or RFC 7231 HTTP-date).
 
     Returns the delay in seconds, or None if unparseable.

--- a/packages/memtomem/src/memtomem/llm/anthropic.py
+++ b/packages/memtomem/src/memtomem/llm/anthropic.py
@@ -7,7 +7,7 @@ import logging
 import httpx
 
 from memtomem.config import LLMConfig
-from memtomem.embedding.retry import _parse_retry_after, with_retry
+from memtomem.embedding.retry import RateLimitError, parse_retry_after, with_retry
 from memtomem.errors import LLMError
 
 logger = logging.getLogger(__name__)
@@ -15,14 +15,6 @@ logger = logging.getLogger(__name__)
 # Hardcoded — users should never change this; incorrect values break the API.
 _ANTHROPIC_VERSION = "2023-06-01"
 _DEFAULT_BASE_URL = "https://api.anthropic.com"
-
-
-class _RateLimitError(Exception):
-    """Raised on HTTP 429 to trigger retry via with_retry decorator."""
-
-    def __init__(self, retry_after: float | None = None) -> None:
-        self.retry_after = retry_after
-        super().__init__(f"Rate limited (retry_after={retry_after})")
 
 
 class AnthropicLLM:
@@ -50,7 +42,7 @@ class AnthropicLLM:
     @with_retry(
         max_attempts=3,
         base_delay=1.0,
-        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException, _RateLimitError),
+        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException, RateLimitError),
     )
     async def _generate_with_retry(self, prompt: str, *, system: str, max_tokens: int) -> str:
         client = self._get_client()
@@ -63,8 +55,8 @@ class AnthropicLLM:
             payload["system"] = system
         resp = await client.post("/v1/messages", json=payload)
         if resp.status_code == 429:
-            ra_val = _parse_retry_after(resp.headers.get("retry-after"))
-            raise _RateLimitError(retry_after=ra_val)
+            ra_val = parse_retry_after(resp.headers.get("retry-after"))
+            raise RateLimitError(retry_after=ra_val)
         if resp.status_code == 401:
             raise LLMError("Anthropic authentication failed. Check your API key.")
         resp.raise_for_status()
@@ -85,7 +77,7 @@ class AnthropicLLM:
             ) from e
         except httpx.TimeoutException as e:
             raise LLMError(f"Anthropic request timed out. Error: {e}") from e
-        except _RateLimitError as e:
+        except RateLimitError as e:
             raise LLMError(
                 "Anthropic rate limit exceeded after retries. "
                 "Please wait before retrying or upgrade your plan."

--- a/packages/memtomem/src/memtomem/llm/openai.py
+++ b/packages/memtomem/src/memtomem/llm/openai.py
@@ -7,18 +7,10 @@ import logging
 import httpx
 
 from memtomem.config import LLMConfig
-from memtomem.embedding.retry import _parse_retry_after, with_retry
+from memtomem.embedding.retry import RateLimitError, parse_retry_after, with_retry
 from memtomem.errors import LLMError
 
 logger = logging.getLogger(__name__)
-
-
-class _RateLimitError(Exception):
-    """Raised on HTTP 429 to trigger retry via with_retry decorator."""
-
-    def __init__(self, retry_after: float | None = None) -> None:
-        self.retry_after = retry_after
-        super().__init__(f"Rate limited (retry_after={retry_after})")
 
 
 class OpenAILLM:
@@ -41,7 +33,7 @@ class OpenAILLM:
     @with_retry(
         max_attempts=3,
         base_delay=1.0,
-        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException, _RateLimitError),
+        retryable_exceptions=(httpx.ConnectError, httpx.TimeoutException, RateLimitError),
     )
     async def _generate_with_retry(self, prompt: str, *, system: str, max_tokens: int) -> str:
         client = self._get_client()
@@ -58,8 +50,8 @@ class OpenAILLM:
             },
         )
         if resp.status_code == 429:
-            ra_val = _parse_retry_after(resp.headers.get("retry-after"))
-            raise _RateLimitError(retry_after=ra_val)
+            ra_val = parse_retry_after(resp.headers.get("retry-after"))
+            raise RateLimitError(retry_after=ra_val)
         if resp.status_code == 401:
             raise LLMError("OpenAI authentication failed. Check your API key.")
         resp.raise_for_status()
@@ -80,7 +72,7 @@ class OpenAILLM:
             ) from e
         except httpx.TimeoutException as e:
             raise LLMError(f"OpenAI request timed out. Error: {e}") from e
-        except _RateLimitError as e:
+        except RateLimitError as e:
             raise LLMError(
                 "OpenAI rate limit exceeded after retries. "
                 "Please wait before retrying or upgrade your plan."

--- a/packages/memtomem/tests/test_embedding_providers.py
+++ b/packages/memtomem/tests/test_embedding_providers.py
@@ -6,7 +6,7 @@ Covers:
   - OpenAIEmbedder (mocked httpx)
   - OnnxEmbedder (mocked fastembed)
   - create_embedder factory
-  - with_retry decorator & _parse_retry_after helper
+  - with_retry decorator & parse_retry_after helper
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from memtomem.embedding.noop import NoopEmbedder
 from memtomem.embedding.ollama import OllamaEmbedder
 from memtomem.embedding.onnx import OnnxEmbedder
 from memtomem.embedding.openai import OpenAIEmbedder
-from memtomem.embedding.retry import _parse_retry_after, with_retry
+from memtomem.embedding.retry import parse_retry_after, with_retry
 from memtomem.errors import ConfigError, EmbeddingError
 
 
@@ -591,7 +591,7 @@ class TestNoopEmbedder:
 
 
 # ---------------------------------------------------------------------------
-# 5. Retry logic — with_retry decorator and _parse_retry_after
+# 5. Retry logic — with_retry decorator and parse_retry_after
 # ---------------------------------------------------------------------------
 
 
@@ -671,19 +671,19 @@ class TestRetryDecorator:
 
 class TestParseRetryAfter:
     def test_none_input(self):
-        assert _parse_retry_after(None) is None
+        assert parse_retry_after(None) is None
 
     def test_empty_string(self):
-        assert _parse_retry_after("") is None
+        assert parse_retry_after("") is None
 
     def test_numeric_seconds(self):
-        assert _parse_retry_after("5") == 5.0
+        assert parse_retry_after("5") == 5.0
 
     def test_float_seconds(self):
-        assert _parse_retry_after("1.5") == 1.5
+        assert parse_retry_after("1.5") == 1.5
 
     def test_unparseable_string(self):
-        assert _parse_retry_after("not-a-date-or-number") is None
+        assert parse_retry_after("not-a-date-or-number") is None
 
     def test_rfc7231_date(self):
         """A valid HTTP-date in the future returns a positive delay."""
@@ -692,7 +692,7 @@ class TestParseRetryAfter:
 
         future = datetime.now(timezone.utc) + timedelta(seconds=30)
         header = format_datetime(future, usegmt=True)
-        result = _parse_retry_after(header)
+        result = parse_retry_after(header)
         assert result is not None
         # Should be roughly 30s (allow some tolerance for test execution time)
         assert 25.0 <= result <= 35.0
@@ -704,6 +704,6 @@ class TestParseRetryAfter:
 
         past = datetime.now(timezone.utc) - timedelta(seconds=60)
         header = format_datetime(past, usegmt=True)
-        result = _parse_retry_after(header)
+        result = parse_retry_after(header)
         assert result is not None
         assert result == 0.0

--- a/packages/memtomem/tests/test_llm_providers.py
+++ b/packages/memtomem/tests/test_llm_providers.py
@@ -232,6 +232,23 @@ class TestOpenAILLM:
         assert mock_client.post.await_count == 2
         mock_sleep.assert_awaited_once_with(5.0)
 
+    @pytest.mark.anyio
+    @patch("memtomem.embedding.retry.asyncio.sleep", new_callable=AsyncMock)
+    async def test_429_exhausts_retries_raises_llm_error(self, mock_sleep):
+        config = _openai_llm_config()
+        llm = OpenAILLM(config)
+        rate_limited = _make_httpx_response(status_code=429, headers={"Retry-After": "1"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = rate_limited
+        llm._client = mock_client
+
+        with pytest.raises(LLMError, match="after retries"):
+            await llm.generate("test")
+
+        # with_retry max_attempts=3 → 3 POST calls, 2 sleeps before giving up
+        assert mock_client.post.await_count == 3
+        assert mock_sleep.await_count == 2
+
 
 # ---------------------------------------------------------------------------
 # 4. AnthropicLLM — mocked httpx
@@ -295,6 +312,22 @@ class TestAnthropicLLM:
         assert result == "Recovered from Claude"
         assert mock_client.post.await_count == 2
         mock_sleep.assert_awaited_once_with(3.0)
+
+    @pytest.mark.anyio
+    @patch("memtomem.embedding.retry.asyncio.sleep", new_callable=AsyncMock)
+    async def test_429_exhausts_retries_raises_llm_error(self, mock_sleep):
+        config = _anthropic_llm_config()
+        llm = AnthropicLLM(config)
+        rate_limited = _make_httpx_response(status_code=429, headers={"Retry-After": "1"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.post.return_value = rate_limited
+        llm._client = mock_client
+
+        with pytest.raises(LLMError, match="after retries"):
+            await llm.generate("test")
+
+        assert mock_client.post.await_count == 3
+        assert mock_sleep.await_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/packages/memtomem/tests/test_retry.py
+++ b/packages/memtomem/tests/test_retry.py
@@ -1,4 +1,4 @@
-"""Tests for embedding/retry.py — _parse_retry_after and with_retry."""
+"""Tests for embedding/retry.py — parse_retry_after and with_retry."""
 
 from __future__ import annotations
 
@@ -6,27 +6,58 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from memtomem.embedding.retry import _parse_retry_after, with_retry
+from memtomem.embedding.retry import RateLimitError, parse_retry_after, with_retry
 
 
-# ── _parse_retry_after ────────────────────────────────────────────────
+# ── RateLimitError ───────────────────────────────────────────────────
+
+
+class TestRateLimitError:
+    def test_default_retry_after_is_none(self):
+        exc = RateLimitError()
+        assert exc.retry_after is None
+
+    def test_retry_after_attribute_set(self):
+        exc = RateLimitError(retry_after=5.0)
+        assert exc.retry_after == 5.0
+
+    @pytest.mark.asyncio
+    async def test_with_retry_honors_retry_after(self):
+        call_count = 0
+
+        @with_retry(max_attempts=2, base_delay=1.0, retryable_exceptions=(RateLimitError,))
+        async def fn():
+            nonlocal call_count
+            call_count += 1
+            raise RateLimitError(retry_after=7.0)
+
+        mock_sleep = AsyncMock()
+        with patch("memtomem.embedding.retry.asyncio.sleep", mock_sleep):
+            with pytest.raises(RateLimitError):
+                await fn()
+
+        # base_delay=1.0, retry_after=7.0 → max(1.0, 7.0) = 7.0
+        assert mock_sleep.call_args_list[0].args[0] == 7.0
+
+
+# ── parse_retry_after ────────────────────────────────────────────────
 
 
 class TestParseRetryAfter:
     def test_numeric_string(self):
-        assert _parse_retry_after("5") == 5.0
+        assert parse_retry_after("5") == 5.0
 
     def test_float_string(self):
-        assert _parse_retry_after("2.5") == 2.5
+        assert parse_retry_after("2.5") == 2.5
 
     def test_none_returns_none(self):
-        assert _parse_retry_after(None) is None
+        assert parse_retry_after(None) is None
 
     def test_empty_string_returns_none(self):
-        assert _parse_retry_after("") is None
+        assert parse_retry_after("") is None
 
     def test_non_numeric_non_date_returns_none(self):
-        assert _parse_retry_after("not-a-number") is None
+        assert parse_retry_after("not-a-number") is None
 
     def test_valid_http_date(self):
         from datetime import datetime, timezone
@@ -37,7 +68,7 @@ class TestParseRetryAfter:
         from datetime import timedelta
 
         future = future + timedelta(seconds=10)
-        result = _parse_retry_after(format_datetime(future))
+        result = parse_retry_after(format_datetime(future))
         assert result is not None
         assert 0 < result <= 11  # allow 1s clock drift
 


### PR DESCRIPTION
## Summary

Follow-up to #1056 (#1083). Three providers — `llm/openai.py`, `llm/anthropic.py`, `embedding/openai.py` — each defined an identical local `_RateLimitError(Exception)` class and reached into `memtomem/embedding/retry.py` for the private `_parse_retry_after` helper.

- Move `RateLimitError` into `retry.py` alongside the `with_retry` contract it satisfies (decorator already inspects `exc.retry_after` via `getattr`).
- Promote `_parse_retry_after` → `parse_retry_after`. The symbol was already imported across modules under its private name, so the underscore was misleading.
- Update all three providers and the two test modules that referenced the old names.
- Add retry-exhaustion tests for both LLM providers (the `LLMError` "after retries" wrapping in `OpenAILLM.generate()` / `AnthropicLLM.generate()` was uncovered).
- Add a `RateLimitError` smoke test that pins the `with_retry` interaction: `retry_after=7.0` wins over `base_delay=1.0` exponential backoff.

No behavior change for callers — same 3-attempt retry budget, same `Retry-After` honoring, same `LLMError` / `EmbeddingError` wrapping.

Closes #1083

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_retry.py packages/memtomem/tests/test_llm_providers.py packages/memtomem/tests/test_embedding_providers.py -m "not ollama"` → 104 passed
- [x] `uv run ruff check` + `uv run ruff format --check` on all touched files → clean
- [x] `grep -rn "_RateLimitError\|_parse_retry_after" packages/memtomem/src/` → no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
