### PR TITLE
feat(context): mark memtomem-owned hook rules so re-sync can update them (ADR-0019)

### DIFF
--- a/docs/adr/0019-hook-rule-ownership-marker.md
+++ b/docs/adr/0019-hook-rule-ownership-marker.md
@@ -61,15 +61,16 @@ an Accepted ADR).
    rule, so memtomem does **not** silently overwrite it (a genuine user rule
    that merely shares a command must not be clobbered). Instead, when an
    unmarked colliding rule shares a `command` with the contribution, the warning
-   is sharpened to "looks like a memtomem-managed rule from a previous version —
-   remove it and re-run sync." After one marked sync, the rule self-updates.
+   explains that it may be a memtomem-managed rule from a previous version and,
+   if so, should be removed before re-running sync. After one marked sync, the
+   rule self-updates.
 
-5. **All Claude write paths agree.** The CLI merge, the web `GET
-   /settings-sync` diff (`_compare_hooks` stamps the canonical before comparing
-   and classifies a differing memtomem-owned target rule as *pending*, not a
-   conflict), and the web `POST /settings-sync/resolve` "use memtomem's version"
-   action all stamp through the one shared helper, so no path writes an unmarked
-   rule.
+5. **All Claude write paths agree.** The CLI merge, settings-migrate target
+   writes, the web `GET /settings-sync` diff (`_compare_hooks` stamps the
+   canonical before comparing and classifies a differing memtomem-owned target
+   rule as *pending*, not a conflict), and the web
+   `POST /settings-sync/resolve` "use memtomem's version" action all stamp
+   through the one shared helper, so no path writes an unmarked rule.
 
 ## Consequences
 
@@ -81,6 +82,10 @@ an Accepted ADR).
 - No new runtime-schema risk: only documented fields are written; the Gemini
   file never receives `statusMessage`, and Claude/Codex never receive a
   Gemini-only field.
+- A user edit inside the reserved marker field is unsupported. The web diff may
+  report a cosmetic-only marker change as already in sync because functional
+  comparison ignores marker-carrier fields; the next sync still rewrites
+  memtomem-owned slots wholesale.
 - One-time upgrade gap: pre-marker rules warn once (command-changed) or after a
   single re-sync (command-unchanged) before they become owned.
 

