### PR TITLE
feat(web): promote Custom Commands to prod tier in Context Gateway

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -553,13 +553,9 @@ function _renderCtxOverview(data) {
   const el = qs('ctx-overview-content');
   if (!el) return;
 
-  // Custom Commands sidebar leaf is dev-tier (Anthropic merged
-  // .claude/commands/ into Skills); the overview tile mirrors that —
-  // surfacing it in prod would let users click through and trigger
-  // the dev-only-section toast in switchSettingsSection.
   const types = [
     { key: 'skills',   label: t('settings.ctx.skills_title'),   section: 'ctx-skills' },
-    { key: 'commands', label: t('settings.ctx.commands_title'), section: 'ctx-commands', devOnly: true },
+    { key: 'commands', label: t('settings.ctx.commands_title'), section: 'ctx-commands' },
     { key: 'agents',   label: t('settings.ctx.agents_title'),   section: 'ctx-agents' },
     { key: 'settings', label: t('settings.hooks.title'),        section: 'hooks-sync' },
   ];
@@ -639,7 +635,6 @@ function _renderCtxOverview(data) {
   html += _ctxTierControls('overview');
   html += '<div class="ctx-overview-grid">';
   for (const typ of types) {
-      if (typ.devOnly && STATE.uiMode !== 'dev') continue;
       const d = data[typ.key] || {};
       const total = d.total || 0;
       const inSync = d.in_sync || 0;
@@ -822,13 +817,7 @@ function _renderCtxOverview(data) {
       syncAllBtn.title = t('settings.ctx.project_local_no_fanout_tooltip');
       syncAllBtn.setAttribute('aria-disabled', 'true');
     } else {
-      // Mirror the overview-tile gate: in prod the Custom Commands
-      // surface is hidden, so its missing_canonical count must not
-      // gate the Sync All button (otherwise prod users would see Sync
-      // All disabled because of an artifact set they can't even see).
-      const syncKinds = STATE.uiMode === 'dev'
-        ? ['skills', 'commands', 'agents']
-        : ['skills', 'agents'];
+      const syncKinds = ['skills', 'commands', 'agents'];
       const totals = syncKinds.reduce((acc, k) => {
         const d = data[k] || {};
         acc.total += d.total || 0;
@@ -1175,13 +1164,7 @@ document.getElementById('ctx-sync-all-btn')?.addEventListener('click', async () 
     const headers = csrf
       ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
       : { 'Content-Type': 'application/json' };
-    // Skip the dev-tier Custom Commands surface in prod — calling its
-    // backend route still 200s, but Sync All advertises itself as
-    // synchronizing what the user can see, and the prod sidebar /
-    // overview no longer expose ``ctx-commands``.
-    const types = STATE.uiMode === 'dev'
-      ? ['skills', 'commands', 'agents']
-      : ['skills', 'agents'];
+    const types = ['skills', 'commands', 'agents'];
     for (const typ of types) {
       anyPhaseStarted = true;
       let resp;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -509,7 +509,7 @@
             <span class="nav-sub" data-i18n="settings.nav.ctx_skills_sub">Reusable workflows</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="dev" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-commands" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">⌘</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_commands">Custom Commands</span>

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -1373,9 +1373,10 @@ class TestNoHardcodedStrings:
         """Q-PR2 Drift-3: the Context Gateway dashboard description must
         not enumerate individual tile names. The desc is rendered
         unconditionally via ``data-i18n="settings.ctx.overview_desc"``
-        but the dashboard renders 3 tiles in prod tier and 4 tiles in
-        dev tier (Custom Commands is ``devOnly``), so any enumeration
-        in the desc is wrong in at least one tier.
+        and the tile set evolves over time (Custom Commands graduated
+        from dev to prod alongside Skills/Subagents/Hooks), so any
+        enumeration in the desc is wrong as soon as a tile is added,
+        removed, or renamed.
 
         Word-bounded, case-sensitive, each token checked separately so a
         creative future regression (``"Subagents and Skills"``,
@@ -1385,7 +1386,7 @@ class TestNoHardcodedStrings:
         KO uses substring (not word-bounded) because Korean has no word
         boundary character; ``"훅"`` matches inside ``"훅을"`` etc. — that's
         the desired strictness, since the desc is intentionally
-        tier-agnostic and shouldn't mention the term at all in any
+        tile-agnostic and shouldn't mention the term at all in any
         inflection.
 
         Positive anchors keep ``"Claude Code"`` + ``"Codex"`` in both
@@ -1397,8 +1398,8 @@ class TestNoHardcodedStrings:
         present_en = {t for t in forbidden_en if re.search(rf"\b{t}\b", desc_en)}
         assert not present_en, (
             f"en overview_desc reintroduced tile-name enumeration: "
-            f"{sorted(present_en)} (must stay tier-agnostic so the dev-tier "
-            f"4th 'Custom Commands' tile doesn't make the desc lie)"
+            f"{sorted(present_en)} (must stay tile-agnostic so the desc "
+            f"doesn't lie when the tile set changes)"
         )
 
         forbidden_ko = {"스킬", "서브에이전트", "훅"}
@@ -1406,7 +1407,7 @@ class TestNoHardcodedStrings:
         present_ko = {t for t in forbidden_ko if t in desc_ko}
         assert not present_ko, (
             f"ko overview_desc reintroduced tile-name enumeration: "
-            f"{sorted(present_ko)} (must stay tier-agnostic)"
+            f"{sorted(present_ko)} (must stay tile-agnostic)"
         )
 
         for locale_name, desc in (("en", desc_en), ("ko", desc_ko)):

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -577,50 +577,27 @@ def test_app_js_pins_ui_mode_default_and_toast_copy() -> None:
     css = _read_static("style.css")
     assert ".home-stats-row { display: grid; grid-template-columns: repeat(4, 1fr);" in css
     assert "body.dev-mode .home-stats-row { grid-template-columns: repeat(6, 1fr); }" in css
-    # The Context Gateway tab is fully prod — Skills / Subagents shipped
-    # first, and Hooks (Phase D) graduated via RFC #761 (ADR-0001 §5
-    # readiness criteria). Custom Commands sits on the same Context Gateway
-    # surface but is dev-tier pending an external deprecation signal from
-    # Anthropic on .claude/commands/ (the docs already mark it merged into
-    # Skills as the recommended path). PR #813 mirrors the sidebar tier
-    # gate in three client-side surfaces — overview tile render, Sync All
-    # POST loop, and the runtime-only totals reducer — so prod users
-    # don't see Custom Commands in the overview, can't click through to a
-    # dev-only-section toast, and aren't gated on an artifact set they
-    # can't see. Pin both directions per
-    # ``feedback_pin_invert_symmetric_assertion.md``: positive marker
-    # (the three Custom Commands gate sites must exist) + negative
-    # marker (no *other* dev gate may sneak in alongside them, since
-    # the historical RFC #761 dev gates were intentionally removed).
+    # The Context Gateway tab is fully prod — Skills / Custom Commands /
+    # Subagents / Hooks all live on the same surface and all render in
+    # prod ``mm web``. Custom Commands was previously dev-tier (PR #813)
+    # pending an external Anthropic deprecation signal on
+    # ``.claude/commands/``; that gate has been removed and the surface
+    # is now treated like the other Context Gateway leaves. Pin the
+    # absence of any client-side ``STATE.uiMode`` gate in
+    # ``context-gateway.js`` so a future refactor doesn't silently
+    # reintroduce a tier split that hides artifacts from prod users.
     cg_js = _read_static("context-gateway.js")
     eq_count = cg_js.count("STATE.uiMode === 'dev'")
     ne_count = cg_js.count("STATE.uiMode !== 'dev'")
-    assert (eq_count, ne_count) == (2, 1), (
-        f"context-gateway.js dev-mode gate distribution drifted from "
-        f"(2 ===, 1 !==), got ({eq_count} ===, {ne_count} !==). "
-        "Expected three Custom Commands gate sites: one negation "
-        "(overview tile devOnly skip via ``!==``) and two ternaries "
-        "(syncKinds reducer split + Sync All POST loop split via "
-        "``===``)."
+    assert (eq_count, ne_count) == (0, 0), (
+        f"context-gateway.js must not gate any surface by ``STATE.uiMode``; "
+        f"found {eq_count} ``=== 'dev'`` and {ne_count} ``!== 'dev'`` site(s). "
+        "Custom Commands is no longer dev-tier — adding a new tier gate here "
+        "would hide an artifact category from prod users."
     )
-    # Tie each gate to a specific marker so a future refactor that
-    # collapses the gates into one helper (or accidentally drops one of
-    # the three sites) trips a precise failure rather than a stale-
-    # count drift.
-    assert "if (typ.devOnly && STATE.uiMode !== 'dev') continue;" in cg_js, (
-        "context-gateway.js lost the overview-tile devOnly skip; prod "
-        "users would see Custom Commands and bounce off the dev-only-"
-        "section toast in switchSettingsSection."
-    )
-    assert "syncKinds = STATE.uiMode === 'dev'" in cg_js, (
-        "context-gateway.js lost the runtime-only totals tier split; "
-        "prod users would see Sync All disabled because of an artifact "
-        "category (commands) they can't see."
-    )
-    assert "STATE.uiMode === 'dev'\n      ? ['skills', 'commands', 'agents']" in cg_js, (
-        "context-gateway.js lost the Sync All POST loop tier split; "
-        "Sync All would still POST /api/context/commands/sync in prod "
-        "even though the surface is dev-only."
+    assert "devOnly" not in cg_js, (
+        "context-gateway.js must not reintroduce a ``devOnly`` flag on the "
+        "overview-tile types list; Custom Commands is prod now."
     )
     assert "const chips = runtimes.map" in cg_js, (
         "Context Gateway runtime tags must render from detected_runtimes."
@@ -718,15 +695,11 @@ def test_html_classification_matches_router_lists() -> None:
         # ``hooks-sync`` graduated to prod via RFC #761 (ADR-0001 §5
         # readiness criteria); the section's data-ui-tier was flipped
         # together with the router move.
-        # ``ctx-commands``: sidebar leaf is dev-tier (hidden in
-        # ``mm web`` prod) following Anthropic's IA shift — the official
-        # Claude Code docs mark ``.claude/commands/`` as "merged into
-        # skills" with Skills as the recommended path, but the files
-        # "keep working", so ``context_commands`` is intentionally kept
-        # in ``_PROD_ROUTERS`` to keep the API responsive for existing
-        # users until an explicit deprecation signal lands. UI-only
-        # demote, no router move.
-        "ctx-commands",
+        # ``ctx-commands`` was previously dev-tier (UI-only demote
+        # pending Anthropic's deprecation signal on ``.claude/commands/``)
+        # and has since been promoted to prod alongside Skills/Subagents
+        # — it now lives in the normal Context Gateway surface and is no
+        # longer expected to appear here.
         "harness-sessions",
         "harness-scratch",
         "harness-procedures",

--- a/packages/memtomem/tests/web/test_context_gateway_detail_meta.py
+++ b/packages/memtomem/tests/web/test_context_gateway_detail_meta.py
@@ -131,11 +131,6 @@ def _open_detail(page, kind: str, name: str) -> None:
     """Navigate Settings → ctx-{kind}, wait for the cwd group items to
     render, click the card, await the detail meta header to mount.
     """
-    if kind == "commands":
-        page.wait_for_function(
-            "() => document.body.classList.contains('dev-mode')",
-            timeout=5_000,
-        )
     page.evaluate("() => activateTab('settings')")
     page.evaluate(f"() => switchSettingsSection('ctx-{kind}')")
     # Wait for the cwd group items to populate (it auto-opens because
@@ -205,20 +200,8 @@ def test_agent_detail_chip_row_renders_role_isolation_kind_temperature(
 
 
 def test_command_detail_chip_row_renders_argument_hint_tools_model(page, mm_web_url: str) -> None:
-    """Command detail surfaces argument_hint / allowed_tools / model chips.
-
-    Commands live in the dev tier (``data-ui-tier="dev"``), so the test
-    has to flip the SPA into dev mode — the prod-mode redirect path
-    otherwise bounces ``switchSettingsSection('ctx-commands')`` to the
-    first visible section.
-    """
+    """Command detail surfaces argument_hint / allowed_tools / model chips."""
     install_default_stubs(page)
-    page.route(
-        "**/api/system/ui-mode",
-        lambda r: r.fulfill(
-            status=200, content_type="application/json", body=json.dumps({"mode": "dev"})
-        ),
-    )
     _stub_list_and_detail(page, "commands", _COMMAND_DETAIL)
 
     page.goto(mm_web_url)

--- a/packages/memtomem/tests/web/test_context_gateway_sync_all.py
+++ b/packages/memtomem/tests/web/test_context_gateway_sync_all.py
@@ -181,6 +181,7 @@ def test_sync_all_happy_path_emits_success_toast(page, mm_web_url: str) -> None:
         route.fulfill(status=200, content_type="application/json", body="{}")
 
     page.route("**/api/context/skills/sync", _record_sync)
+    page.route("**/api/context/commands/sync", _record_sync)
     page.route("**/api/context/agents/sync", _record_sync)
 
     def _settings_sync(route):
@@ -234,15 +235,16 @@ def test_sync_all_happy_path_emits_success_toast(page, mm_web_url: str) -> None:
         f"Happy-path toast must be {SYNC_SUCCESS_TOAST!r}, got {toast_text!r}"
     )
 
-    # All three POSTs fired in the prod-mode order: skills → agents → settings.
+    # All four POSTs fired in order: skills → commands → agents → settings.
     # The exact order matters because a regression that reorders or drops one
-    # would surface here. Commands is dev-only and should not appear.
+    # would surface here.
     sync_paths = [u.split("/api/")[-1] for u in sync_calls]
     assert sync_paths == [
         "context/skills/sync",
+        "context/commands/sync",
         "context/agents/sync",
         "context/settings/sync",
-    ], f"Sync All must fire skills→agents→settings in prod, got {sync_paths!r}"
+    ], f"Sync All must fire skills→commands→agents→settings, got {sync_paths!r}"
 
     # After all POSTs the handler calls ``loadCtxOverview()`` (line 510) to
     # refresh the cards. Pin the second GET to catch a regression that drops
@@ -386,6 +388,7 @@ def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
         route.fulfill(status=200, content_type="application/json", body="{}")
 
     page.route("**/api/context/skills/sync", _record_ok)
+    page.route("**/api/context/commands/sync", _record_ok)
     page.route("**/api/context/agents/sync", _agents_fail)
     page.route("**/api/context/settings/sync", _unexpected_settings)
 
@@ -410,7 +413,7 @@ def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
         page.locator("#toast-container .toast.toast-error .toast-msg").text_content() or ""
     ).strip()
     expected = SYNC_PARTIAL_FAILED_TEMPLATE.format(
-        succeeded="Skills",
+        succeeded="Skills, Custom Commands",
         failed_phase="Subagents",
         reason=agents_reason,
     )
@@ -434,6 +437,7 @@ def test_sync_all_mid_run_failure_refreshes_overview_with_partial_toast(
     sync_paths = [u.split("/api/")[-1] for u in sync_calls]
     assert sync_paths == [
         "context/skills/sync",
+        "context/commands/sync",
         "context/agents/sync",
     ], f"Sync All must stop at the failed phase, got {sync_paths!r}"
 
@@ -467,6 +471,10 @@ def test_sync_all_settings_aborted_emits_mtime_conflict_warning(page, mm_web_url
 
     page.route(
         "**/api/context/skills/sync",
+        lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
+    )
+    page.route(
+        "**/api/context/commands/sync",
         lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
     )
     page.route(
@@ -546,6 +554,10 @@ def test_sync_all_settings_error_emits_failure_toast(page, mm_web_url: str) -> N
         lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
     )
     page.route(
+        "**/api/context/commands/sync",
+        lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
+    )
+    page.route(
         "**/api/context/agents/sync",
         lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
     )
@@ -614,6 +626,10 @@ def test_sync_all_settings_needs_confirmation_opens_hooks_sync(page, mm_web_url:
 
     page.route(
         "**/api/context/skills/sync",
+        lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
+    )
+    page.route(
+        "**/api/context/commands/sync",
         lambda r: r.fulfill(status=200, content_type="application/json", body="{}"),
     )
     page.route(

--- a/packages/memtomem/tests/web/test_ui_smoke_matrix.py
+++ b/packages/memtomem/tests/web/test_ui_smoke_matrix.py
@@ -318,9 +318,13 @@ def test_ui_smoke_matrix(page, mode: str, viewport: tuple[int, int]) -> None:
                 assert tab.get_attribute("aria-selected") == "true"
 
         page.locator('.tab-btn[data-tab="context-gateway"]').click()
-        gateway_sections = ["ctx-overview", "ctx-skills", "ctx-agents", "hooks-sync"]
-        if mode == "dev":
-            gateway_sections.insert(2, "ctx-commands")
+        gateway_sections = [
+            "ctx-overview",
+            "ctx-skills",
+            "ctx-commands",
+            "ctx-agents",
+            "hooks-sync",
+        ]
         for section in gateway_sections:
             nav = _ensure_nav_visible(page, "#tab-context-gateway", section)
             assert nav.count() == 1


### PR DESCRIPTION
## Summary

- Promote Custom Commands from dev-only to prod in the Context Gateway sidebar/overview/Sync All, so all four leaves (Skills / Custom Commands / Subagents / Hooks) render uniformly in prod `mm web`.
- The dev gate was introduced in PR #813 as a holding pattern after Anthropic announced `.claude/commands/` was "merged into Skills" — the files still work and users actively maintain command sets, so hiding them in prod created a discoverability gap with no corresponding code-removal.
- Backend `context_commands` router stays in `_PROD_ROUTERS` (no API change); this is purely a UI tier flip.

## Changes

**Production (`packages/memtomem/src/memtomem/web/static/`)**

- `index.html:512` — sidebar nav `data-ui-tier="dev"` → `"prod"`
- `context-gateway.js` — remove all four `STATE.uiMode` / `devOnly` gate sites:
  - overview tile types list `devOnly: true` flag
  - overview render loop `typ.devOnly` skip
  - Sync All runtime-only totals reducer split
  - Sync All POST loop split — always `[skills, commands, agents]`

**Tests**

- `test_web_mode.py` — `STATE.uiMode` gate count pinned to `(0, 0)` with a negative `devOnly` substring pin (symmetric per `feedback_pin_invert_symmetric_assertion.md`); `ctx-commands` dropped from `expected_dev`.
- `test_i18n.py` — overview-desc tile-enumeration guard rationale updated from "tier-agnostic" to "tile-agnostic".
- `test_context_gateway_detail_meta.py` — drop dev-mode forcing in `_open_detail` for `commands`.
- `test_context_gateway_sync_all.py` — mock `commands/sync` at all four sites; update happy-path + partial-failure `sync_paths` to the new `skills→commands→agents→settings` order.
- `test_ui_smoke_matrix.py` — include `ctx-commands` in `gateway_sections` unconditionally.

## Test plan

- [x] `uv run ruff check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run ruff format --check packages/memtomem/src packages/memtomem/tests`
- [x] `uv run pytest packages/memtomem/tests -m "not ollama"` — **5351 passed, 10 skipped, 46 deselected**
- [ ] Manual smoke: `mm web` in prod mode shows Custom Commands sidebar + overview tile + Sync All POSTs `commands/sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
