### PR TITLE
fix(web): stack Gateway/Settings layout single-column at <=520px (#1072)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=88" />
+  <link rel="stylesheet" href="/style.css?v=89" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=89" />
+  <link rel="stylesheet" href="/style.css?v=90" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -293,6 +293,31 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
   .settings-nav-btn .nav-sub { display: none; }
 }
 
+/* Stack the two-pane Settings/Gateway layout on narrow viewports so the
+   content panel gets full width instead of being squeezed by the 180px nav.
+   See issue #1072. */
+@media (max-width: 520px) {
+  .settings-layout { flex-direction: column; }
+  .settings-nav {
+    width: 100%;
+    max-height: 38vh;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .settings-content {
+    width: 100%;
+    min-width: 0;
+    padding: 12px 12px;
+  }
+  .ctx-header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    row-gap: 8px;
+  }
+  .ctx-header > div { flex-wrap: wrap; }
+  .ctx-overview-grid { grid-template-columns: minmax(0, 1fr); }
+}
+
 /* ── Tab Panels ── */
 .tab-panel { flex: 1; min-height: 0; overflow: hidden; display: none; flex-direction: column; }
 .tab-panel.active { display: flex; }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -293,30 +293,10 @@ header h1 { font-size: 1.2rem; font-weight: 700; color: var(--accent); letter-sp
   .settings-nav-btn .nav-sub { display: none; }
 }
 
-/* Stack the two-pane Settings/Gateway layout on narrow viewports so the
-   content panel gets full width instead of being squeezed by the 180px nav.
-   See issue #1072. */
-@media (max-width: 520px) {
-  .settings-layout { flex-direction: column; }
-  .settings-nav {
-    width: 100%;
-    max-height: 38vh;
-    border-right: 0;
-    border-bottom: 1px solid var(--border);
-  }
-  .settings-content {
-    width: 100%;
-    min-width: 0;
-    padding: 12px 12px;
-  }
-  .ctx-header {
-    flex-wrap: wrap;
-    align-items: flex-start;
-    row-gap: 8px;
-  }
-  .ctx-header > div { flex-wrap: wrap; }
-  .ctx-overview-grid { grid-template-columns: minmax(0, 1fr); }
-}
+/* The mobile (<=520px) Settings/Gateway stacking overrides live at the END
+   of this file (search "issue #1072"). They must come after the base
+   Context Gateway rules below to win the cascade — equal-specificity
+   selectors lose to whichever comes later in source order. */
 
 /* ── Tab Panels ── */
 .tab-panel { flex: 1; min-height: 0; overflow: hidden; display: none; flex-direction: column; }
@@ -4098,4 +4078,35 @@ body.help-hidden #help-toggle { opacity: 0.5; }
   color: var(--muted);
   font-size: 0.85rem;
   margin: 24px 0;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   Mobile (<=520px) Settings + Context Gateway stacking — issue #1072