--- a/docs/adr/0019-hook-rule-ownership-marker.md
+++ b/docs/adr/0019-hook-rule-ownership-marker.md
@@ -1,0 +1,96 @@
+# ADR-0019: Hook-rule ownership marker for idempotent re-sync
+
+**Status:** Accepted
+**Date:** 2026-05-25
+**Context:** ADR-0018 fans the canonical `.memtomem/settings.json` hooks record
+out to Claude / Codex / Gemini through `_merge_hooks_record`, whose conflict
+detection keys on `(event, matcher)` and keeps the existing rule (with a
+warning) on a same-key collision — the "user rules always win" contract. That
+contract cannot tell a *user-authored* rule apart from a rule **memtomem itself
+wrote in a previous release**. So when memtomem's generated output for an
+`(event, matcher)` changes between two releases a user syncs across (a
+`command`, `timeout`, or handler-`name` change), the next
+`mm context sync --include=settings` treats memtomem's own stale rule as a user
+conflict, refuses to update it, and the install stays out-of-sync until the
+user deletes the rule by hand (issue #1110). This ADR records the fix. It
+**layers onto** ADR-0018 rather than amending it, per the repo convention
+(ADR-0018 itself layers onto ADR-0010; ADR-0010 rejects in-place amendment of
+an Accepted ADR).
+
+## Decision
+
+1. **Ownership marker, using only documented handler fields.** memtomem stamps
+   every hook rule it generates with a content-independent ownership marker so
+   re-sync can recognize — and replace — its own rules. A *custom* key (e.g.
+   `_memtomem`) was rejected: the runtime hook schemas do not document
+   tolerance for unknown keys, and a strict validator could reject the entire
+   settings file. The marker therefore reuses officially documented fields:
+
+   | Runtime | Marker field | Reserved value |
+   |---|---|---|
+   | Claude / Codex | command-handler `statusMessage` | prefix `"memtomem · "` |
+   | Gemini | handler `name` | prefix `"memtomem-"` |
+
+   `statusMessage` is the only free-string field both Claude and Codex document
+   on command hooks; Gemini handlers already carry a synthesized `memtomem-`
+   `name` (ADR-0018), so that prefix is reused. Both prefixes are a **reserved
+   namespace**: a rule whose handler `name`/`statusMessage` starts with them is
+   memtomem-owned and will be overwritten on re-sync. Hand-editing such a rule
+   while keeping the prefix loses the edit — to take ownership, drop the marker.
+
+2. **Stamping is idempotent and preserves author text.** `statusMessage` is set
+   to `"memtomem · {event}"` when absent, prefixed (`"memtomem · {text}"`) when
+   the canonical handler already supplies text, and left untouched when already
+   prefixed — a pure, deterministic function of the handler, so an unchanged
+   re-sync is byte-stable. For Gemini, the `memtomem-` `name` is **always
+   (re)stamped**, overriding any canonical-provided `name`, because the name is
+   the ownership marker and memtomem must own it.
+
+3. **Ownership-aware merge.** On a same-`(event, matcher)` collision in
+   `_merge_hooks_record`:
+   - an existing **memtomem-owned** rule is replaced *in place* by the freshly
+     generated contribution (memtomem updates its own rule), while user rules —
+     including a user rule under the same matcher — are preserved verbatim;
+   - an existing **user** rule wins and a guided warning is emitted. Rule
+     equality for the "already in sync" check ignores the marker fields
+     (`_rule_content_equal`) so a user's byte-identical hand-written rule is
+     never flagged as a conflict the moment memtomem stamps its own copy.
+
+4. **Legacy rules: warn, never clobber.** A rule memtomem wrote *before* this
+   shipped carries no marker. On the first post-upgrade sync it is still a user
+   rule, so memtomem does **not** silently overwrite it (a genuine user rule
+   that merely shares a command must not be clobbered). Instead, when an
+   unmarked colliding rule shares a `command` with the contribution, the warning
+   is sharpened to "looks like a memtomem-managed rule from a previous version —
+   remove it and re-run sync." After one marked sync, the rule self-updates.
+
+5. **All Claude write paths agree.** The CLI merge, the web `GET
+   /settings-sync` diff (`_compare_hooks` stamps the canonical before comparing
+   and classifies a differing memtomem-owned target rule as *pending*, not a
+   conflict), and the web `POST /settings-sync/resolve` "use memtomem's version"
+   action all stamp through the one shared helper, so no path writes an unmarked
+   rule.
+
+## Consequences
+
+- memtomem can update its own hook rules across releases without manual user
+  cleanup; the long-standing "user rules always win" contract is unchanged for
+  genuinely user-authored rules.
+- The marker is visible: Claude/Codex users see `memtomem · …` as the hook's
+  spinner message. This is intentional (transparent provenance).
+- No new runtime-schema risk: only documented fields are written; the Gemini
+  file never receives `statusMessage`, and Claude/Codex never receive a
+  Gemini-only field.
+- One-time upgrade gap: pre-marker rules warn once (command-changed) or after a
+  single re-sync (command-unchanged) before they become owned.
+
+## Considered & rejected
+
+- **Custom marker key (`_memtomem: true`).** Simplest and uniform, but the
+  runtime docs don't confirm unknown keys are ignored; a strict validator could
+  reject/ignore the whole settings file and silently break the user's hooks.
+- **Signature-based ownership only** (reuse `settings_doctor`'s
+  `(event, matcher, command-shape)` signature). Zero new fields, but the #1110
+  case is precisely a `command` change, which breaks signature matching — so it
+  cannot recognize the very rules it needs to update. Kept only as the
+  best-effort legacy heuristic in decision 4.

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -225,7 +225,11 @@ def _strip_ownership_markers(rule: dict) -> dict:
 
 
 def _rule_content_equal(a: object, b: object) -> bool:
-    """True if *a* and *b* are functionally equal (ignoring marker-carrier fields)."""
+    """True if *a* and *b* are functionally equal (ignoring marker-carrier fields).
+
+    Shared outside this module by the Web hooks diff and settings-migrate
+    planner; keep its cosmetic-field semantics aligned with merge behavior.
+    """
     if not isinstance(a, dict) or not isinstance(b, dict):
         return a == b
     return _strip_ownership_markers(a) == _strip_ownership_markers(b)
@@ -379,9 +383,10 @@ def _merge_hooks_record(
             contrib_commands = _rule_commands(c)
             if contrib_commands and any(contrib_commands & _rule_commands(u) for u in same_user):
                 warnings.append(
-                    f"Hook rule '{label}' looks like a memtomem-managed rule "
-                    f"from a previous version (same command, no ownership "
-                    f"marker). Remove it, then re-run "
+                    f"Hook rule '{label}' has the same command as a "
+                    f"memtomem-managed rule but no ownership marker. If this "
+                    f"is a memtomem-managed rule from a previous version, "
+                    f"remove it, then re-run "
                     f"`mm context sync --include=settings` to let memtomem "
                     f"update it."
                 )

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -145,19 +145,163 @@ def _register(gen: SettingsGenerator) -> SettingsGenerator:
     return gen
 
 
+# ── Hook-rule ownership marker (ADR-0019) ───────────────────────────
+#
+# memtomem stamps every hook rule it generates with an ownership marker so a
+# later ``mm context sync`` can recognize — and *update* — its own previously
+# emitted rules instead of treating them as user conflicts (issue #1110). The
+# marker uses only **officially documented** handler fields (a custom key risks
+# strict-schema rejection of the whole settings file):
+#   * Gemini handlers carry ``name`` → prefix ``memtomem-`` (synthesized in
+#     :func:`_ensure_gemini_handler_names`).
+#   * Claude/Codex command handlers carry ``statusMessage`` → reserved prefix
+#     ``"memtomem · "`` (stamped by :func:`_stamp_status_markers`).
+# Both prefixes are a *reserved namespace*: a rule whose handler name/
+# statusMessage starts with them is memtomem-owned and will be overwritten on
+# re-sync. Hand-editing such a rule while keeping the prefix loses the edit.
+_MEMTOMEM_NAME_PREFIX = "memtomem-"
+_MEMTOMEM_STATUS_PREFIX = "memtomem · "
+
+
+def _handler_is_memtomem_owned(handler: object) -> bool:
+    """True if *handler* carries a memtomem ownership marker (name/statusMessage)."""
+    if not isinstance(handler, dict):
+        return False
+    name = handler.get("name")
+    if isinstance(name, str) and name.startswith(_MEMTOMEM_NAME_PREFIX):
+        return True
+    status = handler.get("statusMessage")
+    return isinstance(status, str) and status.startswith(_MEMTOMEM_STATUS_PREFIX)
+
+
+def _rule_is_memtomem_owned(rule: object) -> bool:
+    """True if any handler in *rule* is memtomem-owned."""
+    if not isinstance(rule, dict):
+        return False
+    handlers = rule.get("hooks")
+    if not isinstance(handlers, list):
+        return False
+    return any(_handler_is_memtomem_owned(h) for h in handlers)
+
+
+def _rule_commands(rule: object) -> set[str]:
+    """Set of handler ``command`` strings in *rule* (for the legacy-rule heuristic)."""
+    if not isinstance(rule, dict):
+        return set()
+    handlers = rule.get("hooks")
+    if not isinstance(handlers, list):
+        return set()
+    return {
+        h["command"] for h in handlers if isinstance(h, dict) and isinstance(h.get("command"), str)
+    }
+
+
+def _strip_ownership_markers(rule: dict) -> dict:
+    """Return a copy of *rule* with the marker-carrier fields removed.
+
+    Used for *functional* comparison. The marker lives in cosmetic handler
+    fields — ``name`` (Gemini's ``/hooks disable`` handle) and ``statusMessage``
+    (Claude/Codex spinner text) — which do not change what the hook *does*
+    (``type``/``command``/``timeout``/``matcher``). Both are dropped **entirely
+    and symmetrically** so comparison turns purely on hook function. Stripping
+    only the memtomem prefix would be asymmetric: a target with no
+    ``statusMessage`` would compare equal to a stamped contribution while a
+    user's raw pre-stamp ``statusMessage`` would not — hiding/raising conflicts
+    inconsistently (Codex review). A genuine cosmetic-only change to a
+    memtomem-owned rule still propagates: such a rule is replaced wholesale by
+    the merge's in-place owned-slot pass, not gated on this comparison.
+    """
+    handlers = rule.get("hooks")
+    if not isinstance(handlers, list):
+        return rule
+    new_handlers: list = []
+    for h in handlers:
+        if not isinstance(h, dict):
+            new_handlers.append(h)
+            continue
+        nh = {k: v for k, v in h.items() if k not in ("name", "statusMessage")}
+        new_handlers.append(nh)
+    return {**rule, "hooks": new_handlers}
+
+
+def _rule_content_equal(a: object, b: object) -> bool:
+    """True if *a* and *b* are functionally equal (ignoring marker-carrier fields)."""
+    if not isinstance(a, dict) or not isinstance(b, dict):
+        return a == b
+    return _strip_ownership_markers(a) == _strip_ownership_markers(b)
+
+
+def _stamp_status_markers(contributions: dict) -> dict:
+    """Return a deep copy of *contributions* with the ownership marker stamped.
+
+    Sets ``statusMessage`` on every **command** handler to a reserved-prefixed
+    string. Author text is preserved after the prefix (so a canonical
+    ``statusMessage`` still shows a meaningful spinner message) and an
+    already-prefixed value is left unchanged — making the stamp a pure,
+    deterministic function of the handler so re-sync stays idempotent. Used by
+    the Claude/Codex generators; Gemini marks via ``name`` instead and must not
+    receive ``statusMessage`` (not a Gemini handler field).
+    """
+    src_hooks = contributions.get("hooks", {})
+    if not isinstance(src_hooks, dict):
+        return contributions
+    out_hooks: dict[str, list] = {}
+    for event, rules in src_hooks.items():
+        if not isinstance(rules, list):
+            out_hooks[event] = rules
+            continue
+        new_rules: list = []
+        for rule in rules:
+            if not isinstance(rule, dict):
+                new_rules.append(rule)
+                continue
+            new_rule = dict(rule)
+            handlers = rule.get("hooks")
+            if isinstance(handlers, list):
+                new_handlers: list = []
+                for handler in handlers:
+                    if not isinstance(handler, dict) or handler.get("type") != "command":
+                        new_handlers.append(handler)
+                        continue
+                    new_handler = dict(handler)
+                    existing = new_handler.get("statusMessage")
+                    if isinstance(existing, str):
+                        if not existing.startswith(_MEMTOMEM_STATUS_PREFIX):
+                            new_handler["statusMessage"] = f"{_MEMTOMEM_STATUS_PREFIX}{existing}"
+                    else:
+                        new_handler["statusMessage"] = f"{_MEMTOMEM_STATUS_PREFIX}{event}"
+                    new_handlers.append(new_handler)
+                new_rule["hooks"] = new_handlers
+            new_rules.append(new_rule)
+        out_hooks[event] = new_rules
+    return {**contributions, "hooks": out_hooks}
+
+
 def _merge_hooks_record(
     existing: dict | None,
     contributions: dict,
 ) -> tuple[dict, list[str]]:
-    """Additive merge of record-format ``hooks``.  User rules always win.
+    """Additive merge of record-format ``hooks``, ownership-aware (ADR-0019).
 
-    Identity key is ``(event, matcher)``; on a same-key collision with a
-    different payload the user's existing rule is kept and a guided warning
-    is emitted.  Shared by Claude and Codex (identical event names + record
-    shape).  Gemini remaps event/matcher names first via
-    :func:`_remap_for_gemini`, then merges the remapped record through this
-    same function — so the conflict/dedup semantics stay identical across
-    runtimes.
+    Identity key is ``(event, matcher)``. On a same-key collision:
+
+    * an existing **memtomem-owned** rule (carries the ownership marker) is
+      *replaced* by the freshly generated contribution — memtomem updates its
+      own rules across releases (issue #1110) — while any *user* rules under
+      the same matcher are preserved;
+    * an existing **user** rule wins and a guided warning is emitted (the
+      long-standing "user rules always win" contract). When the user rule
+      shares a command with the contribution it is most likely a memtomem rule
+      from before ownership markers existed, so the warning is sharpened to
+      guide the one-time cleanup — but the rule is **never** silently
+      overwritten.
+
+    Shared by Claude and Codex (identical event names + record shape); Gemini
+    remaps event/matcher names via :func:`_remap_for_gemini` first, then merges
+    the remapped record through here, so semantics stay identical across
+    runtimes. Contributions are expected to be marker-stamped before this call
+    (Claude/Codex via :func:`_stamp_status_markers`, Gemini via
+    :func:`_ensure_gemini_handler_names`).
     """
     warnings: list[str] = []
     merged = dict(existing) if existing else {}
@@ -176,38 +320,99 @@ def _merge_hooks_record(
             existing_hooks[event] = list(rules)
             continue
 
-        # Index existing rules by matcher for conflict detection. Keep
-        # the value as a list, not a single dict — Claude Code allows the
-        # same matcher to appear more than once under one event (e.g. a
-        # user keeping two PostToolUse rules without explicit matchers).
-        # Collapsing to a dict-of-rule means whichever same-matcher rule
-        # comes last silently shadows the rest, so byte-identical
-        # contributions can mismatch and emit a noisy warning.
         existing_rules: list = list(existing_hooks[event])
-        existing_by_matcher: dict[str, list[dict]] = {}
-        for rule in existing_rules:
-            if isinstance(rule, dict):
-                existing_by_matcher.setdefault(rule.get("matcher", ""), []).append(rule)
+        contrib_rules: list[dict] = [r for r in rules if isinstance(r, dict)]
+        # Contributions queued per matcher (FIFO, order preserved) so each
+        # memtomem-owned slot consumes exactly one — never double-replacing or
+        # dropping a contribution when canonical emits two rules per matcher.
+        contrib_by_matcher: dict[str, list[dict]] = {}
+        for c in contrib_rules:
+            contrib_by_matcher.setdefault(c.get("matcher", ""), []).append(c)
 
-        for rule in rules:
-            if not isinstance(rule, dict):
+        # Pass 1 — walk existing rules in place: a memtomem-owned rule is
+        # replaced by the next unconsumed contribution of the same matcher
+        # (memtomem updates its own rule across releases, issue #1110); an
+        # owned rule memtomem no longer emits is dropped; user rules are kept
+        # verbatim and in position.
+        result_rules: list = []
+        consumed: dict[str, int] = {}
+        placed_ids: set[int] = set()
+        replaced_any = False
+        for r in existing_rules:
+            if isinstance(r, dict) and _rule_is_memtomem_owned(r):
+                matcher = r.get("matcher", "")
+                queue = contrib_by_matcher.get(matcher, [])
+                idx = consumed.get(matcher, 0)
+                if idx < len(queue):
+                    c = queue[idx]
+                    consumed[matcher] = idx + 1
+                    placed_ids.add(id(c))
+                    result_rules.append(c)
+                    replaced_any = True
+                # else: no current contribution for this matcher → drop the
+                # stale memtomem rule.
                 continue
-            matcher = rule.get("matcher", "")
-            same_matcher = existing_by_matcher.get(matcher, [])
-            if same_matcher:
-                if any(existing == rule for existing in same_matcher):
-                    continue  # already in sync (with at least one)
-                label = f"{event}:{matcher}" if matcher else event
+            result_rules.append(r)
+
+        # Pass 2 — contributions not consumed by an owned slot merge additively
+        # against the *user* rules. Claude Code allows the same matcher to
+        # appear more than once, so user rules stay as a list (not collapsed).
+        for c in contrib_rules:
+            if id(c) in placed_ids:
+                continue
+            matcher = c.get("matcher", "")
+            same_user = [
+                r
+                for r in result_rules
+                if isinstance(r, dict)
+                and r.get("matcher", "") == matcher
+                and not _rule_is_memtomem_owned(r)
+            ]
+            if not same_user:
+                result_rules.append(c)
+                continue
+            if any(_rule_content_equal(u, c) for u in same_user):
+                # Already present ignoring our marker — leave the user's copy
+                # untouched rather than rewrite it just to add the marker.
+                continue
+            label = f"{event}:{matcher}" if matcher else event
+            contrib_commands = _rule_commands(c)
+            if contrib_commands and any(contrib_commands & _rule_commands(u) for u in same_user):
+                warnings.append(
+                    f"Hook rule '{label}' looks like a memtomem-managed rule "
+                    f"from a previous version (same command, no ownership "
+                    f"marker). Remove it, then re-run "
+                    f"`mm context sync --include=settings` to let memtomem "
+                    f"update it."
+                )
+            else:
                 warnings.append(
                     f"Hook rule '{label}' already exists in the target "
                     f"settings with different config. To use memtomem's "
                     f"version, remove the existing rule, then re-run "
                     f"`mm context sync --include=settings`."
                 )
-                continue
-            existing_rules.append(rule)
 
-        existing_hooks[event] = existing_rules
+        if replaced_any:
+            logger.debug("Updated memtomem-managed hook rule(s) for event %r", event)
+        existing_hooks[event] = result_rules
+
+    # Prune memtomem-owned rules from events the canonical no longer emits at
+    # all. The ownership marker makes them safe to remove; user rules under the
+    # same event are preserved, and an event left empty is dropped entirely.
+    for event in list(existing_hooks):
+        if event in contrib_hooks:
+            continue
+        rules = existing_hooks[event]
+        if not isinstance(rules, list):
+            continue
+        kept = [r for r in rules if not (isinstance(r, dict) and _rule_is_memtomem_owned(r))]
+        if len(kept) == len(rules):
+            continue
+        if kept:
+            existing_hooks[event] = kept
+        else:
+            del existing_hooks[event]
 
     merged["hooks"] = existing_hooks
     return merged, warnings
@@ -235,8 +440,8 @@ class ClaudeSettingsGenerator:
         existing: dict | None,
         contributions: dict,
     ) -> tuple[dict, list[str]]:
-        """Additive merge of record-format ``hooks``.  User rules always win."""
-        return _merge_hooks_record(existing, contributions)
+        """Ownership-aware merge of record-format ``hooks`` (ADR-0019)."""
+        return _merge_hooks_record(existing, _stamp_status_markers(contributions))
 
 
 _register(ClaudeSettingsGenerator())
@@ -399,11 +604,15 @@ def _ensure_gemini_handler_names(
       *milliseconds*. A numeric ``timeout`` is multiplied by 1000 so a canonical
       ``timeout: 30`` (30s) doesn't become 30ms on Gemini and kill the hook
       before it can run. ``bool`` (an ``int`` subclass) is left alone.
-    * **stable name.** Gemini exposes ``/hooks disable <name>``, so each handler
-      needs a *distinct* stable name. The slug alone is not enough: distinct
-      Claude matchers can collapse to one Gemini tool (``Edit`` and ``MultiEdit``
-      both map to ``replace``), which previously made two handlers share
-      ``memtomem-<event>-replace-0``. We hash the handler's **canonical
+    * **stable name (ownership marker).** Gemini exposes ``/hooks disable
+      <name>``, so each handler needs a *distinct* stable name; the
+      ``memtomem-`` prefix is also memtomem's ownership marker (ADR-0019), so a
+      re-sync can recognize and update its own Gemini rules (issue #1110). The
+      name is **always (re)stamped**, overriding any canonical-provided
+      ``name`` — memtomem owns the Gemini name. The slug alone is not enough:
+      distinct Claude matchers can collapse to one Gemini tool (``Edit`` and
+      ``MultiEdit`` both map to ``replace``), which would make two handlers
+      share ``memtomem-<event>-replace``. We hash the handler's **canonical
       identity** — the *original* (pre-remap) matcher, its position in the rule,
       and the command — *not* the remapped Gemini matcher. So ``Edit`` and
       ``MultiEdit`` get distinct names even when they run the *same* command,
@@ -422,14 +631,13 @@ def _ensure_gemini_handler_names(
         timeout = new_handler.get("timeout")
         if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
             new_handler["timeout"] = timeout * 1000
-        if not new_handler.get("name"):
-            command = new_handler.get("command")
-            command_str = command if isinstance(command, str) else ""
-            # NUL-delimited so the three fields can't be confused with each
-            # other (e.g. matcher "a" + command "b" vs matcher "a\x00b").
-            identity = f"{original_matcher}\x00{idx}\x00{command_str}"
-            digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:8]
-            new_handler["name"] = f"memtomem-{event}-{slug}-{digest}"
+        command = new_handler.get("command")
+        command_str = command if isinstance(command, str) else ""
+        # NUL-delimited so the three fields can't be confused with each
+        # other (e.g. matcher "a" + command "b" vs matcher "a\x00b").
+        identity = f"{original_matcher}\x00{idx}\x00{command_str}"
+        digest = hashlib.sha1(identity.encode("utf-8")).hexdigest()[:8]
+        new_handler["name"] = f"memtomem-{event}-{slug}-{digest}"
         out.append(new_handler)
     return out
 
@@ -512,7 +720,7 @@ class CodexSettingsGenerator:
         contributions: dict,
     ) -> tuple[dict, list[str]]:
         filtered, drop_warnings = _filter_codex_events(contributions)
-        merged, merge_warnings = _merge_hooks_record(existing, filtered)
+        merged, merge_warnings = _merge_hooks_record(existing, _stamp_status_markers(filtered))
         return merged, drop_warnings + merge_warnings
 
 

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
@@ -628,7 +629,12 @@ def _ensure_gemini_handler_names(
     if not isinstance(handlers, list):
         return []
     out: list = []
-    slug = (matcher or "all").replace("|", "-").replace("*", "all")
+    # Sanitize the remapped matcher to the Gemini name charset: lifecycle or
+    # multi-tool matchers can carry ``|`` / ``*`` / spaces / punctuation, which
+    # would leak into ``memtomem-<event>-<slug>-<digest>`` and break
+    # ``/hooks disable <name>``. Collapse any run of non-[A-Za-z0-9_.-] to ``-``.
+    # Uniqueness still comes from the digest, so the slug is purely cosmetic.
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", matcher or "all").strip("-") or "all"
     for idx, handler in enumerate(handlers):
         if not isinstance(handler, dict):
             continue

--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -29,6 +29,8 @@ from pathlib import Path
 from memtomem.context._atomic import atomic_write_text
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
+    _rule_content_equal,
+    _stamp_status_markers,
     resolve_scope_path,
 )
 from memtomem.context.settings_doctor import (
@@ -52,8 +54,9 @@ class MigrateMove:
     :func:`_classify_target` and surface here as a pair of booleans:
 
     * ``already_at_target=True``, ``conflict_at_target=False`` —
-      target already carries an inner **byte-equal** to the canonical
-      one. Target write is skipped; source is still cleaned.
+      target already carries an inner functionally equal to the
+      canonical one (ownership marker fields ignored). Target write is
+      skipped; source is still cleaned.
     * ``already_at_target=False``, ``conflict_at_target=False`` —
       target either has no rule under ``(event, matcher)`` or has one
       that we can extend safely. Target gets the canonical rule
@@ -210,11 +213,12 @@ def _classify_target(
     * ``("missing", "")`` — no rule under ``(event, matcher)`` exists at
       target. Safe: the canonical rule will be appended.
     * ``("exact", "")`` — a rule under ``(event, matcher)`` carries an
-      inner **byte-equal** to ``canonical_inner``. Safe: target write is
-      skipped, source can still be cleaned (the canonical entry is
-      already exactly there).
+      inner functionally equal to ``canonical_inner``. Ownership marker
+      fields are ignored so an ADR-0019-stamped target is not reported
+      as drift. Safe: target write is skipped, source can still be
+      cleaned (the canonical entry is already there).
     * ``("conflict", reason)`` — a rule under ``(event, matcher)``
-      exists but **no** inner is byte-equal to ``canonical_inner``.
+      exists but **no** inner is functionally equal to ``canonical_inner``.
       Refuse: blindly appending the canonical rule would create a
       second same-matcher rule (Claude Code merges them additively, so
       both would fire); skipping target while cleaning source would
@@ -234,7 +238,9 @@ def _classify_target(
         if not isinstance(rule, dict):
             continue
         for inner in rule.get("hooks", []):
-            if isinstance(inner, dict) and inner == canonical_inner:
+            if isinstance(inner, dict) and _inner_content_equal(
+                sig.matcher, inner, canonical_inner
+            ):
                 return ("exact", "")
     label = f"{sig.event}:{sig.matcher}" if sig.matcher else sig.event
     return (
@@ -246,6 +252,26 @@ def _classify_target(
             f"the source can be cleaned."
         ),
     )
+
+
+def _inner_content_equal(matcher: str, target_inner: dict, canonical_inner: dict) -> bool:
+    """Compare inner handlers using the shared ownership-marker semantics."""
+    return _rule_content_equal(
+        {"matcher": matcher, "hooks": [target_inner]},
+        {"matcher": matcher, "hooks": [canonical_inner]},
+    )
+
+
+def _stamp_rule_for_target(event: str, rule: dict) -> dict:
+    """Stamp one Claude/Codex-shaped rule before writing it to a target tier."""
+    stamped = _stamp_status_markers({"hooks": {event: [rule]}})
+    hooks = stamped.get("hooks", {})
+    if not isinstance(hooks, dict):
+        return rule
+    rules = hooks.get(event, [])
+    if not isinstance(rules, list) or not rules or not isinstance(rules[0], dict):
+        return rule
+    return rules[0]
 
 
 def plan_migration(
@@ -332,10 +358,13 @@ def plan_migration(
                         continue
                     seen_sigs.add(sig)
                     canonical_inner = canonical_inners[sig]
-                    rule_to_write = {
-                        "matcher": sig.matcher,
-                        "hooks": [canonical_inner],
-                    }
+                    rule_to_write = _stamp_rule_for_target(
+                        sig.event,
+                        {
+                            "matcher": sig.matcher,
+                            "hooks": [canonical_inner],
+                        },
+                    )
                     status, reason = _classify_target(target_index, sig, canonical_inner)
                     moves.append(
                         MigrateMove(

--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -16,7 +16,10 @@ from memtomem.config import TargetScope
 from memtomem.context.settings import (
     CANONICAL_SETTINGS_FILE,
     resolve_scope_path,
+    _rule_content_equal,
+    _rule_is_memtomem_owned,
     _safe_load_json,
+    _stamp_status_markers,
     _write_json,
     generate_all_settings,
 )
@@ -167,6 +170,12 @@ def _compare_hooks(
         result["error"] = "hooks must be a record (object), not an array"
         return result
 
+    # Stamp the ownership marker (ADR-0019) so the canonical rules compared
+    # here match what ``generate_all_settings`` actually writes to the Claude
+    # target — otherwise a synced (already-stamped) target rule would mismatch
+    # the raw canonical and surface as a false conflict (issue #1110).
+    canonical_hooks = _stamp_status_markers({"hooks": canonical_hooks})["hooks"]
+
     canonical_index: dict[tuple[str, str], list[dict]] = {}
     for row in _iter_hook_rules(canonical_hooks):
         canonical_index.setdefault((row["event"], row["matcher"]), []).append(row["rule"])
@@ -179,7 +188,16 @@ def _compare_hooks(
     ]
 
     if not _has_hook_rules(canonical_hooks):
-        result["status"] = "no_hooks"
+        # Canonical emits no hooks. A sync still prunes any memtomem-owned
+        # target rule (ADR-0019), so surface that as out_of_sync; only when the
+        # target has none of memtomem's rules is there genuinely nothing to do.
+        owned_in_target = any(
+            _rule_is_memtomem_owned(rule)
+            for rules in target_hooks.values()
+            if isinstance(rules, list)
+            for rule in rules
+        )
+        result["status"] = "out_of_sync" if owned_in_target else "no_hooks"
         return result
 
     if not target_path.is_file():
@@ -209,6 +227,22 @@ def _compare_hooks(
             if isinstance(rule, dict):
                 target_index.setdefault((event, rule.get("matcher", "")), []).append(rule)
 
+    # Mirror _merge_hooks_record's resolution so the GET diff classifies rules
+    # exactly as a sync would (ADR-0019). Each memtomem-owned target rule under
+    # a matcher is one in-place "managed update" slot, consumed FIFO before
+    # falling back to the user-wins conflict / append logic. Comparing against
+    # the *specific* owned rule being consumed — not any same-matcher rule —
+    # keeps the diff and the merge in agreement even when a user rule happens to
+    # equal canonical while a stale owned rule still needs replacing (Codex r2).
+    owned_by_matcher: dict[tuple[str, str], list[dict]] = {}
+    user_by_matcher: dict[tuple[str, str], list[dict]] = {}
+    for key, rules_at in target_index.items():
+        for r in rules_at:
+            (owned_by_matcher if _rule_is_memtomem_owned(r) else user_by_matcher).setdefault(
+                key, []
+            ).append(r)
+    consumed_owned: dict[tuple[str, str], int] = {}
+
     for event, rules in canonical_hooks.items():
         if not isinstance(rules, list):
             continue
@@ -217,34 +251,51 @@ def _compare_hooks(
                 continue
             matcher = rule.get("matcher", "")
             key = (event, matcher)
-            same_matcher = target_index.get(key, [])
 
-            if same_matcher:
-                if any(existing == rule for existing in same_matcher):
-                    result["hooks"]["synced"].append(
-                        {"event": event, "matcher": matcher, "rule": rule}
-                    )
-                else:
-                    # Surface the first same-matcher rule as the conflict
-                    # representative — keeps the API payload shape stable
-                    # for the resolve flow while not silently shadowing the
-                    # rest of the user's same-matcher rules.
-                    result["hooks"]["conflicts"].append(
-                        {
-                            "event": event,
-                            "matcher": matcher,
-                            "existing": same_matcher[0],
-                            "proposed": rule,
-                        }
-                    )
+            owned_slots = owned_by_matcher.get(key, [])
+            used = consumed_owned.get(key, 0)
+            if used < len(owned_slots):
+                # Replaces an existing memtomem-owned rule in place: synced if
+                # byte-equal (ignoring the marker), else a pending managed
+                # update — never a user conflict (issue #1110).
+                consumed_owned[key] = used + 1
+                bucket = "synced" if _rule_content_equal(owned_slots[used], rule) else "pending"
+                result["hooks"][bucket].append({"event": event, "matcher": matcher, "rule": rule})
+                continue
+
+            # Owned slots exhausted → merge additively against the user rules.
+            user_rules = user_by_matcher.get(key, [])
+            if any(_rule_content_equal(u, rule) for u in user_rules):
+                result["hooks"]["synced"].append({"event": event, "matcher": matcher, "rule": rule})
+            elif user_rules:
+                # Surface the first user rule as the conflict representative —
+                # keeps the payload shape stable for the resolve flow while not
+                # silently shadowing the rest of the user's same-matcher rules.
+                result["hooks"]["conflicts"].append(
+                    {
+                        "event": event,
+                        "matcher": matcher,
+                        "existing": user_rules[0],
+                        "proposed": rule,
+                    }
+                )
             else:
                 result["hooks"]["pending"].append(
                     {"event": event, "matcher": matcher, "rule": rule}
                 )
 
+    # Any memtomem-owned target slot a canonical rule did NOT consume will be
+    # pruned by the next sync (ADR-0019) — whether the whole (event, matcher) is
+    # gone from canonical, or canonical simply emits fewer rules under it than
+    # the target currently holds. Those removals put the status out_of_sync even
+    # when there is nothing to add. Plain user hooks are never counted.
+    pending_removals = sum(
+        max(0, len(owned) - consumed_owned.get(key, 0)) for key, owned in owned_by_matcher.items()
+    )
+
     if result["hooks"]["conflicts"]:
         result["status"] = "conflicts"
-    elif result["hooks"]["pending"]:
+    elif result["hooks"]["pending"] or pending_removals:
         result["status"] = "out_of_sync"
     else:
         result["status"] = "in_sync"
@@ -381,6 +432,14 @@ async def resolve_conflict(
                         break
                 if proposed is None:
                     raise HTTPException(404, detail=f"Rule '{label}' not in canonical source")
+
+                # Stamp the ownership marker (ADR-0019) so the rule we write
+                # matches what ``generate_all_settings`` would write — a later
+                # re-sync then recognizes it as memtomem-owned and can update
+                # it instead of re-flagging it as a conflict (issue #1110).
+                proposed = _stamp_status_markers({"hooks": {body.event: [proposed]}})["hooks"][
+                    body.event
+                ][0]
 
                 # Read target + mtime guard. ``st_mtime_ns`` matches
                 # ``hot_reload.py`` precision and detects sub-second writes

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -37,6 +37,17 @@ def _rule(matcher: str = "", command: str = "echo ok", timeout: int = 5000) -> d
     }
 
 
+def _marked(rule: dict, event: str) -> dict:
+    """The rule as memtomem writes it for Claude: the ADR-0019 ownership marker
+    (``statusMessage`` = ``"memtomem · <event>"``) stamped onto each command
+    handler. Used to assert the exact on-disk shape of a memtomem-written rule."""
+    out = json.loads(json.dumps(rule))  # deep copy
+    for handler in out.get("hooks", []):
+        if isinstance(handler, dict) and handler.get("type") == "command":
+            handler["statusMessage"] = f"memtomem · {event}"
+    return out
+
+
 # ── Fixtures ────────────────────────────────────────────────────────
 
 
@@ -136,8 +147,8 @@ class TestClaudeSettingsMergeAdditive:
         assert results["claude_settings"].status == "ok"
 
         written = _read_target(claude_home)
-        assert written["hooks"]["Stop"] == [user_rule]
-        assert written["hooks"]["PostToolUse"] == [mm_rule]
+        assert written["hooks"]["Stop"] == [user_rule]  # user rule untouched (no marker)
+        assert written["hooks"]["PostToolUse"] == [_marked(mm_rule, "PostToolUse")]
 
     def test_appends_rule_to_same_event(self, claude_home, tmp_path):
         """Multiple rules under the same event with different matchers."""
@@ -155,8 +166,8 @@ class TestClaudeSettingsMergeAdditive:
 
         written = _read_target(claude_home)
         assert len(written["hooks"]["PostToolUse"]) == 2
-        assert written["hooks"]["PostToolUse"][0] == user_rule
-        assert written["hooks"]["PostToolUse"][1] == mm_rule
+        assert written["hooks"]["PostToolUse"][0] == user_rule  # user rule untouched
+        assert written["hooks"]["PostToolUse"][1] == _marked(mm_rule, "PostToolUse")
 
 
 class TestClaudeSettingsMergeConflict:
@@ -245,6 +256,239 @@ class TestClaudeSettingsMergeWarningContent:
         # (c) concrete remediation step
         assert "remove" in w
         assert "mm context sync --include=settings" in w
+
+
+class TestClaudeOwnershipResync:
+    """ADR-0019 / issue #1110: re-sync updates memtomem's own emitted rules."""
+
+    def test_resync_updates_own_marked_rule_no_warning(self, claude_home, tmp_path):
+        """A memtomem-marked target rule is replaced when canonical changes."""
+        target = claude_home / ".claude" / "settings.json"
+        old = _marked(_rule("Write", "mm index --v1"), "PostToolUse")
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [old]}}) + "\n", encoding="utf-8")
+
+        _make_canonical_settings(
+            tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index --v2")]}}
+        )
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert r.status == "ok"
+        assert r.warnings == []  # memtomem updating its own rule is not a conflict
+
+        written = _read_target(claude_home)
+        assert written["hooks"]["PostToolUse"] == [
+            _marked(_rule("Write", "mm index --v2"), "PostToolUse")
+        ]
+
+    def test_resync_preserves_user_rule_at_other_matcher(self, claude_home, tmp_path):
+        """Updating memtomem's rule leaves a user rule (other matcher) untouched."""
+        target = claude_home / ".claude" / "settings.json"
+        user_rule = _rule("Bash", "echo user")
+        old = _marked(_rule("Write", "mm index --v1"), "PostToolUse")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [user_rule, old]}}) + "\n", encoding="utf-8"
+        )
+
+        _make_canonical_settings(
+            tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index --v2")]}}
+        )
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []
+
+        written = _read_target(claude_home)
+        # User Bash rule kept in place; memtomem Write rule updated in place.
+        assert written["hooks"]["PostToolUse"][0] == user_rule
+        assert written["hooks"]["PostToolUse"][1] == _marked(
+            _rule("Write", "mm index --v2"), "PostToolUse"
+        )
+
+    def test_resync_marked_and_user_same_matcher_both_kept(self, claude_home, tmp_path):
+        """Marked + user rule under one matcher: marked updated in place, user kept."""
+        target = claude_home / ".claude" / "settings.json"
+        marked_old = _marked(_rule("Write", "mm index --v1"), "PostToolUse")
+        user_rule = _rule("Write", "echo user")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [marked_old, user_rule]}}) + "\n", encoding="utf-8"
+        )
+
+        _make_canonical_settings(
+            tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index --v2")]}}
+        )
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []
+
+        written = _read_target(claude_home)["hooks"]["PostToolUse"]
+        assert written[0] == _marked(
+            _rule("Write", "mm index --v2"), "PostToolUse"
+        )  # updated in place
+        assert written[1] == user_rule  # user rule preserved
+
+    def test_resync_is_idempotent(self, claude_home, tmp_path):
+        """Re-syncing an unchanged canonical produces no warning and no rewrite."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index")]}})
+
+        generate_all_settings(tmp_path, scope="user")
+        first = _read_target(claude_home)
+        # First sync stamps the marker.
+        assert first["hooks"]["PostToolUse"] == [_marked(_rule("Write", "mm index"), "PostToolUse")]
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []
+        assert _read_target(claude_home) == first  # byte-stable
+
+    def test_legacy_unmarked_same_command_warns_not_replaced(self, claude_home, tmp_path):
+        """A pre-marker memtomem rule (unmarked) gets a sharper warning, not a clobber."""
+        target = claude_home / ".claude" / "settings.json"
+        legacy = _rule("Write", "mm index", timeout=5000)  # no marker (old release)
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [legacy]}}) + "\n", encoding="utf-8")
+
+        # Canonical: same command, changed timeout — would be an update if marked.
+        _make_canonical_settings(
+            tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index", timeout=9000)]}}
+        )
+        results = generate_all_settings(tmp_path, scope="user")
+        r = results["claude_settings"]
+        assert len(r.warnings) == 1
+        assert "previous version" in r.warnings[0]  # migration-guidance wording
+
+        written = _read_target(claude_home)
+        assert written["hooks"]["PostToolUse"] == [legacy]  # never silently overwritten
+
+    def test_preserves_author_statusMessage_text(self, claude_home, tmp_path):
+        """A canonical statusMessage is preserved after the reserved prefix."""
+        rule = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index",
+                    "timeout": 5000,
+                    "statusMessage": "Indexing memory",
+                }
+            ],
+        }
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [rule]}})
+        generate_all_settings(tmp_path, scope="user")
+
+        written = _read_target(claude_home)
+        handler = written["hooks"]["PostToolUse"][0]["hooks"][0]
+        assert handler["statusMessage"] == "memtomem · Indexing memory"
+
+    def test_two_same_matcher_canonical_rules_not_dropped(self, claude_home, tmp_path):
+        """Two canonical rules under one matcher both survive (mutation-safety)."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "mm index"), _rule("Write", "mm graph")]}},
+        )
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []
+        written = _read_target(claude_home)["hooks"]["PostToolUse"]
+        commands = {h["command"] for rule in written for h in rule["hooks"]}
+        assert commands == {"mm index", "mm graph"}
+
+        # Re-sync: both are now marked; both update in place, neither dropped.
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []
+        written2 = _read_target(claude_home)["hooks"]["PostToolUse"]
+        assert {h["command"] for rule in written2 for h in rule["hooks"]} == {
+            "mm index",
+            "mm graph",
+        }
+
+    def test_stale_event_owned_rule_pruned_user_kept(self, claude_home, tmp_path):
+        """A memtomem rule under an event canonical no longer emits is pruned;
+        a user rule under that same event is preserved."""
+        target = claude_home / ".claude" / "settings.json"
+        marked_stale = _marked(_rule("", "mm session-log"), "SessionStart")
+        user_rule = _rule("", "echo my-session-hook")
+        target.write_text(
+            json.dumps({"hooks": {"SessionStart": [marked_stale, user_rule]}}) + "\n",
+            encoding="utf-8",
+        )
+        # Canonical no longer emits any SessionStart rule.
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index")]}})
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].status == "ok"
+
+        written = _read_target(claude_home)["hooks"]
+        assert written["SessionStart"] == [user_rule]  # stale memtomem rule pruned, user kept
+        assert written["PostToolUse"] == [_marked(_rule("Write", "mm index"), "PostToolUse")]
+
+    def test_stale_event_fully_pruned_drops_empty_event(self, claude_home, tmp_path):
+        """An event holding only a stale memtomem rule is removed entirely."""
+        target = claude_home / ".claude" / "settings.json"
+        target.write_text(
+            json.dumps({"hooks": {"SessionStart": [_marked(_rule("", "mm log"), "SessionStart")]}})
+            + "\n",
+            encoding="utf-8",
+        )
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index")]}})
+
+        generate_all_settings(tmp_path, scope="user")
+        assert "SessionStart" not in _read_target(claude_home)["hooks"]
+
+    def test_raw_user_rule_matching_pre_stamp_is_in_sync(self, claude_home, tmp_path):
+        """A user rule byte-identical to the canonical (no marker) is in-sync,
+        regardless of statusMessage — comparison ignores the marker-carrier
+        field symmetrically (no spurious conflict warning)."""
+        target = claude_home / ".claude" / "settings.json"
+        # User authored the exact rule, including a hand-written statusMessage.
+        raw = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index",
+                    "timeout": 5000,
+                    "statusMessage": "Indexing",
+                }
+            ],
+        }
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [raw]}}) + "\n", encoding="utf-8")
+        # Canonical is the same command/matcher/timeout (would stamp its own marker).
+        _make_canonical_settings(
+            tmp_path,
+            {"hooks": {"PostToolUse": [_rule("Write", "mm index", timeout=5000)]}},
+        )
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []  # functionally identical → in sync
+        assert _read_target(claude_home)["hooks"]["PostToolUse"] == [raw]  # left untouched
+
+    def test_resync_drops_surplus_owned_duplicate(self, claude_home, tmp_path):
+        """Two memtomem-owned rules at one matcher but one canonical rule → the
+        surplus owned rule is pruned (kept count matches canonical)."""
+        target = claude_home / ".claude" / "settings.json"
+        o1 = _marked(_rule("Write", "mm index"), "PostToolUse")
+        o2 = _marked(_rule("Write", "mm index --dup"), "PostToolUse")  # surplus owned
+        target.write_text(json.dumps({"hooks": {"PostToolUse": [o1, o2]}}) + "\n", encoding="utf-8")
+        _make_canonical_settings(tmp_path, {"hooks": {"PostToolUse": [_rule("Write", "mm index")]}})
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].warnings == []
+        written = _read_target(claude_home)["hooks"]["PostToolUse"]
+        assert written == [_marked(_rule("Write", "mm index"), "PostToolUse")]  # surplus dropped
+
+    def test_empty_canonical_prunes_owned_keeps_user(self, claude_home, tmp_path):
+        """Canonical emitting no hooks prunes every memtomem-owned target rule
+        while leaving user rules in place."""
+        target = claude_home / ".claude" / "settings.json"
+        owned = _marked(_rule("Write", "mm index"), "PostToolUse")
+        user_rule = _rule("Bash", "echo user")
+        target.write_text(
+            json.dumps({"hooks": {"PostToolUse": [owned, user_rule]}}) + "\n", encoding="utf-8"
+        )
+        _make_canonical_settings(tmp_path, {"hooks": {}})
+
+        results = generate_all_settings(tmp_path, scope="user")
+        assert results["claude_settings"].status == "ok"
+        assert _read_target(claude_home)["hooks"]["PostToolUse"] == [user_rule]  # owned pruned
 
 
 class TestClaudeSettingsMergeMalformed:

