### PR TITLE
fix(context): reconstruct unregistered Windows `C--…` ~/.claude/projects dirs (#1157)

### DIFF
--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -263,6 +263,49 @@ def _encode_claude_project_path(root: PurePath) -> str:
     return re.sub(r"[^A-Za-z0-9]", "-", str(root))
 
 
+# A Windows drive-rooted slug: the drive letter survives (ASCII-alnum) and the
+# ``:`` + ``\`` of ``<letter>:\`` both collapse to ``-``, so ``C:\dev`` encodes to
+# ``C--dev``. Anchored at the start; a POSIX absolute slug always leads with ``-``
+# (the ``/`` root) so it never matches here. UNC slugs (``\\host\share`` →
+# ``--host-share``) DO lead with ``-`` and fall through to the POSIX branch — they
+# are out of scope for the drive-root walk and simply fail closed there.
+_WIN_DRIVE_SLUG_RE = re.compile(r"([A-Za-z])--")
+
+
+def _decode_seed(name: str) -> tuple[Path, str] | None:
+    """Return the ``(root, body)`` seed for the FS-walk, or ``None`` if *name* is
+    not a walkable absolute slug.
+
+    Two absolute-root encodings are recognized:
+
+    * **POSIX** — a leading ``-`` is the ``/`` root (``-home-foo`` ← ``/home/foo``).
+    * **Windows** — a drive-rooted slug ``<letter>--…`` ← ``<letter>:\\…`` (the
+      drive ``:`` and the ``\\`` separator both collapsed to ``-``). The walk is
+      seeded at the drive root and the drive prefix is consumed from the body.
+
+    ``Path(...)`` is the native flavor, so on a Windows host the drive seed is a
+    ``WindowsPath`` whose ``os.scandir`` / ``/`` join / ``is_dir`` all hit the real
+    drive. On a non-Windows host ``Path("C:\\")`` is a *relative* ``PosixPath`` (a
+    one-component name, ``is_absolute()`` is False), not a drive root — so the drive
+    branch is gated on ``is_absolute()`` and returns ``None`` there, failing closed
+    by construction rather than depending on the cwd not happening to contain a
+    literal ``C:\\`` child. This is harmless either way: Claude Code never emits a
+    drive-rooted slug for a POSIX path (and vice versa).
+    """
+    if name.startswith("-"):
+        return Path("/"), name[1:]  # the leading "-" is the root "/"
+    m = _WIN_DRIVE_SLUG_RE.match(name)
+    if m:
+        # "C--rest" ← "C:\rest": seed at the drive root, walk "rest". Only honor
+        # it when the seed is a genuine absolute root on THIS host — a real
+        # ``WindowsPath`` drive on Windows; on POSIX ``Path("C:\\")`` is a relative
+        # name, so we fail closed instead of walking it relative to cwd.
+        seed_root = Path(f"{m.group(1)}:\\")
+        if seed_root.is_absolute():
+            return seed_root, name[m.end() :]
+    return None
+
+
 def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) -> list[Path]:
     """Reconstruct candidate absolute paths from a ``~/.claude/projects/<name>``.
 
@@ -286,11 +329,13 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
     leaving the accept-one decision to the caller. Only when no anchor matches
     do we walk the filesystem.
 
-    The slow-path FS walk is POSIX-oriented: its leading ``-`` → ``/`` root
-    convention assumes a POSIX absolute root (a Windows ``C--…`` slug does not
-    start with ``-``), so on Windows only the anchor fast-path resolves. The
-    feature is experimental / off by default. (The *encoder* is platform-agnostic
-    — only this reconstruction is POSIX-leaning.)
+    The slow-path FS walk seeds from :func:`_decode_seed`, which recognizes both a
+    POSIX absolute root (leading ``-`` → ``/``) and a Windows drive-rooted slug
+    (``C--…`` ← ``C:\\…``). The walk itself is platform-agnostic; the drive seed
+    only resolves on a Windows host (where the real drive exists) and fails closed
+    elsewhere, mirroring the anchor fast-path which already resolves registered
+    Windows roots on any host. The feature is experimental / off by default. (The
+    *encoder* is platform-agnostic too — see :func:`_encode_claude_project_path`.)
     """
     # Anchors first — authoritative, cheap, and platform-agnostic: they
     # re-encode through the same encoder, so a Windows ``C--…`` slug resolves
