### PR TITLE
fix(tags): make dry-run tag sample global to match count/apply (#688)

### DIFF
--- a/packages/memtomem/src/memtomem/storage/sqlite_backend.py
+++ b/packages/memtomem/src/memtomem/storage/sqlite_backend.py
@@ -1426,12 +1426,25 @@ class SqliteBackend(
         return int(row[0]) if row else 0
 
     async def list_chunks_by_tag(self, tag: str, limit: int = 10) -> list[Chunk]:
-        # Thin wrapper over ``recall_chunks(tag_filter=...)`` — the post-fusion
-        # tag-filter path (#750) already implements the json_each EXISTS match
-        # and ORDER BY created_at DESC LIMIT shape this helper needs. Keeping
-        # the SQL in one place means the dry-run sample path inherits any
-        # future correctness fixes for free.
-        return await self.recall_chunks(tag_filter=tag, limit=limit)
+        # Dry-run sample for the global tag-management ops (rename / delete /
+        # merge). Those ops mutate EVERY chunk carrying the tag regardless of
+        # scope tier, and ``count_chunks_by_tag`` counts globally to match, so
+        # the sample must draw from the same global row set. Routing through
+        # ``recall_chunks`` looked tidy (#750) but it always appends the
+        # ADR-0011 §6 scope-context fragment, which silently narrowed samples
+        # to ``scope='user'`` when no project context was pinned — a
+        # project-only tag then previewed as "N affected, 0 samples" while the
+        # apply still wiped N rows. Mirror ``count_chunks_by_tag``'s
+        # ``EXISTS(json_each)`` membership here so sample / count / apply agree
+        # on one row set (#688). ``id`` breaks created_at ties deterministically.
+        db = self._get_read_db()
+        rows = db.execute(
+            "SELECT * FROM chunks WHERE EXISTS "
+            "(SELECT 1 FROM json_each(chunks.tags) WHERE value = ?) "
+            "ORDER BY created_at DESC, id LIMIT ?",
+            (tag, limit),
+        ).fetchall()
+        return [self._row_to_chunk(row) for row in rows]
 
     async def count_chunks_by_tag(self, tag: str) -> int:
         db = self._get_read_db()

--- a/packages/memtomem/tests/test_storage.py
+++ b/packages/memtomem/tests/test_storage.py
@@ -1,5 +1,6 @@
 """Tests for storage backend operations."""
 
+import dataclasses
 import unicodedata
 from pathlib import Path
 from uuid import uuid4
@@ -164,6 +165,44 @@ class TestTags:
         assert await storage.count_chunks_by_tag("python") == 2
         assert await storage.count_chunks_by_tag("rust") == 1
         assert await storage.count_chunks_by_tag("absent") == 0
+
+    @pytest.mark.asyncio
+    async def test_list_chunks_by_tag_samples_globally_across_scopes(self, storage):
+        # Regression (#688): the dry-run sample must draw from the same global
+        # row set that count/apply use. It previously routed through
+        # ``recall_chunks``, which appends the ADR-0011 scope fragment — with no
+        # project context pinned that narrowed samples to ``scope='user'``, so a
+        # tag living only on project-tier chunks previewed as "N affected, 0
+        # samples" while the global rename/delete/merge still mutated all N rows.
+        proj_root = Path("/tmp/proj-x")
+        user_chunk = _make_chunk(content="u", tags=("curate",))
+        base_local = _make_chunk(content="p1", source="p1.md", tags=("curate",))
+        proj_local = dataclasses.replace(
+            base_local,
+            metadata=dataclasses.replace(
+                base_local.metadata, scope="project_local", project_root=proj_root
+            ),
+        )
+        base_shared = _make_chunk(content="p2", source="p2.md", tags=("curate",))
+        proj_shared = dataclasses.replace(
+            base_shared,
+            metadata=dataclasses.replace(
+                base_shared.metadata, scope="project_shared", project_root=proj_root
+            ),
+        )
+        await storage.upsert_chunks([user_chunk, proj_local, proj_shared])
+
+        count = await storage.count_chunks_by_tag("curate")
+        sample = await storage.list_chunks_by_tag("curate", limit=10)
+        sample_ids = {c.id for c in sample}
+
+        # Sample membership must match the global count — no scope narrowing.
+        assert count == 3
+        assert len(sample) == count
+        # The project-tier rows the global apply would mutate must show up in
+        # the preview; these are exactly the rows the old user-only sample
+        # dropped, leaving a destructive op with a misleadingly empty preview.
+        assert {user_chunk.id, proj_local.id, proj_shared.id} == sample_ids
 
     @pytest.mark.asyncio
     async def test_merge_tags(self, storage):


### PR DESCRIPTION
## Why

The Tags **rename / delete / merge** ops (#688 PR1, shipped in v0.1.36) are
**global** — they mutate every chunk carrying the tag regardless of scope
tier — and `count_chunks_by_tag` counts globally to match. The dry-run
**sample** that feeds the confirm-modal preview, however, routed through
`recall_chunks(tag_filter=...)`, which always appends the ADR-0011 §6
scope-context fragment. With no project context pinned, that narrowed the
sample to `scope='user'`.

Result: the three paths disagreed on which rows the op touches.

| path | query | scope |
| --- | --- | --- |
| apply (`rename/delete/merge_tags`) | `chunks` whole table | **global** |
| count (`count_chunks_by_*`) | `chunks` whole table | **global** |
| sample (`list_chunks_by_tag`) | via `recall_chunks` | **`scope='user'` only** ❌ |

So a tag living only on project-tier chunks previewed as **"N affected, 0
samples"** while the apply still wiped all N rows — a destructive op with a
misleadingly empty confirmation preview. The mix case (some user, some
project) under-sampled the same way.

## Fix

Query the `chunks` table directly with the **same `EXISTS(json_each ...)`
membership** as `count_chunks_by_tag`, so sample / count / apply all agree
on one global row set. `ORDER BY created_at DESC, id` keeps the sample
deterministic under second-precision timestamp ties (the prior
`recall_chunks` path used a scope-priority tie-break we explicitly don't
want here).

The only caller of `list_chunks_by_tag` is the tag-management dry-run path
(`services/tag_management.py`), so decoupling it from `recall_chunks` has
no search-facing impact.

## Test

`test_list_chunks_by_tag_samples_globally_across_scopes` seeds
user + project_local + project_shared chunks under one tag and pins sample
membership to the global count. Mutation-validated: reverting only the
`sqlite_backend.py` change makes it fail (`assert 1 == 3` — old sample
returned the user-scope row only); the fix makes it pass.

```
uv run pytest packages/memtomem/tests/test_storage.py \
  packages/memtomem/tests/test_services_tag_management.py \
  packages/memtomem/tests/test_mcp_tag_management_parity.py \
  'packages/memtomem/tests/test_web_routes_extended.py::TestTagManagementRoutes'
# 74 passed; ruff check + format clean; mypy clean
```

## Scope

Pre-fix for #688 — surfaced while re-auditing the RFC state before picking
up the remaining UI (PR2) and CLI (PR3) work, both of which make this
dry-run preview user-facing. Not a close of #688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
