### PR TITLE
fix(test): make init settings status test path-separator-agnostic (Windows)

### DIFF
--- a/packages/memtomem/tests/test_init_settings_status.py
+++ b/packages/memtomem/tests/test_init_settings_status.py
@@ -79,11 +79,17 @@ def test_unknown_status_is_not_swallowed(tmp_path, monkeypatch):
 
 
 def test_ok_and_skipped_still_reported(tmp_path, monkeypatch):
+    # Build the target from ``tmp_path`` and expect the same ``str(target)`` the
+    # ok-branch renders (``_step_settings`` does ``f"Merged → {r.target}"``).
+    # A hardcoded ``"/tmp/claude.json"`` literal mismatched the backslash
+    # separator on Windows (``str(Path("/tmp/claude.json"))`` → ``\tmp\claude.json``),
+    # failing the assertion on windows-latest.
+    target = tmp_path / "claude.json"
     out = _drive_step_settings(
         tmp_path,
         monkeypatch,
         {
-            "claude": SettingsSyncResult(status="ok", target=Path("/tmp/claude.json")),
+            "claude": SettingsSyncResult(status="ok", target=target),
             "codex": SettingsSyncResult(status="skipped", reason="not installed"),
         },
     )
@@ -91,5 +97,5 @@ def test_ok_and_skipped_still_reported(tmp_path, monkeypatch):
     # merged into ~/.claude/settings.json additively.") which contains the word
     # "merged" regardless of whether the ``ok`` branch ran — a bare
     # ``"merged" in out.lower()`` would pass even if that branch regressed.
-    assert "Merged → /tmp/claude.json" in out
+    assert f"Merged → {target}" in out
     assert "skipped codex: not installed" in out


### PR DESCRIPTION
## What

`test_init_settings_status.py::test_ok_and_skipped_still_reported` (added in #1134, B7-4) hardcodes:

```python
"claude": SettingsSyncResult(status="ok", target=Path("/tmp/claude.json")),
...
assert "Merged → /tmp/claude.json" in out
```

`_step_settings` renders the target with `click.secho(f"  Merged → {r.target}", fg="green")` — i.e. `str(r.target)`. On Windows `str(Path("/tmp/claude.json"))` is `\tmp\claude.json`, so the literal `"/tmp/claude.json"` assertion mismatches the separator and the test **fails on `windows-latest`** (it passes on POSIX).

## Fix

Build the target from `tmp_path` and assert the same `str(target)` the production code renders, so the comparison is byte-identical on POSIX and Windows:

```python
target = tmp_path / "claude.json"
...
assert f"Merged → {target}" in out
```

Pure test change — no production code touched. The original B7-4 regression intent (the `ok` status is surfaced in the init step output, not just the static intro line) is fully preserved.

## Context

Surfaced while reviewing #1145 (B3): `windows-latest` had three failures, two of which #1145 introduced (fixed there). This third one is a pre-existing #1134 carry-over unrelated to B3, so it gets its own focused PR off `main`.

## Verification

- `ruff check` ✅ · `ruff format --check` ✅
- `test_init_settings_status.py`: 3 passed locally (POSIX). The fix matches the separator by construction, so it holds on Windows too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
