### PR TITLE
fix(context): harden section parser against round-trip data loss (#1123 B1)

### DIFF
--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
+
+from memtomem.context.parser import iter_markdown_sections
 
 
 class AgentGenerator(Protocol):
@@ -269,21 +270,14 @@ def extract_sections_from_agent_file(content: str) -> dict[str, str]:
     }
 
     sections: dict[str, str] = {}
-    current: str | None = None
-    lines: list[str] = []
-
-    for line in content.splitlines():
-        m = re.match(r"^##\s+(.+)$", line)
-        if m:
-            if current is not None:
-                sections[current] = "\n".join(lines).strip()
-            heading = m.group(1).strip()
-            current = aliases.get(heading.lower(), heading)
-            lines = []
-        elif current is not None:
-            lines.append(line)
-
-    if current is not None:
-        sections[current] = "\n".join(lines).strip()
+    for heading, body in iter_markdown_sections(content):
+        key = aliases.get(heading.lower(), heading)
+        # Two source headings can alias to one canonical key (e.g. "Rules" and
+        # "Coding Rules" → "Rules"); merge rather than overwrite so the earlier
+        # block's content is not silently lost (#1123 B1-2).
+        if key in sections:
+            sections[key] = f"{sections[key]}\n\n{body}".strip()
+        else:
+            sections[key] = body
 
     return sections

--- a/packages/memtomem/src/memtomem/context/parser.py
+++ b/packages/memtomem/src/memtomem/context/parser.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Iterator
 from pathlib import Path
 
 CONTEXT_FILENAME = ".memtomem/context.md"
@@ -10,35 +11,73 @@ CONTEXT_FILENAME = ".memtomem/context.md"
 # Known section names (case-insensitive matching)
 KNOWN_SECTIONS = {"project", "commands", "architecture", "rules", "style"}
 
+_HEADING_RE = re.compile(r"^##\s+(.+)$")
+# Opening/closing fence for a Markdown code block (``` or ~~~), allowing
+# leading indentation and a trailing language specifier.
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+
+
+def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
+    """Yield ``(heading, body)`` for each ``## Heading`` block in ``text``.
+
+    Shared by :func:`parse_context` and
+    :func:`memtomem.context.generator.extract_sections_from_agent_file` so the
+    two round-trip halves stay in lock-step. The iterator is deliberately
+    forgiving in two ways the previous naive loop got wrong (#1123 B1):
+
+    - ``##`` lines **inside fenced code blocks** are treated as body, not as
+      section delimiters, so a code sample containing ``## ...`` no longer
+      truncates the real section (B1-1).
+    - **Whitespace-only headings** (``##   ``) are treated as body rather than
+      opening a section with an empty-string key (B1-3).
+
+    Every real heading block is yielded — none are silently dropped. Duplicate
+    headings are yielded once each; merging is left to the caller, which owns
+    the heading→canonical-key mapping (B1-2). Preamble before the first heading
+    is not yielded; callers that need it handle it separately.
+    """
+    current: str | None = None
+    lines: list[str] = []
+    in_code = False
+
+    for line in text.splitlines():
+        if _FENCE_RE.match(line):
+            in_code = not in_code
+            if current is not None:
+                lines.append(line)
+            continue
+
+        m = None if in_code else _HEADING_RE.match(line)
+        heading = m.group(1).strip() if m else ""
+        if heading:
+            if current is not None:
+                yield current, "\n".join(lines).strip()
+            current = heading
+            lines = []
+        elif current is not None:
+            lines.append(line)
+
+    if current is not None:
+        yield current, "\n".join(lines).strip()
+
 
 def parse_context(path: Path) -> dict[str, str]:
     """Parse context.md into {section_name: content} dict.
 
     Sections are delimited by `## SectionName` headings.
-    Unknown sections are preserved as-is.
+    Unknown sections are preserved as-is. Repeated headings are merged
+    (content concatenated) rather than the earlier copy being overwritten.
     """
     if not path.exists():
         return {}
 
     text = path.read_text(encoding="utf-8")
     sections: dict[str, str] = {}