@@ -311,29 +356,44 @@ def _decode_claude_project_dirname(name: str, anchors: tuple[Path, ...] = ()) ->
     if anchor_hits:
         return anchor_hits
 
-    # FS walk slow path is POSIX-rooted: the leading "-" is the "/" root, so a
-    # Windows "C--…" slug (no leading "-") cannot be walked — only the anchor
-    # fast-path above resolves it.
-    if not name.startswith("-"):
+    # FS walk slow path. The seed is the absolute root the body is relative to:
+    # "/" for a POSIX slug, the drive root for a Windows "C--…" slug. A slug that
+    # is neither (no leading "-" and no drive prefix) is not a walkable absolute
+    # path → fail closed.
+    seed = _decode_seed(name)
+    if seed is None:
         return []
-
-    body = name[1:]  # the leading "-" is the root "/"
+    seed_root, body = seed
     children_cache: dict[Path, set[str]] = {}
 
     def children(d: Path) -> set[str]:
         cached = children_cache.get(d)
         if cached is None:
+            names: set[str] = set()
             try:
-                cached = {e.name for e in os.scandir(d) if e.is_dir()}
+                with os.scandir(d) as it:
+                    for e in it:
+                        # Skip a single unreadable entry rather than dropping the
+                        # whole directory's listing — the Windows drive-root walk
+                        # scans busy system dirs (``C:\``, ``C:\Users`` with its
+                        # ``Default User`` / ``All Users`` junctions) where one
+                        # entry's ``is_dir()`` can raise while its siblings (the
+                        # real project ancestors) are fine.
+                        try:
+                            if e.is_dir():
+                                names.add(e.name)
+                        except OSError:
+                            continue
             except OSError:
-                cached = set()
+                pass  # the directory itself is unreadable / gone
+            cached = names
             children_cache[d] = cached
         return cached
 
     # Frontier of (committed_dir, pending_segment): committed_dir is the
     # deepest confirmed-existing directory; pending_segment is the partial
     # component built since the last separator.
-    frontier: list[tuple[Path, str]] = [(Path("/"), "")]
+    frontier: list[tuple[Path, str]] = [(seed_root, "")]
     for ch in body:
         if ch != "-":
             frontier = [(committed, pending + ch) for committed, pending in frontier]

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import multiprocessing as mp
+import os
 import sys
 from pathlib import Path
 
