### PR TITLE
feat(cli): add `mm memory doctor --fix` — subtractive removal of dead index links

### DIFF
--- a/docs/guides/reference.md
+++ b/docs/guides/reference.md
@@ -583,14 +583,18 @@ source file is deleted. `mm memory doctor` surfaces this **3-way drift** between
 what's on disk, what the index file points at, and what's actually in the
 searchable DB.
 
-It is **read-only** — it never writes to disk, the DB, or `config.json`. The DB
-is opened in SQLite `mode=ro`; a missing or too-old DB degrades to disk/index
-checks instead of being created.
+It is **read-only by default** — without `--fix` it never writes to disk, the
+DB, or `config.json`. The DB is opened in SQLite `mode=ro`; a missing or too-old
+DB degrades to disk/index checks instead of being created. The one opt-in write
+path is `--fix --apply` (see [Fixing broken links](#fixing-broken-links)), which
+touches only the index file and never the DB or config.
 
 ```
 mm memory doctor                 # inspect every configured memory_dir
 mm memory doctor <dir>           # scope to one configured memory_dir
 mm memory doctor --json          # structured output for scripting / CI
+mm memory doctor --fix           # preview removable broken links (dry-run)
+mm memory doctor --fix --apply   # remove them from the index file
 ```
 
 #### Example output
@@ -624,7 +628,7 @@ Each dir header line reads `{category} · [index={index_file} ·] indexed {db_co
 | `db_coverage` | warn | On disk and indexable, but zero chunks in the DB — `mem_search` can't find it. | `mm index <dir> --force` |
 | `stale_source` | **error** | A DB chunk's source file no longer exists on disk (deleted; chunks linger). | `mem_do(action="cleanup_orphans", params={"dry_run": false})` (see [Orphan cleanup](#orphan-cleanup)) |
 | `convention_violation` | **error** | An index/meta file (`MEMORY.md` / `README.md` for a `claude-memory` dir) was indexed as searchable content. | `mm purge --matching-excluded --apply` |
-| `broken_link` | **error** | A pointer in the index file resolves to a missing target or escapes the memory root. | Fix or remove the link in the index file. |
+| `broken_link` | **error** | A pointer in the index file resolves to a missing target or escapes the memory root. | `mm memory doctor --fix --apply` removes the `missing_target` subset (see [Fixing broken links](#fixing-broken-links)); fix or remove `outside_root` links by hand. |
 | `db_extra` | warn | A DB source exists on disk but falls outside the current indexable set (unsupported extension or excluded path). | Usually expected. If the path is now excluded, `mm purge --matching-excluded --apply` reclaims it; unsupported-extension residue has no targeted fix yet. |
 | `index_orphan` | warn | An indexable file on disk is not listed in the index file (`MEMORY.md`). | Add a pointer line, or leave it — the TOC is curated. |
 | `budget` | warn | The index file exceeds its hot-cache budget: 24,400 bytes / 200 lines / 200 chars per line. | Trim the index file. |
@@ -681,7 +685,22 @@ The exit code is `0` when clean or when only advisory (warn/info) findings exist
 }
 ```
 
-> **Read-only by design.** `mm memory doctor` reports; it does not fix. Apply the per-check remediation above — most commonly `mm index <dir> --force` to close a coverage gap. An opt-in `--fix` for the safe, mechanical cases is planned behind its own design note.
+> **Read-only by default.** Without `--fix`, `mm memory doctor` reports and never writes. Apply the per-check remediation above — most commonly `mm index <dir> --force` to close a coverage gap.
+
+#### Fixing broken links
+
+`--fix` is the one opt-in write path (contract: [ADR-0020](../adr/0020-memory-index-write-contract.md)). It is **subtractive only**: it removes index-file pointer lines whose target is a `missing_target` — a `- [title](target)` link that resolves *inside* the memory root but points at a file that no longer exists on disk — and nothing else. Removing a provably-dead pointer is the one curation move that can't conflict with the agent that owns the index file, so it is the only thing `--fix` does. It never adds, reorders, reformats, or trims for budget, and never edits the DB.
+
+```
+mm memory doctor --fix           # dry-run: print the lines that would be removed
+mm memory doctor --fix --apply   # rewrite the index file (atomic, mode-preserving)
+```
+
+Scope and guarantees:
+
+- **`missing_target` only.** `outside_root` links (those escaping the memory root) are left alone — the intent is ambiguous (a typo'd path vs. a deliberate out-of-tree reference), so removing them is your call. `budget` (which entries to cut is prose judgement), `index_orphan` (adding a pointer needs a generated title/hook), and the DB-side `stale_source` / `convention_violation` are also out of scope — use their own remediation.
+- **Byte-exact otherwise.** Every surviving line keeps its exact content and end-of-line terminator (LF/CRLF) and the file's trailing-newline state is untouched; a `--fix --apply` on a file with no `missing_target` links is a byte-for-byte no-op.
+- **Concurrency-aware, not race-free.** `--apply` re-reads the file fresh under a sidecar lock and re-validates each candidate (still present *and* still dead) before an atomic replace, so a pointer the agent edited or whose target reappeared is spared. Removals are **count-bounded to the links present and dead at analysis time**: distinct pointers the agent added since are never removed, and an exact byte-duplicate of a dead link keeps the right number of copies (which identical copy survives is unspecified, since they're equal). Because the agent (the memory hook) doesn't take memtomem's lock, a residual sub-rename window remains; it is accepted as bounded (the agent writes `MEMORY.md` at session boundaries, the edit is a small subtraction) — **`--fix` does not claim "never clobbers."** Every removed line is printed (in both dry-run and `--apply`) so any churn is auditable from your editor / VCS / agent history.
 
 ---
 

--- a/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/memory_doctor_cmd.py
@@ -1,10 +1,18 @@
-"""CLI: ``mm memory doctor`` — read-only hygiene report for memory stores.
+"""CLI: ``mm memory doctor`` — hygiene report (+ narrow ``--fix``) for memory stores.
 
 Tier 1 of the ``mm memory doctor`` plan: surface 3-way drift between what's
 on disk, what the agent-managed index file (e.g. Claude Code's ``MEMORY.md``)
-points at, and what's actually indexed in the searchable DB. Report-only — no
-writes to disk, the DB, or config. The curation write contract (``--fix``)
-lands later behind its own ADR.
+points at, and what's actually indexed in the searchable DB. The default
+command is report-only — no writes to disk, the DB, or config.
+
+Tier 2 adds an opt-in ``--fix`` (ADR-0020): a *subtractive-only* curation that
+deletes index-file pointer lines the doctor classifies as ``broken_link`` with
+link-class ``missing_target`` (a ``- [title](target)`` whose target resolves
+inside the memory root but points at a file that no longer exists). It never
+adds, reorders, reformats, or budget-trims, and never touches the DB —
+removing a provably-dead pointer is the one curation move that cannot conflict
+with the agent's own intent. ``--fix`` is dry-run by default; ``--apply``
+writes. See :func:`_run_fix` for the write contract.
 
 Why this exists: a ``memory_dir`` can be *registered* yet barely indexed (the
 fs watcher only reacts to live events, so files that landed while the server
@@ -758,6 +766,227 @@ def _emit_json(reports: list[DirReport]) -> None:
     click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
+# ── Tier 2: subtractive --fix (ADR-0020) ────────────────────────────
+#
+# ``--fix`` deletes index-file pointer lines whose link-class is
+# ``missing_target`` and nothing else. The contract (ADR-0020):
+#   §1 subtractive-only, missing_target-only (outside_root et al. excluded);
+#   §2 byte-exact preservation of every surviving line via a line *splice*
+#      (keepends) of the ORIGINAL text — never a reconstruction from parsed
+#      fields, which would lose CRLF / trailing-newline state;
+#   §4 dry-run by default, ``--apply`` to write;
+#   §5 atomic write (mode-preserving) under the sidecar lock, re-validating
+#      each candidate against fresh content so concurrent agent edits survive.
+
+
+@dataclass
+class FixFileResult:
+    """Per-index-file outcome of a ``--fix`` run (preview or applied)."""
+
+    path: str  # the resolved memory_dir
+    index_file: str  # the index filename (e.g. MEMORY.md)
+    applied: bool
+    removed: list[tuple[int, str]]  # (1-based line_no, raw line text)
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "index_file": self.index_file,
+            "removed": [{"line": n, "text": t} for n, t in self.removed],
+        }
+
+
+def _missing_target_entries(text: str, *, root: Path) -> list[IndexEntry]:
+    """Pointer entries in *text* whose target classifies as ``missing_target``.
+
+    The single link-class ``--fix`` removes (ADR-0020 §1): a pointer that
+    resolves *inside* the memory root but points at a file that does not exist.
+    ``outside_root`` / ``url`` / ``anchor`` / ``ok`` are all left untouched —
+    only a provably-dead in-root reference is safe to delete subtractively.
+    """
+    parsed = parse_memory_index(text)
+    return [
+        e
+        for e in parsed.entries
+        if classify_link(e.target, root=root, source_dir=root) == "missing_target"
+    ]
+
+
+def _splice_lines(original_text: str, remove_line_nos: set[int]) -> str:
+    """Return *original_text* with the given 1-based lines removed, byte-exact.
+
+    ADR-0020 §2: every surviving line keeps its exact end-of-line terminator
+    (LF vs CRLF) and the file's trailing-newline state is untouched. The
+    mechanism is a *splice* of the original text — ``splitlines(keepends=True)``
+    has the same 1-based line indexing as the parser's terminator-stripped
+    ``splitlines()``, so a parser ``line_no`` maps directly to an index here —
+    NOT a reconstruction from ``IndexEntry.raw`` / ``other_lines`` (which are
+    terminator-stripped and could not round-trip CRLF or the EOF newline).
+    """
+    return "".join(
+        line
+        for i, line in enumerate(original_text.splitlines(keepends=True), start=1)
+        if i not in remove_line_nos
+    )
+
+
+def _apply_fix(index_path: Path, root: Path, candidate_raws: list[str]) -> list[tuple[int, str]]:
+    """Under the sidecar lock, splice still-dead candidate lines out of *index_path*.
+
+    Implements ADR-0020 §5's concurrency-aware write. All work happens while
+    holding the ``_file_lock`` sidecar lock so a concurrent *memtomem* writer is
+    serialized; the agent (the memory hook) does not honor the lock, so a
+    residual sub-``os.replace`` race remains and is accepted as bounded — see
+    the ADR.
+
+    1. **Fresh, newline-preserving re-read** (``read_bytes().decode`` — NOT
+       ``read_text``, which would normalize CRLF→LF before the splice could
+       preserve it).
+    2. **Re-validate** each candidate against the fresh content + current disk.
+       A fresh entry is removed only if it still classifies as ``missing_target``
+       (so a target that reappeared on disk is spared) AND its raw line text is
+       still "owed" by *candidate_raws*. Matching is *count-bounded*:
+       ``candidate_raws`` carries one entry per occurrence analysis (T1) saw, and
+       each fresh removal consumes one, so removals never exceed the
+       analysis-time count of a given line. Distinct entries the agent added
+       after T1 are therefore never removed, and an agent *edit* to a candidate
+       line spares it (its raw no longer matches). The one residual case is an
+       agent that added an *exact byte-duplicate* of a still-dead candidate: the
+       budget keeps the right number of copies (the net of the addition is
+       preserved), but because the duplicates are byte-identical, *which*
+       physical line survives is unspecified — and irrelevant, since the spliced
+       result is byte-identical either way. The budget bounds removals to what
+       was provably dead at analysis time.
+    3. **Splice** the still-qualifying lines out of the fresh text, carrying
+       through everything the agent added before the lock.
+    4. **Atomically replace**, preserving the file's existing mode (``mkstemp``
+       defaults to ``0o600``, which would silently downgrade a ``0o644`` TOC).
+
+    Returns the removed lines as ``(line_no, raw)`` for the audit report.
+    """
+    import stat
+    from collections import Counter
+
+    from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_text
+
+    with _file_lock(_lock_path_for(index_path)):
+        # §5.1 — fresh, newline-preserving read (NOT read_text()).
+        fresh_text = index_path.read_bytes().decode("utf-8")
+        fresh = parse_memory_index(fresh_text)
+        # §5.2 — re-validate against a count-bounded budget: remove at most as
+        # many occurrences of each raw line as analysis (T1) saw. Distinct agent
+        # additions are never touched; for a byte-identical duplicate of a dead
+        # candidate the net addition is preserved (one fewer copy), though which
+        # equal copy survives is unspecified (they're identical, so the spliced
+        # result is the same either way).
+        budget: Counter[str] = Counter(candidate_raws)
+        removed: list[tuple[int, str]] = []
+        for e in fresh.entries:
+            if budget[e.raw] <= 0:
+                continue  # not a candidate, or its analysis-time count is exhausted
+            if classify_link(e.target, root=root, source_dir=root) != "missing_target":
+                continue  # target reappeared since analysis — leave it alone
+            budget[e.raw] -= 1
+            removed.append((e.line_no, e.raw))
+        if not removed:
+            return []
+        # §5.3 — splice out of the FRESH text (agent additions carried through).
+        new_text = _splice_lines(fresh_text, {n for n, _ in removed})
+        # §5.4 — atomic replace, preserving the original file mode.
+        original_mode = stat.S_IMODE(index_path.stat().st_mode)
+        atomic_write_text(index_path, new_text, mode=original_mode)
+    return removed
+
+
+def _collect_fixable(inspect_dirs: list[Path]) -> list[tuple[Path, Path, str]]:
+    """Find inspected dirs with a readable index file. Returns ``(dir, index_path, name)``.
+
+    Only providers with a TOC convention (``provider_index_file``) and an index
+    file actually on disk are fixable; everything else is skipped silently
+    (there is nothing for a subtractive fix to act on).
+    """
+    from memtomem.config import categorize_memory_dir, provider_index_file
+
+    out: list[tuple[Path, Path, str]] = []
+    for d in inspect_dirs:
+        resolved = d.expanduser().resolve()
+        index_file_name = provider_index_file(categorize_memory_dir(d))
+        if not index_file_name:
+            continue
+        index_path = resolved / index_file_name
+        if not index_path.is_file():
+            continue
+        out.append((resolved, index_path, index_file_name))
+    return out
+
+
+def _run_fix(*, inspect_dirs: list[Path], apply: bool, json_out: bool) -> None:
+    """Drive ``--fix`` over every inspected dir's index file (preview or apply).
+
+    Per file the analysis-time read (T1) collects the ``missing_target``
+    candidates; ``--apply`` then hands their raw line text to :func:`_apply_fix`,
+    which re-reads fresh under the lock (T2) and re-validates before writing.
+    Dry-run reports the T1 candidates directly. Each removed line is reported
+    (ADR-0020 §5 — even on ``--apply``, the removal must be auditable).
+    """
+    results: list[FixFileResult] = []
+    for resolved, index_path, index_file_name in _collect_fixable(inspect_dirs):
+        try:
+            # T1 (analysis snapshot). Terminator-stripped ``raw`` is CRLF-agnostic,
+            # so this read need not be newline-preserving — only the apply splice is.
+            text = index_path.read_bytes().decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        candidates = _missing_target_entries(text, root=resolved)
+        if not candidates:
+            results.append(FixFileResult(str(resolved), index_file_name, applied=apply, removed=[]))
+            continue
+        if apply:
+            removed = _apply_fix(index_path, resolved, [e.raw for e in candidates])
+        else:
+            removed = [(e.line_no, e.raw) for e in candidates]
+        results.append(
+            FixFileResult(str(resolved), index_file_name, applied=apply, removed=removed)
+        )
+
+    if json_out:
+        _emit_fix_json(results, applied=apply)
+    else:
+        _emit_fix_human(results, applied=apply)
+
+
+def _emit_fix_human(results: list[FixFileResult], *, applied: bool) -> None:
+    total = sum(len(r.removed) for r in results)
+    if total == 0:
+        click.secho("No missing_target links to remove.", fg="green")
+        return
+    verb = "Removed" if applied else "Would remove"
+    for r in results:
+        if not r.removed:
+            continue
+        click.secho(f"\n■ {r.path} · {r.index_file}", bold=True)
+        click.echo(f"  {verb} {len(r.removed)} missing_target link(s):")
+        for line_no, raw in r.removed:
+            click.echo(f"      - L{line_no}: {raw}")
+    n_files = sum(1 for r in results if r.removed)
+    if applied:
+        click.secho(f"\n{total} line(s) removed across {n_files} file(s).", fg="green")
+    else:
+        click.echo(f"\n{total} line(s) across {n_files} file(s). Run with --apply to write.")
+
+
+def _emit_fix_json(results: list[FixFileResult], *, applied: bool) -> None:
+    total = sum(len(r.removed) for r in results)
+    status = "clean" if total == 0 else ("fixed" if applied else "would-fix")
+    payload = {
+        "status": status,
+        "applied": applied,
+        "files": [r.to_json() for r in results if r.removed],
+        "summary": {"files": sum(1 for r in results if r.removed), "lines": total},
+    }
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
 # ── Click entry point ───────────────────────────────────────────────
 
 
@@ -775,7 +1004,24 @@ def memory() -> None:
     default=False,
     help="Emit a structured JSON result instead of human-readable output.",
 )
-def memory_doctor(path: str | None, json_out: bool) -> None:
+@click.option(
+    "--fix",
+    "fix",
+    is_flag=True,
+    default=False,
+    help=(
+        "Subtractively remove broken `missing_target` links from the index file "
+        "(ADR-0020). Dry-run unless --apply. Other findings are left untouched."
+    ),
+)
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    default=False,
+    help="With --fix, actually rewrite the index file. Without it, --fix is a dry-run.",
+)
+def memory_doctor(path: str | None, json_out: bool, fix: bool, apply_: bool) -> None:
     """Report drift between disk, the index file, and the searchable DB (read-only).
 
     With no PATH, inspects every configured ``memory_dir``. Pass a PATH to
@@ -784,7 +1030,16 @@ def memory_doctor(path: str | None, json_out: bool) -> None:
     Exit codes: ``0`` clean (or advisory-only findings), ``1`` when any
     error-severity finding exists (stale DB sources, convention violations,
     or broken index links).
+
+    ``--fix`` switches to a subtractive curation mode: it removes index-file
+    pointer lines whose target is missing on disk (``broken_link`` /
+    ``missing_target``) and nothing else (ADR-0020). It is a dry-run preview
+    unless ``--apply`` is also passed. The default report is read-only and
+    unchanged.
     """
+    if apply_ and not fix:
+        raise click.UsageError("--apply only applies with --fix. See: mm memory doctor --help")
+
     config = _load_config_read_only()
     memory_dirs = config.indexing.all_index_roots()
 
@@ -801,6 +1056,10 @@ def memory_doctor(path: str | None, json_out: bool) -> None:
 
     if not inspect_dirs:
         click.secho("No memory_dirs configured. Run `mm init`.", fg="yellow")
+        return
+
+    if fix:
+        _run_fix(inspect_dirs=inspect_dirs, apply=apply_, json_out=json_out)
         return
 
     reports = _gather_reports(config=config, inspect_dirs=inspect_dirs)

--- a/packages/memtomem/tests/test_memory_doctor.py
+++ b/packages/memtomem/tests/test_memory_doctor.py
@@ -1,6 +1,6 @@
-"""Tests for ``mm memory doctor`` (Tier 1 report-only hygiene report).
+"""Tests for ``mm memory doctor`` (Tier 1 report-only + Tier 2 ``--fix``).
 
-Four layers:
+Layers:
 
 * ``TestParser`` / ``TestClassifyLink`` / ``TestBudget`` — pure functions, no
   DB or disk-config side effects.
@@ -15,12 +15,18 @@ Four layers:
   ``docs/guides/reference.md`` (check/severity table, error-severity set,
   budget caps, ``--json`` status rule, help text) against the implementation
   so the two can't drift.
+* ``TestSpliceRoundTrip`` / ``TestMissingTargetGuard`` / ``TestApplyFix`` /
+  ``TestFixCli`` — Tier 2 ``--fix`` (ADR-0020): byte-exact line splicing across
+  LF/CRLF ± trailing newline, the missing_target-only subtractive guard, the
+  locked re-validate/atomic-write apply path against a real on-disk index file,
+  and the CLI dry-run/apply/exit-code surface.
 """
 
 from __future__ import annotations
 
 import json
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -28,7 +34,10 @@ from click.testing import CliRunner
 
 from memtomem.cli import cli
 from memtomem.cli.memory_doctor_cmd import (
+    _apply_fix,
     _gather_reports,
+    _missing_target_entries,
+    _splice_lines,
     classify_link,
     measure_budget,
     parse_memory_index,
@@ -626,6 +635,28 @@ class TestDocsParity:
         assert "doctor" in result.output
         assert "hygiene" in result.output
 
+    def test_help_documents_fix_flags(self):
+        # The Tier 2 write path (ADR-0020) must be discoverable from --help.
+        # Click hard-wraps and breaks on hyphens, so assert only on the option
+        # names and the underscore-joined (break-safe) scope token.
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--help"])
+        assert result.exit_code == 0
+        out = " ".join(result.output.split())
+        assert "--fix" in out
+        assert "--apply" in out
+        assert "missing_target" in out  # the subtractive scope is documented
+
+    def test_reference_documents_fix(self):
+        # reference.md §5 gains the --fix surface when Tier 2 ships (ADR-0020
+        # consequence). Pin the usage examples + the subtractive-scope wording
+        # so docs can't silently drift from the shipped flags.
+        ref = Path(__file__).resolve().parents[3] / "docs" / "guides" / "reference.md"
+        text = ref.read_text(encoding="utf-8")
+        assert "mm memory doctor --fix --apply" in text
+        assert "Fixing broken links" in text  # the subsection heading
+        assert "subtractive" in text.lower()
+        assert "0020-memory-index-write-contract" in text  # ADR link
+
     def test_json_status_rule_matches_summary(self, capsys):
         # Documented rule: status is "issues" when any error/warn finding
         # exists; an info-only report stays "ok".
@@ -646,3 +677,319 @@ class TestDocsParity:
         report.findings.append(Finding(check="db_coverage", severity="warn", summary="y"))
         _emit_json([report])
         assert json.loads(capsys.readouterr().out)["status"] == "issues"
+
+
+# ── Tier 2: --fix line splice (ADR-0020 §2 — byte-exact preservation) ─
+#
+# The splice is the load-bearing primitive of the write contract: it must keep
+# every surviving line's exact terminator (LF vs CRLF) and the file's
+# trailing-newline state, and a no-removal splice must be a byte-for-byte
+# identity. These cases are the round-trip proof ADR-0020 §2 requires.
+
+
+class TestSpliceRoundTrip:
+    # Each fixture varies the EOL style and trailing-newline state; the identity
+    # case (no removal) must return the input unchanged byte-for-byte.
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "- [A](a.md)\n- [B](b.md)\n- [C](c.md)\n",  # LF, trailing newline
+            "- [A](a.md)\n- [B](b.md)\n- [C](c.md)",  # LF, no trailing newline
+            "- [A](a.md)\r\n- [B](b.md)\r\n- [C](c.md)\r\n",  # CRLF, trailing
+            "- [A](a.md)\r\n- [B](b.md)\r\n- [C](c.md)",  # CRLF, no trailing
+            "",  # empty file
+            "\n\n",  # blank lines only
+        ],
+    )
+    def test_no_removal_is_byte_identity(self, text):
+        assert _splice_lines(text, set()) == text
+
+    def test_removes_only_targeted_line_lf(self):
+        text = "- [A](a.md)\n- [B](b.md)\n- [C](c.md)\n"
+        # Drop line 2 (B); A and C survive with their LF terminators.
+        assert _splice_lines(text, {2}) == "- [A](a.md)\n- [C](c.md)\n"
+
+    def test_removes_only_targeted_line_crlf_preserved(self):
+        text = "- [A](a.md)\r\n- [B](b.md)\r\n- [C](c.md)\r\n"
+        # Survivors keep CRLF — the splice never normalizes to LF.
+        out = _splice_lines(text, {2})
+        assert out == "- [A](a.md)\r\n- [C](c.md)\r\n"
+        assert "\r\n" in out and out.count("\n") == 2
+
+    def test_remove_last_line_without_trailing_newline(self):
+        # Removing the final (un-terminated) line leaves the prior line's
+        # terminator intact; no spurious newline is added or removed.
+        text = "- [A](a.md)\n- [B](b.md)"
+        assert _splice_lines(text, {2}) == "- [A](a.md)\n"
+
+    def test_remove_first_of_no_trailing(self):
+        text = "- [A](a.md)\n- [B](b.md)"
+        assert _splice_lines(text, {1}) == "- [B](b.md)"
+
+
+# ── Tier 2: missing_target-only subtractive guard (ADR-0020 §1) ───────
+
+
+class TestMissingTargetGuard:
+    def _index(self, tmp_path):
+        """A claude-style index with one of every link-class + an existing file."""
+        (tmp_path / "exists.md").write_text("x", encoding="utf-8")
+        text = (
+            "- [Ok](exists.md) — present\n"
+            "- [Dead](gone.md) — missing target\n"
+            "- [Escape](../../../etc/passwd) — outside root\n"
+            "- [Web](https://example.com) — url\n"
+            "- [Anchor](#section) — anchor\n"
+        )
+        return text
+
+    def test_selects_only_missing_target(self, tmp_path):
+        text = self._index(tmp_path)
+        entries = _missing_target_entries(text, root=tmp_path)
+        # ONLY the missing-target line — outside_root/url/anchor/ok excluded.
+        assert [e.target for e in entries] == ["gone.md"]
+        assert entries[0].line_no == 2
+
+    def test_reappeared_target_not_selected(self, tmp_path):
+        text = "- [Dead](gone.md) — x\n"
+        assert _missing_target_entries(text, root=tmp_path)  # gone.md absent → selected
+        (tmp_path / "gone.md").write_text("back", encoding="utf-8")
+        assert _missing_target_entries(text, root=tmp_path) == []  # now present → spared
+
+
+# ── Tier 2: locked apply path (ADR-0020 §5) ──────────────────────────
+
+
+def _candidate_raws(text, root):
+    # A list, not a set — multiplicity matters: the apply budget removes at most
+    # as many occurrences of each raw as analysis saw (ADR-0020 §5).
+    return [e.raw for e in _missing_target_entries(text, root=root)]
+
+
+class TestApplyFix:
+    def _setup(self, tmp_path):
+        root = tmp_path / "mem"
+        root.mkdir()
+        (root / "exists.md").write_text("x", encoding="utf-8")
+        return root
+
+    def test_removes_missing_keeps_other_classes(self, tmp_path):
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        text = (
+            "# TOC\n"
+            "- [Ok](exists.md) — keep\n"
+            "- [Dead](gone.md) — drop\n"
+            "- [Escape](../../etc/passwd) — keep (outside_root, ambiguous)\n"
+            "- [Web](https://x.com) — keep\n"
+        )
+        index.write_text(text, encoding="utf-8")
+        removed = _apply_fix(index, root, _candidate_raws(text, root))
+        assert [r[1] for r in removed] == ["- [Dead](gone.md) — drop"]
+        out = index.read_text(encoding="utf-8")
+        assert "gone.md" not in out
+        # Every non-missing_target line — including outside_root — survives.
+        for keep in ("# TOC", "exists.md", "etc/passwd", "https://x.com"):
+            assert keep in out
+
+    def test_crlf_survivors_preserved(self, tmp_path):
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        text = "- [Ok](exists.md) — keep\r\n- [Dead](gone.md) — drop\r\n"
+        index.write_bytes(text.encode("utf-8"))  # write CRLF bytes verbatim
+        _apply_fix(index, root, _candidate_raws(text, root))
+        raw = index.read_bytes()
+        # Survivor keeps CRLF; the dropped line is gone; no LF normalization.
+        assert raw == b"- [Ok](exists.md) \xe2\x80\x94 keep\r\n"
+
+    def test_no_trailing_newline_preserved(self, tmp_path):
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        text = "- [Ok](exists.md) — a\n- [Dead](gone.md) — b"  # no EOF newline
+        index.write_text(text, encoding="utf-8")
+        _apply_fix(index, root, _candidate_raws(text, root))
+        # Dropping the un-terminated last line leaves the survivor's LF intact.
+        assert index.read_text(encoding="utf-8") == "- [Ok](exists.md) — a\n"
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="POSIX mode bits; NTFS ignores them (atomic_write preserves access via ACL inheritance)",
+    )
+    def test_file_mode_preserved_not_downgraded(self, tmp_path):
+        import os
+        import stat
+
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        text = "- [Dead](gone.md) — x\n- [Ok](exists.md) — y\n"
+        index.write_text(text, encoding="utf-8")
+        os.chmod(index, 0o644)  # a typical TOC mode, NOT atomic_write's 0o600
+        _apply_fix(index, root, _candidate_raws(text, root))
+        assert stat.S_IMODE(index.stat().st_mode) == 0o644
+
+    def test_revalidate_target_reappeared_is_spared(self, tmp_path):
+        # Candidate collected while gone.md is absent; the target reappears
+        # before apply (the locked re-classify sees it as ok → spares the line).
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        text = "- [Dead](gone.md) — x\n- [Ok](exists.md) — y\n"
+        index.write_text(text, encoding="utf-8")
+        candidates = _candidate_raws(text, root)
+        (root / "gone.md").write_text("resurrected", encoding="utf-8")
+        removed = _apply_fix(index, root, candidates)
+        assert removed == []
+        assert index.read_text(encoding="utf-8") == text  # untouched
+
+    def test_revalidate_agent_edited_candidate_line_is_spared(self, tmp_path):
+        # The agent rewrote the candidate line's hook since analysis. Its raw no
+        # longer matches the candidate set, so the fix leaves it alone.
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        analysis_text = "- [Dead](gone.md) — old hook\n"
+        candidates = _candidate_raws(analysis_text, root)
+        index.write_text("- [Dead](gone.md) — NEW hook\n", encoding="utf-8")
+        removed = _apply_fix(index, root, candidates)
+        assert removed == []
+        assert index.read_text(encoding="utf-8") == "- [Dead](gone.md) — NEW hook\n"
+
+    def test_agent_additions_carried_through_new_dead_spared(self, tmp_path):
+        # Between analysis and apply the agent appended two lines: a real pointer
+        # and a *new* dead pointer that was never a candidate. The fix removes
+        # only the original candidate; both additions survive (the new dead one
+        # is spared because it isn't in the candidate set — it may precede a file
+        # the agent is about to create).
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        analysis_text = "- [Dead](gone.md) — drop\n"
+        candidates = _candidate_raws(analysis_text, root)
+        fresh = (
+            "- [Dead](gone.md) — drop\n"
+            "- [Real](exists.md) — agent added\n"
+            "- [Fresh](alsogone.md) — agent added, not yet on disk\n"
+        )
+        index.write_text(fresh, encoding="utf-8")
+        removed = _apply_fix(index, root, candidates)
+        assert [r[1] for r in removed] == ["- [Dead](gone.md) — drop"]
+        out = index.read_text(encoding="utf-8")
+        assert "- [Dead](gone.md) — drop" not in out
+        assert "- [Real](exists.md) — agent added" in out
+        assert "- [Fresh](alsogone.md) — agent added, not yet on disk" in out
+
+    def test_revalidate_duplicate_dead_removes_only_analysis_count(self, tmp_path):
+        # Count-bounded guard (ADR-0020 §5): analysis (T1) saw ONE dead line; the
+        # agent added an *identical* dead pointer before apply (fresh has two).
+        # The fix removes at most the analysis-time count — exactly one — so the
+        # net of the agent's addition is preserved (one copy survives). Which
+        # byte-identical copy survives is irrelevant; the spliced result is the
+        # same either way. (Regression for the frozenset-membership bug that
+        # removed every identical match, emptying the file.)
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        candidates = _candidate_raws("- [Dead](gone.md) — drop\n", root)
+        assert len(candidates) == 1
+        index.write_text("- [Dead](gone.md) — drop\n- [Dead](gone.md) — drop\n", encoding="utf-8")
+        removed = _apply_fix(index, root, candidates)
+        assert len(removed) == 1  # bounded by the analysis-time count, not "all matches"
+        assert index.read_text(encoding="utf-8") == "- [Dead](gone.md) — drop\n"
+
+    def test_apply_does_not_create_lock_artifacts_in_tree(self, tmp_path):
+        # The sidecar lock lives next to the index file; it must be the only
+        # extra artifact (no stray .tmp left behind after a successful replace).
+        root = self._setup(tmp_path)
+        index = root / "MEMORY.md"
+        text = "- [Dead](gone.md) — x\n"
+        index.write_text(text, encoding="utf-8")
+        _apply_fix(index, root, _candidate_raws(text, root))
+        leftovers = {p.name for p in root.iterdir()} - {"MEMORY.md", "exists.md"}
+        # Only the sidecar lockfile may remain; no .tmp residue from mkstemp.
+        assert not any(name.endswith(".tmp") for name in leftovers)
+
+
+# ── Tier 2: --fix CLI surface ────────────────────────────────────────
+
+
+def _fix_env(tmp_path, monkeypatch, *, body):
+    """A claude-memory dir with an existing file + a MEMORY.md *body*.
+
+    Returns ``(config, mem_dir)``. The path classifies as ``claude-memory`` so
+    ``--fix`` resolves the MEMORY.md index convention.
+    """
+    from helpers import isolate_memtomem_env
+
+    isolate_memtomem_env(monkeypatch)
+    mem_dir = tmp_path / ".claude" / "projects" / "-fix-proj" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "exists.md").write_text("x", encoding="utf-8")
+    (mem_dir / "MEMORY.md").write_text(body, encoding="utf-8")
+
+    config = Mem2MemConfig()
+    config.storage.sqlite_path = tmp_path / "fix.db"
+    config.indexing.memory_dirs = [mem_dir]
+    return config, mem_dir
+
+
+class TestFixCli:
+    def _patch_loader(self, monkeypatch, config):
+        import memtomem.cli.memory_doctor_cmd as mod
+
+        monkeypatch.setattr(mod, "_load_config_read_only", lambda: config)
+
+    _BODY = "- [Ok](exists.md) — keep\n- [Dead](gone.md) — drop\n"
+
+    def test_dry_run_previews_without_writing(self, tmp_path, monkeypatch):
+        config, mem_dir = _fix_env(tmp_path, monkeypatch, body=self._BODY)
+        self._patch_loader(monkeypatch, config)
+        before = (mem_dir / "MEMORY.md").read_bytes()
+
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--fix"])
+        assert result.exit_code == 0
+        assert "Would remove" in result.output
+        assert "gone.md" in result.output
+        assert "--apply" in result.output
+        # Dry-run must not touch the file.
+        assert (mem_dir / "MEMORY.md").read_bytes() == before
+
+    def test_apply_writes_and_removes_only_missing(self, tmp_path, monkeypatch):
+        config, mem_dir = _fix_env(tmp_path, monkeypatch, body=self._BODY)
+        self._patch_loader(monkeypatch, config)
+
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--fix", "--apply"])
+        assert result.exit_code == 0
+        assert "Removed" in result.output
+        out = (mem_dir / "MEMORY.md").read_text(encoding="utf-8")
+        assert out == "- [Ok](exists.md) — keep\n"
+
+    def test_apply_without_fix_errors(self, tmp_path, monkeypatch):
+        config, _ = _fix_env(tmp_path, monkeypatch, body=self._BODY)
+        self._patch_loader(monkeypatch, config)
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--apply"])
+        assert result.exit_code != 0
+        assert "--apply only applies with --fix" in result.output
+
+    def test_clean_index_reports_nothing_to_remove(self, tmp_path, monkeypatch):
+        config, _ = _fix_env(tmp_path, monkeypatch, body="- [Ok](exists.md) — keep\n")
+        self._patch_loader(monkeypatch, config)
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--fix"])
+        assert result.exit_code == 0
+        assert "No missing_target links to remove" in result.output
+
+    def test_fix_json_shape(self, tmp_path, monkeypatch):
+        config, _ = _fix_env(tmp_path, monkeypatch, body=self._BODY)
+        self._patch_loader(monkeypatch, config)
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--fix", "--json"])
+        payload = json.loads(result.output)
+        assert payload["status"] == "would-fix"
+        assert payload["applied"] is False
+        assert payload["summary"] == {"files": 1, "lines": 1}
+        f = payload["files"][0]
+        assert f["index_file"] == "MEMORY.md"
+        assert f["removed"] == [{"line": 2, "text": "- [Dead](gone.md) — drop"}]
+
+    def test_fix_json_apply_status(self, tmp_path, monkeypatch):
+        config, mem_dir = _fix_env(tmp_path, monkeypatch, body=self._BODY)
+        self._patch_loader(monkeypatch, config)
+        result = CliRunner().invoke(cli, ["memory", "doctor", "--fix", "--apply", "--json"])
+        payload = json.loads(result.output)
+        assert payload["status"] == "fixed"
+        assert payload["applied"] is True
+        assert (mem_dir / "MEMORY.md").read_text(encoding="utf-8") == "- [Ok](exists.md) — keep\n"


### PR DESCRIPTION
## What

Tier 2 of the memory index doctor: an opt-in `mm memory doctor --fix` that
**subtractively** removes index-file pointer lines whose target is a
`missing_target` — a `- [title](target)` link that resolves *inside* the memory
root but points at a file that no longer exists on disk — and nothing else.
Dry-run by default; `--apply` writes.

```
mm memory doctor --fix           # preview the lines that would be removed
mm memory doctor --fix --apply   # remove them (atomic, mode-preserving)
```

Removing a provably-dead pointer is the one curation move that can't conflict
with the agent that owns `MEMORY.md`, so it is the only thing `--fix` does. The
default `mm memory doctor` and its `--json` payload are unchanged (still
read-only).

## Contract (ADR-0020)

Implements all five decisions from `docs/adr/0020-memory-index-write-contract.md`:

1. **Subtractive, `missing_target`-only.** `outside_root` (ambiguous intent),
   `budget`, `index_orphan`, and the DB-side `stale_source` /
   `convention_violation` are left to their existing remediation.
2. **Byte-exact preservation.** Surviving lines are kept by *splicing* the
   original text (`splitlines(keepends=True)`), never reconstructed from parsed
   fields, with a newline-preserving read (`read_bytes().decode`, **not**
   `read_text`) — so CRLF/LF and the EOF-newline state survive. A `--fix` on a
   file with no `missing_target` links is a byte-for-byte no-op.
3. **Dry-run default + `--apply`** (mirrors `mm purge`).
4. **Atomic + mode-preserving.** `atomic_write_text` (mkstemp + `os.replace`),
   with the original file mode restored so a `0o644` TOC isn't downgraded to
   mkstemp's `0o600`.
5. **Concurrency-aware.** Under the sidecar `_file_lock`, `--apply` re-reads the
   file fresh and re-validates each candidate (still present *and* still dead)
   before the atomic replace. Removals are **count-bounded** to the links
   present and dead at analysis time via a `Counter` budget — so agent edits,
   reappeared targets, and distinct just-added pointers are carried through (for
   an exact byte-duplicate of a dead link the net is preserved; which identical
   copy survives is unspecified and byte-irrelevant). The residual
   sub-`os.replace` race is documented and accepted, not eliminated; every
   removed line is printed (dry-run **and** `--apply`) for auditability. The
   contract does **not** claim "never clobbers."

## Tests

- `TestSpliceRoundTrip` — byte-exact identity on LF / CRLF × trailing/no-trailing
  newline; targeted-line removal preserves survivors' terminators.
- `TestMissingTargetGuard` — only `missing_target` is selected (not
  `outside_root` / `url` / `anchor` / `ok`); a reappeared target is dropped.
- `TestApplyFix` — real on-disk apply: other link-classes survive, CRLF and
  no-trailing-newline preserved, file mode preserved, re-validate spares
  reappeared targets / agent-edited lines, agent additions (incl. exact
  duplicates — multiplicity bounded to the analysis-time count) carried through,
  no `.tmp` residue.
- `TestFixCli` — dry-run no-write, `--apply` writes, `--apply` without `--fix`
  errors, clean-index message, `--json` shape.
- Docs-parity guards for the `--fix`/`--apply` help text and `reference.md` §5.

`docs/guides/reference.md` §5 gains the "Fixing broken links" subsection (the
ADR-0020 doc-update-on-new-surface consequence).

Full suite green (`uv run pytest -m "not ollama"`: 5679 passed). Reviewed by
Codex across three rounds: a multiplicity bug (fixed with the count-bounded
`Counter` budget + regression test) and a guarantee-wording overclaim (made
precise in the docstring, `reference.md`, and the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
