### PR TITLE
feat(cli): add `mm memory doctor` — read-only memory hygiene report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+- **`mm memory doctor` — read-only hygiene report for memory stores.** A
+  registered `memory_dir` can be barely indexed (the fs watcher only reacts to
+  live events, so files that landed while the server was down stay invisible
+  until a forced re-walk) and its index/TOC file can drift from what's on disk
+  — `mem_search` then silently can't find the un-indexed files. The new
+  `mm memory doctor` makes the 3-way drift between disk, the agent index file
+  (e.g. `MEMORY.md`), and the searchable DB visible: per configured dir it
+  reports DB coverage gaps, DB chunks whose source file was deleted, index/meta
+  files indexed as content, broken index links (classified
+  `missing_target`/`outside_root`, leaving `url`/`anchor` alone), files absent
+  from the TOC, hot-cache budget overruns, and never-accessed "cold" files.
+  Human output by default, `--json` for CI; exits `1` only on definite
+  inconsistencies (deleted-source chunks, convention violations, broken links).
+  Report-only — it never writes disk, DB, or config (loads config with
+  `migrate=False` so it can't trigger the legacy auto-discover rewrite). The
+  curation `--fix` path lands later behind its own ADR.
+
 - **Provider index-file conventions enforced on every index path (fixes
   `MEMORY.md` pollution).** The exclude set for agent index/TOC files — Claude
   Code's `MEMORY.md`/`README.md` and Codex's `README.md` — was previously

--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -50,6 +50,7 @@ def _register() -> None:
     from memtomem.cli.ingest_cmd import ingest
     from memtomem.cli.mem_cmd import mem
     from memtomem.cli.memory import add, recall
+    from memtomem.cli.memory_doctor_cmd import memory
     from memtomem.cli.purge_cmd import purge
     from memtomem.cli.reset_cmd import reset
     from memtomem.cli.schedule_cmd import schedule
@@ -70,6 +71,7 @@ def _register() -> None:
     cli.add_command(add)
     cli.add_command(recall)
     cli.add_command(mem)
+    cli.add_command(memory)
     cli.add_command(index)
     cli.add_command(ingest)
     cli.add_command(config)

--- a/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
@@ -1,0 +1,814 @@
+"""CLI: ``mm memory doctor`` — read-only hygiene report for memory stores.
+
+Tier 1 of the ``mm memory doctor`` plan: surface 3-way drift between what's
+on disk, what the agent-managed index file (e.g. Claude Code's ``MEMORY.md``)
+points at, and what's actually indexed in the searchable DB. Report-only — no
+writes to disk, the DB, or config. The curation write contract (``--fix``)
+lands later behind its own ADR.
+
+Why this exists: a ``memory_dir`` can be *registered* yet barely indexed (the
+fs watcher only reacts to live events, so files that landed while the server
+was down stay invisible until a forced re-walk), and the index/TOC file can
+drift from the files on disk. ``mem_search`` silently can't find the
+un-indexed files; this command makes that visible.
+
+Checks (per configured ``memory_dir``):
+
+* **db_coverage** — files on disk the engine would index but that have zero
+  chunks in the DB ("indexed N/M"). The headline signal.
+* **stale_source** — DB chunks whose ``source_file`` is gone from disk (the
+  file was deleted but its chunks linger; there is no single-file delete CLI).
+* **convention_violation** — an index/meta file (``MEMORY.md`` / ``README.md``
+  for a ``claude-memory`` dir) indexed as searchable content despite the
+  provider convention.
+* **broken_link** — links in the index file that don't resolve:
+  ``missing_target`` (file gone) or ``outside_root`` (escapes the memory
+  root). ``url`` and ``anchor`` links are classified and *not* reported.
+* **index_orphan** — files on disk that the index file (``MEMORY.md``) does
+  not list. Distinct from ``db_coverage``: "not in the TOC" ≠ "not indexed".
+* **budget** — the index file exceeds its byte / line / per-line-char budget
+  (the hot cache loaded into the agent's context each session).
+* **cold_candidate** — indexed files never accessed since indexing
+  (``access_count`` sum 0 and ``last_accessed_at`` NULL). Informational.
+
+Output: human glyphs by default, ``--json`` for a structured payload. Exit
+``1`` when any *error*-severity finding exists (``stale_source``,
+``convention_violation``, ``broken_link``), else ``0``. Coverage gaps,
+orphans, budget and cold candidates are advisory (a partially-indexed dir is
+a legitimate steady state) so they warn without failing the exit code —
+mirrors ``mm sync-doctor`` (warns don't fail) while exposing a JSON + exit
+code for CI like ``mm context settings-doctor``.
+
+Read-only contract: config is read via ``Mem2MemConfig`` +
+``load_config_d(quiet=True)`` + ``load_config_overrides(migrate=False)`` so
+the diagnostic never triggers the legacy ``auto_discover`` config rewrite
+(see PR #838 / #873). The DB is opened through a bare ``sqlite3`` connection
+in URI ``mode=ro`` — never the full ``SqliteBackend``, which on
+``initialize()`` would create the file/parent dir, run schema migration, and
+checkpoint the WAL on close. ``mode=ro`` still surfaces committed rows in a
+live writer's WAL (unlike ``immutable=1``); a missing or too-old DB degrades
+to disk/index-only checks instead of being created. Discovery reuses the
+engine's own ``discover_indexable_files`` (via a storage-less, model-less
+engine) so the "should be indexed" set can't drift from what the real indexer
+does.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+import click
+
+if TYPE_CHECKING:
+    from memtomem.config import Mem2MemConfig
+
+# ── Index-file budget ───────────────────────────────────────────────
+# Hot-cache ceiling for an agent-managed index file (``MEMORY.md``). The
+# TOC is loaded into the agent's context every session, so it has a budget
+# the curation process targets. These live here, not in
+# ``ProviderIndexConvention``, because Tier 1 is the only consumer; the
+# write-contract ADR promotes them to config when ``--fix`` needs to enforce
+# them. Per-line cap is measured in characters (not bytes) so CJK prose isn't
+# double-counted.
+_INDEX_MAX_BYTES = 24_400
+_INDEX_MAX_LINES = 200
+_INDEX_MAX_LINE_CHARS = 200
+
+Severity = Literal["error", "warn", "info"]
+
+_GLYPH: dict[Severity, str] = {"error": "✗", "warn": "!", "info": "·"}
+_COLOR: dict[Severity, str | None] = {"error": "red", "warn": "yellow", "info": None}
+
+# The exit code flips to 1 when any finding carries ``severity="error"`` (see
+# ``memory_doctor``). Today that's ``stale_source`` / ``convention_violation``
+# / ``broken_link``; severity is assigned per-finding so the exit logic needs
+# no separate check allowlist to stay in sync.
+
+# Max sample items echoed per finding in human output (JSON carries all).
+_SAMPLE_LIMIT = 8
+
+
+# ── Pure: index-file parsing ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class IndexEntry:
+    """One pointer line from an index file: ``- [title](target) — hook``."""
+
+    line_no: int  # 1-based
+    title: str
+    target: str
+    raw: str
+
+
+@dataclass(frozen=True)
+class ParsedIndex:
+    """Parsed index file: pointer entries plus every other (preserved) line.
+
+    ``other_lines`` keeps prose / comments / blanks verbatim with their line
+    numbers so a future write phase can round-trip the file; Tier 1 only reads
+    them for the budget measurement.
+    """
+
+    entries: tuple[IndexEntry, ...]
+    other_lines: tuple[tuple[int, str], ...]
+
+
+# ``- [Title](target)`` with optional leading whitespace and bullet. The
+# title is non-greedy up to the first ``]`` so nested brackets in a hook (the
+# trailing prose) don't get pulled into the title. Anything after ``)`` is
+# ignored here (it's the hook); link classification handles the target.
+_ENTRY_RE = re.compile(r"^\s*[-*]\s*\[(?P<title>[^\]]*)\]\((?P<target>[^)]*)\)")
+
+
+def parse_memory_index(text: str) -> ParsedIndex:
+    """Parse an index file into pointer entries + preserved other lines."""
+    entries: list[IndexEntry] = []
+    other: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        m = _ENTRY_RE.match(line)
+        if m is None:
+            other.append((i, line))
+            continue
+        entries.append(
+            IndexEntry(
+                line_no=i,
+                title=m.group("title").strip(),
+                target=m.group("target").strip(),
+                raw=line,
+            )
+        )
+    return ParsedIndex(entries=tuple(entries), other_lines=tuple(other))
+
+
+# ── Pure: link classification ───────────────────────────────────────
+
+LinkClass = Literal["ok", "missing_target", "outside_root", "url", "anchor"]
+
+# A URL needs an explicit ``scheme://`` (so a Windows drive ``C:\…`` isn't
+# misread as a scheme) plus the ``mailto:`` special case.
+_URL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*://")
+
+
+def _is_url(target: str) -> bool:
+    return bool(_URL_RE.match(target)) or target.startswith("mailto:")
+
+
+def classify_link(target: str, *, root: Path, source_dir: Path) -> LinkClass:
+    """Classify an index/markdown link target.
+
+    ``root`` is the memory dir (links may not escape it); ``source_dir`` is
+    the directory of the file the link lives in (for resolving relatives).
+    Resolution is path-only — ``Path.resolve()`` is strict=False so a missing
+    target still resolves and is then existence-checked, separating
+    ``missing_target`` from ``outside_root``.
+    """
+    t = target.strip()
+    if not t or t.startswith("#"):
+        return "anchor"  # in-page anchor or empty — not a file reference
+    if _is_url(t):
+        return "url"
+    path_part = t.split("#", 1)[0]  # strip ``file.md#section`` anchor suffix
+    if not path_part:
+        return "anchor"
+    raw = Path(path_part).expanduser()
+    base = raw if raw.is_absolute() else (source_dir / raw)
+    try:
+        resolved = base.resolve()
+        root_resolved = root.resolve()
+    except (OSError, RuntimeError):
+        return "missing_target"
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return "outside_root"
+    return "ok" if resolved.exists() else "missing_target"
+
+
+# ── Pure: budget measurement ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class BudgetMeasure:
+    byte_len: int
+    line_count: int
+    overlong_lines: tuple[int, ...]  # 1-based line numbers exceeding the char cap
+
+    @property
+    def over_budget(self) -> bool:
+        return (
+            self.byte_len > _INDEX_MAX_BYTES
+            or self.line_count > _INDEX_MAX_LINES
+            or bool(self.overlong_lines)
+        )
+
+
+def measure_budget(text: str) -> BudgetMeasure:
+    """Measure an index file against the hot-cache budget.
+
+    Bytes are UTF-8 encoded length; lines are counted from ``splitlines``;
+    per-line length is character count (``len``) so a CJK line isn't penalised
+    for its multi-byte encoding.
+    """
+    lines = text.splitlines()
+    overlong = tuple(
+        i for i, line in enumerate(lines, start=1) if len(line) > _INDEX_MAX_LINE_CHARS
+    )
+    return BudgetMeasure(
+        byte_len=len(text.encode("utf-8")),
+        line_count=len(lines),
+        overlong_lines=overlong,
+    )
+
+
+# ── Finding + report model ──────────────────────────────────────────
+
+
+@dataclass
+class Finding:
+    check: str
+    severity: Severity
+    summary: str
+    items: list[str] = field(default_factory=list)
+
+    @property
+    def count(self) -> int:
+        return len(self.items)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "check": self.check,
+            "severity": self.severity,
+            "count": self.count,
+            "summary": self.summary,
+            "items": self.items,
+        }
+
+
+@dataclass
+class DirReport:
+    path: str
+    category: str
+    index_file: str | None
+    exists: bool
+    disk_indexable: int
+    db_covered: int
+    findings: list[Finding] = field(default_factory=list)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "category": self.category,
+            "index_file": self.index_file,
+            "exists": self.exists,
+            "disk_indexable": self.disk_indexable,
+            "db_covered": self.db_covered,
+            "findings": [f.to_json() for f in self.findings],
+        }
+
+
+# ── Read-only config + engine plumbing ──────────────────────────────
+
+
+def _load_config_read_only() -> Mem2MemConfig:
+    """Load config without triggering the legacy auto-discover migration.
+
+    Mirrors ``mm sync-doctor``: a read-only diagnostic must not rewrite
+    ``config.json`` as a side effect (``migrate=False``).
+    """
+    from memtomem.config import Mem2MemConfig, load_config_d, load_config_overrides
+
+    config = Mem2MemConfig()
+    load_config_d(config, quiet=True)
+    load_config_overrides(config, migrate=False)
+    return config
+
+
+def _build_discovery_engine(config: Mem2MemConfig) -> object:
+    """Build an ``IndexEngine`` purely for its file-discovery method.
+
+    ``discover_indexable_files`` reads only ``config`` (supported extensions,
+    index roots, exclude rules) — it never touches storage or the embedder —
+    so both are passed as inert stand-ins (``None`` storage, a model-less
+    ``NoopEmbedder``). Reusing the engine's own discovery is deliberate: the
+    doctor's "should be indexed" set is then guaranteed identical to what the
+    real indexer produces, so coverage / orphan counts can't drift from
+    reality.
+    """
+    from memtomem.embedding.noop import NoopEmbedder
+    from memtomem.indexing.engine import IndexEngine
+
+    return IndexEngine(
+        storage=None,  # type: ignore[arg-type]
+        embedder=NoopEmbedder(),  # type: ignore[arg-type]
+        config=config.indexing,
+        namespace_config=config.namespace,
+    )
+
+
+# Per-source aggregate the cold-candidate / coverage checks consume.
+# ``MAX(last_accessed_at)`` over ISO-8601 text sorts chronologically and
+# SQLite's ``MAX`` ignores NULL, so a never-accessed multi-chunk file reports
+# ``(…, None, 0, …)``. ``COALESCE`` guards an all-NULL importance column.
+_SOURCE_SIGNALS_SQL = (
+    "SELECT source_file, COUNT(*), MAX(last_accessed_at),"
+    " COALESCE(SUM(access_count), 0),"
+    " COALESCE(MAX(importance_score), 0.0),"
+    " COALESCE(AVG(importance_score), 0.0)"
+    " FROM chunks GROUP BY source_file ORDER BY source_file"
+)
+
+
+def _read_source_signals(
+    db_path: Path,
+) -> list[tuple[Path, int, str | None, int, float, float]] | None:
+    """Read per-source signal rows from an *existing* DB, strictly read-only.
+
+    Opens the SQLite file with ``mode=ro`` (URI) so the doctor can never
+    create the file, run a schema migration, or checkpoint the WAL — the
+    report-only contract. Unlike ``immutable=1``, ``mode=ro`` still surfaces
+    committed rows sitting in an active writer's WAL (e.g. while ``mm web`` is
+    up), so the report reflects live state. Returns ``None`` — not an empty
+    list — when the DB is absent, its schema predates the aggregate's columns
+    (a fresh or very old install), or the file is corrupt / not a database;
+    the caller then degrades to disk/index-only checks rather than crashing or
+    creating the DB. ``sqlite3.DatabaseError`` is the parent of
+    ``OperationalError`` (missing table/column) and also covers the
+    "file is not a database" / malformed-image cases, so one except clause
+    handles every "can't read this DB" path.
+    """
+    db = db_path.expanduser()
+    if not db.is_absolute():
+        db = db.absolute()
+    if not db.exists():
+        return None
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = sqlite3.connect(f"{db.as_uri()}?mode=ro", uri=True, timeout=5)
+        conn.execute("PRAGMA query_only=ON")
+        rows = conn.execute(_SOURCE_SIGNALS_SQL).fetchall()
+    except sqlite3.DatabaseError:
+        return None  # missing/old-schema/corrupt — degrade to disk-only checks
+    finally:
+        if conn is not None:
+            conn.close()
+    return [(Path(r[0]), int(r[1]), r[2], int(r[3]), float(r[4]), float(r[5])) for r in rows]
+
+
+# ── Analysis ────────────────────────────────────────────────────────
+
+
+def _analyze_dir(
+    *,
+    dir_path: Path,
+    config: Mem2MemConfig,
+    engine: object,
+    db_rows: list[tuple[Path, int, str | None, int, float, float]],
+    memory_dirs: list[Path],
+) -> DirReport:
+    """Run every check for one configured ``memory_dir``. Pure given inputs.
+
+    ``memory_dirs`` is the full set of configured roots — needed to attribute
+    each discovered disk file to its *most-specific* owning root, the same
+    longest-prefix rule the DB rows are bucketed by. Without that, a recursive
+    walk of a parent root would pull in files that belong to a nested child
+    root (whose DB rows are bucketed to the child), making the parent falsely
+    report the child's already-indexed files as uncovered.
+    """
+    from memtomem.config import (
+        categorize_memory_dir,
+        index_excluded_filenames,
+        provider_index_file,
+    )
+    from memtomem.indexing.engine import resolve_owning_memory_dir
+    from memtomem.storage.sqlite_helpers import norm_path
+
+    resolved_dir = dir_path.expanduser().resolve()
+    exists = resolved_dir.is_dir()
+    category = categorize_memory_dir(dir_path)
+    index_file_name = provider_index_file(category)
+    excluded = index_excluded_filenames(category)
+    dir_key = norm_path(dir_path.expanduser())
+
+    # Disk side: files the engine would index (post-exclusion, recursive —
+    # faithful to the real indexer), keeping only the files this dir is the
+    # most-specific owner of (symmetry with the DB bucketing in
+    # ``_gather_reports`` — a nested child root owns its own subtree).
+    disk_files = engine.discover_indexable_files(resolved_dir)  # type: ignore[attr-defined]
+    disk_norm: dict[str, Path] = {}
+    for p in disk_files:
+        owning = resolve_owning_memory_dir(p, memory_dirs)
+        if owning is not None and norm_path(owning) == dir_key:
+            disk_norm[norm_path(p)] = p
+
+    # DB side: source-file signal rows already bucketed to this dir.
+    db_norm: dict[str, tuple[Path, int, str | None, int, float, float]] = {
+        norm_path(row[0]): row for row in db_rows
+    }
+
+    report = DirReport(
+        path=str(resolved_dir),
+        category=category,
+        index_file=index_file_name,
+        exists=exists,
+        disk_indexable=len(disk_norm),
+        db_covered=len(disk_norm.keys() & db_norm.keys()),
+    )
+
+    # 1. db_coverage — on disk, no chunks.
+    uncovered = sorted(p for k, p in disk_norm.items() if k not in db_norm)
+    if uncovered:
+        report.findings.append(
+            Finding(
+                check="db_coverage",
+                severity="warn",
+                summary=(
+                    f"{len(uncovered)}/{len(disk_norm)} indexable file(s) have no DB "
+                    "chunks — `mem_search` can't find them (run `mm index <dir> --force`)"
+                ),
+                items=[p.name for p in uncovered],
+            )
+        )
+
+    # 2/3. DB-only sources — split into stale (deleted), convention violation
+    # (meta file indexed), and an unexpected residue.
+    stale: list[str] = []
+    violations: list[str] = []
+    unexpected: list[str] = []
+    for k, row in db_norm.items():
+        if k in disk_norm:
+            continue
+        src = row[0]
+        if not Path(src).exists():
+            stale.append(str(src))
+        elif Path(src).name in excluded:
+            violations.append(str(src))
+        else:
+            unexpected.append(str(src))
+    if stale:
+        report.findings.append(
+            Finding(
+                check="stale_source",
+                severity="error",
+                summary=(
+                    f"{len(stale)} DB source file(s) no longer exist on disk — "
+                    "chunks linger after the file was deleted"
+                ),
+                items=sorted(stale),
+            )
+        )
+    if violations:
+        report.findings.append(
+            Finding(
+                check="convention_violation",
+                severity="error",
+                summary=(
+                    f"{len(violations)} index/meta file(s) indexed as content despite the "
+                    f"{category} convention (run `mm purge --matching-excluded --apply`)"
+                ),
+                items=sorted(violations),
+            )
+        )
+    if unexpected:
+        report.findings.append(
+            Finding(
+                check="db_extra",
+                severity="warn",
+                summary=(
+                    f"{len(unexpected)} DB source file(s) exist on disk but fall outside the "
+                    "current indexable set (unsupported extension or excluded path)"
+                ),
+                items=sorted(unexpected),
+            )
+        )
+
+    # 4. cold_candidate — covered files never accessed since indexing.
+    cold = [
+        (row[0], row[1])  # (path, chunk_count)
+        for k, row in db_norm.items()
+        if k in disk_norm and row[3] == 0 and row[2] is None
+    ]
+    if cold:
+        cold.sort(key=lambda pc: (-pc[1], str(pc[0])))
+        report.findings.append(
+            Finding(
+                check="cold_candidate",
+                severity="info",
+                summary=(
+                    f"{len(cold)} indexed file(s) never accessed since indexing "
+                    "(access_count 0, last_accessed_at unset)"
+                ),
+                items=[f"{p.name} ({c} chunk{'s' if c != 1 else ''})" for p, c in cold],
+            )
+        )
+
+    # 5/6/7. Index-file checks (only for providers with a TOC convention).
+    if index_file_name:
+        _analyze_index_file(
+            report=report,
+            root=resolved_dir,
+            index_file_name=index_file_name,
+            disk_norm=disk_norm,
+            norm_path=norm_path,
+        )
+
+    return report
+
+
+def _analyze_index_file(
+    *,
+    report: DirReport,
+    root: Path,
+    index_file_name: str,
+    disk_norm: dict[str, Path],
+    norm_path: object,
+) -> None:
+    """Broken-link, index-orphan and budget checks against the TOC file."""
+    index_path = root / index_file_name
+    try:
+        text = index_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        report.findings.append(
+            Finding(
+                check="index_missing",
+                severity="warn",
+                summary=f"index file {index_file_name} not found in {root}",
+            )
+        )
+        return
+    except OSError as exc:
+        report.findings.append(
+            Finding(
+                check="index_missing",
+                severity="warn",
+                summary=f"could not read {index_file_name}: {exc}",
+            )
+        )
+        return
+
+    parsed = parse_memory_index(text)
+
+    # broken_link — classify every pointer target; report only the broken
+    # classes. ``listed_norm`` collects the resolvable targets for the orphan
+    # check below.
+    broken: list[str] = []
+    listed_norm: set[str] = set()
+    for entry in parsed.entries:
+        cls = classify_link(entry.target, root=root, source_dir=root)
+        if cls in ("missing_target", "outside_root"):
+            broken.append(f"L{entry.line_no} [{cls}] {entry.target}")
+        elif cls == "ok":
+            resolved = (root / entry.target.split("#", 1)[0]).resolve()
+            listed_norm.add(norm_path(resolved))  # type: ignore[operator]
+    if broken:
+        report.findings.append(
+            Finding(
+                check="broken_link",
+                severity="error",
+                summary=f"{len(broken)} broken link(s) in {index_file_name}",
+                items=broken,
+            )
+        )
+
+    # index_orphan — indexable files on disk the TOC doesn't point at. The
+    # index file itself / excluded meta files are not in ``disk_norm`` (the
+    # engine excludes them), so they're never flagged here.
+    orphans = sorted(p for k, p in disk_norm.items() if k not in listed_norm)
+    if orphans:
+        report.findings.append(
+            Finding(
+                check="index_orphan",
+                severity="warn",
+                summary=(
+                    f"{len(orphans)} file(s) on disk not listed in {index_file_name} "
+                    "(index orphans — present and indexable but absent from the TOC)"
+                ),
+                items=[p.name for p in orphans],
+            )
+        )
+
+    # budget — hot-cache size.
+    budget = measure_budget(text)
+    if budget.over_budget:
+        parts = [f"{budget.byte_len} bytes (cap {_INDEX_MAX_BYTES})"]
+        parts.append(f"{budget.line_count} lines (cap {_INDEX_MAX_LINES})")
+        if budget.overlong_lines:
+            shown = ", ".join(f"L{n}" for n in budget.overlong_lines[:_SAMPLE_LIMIT])
+            parts.append(
+                f"{len(budget.overlong_lines)} line(s) over {_INDEX_MAX_LINE_CHARS} chars ({shown})"
+            )
+        report.findings.append(
+            Finding(
+                check="budget",
+                severity="warn",
+                summary=f"{index_file_name} over budget: " + "; ".join(parts),
+                items=[f"L{n}" for n in budget.overlong_lines],
+            )
+        )
+
+
+def _gather_reports(
+    *,
+    config: Mem2MemConfig,
+    inspect_dirs: list[Path],
+) -> list[DirReport]:
+    """Read DB signals read-only, bucket by owning dir, analyze each inspected dir.
+
+    Fully synchronous: the only DB access is the read-only aggregate in
+    :func:`_read_source_signals`, and discovery is a sync disk walk — no
+    embedder, no async storage backend, no writes.
+    """
+    from collections import defaultdict
+
+    from memtomem.indexing.engine import resolve_owning_memory_dir
+    from memtomem.storage.sqlite_helpers import norm_path
+
+    raw_signals = _read_source_signals(Path(config.storage.sqlite_path))
+    db_unreadable = raw_signals is None
+    signals = raw_signals or []
+    memory_dirs = config.indexing.all_index_roots()
+
+    # Bucket every DB source row to the configured dir that owns it
+    # (longest-prefix), keyed by the resolved dir string so it matches the
+    # per-dir loop below. Unowned rows are surfaced separately.
+    by_dir: dict[str, list[tuple[Path, int, str | None, int, float, float]]] = defaultdict(list)
+    unowned = 0
+    for row in signals:
+        owning = resolve_owning_memory_dir(row[0], memory_dirs)
+        if owning is None:
+            unowned += 1
+        else:
+            by_dir[norm_path(owning)].append(row)
+
+    engine = _build_discovery_engine(config)
+
+    reports: list[DirReport] = []
+    for d in inspect_dirs:
+        key = norm_path(d.expanduser())
+        reports.append(
+            _analyze_dir(
+                dir_path=d,
+                config=config,
+                engine=engine,
+                db_rows=by_dir.get(key, []),
+                memory_dirs=memory_dirs,
+            )
+        )
+
+    if db_unreadable:
+        # Top-level note: no readable DB, so coverage/stale/cold are unknown
+        # and every disk file shows as uncovered. Info — never fails the exit.
+        db_report = _note_report("(database)")
+        db_report.findings.append(
+            Finding(
+                check="db_unavailable",
+                severity="info",
+                summary=(
+                    f"no readable memtomem DB at {Path(config.storage.sqlite_path).expanduser()} "
+                    "— reporting disk/index-only checks (run `mm index` to build it)"
+                ),
+            )
+        )
+        reports.append(db_report)
+
+    if unowned:
+        # Top-level info: chunks attributed to no configured memory_dir
+        # (e.g. a dir was removed from config, or content added elsewhere).
+        # Never affects the exit code.
+        unowned_report = _note_report("(unowned)")
+        unowned_report.findings.append(
+            Finding(
+                check="unowned_chunks",
+                severity="info",
+                summary=(
+                    f"{unowned} DB source file(s) under no configured memory_dir "
+                    "(removed dir, or content added outside the registry)"
+                ),
+            )
+        )
+        reports.append(unowned_report)
+
+    return reports
+
+
+# ── Rendering ───────────────────────────────────────────────────────
+
+
+# A "note" report is a synthetic top-level entry (not a real ``memory_dir``):
+# its parenthesized path is the sentinel. Carries only top-level findings.
+def _note_report(label: str) -> DirReport:
+    return DirReport(
+        path=label, category="", index_file=None, exists=False, disk_indexable=0, db_covered=0
+    )
+
+
+def _is_note(report: DirReport) -> bool:
+    return report.path.startswith("(")
+
+
+def _severity_totals(reports: list[DirReport]) -> dict[str, int]:
+    totals = {"error": 0, "warn": 0, "info": 0}
+    for r in reports:
+        for f in r.findings:
+            totals[f.severity] += 1
+    return totals
+
+
+def _emit_human(reports: list[DirReport]) -> None:
+    for r in reports:
+        if _is_note(r):
+            for f in r.findings:
+                click.secho(f"{_GLYPH[f.severity]} {f.summary}", fg=_COLOR[f.severity])
+            continue
+        header = f"{r.path}"
+        suffix = []
+        if not r.exists:
+            suffix.append("missing")
+        if r.index_file:
+            suffix.append(f"index={r.index_file}")
+        suffix.append(f"indexed {r.db_covered}/{r.disk_indexable}")
+        click.secho(f"\n■ {header}", bold=True)
+        click.echo(f"  {r.category} · " + " · ".join(suffix))
+        if not r.findings:
+            click.secho("  ✓ no issues", fg="green")
+            continue
+        for f in r.findings:
+            click.secho(f"  {_GLYPH[f.severity]} {f.summary}", fg=_COLOR[f.severity])
+            for item in f.items[:_SAMPLE_LIMIT]:
+                click.echo(f"      - {item}")
+            if f.count > _SAMPLE_LIMIT:
+                click.echo(f"      … and {f.count - _SAMPLE_LIMIT} more")
+
+    totals = _severity_totals(reports)
+    click.echo(f"\nSummary: {totals['error']} error, {totals['warn']} warn, {totals['info']} info.")
+
+
+def _emit_json(reports: list[DirReport]) -> None:
+    totals = _severity_totals(reports)
+    payload = {
+        "status": "issues" if totals["error"] or totals["warn"] else "ok",
+        "dirs": [r.to_json() for r in reports],
+        "summary": totals,
+    }
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+# ── Click entry point ───────────────────────────────────────────────
+
+
+@click.group("memory")
+def memory() -> None:
+    """Memory-store hygiene: inspect index/DB/disk consistency."""
+
+
+@memory.command("doctor")
+@click.argument("path", required=False, type=click.Path())
+@click.option(
+    "--json",
+    "json_out",
+    is_flag=True,
+    default=False,
+    help="Emit a structured JSON result instead of human-readable output.",
+)
+def memory_doctor(path: str | None, json_out: bool) -> None:
+    """Report drift between disk, the index file, and the searchable DB (read-only).
+
+    With no PATH, inspects every configured ``memory_dir``. Pass a PATH to
+    scope the report to one configured dir.
+
+    Exit codes: ``0`` clean (or advisory-only findings), ``1`` when any
+    error-severity finding exists (stale DB sources, convention violations,
+    or broken index links).
+    """
+    config = _load_config_read_only()
+    memory_dirs = config.indexing.all_index_roots()
+
+    if path is not None:
+        target = Path(path).expanduser().resolve()
+        inspect_dirs = [d for d in memory_dirs if d.expanduser().resolve() == target]
+        if not inspect_dirs:
+            raise click.ClickException(
+                f"{path} is not a configured memory_dir. Run without PATH to inspect all, "
+                "or `mm config` to see the configured dirs."
+            )
+    else:
+        inspect_dirs = list(memory_dirs)
+
+    if not inspect_dirs:
+        click.secho("No memory_dirs configured. Run `mm init`.", fg="yellow")
+        return
+
+    reports = _gather_reports(config=config, inspect_dirs=inspect_dirs)
+
+    if json_out:
+        _emit_json(reports)
+    else:
+        _emit_human(reports)
+
+    if _severity_totals(reports)["error"] > 0:
+        raise click.exceptions.Exit(1)

--- a/packages/memtomem/tests/test_memory_doctor.py
+++ b/packages/memtomem/tests/test_memory_doctor.py
@@ -1,0 +1,509 @@
+"""Tests for ``mm memory doctor`` (Tier 1 report-only hygiene report).
+
+Three layers:
+
+* ``TestParser`` / ``TestClassifyLink`` / ``TestBudget`` — pure functions, no
+  DB or disk-config side effects.
+* ``TestAnalysis`` — drives ``_gather_reports`` against a **real**
+  ``SqliteBackend`` (a tmp DB) + a real on-disk ``claude-memory`` dir, so the
+  disk↔DB drift detection exercises the actual SQL aggregate and the engine's
+  own discovery (no ``AsyncMock`` masking — memory
+  ``feedback_mocked_storage_hides_sql_bugs``).
+* ``TestCli`` — Click ``CliRunner`` end-to-end with the read-only config
+  loader stubbed, pinning the exit code and the ``--json`` payload shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.cli.memory_doctor_cmd import (
+    _gather_reports,
+    classify_link,
+    measure_budget,
+    parse_memory_index,
+)
+from memtomem.config import Mem2MemConfig
+from memtomem.storage.sqlite_backend import SqliteBackend
+from memtomem.storage.sqlite_helpers import norm_path
+
+
+# ── Pure: parser ────────────────────────────────────────────────────
+
+
+class TestParser:
+    def test_extracts_pointer_entries(self):
+        text = "- [Alpha](alpha.md) — first\n* [Beta](sub/beta.md) — second\n"
+        parsed = parse_memory_index(text)
+        assert [(e.title, e.target) for e in parsed.entries] == [
+            ("Alpha", "alpha.md"),
+            ("Beta", "sub/beta.md"),
+        ]
+        assert parsed.entries[0].line_no == 1
+        assert parsed.entries[1].line_no == 2
+
+    def test_preserves_non_pointer_lines_with_numbers(self):
+        text = "# Header\n\n- [A](a.md) — x\nplain prose line\n<!-- comment -->\n"
+        parsed = parse_memory_index(text)
+        assert len(parsed.entries) == 1
+        # Header(1), blank(2), prose(4), comment(5) preserved in order.
+        assert [n for n, _ in parsed.other_lines] == [1, 2, 4, 5]
+
+    def test_title_with_brackets_in_hook_not_swallowed(self):
+        # Non-greedy title stops at the first ``]``; brackets in the trailing
+        # hook prose must not be pulled into the title or target.
+        parsed = parse_memory_index("- [Title](t.md) — see [note] and (paren)\n")
+        assert parsed.entries[0].title == "Title"
+        assert parsed.entries[0].target == "t.md"
+
+    def test_non_ascii_filename_target(self):
+        parsed = parse_memory_index("- [한글](한글노트.md) — 메모\n")
+        assert parsed.entries[0].target == "한글노트.md"
+
+
+# ── Pure: link classification ───────────────────────────────────────
+
+
+class TestClassifyLink:
+    def test_existing_file_ok(self, tmp_path):
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+        assert classify_link("a.md", root=tmp_path, source_dir=tmp_path) == "ok"
+
+    def test_missing_file(self, tmp_path):
+        assert classify_link("gone.md", root=tmp_path, source_dir=tmp_path) == "missing_target"
+
+    def test_dotdot_escape_is_outside_root(self, tmp_path):
+        inner = tmp_path / "memory"
+        inner.mkdir()
+        assert classify_link("../../etc/passwd", root=inner, source_dir=inner) == "outside_root"
+
+    def test_absolute_path_outside_root(self, tmp_path):
+        inner = tmp_path / "memory"
+        inner.mkdir()
+        assert classify_link("/etc/hosts", root=inner, source_dir=inner) == "outside_root"
+
+    def test_url_not_a_file(self, tmp_path):
+        assert classify_link("https://example.com/x", root=tmp_path, source_dir=tmp_path) == "url"
+        assert classify_link("mailto:a@b.com", root=tmp_path, source_dir=tmp_path) == "url"
+
+    def test_anchor_only(self, tmp_path):
+        assert classify_link("#section", root=tmp_path, source_dir=tmp_path) == "anchor"
+        assert classify_link("", root=tmp_path, source_dir=tmp_path) == "anchor"
+
+    def test_file_with_anchor_suffix_uses_file_part(self, tmp_path):
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+        assert classify_link("a.md#heading", root=tmp_path, source_dir=tmp_path) == "ok"
+
+    def test_whitespace_target_trimmed(self, tmp_path):
+        (tmp_path / "a.md").write_text("x", encoding="utf-8")
+        assert classify_link("  a.md  ", root=tmp_path, source_dir=tmp_path) == "ok"
+
+
+# ── Pure: budget ────────────────────────────────────────────────────
+
+
+class TestBudget:
+    def test_small_file_under_budget(self):
+        m = measure_budget("- [A](a.md) — x\n")
+        assert not m.over_budget
+        assert m.line_count == 1
+
+    def test_line_count_over_cap(self):
+        m = measure_budget("\n".join(["x"] * 250))
+        assert m.over_budget
+        assert m.line_count == 250
+
+    def test_byte_count_over_cap(self):
+        m = measure_budget("x" * 25_000)
+        assert m.over_budget
+        assert m.byte_len == 25_000
+
+    def test_overlong_line_measured_in_chars_not_bytes(self):
+        # 150 CJK chars = 450 UTF-8 bytes but only 150 characters, so it must
+        # NOT trip the 200-char per-line cap (char-based, not byte-based).
+        m = measure_budget("가" * 150)
+        assert m.overlong_lines == ()
+        assert not m.over_budget
+        # 201 chars does trip it.
+        m2 = measure_budget("a" * 201)
+        assert m2.overlong_lines == (1,)
+        assert m2.over_budget
+
+
+# ── Integration: real DB + real disk ────────────────────────────────
+
+
+def _insert_chunk(
+    backend: SqliteBackend,
+    *,
+    chunk_id: str,
+    source_file: Path,
+    access_count: int = 0,
+    last_accessed_at: str | None = None,
+    importance_score: float = 0.0,
+) -> None:
+    """Insert one ``chunks`` row (read-only doctor never touches FTS)."""
+    db = backend._get_db()
+    db.execute(
+        "INSERT INTO chunks (id, content, content_hash, source_file, "
+        "created_at, updated_at, access_count, last_accessed_at, importance_score) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            chunk_id,
+            f"content of {chunk_id}",
+            f"hash-{chunk_id}",
+            norm_path(source_file),
+            "2026-06-01T00:00:00",
+            "2026-06-01T00:00:00",
+            access_count,
+            last_accessed_at,
+            importance_score,
+        ),
+    )
+    db.commit()
+
+
+@pytest.fixture
+def doctor_env(tmp_path, monkeypatch):
+    """A real ``claude-memory`` dir + a tmp DB wired into a ``Mem2MemConfig``.
+
+    Layout (disk):
+      MEMORY.md, README.md   — meta/index (engine-excluded)
+      alpha.md               — indexed, listed, accessed       → clean
+      beta.md                — indexed, listed, never accessed → cold_candidate
+      gamma.md               — NOT indexed, listed             → db_coverage
+      delta.md               — indexed, NOT listed             → index_orphan
+
+    DB also has chunks for ghost.md (no disk file → stale_source) and MEMORY.md
+    (meta indexed as content → convention_violation). Returns ``(config, dir)``.
+    """
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+
+    # Path must end with ``/.claude/projects/<slug>/memory`` to classify as
+    # ``claude-memory`` (so the index_file/exclude convention applies).
+    mem_dir = tmp_path / ".claude" / "projects" / "-test-proj" / "memory"
+    mem_dir.mkdir(parents=True)
+    for name in ("alpha.md", "beta.md", "gamma.md", "delta.md", "README.md"):
+        (mem_dir / name).write_text(f"# {name}\n\nbody\n", encoding="utf-8")
+    (mem_dir / "MEMORY.md").write_text(
+        "- [Alpha](alpha.md) — a\n"
+        "- [Beta](beta.md) — b\n"
+        "- [Gamma](gamma.md) — c\n"
+        "- [Missing](nonexistent.md) — broken\n"
+        "- [Escape](../../../../../../etc/passwd) — escapes root\n"
+        "- [Web](https://example.com) — external\n"
+        "- [Anchor](#top) — in-page\n",
+        encoding="utf-8",
+    )
+
+    db_path = tmp_path / "doctor.db"
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+    return config, mem_dir
+
+
+def _findings_by_check(report) -> dict[str, object]:
+    return {f.check: f for f in report.findings}
+
+
+@pytest.mark.asyncio
+async def test_analysis_detects_all_drift_classes(doctor_env):
+    config, mem_dir = doctor_env
+
+    backend = SqliteBackend(
+        config.storage, dimension=0, embedding_provider="none", embedding_model=""
+    )
+    await backend.initialize()
+    try:
+        _insert_chunk(
+            backend,
+            chunk_id="a1",
+            source_file=mem_dir / "alpha.md",
+            access_count=3,
+            last_accessed_at="2026-06-01T12:00:00",
+            importance_score=0.5,
+        )
+        # beta: two chunks, never accessed → cold_candidate
+        _insert_chunk(backend, chunk_id="b1", source_file=mem_dir / "beta.md")
+        _insert_chunk(backend, chunk_id="b2", source_file=mem_dir / "beta.md")
+        # delta: indexed + accessed (not cold), not in TOC → index_orphan
+        _insert_chunk(backend, chunk_id="d1", source_file=mem_dir / "delta.md", access_count=1)
+        # ghost: chunk with no disk file → stale_source
+        _insert_chunk(backend, chunk_id="g1", source_file=mem_dir / "ghost.md")
+        # MEMORY.md indexed as content → convention_violation
+        _insert_chunk(backend, chunk_id="m1", source_file=mem_dir / "MEMORY.md")
+    finally:
+        await backend.close()
+
+    reports = _gather_reports(config=config, inspect_dirs=[mem_dir])
+    dir_reports = [r for r in reports if r.path != "(unowned)"]
+    assert len(dir_reports) == 1
+    report = dir_reports[0]
+
+    assert report.category == "claude-memory"
+    assert report.index_file == "MEMORY.md"
+    # disk indexable = alpha, beta, gamma, delta (MEMORY.md/README.md excluded)
+    assert report.disk_indexable == 4
+    # covered = alpha, beta, delta (gamma has no chunk)
+    assert report.db_covered == 3
+
+    by = _findings_by_check(report)
+
+    assert by["db_coverage"].items == ["gamma.md"]
+    assert by["stale_source"].severity == "error"
+    assert by["stale_source"].items == [norm_path(mem_dir / "ghost.md")]
+    assert by["convention_violation"].severity == "error"
+    assert by["convention_violation"].items == [norm_path(mem_dir / "MEMORY.md")]
+    assert by["cold_candidate"].severity == "info"
+    assert by["cold_candidate"].count == 1
+    assert by["cold_candidate"].items == ["beta.md (2 chunks)"]
+    # broken links: missing_target + outside_root; url + anchor NOT reported.
+    broken = by["broken_link"]
+    assert broken.severity == "error"
+    assert broken.count == 2
+    assert any("missing_target" in i for i in broken.items)
+    assert any("outside_root" in i for i in broken.items)
+    assert not any("example.com" in i for i in broken.items)
+    assert by["index_orphan"].items == ["delta.md"]
+    assert "budget" not in by  # small index file is under budget
+
+
+@pytest.mark.asyncio
+async def test_clean_dir_has_no_findings(tmp_path, monkeypatch):
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+    mem_dir = tmp_path / ".claude" / "projects" / "-clean" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "alpha.md").write_text("# alpha\n", encoding="utf-8")
+    (mem_dir / "MEMORY.md").write_text("- [Alpha](alpha.md) — a\n", encoding="utf-8")
+
+    db_path = tmp_path / "clean.db"
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+
+    backend = SqliteBackend(
+        config.storage, dimension=0, embedding_provider="none", embedding_model=""
+    )
+    await backend.initialize()
+    try:
+        _insert_chunk(
+            backend,
+            chunk_id="a1",
+            source_file=mem_dir / "alpha.md",
+            access_count=2,
+            last_accessed_at="2026-06-01T00:00:00",
+        )
+    finally:
+        await backend.close()
+
+    reports = _gather_reports(config=config, inspect_dirs=[mem_dir])
+    dir_reports = [r for r in reports if r.path != "(unowned)"]
+    assert len(dir_reports) == 1
+    assert dir_reports[0].findings == []
+
+
+def test_missing_db_is_not_created(tmp_path, monkeypatch):
+    """Read-only contract: a missing DB is never created just by diagnosing.
+
+    Pins the report-only guarantee — running the doctor against a config whose
+    ``sqlite_path`` (and its parent) does not exist must leave the filesystem
+    untouched and degrade to disk/index-only checks.
+    """
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+    mem_dir = tmp_path / ".claude" / "projects" / "-absent" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "a.md").write_text("# a\n", encoding="utf-8")
+
+    db_path = tmp_path / "nope" / "absent.db"  # parent dir also absent
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+
+    reports = _gather_reports(config=config, inspect_dirs=[mem_dir])
+
+    assert not db_path.exists()
+    assert not db_path.parent.exists()  # doctor must not mkdir the parent either
+    note = next(r for r in reports if r.path == "(database)")
+    assert note.findings[0].check == "db_unavailable"
+    # With no DB, every disk file shows as uncovered.
+    dir_report = next(r for r in reports if not r.path.startswith("("))
+    cov = next(f for f in dir_report.findings if f.check == "db_coverage")
+    assert "a.md" in cov.items
+
+
+def test_old_schema_db_degrades_gracefully(tmp_path, monkeypatch):
+    """A DB whose schema predates the aggregate's columns is reported, not
+    crashed on, and is not migrated by the doctor."""
+    import sqlite3
+
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+    mem_dir = tmp_path / ".claude" / "projects" / "-old" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "a.md").write_text("# a\n", encoding="utf-8")
+
+    db_path = tmp_path / "old.db"
+    conn = sqlite3.connect(db_path)
+    # chunks table missing access_count / last_accessed_at / importance_score.
+    conn.execute("CREATE TABLE chunks(id TEXT, source_file TEXT)")
+    conn.commit()
+    conn.close()
+
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+
+    reports = _gather_reports(config=config, inspect_dirs=[mem_dir])
+    note = next(r for r in reports if r.path == "(database)")
+    assert note.findings[0].check == "db_unavailable"
+    # The doctor must not have added the missing columns (no migration).
+    conn = sqlite3.connect(db_path)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(chunks)")}
+    conn.close()
+    assert cols == {"id", "source_file"}
+
+
+def test_corrupt_db_degrades_gracefully(tmp_path, monkeypatch):
+    """A corrupt / non-SQLite file at sqlite_path must not crash the doctor.
+
+    ``mode=ro`` opens the file, but reading it raises
+    ``sqlite3.DatabaseError: file is not a database`` — the reader degrades to
+    the db_unavailable note instead of propagating the error."""
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+    mem_dir = tmp_path / ".claude" / "projects" / "-corrupt" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "a.md").write_text("# a\n", encoding="utf-8")
+
+    db_path = tmp_path / "corrupt.db"
+    db_path.write_bytes(b"this is definitely not a sqlite database\n" * 8)
+
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [mem_dir]
+
+    reports = _gather_reports(config=config, inspect_dirs=[mem_dir])
+    note = next(r for r in reports if r.path == "(database)")
+    assert note.findings[0].check == "db_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_nested_roots_no_false_uncovered(tmp_path, monkeypatch):
+    """Nested configured roots: a child's indexed file is the child's, not a
+    false ``db_coverage`` gap under the parent.
+
+    Disk discovery for the parent is recursive (it sees the child's files),
+    but DB rows for the child are bucketed to the child by longest-prefix
+    ownership. The parent report must attribute disk files the same way, so it
+    reports only its own files — otherwise the child's already-indexed file
+    shows as uncovered under the parent.
+    """
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+    parent = tmp_path / ".codex" / "memories"
+    child = parent / "project-docs"
+    child.mkdir(parents=True)
+    (parent / "p.md").write_text("# p\n", encoding="utf-8")
+    (child / "c.md").write_text("# c\n", encoding="utf-8")
+
+    db_path = tmp_path / "nested.db"
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = db_path
+    config.indexing.memory_dirs = [parent, child]
+
+    backend = SqliteBackend(
+        config.storage, dimension=0, embedding_provider="none", embedding_model=""
+    )
+    await backend.initialize()
+    try:
+        _insert_chunk(backend, chunk_id="p1", source_file=parent / "p.md")
+        _insert_chunk(backend, chunk_id="c1", source_file=child / "c.md")
+    finally:
+        await backend.close()
+
+    reports = _gather_reports(config=config, inspect_dirs=[parent, child])
+    parent_report = next(r for r in reports if Path(r.path) == parent.resolve())
+    child_report = next(r for r in reports if Path(r.path) == child.resolve())
+
+    # Parent owns only p.md; child owns c.md — no double counting.
+    assert parent_report.disk_indexable == 1
+    assert child_report.disk_indexable == 1
+    # Both files are indexed, so neither dir has a coverage gap.
+    assert not any(f.check == "db_coverage" for f in parent_report.findings)
+    assert not any(f.check == "db_coverage" for f in child_report.findings)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+
+
+class TestCli:
+    def _patch_loader(self, monkeypatch, config):
+        import memtomem.cli.memory_doctor_cmd as mod
+
+        monkeypatch.setattr(mod, "_load_config_read_only", lambda: config)
+
+    def test_exit_1_on_error_finding(self, doctor_env, monkeypatch):
+        config, mem_dir = doctor_env
+        backend = SqliteBackend(
+            config.storage, dimension=0, embedding_provider="none", embedding_model=""
+        )
+        import asyncio
+
+        async def _setup():
+            await backend.initialize()
+            _insert_chunk(backend, chunk_id="g1", source_file=mem_dir / "ghost.md")
+            await backend.close()
+
+        asyncio.run(_setup())
+        self._patch_loader(monkeypatch, config)
+
+        result = CliRunner().invoke(cli, ["memory", "doctor"])
+        assert result.exit_code == 1  # stale_source is error-severity
+        assert "no longer exist on disk" in result.output
+
+    def test_json_payload_shape(self, doctor_env, monkeypatch):
+        config, mem_dir = doctor_env
+        backend = SqliteBackend(
+            config.storage, dimension=0, embedding_provider="none", embedding_model=""
+        )
+        import asyncio
+
+        async def _setup():
+            await backend.initialize()
+            _insert_chunk(backend, chunk_id="a1", source_file=mem_dir / "alpha.md")
+            await backend.close()
+
+        asyncio.run(_setup())
+        self._patch_loader(monkeypatch, config)
+
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--json"])
+        payload = json.loads(result.output)
+        assert payload["status"] in ("ok", "issues")
+        assert "summary" in payload and set(payload["summary"]) == {"error", "warn", "info"}
+        dir_entry = next(d for d in payload["dirs"] if d["path"] != "(unowned)")
+        assert dir_entry["category"] == "claude-memory"
+        assert dir_entry["index_file"] == "MEMORY.md"
+        for f in dir_entry["findings"]:
+            assert set(f) == {"check", "severity", "count", "summary", "items"}
+
+    def test_unconfigured_path_errors(self, doctor_env, monkeypatch, tmp_path):
+        config, _ = doctor_env
+        self._patch_loader(monkeypatch, config)
+        result = CliRunner().invoke(cli, ["memory", "doctor", str(tmp_path / "nope")])
+        assert result.exit_code != 0
+        assert "not a configured memory_dir" in result.output


