### PR TITLE
fix(context): surface init settings status + narrow dead tier Literal (#1123 B7)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -964,6 +964,18 @@ def _step_settings(state: dict) -> None:
                 click.secho(f"  Merged → {r.target}", fg="green")
             elif r.status == "skipped":
                 click.secho(f"  skipped {name}: {r.reason}", fg="yellow")
+            elif r.status == "needs_confirmation":
+                # The host-write guard refused this target. Surface it instead
+                # of silently dropping the status (#1123 B7-4) — the user-scope
+                # fan-out can legitimately hit a host file that needs opt-in.
+                click.secho(
+                    f"  {name}: needs confirmation — re-run "
+                    "`mm context sync --include=settings` to apply",
+                    fg="yellow",
+                )
+            else:
+                # Defensive: never swallow an unrecognized status (e.g. error).
+                click.secho(f"  {name}: {r.status}: {r.reason}", fg="yellow")
 
         click.echo()
         click.echo("  Empty hooks file created. Add hooks to .memtomem/settings.json,")

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -85,7 +85,10 @@ class ProjectScope:
     scope_id: str
     label: str
     root: Path | None
-    tier: Literal["user", "project"]
+    # ``discover_project_scopes`` only ever emits "project"; the "user" arm was
+    # never constructed (#1123 B7-5). Narrowed to the real domain so the type
+    # stops advertising a tier the producer can't return.
+    tier: Literal["project"]
     sources: tuple[str, ...]
     missing: bool = False
     experimental: bool = False

--- a/packages/memtomem/tests/test_init_settings_status.py
+++ b/packages/memtomem/tests/test_init_settings_status.py
@@ -1,0 +1,93 @@
+"""Regression: `mm init` settings step must surface every
+``generate_all_settings`` status, not only ``ok``/``skipped`` (#1123 B7-4).
+
+Before the fix, ``_step_settings`` looped over the per-runtime results and only
+handled ``ok`` and ``skipped``; a ``needs_confirmation`` (host-write guard
+refused) or any other status was silently dropped, so the user got no signal
+that a target was not written.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import memtomem.cli.init_cmd as init_cmd
+from memtomem.context.settings import SettingsSyncResult
+
+from .helpers import set_home
+
+
+def _drive_step_settings(tmp_path: Path, monkeypatch, results: dict) -> str:
+    """Run ``_step_settings`` with the interactive bits stubbed and
+    ``generate_all_settings`` replaced by ``results``; return captured stdout."""
+    home = tmp_path / "home"
+    # The step early-returns unless ~/.claude exists.
+    (home / ".claude").mkdir(parents=True)
+    set_home(monkeypatch, home)
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    monkeypatch.chdir(project)
+
+    # Stub the interactive helpers (called as bare module names in init_cmd).
+    monkeypatch.setattr(init_cmd, "step_header", lambda *a, **k: None)
+    monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **k: True)
+
+    # generate_all_settings is imported *locally* inside _step_settings, so it
+    # must be patched on the source module, not on init_cmd.
+    monkeypatch.setattr(
+        "memtomem.context.settings.generate_all_settings",
+        lambda project_root, scope: results,
+    )
+
+    import click
+
+    buf: list[str] = []
+    monkeypatch.setattr(click, "echo", lambda *a, **k: buf.append(a[0] if a else ""))
+    monkeypatch.setattr(click, "secho", lambda msg="", *a, **k: buf.append(msg))
+
+    state: dict = {"step_index": 0, "total_steps": 1}
+    init_cmd._step_settings(state)
+    return "\n".join(str(x) for x in buf)
+
+
+def test_needs_confirmation_is_surfaced(tmp_path, monkeypatch):
+    out = _drive_step_settings(
+        tmp_path,
+        monkeypatch,
+        {
+            "claude": SettingsSyncResult(
+                status="needs_confirmation",
+                reason="host write refused",
+                target=Path("~/.claude/settings.json"),
+            )
+        },
+    )
+    assert "needs confirmation" in out.lower()
+    assert "claude" in out
+
+
+def test_unknown_status_is_not_swallowed(tmp_path, monkeypatch):
+    out = _drive_step_settings(
+        tmp_path,
+        monkeypatch,
+        {"claude": SettingsSyncResult(status="error", reason="boom")},
+    )
+    # The defensive else-branch echoes the raw status + reason.
+    assert "error" in out.lower()
+    assert "boom" in out
+
+
+def test_ok_and_skipped_still_reported(tmp_path, monkeypatch):
+    out = _drive_step_settings(
+        tmp_path,
+        monkeypatch,
+        {
+            "claude": SettingsSyncResult(status="ok", target=Path("/tmp/claude.json")),
+            "codex": SettingsSyncResult(status="skipped", reason="not installed"),
+        },
+    )
+    assert "merged" in out.lower()
+    assert "skipped" in out.lower()

--- a/packages/memtomem/tests/test_init_settings_status.py
+++ b/packages/memtomem/tests/test_init_settings_status.py
@@ -87,5 +87,9 @@ def test_ok_and_skipped_still_reported(tmp_path, monkeypatch):
             "codex": SettingsSyncResult(status="skipped", reason="not installed"),
         },
     )
-    assert "merged" in out.lower()
-    assert "skipped" in out.lower()
+    # Assert on the loop's own output, not the static intro line ("Hooks are
+    # merged into ~/.claude/settings.json additively.") which contains the word
+    # "merged" regardless of whether the ``ok`` branch ran — a bare
+    # ``"merged" in out.lower()`` would pass even if that branch regressed.
+    assert "Merged → /tmp/claude.json" in out
+    assert "skipped codex: not installed" in out

--- a/packages/memtomem/tests/test_init_settings_status.py
+++ b/packages/memtomem/tests/test_init_settings_status.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 import memtomem.cli.init_cmd as init_cmd
 from memtomem.context.settings import SettingsSyncResult
 


### PR DESCRIPTION
## What

Bucket 7 of the #1123 deferred context-gateway audit backlog: two small
correctness/clarity fixes.

| # | Finding | Fix |
|---|---|---|
| B7-4 | `mm init`'s settings step looped over `generate_all_settings` results handling only `ok`/`skipped`, **silently dropping** `needs_confirmation` (host-write guard refused) and any other status | Add an explicit `needs_confirmation` branch pointing at `mm context sync --include=settings`, plus a defensive `else` so no status is ever swallowed. |
| B7-5 | `ProjectScope.tier` was typed `Literal["user", "project"]` but `discover_project_scopes` only ever constructs `"project"` — the `"user"` arm was never produced | Narrow the type to `Literal["project"]`. (The `"user"` tier in `settings_doctor` is a separate dataclass and is unaffected.) |

## Deferred (tracked in #1123, not in this PR)

These three B7 items each have a legitimate as-designed defense, so they are out of scope here:

- **B7-1** — `~/.claude/projects` decoder treats every `-` as a path separator. The encoding (`/`→`-`) is fundamentally lossy; the docstring already owns this and the caller filters via `is_dir()`. A real fix is a design change.
- **B7-2** — the "already exists with different config" merge warning. This is the intended "user rules always win" contract; rewording risks muddying it.
- **B7-3** — `runtime_artifact_names` returns raw on-disk stems without `validate_name`. That's a deliberate listing of whatever is physically on the runtime fan-out root; validating could crash a diff on a pre-existing oddly-named file.

## Test

`test_init_settings_status.py` — drives `_step_settings` with the interactive bits stubbed and asserts every status is surfaced.

- `pytest test_init_settings_status.py` → **3 passed**
- init / projects / settings_doctor suites → green
- `ruff check` ✓ · `ruff format --check` ✓ · `mypy` clean

Refs #1123 (Bucket 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