-    current_section: str | None = None
-    current_lines: list[str] = []
-
-    for line in text.splitlines():
-        heading = re.match(r"^##\s+(.+)$", line)
-        if heading:
-            # Save previous section
-            if current_section is not None:
-                sections[current_section] = "\n".join(current_lines).strip()
-            current_section = heading.group(1).strip()
-            current_lines = []
-        elif current_section is not None:
-            current_lines.append(line)
-
-    # Save last section
-    if current_section is not None:
-        sections[current_section] = "\n".join(current_lines).strip()
+    for name, body in iter_markdown_sections(text):
+        if name in sections:
+            sections[name] = f"{sections[name]}\n\n{body}".strip()
+        else:
+            sections[name] = body
 
     return sections
 

--- a/packages/memtomem/src/memtomem/context/parser.py
+++ b/packages/memtomem/src/memtomem/context/parser.py
@@ -12,9 +12,11 @@ CONTEXT_FILENAME = ".memtomem/context.md"
 KNOWN_SECTIONS = {"project", "commands", "architecture", "rules", "style"}
 
 _HEADING_RE = re.compile(r"^##\s+(.+)$")
-# Opening/closing fence for a Markdown code block (``` or ~~~), allowing
-# leading indentation and a trailing language specifier.
-_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+# A Markdown code fence: 3+ backticks or tildes, indented up to 3 spaces
+# (CommonMark). group(1) is the fence run — its marker char and length
+# identify the block; group(2) is the trailing text, which is an info string
+# on an opening fence and must be blank on a closing fence.
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})(.*)$")
 
 
 def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
@@ -27,7 +29,9 @@ def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
 
     - ``##`` lines **inside fenced code blocks** are treated as body, not as
       section delimiters, so a code sample containing ``## ...`` no longer
-      truncates the real section (B1-1).
+      truncates the real section (B1-1). Fences are matched by marker *type*
+      and length (CommonMark): a ``~~~`` line inside a ``` ``` ``` block does
+      not close it, so nested fenced examples round-trip correctly.
     - **Whitespace-only headings** (``##   ``) are treated as body rather than
       opening a section with an empty-string key (B1-3).
 
@@ -38,16 +42,28 @@ def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
     """
     current: str | None = None
     lines: list[str] = []
-    in_code = False
+    # While inside a fenced code block these hold the opening fence's marker
+    # char ("`" or "~") and length; ``fence_char is None`` means "not in code".
+    fence_char: str | None = None
+    fence_len = 0
 
     for line in text.splitlines():
-        if _FENCE_RE.match(line):
-            in_code = not in_code
+        fence = _FENCE_RE.match(line)
+        if fence:
+            run, rest = fence.group(1), fence.group(2)
+            if fence_char is None:
+                # Opening fence — an info string after the run is allowed.
+                fence_char, fence_len = run[0], len(run)
+            elif run[0] == fence_char and len(run) >= fence_len and not rest.strip():
+                # Closing fence: same marker, at least as long, no info string.
+                # A non-matching fence (e.g. ``~~~`` inside a ``` ``` ``` block)
+                # leaves the block open and falls through to body (B1-1).
+                fence_char, fence_len = None, 0
             if current is not None:
                 lines.append(line)
             continue
 
