### PR TITLE
fix(init): don't gate HTTP embedding providers on unused client packages

### DIFF
--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -478,37 +478,21 @@ def _step_embedding(state: dict) -> None:
 
     elif choice == 3:
         provider = "ollama"
-        # Two orthogonal preconditions for Ollama: the runtime binary
-        # (``_ollama_available()`` = ``shutil.which("ollama")``) and the
-        # ``ollama`` Python client (``_have_module("ollama")``). The
-        # ``-y`` extras gate (#402) checks the Python client, not the
-        # binary — so the refuse-hint must fire whenever the Python
-        # client is missing, whether or not the binary is on PATH.
-        have_ollama_binary = _ollama_available()
-        have_ollama_module = _have_module("ollama")
-
-        if not have_ollama_binary:
+        # The only Ollama precondition that matters is the runtime SERVER (the
+        # ``ollama`` binary, ``_ollama_available()`` / ``_ollama_running()``):
+        # the embedder talks to it over HTTP via ``httpx`` (a core dependency).
+        # The ``ollama`` PyPI client is NOT imported by the embedder, so it is
+        # neither required nor gated — ``-y --provider ollama`` writes config
+        # and embedding runs once the server is up.
+        if not _ollama_available():
             click.secho("  Ollama not found.", fg="yellow")
             click.echo("  Install from https://ollama.com, then run 'mm index' to embed.")
             click.echo("  Saving Ollama config now so you're ready after install.")
-            if not have_ollama_module:
-                click.echo(_y_refuse_hint("--provider ollama", "ollama"))
-                state.setdefault("_extras_warned_inline", set()).add("ollama")
             click.echo()
             # Record intent — config is written, embedding runs when Ollama is available.
             model = "nomic-embed-text"
             dimension = 768
         else:
-            if not have_ollama_module:
-                # Binary is on PATH but the ``-y`` gate additionally
-                # requires the ``ollama`` Python client. Surface the
-                # install hint + refuse note up front so scripted
-                # retries don't surprise the user.
-                click.secho("  ollama Python client not installed.", fg="yellow")
-                click.echo(f"  Install with: {_extra_install_hint(['ollama'], state)}")
-                click.echo(_y_refuse_hint("--provider ollama", "ollama"))
-                click.echo()
-                state.setdefault("_extras_warned_inline", set()).add("ollama")
             # Server reachability + model selection + pull are guarded so
             # a failed step doesn't silently advance the wizard (#626).
             # ``StepRetry`` is caught locally so the user doesn't have to
@@ -579,17 +563,10 @@ def _step_embedding(state: dict) -> None:
 
     else:
         provider = "openai"
-        # Mirror the Ollama / ONNX / kiwipiepy probe pattern (#405 / #403):
-        # the ``-y`` extras gate (#402) refuses without the ``openai``
-        # Python client, so the wizard must hint before prompting for a
-        # key the user could otherwise spend effort validating.
-        if not _have_module("openai"):
-            click.secho("  openai Python client not installed.", fg="yellow")
-            click.echo(f"  Install with: {_extra_install_hint(['openai'], state)}")
-            click.echo("  Saving OpenAI config now so you're ready after install.")
-            click.echo(_y_refuse_hint("--provider openai", "openai"))
-            click.echo()
-            state.setdefault("_extras_warned_inline", set()).add("openai")
+        # The OpenAI embedder calls the HTTP API via ``httpx`` (a core
+        # dependency); the ``openai`` PyPI client is NOT imported, so it is not
+        # required. The real precondition is an API key, collected below /
+        # via ``--api-key``.
 
         click.echo("  Available models:")
         click.echo("    [1] text-embedding-3-small — balanced (1536d)")
@@ -1871,18 +1848,12 @@ def _collect_missing_extras(state: dict) -> list[str]:
         if importable is not None:
             have_fastembed = "fastembed" in importable
             have_web = {"fastapi", "uvicorn"}.issubset(importable)
-            have_ollama = "ollama" in importable
-            have_openai = "openai" in importable
             have_kiwipiepy = "kiwipiepy" in importable
         else:
             have_fastembed, have_web = _inproc_have_extras()
