### PR TITLE
fix(plugin,web): core-mode skill tools + 409 conflict-modal test (#1123 B6-4/B6-5)

### DIFF
--- a/packages/memtomem-claude-plugin/skills/context/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/context/SKILL.md
@@ -2,7 +2,7 @@
 name: context
 description: Inject relevant memories as structured context for the current task. Use when starting complex work that may benefit from past decisions or notes.
 argument-hint: [topic or question]
-allowed-tools: mcp__memtomem__mem_search, mcp__memtomem__mem_related
+allowed-tools: mcp__memtomem__mem_search, mcp__memtomem__mem_do
 ---
 
 Search for relevant memories about: $ARGUMENTS
@@ -10,7 +10,7 @@ Search for relevant memories about: $ARGUMENTS
 ## Instructions
 
 1. Use `mem_search` with the topic as query (top_k=5)
-2. For each high-relevance result (score > 0.5), check `mem_related` for linked memories
+2. For each high-relevance result (score > 0.5), call `mem_do` with `action="related"` and `params={"chunk_id": <result's chunk_id>}` to find linked memories (`mem_related` is non-core; `mem_do` routes to it in the default `core` tool mode)
 3. Present results grouped by namespace, showing:
    - Source file and heading
    - Tags for quick categorization

--- a/packages/memtomem-claude-plugin/skills/setup/SKILL.md
+++ b/packages/memtomem-claude-plugin/skills/setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup
 description: Guide through initial memtomem setup and optional hooks activation.
-allowed-tools: mcp__memtomem__mem_status, mcp__memtomem__mem_config, mcp__memtomem__mem_index
+allowed-tools: mcp__memtomem__mem_status, mcp__memtomem__mem_index, mcp__memtomem__mem_search
 disable-model-invocation: true
 ---
 

--- a/packages/memtomem/tests-js/ctx-conflict-resolution.test.mjs
+++ b/packages/memtomem/tests-js/ctx-conflict-resolution.test.mjs
@@ -1,0 +1,65 @@
+/* Regression pins for the 409 mtime-conflict resolution modal (#763, #1123 B6-5).
+ *
+ * When PUT /context/{type}/{name} returns 409 (the on-disk file changed under
+ * the user's unsaved edits), `_ctxResolveConflict` opens a three-choice dialog
+ * and resolves to the button the user picks — 'reload' | 'diff' | 'force' — or
+ * null when the dialog is dismissed (Escape / backdrop). This client-side flow
+ * had no test. We drive it through the `window.openCtxConflictModal()` dev entry
+ * point, which calls `_ctxResolveConflict('', '')`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { bootApp } from './setup/jsdom-app.mjs';
+
+async function openConflict() {
+  const dom = await bootApp({ scripts: ['i18n.js', 'app.js', 'context-gateway.js'] });
+  const { window } = dom;
+  // openCtxConflictModal() returns the resolution promise from _ctxResolveConflict.
+  const choice = window.openCtxConflictModal();
+  const byId = (id) => window.document.getElementById(id);
+  const modal = byId('ctx-conflict-modal');
+  return { window, modal, byId, choice };
+}
+
+describe('409 mtime-conflict resolution modal', () => {
+  it('opens the modal and focuses the safe (Reload) choice — never Force', async () => {
+    const { window, modal } = await openConflict();
+    expect(modal.hidden).toBe(false);
+    // Safety contract: Force-save overwrites the other writer's edits, so a
+    // reflexive Enter must NOT land on it. The modal focuses Reload instead.
+    const active = window.document.activeElement;
+    expect(active && active.id).toBe('ctx-conflict-reload-btn');
+    expect(active && active.id).not.toBe('ctx-conflict-force-btn');
+  });
+
+  it('resolves to "force" when Force-save is clicked, then hides the modal', async () => {
+    const { modal, byId, choice } = await openConflict();
+    byId('ctx-conflict-force-btn').click();
+    expect(await choice).toBe('force');
+    expect(modal.hidden).toBe(true);
+  });
+
+  it('resolves to "reload" when Reload is clicked', async () => {
+    const { byId, choice } = await openConflict();
+    byId('ctx-conflict-reload-btn').click();
+    expect(await choice).toBe('reload');
+  });
+
+  it('resolves to "diff" when Open-diff is clicked', async () => {
+    const { byId, choice } = await openConflict();
+    byId('ctx-conflict-diff-btn').click();
+    expect(await choice).toBe('diff');
+  });
+
+  it('resolves to null when dismissed via Escape (no silent overwrite)', async () => {
+    const { window, choice } = await openConflict();
+    window.document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+    expect(await choice).toBe(null);
+  });
+
+  it('resolves to null when the backdrop is clicked', async () => {
+    const { modal, choice } = await openConflict();
+    modal.click(); // event target === modal overlay → backdrop dismiss
+    expect(await choice).toBe(null);
+  });
+});


### PR DESCRIPTION
Part of #1123 (bucket **B6**, residual non-ADR items split out of #1138). Two unrelated-but-small fixes on different surfaces.

## B6-4 — plugin skills declared non-core tools

The plugin runs the MCP server in the default `core` mode (it sets no `MEMTOMEM_TOOL_MODE`), and every other plugin skill uses core-only tools. Two skills broke that convention by declaring tools the `core` mode removes:

- **`context/SKILL.md`** used `mem_related` (in the `relations` pack — standard/full only). Step 2 is rewired to **`mem_do` with `action="related"`** — `mem_do` is a core-9 tool and the documented gateway to non-core actions, so the skill now works in the default mode.
- **`setup/SKILL.md`** listed `mem_config` (full-only — an `_ASTERISK_TOOLS` member per `test_docs_guards.py`) that the skill body **never invokes**, and omitted **`mem_search`** which step 3 *does* use. Dropped the unused non-core tool, added the used core one.

## B6-5 — the 409 conflict-resolution flow had no test

`_ctxResolveConflict` (`context-gateway.js`, #763) opens the three-choice dialog when `PUT /context/{type}/{name}` returns 409 (on-disk file changed under unsaved edits). New `tests-js/ctx-conflict-resolution.test.mjs` drives it through the existing `window.openCtxConflictModal()` dev entry point and pins:

- all four outcomes — Force-save → `'force'`, Reload → `'reload'`, Open-diff → `'diff'`, Escape / backdrop → `null`;
- the a11y safety contract: the modal focuses the non-destructive **Reload** button, never **Force**, so a reflexive Enter can't silently overwrite the other writer's edits.

## Verification

- New test: 6 pass. Full `vitest run`: **72 passed (13 files)**.
- `test_docs_guards.py`: 12 passed (unaffected — it validates hooks.json + the Config-tools doc, not SKILL.md `allowed-tools`).
- No Python source touched; docs-guard + plugin tests green.