### PR TITLE
fix(web): bind gateway/config locks per event loop to de-flake tests

### DIFF
--- a/packages/memtomem/src/memtomem/web/routes/_locks.py
+++ b/packages/memtomem/src/memtomem/web/routes/_locks.py
@@ -53,5 +53,79 @@ from __future__ import annotations
 
 import asyncio
 
-_config_lock = asyncio.Lock()
-_gateway_lock = asyncio.Lock()
+
+class _LoopLocalLock:
+    """An ``asyncio.Lock`` proxy that resolves to a per-event-loop lock.
+
+    A bare module-level ``asyncio.Lock`` binds to the first event loop that
+    acquires it and then raises ``RuntimeError: ... is bound to a different
+    event loop`` when reused from another loop. In production this never
+    happens — the web server runs a single long-lived loop — but pytest gives
+    each ``async`` test its own loop, so whichever test acquires the lock first
+    binds it and a later test on a fresh loop fails non-deterministically.
+
+    Keying the underlying lock by the running loop keeps the contract intact:
+    *within* one loop every caller shares the same lock (so two concurrent
+    gateway mutators still serialise), while distinct loops get distinct locks.
+    Call sites use the proxy exactly like a lock — ``async with _gateway_lock:``
+    and ``.locked()`` — so nothing downstream changes, and ``is`` identity (the
+    module singleton) still holds because the proxy object itself is the shared
+    singleton.
+
+    A :class:`weakref.WeakKeyDictionary` cannot bound the registry here: once a
+    lock takes its contended slow path it strongly references its bound loop
+    (``lock._loop``), so the loop value keeps the weak key alive and entries for
+    closed loops never collect. Instead the registry is a plain dict pruned of
+    closed-loop entries each time a new loop is seen — in production it holds
+    exactly one entry; across pytest's per-test loops it stays bounded.
+    """
+
+    __slots__ = ("_locks",)
+
+    def __init__(self) -> None:
+        self._locks: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
+
+    def _current(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            # Each stored lock strongly references its bound loop, so closed
+            # loops must be pruned explicitly (a WeakKeyDictionary would never
+            # reclaim them). Sweep on the new-loop path — cheap and bounded.
+            for dead in [lp for lp in self._locks if lp.is_closed()]:
+                del self._locks[dead]
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def __aenter__(self) -> asyncio.Lock:
+        lock = self._current()
+        await lock.acquire()
+        return lock
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._current().release()
+
+    def locked(self) -> bool:
+        """Whether the gateway lock is held.
+
+        A single shared ``asyncio.Lock`` answered ``.locked()`` the same way
+        from any thread. Handlers offload the synchronous engine call to a
+        worker thread (no running loop) while holding the lock, and the
+        lock-held tests probe from inside that thread — so when no loop is
+        current we report whether *any* per-loop lock is held (in production
+        that is the one lock; in tests it is the request loop's). With a running
+        loop we report that loop's lock without creating one as a side effect.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Snapshot first: the registry may be mutated on the loop thread
+            # (a first contended acquire) while we iterate on a worker thread.
+            return any(lock.locked() for lock in list(self._locks.values()))
+        lock = self._locks.get(loop)
+        return lock.locked() if lock is not None else False
+
+
+_config_lock = _LoopLocalLock()
+_gateway_lock = _LoopLocalLock()

--- a/packages/memtomem/tests/test_web_routes_context_locks.py
+++ b/packages/memtomem/tests/test_web_routes_context_locks.py
@@ -496,3 +496,63 @@ def test_gateway_lock_docstring_describes_two_layer_model():
     assert "settings" in doc
     # The heavy alternative was considered and rejected — keep that on record.
     assert "gateway-wide" in doc
+
+
+# ---------------------------------------------------------------------------
+# Event-loop binding — the proxy must not bind to the first loop (de-flake)
+# ---------------------------------------------------------------------------
+
+
+def test_locks_survive_distinct_event_loops():
+    """Acquiring a gateway/config lock from two independent loops must not raise.
+
+    A bare module-level ``asyncio.Lock`` binds to an event loop the first time
+    it takes its *contended* slow path (the uncontended fast path never calls
+    ``_get_loop()``), then raises ``RuntimeError: ... is bound to a different
+    event loop`` when contended again from another loop — the root cause of the
+    order-dependent flake in ``test_settings_sync_and_skills_sync_share_lock``,
+    which contends the lock via ``asyncio.gather``. ``_LoopLocalLock`` keys the
+    underlying lock per running loop, so each ``asyncio.run`` — a fresh loop
+    that closes on exit — gets its own. Deterministic where the original symptom
+    was not: with a bare ``asyncio.Lock`` the second ``asyncio.run`` raises.
+    """
+    from memtomem.web.routes import _locks
+
+    async def _contend(lock):
+        # Force the slow path: while one holder sleeps inside the lock, a second
+        # waiter must create a future via _get_loop(), binding/checking the loop.
+        async def hold():
+            async with lock:
+                await asyncio.sleep(0)
+
+        await asyncio.gather(hold(), hold())
+
+    for lock in (_locks._gateway_lock, _locks._config_lock):
+        asyncio.run(_contend(lock))  # binds to loop #1, which then closes
+        asyncio.run(_contend(lock))  # loop #2 — a bare asyncio.Lock raises here
+
+
+def test_loop_local_lock_registry_prunes_closed_loops():
+    """The per-loop registry must not accumulate entries for closed loops.
+
+    Each stored ``asyncio.Lock`` strongly references its bound loop, so a
+    ``WeakKeyDictionary`` could never reclaim finished-loop entries (the value
+    keeps the weak key alive). The registry instead prunes closed loops when a
+    new loop is seen, so running many short-lived contended loops leaves at most
+    the most-recent entry — not one per loop.
+    """
+    from memtomem.web.routes import _locks
+
+    async def _contend(lock):
+        async def hold():
+            async with lock:
+                await asyncio.sleep(0)
+
+        await asyncio.gather(hold(), hold())
+
+    lock = _locks._gateway_lock
+    for _ in range(5):
+        asyncio.run(_contend(lock))  # fresh loop each iteration, closed on exit
+
+    # Without pruning this would be 5 (one stranded lock per closed loop).
+    assert len(lock._locks) <= 1


### PR DESCRIPTION
## fix(web): de-flake the gateway/config event-loop lock

### Symptom
`test_web_routes_context_locks.py::test_settings_sync_and_skills_sync_share_lock`
failed on **ubuntu-latest** in v0.2.2's post-merge `main` CI with:

```
RuntimeError: <asyncio.locks.Lock object ...> is bound to a different event loop
```

The release commit (#1161) changed no source — only `pyproject`/`uv.lock`/
`CHANGELOG` — and the same test passed on macos, on the PR run, and on a rerun.
Order-dependent flake, not a regression.

### Root cause
`_gateway_lock` / `_config_lock` were module-level bare `asyncio.Lock()`s. A
bare `Lock` binds to an event loop the first time it takes its **contended**
slow path (the uncontended fast path never calls `_get_loop()`), then raises
"bound to a different event loop" when contended again from another loop.
Production runs one long-lived loop, but pytest gives each `async` test its own;
the flaky test contends the lock via `asyncio.gather`, so whichever test bound
it first could strand a later test on a fresh loop.

### Fix
Wrap both locks in `_LoopLocalLock`, a drop-in proxy keying the underlying
`asyncio.Lock` per running loop:

- **Semantics preserved** — within one loop all callers share one lock
  (serialization intact); distinct loops get distinct locks.
- **Call sites unchanged** — `async with _gateway_lock:` and `.locked()` still
  work; module-singleton `is` identity still holds (the proxy *is* the
  singleton). `.locked()` reports the running loop's lock, or — from the worker
  thread that runs the synchronous engine call under the lock — whether any
  loop's lock is held (one lock in production).
- **Bounded registry** — a `WeakKeyDictionary` can't help here (a stored lock
  strongly refs its bound loop, keeping the weak key alive), so the registry is
  a plain dict pruned of closed-loop entries on the new-loop path. *(Caught in
  review — initial draft used a leaking `WeakKeyDictionary`.)*

### Tests
Two deterministic pins (the original flake was order-dependent):
- `test_locks_survive_distinct_event_loops` — contends each lock across two
  `asyncio.run` loops; raises the exact CI `RuntimeError` on a bare
  `asyncio.Lock`, passes on the proxy (mutation-verified on Python 3.12).
- `test_loop_local_lock_registry_prunes_closed_loops` — asserts closed loops are
  pruned instead of leaking one entry per loop (mutation-verified: 5 without the
  sweep).

Local: 126 passed (`test_web_routes_context_locks` + `_mutators` +
`test_web_hot_reload`, py3.12), ruff + format clean, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
