### PR TITLE
fix(context): resolve duplicate same-matcher hook conflicts by exact rule identity (#1112)

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/settings_sync.py
+++ b/packages/memtomem/src/memtomem/web/routes/settings_sync.py
@@ -180,7 +180,6 @@ def _compare_hooks(
     for row in _iter_hook_rules(canonical_hooks):
         canonical_index.setdefault((row["event"], row["matcher"]), []).append(row["rule"])
 
-    target_index: dict[tuple[str, str], list[dict]] = {}
     result["target_hooks"]["target_only"] = [
         row
         for row in result["target_hooks"]["configured"]
@@ -214,18 +213,49 @@ def _compare_hooks(
         result["status"] = "out_of_sync" if result["hooks"]["pending"] else "in_sync"
         return result
 
-    # Index target rules by (event, matcher) preserving multiplicity. Claude
-    # Code allows the same matcher (or no matcher) to appear more than once
-    # under one event, so collapsing to a single dict-of-rule lets a
-    # byte-identical canonical contribution mismatch the *second* user rule
-    # and surface as a false-positive conflict (mirrors the same fix on the
-    # merge side in PR #844).
-    for event, rules in target_hooks.items():
+    # Split the target rows (which carry their original ``rule_index`` +
+    # ``rule_hash`` via ``_iter_hook_rules``) by (event, matcher), preserving
+    # multiplicity. Claude Code allows the same matcher (or no matcher) to
+    # appear more than once under one event, so collapsing to a single
+    # dict-of-rule lets a byte-identical canonical contribution mismatch the
+    # *second* user rule and surface as a false-positive conflict (mirrors the
+    # merge-side fix in PR #844). Keeping the full rows lets each conflict carry
+    # a stable identity for the resolve endpoint (issue #1112).
+    configured_rows: list[dict] = result["target_hooks"]["configured"]
+    owned_by_matcher: dict[tuple[str, str], list[dict]] = {}
+    user_rows_by_matcher: dict[tuple[str, str], list[dict]] = {}
+    for row in configured_rows:
+        key = (row["event"], row["matcher"])
+        if _rule_is_memtomem_owned(row["rule"]):
+            owned_by_matcher.setdefault(key, []).append(row["rule"])
+        else:
+            user_rows_by_matcher.setdefault(key, []).append(row)
+    consumed_owned: dict[tuple[str, str], int] = {}
+
+    # A user row that is byte-equal to *some* canonical rule under the same
+    # matcher is already in sync and must never be offered as a replacement
+    # target. Everything else is conflict-eligible; we hand those out FIFO so
+    # the Nth colliding canonical rule pairs with a *distinct* Nth user row —
+    # this is what lets the resolve endpoint update the Nth duplicate instead
+    # of always rewriting the first (issue #1112).
+    canonical_by_matcher: dict[tuple[str, str], list[dict]] = {}
+    for event, rules in canonical_hooks.items():
         if not isinstance(rules, list):
             continue
         for rule in rules:
             if isinstance(rule, dict):
-                target_index.setdefault((event, rule.get("matcher", "")), []).append(rule)
+                canonical_by_matcher.setdefault((event, rule.get("matcher", "")), []).append(rule)
+    conflict_user_rows: dict[tuple[str, str], list[dict]] = {
+        key: [
+            row
+            for row in rows
+            if not any(
+                _rule_content_equal(row["rule"], c) for c in canonical_by_matcher.get(key, [])
+            )
+        ]
+        for key, rows in user_rows_by_matcher.items()
+    }
+    consumed_conflict: dict[tuple[str, str], int] = {}
 
     # Mirror _merge_hooks_record's resolution so the GET diff classifies rules
     # exactly as a sync would (ADR-0019). Each memtomem-owned target rule under
@@ -234,15 +264,6 @@ def _compare_hooks(
     # the *specific* owned rule being consumed — not any same-matcher rule —
     # keeps the diff and the merge in agreement even when a user rule happens to
     # equal canonical while a stale owned rule still needs replacing (Codex r2).
-    owned_by_matcher: dict[tuple[str, str], list[dict]] = {}
-    user_by_matcher: dict[tuple[str, str], list[dict]] = {}
-    for key, rules_at in target_index.items():
-        for r in rules_at:
-            (owned_by_matcher if _rule_is_memtomem_owned(r) else user_by_matcher).setdefault(
-                key, []
-            ).append(r)
-    consumed_owned: dict[tuple[str, str], int] = {}
-
     for event, rules in canonical_hooks.items():
         if not isinstance(rules, list):
             continue
@@ -263,26 +284,51 @@ def _compare_hooks(
                 result["hooks"][bucket].append({"event": event, "matcher": matcher, "rule": rule})
                 continue
 
-            # Owned slots exhausted → merge additively against the user rules.
-            user_rules = user_by_matcher.get(key, [])
-            if any(_rule_content_equal(u, rule) for u in user_rules):
+            # Owned slots exhausted → mirror _merge_hooks_record's Pass 2: a
+            # canonical rule byte-equal to a user rule is synced; one with *no*
+            # same-matcher user rule is appended (pending); otherwise the user
+            # rule wins and we surface a conflict the user can manually accept.
+            user_rows = user_rows_by_matcher.get(key, [])
+            if any(_rule_content_equal(r["rule"], rule) for r in user_rows):
                 result["hooks"]["synced"].append({"event": event, "matcher": matcher, "rule": rule})
-            elif user_rules:
-                # Surface the first user rule as the conflict representative —
-                # keeps the payload shape stable for the resolve flow while not
-                # silently shadowing the rest of the user's same-matcher rules.
-                result["hooks"]["conflicts"].append(
-                    {
-                        "event": event,
-                        "matcher": matcher,
-                        "existing": user_rules[0],
-                        "proposed": rule,
-                    }
-                )
-            else:
+                continue
+            if not user_rows:
+                # Merge only appends when nothing under the matcher belongs to
+                # the user — that is the sole "will be added" case.
                 result["hooks"]["pending"].append(
                     {"event": event, "matcher": matcher, "rule": rule}
                 )
+                continue
+
+            # A conflict. Pair it with a *distinct* conflict-eligible user row
+            # (FIFO) and stamp both identities so the resolve endpoint replaces
+            # the *exact* row with the *exact* proposed rule — the Nth conflict
+            # updates the Nth row (issue #1112). ``proposed`` is the
+            # marker-stamped canonical rule so ``proposed_hash`` matches what
+            # resolve re-derives. When more colliding canonical rules share a
+            # matcher than there are distinct user rows, the overflow stays a
+            # conflict (merge would also warn, never append) bound to the
+            # representative row; there is only one slot to replace, and
+            # resolve's ``rule_hash`` guard turns the second attempt on it into
+            # a refresh-and-retry rather than a silent double-write.
+            eligible = conflict_user_rows.get(key, [])
+            taken = consumed_conflict.get(key, 0)
+            if taken < len(eligible):
+                partner = eligible[taken]
+                consumed_conflict[key] = taken + 1
+            else:
+                partner = eligible[-1] if eligible else user_rows[0]
+            result["hooks"]["conflicts"].append(
+                {
+                    "event": event,
+                    "matcher": matcher,
+                    "existing": partner["rule"],
+                    "proposed": rule,
+                    "target_rule_index": partner["rule_index"],
+                    "target_rule_hash": partner["rule_hash"],
+                    "proposed_hash": _rule_hash(rule),
+                }
+            )
 
     # Any memtomem-owned target slot a canonical rule did NOT consume will be
     # pruned by the next sync (ADR-0019) — whether the whole (event, matcher) is
@@ -393,6 +439,17 @@ class ResolveRequest(BaseModel):
     event: str
     matcher: str = ""
     action: str = "use_proposed"
+    # Exact-rule identity (issue #1112). When the client sends these, the
+    # endpoint replaces the *specific* target row (``rule_index`` + ``rule_hash``)
+    # with the *specific* proposed canonical rule (``proposed_hash``), so
+    # duplicate same-matcher conflict rows resolve deterministically — the Nth
+    # displayed conflict updates the Nth row. Omitting them falls back to
+    # best-effort first-match by (event, matcher): old label-only clients keep
+    # working and the single-conflict case is unaffected, at the cost of the
+    # historical "first row wins" ambiguity when a matcher is duplicated.
+    rule_index: int | None = None
+    rule_hash: str | None = None
+    proposed_hash: str | None = None
 
 
 @router.post("/settings-sync/resolve")
@@ -409,6 +466,22 @@ async def resolve_conflict(
     if body.action != "use_proposed":
         raise HTTPException(400, detail=f"Unknown action: {body.action}")
 
+    # Rule identity (issue #1112) is all-or-nothing: ``rule_index`` +
+    # ``rule_hash`` pin the exact target row and ``proposed_hash`` pins the
+    # exact canonical rule. A partial set would mix an exact target row with a
+    # first-match proposed rule and could write the wrong rule when a matcher
+    # is duplicated, so reject it rather than silently mis-resolve. With none
+    # set we fall back to the legacy label-only first-match for both sides.
+    identity = (body.rule_index, body.rule_hash, body.proposed_hash)
+    if any(v is not None for v in identity) and not all(v is not None for v in identity):
+        raise HTTPException(
+            400,
+            detail=(
+                "Partial rule identity: send rule_index, rule_hash, and "
+                "proposed_hash together, or none for label-only resolve."
+            ),
+        )
+
     label = _rule_label(body.event, body.matcher)
 
     canonical_path = project_root / CANONICAL_SETTINGS_FILE
@@ -424,22 +497,37 @@ async def resolve_conflict(
                 if not isinstance(canonical, dict):
                     raise HTTPException(422, detail="Canonical source is not valid JSON")
 
+                # Resolve the proposed canonical rule. Each candidate is
+                # marker-stamped (ADR-0019) so the rule we write matches what
+                # ``generate_all_settings`` would write — a later re-sync then
+                # recognizes it as memtomem-owned and updates it instead of
+                # re-flagging it as a conflict (issue #1110). When the client
+                # sends ``proposed_hash`` (issue #1112) we pick the *exact*
+                # canonical rule whose stamped hash the GET diff published,
+                # which is the same hash the diff computed over stamped
+                # canonical; otherwise we keep the first-match-by-matcher
+                # behavior for old label-only clients.
                 proposed = None
                 canonical_hooks: dict = canonical.get("hooks", {})
                 for rule in canonical_hooks.get(body.event, []):
-                    if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
-                        proposed = rule
+                    if not (isinstance(rule, dict) and rule.get("matcher", "") == body.matcher):
+                        continue
+                    stamped = _stamp_status_markers({"hooks": {body.event: [rule]}})["hooks"][
+                        body.event
+                    ][0]
+                    if body.proposed_hash is None:
+                        proposed = stamped
+                        break
+                    if _rule_hash(stamped) == body.proposed_hash:
+                        proposed = stamped
                         break
                 if proposed is None:
-                    raise HTTPException(404, detail=f"Rule '{label}' not in canonical source")
-
-                # Stamp the ownership marker (ADR-0019) so the rule we write
-                # matches what ``generate_all_settings`` would write — a later
-                # re-sync then recognizes it as memtomem-owned and can update
-                # it instead of re-flagging it as a conflict (issue #1110).
-                proposed = _stamp_status_markers({"hooks": {body.event: [proposed]}})["hooks"][
-                    body.event
-                ][0]
+                    detail = (
+                        f"Proposed rule for '{label}' not found in canonical source"
+                        if body.proposed_hash is not None
+                        else f"Rule '{label}' not in canonical source"
+                    )
+                    raise HTTPException(404, detail=detail)
 
                 # Read target + mtime guard. ``st_mtime_ns`` matches
                 # ``hot_reload.py`` precision and detects sub-second writes
@@ -452,21 +540,44 @@ async def resolve_conflict(
                 if not isinstance(target, dict):
                     raise HTTPException(422, detail="Target settings is not valid JSON")
 
-                # Replace the rule in-place
                 target_hooks: dict = target.get("hooks", {})
                 if not isinstance(target_hooks, dict):
                     raise HTTPException(422, detail="Target hooks is not a record")
 
                 rules = target_hooks.get(body.event, [])
-                replaced = False
-                for i, rule in enumerate(rules):
-                    if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
-                        rules[i] = proposed
-                        replaced = True
-                        break
+                if not isinstance(rules, list):
+                    raise HTTPException(422, detail="Target hook event is not a list")
 
-                if not replaced:
-                    raise HTTPException(404, detail=f"Rule '{label}' not found in target")
+                # Replace the rule in place. With identity (issue #1112) the Nth
+                # duplicate resolves deterministically: address the exact row by
+                # ``rule_index`` and verify ``rule_hash`` so a row that moved or
+                # changed under us is rejected (stale → aborted, not a silent
+                # mis-resolve). Without identity, keep the historical
+                # first-match-by-matcher behavior.
+                if body.rule_index is not None and body.rule_hash is not None:
+                    candidate = (
+                        rules[body.rule_index] if 0 <= body.rule_index < len(rules) else None
+                    )
+                    if (
+                        not isinstance(candidate, dict)
+                        or candidate.get("matcher", "") != body.matcher
+                        or _rule_hash(candidate) != body.rule_hash
+                    ):
+                        return {
+                            "status": "aborted",
+                            "reason": "Target rule changed. Refresh and retry.",
+                            "mtime_ns": str(target_path.stat().st_mtime_ns),
+                        }
+                    rules[body.rule_index] = proposed
+                else:
+                    replaced = False
+                    for i, rule in enumerate(rules):
+                        if isinstance(rule, dict) and rule.get("matcher", "") == body.matcher:
+                            rules[i] = proposed
+                            replaced = True
+                            break
+                    if not replaced:
+                        raise HTTPException(404, detail=f"Rule '{label}' not found in target")
 
                 # mtime check before write — protects against cross-process
                 # writers (CLI, manual edit) that the in-process lock can't see.

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1410,7 +1410,7 @@
   <script src="/settings-maintenance.js?v=2"></script>
   <script src="/settings-namespaces.js?v=8"></script>
   <script src="/settings-harness.js?v=2"></script>
-  <script src="/settings-hooks-watchdog.js?v=12"></script>
+  <script src="/settings-hooks-watchdog.js?v=13"></script>
   <script src="/timeline.js?v=3"></script>
   <script src="/context-gateway.js?v=44"></script>
   <script src="/path-picker.js?v=3"></script>

--- a/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-hooks-watchdog.js
@@ -527,7 +527,16 @@ async function loadHooksSync() {
         const oldText = JSON.stringify(c.existing, null, 2);
         const newText = JSON.stringify(c.proposed, null, 2);
         const ops = diffLines(oldText, newText);
-        html += `<div class="hooks-sync-card hooks-sync-conflict" data-event="${escapeHtml(c.event)}" data-matcher="${escapeHtml(c.matcher || '')}">
+        // Carry the exact rule identity (issue #1112) so resolving the Nth
+        // same-matcher conflict updates the Nth target row, not the first.
+        // Absent on legacy payloads → the resolve POST falls back to
+        // label-only first-match.
+        const idAttrs = (c.target_rule_index != null && c.target_rule_hash != null)
+          ? ` data-rule-index="${escapeHtml(String(c.target_rule_index))}"`
+            + ` data-rule-hash="${escapeHtml(c.target_rule_hash)}"`
+            + ` data-proposed-hash="${escapeHtml(c.proposed_hash || '')}"`
+          : '';
+        html += `<div class="hooks-sync-card hooks-sync-conflict" data-event="${escapeHtml(c.event)}" data-matcher="${escapeHtml(c.matcher || '')}"${idAttrs}>
           <div class="hooks-sync-card-header">
             <strong>${escapeHtml(label)}</strong>
             <button class="btn-sm btn-primary hooks-resolve-btn"
@@ -660,10 +669,19 @@ async function loadHooksSync() {
           const headers = csrf
             ? {'Content-Type': 'application/json', 'X-Memtomem-CSRF': csrf}
             : {'Content-Type': 'application/json'};
+          // Send the exact rule identity when the card carries it (issue
+          // #1112) so the Nth same-matcher conflict resolves the Nth row.
+          // Legacy cards without identity fall back to label-only first-match.
+          const resolveBody = {event, matcher, action: 'use_proposed'};
+          if (card.dataset.ruleIndex !== undefined && card.dataset.ruleHash !== undefined) {
+            resolveBody.rule_index = Number(card.dataset.ruleIndex);
+            resolveBody.rule_hash = card.dataset.ruleHash;
+            if (card.dataset.proposedHash) resolveBody.proposed_hash = card.dataset.proposedHash;
+          }
           const r = await fetch(_hooksScopedUrl('/api/context/settings/resolve'), {
             method: 'POST',
             headers,
-            body: JSON.stringify({event, matcher, action: 'use_proposed'}),
+            body: JSON.stringify(resolveBody),
           });
           if (!r.ok) {
             const err = await r.json().catch(() => ({}));

--- a/packages/memtomem/tests/test_web_routes_extended.py
+++ b/packages/memtomem/tests/test_web_routes_extended.py
@@ -907,6 +907,309 @@ class TestSettingsSync:
             elif target.is_file():
                 target.unlink()
 
+    async def test_conflict_payload_carries_rule_identity(self, app, client: AsyncClient, tmp_path):
+        """Issue #1112: each conflict row exposes a stable identity for both
+        the target row (``target_rule_index`` + ``target_rule_hash``) and the
+        proposed canonical rule (``proposed_hash``) so the resolve endpoint can
+        address the exact row."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo new")]}}),
+            encoding="utf-8",
+        )
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo old")]}}),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            c = data["hooks"]["conflicts"][0]
+            assert c["target_rule_index"] == 0
+            assert isinstance(c["target_rule_hash"], str) and len(c["target_rule_hash"]) == 64
+            assert isinstance(c["proposed_hash"], str) and len(c["proposed_hash"]) == 64
+            # Target identity hashes the unstamped on-disk row; the proposed
+            # identity hashes the marker-stamped canonical rule, so they differ.
+            assert c["target_rule_hash"] != c["proposed_hash"]
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_resolve_replaces_rule_by_identity(self, app, client: AsyncClient, tmp_path):
+        """Issue #1112: the single-conflict case resolves via exact identity
+        (regression) — the row addressed by index+hash is replaced with the
+        proposed canonical rule."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo new")]}}),
+            encoding="utf-8",
+        )
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo old")]}}),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            c = (await client.get("/api/settings-sync?target_scope=user")).json()["hooks"][
+                "conflicts"
+            ][0]
+            resp = await client.post(
+                "/api/settings-sync/resolve?target_scope=user",
+                json={
+                    "event": "PostToolUse",
+                    "matcher": "Write",
+                    "action": "use_proposed",
+                    "rule_index": c["target_rule_index"],
+                    "rule_hash": c["target_rule_hash"],
+                    "proposed_hash": c["proposed_hash"],
+                },
+            )
+            assert resp.json()["status"] == "ok"
+            updated = json.loads(target.read_text(encoding="utf-8"))
+            assert updated["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == "echo new"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_two_same_matcher_conflicts_resolve_independently(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Issue #1112: two canonical rules under one matcher each conflict with
+        a *distinct* user row. Resolving the conflict bound to the Nth row must
+        update that Nth row and leave the others alone — the by-label bug would
+        have rewritten row 0 and left the real conflict unresolved."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            self._rule("Write", "echo c1"),
+                            self._rule("Write", "echo c2"),
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "PostToolUse": [
+                                self._rule("Write", "echo u1"),
+                                self._rule("Write", "echo u2"),
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "conflicts"
+            conflicts = data["hooks"]["conflicts"]
+            assert len(conflicts) == 2
+            by_index = {c["target_rule_index"]: c for c in conflicts}
+            # Distinct target rows — not both pointing at the first slot.
+            assert set(by_index) == {0, 1}
+            assert by_index[1]["existing"]["hooks"][0]["command"] == "echo u2"
+            assert by_index[1]["proposed"]["hooks"][0]["command"] == "echo c2"
+
+            # Resolve only the row-1 conflict.
+            resp = await client.post(
+                "/api/settings-sync/resolve?target_scope=user",
+                json={
+                    "event": "PostToolUse",
+                    "matcher": "Write",
+                    "action": "use_proposed",
+                    "rule_index": by_index[1]["target_rule_index"],
+                    "rule_hash": by_index[1]["target_rule_hash"],
+                    "proposed_hash": by_index[1]["proposed_hash"],
+                },
+            )
+            assert resp.json()["status"] == "ok"
+            rules = json.loads(target.read_text(encoding="utf-8"))["hooks"]["PostToolUse"]
+            assert rules[0]["hooks"][0]["command"] == "echo u1"  # untouched
+            assert rules[1]["hooks"][0]["command"] == "echo c2"  # the Nth row
+
+            # Resolving the row-0 conflict (its identity is still valid since
+            # row 0 was untouched) replaces the first row with the first rule.
+            resp = await client.post(
+                "/api/settings-sync/resolve?target_scope=user",
+                json={
+                    "event": "PostToolUse",
+                    "matcher": "Write",
+                    "action": "use_proposed",
+                    "rule_index": by_index[0]["target_rule_index"],
+                    "rule_hash": by_index[0]["target_rule_hash"],
+                    "proposed_hash": by_index[0]["proposed_hash"],
+                },
+            )
+            assert resp.json()["status"] == "ok"
+            rules = json.loads(target.read_text(encoding="utf-8"))["hooks"]["PostToolUse"]
+            assert rules[0]["hooks"][0]["command"] == "echo c1"
+            assert rules[1]["hooks"][0]["command"] == "echo c2"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_resolve_stale_hash_returns_aborted(self, app, client: AsyncClient, tmp_path):
+        """Issue #1112: an out-of-date ``rule_hash`` (the row moved or changed
+        under the client) aborts with a clear message instead of silently
+        replacing the wrong row."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo new")]}}),
+            encoding="utf-8",
+        )
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo old")]}}),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            c = (await client.get("/api/settings-sync?target_scope=user")).json()["hooks"][
+                "conflicts"
+            ][0]
+            resp = await client.post(
+                "/api/settings-sync/resolve?target_scope=user",
+                json={
+                    "event": "PostToolUse",
+                    "matcher": "Write",
+                    "action": "use_proposed",
+                    "rule_index": c["target_rule_index"],
+                    "rule_hash": "0" * 64,  # stale / wrong identity
+                    "proposed_hash": c["proposed_hash"],
+                },
+            )
+            body = resp.json()
+            assert body["status"] == "aborted"
+            assert "changed" in body["reason"].lower()
+            # No silent mis-resolve: the target row is left exactly as it was.
+            rules = json.loads(target.read_text(encoding="utf-8"))["hooks"]["PostToolUse"]
+            assert rules[0]["hooks"][0]["command"] == "echo old"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_more_canonical_than_user_rows_stays_conflict_not_pending(
+        self, app, client: AsyncClient, tmp_path
+    ):
+        """Issue #1112 (Codex r1): when canonical emits more colliding rules
+        under a matcher than there are user rows, the overflow must remain a
+        conflict — ``_merge_hooks_record`` warns and never appends while a
+        same-matcher user rule exists, so reporting the overflow as ``pending``
+        ("will be added") would lie about what a sync does."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PostToolUse": [
+                            self._rule("Write", "echo c1"),
+                            self._rule("Write", "echo c2"),
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo u1")]}}),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            data = (await client.get("/api/settings-sync?target_scope=user")).json()
+            assert data["status"] == "conflicts"
+            # Both canonical rules collide with the single user row → two
+            # conflicts, zero pending (a sync would emit two warnings, add none).
+            assert len(data["hooks"]["conflicts"]) == 2
+            assert data["hooks"]["pending"] == []
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
+    async def test_resolve_partial_identity_returns_400(self, app, client: AsyncClient, tmp_path):
+        """Issue #1112 (Codex r2): rule identity is all-or-nothing. A request
+        with a target row identity but no ``proposed_hash`` would pin the exact
+        row yet pick the first canonical same-matcher rule — wrong when canonical
+        is duplicated — so it is rejected rather than silently mis-resolved."""
+        canonical = tmp_path / ".memtomem" / "settings.json"
+        canonical.parent.mkdir()
+        canonical.write_text(
+            json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo new")]}}),
+            encoding="utf-8",
+        )
+        target = Path.home() / ".claude" / "settings.json"
+        backup = target.read_text(encoding="utf-8") if target.is_file() else None
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(
+                json.dumps({"hooks": {"PostToolUse": [self._rule("Write", "echo old")]}}),
+                encoding="utf-8",
+            )
+            app.state.project_root = tmp_path
+
+            resp = await client.post(
+                "/api/settings-sync/resolve?target_scope=user",
+                json={
+                    "event": "PostToolUse",
+                    "matcher": "Write",
+                    "action": "use_proposed",
+                    "rule_index": 0,
+                    "rule_hash": "a" * 64,
+                    # proposed_hash deliberately omitted → partial identity.
+                },
+            )
+            assert resp.status_code == 400
+            assert "Partial rule identity" in resp.json()["detail"]
+            # Target untouched by the rejected request.
+            rules = json.loads(target.read_text(encoding="utf-8"))["hooks"]["PostToolUse"]
+            assert rules[0]["hooks"][0]["command"] == "echo old"
+        finally:
+            if backup is not None:
+                target.write_text(backup, encoding="utf-8")
+            elif target.is_file():
+                target.unlink()
+
     async def test_marked_rule_differing_is_not_conflict(self, app, client: AsyncClient, tmp_path):
         """ADR-0019: a memtomem-marked target rule that differs is a pending
         update (a plain re-sync fixes it), not a user conflict (issue #1110)."""


### PR DESCRIPTION
## Summary

`resolve_conflict` (the Web "Use memtomem's version" endpoint) matched conflicts by `(event, matcher)` label and replaced the **first** matching target rule with the **first** matching canonical rule. Claude Code allows more than one rule under a matcher, so distinct conflict rows in the UI could all resolve to the same first slot — resolving the *second* displayed conflict wrote the first canonical rule over the first target row and left the real conflict unresolved.

Closes #1112.

## Changes

- **`_compare_hooks`** now emits a stable identity per conflict — `target_rule_index` + `target_rule_hash` (the exact on-disk row) and `proposed_hash` (the marker-stamped canonical rule) — and pairs each colliding canonical rule with a **distinct** user row (FIFO), skipping rows already byte-equal to canonical. Overflow rules (more canonical than user rows under a matcher) stay **conflicts**, never `pending`, mirroring `_merge_hooks_record` (which warns and never appends while a same-matcher user rule exists).
- **`resolve_conflict`** replaces the exact row (index + hash) with the exact proposed rule (hash). A stale identity returns an `aborted` "refresh and retry" envelope instead of mis-resolving. Rule identity is **all-or-nothing**: a partial set (e.g. row identity without `proposed_hash`) is rejected with HTTP 400, so an exact target row is never paired with a first-match proposed rule.
- **Backward compatibility (decision):** requests without identity keep the historical best-effort first-match by `(event, matcher)` — old label-only clients are unaffected and the single-conflict case is unchanged. (#1112 left this choice to the implementer.)
- **Web UI** — the conflict card carries the identity and sends it on resolve; cards without it fall back to label-only. Cache-bust `?v=12` → `?v=13`.

## Tests

`test_web_routes_extended.py`:
- conflict payload carries rule identity
- single-conflict resolve via identity (regression)
- two same-matcher conflicts resolve **independently** (Nth → Nth row)
- stale `rule_hash` → `aborted`, target untouched
- more canonical than user rows → stays conflict, zero `pending`
- partial identity → HTTP 400, target untouched

Full sweep: 184 passed (`test_web_routes_extended` + `test_context_settings` + `test_web_routes_context_locks` + Playwright `test_settings_hooks_resolve_inline`); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)