-        m = None if in_code else _HEADING_RE.match(line)
+        m = None if fence_char is not None else _HEADING_RE.match(line)
         heading = m.group(1).strip() if m else ""
         if heading:
             if current is not None:

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from memtomem.context.parser import parse_context, sections_to_markdown
+from memtomem.context.parser import (
+    iter_markdown_sections,
+    parse_context,
+    sections_to_markdown,
+)
 from memtomem.context.detector import detect_agent_files
 from memtomem.context.generator import (
     GENERATORS,
@@ -223,3 +227,83 @@ class TestSpecificSectionRoundTrip:
         regenerated = generate_for_agent(agent, sections)
         assert heading in regenerated
         assert marker in regenerated
+
+
+class TestParserHardening:
+    """Round-trip data-loss guards for the section parser (#1123 B1)."""
+
+    def test_fenced_code_hashes_not_treated_as_headings(self, tmp_path):
+        """`##` inside a fenced code block must not split the section (B1-1)."""
+        ctx = tmp_path / "context.md"
+        ctx.write_text(
+            "# Project Context\n\n"
+            "## Architecture\n\n"
+            "Run the example:\n\n"
+            "```python\n"
+            "## This looks like a heading but it is code\n"
+            "value = 1\n"
+            "```\n\n"
+            "Trailing prose under Architecture.\n\n"
+            "## Rules\n\n"
+            "- line-length 100\n",
+            encoding="utf-8",
+        )
+        sections = parse_context(ctx)
+
+        # No spurious section minted from the in-code `##` line.
+        assert set(sections) == {"Architecture", "Rules"}
+        # Both the code block and the prose after it stay under Architecture.
+        assert "## This looks like a heading but it is code" in sections["Architecture"]
+        assert "Trailing prose under Architecture." in sections["Architecture"]
+        assert sections["Rules"] == "- line-length 100"
+
+    def test_tilde_fence_also_guarded(self):
+        """`~~~` fences are guarded the same as backtick fences (B1-1)."""
+        text = "## Architecture\n~~~\n## not a heading\n~~~\nafter\n## Rules\n- r\n"
+        names = [name for name, _ in iter_markdown_sections(text)]
+        assert names == ["Architecture", "Rules"]
+
+    def test_duplicate_headings_merge_not_overwrite(self, tmp_path):
+        """A repeated `## Name` must concatenate, not drop the first (B1-2)."""
+        ctx = tmp_path / "context.md"
+        ctx.write_text(
+            "## Project\nfirst body line\n## Project\nsecond body line\n",
+            encoding="utf-8",
+        )
+        sections = parse_context(ctx)
+
+        assert list(sections) == ["Project"]
+        assert "first body line" in sections["Project"]
+        assert "second body line" in sections["Project"]
+
+    def test_aliased_duplicate_headings_merge_on_extract(self):
+        """Two headings aliasing to one canonical key must merge (B1-2)."""
+        content = "## Rules\n- from rules heading\n## Coding Rules\n- from coding-rules heading\n"
+        sections = extract_sections_from_agent_file(content)
+
+        assert "from rules heading" in sections["Rules"]
+        assert "from coding-rules heading" in sections["Rules"]
+
+    def test_whitespace_only_heading_not_a_section(self, tmp_path):
+        """`##` with no name must not create an empty-string key (B1-3)."""
+        ctx = tmp_path / "context.md"
+        ctx.write_text(
+            "## Project\nreal content\n##   \norphan content\n",
+            encoding="utf-8",
+        )
+        sections = parse_context(ctx)
+
+        assert "" not in sections
+        assert list(sections) == ["Project"]
+        # The malformed heading line and its body fold into the open section.
+        assert "orphan content" in sections["Project"]
+
+    def test_sample_context_still_round_trips(self, tmp_path):
+        """The happy-path round-trip is unchanged by the hardening."""
+        ctx = tmp_path / "context.md"
+        ctx.write_text(SAMPLE_CONTEXT, encoding="utf-8")
+        sections = parse_context(ctx)
+        out = tmp_path / "out.md"
+        out.write_text(sections_to_markdown(sections), encoding="utf-8")
+        reparsed = parse_context(out)
+        assert reparsed == sections

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -263,6 +263,48 @@ class TestParserHardening:
         names = [name for name, _ in iter_markdown_sections(text)]
         assert names == ["Architecture", "Rules"]
 
+    def test_nested_different_marker_fence_does_not_close_early(self):
+        """A nested fence of the *other* marker must not close the block (#1132).
+
+        A backtick-fenced markdown sample that itself shows a ``~~~`` snippet
+        (and vice versa) only closes on a matching-marker fence. The inner
+        marker must stay body so an in-sample ``##`` is not minted as a real
+        section, splitting or dropping content on round-trip. This pins the
+        opener-tracking fix that replaced the naive single-flag toggle.
+        """
+        backtick_outer = (
+            "## Commands\n"
+            "````markdown\n"  # opener: backtick run of 4
+            "~~~\n"  # inner tilde fence — must NOT close the backtick block
+            "## inside the sample, not a heading\n"
+            "~~~\n"  # inner tilde close — still inside the backtick block
+            "````\n"  # real close: matching backtick marker
+            "trailing prose under Commands\n"
+            "## Architecture\n"
+            "- a\n"
+        )
+        sections = dict(iter_markdown_sections(backtick_outer))
+        assert list(sections) == ["Commands", "Architecture"]
+        assert "## inside the sample, not a heading" in sections["Commands"]
+        assert "trailing prose under Commands" in sections["Commands"]
+
+        # Reverse: tilde-fenced block showing a backtick snippet.
+        tilde_outer = (
+            "## Commands\n"
+            "~~~~markdown\n"  # opener: tilde run of 4
+            "```\n"  # inner backtick fence — must NOT close the tilde block
+            "## inside the sample, not a heading\n"
+            "```\n"
+            "~~~~\n"  # real close: matching tilde marker
+            "trailing prose under Commands\n"
+            "## Architecture\n"
+            "- a\n"
+        )
+        sections = dict(iter_markdown_sections(tilde_outer))
+        assert list(sections) == ["Commands", "Architecture"]
+        assert "## inside the sample, not a heading" in sections["Commands"]
+        assert "trailing prose under Commands" in sections["Commands"]
+
     def test_duplicate_headings_merge_not_overwrite(self, tmp_path):
         """A repeated `## Name` must concatenate, not drop the first (B1-2)."""
         ctx = tmp_path / "context.md"


### PR DESCRIPTION
## What

Bucket 1 of the #1123 deferred context-gateway audit backlog: harden the
section parser against three silent round-trip data-loss bugs.

`parse_context` and `extract_sections_from_agent_file` each duplicated a naive
`^## ` heading loop that lost content in three ways:

- **B1-1** — a `##` line *inside a fenced code block* was parsed as a section
  delimiter, truncating the real section and minting a spurious one. (Both
  ` ``` ` and `~~~` fences.)
- **B1-2** — a repeated `## Name`, or two headings aliasing to one canonical
  key (e.g. `Rules` + `Coding Rules` → `Rules`), overwrote the earlier copy.
- **B1-3a** — a whitespace-only `##` heading opened a section under an
  empty-string key, stranding its body there.

## How

Extract a single fence-aware `iter_markdown_sections()` helper in `parser.py`
and route **both** round-trip halves through it, so they can no longer drift.
Merge (concatenate) on duplicate keys instead of overwriting.

## Deferred (tracked in #1123, not in this PR)

These two B1 items are **design questions**, not clean fixes, so they are
deliberately out of scope here:

- **B1-3b preamble capture** — capturing text before the first heading under a
  generic key would make `parse_context` swallow the `# Project Context` H1,
  which `sections_to_markdown` re-prepends → a duplication regression; it would
  also misattribute the heading-less Project body that cursor/copilot emit. It
  changes the dict→markdown contract.
- **B1-4 Rules+Style reverse-merge** — already has a shipped warning
  (`b340bc7`); every fix option trades off the compact-output design intent for
  cursor/codex/copilot.

## Test

Adds `TestParserHardening` (6 cases) covering all three fixed bugs plus a
happy-path round-trip regression guard.

- `uv run pytest -k context -m "not ollama"` → **1183 passed**
- `ruff check` ✓ · `ruff format --check` ✓ · `mypy` clean

Refs #1123 (Bucket 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