--- a/packages/memtomem/tests/test_context_settings_multiruntime.py
+++ b/packages/memtomem/tests/test_context_settings_multiruntime.py
@@ -244,6 +244,96 @@ class TestProjectLocalNoneSkip:
         assert results["gemini_settings"].status == "skipped"
 
 
+# ── Ownership markers + re-sync (ADR-0019 / issue #1110) ─────────────
+
+
+class TestCodexOwnership:
+    def test_fresh_sync_stamps_status_message_marker(self, tmp_path, all_home):
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "mm index")]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        written = json.loads((all_home / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        handler = written["hooks"]["PreToolUse"][0]["hooks"][0]
+        assert handler["statusMessage"] == "memtomem · PreToolUse"
+
+    def test_resync_updates_own_marked_codex_rule(self, tmp_path, all_home):
+        target = all_home / ".codex" / "hooks.json"
+        old = {
+            "matcher": "Bash",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index --v1",
+                    "timeout": 5000,
+                    "statusMessage": "memtomem · PreToolUse",
+                }
+            ],
+        }
+        target.write_text(json.dumps({"hooks": {"PreToolUse": [old]}}) + "\n", encoding="utf-8")
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "mm index --v2")]})
+
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["codex_settings"].warnings == []
+
+        written = json.loads(target.read_text(encoding="utf-8"))
+        rule = written["hooks"]["PreToolUse"][0]
+        assert rule["hooks"][0]["command"] == "mm index --v2"  # updated
+        assert rule["hooks"][0]["statusMessage"] == "memtomem · PreToolUse"
+
+
+class TestGeminiOwnership:
+    def test_canonical_name_is_overridden_with_memtomem_prefix(self, tmp_path, all_home):
+        """A canonical handler ``name`` is overridden so memtomem owns the Gemini name."""
+        rule = {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "mm index", "name": "user-chosen-name"}],
+        }
+        _canonical(tmp_path, {"PreToolUse": [rule]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        name = hooks["BeforeTool"][0]["hooks"][0]["name"]
+        assert name.startswith("memtomem-")
+        assert name != "user-chosen-name"
+
+    def test_no_status_message_leaks_into_gemini(self, tmp_path, all_home):
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "mm index")]})
+        generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+
+        hooks = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))[
+            "hooks"
+        ]
+        for handler in hooks["BeforeTool"][0]["hooks"]:
+            assert "statusMessage" not in handler  # marker is Claude/Codex-only
+
+    def test_resync_updates_own_marked_gemini_rule(self, tmp_path, all_home):
+        target = all_home / ".gemini" / "settings.json"
+        # An old memtomem-emitted Gemini rule (remapped event/matcher, memtomem- name).
+        old = {
+            "matcher": "run_shell_command",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index --v1",
+                    "timeout": 5000000,
+                    "name": "memtomem-BeforeTool-run_shell_command-deadbeef",
+                }
+            ],
+        }
+        target.write_text(json.dumps({"hooks": {"BeforeTool": [old]}}) + "\n", encoding="utf-8")
+        _canonical(tmp_path, {"PreToolUse": [_rule("Bash", "mm index --v2")]})
+
+        results = generate_all_settings(tmp_path, scope="user", allow_host_writes=True)
+        assert results["gemini_settings"].warnings == []
+
+        hooks = json.loads(target.read_text(encoding="utf-8"))["hooks"]
+        rules = hooks["BeforeTool"]
+        assert len(rules) == 1  # replaced in place, not appended alongside
+        assert rules[0]["hooks"][0]["command"] == "mm index --v2"
+
+
 # ── host-write gate across runtimes ──────────────────────────────────
 
 

