### PR TITLE
fix: add project_scope_id context alias

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/context_agents.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_agents.py
@@ -117,7 +117,7 @@ async def list_agents(
         ),
     ),
 ) -> dict:
-    """List canonical agents. Accepts ``?scope_id=`` like list_skills."""
+    """List canonical agents. Accepts project selector aliases like list_skills."""
     canonicals = list_canonical_agents(project_root, scope=target_scope)
     diffs = diff_agents(project_root, scope=target_scope)
 

--- a/packages/memtomem/src/memtomem/web/routes/context_commands.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_commands.py
@@ -104,7 +104,7 @@ async def list_commands(
         ),
     ),
 ) -> dict:
-    """List canonical commands. Accepts ``?scope_id=`` like list_skills."""
+    """List canonical commands. Accepts project selector aliases like list_skills."""
     canonicals = list_canonical_commands(project_root, scope=target_scope)
     diffs = diff_commands(project_root, scope=target_scope)
 

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -90,28 +90,36 @@ def _default_project_root(request: Request) -> Path:
 
 def resolve_scope_root(
     request: Request,
+    project_scope_id: str | None = Query(default=None),
     scope_id: str | None = Query(default=None),
 ) -> Path:
-    """FastAPI dependency that maps an optional ``?scope_id=`` to a project root.
+    """FastAPI dependency that maps an optional project selector to a root.
 