### PR DESCRIPTION
## What

Adds `mm memory doctor` — a **read-only, report-only** hygiene command that surfaces the 3-way drift between what's on disk, what an agent index/TOC file (e.g. Claude Code's `MEMORY.md`) points at, and what's actually indexed in the searchable DB.

PR 2 of the `mm memory doctor` plan; builds on the provider index-file conventions enforced in #1169.

## Why

A registered `memory_dir` can be **barely indexed** — the fs watcher only reacts to live events, so files that landed while the server was down stay invisible until a forced re-walk — and the index file can drift from the files on disk. When that happens, `mem_search` *silently* can't find the un-indexed files. There was also no single-file delete CLI, so deleting a memory file leaves its chunks orphaned in the DB. This command makes all of that visible.

## Checks (per configured `memory_dir`)

- **db_coverage** — files on disk the engine would index but with zero DB chunks (`indexed N/M`). Headline signal.
- **stale_source** — DB chunks whose `source_file` was deleted from disk.
- **convention_violation** — an index/meta file (`MEMORY.md`/`README.md`) indexed as content despite the provider convention.
- **broken_link** — index links classified `missing_target` / `outside_root` (`url` / `anchor` are recognised and *not* reported).
- **index_orphan** — files on disk the index file doesn't list ("not in the TOC" ≠ "not indexed").
- **budget** — index file over its byte / line / per-line-char hot-cache budget (per-line measured in characters, not bytes).
- **cold_candidate** — indexed files never accessed since indexing (informational).