-            have_ollama = _have_module("ollama")
-            have_openai = _have_module("openai")
             have_kiwipiepy = _have_module("kiwipiepy")
     else:
         have_fastembed, have_web = _inproc_have_extras()
-        have_ollama = _have_module("ollama")
-        have_openai = _have_module("openai")
         have_kiwipiepy = _have_module("kiwipiepy")
 
     missing: list[str] = []
@@ -1894,13 +1865,13 @@ def _collect_missing_extras(state: dict) -> list[str]:
     )
     if needs_fastembed and not have_fastembed:
         missing.append("onnx")
-    # [ollama] / [openai] — provider-specific client libs. `mm init -y
-    # --provider <x>` previously wrote the choice to config without this
-    # check and the failure surfaced only at runtime (#396).
-    if provider == "ollama" and not have_ollama:
-        missing.append("ollama")
-    if provider == "openai" and not have_openai:
-        missing.append("openai")
+    # NOTE: the ``ollama`` / ``openai`` providers need NO extra. Their embedders
+    # call the Ollama server / OpenAI API over HTTP via ``httpx`` (a core
+    # dependency) and never import the ``ollama`` / ``openai`` PyPI clients, so
+    # gating them on those packages was a false failure path that aborted valid
+    # ``mm init -y --provider ollama|openai`` runs. The real preconditions are
+    # the Ollama server (binary) and an OpenAI API key, neither of which a
+    # package check proves.
     # [korean] = kiwipiepy. The tokenizer falls back to unicode61 at runtime
     # if kiwipiepy is absent, so missing it is not fatal — but `mm init -y
     # --tokenizer kiwipiepy` should still be caught up front (#396).
@@ -1916,12 +1887,13 @@ def _collect_missing_extras(state: dict) -> list[str]:
 # Extras that ``-y`` must refuse to write a config for when absent. ``web``
 # is excluded — scripted runs often use ``--mcp skip`` without any intention
 # to run the web UI, and the runtime fallback (clear ``mm web`` error on
