### PR TITLE
fix(web): tier-aware Sync All disabled toast for project_local (#1075)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1111,8 +1111,19 @@ window.addEventListener('langchange', () => {
 document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () => {
   const btn = document.getElementById('ctx-sync-all-btn');
   if (btn.dataset.runtimeOnly === 'true') {
-    showToast(t('settings.ctx.sync_all_disabled_tooltip'),
-      'info');
+    // ``_renderCtxOverview`` stamps ``runtimeOnly='true'`` in two cases:
+    // project_local (canonical drafts have no fan-out — ADR-0011 §3 /
+    // ADR-0016 §7) and all-canonicals-empty for any other tier. The
+    // post-click toast must mirror the pre-click hover tooltip's
+    // tier-aware copy choice (already done in ``_renderCtxOverview``
+    // and in the ``langchange`` listener above); otherwise a
+    // project_local user sees "import first" guidance that doesn't
+    // apply, since their canonical drafts may already exist. Issue
+    // #1075 follow-up to #962.
+    const msgKey = _ctxTargetScope === 'project_local'
+      ? 'settings.ctx.project_local_no_fanout_tooltip'
+      : 'settings.ctx.sync_all_disabled_tooltip';
+    showToast(t(msgKey), 'info');
     return;
   }
   const ok = await showConfirm({

--- a/packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs
@@ -97,6 +97,83 @@ describe('Sync All — disabled-state tooltip', () => {
     expect(btn.title).not.toBe('stale tooltip');
   });
 
+  it('toast on click uses project_local copy when the active tier is project_local', async () => {
+    // #1075 / #962: the disabled-state hover title for project_local
+    // says "no runtime fan-out" (canonical drafts only), but the
+    // post-click toast previously hard-coded the generic
+    // ``sync_all_disabled_tooltip`` ("canonicals missing / import
+    // first"). For a project_local user with canonical drafts already
+    // present, that guidance is misleading. Pin the tier-aware toast
+    // copy so the hover/click pair stays consistent.
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubOverviewFetch(window, { allRuntimeOnly: true });
+    await window.I18N.init();
+    await window.loadCtxOverview();
+
+    // Flip to project_local via the tier filter button — this is the
+    // only externally-reachable path to mutate the module-local
+    // ``_ctxTargetScope``. The click handler updates it synchronously
+    // before the (awaited-here) loadCtxOverview re-render runs.
+    const tierBtn = window.document.querySelector(
+      '.ctx-tier-filter button[data-scope="project_local"]'
+    );
+    expect(tierBtn).not.toBeNull();
+    tierBtn.click();
+    // The click schedules a loadCtxOverview but doesn't await it; await
+    // one explicitly so the re-render's project_local branch lands
+    // (``dataset.runtimeOnly='true'`` + project_local hover title).
+    await window.loadCtxOverview();
+
+    const btn = window.document.getElementById('ctx-sync-all-btn');
+    expect(btn.dataset.runtimeOnly).toBe('true');
+    expect(btn.title).toBe(window.I18N.t('settings.ctx.project_local_no_fanout_tooltip'));
+
+    // Click and assert the toast text matches the project_local copy,
+    // not the generic "canonicals missing" message. Toast rendering is
+    // synchronous in ``showToast`` (DOM append before the dismiss
+    // timer), so we can read it back immediately.
+    btn.click();
+    const toastMsg = window.document.querySelector('#toast-container .toast-msg');
+    expect(toastMsg).not.toBeNull();
+    expect(toastMsg.textContent).toBe(
+      window.I18N.t('settings.ctx.project_local_no_fanout_tooltip')
+    );
+    expect(toastMsg.textContent).not.toBe(
+      window.I18N.t('settings.ctx.sync_all_disabled_tooltip')
+    );
+  });
+
+  it('toast on click keeps the generic copy on non-project_local tiers', async () => {
+    // Negative companion to the project_local test above: on
+    // project_shared (default) with everything runtime-only, the toast
+    // must still surface the generic ``sync_all_disabled_tooltip``
+    // ("import first") copy. Without this pin, a future refactor that
+    // accidentally branches both tiers to the project_local copy would
+    // silently slip through.
+    const dom = await bootApp({
+      scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+    });
+    const { window } = dom;
+    stubOverviewFetch(window, { allRuntimeOnly: true });
+    await window.I18N.init();
+    await window.loadCtxOverview();
+
+    const btn = window.document.getElementById('ctx-sync-all-btn');
+    expect(btn.dataset.runtimeOnly).toBe('true');
+    btn.click();
+    const toastMsg = window.document.querySelector('#toast-container .toast-msg');
+    expect(toastMsg).not.toBeNull();
+    expect(toastMsg.textContent).toBe(
+      window.I18N.t('settings.ctx.sync_all_disabled_tooltip')
+    );
+    expect(toastMsg.textContent).not.toBe(
+      window.I18N.t('settings.ctx.project_local_no_fanout_tooltip')
+    );
+  });
+
   it('refreshes title on langchange while the gate is still active', async () => {
     const dom = await bootApp({
       scripts: ['i18n.js', 'app.js', 'context-gateway.js'],


### PR DESCRIPTION
## Summary

- Branch the Sync All disabled-state **toast** (click handler) on `_ctxTargetScope === 'project_local'`, matching the hover `title` already set by `_renderCtxOverview` and refreshed by the `langchange` listener.
- Extend `ctx-sync-all-tooltip.test.mjs` with two pin tests: project_local tier surfaces the `project_local_no_fanout_tooltip` copy on click; default tier with everything runtime-only stays on the generic `sync_all_disabled_tooltip` copy.

Closes #1075. Follow-up to #962.

### Why this is a bug

On `target_scope=project_local`, the Sync All button:

- **Hover (`title`)** → "project_local is a draft tier with no runtime fan-out." ✅
- **Click (toast, before)** → "No canonical artifacts to fan out yet. Click Import in each section first." ❌

The two messages contradict each other. The "import first" guidance is especially misleading because project_local canonical drafts may already exist — import is not the user's next step, the user just needs to know that this tier doesn't fan out at runtime.

### Code references

- `packages/memtomem/src/memtomem/web/static/context-gateway.js:1113` — click handler now mirrors the tier-aware choice already made in `_renderCtxOverview` (line 785) and the `langchange` listener (line 970).

### Test changes

`packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs` gains:

- `toast on click uses project_local copy when the active tier is project_local` — flips to project_local via the tier filter button, clicks Sync All, asserts the toast `.toast-msg` matches the project_local copy and explicitly **not** the generic copy.
- `toast on click keeps the generic copy on non-project_local tiers` — negative pin so a future refactor that accidentally collapses both branches to the project_local copy fails loudly.

Mutation-tested locally by flattening the ternary to `'settings.ctx.sync_all_disabled_tooltip'` on both sides — only the new project_local test fails, all four other tests in the file plus the negative pin keep passing.

## Test plan

- [x] `cd packages/memtomem && npx vitest run tests-js/ctx-sync-all-tooltip.test.mjs` (5 tests pass — 3 prior + 2 new)
- [x] `cd packages/memtomem && npx vitest run` (52 tests / 11 files all pass)
- [x] Mutation check (revert just the ternary → only project_local test fails)
- [ ] Manual: switch to project_local tier in the Context Gateway UI, click Sync All, confirm toast says "project_local is a draft tier with no runtime fan-out." (KO + EN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
