### PR TITLE
feat(cli): add `mm tags` — list / rename / delete / merge tags (#688 PR3)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/__init__.py
+++ b/packages/memtomem/src/memtomem/cli/__init__.py
@@ -60,6 +60,7 @@ def _register() -> None:
     from memtomem.cli.shell import shell
     from memtomem.cli.status_cmd import status
     from memtomem.cli.sync_doctor_cmd import sync_doctor
+    from memtomem.cli.tags_cmd import tags
     from memtomem.cli.uninstall_cmd import uninstall
     from memtomem.cli.upgrade_cmd import upgrade
     from memtomem.cli.watchdog_cmd import watchdog
@@ -84,6 +85,7 @@ def _register() -> None:
     cli.add_command(activity)
     cli.add_command(status)
     cli.add_command(sync_doctor)
+    cli.add_command(tags)
     cli.add_command(watchdog)
     cli.add_command(schedule)
     cli.add_command(web)

--- a/packages/memtomem/src/memtomem/cli/tags_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/tags_cmd.py
@@ -1,0 +1,245 @@
+"""CLI: ``mm tags`` — list / rename / delete / merge tags across chunks (#688 PR3).
+
+Thin CLI surface over :mod:`memtomem.services.tag_management` — the same
+shared service the Web ``/api/tags/{...}`` routes and the MCP ``mem_tag_*``
+tools call, so all three surfaces share one write lock, one ``updated_at``
+policy, and one search-cache invalidation. Mutations are **global**: they
+touch every chunk carrying the tag regardless of scope tier, matching the
+``count``/sample the dry-run preview shows.
+
+UX mirrors ``mm gc orphan-projects``: the default is a dry-run preview
+(count + sample); ``--apply`` performs the write behind a confirmation
+prompt; ``--apply --yes`` is the non-interactive form.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import click
+
+from memtomem.services import tag_management as tag_svc
+
+
+@click.group("tags")
+def tags() -> None:
+    """Manage tags: list, rename, delete, or merge them across all chunks."""
+
+
+def _print_samples(result: tag_svc.TagOpResult) -> None:
+    """Render the dry-run sample chunks (same shape the Web modal shows)."""
+    if not result.samples:
+        return
+    click.echo("\nSample affected chunks:")
+    for s in result.samples:
+        click.echo(f"  {s.chunk_id}  ({s.source_file})")
+        click.echo(f"    tags: [{', '.join(s.current_tags)}]")
+        click.echo(f"    {s.content_preview}")
+
+
+# --------------------------------------------------------------------------- #
+# list
+# --------------------------------------------------------------------------- #
+@tags.command("list")
+def list_tags() -> None:
+    """List every tag and its chunk count, most frequent first."""
+    asyncio.run(_run_list())
+
+
+async def _run_list() -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        tag_counts = await comp.storage.get_tag_counts()
+        if not tag_counts:
+            click.secho("No tags found.", fg="yellow")
+            return
+        for tag, count in tag_counts:
+            click.echo(f"  {tag}  — {count} chunks")
+        total = sum(c for _, c in tag_counts)
+        click.echo(f"\n{len(tag_counts)} tags across {total} chunk-tag assignments.")
+
+
+# --------------------------------------------------------------------------- #
+# rename
+# --------------------------------------------------------------------------- #
+@tags.command("rename")
+@click.argument("old_tag")
+@click.argument("new_tag")
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    help="Actually write. Without this flag, prints what would change (dry-run).",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt. Requires --apply.",
+)
+def rename(old_tag: str, new_tag: str, apply_: bool, assume_yes: bool) -> None:
+    """Rename OLD_TAG to NEW_TAG across every chunk that carries it."""
+    if assume_yes and not apply_:
+        raise click.UsageError("--yes requires --apply.")
+    asyncio.run(_run_rename(old_tag, new_tag, apply_=apply_, assume_yes=assume_yes))
+
+
+async def _run_rename(old_tag: str, new_tag: str, *, apply_: bool, assume_yes: bool) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        try:
+            preview = await tag_svc.rename_tag(comp.storage, old_tag, new_tag, dry_run=True)
+        except ValueError as exc:
+            raise click.ClickException(str(exc))
+
+        old_s, new_s = old_tag.strip(), new_tag.strip()
+        if preview.affected_chunks == 0:
+            click.secho(f"No chunks carry tag '{old_s}'. Nothing to do.", fg="yellow")
+            return
+
+        click.echo(f"Rename '{old_s}' → '{new_s}' would affect {preview.affected_chunks} chunks.")
+        _print_samples(preview)
+        if not apply_:
+            click.echo("\nRun with --apply to perform the rename.")
+            return
+        if not assume_yes and not click.confirm(
+            f"\nRename '{old_s}' → '{new_s}' across {preview.affected_chunks} chunks?",
+            default=False,
+        ):
+            click.echo("Aborted.")
+            return
+
+        result = await tag_svc.rename_tag(
+            comp.storage, old_tag, new_tag, dry_run=False, search_pipeline=comp.search_pipeline
+        )
+        click.secho(
+            f"Renamed '{old_s}' → '{new_s}' in {result.affected_chunks} chunks.", fg="green"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# delete
+# --------------------------------------------------------------------------- #
+@tags.command("delete")
+@click.argument("name")
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    help="Actually write. Without this flag, prints what would change (dry-run).",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt. Requires --apply.",
+)
+def delete(name: str, apply_: bool, assume_yes: bool) -> None:
+    """Remove NAME from every chunk that carries it (the chunks stay indexed)."""
+    if assume_yes and not apply_:
+        raise click.UsageError("--yes requires --apply.")
+    asyncio.run(_run_delete(name, apply_=apply_, assume_yes=assume_yes))
+
+
+async def _run_delete(name: str, *, apply_: bool, assume_yes: bool) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        try:
+            preview = await tag_svc.delete_tag(comp.storage, name, dry_run=True)
+        except ValueError as exc:
+            raise click.ClickException(str(exc))
+
+        name_s = name.strip()
+        if preview.affected_chunks == 0:
+            click.secho(f"No chunks carry tag '{name_s}'. Nothing to do.", fg="yellow")
+            return
+
+        click.echo(f"Delete '{name_s}' would affect {preview.affected_chunks} chunks.")
+        _print_samples(preview)
+        if not apply_:
+            click.echo("\nRun with --apply to perform the delete.")
+            return
+        if not assume_yes and not click.confirm(
+            f"\nDelete '{name_s}' from {preview.affected_chunks} chunks?",
+            default=False,
+        ):
+            click.echo("Aborted.")
+            return
+
+        result = await tag_svc.delete_tag(
+            comp.storage, name, dry_run=False, search_pipeline=comp.search_pipeline
+        )
+        click.secho(f"Removed '{name_s}' from {result.affected_chunks} chunks.", fg="green")
+
+
+# --------------------------------------------------------------------------- #
+# merge
+# --------------------------------------------------------------------------- #
+@tags.command("merge")
+@click.argument("sources", nargs=-1, required=True)
+@click.option("--into", "target", required=True, help="The tag every source is folded into.")
+@click.option(
+    "--apply",
+    "apply_",
+    is_flag=True,
+    help="Actually write. Without this flag, prints what would change (dry-run).",
+)
+@click.option(
+    "--yes",
+    "assume_yes",
+    is_flag=True,
+    help="Skip the confirmation prompt. Requires --apply.",
+)
+def merge(sources: tuple[str, ...], target: str, apply_: bool, assume_yes: bool) -> None:
+    """Fold one or more SOURCES tags into --into TARGET across all chunks."""
+    if assume_yes and not apply_:
+        raise click.UsageError("--yes requires --apply.")
+    asyncio.run(_run_merge(sources, target, apply_=apply_, assume_yes=assume_yes))
+
+
+async def _run_merge(
+    sources: tuple[str, ...], target: str, *, apply_: bool, assume_yes: bool
+) -> None:
+    from memtomem.cli._bootstrap import cli_components
+
+    async with cli_components() as comp:
+        try:
+            preview = await tag_svc.merge_tags(comp.storage, list(sources), target, dry_run=True)
+        except ValueError as exc:
+            raise click.ClickException(str(exc))
+
+        target_s = target.strip()
+        src_display = ", ".join(f"'{s.strip()}'" for s in sources if s.strip())
+        if preview.affected_chunks == 0:
+            # Covers both "no chunk carries a source tag" and "every source
+            # collapsed to the target" (e.g. `merge python --into python`) —
+            # in the latter the chunks exist, so a membership claim would lie.
+            click.secho(
+                f"Nothing to merge into '{target_s}' — no chunks would change.", fg="yellow"
+            )
+            return
+
+        click.echo(
+            f"Merge {src_display} → '{target_s}' would affect {preview.affected_chunks} chunks."
+        )
+        _print_samples(preview)
+        if not apply_:
+            click.echo("\nRun with --apply to perform the merge.")
+            return
+        if not assume_yes and not click.confirm(
+            f"\nMerge {src_display} → '{target_s}' across {preview.affected_chunks} chunks?",
+            default=False,
+        ):
+            click.echo("Aborted.")
+            return
+
+        result = await tag_svc.merge_tags(
+            comp.storage, list(sources), target, dry_run=False, search_pipeline=comp.search_pipeline
+        )
+        click.secho(
+            f"Merged {src_display} → '{target_s}' across {result.affected_chunks} chunks.",
+            fg="green",
+        )

--- a/packages/memtomem/tests/test_tags_cmd.py
+++ b/packages/memtomem/tests/test_tags_cmd.py
@@ -1,0 +1,274 @@
+"""CLI tests for ``mm tags`` (list / rename / delete / merge) — #688 PR3.
+
+The service SQL surface (rename/delete/merge dry-run + apply, lock,
+``updated_at`` policy, cache invalidation) is covered in
+``test_services_tag_management.py`` and ``test_storage.py``. Here we mock
+``services.tag_management`` and only pin the CLI glue: dry-run-by-default,
+the ``--apply`` / ``--yes`` gate, the confirmation prompt, sample
+rendering, error surfacing, and that ``search_pipeline`` is threaded into
+the apply call.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from click.testing import CliRunner
+
+from memtomem.cli import cli
+from memtomem.services.tag_management import TagOpResult, TagOpSample
+
+_STORAGE = object()
+_PIPELINE = object()
+
+
+def _comp():
+    return SimpleNamespace(storage=_STORAGE, search_pipeline=_PIPELINE)
+
+
+def _patch_bootstrap(monkeypatch, comp):
+    @asynccontextmanager
+    async def fake():
+        yield comp
+
+    monkeypatch.setattr("memtomem.cli._bootstrap.cli_components", fake)
+
+
+def _result(tag, affected, *, dry_run, with_sample=False):
+    samples = ()
+    if with_sample:
+        samples = (
+            TagOpSample(
+                chunk_id=uuid4(),
+                source_file="/tmp/a.md",
+                content_preview="hello world",
+                current_tags=("old", "keep"),
+            ),
+        )
+    return TagOpResult(tag=tag, affected_chunks=affected, dry_run=dry_run, samples=samples)
+
+
+# --------------------------------------------------------------------------- #
+# list
+# --------------------------------------------------------------------------- #
+class TestTagsList:
+    def test_list_renders_counts(self, monkeypatch):
+        comp = _comp()
+        comp.storage = SimpleNamespace(
+            get_tag_counts=AsyncMock(return_value=[("python", 5), ("rust", 2)])
+        )
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["tags", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "python  — 5 chunks" in result.output
+        assert "rust  — 2 chunks" in result.output
+        assert "2 tags across 7 chunk-tag assignments." in result.output
+
+    def test_list_empty(self, monkeypatch):
+        comp = _comp()
+        comp.storage = SimpleNamespace(get_tag_counts=AsyncMock(return_value=[]))
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["tags", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "No tags found." in result.output
+
+
+# --------------------------------------------------------------------------- #
+# rename
+# --------------------------------------------------------------------------- #
+class TestTagsRename:
+    def test_dry_run_default_does_not_apply(self, monkeypatch):
+        mock = AsyncMock(return_value=_result("new", 3, dry_run=True, with_sample=True))
+        monkeypatch.setattr("memtomem.services.tag_management.rename_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "rename", "old", "new"])
+
+        assert result.exit_code == 0, result.output
+        assert "Rename 'old' → 'new' would affect 3 chunks." in result.output
+        assert "Sample affected chunks:" in result.output
+        assert "Run with --apply" in result.output
+        # Exactly one call, and it was the dry-run preview.
+        mock.assert_awaited_once()
+        assert mock.call_args_list[0].kwargs == {"dry_run": True}
+
+    def test_apply_confirm_yes_writes(self, monkeypatch):
+        mock = AsyncMock(
+            side_effect=[
+                _result("new", 3, dry_run=True),
+                _result("new", 3, dry_run=False),
+            ]
+        )
+        monkeypatch.setattr("memtomem.services.tag_management.rename_tag", mock)
+        comp = _comp()
+        _patch_bootstrap(monkeypatch, comp)
+
+        result = CliRunner().invoke(cli, ["tags", "rename", "old", "new", "--apply"], input="y\n")
+
+        assert result.exit_code == 0, result.output
+        assert "Renamed 'old' → 'new' in 3 chunks." in result.output
+        assert mock.await_count == 2
+        # The apply call carries dry_run=False and the live search pipeline.
+        assert mock.call_args_list[1].kwargs == {"dry_run": False, "search_pipeline": _PIPELINE}
+
+    def test_apply_abort_on_no(self, monkeypatch):
+        mock = AsyncMock(return_value=_result("new", 3, dry_run=True))
+        monkeypatch.setattr("memtomem.services.tag_management.rename_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "rename", "old", "new", "--apply"], input="n\n")
+
+        assert result.exit_code == 0, result.output
+        assert "Aborted." in result.output
+        # Preview only — no apply call.
+        mock.assert_awaited_once()
+
+    def test_apply_yes_non_interactive(self, monkeypatch):
+        mock = AsyncMock(
+            side_effect=[
+                _result("new", 3, dry_run=True),
+                _result("new", 3, dry_run=False),
+            ]
+        )
+        monkeypatch.setattr("memtomem.services.tag_management.rename_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "rename", "old", "new", "--apply", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        assert "Rename 'old' → 'new' across" not in result.output  # no prompt prose
+        assert "Renamed 'old' → 'new' in 3 chunks." in result.output
+        assert mock.await_count == 2
+
+    def test_zero_affected_skips_apply(self, monkeypatch):
+        mock = AsyncMock(return_value=_result("new", 0, dry_run=True))
+        monkeypatch.setattr("memtomem.services.tag_management.rename_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "rename", "old", "new", "--apply", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        assert "Nothing to do." in result.output
+        # Even with --apply --yes, a 0-row preview never reaches the write call.
+        mock.assert_awaited_once()
+
+    def test_service_value_error_surfaces(self, monkeypatch):
+        mock = AsyncMock(side_effect=ValueError("rename_tag old and new tag names are identical"))
+        monkeypatch.setattr("memtomem.services.tag_management.rename_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "rename", "x", "x"])
+
+        assert result.exit_code != 0
+        assert "identical" in result.output
+
+    def test_yes_without_apply_is_usage_error(self):
+        result = CliRunner().invoke(cli, ["tags", "rename", "a", "b", "--yes"])
+
+        assert result.exit_code != 0
+        assert "--yes requires --apply" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# delete
+# --------------------------------------------------------------------------- #
+class TestTagsDelete:
+    def test_dry_run_default(self, monkeypatch):
+        mock = AsyncMock(return_value=_result("dead", 4, dry_run=True, with_sample=True))
+        monkeypatch.setattr("memtomem.services.tag_management.delete_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "delete", "dead"])
+
+        assert result.exit_code == 0, result.output
+        assert "Delete 'dead' would affect 4 chunks." in result.output
+        assert "Run with --apply" in result.output
+        mock.assert_awaited_once()
+
+    def test_apply_yes_writes_with_pipeline(self, monkeypatch):
+        mock = AsyncMock(
+            side_effect=[
+                _result("dead", 4, dry_run=True),
+                _result("dead", 4, dry_run=False),
+            ]
+        )
+        monkeypatch.setattr("memtomem.services.tag_management.delete_tag", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "delete", "dead", "--apply", "--yes"])
+
+        assert result.exit_code == 0, result.output
+        assert "Removed 'dead' from 4 chunks." in result.output
+        assert mock.call_args_list[1].kwargs == {"dry_run": False, "search_pipeline": _PIPELINE}
+
+    def test_yes_without_apply_is_usage_error(self):
+        result = CliRunner().invoke(cli, ["tags", "delete", "dead", "--yes"])
+
+        assert result.exit_code != 0
+        assert "--yes requires --apply" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# merge
+# --------------------------------------------------------------------------- #
+class TestTagsMerge:
+    def test_dry_run_default(self, monkeypatch):
+        mock = AsyncMock(return_value=_result("python", 6, dry_run=True))
+        monkeypatch.setattr("memtomem.services.tag_management.merge_tags", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(cli, ["tags", "merge", "py", "python3", "--into", "python"])
+
+        assert result.exit_code == 0, result.output
+        assert "Merge 'py', 'python3' → 'python' would affect 6 chunks." in result.output
+        assert "Run with --apply" in result.output
+        # The service receives the raw source list and the target.
+        assert mock.call_args_list[0].args[1] == ["py", "python3"]
+        assert mock.call_args_list[0].args[2] == "python"
+
+    def test_apply_yes_writes(self, monkeypatch):
+        mock = AsyncMock(
+            side_effect=[
+                _result("python", 6, dry_run=True),
+                _result("python", 6, dry_run=False),
+            ]
+        )
+        monkeypatch.setattr("memtomem.services.tag_management.merge_tags", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(
+            cli, ["tags", "merge", "py", "python3", "--into", "python", "--apply", "--yes"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Merged 'py', 'python3' → 'python' across 6 chunks." in result.output
+        assert mock.call_args_list[1].kwargs == {"dry_run": False, "search_pipeline": _PIPELINE}
+
+    def test_zero_affected_nothing_to_do(self, monkeypatch):
+        mock = AsyncMock(return_value=_result("python", 0, dry_run=True))
+        monkeypatch.setattr("memtomem.services.tag_management.merge_tags", mock)
+        _patch_bootstrap(monkeypatch, _comp())
+
+        result = CliRunner().invoke(
+            cli, ["tags", "merge", "python", "--into", "python", "--apply", "--yes"]
+        )
+
+        assert result.exit_code == 0, result.output
+        # Target-only collapse: chunks carrying 'python' exist, so the message
+        # must not claim no chunk carries it — only that nothing would change.
+        assert "Nothing to merge into 'python' — no chunks would change." in result.output
+        assert "No chunks carry" not in result.output
+        mock.assert_awaited_once()
+
+    def test_target_required(self):
+        result = CliRunner().invoke(cli, ["tags", "merge", "py"])
+
+        assert result.exit_code != 0
+        assert "into" in result.output.lower()


### PR DESCRIPTION
## Why

PR3 of the #688 tag-management split. PR1 shipped the shared
`services.tag_management` service plus the Web `/api/tags` routes and MCP
`mem_tag_*` tools (v0.1.36); #1175 fixed the dry-run sample scope. The CLI
was the remaining gap — `mm` had no way to rename/delete/merge tags, so
scripts and the UI were asymmetric.

This adds a thin CLI surface that funnels through the **same** service, so
the gate (strip, same-name reject, in-process write lock, `updated_at`
curation bump, search-cache invalidation) lives in one place and all three
surfaces — Web, MCP, CLI — stay symmetric. The CLI only renders and gates
the write.

## Commands

```
mm tags list                            # tags + chunk counts (most frequent first)
mm tags rename OLD NEW [--apply] [--yes]
mm tags delete NAME    [--apply] [--yes]
mm tags merge SRC...   --into TARGET [--apply] [--yes]
```

UX mirrors the existing `mm gc orphan-projects`:

- **dry-run by default** — prints the affected count + a sample (cap 10),
  no write;
- `--apply` performs the write behind a confirmation prompt;
- `--apply --yes` is the non-interactive form;
- `--yes` without `--apply` is a usage error.

Mutations are **global** (every chunk carrying the tag, regardless of scope
tier), so the preview count/sample matches exactly what apply will touch
(this is what #1175 guaranteed). `search_pipeline` is threaded only into
the apply call — a dry-run never invalidates the search cache. A 0-row
preview short-circuits before the write even under `--apply --yes`.

## `mm tags list`

Included as a 4th read-only subcommand for parity with MCP `mem_tag_list`
and so the group has a way to discover tag names before renaming — beyond
the RFC's original three, but read-only and trivial.

## Tests

`test_tags_cmd.py` mocks `services.tag_management` and pins the CLI glue:
dry-run default, the `--apply`/`--yes` gate, confirm-abort, the 0-row
short-circuit, `ValueError` surfacing, and `search_pipeline` threaded only
on apply. Mirrors the mock-based CLI tests for `mm gc` (`test_orphan_gc.py`
`TestCli`); the service SQL surface is covered in
`test_services_tag_management.py` and `test_storage.py`.

```
uv run pytest packages/memtomem/tests/test_tags_cmd.py \
  packages/memtomem/tests/test_services_tag_management.py \
  packages/memtomem/tests/test_storage.py packages/memtomem/tests/test_orphan_gc.py
# 87 passed; ruff check + format clean; mypy clean; `mm tags --help` smoke OK
```

## Scope

Closes the CLI gap for #688 (PR3). Remaining: PR2 — the Tags-tab UI
(hover Rename/Merge/Delete + dry-run confirm modal + i18n). Not a close of
#688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
