### PR TITLE
fix(context): mirror Claude Code's real ~/.claude/projects slug rule (#1155)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/sync_doctor_cmd.py
@@ -228,16 +228,18 @@ def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
     Skipped silently when ``~/.claude/projects/`` is absent (user doesn't run
     Claude Code). Two-tier match:
 
-    1. **Fast path** — encode ``cwd`` (POSIX ``/`` → ``-``, Windows ``\\`` /
-       drive ``:`` → ``-``) and look up the resulting directory directly. The
-       previous one-shot ``str(cwd).replace("/", "-")`` only handled POSIX
-       and produced an invalid slug on Windows (drive prefix + backslashes
-       remained), causing false failures for valid Windows layouts.
+    1. **Fast path** — encode ``cwd`` to Claude Code's slug via
+       :func:`memtomem.context.projects._encode_claude_project_path` (every
+       character outside ASCII ``[A-Za-z0-9]`` → ``-``, so POSIX ``/``/``.``/``_``
+       and Windows ``\\`` / drive ``:`` all collapse — ``C:\\dev\\repo`` →
+       ``C--dev-repo``) and look up that directory directly. This single encoder
+       is the source of truth, so the slug matches on every platform.
     2. **Slow path** — iterate real entries and FS-guided-decode-then-
        ``samefile`` each against ``cwd`` via
        :func:`memtomem.context.projects._decode_claude_project_dirname`, which
-       reconstructs ``/``, ``.`` and literal-``-`` segments (so kebab-case and
-       dotted directories round-trip, unlike the old blind ``-`` → ``/``).
+       reverses each ``-`` to the real character on disk (``/``, ``.``, ``_``,
+       literal ``-``, space, non-ASCII, …) so kebab-case, dotted and
+       underscored directories round-trip, unlike the old blind ``-`` → ``/``.
     """
     projects = (home or Path.home()) / ".claude" / "projects"
     if not projects.is_dir():
@@ -252,27 +254,16 @@ def check_claude_slug(cwd: Path, *, home: Path | None = None) -> CheckResult:
         _encode_claude_project_path,
     )
 
-    cwd_str = str(cwd_resolved)
-    encoded_candidates = {
-        # Authoritative POSIX encoding — Claude Code collapses BOTH "/" and "."
-        # to "-" (so a dotted segment like ``.config-dir`` round-trips), which
-        # the bare ``replace("/", "-")`` below misses.
-        _encode_claude_project_path(cwd_resolved),
-        cwd_str.replace("/", "-"),  # POSIX absolute (dot-less)
-        cwd_str.replace("\\", "-").replace(":", ""),  # Windows: drop drive colon
-        cwd_str.replace("\\", "-").replace(":", "-"),  # Windows: encode drive colon as "-"
-    }
-    for cand in encoded_candidates:
-        # Skip candidates that still contain a path separator — the encoding
-        # didn't fully strip them (wrong platform), and ``projects / cand``
-        # would silently resolve to ``cand`` itself when it's absolute.
-        if "/" in cand or "\\" in cand:
-            continue
-        if (projects / cand).is_dir():
-            return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
+    # Claude Code's encoder maps every non-ASCII-alphanumeric char (incl. "/",
+    # ".", "_", Windows "\\" and the drive ":") to "-", so the slug never
+    # contains a path separator and ``projects / encoded`` stays under
+    # ``projects`` on every platform (anthropics/claude-code#19972).
+    encoded = _encode_claude_project_path(cwd_resolved)
+    if (projects / encoded).is_dir():
+        return CheckResult("pass", "~/.claude/projects/ slug matches synced layout")
     # Slow path: FS-guided decode of existing entries, then samefile-compare.
-    # Shares ``_decode_claude_project_dirname`` (the 3-way reconstruction that
-    # handles "/", "." and literal "-") so a dotted/dashed cwd the UI can
+    # Shares ``_decode_claude_project_dirname`` (which reverses each "-" to the
+    # real on-disk char) so a dotted / dashed / underscored cwd the UI can
     # discover is not falsely failed here.
     for child in projects.iterdir():
         if not child.is_dir():

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -19,10 +19,11 @@ import hashlib
 import json
 import logging
 import os
+import re
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Literal
 
 from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_bytes
@@ -237,26 +238,45 @@ class _DecodeBudgetError(Exception):
     """
 
 
