### PR TITLE
fix(context): FS-guided reconstruction of kebab-case ~/.claude/projects names (#1147 B7-1)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
@@ -233,11 +233,11 @@ def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
        previous one-shot ``str(cwd).replace("/", "-")`` only handled POSIX
        and produced an invalid slug on Windows (drive prefix + backslashes
        remained), causing false failures for valid Windows layouts.
-    2. **Slow path** — iterate real entries and decode-then-``samefile`` each
-       against ``cwd``. Catches cases where the encoded form isn't
-       predictable (e.g., the entry on disk uses an encoding variant we
-       didn't enumerate) but skips entries whose name has literal dashes
-       and so doesn't round-trip to a real directory.
+    2. **Slow path** — iterate real entries and FS-guided-decode-then-
+       ``samefile`` each against ``cwd`` via
+       :func:`memtomem.context.projects._decode_claude_project_dirname`, which
+       reconstructs ``/``, ``.`` and literal-``-`` segments (so kebab-case and
+       dotted directories round-trip, unlike the old blind ``-`` → ``/``).
     """
     projects = (home or Path.home()) / ".claude" / "projects"
     if not projects.is_dir():
@@ -246,9 +246,19 @@ def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
         cwd_resolved = cwd.resolve()
     except OSError:
         return CheckResult("info", "cwd resolution failed — Claude slug check skipped")
+    from memtomem.context.projects import (
+        _DecodeBudgetError,
+        _decode_claude_project_dirname,
+        _encode_claude_project_path,
+    )
+
     cwd_str = str(cwd_resolved)
     encoded_candidates = {
-        cwd_str.replace("/", "-"),  # POSIX absolute
+        # Authoritative POSIX encoding — Claude Code collapses BOTH "/" and "."
+        # to "-" (so a dotted segment like ``.config-dir`` round-trips), which
+        # the bare ``replace("/", "-")`` below misses.
+        _encode_claude_project_path(cwd_resolved),
+        cwd_str.replace("/", "-"),  # POSIX absolute (dot-less)
         cwd_str.replace("\\", "-").replace(":", ""),  # Windows: drop drive colon
         cwd_str.replace("\\", "-").replace(":", "-"),  # Windows: encode drive colon as "-"
     }
@@ -260,18 +270,23 @@ def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
             continue
         if (projects / cand).is_dir():
             return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
-    # Slow path: decode existing entries and samefile-compare.
+    # Slow path: FS-guided decode of existing entries, then samefile-compare.
+    # Shares ``_decode_claude_project_dirname`` (the 3-way reconstruction that
+    # handles "/", "." and literal "-") so a dotted/dashed cwd the UI can
+    # discover is not falsely failed here.
     for child in projects.iterdir():
         if not child.is_dir():
             continue
-        # Decode follows ``_decode_claude_project_dirname`` in
-        # ``memtomem.context.projects``: every ``-`` becomes ``/``.
-        decoded = Path(child.name.replace("-", "/"))
         try:
-            if decoded.is_dir() and decoded.samefile(cwd):
-                return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
-        except OSError:
+            decoded_candidates = _decode_claude_project_dirname(child.name)
+        except _DecodeBudgetError:
             continue
+        for decoded in decoded_candidates:
+            try:
+                if decoded.samefile(cwd):
+                    return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
+            except OSError:
+                continue
     return CheckResult(
         "fail",
         "~/.claude/projects/ slug differs from synced layout — see doc",

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -366,6 +366,14 @@ def _discover_claude_projects(anchors: tuple[Path, ...] = ()) -> list[Path]:
                 child.name,
             )
             continue
+        # Drop stale candidates BEFORE the accept-one decision. Anchor hits are
+        # not is_dir()-checked inside the decoder, so a stale known-project root
+        # whose lossy encoding collides with a live cwd/project root would
+        # otherwise make a valid live match look ambiguous and get skipped. (FS
+        # walk candidates are already is_dir()-confirmed; this also preserves
+        # the fail-closed guarantee.) Stale known-projects still surface through
+        # the known-projects source in discover_project_scopes.
+        candidates = [c for c in candidates if c.is_dir()]
         if not candidates:
             logger.warning(
                 "claude-projects: skip %r: no matching directory on disk; "
@@ -382,12 +390,7 @@ def _discover_claude_projects(anchors: tuple[Path, ...] = ()) -> list[Path]:
                 ", ".join(str(c) for c in candidates),
             )
             continue
-        decoded = candidates[0]
-        # Re-assert the fail-closed guarantee at the call site (an anchor hit
-        # could be a stale known-project root that no longer exists).
-        if not decoded.is_dir():
-            continue
-        found.append(decoded)
+        found.append(candidates[0])
     return found
 
 

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -221,9 +221,20 @@ _CLAUDE_PROJECTS_DIR = Path("~/.claude/projects").expanduser()
 
 
 # Frontier cap: a runaway backstop so a pathologically dashed name cannot
-# explode the reconstruction. Real names collapse to a handful of FS-confirmed
-# branches well under this.
-_MAX_DECODE_CANDIDATES = 64
+# explode the reconstruction. With per-step dedup, real names collapse to a
+# handful of FS-confirmed branches far under this; the cap only fires on
+# adversarial inputs, and hitting it raises ``_DecodeBudgetError`` (NOT a silent
+# no-match) so the caller reports it distinctly.
+_MAX_DECODE_CANDIDATES = 512
+
+
+class _DecodeBudgetError(Exception):
+    """FS-guided reconstruction exceeded the frontier budget.
+
+    The encoded name is too ambiguous to reconstruct safely. Kept distinct from
+    an empty (no-match) result so the caller does not misreport overflow as
+    "no matching directory" and can point the user at ``known_projects.json``.
+    """
 
 
 def _encode_claude_project_path(root: Path) -> str:
@@ -263,7 +274,17 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
 
     # Anchors first — authoritative and cheap. Collect ALL matches (not
     # first-match): the encoding is many-to-one so distinct roots can collide.
-    anchor_hits = [a for a in anchors if _encode_claude_project_path(a) == name]
+    # Dedup by resolved path so the same root reached via cwd AND a
+    # known-project entry is not mistaken for two ambiguous candidates.
+    anchor_hits: list[Path] = []
+    seen_anchors: set[str] = set()
+    for a in anchors:
+        if _encode_claude_project_path(a) != name:
+            continue
+        key = _normalize_for_scope_id(a)
+        if key not in seen_anchors:
+            seen_anchors.add(key)
+            anchor_hits.append(a)
     if anchor_hits:
         return anchor_hits
 
@@ -290,21 +311,28 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
     for ch in body:
         if ch != "-":
             frontier = [(committed, pending + ch) for committed, pending in frontier]
-            continue
-        nxt: list[tuple[Path, str]] = []
-        for committed, pending in frontier:
-            # Separator: pending is a complete component that must exist.
-            if pending and pending in children(committed):
-                nxt.append((committed / pending, ""))
-            # Dot / literal-dash: keep building the component, pruned to viable
-            # prefixes so the branch factor cannot explode.
-            for sep in (".", "-"):
-                extended = pending + sep
-                if viable_prefix(committed, extended):
-                    nxt.append((committed, extended))
-        frontier = nxt
-        if not frontier or len(frontier) > _MAX_DECODE_CANDIDATES:
+        else:
+            nxt: list[tuple[Path, str]] = []
+            for committed, pending in frontier:
+                # Separator: pending is a complete component that must exist.
+                if pending and pending in children(committed):
+                    nxt.append((committed / pending, ""))
+                # Dot / literal-dash: keep building the component, pruned to
+                # viable prefixes so the branch factor cannot explode.
+                for sep in (".", "-"):
+                    extended = pending + sep
+                    if viable_prefix(committed, extended):
+                        nxt.append((committed, extended))
+            frontier = nxt
+        # Collapse convergent states so the budget reflects DISTINCT
+        # reconstructions, not duplicate (committed, pending) paths.
+        frontier = list(dict.fromkeys(frontier))
+        if not frontier:
             return []
+        if len(frontier) > _MAX_DECODE_CANDIDATES:
+            # Genuine overflow — raise rather than return [] so the caller
+            # does not misreport it as "no matching directory".
+            raise _DecodeBudgetError(name)
 
     results: list[Path] = []
     seen: set[str] = set()
@@ -328,7 +356,16 @@ def _discover_claude_projects(anchors: tuple[Path, ...] = ()) -> list[Path]:
     for child in _CLAUDE_PROJECTS_DIR.iterdir():
         if not child.is_dir():
             continue
-        candidates = _decode_claude_project_dirname(child.name, anchors)
+        try:
+            candidates = _decode_claude_project_dirname(child.name, anchors)
+        except _DecodeBudgetError:
+            logger.warning(
+                "claude-projects: skip %r: too ambiguous to reconstruct safely "
+                "(exceeded decode budget); register the project in "
+                "known_projects.json to resolve it.",
+                child.name,
+            )
+            continue
         if not candidates:
             logger.warning(
                 "claude-projects: skip %r: no matching directory on disk; "

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -220,35 +220,138 @@ class KnownProjectsStore:
 _CLAUDE_PROJECTS_DIR = Path("~/.claude/projects").expanduser()
 
 
-def _decode_claude_project_dirname(name: str) -> Path | None:
-    """Decode a ``~/.claude/projects/<encoded>`` directory name into a path.
+# Frontier cap: a runaway backstop so a pathologically dashed name cannot
+# explode the reconstruction. Real names collapse to a handful of FS-confirmed
+# branches well under this.
+_MAX_DECODE_CANDIDATES = 64
 
-    The encoding is "every ``/`` becomes ``-``", so paths with literal
-    dashes round-trip to the wrong spelling. The caller filters via
-    ``Path.is_dir()`` to drop misdecoded entries (RFC §Decision 2).
+
+def _encode_claude_project_path(root: Path) -> str:
+    """Encode an absolute path the way Claude Code names ``~/.claude/projects/<dir>``.
+
+    Verified empirically against a live ``~/.claude/projects/``: every ``/`` and
+    ``.`` becomes ``-`` (e.g. ``/a/.config`` → ``-a--config``). Literal dashes
+    are also ``-`` — exactly the many-to-one lossiness this module reconstructs
+    around. Best-effort / POSIX-oriented: other characters are left as-is.
+    """
+    return str(root).replace("/", "-").replace(".", "-")
+
+
+def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) -> list[Path]:
+    """Reconstruct candidate absolute paths from a ``~/.claude/projects/<name>``.
+
+    The on-disk encoding maps ``/``, ``.`` AND literal ``-`` all to ``-`` (see
+    :func:`_encode_claude_project_path`), so it is lossy / many-to-one. We
+    reconstruct **FS-guided**: each encoded ``-`` is a 3-way choice — path
+    separator, ``.``, or a literal dash — and only branches whose committed
+    directory prefix actually exists survive, so the filesystem prunes the
+    otherwise ``3**k`` partition space down to the paths that really exist.
+
+    Returns the FS-confirmed candidate directories (``[]`` if none). The caller
+    applies the accept-one-match rule. ``anchors`` (the ``known_projects.json``
+    roots, plus the server cwd) are tried first: any whose encoding equals
+    ``name`` are authoritative and returned directly — but *all* matches are
+    returned (the encoding is many-to-one, so two distinct roots can collide),
+    leaving the accept-one decision to the caller. Only when no anchor matches
+    do we walk the filesystem.
+
+    POSIX-oriented: the leading ``-`` → ``/`` root convention assumes a POSIX
+    absolute root, and the feature is experimental / off by default.
     """
     if not name.startswith("-"):
-        return None
-    decoded = name.replace("-", "/")
-    return Path(decoded)
+        return []
+
+    # Anchors first — authoritative and cheap. Collect ALL matches (not
+    # first-match): the encoding is many-to-one so distinct roots can collide.
+    anchor_hits = [a for a in anchors if _encode_claude_project_path(a) == name]
+    if anchor_hits:
+        return anchor_hits
+
+    body = name[1:]  # the leading "-" is the root "/"
+    children_cache: dict[Path, set[str]] = {}
+
+    def children(d: Path) -> set[str]:
+        cached = children_cache.get(d)
+        if cached is None:
+            try:
+                cached = {e.name for e in os.scandir(d) if e.is_dir()}
+            except OSError:
+                cached = set()
+            children_cache[d] = cached
+        return cached
+
+    def viable_prefix(d: Path, prefix: str) -> bool:
+        return any(c == prefix or c.startswith(prefix) for c in children(d))
+
+    # Frontier of (committed_dir, pending_segment): committed_dir is the
+    # deepest confirmed-existing directory; pending_segment is the partial
+    # component built since the last separator.
+    frontier: list[tuple[Path, str]] = [(Path("/"), "")]
+    for ch in body:
+        if ch != "-":
+            frontier = [(committed, pending + ch) for committed, pending in frontier]
+            continue
+        nxt: list[tuple[Path, str]] = []
+        for committed, pending in frontier:
+            # Separator: pending is a complete component that must exist.
+            if pending and pending in children(committed):
+                nxt.append((committed / pending, ""))
+            # Dot / literal-dash: keep building the component, pruned to viable
+            # prefixes so the branch factor cannot explode.
+            for sep in (".", "-"):
+                extended = pending + sep
+                if viable_prefix(committed, extended):
+                    nxt.append((committed, extended))
+        frontier = nxt
+        if not frontier or len(frontier) > _MAX_DECODE_CANDIDATES:
+            return []
+
+    results: list[Path] = []
+    seen: set[str] = set()
+    for committed, pending in frontier:
+        if not pending:
+            continue
+        full = committed / pending
+        key = _normalize_for_scope_id(full)
+        if key in seen:
+            continue
+        if full.is_dir():
+            seen.add(key)
+            results.append(full)
+    return results
 
 
-def _discover_claude_projects() -> list[Path]:
+def _discover_claude_projects(anchors: tuple[Path, ...] = ()) -> list[Path]:
     if not _CLAUDE_PROJECTS_DIR.is_dir():
         return []
-    candidates: list[Path] = []
+    found: list[Path] = []
     for child in _CLAUDE_PROJECTS_DIR.iterdir():
         if not child.is_dir():
             continue
-        decoded = _decode_claude_project_dirname(child.name)
-        if decoded is None:
+        candidates = _decode_claude_project_dirname(child.name, anchors)
+        if not candidates:
+            logger.warning(
+                "claude-projects: skip %r: no matching directory on disk; "
+                "register the project in known_projects.json to surface it.",
+                child.name,
+            )
             continue
-        # Filter: only paths that actually resolve to a directory.
-        # The decoder is fragile around dashes so most non-cwd hits drop here.
+        if len(candidates) > 1:
+            logger.warning(
+                "claude-projects: skip %r: ambiguous decode (%d matches: %s); "
+                "register the project in known_projects.json to disambiguate.",
+                child.name,
+                len(candidates),
+                ", ".join(str(c) for c in candidates),
+            )
+            continue
+        decoded = candidates[0]
+        # Re-assert the fail-closed guarantee at the call site (an anchor hit
+        # could be a stale known-project root that no longer exists).
         if not decoded.is_dir():
             continue
-        candidates.append(decoded)
-    return candidates
+        found.append(decoded)
+    return found
 
 
 def _label_for(root: Path) -> str:
@@ -296,13 +399,18 @@ def discover_project_scopes(
 
     # 2. User-registered roots from known_projects.json.
     store = KnownProjectsStore(known_projects_file)
-    for entry in store.load():
+    known_entries = store.load()
+    for entry in known_entries:
         _add(entry.root, "known-projects", missing=not entry.root.is_dir())
 
     # 3. Opt-in scan of ~/.claude/projects/ — silently skipped when the flag is
-    #    False so the default discovery path stays cheap.
+    #    False so the default discovery path stays cheap. The cwd and the
+    #    user-registered roots are passed as authoritative decode anchors so a
+    #    kebab-case project resolves unambiguously even where the FS walk would
+    #    flag it ambiguous.
     if experimental_claude_projects_scan:
-        for decoded in _discover_claude_projects():
+        anchors = (cwd, *(entry.root for entry in known_entries))
+        for decoded in _discover_claude_projects(anchors):
             _add(decoded, "claude-projects", missing=False)
 
     scopes: list[ProjectScope] = []

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -505,3 +505,65 @@ def test_decode_known_root_anchor_resolves_ambiguity(
     resolved = [s for s in scopes if "claude-projects" in s.sources]
     assert len(resolved) == 1
     assert resolved[0].root == chosen.resolve()
+
+
+@_WIN_SKIP
+def test_decode_anchor_dedup_cwd_equals_known_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cwd that is ALSO a registered known-project root appears twice in the
+    anchor list; dedup by resolved path must not flag it ambiguous (#1151
+    review Minor)."""
+    from memtomem.context import projects as proj_mod
+
+    target = tmp_path / "work" / "agent-harness"
+    target.mkdir(parents=True)
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / proj_mod._encode_claude_project_path(target)).mkdir()
+
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(target)  # known-projects entry for cwd
+
+    # cwd == target → anchors = (target, target). Without dedup this looks like
+    # two ambiguous candidates and the entry is dropped.
+    scopes = proj_mod.discover_project_scopes(target, kp, experimental_claude_projects_scan=True)
+    claude = [s for s in scopes if "claude-projects" in s.sources]
+    assert len(claude) == 1
+    assert claude[0].root == target.resolve()
+
+
+@_WIN_SKIP
+def test_decode_budget_overflow_raises_distinct_from_no_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A frontier overflow must raise ``_DecodeBudgetError`` (distinct from a
+    no-match []) so the caller reports it as 'exceeded decode budget', not
+    'no matching directory' (#1151 review Major)."""
+    from memtomem.context import projects as proj_mod
+
+    base = tmp_path / "base"
+    (base / "a").mkdir(parents=True)  # forces a second branch at the 'a-' dash
+    (base / "a-b" / "c").mkdir(parents=True)
+    target = base / "a-b" / "c"
+    encoded = proj_mod._encode_claude_project_path(target)
+
+    # Tiny budget so the genuine multi-branch reconstruction overflows.
+    monkeypatch.setattr(proj_mod, "_MAX_DECODE_CANDIDATES", 1)
+
+    # Direct: overflow raises the distinct error rather than returning [].
+    with pytest.raises(proj_mod._DecodeBudgetError):
+        proj_mod._decode_claude_project_dirname(encoded)
+
+    # Discovery: the warning names the budget, NOT "no matching directory".
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / encoded).mkdir()
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    with caplog.at_level("WARNING"):
+        scopes = proj_mod.discover_project_scopes(
+            cwd, tmp_path / "kp.json", experimental_claude_projects_scan=True
+        )
+    assert not [s for s in scopes if "claude-projects" in s.sources]
+    msgs = " ".join(r.message for r in caplog.records)
+    assert "exceeded decode budget" in msgs
+    assert "no matching directory" not in msgs

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -567,3 +567,30 @@ def test_decode_budget_overflow_raises_distinct_from_no_match(
     msgs = " ".join(r.message for r in caplog.records)
     assert "exceeded decode budget" in msgs
     assert "no matching directory" not in msgs
+
+
+@_WIN_SKIP
+def test_decode_stale_colliding_anchor_does_not_drop_live_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stale known-project root whose lossy encoding collides with the live
+    cwd must NOT make the live match look ambiguous (#1151 re-review): stale
+    candidates are filtered by is_dir() before the accept-one decision."""
+    from memtomem.context import projects as proj_mod
+
+    live = tmp_path / "work" / "agent-harness"
+    live.mkdir(parents=True)
+    stale = tmp_path / "work" / "agent" / "harness"  # same encoding, never created
+    assert proj_mod._encode_claude_project_path(live) == proj_mod._encode_claude_project_path(stale)
+
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / proj_mod._encode_claude_project_path(live)).mkdir()
+
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(stale)  # stale anchor (does not exist on disk)
+
+    # cwd == live, so the live anchor + the stale anchor both encode to the slug.
+    scopes = proj_mod.discover_project_scopes(live, kp, experimental_claude_projects_scan=True)
+    claude = [s for s in scopes if "claude-projects" in s.sources]
+    assert len(claude) == 1
+    assert claude[0].root == live.resolve()

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -361,3 +361,147 @@ def test_has_runtime_marker_file_doesnt_count(tmp_path: Path) -> None:
     """A *file* named ``.claude`` should not satisfy the marker — only directories."""
     (tmp_path / ".claude").write_text("")
     assert has_runtime_marker(tmp_path) is False
+
+
+# ── FS-guided kebab-case decoder (#1147 B7-1) ────────────────────────────
+#
+# The encoded ``~/.claude/projects/<name>`` directory maps ``/``, ``.`` and
+# literal ``-`` all to ``-`` (lossy / many-to-one). These tests pin the
+# FS-guided reconstruction. Hermetic: ``_CLAUDE_PROJECTS_DIR`` (bound at import
+# via ``expanduser()``) is monkeypatched, and target dirs live under a real
+# ``tmp_path`` so the reconstruction's absolute ``is_dir()`` probes hit
+# fixtures. POSIX-only (the leading ``-`` → ``/`` root convention).
+
+_WIN_SKIP = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX-only: the leading `-` → `/` root convention and the "
+    "claude-projects encoding are POSIX-oriented (see _decode_claude_project_dirname)",
+)
+
+
+def _claude_projects_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from memtomem.context import projects as proj_mod
+
+    cp = tmp_path / "fake_home" / ".claude" / "projects"
+    cp.mkdir(parents=True)
+    monkeypatch.setattr(proj_mod, "_CLAUDE_PROJECTS_DIR", cp)
+    return cp
+
+
+@_WIN_SKIP
+def test_decode_kebab_case_resolves_single_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A literal-dash component (``agent-harness``) resolves — the blind
+    ``replace('-', '/')`` decoder would have mis-decoded it to ``agent/harness``."""
+    from memtomem.context import projects as proj_mod
+
+    target = tmp_path / "work" / "agent-harness"
+    target.mkdir(parents=True)
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / proj_mod._encode_claude_project_path(target)).mkdir()
+
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    scopes = proj_mod.discover_project_scopes(
+        cwd, tmp_path / "kp.json", experimental_claude_projects_scan=True
+    )
+    claude = [s for s in scopes if "claude-projects" in s.sources and "server-cwd" not in s.sources]
+    assert len(claude) == 1
+    assert claude[0].root == target.resolve()
+
+
+@_WIN_SKIP
+def test_decode_dot_hidden_dir_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A hidden, dashed component (``.config-dir``, encoded ``--config-dir``)
+    reconstructs — the 3-way branch must consider ``.`` as well as separator
+    and literal dash (Codex blocker)."""
+    from memtomem.context import projects as proj_mod
+
+    target = tmp_path / "proj" / ".config-dir"
+    target.mkdir(parents=True)
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    encoded = proj_mod._encode_claude_project_path(target)
+    assert "--config-dir" in encoded  # the `/.` collapsed to `--`
+    (cp / encoded).mkdir()
+
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    scopes = proj_mod.discover_project_scopes(
+        cwd, tmp_path / "kp.json", experimental_claude_projects_scan=True
+    )
+    claude = [s for s in scopes if "claude-projects" in s.sources and "server-cwd" not in s.sources]
+    assert len(claude) == 1
+    assert claude[0].root == target.resolve()
+
+
+@_WIN_SKIP
+def test_decode_no_match_skips_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    from memtomem.context import projects as proj_mod
+
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / "-this-does-not-exist-anywhere-xyz").mkdir()
+
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    with caplog.at_level("WARNING"):
+        scopes = proj_mod.discover_project_scopes(
+            cwd, tmp_path / "kp.json", experimental_claude_projects_scan=True
+        )
+    assert not [s for s in scopes if "claude-projects" in s.sources]
+    assert any("no matching directory" in r.message for r in caplog.records)
+
+
+@_WIN_SKIP
+def test_decode_ambiguous_two_real_dirs_skips_and_warns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``base/a-b/c`` and ``base/a/b-c`` encode to the *same* name; with both on
+    disk the decode is genuinely ambiguous → skip + warn (never guess)."""
+    from memtomem.context import projects as proj_mod
+
+    base = tmp_path / "base"
+    (base / "a-b" / "c").mkdir(parents=True)
+    (base / "a" / "b-c").mkdir(parents=True)
+    encoded = proj_mod._encode_claude_project_path(base / "a-b" / "c")
+    assert encoded == proj_mod._encode_claude_project_path(base / "a" / "b-c")
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / encoded).mkdir()
+
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    with caplog.at_level("WARNING"):
+        scopes = proj_mod.discover_project_scopes(
+            cwd, tmp_path / "kp.json", experimental_claude_projects_scan=True
+        )
+    assert not [s for s in scopes if "claude-projects" in s.sources]
+    assert any("ambiguous decode" in r.message for r in caplog.records)
+
+
+@_WIN_SKIP
+def test_decode_known_root_anchor_resolves_ambiguity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A registered known-project root is an authoritative anchor: it resolves
+    a name the pure-FS walk would flag ambiguous."""
+    from memtomem.context import projects as proj_mod
+
+    base = tmp_path / "base"
+    chosen = base / "a-b" / "c"
+    chosen.mkdir(parents=True)
+    (base / "a" / "b-c").mkdir(parents=True)  # the rival decode
+    encoded = proj_mod._encode_claude_project_path(chosen)
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    (cp / encoded).mkdir()
+
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(chosen)
+
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    scopes = proj_mod.discover_project_scopes(cwd, kp, experimental_claude_projects_scan=True)
+    resolved = [s for s in scopes if "claude-projects" in s.sources]
+    assert len(resolved) == 1
+    assert resolved[0].root == chosen.resolve()

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -283,6 +283,22 @@ class TestCheckClaudeSlug:
         r = check_claude_slug(cwd, home=home)
         assert r.status == "fail"
 
+    def test_dotted_cwd_slug_matches(self, tmp_path: Path) -> None:
+        # Claude Code collapses '.' to '-' too; the old '/'-only encode + blind
+        # '-'->'/' decode falsely failed a dotted cwd the UI can now resolve
+        # (#1151 re-review). The shared encoder/decoder must make it pass.
+        from memtomem.context import projects as proj_mod
+
+        home = tmp_path / "home"
+        home.mkdir()
+        cwd = home / "work" / ".config-dir"
+        cwd.mkdir(parents=True)
+        projects = home / ".claude" / "projects"
+        projects.mkdir(parents=True)
+        (projects / proj_mod._encode_claude_project_path(cwd.resolve())).mkdir()
+        r = check_claude_slug(cwd, home=home)
+        assert r.status == "pass"
+
 
 # ---- CLI end-to-end --------------------------------------------------------
 


### PR DESCRIPTION
## What

Replaces the blind `-`→`/` decoder for the experimental `~/.claude/projects/`
scan with an **FS-guided reconstruction** so kebab-case paths resolve. Closes
the **B7-1** item of #1147.

## Why

Claude Code's on-disk project-dir encoding maps `/`, `.` **and** literal `-` all
to `-`. The old decoder blind-replaced every `-` with `/`, so any path with a
literal-dash component (`agent-harness`) or a hidden dir (`.claude-worktrees`)
mis-decoded and never resolved — the project silently never surfaced. (Verified
against a live `~/.claude/projects/`: this repo's own
`-Users-…-Work-agent-harness-memtomem` is an instance; `…-prep--claude-worktrees-…`
shows the `/.` → `--` double-dash.)

## How

- Each encoded `-` becomes a **3-way** choice — path separator, `.`, or a
  literal dash — and only branches whose committed directory prefix actually
  exists survive, so the filesystem prunes the otherwise `3**k` partition space
  to the paths that really exist (memoized `scandir` prefix-prune + a frontier
  cap as a runaway backstop). `_decode_claude_project_dirname` now returns a
  candidate **list**.
- `known_projects.json` roots and the server **cwd** are passed as
  authoritative decode **anchors**: any whose encoding equals the dir name are
  returned directly — but **all** matches (the encoding is many-to-one, so
  distinct roots can collide), leaving the accept-one decision to the caller.
- The caller accepts exactly one candidate; **zero → skip + warn** (point at
  `known_projects.json`), **>1 → skip + warn ambiguous** (never guess). The
  `is_dir()` fail-closed guarantee and the **off-by-default** experimental gate
  are preserved.

## Tests

POSIX-only and hermetic (monkeypatched import-bound `_CLAUDE_PROJECTS_DIR` +
real fixture dirs under `tmp_path` so the absolute `is_dir()` probes hit
fixtures): kebab-case single-match resolves; a dotted hidden-dir component
(`.config-dir`) reconstructs; genuinely-ambiguous twin dirs (`a-b/c` vs `a/b-c`)
skip + warn; no-match skips + warns; a known-root **anchor** resolves an
otherwise-ambiguous name. Existing misdecoded-filter / dedup / experimental-off
behaviors preserved.

`uv run pytest -m "not ollama"` (project suites, 348 tests) green;
`ruff check` / `ruff format --check` clean; `mypy` clean. Feature stays
experimental / off by default — no config flip.

Independent of the other #1147 items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