+   ───────────────────────────────────────────────────────────────
+   Keep this block at the END of the file. The .ctx-* overrides have
+   the same specificity as the base Context Gateway rules higher up,
+   so source order is what makes them win in the 436–520px band
+   (where auto-fill, minmax(200px, 1fr) would otherwise pick 2
+   columns).
+   ═══════════════════════════════════════════════════════════════ */
+@media (max-width: 520px) {
+  .settings-layout { flex-direction: column; }
+  .settings-nav {
+    width: 100%;
+    max-height: 38vh;
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .settings-content {
+    width: 100%;
+    min-width: 0;
+    padding: 12px 12px;
+  }
+  .ctx-header {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    row-gap: 8px;
+  }
+  .ctx-header > div { flex-wrap: wrap; }
+  .ctx-overview-grid { grid-template-columns: minmax(0, 1fr); }
 }

--- a/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
+++ b/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
@@ -1,0 +1,104 @@
+"""Browser test pinning the Context Gateway mobile layout (issue #1072).
+
+At 390px viewport the two-pane Settings/Gateway layout used to leave only
+~178px of usable content width, clipping overview cards and pushing the
+Sync All button past the viewport edge. The fix in ``style.css`` adds a
+``@media (max-width: 520px)`` block that stacks the layout single-column
+and collapses the overview grid to one column.
+
+This test asserts:
+
+* No horizontal page overflow at 390px.
+* ``#ctx-sync-all-btn`` fits inside the viewport.
+* The settings nav is no longer occupying the 180px sidebar slot — the
+  content pane takes the full viewport width.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import install_default_stubs
+
+pytestmark = pytest.mark.browser
+
+
+_EMPTY_OVERVIEW = {
+    "skills": {"total": 0, "in_sync": 0},
+    "commands": {"total": 0, "in_sync": 0},
+    "agents": {"total": 0, "in_sync": 0},
+    "settings": {"total": 0, "in_sync": 0, "out_of_sync": 0, "missing_target": 0},
+    "hooks": {"total": 0, "in_sync": 0, "pending": 0, "conflicts": 0},
+    "root": "/tmp/mtm-mobile-pin",
+    "runtimes": [],
+    "last_sync_at": None,
+}
+
+
+def test_gateway_mobile_390px_no_overflow(page, mm_web_url) -> None:
+    page.set_viewport_size({"width": 390, "height": 844})
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_EMPTY_OVERVIEW),
+        ),
+    )
+
+    page.goto(mm_web_url, wait_until="domcontentloaded")
+    page.wait_for_selector(".tab-nav .tab-btn", timeout=5_000)
+
+    page.locator('.tab-btn[data-tab="context-gateway"]').click()
+    page.wait_for_function(
+        "() => document.querySelector('.tab-btn.active')?.dataset.tab === 'context-gateway'",
+        timeout=4_000,
+    )
+    page.wait_for_selector("#ctx-sync-all-btn", timeout=4_000)
+
+    metrics = page.evaluate(
+        """
+        () => {
+          const root = document.documentElement;
+          const btn = document.getElementById('ctx-sync-all-btn');
+          const content = document.querySelector(
+            '#tab-context-gateway .settings-content'
+          );
+          const layout = document.querySelector(
+            '#tab-context-gateway .settings-layout'
+          );
+          const btnRect = btn ? btn.getBoundingClientRect() : null;
+          return {
+            innerWidth: window.innerWidth,
+            scrollWidth: root.scrollWidth,
+            btnRight: btnRect ? btnRect.right : null,
+            contentWidth: content ? content.getBoundingClientRect().width : null,
+            layoutDirection: layout
+              ? getComputedStyle(layout).flexDirection
+              : null,
+          };
+        }
+        """
+    )
+
+    assert metrics["scrollWidth"] <= metrics["innerWidth"], (
+        f"horizontal overflow at 390px: scrollWidth={metrics['scrollWidth']} "
+        f"> innerWidth={metrics['innerWidth']}"
+    )
+    assert metrics["btnRight"] is not None
+    assert metrics["btnRight"] <= metrics["innerWidth"], (
+        f"#ctx-sync-all-btn extends past viewport: right={metrics['btnRight']} "
+        f"> innerWidth={metrics['innerWidth']}"
+    )
+    assert metrics["layoutDirection"] == "column", (
+        f"settings-layout should stack to column at 390px, got {metrics['layoutDirection']!r}"
+    )
+    assert metrics["contentWidth"] is not None
+    assert metrics["contentWidth"] >= metrics["innerWidth"] - 1, (
+        "settings-content should span the full viewport width at 390px, got "
+        f"contentWidth={metrics['contentWidth']} vs "
+        f"innerWidth={metrics['innerWidth']}"
+    )

--- a/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
+++ b/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
@@ -12,6 +12,10 @@ This test asserts:
 * ``#ctx-sync-all-btn`` fits inside the viewport.
 * The settings nav is no longer occupying the 180px sidebar slot — the
   content pane takes the full viewport width.
+* The overview grid resolves to one column at 480px. At 390px the base
+  ``minmax(200px, 1fr)`` already happens to pick one track due to the
+  narrow content width, which masks the cascade-order regression Codex
+  caught — the 480px assertion is what actually pins it.
 """
 
 from __future__ import annotations
@@ -101,4 +105,54 @@ def test_gateway_mobile_390px_no_overflow(page, mm_web_url) -> None:
         "settings-content should span the full viewport width at 390px, got "
         f"contentWidth={metrics['contentWidth']} vs "
         f"innerWidth={metrics['innerWidth']}"
+    )
+
+
+def test_gateway_overview_grid_single_column_at_480px(page, mm_web_url) -> None:
+    """At 480px the override must beat the base auto-fill rule.
+
+    The cascade-order bug (Codex P2 on PR #1087) lived in the 436–520px
+    band: the @media block was placed BEFORE the base
+    ``.ctx-overview-grid { grid-template-columns: repeat(auto-fill,
+    minmax(200px, 1fr)); }`` rule, so the equal-specificity base rule
+    won source order and produced two columns. Pin this by asserting
+    the resolved track count at 480px.
+    """
+    page.set_viewport_size({"width": 480, "height": 800})
+    install_default_stubs(page)
+    page.route(
+        "**/api/context/overview",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_EMPTY_OVERVIEW),
+        ),
+    )
+
+    page.goto(mm_web_url, wait_until="domcontentloaded")
+    page.wait_for_selector(".tab-nav .tab-btn", timeout=5_000)
+    page.locator('.tab-btn[data-tab="context-gateway"]').click()
+    page.wait_for_function(
+        "() => document.querySelector('.tab-btn.active')?.dataset.tab === 'context-gateway'",
+        timeout=4_000,
+    )
+    page.wait_for_selector("#tab-context-gateway .ctx-overview-grid", timeout=4_000)
+
+    track_count = page.evaluate(
+        """
+        () => {
+          const grid = document.querySelector(
+            '#tab-context-gateway .ctx-overview-grid'
+          );
+          if (!grid) return null;
+          const tracks = getComputedStyle(grid).gridTemplateColumns.trim();
+          return tracks ? tracks.split(/\\s+/).length : 0;
+        }
+        """
+    )
+
+    assert track_count == 1, (
+        "ctx-overview-grid should resolve to one column at 480px, got "
+        f"{track_count} tracks (cascade-order regression on the @media "
+        "override — see PR #1087 review)"
     )


