### PR TITLE
typing(web): drop return-value type-ignore via TypeGuard

### DIFF
--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -9,7 +9,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType
-from typing import Literal, get_args
+from typing import Literal, TypeGuard, get_args
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
@@ -54,6 +54,18 @@ WebMode = Literal["prod", "dev"]
 # (e.g. "preview") in one place updates both type-checking and runtime
 # membership tests — see `feedback_literal_drives_frozenset.md`.
 _VALID_WEB_MODES: frozenset[str] = frozenset(get_args(WebMode))
+
+
+def _is_valid_web_mode(value: str) -> TypeGuard[WebMode]:
+    """Narrow ``str`` to ``WebMode`` when ``value`` matches a known mode.
+
+    Lets ``resolve_web_mode_from_env`` return without ``# type: ignore`` —
+    membership in the runtime ``_VALID_WEB_MODES`` set is now also a
+    type-level narrowing.
+    """
+    return value in _VALID_WEB_MODES
+
+
 _WEB_MODE_ENV = "MEMTOMEM_WEB__MODE"
 
 # CSRF enforcement default flipped to True in RFC #787 stage 2. The env var
@@ -122,8 +134,8 @@ def resolve_web_mode_from_env(*, strict: bool = False) -> WebMode:
     raw = os.environ.get(_WEB_MODE_ENV, "").strip().lower()
     if not raw:
         return "prod"
-    if raw in _VALID_WEB_MODES:
-        return raw  # type: ignore[return-value]
+    if _is_valid_web_mode(raw):
+        return raw
     if strict:
         raise ValueError(
             f"Invalid {_WEB_MODE_ENV}={raw!r}; expected one of {sorted(_VALID_WEB_MODES)}"


### PR DESCRIPTION
## Summary

Drop the `# type: ignore[return-value]` from `resolve_web_mode_from_env()` per #1036 by introducing a small `_is_valid_web_mode` `TypeGuard` that lets the type checker narrow `str` -> `WebMode` at the membership-test site. Runtime behaviour is unchanged; the type ignore is the only thing that goes away.

## Why this matters

The CLAUDE.md "Literal drives frozenset" invariant keeps `_VALID_WEB_MODES` derived from `Literal["prod", "dev"]`, so adding a future mode updates both the type and the runtime check in one place. The membership test `raw in _VALID_WEB_MODES` is correct at runtime, but `frozenset[str]` doesn't carry the `Literal` through narrowing, which is why the `# type: ignore[return-value]` was there.

`TypeGuard` is the canonical way to tell the type checker that a runtime predicate also tightens the inferred type. `_is_valid_web_mode(raw)` returns the same boolean as the inline check; when it returns `True`, mypy now narrows `raw` to `WebMode`, so `return raw` typechecks without the ignore. The `_VALID_WEB_MODES` source-of-truth invariant is preserved exactly - the guard delegates to it.

The fix is local to the file: one extra import (`TypeGuard`), one ~5-line helper, and the two-line swap inside `resolve_web_mode_from_env`.

## Testing

- `uv run ruff check packages/memtomem/src/memtomem/web/app.py` is clean.
- `uv run ruff format --check packages/memtomem/src/memtomem/web/app.py` is clean.
- `uv run mypy packages/memtomem/src/memtomem/web/app.py` reports no issues - the previously-required `type: ignore` is gone and no new errors appear in its place.
- `uv run pytest packages/memtomem/tests/test_web_mode.py` passes (39 cases).

Closes #1036

AI-assisted.