-    No ``scope_id`` → server cwd (legacy single-project behavior preserved
-    so PR1's mutating cwd flow keeps working). Unknown ``scope_id`` →
-    404. Stale ``scope_id`` (registered but root no longer exists) → 404
-    too — read endpoints can't usefully serve from a missing dir.
+    No selector → server cwd (legacy single-project behavior preserved so PR1's
+    mutating cwd flow keeps working). ``project_scope_id`` is the canonical
+    query name; ``scope_id`` stays accepted as a permanent alias per ADR-0015.
+    Unknown selectors → 404. Stale selectors (registered but root no longer
+    exists) → 404 too — read endpoints can't usefully serve from a missing dir.
     """
-    if scope_id is None:
+    if project_scope_id is not None and scope_id is not None and project_scope_id != scope_id:
+        raise HTTPException(
+            status_code=400,
+            detail="project_scope_id and scope_id must match when both are provided",
+        )
+    selected_scope_id = project_scope_id or scope_id
+    if selected_scope_id is None:
         return _default_project_root(request)
 
     for scope in _discover_for(request):
-        if scope.scope_id != scope_id:
+        if scope.scope_id != selected_scope_id:
             continue
         if scope.root is None or scope.missing:
             raise HTTPException(
                 status_code=404,
-                detail=f"scope {scope_id!r} is registered but its root is missing",
+                detail=f"scope {selected_scope_id!r} is registered but its root is missing",
             )
         return scope.root
-    raise HTTPException(status_code=404, detail=f"unknown scope_id: {scope_id!r}")
+    raise HTTPException(status_code=404, detail=f"unknown project_scope_id: {selected_scope_id!r}")
 
 
 # ── GET /context/projects ────────────────────────────────────────────────
@@ -182,6 +190,7 @@ def _counts_for(root: Path, *, target_scope: TargetScope) -> dict[str, int]:
 
 def _scope_to_dict(scope: ProjectScope, *, with_counts: bool, target_scope: TargetScope) -> dict:
     return {
+        "project_scope_id": scope.scope_id,
         "scope_id": scope.scope_id,
         "label": scope.label,
         "root": str(scope.root) if scope.root is not None else None,
@@ -255,9 +264,11 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
     cfg = _gateway_config(request)
     store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
     entry = store.add(candidate, label=body.label)
+    project_scope_id = compute_scope_id(entry.root)
 
     response: dict = {
-        "scope_id": compute_scope_id(entry.root),
+        "project_scope_id": project_scope_id,
+        "scope_id": project_scope_id,
         "root": str(entry.root),
         "label": entry.label,
     }

--- a/packages/memtomem/src/memtomem/web/routes/context_skills.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_skills.py
@@ -101,11 +101,12 @@ async def list_skills(
 ) -> dict:
     """List canonical skills with per-runtime sync status.
 
-    Without ``?scope_id=``, lists for the server cwd (legacy single-project
-    path). With ``?scope_id=`` from ``GET /api/context/projects``, lists
-    for that scope's root. The detail and write routes use the same scope
-    resolver, so the Web UI's active-project switcher can manage any
-    registered project without restarting ``mm web``.
+    Without a project selector, lists for the server cwd (legacy single-project
+    path). With ``?project_scope_id=`` from ``GET /api/context/projects``
+    (or its permanent ``?scope_id=`` alias), lists for that scope's root.
+    The detail and write routes use the same scope resolver, so the Web UI's
+    active-project switcher can manage any registered project without
+    restarting ``mm web``.
     """
     canonicals = list_canonical_skills(project_root, scope=target_scope)
     diffs = diff_skills(project_root, scope=target_scope)

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -2,7 +2,7 @@
 
 Covers:
 - ``GET /api/context/projects`` shape with cwd-only and cwd+known scopes.
-- ``?scope_id=`` query on context overview, list, detail, and write routes.
+- ``?project_scope_id=`` / ``?scope_id=`` queries on scoped routes.
 - ``POST /api/context/known-projects`` validation + marker warning.
 - ``DELETE /api/context/known-projects/{scope_id}`` success / 404.
 """
@@ -79,6 +79,7 @@ async def test_get_projects_cwd_only(client) -> None:
     assert "scopes" in data
     assert len(data["scopes"]) == 1
     scope = data["scopes"][0]
+    assert scope["project_scope_id"] == scope["scope_id"]
     assert scope["label"] == "Server CWD"
     assert scope["sources"] == ["server-cwd"]
     assert scope["tier"] == "project"
@@ -290,6 +291,34 @@ async def test_skills_with_scope_id_serves_other_scope(client, tmp_path: Path) -
 
 
 @pytest.mark.asyncio
+async def test_project_scope_id_alias_serves_other_scope(client, tmp_path: Path) -> None:
+    other = tmp_path / "canonical-selector"
+    other.mkdir()
+    (other / ".claude").mkdir()
+    skill_dir = other / ".memtomem" / "skills" / "from_project_scope_id"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# from project_scope_id\n", encoding="utf-8")
+
+    add_resp = await client.post("/api/context/known-projects", json={"root": str(other)})
+    sid = add_resp.json()["project_scope_id"]
+    assert sid == add_resp.json()["scope_id"]
+
+    resp = await client.get("/api/context/skills", params={"project_scope_id": sid})
+    assert resp.status_code == 200, resp.text
+    names = {s["name"] for s in resp.json()["skills"]}
+    assert "from_project_scope_id" in names
+
+
+@pytest.mark.asyncio
+async def test_conflicting_project_scope_aliases_400(client) -> None:
+    resp = await client.get(
+        "/api/context/skills",
+        params={"project_scope_id": "p-111111111111", "scope_id": "p-222222222222"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_overview_with_scope_id_serves_other_scope(client, tmp_path: Path) -> None:
     """The dashboard overview follows the selected project scope."""
     other = tmp_path / "overview-scope"
@@ -391,6 +420,7 @@ async def test_post_warns_on_missing_marker(client, tmp_path: Path) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert "scope_id" in data
+    assert data["project_scope_id"] == data["scope_id"]
     # Both human prose and the machine-readable code (PR1 pattern) must be present.
     assert "warning" in data
     assert ".claude" in data["warning"]


### PR DESCRIPTION
Closes #1081.

## Summary
- accept canonical `project_scope_id` alongside legacy `scope_id` in the shared context scope resolver
- return additive `project_scope_id` fields in project discovery and add-project responses
- cover canonical selector, alias parity, and conflicting selector behavior in route tests
- update stale route docstrings to describe selector aliases

## Verification
- `uv run ruff check packages/memtomem/src/memtomem/web/routes/context_projects.py packages/memtomem/src/memtomem/web/routes/context_skills.py packages/memtomem/src/memtomem/web/routes/context_commands.py packages/memtomem/src/memtomem/web/routes/context_agents.py packages/memtomem/tests/test_web_routes_context_projects.py`
- `uv run pytest packages/memtomem/tests/test_web_routes_context_projects.py packages/memtomem/tests/web/test_context_gateway_lists.py packages/memtomem/tests/web/test_context_gateway_detail_meta.py packages/memtomem/tests/web/test_context_gateway_write_blocked.py -q`