### PR TITLE
fix(indexing): enforce provider index-file conventions on every index path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **Provider index-file conventions enforced on every index path (fixes
+  `MEMORY.md` pollution).** The exclude set for agent index/TOC files — Claude
+  Code's `MEMORY.md`/`README.md` and Codex's `README.md` — was previously
+  honored only by `mm ingest`, so the general `memory_dirs` walk, the file
+  watcher, and `mm index <dir>` indexed `MEMORY.md` as searchable content: a
+  pointer-only table of contents that then surfaced as a high-score duplicate
+  on every query. The conventions now live in one table
+  (`config._PROVIDER_INDEX_CONVENTIONS`) consulted by the shared
+  `_path_is_excluded` funnel, so ingest, the engine walk, the watcher, and
+  `mm purge --matching-excluded` all skip the same files. `mm purge
+  --matching-excluded --apply` consequently reclaims `MEMORY.md` chunks indexed
+  before this fix. The convention is provider-scoped — a `MEMORY.md` in a plain
+  user folder is still indexed as real content.
+
 - **MCP server definitions in the Context Gateway (#1165).** A new **MCP Servers**
   gateway section manages canonical definitions under
   `.memtomem/mcp-servers/<name>.json` and fans them out to the project

--- a/packages/memtomem/src/memtomem/cli/ingest_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/ingest_cmd.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import click
 
+from memtomem.config import index_excluded_filenames
 from memtomem.storage.sqlite_namespace import sanitize_namespace_segment
 
 if TYPE_CHECKING:
@@ -39,10 +40,12 @@ class IngestComponents(Protocol):
 
 
 # Files that sit inside a Claude memory directory but should never be
-# indexed as memory content. MEMORY.md is an index (table of contents) whose
-# text is just pointers to the other files — indexing it would surface a
-# high-score duplicate on every query. README.md is usually meta/how-to-read.
-_EXCLUDE_FILENAMES = frozenset({"MEMORY.md", "README.md"})
+# indexed as memory content (MEMORY.md is a pointer-only index whose text
+# would surface a high-score duplicate on every query; README.md is
+# how-to-read meta). Sourced from the single convention table in ``config``
+# so the general engine walk, the file watcher, and ``mm purge`` all enforce
+# the exact same set — see ``_PROVIDER_INDEX_CONVENTIONS``.
+_EXCLUDE_FILENAMES = index_excluded_filenames("claude-memory")
 
 # Filename prefix → tag. Trailing underscore is required so we only match
 # the prefix component, not any substring (``feedbackXYZ.md`` is not a
@@ -85,7 +88,8 @@ _GEMINI_BASE_TAG = "gemini-memory"
 
 _CODEX_NAMESPACE_PREFIX = "codex-memory:"
 _CODEX_BASE_TAG = "codex-memory"
-_CODEX_EXCLUDE_FILENAMES = frozenset({"README.md"})
+# Sourced from the central convention table — see ``_EXCLUDE_FILENAMES`` above.
+_CODEX_EXCLUDE_FILENAMES = index_excluded_filenames("codex")
 
 
 @click.group()

--- a/packages/memtomem/src/memtomem/cli/purge_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/purge_cmd.py
@@ -12,20 +12,23 @@ import click
 def find_sources_matching_excluded(
     sources: Iterable[Path],
     user_patterns: Iterable[str],
+    memory_dirs: Iterable[str | Path],
 ) -> list[Path]:
-    """Return source paths matching the current exclude set (built-in + user).
+    """Return source paths the indexer would now exclude.
 
-    Exposed for testing — the CLI calls this with storage.get_all_source_files().
+    Routes through the indexer's own :func:`_path_is_excluded` so purge
+    targets exactly what indexing skips: provider index-file conventions
+    (e.g. a ``claude-memory`` root's ``MEMORY.md``/``README.md``), the
+    built-in secret/noise denylist, and ``indexing.exclude_patterns``.
+    Sharing the predicate is what lets ``mm purge --matching-excluded``
+    reclaim chunks that were indexed before a convention/exclude was
+    added. Exposed for testing — the CLI calls this with
+    ``storage.get_all_source_files()`` and the configured index roots.
     """
-    from memtomem.indexing.engine import _BUILTIN_EXCLUDE_SPEC, _build_exclude_spec
+    from memtomem.indexing.engine import _build_exclude_spec, _path_is_excluded
 
     user_spec = _build_exclude_spec(user_patterns)
-    matched: list[Path] = []
-    for sf in sources:
-        key = sf.as_posix().lower()
-        if _BUILTIN_EXCLUDE_SPEC.match_file(key) or user_spec.match_file(key):
-            matched.append(sf)
-    return matched
+    return [sf for sf in sources if _path_is_excluded(sf, memory_dirs, user_spec)]
 
 
 @click.command("purge")
@@ -33,7 +36,11 @@ def find_sources_matching_excluded(
     "--matching-excluded",
     "matching_excluded",
     is_flag=True,
-    help="Target chunks whose source_path matches built-in denylist or indexing.exclude_patterns.",
+    help=(
+        "Target chunks whose source_path matches built-in denylist, "
+        "indexing.exclude_patterns, or a provider index-file convention "
+        "(e.g. claude-memory MEMORY.md/README.md)."
+    ),
 )
 @click.option(
     "--apply",
@@ -52,8 +59,11 @@ def purge(matching_excluded: bool, apply_: bool, sample_size: int) -> None:
     """Remove stored chunks matching a selector.
 
     Currently one selector is supported: ``--matching-excluded`` scans every
-    source_file in storage and deletes chunks whose path matches the current
-    exclude set (built-in secret/noise patterns + indexing.exclude_patterns).
+    source_file in storage and deletes chunks whose path the indexer would
+    now exclude — built-in secret/noise patterns, ``indexing.exclude_patterns``,
+    and provider index-file conventions (e.g. a ``claude-memory`` root's
+    ``MEMORY.md``/``README.md``). Use it to reclaim chunks indexed before a
+    convention/exclude was added.
 
     Default is dry-run. Pass ``--apply`` to execute deletion.
     """
@@ -67,7 +77,11 @@ async def _run_matching_excluded(*, apply_: bool, sample_size: int) -> None:
 
     async with cli_components() as comp:
         sources: set[Path] = await comp.storage.get_all_source_files()
-        matched = find_sources_matching_excluded(sources, comp.config.indexing.exclude_patterns)
+        matched = find_sources_matching_excluded(
+            sources,
+            comp.config.indexing.exclude_patterns,
+            comp.config.indexing.all_index_roots(),
+        )
 
         if not matched:
             click.secho("No stored chunks match the current exclude set.", fg="green")

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -1459,6 +1459,68 @@ def categorize_memory_dir(path: str | Path) -> ProviderCategory:
     return "user"
 
 
+# ── Provider index-file conventions ─────────────────────────────────
+# Per-category rules for the agent-managed index/TOC file that lives
+# inside a memory dir. ``index_file`` is the table-of-contents the agent
+# maintains and loads into its context each session (e.g. Claude Code's
+# ``MEMORY.md``). ``exclude_filenames`` are meta files that must never be
+# indexed as searchable content: the TOC is just pointers, so indexing it
+# surfaces a high-score duplicate on every query, and READMEs are
+# how-to-read meta. Centralized here (previously hardcoded in
+# ``cli/ingest_cmd.py``) so EVERY index path — ``mm ingest``, the general
+# engine walk, the file watcher, and ``mm purge`` — honors one set.
+@dataclass(frozen=True)
+class ProviderIndexConvention:
+    """Index-file convention for a single :data:`ProviderCategory`."""
+
+    index_file: str | None
+    exclude_filenames: frozenset[str]
+
+
+_PROVIDER_INDEX_CONVENTIONS: dict[ProviderCategory, ProviderIndexConvention] = {
+    "user": ProviderIndexConvention(index_file=None, exclude_filenames=frozenset()),
+    "claude-memory": ProviderIndexConvention(
+        index_file="MEMORY.md",
+        exclude_filenames=frozenset({"MEMORY.md", "README.md"}),
+    ),
+    "claude-plans": ProviderIndexConvention(index_file=None, exclude_filenames=frozenset()),
+    "codex": ProviderIndexConvention(index_file=None, exclude_filenames=frozenset({"README.md"})),
+}
+
+# Lock: every category must declare a convention. Mirrors the
+# ``_PROVIDER_CATEGORY_PATTERNS`` vocabulary lock above — adding a category
+# to the ``ProviderCategory`` Literal without a convention here trips at
+# import, not silently at the first index of the new provider's dir.
+_INDEX_CONVENTION_LOCK_MESSAGE = (
+    "_PROVIDER_INDEX_CONVENTIONS keys out of sync with ProviderCategory. "
+    "Add the matching convention when adding a category. See RFC #304."
+)
+assert set(_PROVIDER_INDEX_CONVENTIONS.keys()) == _VALID_PROVIDER_CATEGORIES, (
+    _INDEX_CONVENTION_LOCK_MESSAGE
+)
+
+
+def index_excluded_filenames(category: str) -> frozenset[str]:
+    """Filenames never indexed as content for a ``memory_dir`` *category*.
+
+    Accepts ``str`` (not ``ProviderCategory``) so callers can pass the
+    result of :func:`categorize_memory_dir` without narrowing. Unknown
+    categories return the empty set (index everything).
+    """
+    conv = _PROVIDER_INDEX_CONVENTIONS.get(cast(ProviderCategory, category))
+    return conv.exclude_filenames if conv else frozenset()
+
+
+def provider_index_file(category: str) -> str | None:
+    """The agent-managed index/TOC filename for *category*, or ``None``.
+
+    Companion to :func:`index_excluded_filenames` — consumed by the
+    memory-index doctor to locate the per-provider hot-cache index.
+    """
+    conv = _PROVIDER_INDEX_CONVENTIONS.get(cast(ProviderCategory, category))
+    return conv.index_file if conv else None
+
+
 # Pattern matchers for project-tier scope dirs. ``project_local`` MUST
 # precede ``project_shared`` here because ``.local`` is a strict suffix
 # of ``memories`` after the leading-dir match — match the more specific

--- a/packages/memtomem/src/memtomem/indexing/engine.py
+++ b/packages/memtomem/src/memtomem/indexing/engine.py
@@ -26,6 +26,7 @@ from memtomem.config import (
     NamespacePolicyRule,
     categorize_memory_dir,
     classify_scope,
+    index_excluded_filenames,
     memory_dir_kind,
     provider_for_category,
 )
@@ -99,7 +100,30 @@ def _path_is_excluded(
     memory_dirs: Iterable[str | Path],
     user_spec: pathspec.GitIgnoreSpec,
 ) -> bool:
-    """True if ``file_path`` matches any built-in or user exclude pattern."""
+    """True if ``file_path`` matches any exclude rule.
+
+    Three layers, any of which excludes: (1) the provider index-file
+    convention for the ``memory_dir`` root that *owns* the file — e.g. a
+    ``claude-memory`` root's ``MEMORY.md``/``README.md`` is an index/meta
+    file, never content; (2) the built-in secret/noise denylist; (3) the
+    user's ``indexing.exclude_patterns``. Layer (1) is the single
+    enforcement point shared by ``_discover_files`` (dir walk),
+    ``_index_file`` (per-file funnel for watcher/CLI/MCP), and
+    ``mm purge`` — so the convention can't be honored on one path and
+    bypassed on another (the bug where the general walk indexed
+    ``MEMORY.md`` while ``mm ingest`` skipped it).
+
+    Ownership uses :func:`resolve_owning_memory_dir` (most-specific,
+    longest-prefix root), so a nested configured root overrides its
+    parent's convention — a plain ``project-docs/`` root configured under
+    ``~/.codex/memories`` keeps its own ``README.md`` rather than
+    inheriting Codex's exclude.
+    """
+    owning = resolve_owning_memory_dir(file_path, memory_dirs)
+    if owning is not None and Path(file_path).name in index_excluded_filenames(
+        categorize_memory_dir(owning)
+    ):
+        return True
     for key in _exclude_match_keys(file_path, memory_dirs):
         if _BUILTIN_EXCLUDE_SPEC.match_file(key) or user_spec.match_file(key):
             return True

--- a/packages/memtomem/tests/test_config_overrides.py
+++ b/packages/memtomem/tests/test_config_overrides.py
@@ -628,6 +628,40 @@ def test_categorize_memory_dir_accepts_windows_separators(
     assert _cfg.categorize_memory_dir(path) == expected
 
 
+def test_provider_index_conventions_cover_every_category() -> None:
+    """Lock: every ProviderCategory declares an index convention.
+
+    Mirrors the ``_PROVIDER_CATEGORY_PATTERNS`` vocabulary lock — a new
+    category added to the ``ProviderCategory`` Literal without a matching
+    convention trips the module-level assert at import. Pinned here too so
+    the intent is visible in the test suite.
+    """
+    assert set(_cfg._PROVIDER_INDEX_CONVENTIONS) == _cfg._VALID_PROVIDER_CATEGORIES
+
+
+@pytest.mark.parametrize(
+    ("category", "expected"),
+    [
+        ("claude-memory", frozenset({"MEMORY.md", "README.md"})),
+        ("codex", frozenset({"README.md"})),
+        ("claude-plans", frozenset()),
+        ("user", frozenset()),
+        ("unknown-category", frozenset()),
+    ],
+)
+def test_index_excluded_filenames(category: str, expected: frozenset) -> None:
+    """The centralized exclude set per category (replaces the constants that
+    used to live in cli/ingest_cmd.py). Unknown categories index everything."""
+    assert _cfg.index_excluded_filenames(category) == expected
+
+
+def test_provider_index_file() -> None:
+    assert _cfg.provider_index_file("claude-memory") == "MEMORY.md"
+    assert _cfg.provider_index_file("codex") is None
+    assert _cfg.provider_index_file("user") is None
+    assert _cfg.provider_index_file("unknown-category") is None
+
+
 def test_detect_provider_dirs_excludes_gemini(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/packages/memtomem/tests/test_indexing_engine.py
+++ b/packages/memtomem/tests/test_indexing_engine.py
@@ -13,9 +13,11 @@ from pydantic import ValidationError
 from memtomem.config import NamespaceConfig, NamespacePolicyRule
 from memtomem.indexing.engine import (
     IndexEngine,
+    _build_exclude_spec,
     _merge_short_chunks,
     _add_overlap,
     _estimate_tokens,
+    _path_is_excluded,
 )
 from memtomem.models import Chunk, ChunkMetadata
 from .helpers import set_home
@@ -40,6 +42,61 @@ def _make_chunk_with(
             namespace=namespace,
         ),
     )
+
+
+# ===========================================================================
+# 0. _path_is_excluded — provider index-file conventions
+# ===========================================================================
+
+
+class TestPathIsExcludedProviderConventions:
+    """The single exclude funnel for ``_discover_files``, ``_index_file``,
+    and ``mm purge`` must honor provider index-file conventions.
+
+    Regression for the drift where the general engine walk (and watcher)
+    indexed a ``claude-memory`` dir's ``MEMORY.md`` — a pointer-only TOC —
+    while ``mm ingest claude-memory`` skipped it, so the index file surfaced
+    as a high-score duplicate on every query. The convention is now sourced
+    from ``config._PROVIDER_INDEX_CONVENTIONS`` and enforced here, on the
+    path every indexing caller funnels through.
+    """
+
+    def test_claude_memory_index_and_meta_excluded(self, tmp_path):
+        root = tmp_path / ".claude" / "projects" / "slug" / "memory"
+        root.mkdir(parents=True)
+        spec = _build_exclude_spec([])
+        assert _path_is_excluded(root / "MEMORY.md", [root], spec)
+        assert _path_is_excluded(root / "README.md", [root], spec)
+        assert not _path_is_excluded(root / "feedback_x.md", [root], spec)
+
+    def test_user_dir_memory_md_is_kept(self, tmp_path):
+        """``MEMORY.md`` in a plain user dir is real content — convention is
+        provider-scoped, not a global filename ban."""
+        root = tmp_path / "notes"
+        root.mkdir()
+        spec = _build_exclude_spec([])
+        assert not _path_is_excluded(root / "MEMORY.md", [root], spec)
+
+    def test_codex_readme_excluded(self, tmp_path):
+        root = tmp_path / ".codex" / "memories"
+        root.mkdir(parents=True)
+        spec = _build_exclude_spec([])
+        assert _path_is_excluded(root / "README.md", [root], spec)
+        assert not _path_is_excluded(root / "rollout.md", [root], spec)
+
+    def test_nested_root_uses_most_specific_convention(self, tmp_path):
+        """Nested configured roots resolve by longest prefix: a plain subdir
+        explicitly configured as its own root keeps its files, rather than
+        inheriting the parent provider root's exclude set."""
+        codex_root = tmp_path / ".codex" / "memories"
+        nested = codex_root / "project-docs"  # own (user-category) root under Codex
+        nested.mkdir(parents=True)
+        spec = _build_exclude_spec([])
+        roots = [codex_root, nested]
+        # Owned by the deeper `nested` (user) root → README kept.
+        assert not _path_is_excluded(nested / "README.md", roots, spec)
+        # Owned directly by the Codex root → still excluded.
+        assert _path_is_excluded(codex_root / "README.md", roots, spec)
 
 
 # ===========================================================================

--- a/packages/memtomem/tests/test_purge_cli.py
+++ b/packages/memtomem/tests/test_purge_cli.py
@@ -13,7 +13,7 @@ from memtomem.cli import cli
 from memtomem.cli.purge_cmd import find_sources_matching_excluded
 
 
-def _mock_components(matched_sources, indexing_exclude_patterns=()):
+def _mock_components(matched_sources, indexing_exclude_patterns=(), memory_dirs=()):
     """Build a fake Components-like object where storage returns the given sources."""
     storage = SimpleNamespace(
         get_all_source_files=AsyncMock(return_value=set(matched_sources)),
@@ -22,8 +22,12 @@ def _mock_components(matched_sources, indexing_exclude_patterns=()):
         ),
         delete_by_source=AsyncMock(return_value=2),
     )
+    roots = list(memory_dirs)
     config = SimpleNamespace(
-        indexing=SimpleNamespace(exclude_patterns=list(indexing_exclude_patterns))
+        indexing=SimpleNamespace(
+            exclude_patterns=list(indexing_exclude_patterns),
+            all_index_roots=lambda: roots,
+        )
     )
     return SimpleNamespace(storage=storage, config=config)
 
@@ -44,7 +48,7 @@ class TestFindSourcesMatchingExcluded:
             Path("/home/u/.gemini/oauth_creds.json"),
             Path("/home/u/notes/day.md"),
         }