-def _encode_claude_project_path(root: Path) -> str:
+def _encode_claude_project_path(root: PurePath) -> str:
     """Encode an absolute path the way Claude Code names ``~/.claude/projects/<dir>``.
 
-    Verified empirically against a live ``~/.claude/projects/``: every ``/`` and
-    ``.`` becomes ``-`` (e.g. ``/a/.config`` → ``-a--config``). Literal dashes
-    are also ``-`` — exactly the many-to-one lossiness this module reconstructs
-    around. Best-effort / POSIX-oriented: other characters are left as-is.
+    Claude Code replaces **every character outside ASCII** ``[A-Za-z0-9]`` in the
+    absolute path with a single ``-`` — equivalent to
+    ``re.sub(r"[^A-Za-z0-9]", "-", …)`` (anthropics/claude-code issue #19972).
+    This is platform-agnostic and broader than it looks:
+
+    * POSIX ``/`` and ``.`` collapse to ``-`` — AND so does ``_`` (verified
+      empirically against a live ``~/.claude/projects/``; e.g. ``/a/.config`` →
+      ``-a--config`` and a ``foo_bar`` segment → ``foo-bar``).
+    * On Windows the ``\\`` separators and the drive ``:`` also become ``-``
+      (``C:\\dev\\repo`` → ``C--dev-repo``); the drive colon is not special-cased.
+    * Non-ASCII characters (Korean / CJK / accented) each become ``-`` too — so a
+      Unicode letter, which ``str.isalnum()`` would count as alphanumeric, is NOT
+      preserved.
+
+    Literal dashes are also ``-`` — exactly the many-to-one lossiness that
+    :func:`_decode_claude_project_dirname` reconstructs around. Accepts any
+    ``PurePath`` (only ``str(root)`` is used) so a ``PureWindowsPath`` can be
+    encoded for testing on a POSIX host.
     """
-    return str(root).replace("/", "-").replace(".", "-")
+    return re.sub(r"[^A-Za-z0-9]", "-", str(root))
 
 
 def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) -> list[Path]:
     """Reconstruct candidate absolute paths from a ``~/.claude/projects/<name>``.
 
-    The on-disk encoding maps ``/``, ``.`` AND literal ``-`` all to ``-`` (see
-    :func:`_encode_claude_project_path`), so it is lossy / many-to-one. We
-    reconstruct **FS-guided**: each encoded ``-`` is a 3-way choice — path
-    separator, ``.``, or a literal dash — and only branches whose committed
-    directory prefix actually exists survive, so the filesystem prunes the
-    otherwise ``3**k`` partition space down to the paths that really exist.
+    The on-disk encoding collapses *every* non-ASCII-alphanumeric character to
+    ``-`` (see :func:`_encode_claude_project_path`), so it is lossy / many-to-one.
+    We reconstruct **FS-guided**: at each encoded ``-`` a branch may either treat
+    it as a path separator (commit the pending component if it exists as a real
+    child) or keep building the component — and the non-separator case reads the
+    *actual* next character from each existing child, so a ``-`` is reversed to
+    whatever the real path holds there (``.``, ``_``, a literal ``-``, a space, a
+    non-ASCII char, …). Only branches whose committed directory prefix actually
+    exists survive, so the filesystem prunes the otherwise exponential partition
+    space down to the paths that really exist. The anchor fast-path below is exact
+    for any character because it re-encodes candidates through the same encoder.
 
     Returns the FS-confirmed candidate directories (``[]`` if none). The caller
     applies the accept-one-match rule. ``anchors`` (the ``known_projects.json``
@@ -266,16 +286,19 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
     leaving the accept-one decision to the caller. Only when no anchor matches
     do we walk the filesystem.
 
-    POSIX-oriented: the leading ``-`` → ``/`` root convention assumes a POSIX
-    absolute root, and the feature is experimental / off by default.
+    The slow-path FS walk is POSIX-oriented: its leading ``-`` → ``/`` root
+    convention assumes a POSIX absolute root (a Windows ``C--…`` slug does not
+    start with ``-``), so on Windows only the anchor fast-path resolves. The
+    feature is experimental / off by default. (The *encoder* is platform-agnostic
+    — only this reconstruction is POSIX-leaning.)
     """