--- a/packages/memtomem/tests/test_context_settings_multiruntime.py
+++ b/packages/memtomem/tests/test_context_settings_multiruntime.py
@@ -543,3 +543,21 @@ class TestGeminiHandlerNormalization:
         assert not results["gemini_settings"].warnings
         second = json.loads((all_home / ".gemini" / "settings.json").read_text(encoding="utf-8"))
         assert first == second  # byte-identical → idempotent
+
+    def test_handler_name_slug_sanitizes_unsafe_matcher_chars(self):
+        """A matcher carrying spaces/punctuation must not leak unsafe chars into
+        the synthesized ``memtomem-<event>-<slug>-<digest>`` name — that would
+        break Gemini's ``/hooks disable <name>``. Uniqueness still comes from the
+        digest, so the slug is sanitized to the safe charset (slug-regex fold)."""
+        from memtomem.context.settings import _ensure_gemini_handler_names
+
+        out = _ensure_gemini_handler_names(
+            [{"type": "command", "command": "echo hi"}],
+            "BeforeTool",
+            "weird matcher!@#|*",
+            "weird matcher!@#|*",
+        )
+        name = out[0]["name"]
+        assert name.startswith("memtomem-BeforeTool-")
+        allowed = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.-")
+        assert set(name) <= allowed, f"unsafe chars leaked into Gemini name: {name!r}"

