### PR TITLE
fix(web): route shape-invalid 200 /api/context/projects through the failure path (#1100)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -219,7 +219,7 @@ function _ctxNormalizeActiveScope(scopes) {
 
 async function _ctxFetchProjects() {
   let data;
-  // Three failure shapes need to stay distinguishable per #1080:
+  // Four failure shapes need to stay distinguishable per #1080:
   //   - 404 / network throw   → older deployment or absent endpoint; the
   //     legacy single-server-CWD fallback is the documented contract here,
   //     so stay silent to avoid noise on intentional-omit deployments.
@@ -228,6 +228,8 @@ async function _ctxFetchProjects() {
   //     registered projects".
   //   - 200 with malformed JSON → endpoint reachable, response unreadable;
   //     same "endpoint exists but failing" class, surface a toast.
+  //   - 200 with unexpected shape → parses cleanly but isn't {scopes: Array};
+  //     same "endpoint exists but failing" class, surface a toast (#1100).
   let warn = null;
   try {
     const res = await fetch(_ctxWithTargetScope('/api/context/projects', { includeScope: false }));
@@ -241,6 +243,18 @@ async function _ctxFetchProjects() {
     } catch (parseErr) {
       warn = { kind: 'parse', detail: String((parseErr && parseErr.message) || parseErr) };
       throw parseErr;
+    }
+    // Validate the shape *outside* the parse try/catch so it isn't
+    // misclassified as a parse failure. A 200 that parses but isn't
+    // {scopes: Array} — null, {}, {error: …}, a string, an array — would
+    // otherwise fall through to ``data.scopes || []`` below: literal ``null``
+    // TypeErrors (caller shows a generic "Failed to load overview", toast
+    // never reached) and ``{}`` silently empties the cache, reproducing the
+    // #1080 "unreadable store masquerading as no-projects" symptom. Route it
+    // through the same loud-fallback path as the other failing-endpoint shapes.
+    if (!data || !Array.isArray(data.scopes)) {
+      warn = { kind: 'shape', detail: `unexpected response shape: ${typeof data}` };
+      throw new Error(warn.detail);
     }
   } catch (_err) {
     // Browser tests and older deployments may not provide the multi-project

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1412,7 +1412,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=13"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=45"></script>
+  <script src="/context-gateway.js?v=46"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/tests-js/ctx-project-fetch-failure.test.mjs
+++ b/packages/memtomem/tests-js/ctx-project-fetch-failure.test.mjs
@@ -1,18 +1,20 @@
-/* Regression guard for #1080 — distinguish the three failure shapes of
+/* Regression guard for #1080 / #1100 — distinguish the failure shapes of
  * ``GET /api/context/projects`` instead of silently collapsing them all
  * onto the Server-CWD-only fallback.
  *
  *   - 404 / network throw     → silent fallback (legacy/older-deploy contract)
  *   - 5xx / non-404 4xx       → toast + fallback (endpoint failing)
  *   - 200 + malformed JSON    → toast + fallback (response unreadable)
+ *   - 200 + unexpected shape  → toast + fallback (parses but not {scopes:[…]})
  *   - 200 + real {scopes:[…]} → no toast, real scopes rendered (baseline)
  *
- * The four cells together pin the symmetric pair per
+ * The cells together pin the symmetric pair per
  * ``feedback_pin_invert_symmetric_assertion.md``: positive-only or
- * negative-only would false-pass since the bug is "three cases collapsing
- * to one". The mutation that proves these tests bite is restoring the
- * original blanket ``catch (_err) { fallback }`` — the 503 / parse cases
- * then stop toasting.
+ * negative-only would false-pass since the bug is "several failing cases
+ * collapsing to one silent no-projects state". The mutation that proves
+ * these tests bite is restoring the original blanket ``catch (_err)
+ * { fallback }`` — the 503 / parse cases then stop toasting; deleting the
+ * shape branch (#1100) flips the null / {} cells specifically.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -132,6 +134,35 @@ describe('_ctxFetchProjects — failure-shape signal split (#1080)', () => {
     expect(toasts[0].level).toBe('error');
     // Parse-error detail string varies by engine; just pin that *something*
     // about the failure surfaced (not the empty/raw key fallback).
+    expect(toasts[0].msg).not.toBe('settings.ctx.projects_fetch_failed');
+    expect(toasts[0].msg.length).toBeGreaterThan(0);
+  });
+
+  it('200 with null body — toast + fallback (shape failure, #1100)', async () => {
+    // Server returns the JSON literal ``null``. Pre-#1100 this slipped past
+    // both the !res.ok and parse branches, then ``data.scopes`` TypeErrored —
+    // the caller surfaced a generic "Failed to load overview" and the toast
+    // line was never reached. Now it routes through the shape branch.
+    installProjectsFetch(window, () => jsonRes(null));
+    const data = await window._ctxFetchProjects();
+    expect(data.scopes).toHaveLength(1);
+    expect(data.scopes[0].sources).toEqual(['server-cwd']);
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].level).toBe('error');
+    expect(toasts[0].msg).not.toBe('settings.ctx.projects_fetch_failed');
+    expect(toasts[0].msg.length).toBeGreaterThan(0);
+  });
+
+  it('200 with {} body — toast + fallback (shape failure, #1100)', async () => {
+    // Parses fine but has no ``scopes`` array. Pre-#1100 this silently set
+    // ``_ctxProjectsCache = []`` with no toast — indistinguishable from "no
+    // registered projects", the exact #1080 symptom via a different path.
+    installProjectsFetch(window, () => jsonRes({}));
+    const data = await window._ctxFetchProjects();
+    expect(data.scopes).toHaveLength(1);
+    expect(data.scopes[0].sources).toEqual(['server-cwd']);
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].level).toBe('error');
     expect(toasts[0].msg).not.toBe('settings.ctx.projects_fetch_failed');
     expect(toasts[0].msg.length).toBeGreaterThan(0);
   });

--- a/packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs
+++ b/packages/memtomem/tests-js/ctx-sync-all-tooltip.test.mjs
@@ -42,6 +42,16 @@ function stubOverviewFetch(window, { allRuntimeOnly }) {
     if (url.endsWith('/api/context/overview')) {
       return { ok: true, status: 200, json: async () => data };
     }
+    // ``loadCtxOverview`` also calls ``_ctxFetchProjects`` → GET
+    // /api/context/projects. bootApp's default stub returns ``{}`` for it,
+    // which since #1100 is a shape failure that fires its own error toast —
+    // that would land *first* in ``#toast-container`` and shadow the
+    // click-toast these tests read back. Return a minimal valid scopes
+    // payload so the projects fetch stays silent and the subject toast is
+    // the only one present.
+    if (url.includes('/api/context/projects')) {
+      return { ok: true, status: 200, json: async () => ({ scopes: [] }) };
+    }
     return upstream(input);
   };
 }

--- a/packages/memtomem/tests/web/conftest.py
+++ b/packages/memtomem/tests/web/conftest.py
@@ -119,3 +119,31 @@ def install_default_stubs(page) -> None:
     page.route("**/api/namespaces", lambda r: _ok(r, {"namespaces": []}))
     page.route("**/api/stats", lambda r: _ok(r, {}))
     page.route("**/api/privacy/patterns", lambda r: _ok(r, {"patterns": []}))
+    # ``/api/context/projects`` needs a valid ``{scopes: [...]}`` shape, not
+    # the catch-all ``{}``: since #1100 ``_ctxFetchProjects`` treats a 200 that
+    # isn't ``{scopes: Array}`` as a failure and fires a "project list failed to
+    # load" error toast. Under the bare ``{}`` that toast lands in
+    # ``#toast-container`` on every boot and shadows / duplicates the toast
+    # specs assert on (strict-mode "resolved to 2 elements"). One synthetic
+    # server-CWD scope mirrors the legacy single-project payload and stays
+    # silent. ``**`` tail also matches the ``?target_scope=`` query variant.
+    page.route(
+        "**/api/context/projects**",
+        lambda r: _ok(
+            r,
+            {
+                "scopes": [
+                    {
+                        "scope_id": "",
+                        "label": "Server CWD",
+                        "root": "",
+                        "tier": "project",
+                        "sources": ["server-cwd"],
+                        "experimental": False,
+                        "missing": False,
+                        "counts": {"skills": 0, "commands": 0, "agents": 0},
+                    }
+                ]
+            },
+        ),
+    )


### PR DESCRIPTION
## Summary

Follow-up to #1080 / PR #1099. That fix split `_ctxFetchProjects`'s catch into HTTP / parse / 404 / network branches, but a `200` response whose body **parses cleanly yet isn't `{scopes: Array}`** — `null`, `{}`, `{error: …}`, a bare string, an array — still escaped every warning branch and fell through to `data.scopes || []`:

- literal `null` → `data.scopes` **TypeErrors**, the caller surfaces a generic "Failed to load overview", and the toast line is never reached.
- `{}` → `_ctxProjectsCache = []` **silently**, indistinguishable from "no registered projects" — the exact #1080 "unreadable store masquerading as no-projects" symptom, reached via a different code path than #1099 covered.

## Fix

Validate the shape right after `res.json()` succeeds, **outside** the parse `try/catch` so a shape failure isn't misclassified as a parse error, and route it through the same loud `{ kind: 'shape' }` fallback + toast as the other failing-endpoint shapes:

\`\`\`js
if (!data || !Array.isArray(data.scopes)) {
  warn = { kind: 'shape', detail: \`unexpected response shape: \${typeof data}\` };
  throw new Error(warn.detail);
}
\`\`\`

The throw lands in the outer `catch (_err)` → synthetic Server-CWD fallback, and `warn` being set means normalization is skipped (per #1102) and the toast surfaces. Reuses `settings.ctx.projects_fetch_failed` — **no locale change, no API change**. Bumps `context-gateway.js?v=45 → v=46`.

## Test plan

Two cells added to `tests-js/ctx-project-fetch-failure.test.mjs`, mirroring the symmetric-pin pattern already in the file:

| Response | Toast | Fallback Server-CWD |
| --- | :---: | :---: |
| 200 + `null` body | yes | yes |
| 200 + `{}` body | yes | yes |

- [x] `npx vitest run ctx-project-fetch-failure` — 12/12 (was 10, +2)
- [x] `npx vitest run` — 66/66 (full `tests-js`)
- [x] **Mutation-validated**: deleting the shape branch flips both new cells red — `{}` fails its assertion; `null` throws the very `data.scopes` TypeError the issue describes (run errors out). With the branch present both are green.

### Collateral test-harness fix

`ctx-sync-all-tooltip.test.mjs` only stubbed `/api/context/overview` and let `/api/context/projects` fall to bootApp's default `{}` stub. Since this PR makes `{}` a shape failure, that fetch now fires its own error toast which landed **first** in `#toast-container` and shadowed the click-toast two tests read back. Fixed by stubbing `/api/context/projects` with a valid `{scopes: []}` so the projects fetch stays silent — isolating each test to its actual subject.

Fixes #1100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)