-    if not name.startswith("-"):
-        return []
-
-    # Anchors first — authoritative and cheap. Collect ALL matches (not
-    # first-match): the encoding is many-to-one so distinct roots can collide.
-    # Dedup by resolved path so the same root reached via cwd AND a
-    # known-project entry is not mistaken for two ambiguous candidates.
+    # Anchors first — authoritative, cheap, and platform-agnostic: they
+    # re-encode through the same encoder, so a Windows ``C--…`` slug resolves
+    # here even though the POSIX FS walk below cannot. Tried BEFORE the
+    # leading-``-`` gate so registered Windows roots are not dropped. Collect
+    # ALL matches (not first-match): the encoding is many-to-one so distinct
+    # roots can collide. Dedup by resolved path so the same root reached via cwd
+    # AND a known-project entry is not mistaken for two ambiguous candidates.
     anchor_hits: list[Path] = []
     seen_anchors: set[str] = set()
     for a in anchors:
@@ -287,6 +310,12 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
             anchor_hits.append(a)
     if anchor_hits:
         return anchor_hits
+
+    # FS walk slow path is POSIX-rooted: the leading "-" is the "/" root, so a
+    # Windows "C--…" slug (no leading "-") cannot be walked — only the anchor
+    # fast-path above resolves it.
+    if not name.startswith("-"):
+        return []
 
     body = name[1:]  # the leading "-" is the root "/"
     children_cache: dict[Path, set[str]] = {}
@@ -301,9 +330,6 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
             children_cache[d] = cached
         return cached
 
-    def viable_prefix(d: Path, prefix: str) -> bool:
-        return any(c == prefix or c.startswith(prefix) for c in children(d))
-
     # Frontier of (committed_dir, pending_segment): committed_dir is the
     # deepest confirmed-existing directory; pending_segment is the partial
     # component built since the last separator.
@@ -317,12 +343,17 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
                 # Separator: pending is a complete component that must exist.
                 if pending and pending in children(committed):
                     nxt.append((committed / pending, ""))
-                # Dot / literal-dash: keep building the component, pruned to
-                # viable prefixes so the branch factor cannot explode.
-                for sep in (".", "-"):
-                    extended = pending + sep
-                    if viable_prefix(committed, extended):
-                        nxt.append((committed, extended))
+                # Non-separator: the encoded "-" stands for some character the
+                # encoder collapsed (".", "_", a literal "-", a space, a
+                # non-ASCII char, …). FS-guided: read the actual next character
+                # from each existing child that extends ``pending`` — it must be
+                # a char the encoder maps to "-" (i.e. NOT ASCII-alphanumeric).
+                # Bounded by the child count, so the branch factor cannot explode.
+                for child_name in children(committed):
+                    if len(child_name) > len(pending) and child_name.startswith(pending):
+                        real_char = child_name[len(pending)]
+                        if not (real_char.isascii() and real_char.isalnum()):
+                            nxt.append((committed, pending + real_char))
             frontier = nxt
         # Collapse convergent states so the budget reflects DISTINCT
         # reconstructions, not duplicate (committed, pending) paths.

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -365,17 +365,21 @@ def test_has_runtime_marker_file_doesnt_count(tmp_path: Path) -> None:
 
 # ── FS-guided kebab-case decoder (#1147 B7-1) ────────────────────────────
 #
