### PR TITLE
fix(web): surface non-404 /api/context/projects failures (#1080)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -194,10 +194,29 @@ function _ctxNormalizeActiveScope(scopes) {
 
 async function _ctxFetchProjects() {
   let data;
+  // Three failure shapes need to stay distinguishable per #1080:
+  //   - 404 / network throw   → older deployment or absent endpoint; the
+  //     legacy single-server-CWD fallback is the documented contract here,
+  //     so stay silent to avoid noise on intentional-omit deployments.
+  //   - 5xx (and non-404 4xx)  → endpoint exists but is failing; surface a
+  //     non-blocking toast so a broken store doesn't masquerade as "no
+  //     registered projects".
+  //   - 200 with malformed JSON → endpoint reachable, response unreadable;
+  //     same "endpoint exists but failing" class, surface a toast.
+  let warn = null;
   try {
     const res = await fetch(_ctxWithTargetScope('/api/context/projects', { includeScope: false }));
-    if (!res.ok) throw new Error((await res.json().catch(() => ({}))).detail || 'Failed to load projects');
-    data = await res.json();
+    if (!res.ok) {
+      const detail = (await res.json().catch(() => ({}))).detail || `HTTP ${res.status}`;
+      if (res.status !== 404) warn = { kind: 'http', status: res.status, detail };
+      throw new Error(detail);
+    }
+    try {
+      data = await res.json();
+    } catch (parseErr) {
+      warn = { kind: 'parse', detail: String((parseErr && parseErr.message) || parseErr) };
+      throw parseErr;
+    }
   } catch (_err) {
     // Browser tests and older deployments may not provide the multi-project
     // discovery endpoint. Preserve the legacy single-project behavior by
@@ -218,6 +237,9 @@ async function _ctxFetchProjects() {
   }
   _ctxProjectsCache = data.scopes || [];
   _ctxNormalizeActiveScope(_ctxProjectsCache);
+  if (warn && typeof showToast === 'function') {
+    showToast(t('settings.ctx.projects_fetch_failed', { error: warn.detail }), 'error');
+  }
   return data;
 }
 

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1412,7 +1412,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=12"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=43"></script>
+  <script src="/context-gateway.js?v=44"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -345,6 +345,7 @@
   "settings.ctx.project_root_label": "Project",
   "settings.ctx.active_project": "Active project",
   "settings.ctx.server_cwd": "Server CWD",
+  "settings.ctx.projects_fetch_failed": "Project list failed to load — falling back to Server CWD only ({error})",
   "settings.ctx.user_canonical_label": "User canonical",
   "settings.ctx.user_canonical_path": "~/.memtomem/",
   "settings.ctx.runtimes_label": "Runtimes",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -345,6 +345,7 @@
   "settings.ctx.project_root_label": "프로젝트",
   "settings.ctx.active_project": "활성 프로젝트",
   "settings.ctx.server_cwd": "서버 실행 폴더",
+  "settings.ctx.projects_fetch_failed": "프로젝트 목록을 불러오지 못해 서버 실행 폴더로 폴백했습니다 ({error})",
   "settings.ctx.user_canonical_label": "사용자 canonical",
   "settings.ctx.user_canonical_path": "~/.memtomem/",
   "settings.ctx.runtimes_label": "런타임",

--- a/packages/memtomem/tests-js/ctx-project-fetch-failure.test.mjs
+++ b/packages/memtomem/tests-js/ctx-project-fetch-failure.test.mjs
@@ -1,0 +1,138 @@
+/* Regression guard for #1080 — distinguish the three failure shapes of
+ * ``GET /api/context/projects`` instead of silently collapsing them all
+ * onto the Server-CWD-only fallback.
+ *
+ *   - 404 / network throw     → silent fallback (legacy/older-deploy contract)
+ *   - 5xx / non-404 4xx       → toast + fallback (endpoint failing)
+ *   - 200 + malformed JSON    → toast + fallback (response unreadable)
+ *   - 200 + real {scopes:[…]} → no toast, real scopes rendered (baseline)
+ *
+ * The four cells together pin the symmetric pair per
+ * ``feedback_pin_invert_symmetric_assertion.md``: positive-only or
+ * negative-only would false-pass since the bug is "three cases collapsing
+ * to one". The mutation that proves these tests bite is restoring the
+ * original blanket ``catch (_err) { fallback }`` — the 503 / parse cases
+ * then stop toasting.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+const REAL_SCOPES = [
+  {
+    scope_id: '',
+    label: 'Server CWD',
+    root: '/srv',
+    tier: 'project',
+    sources: ['server-cwd'],
+    missing: false,
+    experimental: false,
+    counts: { skills: 0, commands: 0, agents: 0 },
+  },
+  {
+    scope_id: 'proj-abc',
+    label: 'proj-abc',
+    root: '/work/proj-abc',
+    tier: 'project',
+    sources: ['memtomem-config'],
+    missing: false,
+    experimental: false,
+    counts: { skills: 0, commands: 0, agents: 0 },
+  },
+];
+
+function jsonRes(body, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function malformedJsonRes() {
+  // The fix splits ``res.json()`` into its own try/catch — to exercise that
+  // branch we need ``ok: true`` but a ``json()`` that throws like real
+  // browser fetch would on invalid JSON. ``text()`` is included for parity
+  // with the other stubs even though context-gateway never reads it.
+  return {
+    ok: true,
+    status: 200,
+    json: async () => { throw new SyntaxError('Unexpected token < in JSON at position 0'); },
+    text: async () => '<html>oops</html>',
+  };
+}
+
+function installProjectsFetch(window, responder) {
+  const upstream = window.fetch;
+  window.fetch = async (input) => {
+    const url = typeof input === 'string' ? input : input?.url || '';
+    if (url.startsWith('/api/context/projects')) return responder();
+    return upstream(input);
+  };
+}
+
+async function bootWithToastSpy() {
+  const dom = await bootApp({
+    scripts: ['i18n.js', 'app.js', 'context-gateway.js'],
+  });
+  const { window } = dom;
+  // ``showToast`` is a function declaration in app.js so it lives on the
+  // window-global lookup chain; overwriting ``window.showToast`` after
+  // load swaps every later free-reference call site in context-gateway.js
+  // (verified against the existing pattern in
+  // ``search-drag-zone-toast-chunks.test.mjs``).
+  const toasts = [];
+  window.showToast = (msg, level) => { toasts.push({ msg, level }); };
+  return { dom, window, toasts };
+}
+
+describe('_ctxFetchProjects — failure-shape signal split (#1080)', () => {
+  let window;
+  let toasts;
+
+  beforeEach(async () => {
+    ({ window, toasts } = await bootWithToastSpy());
+  });
+
+  it('baseline 200 with real scopes — no toast, scopes rendered as-is', async () => {
+    installProjectsFetch(window, () => jsonRes({ scopes: REAL_SCOPES }));
+    const data = await window._ctxFetchProjects();
+    expect(data.scopes).toHaveLength(2);
+    expect(data.scopes[1].scope_id).toBe('proj-abc');
+    expect(toasts).toHaveLength(0);
+  });
+
+  it('404 — silent fallback to Server CWD (older-deploy contract)', async () => {
+    installProjectsFetch(window, () => jsonRes({ detail: 'not found' }, 404));
+    const data = await window._ctxFetchProjects();
+    expect(data.scopes).toHaveLength(1);
+    expect(data.scopes[0].sources).toEqual(['server-cwd']);
+    // Pin the silent half: 404 must NOT toast, or older deployments / test
+    // stubs that legitimately omit the endpoint would spam users.
+    expect(toasts).toHaveLength(0);
+  });
+
+  it('503 — toast + fallback (endpoint exists but failing)', async () => {
+    installProjectsFetch(window, () => jsonRes({ detail: 'store unavailable' }, 503));
+    const data = await window._ctxFetchProjects();
+    expect(data.scopes).toHaveLength(1);
+    expect(data.scopes[0].sources).toEqual(['server-cwd']);
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].level).toBe('error');
+    expect(toasts[0].msg).toContain('store unavailable');
+  });
+
+  it('200 with malformed JSON — toast + fallback (response unreadable)', async () => {
+    installProjectsFetch(window, () => malformedJsonRes());
+    const data = await window._ctxFetchProjects();
+    expect(data.scopes).toHaveLength(1);
+    expect(data.scopes[0].sources).toEqual(['server-cwd']);
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].level).toBe('error');
+    // Parse-error detail string varies by engine; just pin that *something*
+    // about the failure surfaced (not the empty/raw key fallback).
+    expect(toasts[0].msg).not.toBe('settings.ctx.projects_fetch_failed');
+    expect(toasts[0].msg.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fix #1080 — the ctx-gateway project switcher silently collapses every fetch failure on `GET /api/context/projects` into the legacy Server-CWD-only fallback, so a broken endpoint or unreadable project store looks indistinguishable from "no registered projects".

The catch now splits into three signal classes:

- **404 / network throw** — keep the silent fallback (older-deploy contract the original comment was protecting).
- **5xx and non-404 4xx** — fallback **plus** a non-blocking error toast.
- **200 with malformed JSON** — fallback **plus** a non-blocking error toast (the issue's "unreadable store" framing — endpoint reachable, response unusable).

`_ctxNormalizeActiveScope` still runs against the synthetic scope so a transient 5xx doesn't leave `_ctxActiveScopeId` dangling at a now-absent project. New i18n key `settings.ctx.projects_fetch_failed` lands in both `en.json` and `ko.json` together (the `test_i18n` parity guard would catch a one-locale add). `context-gateway.js?v=43` → `?v=44` so browsers don't keep the silent build cached.

## Test plan

JS-side regression lives in `packages/memtomem/tests-js/ctx-project-fetch-failure.test.mjs` (JSDOM + Vitest, mirroring the `ctx-project-switch-server-cwd.test.mjs` sibling). Symmetric 4-cell pin per `feedback_pin_invert_symmetric_assertion.md`:

| Response                  | Toast | Fallback Server-CWD |
| ------------------------- | :---: | :-----------------: |
| 200 + real `scopes`       |  no   |          —          |
| 404                       |  no   |        yes          |
| 503 (with `detail`)       |  yes  |        yes          |
| 200 + malformed JSON      |  yes  |        yes          |

Mutation-validated: reverting the production code to the prior blanket `catch (_err)` flips the 503 and parse cells to red as expected, while the 200/404 cells stay green.

- [x] `npx vitest run` — 58/58 pass (full tests-js suite)
- [x] `npx vitest run ctx-project-fetch-failure` against pre-fix production code — 503 + parse cells fail as designed; baseline + 404 cells still pass
- [x] `uv run pytest packages/memtomem/tests/test_i18n.py` — 47/47 (locale parity intact for the new key)
- [x] `uv run ruff check packages/memtomem/src && uv run ruff format --check packages/memtomem/src`

## Out of scope

Backend route-side coverage for an actual 5xx on `/api/context/projects` is left for a separate PR; the `tests/web/conftest.py` layer is deliberately API-stubbed and the right place for a SQL-exercising regression is a route test in `tests/test_web_routes_context_projects.py`.

Fixes #1080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
