### PR TITLE
fix(dedup): align scan timeout to 120s + cover 408 path

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/dedup.py
+++ b/packages/memtomem/src/memtomem/web/routes/dedup.py
@@ -18,7 +18,7 @@ from memtomem.web.schemas.core import chunk_to_out
 
 router = APIRouter(prefix="/dedup", tags=["dedup"])
 
-_DEDUP_SCAN_TIMEOUT = 30  # seconds
+_DEDUP_SCAN_TIMEOUT = 120  # seconds
 
 
 @router.get("/candidates", response_model=DedupScanResponse)

--- a/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
@@ -11,6 +11,7 @@
 qs('dedup-scan-btn').addEventListener('click', runDedupScan);
 
 // STATE.dedupScanActive, STATE.dedupAbortCtrl now in STATE
+const DEDUP_SCAN_TIMEOUT_MS = 120_000;
 
 function resetDedupPanel() {
   // Don't reset while a scan is still running — keep the UI consistent
@@ -35,19 +36,22 @@ async function runDedupScan() {
   show(empty);
   empty.innerHTML = '<div class="spinner-panel"></div>';
 
-  // Abort any previous request and set a 30 s timeout
+  // Abort any previous request and set a timeout aligned with the server.
   if (STATE.dedupAbortCtrl) STATE.dedupAbortCtrl.abort();
   STATE.dedupAbortCtrl = new AbortController();
-  const timeoutId = setTimeout(() => STATE.dedupAbortCtrl.abort(), 30_000);
+  const timeoutId = setTimeout(() => STATE.dedupAbortCtrl.abort(), DEDUP_SCAN_TIMEOUT_MS);
 
   try {
     const params = new URLSearchParams({ threshold, limit, max_scan: maxScan });
     const res = await fetch(`/api/dedup/candidates?${params}`, { signal: STATE.dedupAbortCtrl.signal });
-    if (!res.ok) throw new Error(res.statusText);
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ detail: res.statusText }));
+      throw new Error(typeof err.detail === 'string' ? err.detail : res.statusText);
+    }
     const data = await res.json();
     renderDedupCandidates(data.candidates, threshold);
   } catch (err) {
-    const msg = err.name === 'AbortError' ? 'Scan timed out (30 s). Try a smaller Max Scan.' : err.message;
+    const msg = err.name === 'AbortError' ? 'Scan timed out (120 s). Try a smaller Max Scan.' : err.message;
     setMsg(qs('dedup-msg'), 'Scan error: ' + msg, true);
     empty.innerHTML = emptyState('📋', 'Scan failed');
   } finally {

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -7,6 +7,7 @@ with mocked app.state dependencies.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -529,6 +530,26 @@ class TestDedup:
         assert resp.status_code == 200
         data = resp.json()
         assert data["scanned_chunks"] == 200
+
+    async def test_dedup_scan_timeout_returns_408(
+        self,
+        app,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        async def slow_scan(**_kwargs):
+            await asyncio.sleep(0.05)
+            return []
+
+        app.state.dedup_scanner.scan = AsyncMock(side_effect=slow_scan)
+        monkeypatch.setattr("memtomem.web.routes.dedup._DEDUP_SCAN_TIMEOUT", 0.001)
+
+        resp = await client.get("/api/dedup/candidates", params={"max_scan": 500})
+
+        assert resp.status_code == 408
+        assert resp.json()["detail"] == (
+            "Dedup scan timed out after 0.001s. Try reducing max_scan (current: 500)."
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The dedup scan was timing out at 30 s on larger workspaces. The server raised a 408 with a helpful `Try reducing max_scan (current: N).` detail, but the client's `AbortController` fired first (also 30 s) and surfaced a generic `Scan timed out (30 s)` toast instead of the server hint. Symptom: on a 1000+ chunk workspace a scan that would have completed in ~60 s aborted with an unhelpful message.

- **Server** (`web/routes/dedup.py`): bump `_DEDUP_SCAN_TIMEOUT` 30 → 120 s.
- **Client** (`web/static/settings-maintenance.js`): bump fetch abort timer to 120 000 ms and lift it into a named constant. When `res.ok` is false, parse the JSON detail and surface it — the server's `Try reducing max_scan (current: N)` message is more actionable than the bare status text.
- **Test** (`tests/test_web_routes_extended.py`): add `test_dedup_scan_timeout_returns_408` that monkeypatches the timeout to 0.001 s and asserts both the 408 status and the exact detail string. The 408 path was uncovered.

No DB-touching changes; dedup is a read-only candidate scan.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_web_routes_extended.py::TestDedup -m "not ollama"` → 3 passed (incl. new test)
- [x] `uv run ruff check` + `uv run ruff format --check` on touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
