### PR TITLE
fix(web): keyboard + SR semantics on context-gateway clickable rows (#1073)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -844,7 +844,14 @@ function _renderCtxOverview(data) {
     });
     // #1073: role=button without Enter/Space activation is a lie. Mirrors
     // the search/timeline/chunk-card pattern (see app.js result-item).
+    // ``e.target !== card`` guard (PR #1088 review): the tile contains
+    // ``.ctx-overview-pointer`` buttons whose own Enter/Space activation
+    // bubbles up here — without the guard, ``preventDefault`` would
+    // swallow the pointer button's native click AND ``card.click()``
+    // would navigate to the section, so a keyboard user could not
+    // activate Sync All from the tile's pointer line.
     card.addEventListener('keydown', (e) => {
+      if (e.target !== card) return;
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         card.click();
@@ -1071,7 +1078,7 @@ window.addEventListener('langchange', () => {
             // Re-resolve panes — the previous detailEl children were
             // wiped by loadCtxDetail's innerHTML rewrite.
             const newTa = detailEl.querySelector('#ctx-edit-content');
-            const newCanonPane = detailEl.querySelector('#ctx-pane-canonical');
+            const newCanonPane = detailEl.querySelector(`#ctx-pane-${type}-canonical`);
             const newEditPane = detailEl.querySelector('#ctx-pane-edit');
             if (!newTa || !newEditPane) return;
             newTa.value = pending.content;
@@ -2177,12 +2184,22 @@ async function loadCtxDetail(type, name, opts = {}) {
     // by the tab that controls them, and only the active tab is in the
     // focus order (others tabindex=-1, arrow keys move focus). Mirrors
     // the main app's ``.tab-nav`` pattern in app.js.
+    //
+    // IDs are qualified by ``type`` (PR #1088 review): inactive sections
+    // keep their detail DOM mounted, so ``ctx-tab-canonical`` /
+    // ``ctx-pane-canonical`` would collide across skills/commands/agents.
+    // ``aria-controls`` and ``aria-labelledby`` resolve via document-level
+    // ``getElementById`` regardless of the surrounding DOM tree, so an
+    // un-qualified ID would point at a hidden earlier section's pane
+    // instead of the active one's. (The pre-existing ``ctx-pane-edit``
+    // duplicate is functionally invisible because its lookups are all
+    // detailEl-scoped — only the new ARIA refs needed qualifying.)
     html += '<div class="ctx-detail-tabs" role="tablist">';
-    html += `<button type="button" class="ctx-detail-tab active" data-pane="canonical" role="tab" id="ctx-tab-canonical" aria-controls="ctx-pane-canonical" aria-selected="true" tabindex="0">${t('settings.ctx.canonical_source')}</button>`;
-    html += `<button type="button" class="ctx-detail-tab" data-pane="diff" role="tab" id="ctx-tab-diff" aria-controls="ctx-pane-diff" aria-selected="false" tabindex="-1">${t('settings.ctx.diff_view')}</button>`;
+    html += `<button type="button" class="ctx-detail-tab active" data-pane="canonical" role="tab" id="ctx-tab-${type}-canonical" aria-controls="ctx-pane-${type}-canonical" aria-selected="true" tabindex="0">${t('settings.ctx.canonical_source')}</button>`;
+    html += `<button type="button" class="ctx-detail-tab" data-pane="diff" role="tab" id="ctx-tab-${type}-diff" aria-controls="ctx-pane-${type}-diff" aria-selected="false" tabindex="-1">${t('settings.ctx.diff_view')}</button>`;
     html += '</div>';
 
-    html += '<div class="ctx-detail-pane active" id="ctx-pane-canonical" role="tabpanel" aria-labelledby="ctx-tab-canonical">';
+    html += `<div class="ctx-detail-pane active" id="ctx-pane-${type}-canonical" role="tabpanel" aria-labelledby="ctx-tab-${type}-canonical">`;
     html += `<pre class="ctx-content-pre">${escapeHtml(data.content || '')}</pre>`;
     if (data.files && data.files.length) {
       html += `<div style="margin-top:8px"><strong>${t('settings.ctx.auxiliary_files')}</strong>`;
@@ -2193,7 +2210,7 @@ async function loadCtxDetail(type, name, opts = {}) {
     }
     html += '</div>';
 
-    html += '<div class="ctx-detail-pane" id="ctx-pane-diff" role="tabpanel" aria-labelledby="ctx-tab-diff"><div class="text-muted">Click Diff tab to load...</div></div>';
+    html += `<div class="ctx-detail-pane" id="ctx-pane-${type}-diff" role="tabpanel" aria-labelledby="ctx-tab-${type}-diff"><div class="text-muted">Click Diff tab to load...</div></div>`;
 
     // ``ctx-conflict-banner`` stays hidden in the normal edit flow. When a
     // 409 reaches the dialog and the user picks "Open diff editor", we
@@ -2221,7 +2238,7 @@ async function loadCtxDetail(type, name, opts = {}) {
     if (stashed != null) {
       const ta = detailEl.querySelector('#ctx-edit-content');
       if (ta) ta.value = stashed;
-      const canonPane = detailEl.querySelector('#ctx-pane-canonical');
+      const canonPane = detailEl.querySelector(`#ctx-pane-${type}-canonical`);
       const editPane = detailEl.querySelector('#ctx-pane-edit');
       if (canonPane) canonPane.hidden = true;
       if (editPane) editPane.hidden = false;
@@ -2245,7 +2262,7 @@ async function loadCtxDetail(type, name, opts = {}) {
       tab.setAttribute('aria-selected', 'true');
       tab.setAttribute('tabindex', '0');
       if (opts.focus) tab.focus();
-      const pane = detailEl.querySelector(`#ctx-pane-${tab.dataset.pane}`);
+      const pane = detailEl.querySelector(`#ctx-pane-${type}-${tab.dataset.pane}`);
       if (pane) pane.classList.add('active');
       if (tab.dataset.pane === 'diff') _ctxLoadDiff(type, name, detailEl);
     };
@@ -2276,7 +2293,7 @@ async function loadCtxDetail(type, name, opts = {}) {
 
     // Edit
     detailEl.querySelector('.ctx-detail-edit-btn')?.addEventListener('click', () => {
-      const canonPane = detailEl.querySelector('#ctx-pane-canonical');
+      const canonPane = detailEl.querySelector(`#ctx-pane-${type}-canonical`);
       const editPane = detailEl.querySelector('#ctx-pane-edit');
       if (canonPane) canonPane.hidden = true;
       if (editPane) editPane.hidden = false;
@@ -2285,7 +2302,7 @@ async function loadCtxDetail(type, name, opts = {}) {
 
     // Cancel edit
     detailEl.querySelector('.ctx-edit-cancel')?.addEventListener('click', () => {
-      const canonPane = detailEl.querySelector('#ctx-pane-canonical');
+      const canonPane = detailEl.querySelector(`#ctx-pane-${type}-canonical`);
       const editPane = detailEl.querySelector('#ctx-pane-edit');
       if (canonPane) canonPane.hidden = false;
       if (editPane) editPane.hidden = true;
@@ -2452,7 +2469,7 @@ async function _ctxFetchFieldMap(type, name) {
 }
 
 async function _ctxLoadDiff(type, name, detailEl) {
-  const pane = detailEl.querySelector('#ctx-pane-diff');
+  const pane = detailEl.querySelector(`#ctx-pane-${type}-diff`);
   if (!pane) return;
   pane.innerHTML = '<div class="empty-state"><div class="spinner-panel"></div></div>';
   try {

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -742,17 +742,29 @@ function _renderCtxOverview(data) {
       // too — the tile routes to ``hooks-sync`` (not a context list), so
       // the filter is a no-op there, but keeping the attribute uniform
       // avoids a dataset-shape branch in the click loop.
-      // #1073: tiles navigate to a settings section, so they're buttons —
-      // expose ``role=button`` + ``tabindex=0`` so keyboard users can reach
-      // them and screen readers announce the correct widget type. The
-      // accessible name composes the dominant badge text with the kind
-      // label ("12 out of sync — Skills") so screen-reader announce isn't
-      // just "Skills" with no context.
+      //
+      // #1073 / PR #1088 review: the navigation control is a real
+      // ``<button>`` *inside* the tile, NOT ``role=button`` on the outer
+      // ``<div>``. Putting the role on the outer div nests the
+      // ``.ctx-overview-pointer`` buttons inside a button-role element —
+      // invalid ARIA (interactive content inside ``role=button`` is
+      // forbidden) and inconsistently exposed by assistive tech. The
+      // pointer buttons are siblings of the nav button so they keep
+      // their own focus / activation. The accessible name composes the
+      // dominant badge text with the kind label ("12 out of sync —
+      // Skills") so screen-reader announce isn't just "Skills" with no
+      // context.
+      // ``data-section`` / ``data-tile-key`` stay on the outer tile div
+      // because existing selectors (browser tests, deep-link applier,
+      // CSS scoping) use them to identify the tile by kind — the click
+      // handler reads them via ``navBtn.closest('.ctx-overview-stat')``.
       const tileAriaLabel = `${badgeText} — ${typ.label}`;
-      html += `<div class="ctx-overview-stat" role="button" tabindex="0" aria-label="${escapeHtml(tileAriaLabel)}" data-section="${typ.section}" data-tile-key="${typ.key}">
-        <div class="ctx-overview-count">${total}</div>
-        <div class="ctx-overview-label">${escapeHtml(typ.label)}</div>
-        <div class="ctx-overview-badge"><span class="badge ${badgeCls}">${escapeHtml(badgeText)}</span></div>
+      html += `<div class="ctx-overview-stat" data-section="${typ.section}" data-tile-key="${typ.key}">
+        <button type="button" class="ctx-overview-stat-nav" aria-label="${escapeHtml(tileAriaLabel)}">
+          <div class="ctx-overview-count">${total}</div>
+          <div class="ctx-overview-label">${escapeHtml(typ.label)}</div>
+          <div class="ctx-overview-badge"><span class="badge ${badgeCls}">${escapeHtml(badgeText)}</span></div>
+        </button>
         ${pointersHtml}
       </div>`;
     }
@@ -829,33 +841,27 @@ function _renderCtxOverview(data) {
   // empty. The artifact slot exists for shareable URLs (a teammate
   // pasting "open this URL to see the artifact I'm asking about") and
   // for future per-artifact issue panels.
-  el.querySelectorAll('.ctx-overview-stat').forEach(card => {
-    const tileKey = card.dataset.tileKey;
+  // PR #1088 review: navigation lives on the inner ``.ctx-overview-stat-nav``
+  // <button> (a real button — Enter/Space activate natively, no custom
+  // keydown shim). ``data-section`` / ``data-tile-key`` stay on the outer
+  // tile so existing selectors keep working; the click handler reads them
+  // via ``navBtn.closest('.ctx-overview-stat').dataset``. Pointer buttons
+  // are siblings of the nav button (separate ``.ctx-overview-pointer``
+  // selector below), so they're no longer nested inside the navigation
+  // control.
+  el.querySelectorAll('.ctx-overview-stat-nav').forEach(navBtn => {
+    const tile = navBtn.closest('.ctx-overview-stat');
+    const tileKey = tile ? tile.dataset.tileKey : '';
     const tileData = tileKey ? (data[tileKey] || {}) : null;
     const filter = tileData ? _ctxTileDominantFilter(tileData) : null;
-    const section = card.dataset.section;
-    card.addEventListener('click', () => {
+    const section = tile ? tile.dataset.section : '';
+    navBtn.addEventListener('click', () => {
       if (filter) {
         _ctxSetDeepLink({ section, filter, artifact: '' });
       } else {
         _ctxClearDeepLink();
       }
       switchSettingsSection(section);
-    });
-    // #1073: role=button without Enter/Space activation is a lie. Mirrors
-    // the search/timeline/chunk-card pattern (see app.js result-item).
-    // ``e.target !== card`` guard (PR #1088 review): the tile contains
-    // ``.ctx-overview-pointer`` buttons whose own Enter/Space activation
-    // bubbles up here — without the guard, ``preventDefault`` would
-    // swallow the pointer button's native click AND ``card.click()``
-    // would navigate to the section, so a keyboard user could not
-    // activate Sync All from the tile's pointer line.
-    card.addEventListener('keydown', (e) => {
-      if (e.target !== card) return;
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        card.click();
-      }
     });
   });
 
@@ -1412,14 +1418,37 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
     if (!item.canonical_path) buckets.add('missing_canonical');
     const statusesAttr = ` data-statuses="${escapeHtml(Array.from(buckets).join(' '))}"`;
     const tierBadge = _tierBadgeHtml(item.target_scope, { isContextRow: true });
-    // #1073: clickable cards expose button semantics + keyboard focus so a
-    // screen-reader user can hear the artifact name + sync status and a
-    // keyboard user can tab through the list. Readonly cards (other-scope
-    // groups) stay non-interactive and inherit ``ctx-card--readonly``.
+    // #1073 / PR #1088 review: clickable cards expose button semantics +
+    // keyboard focus, AND the aria-label includes every distinct non-
+    // ``in sync`` status across runtimes (plus runtime-only if the
+    // canonical is absent). The previous label was just the name + an
+    // ``out of sync`` suffix, which silently dropped ``missing target``
+    // / ``missing canonical`` / ``parse error`` / runtime-only cards —
+    // because ``aria-label`` overrides the visible runtime-badge
+    // contents for screen readers, those users would tab past a card
+    // with no clue why it needed action. Statuses come from
+    // ``_ctxStatusText`` so the SR string matches the visible badge
+    // text (and stays localized). Readonly cards (other-scope groups)
+    // stay non-interactive and inherit ``ctx-card--readonly``.
     const a11yAttrs = clickable ? ' role="button" tabindex="0"' : '';
-    const cardAriaLabel = clickable
-      ? ` aria-label="${escapeHtml(item.name)}${outOfSync ? ' — out of sync' : ''}"`
-      : '';
+    let cardAriaLabel = '';
+    if (clickable) {
+      const statusSet = new Set();
+      for (const r of (item.runtimes || [])) {
+        if (r.status && r.status !== 'in sync') {
+          statusSet.add(_ctxStatusText(r.status));
+        }
+      }
+      // Mirrors the bucket fallback below: ``!canonical_path`` is the
+      // wire signal that the artifact is runtime-only, even when no
+      // per-runtime row carries the ``missing canonical`` status.
+      if (!item.canonical_path) {
+        statusSet.add(_ctxStatusText('missing canonical'));
+      }
+      const statusParts = Array.from(statusSet);
+      const suffix = statusParts.length ? ` — ${statusParts.join(', ')}` : '';
+      cardAriaLabel = ` aria-label="${escapeHtml(item.name + suffix)}"`;
+    }
     html += `<div class="${cardClass}"${a11yAttrs}${cardAriaLabel} data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}"${statusesAttr}>
       <div class="ctx-card-header">
         <div>

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -742,7 +742,14 @@ function _renderCtxOverview(data) {
       // too — the tile routes to ``hooks-sync`` (not a context list), so
       // the filter is a no-op there, but keeping the attribute uniform
       // avoids a dataset-shape branch in the click loop.
-      html += `<div class="ctx-overview-stat" data-section="${typ.section}" data-tile-key="${typ.key}">
+      // #1073: tiles navigate to a settings section, so they're buttons —
+      // expose ``role=button`` + ``tabindex=0`` so keyboard users can reach
+      // them and screen readers announce the correct widget type. The
+      // accessible name composes the dominant badge text with the kind
+      // label ("12 out of sync — Skills") so screen-reader announce isn't
+      // just "Skills" with no context.
+      const tileAriaLabel = `${badgeText} — ${typ.label}`;
+      html += `<div class="ctx-overview-stat" role="button" tabindex="0" aria-label="${escapeHtml(tileAriaLabel)}" data-section="${typ.section}" data-tile-key="${typ.key}">
         <div class="ctx-overview-count">${total}</div>
         <div class="ctx-overview-label">${escapeHtml(typ.label)}</div>
         <div class="ctx-overview-badge"><span class="badge ${badgeCls}">${escapeHtml(badgeText)}</span></div>
@@ -834,6 +841,14 @@ function _renderCtxOverview(data) {
         _ctxClearDeepLink();
       }
       switchSettingsSection(section);
+    });
+    // #1073: role=button without Enter/Space activation is a lie. Mirrors
+    // the search/timeline/chunk-card pattern (see app.js result-item).
+    card.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        card.click();
+      }
     });
   });
 
@@ -1390,7 +1405,15 @@ function _ctxRenderItemsHtml(items, type, projectRoot, scannedDirs, { clickable 
     if (!item.canonical_path) buckets.add('missing_canonical');
     const statusesAttr = ` data-statuses="${escapeHtml(Array.from(buckets).join(' '))}"`;
     const tierBadge = _tierBadgeHtml(item.target_scope, { isContextRow: true });
-    html += `<div class="${cardClass}" data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}"${statusesAttr}>
+    // #1073: clickable cards expose button semantics + keyboard focus so a
+    // screen-reader user can hear the artifact name + sync status and a
+    // keyboard user can tab through the list. Readonly cards (other-scope
+    // groups) stay non-interactive and inherit ``ctx-card--readonly``.
+    const a11yAttrs = clickable ? ' role="button" tabindex="0"' : '';
+    const cardAriaLabel = clickable
+      ? ` aria-label="${escapeHtml(item.name)}${outOfSync ? ' — out of sync' : ''}"`
+      : '';
+    html += `<div class="${cardClass}"${a11yAttrs}${cardAriaLabel} data-name="${escapeHtml(item.name)}"${canonAttr} data-out-of-sync="${outOfSync}"${statusesAttr}>
       <div class="ctx-card-header">
         <div>
           <div class="ctx-card-name">${escapeHtml(item.name)}${tierBadge}</div>
@@ -1462,6 +1485,15 @@ async function _loadScopeGroupItems(type, scope, container, seq) {
             } else {
               const detailEl = qs(`ctx-${type}-detail`);
               _ctxLoadRuntimeOnlyDetail(type, card.dataset.name, detailEl);
+            }
+          });
+          // #1073: keyboard activation parity with click. Card renders with
+          // role=button + tabindex=0 in ``_ctxRenderItemsHtml``; without
+          // this handler the SR announce ("button") would be a lie.
+          card.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              card.click();
             }
           });
         });
@@ -2141,12 +2173,16 @@ async function loadCtxDetail(type, name, opts = {}) {
     // commands. Skills get the meta only — no chip row.
     html += _ctxRenderDetailMetaHeader(type, data);
 
-    html += '<div class="ctx-detail-tabs">';
-    html += `<div class="ctx-detail-tab active" data-pane="canonical">${t('settings.ctx.canonical_source')}</div>`;
-    html += `<div class="ctx-detail-tab" data-pane="diff">${t('settings.ctx.diff_view')}</div>`;
+    // #1073: ARIA tablist — tabs are buttons, panes are tabpanels labelled
+    // by the tab that controls them, and only the active tab is in the
+    // focus order (others tabindex=-1, arrow keys move focus). Mirrors
+    // the main app's ``.tab-nav`` pattern in app.js.
+    html += '<div class="ctx-detail-tabs" role="tablist">';
+    html += `<button type="button" class="ctx-detail-tab active" data-pane="canonical" role="tab" id="ctx-tab-canonical" aria-controls="ctx-pane-canonical" aria-selected="true" tabindex="0">${t('settings.ctx.canonical_source')}</button>`;
+    html += `<button type="button" class="ctx-detail-tab" data-pane="diff" role="tab" id="ctx-tab-diff" aria-controls="ctx-pane-diff" aria-selected="false" tabindex="-1">${t('settings.ctx.diff_view')}</button>`;
     html += '</div>';
 
-    html += '<div class="ctx-detail-pane active" id="ctx-pane-canonical">';
+    html += '<div class="ctx-detail-pane active" id="ctx-pane-canonical" role="tabpanel" aria-labelledby="ctx-tab-canonical">';
     html += `<pre class="ctx-content-pre">${escapeHtml(data.content || '')}</pre>`;
     if (data.files && data.files.length) {
       html += `<div style="margin-top:8px"><strong>${t('settings.ctx.auxiliary_files')}</strong>`;
@@ -2157,7 +2193,7 @@ async function loadCtxDetail(type, name, opts = {}) {
     }
     html += '</div>';
 
-    html += '<div class="ctx-detail-pane" id="ctx-pane-diff"><div class="text-muted">Click Diff tab to load...</div></div>';
+    html += '<div class="ctx-detail-pane" id="ctx-pane-diff" role="tabpanel" aria-labelledby="ctx-tab-diff"><div class="text-muted">Click Diff tab to load...</div></div>';
 
     // ``ctx-conflict-banner`` stays hidden in the normal edit flow. When a
     // 409 reaches the dialog and the user picks "Open diff editor", we
@@ -2193,17 +2229,41 @@ async function loadCtxDetail(type, name, opts = {}) {
       showToast(t('settings.ctx.conflict_draft_restored'), 'info');
     }
 
-    // Tab switching
-    detailEl.querySelectorAll('.ctx-detail-tab').forEach(tab => {
-      tab.addEventListener('click', () => {
-        detailEl.querySelectorAll('.ctx-detail-tab').forEach(t => t.classList.remove('active'));
-        detailEl.querySelectorAll('.ctx-detail-pane').forEach(p => p.classList.remove('active'));
-        tab.classList.add('active');
-        const pane = detailEl.querySelector(`#ctx-pane-${tab.dataset.pane}`);
-        if (pane) pane.classList.add('active');
-        if (tab.dataset.pane === 'diff') _ctxLoadDiff(type, name, detailEl);
+    // Tab switching — click + keyboard. ARIA state (aria-selected,
+    // tabindex roving) tracks the visual ``.active`` class so the screen
+    // reader announces the right tab and only one tab is in the focus
+    // order at a time (#1073). Mirrors app.js's main ``.tab-nav``.
+    const _activateCtxDetailTab = (tab, opts = {}) => {
+      const tabs = Array.from(detailEl.querySelectorAll('.ctx-detail-tab'));
+      tabs.forEach(t => {
+        t.classList.remove('active');
+        t.setAttribute('aria-selected', 'false');
+        t.setAttribute('tabindex', '-1');
       });
+      detailEl.querySelectorAll('.ctx-detail-pane').forEach(p => p.classList.remove('active'));
+      tab.classList.add('active');
+      tab.setAttribute('aria-selected', 'true');
+      tab.setAttribute('tabindex', '0');
+      if (opts.focus) tab.focus();
+      const pane = detailEl.querySelector(`#ctx-pane-${tab.dataset.pane}`);
+      if (pane) pane.classList.add('active');
+      if (tab.dataset.pane === 'diff') _ctxLoadDiff(type, name, detailEl);
+    };
+    detailEl.querySelectorAll('.ctx-detail-tab').forEach(tab => {
+      tab.addEventListener('click', () => _activateCtxDetailTab(tab));
     });
+    const _ctxTabsContainer = detailEl.querySelector('.ctx-detail-tabs');
+    if (_ctxTabsContainer) {
+      _ctxTabsContainer.addEventListener('keydown', (e) => {
+        if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(e.key)) return;
+        const tabs = Array.from(_ctxTabsContainer.querySelectorAll('.ctx-detail-tab'));
+        const currentIdx = tabs.indexOf(document.activeElement);
+        const nextIdx = _arrowNavIndex(tabs.length, currentIdx === -1 ? 0 : currentIdx, e.key);
+        if (nextIdx < 0) return;
+        e.preventDefault();
+        _activateCtxDetailTab(tabs[nextIdx], { focus: true });
+      });
+    }
 
     // Out-of-sync prefetch + tab activation. Uses a synthetic ``click()``
     // on the Diff tab so the same handler above runs — keeps the active

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -6,7 +6,7 @@
   <title>memtomem</title>
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/favicon.svg" />
-  <link rel="stylesheet" href="/style.css?v=90" />
+  <link rel="stylesheet" href="/style.css?v=91" />
   <link rel="stylesheet" href="/vendor/prism-tomorrow.min.css?v=1" />
 </head>
 <body>
@@ -1412,7 +1412,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=37"></script>
+  <script src="/context-gateway.js?v=38"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3707,12 +3707,22 @@ body.help-hidden #help-toggle { opacity: 0.5; }
 .ctx-overview-last-sync-value { font-variant-numeric: tabular-nums; }
 
 .ctx-overview-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 12px; }
-.ctx-overview-stat { text-align: center; padding: 20px 16px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); cursor: pointer; transition: border-color 0.15s; }
+/* PR #1088 review: tile is now a layout container holding a separate
+   ``<button class="ctx-overview-stat-nav">`` (navigation target) plus the
+   pointer buttons as siblings — avoids nesting interactive descendants
+   inside a button-role element. The visual frame stays on the outer div
+   so hover still highlights the whole tile. */
+.ctx-overview-stat { border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); transition: border-color 0.15s; overflow: hidden; }
 .ctx-overview-stat:hover { border-color: var(--accent); }
+.ctx-overview-stat-nav { display: block; width: 100%; padding: 20px 16px; background: transparent; border: none; cursor: pointer; color: inherit; font: inherit; text-align: center; }
 .ctx-overview-count { font-size: 2rem; font-weight: 700; color: var(--accent); }
 .ctx-overview-label { font-size: 0.85rem; color: var(--muted); margin-top: 4px; }
 .ctx-overview-badge { font-size: 0.72rem; margin-top: 8px; }
-.ctx-overview-pointers { margin-top: 10px; display: flex; flex-direction: column; gap: 4px; text-align: left; }
+/* Pointer line sits BELOW the nav button (sibling, not child). Inset it
+   horizontally to match the nav button's 16px padding so the visual gutter
+   stays continuous, and pull it up against the nav button's bottom padding
+   so the row reads as one tile rather than two stacked panels. */
+.ctx-overview-pointers { margin: 0 0 12px; padding: 0 16px; display: flex; flex-direction: column; gap: 4px; text-align: left; }
 .ctx-overview-pointer { background: transparent; border: 1px solid transparent; padding: 4px 6px; color: var(--muted); font: inherit; font-size: 0.72rem; text-align: left; cursor: pointer; border-radius: 4px; line-height: 1.35; }
 .ctx-overview-pointer:hover { background: rgba(108, 143, 255, 0.08); color: var(--text); border-color: var(--border); }
 .ctx-overview-pointer:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }

--- a/packages/memtomem/src/memtomem/web/static/style.css
+++ b/packages/memtomem/src/memtomem/web/static/style.css
@@ -3976,7 +3976,11 @@ body.help-hidden #help-toggle { opacity: 0.5; }
   font-family: var(--mono);
 }
 .ctx-detail-tabs { display: flex; gap: 0; border-bottom: 1px solid var(--border); margin-bottom: 12px; }
-.ctx-detail-tab { padding: 8px 16px; cursor: pointer; border-bottom: 2px solid transparent; color: var(--muted); font-size: 0.85rem; transition: color 0.15s; }
+/* #1073: rendered as real <button role=tab> so screen readers announce
+   "tab" and Enter/Space activate without a custom keydown shim. The
+   button defaults (background, border, font) are reset so the visual
+   matches the prior <div>-based tab. */
+.ctx-detail-tab { padding: 8px 16px; cursor: pointer; border: none; border-bottom: 2px solid transparent; background: transparent; color: var(--muted); font-family: inherit; font-size: 0.85rem; line-height: inherit; transition: color 0.15s; }
 .ctx-detail-tab:hover { color: var(--text); }
 .ctx-detail-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 .ctx-detail-pane { display: none; }

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -431,6 +431,23 @@ class TestIssue1073CtxKeyboardSemantics:
         )
         assert "'Enter'" in block and "' '" in block, "keydown handler must accept Enter and Space"
 
+    def test_overview_tile_keydown_skips_nested_pointers(self, ctx_js: str) -> None:
+        # Regression pin (PR #1088 review): tiles render nested
+        # ``.ctx-overview-pointer`` buttons. Without an
+        # ``e.target !== card`` guard, pressing Enter/Space on a pointer
+        # button bubbles into the tile keydown handler, which then
+        # ``preventDefault()``s the pointer button's native click AND
+        # fires ``card.click()`` — so keyboard users could not activate
+        # Sync All from the tile's pointer line.
+        loop_start = ctx_js.index("el.querySelectorAll('.ctx-overview-stat').forEach(card => {")
+        loop_end = ctx_js.index("\n  });", loop_start)
+        block = ctx_js[loop_start:loop_end]
+        assert "e.target !== card" in block, (
+            "ctx-overview-stat keydown handler must early-return when the "
+            "event target is not the tile itself, so nested pointer "
+            "buttons keep their native keyboard activation (#1088 review)"
+        )
+
     # ── Artifact cards (.ctx-card) ────────────────────────────────────
     def test_clickable_ctx_card_has_button_semantics(self, ctx_js: str) -> None:
         # _ctxRenderItemsHtml gates a11y attrs on ``clickable``; readonly
@@ -492,7 +509,7 @@ class TestIssue1073CtxKeyboardSemantics:
             "ctx-detail-tabs container must declare role=tablist (#1073)"
         )
         # Both tab buttons must exist, with aria-controls pointing at
-        # their pane id (canonical / diff).
+        # their pane id (type-qualified, see ``test_detail_ids_qualified_by_type``).
         canonical_tab = re.search(
             r'<button[^>]*class="ctx-detail-tab active"[^>]*data-pane="canonical"[^>]*>',
             ctx_js,
@@ -505,7 +522,7 @@ class TestIssue1073CtxKeyboardSemantics:
         assert diff_tab, "diff tab must render as <button role=tab>"
         for label, tag in (("canonical", canonical_tab.group(0)), ("diff", diff_tab.group(0))):
             assert 'role="tab"' in tag, f"{label} tab missing role=tab"
-            assert 'aria-controls="ctx-pane-' in tag, (
+            assert "aria-controls=" in tag and "ctx-pane-" in tag, (
                 f"{label} tab must declare aria-controls pointing at its pane id"
             )
             assert "aria-selected=" in tag, (
@@ -518,17 +535,53 @@ class TestIssue1073CtxKeyboardSemantics:
     def test_detail_panes_are_tabpanels(self, ctx_js: str) -> None:
         # Each pane must declare role=tabpanel + aria-labelledby pointing
         # at its tab, so the SR announces "canonical source, tab panel"
-        # on focus enter.
+        # on focus enter. IDs are type-qualified per ``test_detail_ids_
+        # qualified_by_type``, so anchor on the role/aria pair alone.
         canonical_pane = re.search(
-            r'id="ctx-pane-canonical"[^>]*role="tabpanel"[^>]*aria-labelledby="ctx-tab-canonical"',
+            r'id="ctx-pane-\$\{type\}-canonical"[^>]*role="tabpanel"'
+            r'[^>]*aria-labelledby="ctx-tab-\$\{type\}-canonical"',
             ctx_js,
         )
         diff_pane = re.search(
-            r'id="ctx-pane-diff"[^>]*role="tabpanel"[^>]*aria-labelledby="ctx-tab-diff"',
+            r'id="ctx-pane-\$\{type\}-diff"[^>]*role="tabpanel"'
+            r'[^>]*aria-labelledby="ctx-tab-\$\{type\}-diff"',
             ctx_js,
         )
         assert canonical_pane, "canonical pane missing role=tabpanel + aria-labelledby"
         assert diff_pane, "diff pane missing role=tabpanel + aria-labelledby"
+
+    def test_detail_ids_qualified_by_type(self, ctx_js: str) -> None:
+        # Regression pin (PR #1088 review): inactive sections (skills /
+        # commands / agents) keep their detail DOM mounted, so the new
+        # ``ctx-tab-*`` and ``ctx-pane-*`` IDs MUST include ``type`` —
+        # otherwise multiple sections share the same id and the
+        # ``aria-controls`` / ``aria-labelledby`` references (which
+        # resolve via document-wide ``getElementById``) point at an
+        # earlier hidden section's pane instead of the active one.
+        for fragment in (
+            'id="ctx-tab-${type}-canonical"',
+            'id="ctx-tab-${type}-diff"',
+            'id="ctx-pane-${type}-canonical"',
+            'id="ctx-pane-${type}-diff"',
+            'aria-controls="ctx-pane-${type}-canonical"',
+            'aria-controls="ctx-pane-${type}-diff"',
+            'aria-labelledby="ctx-tab-${type}-canonical"',
+            'aria-labelledby="ctx-tab-${type}-diff"',
+        ):
+            assert fragment in ctx_js, (
+                f"detail-tab/pane fragment must be type-qualified to avoid "
+                f"duplicate-ID collisions across sections (#1088 review): {fragment}"
+            )
+        # And the negative: the previous un-qualified literals must NOT
+        # appear as JS strings or HTML attributes (the only allowed
+        # mentions are in the explanatory comment paragraph above the
+        # tablist HTML).
+        for literal in ('"ctx-tab-canonical"', '"ctx-pane-canonical"',
+                        '"ctx-tab-diff"', '"ctx-pane-diff"'):
+            assert literal not in ctx_js, (
+                f"un-qualified ID {literal} must not appear — see the"
+                " type-qualified version above"
+            )
 
     def test_detail_tab_keyboard_navigation(self, ctx_js: str) -> None:
         # Arrow nav within the tablist + ARIA state update on activation.

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -433,16 +433,18 @@ class TestIssue1073CtxKeyboardSemantics:
 
     def test_overview_tile_keydown_skips_nested_pointers(self, ctx_js: str) -> None:
         # Regression pin (PR #1088 review): tiles render nested
-        # ``.ctx-overview-pointer`` buttons. Without an
-        # ``e.target !== card`` guard, pressing Enter/Space on a pointer
-        # button bubbles into the tile keydown handler, which then
-        # ``preventDefault()``s the pointer button's native click AND
-        # fires ``card.click()`` — so keyboard users could not activate
-        # Sync All from the tile's pointer line.
+        # ``.ctx-overview-pointer`` buttons. Without a target guard,
+        # pressing Enter/Space on a pointer button bubbles into the tile
+        # keydown handler, which then ``preventDefault()``s the pointer
+        # button's native click AND fires ``card.click()`` — so keyboard
+        # users could not activate Sync All from the tile's pointer line.
         loop_start = ctx_js.index("el.querySelectorAll('.ctx-overview-stat').forEach(card => {")
         loop_end = ctx_js.index("\n  });", loop_start)
         block = ctx_js[loop_start:loop_end]
-        assert "e.target !== card" in block, (
+        # Anchor on the actual statement (``if (...) return;``) rather
+        # than the bare expression, since the substring also appears in
+        # the explanatory comment paragraph above the handler.
+        assert re.search(r"if\s*\(\s*e\.target\s*!==\s*card\s*\)\s*return\s*;", block), (
             "ctx-overview-stat keydown handler must early-return when the "
             "event target is not the tile itself, so nested pointer "
             "buttons keep their native keyboard activation (#1088 review)"
@@ -576,11 +578,14 @@ class TestIssue1073CtxKeyboardSemantics:
         # appear as JS strings or HTML attributes (the only allowed
         # mentions are in the explanatory comment paragraph above the
         # tablist HTML).
-        for literal in ('"ctx-tab-canonical"', '"ctx-pane-canonical"',
-                        '"ctx-tab-diff"', '"ctx-pane-diff"'):
+        for literal in (
+            '"ctx-tab-canonical"',
+            '"ctx-pane-canonical"',
+            '"ctx-tab-diff"',
+            '"ctx-pane-diff"',
+        ):
             assert literal not in ctx_js, (
-                f"un-qualified ID {literal} must not appear — see the"
-                " type-qualified version above"
+                f"un-qualified ID {literal} must not appear — see the type-qualified version above"
             )
 
     def test_detail_tab_keyboard_navigation(self, ctx_js: str) -> None:

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -393,61 +393,73 @@ class TestIssue1073CtxKeyboardSemantics:
     """
 
     # ── Overview tiles ────────────────────────────────────────────────
-    def test_overview_tile_renders_with_button_role(self, ctx_js: str) -> None:
-        # The tile HTML is built in a template literal — pin that the
-        # rendered ``ctx-overview-stat`` element carries ``role="button"``
-        # + ``tabindex="0"`` + an ``aria-label``. Without all three, a
-        # screen-reader user can't reach it (no focus order) and a
-        # keyboard user can't activate it (no tabindex / no name).
-        tile_decl = re.search(
-            r'`<div class="ctx-overview-stat"[^`]*data-tile-key=', ctx_js, re.DOTALL
+    def test_overview_tile_uses_inner_nav_button(self, ctx_js: str) -> None:
+        # PR #1088 review (Codex P2): the navigation control must be a
+        # real ``<button class="ctx-overview-stat-nav">`` *inside* the
+        # tile, NOT ``role=button`` on the outer ``<div>``. Putting the
+        # role on the outer div nests the ``.ctx-overview-pointer``
+        # button children inside a button-role ancestor — invalid ARIA
+        # (interactive content inside ``role=button`` is forbidden) and
+        # inconsistently exposed by assistive tech.
+        outer_match = re.search(
+            r'`<div class="ctx-overview-stat"([^>]*)>\s*\n\s*'
+            r'<button([^`>]*)class="ctx-overview-stat-nav"([^`>]*)>',
+            ctx_js,
+            re.DOTALL,
         )
-        assert tile_decl, "ctx-overview-stat template literal not found"
-        decl = tile_decl.group(0)
-        assert 'role="button"' in decl, (
-            "ctx-overview-stat must render with role=button so screen "
-            "readers announce it as a navigation control, not a generic group"
+        assert outer_match, (
+            "tile must render as a plain <div class='ctx-overview-stat'> "
+            "containing a <button class='ctx-overview-stat-nav'> — see"
+            " PR #1088 review (nested-button regression)."
         )
-        assert 'tabindex="0"' in decl, (
-            "ctx-overview-stat must render with tabindex=0 so keyboard "
-            "users can tab into the overview row"
+        outer_attrs = outer_match.group(1)
+        # ``data-section`` / ``data-tile-key`` stay on the outer div so
+        # existing selectors (test suite, deep-link applier, CSS scoping)
+        # keep working — the click handler reads them via
+        # ``closest('.ctx-overview-stat')``.
+        for marker in ("data-section=", "data-tile-key="):
+            assert marker in outer_attrs, (
+                f"outer .ctx-overview-stat must carry {marker} — "
+                "existing browser-test selectors scope by these attrs"
+            )
+        nav_attrs = outer_match.group(2) + outer_match.group(3)
+        for marker in ('type="button"', "aria-label="):
+            assert marker in nav_attrs, (
+                f"ctx-overview-stat-nav <button> must declare {marker} "
+                "(carries the activation semantics + accessible name)"
+            )
+
+    def test_outer_tile_has_no_role_button(self, ctx_js: str) -> None:
+        # Negative pin: the outer ``.ctx-overview-stat`` <div> must NOT
+        # carry ``role="button"`` / ``tabindex="0"`` — that's what made
+        # the pointer buttons nested-interactive (Codex P2 #1088 review).
+        outer_match = re.search(r'`<div class="ctx-overview-stat"([^>]*)>', ctx_js)
+        assert outer_match, "outer ctx-overview-stat div literal not found"
+        outer_attrs = outer_match.group(1)
+        assert "role=" not in outer_attrs, (
+            "outer .ctx-overview-stat <div> must not carry role= — the "
+            "navigation role belongs on the inner .ctx-overview-stat-nav"
+            " button so pointer descendants aren't nested interactives"
         )
-        assert "aria-label=" in decl, (
-            "ctx-overview-stat must carry an aria-label so screen readers "
-            "announce a meaningful name (kind + dominant status)"
+        assert "tabindex=" not in outer_attrs, (
+            "outer .ctx-overview-stat <div> must not be focusable — only "
+            "the inner nav button is in the keyboard focus order"
         )
 
-    def test_overview_tile_keydown_activates(self, ctx_js: str) -> None:
-        # Anchor on the ``ctx-overview-stat`` querySelectorAll wiring
-        # block and pin a keydown handler exists alongside the click
-        # handler — Enter/Space activation parity is what makes
-        # ``role=button`` honest.
-        loop_start = ctx_js.index("el.querySelectorAll('.ctx-overview-stat').forEach(card => {")
-        loop_end = ctx_js.index("\n  });", loop_start)
-        block = ctx_js[loop_start:loop_end]
-        assert "addEventListener('keydown'" in block, (
-            "ctx-overview-stat must wire a keydown handler — role=button "
-            "without Enter/Space is a screen-reader lie (#1073)"
+    def test_overview_tile_click_wired_to_nav_button(self, ctx_js: str) -> None:
+        # The click handler must target the inner ``.ctx-overview-stat-nav``
+        # selector, not the outer ``.ctx-overview-stat``. Otherwise the
+        # nested-button regression would silently re-appear if someone
+        # restored ``role=button`` on the outer div and re-wired
+        # ``.ctx-overview-stat`` as the click target.
+        assert "el.querySelectorAll('.ctx-overview-stat-nav').forEach" in ctx_js, (
+            "tile click wiring must use the inner .ctx-overview-stat-nav selector (PR #1088 review)"
         )
-        assert "'Enter'" in block and "' '" in block, "keydown handler must accept Enter and Space"
-
-    def test_overview_tile_keydown_skips_nested_pointers(self, ctx_js: str) -> None:
-        # Regression pin (PR #1088 review): tiles render nested
-        # ``.ctx-overview-pointer`` buttons. Without a target guard,
-        # pressing Enter/Space on a pointer button bubbles into the tile
-        # keydown handler, which then ``preventDefault()``s the pointer
-        # button's native click AND fires ``card.click()`` — so keyboard
-        # users could not activate Sync All from the tile's pointer line.
-        loop_start = ctx_js.index("el.querySelectorAll('.ctx-overview-stat').forEach(card => {")
-        loop_end = ctx_js.index("\n  });", loop_start)
-        block = ctx_js[loop_start:loop_end]
-        # Anchor on the actual statement (``if (...) return;``) rather
-        # than the bare expression, since the substring also appears in
-        # the explanatory comment paragraph above the handler.
-        assert re.search(r"if\s*\(\s*e\.target\s*!==\s*card\s*\)\s*return\s*;", block), (
-            "ctx-overview-stat keydown handler must early-return when the "
-            "event target is not the tile itself, so nested pointer "
-            "buttons keep their native keyboard activation (#1088 review)"
+        # Pointer line stays its own wiring loop (sibling, not child).
+        assert "el.querySelectorAll('.ctx-overview-pointer').forEach" in ctx_js, (
+            "pointer-line wiring must remain a separate forEach loop on "
+            ".ctx-overview-pointer so each pointer button keeps its own "
+            "click handler"
         )
 
     # ── Artifact cards (.ctx-card) ────────────────────────────────────
@@ -469,6 +481,52 @@ class TestIssue1073CtxKeyboardSemantics:
         assert "aria-label=" in body and "item.name" in body, (
             "ctx-card aria-label must include the artifact name so screen "
             "readers announce which item the row activates"
+        )
+
+    def test_clickable_ctx_card_aria_label_covers_all_statuses(self, ctx_js: str) -> None:
+        # PR #1088 review (Codex P2): the aria-label must surface every
+        # distinct non-``in sync`` runtime status, not just the
+        # ``out of sync`` case. Otherwise cards with missing target /
+        # missing canonical / parse error / runtime-only would announce
+        # just the artifact name — and aria-label overrides the visible
+        # runtime-badge text for screen readers, so the SR user would
+        # lose the status that explains why the card needs action.
+        render_start = ctx_js.index("function _ctxRenderItemsHtml(")
+        render_end = ctx_js.index("\n}\n", render_start)
+        body = ctx_js[render_start:render_end]
+        # Pin the loop that collects per-runtime statuses via the shared
+        # ``_ctxStatusText`` helper (same source the visible badge uses,
+        # so SR string and visual badge cannot drift).
+        assert re.search(
+            r"for\s*\(\s*const\s+r\s+of\s*\(item\.runtimes.*?\)\s*\)\s*\{[^}]*"
+            r"_ctxStatusText\s*\(\s*r\.status\s*\)",
+            body,
+            re.DOTALL,
+        ), (
+            "ctx-card aria-label builder must iterate ``item.runtimes`` "
+            "and translate each non-in-sync status via ``_ctxStatusText`` "
+            "so SR announce mirrors the visible badge (PR #1088 review)"
+        )
+        # And the runtime-only fallback: ``!item.canonical_path`` must
+        # inject the ``missing canonical`` translation into the status
+        # set so cards with an empty ``runtimes`` list still announce
+        # the runtime-only state.
+        assert re.search(
+            r"!item\.canonical_path[^}]*?_ctxStatusText\s*\(\s*['\"]missing canonical['\"]\s*\)",
+            body,
+            re.DOTALL,
+        ), (
+            "ctx-card aria-label builder must add the localized "
+            "``missing canonical`` text when ``item.canonical_path`` is "
+            "empty, so runtime-only cards announce their state even "
+            "when no per-runtime row carries the status"
+        )
+        # Negative pin: the old ``outOfSync ? ' — out of sync' : ''``
+        # short-circuit MUST be gone — that's what hid the other four
+        # status classes from SR users.
+        assert "' — out of sync'" not in body, (
+            "the legacy single-status aria-label suffix must be removed; "
+            "use the per-runtime status set instead (PR #1088 review)"
         )
 
     def test_clickable_ctx_card_keydown_activates(self, ctx_js: str) -> None:

--- a/packages/memtomem/tests/test_web_a11y.py
+++ b/packages/memtomem/tests/test_web_a11y.py
@@ -16,6 +16,7 @@ _STATIC_DIR = Path(__file__).resolve().parents[1] / "src" / "memtomem" / "web" /
 _APP_JS = _STATIC_DIR / "app.js"
 _INDEX_HTML = _STATIC_DIR / "index.html"
 _TIMELINE_JS = _STATIC_DIR / "timeline.js"
+_CTX_JS = _STATIC_DIR / "context-gateway.js"
 
 
 @pytest.fixture(scope="module")
@@ -34,6 +35,12 @@ def index_html() -> str:
 def timeline_js() -> str:
     assert _TIMELINE_JS.exists(), f"timeline.js missing: {_TIMELINE_JS}"
     return _TIMELINE_JS.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def ctx_js() -> str:
+    assert _CTX_JS.exists(), f"context-gateway.js missing: {_CTX_JS}"
+    return _CTX_JS.read_text(encoding="utf-8")
 
 
 def _extract_function(source: str, name: str) -> str:
@@ -374,4 +381,180 @@ class TestChunkCardA11y:
         assert "chunk-card-actions" in block, (
             "keydown handler must skip when focus is in .chunk-card-actions "
             "(button Enter must not also toggle the parent card)"
+        )
+
+
+class TestIssue1073CtxKeyboardSemantics:
+    """Pin keyboard/screen-reader semantics on Context Gateway clickable
+    rows (issue #1073). Overview tiles, artifact cards, and detail tabs
+    were rendered as clickable ``<div>``s with mouse-only handlers — same
+    defect class as the search/timeline rows in issue #700 but specific
+    to ``context-gateway.js``.
+    """
+
+    # ── Overview tiles ────────────────────────────────────────────────
+    def test_overview_tile_renders_with_button_role(self, ctx_js: str) -> None:
+        # The tile HTML is built in a template literal — pin that the
+        # rendered ``ctx-overview-stat`` element carries ``role="button"``
+        # + ``tabindex="0"`` + an ``aria-label``. Without all three, a
+        # screen-reader user can't reach it (no focus order) and a
+        # keyboard user can't activate it (no tabindex / no name).
+        tile_decl = re.search(
+            r'`<div class="ctx-overview-stat"[^`]*data-tile-key=', ctx_js, re.DOTALL
+        )
+        assert tile_decl, "ctx-overview-stat template literal not found"
+        decl = tile_decl.group(0)
+        assert 'role="button"' in decl, (
+            "ctx-overview-stat must render with role=button so screen "
+            "readers announce it as a navigation control, not a generic group"
+        )
+        assert 'tabindex="0"' in decl, (
+            "ctx-overview-stat must render with tabindex=0 so keyboard "
+            "users can tab into the overview row"
+        )
+        assert "aria-label=" in decl, (
+            "ctx-overview-stat must carry an aria-label so screen readers "
+            "announce a meaningful name (kind + dominant status)"
+        )
+
+    def test_overview_tile_keydown_activates(self, ctx_js: str) -> None:
+        # Anchor on the ``ctx-overview-stat`` querySelectorAll wiring
+        # block and pin a keydown handler exists alongside the click
+        # handler — Enter/Space activation parity is what makes
+        # ``role=button`` honest.
+        loop_start = ctx_js.index("el.querySelectorAll('.ctx-overview-stat').forEach(card => {")
+        loop_end = ctx_js.index("\n  });", loop_start)
+        block = ctx_js[loop_start:loop_end]
+        assert "addEventListener('keydown'" in block, (
+            "ctx-overview-stat must wire a keydown handler — role=button "
+            "without Enter/Space is a screen-reader lie (#1073)"
+        )
+        assert "'Enter'" in block and "' '" in block, "keydown handler must accept Enter and Space"
+
+    # ── Artifact cards (.ctx-card) ────────────────────────────────────
+    def test_clickable_ctx_card_has_button_semantics(self, ctx_js: str) -> None:
+        # _ctxRenderItemsHtml gates a11y attrs on ``clickable``; readonly
+        # cards (other-scope groups) must NOT get role=button. Anchor on
+        # the ternary that builds the attrs.
+        render_start = ctx_js.index("function _ctxRenderItemsHtml(")
+        render_end = ctx_js.index("\n}\n", render_start)
+        body = ctx_js[render_start:render_end]
+        assert 'role="button" tabindex="0"' in body, (
+            "clickable ctx-card must render with role=button + tabindex=0 "
+            "(#1073) so it joins the keyboard focus order"
+        )
+        # The aria-label must be derived from the artifact name (and flag
+        # out-of-sync state) — pinning the substring is enough; an
+        # implementation that aria-labels with a stale string would still
+        # need to read ``item.name``.
+        assert "aria-label=" in body and "item.name" in body, (
+            "ctx-card aria-label must include the artifact name so screen "
+            "readers announce which item the row activates"
+        )
+
+    def test_clickable_ctx_card_keydown_activates(self, ctx_js: str) -> None:
+        # Anchor on the card-wiring loop inside _loadScopeGroupItems
+        # (clickable branch) and pin keydown next to click. Without this,
+        # a SR user hears "button" but pressing Enter does nothing.
+        loop_start = ctx_js.index("container.querySelectorAll('.ctx-card').forEach(card => {")
+        # The forEach body ends at the matching ``});`` — slice generously
+        # and pin both handlers exist within the same block.
+        loop_end = ctx_js.index("\n        });", loop_start)
+        block = ctx_js[loop_start:loop_end]
+        assert "addEventListener('click'" in block, "ctx-card click handler missing"
+        assert "addEventListener('keydown'" in block, (
+            "ctx-card must wire a keydown handler so Enter/Space activate "
+            "the same path as click (#1073)"
+        )
+
+    def test_readonly_ctx_card_skips_button_role(self, ctx_js: str) -> None:
+        # Pin that the a11y attrs are gated on ``clickable`` — a readonly
+        # row would render a focusable button with no handler, which is
+        # worse than a non-focusable div.
+        render_start = ctx_js.index("function _ctxRenderItemsHtml(")
+        render_end = ctx_js.index("\n}\n", render_start)
+        body = ctx_js[render_start:render_end]
+        assert re.search(
+            r"clickable\s*\?\s*'\s*role=\"button\"\s*tabindex=\"0\"'\s*:\s*''",
+            body,
+        ), (
+            "role=button + tabindex must be gated on ``clickable`` so "
+            "readonly other-scope cards don't enter the focus order with "
+            "no activation handler"
+        )
+
+    # ── Detail tabs ───────────────────────────────────────────────────
+    def test_detail_tabs_render_as_tablist(self, ctx_js: str) -> None:
+        # The tabs row must declare role=tablist; each tab must be a
+        # <button role=tab> with aria-selected + aria-controls so the
+        # screen reader announces the tab name AND the panel it controls.
+        assert 'class="ctx-detail-tabs" role="tablist"' in ctx_js, (
+            "ctx-detail-tabs container must declare role=tablist (#1073)"
+        )
+        # Both tab buttons must exist, with aria-controls pointing at
+        # their pane id (canonical / diff).
+        canonical_tab = re.search(
+            r'<button[^>]*class="ctx-detail-tab active"[^>]*data-pane="canonical"[^>]*>',
+            ctx_js,
+        )
+        diff_tab = re.search(
+            r'<button[^>]*class="ctx-detail-tab"[^>]*data-pane="diff"[^>]*>',
+            ctx_js,
+        )
+        assert canonical_tab, "canonical tab must render as <button role=tab>"
+        assert diff_tab, "diff tab must render as <button role=tab>"
+        for label, tag in (("canonical", canonical_tab.group(0)), ("diff", diff_tab.group(0))):
+            assert 'role="tab"' in tag, f"{label} tab missing role=tab"
+            assert 'aria-controls="ctx-pane-' in tag, (
+                f"{label} tab must declare aria-controls pointing at its pane id"
+            )
+            assert "aria-selected=" in tag, (
+                f"{label} tab must declare aria-selected so the SR announces the selected state"
+            )
+            assert "tabindex=" in tag, (
+                f"{label} tab must declare tabindex for the roving focus model"
+            )
+
+    def test_detail_panes_are_tabpanels(self, ctx_js: str) -> None:
+        # Each pane must declare role=tabpanel + aria-labelledby pointing
+        # at its tab, so the SR announces "canonical source, tab panel"
+        # on focus enter.
+        canonical_pane = re.search(
+            r'id="ctx-pane-canonical"[^>]*role="tabpanel"[^>]*aria-labelledby="ctx-tab-canonical"',
+            ctx_js,
+        )
+        diff_pane = re.search(
+            r'id="ctx-pane-diff"[^>]*role="tabpanel"[^>]*aria-labelledby="ctx-tab-diff"',
+            ctx_js,
+        )
+        assert canonical_pane, "canonical pane missing role=tabpanel + aria-labelledby"
+        assert diff_pane, "diff pane missing role=tabpanel + aria-labelledby"
+
+    def test_detail_tab_keyboard_navigation(self, ctx_js: str) -> None:
+        # Arrow nav within the tablist + ARIA state update on activation.
+        # Pin (a) the helper that mutates aria-selected/tabindex on
+        # activation, and (b) a keydown handler that delegates to
+        # ``_arrowNavIndex`` so the tablist follows the same convention
+        # as the main app's ``.tab-nav``.
+        helper_start = ctx_js.index("_activateCtxDetailTab")
+        helper_end = ctx_js.index("\n    };", helper_start)
+        helper = ctx_js[helper_start:helper_end]
+        assert "aria-selected" in helper, (
+            "_activateCtxDetailTab must update aria-selected so the SR "
+            "announce stays in sync with the visual .active class"
+        )
+        assert "tabindex" in helper, (
+            "_activateCtxDetailTab must update tabindex (roving focus model) "
+            "so only the active tab is in the keyboard focus order"
+        )
+        # The arrow-key listener must call _arrowNavIndex (shared helper
+        # in app.js, used by .tab-nav and sources vendor tabs).
+        nav_match = re.search(
+            r"_ctxTabsContainer\.addEventListener\('keydown'.*?_arrowNavIndex",
+            ctx_js,
+            re.DOTALL,
+        )
+        assert nav_match, (
+            "ctx-detail-tabs must wire keydown → _arrowNavIndex so Left/Right/"
+            "Home/End move focus between tabs (#1073)"
         )


### PR DESCRIPTION
## Summary

Closes #1073. Adds keyboard and screen-reader semantics to the three clickable-`<div>` surfaces in the Context Gateway flagged in the 2026-05-19 UI/UX review (#1073, follow-up to #962):

- **Overview tiles** (`.ctx-overview-stat`) — `role="button"`, `tabindex="0"`, composed `aria-label` (dominant badge + kind, e.g. `"12 out of sync — Skills"`), Enter/Space activation.
- **Artifact cards** (`.ctx-card`, clickable variant only) — `role="button"`, `tabindex="0"`, `aria-label` with artifact name + out-of-sync flag, Enter/Space activation. Readonly cards (other-scope groups) stay non-interactive.
- **Detail tabs** (`.ctx-detail-tab`) — promoted to a proper ARIA tablist:
  - Container gets `role="tablist"`.
  - Each tab becomes a real `<button role="tab">` with `aria-controls`, `aria-selected`, and roving `tabindex` (active tab is `0`, others `-1`).
  - Panes get `role="tabpanel"` + `aria-labelledby`.
  - Left/Right/Home/End move focus between tabs (delegates to the existing `_arrowNavIndex` helper used by the main `.tab-nav` and sources vendor tabs).
  - CSS resets `<button>` defaults so the visual matches the prior `<div>` tab; existing global `:focus-visible` rule provides the focus outline.

## Test plan

- [x] `TestIssue1073CtxKeyboardSemantics` in `packages/memtomem/tests/test_web_a11y.py` — 8 source-scan pins covering all three surfaces (role/tabindex/aria-label on tiles + cards, tablist semantics on tabs, keyboard activation + arrow nav, readonly-card gate).
- [x] Mutation-tested: stripping any of the new attributes makes the corresponding pin fail.
- [x] `uv run pytest packages/memtomem/tests/test_web_a11y.py packages/memtomem/tests/web -m "not ollama"` — **188 passed** (31 a11y source-scan + 157 web behavior, including the existing context-gateway browser tests that locate `.ctx-card` / `.ctx-detail-tab` by class — class names preserved).
- [x] `uv run ruff check && uv run ruff format --check` — clean.
- [ ] Manual VoiceOver pass — out of scope for this PR; covered by the human-VO checklist noted on #1062 / #1073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