@@ -275,9 +276,10 @@ def test_discover_experimental_scan_disabled(
 
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="POSIX-only: relies on `/tmp` existing as a real directory and on "
-    "the claude-projects encoding (`-tmp` → `/tmp` via `replace('-', '/')`) "
-    "which is POSIX-only by production design (see _decode_claude_project_dirname)",
+    reason="POSIX-only fixture: the `-tmp` slug decodes to `/tmp`, which exists "
+    "as a real directory on Unix hosts but not on Windows (the decoder itself is "
+    "cross-platform since #1157 — this skip is about the `/tmp` fixture, not the "
+    "encoding).",
 )
 def test_discover_experimental_scan_enabled_filters_misdecoded(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -314,8 +316,9 @@ def test_discover_experimental_scan_enabled_filters_misdecoded(
 
 @pytest.mark.skipif(
     sys.platform == "win32",
-    reason="POSIX-only: uses cwd=Path('/tmp') and the `-tmp` → `/tmp` encoding; "
-    "/tmp does not exist on Windows and the encoding scheme is POSIX-only",
+    reason="POSIX-only fixture: uses cwd=Path('/tmp') and the `-tmp` → `/tmp` "
+    "slug; `/tmp` does not exist on Windows (the decoder is cross-platform since "
+    "#1157 — this skip is about the `/tmp` fixture, not the encoding).",
 )
 def test_discover_experimental_dedup_with_cwd(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -363,7 +366,7 @@ def test_has_runtime_marker_file_doesnt_count(tmp_path: Path) -> None:
     assert has_runtime_marker(tmp_path) is False
 
 
-# ── FS-guided kebab-case decoder (#1147 B7-1) ────────────────────────────
+# ── FS-guided kebab-case decoder (#1147 B7-1, Windows #1157) ──────────────
 #
 # The encoder collapses *every* non-ASCII-alphanumeric char to ``-`` (lossy /
 # many-to-one); these tests pin the FS-guided reconstruction, which reverses each
@@ -372,14 +375,25 @@ def test_has_runtime_marker_file_doesnt_count(tmp_path: Path) -> None:
 # exercise the underscore round-trip too. Hermetic: ``_CLAUDE_PROJECTS_DIR``
 # (bound at import via ``expanduser()``) is monkeypatched, and target dirs live
 # under a real ``tmp_path`` so the reconstruction's absolute ``is_dir()`` probes
-# hit fixtures. POSIX-only because the *reconstruction* assumes the leading
-# ``-`` → ``/`` root convention — the encoder itself is platform-agnostic.
+# hit fixtures.
+#
+# These ``@_WIN_SKIP`` cases stay POSIX-only because of the FIXTURE, not the
+# decoder: each creates ``~/.claude/projects/<full-encoded-absolute-path>`` — a
+# directory whose *name* re-encodes the deep ``tmp_path`` — which on Windows risks
+# bumping the legacy ``MAX_PATH`` (260) limit and makes the ``C:\``→target walk
+# environment-sensitive (sibling ambiguity), neither of which is decoder
+# correctness. The decoder itself IS cross-platform since #1157; its Windows path
+# is covered directly by ``test_decode_seed_recognizes_posix_and_windows_roots``
+# (string logic, every host) and ``test_decode_windows_drive_root_walk`` (the real
+# drive-root walk, Windows-only, no long-named fixture dir).
 
 _WIN_SKIP = pytest.mark.skipif(
     sys.platform == "win32",
-    reason="POSIX-only: the decoder slow-path's leading `-` → `/` root walk "
-    "assumes a POSIX absolute root (see _decode_claude_project_dirname). The "
-    "encoder is cross-platform; only this reconstruction is POSIX-leaning.",
+    reason="POSIX-only FIXTURE: builds `~/.claude/projects/<full-encoded-abspath>` "
+    "from a deep tmp_path, which risks MAX_PATH (260) on Windows and an "
+    "environment-sensitive C:\\-rooted walk. The decoder is cross-platform since "
+    "#1157 — Windows coverage is in test_decode_seed_* and "
+    "test_decode_windows_drive_root_walk.",
 )
 
 
@@ -443,20 +457,88 @@ def test_decode_underscore_and_non_ascii_component(
 
 
 def test_decode_windows_slug_resolves_via_anchor() -> None:
-    """A Windows ``C--…`` slug has no leading ``-``, so the POSIX FS walk can't
-    reconstruct it — but a registered anchor (cwd / known_projects) re-encodes to
-    the same slug and must still resolve. Regression: the ``startswith("-")`` gate
-    used to run BEFORE the anchor loop and silently dropped Windows roots (Codex
-    review). Cross-platform (PureWindowsPath + anchors only, no filesystem), so it
-    runs on the windows job too."""
+    """A Windows ``C--…`` slug is resolved by a registered anchor (cwd /
+    known_projects) that re-encodes to the same slug — the authoritative,
+    filesystem-free resolution path that works on every host. (The FS walk also
+    reconstructs an *unregistered* drive dir, but only on a real Windows drive,
+    #1157; here we pass anchors and no filesystem, so the anchor returns first.)
+    Regression: the ``startswith("-")`` gate used to run BEFORE the anchor loop
+    and silently dropped Windows roots (Codex review). Cross-platform
+    (PureWindowsPath + anchors only, no filesystem), so it runs on every job."""
     from pathlib import PureWindowsPath
 
     from memtomem.context import projects as proj_mod
 
     anchor = PureWindowsPath(r"C:\Users\foo")
     name = proj_mod._encode_claude_project_path(anchor)
-    assert name == "C--Users-foo" and not name.startswith("-")  # the bug condition
+    assert name == "C--Users-foo" and not name.startswith("-")  # no leading "-"
     assert proj_mod._decode_claude_project_dirname(name, anchors=(anchor,)) == [anchor]
+
+
+def test_decode_seed_recognizes_posix_and_windows_roots() -> None:
+    """``_decode_seed`` maps an absolute slug to its ``(root, body)`` walk seed.
+    Pure string logic (no filesystem), so the Windows drive-root detection added
+    in #1157 is pinned on every platform — not just the windows job."""
+    from memtomem.context import projects as proj_mod
+
+    # POSIX absolute root: leading "-" is "/" — identical on every host.
+    assert proj_mod._decode_seed("-home-foo") == (Path("/"), "home-foo")
+    # A UNC slug ("\\host\share" → "--host-share") leads with "-", so it falls
+    # through to the POSIX branch (out of scope for the drive-root walk).
+    assert proj_mod._decode_seed("--host-share") == (Path("/"), "-host-share")
+    # Slugs that are no absolute root at all → None on every host (fail closed):
+    assert proj_mod._decode_seed("C-foo") is None  # drive-relative "C:foo", not "C:\"
+    assert proj_mod._decode_seed("Ca--b") is None  # two leading letters ≠ a drive
+    assert proj_mod._decode_seed("foo-bar") is None  # neither root encoding
+
+    # The drive branch only yields a seed where "C:\" is a genuine absolute root,
+    # i.e. on Windows. On POSIX "C:\" is a relative PosixPath, so the slug fails
+    # closed — proving the contract instead of relying on cwd contents (#1157
+    # review). The drive prefix (and its ":" + "\") is consumed from the body.
+    if os.name == "nt":
+        assert proj_mod._decode_seed("C--Users-foo") == (Path("C:\\"), "Users-foo")
+        assert proj_mod._decode_seed("d--data") == (Path("d:\\"), "data")  # lowercase
+        assert proj_mod._decode_seed("C--") == (Path("C:\\"), "")  # bare drive root
+    else:
+        assert proj_mod._decode_seed("C--Users-foo") is None
+        assert proj_mod._decode_seed("C--") is None
+
+    # End-to-end: a drive-rooted slug with no anchors and no matching dir resolves
+    # to [] on every host — on POSIX via the None seed, on Windows via a walk that
+    # finds nothing. (Cross-platform fail-closed guarantee.)
+    assert proj_mod._decode_claude_project_dirname("C--Zzqq-nope-xyzplace") == []
+
+
+@pytest.mark.skipif(
+    os.name != "nt",
+    reason="Windows-only: exercises the real C:\\-rooted FS walk for an "
+    "unregistered drive slug (#1157). Passes the slug straight to the decoder — no "
+    "~/.claude/projects/<long-name> fixture dir — so it avoids the MAX_PATH limit "
+    "that keeps the @_WIN_SKIP reconstruction cases POSIX-only.",
+)
+def test_decode_windows_drive_root_walk(tmp_path: Path) -> None:
+    """On Windows, an *unregistered* ``C--…`` slug reconstructs via the drive-root
+    FS walk (the gap #1157 closes). No anchors, no ``~/.claude/projects`` fixture:
+    the encoded slug goes straight to the decoder, so the only on-disk artifact is
+    the short real ``tmp_path`` target — no long-named directory, no MAX_PATH."""
+    from memtomem.context import projects as proj_mod
+
+    target = tmp_path / "agent-harness"  # literal-dash leaf, like a real repo
+    target.mkdir()
+    # Canonicalize BEFORE encoding: GitHub's hosted Windows runners can expose the
+    # temp dir via an 8.3 short alias (e.g. ``C:\Users\RUNNER~1\...``) while
+    # ``os.scandir`` reports the long name (``runneradmin``). The decoder matches
+    # entries with a case-sensitive ``startswith``, so the slug must be spelled the
+    # way the filesystem lists it — ``resolve()`` gives that canonical long form.
+    target = target.resolve(strict=True)
+    slug = proj_mod._encode_claude_project_path(target)
+    assert not slug.startswith("-")  # drive-rooted: no leading "-" to strip
+
+    result = proj_mod._decode_claude_project_dirname(slug)
+    # Membership, not equality: a deep tmp_path walk could surface a
+    # sibling-ambiguous candidate, but the real target must always be among the
+    # FS-confirmed results — proving the drive-root walk reaches it.
+    assert target in {r.resolve() for r in result}
 
 
 @_WIN_SKIP


### PR DESCRIPTION
## Summary

Closes #1157. The decoder's slow-path FS walk (`_decode_claude_project_dirname`)
reconstructs an absolute path from a `~/.claude/projects/<slug>` directory name.
It was POSIX-root-only: it seeded the frontier at `Path("/")` after stripping a
leading `-`, so a Windows drive-rooted slug like `C--Users-foo`
(`C:\Users\foo` — the drive `C` leads; `:` and `\` both became `-`, so **no**
leading `-`) bailed with `[]`. Registered roots already resolved via the
platform-agnostic anchor fast-path, but the experimental `~/.claude/projects`
scan could not discover an **unregistered** Windows dir.

## What changed

**`context/projects.py`**

- New `_decode_seed(name)` maps an absolute slug to its `(root, body)` walk seed
  for both encodings:
  - POSIX: leading `-` → `/` root (unchanged).
  - Windows: `<letter>--…` ← `<letter>:\…` → seed at the drive root, consume the
    drive prefix from the body.
- The drive branch is gated on `seed_root.is_absolute()`. On Windows
  `Path("C:\\")` is a real absolute `WindowsPath` (scandir / join / `is_dir` hit
  the actual drive); on POSIX it is a **relative** `PosixPath` (a one-component
  name), so the slug **fails closed by construction** instead of being walked
  relative to cwd. Claude Code never emits a drive-rooted slug for a POSIX path
  anyway.
- Hardened `children()`: a single unreadable `DirEntry` now skips only itself
  instead of the outer `except OSError` dropping the whole directory listing.
  The drive-root walk necessarily scans busy system dirs (`C:\`, `C:\Users` with
  its `Default User` / `All Users` junctions) where one entry's `is_dir()` can
  raise while the real project ancestors are fine.

## Tests

- `test_decode_seed_recognizes_posix_and_windows_roots` — string-only, runs on
  every host. POSIX proves a drive slug fails closed (`None`, and end-to-end
  `[]`); Windows asserts the drive seed.
- `test_decode_windows_drive_root_walk` (Windows-only) — exercises the real
  `C:\`-rooted walk by handing the slug straight to the decoder (no
  `~/.claude/projects/<long-name>` fixture, so no `MAX_PATH` risk).
  Canonicalizes the target with `resolve()` first so the slug spelling matches
  what `os.scandir` returns (GitHub's hosted Windows runners can expose the temp
  dir via an 8.3 short alias like `C:\Users\RUNNER~1\...`).
- The 9 deep-`tmp_path` reconstruction cases stay `@_WIN_SKIP`: their fixture
  creates a directory whose **name** is the full encoded absolute path, which
  risks Windows `MAX_PATH` (260) — a fixture limit, not a decoder limit. The
  skip rationales (and the two `/tmp` discovery skips) are corrected so they no
  longer claim the encoding itself is POSIX-only.

## Severity / scope

Low. The `~/.claude/projects` scan is experimental and off by default
(`experimental_claude_projects_scan`), and the path **fails closed** on both
platforms (`[]` → the dir is simply not surfaced; no wrong result, no crash).
Registered roots are unaffected (anchor fast-path). Refs #1156, #1147.

## Verification

- `uv run pytest packages/memtomem/tests/test_context_projects.py` — 36 passed,
  1 skipped (Windows-only); `test_sync_doctor_cli.py` — 39 passed.
- `ruff check` + `ruff format --check` clean; `mypy` clean; no SyntaxWarnings.
- Windows-specific paths can only be exercised on the `test (windows-latest)` CI
  job — that job is the real gate for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