-        matched = find_sources_matching_excluded(sources, user_patterns=[])
+        matched = find_sources_matching_excluded(sources, user_patterns=[], memory_dirs=[])
         assert Path("/home/u/.gemini/oauth_creds.json") in matched
         assert Path("/home/u/notes/day.md") not in matched
 
@@ -53,25 +57,45 @@ class TestFindSourcesMatchingExcluded:
             Path("/home/u/.claude/projects/abc/subagents/x.meta.json"),
             Path("/home/u/notes/day.md"),
         }
-        matched = find_sources_matching_excluded(sources, user_patterns=[])
+        matched = find_sources_matching_excluded(sources, user_patterns=[], memory_dirs=[])
         assert Path("/home/u/.claude/projects/abc/subagents/x.meta.json") in matched
 
     def test_user_pattern_matches(self):
         sources = {Path("/home/u/drafts/todo.md"), Path("/home/u/notes/day.md")}
-        matched = find_sources_matching_excluded(sources, user_patterns=["**/drafts/**"])
+        matched = find_sources_matching_excluded(
+            sources, user_patterns=["**/drafts/**"], memory_dirs=[]
+        )
         assert Path("/home/u/drafts/todo.md") in matched
         assert Path("/home/u/notes/day.md") not in matched
 
     def test_user_negation_cannot_unset_builtin(self):
         """Security regression: user cannot whitelist a built-in secret."""
         sources = {Path("/home/u/.gemini/oauth_creds.json")}