-# missing fastapi) is already loud. Update this set alongside new provider/
-# tokenizer entries in ``_collect_missing_extras`` if they gain a runtime
-# fallback that silently flips the user-visible config.
-_REQUIRED_EXTRAS_FOR_NON_INTERACTIVE: frozenset[str] = frozenset(
-    {"onnx", "ollama", "openai", "korean"}
-)
+# missing fastapi) is already loud. ``ollama`` / ``openai`` are excluded too:
+# their providers run on ``httpx`` (core) without the PyPI clients, so a
+# missing client never blocks a valid config (see ``_collect_missing_extras``).
+# Update this set alongside new provider/tokenizer entries in
+# ``_collect_missing_extras`` if they gain a runtime fallback that silently
+# flips the user-visible config.
+_REQUIRED_EXTRAS_FOR_NON_INTERACTIVE: frozenset[str] = frozenset({"onnx", "korean"})
 
 
 def _emit_cwd_runtime_mismatch_banner(state: dict) -> None:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -5538,12 +5538,13 @@ class TestInitialSeedThreshold:
 class TestNonInteractiveExtrasValidation:
     """Issue #396: ``mm init -y`` must refuse to write a config when the
     requested ``--provider`` / ``--tokenizer`` needs an extra that is not
-    importable. Previously ``-y`` accepted the flag values as given and
-    the mismatch surfaced only at runtime (embedder falls back to 0d,
-    kiwipiepy falls back to unicode61, etc.). Scripted workflows prefer
-    a non-zero exit here over a silently-stale config."""
+    importable AND has no working runtime fallback — e.g. ``onnx`` (fastembed),
+    whose absence leaves the embedder at dimension 0. (``kiwipiepy`` falls back
+    to unicode61, so it warns rather than aborts.) The ``ollama`` / ``openai``
+    HTTP providers need NO extra — their embedders run on httpx — so they must
+    NOT be gated on the PyPI clients."""
 
-    def test_collect_missing_extras_ollama_when_client_absent(
+    def test_collect_missing_extras_ollama_needs_no_client_package(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from memtomem.cli import init_cmd
@@ -5554,9 +5555,10 @@ class TestNonInteractiveExtrasValidation:
         )
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
         state = {"provider": "ollama", "rerank_enabled": False}
-        assert init_cmd._collect_missing_extras(state) == ["ollama"]
+        # Ollama embedder uses httpx, not the ``ollama`` PyPI client.
+        assert init_cmd._collect_missing_extras(state) == []
 
-    def test_collect_missing_extras_openai_when_client_absent(
+    def test_collect_missing_extras_openai_needs_no_client_package(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from memtomem.cli import init_cmd
@@ -5567,7 +5569,8 @@ class TestNonInteractiveExtrasValidation:
         )
         monkeypatch.setattr("memtomem.cli.web._missing_web_deps", lambda: None, raising=False)
         state = {"provider": "openai", "rerank_enabled": False}
-        assert init_cmd._collect_missing_extras(state) == ["openai"]
+        # OpenAI embedder uses httpx + an API key, not the ``openai`` PyPI client.
+        assert init_cmd._collect_missing_extras(state) == []
 
     def test_collect_missing_extras_kiwipiepy_when_tokenizer_chose(
         self, monkeypatch: pytest.MonkeyPatch
@@ -5645,9 +5648,14 @@ class TestNonInteractiveExtrasValidation:
         assert "korean" in result.output
         assert not (tmp_path / ".memtomem" / "config.json").exists()
 
-    def test_yes_flag_provider_ollama_missing_client_exits_non_zero(
+    def test_yes_flag_provider_ollama_missing_client_still_writes_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """The Ollama embedder runs on httpx, not the ``ollama`` PyPI client, so
+        a missing client must NOT block ``-y --provider ollama`` — the config is
+        written and embedding runs once the server is up. (Previously this
+        aborted with "Missing required extras", a false failure for valid
+        configs.)"""
         from click.testing import CliRunner
 
         from memtomem.cli import cli, init_cmd
@@ -5674,10 +5682,9 @@ class TestNonInteractiveExtrasValidation:
             ],
         )
 
-        assert result.exit_code != 0, result.output
-        assert "Missing required extras" in result.output
-        assert "ollama" in result.output
-        assert not (tmp_path / ".memtomem" / "config.json").exists()
+        assert result.exit_code == 0, result.output
+        assert "Missing required extras" not in result.output
+        assert (tmp_path / ".memtomem" / "config.json").exists()
 
     def test_yes_flag_web_only_missing_still_writes_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -5723,14 +5730,16 @@ class TestNonInteractiveExtrasValidation:
         assert result.exit_code == 0, result.output
         assert (tmp_path / ".memtomem" / "config.json").exists()
 
-    def test_yes_flag_provider_openai_missing_client_exits_non_zero(
+    def test_yes_flag_provider_openai_missing_client_still_writes_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``--provider openai`` is shaped the same as ollama/onnx at the
-        extras-gate layer, but ``--api-key`` plumbing sits alongside in
-        ``_override_from_flags``. Exercising the full CLI path proves the
-        two don't accidentally interact — the gate fires before the key
-        handling runs."""
+        """The OpenAI embedder runs on httpx + an API key, not the ``openai``
+        PyPI client, so a missing client must NOT block ``-y --provider openai``
+        when a key is supplied — the config is written. (Previously this aborted
+        with "Missing required extras" even with ``--api-key`` present, a false
+        failure for valid configs.) ``--api-key`` plumbing sits alongside in
+        ``_override_from_flags``; exercising the full CLI path proves the key
+        handling still runs."""
         from click.testing import CliRunner
 
         from memtomem.cli import cli, init_cmd
@@ -5759,10 +5768,9 @@ class TestNonInteractiveExtrasValidation:
             ],
         )
 
