### PR TITLE
docs: relabel Gemini CLI → Antigravity CLI as the primary terminal target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   configs, and reverse import are deferred to a follow-up that needs stronger
   host-write and secret-handling policy.
 
+- **Antigravity CLI (`agy`) documented as an MCP target; Gemini CLI marked
+  deprecated (#1167).** Google is replacing Gemini CLI with the Go-based
+  Antigravity CLI; Gemini CLI stops serving free/Pro/Ultra individual tiers on
+  2026-06-18 (enterprise Gemini Code Assist keeps it). Antigravity CLI registers
+  MCP servers in its own `~/.gemini/antigravity-cli/mcp_config.json` (key
+  `mcpServers`, stdio entries with `"type": "stdio"`) — distinct from both Gemini
+  CLI's `~/.gemini/settings.json` and the Antigravity IDE's
+  `~/.gemini/antigravity/mcp_config.json`. The `mm init` paste-hints plus the
+  getting-started, mcp-clients, uninstall, llm-providers, and PyPI README guides
+  now surface this path and the deprecation date. The shared Gemini-compatible
+  surfaces are intentionally unchanged: Antigravity CLI reads `~/.gemini/GEMINI.md`,
+  so `mm ingest gemini-memory` and the `.gemini/` context fan-out keep working —
+  no runtime removed, no config repathed.
+
 - **`mm init` splits Codex memories into per-subdir namespaces (#1164).** The provider
   preset for `~/.codex/memories/` now generates three ordered namespace rules
   instead of one flat `codex` rule: `codex:rollout_summaries` (per-session

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -404,8 +404,9 @@ error.
 Gemini CLI's memory surface is the single file `~/.gemini/GEMINI.md`,
 which doesn't fit a `memory_dirs` (directory) abstraction, and the parent
 `~/.gemini/` directory contains secrets like `oauth_creds.json`. For
-Gemini users, run `mm ingest gemini-memory` for a one-shot import — it
-applies tool-specific tags and skips the noise.
+Gemini users — and Antigravity CLI (`agy`) users, which read the same
+`~/.gemini/GEMINI.md` — run `mm ingest gemini-memory` for a one-shot import;
+it applies tool-specific tags and skips the noise.
 
 #### Migrating from `auto_discover` (legacy)
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -206,7 +206,7 @@ claude mcp add memtomem -s user -- uv run --directory /path/to/memtomem memtomem
 
 Use `-s user` to make memtomem available in all projects. Use `-s project` for one project only.
 
-### Cursor, Windsurf, Claude Desktop, Gemini CLI
+### Cursor, Windsurf, Claude Desktop, Antigravity CLI, Gemini CLI
 
 Add to your MCP config file:
 
@@ -245,9 +245,19 @@ Add to your MCP config file:
 | Cursor | `~/.cursor/mcp.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 | Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Gemini CLI | `~/.gemini/settings.json` |
+| Antigravity CLI (`agy`) | `~/.gemini/antigravity-cli/mcp_config.json` |
+| Gemini CLI (deprecated 2026-06-18) | `~/.gemini/settings.json` |
 
 > **Note**: Claude Code stores its MCP config in `~/.claude.json`, not a separate file.
+>
+> **Gemini CLI → Antigravity CLI.** Google is replacing Gemini CLI with the
+> Antigravity CLI (`agy`); Gemini CLI stops serving free/Pro/Ultra individual
+> tiers on 2026-06-18 (enterprise keeps it). Antigravity CLI uses its own
+> `mcp_config.json` above but still reads `~/.gemini/GEMINI.md`, so memory
+> indexed with `mm ingest gemini-memory` keeps working. In that file each
+> server object also carries `"type": "stdio"` — see the
+> [Antigravity section](mcp-clients.md#7-antigravity) of the MCP client guide
+> for the exact CLI shape.
 
 ### Verify connection
 
@@ -383,7 +393,7 @@ mm watchdog status         # show latest health check results
 mm watchdog run            # run health checks immediately
 mm watchdog history        # view historical health check results
 mm ingest claude-memory    # index Claude Code auto-memory
-mm ingest gemini-memory    # index Gemini CLI memory
+mm ingest gemini-memory    # index Gemini CLI / Antigravity CLI memory (GEMINI.md)
 mm ingest codex-memory     # index Codex CLI memory
 mm shell                   # interactive REPL
 mm web                     # launch Web UI (http://localhost:8080)

--- a/docs/guides/integrations/claude-code.md
+++ b/docs/guides/integrations/claude-code.md
@@ -415,7 +415,7 @@ Yes. Auto-memory automatically extracts from conversations, while memtomem only 
 
 ## Cross-runtime agent context with `mm context`
 
-If you also use Gemini CLI or Codex CLI on the same repo, treat `.memtomem/` as the single source of truth and let memtomem fan it out. Claude Code is the richest target — it preserves every canonical sub-agent field (`name`, `description`, `tools`, `model`, `skills`, `isolation`) without loss, so Claude is the natural place to author canonical agents and skills.
+If you also use Gemini CLI (or its Antigravity CLI successor) or Codex CLI on the same repo, treat `.memtomem/` as the single source of truth and let memtomem fan it out. Claude Code is the richest target — it preserves every canonical sub-agent field (`name`, `description`, `tools`, `model`, `skills`, `isolation`) without loss, so Claude is the natural place to author canonical agents and skills.
 
 ```bash
 # Mirror .memtomem/skills/<name>/SKILL.md to .claude/skills/, .gemini/skills/, .agents/skills/

--- a/docs/guides/llm-providers.md
+++ b/docs/guides/llm-providers.md
@@ -89,7 +89,10 @@ Add the following to your editor's MCP config file — e.g.,
 `~/.cursor/mcp.json` (Cursor),
 `~/.codeium/windsurf/mcp_config.json` (Windsurf),
 `~/Library/Application Support/Claude/claude_desktop_config.json`
-(Claude Desktop), or `~/.gemini/settings.json` (Gemini CLI). For Claude
+(Claude Desktop), `~/.gemini/antigravity-cli/mcp_config.json`
+(Antigravity CLI — its entries also carry `"type": "stdio"`; see
+[mcp-clients.md](mcp-clients.md#7-antigravity)), or
+`~/.gemini/settings.json` (Gemini CLI, deprecated 2026-06-18). For Claude
 Code, use `claude mcp add` instead of editing a file. See
 [MCP Client Configuration](mcp-clients.md) for the full list.
 

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -679,7 +679,8 @@ Per-slug results are printed individually, followed by an aggregate total.
 
 `mm ingest gemini-memory` indexes a Gemini CLI `GEMINI.md` file. Global
 memories live at `~/.gemini/GEMINI.md`; per-project memories sit in the
-project root.
+project root. The Antigravity CLI (`agy`, Gemini CLI's successor) reads the
+same `GEMINI.md`, so this command serves Antigravity users unchanged.
 
 ```
 mm ingest gemini-memory --source ~/.gemini/GEMINI.md --dry-run

--- a/docs/guides/uninstall.md
+++ b/docs/guides/uninstall.md
@@ -44,8 +44,9 @@ config file, then restart the editor.
 | Cursor | `~/.cursor/mcp.json` |
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` |
 | Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) |
-| Gemini CLI | `~/.gemini/settings.json` |
-| Antigravity | MCP Servers panel → remove the memtomem entry |
+| Antigravity CLI (`agy`) | `~/.gemini/antigravity-cli/mcp_config.json` |
+| Antigravity IDE | MCP Servers panel → remove the memtomem entry |
+| Gemini CLI (deprecated 2026-06-18) | `~/.gemini/settings.json` |
 
 Also delete any project-level `.mcp.json` files that contain a memtomem server
 block.

--- a/packages/memtomem/README.md
+++ b/packages/memtomem/README.md
@@ -67,7 +67,9 @@ Or add the following to your MCP client config file — the path depends on
 the editor: `~/.cursor/mcp.json` (Cursor),
 `~/.codeium/windsurf/mcp_config.json` (Windsurf),
 `~/Library/Application Support/Claude/claude_desktop_config.json`
-(Claude Desktop), or `~/.gemini/settings.json` (Gemini CLI):
+(Claude Desktop), `~/.gemini/antigravity-cli/mcp_config.json`
+(Antigravity CLI — entries also carry `"type": "stdio"`), or
+`~/.gemini/settings.json` (Gemini CLI, deprecated 2026-06-18):
 
 ```json
 {


### PR DESCRIPTION
## Why

Follow-up to #1167. Google is replacing **Gemini CLI** with the **Antigravity
CLI** (`agy`); Gemini CLI stops serving free/Pro/Ultra individual tiers on
**2026-06-18** (enterprise Gemini Code Assist keeps it). #1167 added the new MCP
registration path to the init wizard + `mcp-clients.md`; this PR brings the
*rest* of the user-facing guides in line so new users don't set up against a
runtime that stops working in weeks.

## What

- **MCP config location** (Antigravity CLI's own `~/.gemini/antigravity-cli/mcp_config.json`)
  added, Gemini CLI flagged `(deprecated 2026-06-18)`:
  `getting-started.md` (table + note), `uninstall.md` (table — also splits
  Antigravity **IDE** vs **CLI**), `llm-providers.md`, and the PyPI
  `packages/memtomem/README.md`.
- **Shared surfaces noted, not duplicated**: `reference.md`, `configuration.md`,
  and the getting-started command list now say `mm ingest gemini-memory` and the
  `.gemini/` context fan-out also serve Antigravity CLI (it reads
  `~/.gemini/GEMINI.md` unchanged).
- `CHANGELOG.md` [Unreleased] entry.

## What this PR intentionally does **not** do

No implementation runtime key is renamed or repathed. The `gemini` fan-out
(`.gemini/agents|skills|commands`) and `mm ingest gemini-memory` are the
**shared** surfaces Antigravity CLI consumes (it imports Gemini/Claude plugins
and reads `GEMINI.md`), so removing them would break Antigravity. Hooks — the one
genuinely-different, still-unverified surface — are deferred to a separate
spec-gated change.

## Verification

- `uv run pytest packages/memtomem/tests/test_docs_guards.py` — 12 passed.
- All paths/flags verified against a live `agy` install and the real
  `~/.gemini/antigravity-cli/` layout (per docs-as-tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
