### PR TITLE
docs(adr): correct non-existent `mm context list` refs + flip ADR-0011 to Accepted (#1123 B6)

### DIFF
--- a/docs/adr/0011-canonical-artifact-scope-hierarchy.md
+++ b/docs/adr/0011-canonical-artifact-scope-hierarchy.md
@@ -1,6 +1,6 @@
 # ADR-0011: Canonical artifact scope hierarchy (user / project shared / project local)
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-09
 **Context:** ADR-0010 introduced a 3-tier `target_scope` axis for settings
 hooks. This ADR records whether and how to extend the same axis to the
@@ -168,7 +168,7 @@ Rationale:
   surface that confuses users coming in from the runtime side.
 - (a) is the cleanest semantic. The canonical lives under
   `<proj>/.memtomem/agents.local/`, gitignored, indexed by
-  `mm context list` for the user's own awareness, and explicitly
+  `mm context status` for the user's own awareness, and explicitly
   invisible to the runtime. Promotion to `project_shared` is
   `git mv agents.local/X.md → agents/X.md` followed by `mm context
   sync`, which fans out the new project_shared canonical normally.
@@ -419,7 +419,7 @@ Accepted flip — not the PR-A merge — as the unblock signal.
   not fan out to runtime. Users who expect "everything I author
   ships to .claude/" will be surprised by drafts staying invisible.
   The CLI surfaces this with a `(draft, no fan-out)` annotation in
-  `mm context list` output.
+  `mm context status` output.
 
 ## Considered & rejected
 
@@ -480,7 +480,8 @@ they do not block this ADR's acceptance.
 - The same-name conflict resolution for agents / skills / commands
   when one name appears in both project_shared and user scopes. §1
   notes Claude Code natively merges; for memtomem-managed views
-  (`mm context list`), highlight the conflict so the user knows.
+  (`mm context status --scope <tier>`, or the Web overview's per-tier
+  views), highlight the conflict so the user knows.
   The exact warning copy is implementation issue territory.
 - Orphan project chunk garbage collection. If a user indexes
   `/tmp/foo/.memtomem/memories/` then deletes the directory, stale
@@ -499,8 +500,16 @@ they do not block this ADR's acceptance.
 - MCP exposure for `mm context init` / `sync` / `migrate`.
   PR-E shipped through #889 / #890 / #893, with scope-tier moves
   consolidated into `mm context migrate <kind> <name> --to <scope>`.
-  v1 keeps these as CLI / authoring tools only. MCP parity is a
-  separate ask, tracked in #887.
+  #887 since landed MCP parity for `init` / `sync` / `generate` /
+  `diff` (the `mem_context_*` tools), and memory migration is exposed
+  as `mem_context_migrate` — a thin wrapper over `mm context
+  memory-migrate` (markdown memory files only). The **artifact**
+  scope-tier and flat→dir modes of `mm context migrate <kind> <name>`
+  remain **CLI-only by design**: there is no MCP path that migrates
+  agents / skills / commands between tiers. #1123 (B5-1 / B5-2) records
+  this as a deliberately-deferred gap rather than built — `migrate`'s
+  destructive, layout-aware semantics are an interactive/authoring
+  surface, not an agent-runtime one.
 
 ## References
 

--- a/docs/adr/0016-three-tier-canonical-context-store.md
+++ b/docs/adr/0016-three-tier-canonical-context-store.md
@@ -204,11 +204,14 @@ Which surfaces actually perform a cross-tier read by default is **not**
 uniform; the precedence rule above applies only when the surface has
 chosen to span tiers. Three clarifications worth recording here:
 
-- **CLI and runtime spans by default.** `mm context list`, `mm mem
-  search` without an explicit `--scope`, and the Claude Code runtime
-  load span tiers by default and rank under the precedence rule above
-  (the runtime via Claude Code 2.x's tier-merge; CLI / memory via
-  ADR-0011 §6).
+- **Memory search and runtime span by default.** `mm mem search`
+  without an explicit `--scope` and the Claude Code runtime load span
+  tiers by default and rank under the precedence rule above (the
+  runtime via Claude Code 2.x's tier-merge; memory via ADR-0011 §6).
+  Canonical *artifact* reads have no all-tier span: `mm context
+  status` shows the project tiers (`--scope user` adds the user tier)
+  and the Web overview shows one tier at a time (next bullet) — no
+  single surface merges all three.
 - **Web defaults are single-tier, not cross-tier.** ADR-0015 §4a / §4f
   pins the Web overview and list views to **hide `project_local`** and
   **default `?target_scope=` to `project_shared`** when omitted.
@@ -285,10 +288,11 @@ field must reopen one of those ADRs, not this one.
 ### 6. Conflict resolution
 
 Within a single tier, conflicts on artifact name are an error
-(`mm context list` highlights; `mm context migrate --to <tier>`
+(`mm context status` surfaces them; `mm context migrate --to <tier>`
 refuses to overwrite without `--force`). Across tiers, the read
 merge order (§4) decides which entry wins at read time; both
-entries remain visible to `mm context list`. ADR-0011 §"Open
+entries remain visible by inspecting each tier (`mm context status
+--scope <tier>`, or the Web overview's per-tier views). ADR-0011 §"Open
 questions" item 2 owns the user-facing warning copy for the
 cross-tier collision case.
 


### PR DESCRIPTION
Part of #1123 (bucket **B6 — docs/ADR**). Docs-only ADR accuracy fixes. The user decided to **amend the docs** (not build a tier-spanning `mm context list` verb — that's feature work beyond this Minor/Nit backlog).

## B6-1 / B6-2 — the non-existent `mm context list` verb (6 refs)

The ADRs cite `mm context list`, which **does not exist**. Real verbs: `detect / diff / generate / init / install / memory-migrate / migrate / rescan / settings-doctor / settings-migrate / status / sync / update`.

- 5 refs → **`mm context status`** — the real per-tier listing verb, which already emits the exact `(draft, no fan-out)` annotation the ADRs attribute to `list` (`context/status.py`).
- The ADR-0016 §3 *"CLI spans by default"* claim was **false for artifacts**: only `mm mem search` (memory) and the Claude Code runtime span by default. Canonical artifact reads have **no all-tier surface** (`status` is per-tier; the Web overview is single-tier-by-default per ADR-0015 §4a/§4f). Reworded so it no longer implies a single all-tier view; cross-tier collision visibility is "inspect each tier."

## B6-3 — ADR-0011 status

Flip `**Status:** Proposed` → `Accepted`. ADR-0011 is the oldest gateway ADR (2026-05-09), fully implemented via PR-E (#889/#890/#893); all peers (ADR-0009/0010/0015/0016) are already Accepted.

## B5-1 / B5-2 (deferred, documented here per maintainer decision)

The existing ADR-0011 *"MCP exposure for `mm context init`/`sync`/`migrate`"* open-question item is updated to current reality: #887 landed MCP parity for `init`/`sync`/`generate`/`diff`, and memory migration is `mem_context_migrate` — but the **artifact** scope-tier + flat→dir modes of `mm context migrate <kind> <name>` remain **CLI-only by design** (no agent/skill/command MCP migrate path). Recorded as a deliberate gap rather than built.

## Scoped out → follow-up

Different surface (not ADR prose), so kept out of this focused PR:
- **B6-4** — plugin `SKILL.md` frontmatter (`context/`, `setup/`) lists non-core `mem_related` / `mem_config`.
- **B6-5** — web client-side 409 conflict-flow has no test.

Docs-only; no code paths touched. Disjoint from #1137 (no `mcp-clients.md` edit — the B5-1/B5-2 note lives in ADR-0011 to avoid overlap).