### PR TITLE
fix(context): migrate lockfile cleanup, user-tier status, settings-migrate apply re-classify (#1123 B4)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -59,7 +59,7 @@ from memtomem.context.migrate import (
 )
 from memtomem.context.projects import KnownProjectsStore
 from memtomem.context.lockfile import LockfileVersionError
-from memtomem.context.status import classify_status, load_with_recovery
+from memtomem.context.status import classify_status, load_with_recovery, scan_user_artifacts
 from memtomem.context.generator import (
     GENERATORS,
     extract_sections_from_agent_file,
@@ -1562,7 +1562,13 @@ def status_cmd(scope_flag: TargetScope) -> None:
 
     wiki = WikiStore.at_default()
     wiki_head, rows = classify_status(root, wiki=wiki)
-    rows = [row for row in rows if row.tier == scope_flag]
+    if scope_flag == "user":
+        # User-tier artifacts live in the global ~/.memtomem store, outside
+        # the project root classify_status walks; enumerate them on demand
+        # only when this scope is requested (#1123 B4-2).
+        rows = sorted(scan_user_artifacts(), key=lambda r: (r.asset_type, r.name))
+    else:
+        rows = [row for row in rows if row.tier == scope_flag]
 
     if lockfile_error is not None:
         click.secho(f"  ✗ lock.json: {lockfile_error}", fg="red", err=True)
@@ -1571,8 +1577,8 @@ def status_cmd(scope_flag: TargetScope) -> None:
     # Lockfile-tracked installs (project_shared) drive the "installed"
     # count; project_local rows are surfaced separately so the header
     # word ("installed") stays accurate for both groups.
-    installed_count = sum(1 for r in rows if r.tier != "project_local")
-    draft_count = sum(1 for r in rows if r.tier == "project_local")
+    installed_count = sum(1 for r in rows if r.state != "local-draft")
+    draft_count = sum(1 for r in rows if r.state == "local-draft")
     draft_suffix = (
         f" (+ {draft_count} local draft{'s' if draft_count != 1 else ''})" if draft_count else ""
     )
@@ -1592,6 +1598,8 @@ def status_cmd(scope_flag: TargetScope) -> None:
     if not rows and lockfile_error is None:
         if scope_flag == "project_local":
             click.echo("\nNo project_local draft assets in this project.")
+        elif scope_flag == "user":
+            click.echo("\nNo user-scope assets found under ~/.memtomem/.")
         else:
             click.echo(f"\nNo wiki assets installed in this project for scope {scope_flag}.")
         return
@@ -1618,7 +1626,7 @@ def status_cmd(scope_flag: TargetScope) -> None:
         # "?"/"—" placeholders the lockfile-tracked branches use, so
         # the visual distinction is obvious to a reader scanning the
         # column.
-        if row.tier == "project_local":
+        if row.state == "local-draft":
             line = f"  {glyph}  {row.name:24s}  {'—':<12}  {'(no install record)':<23}"
         else:
             installed_date = row.installed_at[:10] if row.installed_at else "—"
@@ -2522,7 +2530,7 @@ def settings_migrate_cmd(
     summary = format_plan_summary(plan)
 
     if json_out:
-        payload = {
+        payload: dict[str, Any] = {
             "status": "noop" if plan.is_noop else ("conflicts" if conflicts else "ok"),
             "applied": False,
             "from": plan.source_scope,
@@ -2612,11 +2620,18 @@ def settings_migrate_cmd(
             raise click.exceptions.Exit(1)
 
     result = apply_migration(plan)
+    # Drift the planner could not see — the target changed between plan and
+    # apply — surfaces as apply-time warnings (#1123 B4-3). Treat it like a
+    # plan-time conflict for reporting and the exit code.
+    apply_drift = bool(result.warnings)
 
     if json_out:
         payload["applied"] = True
         payload["target_written"] = result.target_written
         payload["source_written"] = result.source_written
+        if result.warnings:
+            payload["warnings"] = result.warnings
+            payload["status"] = "conflicts"
         click.echo(json.dumps(payload, indent=2))
     else:
         if result.target_written:
@@ -2629,7 +2644,9 @@ def settings_migrate_cmd(
                 f"  ✓ cleaned source {plan.source_path}",
                 fg="green",
             )
-        if not result.target_written and not result.source_written:
+        for warning in result.warnings:
+            click.secho(f"  ⚠ {warning}", fg="yellow", err=True)
+        if not result.target_written and not result.source_written and not result.warnings:
             if conflicts:
                 click.secho(
                     "  (no changes written — conflicts must be resolved first)",
@@ -2638,10 +2655,11 @@ def settings_migrate_cmd(
             else:
                 click.echo("  (no changes written — source was already clean)")
 
-    if conflicts:
-        # Conflicts left in source; user must resolve manually before
-        # re-running migrate. Match `mm context migrate`'s exit-1 on
-        # any partial failure.
+    if conflicts or apply_drift:
+        # Conflicts left in source — flagged at plan time, or drift
+        # discovered at apply time; the user must resolve manually before
+        # re-running migrate. Match `mm context migrate`'s exit-1 on any
+        # partial failure.
         raise click.exceptions.Exit(1)
 
 

--- a/packages/memtomem/src/memtomem/context/lockfile.py
+++ b/packages/memtomem/src/memtomem/context/lockfile.py
@@ -202,3 +202,32 @@ class Lockfile:
                 self._path,
                 json.dumps(doc, indent=2, ensure_ascii=False).encode("utf-8"),
             )
+
+    def remove_entry(self, asset_type: str, name: str) -> bool:
+        """Delete the ``(asset_type, name)`` entry if present.
+
+        Returns ``True`` when an entry was removed, ``False`` when there
+        was nothing to remove (no such section, or no such name) — in
+        which case the file is left untouched: no atomic write happens, so
+        ``mtime`` is unchanged and a concurrent reader sees no spurious
+        churn.
+
+        Holds the sidecar lock for the load → mutate → write triple,
+        mirroring :meth:`upsert_entry`. Only the targeted entry is
+        deleted; sibling entries and unknown top-level / per-entry fields
+        round-trip verbatim per ADR-0008. The (possibly now-empty) section
+        dict is left in place rather than pruned, so a section a newer
+        tool populated out-of-band is never dropped as a side effect of
+        removing one entry.
+        """
+        with _file_lock(_lock_path_for(self._path)):
+            doc = self.load()
+            section = doc.get(asset_type)
+            if not isinstance(section, dict) or name not in section:
+                return False
+            del section[name]
+            atomic_write_bytes(
+                self._path,
+                json.dumps(doc, indent=2, ensure_ascii=False).encode("utf-8"),
+            )
+            return True

--- a/packages/memtomem/src/memtomem/context/migrate.py
+++ b/packages/memtomem/src/memtomem/context/migrate.py
@@ -1024,7 +1024,28 @@ def migrate_scope(
                     dst_path=dst_path,
                 ) from exc
 
-    # Lock released. Cleanup stale src runtime fan-out (best-effort).
+    # Lock released. The wiki-install lockfile (``lock.json``) only tracks
+    # project_shared installs; migrating an artifact OUT of project_shared
+    # leaves its entry dangling, and `mm context status` would then iterate
+    # that entry, find the canonical gone from the project_shared dest, and
+    # report the (now-moved) artifact as "missing" (#1123 B4-1). Drop the
+    # stale entry. Best-effort: the canonical move already committed inside
+    # the lock above, so a lock.json bookkeeping failure must NOT undo or
+    # fail the migration — log loudly and continue.
+    if src_scope == "project_shared":
+        try:
+            Lockfile.at(project_root).remove_entry(kind, name)
+        except Exception as exc:  # bookkeeping must never fail a committed move
+            logger.warning(
+                "migrate_scope: failed to drop stale lock.json entry for %s/%s "
+                "after moving out of project_shared (%s); `mm context status` may "
+                "report it as missing until the entry is removed.",
+                kind,
+                name,
+                exc,
+            )
+
+    # Cleanup stale src runtime fan-out (best-effort).
     fanout_cleaned = _remove_runtime_fanout_for(kind, name, src_scope, project_root)
 
     return MigrateScopeResult(

--- a/packages/memtomem/src/memtomem/context/settings_migrate.py
+++ b/packages/memtomem/src/memtomem/context/settings_migrate.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from memtomem.context._atomic import atomic_write_text
@@ -472,37 +472,97 @@ def _write_json(path: Path, data: dict) -> None:
     atomic_write_text(path, payload, mode=0o600)
 
 
+def _canonical_inner_of(move: MigrateMove) -> dict:
+    """Recover the canonical inner-hook dict from a move's target rule.
+
+    ``rule_to_write_at_target`` is the stamped ``{matcher, hooks: [inner]}``
+    rule; the single inner is what :func:`_classify_target` compares against
+    the live target tier at apply time. Ownership-marker fields are ignored
+    by that comparison (:func:`_inner_content_equal`), so the stamped inner
+    classifies identically to the raw canonical one the planner used.
+    """
+    rule = move.rule_to_write_at_target
+    if not isinstance(rule, dict):
+        return {}
+    inners = rule.get("hooks", [])
+    if isinstance(inners, list) and inners and isinstance(inners[0], dict):
+        return inners[0]
+    return {}
+
+
 def apply_migration(plan: MigratePlan) -> MigrateResult:
     """Apply *plan* to disk.
 
     Write order: **target first, then source.** A crash between the two
     leaves the user with a transient duplicate that the next plan run
     detects and heals (idempotent — target's inner hook now matches the
-    canonical signature, so ``already_at_target`` is True and only the
+    canonical signature, so it re-classifies as ``exact`` and only the
     source clean-up step runs).
+
+    The plan's per-move ``already_at_target`` / ``conflict_at_target`` flags
+    were frozen at *plan* time. ``apply`` therefore **re-reads and
+    re-classifies** the target tier against the live file before writing
+    (#1123 B4-3): between plan and apply the target can drift — another
+    writer, a manual edit, or a second ``settings-migrate`` run. Trusting
+    the stale flags would either append a canonical rule the target already
+    grew (a same-matcher duplicate Claude Code fires twice) or write past a
+    freshly introduced conflict. Re-classification closes that TOCTOU
+    window so a separated dry-run → apply workflow stays sound.
+
+    Drift discovered at apply time (a move that became a conflict) is
+    refused per-move: the target is not appended to and the source entry is
+    not cleaned, and a human-readable note is added to
+    :attr:`MigrateResult.warnings` for the CLI to surface.
     """
     result = MigrateResult(plan=plan)
     if plan.is_noop:
         return result
 
-    applicable = list(plan.applicable_moves)
+    # Re-read + re-classify the target against its current on-disk state,
+    # deriving the write-set and the source-clean-set from the LIVE target
+    # rather than the plan-time snapshot.
+    target_existing = _safe_load_json_dict(plan.target_path) or {}
+    target_index = _target_rule_lookup(target_existing.get("hooks", {}))
+
+    moves_to_write: list[MigrateMove] = []
+    sigs_to_drop: set[HookSignature] = set()
+    for move in plan.applicable_moves:
+        status, reason = _classify_target(target_index, move.signature, _canonical_inner_of(move))
+        if status == "conflict":
+            # Drift introduced after planning: refuse this move. Appending
+            # would duplicate the matcher; cleaning source would leave the
+            # target permanently drifted from the canonical contract.
+            result.warnings.append(reason)
+            continue
+        if status == "missing":
+            # No rule under (event, matcher) at target → append it.
+            moves_to_write.append(move)
+        # status == "exact": target already carries the canonical inner —
+        # skip the append, but still drop the now-redundant source entry.
+        sigs_to_drop.add(move.signature)
 
     # --- Target write ---------------------------------------------------
-    target_existing = _safe_load_json_dict(plan.target_path) or {}
-    target_new_inners = [m for m in applicable if not m.already_at_target]
-    if target_new_inners:
-        target_merged = _add_target_rules(target_existing, target_new_inners)
+    if moves_to_write:
+        # ``already_at_target`` is forced False so _add_target_rules appends
+        # every move we decided to write — including a plan-time "already"
+        # move that re-classified to "missing" because the target lost the
+        # entry between plan and apply.
+        target_merged = _add_target_rules(
+            target_existing,
+            [replace(m, already_at_target=False) for m in moves_to_write],
+        )
         _write_json(plan.target_path, target_merged)
         result.target_written = True
 
     # --- Source write ---------------------------------------------------
+    if not sigs_to_drop:
+        return result
     source_existing = _safe_load_json_dict(plan.source_path)
     if source_existing is None:
         # Source vanished between plan and apply (rare). Source is already
         # clean from this command's POV; leave as-is.
         return result
 
-    sigs_to_drop = {m.signature for m in applicable}
     source_new = _strip_source_inner_entries(source_existing, sigs_to_drop)
     if source_new != source_existing:
         _write_json(plan.source_path, source_new)

--- a/packages/memtomem/src/memtomem/context/status.py
+++ b/packages/memtomem/src/memtomem/context/status.py
@@ -42,6 +42,7 @@ __all__ = [
     "StatusRow",
     "StatusState",
     "classify_status",
+    "scan_user_artifacts",
 ]
 
 
@@ -71,12 +72,18 @@ class StatusRow:
     not reachable"`` / ``"wiki not present"`` for stale-pin.
 
     ``tier`` distinguishes lockfile-tracked installs (``project_shared``)
-    from locally-authored drafts discovered by walking
-    ``<proj>/.memtomem/<artifact>.local/`` (``project_local``). The CLI
-    appends ``(draft, no fan-out)`` after project_local rows per ADR-0011
-    §3 / ADR-0016 §7. ``user`` tier is reserved for a future scan;
-    today's `mm context install` only writes project_shared, so no
-    ``user``-tier rows are produced.
+    from author-managed drafts. :func:`classify_status` walks the
+    project-rooted tiers — lockfile installs plus
+    ``<proj>/.memtomem/<artifact>.local/`` (``project_local``) drafts. The
+    global ``~/.memtomem/<artifact>/`` (``user``) tier is enumerated
+    separately by :func:`scan_user_artifacts`, which the CLI surfaces for
+    ``--scope user`` (folding it into ``classify_status`` would couple every
+    status read to the caller's real home). Both draft tiers carry
+    ``state="local-draft"`` and empty ``pin_commit``/``installed_at`` — not
+    lockfile-tracked, so no wiki pin to report. The CLI appends
+    ``(draft, no fan-out)`` after project_local rows per ADR-0011 §3 /
+    ADR-0016 §7; user-tier drafts DO fan out to runtime dirs, so they get no
+    such annotation.
     """
 
     asset_type: Literal["skills", "agents", "commands"]
@@ -201,12 +208,12 @@ _TIER_RENDER_ORDER: dict[str, int] = {
 }
 
 
-def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
-    """Yield ``StatusRow``s for every valid project_local draft on disk.
+def _scan_draft_tier(scope: TargetScope, project_root: Path | None) -> Iterator[StatusRow]:
+    """Yield ``local-draft`` ``StatusRow``s for every valid artifact in *scope*.
 
-    Walks ``<proj>/.memtomem/{agents,commands,skills}.local/`` and emits
-    one row per valid artifact. Both layouts that ``migrate._detect_source_scope``
-    accepts are recognised:
+    Shared walk for the two non-lockfile canonical tiers — ``project_local``
+    (``<proj>/.memtomem/{kind}.local/``) and ``user`` (``~/.memtomem/{kind}/``).
+    Both layouts that ``migrate._detect_source_scope`` accepts are recognised:
 
     - **Directory layout** (all three kinds): ``<root>/<name>/`` containing
       the kind-specific manifest file (``agent.md`` / ``command.md`` /
@@ -215,29 +222,26 @@ def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
       design — see ``migrate._detect_source_scope``): ``<root>/<name>.md``
       as a single file. ``<name>`` is the file stem.
 
-    When the same name exists in both layouts at the same tier the
-    directory wins (mirrors migrate's ``continue`` after a dir match),
-    so flat siblings of a directory artifact are silently shadowed.
+    When the same name exists in both layouts the directory wins (mirrors
+    migrate's ``continue`` after a dir match), so a flat sibling of a
+    directory artifact is silently shadowed.
 
-    Emitted rows carry ``tier="project_local"``, ``state="local-draft"``,
-    and empty ``pin_commit``/``installed_at`` — project_local artifacts
-    are not currently tracked in the lockfile (install path is
-    project_shared-only today; locally-authored drafts never enter
-    ``lock.json``). The CLI render layer appends ``(draft, no fan-out)``
-    to these rows per ADR-0011 §3 / ADR-0016 §7.
+    Emitted rows carry ``tier=scope``, ``state="local-draft"`` and empty
+    ``pin_commit``/``installed_at`` — neither tier is lockfile-tracked, so
+    there is no wiki pin to report.
     """
     for asset_type in ("agents", "commands", "skills"):
-        local_root = canonical_artifact_dir(
+        root = canonical_artifact_dir(
             asset_type,  # type: ignore[arg-type]
-            "project_local",
+            scope,
             project_root,
         )
-        if not local_root.is_dir():
+        if not root.is_dir():
             continue
         manifest = _LOCAL_DRAFT_MANIFEST[asset_type]
         seen_names: set[str] = set()
 
-        for entry in sorted(local_root.iterdir(), key=lambda p: p.name):
+        for entry in sorted(root.iterdir(), key=lambda p: p.name):
             if not entry.is_dir():
                 continue
             if not (entry / manifest).is_file():
@@ -254,13 +258,13 @@ def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
                 state="local-draft",
                 dirty_file_count=0,
                 reason=None,
-                tier="project_local",
+                tier=scope,
             )
 
         if asset_type == "skills":
             # Skills have no flat layout (migrate._detect_source_scope:792).
             continue
-        for entry in sorted(local_root.iterdir(), key=lambda p: p.name):
+        for entry in sorted(root.iterdir(), key=lambda p: p.name):
             if not entry.is_file() or entry.suffix != ".md":
                 continue
             name = entry.stem
@@ -277,8 +281,35 @@ def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
                 state="local-draft",
                 dirty_file_count=0,
                 reason=None,
-                tier="project_local",
+                tier=scope,
             )
+
+
+def _scan_project_local_drafts(project_root: Path) -> Iterator[StatusRow]:
+    """Yield project_local draft rows (``<proj>/.memtomem/{kind}.local/``).
+
+    Thin wrapper over :func:`_scan_draft_tier`. The CLI render layer appends
+    ``(draft, no fan-out)`` to these rows per ADR-0011 §3 / ADR-0016 §7 —
+    project_local artifacts have no runtime fan-out path.
+    """
+    yield from _scan_draft_tier("project_local", project_root)
+
+
+def scan_user_artifacts() -> Iterator[StatusRow]:
+    """Yield user-tier (``~/.memtomem/{kind}/``) draft rows — #1123 B4-2.
+
+    Thin public wrapper over :func:`_scan_draft_tier` for the CLI's
+    ``mm context status --scope user`` view. The user tier is the global
+    ``~/.memtomem`` store, NOT under the project root that
+    :func:`classify_status` walks, so it is enumerated here on demand
+    rather than folded into ``classify_status`` — folding it in would make
+    every status call (and every test exercising one) depend on the
+    caller's real home directory. Without this, ``--scope user`` filtered an
+    all-empty row set and reported "nothing" even when ``~/.memtomem`` held
+    artifacts. Unlike project_local, user artifacts DO fan out to runtime
+    dirs, so the CLI must not tag them ``(no fan-out)``.
+    """
+    yield from _scan_draft_tier("user", None)
 
 
 def load_with_recovery(project_root: Path | str) -> tuple[dict, str | None]:

--- a/packages/memtomem/tests/test_context_status.py
+++ b/packages/memtomem/tests/test_context_status.py
@@ -25,8 +25,11 @@ from click.testing import CliRunner
 from memtomem.cli.context_cmd import context as context_group
 from memtomem.context._atomic import atomic_write_bytes, installed_at_from_dest
 from memtomem.context.lockfile import Lockfile
-from memtomem.context.status import StatusRow, classify_status
+from memtomem.context.migrate import migrate_scope
+from memtomem.context.status import StatusRow, classify_status, scan_user_artifacts
 from memtomem.wiki.store import WikiStore
+
+from .helpers import set_home
 
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -642,3 +645,145 @@ def test_status_row_dataclass_shape() -> None:
     # (and the lockfile-walk branch in classify_status) remain valid
     # without explicit tier= updates.
     assert row.tier == "project_shared"
+
+
+# ── migrate drops the dangling lockfile entry (#1123 B4-1) ─────────────────
+
+
+def test_status_no_missing_after_scope_migration_drops_lockfile_entry(
+    monkeypatch, wiki_root: Path, tmp_path: Path
+) -> None:
+    """Migrating a project_shared install out of project_shared must drop
+    its lock.json entry, so status no longer iterates a stale entry and
+    reports the moved artifact as 'missing' (#1123 B4-1)."""
+    set_home(monkeypatch, tmp_path / "home")
+    _initialized_wiki(wiki_root)
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"v1\n"}, "a" * 40)
+    assert Lockfile.at(tmp_path).read_entry("skills", "foo") is not None
+
+    migrate_scope(
+        "skills",
+        "foo",
+        from_scope="project_shared",
+        to_scope="project_local",
+        project_root=tmp_path,
+        apply_=True,
+    )
+
+    # Lockfile entry is gone …
+    assert Lockfile.at(tmp_path).read_entry("skills", "foo") is None
+    # … and status surfaces only the project_local draft — no 'missing' row.
+    _, rows = classify_status(tmp_path)
+    foo_rows = [r for r in rows if r.asset_type == "skills" and r.name == "foo"]
+    assert [r.state for r in foo_rows] == ["local-draft"]
+    assert all(r.state != "missing" for r in rows)
+
+
+def test_status_no_missing_after_scope_migration_to_user_drops_lockfile_entry(
+    monkeypatch, wiki_root: Path, tmp_path: Path
+) -> None:
+    """The same lock.json cleanup must apply on the other project_shared exit
+    path — migrating project_shared → user (#1123 B4-1)."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    _initialized_wiki(wiki_root)
+    _setup_installed_at_pin(tmp_path, "skills", "foo", {"SKILL.md": b"v1\n"}, "a" * 40)
+    assert Lockfile.at(tmp_path).read_entry("skills", "foo") is not None
+
+    migrate_scope(
+        "skills",
+        "foo",
+        from_scope="project_shared",
+        to_scope="user",
+        project_root=tmp_path,
+        apply_=True,
+    )
+
+    # Lockfile entry dropped; status surfaces no 'missing' row …
+    assert Lockfile.at(tmp_path).read_entry("skills", "foo") is None
+    _, rows = classify_status(tmp_path)
+    assert all(r.state != "missing" for r in rows)
+    # … and the artifact now lives in the user tier.
+    user_keys = {(r.asset_type, r.name) for r in scan_user_artifacts()}
+    assert ("skills", "foo") in user_keys
+
+
+# ── user-tier scan (#1123 B4-2) ────────────────────────────────────────────
+
+
+def _seed_user_artifact_dir(home: Path, asset_type: str, name: str, manifest: str) -> None:
+    """Create ``~/.memtomem/<asset_type>/<name>/<manifest>`` under *home*."""
+    d = home / ".memtomem" / asset_type / name
+    d.mkdir(parents=True)
+    (d / manifest).write_bytes(b"# user draft\n")
+
+
+def test_scan_user_artifacts_recognises_dir_and_flat_layout(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    _seed_user_artifact_dir(home, "agents", "dir-agent", "agent.md")
+    (home / ".memtomem" / "agents" / "flat-agent.md").write_bytes(b"# flat\n")
+    _seed_user_artifact_dir(home, "skills", "myskill", "SKILL.md")
+
+    rows = list(scan_user_artifacts())
+
+    keys = {(r.asset_type, r.name) for r in rows}
+    assert ("agents", "dir-agent") in keys
+    assert ("agents", "flat-agent") in keys  # flat .md recognised for agents
+    assert ("skills", "myskill") in keys
+    for r in rows:
+        assert r.tier == "user"
+        assert r.state == "local-draft"
+        assert r.pin_commit == "" and r.installed_at == ""
+
+
+def test_scan_user_artifacts_skills_flat_layout_not_recognised(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    (home / ".memtomem" / "skills").mkdir(parents=True)
+    (home / ".memtomem" / "skills" / "loose.md").write_bytes(b"# not a skill\n")
+
+    assert list(scan_user_artifacts()) == []
+
+
+def test_classify_status_stays_project_rooted_no_user_tier(monkeypatch, tmp_path: Path) -> None:
+    """classify_status must NOT scan ~/.memtomem — folding the global user
+    tier into it would couple every status read (and test) to the caller's
+    real home. User rows are the CLI's job (#1123 B4-2)."""
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    _seed_user_artifact_dir(home, "agents", "u", "agent.md")
+
+    _, rows = classify_status(tmp_path)
+
+    assert all(r.tier != "user" for r in rows)
+
+
+def test_cli_status_user_scope_lists_user_artifacts(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+    _seed_user_artifact_dir(home, "agents", "myagent", "agent.md")
+
+    result = CliRunner().invoke(
+        context_group, ["status", "--scope", "user"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    assert "myagent" in result.output
+    assert "scope user" in result.output
+
+
+def test_cli_status_user_scope_empty_message(monkeypatch, tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    set_home(monkeypatch, home)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".git").mkdir()
+
+    result = CliRunner().invoke(
+        context_group, ["status", "--scope", "user"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    assert "No user-scope assets found" in result.output

--- a/packages/memtomem/tests/test_lockfile.py
+++ b/packages/memtomem/tests/test_lockfile.py
@@ -201,3 +201,60 @@ def test_concurrent_upserts_keep_file_valid(tmp_path: Path) -> None:
         assert name in skills, f"missing entry for {name}; got {sorted(skills)}"
         assert "wiki_commit" in skills[name]
         assert "installed_at" in skills[name]
+
+
+# ── remove_entry (#1123 B4-1) ─────────────────────────────────────────────
+
+
+def test_remove_entry_deletes_and_returns_true(tmp_path: Path) -> None:
+    lock = Lockfile.at(tmp_path)
+    lock.upsert_entry(
+        "skills", "foo", wiki_commit="a" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    assert lock.read_entry("skills", "foo") is not None
+
+    assert lock.remove_entry("skills", "foo") is True
+    assert lock.read_entry("skills", "foo") is None
+
+
+def test_remove_entry_absent_returns_false_and_leaves_file_untouched(tmp_path: Path) -> None:
+    lock = Lockfile.at(tmp_path)
+    # No lockfile yet: removing is a no-op and must NOT create the file.
+    assert lock.remove_entry("skills", "ghost") is False
+    assert not lock.path.exists()
+
+    lock.upsert_entry(
+        "agents", "keep", wiki_commit="b" * 40, installed_at="2026-01-01T00:00:00.000000Z"
+    )
+    before = lock.path.read_bytes()
+    # Existing file, but neither the section nor the name matches → no rewrite.
+    assert lock.remove_entry("commands", "ghost") is False
+    assert lock.remove_entry("agents", "ghost") is False
+    assert lock.path.read_bytes() == before  # byte-identical: mtime/content untouched
+
+
+def test_remove_entry_preserves_siblings_and_unknown_fields(tmp_path: Path) -> None:
+    project = tmp_path
+    (project / ".memtomem").mkdir()
+    seed = {
+        "version": LOCKFILE_VERSION,
+        "future_root": "preserved",
+        "skills": {
+            "alpha": {"wiki_commit": "a" * 40, "installed_at": "2026-01-01T00:00:00.000000Z"},
+            "beta": {
+                "wiki_commit": "b" * 40,
+                "installed_at": "2026-01-02T00:00:00.000000Z",
+                "compat": "v2",
+            },
+        },
+    }
+    (project / ".memtomem" / "lock.json").write_text(json.dumps(seed), encoding="utf-8")
+
+    lock = Lockfile.at(project)
+    assert lock.remove_entry("skills", "alpha") is True
+
+    doc = lock.load()
+    assert "alpha" not in doc["skills"]
+    assert doc["skills"]["beta"]["wiki_commit"] == "b" * 40
+    assert doc["skills"]["beta"]["compat"] == "v2"  # unknown per-entry field kept
+    assert doc["future_root"] == "preserved"  # unknown top-level field kept

--- a/packages/memtomem/tests/test_settings_migrate.py
+++ b/packages/memtomem/tests/test_settings_migrate.py
@@ -20,6 +20,7 @@ from memtomem.context.settings import CANONICAL_SETTINGS_FILE
 from memtomem.context.settings_migrate import (
     MigrateMove,
     MigratePlan,
+    MigrateResult,
     apply_migration,
     format_plan_summary,
     plan_migration,
@@ -661,3 +662,90 @@ class TestFormatPlanSummary:
 
         nums = [int(n) for n in re.findall(r"\b(\d+)\b", summary)]
         assert sum(nums) == len(plan.moves)
+
+
+class TestApplyTimeDrift:
+    """apply_migration re-reads + re-classifies the target at apply time, so a
+    target that drifts between plan and apply is handled against its live
+    state instead of the frozen plan-time snapshot (#1123 B4-3)."""
+
+    def test_refuses_target_that_drifted_to_conflict_after_plan(self, project_root, fake_home):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan.applicable_moves  # planner saw a clean, applicable move
+
+        # Drift AFTER planning: target grows a DIFFERENT inner under the same
+        # (event, matcher) — what the planner classified "missing" is now a
+        # conflict.
+        drift = {"PostToolUse": [_rule("Edit|Write", inners=[_inner("other-command")])]}
+        _write_settings(project_root / ".claude" / "settings.local.json", _settings_doc(drift))
+
+        result = apply_migration(plan)
+
+        assert result.target_written is False
+        assert result.source_written is False
+        assert result.warnings  # drift surfaced for the CLI to print + exit 1
+        # Source still carries the entry (NOT cleaned) so a re-plan retries.
+        user_doc = _read_settings(fake_home / ".claude" / "settings.json")
+        cmds = [
+            i.get("command") for r in user_doc["hooks"]["PostToolUse"] for i in r.get("hooks", [])
+        ]
+        assert "mm session start" in cmds
+        # Target's drifted rule was NOT duplicated (still exactly one rule).
+        target_doc = _read_settings(project_root / ".claude" / "settings.local.json")
+        assert len(target_doc["hooks"]["PostToolUse"]) == 1
+
+    def test_skips_redundant_write_when_target_gained_identical_entry(
+        self, project_root, fake_home
+    ):
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+        plan = plan_migration(project_root, source_scope="user", target_scope="project_local")
+        assert plan.moves[0].already_at_target is False  # planner saw an empty target
+
+        # Drift AFTER planning: target now already carries the canonical rule.
+        _write_settings(
+            project_root / ".claude" / "settings.local.json",
+            _settings_doc(_bundled_hook()),
+        )
+
+        result = apply_migration(plan)
+
+        # Re-classified as exact → no redundant append, but source IS cleaned.
+        assert result.target_written is False
+        assert result.source_written is True
+        assert not result.warnings
+        # Exactly one rule under the matcher — no same-matcher duplicate.
+        target_doc = _read_settings(project_root / ".claude" / "settings.local.json")
+        assert len(target_doc["hooks"]["PostToolUse"]) == 1
+
+    def test_cli_surfaces_apply_drift_warning_and_exits_1(
+        self, monkeypatch, project_root, fake_home
+    ):
+        """The settings-migrate CLI prints apply-time drift warnings (stderr)
+        and exits 1 even when the plan itself was conflict-free."""
+        from memtomem.cli import context_cmd as ctx
+
+        _write_canonical(project_root, _bundled_hook())
+        _write_settings(fake_home / ".claude" / "settings.json", _settings_doc(_bundled_hook()))
+
+        def _fake_apply(plan: MigratePlan) -> MigrateResult:
+            res = MigrateResult(plan=plan)
+            res.warnings.append(
+                "target tier already has a rule under 'PostToolUse:Edit|Write' "
+                "whose inner hooks differ from the canonical entry."
+            )
+            return res
+
+        monkeypatch.setattr(ctx, "apply_migration", _fake_apply)
+        monkeypatch.chdir(project_root)
+
+        result = CliRunner().invoke(
+            ctx.context,
+            ["settings-migrate", "--from", "user", "--to", "project_local", "--apply", "--yes"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        assert "PostToolUse:Edit|Write" in result.output


### PR DESCRIPTION
## What

Bucket **B4 (migrate/status)** of the Context-Gateway deferred backlog (#1123) — three correctness fixes:

### B4-1 — dangling lockfile entry → status "missing"
`migrate_scope` moved a canonical artifact out of `project_shared` but never touched `lock.json`, so a later `mm context status` iterated the stale entry, found the canonical gone from the project_shared dest, and reported the (now-moved) artifact as **missing**.

- New `Lockfile.remove_entry(asset_type, name)` — atomic (sidecar-lock + `atomic_write_bytes`), mirrors `upsert_entry`; preserves sibling entries and unknown top-level/per-entry fields per ADR-0008; returns `False` and leaves the file untouched when there's nothing to remove.
- `migrate_scope` calls it **best-effort** after the move commits, only when `src_scope == "project_shared"` (the sole lockfile-tracked tier). The canonical move already committed inside the lock, so a bookkeeping failure must never undo or fail the migration — it logs and continues.

### B4-2 — `status --scope user` returned empty
The `--scope user` flag was wired but nothing enumerated the user tier, so it always filtered an empty row set.

- New `scan_user_artifacts()` walks `~/.memtomem/{agents,commands,skills}/` (shared draft-walk helper with `project_local`), surfaced by the CLI **only for `--scope user`**.
- **Design decision:** the user-tier walk is kept OUT of `classify_status`. Folding the global `~/.memtomem` walk into it would couple every status read — and every test exercising one — to the caller's real home directory (a local↔CI flake source). `classify_status` stays project-rooted; the CLI surfaces the global tier on demand.
- Render now keys its "draft" columns/counts on `state == "local-draft"` (behavior-preserving for project_shared & project_local). User drafts get dash columns but **no `(draft, no fan-out)`** tag — user artifacts, unlike project_local, *do* fan out to runtime dirs.

### B4-3 — settings-migrate applied stale plan-time classification (TOCTOU)
`apply_migration` trusted the `already_at_target` / `conflict_at_target` flags frozen at **plan** time. If the target tier drifted between plan and apply (another writer, a manual edit, a second run), it could append a canonical rule the target already grew — a same-matcher duplicate Claude Code fires twice — or write past a freshly introduced conflict.

- `apply_migration` now re-reads and **re-classifies** the target against its live state, deriving the write-set and source-clean-set from the current target, not the snapshot. Drift discovered at apply time is refused per-move (no append, source entry left intact) and recorded in `MigrateResult.warnings`.
- The CLI prints those warnings and turns them into **exit 1**, matching the existing plan-time conflict contract.

## Tests
- `Lockfile.remove_entry`: delete + return True; absent → False with **no rewrite** (byte-identical); sibling + unknown-field round-trip.
- Migrate `project_shared → {project_local, user}` drops the entry; status shows no `missing` row.
- User-tier scan: dir + flat layout, skills-flat-not-recognised, `classify_status` stays project-rooted (no user rows), CLI `--scope user` lists artifacts / shows the empty message.
- Apply-time drift: drift-to-conflict refuses + warns + leaves source intact; drift-to-identical skips the redundant write but cleans source; CLI surfaces the warning and exits 1.

## Gates
- `ruff check` ✅ · `ruff format --check` ✅ · `mypy` ✅ (changed files clean) · full suite **5455 passed, 10 skipped**.

## Deferred
- **MCP parity** for status/settings-migrate is out of scope here (consistent with the bucket's audit-vs-runtime split); the user-tier status surface and the apply-time drift guard are CLI/engine-side. Tracked under #1123.

Closes part of #1123 (B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
