### PR TITLE
typing(context): cast validated TargetScope instead of return-value ignores (#1031)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -472,7 +472,8 @@ def _resolve_artifact_cli_scope(scope_flag: str | None) -> TargetScope:
     pre-PR-E2 import behavior — implicit invocation stays back-compat.
     """
     if scope_flag is not None:
-        return scope_flag  # type: ignore[return-value]
+        # Validated upstream by the click.Choice on --scope; cast for mypy.
+        return cast(TargetScope, scope_flag)
     return "project_shared"
 
 

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -65,7 +65,8 @@ def _resolve_artifact_mcp_scope(scope: str | None) -> TargetScope:
         raise ValueError(
             f"Unknown scope value '{scope}'. Supported: {sorted(_KNOWN_ARTIFACT_SCOPES)}"
         )
-    return scope  # type: ignore[return-value]
+    # Narrowed against _KNOWN_ARTIFACT_SCOPES above; cast expresses that to mypy.
+    return cast(TargetScope, scope)
 
 
 def _parse_include(include: str) -> set[str]:


### PR DESCRIPTION
Closes #1031.

## What

Two artifact-scope resolvers validated a raw string against the known scope set and then used `# type: ignore[return-value]` to hand it back as `TargetScope`:

- `server/tools/context.py::_resolve_artifact_mcp_scope` — checks `_KNOWN_ARTIFACT_SCOPES` and raises `ValueError` on a miss, then returned the `str`.
- `cli/context_cmd.py::_resolve_artifact_cli_scope` — every `--scope` option that feeds it is a `click.Choice(get_args(TargetScope))` (verified at lines 613 / 986 / 1543), so the value is already a `TargetScope` member.

## Change

Both blanket ignores replaced with `typing.cast(TargetScope, value)` at the validated point. `cast` was already imported in both modules — no new imports.

```python
# MCP — after the _KNOWN_ARTIFACT_SCOPES check
return cast(TargetScope, scope)

# CLI — value comes from click.Choice(get_args(TargetScope))
return cast(TargetScope, scope_flag)
```

## Invariants held (per acceptance criteria)

- Both `# type: ignore[return-value]` comments gone.
- MCP helper still raises `ValueError` on unknown scope.
- CLI default stays exactly `project_shared` and still does **not** read `hooks.target_scope`.
- No rename of `scope` / `tier` / `target_scope`.

## Checks

- `uv run mypy` on both files → **Success: no issues found** (no new errors, no unused-ignore).
- `uv run pytest test_context_init_scope.py test_server_tools_context_scope.py` → 50 passed.
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