-        matched = find_sources_matching_excluded(sources, user_patterns=["!**/oauth_creds.json"])
+        matched = find_sources_matching_excluded(
+            sources, user_patterns=["!**/oauth_creds.json"], memory_dirs=[]
+        )
         assert Path("/home/u/.gemini/oauth_creds.json") in matched
 
     def test_case_insensitive(self):
         sources = {Path("/home/u/OAuth_Creds.JSON")}
-        matched = find_sources_matching_excluded(sources, user_patterns=[])
+        matched = find_sources_matching_excluded(sources, user_patterns=[], memory_dirs=[])
         assert Path("/home/u/OAuth_Creds.JSON") in matched
+
+    def test_provider_index_convention_matches(self):
+        """A claude-memory root's MEMORY.md/README.md are index/meta, not content."""
+        root = Path("/home/u/.claude/projects/slug/memory")
+        sources = {root / "MEMORY.md", root / "README.md", root / "feedback_note.md"}
+        matched = find_sources_matching_excluded(sources, user_patterns=[], memory_dirs=[root])
+        assert root / "MEMORY.md" in matched
+        assert root / "README.md" in matched
+        assert root / "feedback_note.md" not in matched
+
+    def test_memory_md_outside_provider_root_not_excluded(self):
+        """MEMORY.md in a plain user dir is real content — the convention is provider-scoped."""
+        root = Path("/home/u/notes")
+        sources = {root / "MEMORY.md"}
+        matched = find_sources_matching_excluded(sources, user_patterns=[], memory_dirs=[root])
+        assert root / "MEMORY.md" not in matched
 
 
 class TestPurgeCLI:


