### PR TITLE
fix(web): include root path in remove-project confirm (#1078)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1905,8 +1905,13 @@ async function loadCtxList(type) {
           ev.stopPropagation();
           const ok = await showConfirm({
             title: t('settings.ctx.remove_project'),
+            // Include the full root path so the user can disambiguate
+            // duplicate folder names (e.g. ``Edu/app`` vs ``Work/app``)
+            // at the moment of confirmation — labels alone default to
+            // the basename and Add Project doesn't expose a rename. #1078
             message: t('settings.ctx.confirm_remove_project')
-              .replace('{label}', scope.label),
+              .replace('{label}', scope.label)
+              .replace('{root}', scope.root || scope.scope_id),
             confirmText: t('settings.ctx.remove'),
           });
           if (!ok) return;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1412,7 +1412,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=41"></script>
+  <script src="/context-gateway.js?v=42"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -473,7 +473,7 @@
   "settings.ctx.add_project_success": "Project added",
   "settings.ctx.add_project_warning_no_runtime_marker": "No .claude/.gemini/.agents/.memtomem directory found under this root.",
   "settings.ctx.remove_project": "Remove project",
-  "settings.ctx.confirm_remove_project": "Stop tracking \"{label}\"? Files on disk are unaffected.",
+  "settings.ctx.confirm_remove_project": "Stop tracking \"{label}\" ({root})? Files on disk are unaffected.",
   "settings.ctx.remove": "Remove",
   "settings.ctx.scope_experimental": "experimental",
   "settings.ctx.scope_experimental_tip": "Discovered via the opt-in ~/.claude/projects scan; the path may be misdecoded.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -473,7 +473,7 @@
   "settings.ctx.add_project_success": "프로젝트가 추가되었습니다",
   "settings.ctx.add_project_warning_no_runtime_marker": "이 루트 아래에 .claude/.gemini/.agents/.memtomem 디렉터리를 찾지 못했습니다.",
   "settings.ctx.remove_project": "프로젝트 제거",
-  "settings.ctx.confirm_remove_project": "\"{label}\" 추적을 중지하시겠습니까? 디스크상의 파일은 영향받지 않습니다.",
+  "settings.ctx.confirm_remove_project": "\"{label}\" ({root}) 추적을 중지하시겠습니까? 디스크상의 파일은 영향받지 않습니다.",
   "settings.ctx.remove": "제거",
   "settings.ctx.scope_experimental": "experimental",
   "settings.ctx.scope_experimental_tip": "~/.claude/projects 옵트인 스캔으로 발견된 경로 — 잘못 디코딩되었을 수 있습니다.",


### PR DESCRIPTION
## Summary

- Add the root path to the "Remove project" confirmation message so the user can tell duplicate folder names apart at the moment of deletion (closes #1078).
- Adds a `{root}` placeholder to `settings.ctx.confirm_remove_project` in `en.json` / `ko.json` and threads `scope.root` through the `showConfirm` call in `context-gateway.js`. Bumps the `context-gateway.js?v=` cache buster.

Before:

> Stop tracking "app"? Files on disk are unaffected.

After:

> Stop tracking "app" (/Users/me/Work/app)? Files on disk are unaffected.

The hover-only `title=` on the summary stays as-is — this just stops relying on hover for the destructive step. Optional label entry / rename is out of scope (separate concern, larger UX surface).

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — placeholder parity stays green (47 passed).
- [x] `uv run ruff check && uv run ruff format --check` clean.
- [ ] Manual: register two project roots with the same basename (e.g. `~/a/app` + `~/b/app`) via Add Project, click the `×` on one, confirm dialog now shows the disambiguating root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
