### PR TITLE
docs(reference): document `mm memory doctor` + pin the contract with parity tests

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -659,6 +659,20 @@ The exit code is `0` when clean or when only advisory (warn/info) findings exist
           "count": 3,
           "summary": "3/15 indexable file(s) have no DB chunks — `mem_search` can't find them (run `mm index <dir> --force`)",
           "items": ["project_roadmap.md", "feedback_review_style.md", "user_role.md"]
+        },
+        {
+          "check": "stale_source",
+          "severity": "error",
+          "count": 1,
+          "summary": "1 DB source file(s) no longer exist on disk — chunks linger after the file was deleted",
+          "items": ["/Users/you/.claude/projects/-Users-you-Work-myproj/memory/old_notes.md"]
+        },
+        {
+          "check": "budget",
+          "severity": "warn",
+          "count": 2,
+          "summary": "MEMORY.md over budget: 25600 bytes (cap 24400); 212 lines (cap 200); 2 line(s) over 200 chars (L8, L40)",
+          "items": ["L8", "L40"]
         }
       ]
     }

--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -573,6 +573,102 @@ mem_do(action="cleanup_orphans")                    # preview (dry_run=True)
 mem_do(action="cleanup_orphans", params={"dry_run": false})  # delete
 ```
 
+### Memory hygiene — `mm memory doctor`
+
+A `memory_dir` can be *registered* yet barely indexed: the filesystem watcher
+only reacts to live events, so files that landed while the server was down stay
+invisible to `mem_search` until a forced re-walk. The index/TOC file
+(`MEMORY.md`) can also drift from what's on disk, and chunks can linger after a
+source file is deleted. `mm memory doctor` surfaces this **3-way drift** between
+what's on disk, what the index file points at, and what's actually in the
+searchable DB.
+
+It is **read-only** — it never writes to disk, the DB, or `config.json`. The DB
+is opened in SQLite `mode=ro`; a missing or too-old DB degrades to disk/index
+checks instead of being created.
+
+```
+mm memory doctor                 # inspect every configured memory_dir
+mm memory doctor <dir>           # scope to one configured memory_dir
+mm memory doctor --json          # structured output for scripting / CI
+```
+
+#### Example output
+
+```
+■ /Users/you/.claude/projects/-Users-you-Work-myproj/memory
+  claude-memory · index=MEMORY.md · indexed 12/15
+  ! 3/15 indexable file(s) have no DB chunks — `mem_search` can't find them (run `mm index <dir> --force`)
+      - project_roadmap.md
+      - feedback_review_style.md
+      - user_role.md
+  ✗ 1 DB source file(s) no longer exist on disk — chunks linger after the file was deleted
+      - /Users/you/.claude/projects/-Users-you-Work-myproj/memory/old_notes.md
+  ! MEMORY.md over budget: 25600 bytes (cap 24400); 212 lines (cap 200); 2 line(s) over 200 chars (L8, L40)
+      - L8
+      - L40
+
+■ /Users/you/notes
+  user · indexed 40/40
+  ✓ no issues
+
+Summary: 1 error, 2 warn, 0 info.
+```
+
+Each dir header line reads `{category} · [index={index_file} ·] indexed {db_covered}/{disk_indexable}`. Glyphs mark severity: `✗` error, `!` warn, `·` info. Up to 8 sample items are listed per finding (`--json` carries them all).
+
+#### Checks
+
+| Check | Severity | What it means | Remediation |
+|-------|----------|---------------|-------------|
+| `db_coverage` | warn | On disk and indexable, but zero chunks in the DB — `mem_search` can't find it. | `mm index <dir> --force` |
+| `stale_source` | **error** | A DB chunk's source file no longer exists on disk (deleted; chunks linger). | `mem_do(action="cleanup_orphans", params={"dry_run": false})` (see [Orphan cleanup](#orphan-cleanup)) |
+| `convention_violation` | **error** | An index/meta file (`MEMORY.md` / `README.md` for a `claude-memory` dir) was indexed as searchable content. | `mm purge --matching-excluded --apply` |
+| `broken_link` | **error** | A pointer in the index file resolves to a missing target or escapes the memory root. | Fix or remove the link in the index file. |
+| `db_extra` | warn | A DB source exists on disk but falls outside the current indexable set (unsupported extension or excluded path). | Usually expected. If the path is now excluded, `mm purge --matching-excluded --apply` reclaims it; unsupported-extension residue has no targeted fix yet. |
+| `index_orphan` | warn | An indexable file on disk is not listed in the index file (`MEMORY.md`). | Add a pointer line, or leave it — the TOC is curated. |
+| `budget` | warn | The index file exceeds its hot-cache budget: 24,400 bytes / 200 lines / 200 chars per line. | Trim the index file. |
+| `index_missing` | warn | The provider's index file (e.g. `MEMORY.md`) is absent or unreadable. | Create it, or ignore if the dir has no TOC convention. |
+| `cold_candidate` | info | An indexed file never accessed since indexing (`access_count` 0, `last_accessed_at` unset). | Advisory — a future decay/curation candidate. |
+| `db_unavailable` | info | No readable memtomem DB at the configured path — only disk/index checks ran. | `mm index` to build the DB. |
+| `unowned_chunks` | info | DB sources under no configured `memory_dir` (a dir was removed, or content was added elsewhere). | Re-add the dir to keep it indexed; for a project root that was deleted from disk, `mm gc orphan-projects`. |
+
+`db_unavailable` and `unowned_chunks` are store-wide, so they print as top-level lines (`(database)` / `(unowned)`) rather than under a dir header.
+
+#### Exit codes and JSON
+
+The exit code is `0` when clean or when only advisory (warn/info) findings exist, and `1` when any **error**-severity finding is present (`stale_source`, `convention_violation`, `broken_link`) — so a coverage gap or budget overflow won't fail CI, but a deleted-source leak or broken TOC link will.
+
+`--json` emits a stable payload: a top-level `{status, dirs, summary}`, where `status` is `"issues"` when any error- or warn-severity finding exists and `"ok"` otherwise (info-only stays `"ok"`).
+
+```json
+{
+  "status": "issues",
+  "dirs": [
+    {
+      "path": "/Users/you/.claude/projects/-Users-you-Work-myproj/memory",
+      "category": "claude-memory",
+      "index_file": "MEMORY.md",
+      "exists": true,
+      "disk_indexable": 15,
+      "db_covered": 12,
+      "findings": [
+        {
+          "check": "db_coverage",
+          "severity": "warn",
+          "count": 3,
+          "summary": "3/15 indexable file(s) have no DB chunks — `mem_search` can't find them (run `mm index <dir> --force`)",
+          "items": ["project_roadmap.md", "feedback_review_style.md", "user_role.md"]
+        }
+      ]
+    }
+  ],
+  "summary": { "error": 1, "warn": 2, "info": 0 }
+}
+```
+
+> **Read-only by design.** `mm memory doctor` reports; it does not fix. Apply the per-check remediation above — most commonly `mm index <dir> --force` to close a coverage gap. An opt-in `--fix` for the safe, mechanical cases is planned behind its own design note.
+
 ---
 
 ## 6. Data — `mem_export`, `mem_import`

--- a/packages/memtomem/tests/test_memory_doctor.py
+++ b/packages/memtomem/tests/test_memory_doctor.py
@@ -1,6 +1,6 @@
 """Tests for ``mm memory doctor`` (Tier 1 report-only hygiene report).
 
-Three layers:
+Four layers:
 
 * ``TestParser`` / ``TestClassifyLink`` / ``TestBudget`` — pure functions, no
   DB or disk-config side effects.
@@ -11,11 +11,16 @@ Three layers:
   ``feedback_mocked_storage_hides_sql_bugs``).
 * ``TestCli`` — Click ``CliRunner`` end-to-end with the read-only config
   loader stubbed, pinning the exit code and the ``--json`` payload shape.
+* ``TestDocsParity`` — pins the contract documented in
+  ``docs/guides/reference.md`` (check/severity table, error-severity set,
+  budget caps, ``--json`` status rule, help text) against the implementation
+  so the two can't drift.
 """
 
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -507,3 +512,137 @@ class TestCli:
         result = CliRunner().invoke(cli, ["memory", "doctor", str(tmp_path / "nope")])
         assert result.exit_code != 0
         assert "not a configured memory_dir" in result.output
+
+
+# ── Docs-as-tests parity ────────────────────────────────────────────
+#
+# These guards bind the public contract published in
+# ``docs/guides/reference.md`` (§5 "Memory hygiene — `mm memory doctor`")
+# directly to the implementation, so neither can drift unnoticed: the
+# check/severity table is **parsed out of the markdown** and compared to the
+# check/severity pairs **extracted from the command's own ``Finding(...)`` call
+# sites via AST**. Adding, renaming, or re-classifying a check fails here until
+# the reference table is edited to match — and vice versa. The budget caps
+# quoted in the table, the ``--json`` status rule, and the help text are pinned
+# too (memory ``feedback_docs_as_tests`` / ``feedback_docs_parity_canonical_fixture``).
+
+
+def _docs_check_severities() -> dict[str, str]:
+    """Parse the published check→severity table from ``reference.md``.
+
+    Matches table rows whose first cell is a backticked identifier and whose
+    second cell is a (optionally bold) severity word, so only the checks table
+    rows are picked up — not the Glossary or other tables.
+    """
+    ref = Path(__file__).resolve().parents[3] / "docs" / "guides" / "reference.md"
+    assert ref.is_file(), f"reference guide not found at {ref}"
+    row = re.compile(r"^\|\s*`(\w+)`\s*\|\s*\*{0,2}(warn|error|info)\*{0,2}\s*\|")
+    table: dict[str, str] = {}
+    for line in ref.read_text(encoding="utf-8").splitlines():
+        m = row.match(line)
+        if m:
+            table[m.group(1)] = m.group(2)
+    return table
+
+
+def _source_check_severities() -> dict[str, str]:
+    """Extract the check→severity map from every ``Finding(...)`` call site in
+    the command module via AST.
+
+    Fails loudly if any ``Finding`` call omits a string-literal ``check`` /
+    ``severity`` (e.g. a future check moved to a named constant) so a new check
+    cannot slip past the parity guard by being non-literal.
+    """
+    import ast
+
+    import memtomem.cli.memory_doctor_cmd as mod
+
+    tree = ast.parse(Path(mod.__file__).read_text(encoding="utf-8"))
+    found: dict[str, str] = {}
+    calls = 0
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+            continue
+        if node.func.id != "Finding":
+            continue
+        calls += 1
+        kw = {k.arg: k.value for k in node.keywords}
+        check_node, sev_node = kw.get("check"), kw.get("severity")
+        assert isinstance(check_node, ast.Constant) and isinstance(check_node.value, str), (
+            f"Finding at line {node.lineno} has a non-literal/missing check= — "
+            "the docs-parity guard requires string literals"
+        )
+        assert isinstance(sev_node, ast.Constant) and isinstance(sev_node.value, str), (
+            f"Finding at line {node.lineno} has a non-literal/missing severity="
+        )
+        check, sev = check_node.value, sev_node.value
+        # Same check at two call sites (index_missing) must agree on severity.
+        assert found.get(check, sev) == sev, f"{check} has conflicting severities"
+        found[check] = sev
+    assert calls > 0, "no Finding(...) call sites found — was the symbol renamed?"
+    return found
+
+
+class TestDocsParity:
+    def test_docs_table_matches_source(self):
+        docs = _docs_check_severities()
+        assert docs, "no check rows parsed from reference.md — did the table format change?"
+        # The published markdown table must equal the implementation's checks.
+        assert docs == _source_check_severities()
+
+    def test_error_severity_set_documented(self):
+        # The reference guide names exactly these three as the exit-1 drivers
+        # (independent anchor: catches docs+source drifting together).
+        errors = {c for c, s in _docs_check_severities().items() if s == "error"}
+        assert errors == {"stale_source", "convention_violation", "broken_link"}
+
+    def test_budget_caps_match_documented_numbers(self):
+        import memtomem.cli.memory_doctor_cmd as mod
+
+        # Quoted in the checks table: "24,400 bytes / 200 lines / 200 chars".
+        assert mod._INDEX_MAX_BYTES == 24_400
+        assert mod._INDEX_MAX_LINES == 200
+        assert mod._INDEX_MAX_LINE_CHARS == 200
+
+    def test_help_documents_usage_flags_and_exit_codes(self):
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--help"])
+        assert result.exit_code == 0
+        # Click hard-wraps help to the terminal width and breaks on hyphens, so
+        # collapse whitespace and assert on non-hyphenated prose tokens.
+        out = " ".join(result.output.split())
+        for token in (
+            "PATH",  # optional dir argument
+            "--json",  # structured-output flag
+            "Exit codes",  # exit-code documentation
+            "stale DB sources",  # the three documented error-severity checks…
+            "convention violations",
+            "broken index links",
+        ):
+            assert token in out, f"help text missing {token!r}"
+
+    def test_memory_group_lists_doctor(self):
+        result = CliRunner().invoke(cli, ["memory", "--help"])
+        assert result.exit_code == 0
+        assert "doctor" in result.output
+        assert "hygiene" in result.output
+
+    def test_json_status_rule_matches_summary(self, capsys):
+        # Documented rule: status is "issues" when any error/warn finding
+        # exists; an info-only report stays "ok".
+        from memtomem.cli.memory_doctor_cmd import DirReport, Finding, _emit_json
+
+        report = DirReport(
+            path="/d",
+            category="user",
+            index_file=None,
+            exists=True,
+            disk_indexable=1,
+            db_covered=1,
+        )
+        report.findings.append(Finding(check="cold_candidate", severity="info", summary="x"))
+        _emit_json([report])
+        assert json.loads(capsys.readouterr().out)["status"] == "ok"
+
+        report.findings.append(Finding(check="db_coverage", severity="warn", summary="y"))
+        _emit_json([report])
+        assert json.loads(capsys.readouterr().out)["status"] == "issues"


### PR DESCRIPTION
## What

`mm memory doctor` (the read-only memory-hygiene report from #1170) shipped without user-facing docs. This adds them and pins the documented contract with tests so the docs can't drift from the implementation.

- **`docs/guides/reference.md` §5 "Memory hygiene — `mm memory doctor`"** — what the command does (the 3-way drift between disk, the index/TOC file, and the searchable DB), usage, the full **check → severity → remediation** table (all 11 checks), example human + `--json` output, exit-code semantics, and the read-only-by-design note.
- **`tests/test_memory_doctor.py::TestDocsParity`** — docs-as-tests guards.

## Docs-as-tests binding

The parity test **parses the check/severity table out of `reference.md`** and asserts it equals the `{check: severity}` pairs **extracted from the command's own `Finding(...)` call sites via AST** — so adding, renaming, or re-classifying a check fails the test until the published table is edited to match (and vice versa). Mutation-validated: flipping a severity in the source makes `test_docs_table_matches_source` fail with a clear diff. The AST extractor fails loudly on any non-literal `check`/`severity` rather than silently skipping it. Budget caps, the `--json` status rule, and the `--help` text are pinned too.

## Verified before writing

| Documented claim | Verified against |
|---|---|
| Check names + severities (11) | AST of `Finding(...)` call sites in `memory_doctor_cmd.py` (12 sites; `index_missing` ×2) |
| Exit code `1` on `stale_source`/`convention_violation`/`broken_link` | `memory_doctor` exit logic + `--help` |
| `--json` shape `{status, dirs[], summary}`; `status="issues"` on error/warn | live `mm memory doctor --json` |
| Budget caps 24,400 B / 200 lines / 200 chars | `_INDEX_MAX_*` constants |
| `db_coverage` → `mm index <dir> --force` | `mm index --help` |
| `convention_violation` → `mm purge --matching-excluded --apply` | `mm purge --help` / `purge_cmd.py` |
| `stale_source` → `mem_do(action="cleanup_orphans")` | `reference.md` §5 / `dedup_decay.py` |
| `unowned_chunks` → `mm gc orphan-projects` only for deleted project roots | `mm gc orphan-projects --help` / `gc_cmd.py` |
| Example human output format | live `mm memory doctor` |

## Tests

`uv run pytest packages/memtomem/tests/test_memory_doctor.py` → 31 passed. `ruff check` + `ruff format --check` clean. Reviewed by Codex (round 2: SHIP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