Human output by default; `--json` for CI. Exits `1` only on **definite** inconsistencies (`stale_source`, `convention_violation`, `broken_link`); coverage/orphan/budget/cold are advisory and don't fail the exit code (a partially-indexed dir is a legitimate steady state) — mirrors `mm sync-doctor`, with a JSON + exit code like `mm context settings-doctor`.

## Read-only contract

- Config loads via `Mem2MemConfig` + `load_config_d(quiet=True)` + `load_config_overrides(migrate=False)` — never triggers the legacy auto-discover config rewrite.
- The DB is read through a bare `sqlite3` URI `mode=ro` connection, **never** `SqliteBackend.initialize()` (which would create the file/parent dir, run schema migration, and checkpoint the WAL on close). `mode=ro` still surfaces committed rows in a live writer's WAL; a missing / too-old / corrupt DB degrades to disk/index-only checks instead of being created.
- Discovery reuses the engine's own `discover_indexable_files` with **most-specific-owner** attribution (symmetric with the DB row bucketing), so coverage/orphan counts match the real indexer even with nested configured roots.

## Tests

`tests/test_memory_doctor.py` (25 tests): parser (`..`/absolute/url/anchor/whitespace/non-ASCII), link classification, budget (byte vs char), full drift detection against a **real** `SqliteBackend` + on-disk `claude-memory` dir, golden human + `--json` output, exit codes, and read-only regression pins — missing DB not created, parent dir not `mkdir`-ed, old-schema not migrated, corrupt DB doesn't crash, nested roots don't false-flag coverage.

## Validation

`ruff check` + `ruff format --check` clean; `mypy` clean. Run against the real auto-memory dir it correctly reports the known drift (incl. a deleted file's lingering chunk → `stale_source`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
