### PR TITLE
fix(context): preserve non-canonical generated sections

### DIFF
--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -42,27 +42,27 @@ def _section_block(heading: str, content: str) -> str:
 
 
 _RESERVED_SECTION_KEYS = {
-    "Project",
-    "Commands",
-    "Architecture",
-    "Rules",
-    "Style",
-    "Claude",
-    "Cursor",
-    "Gemini",
-    "Codex",
-    "Copilot",
-    "Claude-Specific",
-    "Cursor-Specific",
-    "Gemini-Specific",
-    "Codex-Specific",
-    "Copilot-Specific",
+    "project",
+    "commands",
+    "architecture",
+    "rules",
+    "style",
+    "claude",
+    "cursor",
+    "gemini",
+    "codex",
+    "copilot",
+    "claude-specific",
+    "cursor-specific",
+    "gemini-specific",
+    "codex-specific",
+    "copilot-specific",
 }
 
 
 def _append_unknown_sections(lines: list[str], sections: dict[str, str]) -> None:
     for heading, content in sections.items():
-        if heading not in _RESERVED_SECTION_KEYS:
+        if heading.lower() not in _RESERVED_SECTION_KEYS:
             lines.append(_section_block(heading, content))
 
 

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -42,16 +42,19 @@ def _section_block(heading: str, content: str) -> str:
 
 
 _RESERVED_SECTION_KEYS = {
-    "project",
-    "commands",
-    "architecture",
-    "rules",
-    "style",
-    "claude",
-    "cursor",
-    "gemini",
-    "codex",
-    "copilot",
+    "Project",
+    "Commands",
+    "Architecture",
+    "Rules",
+    "Style",
+    "Claude",
+    "Cursor",
+    "Gemini",
+    "Codex",
+    "Copilot",
+}
+
+_RESERVED_SECTION_KEYS_CASEFOLD = {
     "claude-specific",
     "cursor-specific",
     "gemini-specific",
@@ -62,7 +65,10 @@ _RESERVED_SECTION_KEYS = {
 
 def _append_unknown_sections(lines: list[str], sections: dict[str, str]) -> None:
     for heading, content in sections.items():
-        if heading.lower() not in _RESERVED_SECTION_KEYS:
+        if (
+            heading not in _RESERVED_SECTION_KEYS
+            and heading.lower() not in _RESERVED_SECTION_KEYS_CASEFOLD
+        ):
             lines.append(_section_block(heading, content))
 
 

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -41,6 +41,26 @@ def _section_block(heading: str, content: str) -> str:
     return f"## {heading}\n\n{content}\n"
 
 
+_RESERVED_SECTION_KEYS = {
+    "Project",
+    "Commands",
+    "Architecture",
+    "Rules",
+    "Style",
+    "Claude",
+    "Cursor",
+    "Gemini",
+    "Codex",
+    "Copilot",
+}
+
+
+def _append_unknown_sections(lines: list[str], sections: dict[str, str]) -> None:
+    for heading, content in sections.items():
+        if heading not in _RESERVED_SECTION_KEYS:
+            lines.append(_section_block(heading, content))
+
+
 def _compact_rules(sections: dict[str, str]) -> str:
     """Extract Rules + Style as compact bullet points."""
     parts = []
@@ -77,6 +97,7 @@ class ClaudeGenerator:
         # Include any agent-specific overrides
         if "Claude" in sections:
             lines.append(_section_block("Claude-Specific", sections["Claude"]))
+        _append_unknown_sections(lines, sections)
         return "\n".join(lines)
 
     def detect(self, project_root: Path) -> Path | None:
@@ -117,6 +138,7 @@ class CursorGenerator:
             lines.append("## Cursor-Specific\n")
             lines.append(sections["Cursor"])
             lines.append("")
+        _append_unknown_sections(lines, sections)
         return "\n".join(lines)
 
     def detect(self, project_root: Path) -> Path | None:
@@ -153,6 +175,7 @@ class GeminiGenerator:
             lines.append(_section_block("Style", sections["Style"]))
         if "Gemini" in sections:
             lines.append(_section_block("Gemini-Specific", sections["Gemini"]))
+        _append_unknown_sections(lines, sections)
         return "\n".join(lines)
 
     def detect(self, project_root: Path) -> Path | None:
@@ -184,6 +207,7 @@ class CodexGenerator:
             lines.append(_section_block("Rules", rules))
         if "Codex" in sections:
             lines.append(_section_block("Codex-Specific", sections["Codex"]))
+        _append_unknown_sections(lines, sections)
         return "\n".join(lines)
 
     def detect(self, project_root: Path) -> Path | None:
@@ -220,6 +244,7 @@ class CopilotGenerator:
             lines.append("## Copilot-Specific\n")
             lines.append(sections["Copilot"])
             lines.append("")
+        _append_unknown_sections(lines, sections)
         return "\n".join(lines)
 
     def detect(self, project_root: Path) -> Path | None:

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -52,6 +52,11 @@ _RESERVED_SECTION_KEYS = {
     "Gemini",
     "Codex",
     "Copilot",
+    "Claude-Specific",
+    "Cursor-Specific",
+    "Gemini-Specific",
+    "Codex-Specific",
+    "Copilot-Specific",
 }
 
 

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -180,18 +180,19 @@ class TestGenerator:
         assert "## Cursor" not in content
         assert "## Deployment" in content
 
-    def test_generate_does_not_emit_literal_agent_specific_headings_as_unknown(self):
+    @pytest.mark.parametrize("heading", ["Claude-Specific", "claude-specific"])
+    def test_generate_does_not_emit_literal_agent_specific_headings_as_unknown(self, heading):
         content = generate_for_agent(
             "cursor",
             {
                 "Project": "Intro line.",
-                "Claude-Specific": "Claude-only override.",
+                heading: "Claude-only override.",
                 "Deployment": "Ship it.",
             },
         )
 
         assert "Claude-only override." not in content
-        assert "## Claude-Specific" not in content
+        assert heading not in content
         assert "## Deployment" in content
 
     def test_unknown_agent_raises(self):

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -166,6 +166,18 @@ class TestGenerator:
         reparsed = extract_sections_from_agent_file(content, source=agent)
         assert reparsed["Deployment"] == "Ship it."
 
+    def test_generate_preserves_case_variant_canonical_headings_as_unknown(self):
+        content = generate_for_agent(
+            "cursor",
+            {
+                "Project": "Intro line.",
+                "rules": "- lower-case hand-authored rules",
+            },
+        )
+
+        assert "## rules" in content
+        assert "- lower-case hand-authored rules" in content
+
     def test_generate_does_not_emit_other_agent_overrides_as_unknown(self):
         content = generate_for_agent(
             "claude",

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -180,6 +180,20 @@ class TestGenerator:
         assert "## Cursor" not in content
         assert "## Deployment" in content
 
+    def test_generate_does_not_emit_literal_agent_specific_headings_as_unknown(self):
+        content = generate_for_agent(
+            "cursor",
+            {
+                "Project": "Intro line.",
+                "Claude-Specific": "Claude-only override.",
+                "Deployment": "Ship it.",
+            },
+        )
+
+        assert "Claude-only override." not in content
+        assert "## Claude-Specific" not in content
+        assert "## Deployment" in content
+
     def test_unknown_agent_raises(self):
         with pytest.raises(KeyError):
             generate_for_agent("unknown", self._sections())

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -151,6 +151,35 @@ class TestGenerator:
         for name, content in result.items():
             assert len(content) > 0
 
+    @pytest.mark.parametrize("agent", ["claude", "cursor", "gemini", "codex", "copilot"])
+    def test_generate_preserves_unknown_sections(self, agent):
+        sections = {
+            "Project": "Intro line.",
+            "Deployment": "Ship it.",
+            "Rules": "- be terse",
+        }
+
+        content = generate_for_agent(agent, sections)
+
+        assert "## Deployment" in content
+        assert "Ship it." in content
+        reparsed = extract_sections_from_agent_file(content, source=agent)
+        assert reparsed["Deployment"] == "Ship it."
+
+    def test_generate_does_not_emit_other_agent_overrides_as_unknown(self):
+        content = generate_for_agent(
+            "claude",
+            {
+                "Project": "Intro line.",
+                "Cursor": "Cursor-only override.",
+                "Deployment": "Ship it.",
+            },
+        )
+
+        assert "Cursor-only override." not in content
+        assert "## Cursor" not in content
+        assert "## Deployment" in content
+
     def test_unknown_agent_raises(self):
         with pytest.raises(KeyError):
             generate_for_agent("unknown", self._sections())
@@ -503,10 +532,6 @@ class TestPreambleProjectSubheadings:
         # the persisted form re-parses to the identical dict, with no `## `
         # embedded in any section body (the soundness win of the section model).
         #
-        # NB: whether a *generator* re-emits the unknown `Deployment` section is
-        # a separate, pre-existing concern (generators only emit canonical
-        # sections; true on main and for source=None alike) tracked outside
-        # B1-3 — this test deliberately pins the parser/persistence layer only.
         content = "Intro line.\n\n## Deployment\n\nShip it.\n\n## Rules\n\n- be terse\n"
         sections = extract_sections_from_agent_file(content, source="cursor")
 
@@ -523,6 +548,11 @@ class TestPreambleProjectSubheadings:
         # Persisted form is a fixed point: re-serialize → re-parse is stable.
         ctx.write_text(sections_to_markdown(reparsed), encoding="utf-8")
         assert parse_context(ctx) == reparsed
+
+        # Runtime generation is also no longer lossy for non-canonical sections.
+        generated = generate_for_agent("cursor", reparsed)
+        extracted = extract_sections_from_agent_file(generated, source="cursor")
+        assert extracted["Deployment"] == "Ship it."
 
     @pytest.mark.parametrize("source", ["cursor", "copilot"])
     def test_h3_subheading_stays_in_project_and_round_trips(self, source):


### PR DESCRIPTION
## Summary
- append non-canonical context sections to each runtime generator output
- keep canonical sections and other-agent overrides reserved so they do not leak as unknown headings
- add round-trip regression coverage for preserving a `## Deployment` section

Closes #1154.

## Verification
- `uv run pytest packages/memtomem/tests/test_context.py -q`
- `uv run pytest packages/memtomem/tests/test_context_generate_warnings.py packages/memtomem/tests/test_server_tools_context_on_drop.py -q`
- `uv run ruff check packages/memtomem/src/memtomem/context/generator.py packages/memtomem/tests/test_context.py`
- `git diff --check`