### PR TITLE
a11y(web): aria-label remove-project × button with label + root (#1079)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -1839,8 +1839,16 @@ async function loadCtxList(type) {
       const count = _ctxScopeCount(scope, type);
       const groupId = `ctx-${type}-group-${escapeHtml(scope.scope_id)}`;
       const removable = !_ctxScopeIsServerCwd(scope);
+      // ``×`` is the visible glyph; ``aria-label`` carries the
+      // disambiguating "Remove project {label} ({root})" so screen-reader
+      // users hear which destructive control they're on, and ``title``
+      // mirrors it for sighted hover. Two registrations sharing a
+      // basename (``app`` x2) otherwise read identically. #1079
+      const removeAria = t('settings.ctx.remove_project_aria')
+        .replace('{label}', scope.label)
+        .replace('{root}', scope.root || scope.scope_id);
       const removeBtn = removable
-        ? `<button class="ctx-scope-remove" data-scope-id="${escapeHtml(scope.scope_id)}" title="${escapeHtml(t('settings.ctx.remove_project'))}">×</button>`
+        ? `<button class="ctx-scope-remove" data-scope-id="${escapeHtml(scope.scope_id)}" aria-label="${escapeHtml(removeAria)}" title="${escapeHtml(removeAria)}">×</button>`
         : '';
       // Full root path on the summary's title attribute lets the user
       // disambiguate same-name scopes (``Edu/inflearn`` vs ``Work/inflearn``)

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1412,7 +1412,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=42"></script>
+  <script src="/context-gateway.js?v=43"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -473,6 +473,7 @@
   "settings.ctx.add_project_success": "Project added",
   "settings.ctx.add_project_warning_no_runtime_marker": "No .claude/.gemini/.agents/.memtomem directory found under this root.",
   "settings.ctx.remove_project": "Remove project",
+  "settings.ctx.remove_project_aria": "Remove project {label} ({root})",
   "settings.ctx.confirm_remove_project": "Stop tracking \"{label}\" ({root})? Files on disk are unaffected.",
   "settings.ctx.remove": "Remove",
   "settings.ctx.scope_experimental": "experimental",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -473,6 +473,7 @@
   "settings.ctx.add_project_success": "프로젝트가 추가되었습니다",
   "settings.ctx.add_project_warning_no_runtime_marker": "이 루트 아래에 .claude/.gemini/.agents/.memtomem 디렉터리를 찾지 못했습니다.",
   "settings.ctx.remove_project": "프로젝트 제거",
+  "settings.ctx.remove_project_aria": "프로젝트 {label} ({root}) 제거",
   "settings.ctx.confirm_remove_project": "\"{label}\" ({root}) 추적을 중지하시겠습니까? 디스크상의 파일은 영향받지 않습니다.",
   "settings.ctx.remove": "제거",
   "settings.ctx.scope_experimental": "experimental",


### PR DESCRIPTION
## Summary

- Give the project remove (`×`) button a proper accessible name (closes #1079).
- Adds `settings.ctx.remove_project_aria` = `Remove project {label} ({root})` in en/ko, then sets both `aria-label` and `title` on the button. Visible `×` glyph and click handler unchanged.
- Pairs with #1078 — both surfaces (button label + confirm copy) now include the root so duplicate basenames (`app` x2) are distinguishable for screen-reader users and on hover.

## Test plan

- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — placeholder parity green (47 passed).
- [x] `uv run ruff check` clean.
- [ ] Manual: register two roots with the same basename, Tab through to the `×` buttons, verify VoiceOver / NVDA announces the disambiguating root; hover tooltip mirrors it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
