### PR TITLE
fix(web): localize Add Project no_runtime_marker warning toast (#1077)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -2967,7 +2967,24 @@ document.querySelectorAll('.ctx-add-project-btn').forEach(btn => {
           return;
         }
         const data = await r.json();
-        if (data.warning) {
+        // Prefer ``warning_code`` so the toast is localized; fall back to
+        // ``data.warning`` only when the server emitted a code this client
+        // doesn't have a translation for yet. Plain ``data.warning`` would
+        // ship English prose to KO users even though the route already
+        // provides a stable code (#1077 follow-up to #962).
+        const warningKey = data.warning_code
+          ? `settings.ctx.add_project_warning_${data.warning_code}`
+          : null;
+        if (warningKey) {
+          const localized = t(warningKey);
+          // ``t()`` returns the key itself when no translation exists; in
+          // that case fall back to the server prose rather than showing the
+          // bare lookup key to the user.
+          const message = localized === warningKey
+            ? (data.warning || localized)
+            : localized;
+          showToast(message, 'warning');
+        } else if (data.warning) {
           showToast(data.warning, 'warning');
         } else {
           showToast(t('settings.ctx.add_project_success'), 'success');

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1412,7 +1412,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=40"></script>
+  <script src="/context-gateway.js?v=41"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -471,6 +471,7 @@
   "settings.ctx.add_project": "Add Project",
   "settings.ctx.add_project_prompt": "Absolute path to a project root (e.g. /Users/me/Edu/inflearn):",
   "settings.ctx.add_project_success": "Project added",
+  "settings.ctx.add_project_warning_no_runtime_marker": "No .claude/.gemini/.agents/.memtomem directory found under this root.",
   "settings.ctx.remove_project": "Remove project",
   "settings.ctx.confirm_remove_project": "Stop tracking \"{label}\"? Files on disk are unaffected.",
   "settings.ctx.remove": "Remove",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -471,6 +471,7 @@
   "settings.ctx.add_project": "프로젝트 추가",
   "settings.ctx.add_project_prompt": "프로젝트 루트 절대 경로 (예: /Users/me/Edu/inflearn):",
   "settings.ctx.add_project_success": "프로젝트가 추가되었습니다",
+  "settings.ctx.add_project_warning_no_runtime_marker": "이 루트 아래에 .claude/.gemini/.agents/.memtomem 디렉터리를 찾지 못했습니다.",
   "settings.ctx.remove_project": "프로젝트 제거",
   "settings.ctx.confirm_remove_project": "\"{label}\" 추적을 중지하시겠습니까? 디스크상의 파일은 영향받지 않습니다.",
   "settings.ctx.remove": "제거",

--- a/packages/memtomem/tests-js/path-picker-purpose.test.mjs
+++ b/packages/memtomem/tests-js/path-picker-purpose.test.mjs
@@ -1,7 +1,9 @@
 /* Regression guards for purpose-scoped folder picker discovery (#1015). */
 
 import { describe, it, expect } from 'vitest';
-import { bootApp } from './setup/jsdom-app.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import { bootApp, STATIC_DIR } from './setup/jsdom-app.mjs';
 
 function jsonResponse(body, ok = true, status = 200) {
   return {
@@ -94,5 +96,106 @@ describe('Context Gateway Add Project picker', () => {
     expect(optsSeen).toBeTruthy();
     expect(optsSeen.purpose).toBe('project');
     expect(typeof optsSeen.onSelect).toBe('function');
+  });
+
+  async function captureOnSelectToast({ scripts, response, lang }) {
+    // Drive the Add Project ``onSelect`` callback with a stubbed POST
+    // response and read the resulting toast text back from the DOM. The
+    // i18n locale fetch in ``bootApp`` is async, so we await ``I18N.init``
+    // before invoking the callback to make sure ``t()`` resolves to the
+    // real translation map rather than the bare-key fallback.
+    const dom = await bootApp({ scripts });
+    const { window } = dom;
+    await window.I18N.init();
+    if (lang) await window.I18N.setLang(lang);
+
+    const upstream = window.fetch;
+    window.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input?.url || '';
+      if (url === '/api/session') {
+        return { ok: true, status: 200, json: async () => ({ csrf: 'test' }) };
+      }
+      if (url === '/api/context/known-projects') {
+        return { ok: true, status: 200, json: async () => response };
+      }
+      return upstream(input, init);
+    };
+
+    let captured = null;
+    window.PathPicker = {
+      open: (opts) => { captured = opts; },
+    };
+    window.document
+      .querySelector('.ctx-add-project-btn[data-type="skills"]')
+      .dispatchEvent(new window.Event('click', { bubbles: true }));
+    expect(captured).toBeTruthy();
+
+    await captured.onSelect('/tmp/project-a');
+    await waitFor(
+      () => window.document.querySelector('#toast-container .toast-msg'),
+    );
+    const toast = window.document.querySelector('#toast-container .toast-msg');
+    return { window, toast };
+  }
+
+  it('localizes the no_runtime_marker warning instead of showing server prose', async () => {
+    // #1077: the POST /api/context/known-projects route returns a stable
+    // ``warning_code`` ("no_runtime_marker") plus an English ``warning``
+    // string for back-compat. Pre-fix the client showed ``data.warning``
+    // verbatim — Korean users got an English toast. Pin the i18n-aware
+    // branch by stubbing the response with a deliberately-distinct
+    // English prose: the assertion compares against the localized
+    // ``settings.ctx.add_project_warning_no_runtime_marker`` so a future
+    // regression that re-introduces ``data.warning`` would fail.
+    const { window, toast } = await captureOnSelectToast({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js', 'context-gateway.js'],
+      response: {
+        scope_id: 'scope-1',
+        root: '/tmp/project-a',
+        label: 'project-a',
+        warning_code: 'no_runtime_marker',
+        warning: 'ORIGINAL ENGLISH PROSE FROM SERVER',
+      },
+      lang: 'ko',
+    });
+    const koValue = window.I18N.t('settings.ctx.add_project_warning_no_runtime_marker');
+    expect(toast.textContent).toBe(koValue);
+    expect(toast.textContent).not.toBe('ORIGINAL ENGLISH PROSE FROM SERVER');
+    // Symmetric pin (feedback_pin_invert_symmetric_assertion.md): assert
+    // the KO toast differs from the EN locale value too. Without this, a
+    // ko.json regression that copy-pasted the English string into the
+    // same key would still satisfy the ``toast === t()`` equality above
+    // while recreating the user-visible #1077 failure. Read en.json off
+    // disk (``I18N`` keeps its locale cache in a closure) to avoid
+    // coupling the test to specific prose.
+    const enLocale = JSON.parse(
+      fs.readFileSync(path.join(STATIC_DIR, 'locales/en.json'), 'utf-8'),
+    );
+    const enValue = enLocale['settings.ctx.add_project_warning_no_runtime_marker'];
+    expect(enValue).toBeTruthy();
+    expect(koValue).not.toBe(enValue);
+  });
+
+  it('falls back to data.warning when warning_code is unknown to the client', async () => {
+    // Forward-compat guard: a future server may emit a code this client
+    // doesn't have a translation for yet. The fallback shape is "use the
+    // server prose rather than the raw lookup key" — without this branch
+    // users would see a bare ``settings.ctx.add_project_warning_xxx``
+    // string. (The English locale stays the default so we don't need to
+    // setLang here.)
+    const { toast } = await captureOnSelectToast({
+      scripts: ['i18n.js', 'app.js', 'path-picker.js', 'context-gateway.js'],
+      response: {
+        scope_id: 'scope-2',
+        root: '/tmp/project-b',
+        label: 'project-b',
+        warning_code: 'future_unknown_code',
+        warning: 'fallback prose for unknown code',
+      },
+    });
+    expect(toast.textContent).toBe('fallback prose for unknown code');
+    expect(toast.textContent).not.toBe(
+      'settings.ctx.add_project_warning_future_unknown_code',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #1077: `POST /api/context/known-projects` returns a stable `warning_code: "no_runtime_marker"` alongside English prose for back-compat, but `context-gateway.js` displayed `data.warning` verbatim — Korean UI users got an English toast in a core Add Project flow.
- The client now switches on `warning_code` with a `settings.ctx.add_project_warning_<code>` key namespace, and falls back to `data.warning` (not the bare lookup key) when the code is unknown to this client. Added the `no_runtime_marker` translation to both `en.json` and `ko.json`, cache-busted `context-gateway.js?v=40 → v=41`.
- Pins both branches in `path-picker-purpose.test.mjs`:
  - **KO toast** equals the localized key **and** differs from the EN value read off disk (symmetric pin per `feedback_pin_invert_symmetric_assertion.md` — protects against a `ko.json` regression that copy-pastes the English string into the same key).
  - **Unknown `warning_code`** falls back to `data.warning` rather than the bare lookup key.

## Test plan
- [x] `npx vitest run path-picker-purpose.test.mjs` (5/5 passed, +2 new)
- [x] Mutation-test: set `ko.json` value = `en.json` value for the new key → KO test fails on the `koValue !== enValue` symmetric assertion; restored.
- [x] `uv run pytest packages/memtomem/tests/test_web_routes_context_projects.py` (21 passed)
- [x] `uv run pytest packages/memtomem/tests/test_web_mode.py packages/memtomem/tests/test_web_routes.py` (225 passed)
- [x] `uv run ruff check packages/memtomem/src && ruff format --check packages/memtomem/src` (clean)
- [x] EN/KO locale parity preserved (925 keys each, no diff)
- [x] Codex review: `NEEDS-FIX` on under-pinned KO assertion → fixed in this commit; symmetric pin verified by mutation test
