### PR TITLE
fix(context): refuse to overwrite agent files when context.md has zero sections

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1086,24 +1086,36 @@ def sync_cmd(
 
     if ctx_path.exists():
         sections = parse_context(ctx_path)
-        files = detect_agent_files(root)
-
-        if files:
-            agents_to_sync = {f.agent for f in files}
-
-            for agent_name in sorted(agents_to_sync):
-                gen = GENERATORS.get(agent_name)
-                if not gen:
-                    continue
-
-                content = gen.generate(sections)
-                out_path = root / gen.output_path
-                out_path.write_text(content, encoding="utf-8")
-                click.echo(f"  {agent_name:10s}  {gen.output_path}")
-        else:
-            click.echo(
-                "No agent files detected. Use 'mm context generate --agent all' to create them."
+        if not sections:
+            # Mirror generate_cmd's empty-guard (line ~932). parse_context
+            # returns {} for any context.md with content but no ``## Heading``
+            # delimiters (a stub, all-prose, or a mid-edit file). Without this
+            # guard, gen.generate({}) yields header-only/empty output that would
+            # overwrite the user's existing CLAUDE.md/GEMINI.md/.cursorrules —
+            # silent data loss with no backup. Refuse instead.
+            click.secho(
+                f"{CONTEXT_FILENAME} is empty — refusing to overwrite agent files.",
+                fg="yellow",
             )
+        else:
+            files = detect_agent_files(root)
+
+            if files:
+                agents_to_sync = {f.agent for f in files}
+
+                for agent_name in sorted(agents_to_sync):
+                    gen = GENERATORS.get(agent_name)
+                    if not gen:
+                        continue
+
+                    content = gen.generate(sections)
+                    out_path = root / gen.output_path
+                    out_path.write_text(content, encoding="utf-8")
+                    click.echo(f"  {agent_name:10s}  {gen.output_path}")
+            else:
+                click.echo(
+                    "No agent files detected. Use 'mm context generate --agent all' to create them."
+                )
     elif not inc:
         click.secho(f"{CONTEXT_FILENAME} not found. Run 'mm context init' first.", fg="red")
         return

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -709,23 +709,30 @@ async def mem_context_sync(
 
     if ctx_path.exists():
         sections = parse_context(ctx_path)
-        files = detect_agent_files(root)
+        if not sections:
+            # Mirror mem_context_generate's empty-guard. parse_context returns
+            # {} for a content-but-no-``## Heading`` context.md; syncing it would
+            # overwrite the user's existing agent files with header-only/empty
+            # output (silent data loss). Refuse, matching the CLI sync guard.
+            results.append(f"{CONTEXT_FILENAME} is empty — refusing to overwrite agent files.")
+        else:
+            files = detect_agent_files(root)
 
-        if files:
-            agents_synced: set[str] = set()
-            for f in files:
-                if f.agent in agents_synced:
-                    continue
-                gen = GENERATORS.get(f.agent)
-                if not gen:
-                    continue
-                content = gen.generate(sections)
-                out_path = root / gen.output_path
-                await asyncio.to_thread(out_path.write_text, content, encoding="utf-8")
-                results.append(f"{f.agent}: {gen.output_path}")
-                agents_synced.add(f.agent)
-        elif not inc:
-            return "No agent files detected. Use mem_context_generate to create them."
+            if files:
+                agents_synced: set[str] = set()
+                for f in files:
+                    if f.agent in agents_synced:
+                        continue
+                    gen = GENERATORS.get(f.agent)
+                    if not gen:
+                        continue
+                    content = gen.generate(sections)
+                    out_path = root / gen.output_path
+                    await asyncio.to_thread(out_path.write_text, content, encoding="utf-8")
+                    results.append(f"{f.agent}: {gen.output_path}")
+                    agents_synced.add(f.agent)
+            elif not inc:
+                return "No agent files detected. Use mem_context_generate to create them."
     elif not inc:
         return f"{CONTEXT_FILENAME} not found. Create it with 'mm context init'."
     else:

--- a/packages/memtomem/tests/test_context_sync_empty_guard.py
+++ b/packages/memtomem/tests/test_context_sync_empty_guard.py
@@ -1,0 +1,88 @@
+"""Regression: `mm context sync` / mem_context_sync must NOT overwrite existing
+agent files when context.md parses to zero sections.
+
+``parse_context`` returns ``{}`` for any context.md that has content but no
+``## Heading`` delimiters (a stub, an all-prose file, or a file the user is
+mid-edit on). Before the guard, ``gen.generate({})`` produced header-only /
+empty output that ``sync`` wrote straight over the user's existing
+CLAUDE.md / GEMINI.md / .cursorrules — silent data loss with no backup. The
+sibling ``generate`` verb has always had this guard; ``sync`` (and its MCP
+twin) did not. These tests pin the parity.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.context.parser import CONTEXT_FILENAME
+from memtomem.server.tools.context import mem_context_sync
+
+from .helpers import set_home
+
+PROSE_ONLY = "Just some working notes with no markdown headings yet.\nMore prose.\n"
+WITH_SECTION = "# Context\n\n## Project\n- Name: demo\n- Language: Python\n"
+ORIGINAL_CLAUDE = "# My real project rules\n\nIMPORTANT: do not delete this.\n"
+
+
+def _seed_project(tmp_path: Path, context_body: str) -> Path:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".git").mkdir()
+    ctx = project / CONTEXT_FILENAME
+    ctx.parent.mkdir(parents=True, exist_ok=True)
+    ctx.write_text(context_body, encoding="utf-8")
+    (project / "CLAUDE.md").write_text(ORIGINAL_CLAUDE, encoding="utf-8")
+    return project
+
+
+class TestCliSyncEmptyGuard:
+    def test_sync_refuses_to_overwrite_when_no_sections(self, tmp_path, monkeypatch):
+        project = _seed_project(tmp_path, PROSE_ONLY)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        result = CliRunner().invoke(context, ["sync"])
+
+        assert result.exit_code == 0
+        assert "empty" in result.output.lower()
+        # The user's existing CLAUDE.md must be untouched.
+        assert (project / "CLAUDE.md").read_text(encoding="utf-8") == ORIGINAL_CLAUDE
+
+    def test_sync_still_writes_when_sections_present(self, tmp_path, monkeypatch):
+        """The guard must NOT block the happy path."""
+        project = _seed_project(tmp_path, WITH_SECTION)
+        monkeypatch.chdir(project)
+
+        from memtomem.cli.context_cmd import context
+
+        result = CliRunner().invoke(context, ["sync"])
+
+        assert result.exit_code == 0
+        # CLAUDE.md was regenerated from the parsed sections, replacing the sentinel.
+        assert (project / "CLAUDE.md").read_text(encoding="utf-8") != ORIGINAL_CLAUDE
+
+
+@pytest.mark.anyio
+class TestMcpSyncEmptyGuard:
+    async def test_mem_context_sync_refuses_when_no_sections(self, tmp_path, monkeypatch):
+        project = _seed_project(tmp_path, PROSE_ONLY)
+        monkeypatch.chdir(project)
+        set_home(monkeypatch, tmp_path / "home")
+
+        out = await mem_context_sync()
+
+        assert "empty" in out.lower()
+        assert (project / "CLAUDE.md").read_text(encoding="utf-8") == ORIGINAL_CLAUDE
+
+    async def test_mem_context_sync_still_writes_when_sections_present(self, tmp_path, monkeypatch):
+        project = _seed_project(tmp_path, WITH_SECTION)
+        monkeypatch.chdir(project)
+        set_home(monkeypatch, tmp_path / "home")
+
+        await mem_context_sync()
+
+        assert (project / "CLAUDE.md").read_text(encoding="utf-8") != ORIGINAL_CLAUDE


### PR DESCRIPTION
## Problem
`mm context sync` (and its MCP twin `mem_context_sync`) wrote `gen.generate(sections)` to every detected agent file even when `parse_context()` returned `{}` — which happens for any `context.md` that has content but no `## Heading` delimiters (a stub, an all-prose file, or one the user is mid-edit on). `ClaudeGenerator.generate({})` yields only header boilerplate and `CursorGenerator` yields `""`, so `sync` silently overwrote the user's existing `CLAUDE.md` / `GEMINI.md` / `.cursorrules` with near-empty output — **data loss with no `.bak`**.

The sibling `generate` verb has always guarded this (`context_cmd.py:932`); `sync` and `mem_context_sync` did not.

## Fix
Mirror the empty-sections guard on both surfaces: when `sections` is empty, emit a "refusing to overwrite" notice and skip the write loop. The happy path (sections present) is unchanged.

## Tests
`test_context_sync_empty_guard.py` pins both the refusal (existing file preserved) and the happy path (file still regenerated) for CLI + MCP. Full context suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)