### PR TITLE
fix(web): disclose actual runtime target files in hooks-sync confirm (#1109 follow-up)

### DIFF
--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -22,9 +22,11 @@ Claude's ``$ARGUMENTS`` placeholder and Gemini's ``{{args}}`` placeholder have
 the same semantics — both substitute the entire user-supplied argument string.
 When fanning out Claude-flavoured canonical → Gemini TOML we rewrite
 ``$ARGUMENTS`` → ``{{args}}``; the reverse import rewrites it back.
-``!{...}`` shell injection and ``@{...}`` file embed syntax are Gemini-only
-advanced features and remain out of scope — users who need them can hand-edit
-``.gemini/commands/*.toml`` directly.
+Codex custom prompts are not generated today, so Codex placeholder syntax is
+documented here only as migration context. ``!{...}`` shell injection and
+``@{...}`` file embed syntax are Gemini-only advanced features and remain out
+of scope — users who need them can hand-edit ``.gemini/commands/*.toml``
+directly.
 """
 
 from __future__ import annotations

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -873,7 +873,7 @@
   "confirm.hooks_replace_title": "Replace hook rule",
   "confirm.hooks_replace_msg": "Replace your \"{label}\" rule with memtomem's version?",
   "confirm.hooks_sync_title": "Sync settings",
-  "confirm.hooks_sync_msg": "Merge .memtomem/settings.json hooks into the installed runtimes' settings files (Claude, Codex, and Gemini where present)? This writes user-level config under your home directory.",
+  "confirm.hooks_sync_msg": "Merge .memtomem/settings.json hooks into these runtime settings files?\n{targets}",
 
   "settings.exclude_patterns.builtin_title": "Built-in (read-only)",
   "settings.exclude_patterns.builtin_hint": "cannot be disabled",

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -849,6 +849,8 @@
   "toast.request_failed": "Request failed",
   "toast.unexpected_response": "Unexpected response",
   "toast.sync_failed": "Sync failed: {error}",
+  "toast.sync_scope_changed": "Target scope changed during confirmation — sync cancelled. Re-run sync for the current scope.",
+  "toast.sync_targets_unavailable": "Sync cancelled — the server did not disclose which files the write would touch.",
   "toast.create_failed": "Create failed: {error}",
   "toast.refresh_complete": "Refresh complete",
   "toast.name_required": "Name is required",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -849,6 +849,8 @@
   "toast.request_failed": "요청 실패",
   "toast.unexpected_response": "예상치 못한 응답",
   "toast.sync_failed": "동기화 실패: {error}",
+  "toast.sync_scope_changed": "확인 중 대상 범위가 변경되어 동기화를 취소했습니다. 현재 범위에서 동기화를 다시 실행하세요.",
+  "toast.sync_targets_unavailable": "동기화 취소됨 — 서버가 쓰기 대상 파일을 알려주지 않았습니다.",
   "toast.create_failed": "생성 실패: {error}",
   "toast.refresh_complete": "새로고침 완료",
   "toast.name_required": "이름을 입력해주세요",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -873,7 +873,7 @@
   "confirm.hooks_replace_title": "훅 규칙 교체",
   "confirm.hooks_replace_msg": "\"{label}\" 규칙을 memtomem 버전으로 교체하시겠습니까?",
   "confirm.hooks_sync_title": "설정 동기화",
-  "confirm.hooks_sync_msg": ".memtomem/settings.json 훅을 설치된 런타임의 설정 파일(Claude, Codex, 그리고 있으면 Gemini)에 병합하시겠습니까? 홈 디렉터리의 사용자 레벨 설정에 기록됩니다.",
+  "confirm.hooks_sync_msg": ".memtomem/settings.json 훅을 다음 런타임 설정 파일에 병합하시겠습니까?\n{targets}",
 
   "settings.exclude_patterns.builtin_title": "기본 제공 (읽기 전용)",
   "settings.exclude_patterns.builtin_hint": "비활성화할 수 없습니다",

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -694,12 +694,20 @@ async function loadHooksSync() {
 // Sync Now button
 document.getElementById('hooks-sync-btn')?.addEventListener('click', async () => {
   const btn = document.getElementById('hooks-sync-btn');
+  // Snapshot the scoped URL at click time and reuse it for BOTH the probe and
+  // the authorized write, so the targets disclosed in the confirm dialog and
+  // the files actually written belong to the SAME scope. The scope globals
+  // (`_ctxTargetScope` / `_ctxActiveScopeId`) are live; recomputing the URL per
+  // call would let a mid-flight scope change authorize a write against a
+  // different tier than was disclosed (TOCTOU). Before the write we re-derive
+  // the URL and abort if it drifted.
+  const scopedUrl = _hooksScopedUrl('/api/settings-sync');
   const postSettingsSync = async (allowHostWrites) => {
     const csrf = await ensureCsrfToken();
     const headers = csrf
       ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
       : { 'Content-Type': 'application/json' };
-    const res = await fetch(_hooksScopedUrl('/api/settings-sync'), {
+    const res = await fetch(scopedUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify({ allow_host_writes: allowHostWrites }),
@@ -777,12 +785,27 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
     if (needsConfirmation.length) {
       const targets = needsConfirmation.map(r => r.target).filter(Boolean);
       btnLoading(btn, false);
+      if (targets.length === 0) {
+        // Fail closed: never authorize a host write whose targets the server
+        // did not disclose. (The backend currently always populates ``target``.)
+        showToast(t('toast.sync_targets_unavailable'), 'error');
+        loadHooksSync();
+        return;
+      }
       const ok = await showConfirm({
         title: t('confirm.hooks_sync_title'),
         message: t('confirm.hooks_sync_msg', { targets: targets.join('\n') }),
         confirmText: t('common.sync'),
       });
       if (!ok) {
+        loadHooksSync();
+        return;
+      }
+      // Trust gate: the scope must not have drifted between the disclosure
+      // (probe) and this authorization. Re-derive the scoped URL and abort if
+      // it no longer matches the one the disclosed targets came from.
+      if (_hooksScopedUrl('/api/settings-sync') !== scopedUrl) {
+        showToast(t('toast.sync_scope_changed'), 'error');
         loadHooksSync();
         return;
       }

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -694,35 +694,46 @@ async function loadHooksSync() {
 // Sync Now button
 document.getElementById('hooks-sync-btn')?.addEventListener('click', async () => {
   const btn = document.getElementById('hooks-sync-btn');
-  const ok = await showConfirm({
-    title: t('confirm.hooks_sync_title'),
-    message: t('confirm.hooks_sync_msg'),
-    confirmText: t('common.sync'),
-  });
-  if (!ok) return;
-  btnLoading(btn, true);
-  try {
+  const postSettingsSync = async (allowHostWrites) => {
     const csrf = await ensureCsrfToken();
     const headers = csrf
       ? { 'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf }
       : { 'Content-Type': 'application/json' };
-    // The confirm modal IS the host-write trust gate (issue #962). Its copy
-    // (``confirm.hooks_sync_msg``) discloses that the merge fans out to every
-    // installed runtime's user-scope settings file (Claude/Codex/Gemini,
-    // ADR-0018) — not just ``~/.claude``. Send ``allow_host_writes: true`` so
-    // the server doesn't re-prompt with ``needs_confirmation`` for those host
-    // paths — the same gate the CLI confirms interactively
-    // (``cli/context_cmd.py:_confirm_settings_host_writes``).
     const res = await fetch(_hooksScopedUrl('/api/settings-sync'), {
       method: 'POST',
       headers,
-      body: JSON.stringify({ allow_host_writes: true }),
+      body: JSON.stringify({ allow_host_writes: allowHostWrites }),
     });
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
       throw new Error(err.detail || `Request failed: ${res.status}`);
     }
-    const data = await res.json();
+    return res.json();
+  };
+
+  const renderNeedsConfirmation = (needsConfirmation) => {
+    const targets = needsConfirmation.map(r => r.target).filter(Boolean);
+    const body = t('settings.hooks.needs_confirmation_body', {
+      targets: targets.join('\n'),
+    });
+    const statusEl = qs('hooks-sync-status');
+    if (statusEl) {
+      const banner = document.createElement('div');
+      banner.className = 'hooks-sync-needs-confirmation';
+      banner.setAttribute('role', 'alert');
+      const title = document.createElement('strong');
+      title.textContent = t('settings.hooks.needs_confirmation_title');
+      const detail = document.createElement('div');
+      detail.className = 'hooks-sync-needs-confirmation-body';
+      detail.textContent = body;
+      banner.appendChild(title);
+      banner.appendChild(detail);
+      statusEl.appendChild(banner);
+    }
+    showToast(t('settings.hooks.needs_confirmation_title'), 'warning');
+  };
+
+  const finishSyncResponse = (data) => {
     const results = Array.isArray(data.results) ? data.results : [];
     // Multi-runtime fan-out (Codex/Gemini, ADR-0018): a per-runtime
     // ``error`` (malformed target JSON) or ``aborted`` (concurrent write)
@@ -739,31 +750,10 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
     }
     const needsConfirmation = results.filter(r => r.status === 'needs_confirmation');
     if (needsConfirmation.length) {
-      // Defensive branch: the first POST already carried
-      // ``allow_host_writes: true``. If the server still returns
-      // ``needs_confirmation`` a deeper trust-gate kicked in (e.g.
-      // unexpected scope resolution); surface the targets so the user
-      // can investigate via the CLI rather than silently retrying
-      // with the same flag (would loop).
-      const targets = needsConfirmation.map(r => r.target).filter(Boolean);
-      const body = t('settings.hooks.needs_confirmation_body', {
-        targets: targets.join('\n'),
-      });
-      const statusEl = qs('hooks-sync-status');
-      if (statusEl) {
-        const banner = document.createElement('div');
-        banner.className = 'hooks-sync-needs-confirmation';
-        banner.setAttribute('role', 'alert');
-        const title = document.createElement('strong');
-        title.textContent = t('settings.hooks.needs_confirmation_title');
-        const detail = document.createElement('div');
-        detail.className = 'hooks-sync-needs-confirmation-body';
-        detail.textContent = body;
-        banner.appendChild(title);
-        banner.appendChild(detail);
-        statusEl.appendChild(banner);
-      }
-      showToast(t('settings.hooks.needs_confirmation_title'), 'warning');
+      // Defensive branch: this should only happen after the user has
+      // confirmed the returned host targets. Surface the server's targets
+      // and stop; retrying with the same flag would loop.
+      renderNeedsConfirmation(needsConfirmation);
       // Do NOT show sync_success on this branch — silent failure 금지.
       return;
     }
@@ -774,6 +764,33 @@ document.getElementById('hooks-sync-btn')?.addEventListener('click', async () =>
       showToast(t('settings.hooks.sync_success'));
     }
     loadHooksSync();
+  };
+
+  btnLoading(btn, true);
+  try {
+    // Probe first without host-write permission. For user-scope installs the
+    // server returns the exact host targets (Claude/Codex/Gemini) to disclose
+    // in the confirmation modal; project-scope writes proceed immediately.
+    const firstData = await postSettingsSync(false);
+    const firstResults = Array.isArray(firstData.results) ? firstData.results : [];
+    const needsConfirmation = firstResults.filter(r => r.status === 'needs_confirmation');
+    if (needsConfirmation.length) {
+      const targets = needsConfirmation.map(r => r.target).filter(Boolean);
+      btnLoading(btn, false);
+      const ok = await showConfirm({
+        title: t('confirm.hooks_sync_title'),
+        message: t('confirm.hooks_sync_msg', { targets: targets.join('\n') }),
+        confirmText: t('common.sync'),
+      });
+      if (!ok) {
+        loadHooksSync();
+        return;
+      }
+      btnLoading(btn, true);
+      finishSyncResponse(await postSettingsSync(true));
+      return;
+    }
+    finishSyncResponse(firstData);
   } catch (err) {
     showToast(t('toast.sync_failed', { error: err.message }), 'error');
   } finally { btnLoading(btn, false); }

--- a/packages/memtomem/tests/test_context_commands.py
+++ b/packages/memtomem/tests/test_context_commands.py
@@ -5,6 +5,7 @@ import tomllib
 
 import pytest
 
+import memtomem.context.commands as commands_mod
 from memtomem.context.commands import (
     CANONICAL_COMMAND_ROOT,
     COMMAND_GENERATORS,
@@ -46,6 +47,13 @@ def _make_canonical_command(project_root, name, body=SAMPLE_FULL_COMMAND):
     path = root / f"{name}.md"
     path.write_text(body, encoding="utf-8")
     return path
+
+
+def test_module_docstring_does_not_claim_codex_command_fanout() -> None:
+    """Codex prompts are reserved/deprecated, not an active command target."""
+    doc = commands_mod.__doc__ or ""
+    assert "Codex commands are **not** fanned out" in doc
+    assert "passes through unchanged\nfor the Codex target" not in doc
 
 
 class TestParseCanonicalCommand:

--- a/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
@@ -8,12 +8,12 @@ it, the Web UI bypasses the host-write gate the audit P0 was designed to
 enforce. This spec pins the modal + the badge transition that follows a
 successful sync.
 
-The handler's contract (``static/settings-hooks-watchdog.js:158-188``):
+The handler's contract (``static/settings-hooks-watchdog.js``):
 
-* ``showConfirm`` first; cancel returns without firing the POST.
-* On confirm, ``POST /api/settings-sync`` (with CSRF if available).
-* The POST response is parsed for ``data.results[].warnings`` only —
-  ``status`` is **not** read from the POST body.
+* ``POST /api/settings-sync`` first with ``allow_host_writes: false``.
+* If the server returns host targets, ``showConfirm`` lists those targets.
+* On confirm, ``POST /api/settings-sync`` again with ``allow_host_writes: true``.
+* The POST response is parsed for per-runtime status, warnings, and targets.
 * After the POST, ``loadHooksSync()`` (line 184) fires a fresh
   ``GET /api/settings-sync`` and the badge is rendered from
   ``data.status`` of the GET response (line 36-43).
@@ -142,21 +142,40 @@ def _stub_settings_sync(
     return state
 
 
-def test_hooks_sync_cancel_fires_no_post(page, mm_web_url: str) -> None:
+def _needs_confirmation_payload(*targets: str) -> dict:
+    return {
+        "results": [
+            {
+                "name": f"runtime_{idx}",
+                "status": "needs_confirmation",
+                "reason": "Refusing host write outside the project root",
+                "warnings": [],
+                "target": target,
+            }
+            for idx, target in enumerate(targets)
+        ],
+        "duplicate_tier_warnings": [],
+    }
+
+
+def test_hooks_sync_cancel_fires_no_host_write_post(page, mm_web_url: str) -> None:
     """S2-a: clicking Cancel on the Hooks Sync confirm dialog must fire
-    zero ``POST /api/settings-sync`` requests. Audit P0 host-write trust
-    gate — without this guard, every Sync Now click writes to
-    ``~/.claude/settings.json`` unconditionally.
+    no ``allow_host_writes: true`` request. The initial probe POST is safe:
+    it asks the server for the exact host paths before the trust gate opens.
 
     Negative half of the symmetric cancel/confirm pair.
     """
     install_default_stubs(page)
 
-    post_calls: list[str] = []
+    post_bodies: list[dict] = []
 
     def _post(route):
-        post_calls.append(route.request.url)
-        route.fulfill(status=200, content_type="application/json", body="{}")
+        post_bodies.append(json.loads(route.request.post_data or "{}"))
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_needs_confirmation_payload("/fake/.claude/settings.json")),
+        )
 
     # Cancel never POSTs, so the GET payload only ever needs to reflect the
     # cold-mount ``out_of_sync`` state.
@@ -183,8 +202,8 @@ def test_hooks_sync_cancel_fires_no_post(page, mm_web_url: str) -> None:
         timeout=2_000,
     )
 
-    assert post_calls == [], (
-        f"Cancel on Sync Now must not POST to /api/settings-sync, got {post_calls!r}"
+    assert post_bodies == [{"allow_host_writes": False}], (
+        f"Cancel must stop before an allow_host_writes POST, got {post_bodies!r}"
     )
 
 
@@ -205,9 +224,18 @@ def test_hooks_sync_confirm_transitions_badge_to_in_sync(page, mm_web_url: str) 
     install_default_stubs(page)
 
     post_calls: list[str] = []
+    post_count = {"n": 0}
 
     def _post(route):
+        post_count["n"] += 1
         post_calls.append(route.request.url)
+        if post_count["n"] == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(_needs_confirmation_payload("/fake/.claude/settings.json")),
+            )
+            return
         route.fulfill(
             status=200,
             content_type="application/json",
@@ -312,19 +340,27 @@ def test_hooks_sync_confirm_transitions_badge_to_in_sync(page, mm_web_url: str) 
 
 
 def test_hooks_sync_post_body_carries_allow_host_writes(page, mm_web_url: str) -> None:
-    """Issue #962: the Sync Now confirm modal IS the host-write trust
-    gate, so the resulting POST must carry ``{"allow_host_writes": true}``
-    rather than an empty body. Without it the server returns
-    ``needs_confirmation`` for the user-scope ``~/.claude/settings.json``
-    write and the UI silently shows ``sync_success`` — the exact silent
-    failure #962 calls out.
+    """The confirm modal must disclose every returned host-write target and
+    only then retry with ``{"allow_host_writes": true}``.
     """
     install_default_stubs(page)
 
-    post_bodies: list[str] = []
+    targets = [
+        "/fake/.claude/settings.json",
+        "/fake/.codex/hooks.json",
+        "/fake/.gemini/settings.json",
+    ]
+    post_bodies: list[dict] = []
 
     def _post(route):
-        post_bodies.append(route.request.post_data or "")
+        post_bodies.append(json.loads(route.request.post_data or "{}"))
+        if len(post_bodies) == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(_needs_confirmation_payload(*targets)),
+            )
+            return
         route.fulfill(
             status=200,
             content_type="application/json",
@@ -354,6 +390,11 @@ def test_hooks_sync_post_body_carries_allow_host_writes(page, mm_web_url: str) -
         "() => !document.getElementById('confirm-modal').hidden",
         timeout=2_000,
     )
+    confirm_text = page.locator("#confirm-message").text_content() or ""
+    for target in targets:
+        assert target in confirm_text, (
+            f"confirm modal must disclose host-write target {target!r}, got {confirm_text!r}"
+        )
     page.locator("#confirm-ok-btn").click()
     # Wait for the badge to transition to in_sync — this happens after
     # the POST + post-sync GET reload, so by then the route handler has
@@ -367,10 +408,11 @@ def test_hooks_sync_post_body_carries_allow_host_writes(page, mm_web_url: str) -
         timeout=5_000,
     )
 
-    assert post_bodies, "POST must have fired after confirm"
-    body = json.loads(post_bodies[0])
-    assert body == {"allow_host_writes": True}, (
-        f"Sync Now POST body must be {{'allow_host_writes': true}}, got {body!r}"
+    assert post_bodies == [
+        {"allow_host_writes": False},
+        {"allow_host_writes": True},
+    ], (
+        f"Sync Now must probe first, then retry with host writes after confirm; got {post_bodies!r}"
     )
 
 
@@ -418,25 +460,14 @@ def test_hooks_sync_needs_confirmation_surfaces_banner(page, mm_web_url: str) ->
     explicitly calls out.
     """
     install_default_stubs(page)
+    post_count = {"n": 0}
 
     def _post(route):
+        post_count["n"] += 1
         route.fulfill(
             status=200,
             content_type="application/json",
-            body=json.dumps(
-                {
-                    "results": [
-                        {
-                            "name": "claude_settings",
-                            "status": "needs_confirmation",
-                            "reason": "Refusing host write outside the project root",
-                            "warnings": [],
-                            "target": "/fake/.claude/settings.json",
-                        }
-                    ],
-                    "duplicate_tier_warnings": [],
-                }
-            ),
+            body=json.dumps(_needs_confirmation_payload("/fake/.claude/settings.json")),
         )
 
     _stub_settings_sync(page, _OUT_OF_SYNC_GET, post_handler=_post)
@@ -488,8 +519,17 @@ def test_hooks_sync_runtime_error_not_reported_as_success(page, mm_web_url: str)
     Codex/Gemini statuses (mirror of the needs_confirmation pin above).
     """
     install_default_stubs(page)
+    post_count = {"n": 0}
 
     def _post(route):
+        post_count["n"] += 1
+        if post_count["n"] == 1:
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(_needs_confirmation_payload("/fake/.claude/settings.json")),
+            )
+            return
         route.fulfill(
             status=200,
             content_type="application/json",
@@ -546,26 +586,3 @@ def test_hooks_sync_runtime_error_not_reported_as_success(page, mm_web_url: str)
         assert msg != "Sync completed", (
             f"a runtime error must NOT show the sync_success toast, got {msg!r}"
         )
-
-
-def test_hooks_sync_confirm_discloses_multiruntime_targets(page, mm_web_url: str) -> None:
-    """ADR-0018: the confirm modal is the host-write trust gate, and the click
-    handler authorizes ``allow_host_writes`` for Codex + Gemini too — not just
-    ``~/.claude``. The modal copy must therefore disclose all three runtimes so
-    the user isn't approving a Claude-only write while silently getting three.
-    """
-    install_default_stubs(page)
-    _stub_settings_sync(page, _OUT_OF_SYNC_GET)
-
-    page.goto(mm_web_url)
-    _open_hooks_sync(page)
-
-    page.locator("#hooks-sync-btn").click()
-    page.wait_for_function(
-        "() => !document.getElementById('confirm-modal').hidden",
-        timeout=2_000,
-    )
-    msg = page.locator("#confirm-message").text_content() or ""
-    assert "Codex" in msg and "Gemini" in msg, (
-        f"consent modal must disclose all fan-out runtimes (Codex/Gemini), got {msg!r}"
-    )

--- a/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
+++ b/packages/memtomem/tests/web/test_settings_hooks_sync_confirm.py
@@ -411,8 +411,63 @@ def test_hooks_sync_post_body_carries_allow_host_writes(page, mm_web_url: str) -
     assert post_bodies == [
         {"allow_host_writes": False},
         {"allow_host_writes": True},
-    ], (
-        f"Sync Now must probe first, then retry with host writes after confirm; got {post_bodies!r}"
+    ], f"Sync Now must probe first, then retry with host writes after confirm; got {post_bodies!r}"
+
+
+def test_hooks_sync_scope_drift_aborts_before_host_write(page, mm_web_url: str) -> None:
+    """Trust gate: if the target scope changes between the probe (which
+    discloses the host targets) and the user's confirmation, the authorized
+    write must NOT fire — the disclosed targets no longer match the scope
+    being written. The flow aborts with a scope-changed toast and sends no
+    ``allow_host_writes: true`` POST (TOCTOU guard, Codex review on PR #1114).
+    """
+    install_default_stubs(page)
+
+    post_bodies: list[dict] = []
+
+    def _handler(route):
+        if route.request.method == "POST":
+            post_bodies.append(json.loads(route.request.post_data or "{}"))
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(_needs_confirmation_payload("/fake/.claude/settings.json")),
+            )
+            return
+        # GET (cold-mount + post-abort reload): always out_of_sync.
+        route.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_OUT_OF_SYNC_GET)
+        )
+
+    # Broad glob so the post-abort reload GET against the *drifted* URL
+    # (``?target_scope=user``) is stubbed too, not sent to a real backend.
+    page.route("**/api/settings-sync**", _handler)
+
+    page.goto(mm_web_url)
+    _open_hooks_sync(page)
+
+    # Baseline: project_shared emits no query param, so the snapshot URL is
+    # unscoped (``/api/settings-sync``).
+    page.evaluate("() => { _ctxTargetScope = 'project_shared'; }")
+
+    page.locator("#hooks-sync-btn").click()
+    page.wait_for_function(
+        "() => !document.getElementById('confirm-modal').hidden",
+        timeout=2_000,
+    )
+
+    # Drift the scope while the modal is open: _hooksScopedUrl() now appends
+    # ``?target_scope=user``, diverging from the snapshot taken at click time.
+    page.evaluate("() => { _ctxTargetScope = 'user'; }")
+
+    page.locator("#confirm-ok-btn").click()
+
+    msg_el = page.wait_for_selector("#toast-container .toast.toast-error .toast-msg", timeout=3_000)
+    assert "Target scope changed" in (msg_el.text_content() or ""), (
+        "scope drift must surface the sync_scope_changed toast"
+    )
+    assert post_bodies == [{"allow_host_writes": False}], (
+        f"Scope drift must abort before an allow_host_writes POST, got {post_bodies!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Follow-up to the ADR-0018 hook fan-out (#1109).

Since hooks fan out to whichever runtimes are installed (Claude / Codex / Gemini), the hooks-sync confirmation now does a **two-step host-write flow**: it first asks the server which host settings files the merge would touch (via `/api/settings-sync`), then surfaces the **exact returned targets** in the confirm dialog (`{targets}`) before the write — so the user sees the full blast radius, and a cancel fires no host write. (`settings-hooks-watchdog.js`, en/ko locales, `test_settings_hooks_sync_confirm.py`.)

Also clarifies in `commands.py` that Codex custom prompts are not generated today, so Codex placeholder syntax is documented only as migration context.

## Scope

This branch was rebased onto current `main` and **scoped down**. The Gemini handler-naming / timeout work it originally carried is dropped here because it overlaps **PR #1111** (ADR-0019 ownership marker), which owns the always-restamp behavior. The slug-regex sanitizer is folded into #1111 instead. Net result: this PR touches **no `settings.py`**, so it does not collide with #1111.

## Tests

`test_settings_hooks_sync_confirm.py` (multi-target confirm + cancel-fires-no-write) and `test_context_commands.py`. `ruff check` + `ruff format --check` clean; 57 passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)