### PR TITLE
test(webhooks): pin _validate_webhook_url URL safety behavior (#1030)

### DIFF
--- a/packages/memtomem/tests/test_webhooks.py
+++ b/packages/memtomem/tests/test_webhooks.py
@@ -46,6 +46,65 @@ class TestWebhookManager:
         assert mgr._client is None
 
 
+class TestValidateWebhookUrl:
+    """Pin the URL safety checks in ``_validate_webhook_url`` (#1030).
+
+    Assertions stay at the rejection-reason level (scheme vs IP) rather than
+    pinning the exact message, so wording can change without churning tests.
+    """
+
+    def test_accepts_https_url(self):
+        from memtomem.server.webhooks import _validate_webhook_url
+
+        assert _validate_webhook_url("https://example.com/hook") is None
+
+    def test_accepts_http_dns_host(self):
+        from memtomem.server.webhooks import _validate_webhook_url
+
+        # A public DNS name over http is allowed — only IP literals are checked.
+        assert _validate_webhook_url("http://example.com/hook") is None
+
+    def test_rejects_unsupported_scheme(self):
+        from memtomem.server.webhooks import _validate_webhook_url
+
+        err = _validate_webhook_url("file:///etc/passwd")
+        assert err is not None and "scheme" in err
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/hook",  # loopback
+            "http://10.0.0.1/hook",  # private
+            "http://[::1]/hook",  # loopback (IPv6)
+        ],
+    )
+    def test_rejects_private_or_reserved_ip(self, url):
+        from memtomem.server.webhooks import _validate_webhook_url
+
+        err = _validate_webhook_url(url)
+        assert err is not None and "private/reserved" in err
+
+    def test_manager_disables_on_rejected_url(self):
+        """A rejected URL flips the manager's effective config to disabled."""
+        from memtomem.config import WebhookConfig
+        from memtomem.server.webhooks import WebhookManager
+
+        mgr = WebhookManager(WebhookConfig(enabled=True, url="http://127.0.0.1/hook"))
+        assert mgr._config.enabled is False
+
+    @pytest.mark.asyncio
+    async def test_manager_does_not_fire_on_rejected_url(self):
+        """Self-disabled manager is inert even for a configured event."""
+        from memtomem.config import WebhookConfig
+        from memtomem.server.webhooks import WebhookManager
+
+        mgr = WebhookManager(
+            WebhookConfig(enabled=True, url="http://10.0.0.1/hook", events=["add"])
+        )
+        await mgr.fire("add", {})
+        assert mgr._client is None
+
+
 class TestRerankerFactory:
     def test_disabled_returns_none(self):
         from memtomem.config import RerankConfig

--- a/packages/memtomem/tests/test_webhooks.py
+++ b/packages/memtomem/tests/test_webhooks.py
@@ -70,6 +70,14 @@ class TestValidateWebhookUrl:
         err = _validate_webhook_url("file:///etc/passwd")
         assert err is not None and "scheme" in err
 
+    def test_rejects_malformed_url(self):
+        from memtomem.server.webhooks import _validate_webhook_url
+
+        # An unclosed IPv6 bracket makes urlparse() raise ValueError; the helper
+        # catches it and returns the malformed-URL reason (the try/except branch).
+        err = _validate_webhook_url("http://[::1")
+        assert err is not None and "malformed" in err
+
     @pytest.mark.parametrize(
         "url",
         [


### PR DESCRIPTION
Closes #1030.

## What

`server/webhooks.py::_validate_webhook_url()` rejects unsupported schemes and private/reserved IP literals, and `WebhookManager` self-disables when constructed with a rejected URL. `test_webhooks.py` already covered lifecycle (fire / event-filtering) but never pinned the validation contract directly — so a regression in the safety checks would slip past CI.

## Tests added — `TestValidateWebhookUrl`

- `https://example.com/hook` and `http://example.com/hook` (public DNS host) → accepted
- `file:///etc/passwd` → rejected (asserts the **"scheme"** reason)
- `http://127.0.0.1/hook`, `http://10.0.0.1/hook`, `http://[::1]/hook` → rejected (asserts the **"private/reserved"** reason; covers loopback, private, and IPv6 loopback)
- `WebhookManager(enabled=True, url=<rejected>)` → effective config is disabled, and stays inert (`_client is None`) even when a configured event fires

Assertions are at the rejection-**reason** level (scheme vs IP), not the exact message, per the issue's "stable, not overly-specific" guidance — wording can change without churning tests.

## Notes

Test coverage only — no production behavior change, no network access, no DNS-pinning scope creep (that would be a separate security design change, per the issue).

`uv run pytest packages/memtomem/tests/test_webhooks.py` → 19 passed. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
