### PR TITLE
test(context): de-flake settings lock-budget timing assertion

### DIFF
--- a/packages/memtomem/tests/test_context_settings.py
+++ b/packages/memtomem/tests/test_context_settings.py
@@ -698,28 +698,57 @@ class TestClaudeSettingsCrossProcessLock:
         claude_t = claude_home / ".claude" / "settings.json"
         codex_t = claude_home / ".codex" / "hooks.json"
         gemini_t = claude_home / ".gemini" / "settings.json"
-        for t in (claude_t, codex_t, gemini_t):
-            t.parent.mkdir(parents=True, exist_ok=True)
-            t.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
+
+        def _reset_targets() -> None:
+            for t in (claude_t, codex_t, gemini_t):
+                t.parent.mkdir(parents=True, exist_ok=True)
+                t.write_text(json.dumps({"hooks": {}}) + "\n", encoding="utf-8")
+
+        _reset_targets()
         _make_canonical_settings(
             tmp_path,
             {"hooks": {"PostToolUse": [_rule("Write", "echo")]}},
         )
 
-        budget = 0.3
-        monkeypatch.setattr(settings_mod, "_SETTINGS_LOCK_BUDGET_S", budget)
+        budget = 0.5
 
-        # Hold TWO of the three target locks. Per-target bounding would wait
-        # ~2×budget; the shared deadline caps the total at ~one budget (once it
-        # expires, the remaining targets get a 0s non-blocking attempt).
+        # An absolute wall-clock bound was flaky: it folds the lock wait together
+        # with fixed I/O + portalocker overhead, which on a slow/loaded runner
+        # (the Windows CI runner) can dwarf the budget. Isolate the lock wait by
+        # subtracting a *symmetric* baseline — the SAME two locks held, but with a
+        # 0s budget so the contended targets abort immediately. That baseline runs
+        # the identical work profile (two aborts + one Gemini write) minus only
+        # the budgeted wait, so the subtraction removes overhead without the
+        # asymmetry of a no-lock 3-write fan-out (which would over-subtract and
+        # could mask a per-target regression).
+        monkeypatch.setattr(settings_mod, "_SETTINGS_LOCK_BUDGET_S", 0.0)
+        start = time.monotonic()
+        with _file_lock(_lock_path_for(claude_t)), _file_lock(_lock_path_for(codex_t)):
+            base_results = generate_all_settings(tmp_path, scope="user")
+        baseline = time.monotonic() - start
+        _reset_targets()
+        # The 0s baseline already shows the abort/ok split — both held targets
+        # abort and the free one writes, identical to the measured run's profile;
+        # its only difference is the budgeted wait.
+        assert base_results["claude_settings"].status == "aborted"
+        assert base_results["codex_settings"].status == "aborted"
+        assert base_results["gemini_settings"].status == "ok"
+
+        # Now the real budget. Hold the same TWO locks: per-target bounding waits
+        # ~2×budget; the shared deadline caps the *total* lock wait at ~one budget
+        # (once it expires the remaining held target gets a 0s non-blocking
+        # attempt).
+        monkeypatch.setattr(settings_mod, "_SETTINGS_LOCK_BUDGET_S", budget)
         start = time.monotonic()
         with _file_lock(_lock_path_for(claude_t)), _file_lock(_lock_path_for(codex_t)):
             results = generate_all_settings(tmp_path, scope="user")
-        elapsed = time.monotonic() - start
+        held_elapsed = time.monotonic() - start
 
-        # Whole call bounded by ~one budget — strictly less than the 2×budget a
-        # per-target bound would have spent.
-        assert elapsed < budget * 1.8
+        # The wait added over the symmetric baseline reflects ONE shared budget
+        # (~1×budget), strictly less than the ~2×budget a per-target bound would
+        # accumulate — discriminated without a fragile absolute threshold.
+        lock_wait = held_elapsed - baseline
+        assert lock_wait < budget * 1.8, (held_elapsed, baseline, lock_wait)
         # Held targets aborted; the free one (gemini) still wrote ok.
         assert results["claude_settings"].status == "aborted"
         assert results["codex_settings"].status == "aborted"


### PR DESCRIPTION
## test(context): de-flake the settings lock-budget timing assertion

### Symptom
`test_context_settings.py::TestClaudeSettingsCrossProcessLock::test_lock_budget_bounds_whole_call_not_per_target`
failed on **windows-latest** during v0.2.2 post-merge CI:

```
assert 1.3590000000000373 < (0.3 * 1.8)
```

A rerun passed — timing flake on the slow/loaded Windows runner, unrelated to
the change under test.

### Root cause
The test asserted an **absolute wall-clock** bound (`elapsed < budget * 1.8`,
`budget=0.3s`) around the whole `generate_all_settings` call. That folds the
lock wait it actually wants to measure together with fixed I/O +
portalocker-setup overhead. On a fast runner the overhead is negligible vs the
budget; on a slow Windows runner it was ~1s, dwarfing the 0.3s budget and
blowing past the `< 0.54s` threshold even though the whole-call lock bound was
working correctly.

### Fix
Isolate the lock wait by subtracting a **symmetric baseline**: the *same two
target locks held*, but with `_SETTINGS_LOCK_BUDGET_S = 0` so the contended
targets abort immediately. The baseline runs the identical work profile (two
aborts + one Gemini write) minus only the budgeted wait, so the subtraction
removes runner-dependent overhead and the assertion bounds the **incremental**
lock wait:

```python
lock_wait = held_elapsed - baseline
assert lock_wait < budget * 1.8
```

This still discriminates whole-call (~1×budget) from per-target (~2×budget)
bounding without a fragile absolute threshold. Budget bumped to 0.5s for signal
margin.

*(First draft used a no-lock 3-write baseline; review flagged that the
write-count asymmetry could over-subtract and mask a per-target regression, so
the baseline was made symmetric.)*

### Verification
- Mutation-tested on Python 3.12: passes on the shared-deadline production code;
  flipping the production wait to a fresh per-target budget makes the measured
  `lock_wait` ~2×budget (1.0s) and the assertion fails as intended.
- `TestClaudeSettingsCrossProcessLock` (4 tests) pass; ruff check + format clean.
- Test-only change — no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
