### PR TITLE
fix(context): close issue 1147 quick-win contracts

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -620,32 +620,6 @@ _SCOPE_OPTION = click.option(
 )
 
 
-_RULES_STYLE_MERGE_RUNTIMES: frozenset[str] = frozenset({"cursor", "codex", "copilot"})
-
-
-def _warn_rules_style_merge(sections: dict[str, str], targets: list[str]) -> None:
-    """Warn when generated targets fold Rules and Style into one block.
-
-    Cursor / Codex / Copilot generators concatenate Rules + Style under a
-    single heading via ``_compact_rules`` in :mod:`memtomem.context.generator`.
-    Claude / Gemini emit them as separate ``##`` blocks. When both sections
-    are present in ``context.md`` and at least one merging runtime is in the
-    target list, surface a single stderr notice naming only the affected
-    runtimes — file format itself is unchanged.
-    """
-    if not (sections.get("Rules", "").strip() and sections.get("Style", "").strip()):
-        return
-    affected = [t for t in targets if t in _RULES_STYLE_MERGE_RUNTIMES]
-    if not affected:
-        return
-    click.secho(
-        f"warning: {'/'.join(affected)} merge Rules and Style into a single block; "
-        "context.md remains the source of truth — edit there, not in generated files.",
-        err=True,
-        fg="yellow",
-    )
-
-
 @click.group("context")
 def context() -> None:
     """Manage unified agent context (CLAUDE.md, .cursorrules, GEMINI.md, etc.)."""
