### PR TITLE
fix(context): stop overrides/ leaking into skill fan-out and clear false diff drift

### DIFF
--- a/packages/memtomem/src/memtomem/context/_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_atomic.py
@@ -155,7 +155,13 @@ def atomic_write_text(
     atomic_write_bytes(path, text.encode(encoding), mode=mode)
 
 
-def copy_tree_atomic(src: Path, dst: Path, *, mode: int = 0o644) -> int:
+def copy_tree_atomic(
+    src: Path,
+    dst: Path,
+    *,
+    mode: int = 0o644,
+    skip_top_level: frozenset[str] | None = None,
+) -> int:
     """Recursively mirror *src* → *dst*, each file via :func:`atomic_write_bytes`.
 
     Returns the number of files written. ``mode`` (default ``0o644``) is the
@@ -164,16 +170,23 @@ def copy_tree_atomic(src: Path, dst: Path, *, mode: int = 0o644) -> int:
     target runtimes), unlike the ``0o600`` default of ``atomic_write_bytes``
     which is tuned for state files.
 
-    Entries named in :data:`COPY_SKIP_NAMES` are skipped silently. Symlinks
-    are skipped with a warning — this helper promises a *byte-for-byte tree
-    mirror*, and silently dereferencing a symlink to ``/etc/passwd`` (or any
-    out-of-tree target) would violate that contract. Callers who want to
-    mirror symlinks must do so explicitly.
+    Entries named in :data:`COPY_SKIP_NAMES` are skipped silently at every
+    depth. ``skip_top_level`` names additional entries skipped ONLY at the
+    root of this call (it is deliberately not propagated into the recursion),
+    so e.g. a skill's top-level ``overrides/`` source can be excluded without
+    also dropping a legitimate nested ``scripts/overrides/``. Skipping during
+    the copy (rather than deleting afterwards) means those bytes never touch
+    *dst* — no crash window where they exist, no silent leak if a later delete
+    fails. Symlinks are skipped with a warning — this helper promises a
+    *byte-for-byte tree mirror*, and silently dereferencing a symlink to
+    ``/etc/passwd`` (or any out-of-tree target) would violate that contract.
+    Callers who want to mirror symlinks must do so explicitly.
     """
+    extra_skip = skip_top_level or frozenset()
     dst.mkdir(parents=True, exist_ok=True)
     written = 0
     for entry in src.iterdir():
-        if entry.name in COPY_SKIP_NAMES:
+        if entry.name in COPY_SKIP_NAMES or entry.name in extra_skip:
             continue
         if entry.is_symlink():
             logger.warning("copy_tree_atomic: skipping symlink %s", entry)
@@ -183,6 +196,7 @@ def copy_tree_atomic(src: Path, dst: Path, *, mode: int = 0o644) -> int:
             atomic_write_bytes(target, entry.read_bytes(), mode=mode)
             written += 1
         elif entry.is_dir():
+            # skip_top_level intentionally not threaded into the recursion.
             written += copy_tree_atomic(entry, target, mode=mode)
     return written
 

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -39,10 +39,11 @@ from pathlib import Path
 from typing import Any, Protocol, cast
 
 from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import InvalidNameError, Layout, validate_name
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context._sync_atomic import (
     ON_DROP_LEVELS,
@@ -930,13 +931,39 @@ def diff_agents(
             except AgentParseError:
                 results.append((gen_name, name, "parse error"))
                 continue
-            expected, _ = gen.render(agent)
             # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
             # above guarantees this runtime+scope has a fan-out root, so
             # ``gen.target_file`` cannot return ``None`` for any name.
             # Earlier defensive ``if target is None: continue`` removed.
             target = gen.target_file(project_root, name, scope=scope)
             assert target is not None  # narrowed by upstream NO_FANOUT guard
+
+            # A per-vendor override replaces the rendered runtime file at sync
+            # time (``_sync_atomic`` Phase 2 / ADR-0008 Invariant 4) via
+            # ``atomic_write_bytes`` — raw bytes, no strip. Compare byte-exact
+            # against the same source so an override-carrying agent isn't
+            # reported permanently "out of sync"; decoding as text would crash
+            # on a non-UTF-8 override and would mask whitespace-only byte drift.
+            vendor = GENERATOR_VENDOR.get(gen_name)
+            override_path = (
+                _override.resolve(project_root, "agents", name, vendor, scope=scope)
+                if vendor is not None
+                else None
+            )
+            if override_path is not None:
+                try:
+                    expected_bytes = override_path.read_bytes()
+                except OSError:
+                    # Sync skips an unreadable override (no effective fan-out),
+                    # so we can't assert parity — report drift, never mask it.
+                    results.append((gen_name, name, "out of sync"))
+                    continue
+                actual_bytes = target.read_bytes() if target.is_file() else b""
+                status = "in sync" if expected_bytes == actual_bytes else "out of sync"
+                results.append((gen_name, name, status))
+                continue
+
+            expected, _ = gen.render(agent)
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -39,10 +39,11 @@ from pathlib import Path
 from typing import Protocol, cast
 
 from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes, atomic_write_text
 from memtomem.context._gate_a import GateABlocked, apply_gate_a
 from memtomem.config import TargetScope
-from memtomem.context._names import InvalidNameError, Layout, validate_name
+from memtomem.context._names import GENERATOR_VENDOR, InvalidNameError, Layout, validate_name
 from memtomem.context._runtime_targets import runtime_artifact_names, runtime_fanout_root
 from memtomem.context._sync_atomic import (
     AtomicSyncAdapter,
@@ -771,13 +772,39 @@ def diff_commands(
             except CommandParseError:
                 results.append((gen_name, name, "parse error"))
                 continue
-            expected, _ = gen.render(cmd)
             # Cleanup item #2: the upstream ``runtime_fanout_root`` guard
             # above guarantees this runtime+scope has a fan-out root, so
             # ``gen.target_file`` cannot return ``None`` for any name.
             # Earlier defensive ``if target is None: continue`` removed.
             target = gen.target_file(project_root, name, scope=scope)
             assert target is not None  # narrowed by upstream NO_FANOUT guard
+
+            # A per-vendor override replaces the rendered runtime file at sync
+            # time (``_sync_atomic`` Phase 2 / ADR-0008 Invariant 4) via
+            # ``atomic_write_bytes`` — raw bytes, no strip. Compare byte-exact
+            # against the same source so an override-carrying command isn't
+            # reported permanently "out of sync"; decoding as text would crash
+            # on a non-UTF-8 override and would mask whitespace-only byte drift.
+            vendor = GENERATOR_VENDOR.get(gen_name)
+            override_path = (
+                _override.resolve(project_root, "commands", name, vendor, scope=scope)
+                if vendor is not None
+                else None
+            )
+            if override_path is not None:
+                try:
+                    expected_bytes = override_path.read_bytes()
+                except OSError:
+                    # Sync skips an unreadable override (no effective fan-out),
+                    # so we can't assert parity — report drift, never mask it.
+                    results.append((gen_name, name, "out of sync"))
+                    continue
+                actual_bytes = target.read_bytes() if target.is_file() else b""
+                status = "in sync" if expected_bytes == actual_bytes else "out of sync"
+                results.append((gen_name, name, status))
+                continue
+
+            expected, _ = gen.render(cmd)
             actual = target.read_text(encoding="utf-8") if target.is_file() else ""
             if expected.strip() == actual.strip():
                 results.append((gen_name, name, "in sync"))

--- a/packages/memtomem/src/memtomem/context/skills.py
+++ b/packages/memtomem/src/memtomem/context/skills.py
@@ -30,6 +30,7 @@ from typing import Protocol
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import override as _override
 from memtomem.context._atomic import (
+    COPY_SKIP_NAMES,
     _file_lock,
     _lock_path_for,
     atomic_write_bytes,
@@ -49,6 +50,12 @@ logger = logging.getLogger(__name__)
 
 CANONICAL_SKILL_ROOT = ".memtomem/skills"
 SKILL_MANIFEST = "SKILL.md"
+# Canonical-side subdirectory that holds per-vendor SKILL.md overrides
+# (``<canonical>/<name>/overrides/<vendor>.<ext>`` — see
+# :mod:`memtomem.context.override`). It is the SOURCE of overrides, never part
+# of a runtime fan-out payload, so it is stripped from the staged tree before
+# fan-out and excluded from diff comparison.
+_OVERRIDES_DIRNAME = "overrides"
 
 
 class SkillGenerator(Protocol):
@@ -190,7 +197,7 @@ def list_canonical_skills(
 # ── Copy primitive ────────────────────────────────────────────────────
 
 
-def _stage_skill(src: Path, dst: Path) -> Path:
+def _stage_skill(src: Path, dst: Path, *, strip_overrides: bool = False) -> Path:
     """Mirror ``src`` into a same-fs staging directory under ``dst.parent``.
 
     Picks ``dst.parent / .staging-<dst.name>-<pid>-<rand>.tmp`` so the
@@ -201,6 +208,14 @@ def _stage_skill(src: Path, dst: Path) -> Path:
 
     ``src`` MUST contain ``SKILL.md``. ``dst.parent`` is created if it
     does not yet exist.
+
+    ``strip_overrides`` removes the top-level ``overrides/`` directory from
+    the staged tree. Runtime fan-out passes ``True`` so the canonical
+    override SOURCE never lands in a runtime tree (which would leak every
+    other vendor's override bytes into this vendor's tree, and let one
+    vendor's override secret block the whole fan-out at scan time). Pure
+    canonical→canonical / runtime→canonical copies keep the default
+    (``False``) so the override source survives.
     """
     manifest = src / SKILL_MANIFEST
     if not manifest.is_file():
@@ -214,13 +229,22 @@ def _stage_skill(src: Path, dst: Path) -> Path:
         # happens, the leftover tree is from us; safe to remove.
         shutil.rmtree(staging)
     staging.mkdir()
+    # ``strip_overrides`` excludes the top-level ``overrides/`` source DURING
+    # the copy (via ``skip_top_level``) so those bytes never reach the runtime
+    # staging tree — no crash window where they exist, no silent leak if a
+    # post-copy delete failed. The override itself is applied separately from
+    # the canonical source via ``_override.resolve`` (which reads canonical,
+    # not staging), so the skip never affects override application; and the
+    # scan therefore never sees (and cannot block on) an unrelated vendor's
+    # override.
+    skip = frozenset({_OVERRIDES_DIRNAME}) if strip_overrides else None
     # Codex review fold: if ``copy_tree_atomic`` raises after partial
     # copy, the caller would never see ``staging`` (no return value),
     # leaving an unscanned partial tree under the runtime fan-out root.
     # Clean up here before re-raising so Gate A's staging-dir-first
     # contract holds even on copy failure.
     try:
-        copy_tree_atomic(src, staging)
+        copy_tree_atomic(src, staging, skip_top_level=skip)
     except BaseException:
         shutil.rmtree(staging, ignore_errors=True)
         raise
@@ -360,7 +384,7 @@ def generate_all_skills(
                     # commands.py read_bytes failure handling. Privacy block
                     # is the only failure that still aborts the batch.
                     try:
-                        staging = _stage_skill(skill_dir, dst)
+                        staging = _stage_skill(skill_dir, dst, strip_overrides=True)
                     except OSError as exc:
                         skipped.append(
                             (skill_dir.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR)
@@ -468,7 +492,7 @@ def generate_all_skills(
                 # an exception bubbling up — symmetric with agents.py /
                 # commands.py read_bytes failure handling.
                 try:
-                    staging = _stage_skill(skill_dir, dst)
+                    staging = _stage_skill(skill_dir, dst, strip_overrides=True)
                 except OSError as exc:
                     skipped.append((skill_dir.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
                     continue
@@ -685,21 +709,59 @@ def extract_skills_to_canonical(
 # ── Diff: canonical ↔ runtimes ────────────────────────────────────────
 
 
-def _skill_dirs_equal(a: Path, b: Path) -> bool:
-    """Shallow structural + byte-level equality between two skill directories."""
-    if not (a.is_dir() and b.is_dir()):
+def _skill_effective_equal(
+    canonical: Path,
+    runtime: Path,
+    override_bytes: bytes | None,
+    *,
+    top_level: bool = True,
+) -> bool:
+    """Whether ``runtime`` equals the tree ``generate_all_skills`` produces.
+
+    Must mirror :func:`copy_tree_atomic` exactly, else a skill that synced
+    perfectly reports false drift:
+
+    * :data:`COPY_SKIP_NAMES` (``.git`` / ``.DS_Store`` / ``__pycache__``) and
+      symlinks are excluded at EVERY depth — sync never copies them, so they
+      are ignored on both sides (a stray cache on either side is not drift).
+    * the top-level ``overrides/`` SOURCE directory is excluded from the
+      canonical side only (a leaked ``overrides/`` on the runtime side IS drift,
+      so re-sync is prompted to clean it).
+    * the top-level ``SKILL.md`` is replaced by ``override_bytes`` when a
+      per-vendor override exists; everything else is byte-compared verbatim.
+
+    Comparing the raw canonical directory instead (as the previous code did)
+    reported any override-carrying skill as permanently "out of sync".
+    """
+    if not (canonical.is_dir() and runtime.is_dir()):
         return False
-    a_entries = sorted(p.name for p in a.iterdir())
-    b_entries = sorted(p.name for p in b.iterdir())
-    if a_entries != b_entries:
+
+    def _entries(d: Path, *, is_canonical: bool) -> list[str]:
+        names = []
+        for p in d.iterdir():
+            if p.name in COPY_SKIP_NAMES or p.is_symlink():
+                continue
+            if top_level and is_canonical and p.name == _OVERRIDES_DIRNAME:
+                continue
+            names.append(p.name)
+        return sorted(names)
+
+    can_entries = _entries(canonical, is_canonical=True)
+    if can_entries != _entries(runtime, is_canonical=False):
         return False
-    for name in a_entries:
-        ap, bp = a / name, b / name
-        if ap.is_file() and bp.is_file():
-            if ap.read_bytes() != bp.read_bytes():
+    for name in can_entries:
+        cp, rp = canonical / name, runtime / name
+        if cp.is_file() and rp.is_file():
+            if top_level and name == SKILL_MANIFEST and override_bytes is not None:
+                expected = override_bytes
+            else:
+                expected = cp.read_bytes()
+            if expected != rp.read_bytes():
                 return False
-        elif ap.is_dir() and bp.is_dir():
-            if not _skill_dirs_equal(ap, bp):
+        elif cp.is_dir() and rp.is_dir():
+            # Aux subtrees (scripts/, references/, assets/) compare verbatim;
+            # only the top-level SKILL.md / overrides/ get special handling.
+            if not _skill_effective_equal(cp, rp, None, top_level=False):
                 return False
         else:
             return False
@@ -753,7 +815,26 @@ def diff_skills(
                 # Earlier defensive ``if dst is None: continue`` removed.
                 dst = gen.target_dir(project_root, name, scope=scope)
                 assert dst is not None  # narrowed by upstream NO_FANOUT guard
-                if _skill_dirs_equal(src, dst):
+                # Resolve the per-vendor override the sync path applies so the
+                # comparison reflects the effective fan-out tree, not the raw
+                # canonical (which would always report override skills as drift).
+                override_bytes: bytes | None = None
+                vendor = GENERATOR_VENDOR.get(gen_name)
+                if vendor is not None:
+                    override_path = _override.resolve(
+                        project_root, "skills", name, vendor, scope=scope
+                    )
+                    if override_path is not None:
+                        try:
+                            override_bytes = override_path.read_bytes()
+                        except OSError:
+                            # Sync skips an unreadable override (typed PARSE_ERROR,
+                            # no effective fan-out), so we cannot claim parity.
+                            # Report drift rather than comparing against the
+                            # un-overridden canonical (which could mask it).
+                            results.append((gen_name, name, "out of sync"))
+                            continue
+                if _skill_effective_equal(src, dst, override_bytes):
                     results.append((gen_name, name, "in sync"))
                 else:
                     results.append((gen_name, name, "out of sync"))

--- a/packages/memtomem/tests/test_context_override.py
+++ b/packages/memtomem/tests/test_context_override.py
@@ -15,11 +15,13 @@ import hashlib
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from memtomem.context import override
-from memtomem.context.agents import generate_all_agents
-from memtomem.context.commands import generate_all_commands
+from memtomem.context.agents import diff_agents, generate_all_agents
+from memtomem.context.commands import diff_commands, generate_all_commands
 from memtomem.context.install import install_skill
-from memtomem.context.skills import SKILL_GENERATORS, generate_all_skills
+from memtomem.context.skills import SKILL_GENERATORS, diff_skills, generate_all_skills
 from memtomem.wiki.store import WikiStore
 
 
@@ -340,3 +342,175 @@ def test_override_only_touches_skill_md_not_scripts(wiki_root: Path, tmp_path: P
     assert (claude_dir / "SKILL.md").read_bytes() == b"# claude only\n"
     # The script came from canonical and was NOT replaced by any override.
     assert (claude_dir / "scripts" / "run.sh").read_bytes() == (b"#!/bin/bash\necho canonical\n")
+
+
+# ── M3: overrides/ source must NOT leak into runtime fan-out trees ─────
+
+
+def test_skills_fanout_does_not_leak_overrides_dir(wiki_root: Path, tmp_path: Path) -> None:
+    """The canonical top-level ``overrides/`` directory is the SOURCE of
+    per-vendor SKILL.md overrides — it must never be copied into a runtime tree
+    (doing so leaks every other vendor's override bytes into this vendor's
+    tree). A *nested* ``scripts/overrides/`` is legitimate payload and MUST
+    survive (the skip is top-level only)."""
+    _initialized_wiki()
+    _seed_skill(
+        wiki_root,
+        "hello",
+        {"SKILL.md": b"# canonical\n", "scripts/overrides/helper.md": b"# nested payload\n"},
+    )
+    project = tmp_path
+    install_skill(project, "hello")
+
+    overrides_dir = project / ".memtomem" / "skills" / "hello" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# claude\n")
+    (overrides_dir / "gemini.md").write_bytes(b"# gemini\n")
+
+    generate_all_skills(project)
+
+    claude_dir = SKILL_GENERATORS["claude_skills"].target_dir(project, "hello")
+    gemini_dir = SKILL_GENERATORS["gemini_skills"].target_dir(project, "hello")
+    # Neither runtime tree may carry the top-level override SOURCE directory.
+    assert not (claude_dir / "overrides").exists()
+    assert not (gemini_dir / "overrides").exists()
+    # A nested overrides/ that is real skill payload must NOT be stripped.
+    assert (
+        claude_dir / "scripts" / "overrides" / "helper.md"
+    ).read_bytes() == b"# nested payload\n"
+    # And each vendor's SKILL.md still carries its own override (M3 strip must
+    # not break override application, which reads from canonical).
+    assert (claude_dir / "SKILL.md").read_bytes() == b"# claude\n"
+    assert (gemini_dir / "SKILL.md").read_bytes() == b"# gemini\n"
+
+
+# ── M2: diff must apply overrides so synced artifacts report "in sync" ──
+
+
+def test_diff_skills_in_sync_after_override_fanout(wiki_root: Path, tmp_path: Path) -> None:
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello", {"SKILL.md": b"# canonical\n"})
+    project = tmp_path
+    install_skill(project, "hello")
+
+    overrides_dir = project / ".memtomem" / "skills" / "hello" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# claude override\n")
+
+    generate_all_skills(project)
+
+    rows = [r for r in diff_skills(project) if r[1] == "hello"]
+    assert ("claude_skills", "hello", "in sync") in rows
+    assert all(status != "out of sync" for _, _, status in rows)
+
+
+def test_diff_skills_in_sync_ignores_copy_skipped_entries(wiki_root: Path, tmp_path: Path) -> None:
+    """``copy_tree_atomic`` skips ``COPY_SKIP_NAMES`` (e.g. ``__pycache__``) at
+    sync time, so a canonical cache dir must NOT make diff report false drift —
+    the effective-tree comparison must mirror the same skip rules."""
+    _initialized_wiki()
+    _seed_skill(wiki_root, "hello", {"SKILL.md": b"# canonical\n"})
+    project = tmp_path
+    install_skill(project, "hello")
+
+    # A tool drops a bytecode cache into the canonical skill dir post-install.
+    cache = project / ".memtomem" / "skills" / "hello" / "__pycache__"
+    cache.mkdir()
+    (cache / "x.pyc").write_bytes(b"\x00not copied\n")
+
+    generate_all_skills(project)
+
+    rows = [r for r in diff_skills(project) if r[1] == "hello"]
+    assert rows
+    assert all(status != "out of sync" for _, _, status in rows)
+
+
+def test_diff_agents_in_sync_after_override_fanout(tmp_path: Path) -> None:
+    canonical_dir = tmp_path / ".memtomem" / "agents"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "bar.md").write_text(_SAMPLE_AGENT_BODY, encoding="utf-8")
+    overrides_dir = canonical_dir / "bar" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# OVERRIDE_MARKER_AGENT\nclaude body\n")
+
+    generate_all_agents(tmp_path)
+
+    rows = [r for r in diff_agents(tmp_path) if r[1] == "bar"]
+    assert ("claude_agents", "bar", "in sync") in rows
+    assert all(status != "out of sync" for _, _, status in rows)
+
+
+def test_diff_commands_in_sync_after_override_fanout(tmp_path: Path) -> None:
+    canonical_dir = tmp_path / ".memtomem" / "commands"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "baz.md").write_text(_SAMPLE_COMMAND_BODY, encoding="utf-8")
+    overrides_dir = canonical_dir / "baz" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# OVERRIDE_MARKER_COMMAND\nclaude body\n")
+
+    generate_all_commands(tmp_path)
+
+    rows = [r for r in diff_commands(tmp_path) if r[1] == "baz"]
+    assert ("claude_commands", "baz", "in sync") in rows
+    assert all(status != "out of sync" for _, _, status in rows)
+
+
+def test_diff_agents_byte_exact_with_non_utf8_override(tmp_path: Path) -> None:
+    """Sync writes override bytes verbatim (atomic_write_bytes); diff must
+    byte-compare, not decode as UTF-8 (which would crash on non-UTF-8 bytes)."""
+    canonical_dir = tmp_path / ".memtomem" / "agents"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "bar.md").write_text(_SAMPLE_AGENT_BODY, encoding="utf-8")
+    overrides_dir = canonical_dir / "bar" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# OVERRIDE\n\xff\xfe not utf-8\n")
+
+    generate_all_agents(tmp_path)
+
+    rows = [r for r in diff_agents(tmp_path) if r[1] == "bar"]  # must not raise
+    assert ("claude_agents", "bar", "in sync") in rows
+
+
+def test_diff_commands_byte_exact_with_non_utf8_override(tmp_path: Path) -> None:
+    canonical_dir = tmp_path / ".memtomem" / "commands"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "baz.md").write_text(_SAMPLE_COMMAND_BODY, encoding="utf-8")
+    overrides_dir = canonical_dir / "baz" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# OVERRIDE\n\xff\xfe not utf-8\n")
+
+    generate_all_commands(tmp_path)
+
+    rows = [r for r in diff_commands(tmp_path) if r[1] == "baz"]  # must not raise
+    assert ("claude_commands", "baz", "in sync") in rows
+
+
+def test_diff_agents_unreadable_override_reports_drift(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If an override resolves but cannot be read, sync would skip it (no
+    effective fan-out), so diff must report drift rather than masking it as
+    "in sync" by falling back to the un-overridden render."""
+    canonical_dir = tmp_path / ".memtomem" / "agents"
+    canonical_dir.mkdir(parents=True)
+    (canonical_dir / "bar.md").write_text(_SAMPLE_AGENT_BODY, encoding="utf-8")
+    overrides_dir = canonical_dir / "bar" / "overrides"
+    overrides_dir.mkdir(parents=True)
+    (overrides_dir / "claude.md").write_bytes(b"# claude override\n")
+
+    generate_all_agents(tmp_path)
+
+    real_resolve = override.resolve
+
+    def fake_resolve(project_root, asset_type, name, vendor, *, scope=None):
+        p = real_resolve(project_root, asset_type, name, vendor, scope=scope)
+        # Return the overrides DIRECTORY for claude so read_bytes() raises
+        # IsADirectoryError (an OSError) — simulating an unreadable override.
+        if p is not None and vendor == "claude":
+            return overrides_dir
+        return p
+
+    monkeypatch.setattr(override, "resolve", fake_resolve)
+
+    rows = [r for r in diff_agents(tmp_path) if r == ("claude_agents", "bar", "out of sync")]
+    assert rows == [("claude_agents", "bar", "out of sync")]

--- a/packages/memtomem/tests/test_context_skills.py
+++ b/packages/memtomem/tests/test_context_skills.py
@@ -170,10 +170,10 @@ class TestUnreadableSources:
 
         real_stage = skills_module._stage_skill
 
-        def fake_stage(src, dst):
+        def fake_stage(src, dst, **kwargs):
             if src.name == "broken":
                 raise PermissionError("permission denied")
-            return real_stage(src, dst)
+            return real_stage(src, dst, **kwargs)
 
         monkeypatch.setattr(skills_module, "_stage_skill", fake_stage)
 
@@ -246,10 +246,10 @@ class TestUnreadableSources:
 
         real_stage = skills_module._stage_skill
 
-        def fake_stage(src, dst):
+        def fake_stage(src, dst, **kwargs):
             if src.name == "broken":
                 raise PermissionError("permission denied")
-            return real_stage(src, dst)
+            return real_stage(src, dst, **kwargs)
 
         monkeypatch.setattr(skills_module, "_stage_skill", fake_stage)
 


### PR DESCRIPTION
Two coupled per-vendor-override bugs in the canonical→runtime fan-out.

## M3 — `overrides/` leak (skills)
`generate_all_skills` staged the whole canonical skill tree via `copy_tree_atomic`, which copied the canonical-side `overrides/` SOURCE directory into every runtime tree (`.claude/skills/<n>/overrides/gemini.md` ended up in Claude's tree). That leaks every other vendor's override bytes cross-vendor, and lets one vendor's override secret block the whole fan-out at scan time.

**Fix:** `copy_tree_atomic` gains a keyword-only `skip_top_level` set applied **only at the root** of the call (not propagated into recursion); `_stage_skill` passes `{"overrides"}` on the two fan-out paths so the source is **never written** to staging — no crash window, no silent leak if a post-copy delete failed. A legitimate nested `scripts/overrides/` is preserved. Import (runtime→canonical) and migrate (canonical→canonical) keep the default and retain the source.

## M2 — permanent false "out of sync"
`diff_{agents,commands,skills}` compared the **plain** canonical render against the override-**applied** runtime file, so any artifact carrying a per-vendor override reported "out of sync" forever — in `mm context diff`/`status`, the web status routes, and the MCP diff tool — unresolvable by re-sync.

**Fix:** agents/commands diff compare the override **byte-exact** against the runtime (sync writes raw bytes via `atomic_write_bytes`; decoding as UTF-8 + strip crashed on non-UTF-8 overrides and masked whitespace-only drift). `diff_skills` compares against the effective fan-out tree via `_skill_effective_equal`, which mirrors `copy_tree_atomic` exactly: `COPY_SKIP_NAMES` + symlinks excluded at every depth, top-level `overrides/` excluded canonical-side only, `SKILL.md` replaced by the override bytes. An unreadable resolved override reports drift (matching sync's typed skip) instead of masking it.

## Tests
overrides/ does not leak (+ nested `scripts/overrides/` survives); diff in-sync after override fan-out for all three kinds; byte-exact non-UTF-8 override (agents+commands); unreadable override → drift; `__pycache__` no longer causes false drift. Full context + wiki/install/atomic suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)