### PR TITLE
fix(context): capture runtime-file preamble on reverse-import (#1147 B1-3)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -811,12 +811,12 @@ def init_cmd(
             best = max(files, key=lambda f: f.size)
             click.echo(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
             content = _read_agent_file(best.path)
-            sections = extract_sections_from_agent_file(content)
+            sections = extract_sections_from_agent_file(content, source=best.agent)
             for f in files:
                 if f.path == best.path:
                     continue
                 other_content = _read_agent_file(f.path)
-                other_sections = extract_sections_from_agent_file(other_content)
+                other_sections = extract_sections_from_agent_file(other_content, source=f.agent)
                 for key, val in other_sections.items():
                     if key not in sections and val.strip():
                         sections[key] = val

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -63,6 +63,7 @@ from memtomem.context.status import classify_status, load_with_recovery, scan_us
 from memtomem.context.generator import (
     GENERATORS,
     extract_sections_from_agent_file,
+    preamble_source,
 )
 from memtomem.context.parser import CONTEXT_FILENAME, parse_context, sections_to_markdown
 from memtomem.context.privacy_scan import PrivacyScanError, scan_artifact_tree
@@ -811,12 +812,16 @@ def init_cmd(
             best = max(files, key=lambda f: f.size)
             click.echo(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
             content = _read_agent_file(best.path)
-            sections = extract_sections_from_agent_file(content, source=best.agent)
+            sections = extract_sections_from_agent_file(
+                content, source=preamble_source(best.agent, best.path)
+            )
             for f in files:
                 if f.path == best.path:
                     continue
                 other_content = _read_agent_file(f.path)
-                other_sections = extract_sections_from_agent_file(other_content, source=f.agent)
+                other_sections = extract_sections_from_agent_file(
+                    other_content, source=preamble_source(f.agent, f.path)
+                )
                 for key, val in other_sections.items():
                     if key not in sections and val.strip():
                         sections[key] = val

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -283,6 +283,27 @@ def _clean_preamble(preamble: str, source: str) -> str:
     return "\n".join(kept).strip()
 
 
+def preamble_source(agent: str | None, path: Path) -> str | None:
+    """Return *agent* as a reverse-import preamble source only when *path* is
+    that agent's canonical Project-bearing file (its generator ``output_path``).
+
+    ``detect_agent_files`` reports rule fragments such as ``.cursor/rules/*.mdc``
+    with ``agent="cursor"`` too; those are not Project prose, so importing them
+    via ``extract_sections_from_agent_file(..., source="cursor")`` would wrongly
+    seed ``Project`` with rule-fragment content. Gating on the generator's own
+    ``output_path`` keeps fragments on the ``source=None`` (drop-preamble) path,
+    while ``.cursorrules`` / ``CLAUDE.md`` / ``GEMINI.md`` / ``AGENTS.md`` /
+    ``copilot-instructions.md`` still capture their leading Project prose
+    (#1147 B1-3 review).
+    """
+    if agent is None:
+        return None
+    gen = GENERATORS.get(agent)
+    if gen is None:
+        return None
+    return agent if path.name == Path(gen.output_path).name else None
+
+
 def extract_sections_from_agent_file(content: str, source: str | None = None) -> dict[str, str]:
     """Reverse-extract sections from an existing agent file (CLAUDE.md, etc.).
 
@@ -290,12 +311,19 @@ def extract_sections_from_agent_file(content: str, source: str | None = None) ->
 
     ``source`` is the detecting generator's name (``"claude"``, ``"cursor"``,
     ``"gemini"``, ``"codex"``, ``"copilot"``). When given, leading text before
-    the first ``##`` heading — which is real project prose for the
+    the first *generated* section heading — which is real project prose for the
     cursor/copilot targets that emit the Project body with no H1 — is captured
     into the canonical ``Project`` section after stripping the source's
-    generated boilerplate (#1147 B1-3). When ``source`` is ``None`` the
-    preamble is dropped exactly as before (back-compat): the canonical parser
-    contract is unchanged.
+    generated boilerplate (#1147 B1-3). The split boundary is the first heading
+    that aliases to a known section, so a Project body's own ``##`` subheadings
+    stay inside Project rather than mis-splitting at the first one. When
+    ``source`` is ``None`` the preamble is dropped exactly as before
+    (back-compat): the canonical parser contract is unchanged.
+
+    Pass ``source`` only for a generator's *canonical* Project-bearing file
+    (see :func:`preamble_source`); rule fragments such as ``.cursor/rules/*``
+    are also detected as ``agent="cursor"`` but are not Project prose, so they
+    must reach this function with ``source=None``.
     """
     # Heading aliases → canonical section name
     aliases: dict[str, str] = {
@@ -317,7 +345,10 @@ def extract_sections_from_agent_file(content: str, source: str | None = None) ->
         "copilot-specific": "Copilot",
     }
 
-    preamble, rest = split_preamble(content)
+    # For a known source the boundary is the first *generated* heading (a known
+    # alias), so unknown Project subheadings stay in the preamble → Project.
+    boundary = set(aliases) if source is not None else None
+    preamble, rest = split_preamble(content, boundary)
 
     sections: dict[str, str] = {}
     for heading, body in iter_markdown_sections(rest):

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -311,12 +311,12 @@ def extract_sections_from_agent_file(content: str, source: str | None = None) ->
 
     ``source`` is the detecting generator's name (``"claude"``, ``"cursor"``,
     ``"gemini"``, ``"codex"``, ``"copilot"``). When given, leading text before
-    the first *generated* section heading — which is real project prose for the
+    the first ``##`` heading — which is real project prose for the
     cursor/copilot targets that emit the Project body with no H1 — is captured
     into the canonical ``Project`` section after stripping the source's
-    generated boilerplate (#1147 B1-3). The split boundary is the first heading
-    that aliases to a known section, so a Project body's own ``##`` subheadings
-    stay inside Project rather than mis-splitting at the first one. When
+    generated boilerplate (#1147 B1-3). Every ``##`` starts a section, so a
+    captured ``Project`` body never contains a ``##`` that would re-split on
+    the next round-trip; keep subheadings inside a section with ``###``. When
     ``source`` is ``None`` the preamble is dropped exactly as before
     (back-compat): the canonical parser contract is unchanged.
 
@@ -345,10 +345,11 @@ def extract_sections_from_agent_file(content: str, source: str | None = None) ->
         "copilot-specific": "Copilot",
     }
 
-    # For a known source the boundary is the first *generated* heading (a known
-    # alias), so unknown Project subheadings stay in the preamble → Project.
-    boundary = set(aliases) if source is not None else None
-    preamble, rest = split_preamble(content, boundary)
+    # Every ## heading starts a section; the text before the first one is the
+    # preamble (captured into Project for known sources below). A section's own
+    # subheadings must use ### so they are not mis-read as separate sections —
+    # this keeps the captured Project body free of round-trip-unstable ## lines.
+    preamble, rest = split_preamble(content)
 
     sections: dict[str, str] = {}
     for heading, body in iter_markdown_sections(rest):

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from memtomem.context.parser import iter_markdown_sections
+from memtomem.context.parser import iter_markdown_sections, split_preamble
 
 
 class AgentGenerator(Protocol):
@@ -244,10 +244,58 @@ def generate_all(sections: dict[str, str]) -> dict[str, str]:
     return {name: gen.generate(sections) for name, gen in GENERATORS.items()}
 
 
-def extract_sections_from_agent_file(content: str) -> dict[str, str]:
+# Boilerplate each generator's generate() emits *before* the first "##"
+# heading. On reverse-import we strip it so it is not re-imported as project
+# text. MUST stay in lock-step with the generate() methods above and with
+# parser.sections_to_markdown's "# Project Context" wrapper (_WRAPPER_H1).
+# cursor/copilot emit the Project body directly as leading text with no H1 —
+# nothing to strip; for them the preamble *is* the Project section (the
+# round-trip loss this fixes, #1147 B1-3).
+_SOURCE_BOILERPLATE: dict[str, tuple[str, ...]] = {
+    "claude": (
+        "# CLAUDE.md",
+        "This file provides guidance to Claude Code (claude.ai/code) "
+        "when working with code in this repository.",
+    ),
+    "gemini": (
+        "# GEMINI.md",
+        "This file provides guidance to Gemini CLI when working with code in this repository.",
+    ),
+    "codex": ("# AGENTS.md",),
+    "cursor": (),
+    "copilot": (),
+}
+
+# Wrapper H1 emitted by parser.sections_to_markdown, regardless of source.
+_WRAPPER_H1 = "# Project Context"
+
+
+def _clean_preamble(preamble: str, source: str) -> str:
+    """Drop generated boilerplate lines from a reverse-import preamble.
+
+    Removes the canonical wrapper H1 plus ``source``'s known boilerplate
+    lines, then returns the remaining real project prose (stripped). An empty
+    return means the preamble was pure boilerplate (the claude/gemini/codex
+    case) and contributes nothing.
+    """
+    drop = {_WRAPPER_H1, *_SOURCE_BOILERPLATE.get(source, ())}
+    kept = [line for line in preamble.splitlines() if line.strip() not in drop]
+    return "\n".join(kept).strip()
+
+
+def extract_sections_from_agent_file(content: str, source: str | None = None) -> dict[str, str]:
     """Reverse-extract sections from an existing agent file (CLAUDE.md, etc.).
 
     Maps agent-specific headings back to canonical section names.
+
+    ``source`` is the detecting generator's name (``"claude"``, ``"cursor"``,
+    ``"gemini"``, ``"codex"``, ``"copilot"``). When given, leading text before
+    the first ``##`` heading — which is real project prose for the
+    cursor/copilot targets that emit the Project body with no H1 — is captured
+    into the canonical ``Project`` section after stripping the source's
+    generated boilerplate (#1147 B1-3). When ``source`` is ``None`` the
+    preamble is dropped exactly as before (back-compat): the canonical parser
+    contract is unchanged.
     """
     # Heading aliases → canonical section name
     aliases: dict[str, str] = {
@@ -269,8 +317,10 @@ def extract_sections_from_agent_file(content: str) -> dict[str, str]:
         "copilot-specific": "Copilot",
     }
 
+    preamble, rest = split_preamble(content)
+
     sections: dict[str, str] = {}
-    for heading, body in iter_markdown_sections(content):
+    for heading, body in iter_markdown_sections(rest):
         key = aliases.get(heading.lower(), heading)
         # Two source headings can alias to one canonical key (e.g. "Rules" and
         # "Coding Rules" → "Rules"); merge rather than overwrite so the earlier
@@ -279,5 +329,15 @@ def extract_sections_from_agent_file(content: str) -> dict[str, str]:
             sections[key] = f"{sections[key]}\n\n{body}".strip()
         else:
             sections[key] = body
+
+    # Capture non-boilerplate leading prose into Project for known sources,
+    # prepended to any existing ## Project body to preserve document order.
+    if source is not None:
+        leading = _clean_preamble(preamble, source)
+        if leading:
+            if "Project" in sections:
+                sections["Project"] = f"{leading}\n\n{sections['Project']}".strip()
+            else:
+                sections["Project"] = leading
 
     return sections

--- a/packages/memtomem/src/memtomem/context/parser.py
+++ b/packages/memtomem/src/memtomem/context/parser.py
@@ -77,12 +77,54 @@ def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
         yield current, "\n".join(lines).strip()
 
 
+def split_preamble(text: str) -> tuple[str, str]:
+    """Split ``text`` at the first real ``## Heading`` line.
+
+    Returns ``(preamble, rest)`` where ``rest`` begins at the first heading
+    that :func:`iter_markdown_sections` would recognise and ``preamble`` is
+    everything before it. If there is no real heading, the whole text is the
+    preamble and ``rest`` is empty.
+
+    The fence/heading rules are kept in lock-step with
+    :func:`iter_markdown_sections` so a ``##`` inside a fenced code block is
+    not a false boundary (B1-1) and a whitespace-only ``##`` is not treated
+    as a heading (B1-3). Callers that want the preamble (e.g.
+    :func:`memtomem.context.generator.extract_sections_from_agent_file`)
+    use this; the section iterator itself still drops it.
+    """
+    lines = text.splitlines()
+    fence_char: str | None = None
+    fence_len = 0
+
+    for i, line in enumerate(lines):
+        fence = _FENCE_RE.match(line)
+        if fence:
+            run, rest = fence.group(1), fence.group(2)
+            if fence_char is None:
+                fence_char, fence_len = run[0], len(run)
+            elif run[0] == fence_char and len(run) >= fence_len and not rest.strip():
+                fence_char, fence_len = None, 0
+            continue
+        m = None if fence_char is not None else _HEADING_RE.match(line)
+        if m and m.group(1).strip():
+            return "\n".join(lines[:i]), "\n".join(lines[i:])
+
+    return text, ""
+
+
 def parse_context(path: Path) -> dict[str, str]:
     """Parse context.md into {section_name: content} dict.
 
     Sections are delimited by `## SectionName` headings.
     Unknown sections are preserved as-is. Repeated headings are merged
     (content concatenated) rather than the earlier copy being overwritten.
+
+    Text before the first `## SectionName` heading is not a section and is
+    not preserved — put project description under `## Project`. (Runtime-file
+    reverse-import via
+    :func:`memtomem.context.generator.extract_sections_from_agent_file` does
+    capture such leading prose for known sources; canonical-parser preamble
+    capture is deferred — see #1147 B1-3.)
     """
     if not path.exists():
         return {}

--- a/packages/memtomem/src/memtomem/context/parser.py
+++ b/packages/memtomem/src/memtomem/context/parser.py
@@ -77,7 +77,7 @@ def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
         yield current, "\n".join(lines).strip()
 
 
-def split_preamble(text: str, boundary_headings: set[str] | None = None) -> tuple[str, str]:
+def split_preamble(text: str) -> tuple[str, str]:
     """Split ``text`` at the first real ``## Heading`` line.
 
     Returns ``(preamble, rest)`` where ``rest`` begins at the first heading
@@ -85,13 +85,12 @@ def split_preamble(text: str, boundary_headings: set[str] | None = None) -> tupl
     everything before it. If there is no real heading, the whole text is the
     preamble and ``rest`` is empty.
 
-    ``boundary_headings`` (lower-cased) narrows what counts as the split
-    boundary: when given, a heading splits only if its lower-cased text is in
-    the set; other (unknown) headings are treated as preamble content. This
-    lets source-aware reverse-import keep a Project body's own ``##``
-    subheadings inside Project instead of mis-splitting at the first one — the
-    boundary is the first *generated* section heading, not any heading (#1147
-    B1-3). When ``None``, every real heading is a boundary (the default).
+    Every ``## Heading`` is a section boundary: on reverse-import the text
+    before the first one is the preamble (mapped to ``Project`` for known
+    sources) and each heading starts its own section. This keeps a captured
+    ``Project`` body free of ``##`` headings that would re-split on the next
+    round-trip — to keep a subheading inside a section body, use ``###``
+    (#1147 B1-3).
 
     The fence/heading rules are kept in lock-step with
     :func:`iter_markdown_sections` so a ``##`` inside a fenced code block is
@@ -115,8 +114,7 @@ def split_preamble(text: str, boundary_headings: set[str] | None = None) -> tupl
             continue
         m = None if fence_char is not None else _HEADING_RE.match(line)
         if m and m.group(1).strip():
-            if boundary_headings is None or m.group(1).strip().lower() in boundary_headings:
-                return "\n".join(lines[:i]), "\n".join(lines[i:])
+            return "\n".join(lines[:i]), "\n".join(lines[i:])
 
     return text, ""
 

--- a/packages/memtomem/src/memtomem/context/parser.py
+++ b/packages/memtomem/src/memtomem/context/parser.py
@@ -77,13 +77,21 @@ def iter_markdown_sections(text: str) -> Iterator[tuple[str, str]]:
         yield current, "\n".join(lines).strip()
 
 
-def split_preamble(text: str) -> tuple[str, str]:
+def split_preamble(text: str, boundary_headings: set[str] | None = None) -> tuple[str, str]:
     """Split ``text`` at the first real ``## Heading`` line.
 
     Returns ``(preamble, rest)`` where ``rest`` begins at the first heading
     that :func:`iter_markdown_sections` would recognise and ``preamble`` is
     everything before it. If there is no real heading, the whole text is the
     preamble and ``rest`` is empty.
+
+    ``boundary_headings`` (lower-cased) narrows what counts as the split
+    boundary: when given, a heading splits only if its lower-cased text is in
+    the set; other (unknown) headings are treated as preamble content. This
+    lets source-aware reverse-import keep a Project body's own ``##``
+    subheadings inside Project instead of mis-splitting at the first one — the
+    boundary is the first *generated* section heading, not any heading (#1147
+    B1-3). When ``None``, every real heading is a boundary (the default).
 
     The fence/heading rules are kept in lock-step with
     :func:`iter_markdown_sections` so a ``##`` inside a fenced code block is
@@ -107,7 +115,8 @@ def split_preamble(text: str) -> tuple[str, str]:
             continue
         m = None if fence_char is not None else _HEADING_RE.match(line)
         if m and m.group(1).strip():
-            return "\n".join(lines[:i]), "\n".join(lines[i:])
+            if boundary_headings is None or m.group(1).strip().lower() in boundary_headings:
+                return "\n".join(lines[:i]), "\n".join(lines[i:])
 
     return text, ""
 

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -227,12 +227,12 @@ async def mem_context_init(
             best = max(files, key=lambda f: f.size)
             results.append(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
             content = await asyncio.to_thread(best.path.read_text, encoding="utf-8")
-            sections = extract_sections_from_agent_file(content)
+            sections = extract_sections_from_agent_file(content, source=best.agent)
             for f in files:
                 if f.path == best.path:
                     continue
                 other_content = await asyncio.to_thread(f.path.read_text, encoding="utf-8")
-                other_sections = extract_sections_from_agent_file(other_content)
+                other_sections = extract_sections_from_agent_file(other_content, source=f.agent)
                 for key, val in other_sections.items():
                     if key not in sections and val.strip():
                         sections[key] = val

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -161,7 +161,7 @@ async def mem_context_init(
     )
     from memtomem.context.commands import extract_commands_to_canonical
     from memtomem.context.detector import detect_agent_files
-    from memtomem.context.generator import extract_sections_from_agent_file
+    from memtomem.context.generator import extract_sections_from_agent_file, preamble_source
     from memtomem.context.parser import CONTEXT_FILENAME, sections_to_markdown
     from memtomem.context.privacy_scan import PrivacyScanError
     from memtomem.context.scope_resolver import canonical_artifact_dir
@@ -227,12 +227,16 @@ async def mem_context_init(
             best = max(files, key=lambda f: f.size)
             results.append(f"Extracting from {best.agent}: {best.path.name} ({best.size} bytes)")
             content = await asyncio.to_thread(best.path.read_text, encoding="utf-8")
-            sections = extract_sections_from_agent_file(content, source=best.agent)
+            sections = extract_sections_from_agent_file(
+                content, source=preamble_source(best.agent, best.path)
+            )
             for f in files:
                 if f.path == best.path:
                     continue
                 other_content = await asyncio.to_thread(f.path.read_text, encoding="utf-8")
-                other_sections = extract_sections_from_agent_file(other_content, source=f.agent)
+                other_sections = extract_sections_from_agent_file(
+                    other_content, source=preamble_source(f.agent, f.path)
+                )
                 for key, val in other_sections.items():
                     if key not in sections and val.strip():
                         sections[key] = val

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -479,26 +479,68 @@ class TestPreambleSourceGuard:
 
 
 class TestPreambleProjectSubheadings:
-    """A Project body's own ## subheading must survive cursor/copilot
-    round-trip — the split boundary is the first *generated* heading, not any
-    heading (#1147 B1-3 review, Major 2)."""
+    """Reverse-import contract: every ## starts a section, so a captured
+    Project body never embeds a ## that would re-split on the next round-trip;
+    keep subheadings inside a section body with ### (#1147 B1-3 review)."""
+
+    def test_h2_in_flat_body_splits_into_its_own_section(self):
+        # A hand-authored flat file with a ## heading: that heading starts a
+        # section rather than folding into Project as an unsound embedded ##
+        # (which would re-split on the next generate->import cycle).
+        content = "Intro line.\n\n## Goals\n\nBe fast.\n\n## Rules\n\n- be terse\n"
+        result = extract_sections_from_agent_file(content, source="cursor")
+        assert result["Project"] == "Intro line."
+        assert result["Goals"] == "Be fast."
+        assert "- be terse" in result["Rules"]
+        # Soundness invariant: no captured section body contains a ## heading.
+        assert all("## " not in body for body in result.values())
+
+    def test_persisted_context_md_round_trip_is_idempotent(self, tmp_path):
+        # The user-visible contract is the *persisted* round-trip: extracted
+        # sections are written to context.md (sections_to_markdown) and re-read
+        # (parse_context) on every later `generate`/`sync`. Pin that this is
+        # stable — a flat-file `## Deployment` survives as its own section and
+        # the persisted form re-parses to the identical dict, with no `## `
+        # embedded in any section body (the soundness win of the section model).
+        #
+        # NB: whether a *generator* re-emits the unknown `Deployment` section is
+        # a separate, pre-existing concern (generators only emit canonical
+        # sections; true on main and for source=None alike) tracked outside
+        # B1-3 — this test deliberately pins the parser/persistence layer only.
+        content = "Intro line.\n\n## Deployment\n\nShip it.\n\n## Rules\n\n- be terse\n"
+        sections = extract_sections_from_agent_file(content, source="cursor")
+
+        ctx = tmp_path / "context.md"
+        ctx.write_text(sections_to_markdown(sections), encoding="utf-8")
+        reparsed = parse_context(ctx)
+
+        # The non-canonical heading persists as its own section, not lost.
+        assert reparsed["Project"] == "Intro line."
+        assert reparsed["Deployment"] == "Ship it."
+        assert reparsed["Rules"] == "- be terse"
+        # No section body smuggles a ## that would re-split on the next read.
+        assert all("## " not in body for body in reparsed.values())
+        # Persisted form is a fixed point: re-serialize → re-parse is stable.
+        ctx.write_text(sections_to_markdown(reparsed), encoding="utf-8")
+        assert parse_context(ctx) == reparsed
 
     @pytest.mark.parametrize("source", ["cursor", "copilot"])
-    def test_project_with_h2_round_trips(self, source):
+    def test_h3_subheading_stays_in_project_and_round_trips(self, source):
+        # ### is the documented escape hatch: it is not a section boundary, so a
+        # Project body keeps its ### subheadings and round-trips byte-for-byte.
         original = {
-            "Project": "Intro line.\n\n## Goals\n\nBe fast.",
+            "Project": "Intro line.\n\n### Goals\n\nBe fast.",
             "Rules": "- be terse",
         }
         gen = generate_for_agent(source, original)
         result = extract_sections_from_agent_file(gen, source=source)
-        # The unknown '## Goals' subheading stays inside Project (not split out).
-        assert "## Goals" in result["Project"]
+        assert "### Goals" in result["Project"]
         assert "Be fast." in result["Project"]
         assert "Goals" not in result  # not a separate section
         assert generate_for_agent(source, result) == gen
 
-    def test_known_heading_still_splits(self):
-        # A generated section heading (Rules) is still a boundary.
+    def test_known_section_heading_splits(self):
+        # A canonical section heading (Rules) is a boundary; preamble -> Project.
         content = "Project prose.\n\n## Rules\n\n- foo\n"
         result = extract_sections_from_agent_file(content, source="cursor")
         assert result["Project"] == "Project prose."

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -6,6 +6,7 @@ from memtomem.context.parser import (
     iter_markdown_sections,
     parse_context,
     sections_to_markdown,
+    split_preamble,
 )
 from memtomem.context.detector import detect_agent_files
 from memtomem.context.generator import (
@@ -349,3 +350,88 @@ class TestParserHardening:
         out.write_text(sections_to_markdown(sections), encoding="utf-8")
         reparsed = parse_context(out)
         assert reparsed == sections
+
+
+class TestSplitPreamble:
+    """`split_preamble` finds the first real heading, fence/whitespace aware."""
+
+    def test_no_heading_is_all_preamble(self):
+        preamble, rest = split_preamble("just prose\nmore prose")
+        assert preamble == "just prose\nmore prose"
+        assert rest == ""
+
+    def test_basic_split(self):
+        preamble, rest = split_preamble("intro line\n\n## A\n\nbody")
+        assert "intro line" in preamble
+        assert rest.startswith("## A")
+        assert "body" in rest
+
+    def test_fence_in_preamble_is_not_a_boundary(self):
+        # A ``##``-lookalike inside a fenced code block must NOT end the
+        # preamble early (B1-1 fence awareness, shared with the iterator).
+        text = "intro\n```\n## fake heading\n```\n\n## Real\n\nbody"
+        preamble, rest = split_preamble(text)
+        assert "## fake heading" in preamble
+        assert rest.startswith("## Real")
+
+    def test_whitespace_only_heading_is_not_a_boundary(self):
+        # ``##   `` is not a heading (B1-3); the first real boundary is ## Real.
+        preamble, rest = split_preamble("intro\n##   \n\n## Real\nbody")
+        assert "##   " in preamble
+        assert rest.startswith("## Real")
+
+
+class TestPreambleReverseImport:
+    """Source-aware reverse-import captures leading project prose (#1147 B1-3)."""
+
+    @pytest.mark.parametrize("source", ["claude", "gemini", "codex", "cursor", "copilot"])
+    def test_generate_import_generate_is_idempotent(self, source):
+        # No Rules/Style here so the B1-4 merge lossiness (a separate item)
+        # does not confound the B1-3 round-trip.
+        original = {"Project": "Proj prose line.", "Commands": "- run: x"}
+        gen = generate_for_agent(source, original)
+        result = extract_sections_from_agent_file(gen, source=source)
+
+        # The project prose survives reverse-import...
+        assert "Project" in result
+        assert "Proj prose line." in result["Project"]
+        # ...and no generated boilerplate leaks into the captured sections.
+        for value in result.values():
+            assert "# Project Context" not in value
+            assert "# CLAUDE.md" not in value
+            assert "# GEMINI.md" not in value
+            assert "# AGENTS.md" not in value
+            assert "This file provides guidance" not in value
+        # Full round-trip is stable.
+        assert generate_for_agent(source, result) == gen
+
+    def test_cursor_user_prose_is_captured(self):
+        # The exact bug: a hand-authored .cursorrules has leading prose with
+        # no H1 — previously dropped, now mapped to Project.
+        content = "We build a CLI in Rust.\n\n## Rules\n\n- be fast\n"
+        result = extract_sections_from_agent_file(content, source="cursor")
+        assert result["Project"] == "We build a CLI in Rust."
+        assert "- be fast" in result["Rules"]
+
+    def test_collision_prepends_preamble_to_existing_project(self):
+        # codex emits "# AGENTS.md" then "## Project"; extra prose after the H1
+        # must prepend to (not clobber) the ## Project body, preserving order.
+        content = "# AGENTS.md\n\nExtra note.\n\n## Project\n\nBody text.\n"
+        result = extract_sections_from_agent_file(content, source="codex")
+        assert result["Project"].startswith("Extra note.")
+        assert "Body text." in result["Project"]
+        assert "# AGENTS.md" not in result["Project"]
+
+    def test_wrapper_h1_is_stripped_for_known_source(self):
+        content = sections_to_markdown({"Project": "P", "Commands": "C"})
+        result = extract_sections_from_agent_file(content, source="cursor")
+        assert "# Project Context" not in result["Project"]
+        assert result["Project"] == "P"
+
+    def test_source_none_preserves_old_drop_behavior(self):
+        # Back-compat: with no source, leading prose is dropped exactly as
+        # before — the canonical contract is unchanged.
+        content = "# CLAUDE.md\n\nThis file...\n\nLeftover prose.\n\n## Project\n\nBody\n"
+        result = extract_sections_from_agent_file(content)
+        assert "Leftover prose." not in result.get("Project", "")
+        assert result["Project"] == "Body"

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -1,5 +1,7 @@
 """Tests for agent context management module."""
 
+from pathlib import Path
+
 import pytest
 
 from memtomem.context.parser import (
@@ -14,6 +16,7 @@ from memtomem.context.generator import (
     generate_for_agent,
     generate_all,
     extract_sections_from_agent_file,
+    preamble_source,
 )
 
 
@@ -435,3 +438,68 @@ class TestPreambleReverseImport:
         result = extract_sections_from_agent_file(content)
         assert "Leftover prose." not in result.get("Project", "")
         assert result["Project"] == "Body"
+
+
+class TestPreambleSourceGuard:
+    """`preamble_source` gates capture to a generator's canonical file (#1147
+    B1-3 review): rule fragments detected as agent='cursor' must NOT import as
+    Project."""
+
+    def test_canonical_cursorrules_gets_source(self):
+        assert preamble_source("cursor", Path("/proj/.cursorrules")) == "cursor"
+
+    @pytest.mark.parametrize(
+        "agent,name",
+        [
+            ("claude", "CLAUDE.md"),
+            ("gemini", "GEMINI.md"),
+            ("codex", "AGENTS.md"),
+            ("copilot", "copilot-instructions.md"),
+        ],
+    )
+    def test_canonical_files_get_source(self, agent, name):
+        assert preamble_source(agent, Path(f"/proj/{name}")) == agent
+
+    def test_cursor_rules_fragment_gets_no_source(self):
+        # .cursor/rules/*.mdc is detected as agent='cursor' but is a rule
+        # fragment, not Project prose — must fall back to source=None.
+        assert preamble_source("cursor", Path("/proj/.cursor/rules/style.mdc")) is None
+        assert preamble_source("cursor", Path("/proj/.cursor/rules/style.md")) is None
+
+    def test_none_agent_is_none(self):
+        assert preamble_source(None, Path("/proj/whatever.md")) is None
+
+    def test_fragment_content_not_imported_as_project(self):
+        # End-to-end: a Cursor MDC rule fragment routed with the guarded source
+        # (None) drops its prose instead of seeding Project.
+        fragment = "---\ndescription: Python style\nglobs: **/*.py\n---\nUse type hints.\n"
+        src = preamble_source("cursor", Path("/proj/.cursor/rules/py.mdc"))
+        result = extract_sections_from_agent_file(fragment, source=src)
+        assert "Use type hints." not in result.get("Project", "")
+
+
+class TestPreambleProjectSubheadings:
+    """A Project body's own ## subheading must survive cursor/copilot
+    round-trip — the split boundary is the first *generated* heading, not any
+    heading (#1147 B1-3 review, Major 2)."""
+
+    @pytest.mark.parametrize("source", ["cursor", "copilot"])
+    def test_project_with_h2_round_trips(self, source):
+        original = {
+            "Project": "Intro line.\n\n## Goals\n\nBe fast.",
+            "Rules": "- be terse",
+        }
+        gen = generate_for_agent(source, original)
+        result = extract_sections_from_agent_file(gen, source=source)
+        # The unknown '## Goals' subheading stays inside Project (not split out).
+        assert "## Goals" in result["Project"]
+        assert "Be fast." in result["Project"]
+        assert "Goals" not in result  # not a separate section
+        assert generate_for_agent(source, result) == gen
+
+    def test_known_heading_still_splits(self):
+        # A generated section heading (Rules) is still a boundary.
+        content = "Project prose.\n\n## Rules\n\n- foo\n"
+        result = extract_sections_from_agent_file(content, source="cursor")
+        assert result["Project"] == "Project prose."
+        assert "- foo" in result["Rules"]


### PR DESCRIPTION
## What

Stops `mm context init` / `mem_context_init` from silently dropping the
**preamble** (text before the first `##` heading) when reverse-importing a
runtime agent file. Closes the **B1-3** item of #1147.

## Why

For the **cursor** and **copilot** generators the leading text *is* the project
description — they emit the `Project` body directly with no H1. So a user's
hand-authored `.cursorrules` / `.github/copilot-instructions.md` prose was lost
on import.

The round-trippable fix lives on the **reverse-import** side, not the canonical
parser: capturing preamble in `parse_context` would break the dict→markdown
round-trip contract (the `# Project Context` wrapper) and silently mutate
hand-edited `context.md`. (Canonical-parser preamble capture is consciously
deferred — noted on #1147.)

## How

- Add `parser.split_preamble(text) → (preamble, rest)`, sharing the fence /
  heading state machine with `iter_markdown_sections` so a `##` inside a code
  fence (B1-1) or a whitespace-only `##` (B1-3 #1132) is not a false boundary.
- Make `extract_sections_from_agent_file(content, source=...)` source-aware:
  for a known source it strips that generator's boilerplate — the
  `# CLAUDE.md` / `# GEMINI.md` / `# AGENTS.md` H1s and intro sentences plus the
  `# Project Context` wrapper — via a data-driven table kept in lock-step with
  the generators, then maps the remaining prose onto canonical `Project`,
  **prepended** to any existing `## Project` body to preserve document order.
  The CLI and MCP callers pass `source=best.agent` / `f.agent`.
- `source=None` keeps the **exact prior behavior** (preamble dropped) — the
  canonical parser contract is unchanged and existing callers are unaffected.

## Tests

`split_preamble` fence/whitespace awareness; per-source
generate→import→generate **idempotence** with no boilerplate leakage (claude /
gemini / codex / cursor / copilot); the cursor user-prose capture (the bug);
the collision **prepend** rule; wrapper-H1 strip; and the `source=None`
back-compat drop.

`uv run pytest -m "not ollama"` (context suites, 1235 tests) green;
`ruff check` / `ruff format --check` clean; `mypy` clean on changed modules.

Independent of the other #1147 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