### PR DESCRIPTION
## What

Provider index-file conventions — the meta/TOC files an agent keeps inside a memory dir (Claude Code's `MEMORY.md`/`README.md`, Codex's `README.md`) — are now centralized in one table and enforced on **every** index path, not just `mm ingest`.

## Why

The exclude set lived only in `cli/ingest_cmd.py`, so the general `memory_dirs` indexing path (`engine._discover_files` / `_index_file` / the file watcher) and `mm index <dir>` indexed `MEMORY.md` as searchable content. Since `MEMORY.md` is a pointer-only table of contents, it then surfaced as a high-score duplicate on every query. Verified live: this project's auto-memory dir had `MEMORY.md` indexed with 10 chunks.

## How

- **`config._PROVIDER_INDEX_CONVENTIONS`** — one frozen `ProviderIndexConvention` per `ProviderCategory` (`index_file` + `exclude_filenames`), plus `index_excluded_filenames()` / `provider_index_file()` helpers and a keys-vs-categories lock assert mirroring the existing `_PROVIDER_CATEGORY_PATTERNS` lock.
- **`engine._path_is_excluded`** (the single funnel for `_discover_files`, `_index_file`, `index_file`, and the watcher) now also excludes a file whose name matches the convention of its **owning** `memory_dir` root. Ownership uses the existing `resolve_owning_memory_dir` (most-specific, longest-prefix root), so a nested configured root overrides its parent's convention.
- **`cli/ingest_cmd.py`** derives `_EXCLUDE_FILENAMES` / `_CODEX_EXCLUDE_FILENAMES` from the central helper (behavior identical).
- **`mm purge --matching-excluded`** routes through `_path_is_excluded`, so it skips the same files and can reclaim `MEMORY.md` chunks indexed before this fix.

Provider-scoped: a `MEMORY.md` in a plain user folder is still indexed as real content.

## Tests

- `test_indexing_engine.py::TestPathIsExcludedProviderConventions` — claude-memory index/meta excluded, user-dir `MEMORY.md` kept, codex `README.md` excluded, and a nested-root regression (deepest root wins).
- `test_purge_cli.py` — provider-convention match + provider-scoping; existing calls updated for the new `memory_dirs` arg.
- `test_config_overrides.py` — convention lock + helper behavior.
- Full suite: **5617 passed**, ruff + mypy clean.

## Review

Design and diff reviewed by Codex. Its one Major — nested configured roots inheriting a parent provider's exclude set — was fixed by resolving the owning root with longest-prefix semantics, with a regression test.

First PR of a small series adding `mm memory doctor` (memory-index hygiene); this one is the conventions refactor + the exclude-enforcement bug fix it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