--- a/packages/memtomem/tests/test_settings_doctor.py
+++ b/packages/memtomem/tests/test_settings_doctor.py
@@ -58,6 +58,25 @@ def _bundled_hook() -> dict:
     return {"PostToolUse": [_rule("Edit|Write", "mm session start")]}
 
 
+def _stamped_bundled_hook() -> dict:
+    """A generated ADR-0019-stamped hook record."""
+    return {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "mm session start",
+                        "timeout": 5000,
+                        "statusMessage": "memtomem · PostToolUse",
+                    }
+                ],
+            }
+        ]
+    }
+
+
 # ── Fixtures ────────────────────────────────────────────────────────
 
 
@@ -135,6 +154,18 @@ class TestDetectDuplicateTiers:
         assert duplicates[0].tier == "user"
         assert duplicates[0].path == fake_home / ".claude" / "settings.json"
         assert len(duplicates[0].entries) == 1
+
+    def test_stamped_duplicate_in_user_when_active_is_project_local(self, project_root, fake_home):
+        """ADR-0019 statusMessage markers do not perturb doctor classification."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _stamped_bundled_hook())
+        duplicates = detect_duplicate_tiers(project_root, active_scope="project_local")
+        assert len(duplicates) == 1
+        assert duplicates[0].entries[0] == HookSignature(
+            event="PostToolUse",
+            matcher="Edit|Write",
+            command_shape="mm session start",
+        )
 
     def test_duplicate_in_project_shared_when_active_is_user(self, project_root, fake_home):
         _write_canonical(project_root, _bundled_hook())

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -82,6 +82,22 @@ def _bundled_hook() -> dict:
     return {"PostToolUse": [_rule("Edit|Write", inners=[_inner("mm session start")])]}
 
 
+def _stamped_bundled_hook() -> dict:
+    return {
+        "PostToolUse": [
+            _rule(
+                "Edit|Write",
+                inners=[
+                    {
+                        **_inner("mm session start"),
+                        "statusMessage": "memtomem · PostToolUse",
+                    }
+                ],
+            )
+        ]
+    }
+
+
 def _read_settings(path) -> dict:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -251,6 +267,19 @@ class TestPlanMigration:
         assert plan.moves[0].already_at_target is True
         assert plan.moves[0].conflict_at_target is False
 
+    def test_target_stamped_canonical_inner_is_already_at_target(self, project_root, fake_home):
+        """ADR-0019 marker fields are cosmetic for migrate's target check."""
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc(_stamped_bundled_hook()),
+        )
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert len(plan.moves) == 1
+        assert plan.moves[0].already_at_target is True
+        assert plan.moves[0].conflict_at_target is False
+
 
 # ── Apply unit tests ───────────────────────────────────────────────
 