-        assert result.exit_code != 0, result.output
-        assert "Missing required extras" in result.output
-        assert "openai" in result.output
-        assert not (tmp_path / ".memtomem" / "config.json").exists()
+        assert result.exit_code == 0, result.output
+        assert "Missing required extras" not in result.output
+        assert (tmp_path / ".memtomem" / "config.json").exists()
 
     def test_yes_flag_multi_extra_missing_reports_both(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -5900,17 +5908,14 @@ class TestYRefuseHintParity:
         assert _count_calls(embedding_src, "--provider onnx", "onnx") >= 1, (
             "ONNX fallback must surface -y refuse hint (#403)"
         )
-        # Ollama has two orthogonal preconditions (binary + Python client),
-        # so the wizard must hint in both branches — binary-missing and
-        # binary-present-but-module-missing — to cover what ``-y`` refuses
-        # (#405 follow-up to #403).
-        assert _count_calls(embedding_src, "--provider ollama", "ollama") >= 2, (
-            "Ollama fallback must surface -y refuse hint in both "
-            "binary-missing and module-missing branches (#405)"
+        # ollama / openai are HTTP providers (httpx) that need NO PyPI client,
+        # so ``-y`` no longer refuses on a missing client — the wizard must NOT
+        # print a (now false) "-y will refuse" hint for them.
+        assert _count_calls(embedding_src, "--provider ollama", "ollama") == 0, (
+            "ollama needs no client package; -y does not refuse, so no refuse hint"
         )
-        assert _count_calls(embedding_src, "--provider openai", "openai") >= 1, (
-            "OpenAI fallback must surface -y refuse hint when the openai "
-            "Python client is missing (#407)"
+        assert _count_calls(embedding_src, "--provider openai", "openai") == 0, (
+            "openai needs no client package; -y does not refuse, so no refuse hint"
         )
         assert _count_calls(language_src, "--tokenizer kiwipiepy", "korean") >= 1, (
             "kiwipiepy fallback must surface -y refuse hint (#403)"


### PR DESCRIPTION
## Problem

`mm init -y --provider ollama` (or `--provider openai`) **aborts in a base install**, reporting the `ollama`/`openai` PyPI client as a required missing extra — even for `--provider openai --api-key …`. This breaks valid scripted setup flows.

But the Ollama/OpenAI **embedding providers use `httpx` directly** (a core dependency) and never import the `ollama`/`openai` Python packages:
- `embedding/ollama.py` / `embedding/openai.py` → `import httpx` only.
- `embedding/factory.py` imports those httpx-based embedders directly.
- Zero `ollama`/`openai` imports anywhere under `packages/memtomem/src`.

So the gate is a **false failure path** rejecting configs that would work fine.

## Why removing it is safe

The package was never the right signal. `mm init -y` already does **not** prove the Ollama server is running or that an OpenAI key is set (the *real* preconditions), so removing the client-SDK gate does **not** reintroduce the runtime failure #402 guarded against. The real preconditions remain checked: Ollama via the binary/server probe, OpenAI via the API key.

The gating was applied consistently across the non-interactive path, the interactive wizard, **and** a source-scan test — so a partial (non-interactive-only) fix would leave the interactive wizard printing a now-false *"-y will refuse"* hint. This PR fixes all of them.

## Change

- `_collect_missing_extras`: drop the ollama/openai PyPI-client probes + appends.
- `_REQUIRED_EXTRAS_FOR_NON_INTERACTIVE`: `{onnx, ollama, openai, korean}` → `{onnx, korean}`.
- interactive `_step_embedding`: drop the `"<x> Python client not installed"` warning + `_y_refuse_hint` for ollama/openai (Ollama still checks the binary/server; OpenAI still collects an API key).
- tests: invert the four ollama/openai abort / missing-extra tests to assert the config **is** written; update the source-scan refuse-hint pin (onnx/korean keep it, ollama/openai must not); correct the test-class docstring premise.

`onnx` (fastembed) and `korean` (kiwipiepy) gating is **unchanged** — those packages ARE imported at runtime.

## Behavior change

`mm init -y --provider ollama|openai` in a base install now **writes the config** (exit 0) instead of aborting; embedding runs once the Ollama server is up / with the OpenAI key. The interactive wizard no longer claims `-y` will refuse for these providers.

## Not in scope

The `[ollama]`/`[openai]` `pyproject` extras (which install the unused PyPI clients) are left as-is — removing them is a separate, user-facing API decision (`memtomem[all]` references them).

## Tests

Full suite green: `uv run pytest -m "not ollama"` → 5499 passed, 10 skipped, 46 deselected. Lint + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)