### PR TITLE
fix(context): resolve web project root by walking up, matching CLI/MCP

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -80,7 +80,7 @@ from memtomem.context.settings_migrate import (
     format_plan_summary,
     plan_migration,
 )
-from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.scope_resolver import canonical_artifact_dir, find_project_root
 from memtomem.context.skills import (
     diff_skills,
     extract_skills_to_canonical,
@@ -103,13 +103,12 @@ _KNOWN_INCLUDES: frozenset[str] = frozenset({"skills", "agents", "commands", "se
 
 
 def _find_project_root() -> Path:
-    """Walk up from cwd to find project root (has .git or pyproject.toml)."""
-    p = Path.cwd()
-    for _ in range(10):
-        if (p / ".git").exists() or (p / "pyproject.toml").exists():
-            return p
-        p = p.parent
-    return Path.cwd()
+    """Walk up from cwd to find project root (has .git or pyproject.toml).
+
+    Thin wrapper over the shared ``scope_resolver.find_project_root`` so the
+    CLI, MCP tools, and web app share one definition of the project root.
+    """
+    return find_project_root()
 
 
 def _context_path(root: Path) -> Path:

--- a/packages/memtomem/src/memtomem/context/scope_resolver.py
+++ b/packages/memtomem/src/memtomem/context/scope_resolver.py
@@ -45,6 +45,37 @@ class ContextScopeError(ValueError):
     """
 
 
+_PROJECT_MARKERS: tuple[str, ...] = (".git", "pyproject.toml")
+_PROJECT_ROOT_MAX_DEPTH = 10
+
+
+def find_project_root(start: Path | None = None) -> Path:
+    """Walk up from ``start`` (default cwd) to the nearest project root.
+
+    Looks up to :data:`_PROJECT_ROOT_MAX_DEPTH` ancestors for a ``.git`` or
+    ``pyproject.toml`` marker and returns the first match; falls back to the
+    original ``start`` when no marker is found.
+
+    This is the SINGLE definition of "what is the project root", shared by the
+    CLI (``mm context``), the MCP context tools, and the web-app lifespan, so a
+    launch from a project subdirectory resolves the same canonical ``.memtomem``
+    tree on every surface. Previously the web app pinned the bare ``cwd`` and so
+    wrote artifacts to ``<subdir>/.memtomem`` while the CLI/MCP walked up to the
+    repo root — silently targeting different canonical trees for one project.
+
+    The returned path is not resolved — callers that need symlink
+    canonicalisation should ``.resolve()`` themselves (matches the historical
+    ``cli/context_cmd.py`` / ``server/tools/context.py`` behavior).
+    """
+    origin = Path.cwd() if start is None else start
+    p = origin
+    for _ in range(_PROJECT_ROOT_MAX_DEPTH):
+        if any((p / marker).exists() for marker in _PROJECT_MARKERS):
+            return p
+        p = p.parent
+    return origin
+
+
 def canonical_artifact_dir(
     artifact: ArtifactKind,
     scope: TargetScope,

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -9,6 +9,7 @@ from typing import cast
 import click
 
 from memtomem.config import TargetScope
+from memtomem.context.scope_resolver import find_project_root
 from memtomem.server import mcp
 from memtomem.server.context import CtxType
 from memtomem.server.error_handler import tool_handler
@@ -20,13 +21,12 @@ _KNOWN_ARTIFACT_SCOPES: frozenset[str] = frozenset({"user", "project_shared", "p
 
 
 def _find_project_root() -> Path:
-    """Walk up from cwd to find project root."""
-    p = Path.cwd()
-    for _ in range(10):
-        if (p / ".git").exists() or (p / "pyproject.toml").exists():
-            return p
-        p = p.parent
-    return Path.cwd()
+    """Walk up from cwd to find project root.
+
+    Thin wrapper over the shared ``scope_resolver.find_project_root`` so the
+    MCP context tools, the CLI, and the web app share one definition.
+    """
+    return find_project_root()
 
 
 def _resolve_mcp_scope(override: str | None = None) -> str:

--- a/packages/memtomem/src/memtomem/web/app.py
+++ b/packages/memtomem/src/memtomem/web/app.py
@@ -312,8 +312,12 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
     comp = await create_components()
 
     from memtomem.search.dedup import DedupScanner
+    from memtomem.context.scope_resolver import find_project_root
 
-    app.state.project_root = Path.cwd()
+    # Walk up to the project root (.git / pyproject.toml) so launching
+    # ``mm web`` from a subdirectory resolves the same canonical .memtomem tree
+    # the CLI/MCP write to — not ``<subdir>/.memtomem``. Single shared helper.
+    app.state.project_root = find_project_root()
     app.state.config = comp.config
     app.state.storage = comp.storage
     app.state.embedder = comp.embedder

--- a/packages/memtomem/tests/test_context_scope_resolver.py
+++ b/packages/memtomem/tests/test_context_scope_resolver.py
@@ -14,12 +14,89 @@ import pytest
 from memtomem.context.scope_resolver import (
     ContextScopeError,
     canonical_artifact_dir,
+    find_project_root,
     list_artifact_scopes_present,
     project_root_from_artifact_path,
 )
 
 
 ARTIFACTS = ("agents", "skills", "commands")
+
+
+# ---------------------------------------------------------------------------
+# find_project_root — shared CLI/MCP/web root detection (M4)
+# ---------------------------------------------------------------------------
+
+
+class TestFindProjectRoot:
+    def test_returns_cwd_when_marker_at_cwd(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / ".git").mkdir()
+        monkeypatch.chdir(tmp_path)
+        assert find_project_root() == tmp_path
+
+    def test_walks_up_to_git_ancestor_from_subdir(self, tmp_path: Path, monkeypatch) -> None:
+        """The M4 bug scenario: launched from a project subdirectory, the root
+        must resolve to the repo root (so web/CLI/MCP target one .memtomem)."""
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "packages" / "foo"
+        subdir.mkdir(parents=True)
+        monkeypatch.chdir(subdir)
+        assert find_project_root() == tmp_path
+
+    def test_walks_up_to_pyproject_ancestor(self, tmp_path: Path, monkeypatch) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+        subdir = tmp_path / "src"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+        assert find_project_root() == tmp_path
+
+    def test_falls_back_to_origin_when_no_marker(self, tmp_path: Path, monkeypatch) -> None:
+        subdir = tmp_path / "a" / "b"
+        subdir.mkdir(parents=True)
+        monkeypatch.chdir(subdir)
+        # No .git/pyproject.toml anywhere up the (tmp) tree → original cwd.
+        assert find_project_root() == subdir
+
+    def test_explicit_start_argument(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "x"
+        subdir.mkdir()
+        assert find_project_root(start=subdir) == tmp_path
+
+    def test_cli_and_mcp_helpers_delegate_to_shared(self, tmp_path: Path, monkeypatch) -> None:
+        """CLI and MCP ``_find_project_root`` now share one definition (dedup)."""
+        from memtomem.cli.context_cmd import _find_project_root as cli_root
+        from memtomem.server.tools.context import _find_project_root as mcp_root
+
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "deep" / "nested"
+        subdir.mkdir(parents=True)
+        monkeypatch.chdir(subdir)
+        assert cli_root() == tmp_path
+        assert mcp_root() == tmp_path
+
+    def test_web_lifespan_resolves_root_via_shared_walk(self) -> None:
+        """Pin the actual M4 fix SITE, not just the helper.
+
+        ``find_project_root`` being correct does not prove the web app uses it:
+        a regression reverting ``app.state.project_root`` back to ``Path.cwd()``
+        would still pass the behavioral cases above and silently re-introduce
+        the subdir split-brain. The real lifespan is too heavy to run here
+        (``create_components`` + FileWatcher + embedding sync), so this is a
+        source-level pin in the same spirit as the static asserts elsewhere in
+        the web suite: the lifespan MUST resolve the root through the shared
+        walk and MUST NOT pin the bare cwd.
+        """
+        import inspect
+
+        from memtomem.web.app import _lifespan
+
+        src = inspect.getsource(_lifespan)
+        assert "find_project_root()" in src, "web lifespan no longer uses the shared walk"
+        assert "project_root = Path.cwd()" not in src, (
+            "web lifespan pins the bare cwd again — subdir launches will write to "
+            "<subdir>/.memtomem instead of the repo root (M4 regression)"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
The web lifespan pinned `app.state.project_root = Path.cwd()` with no ancestor walk, while `cli/context_cmd.py` and `server/tools/context.py` both walk up to 10 levels for a `.git`/`pyproject.toml` marker. Launching `mm web` from a project subdirectory therefore wrote canonical artifacts to `<subdir>/.memtomem` (via `resolve_scope_root` → `canonical_artifact_dir`) while the same user's `mm context sync` wrote to `<repo>/.memtomem` — the two surfaces silently targeted **different canonical trees** for one project.

## Fix
Extract root detection into a single shared `find_project_root()` in `context/scope_resolver.py` (its natural home, beside `project_root_from_artifact_path`) and route all three surfaces through it: the web lifespan now walks, and the CLI/MCP `_find_project_root` become thin wrappers — also removing the byte-for-byte duplicated helper so root detection is defined **once**. Prior CLI/MCP semantics preserved (walk 10, `.git` OR `pyproject.toml`, fall back to original cwd, no resolve).

The memory write path (`system.py`) already prefers `_resolve_project_context_from_dirs` and only falls back to `app.state.project_root`, so the walked root only **improves** that fallback; no consumer regresses.

## Tests
`find_project_root` unit cases (cwd marker, subdir→repo-root walk, pyproject ancestor, no-marker fallback, explicit start), a CLI/MCP wrapper-delegation parity pin, and a source-level lifespan pin (`inspect.getsource`) that fails if `app.py` reverts to `Path.cwd()`. 30 scope-resolver tests + full context suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)