@@ -279,6 +308,8 @@ class TestApplyMigration:
             and any(inner.get("command") == "mm session start" for inner in rule.get("hooks", []))
             for rule in post
         )
+        handler = post[0]["hooks"][0]
+        assert handler["statusMessage"] == "memtomem · PostToolUse"
 
     def test_idempotent_rerun(self, project_root, fake_home):
         """After a successful apply, a second plan/apply is a no-op."""

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -907,6 +907,325 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
+    async def test_marked_rule_differing_is_not_conflict(self, app, client: AsyncClient, tmp_path):
+        """ADR-0019: a memtomem-marked target rule that differs is a pending
+        update (a plain re-sync fixes it), not a user conflict (issue #1110)."""
+        canonical_rule = self._rule("Write", "mm index --v2")
+        # Target rule is memtomem-owned (statusMessage marker) with the old command.
+        marked = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index --v1",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}), encoding="utf-8"
+        )
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(json.dumps({"hooks": {"PostToolUse": [marked]}}), encoding="utf-8")
+            app.state.project_root = tmp_path
+
+            resp = await client.get("/api/settings-sync?target_scope=user")
+            data = resp.json()
+            assert data["status"] != "conflicts"
+            assert data["hooks"]["conflicts"] == []
+            assert len(data["hooks"]["pending"]) == 1
+            assert data["hooks"]["pending"][0]["matcher"] == "Write"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_resolve_writes_ownership_marker(self, app, client: AsyncClient, tmp_path):
+        """ADR-0019: resolving via 'use memtomem's version' writes a *marked*
+        rule, so a later GET reports it synced rather than re-flagging it."""
+        canonical_rule = self._rule("Write", "echo new")
+        target_rule = self._rule("Write", "echo old")
+
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [canonical_rule]}}), encoding="utf-8"
+        )
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [target_rule]}}), encoding="utf-8"
+            )
+            app.state.project_root = tmp_path
+
+            resp = await client.post(
+                "/api/settings-sync/resolve?target_scope=user",
+                json={"event": "PostToolUse", "matcher": "Write", "action": "use_proposed"},
+            )
+            assert resp.json()["status"] == "ok"
+
+            written = json.loads(target.read_text(encoding="utf-8"))
+            handler = written["hooks"]["PostToolUse"][0]["hooks"][0]
+            assert handler["statusMessage"].startswith("memtomem · ")
+
+            # A follow-up sync status read sees it as synced, not a conflict.
+            resp2 = await client.get("/api/settings-sync?target_scope=user")
+            data = resp2.json()
+            assert data["status"] == "in_sync"
+            assert data["hooks"]["conflicts"] == []
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_diff_mirrors_merge_owned_slot_fifo(self, app, client: AsyncClient, tmp_path):
+        """ADR-0019: with two canonical rules at one matcher and a target that
+        has one owned + one user rule there, the GET diff consumes the single
+        owned slot (1 pending) and reports the leftover as a conflict — matching
+        what a sync actually does (Codex review)."""
+        marked = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm a --v1",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+        user_rule = self._rule("Write", "echo user")
+
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            self._rule("Write", "mm a --v2"),
+                            self._rule("Write", "mm b"),
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [marked, user_rule]}}), encoding="utf-8"
+            )
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            # One owned slot → one managed-update pending; the second canonical
+            # rule has no slot and collides with the user rule → one conflict.
+            assert len(data["hooks"]["pending"]) == 1
+            assert len(data["hooks"]["conflicts"]) == 1
+            assert data["hooks"]["conflicts"][0]["existing"]["hooks"][0]["command"] == "echo user"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_diff_consumes_owned_slot_before_user_equality(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """ADR-0019: a stale owned rule + a user rule that equals canonical (same
+        matcher) → the owned slot is consumed first, so GET reports the update as
+        pending (the sync still replaces the stale rule), not a false in_sync."""
+        marked_stale = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm a --v1",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+        user_equal = self._rule("Write", "mm a --v2")  # functionally == canonical
+
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "mm a --v2")]}}),
+            encoding="utf-8",
+        )
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [marked_stale, user_equal]}}), encoding="utf-8"
+            )
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "out_of_sync"
+            assert len(data["hooks"]["pending"]) == 1
+            assert data["hooks"]["conflicts"] == []
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_diff_owned_target_only_is_out_of_sync(self, app, client: AsyncClient, tmp_path):
+        """ADR-0019: a memtomem-owned rule under an event canonical no longer
+        emits is pruned by a sync, so GET reports out_of_sync (not in_sync) even
+        when every canonical rule is already synced."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "mm index")]}}),
+            encoding="utf-8",
+        )
+        # Target: the PostToolUse rule already synced (marked), plus a stale
+        # memtomem-owned SessionStart rule the canonical no longer emits.
+        synced_marked = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+        stale_owned = {
+            "matcher": "",
+            "hooks": [
+                {"type": "command", "command": "mm log", "statusMessage": "memtomem · SessionStart"}
+            ],
+        }
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(
+                json.dumps(
+                    {"hooks": {"PostToolUse": [synced_marked], "SessionStart": [stale_owned]}}
+                ),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "out_of_sync"  # stale owned rule will be pruned
+            assert data["hooks"]["conflicts"] == []
+            assert data["hooks"]["pending"] == []  # nothing to add; only a removal
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_diff_surplus_owned_duplicate_is_out_of_sync(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """ADR-0019: two memtomem-owned rules at one matcher but a single
+        canonical rule → the surplus owned rule will be pruned, so GET reports
+        out_of_sync even though the first owned rule is already synced."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "mm index")]}}),
+            encoding="utf-8",
+        )
+        o1 = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+        o2 = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index --dup",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.write_text(json.dumps({"hooks": {"PostToolUse": [o1, o2]}}), encoding="utf-8")
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "out_of_sync"  # surplus owned rule will be pruned
+            assert data["hooks"]["conflicts"] == []
+            assert len(data["hooks"]["synced"]) == 1  # first owned rule matches canonical
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_diff_empty_canonical_owned_target_is_out_of_sync(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """ADR-0019: an empty canonical still prunes memtomem-owned target rules,
+        so GET reports out_of_sync (not no_hooks); a target with only user rules
+        stays no_hooks."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+
+        owned = {
+            "matcher": "Write",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "mm index",
+                    "statusMessage": "memtomem · PostToolUse",
+                }
+            ],
+        }
+
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            # Owned rule present → a sync prunes it → out_of_sync.
+            target.write_text(json.dumps({"hooks": {"PostToolUse": [owned]}}), encoding="utf-8")
+            app.state.project_root = tmp_path
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "out_of_sync"
+
+            # Only user rules → nothing for memtomem to do → no_hooks.
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [self._rule("Bash", "echo user")]}}),
+                encoding="utf-8",
+            )
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "no_hooks"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
     # -- URL alias tests (/api/context/settings/*) ----------------------------
 
     async def test_alias_get_context_settings(self, app, client: AsyncClient, tmp_path):


### PR DESCRIPTION
## Summary

`_merge_hooks_record` keyed conflict detection on `(event, matcher)` with no way to tell a **user-authored** rule from one **memtomem wrote in a prior release**. So when memtomem's generated output for an `(event, matcher)` changed between two releases (a `command`, `timeout`, or handler-`name` change), the next `mm context sync --include=settings` treated memtomem's own stale rule as a user conflict, refused to update it, and the install stayed warning/out-of-sync until the user deleted the rule by hand. Pre-existing; applied to all three runtimes (Claude, Codex, Gemini).

Closes #1110. Records the decision in **ADR-0019** (layers onto ADR-0018).

## Approach — official-field ownership marker

A custom marker key (`_memtomem`) was **rejected**: the runtime hook schemas don't document tolerance for unknown keys, and a strict validator could reject the whole settings file. The marker reuses only **documented** handler fields:

| Runtime | Marker field | Reserved value |
|---|---|---|
| Claude / Codex | command-handler `statusMessage` | prefix `memtomem · ` |
| Gemini | handler `name` | prefix `memtomem-` |

- **Stamping** is idempotent and preserves any author-supplied `statusMessage` after the prefix; Gemini's `memtomem-` `name` is always (re)stamped so memtomem owns it.
- **Merge** replaces a same-`(event, matcher)` memtomem-owned rule in place (FIFO per matcher), prunes owned rules canonical no longer emits, and keeps the **user-wins** warning for unmarked rules — sharpened for legacy command-matches, but **never silently clobbered**.
- **Functional comparison** ignores the marker-carrier fields, so a byte-identical user rule is not flagged as a conflict the moment memtomem stamps its copy.
- All three Claude **web paths** (GET diff, `resolve`, POST sync) stamp/classify through one shared helper; the GET diff mirrors the merge's owned-slot resolution exactly (add / update / conflict / prune / surplus).

## Tests

New coverage in `test_context_settings.py` (Claude), `test_context_settings_multiruntime.py` (Codex/Gemini), and `test_web_routes_extended.py` (web): re-sync update, user-wins + legacy warning, idempotency, preserve-author-text, Gemini name override + no `statusMessage` leak, stale-event / surplus-duplicate / empty-canonical pruning, and GET↔merge consistency. `ruff` + `mypy` clean.

## Reviewed

Multi-round Codex review (dev-trio); all blocker/major findings on the merge engine and primary write paths addressed. One **deferred** follow-up (filed separately): `resolve_conflict` matches conflicts by `(event, matcher)` and can't disambiguate *duplicate* same-matcher rows — a **pre-existing** limitation (other mutation endpoints already use `rule_index`/`rule_hash`), out of scope for #1110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)