### PR TITLE
release: v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-06-01
+
 - **`mm memory doctor` — read-only hygiene report for memory stores.** A
   registered `memory_dir` can be barely indexed (the fs watcher only reacts to
   live events, so files that landed while the server was down stay invisible
@@ -18,9 +20,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
   from the TOC, hot-cache budget overruns, and never-accessed "cold" files.
   Human output by default, `--json` for CI; exits `1` only on definite
   inconsistencies (deleted-source chunks, convention violations, broken links).
-  Report-only — it never writes disk, DB, or config (loads config with
-  `migrate=False` so it can't trigger the legacy auto-discover rewrite). The
-  curation `--fix` path lands later behind its own ADR.
+  Report-only by default — the report never writes disk, DB, or config (loads
+  config with `migrate=False` so it can't trigger the legacy auto-discover
+  rewrite). A narrow, opt-in `--fix` then removes *only* broken
+  `missing_target` index links (`outside_root`/`url`/`anchor` left alone),
+  dry-run by default with `--apply` to write — byte-exact line-splice under a
+  sidecar lock with fresh re-validation, removals count-bounded to what the
+  report saw, per the ADR-0020 subtractive write contract (#1172, #1173).
 
 - **Provider index-file conventions enforced on every index path (fixes
   `MEMORY.md` pollution).** The exclude set for agent index/TOC files — Claude

--- a/packages/memtomem/pyproject.toml
+++ b/packages/memtomem/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "memtomem"
-version = "0.2.2"
+version = "0.2.3"
 description = "Markdown-first memory infrastructure for AI agents with hybrid search"
 authors = [
     {name = "DAPADA Inc.", email = "contact@dapada.co.kr"},

--- a/uv.lock
+++ b/uv.lock
@@ -877,7 +877,7 @@ wheels = [
 
 [[package]]
 name = "memtomem"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "packages/memtomem" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## release: v0.2.3

Release PR for `memtomem` 0.2.2 → **0.2.3**. Split 2-PR pattern — all features
already merged to `main`; this PR is the version-bump half (3-file diff:
`pyproject.toml` + `uv.lock` + `CHANGELOG.md`).

### What's in this release (12 commits since `v0.2.2`)

User-facing:

- **`mm memory doctor` + `--fix`** — read-only 3-way-drift hygiene report
  (disk ↔ agent index file ↔ searchable DB), plus a narrow opt-in `--fix` that
  subtractively removes broken `missing_target` index links under the ADR-0020
  write contract. (#1170, #1171, #1172, #1173)
- **Provider index-file conventions enforced on every index path** — fixes
  `MEMORY.md`/`README.md` being indexed as searchable content (it surfaced as a
  high-score duplicate on every query). `mm purge --matching-excluded --apply`
  reclaims pre-fix chunks. (#1169)
- **Context Gateway: MCP server definitions** — manage canonical defs under
  `.memtomem/mcp-servers/<name>.json`, fan out to project `.mcp.json` (privacy
  write-guard on `env`). (#1165)
- **Context Gateway: Kimi CLI runtime** — skills/agents/hooks/MCP fan-out to
  `.kimi/`. (#1166)
- **`mm init`: Antigravity CLI (`agy`) MCP target** + Gemini CLI deprecation
  notice; Gemini-compatible `GEMINI.md` surfaces unchanged. (#1167, #1168)
- **`mm init`: Codex memories split into per-subdir namespaces**
  (`codex:rollout_summaries` / `codex:extensions` / `codex:global`). (#1164)

Internal (no changelog entry): test de-flake (#1162, #1163).

### Migration notes

- **`MEMORY.md` pollution (#1169):** existing installs should run
  `mm purge --matching-excluded --apply` once to reclaim index/TOC chunks
  indexed before the convention fix.
- **Codex namespace split (#1164):** re-run `mm init` to migrate a flat `codex`
  rule in place, then `mm index ~/.codex/memories --force` to re-namespace
  already-indexed data.

### Release mechanics

- Behavior-change release (new CLI commands + flags + indexing behavior) →
  **TestPyPI dry-run required** before the production tag (`test-v0.2.3aN` →
  isolated-HOME smoke → `v0.2.3`).
- Trusted-publisher (OIDC) upload via `.github/workflows/release.yml`; no API
  token.
- CHANGELOG amends the `mm memory doctor` entry, which still read "the curation
  `--fix` path lands later" — it shipped in #1173, so the entry is corrected in
  place (no release happened between #1170 and #1173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
