### PR TITLE
fix(retry): honor string retry_after attributes in with_retry (#1029)

### DIFF
--- a/packages/memtomem/src/memtomem/embedding/retry.py
+++ b/packages/memtomem/src/memtomem/embedding/retry.py
@@ -72,10 +72,19 @@ def with_retry(
                     last_exc = exc
                     if attempt < max_attempts - 1:
                         delay = min(base_delay * (2**attempt), max_delay)
-                        # Honour Retry-After from rate-limit responses
+                        # Honour Retry-After from rate-limit responses. The
+                        # attribute may be numeric (seconds) or a string (a raw
+                        # Retry-After header: seconds or an RFC 7231 HTTP-date);
+                        # strings go through parse_retry_after, which returns
+                        # None for unparseable values so we fall back to backoff.
                         ra = getattr(exc, "retry_after", None)
-                        if ra is not None and isinstance(ra, (int, float)):
-                            delay = max(delay, float(ra))
+                        ra_delay: float | None = None
+                        if isinstance(ra, (int, float)):
+                            ra_delay = float(ra)
+                        elif isinstance(ra, str):
+                            ra_delay = parse_retry_after(ra)
+                        if ra_delay is not None:
+                            delay = max(delay, ra_delay)
                         logger.warning(
                             "Retry %d/%d for %s after %.1fs: %s",
                             attempt + 1,

--- a/packages/memtomem/tests/test_retry.py
+++ b/packages/memtomem/tests/test_retry.py
@@ -202,3 +202,63 @@ class TestWithRetryBackoff:
 
         # delay should be max(base_delay=1.0, retry_after=10) = 10
         assert mock_sleep.call_args_list[0].args[0] == 10.0
+
+
+# ── with_retry — string retry_after (#1029) ──────────────────────────
+
+
+def _raise_with_retry_after(retry_after):
+    """Build a decorated fn that raises OSError carrying ``retry_after``."""
+
+    @with_retry(max_attempts=2, base_delay=1.0)
+    async def fn():
+        exc = OSError("rate limited")
+        exc.retry_after = retry_after  # type: ignore[attr-defined]
+        raise exc
+
+    return fn
+
+
+class TestWithRetryStringRetryAfter:
+    @pytest.mark.asyncio
+    async def test_numeric_string_honored(self):
+        """retry_after="5" parses to 5.0 and wins over the 1.0 backoff."""
+        mock_sleep = AsyncMock()
+        with patch("memtomem.embedding.retry.asyncio.sleep", mock_sleep):
+            with pytest.raises(OSError):
+                await _raise_with_retry_after("5")()
+        assert mock_sleep.call_args_list[0].args[0] == 5.0
+
+    @pytest.mark.asyncio
+    async def test_http_date_string_parsed(self):
+        """An HTTP-date string is routed through parse_retry_after."""
+        from datetime import datetime, timedelta, timezone
+        from email.utils import format_datetime
+
+        future = datetime.now(timezone.utc).replace(microsecond=0) + timedelta(seconds=10)
+        mock_sleep = AsyncMock()
+        with patch("memtomem.embedding.retry.asyncio.sleep", mock_sleep):
+            with pytest.raises(OSError):
+                await _raise_with_retry_after(format_datetime(future))()
+        # ~10s in the future and larger than the 1.0 backoff
+        slept = mock_sleep.call_args_list[0].args[0]
+        assert 1.0 < slept <= 11.0
+
+    @pytest.mark.asyncio
+    async def test_invalid_string_falls_back_to_backoff(self):
+        """Unparseable strings are ignored; exponential backoff (1.0) stands."""
+        mock_sleep = AsyncMock()
+        with patch("memtomem.embedding.retry.asyncio.sleep", mock_sleep):
+            with pytest.raises(OSError):
+                await _raise_with_retry_after("not-a-number")()
+        assert mock_sleep.call_args_list[0].args[0] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_small_string_loses_to_backoff(self):
+        """A string smaller than the backoff does not shrink the delay."""
+        mock_sleep = AsyncMock()
+        with patch("memtomem.embedding.retry.asyncio.sleep", mock_sleep):
+            with pytest.raises(OSError):
+                # base_delay=1.0 backoff vs retry_after="0.2" → max keeps 1.0
+                await _raise_with_retry_after("0.2")()
+        assert mock_sleep.call_args_list[0].args[0] == 1.0


### PR DESCRIPTION
Closes #1029.

## What

`with_retry()` honored an exception's `retry_after` attribute only when it was already an `int`/`float`. The module already ships `parse_retry_after()` (handles numeric strings **and** RFC 7231 HTTP-dates), but `with_retry()` never used it for string-valued attributes — so a provider that surfaces the `Retry-After` header verbatim as a string fell back to plain exponential backoff.

## Change

`packages/memtomem/src/memtomem/embedding/retry.py` — string `retry_after` now routes through `parse_retry_after()`:

```python
ra = getattr(exc, "retry_after", None)
ra_delay: float | None = None
if isinstance(ra, (int, float)):
    ra_delay = float(ra)
elif isinstance(ra, str):
    ra_delay = parse_retry_after(ra)
if ra_delay is not None:
    delay = max(delay, ra_delay)
```

- Numeric (int/float) behavior is unchanged.
- Unparseable strings return `None` → fall back to backoff; a bad header can't break the delay.
- The `max(delay, ...)` floor means a string smaller than the backoff can't shrink it either.

> Note: the issue referenced the helper as `_parse_retry_after`; the real public helper is `parse_retry_after` (no leading underscore). No duplicated parsing logic.

## Tests

`packages/memtomem/tests/test_retry.py` — new `TestWithRetryStringRetryAfter`:
- `retry_after="5"` → sleeps 5.0 (wins over 1.0 backoff)
- HTTP-date string → routed through `parse_retry_after`, ~10s
- `"not-a-number"` → falls back to 1.0 backoff
- `"0.2"` → loses to the 1.0 backoff floor

`uv run pytest packages/memtomem/tests/test_retry.py` → 22 passed. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