### PR DESCRIPTION
## Summary

- Fixes #1072. At 390px the two-pane Settings/Gateway layout left only ~178px of usable content width after the 180px sidebar, clipping the overview grid and pushing `#ctx-sync-all-btn` 38px past the viewport edge.
- Adds a `@media (max-width: 520px)` block that stacks `.settings-layout` to column, caps `.settings-nav` at `38vh` with vertical scroll (preserves the group-header / danger-separator layout — switching to `flex-direction: row` would break `margin-top: auto` on `.settings-nav-group--danger`), gives `.settings-content` the full viewport width, and collapses `.ctx-overview-grid` to a single column.
- Bumps `style.css` cache-bust `?v=88` → `?v=89`.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/web/test_context_gateway_mobile_layout.py` — new pin at 390px asserts no horizontal page overflow, `#ctx-sync-all-btn` right edge ≤ viewport, `.settings-layout` is `flex-direction: column`, and `.settings-content` width spans the viewport.
- [x] Mutation test: removed the CSS block and re-ran the pin — it failed with `right=428.5625 > 390`, matching the metric in the issue body. Restored and re-ran → PASS.
- [x] `uv run pytest packages/memtomem/tests/web/test_ui_smoke_matrix.py packages/memtomem/tests/web/test_context_gateway_overview.py packages/memtomem/tests/web/test_context_gateway_main_tab.py packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py` — 30 passed (1440px desktop and 390px mobile, prod + dev modes).
- [x] `uv run ruff check` + `uv run ruff format --check` on the new test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
