### PR TITLE
feat(context): fan out hooks to Codex + Gemini runtimes (ADR-0018)

### DIFF
--- a/docs/adr/0018-multi-runtime-hook-fanout.md
+++ b/docs/adr/0018-multi-runtime-hook-fanout.md
@@ -1,0 +1,101 @@
+# ADR-0018: Multi-runtime hook fan-out (Codex + Gemini)
+
+**Status:** Accepted
+**Date:** 2026-05-25
+**Context:** ADR-0010 established the `hooks.target_scope` tiers but fan-out
+was Claude-only (`~/.claude/settings.json`). Codex CLI and Gemini CLI have
+since shipped their own hook systems, so the single canonical
+`.memtomem/settings.json` hooks record can now fan out to all three runtimes —
+the highest-automation-value artifact in the gateway, previously the only one
+locked to one runtime. This ADR records that decision and the conversion
+rules. It **layers onto** ADR-0010 rather than amending it, per the repo
+convention (ADR-0010 §"Considered & rejected" rejects in-place amendment of an
+Accepted ADR; ADR-0007 / ADR-0008 layer onto ADR-0001 the same way).
+
+## Decision
+
+1. **Three generators.** `SETTINGS_GENERATORS` gains `CodexSettingsGenerator`
+   and `GeminiSettingsGenerator` next to `ClaudeSettingsGenerator`. The
+   canonical hooks record (keyed by Claude event name) fans out to:
+
+   | Runtime | user scope | project_shared | project_local |
+   |---|---|---|---|
+   | Claude | `~/.claude/settings.json` | `<proj>/.claude/settings.json` | `<proj>/.claude/settings.local.json` |
+   | Codex  | `~/.codex/hooks.json` | `<proj>/.codex/hooks.json` | — (none) |
+   | Gemini | `~/.gemini/settings.json` | `<proj>/.gemini/settings.json` | — (none) |
+
+2. **Codex is near-identical.** Codex shares Claude's event names and accepts
+   `Bash` / `Edit` / `Write` matchers natively, so it reuses the same
+   `_merge_hooks_record` additive merge as Claude. Events Codex lacks
+   (`Notification`, `SessionEnd`) are dropped with a warning. Codex hooks are
+   written to a dedicated `hooks.json` (the user's `config.toml` is left
+   untouched).
+
+3. **Gemini is a lossy remap** (`_remap_for_gemini`), applied before the shared
+   merge:
+   - *Event map*: `PreToolUse`→`BeforeTool`, `PostToolUse`→`AfterTool`,
+     `SessionStart`, `SessionEnd`, `Notification`, `PreCompact`→`PreCompress`.
+     Plus two **best-effort lifecycle mappings — approximate, not a verified
+     1:1** (Gemini documents no exact analog): `UserPromptSubmit`→`BeforeAgent`
+     (prompt-time context injection) and `Stop`→`AfterAgent` (session/agent
+     close). These preserve those memtomem hook paths on Gemini while
+     acknowledging the firing timing is not formally identical. Canonical
+     events with no Gemini equivalent (`SubagentStop`, `PermissionRequest`)
+     are dropped with a warning.
+   - *Tool-name matcher map* (tool events only): `Bash`→`run_shell_command`,
+     `Edit`/`MultiEdit`→`replace` (Gemini's in-place edit tool), `Write`→
+     `write_file` (whole-file create/overwrite), `Read`→`read_file`. A matcher
+     whose tokens don't all map is dropped with a warning — a hook that can't
+     match its tool would never fire. Empty / separator-only matchers map to
+     `*` (all tools). Handlers gain a synthesized `name` (Gemini hook entries
+     carry one).
+
+4. **No `project_local` fan-out for Codex/Gemini.** `target_file()` returns
+   `None` there, which widens the `SettingsGenerator.target_file` contract to
+   `Path | None`. Every consumer (`generate_all_settings`, `diff_settings`,
+   `host_write_targets`, `detector.detect_settings_files`) treats `None` as
+   *skipped* (no write, not an error).
+
+5. **Lossy conversion is surfaced, never silent.** Every dropped event or
+   matcher produces a message in `SettingsSyncResult.warnings`, shown by the
+   CLI / MCP / Web front-ends. Front-ends must also report a per-runtime
+   `error` / `aborted` status (not just Claude's) — a partial failure is not a
+   success. A `--strict` mode (fail instead of warn) is future work.
+
+## Verification
+
+Mappings were verified against the official docs (2026-05):
+
+- Claude — <https://code.claude.com/docs/en/hooks>
+- Codex — <https://developers.openai.com/codex/hooks> (event names; matchers
+  accept `Bash` / `apply_patch` and the `Edit` / `Write` aliases)
+- Gemini hooks — <https://github.com/google-gemini/gemini-cli/blob/main/docs/hooks/writing-hooks.md>
+  (event list, hook-entry `name`/`type`/`command` shape)
+- Gemini tools — <https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/file-system.md>
+  (`replace` = in-place edit, `write_file` = create/overwrite, `read_file`,
+  `run_shell_command`). The `UserPromptSubmit`→`BeforeAgent` and
+  `Stop`→`AfterAgent` lifecycle mappings are best-effort — Gemini documents no
+  exact analog — see Decision §3.
+
+## Consequences
+
+- Settings is now the only artifact that fans a single canonical record out to
+  three runtimes. The conversion tables in `context/settings.py`
+  (`_GEMINI_EVENT_MAP`, `_GEMINI_TOOL_MAP`, `_CODEX_EVENTS`) are the source of
+  truth and must be extended as the runtimes add events/tools.
+- Gemini fan-out is inherently lossy; the emitted warnings are the contract,
+  not a defect. Users who need 1:1 fidelity author per-runtime hooks directly.
+- Rich Web surfacing of per-runtime conversion status (a runtime-readiness
+  doctor + per-artifact compatibility badges) is intentionally deferred to a
+  follow-up PR. This PR keeps the Web change minimal: the sync result list
+  already renders per-runtime `status` / `warnings` generically, and the
+  Settings hooks Sync button no longer masks a per-runtime `error` / `aborted`
+  as success.
+
+## References
+
+- ADR-0010 — settings hooks target scope (this ADR layers on it).
+- ADR-0001 §1 — canonical = project-scope policy; ADR-0007 / ADR-0008 layering
+  precedent.
+- `packages/memtomem/src/memtomem/context/settings.py` — generators + mapping
+  tables; `tests/test_context_settings_multiruntime.py` — conversion pins.

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -415,11 +415,11 @@ mm context sync --include=skills
 # Fan out .memtomem/agents/<name>.md to .claude/agents/, .gemini/agents/, .codex/agents/
 mm context sync --include=agents
 
-# Fan out .memtomem/commands/<name>.md to .claude/commands/*.md, .gemini/commands/*.toml, and ~/.codex/prompts/*.md
+# Fan out .memtomem/commands/<name>.md to .claude/commands/*.md and .gemini/commands/*.toml
 mm context sync --include=commands
 ```
 
-Sub-agent conversions are lossy for non-Claude targets — Gemini drops `skills` + `isolation`, Codex additionally drops `tools`, `kind`, `temperature`. Slash commands fan out to all three runtimes — Codex keeps `description` / `argument-hint` and the `$ARGUMENTS` placeholder natively, dropping only `allowed-tools` and `model` (Codex custom prompts are upstream-deprecated; prefer a skill for new workflows). memtomem reports every dropped field; add `--strict` to fail if you need 1:1 fidelity. Run `mm context --help` for the full per-runtime field-drop matrix.
+Sub-agent conversions are lossy for non-Claude targets — Gemini drops `skills` + `isolation`, Codex additionally drops `tools`, `kind`, `temperature`. Slash commands fan out to **Claude + Gemini only** — Codex command fan-out is not implemented (Codex custom prompts are upstream-deprecated; use a skill for Codex command-like workflows). memtomem reports every dropped field; add `--strict` to fail if you need 1:1 fidelity. Run `mm context --help` for the full per-runtime field-drop matrix.
 
 ---
 

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -22,12 +22,9 @@ Claude's ``$ARGUMENTS`` placeholder and Gemini's ``{{args}}`` placeholder have
 the same semantics — both substitute the entire user-supplied argument string.
 When fanning out Claude-flavoured canonical → Gemini TOML we rewrite
 ``$ARGUMENTS`` → ``{{args}}``; the reverse import rewrites it back.
-Codex natively supports ``$ARGUMENTS``, ``$1``..``$9``, ``$NAME``, and ``$$``
-(verbatim to Claude's surface), so the canonical body passes through unchanged
-for the Codex target — **no rewrite**. ``!{...}`` shell injection and
-``@{...}`` file embed syntax are Gemini-only advanced features and remain out
-of scope — users who need them can hand-edit ``.gemini/commands/*.toml``
-directly.
+``!{...}`` shell injection and ``@{...}`` file embed syntax are Gemini-only
+advanced features and remain out of scope — users who need them can hand-edit
+``.gemini/commands/*.toml`` directly.
 """
 
 from __future__ import annotations

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -1,19 +1,20 @@
 """Canonical ⇄ runtime slash/custom command fan-out.
 
-Phase 3 (+ Phase 3.5) of the "memtomem as canonical context gateway" plan. A
-slash command lives at ``.memtomem/commands/<name>.md`` with YAML frontmatter
-(Claude Code-compatible superset) and a Markdown body that acts as the prompt
-template. From that single canonical source we fan out to three runtimes:
+Phase 3 of the "memtomem as canonical context gateway" plan. A slash command
+lives at ``.memtomem/commands/<name>.md`` with YAML frontmatter (Claude
+Code-compatible superset) and a Markdown body that acts as the prompt
+template. From that single canonical source we fan out to **two** runtimes:
 
 * ``.claude/commands/<name>.md`` — Claude Code (Markdown + YAML, pass-through)
 * ``.gemini/commands/<name>.toml`` — Gemini CLI (TOML: ``prompt`` + ``description``)
-* ``~/.codex/prompts/<name>.md`` — OpenAI Codex CLI (**user-scope**, Markdown +
-  YAML superset minus ``allowed-tools`` / ``model``)
 
-Codex custom prompts are *upstream-deprecated* — OpenAI recommends migrating
-command-like workflows to **skills** (which memtomem already fans out to Codex
-via ``.agents/skills/`` in Phase 1). Phase 3.5 still provides fan-out for
-parity with the Claude + Gemini pipeline; new workflows should prefer skills.
+Codex commands are **not** fanned out: :data:`COMMAND_GENERATORS` registers
+only Claude + Gemini, and Codex custom prompts (``~/.codex/prompts/*.md``) are
+*upstream-deprecated*. OpenAI recommends migrating command-like workflows to
+**skills**, which memtomem already fans out to Codex via ``.agents/skills/``
+(Phase 1). The runtime fan-out table reserves a ``("commands", "codex", "user")``
+slot so a future ``CodexCommandsGenerator`` can land without churn, but none is
+registered today.
 
 Placeholder normalization
 -------------------------

--- a/packages/memtomem/src/memtomem/context/detector.py
+++ b/packages/memtomem/src/memtomem/context/detector.py
@@ -225,6 +225,8 @@ def detect_settings_files(project_root: Path, scope: str) -> list[DetectedFile]:
         if not gen.is_available(project_root):
             continue
         target = gen.target_file(project_root, scope)
+        if target is None:
+            continue  # no fan-out target for this (runtime, scope)
         if target.is_file():
             found.append(
                 DetectedFile(

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -44,6 +44,7 @@ Merge semantics
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
@@ -387,8 +388,29 @@ def _map_gemini_matcher(matcher: str) -> tuple[str | None, list[str]]:
     return "|".join(mapped), []
 
 
-def _ensure_gemini_handler_names(handlers: object, event: str, matcher: str) -> list:
-    """Gemini hook handlers carry a ``name``; synthesize a stable one if absent."""
+def _ensure_gemini_handler_names(
+    handlers: object, event: str, matcher: str, original_matcher: str
+) -> list:
+    """Normalize handlers for Gemini: synthesize a ``name`` and rescale ``timeout``.
+
+    Two conversions, both keyed off the canonical (Claude/Codex-shaped) handler:
+
+    * **timeout unit.** Claude/Codex hook timeouts are *seconds*; Gemini's are
+      *milliseconds*. A numeric ``timeout`` is multiplied by 1000 so a canonical
+      ``timeout: 30`` (30s) doesn't become 30ms on Gemini and kill the hook
+      before it can run. ``bool`` (an ``int`` subclass) is left alone.
+    * **stable name.** Gemini exposes ``/hooks disable <name>``, so each handler
+      needs a *distinct* stable name. The slug alone is not enough: distinct
+      Claude matchers can collapse to one Gemini tool (``Edit`` and ``MultiEdit``
+      both map to ``replace``), which previously made two handlers share
+      ``memtomem-<event>-replace-0``. We hash the handler's **canonical
+      identity** — the *original* (pre-remap) matcher, its position in the rule,
+      and the command — *not* the remapped Gemini matcher. So ``Edit`` and
+      ``MultiEdit`` get distinct names even when they run the *same* command,
+      and the hash is content-derived → stable across re-syncs (idempotent).
+      Two byte-identical canonical rules intentionally share a name: they are
+      the same hook, and ``/hooks disable`` should govern both.
+    """
     if not isinstance(handlers, list):
         return []
     out: list = []
@@ -397,8 +419,17 @@ def _ensure_gemini_handler_names(handlers: object, event: str, matcher: str) -> 
         if not isinstance(handler, dict):
             continue
         new_handler = dict(handler)
+        timeout = new_handler.get("timeout")
+        if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
+            new_handler["timeout"] = timeout * 1000
         if not new_handler.get("name"):
-            new_handler["name"] = f"memtomem-{event}-{slug}-{idx}"
+            command = new_handler.get("command")
+            command_str = command if isinstance(command, str) else ""
+            # NUL-delimited so the three fields can't be confused with each
+            # other (e.g. matcher "a" + command "b" vs matcher "a\x00b").
+            identity = f"{original_matcher}\x00{idx}\x00{command_str}"
+            digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:8]
+            new_handler["name"] = f"memtomem-{event}-{slug}-{digest}"
         out.append(new_handler)
     return out
 
@@ -447,7 +478,7 @@ def _remap_for_gemini(contributions: dict) -> tuple[dict, list[str]]:
                     continue
                 new_rule["matcher"] = mapped_matcher
             new_rule["hooks"] = _ensure_gemini_handler_names(
-                rule.get("hooks", []), gemini_event, new_rule.get("matcher", "")
+                rule.get("hooks", []), gemini_event, new_rule.get("matcher", ""), matcher
             )
             out.setdefault(gemini_event, []).append(new_rule)
     return {"hooks": out}, warnings

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -2,14 +2,22 @@
 
 Phase D of the "memtomem as canonical context gateway" plan.  A project's
 canonical settings live at ``.memtomem/settings.json`` with a ``hooks``
-record (keyed by event name).  From that single canonical source we fan
-out to:
+record (keyed by Claude-style event name).  From that single canonical
+source we fan out to each installed runtime's hooks file:
 
 * ``~/.claude/settings.json`` — Claude Code (JSON deep-merge into ``hooks``)
+* ``~/.codex/hooks.json`` — Codex CLI (same event names + record shape as
+  Claude; matchers ``Bash``/``Edit``/``Write`` are accepted natively, so
+  the merge is near-identical — events Codex lacks, ``Notification`` /
+  ``SessionEnd``, are dropped with a warning)
+* ``~/.gemini/settings.json`` — Gemini CLI (event names AND tool-name
+  matchers are remapped — ``PreToolUse``→``BeforeTool``, ``Bash``→
+  ``run_shell_command`` etc.; unmappable events/matchers are dropped with a
+  warning — see :func:`_remap_for_gemini`)
 
-Gemini and Codex have no known settings-file equivalent as of 2026-04-12;
-runtimes can be added by implementing :class:`SettingsGenerator` and
-registering in :data:`SETTINGS_GENERATORS`.
+Codex/Gemini have no ``project_local`` hooks target (``target_file`` returns
+``None`` there).  Additional runtimes can be added by implementing
+:class:`SettingsGenerator` and registering in :data:`SETTINGS_GENERATORS`.
 
 Hooks format (Claude Code ≥ 2.1.104)
 -------------------------------------
@@ -89,8 +97,13 @@ class SettingsGenerator(Protocol):
         """
         ...
 
-    def target_file(self, project_root: Path, scope: str) -> Path:
-        """Return the path to the runtime's settings file for *scope*."""
+    def target_file(self, project_root: Path, scope: str) -> Path | None:
+        """Return the runtime's settings file for *scope*.
+
+        ``None`` means "no runtime fan-out for this (runtime, scope)" —
+        e.g. Codex/Gemini have no ``project_local`` hooks target. Every
+        consumer treats ``None`` as *skipped* (no write, not an error).
+        """
         ...
 
     def canonical_source(self, project_root: Path) -> Path:
@@ -131,6 +144,74 @@ def _register(gen: SettingsGenerator) -> SettingsGenerator:
     return gen
 
 
+def _merge_hooks_record(
+    existing: dict | None,
+    contributions: dict,
+) -> tuple[dict, list[str]]:
+    """Additive merge of record-format ``hooks``.  User rules always win.
+
+    Identity key is ``(event, matcher)``; on a same-key collision with a
+    different payload the user's existing rule is kept and a guided warning
+    is emitted.  Shared by Claude and Codex (identical event names + record
+    shape).  Gemini remaps event/matcher names first via
+    :func:`_remap_for_gemini`, then merges the remapped record through this
+    same function — so the conflict/dedup semantics stay identical across
+    runtimes.
+    """
+    warnings: list[str] = []
+    merged = dict(existing) if existing else {}
+
+    contrib_hooks: dict = contributions.get("hooks", {})
+    if not isinstance(contrib_hooks, dict):
+        contrib_hooks = {}
+    existing_hooks: dict = dict(merged.get("hooks", {}))
+    if not isinstance(existing_hooks, dict):
+        existing_hooks = {}
+
+    for event, rules in contrib_hooks.items():
+        if not isinstance(rules, list):
+            continue
+        if event not in existing_hooks:
+            existing_hooks[event] = list(rules)
+            continue
+
+        # Index existing rules by matcher for conflict detection. Keep
+        # the value as a list, not a single dict — Claude Code allows the
+        # same matcher to appear more than once under one event (e.g. a
+        # user keeping two PostToolUse rules without explicit matchers).
+        # Collapsing to a dict-of-rule means whichever same-matcher rule
+        # comes last silently shadows the rest, so byte-identical
+        # contributions can mismatch and emit a noisy warning.
+        existing_rules: list = list(existing_hooks[event])
+        existing_by_matcher: dict[str, list[dict]] = {}
+        for rule in existing_rules:
+            if isinstance(rule, dict):
+                existing_by_matcher.setdefault(rule.get("matcher", ""), []).append(rule)
+
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            matcher = rule.get("matcher", "")
+            same_matcher = existing_by_matcher.get(matcher, [])
+            if same_matcher:
+                if any(existing == rule for existing in same_matcher):
+                    continue  # already in sync (with at least one)
+                label = f"{event}:{matcher}" if matcher else event
+                warnings.append(
+                    f"Hook rule '{label}' already exists in the target "
+                    f"settings with different config. To use memtomem's "
+                    f"version, remove the existing rule, then re-run "
+                    f"`mm context sync --include=settings`."
+                )
+                continue
+            existing_rules.append(rule)
+
+        existing_hooks[event] = existing_rules
+
+    merged["hooks"] = existing_hooks
+    return merged, warnings
+
+
 @dataclass
 class ClaudeSettingsGenerator:
     """Fan out canonical hooks to ``~/.claude/settings.json``."""
@@ -154,61 +235,292 @@ class ClaudeSettingsGenerator:
         contributions: dict,
     ) -> tuple[dict, list[str]]:
         """Additive merge of record-format ``hooks``.  User rules always win."""
-        warnings: list[str] = []
-        merged = dict(existing) if existing else {}
-
-        contrib_hooks: dict = contributions.get("hooks", {})
-        if not isinstance(contrib_hooks, dict):
-            contrib_hooks = {}
-        existing_hooks: dict = dict(merged.get("hooks", {}))
-        if not isinstance(existing_hooks, dict):
-            existing_hooks = {}
-
-        for event, rules in contrib_hooks.items():
-            if not isinstance(rules, list):
-                continue
-            if event not in existing_hooks:
-                existing_hooks[event] = list(rules)
-                continue
-
-            # Index existing rules by matcher for conflict detection. Keep
-            # the value as a list, not a single dict — Claude Code allows the
-            # same matcher to appear more than once under one event (e.g. a
-            # user keeping two PostToolUse rules without explicit matchers).
-            # Collapsing to a dict-of-rule means whichever same-matcher rule
-            # comes last silently shadows the rest, so byte-identical
-            # contributions can mismatch and emit a noisy warning.
-            existing_rules: list = list(existing_hooks[event])
-            existing_by_matcher: dict[str, list[dict]] = {}
-            for rule in existing_rules:
-                if isinstance(rule, dict):
-                    existing_by_matcher.setdefault(rule.get("matcher", ""), []).append(rule)
-
-            for rule in rules:
-                if not isinstance(rule, dict):
-                    continue
-                matcher = rule.get("matcher", "")
-                same_matcher = existing_by_matcher.get(matcher, [])
-                if same_matcher:
-                    if any(existing == rule for existing in same_matcher):
-                        continue  # already in sync (with at least one)
-                    label = f"{event}:{matcher}" if matcher else event
-                    warnings.append(
-                        f"Hook rule '{label}' already exists in the target "
-                        f"settings with different config. To use memtomem's "
-                        f"version, remove the existing rule, then re-run "
-                        f"`mm context sync --include=settings`."
-                    )
-                    continue
-                existing_rules.append(rule)
-
-            existing_hooks[event] = existing_rules
-
-        merged["hooks"] = existing_hooks
-        return merged, warnings
+        return _merge_hooks_record(existing, contributions)
 
 
 _register(ClaudeSettingsGenerator())
+
+
+# ── Codex + Gemini hook fan-out (ADR-0010 multi-runtime) ─────────────
+#
+# Canonical hook event names are Claude's. Mappings below were verified
+# against official docs this session: code.claude.com/docs/en/hooks,
+# developers.openai.com/codex/hooks, and gemini-cli
+# docs/hooks/writing-hooks.md (event list + tool-name matchers).
+
+# Events Codex understands. Codex shares Claude's event names and accepts
+# Bash/Edit/Write matchers natively, so supported events pass through
+# unchanged; canonical events outside this set (Notification, SessionEnd)
+# are dropped with a warning.
+_CODEX_EVENTS: frozenset[str] = frozenset(
+    {
+        "SessionStart",
+        "SubagentStart",
+        "PreToolUse",
+        "PermissionRequest",
+        "PostToolUse",
+        "PreCompact",
+        "PostCompact",
+        "UserPromptSubmit",
+        "SubagentStop",
+        "Stop",
+    }
+)
+
+# Canonical (Claude) event → Gemini event. Canonical events with no entry
+# here have no Gemini equivalent and are dropped with a warning.
+#
+# ``UserPromptSubmit`` and ``Stop`` are **best-effort lifecycle mappings — not
+# a verified 1:1**. Gemini's docs define no exact analog for either; we map
+# them so memtomem's prompt-time context-injection (UserPromptSubmit) and
+# session-close (Stop) hook paths still fire on Gemini — ``BeforeAgent``
+# injects context before agent processing, ``AfterAgent`` runs after the agent
+# completes — while acknowledging the firing timing is approximate, not
+# formally identical (see ADR-0018).
+_GEMINI_EVENT_MAP: dict[str, str] = {
+    "PreToolUse": "BeforeTool",
+    "PostToolUse": "AfterTool",
+    "SessionStart": "SessionStart",
+    "SessionEnd": "SessionEnd",
+    "Notification": "Notification",
+    "PreCompact": "PreCompress",
+    "UserPromptSubmit": "BeforeAgent",  # best-effort — approximate timing
+    "Stop": "AfterAgent",  # best-effort — approximate timing
+}
+
+# Gemini events whose matcher is a *tool name* (matcher must be remapped);
+# other Gemini events take their matcher through unchanged.
+_GEMINI_TOOL_EVENTS: frozenset[str] = frozenset({"BeforeTool", "AfterTool", "BeforeToolSelection"})
+
+# Claude tool token → Gemini built-in tool name. Claude matchers are
+# tool-name regexes (e.g. "Edit|Write"); each pipe-delimited token is
+# mapped. A token with no entry here makes the hook undeliverable (it could
+# never fire), so the rule is dropped with a warning rather than emitted.
+_GEMINI_TOOL_MAP: dict[str, str] = {
+    "Bash": "run_shell_command",
+    # Gemini's in-place edit tool is ``replace``; ``write_file`` is whole-file
+    # create/overwrite. Claude Edit/MultiEdit are surgical edits → ``replace``;
+    # Claude Write (full file) → ``write_file``. Verified against gemini-cli
+    # docs/tools/file-system.md.
+    "Edit": "replace",
+    "MultiEdit": "replace",
+    "Write": "write_file",
+    "Read": "read_file",
+}
+
+
+def _codex_target_file(project_root: Path, scope: str) -> Path | None:
+    """Codex hooks file per scope. ``project_local`` has no fan-out (``None``)."""
+    if scope == "user":
+        return Path.home() / ".codex" / "hooks.json"
+    if scope == "project_shared":
+        return project_root / ".codex" / "hooks.json"
+    if scope == "project_local":
+        return None
+    raise ValueError(f"Unknown target_scope: {scope!r}")
+
+
+def _gemini_target_file(project_root: Path, scope: str) -> Path | None:
+    """Gemini settings file per scope. ``project_local`` has no fan-out (``None``)."""
+    if scope == "user":
+        return Path.home() / ".gemini" / "settings.json"
+    if scope == "project_shared":
+        return project_root / ".gemini" / "settings.json"
+    if scope == "project_local":
+        return None
+    raise ValueError(f"Unknown target_scope: {scope!r}")
+
+
+def _filter_codex_events(contributions: dict) -> tuple[dict, list[str]]:
+    """Drop canonical events Codex doesn't support (Notification, SessionEnd).
+
+    Codex shares Claude's event names and accepts Bash/Edit/Write matchers,
+    so supported events pass through verbatim; only the unsupported ones are
+    dropped, each with a warning.
+    """
+    warnings: list[str] = []
+    src_hooks = contributions.get("hooks", {})
+    if not isinstance(src_hooks, dict):
+        return {"hooks": {}}, warnings
+    out: dict[str, list] = {}
+    for event, rules in src_hooks.items():
+        if event not in _CODEX_EVENTS:
+            warnings.append(
+                f"Hook event '{event}' has no Codex equivalent and was dropped "
+                f"from the Codex hooks file. Codex supports: "
+                f"{', '.join(sorted(_CODEX_EVENTS))}."
+            )
+            continue
+        out[event] = rules
+    return {"hooks": out}, warnings
+
+
+def _map_gemini_matcher(matcher: str) -> tuple[str | None, list[str]]:
+    """Map a Claude tool-name matcher to Gemini tool names.
+
+    Returns ``(mapped_matcher, unmapped_tokens)``. An empty matcher (Claude
+    "all tools") maps to ``"*"``. Pipe-delimited tokens are mapped
+    individually and de-duplicated. If *any* token has no Gemini equivalent
+    the rule is undeliverable, so ``unmapped_tokens`` is returned non-empty
+    and ``mapped_matcher`` is ``None`` (the caller drops the rule).
+    """
+    matcher = matcher.strip()
+    if not matcher:
+        return "*", []
+    mapped: list[str] = []
+    unmapped: list[str] = []
+    for raw in matcher.split("|"):
+        token = raw.strip()
+        if not token:
+            continue
+        gemini_tool = _GEMINI_TOOL_MAP.get(token)
+        if gemini_tool is None:
+            unmapped.append(token)
+        elif gemini_tool not in mapped:
+            mapped.append(gemini_tool)
+    if unmapped:
+        return None, unmapped
+    if not mapped:
+        # Separator-only matcher (e.g. "|") — no real tokens to map, so
+        # treat it the same as an empty matcher: all tools ("*").
+        return "*", []
+    return "|".join(mapped), []
+
+
+def _ensure_gemini_handler_names(handlers: object, event: str, matcher: str) -> list:
+    """Gemini hook handlers carry a ``name``; synthesize a stable one if absent."""
+    if not isinstance(handlers, list):
+        return []
+    out: list = []
+    slug = (matcher or "all").replace("|", "-").replace("*", "all")
+    for idx, handler in enumerate(handlers):
+        if not isinstance(handler, dict):
+            continue
+        new_handler = dict(handler)
+        if not new_handler.get("name"):
+            new_handler["name"] = f"memtomem-{event}-{slug}-{idx}"
+        out.append(new_handler)
+    return out
+
+
+def _remap_for_gemini(contributions: dict) -> tuple[dict, list[str]]:
+    """Rewrite canonical (Claude-shaped) hooks into Gemini's settings.json shape.
+
+    Two-stage conversion (verified against gemini-cli writing-hooks.md):
+    event names are remapped (``PreToolUse``→``BeforeTool`` …) and, for
+    tool-matching events, the matcher tool tokens are remapped
+    (``Bash``→``run_shell_command`` …); handlers gain a synthesized
+    ``name``. Anything that can't convert faithfully — an event with no
+    Gemini equivalent, or a matcher whose tokens don't map to a Gemini tool
+    — is dropped and reported in the returned warnings (a hook that can
+    never fire is worse than a clear warning).
+    """
+    warnings: list[str] = []
+    src_hooks = contributions.get("hooks", {})
+    if not isinstance(src_hooks, dict):
+        return {"hooks": {}}, warnings
+    out: dict[str, list] = {}
+    for event, rules in src_hooks.items():
+        gemini_event = _GEMINI_EVENT_MAP.get(event)
+        if gemini_event is None:
+            warnings.append(
+                f"Hook event '{event}' has no Gemini equivalent and was dropped. "
+                f"Gemini supports: {', '.join(sorted(_GEMINI_EVENT_MAP))}."
+            )
+            continue
+        if not isinstance(rules, list):
+            continue
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            matcher = rule.get("matcher", "")
+            new_rule = dict(rule)
+            if gemini_event in _GEMINI_TOOL_EVENTS:
+                mapped_matcher, unmapped = _map_gemini_matcher(matcher)
+                if mapped_matcher is None:
+                    warnings.append(
+                        f"Hook '{event}:{matcher}' matcher token(s) "
+                        f"{', '.join(unmapped)} have no Gemini tool equivalent; "
+                        f"rule dropped (would never fire). Known tools: "
+                        f"{', '.join(sorted(set(_GEMINI_TOOL_MAP.values())))}."
+                    )
+                    continue
+                new_rule["matcher"] = mapped_matcher
+            new_rule["hooks"] = _ensure_gemini_handler_names(
+                rule.get("hooks", []), gemini_event, new_rule.get("matcher", "")
+            )
+            out.setdefault(gemini_event, []).append(new_rule)
+    return {"hooks": out}, warnings
+
+
+@dataclass
+class CodexSettingsGenerator:
+    """Fan out canonical hooks to Codex's ``hooks.json`` (ADR-0010 multi-runtime).
+
+    Codex shares Claude's event names + record shape and accepts
+    ``Bash``/``Edit``/``Write`` matchers natively, so the merge is the same
+    :func:`_merge_hooks_record` Claude uses — only events Codex lacks
+    (``Notification`` / ``SessionEnd``) are dropped with a warning. Writes a
+    dedicated ``hooks.json`` rather than touching the user's ``config.toml``.
+    """
+
+    name: str = "codex_settings"
+
+    def is_available(self, project_root: Path) -> bool:
+        return (Path.home() / ".codex").is_dir() or (project_root / ".codex").is_dir()
+
+    def target_file(self, project_root: Path, scope: str) -> Path | None:
+        return _codex_target_file(project_root, scope)
+
+    def canonical_source(self, project_root: Path) -> Path:
+        return project_root / CANONICAL_SETTINGS_FILE
+
+    def merge(
+        self,
+        existing: dict | None,
+        contributions: dict,
+    ) -> tuple[dict, list[str]]:
+        filtered, drop_warnings = _filter_codex_events(contributions)
+        merged, merge_warnings = _merge_hooks_record(existing, filtered)
+        return merged, drop_warnings + merge_warnings
+
+
+_register(CodexSettingsGenerator())
+
+
+@dataclass
+class GeminiSettingsGenerator:
+    """Fan out canonical hooks to Gemini's ``settings.json`` (ADR-0010 multi-runtime).
+
+    Gemini renames events and matches on its own tool names, so canonical
+    hooks are remapped via :func:`_remap_for_gemini` (dropping anything that
+    can't convert faithfully, with warnings) before the shared additive
+    merge. The merge preserves the user's other ``settings.json`` keys and
+    their own hook rules.
+    """
+
+    name: str = "gemini_settings"
+
+    def is_available(self, project_root: Path) -> bool:
+        return (Path.home() / ".gemini").is_dir() or (project_root / ".gemini").is_dir()
+
+    def target_file(self, project_root: Path, scope: str) -> Path | None:
+        return _gemini_target_file(project_root, scope)
+
+    def canonical_source(self, project_root: Path) -> Path:
+        return project_root / CANONICAL_SETTINGS_FILE
+
+    def merge(
+        self,
+        existing: dict | None,
+        contributions: dict,
+    ) -> tuple[dict, list[str]]:
+        remapped, drop_warnings = _remap_for_gemini(contributions)
+        merged, merge_warnings = _merge_hooks_record(existing, remapped)
+        return merged, drop_warnings + merge_warnings
+
+
+_register(GeminiSettingsGenerator())
 
 
 # ── Helpers ─────────────────────────────────────────────────────────
@@ -256,6 +568,8 @@ def host_write_targets(project_root: Path, *, scope: str) -> list[Path]:
         if not gen.canonical_source(project_root).exists():
             continue
         target = gen.target_file(project_root, scope)
+        if target is None:
+            continue  # no runtime fan-out for this (runtime, scope)
         if not _is_under_project_root(target, project_root):
             pending.append(target)
     return pending
@@ -348,6 +662,12 @@ def generate_all_settings(
         contributions: dict = raw  # type: ignore[assignment]
 
         target_path = gen.target_file(project_root, scope)
+        if target_path is None:
+            results[name] = SettingsSyncResult(
+                status="skipped",
+                reason=f"{name} has no fan-out target for scope {scope!r}",
+            )
+            continue
         if not allow_host_writes and not _is_under_project_root(target_path, project_root):
             results[name] = SettingsSyncResult(
                 status="needs_confirmation",
@@ -434,6 +754,12 @@ def diff_settings(
         contributions: dict = raw  # type: ignore[assignment]
 
         target_path = gen.target_file(project_root, scope)
+        if target_path is None:
+            results[name] = SettingsSyncResult(
+                status="skipped",
+                reason=f"{name} has no fan-out target for scope {scope!r}",
+            )
+            continue
         existing_raw, _ = _read_with_mtime(target_path)
         if existing_raw is _MALFORMED:
             results[name] = SettingsSyncResult(
@@ -471,6 +797,8 @@ sync_all_settings = generate_all_settings
 __all__ = [
     "CANONICAL_SETTINGS_FILE",
     "ClaudeSettingsGenerator",
+    "CodexSettingsGenerator",
+    "GeminiSettingsGenerator",
     "SETTINGS_GENERATORS",
     "SettingsGenerator",
     "SettingsSyncResult",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -873,7 +873,7 @@
   "confirm.hooks_replace_title": "Replace hook rule",
   "confirm.hooks_replace_msg": "Replace your \"{label}\" rule with memtomem's version?",
   "confirm.hooks_sync_title": "Sync settings",
-  "confirm.hooks_sync_msg": "Merge .memtomem/settings.json hooks into ~/.claude/settings.json?",
+  "confirm.hooks_sync_msg": "Merge .memtomem/settings.json hooks into the installed runtimes' settings files (Claude, Codex, and Gemini where present)? This writes user-level config under your home directory.",
 
   "settings.exclude_patterns.builtin_title": "Built-in (read-only)",
   "settings.exclude_patterns.builtin_hint": "cannot be disabled",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -873,7 +873,7 @@
   "confirm.hooks_replace_title": "훅 규칙 교체",
   "confirm.hooks_replace_msg": "\"{label}\" 규칙을 memtomem 버전으로 교체하시겠습니까?",
   "confirm.hooks_sync_title": "설정 동기화",
-  "confirm.hooks_sync_msg": ".memtomem/settings.json 훅을 ~/.claude/settings.json에 병합하시겠습니까?",
+  "confirm.hooks_sync_msg": ".memtomem/settings.json 훅을 설치된 런타임의 설정 파일(Claude, Codex, 그리고 있으면 Gemini)에 병합하시겠습니까? 홈 디렉터리의 사용자 레벨 설정에 기록됩니다.",
 
   "settings.exclude_patterns.builtin_title": "기본 제공 (읽기 전용)",
   "settings.exclude_patterns.builtin_hint": "비활성화할 수 없습니다",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -706,10 +706,12 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
     const headers = csrf
       ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
       : { 'Content-Type': 'application/json' };
-    // The confirm modal IS the host-write trust gate (issue #962). Send
-    // ``allow_host_writes: true`` so the server doesn't re-prompt with
-    // ``needs_confirmation`` for the user-scope ``~/.claude/settings.json``
-    // path — the same gate the CLI confirms interactively
+    // The confirm modal IS the host-write trust gate (issue #962). Its copy
+    // (``confirm.hooks_sync_msg``) discloses that the merge fans out to every
+    // installed runtime's user-scope settings file (Claude/Codex/Gemini,
+    // ADR-0018) — not just ``~/.claude``. Send ``allow_host_writes: true`` so
+    // the server doesn't re-prompt with ``needs_confirmation`` for those host
+    // paths — the same gate the CLI confirms interactively
     // (``cli/context_cmd.py:_confirm_settings_host_writes``).
     const res = await fetch(_hooksScopedUrl('/api/settings-sync'), {
       method: 'POST',

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -722,6 +722,19 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
     }
     const data = await res.json();
     const results = Array.isArray(data.results) ? data.results : [];
+    // Multi-runtime fan-out (Codex/Gemini, ADR-0018): a per-runtime
+    // ``error`` (malformed target JSON) or ``aborted`` (concurrent write)
+    // must NOT be reported as success — same no-silent-failure contract as
+    // the needs_confirmation branch below. Without this a Codex/Gemini
+    // failure would fall through to ``sync_success`` while only Claude
+    // actually synced.
+    const failed = results.filter(r => r.status === 'error' || r.status === 'aborted');
+    if (failed.length) {
+      const detail = failed.map(r => `${r.name}: ${r.reason || r.status}`).join('; ');
+      showToast(t('toast.sync_failed', { error: detail }), 'error');
+      loadHooksSync();
+      return;
+    }
     const needsConfirmation = results.filter(r => r.status === 'needs_confirmation');
     if (needsConfirmation.length) {
       // Defensive branch: the first POST already carried

--- a/packages/memtomem/tests/test_context_settings_multiruntime.py
+++ b/packages/memtomem/tests/test_context_settings_multiruntime.py
@@ -1,0 +1,362 @@
+"""Tests for multi-runtime hook fan-out — Codex + Gemini settings generators.
+
+Companion to ``test_context_settings.py`` (Claude). Pins the ADR-0010
+multi-runtime extension: canonical ``.memtomem/settings.json`` (Claude-shaped
+hooks record) fans out to Codex ``.codex/hooks.json`` (near-identity) and
+Gemini ``.gemini/settings.json`` (event + tool-name remap, drop-with-warning
+for anything that can't convert faithfully).
+
+Mappings were verified against official docs (developers.openai.com/codex/hooks,
+gemini-cli docs/hooks/writing-hooks.md).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from memtomem.context.settings import (
+    CANONICAL_SETTINGS_FILE,
+    CodexSettingsGenerator,
+    GeminiSettingsGenerator,
+    diff_settings,
+    generate_all_settings,
+    host_write_targets,
+)
+
+from .helpers import set_home
+
+
+def _rule(matcher: str = "", command: str = "echo ok", timeout: int = 5000) -> dict:
+    """A single hook rule in canonical (Claude) record format."""
+    return {
+        "matcher": matcher,
+        "hooks": [{"type": "command", "command": command, "timeout": timeout}],
+    }
+
+
+def _canonical(project_root, hooks: dict) -> None:
+    """Write ``.memtomem/settings.json`` with the given ``hooks`` record."""
+    path = project_root / CANONICAL_SETTINGS_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"hooks": hooks}, indent=2) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def all_home(tmp_path, monkeypatch):
+    """Redirect HOME and create ``~/.claude``, ``~/.codex``, ``~/.gemini`` so
+    all three runtimes register as installed."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    for marker in (".claude", ".codex", ".gemini"):
+        (fake_home / marker).mkdir()
+    set_home(monkeypatch, fake_home)
+    return fake_home
+
+
+# ── Codex (near-identity) ───────────────────────────────────────────
+
+
+class TestCodexGenerator:
+    def test_target_file_scopes(self, tmp_path, all_home):
+        gen = CodexSettingsGenerator()
+        assert gen.target_file(tmp_path, "user") == all_home / ".codex" / "hooks.json"
+        assert gen.target_file(tmp_path, "project_shared") == tmp_path / ".codex" / "hooks.json"
+        # Codex has no project_local hooks target.
+        assert gen.target_file(tmp_path, "project_local") is None
+
+    def test_near_identity_fanout(self, tmp_path, all_home):
+        """Supported events + Bash/Edit/Write matchers pass through verbatim."""
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "echo hi")]})
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["codex_settings"].status == "ok"
+
+        written = json.loads((all_home / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        rule = written["hooks"]["PreToolUse"][0]
+        assert rule["matcher"] == "Bash"  # NOT remapped — Codex accepts it natively
+        assert rule["hooks"][0]["command"] == "echo hi"
+
+    def test_unsupported_events_dropped_with_warning(self, tmp_path, all_home):
+        """Events Codex lacks (Notification, SessionEnd) are dropped + warned."""
+        _canonical(
+            tmp_path,
+            {
+                "PreToolUse": [_rule("Bash", "ok")],
+                "Notification": [_rule("", "n")],
+                "SessionEnd": [_rule("", "e")],
+            },
+        )
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        r = results["codex_settings"]
+        assert r.status == "ok"
+
+        written = json.loads((all_home / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        assert "PreToolUse" in written["hooks"]
+        assert "Notification" not in written["hooks"]
+        assert "SessionEnd" not in written["hooks"]
+        assert any("Notification" in w for w in r.warnings)
+        assert any("SessionEnd" in w for w in r.warnings)
+
+    def test_additive_merge_preserves_user_codex_rules(self, tmp_path, all_home):
+        target = all_home / ".codex" / "hooks.json"
+        user_rule = _rule("apply_patch", "user codex")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [user_rule]}}) + "\n", encoding="utf-8"
+        )
+        _canonical(tmp_path, {"PostToolUse": [_rule("Bash", "mm")]})
+
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["codex_settings"].status == "ok"
+
+        written = json.loads(target.read_text(encoding="utf-8"))
+        assert user_rule in written["hooks"]["PostToolUse"]
+        assert any(rr["matcher"] == "Bash" for rr in written["hooks"]["PostToolUse"])
+
+
+# ── Gemini (event + tool-name remap) ─────────────────────────────────
+
+
+class TestGeminiGenerator:
+    def test_target_file_scopes(self, tmp_path, all_home):
+        gen = GeminiSettingsGenerator()
+        assert gen.target_file(tmp_path, "user") == all_home / ".gemini" / "settings.json"
+        assert gen.target_file(tmp_path, "project_shared") == tmp_path / ".gemini" / "settings.json"
+        assert gen.target_file(tmp_path, "project_local") is None
+
+    def test_event_and_tool_name_mapping(self, tmp_path, all_home):
+        _canonical(
+            tmp_path,
+            {
+                "PreToolUse": [_rule("Bash", "b"), _rule("Edit|Write", "w")],
+                "PostToolUse": [_rule("Read", "r")],
+            },
+        )
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["gemini_settings"].status == "ok"
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        # Event names remapped.
+        assert "BeforeTool" in hooks and "AfterTool" in hooks
+        assert "PreToolUse" not in hooks and "PostToolUse" not in hooks
+        # Tool-name matchers remapped: Bash→run_shell_command; Edit|Write→
+        # replace|write_file (Edit = in-place → replace, Write = create → write_file).
+        before_matchers = {rr["matcher"] for rr in hooks["BeforeTool"]}
+        assert before_matchers == {"run_shell_command", "replace|write_file"}
+        assert hooks["AfterTool"][0]["matcher"] == "read_file"
+        # Handler name synthesized (Gemini handlers carry a name).
+        assert hooks["BeforeTool"][0]["hooks"][0].get("name")
+
+    def test_empty_matcher_maps_to_star(self, tmp_path, all_home):
+        _canonical(tmp_path, {"PreToolUse": [_rule("", "all-tools")]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        assert hooks["BeforeTool"][0]["matcher"] == "*"
+
+    def test_lifecycle_events_best_effort_mapped(self, tmp_path, all_home):
+        """UserPromptSubmit→BeforeAgent and Stop→AfterAgent are best-effort
+        lifecycle mappings (approximate timing) — they must be emitted, not
+        dropped, so memtomem's context-injection / session-close hook paths
+        still fire on Gemini."""
+        _canonical(
+            tmp_path,
+            {
+                "UserPromptSubmit": [_rule("", "inject")],
+                "Stop": [_rule("", "close")],
+            },
+        )
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["gemini_settings"].status == "ok"
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        assert "BeforeAgent" in hooks and "AfterAgent" in hooks
+        assert "UserPromptSubmit" not in hooks and "Stop" not in hooks
+
+    def test_unmapped_event_dropped_with_warning(self, tmp_path, all_home):
+        # SubagentStop has no Gemini equivalent (UserPromptSubmit/Stop are now
+        # best-effort-mapped to BeforeAgent/AfterAgent).
+        _canonical(tmp_path, {"SubagentStop": [_rule("", "x")]})
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        r = results["gemini_settings"]
+        assert r.status == "ok"
+        assert any("SubagentStop" in w for w in r.warnings)
+        written = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))
+        assert written.get("hooks", {}) == {}
+
+    def test_unmapped_matcher_token_dropped_with_warning(self, tmp_path, all_home):
+        # WebFetch is a Claude tool with no Gemini equivalent — the rule would
+        # never fire, so it is dropped (not silently emitted with a dead matcher).
+        _canonical(tmp_path, {"PreToolUse": [_rule("WebFetch", "x")]})
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        r = results["gemini_settings"]
+        assert any("WebFetch" in w for w in r.warnings)
+        written = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))
+        assert written.get("hooks", {}) == {}
+
+    def test_preserves_other_settings_keys(self, tmp_path, all_home):
+        target = all_home / ".gemini" / "settings.json"
+        target.write_text(
+            json.dumps({"theme": "dark", "mcpServers": {"x": {"command": "y"}}}) + "\n",
+            encoding="utf-8",
+        )
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "b")]})
+
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["gemini_settings"].status == "ok"
+
+        written = json.loads(target.read_text(encoding="utf-8"))
+        assert written["theme"] == "dark"
+        assert written["mcpServers"] == {"x": {"command": "y"}}
+        assert "BeforeTool" in written["hooks"]
+
+
+# ── None fan-out (project_local) skip semantics ──────────────────────
+
+
+class TestProjectLocalNoneSkip:
+    def test_generate_skips_codex_gemini_at_project_local(self, tmp_path, all_home):
+        (tmp_path / ".claude").mkdir()
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "b")]})
+
+        results = generate_all_settings(tmp_path, scope="project_local", allow_host_writes=False)
+        # Claude has a project_local target (.claude/settings.local.json).
+        assert results["claude_settings"].status == "ok"
+        assert (tmp_path / ".claude" / "settings.local.json").is_file()
+        # Codex/Gemini have no project_local target → skipped, dirs not created.
+        assert results["codex_settings"].status == "skipped"
+        assert "no fan-out target" in results["codex_settings"].reason
+        assert results["gemini_settings"].status == "skipped"
+        assert not (tmp_path / ".codex").exists()
+        assert not (tmp_path / ".gemini").exists()
+
+    def test_diff_skips_codex_gemini_at_project_local(self, tmp_path, all_home):
+        (tmp_path / ".claude").mkdir()
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "b")]})
+
+        results = diff_settings(tmp_path, scope="project_local")
+        assert results["codex_settings"].status == "skipped"
+        assert results["gemini_settings"].status == "skipped"
+
+
+# ── host-write gate across runtimes ──────────────────────────────────
+
+
+class TestHostWriteMultiRuntime:
+    def _setup(self, tmp_path):
+        project = tmp_path / "proj"
+        project.mkdir()
+        canonical = project / CANONICAL_SETTINGS_FILE
+        canonical.parent.mkdir(parents=True)
+        canonical.write_text(
+            json.dumps({"hooks": {"PreToolUse": [_rule("Bash", "b")]}}) + "\n", encoding="utf-8"
+        )
+        return project
+
+    def test_all_three_markers_yields_three_host_paths(self, tmp_path, all_home):
+        project = self._setup(tmp_path)
+        pending = host_write_targets(project, scope="user")
+        assert set(pending) == {
+            all_home / ".claude" / "settings.json",
+            all_home / ".codex" / "hooks.json",
+            all_home / ".gemini" / "settings.json",
+        }
+
+    def test_only_present_markers_are_listed(self, tmp_path, monkeypatch):
+        """``is_available`` skips runtimes with no home/project marker, so the
+        host-write list reflects only installed runtimes."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        (fake_home / ".codex").mkdir()  # only Codex installed
+        set_home(monkeypatch, fake_home)
+
+        project = self._setup(tmp_path)
+        pending = host_write_targets(project, scope="user")
+        assert pending == [fake_home / ".codex" / "hooks.json"]
+
+
+class TestIsAvailable:
+    def test_codex_available_via_project_marker(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        set_home(monkeypatch, fake_home)
+        (tmp_path / ".codex").mkdir()
+        assert CodexSettingsGenerator().is_available(tmp_path) is True
+        assert GeminiSettingsGenerator().is_available(tmp_path) is False
+
+    def test_neither_marker_unavailable(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        set_home(monkeypatch, fake_home)
+        assert CodexSettingsGenerator().is_available(tmp_path) is False
+        assert GeminiSettingsGenerator().is_available(tmp_path) is False
+
+
+# ── End-to-end through the CLI ───────────────────────────────────────
+
+
+class TestCliMultiRuntimeSync:
+    """``mm context sync --include=settings`` fans out to every installed
+    runtime (end-to-end through the CLI wrapper, not just the engine)."""
+
+    def test_sync_fans_out_to_three_runtimes(self, tmp_path, all_home, monkeypatch):
+        from click.testing import CliRunner
+
+        from memtomem.cli.context_cmd import context
+
+        # Project is a sibling of the fake HOME so user-tier targets resolve
+        # *outside* the project root (host writes) — ``--yes`` bypasses the
+        # confirmation that would otherwise block the three home writes.
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / ".git").mkdir()
+        _canonical(project, {"PreToolUse": [_rule("Bash", "echo e2e")]})
+        monkeypatch.chdir(project)
+
+        result = CliRunner().invoke(context, ["sync", "--include=settings", "--yes"])
+        assert result.exit_code == 0, result.output
+
+        assert (all_home / ".claude" / "settings.json").is_file()
+        assert (all_home / ".codex" / "hooks.json").is_file()
+        assert (all_home / ".gemini" / "settings.json").is_file()
+        # Gemini event remap (PreToolUse → BeforeTool) landed end-to-end.
+        gemini = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))
+        assert "BeforeTool" in gemini["hooks"]
+        assert gemini["hooks"]["BeforeTool"][0]["matcher"] == "run_shell_command"
+
+
+# ── _map_gemini_matcher edge cases (Codex review Major 2) ────────────
+
+
+class TestGeminiMatcherEdgeCases:
+    """A whitespace-only or separator-only matcher must map to ``"*"`` (all
+    tools), not an empty string — an empty Gemini matcher is invalid."""
+
+    def test_empty_blank_and_separator_only_map_to_star(self):
+        from memtomem.context.settings import _map_gemini_matcher
+
+        assert _map_gemini_matcher("") == ("*", [])
+        assert _map_gemini_matcher("   ") == ("*", [])
+        assert _map_gemini_matcher("|") == ("*", [])
+        assert _map_gemini_matcher(" | ") == ("*", [])
+
+    def test_real_tokens_still_map_and_dedupe(self):
+        from memtomem.context.settings import _map_gemini_matcher
+
+        assert _map_gemini_matcher("Bash") == ("run_shell_command", [])
+        # Edit and Write map to DIFFERENT Gemini tools (replace vs write_file).
+        assert _map_gemini_matcher("Edit|Write") == ("replace|write_file", [])
+        # Edit and MultiEdit both → replace → deduped to a single token.
+        assert _map_gemini_matcher("Edit|MultiEdit") == ("replace", [])
+
+    def test_unmapped_token_returns_none(self):
+        from memtomem.context.settings import _map_gemini_matcher
+
+        mapped, unmapped = _map_gemini_matcher("WebFetch")
+        assert mapped is None
+        assert unmapped == ["WebFetch"]

--- a/packages/memtomem/tests/test_context_settings_multiruntime.py
+++ b/packages/memtomem/tests/test_context_settings_multiruntime.py
@@ -360,3 +360,96 @@ class TestGeminiMatcherEdgeCases:
         mapped, unmapped = _map_gemini_matcher("WebFetch")
         assert mapped is None
         assert unmapped == ["WebFetch"]
+
+
+# ── Gemini handler normalization (timeout units + name collisions) ───
+
+
+class TestGeminiHandlerNormalization:
+    """Gemini handler config needs two conversions the Claude/Codex paths
+    don't: seconds→ms timeout rescale, and collision-proof synthesized names
+    (distinct Claude matchers can collapse to one Gemini tool)."""
+
+    def test_timeout_seconds_rescaled_to_milliseconds(self, tmp_path, all_home):
+        """Claude/Codex timeouts are seconds; Gemini's are ms. A canonical
+        ``timeout: 30`` (30s) must land as ``30000`` on Gemini — otherwise it
+        would be read as 30ms and kill the hook before it runs."""
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "b", timeout=30)]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        assert hooks["BeforeTool"][0]["hooks"][0]["timeout"] == 30000
+
+    def test_codex_timeout_left_in_seconds(self, tmp_path, all_home):
+        """Codex shares Claude's seconds unit — its timeout must NOT be rescaled."""
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "b", timeout=30)]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        hooks = json.loads((all_home / ".codex" / "hooks.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        assert hooks["PreToolUse"][0]["hooks"][0]["timeout"] == 30
+
+    def test_collapsed_matchers_get_distinct_handler_names(self, tmp_path, all_home):
+        """``Edit`` and ``MultiEdit`` both map to Gemini's ``replace`` tool. Two
+        handlers with DIFFERENT commands must NOT share one synthesized name —
+        Gemini's ``/hooks disable <name>`` would otherwise be ambiguous."""
+        _canonical(
+            tmp_path,
+            {
+                "PreToolUse": [
+                    _rule("Edit", "edit-cmd"),
+                    _rule("MultiEdit", "multiedit-cmd"),
+                ]
+            },
+        )
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        before = hooks["BeforeTool"]
+        # Both rules collapsed onto the same ``replace`` matcher...
+        assert {r["matcher"] for r in before} == {"replace"}
+        # ...but the synthesized handler names are distinct.
+        names = [r["hooks"][0]["name"] for r in before]
+        assert len(names) == 2
+        assert names[0] != names[1]
+
+    def test_collapsed_matchers_same_command_still_distinct(self, tmp_path, all_home):
+        """Even when ``Edit`` and ``MultiEdit`` collapse to ``replace`` AND run
+        the SAME command, the names must differ — the synthesized name hashes
+        the *original* (pre-remap) matcher, not just the command, so
+        ``/hooks disable <name>`` stays unambiguous."""
+        _canonical(
+            tmp_path,
+            {
+                "PreToolUse": [
+                    _rule("Edit", "same-cmd"),
+                    _rule("MultiEdit", "same-cmd"),
+                ]
+            },
+        )
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        names = [r["hooks"][0]["name"] for r in hooks["BeforeTool"]]
+        assert len(names) == 2
+        assert names[0] != names[1], f"same-command collapsed matchers must differ, got {names!r}"
+
+    def test_synthesized_name_is_deterministic_across_syncs(self, tmp_path, all_home):
+        """The command-hash name is stable, so a re-sync is idempotent (no dup
+        rule, no spurious conflict warning)."""
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "stable")]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        first = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))
+
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["gemini_settings"].status == "ok"
+        assert not results["gemini_settings"].warnings
+        second = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))
+        assert first == second  # byte-identical → idempotent

--- a/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
@@ -546,3 +546,26 @@ def test_hooks_sync_runtime_error_not_reported_as_success(page, mm_web_url: str)
         assert msg != "Sync completed", (
             f"a runtime error must NOT show the sync_success toast, got {msg!r}"
         )
+
+
+def test_hooks_sync_confirm_discloses_multiruntime_targets(page, mm_web_url: str) -> None:
+    """ADR-0018: the confirm modal is the host-write trust gate, and the click
+    handler authorizes ``allow_host_writes`` for Codex + Gemini too — not just
+    ``~/.claude``. The modal copy must therefore disclose all three runtimes so
+    the user isn't approving a Claude-only write while silently getting three.
+    """
+    install_default_stubs(page)
+    _stub_settings_sync(page, _OUT_OF_SYNC_GET)
+
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    page.locator("#hooks-sync-btn").click()
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    msg = page.locator("#confirm-message").text_content() or ""
+    assert "Codex" in msg and "Gemini" in msg, (
+        f"consent modal must disclose all fan-out runtimes (Codex/Gemini), got {msg!r}"
+    )

--- a/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
@@ -478,3 +478,71 @@ def test_hooks_sync_needs_confirmation_surfaces_banner(page, mm_web_url: str) ->
             f"needs_confirmation branch must NOT show the sync_success toast, "
             f"got toast text = {msg!r}"
         )
+
+
+def test_hooks_sync_runtime_error_not_reported_as_success(page, mm_web_url: str) -> None:
+    """ADR-0018 multi-runtime fan-out: a per-runtime ``error`` (or
+    ``aborted``) result — e.g. Codex's ``.codex/hooks.json`` is malformed
+    while Claude syncs fine — must surface an error toast and must NOT show
+    the success toast. Pins the no-silent-failure branch PR1 added for the
+    Codex/Gemini statuses (mirror of the needs_confirmation pin above).
+    """
+    install_default_stubs(page)
+
+    def _post(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "results": [
+                        {
+                            "name": "claude_settings",
+                            "status": "ok",
+                            "reason": None,
+                            "warnings": [],
+                            "target": "/fake/.claude/settings.json",
+                        },
+                        {
+                            "name": "codex_settings",
+                            "status": "error",
+                            "reason": "/fake/.codex/hooks.json is not valid JSON",
+                            "warnings": [],
+                            "target": "/fake/.codex/hooks.json",
+                        },
+                    ],
+                    "duplicate_tier_warnings": [],
+                }
+            ),
+        )
+
+    _stub_settings_sync(page, _OUT_OF_SYNC_GET, post_handler=_post)
+
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    page.locator("#hooks-sync-btn").click()
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+    with page.expect_request(
+        lambda req: "/api/settings-sync" in req.url and req.method == "POST",
+        timeout=4_000,
+    ):
+        page.locator("#confirm-ok-btn").click()
+
+    # An error toast must surface and name the failing runtime.
+    err_toast = page.wait_for_selector("#toast-container .toast-error .toast-msg", timeout=4_000)
+    err_text = (err_toast.text_content() or "").strip()
+    assert "codex_settings" in err_text, (
+        f"error toast must name the failing runtime, got {err_text!r}"
+    )
+
+    # The success toast must NOT have fired — silent failure 금지.
+    success_toasts = page.locator("#toast-container .toast-success .toast-msg")
+    for i in range(success_toasts.count()):
+        msg = (success_toasts.nth(i).text_content() or "").strip()
+        assert msg != "Sync completed", (
+            f"a runtime error must NOT show the sync_success toast, got {msg!r}"
+        )


### PR DESCRIPTION
## What

Fan out canonical `.memtomem/settings.json` hooks to **Codex** and **Gemini**, not just Claude. Hooks were the only context-gateway artifact locked to a single runtime; they now fan out to all three from one canonical source. (ADR-0018, layering on ADR-0010.)

Two commits (kept separate for cleaner review/revert/release-notes):
1. `feat(context): fan out hooks to Codex + Gemini runtimes (ADR-0018)`
2. `docs(context): correct Codex command fan-out wording` — drive-by: commands fan out to Claude/Gemini only (no `CodexCommandsGenerator` exists; the docstring + guide claimed otherwise).

## How

- **Codex** (`~/.codex/hooks.json`): same event names + native `Bash`/`Edit`/`Write` matchers → reuses the Claude additive merge; drops `Notification`/`SessionEnd` (unsupported) with a warning.
- **Gemini** (`~/.gemini/settings.json`): event remap (`PreToolUse`→`BeforeTool`…) + tool-name matcher remap (`Bash`→`run_shell_command`, `Edit`/`MultiEdit`→`replace`, `Write`→`write_file`, `Read`→`read_file`) + handler `name` synthesis; unmappable events/matchers dropped with a warning.
  - `UserPromptSubmit`→`BeforeAgent` and `Stop`→`AfterAgent` are **best-effort** lifecycle mappings (approximate timing — Gemini documents no exact analog; recorded as a policy choice in code + ADR-0018, **not** a verified 1:1).
- `SettingsGenerator.target_file()` widened to `Path | None` (Codex/Gemini have no `project_local` hooks target); `generate_all_settings` / `diff_settings` / `host_write_targets` / `detector.detect_settings_files` treat `None` as skipped.
- Web Settings hooks sync no longer masks a per-runtime `error`/`aborted` result as success.

Mappings verified against official docs: Claude (code.claude.com/docs/en/hooks), Codex (developers.openai.com/codex/hooks), Gemini (gemini-cli `docs/hooks/writing-hooks.md` + `docs/tools/file-system.md`).

## Scope / follow-ups (intentional)
- Rich Web surfacing of per-runtime conversion status (runtime-readiness doctor + per-artifact compatibility badges) is **PR2** in the roadmap; this PR keeps the Web change minimal.
- A `--strict` mode (fail instead of warn on lossy conversion) is future work.

## Test plan
- `uv run pytest packages/memtomem/tests/test_context_settings.py packages/memtomem/tests/test_context_settings_multiruntime.py -q` → **88 passed**
- `uv run pytest packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py -q` → **6 passed** (incl. new per-runtime error → no-silent-success pin)
- `uv run ruff check packages/memtomem/src` + `ruff format --check` → clean
- `uv run mypy packages/memtomem/src/memtomem/context/settings.py` → clean

## Review
Codex (3-agent reviewer) round-3 verdict: **SHIP**. Round-1 (silent-failure masking + matcher normalization) and round-2 (Gemini `replace` / lifecycle mapping) were NEEDS-FIX — all resolved and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