-# The encoded ``~/.claude/projects/<name>`` directory maps ``/``, ``.`` and
-# literal ``-`` all to ``-`` (lossy / many-to-one). These tests pin the
-# FS-guided reconstruction. Hermetic: ``_CLAUDE_PROJECTS_DIR`` (bound at import
-# via ``expanduser()``) is monkeypatched, and target dirs live under a real
-# ``tmp_path`` so the reconstruction's absolute ``is_dir()`` probes hit
-# fixtures. POSIX-only (the leading ``-`` → ``/`` root convention).
+# The encoder collapses *every* non-ASCII-alphanumeric char to ``-`` (lossy /
+# many-to-one); these tests pin the FS-guided reconstruction, which reverses each
+# ``-`` to the real on-disk char (``/``, ``.``, ``_``, literal ``-``, …). Note
+# pytest's ``tmp_path`` leaf carries ``_`` from the test name, so these fixtures
+# exercise the underscore round-trip too. Hermetic: ``_CLAUDE_PROJECTS_DIR``
+# (bound at import via ``expanduser()``) is monkeypatched, and target dirs live
+# under a real ``tmp_path`` so the reconstruction's absolute ``is_dir()`` probes
+# hit fixtures. POSIX-only because the *reconstruction* assumes the leading
+# ``-`` → ``/`` root convention — the encoder itself is platform-agnostic.
 
 _WIN_SKIP = pytest.mark.skipif(
     sys.platform == "win32",
-    reason="POSIX-only: the leading `-` → `/` root convention and the "
-    "claude-projects encoding are POSIX-oriented (see _decode_claude_project_dirname)",
+    reason="POSIX-only: the decoder slow-path's leading `-` → `/` root walk "
+    "assumes a POSIX absolute root (see _decode_claude_project_dirname). The "
+    "encoder is cross-platform; only this reconstruction is POSIX-leaning.",
 )
 
 
