### PR TITLE
feat(init): split Codex memories into per-subdir namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`mm init` splits Codex memories into per-subdir namespaces.** The provider
+  preset for `~/.codex/memories/` now generates three ordered namespace rules
+  instead of one flat `codex` rule: `codex:rollout_summaries` (per-session
+  episodic recaps), `codex:extensions` (the ad-hoc note inbox), and
+  `codex:global` (the consolidated top-level memory) as the catch-all. Folding
+  those three distinct memory classes into one namespace defeated per-class
+  search and time-decay. Rules use literal namespaces only, so the RFC #304
+  placeholder lock is unaffected. Re-running `mm init` after upgrading migrates
+  an existing flat `codex` rule in place: the stale catch-all is removed and the
+  split takes its position (reported with a `↻` line), so the new subdir rules
+  resolve correctly under first-match-wins instead of being shadowed. A
+  hand-edited codex rule (custom namespace) is never touched. Existing indexed
+  data is migrated by re-running `mm index ~/.codex/memories --force`.
+
 ## [0.2.2] — 2026-05-31
 
 Patch release on top of 0.2.1: adds network MCP transports, a `mm web`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
-- **`mm init` splits Codex memories into per-subdir namespaces.** The provider
+- **`mm init` splits Codex memories into per-subdir namespaces (#1164).** The provider
   preset for `~/.codex/memories/` now generates three ordered namespace rules
   instead of one flat `codex` rule: `codex:rollout_summaries` (per-session
   episodic recaps), `codex:extensions` (the ad-hoc note inbox), and

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -566,7 +566,9 @@ Example `~/.memtomem/config.d/10-namespace-rules.json`:
     "rules": [
       { "path_glob": "~/.claude/projects/*/memory/**",      "namespace": "claude:memory" },
       { "path_glob": "~/.claude/projects/*/*/subagents/**", "namespace": "claude:subagents" },
-      { "path_glob": "~/.codex/memories/**",                "namespace": "codex:memories" },
+      { "path_glob": "~/.codex/memories/rollout_summaries/**", "namespace": "codex:rollout_summaries" },
+      { "path_glob": "~/.codex/memories/extensions/**",        "namespace": "codex:extensions" },
+      { "path_glob": "~/.codex/memories/**",                   "namespace": "codex:global" },
       { "path_glob": "~/.gemini/**",                        "namespace": "gemini:{parent}" },
       { "path_glob": "~/Library/CloudStorage/GoogleDrive-*/**/memtomem-memories/*/**",
         "namespace": "gdrive:{parent}" }

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -667,15 +667,27 @@ def _step_memory_dir(state: dict) -> None:
 # wizard step so auto_ns doesn't collapse ``~/.claude/projects/FOO/memory/**``
 # to the generic ``default`` namespace (issue #296).
 #
+# Each category maps to an ORDERED tuple of ``(path_glob, namespace)`` rules.
+# Order is significant: the indexer resolves the first matching rule
+# (``_resolve_namespace``), so per-subdir rules MUST precede the catch-all.
+#
 # ``claude-memory`` uses ``{ancestor:1}`` (the project-id folder above the
-# generic ``memory`` basename); single-dir categories use literal namespaces.
-# The flat ``claude-plans`` / ``codex`` labels are deliberately conservative:
-# RFC #304 may migrate these into a vendor/product hierarchy later. Re-visit
-# when that issue settles a wire format.
-_PROVIDER_RULE_TEMPLATES: dict[str, tuple[str, str]] = {
-    "claude-memory": ("~/.claude/projects/*/memory/**", "claude:{ancestor:1}"),
-    "claude-plans": ("~/.claude/plans/**", "claude-plans"),
-    "codex": ("~/.codex/memories/**", "codex"),
+# generic ``memory`` basename). ``codex`` splits ``~/.codex/memories/`` by its
+# first-level subdir: that tree mixes three distinct memory classes —
+# ``rollout_summaries/`` (per-session episodic recaps) and ``extensions/``
+# (ad-hoc note inbox) alongside the consolidated top-level memory — and
+# folding all of them into one ``codex`` namespace defeats per-class
+# search/decay. The split uses literal namespaces (no new placeholder), so the
+# ``_VALID_PRESET_PLACEHOLDERS`` lock below stays satisfied; RFC #304's broader
+# vendor/product hierarchy can still supersede these later.
+_PROVIDER_RULE_TEMPLATES: dict[str, tuple[tuple[str, str], ...]] = {
+    "claude-memory": (("~/.claude/projects/*/memory/**", "claude:{ancestor:1}"),),
+    "claude-plans": (("~/.claude/plans/**", "claude-plans"),),
+    "codex": (
+        ("~/.codex/memories/rollout_summaries/**", "codex:rollout_summaries"),
+        ("~/.codex/memories/extensions/**", "codex:extensions"),
+        ("~/.codex/memories/**", "codex:global"),
+    ),
 }
 
 # Lock placeholders permitted in the preset table until RFC #304 settles the
@@ -685,8 +697,22 @@ _VALID_PRESET_PLACEHOLDERS: frozenset[str] = frozenset({"{ancestor:1}"})
 
 assert all(
     not any(tok in ns for tok in ("{", "}")) or any(tok in ns for tok in _VALID_PRESET_PLACEHOLDERS)
-    for _, ns in _PROVIDER_RULE_TEMPLATES.values()
+    for rules in _PROVIDER_RULE_TEMPLATES.values()
+    for _, ns in rules
 ), "preset namespaces may only use _VALID_PRESET_PLACEHOLDERS until #304 decides the hierarchy"
+
+# Legacy wizard presets that a newer preset replaces. When a prior ``mm init``
+# wrote one of these and the user re-runs after upgrading, the exact old rule
+# is dropped during merge so its replacement lands in the correct
+# first-match-wins position instead of shadowing (or being shadowed by) the
+# stale rule. Keyed by provider category; a rule is only removed when that
+# category's preset is being (re-)applied this run. Matching is exact on BOTH
+# namespace and path_glob (after ``~`` expansion), so a hand-edited rule is
+# never touched.
+_SUPERSEDED_PRESET_RULES: dict[str, tuple[tuple[str, str], ...]] = {
+    # codex was a single flat ``codex`` catch-all before the per-subdir split.
+    "codex": (("~/.codex/memories/**", "codex"),),
+}
 
 
 def _expand_glob_for_compare(path_glob: str) -> str:
@@ -723,30 +749,99 @@ def _rule_matches_existing(new_path_glob: str, existing_rules: list[dict]) -> bo
     return False
 
 
-def _proposed_rule_for_category(category: str) -> dict | None:
-    """Return the ``{path_glob, namespace}`` dict for a category, or None."""
-    template = _PROVIDER_RULE_TEMPLATES.get(category)
-    if template is None:
+def _proposed_rules_for_category(category: str) -> list[dict]:
+    """Return the ordered ``{path_glob, namespace}`` rule dicts for a category.
+
+    A category may map to multiple rules (e.g. Codex splits its memories
+    directory into per-subdir namespaces). Returns an empty list for
+    categories with no preset. Order is preserved and significant: callers
+    MUST keep it so first-match-wins resolution places specific subdir rules
+    before the catch-all.
+    """
+    return [
+        {"path_glob": path_glob, "namespace": namespace}
+        for path_glob, namespace in _PROVIDER_RULE_TEMPLATES.get(category, ())
+    ]
+
+
+def _superseded_category(rule: dict, proposed_categories: set[str]) -> str | None:
+    """Return the category whose superseded-preset list contains *rule*.
+
+    Only categories in *proposed_categories* (the ones whose preset is being
+    applied this run) are considered. Matches exactly on namespace and on
+    path_glob after ``~`` expansion, so a user's customised rule is never
+    removed. Returns ``None`` when *rule* is not a superseded legacy preset.
+    """
+    pg = rule.get("path_glob")
+    ns = rule.get("namespace")
+    if not isinstance(pg, str) or not isinstance(ns, str):
         return None
-    path_glob, namespace = template
-    return {"path_glob": path_glob, "namespace": namespace}
+    target = _expand_glob_for_compare(pg)
+    for cat in proposed_categories:
+        for old_glob, old_ns in _SUPERSEDED_PRESET_RULES.get(cat, ()):
+            if old_ns == ns and _expand_glob_for_compare(old_glob) == target:
+                return cat
+    return None
+
+
+def _recursive_glob_prefix(path_glob: str) -> str | None:
+    """Return the directory prefix of a recursive ``BASE/**`` glob, else None.
+
+    ``~`` is expanded and case is folded so the result is comparable across
+    the tilde/absolute forms a config may store. Returns ``None`` for
+    non-recursive globs (``BASE/*`` or a bare path), which never act as a
+    catch-all over a nested subtree.
+    """
+    g = _expand_glob_for_compare(path_glob).lower().rstrip("/")
+    if g.endswith("/**"):
+        return g[: -len("/**")]
+    return None
+
+
+def _glob_shadows(outer_glob: str, inner_glob: str) -> bool:
+    """True if recursive *outer_glob* covers everything *inner_glob* matches.
+
+    Pure prefix logic on the expanded directory bases — enough to catch a
+    user-kept ``~/.codex/memories/** -> custom`` catch-all shadowing a freshly
+    proposed ``~/.codex/memories/<subdir>/**`` rule (first-match-wins would
+    leave the subdir rule dead). Conservative: only recognises the recursive
+    catch-all case, so it never drops a rule that would actually be reachable.
+    """
+    outer = _recursive_glob_prefix(outer_glob)
+    if outer is None:
+        return False
+    inner = _recursive_glob_prefix(inner_glob)
+    inner_base = (
+        inner if inner is not None else _expand_glob_for_compare(inner_glob).lower().rstrip("/")
+    )
+    return inner_base == outer or inner_base.startswith(outer + "/")
 
 
 def _emit_rules_banner(
     proposed: list[tuple[str, dict]],
     skipped: list[tuple[str, dict]],
+    replaced: list[tuple[str, dict]] | None = None,
+    shadowed: list[tuple[str, dict]] | None = None,
 ) -> None:
     """Print the pre-write rules banner.
 
-    ``proposed`` and ``skipped`` carry ``(category, rule_dict)`` pairs.
-    Banner is emitted only when at least one rule was offered; an
-    all-skipped run still prints a one-liner so the user knows the wizard
-    looked at rules but decided existing ones covered them.
+    ``proposed``, ``skipped``, ``replaced``, and ``shadowed`` carry
+    ``(category, rule_dict)`` pairs. ``replaced`` lists legacy preset rules
+    being removed so a newer preset can take their place (e.g. the codex
+    flat→split migration); each ``rule_dict`` there is the *old* rule.
+    ``shadowed`` lists proposed rules that were *not* written because an
+    existing rule already covers their tree (first-match-wins) — surfaced so
+    the wizard never silently drops a rule it would otherwise claim to add.
+    Banner is emitted only when there is something to report; an all-skipped
+    run still prints a one-liner so the user knows the wizard looked at rules
+    but decided existing ones covered them.
     """
-    if not proposed and not skipped:
+    replaced = replaced or []
+    shadowed = shadowed or []
+    if not proposed and not skipped and not replaced and not shadowed:
         return
     click.echo("  Namespace rules:")
-    if not proposed and skipped:
+    if not proposed and not replaced and not shadowed and skipped:
         n = len(skipped)
         click.secho(
             f"    {n} rule(s) already managed, nothing to add.",
@@ -754,11 +849,17 @@ def _emit_rules_banner(
         )
         click.echo()
         return
+    for _, rule in replaced:
+        line = f"    ↻ {rule['path_glob']:<40} (replaced legacy '{rule['namespace']}' rule)"
+        click.secho(line, fg="cyan")
     for _, rule in proposed:
         line = f"    + {rule['path_glob']:<40} → {rule['namespace']}"
         click.secho(line, fg="green")
     for _, rule in skipped:
         line = f"    ⏭ {rule['path_glob']:<40} (existing rule kept)"
+        click.secho(line, fg="yellow")
+    for _, rule in shadowed:
+        line = f"    ⚠ {rule['path_glob']:<40} (shadowed by an existing rule — not added)"
         click.secho(line, fg="yellow")
     click.echo()
 
@@ -827,9 +928,7 @@ def _step_provider_dirs(state: dict) -> None:
 
     state["provider_dirs"] = [str(p) for p in selected]
     state["provider_rules"] = [
-        (cat, _proposed_rule_for_category(cat))
-        for cat in accepted_categories
-        if _proposed_rule_for_category(cat) is not None
+        (cat, rule) for cat in accepted_categories for rule in _proposed_rules_for_category(cat)
     ]
     if selected:
         click.secho(f"  Added {len(selected)} provider folder(s) to memory_dirs.", fg="green")
@@ -2105,6 +2204,24 @@ def _write_config_and_summary(
         existing_ns = existing.setdefault("namespace", {})
         raw_rules = existing_ns.get("rules")
         existing_rules: list[dict] = raw_rules if isinstance(raw_rules, list) else []
+
+        # Drop superseded legacy presets for the categories being applied so a
+        # re-run after upgrading replaces — rather than shadows — the stale
+        # rule (e.g. the codex flat ``codex`` catch-all that the per-subdir
+        # split supersedes). Without this, the new subdir rules would land
+        # *after* the old catch-all and never match (first-match-wins).
+        proposed_cats = {cat for cat, _ in proposed_rules}
+        replaced: list[tuple[str, dict]] = []
+        if existing_rules:
+            kept: list[dict] = []
+            for r in existing_rules:
+                cat = _superseded_category(r, proposed_cats)
+                if cat is not None:
+                    replaced.append((cat, r))
+                else:
+                    kept.append(r)
+            existing_rules = kept
+
         to_append: list[tuple[str, dict]] = []
         to_skip: list[tuple[str, dict]] = []
         for cat, rule in proposed_rules:
@@ -2112,8 +2229,27 @@ def _write_config_and_summary(
                 to_skip.append((cat, rule))
             else:
                 to_append.append((cat, rule))
-        _emit_rules_banner(to_append, to_skip)
-        if to_append:
+
+        # Drop proposals made unreachable by a surviving existing rule whose
+        # recursive glob already covers their tree (first-match-wins). Without
+        # this, a user-kept custom catch-all (e.g. ``~/.codex/memories/** ->
+        # my-ns``) would get the proposed subdir rules appended after it —
+        # dead config the banner would falsely report as added.
+        existing_globs = [
+            r["path_glob"] for r in existing_rules if isinstance(r.get("path_glob"), str)
+        ]
+        shadowed: list[tuple[str, dict]] = []
+        if existing_globs and to_append:
+            reachable: list[tuple[str, dict]] = []
+            for cat, rule in to_append:
+                if any(_glob_shadows(g, rule["path_glob"]) for g in existing_globs):
+                    shadowed.append((cat, rule))
+                else:
+                    reachable.append((cat, rule))
+            to_append = reachable
+
+        _emit_rules_banner(to_append, to_skip, replaced, shadowed)
+        if replaced or to_append:
             merged_rules = list(existing_rules)
             for _, rule in to_append:
                 merged_rules.append(dict(rule))
@@ -2546,9 +2682,7 @@ def _step_provider_dirs_auto(state: dict) -> None:
 
     state["provider_dirs"] = [str(p) for p in selected]
     state["provider_rules"] = [
-        (cat, _proposed_rule_for_category(cat))
-        for cat in accepted_categories
-        if _proposed_rule_for_category(cat) is not None
+        (cat, rule) for cat in accepted_categories for rule in _proposed_rules_for_category(cat)
     ]
     click.secho(
         f"  Auto-added {len(selected)} provider folder(s) "
@@ -2593,8 +2727,7 @@ def _resolve_provider_dirs_non_interactive(
         if cat in categories_to_add:
             for d in grouped.get(cat, []):
                 provider_dirs.append(str(d))
-            rule = _proposed_rule_for_category(cat)
-            if rule is not None:
+            for rule in _proposed_rules_for_category(cat):
                 provider_rules.append((cat, rule))
     state["provider_dirs"] = provider_dirs
     state["provider_rules"] = provider_rules

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -784,15 +784,27 @@ def _superseded_category(rule: dict, proposed_categories: set[str]) -> str | Non
     return None
 
 
+def _normalize_glob_for_prefix(path_glob: str) -> str:
+    """Expand ``~``, fold case, and unify separators for prefix comparison.
+
+    Crucially normalises ``\\`` → ``/``: ``_expand_glob_for_compare`` runs
+    ``Path.expanduser()``, which on Windows yields backslash separators
+    (``C:\\Users\\me\\.codex\\memories\\**``). The prefix/suffix logic below
+    is separator-sensitive, so without this the ``/**`` check silently fails
+    on Windows and shadowing is never detected.
+    """
+    return _expand_glob_for_compare(path_glob).replace("\\", "/").lower().rstrip("/")
+
+
 def _recursive_glob_prefix(path_glob: str) -> str | None:
     """Return the directory prefix of a recursive ``BASE/**`` glob, else None.
 
-    ``~`` is expanded and case is folded so the result is comparable across
-    the tilde/absolute forms a config may store. Returns ``None`` for
-    non-recursive globs (``BASE/*`` or a bare path), which never act as a
-    catch-all over a nested subtree.
+    ``~`` is expanded, separators unified, and case folded so the result is
+    comparable across the tilde/absolute/Windows forms a config may store.
+    Returns ``None`` for non-recursive globs (``BASE/*`` or a bare path),
+    which never act as a catch-all over a nested subtree.
     """
-    g = _expand_glob_for_compare(path_glob).lower().rstrip("/")
+    g = _normalize_glob_for_prefix(path_glob)
     if g.endswith("/**"):
         return g[: -len("/**")]
     return None
@@ -811,9 +823,7 @@ def _glob_shadows(outer_glob: str, inner_glob: str) -> bool:
     if outer is None:
         return False
     inner = _recursive_glob_prefix(inner_glob)
-    inner_base = (
-        inner if inner is not None else _expand_glob_for_compare(inner_glob).lower().rstrip("/")
-    )
+    inner_base = inner if inner is not None else _normalize_glob_for_prefix(inner_glob)
     return inner_base == outer or inner_base.startswith(outer + "/")
 
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3691,6 +3691,30 @@ class TestProviderPresetRules:
         assert _rule_matches_existing("~/.codex/memories/**", existing) is True
         assert _rule_matches_existing("~/.claude/plans/**", existing) is False
 
+    def test_glob_shadows_is_separator_agnostic(self) -> None:
+        """``_glob_shadows`` must handle backslash separators — on Windows
+        ``Path.expanduser()`` yields ``C:\\Users\\…\\**``, and a separator-naive
+        ``/**`` check silently stops detecting shadowing there (regression: the
+        codex split shipped subdir rules behind a user catch-all on Windows)."""
+        from memtomem.cli.init_cmd import _glob_shadows
+
+        # Windows-style backslash globs (already expanded, no tilde).
+        outer_win = r"C:\Users\me\.codex\memories\**"
+        inner_win = r"C:\Users\me\.codex\memories\rollout_summaries\**"
+        assert _glob_shadows(outer_win, inner_win) is True
+        # POSIX equivalents still shadow.
+        assert (
+            _glob_shadows(
+                "/Users/me/.codex/memories/**",
+                "/Users/me/.codex/memories/rollout_summaries/**",
+            )
+            is True
+        )
+        # An unrelated tree never shadows, on either separator.
+        assert _glob_shadows(r"C:\Users\me\.gemini\**", inner_win) is False
+        # A non-recursive outer glob never acts as a catch-all.
+        assert _glob_shadows(r"C:\Users\me\.codex\memories\*", inner_win) is False
+
     def test_include_provider_flag_writes_rule_when_dirs_present(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3430,7 +3430,6 @@ class TestProviderPresetRules:
         [
             ("claude-memory", "~/.claude/projects/*/memory/**", "claude:{ancestor:1}"),
             ("claude-plans", "~/.claude/plans/**", "claude-plans"),
-            ("codex", "~/.codex/memories/**", "codex"),
         ],
     )
     def test_step_collects_rule_for_accepted_category(
@@ -3458,6 +3457,38 @@ class TestProviderPresetRules:
         cat, rule = rules[0]
         assert cat == category
         assert rule == {"path_glob": expected_glob, "namespace": expected_ns}
+
+    def test_step_collects_codex_split_rules(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Codex maps to an ordered 3-rule split: the per-subdir rules
+        (rollout_summaries, extensions) MUST precede the ``codex:global``
+        catch-all so first-match-wins routes each subtree correctly."""
+        from memtomem.cli import init_cmd
+
+        target = tmp_path / "codex"
+        target.mkdir()
+        monkeypatch.setattr(
+            "memtomem.config._detect_provider_dirs",
+            lambda: {"claude-memory": [], "claude-plans": [], "codex": [target]},
+        )
+        monkeypatch.setattr(init_cmd, "nav_confirm", lambda *a, **kw: True)
+
+        state: dict = {}
+        init_cmd._step_provider_dirs(state)
+
+        rules = state.get("provider_rules", [])
+        assert [(cat, r["namespace"]) for cat, r in rules] == [
+            ("codex", "codex:rollout_summaries"),
+            ("codex", "codex:extensions"),
+            ("codex", "codex:global"),
+        ]
+        globs = [r["path_glob"] for _, r in rules]
+        # catch-all is last; subdir rules precede it (first-match-wins)
+        assert globs[-1] == "~/.codex/memories/**"
+        assert globs.index("~/.codex/memories/rollout_summaries/**") < globs.index(
+            "~/.codex/memories/**"
+        )
 
     def test_step_skips_rule_when_category_declined(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
@@ -3490,7 +3521,7 @@ class TestProviderPresetRules:
                 "claude-memory",
                 {"path_glob": "~/.claude/projects/*/memory/**", "namespace": "claude:{ancestor:1}"},
             ),
-            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"}),
         ]
         _write_config_and_summary(state, tmp_path)
 
@@ -3500,7 +3531,7 @@ class TestProviderPresetRules:
             "path_glob": "~/.claude/projects/*/memory/**",
             "namespace": "claude:{ancestor:1}",
         } in rules
-        assert {"path_glob": "~/.codex/memories/**", "namespace": "codex"} in rules
+        assert {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"} in rules
 
     def test_write_is_idempotent_on_rerun(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3512,7 +3543,18 @@ class TestProviderPresetRules:
         set_home(monkeypatch, tmp_path)
         state = _make_init_state(tmp_path)
         state["provider_rules"] = [
-            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+            (
+                "codex",
+                {
+                    "path_glob": "~/.codex/memories/rollout_summaries/**",
+                    "namespace": "codex:rollout_summaries",
+                },
+            ),
+            (
+                "codex",
+                {"path_glob": "~/.codex/memories/extensions/**", "namespace": "codex:extensions"},
+            ),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"}),
         ]
 
         _write_config_and_summary(state, tmp_path)
@@ -3520,8 +3562,71 @@ class TestProviderPresetRules:
 
         data = json.loads((tmp_path / ".memtomem" / "config.json").read_text(encoding="utf-8"))
         rules = data["namespace"]["rules"]
-        matching = [r for r in rules if r.get("path_glob") == "~/.codex/memories/**"]
-        assert len(matching) == 1, f"expected one codex rule, got {matching}"
+        # each codex glob appears exactly once — dedup by path_glob, and the
+        # re-run's ``codex:global`` is not mistaken for the legacy flat rule.
+        for glob in (
+            "~/.codex/memories/rollout_summaries/**",
+            "~/.codex/memories/extensions/**",
+            "~/.codex/memories/**",
+        ):
+            matching = [r for r in rules if r.get("path_glob") == glob]
+            assert len(matching) == 1, f"expected one {glob} rule, got {matching}"
+
+    def test_write_migrates_legacy_flat_codex_rule(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Upgrade path: a config written by the old flat-``codex`` preset is
+        migrated on re-run. The stale ``~/.codex/memories/** -> codex`` rule is
+        removed and the per-subdir split takes its place — in order, with no
+        dead/duplicate catch-all (Codex review Blocker #1)."""
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        set_home(monkeypatch, tmp_path)
+        # Seed a config carrying the exact legacy flat codex preset.
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "namespace": {
+                        "rules": [{"path_glob": "~/.codex/memories/**", "namespace": "codex"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            (
+                "codex",
+                {
+                    "path_glob": "~/.codex/memories/rollout_summaries/**",
+                    "namespace": "codex:rollout_summaries",
+                },
+            ),
+            (
+                "codex",
+                {"path_glob": "~/.codex/memories/extensions/**", "namespace": "codex:extensions"},
+            ),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"}),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
+        rules = data["namespace"]["rules"]
+        namespaces = [r["namespace"] for r in rules]
+        globs = [r["path_glob"] for r in rules]
+
+        # Legacy flat codex is gone; the split is present.
+        assert "codex" not in namespaces
+        assert {"codex:rollout_summaries", "codex:extensions", "codex:global"} <= set(namespaces)
+        # Exactly one catch-all, and subdir rules precede it (first-match-wins).
+        assert globs.count("~/.codex/memories/**") == 1
+        assert globs.index("~/.codex/memories/rollout_summaries/**") < globs.index(
+            "~/.codex/memories/**"
+        )
+        assert globs.index("~/.codex/memories/extensions/**") < globs.index("~/.codex/memories/**")
 
     def test_write_preserves_user_rule_on_same_glob_diff_namespace(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -3546,14 +3651,30 @@ class TestProviderPresetRules:
         )
 
         state = _make_init_state(tmp_path)
+        # Propose the real codex split. The custom catch-all wins for the
+        # ``**`` glob, AND the subdir rules must NOT be appended behind it —
+        # they would be unreachable (first-match-wins) and dead config.
         state["provider_rules"] = [
-            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+            (
+                "codex",
+                {
+                    "path_glob": "~/.codex/memories/rollout_summaries/**",
+                    "namespace": "codex:rollout_summaries",
+                },
+            ),
+            (
+                "codex",
+                {"path_glob": "~/.codex/memories/extensions/**", "namespace": "codex:extensions"},
+            ),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"}),
         ]
         _write_config_and_summary(state, tmp_path)
 
         data = json.loads((config_dir / "config.json").read_text(encoding="utf-8"))
         rules = data["namespace"]["rules"]
-        assert len(rules) == 1
+        # Only the user's custom catch-all remains: codex:global deduped away,
+        # the two subdir rules dropped as shadowed (not written behind it).
+        assert len(rules) == 1, f"no shadowed subdir rules should be written, got {rules}"
         assert rules[0]["namespace"] == "my-codex", "user override should be preserved"
 
     def test_dedup_expanduser_normalizes_both_sides(
@@ -3647,7 +3768,50 @@ class TestProviderPresetRules:
         from memtomem.cli.init_cmd import _write_config_and_summary
 
         set_home(monkeypatch, tmp_path)
-        # Seed: codex rule already present, claude-plans not.
+        # Seed: claude-plans rule already present, codex not. (A pre-existing
+        # rule with a namespace that is *not* a superseded preset is kept and
+        # reported as skipped, not replaced.)
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "namespace": {
+                        "rules": [{"path_glob": "~/.claude/plans/**", "namespace": "claude-plans"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            ("claude-plans", {"path_glob": "~/.claude/plans/**", "namespace": "claude-plans"}),
+            (
+                "codex",
+                {
+                    "path_glob": "~/.codex/memories/rollout_summaries/**",
+                    "namespace": "codex:rollout_summaries",
+                },
+            ),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "Namespace rules:" in out
+        assert "+ ~/.codex/memories/rollout_summaries/**" in out
+        assert "⏭ ~/.claude/plans/**" in out
+
+    def test_banner_reports_replaced_legacy_rule(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Migrating the flat codex preset surfaces a ``↻`` replaced line so
+        the rewrite is not silent."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
@@ -3660,18 +3824,55 @@ class TestProviderPresetRules:
             ),
             encoding="utf-8",
         )
-
         state = _make_init_state(tmp_path)
         state["provider_rules"] = [
-            ("claude-plans", {"path_glob": "~/.claude/plans/**", "namespace": "claude-plans"}),
-            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"}),
         ]
         _write_config_and_summary(state, tmp_path)
 
         out = unstyle(capsys.readouterr().out)
-        assert "Namespace rules:" in out
-        assert "+ ~/.claude/plans/**" in out
-        assert "⏭ ~/.codex/memories/**" in out
+        assert "↻ ~/.codex/memories/**" in out
+        assert "replaced legacy 'codex'" in out
+
+    def test_banner_reports_shadowed_subdir_rule(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A subdir rule made unreachable by a user's custom catch-all is
+        surfaced with a ``⚠`` line rather than silently appended as dead
+        config (Codex review Major)."""
+        from click import unstyle
+
+        from memtomem.cli.init_cmd import _write_config_and_summary
+
+        set_home(monkeypatch, tmp_path)
+        config_dir = tmp_path / ".memtomem"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "namespace": {
+                        "rules": [{"path_glob": "~/.codex/memories/**", "namespace": "my-codex"}]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        state = _make_init_state(tmp_path)
+        state["provider_rules"] = [
+            (
+                "codex",
+                {
+                    "path_glob": "~/.codex/memories/rollout_summaries/**",
+                    "namespace": "codex:rollout_summaries",
+                },
+            ),
+            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex:global"}),
+        ]
+        _write_config_and_summary(state, tmp_path)
+
+        out = unstyle(capsys.readouterr().out)
+        assert "⚠ ~/.codex/memories/rollout_summaries/**" in out
+        assert "shadowed by an existing rule" in out
 
     def test_banner_silent_when_no_proposals(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
@@ -3702,11 +3903,13 @@ class TestProviderPresetRules:
         set_home(monkeypatch, tmp_path)
         config_dir = tmp_path / ".memtomem"
         config_dir.mkdir()
+        # Use a non-superseded preset (claude-plans) so the proposed rule is
+        # skipped (already present), not migrated.
         (config_dir / "config.json").write_text(
             json.dumps(
                 {
                     "namespace": {
-                        "rules": [{"path_glob": "~/.codex/memories/**", "namespace": "codex"}]
+                        "rules": [{"path_glob": "~/.claude/plans/**", "namespace": "claude-plans"}]
                     }
                 }
             ),
@@ -3714,7 +3917,7 @@ class TestProviderPresetRules:
         )
         state = _make_init_state(tmp_path)
         state["provider_rules"] = [
-            ("codex", {"path_glob": "~/.codex/memories/**", "namespace": "codex"}),
+            ("claude-plans", {"path_glob": "~/.claude/plans/**", "namespace": "claude-plans"}),
         ]
         _write_config_and_summary(state, tmp_path)
 
@@ -3731,13 +3934,14 @@ class TestProviderPresetRules:
             _VALID_PRESET_PLACEHOLDERS,
         )
 
-        for _category, (_glob, namespace) in _PROVIDER_RULE_TEMPLATES.items():
-            if "{" in namespace or "}" in namespace:
-                # If placeholders are used, they must be one of the allowed set.
-                assert any(p in namespace for p in _VALID_PRESET_PLACEHOLDERS), (
-                    f"namespace {namespace!r} uses a placeholder outside "
-                    f"_VALID_PRESET_PLACEHOLDERS={_VALID_PRESET_PLACEHOLDERS}"
-                )
+        for _category, rules in _PROVIDER_RULE_TEMPLATES.items():
+            for _glob, namespace in rules:
+                if "{" in namespace or "}" in namespace:
+                    # If placeholders are used, they must be one of the allowed set.
+                    assert any(p in namespace for p in _VALID_PRESET_PLACEHOLDERS), (
+                        f"namespace {namespace!r} uses a placeholder outside "
+                        f"_VALID_PRESET_PLACEHOLDERS={_VALID_PRESET_PLACEHOLDERS}"
+                    )
 
 
 def test_valid_presets_frozenset_matches_literal() -> None:


### PR DESCRIPTION
## Summary

`mm init`'s provider preset routed everything under `~/.codex/memories/` into a
single flat `codex` namespace. That directory actually holds three distinct
memory classes:

| subtree | role |
| --- | --- |
| `rollout_summaries/` | per-session episodic recaps Codex auto-writes |
| `extensions/` | the ad-hoc note inbox awaiting consolidation |
| top-level (`MEMORY.md`, `memory_summary.md`, …) | the consolidated long-term memory |

Folding all three into one namespace defeats per-class search and time-decay
(e.g. you can't decay high-volume rollout recaps harder than the curated core).

This splits the codex preset into three **ordered, literal-namespace** rules,
mirroring the existing `claude:<slug>` convention:

```
~/.codex/memories/rollout_summaries/**  → codex:rollout_summaries
~/.codex/memories/extensions/**         → codex:extensions
~/.codex/memories/**                    → codex:global   (catch-all, last)
```

A single `{parent}`/`{ancestor:N}` template can't express this (codex's depth
varies), so the split is N ordered rules resolved first-match-wins. No new
placeholder is introduced, so the RFC #304 `_VALID_PRESET_PLACEHOLDERS` lock is
left intact — RFC #304's broader vendor/product hierarchy can still supersede
these later.

## Changes

- **Preset machinery now supports multiple rules per category.**
  `_PROVIDER_RULE_TEMPLATES` values become ordered tuples of `(path_glob,
  namespace)`; `_proposed_rule_for_category` → `_proposed_rules_for_category`
  (returns a list). All three build sites and the module-level assert updated.
- **Re-run migration.** The exact legacy flat `codex` rule is removed before the
  split is appended, so the subdir rules land *before* the catch-all
  (first-match-wins). Surfaced with a `↻` banner line. A user's hand-edited
  codex rule (custom namespace) is matched exactly on path_glob **and**
  namespace, so it is never touched.
- **Shadow guard.** If a surviving recursive catch-all (e.g. a user-kept
  `~/.codex/memories/** → custom`) would make a proposed subdir rule
  unreachable, the subdir rule is dropped rather than written as dead config,
  and reported with a `⚠` banner line.
- **Docs / changelog.** `docs/guides/configuration.md` rule example updated to
  the split (also demonstrates first-match-wins ordering); `CHANGELOG.md`
  `[Unreleased]` entry added.

## Migrating existing data

The preset only governs *new* config generation. An already-indexed instance
moves to the new namespaces with a forced re-index (no `--namespace`, so policy
rules apply):

```bash
mm index ~/.codex/memories --force
```

Force re-index re-namespaces chunks in place (chunk identity and per-chunk
personalization preserved, ADR-0005); deleted-source orphans, if any, clear via
the normal delete-by-source path.

## Out of scope

The separate `mm ingest codex-memory` importer (which writes the
`codex-memory:` prefix) is intentionally **not** touched — unifying its prefix
would be a breaking, documented CLI change and belongs in its own PR.

## Review

Design and implementation were both reviewed by Codex (reviewer agent). The
diff-level pass returned no blockers; its one Major — a user's custom catch-all
silently shadowing freshly-appended subdir rules — is fixed by the shadow guard
above (`test_banner_reports_shadowed_subdir_rule`,
`test_write_preserves_user_rule_on_same_glob_diff_namespace`).

## Tests

New: codex 3-rule ordering, flat→split re-run migration, shadow-drop, and the
`↻`/`⚠` banner lines. Updated: the banner skip/all-skipped and idempotency
tests to non-superseded presets. Full suite: 5585 passed, 11 skipped; ruff +
mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
