### PR TITLE
feat(init): add Antigravity CLI MCP registration target

### DIFF
--- a/docs/guides/mcp-clients.md
+++ b/docs/guides/mcp-clients.md
@@ -166,6 +166,12 @@ Restart Claude Desktop after configuration.
 
 ## 5. Gemini CLI
 
+> **Deprecated upstream.** Google is transitioning Gemini CLI to the
+> Antigravity CLI (see [§7](#7-antigravity)). Gemini CLI stops serving
+> free/Pro/Ultra individual tiers on **2026-06-18** (enterprise Gemini Code
+> Assist Standard/Enterprise keep it). New setups should prefer the
+> **Antigravity CLI (`agy`)** instructions in §7.
+
 Create or edit the `~/.gemini/settings.json` file:
 
 ```json
@@ -223,6 +229,17 @@ Call mem_status to check the memtomem connection status
 
 ## 7. Antigravity
 
+"Antigravity" ships as two distinct surfaces with **separate** MCP config
+files — register memtomem in whichever you actually use:
+
+- **Antigravity IDE** (the desktop app / VS Code fork) — configured through
+  the Agent panel UI below.
+- **Antigravity CLI** (`agy`, Google's terminal-native successor to Gemini
+  CLI) — configured by editing `~/.gemini/antigravity-cli/mcp_config.json`
+  directly; see [Antigravity CLI (`agy`)](#antigravity-cli-agy) below.
+
+### Antigravity IDE
+
 1. Click the `...` menu at the top of the Agent panel > **MCP Servers**
 2. Click **Manage MCP Servers** at the top of the MCP Store
 3. Select **View raw config** > `mcp_config.json` will open
@@ -256,6 +273,33 @@ Call mem_status to check the memtomem connection status
 > `Application Support/<AppName>/User/` directory. Register memtomem in
 > whichever file matches the agent you plan to call it from — or both, if
 > you use both.
+
+### Antigravity CLI (`agy`)
+
+The Antigravity CLI is a **separate** surface from the IDE above: it reads
+MCP servers from `~/.gemini/antigravity-cli/mcp_config.json` (key
+`mcpServers`), **not** the IDE's `~/.gemini/antigravity/mcp_config.json`.
+Create or edit that file:
+
+```json
+{
+  "mcpServers": {
+    "memtomem": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["--from", "memtomem", "memtomem-server"],
+      "env": {
+        "MEMTOMEM_INDEXING__MEMORY_DIRS": "[\"~/memories\"]"
+      }
+    }
+  }
+}
+```
+
+Restart the `agy` session after editing. The CLI also reads your existing
+`~/.gemini/GEMINI.md` context and can pull in Gemini/Claude plugins via
+`agy plugin import`, so memory indexed with `mm ingest gemini-memory` keeps
+working unchanged.
 
 ---
 

--- a/packages/memtomem/src/memtomem/cli/init_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/init_cmd.py
@@ -1090,8 +1090,9 @@ def _claude_desktop_config_hint() -> str:
     """Return the Claude Desktop config path for the current OS.
 
     Claude Desktop is the only editor in ``_emit_mcp_paste_hints`` whose
-    config location is OS-specific; Cursor / Windsurf / Gemini CLI all use
-    a single ``~/<dot-dir>/...`` layout that works on every platform."""
+    config location is OS-specific; Cursor / Windsurf / Antigravity CLI /
+    Gemini CLI all use a single ``~/<dot-dir>/...`` layout that works on
+    every platform."""
     if sys.platform == "darwin":
         return "~/Library/Application Support/Claude/claude_desktop_config.json"
     if sys.platform == "win32":
@@ -1105,11 +1106,22 @@ def _emit_mcp_paste_hints() -> None:
     Claude Code auto-loads a project-root ``.mcp.json``; other editors do not
     and expect their own config file. Shown after every path that writes the
     file so users know the generated JSON is a template, not a drop-in config
-    for Cursor/Windsurf/Claude Desktop/Gemini CLI."""
+    for Cursor/Windsurf/Claude Desktop/Antigravity CLI/Gemini CLI.
+
+    Antigravity CLI (``agy``, Google's successor to Gemini CLI) reads MCP
+    servers from its own ``~/.gemini/antigravity-cli/mcp_config.json`` (key
+    ``mcpServers``) — distinct from the Antigravity IDE's
+    ``~/.gemini/antigravity/mcp_config.json``. Each server entry carries
+    ``"type": "stdio"`` there; the generated ``.mcp.json`` omits it, so the
+    hint reminds users to add it when pasting. Gemini CLI's
+    ``~/.gemini/settings.json`` is deprecated upstream on 2026-06-18 for
+    free/Pro/Ultra tiers (enterprise Gemini Code Assist keeps it)."""
     click.echo("    Cursor          → paste into ~/.cursor/mcp.json")
     click.echo("    Windsurf        → paste into ~/.codeium/windsurf/mcp_config.json")
     click.echo(f"    Claude Desktop  → paste into {_claude_desktop_config_hint()}")
-    click.echo("    Gemini CLI      → paste into ~/.gemini/settings.json")
+    click.echo("    Antigravity CLI → paste into ~/.gemini/antigravity-cli/mcp_config.json")
+    click.echo('                      (add "type": "stdio" to the memtomem entry)')
+    click.echo("    Gemini CLI      → paste into ~/.gemini/settings.json (deprecated 2026-06-18)")
     click.echo("  (Claude Code picks up ./.mcp.json in this project automatically.)")
 
 

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -2550,7 +2550,8 @@ class TestFreshFlag:
 class TestMcpPasteHints:
     """The wizard's MCP step writes a Claude-Code-scoped ``.mcp.json`` and must
     surface what the user still has to do for Cursor / Windsurf / Claude
-    Desktop / Gemini CLI (none of which auto-load the project file).
+    Desktop / Antigravity CLI / Gemini CLI (none of which auto-load the
+    project file).
 
     Regression for #246: earlier wording implied ``.mcp.json`` is the config
     file for those editors, which it isn't — each has its own canonical path."""
@@ -2578,6 +2579,10 @@ class TestMcpPasteHints:
         assert "Windsurf" in out and "~/.codeium/windsurf/mcp_config.json" in out
         assert "Claude Desktop" in out
         assert _claude_desktop_config_hint() in out
+        assert "Antigravity CLI → paste into ~/.gemini/antigravity-cli/mcp_config.json" in out
+        # Antigravity CLI's mcp_config.json carries "type": "stdio" on each entry,
+        # which the generated .mcp.json omits — the hint must flag it.
+        assert '(add "type": "stdio" to the memtomem entry)' in out
         assert "Gemini CLI" in out and "~/.gemini/settings.json" in out
         assert "Claude Code picks up ./.mcp.json in this project automatically" in out
 
@@ -2701,8 +2706,8 @@ class TestMcpChoiceOneClaudeAddBranches:
         # user-scope entry covering it.
         assert not (tmp_path / ".mcp.json").exists()
         assert "MCP config: wrote ./.mcp.json" not in out
-        # And paste-hints (Cursor / Windsurf / Claude Desktop / Gemini CLI)
-        # must NOT fire either — the user opted for "auto-register Claude
+        # And paste-hints (Cursor / Windsurf / Claude Desktop / Antigravity CLI
+        # / Gemini CLI) must NOT fire either — the user opted for "auto-register Claude
         # Code", and the existing user-scope entry already covers it. A
         # future refactor that hoists _emit_mcp_paste_hints() out of the
         # generic-failure block would silently spam unrelated paste paths


### PR DESCRIPTION
## Why

Google is transitioning **Gemini CLI → Antigravity CLI** (`agy`, Go). Gemini
CLI stops serving free/Pro/Ultra individual tiers on **2026-06-18** (enterprise
Gemini Code Assist Standard/Enterprise keep it). Verified against a live `agy`
install: Antigravity CLI reads MCP servers from its **own**
`~/.gemini/antigravity-cli/mcp_config.json` (key `mcpServers`, stdio entries) —
distinct from both Gemini CLI's `~/.gemini/settings.json` and the Antigravity
**IDE**'s `~/.gemini/antigravity/mcp_config.json`. memtomem previously surfaced
neither the CLI path nor the Gemini deprecation, so new users could land on a
runtime that stops working in weeks.

## What

- **`mm init` paste-hints** now list **Antigravity CLI** →
  `~/.gemini/antigravity-cli/mcp_config.json` and flag the Gemini CLI line as
  `(deprecated 2026-06-18)`.
- **`docs/guides/mcp-clients.md`** §7 now distinguishes the Antigravity **IDE**
  (existing UI steps) from the **CLI (`agy`)** and documents the CLI's
  `mcp_config.json` shape; §5 **Gemini CLI** gains a deprecation banner pointing
  to §7.

## What this PR intentionally does **not** do

Antigravity CLI *reuses* Gemini's on-disk surfaces — it reads `~/.gemini/GEMINI.md`
unchanged and `agy plugin import` pulls in Gemini/Claude plugins. So the shared
machinery (`GEMINI.md` generator, `mm ingest gemini-memory`, the `gemini` runtime
fan-out) is **kept** — removing it would break Antigravity itself. Hooks are the
one genuinely-different-and-unverified surface (`~/.gemini/antigravity-cli/settings.json`
has no `hooks` key) and are deferred to a separate, spec-gated change.

## Verification

- `uv run pytest packages/memtomem/tests/test_init_cmd.py` — 276 passed (paste-hint
  test extended to assert the Antigravity CLI line).
- `ruff check` + `ruff format --check` clean.
- Doc MCP example verified byte-for-byte against the real on-disk
  `~/.gemini/antigravity-cli/mcp_config.json` (key `mcpServers`, `type: "stdio"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