@@ -409,6 +413,50 @@ def test_decode_kebab_case_resolves_single_match(
     claude = [s for s in scopes if "claude-projects" in s.sources and "server-cwd" not in s.sources]
     assert len(claude) == 1
     assert claude[0].root == target.resolve()
+
+
+@_WIN_SKIP
+def test_decode_underscore_and_non_ascii_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_`` and non-ASCII chars both encode to ``-`` (Claude Code's real rule,
+    anthropics/claude-code#19972). The FS-guided decoder reverses each ``-`` to
+    the actual on-disk char, so an underscored / non-Latin path still
+    reconstructs — the old hardcoded (``.``, ``-``) branch could not."""
+    from memtomem.context import projects as proj_mod
+
+    target = tmp_path / "my_proj" / "데이터"  # underscore + Hangul component
+    target.mkdir(parents=True)
+    cp = _claude_projects_dir(tmp_path, monkeypatch)
+    encoded = proj_mod._encode_claude_project_path(target)
+    assert "_" not in encoded and "데이터" not in encoded  # both collapsed to "-"
+    (cp / encoded).mkdir()
+
+    cwd = tmp_path / "elsewhere"
+    cwd.mkdir()
+    scopes = proj_mod.discover_project_scopes(
+        cwd, tmp_path / "kp.json", experimental_claude_projects_scan=True
+    )
+    claude = [s for s in scopes if "claude-projects" in s.sources and "server-cwd" not in s.sources]
+    assert len(claude) == 1
+    assert claude[0].root == target.resolve()
+
+
+def test_decode_windows_slug_resolves_via_anchor() -> None:
+    """A Windows ``C--…`` slug has no leading ``-``, so the POSIX FS walk can't
+    reconstruct it — but a registered anchor (cwd / known_projects) re-encodes to
+    the same slug and must still resolve. Regression: the ``startswith("-")`` gate
+    used to run BEFORE the anchor loop and silently dropped Windows roots (Codex
+    review). Cross-platform (PureWindowsPath + anchors only, no filesystem), so it
+    runs on the windows job too."""
+    from pathlib import PureWindowsPath
+
+    from memtomem.context import projects as proj_mod
+
+    anchor = PureWindowsPath(r"C:\Users\foo")
+    name = proj_mod._encode_claude_project_path(anchor)
+    assert name == "C--Users-foo" and not name.startswith("-")  # the bug condition
+    assert proj_mod._decode_claude_project_dirname(name, anchors=(anchor,)) == [anchor]
 
 
 @_WIN_SKIP

--- a/packages/memtomem/tests/test_sync_doctor_cli.py
+++ b/packages/memtomem/tests/test_sync_doctor_cli.py
@@ -42,14 +42,16 @@ def _set_home(monkeypatch: pytest.MonkeyPatch, home: Path) -> None:
 
 
 def _claude_slug_for(cwd: Path) -> str:
-    """Encode ``cwd`` into a Claude-style hyphenated slug, cross-platform.
+    """Encode ``cwd`` into Claude Code's hyphenated slug for test fixtures.
 
-    POSIX cwd ``/Users/foo/bar`` → ``-Users-foo-bar``.
-    Windows cwd ``C:\\Users\\foo\\bar`` → ``CUsers-foo-bar`` (drive colon
-    dropped) — matches the Windows-no-colon candidate the doctor's
-    ``check_claude_slug`` fast path looks up.
+    Delegates to the production encoder so fixtures always match the real rule
+    (every character outside ASCII ``[A-Za-z0-9]`` → ``-``, incl. ``_`` and the
+    Windows drive ``:``). POSIX ``/Users/foo/bar`` → ``-Users-foo-bar``; Windows
+    ``C:\\Users\\foo\\bar`` → ``C--Users-foo-bar``.
     """
-    return str(cwd.resolve()).replace("\\", "-").replace(":", "").replace("/", "-")
+    from memtomem.context.projects import _encode_claude_project_path
+
+    return _encode_claude_project_path(cwd.resolve())
 
 
 # ---- cloud_mount_prefix helper ---------------------------------------------
@@ -298,6 +300,38 @@ class TestCheckClaudeSlug:
         (projects / proj_mod._encode_claude_project_path(cwd.resolve())).mkdir()
         r = check_claude_slug(cwd, home=home)
         assert r.status == "pass"
+
+
+class TestEncodeClaudeProjectPath:
+    """Pin Claude Code's slug rule (anthropics/claude-code#19972): every char
+    outside ASCII ``[A-Za-z0-9]`` becomes a single ``-``. Expected values are
+    literals checked against the production encoder — never recomputed with
+    ``re.sub`` (that would be tautological and could not catch a revert)."""
+
+    def test_posix_collapses_slash_dot_and_underscore(self) -> None:
+        # The old ``replace("/","-").replace(".","-")`` left ``_`` intact (and
+        # only ran on POSIX); this literal fails on that old body.
+        from memtomem.context.projects import _encode_claude_project_path
+
+        assert _encode_claude_project_path(Path("/a/b_c.d")) == "-a-b-c-d"
+
+    def test_windows_drive_and_backslash(self) -> None:
+        # PureWindowsPath renders backslashes + the drive colon even on a POSIX
+        # CI host, so this exercises the real ``C--`` slug without a Windows box.
+        # The drive colon is not special-cased: ``C:\`` → ``C--``.
+        from pathlib import PureWindowsPath
+
+        from memtomem.context.projects import _encode_claude_project_path
+
+        assert _encode_claude_project_path(PureWindowsPath(r"C:\Users\foo")) == "C--Users-foo"
+
+    def test_non_ascii_becomes_single_dash(self) -> None:
+        # Korean/CJK/accented chars are replaced, not preserved (#19972) — one
+        # dash per char. ``가`` is the Hangul syllable 가 (single codepoint,
+        # so this does not depend on the source file's NFC/NFD normalization).
+        from memtomem.context.projects import _encode_claude_project_path
+
+        assert _encode_claude_project_path(Path("/a/b가c")) == "-a-b-c"
 
 
 # ---- CLI end-to-end --------------------------------------------------------


### PR DESCRIPTION
## Summary

`_encode_claude_project_path` (the helper that mirrors how Claude Code names
`~/.claude/projects/<slug>` directories) was **POSIX-only**:

```python
return str(root).replace("/", "-").replace(".", "-")
```

On Windows the `\` separators and the drive `:` weren't normalized, so the
dotted-slug doctor test went **red on `test (windows-latest)`** (it landed on
`main` via #1151 because the windows job isn't a required check). It was also
wrong on **POSIX**: it left `_`, spaces and non-ASCII characters intact.

## Root cause — what Claude Code actually does

Claude Code replaces **every character outside ASCII `[A-Za-z0-9]`** with a
single `-` — equivalent to `re.sub(r"[^A-Za-z0-9]", "-", abspath)`. This is
documented (with a reproduced example + reverse-engineered impl) in
[anthropics/claude-code#19972](https://github.com/anthropics/claude-code/issues/19972),
and confirmed empirically: on a live macOS install the temp-dir hash
`…_b0w_…` is stored under `~/.claude/projects/` as `…-b0w-…`, i.e. `_`→`-`.
The drive colon is **not** special-cased, so `C:\dev\repo` → `C--dev-repo`;
non-ASCII (Korean/CJK/accented) chars each become `-`.

## Changes

- **Encoder** → `re.sub(r"[^A-Za-z0-9]", "-", str(root))`; param widened
  `Path` → `PurePath` (only `str(root)` is used) so a `PureWindowsPath` fixture
  can exercise the `C--` drive form on a POSIX CI host.
- **`check_claude_slug` fast path** → collapse the 4-entry candidate hand-list
  (3 entries kept `_`/`.` or used a wrong colon-dropped `C-`) to the single
  correct encoder output; drop the now-dead separator guard.
- **Decoder (`_decode_claude_project_dirname`)** → the encoder change makes it
  build realistic CC names containing `_`/non-ASCII that the hardcoded
  `(".", "-")` reconstruction couldn't reverse. Generalize the non-separator
  branch to read the **actual** next character from each existing child
  (FS-guided, bounded by child count), so a `-` reverses to whatever the real
  path holds (`.`, `_`, literal `-`, space, non-ASCII, …). Also try the
  **anchors before** the leading-`-` gate so a registered Windows `C--…` root
  resolves through the (platform-agnostic) anchor fast-path — it previously
  returned `[]` before anchors were considered. The slow-path FS walk stays
  POSIX-root-only (a `C--…` slug has no leading `-`).

## Tests

- `_claude_slug_for` now delegates to the production encoder (its old form kept
  `_`/`.` and dropped the drive colon → stale fixtures).
- New literal-assertion encoder tests (incl. `PureWindowsPath(r"C:\Users\foo")`
  → `C--Users-foo`, plus underscore/dot and Hangul cases) — expected values are
  literals, never recomputed via `re.sub`.
- New decoder tests: `_`/Hangul FS-walk round-trip, and a Windows-slug-via-anchor
  regression (cross-platform, runs on the windows job too).
- Mutation-checked: reverting the encoder to the old body fails the new tests.

`ruff check` + `ruff format` clean; `mypy` clean (249 files); full suite
**5565 passed / 10 skipped**.

## Scope / follow-up

Encoder fix necessarily came with the decoder generalization (the encoder
change made the existing FS-walk tests build realistic CC names the old decoder
couldn't reverse). The `_`/non-ASCII gap is now fully closed. The only remaining
limitation: **unregistered** Windows dirs in the experimental, off-by-default
`~/.claude/projects` scan still can't be FS-walk-reconstructed (the `C--…` slug
has no leading `-`); registered roots resolve via the anchor path. Tracked as a
follow-up.

Closes #1155. Refs #1151, #1147, anthropics/claude-code#19972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