@@ -955,8 +929,6 @@ def generate_cmd(
             click.secho(f"{CONTEXT_FILENAME} is empty.", fg="yellow")
         else:
             targets = list(GENERATORS.keys()) if agent == "all" else [agent]
-
-            _warn_rules_style_merge(sections, targets)
 
             for name in targets:
                 gen = GENERATORS[name]

--- a/packages/memtomem/src/memtomem/context/_runtime_targets.py
+++ b/packages/memtomem/src/memtomem/context/_runtime_targets.py
@@ -40,10 +40,14 @@ Design rules:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from memtomem.config import TargetScope
+from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.scope_resolver import ArtifactKind
+
+logger = logging.getLogger(__name__)
 
 
 # Sentinel for "no fan-out by design — caller should emit
@@ -196,7 +200,28 @@ def runtime_artifact_names(
     root = runtime_fanout_root(artifact, runtime, scope, project_root)
     if root is None or not root.is_dir():
         return set()
+    kind = f"{artifact[:-1]} name"
+    names: set[str] = set()
     if file_suffix is not None:
-        return {p.stem for p in root.iterdir() if p.is_file() and p.suffix == file_suffix}
-    assert dir_manifest is not None  # mypy narrow
-    return {p.name for p in root.iterdir() if p.is_dir() and (p / dir_manifest).is_file()}
+        entries = ((p.stem, p) for p in root.iterdir() if p.is_file() and p.suffix == file_suffix)
+    else:
+        assert dir_manifest is not None  # mypy narrow
+        entries = (
+            (p.name, p) for p in root.iterdir() if p.is_dir() and (p / dir_manifest).is_file()
+        )
+    for raw_name, path in entries:
+        try:
+            names.add(validate_name(raw_name, kind=kind))
+        except InvalidNameError as exc:
+            logger.warning(
+                "Skipping invalid runtime artifact name",
+                extra={
+                    "artifact": artifact,
+                    "runtime": runtime,
+                    "scope": scope,
+                    "runtime_path": str(path),
+                    "artifact_name": raw_name,
+                    "reason": str(exc),
+                },
+            )
+    return names

--- a/packages/memtomem/src/memtomem/context/generator.py
+++ b/packages/memtomem/src/memtomem/context/generator.py
@@ -72,15 +72,6 @@ def _append_unknown_sections(lines: list[str], sections: dict[str, str]) -> None
             lines.append(_section_block(heading, content))
 
 
-def _compact_rules(sections: dict[str, str]) -> str:
-    """Extract Rules + Style as compact bullet points."""
-    parts = []
-    for key in ("Rules", "Style"):
-        if key in sections:
-            parts.append(sections[key])
-    return "\n\n".join(parts)
-
-
 # ── Claude Code ────────────────────────────────────────────────────────
 
 
@@ -136,10 +127,13 @@ class CursorGenerator:
             lines.append("## Commands\n")
             lines.append(sections["Commands"])
             lines.append("")
-        rules = _compact_rules(sections)
-        if rules:
+        if "Rules" in sections:
             lines.append("## Rules\n")
-            lines.append(rules)
+            lines.append(sections["Rules"])
+            lines.append("")
+        if "Style" in sections:
+            lines.append("## Style\n")
+            lines.append(sections["Style"])
             lines.append("")
         if "Architecture" in sections:
             lines.append("## Architecture\n")
@@ -213,9 +207,10 @@ class CodexGenerator:
             lines.append(_section_block("Commands", sections["Commands"]))
         if "Architecture" in sections:
             lines.append(_section_block("Architecture", sections["Architecture"]))
-        rules = _compact_rules(sections)
-        if rules:
-            lines.append(_section_block("Rules", rules))
+        if "Rules" in sections:
+            lines.append(_section_block("Rules", sections["Rules"]))
+        if "Style" in sections:
+            lines.append(_section_block("Style", sections["Style"]))
         if "Codex" in sections:
             lines.append(_section_block("Codex-Specific", sections["Codex"]))
         _append_unknown_sections(lines, sections)
@@ -242,10 +237,13 @@ class CopilotGenerator:
         if "Project" in sections:
             lines.append(sections["Project"])
             lines.append("")
-        rules = _compact_rules(sections)
-        if rules:
+        if "Rules" in sections:
             lines.append("## Rules\n")
-            lines.append(rules)
+            lines.append(sections["Rules"])
+            lines.append("")
+        if "Style" in sections:
+            lines.append("## Style\n")
+            lines.append(sections["Style"])
             lines.append("")
         if "Commands" in sections:
             lines.append("## Commands\n")

--- a/packages/memtomem/src/memtomem/context/settings.py
+++ b/packages/memtomem/src/memtomem/context/settings.py
@@ -407,10 +407,11 @@ def _merge_hooks_record(
                 )
             else:
                 warnings.append(
-                    f"Hook rule '{label}' already exists in the target "
-                    f"settings with different config. To use memtomem's "
-                    f"version, remove the existing rule, then re-run "
-                    f"`mm context sync --include=settings`."
+                    f"Skipped memtomem hook '{label}': the target settings "
+                    f"already contain a user-owned rule with the same "
+                    f"event+matcher. Change one matcher to keep both rules, "
+                    f"or remove the user rule and re-run "
+                    f"`mm context sync --include=settings` to replace it."
                 )
 
         if replaced_any:

--- a/packages/memtomem/tests/test_context.py
+++ b/packages/memtomem/tests/test_context.py
@@ -130,6 +130,8 @@ class TestGenerator:
     def test_cursor_generate(self):
         content = generate_for_agent("cursor", self._sections())
         assert "line-length 100" in content
+        assert "## Style" in content
+        assert content.index("## Rules") < content.index("## Style")
         assert "pytest" in content
 
     def test_gemini_generate(self):
@@ -140,10 +142,13 @@ class TestGenerator:
     def test_codex_generate(self):
         content = generate_for_agent("codex", self._sections())
         assert "AGENTS.md" in content
+        assert "line-length 100" in content
+        assert "## Style" in content
 
     def test_copilot_generate(self):
         content = generate_for_agent("copilot", self._sections())
         assert "line-length 100" in content
+        assert "## Style" in content
 
     def test_generate_all(self):
         result = generate_all(self._sections())

--- a/packages/memtomem/tests/test_context_generate_warnings.py
+++ b/packages/memtomem/tests/test_context_generate_warnings.py
@@ -1,15 +1,4 @@
-"""Tests for the Rules+Style merge stderr warning in ``mm context generate``.
-
-Cursor / Codex / Copilot generators concatenate the ``Rules`` and ``Style``
-context.md sections under a single heading via ``_compact_rules`` (see
-:mod:`memtomem.context.generator`). When both sections are populated and at
-least one merging runtime is targeted, the CLI should emit a single stderr
-warning naming only the affected runtimes — generated file format itself
-is unchanged.
-
-Click 8.3 keeps ``result.stderr`` separate from ``result.output`` (stdout) by
-default; assertions below pin both surfaces.
-"""
+"""Tests for Rules/Style generation through ``mm context generate``."""
 
 from __future__ import annotations
 
@@ -44,17 +33,16 @@ def project_with_rules_and_style(tmp_path, monkeypatch):
     return tmp_path
 
 
-def test_generate_warns_on_rules_style_merge_for_cursor(project_with_rules_and_style):
-    """Positive: --agent=cursor with both sections → warning on stderr."""
+def test_generate_preserves_rules_and_style_for_cursor(project_with_rules_and_style):
     runner = CliRunner()
     result = runner.invoke(context, ["generate", "--agent=cursor"])
 
     assert result.exit_code == 0, result.output
-    assert "Rules and Style" in result.stderr
-    assert "cursor" in result.stderr
-    # Stdout must not contain the warning (Click 8.3 separates streams;
-    # ``result.output`` is interleaved, ``result.stdout`` is stdout-only).
+    assert "Rules and Style" not in result.stderr
     assert "Rules and Style" not in result.stdout
+    generated = project_with_rules_and_style.joinpath(".cursorrules").read_text(encoding="utf-8")
+    assert "## Rules" in generated
+    assert "## Style" in generated
 
 
 def test_generate_no_warning_when_only_rules(tmp_path, monkeypatch):
@@ -74,7 +62,6 @@ def test_generate_no_warning_when_only_rules(tmp_path, monkeypatch):
 
 
 def test_generate_no_warning_for_claude_only_target(project_with_rules_and_style):
-    """Negative: --agent=claude does not use ``_compact_rules`` → no warning."""
     runner = CliRunner()
     result = runner.invoke(context, ["generate", "--agent=claude"])
 
@@ -82,16 +69,22 @@ def test_generate_no_warning_for_claude_only_target(project_with_rules_and_style
     assert "Rules and Style" not in result.stderr
 
 
-def test_generate_warning_lists_only_intersecting_runtimes(project_with_rules_and_style):
-    """The warning names only runtimes that intersect with the target set.
-
-    With ``--agent=cursor``, codex and copilot must NOT appear — otherwise
-    the message implies the user is generating files they did not request.
-    """
+@pytest.mark.parametrize(
+    ("agent", "path"),
+    [
+        ("cursor", ".cursorrules"),
+        ("codex", "AGENTS.md"),
+        ("copilot", ".github/copilot-instructions.md"),
+    ],
+)
+def test_generate_preserves_rules_style_for_markdown_targets(
+    project_with_rules_and_style, agent, path
+):
     runner = CliRunner()
-    result = runner.invoke(context, ["generate", "--agent=cursor"])
+    result = runner.invoke(context, ["generate", f"--agent={agent}"])
 
     assert result.exit_code == 0, result.output
-    assert "cursor" in result.stderr
-    assert "codex" not in result.stderr
-    assert "copilot" not in result.stderr
+    assert result.stderr == ""
+    generated = project_with_rules_and_style.joinpath(path).read_text(encoding="utf-8")
+    assert "## Rules" in generated
+    assert "## Style" in generated

--- a/packages/memtomem/tests/test_context_runtime_targets.py
+++ b/packages/memtomem/tests/test_context_runtime_targets.py
@@ -14,6 +14,7 @@ import pytest
 from memtomem.context._runtime_targets import (
     KNOWN_RUNTIMES,
     RUNTIME_FANOUT_TABLE,
+    runtime_artifact_names,
     runtime_fanout_root,
 )
 
@@ -120,3 +121,51 @@ def test_project_local_without_root_returns_none_first() -> None:
     """project_local entries are None — that branch wins before the
     project_root check, so passing None is harmless for project_local."""
     assert runtime_fanout_root("agents", "claude", "project_local", project_root=None) is None
+
+
+def test_runtime_artifact_names_skips_invalid_file_names(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    root = tmp_path / ".claude" / "agents"
+    root.mkdir(parents=True)
+    (root / "ok.md").write_text("", encoding="utf-8")
+    (root / "-bad.md").write_text("", encoding="utf-8")
+
+    names = runtime_artifact_names(
+        "agents", "claude", tmp_path, "project_shared", file_suffix=".md"
+    )
+
+    assert names == {"ok"}
+    assert any(
+        record.message == "Skipping invalid runtime artifact name"
+        and record.name == "memtomem.context._runtime_targets"
+        and getattr(record, "artifact") == "agents"
+        and getattr(record, "runtime") == "claude"
+        and getattr(record, "scope") == "project_shared"
+        and getattr(record, "artifact_name") == "-bad"
+        for record in caplog.records
+    )
+
+
+def test_runtime_artifact_names_skips_invalid_manifest_dirs(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    good = tmp_path / ".agents" / "skills" / "ok"
+    bad = tmp_path / ".agents" / "skills" / "-bad"
+    good.mkdir(parents=True)
+    bad.mkdir()
+    (good / "SKILL.md").write_text("", encoding="utf-8")
+    (bad / "SKILL.md").write_text("", encoding="utf-8")
+
+    names = runtime_artifact_names(
+        "skills", "codex", tmp_path, "project_shared", dir_manifest="SKILL.md"
+    )
+
+    assert names == {"ok"}
+    assert any(
+        record.message == "Skipping invalid runtime artifact name"
+        and getattr(record, "artifact") == "skills"
+        and getattr(record, "runtime") == "codex"
+        and getattr(record, "artifact_name") == "-bad"
+        for record in caplog.records
+    )

--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -255,8 +255,9 @@ class TestClaudeSettingsMergeWarningContent:
         # (a) rule label
         assert "PostToolUse:Write" in w
         # (b) reason
-        assert "already exists" in w
+        assert "user-owned rule with the same event+matcher" in w
         # (c) concrete remediation step
+        assert "Change one matcher" in w
         assert "remove" in w
         assert "mm context sync --include=settings" in w
 


### PR DESCRIPTION
## Summary
- preserve Rules and Style as separate sections for cursor/codex/copilot generated Markdown targets
- reword same-matcher hook conflicts to explain the user-owned rule contract and remediation
- validate runtime artifact names during diff discovery, skipping invalid on-disk names with structured warnings

## Validation
- uv run pytest packages/memtomem/tests/test_context.py packages/memtomem/tests/test_context_generate_warnings.py packages/memtomem/tests/test_context_settings.py packages/memtomem/tests/test_context_runtime_targets.py -q
- uv run pytest packages/memtomem/tests/test_context_agents.py packages/memtomem/tests/test_context_commands.py packages/memtomem/tests/test_context_skills.py packages/memtomem/tests/test_context_runtime_table_none_skips.py packages/memtomem/tests/test_web_routes_extended.py -q
- uv run ruff check packages/memtomem/src/memtomem/context/generator.py packages/memtomem/src/memtomem/cli/context_cmd.py packages/memtomem/src/memtomem/context/settings.py packages/memtomem/src/memtomem/context/_runtime_targets.py packages/memtomem/tests/test_context.py packages/memtomem/tests/test_context_generate_warnings.py packages/memtomem/tests/test_context_settings.py packages/memtomem/tests/test_context_runtime_targets.py
- git diff --check

Closes #1147