### PR TITLE
typing(cli): annotate gc orphan-project report renderer (#1032)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/gc_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/gc_cmd.py
@@ -16,8 +16,12 @@ maintenance subcommands (#884 review point 1).
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from memtomem.storage.orphan_gc import OrphanProjectReport
 
 
 @click.group("gc")
@@ -111,7 +115,7 @@ async def _run(*, apply_: bool, assume_yes: bool) -> None:
         )
 
 
-def _print_report(report) -> None:  # type: ignore[no-untyped-def]
+def _print_report(report: OrphanProjectReport) -> None:
     """Render one ``OrphanProjectReport`` to stdout."""
     scope_summary = ", ".join(
         f"{scope}={count}" for scope, count in sorted(report.scope_counts.items())


### PR DESCRIPTION
Closes #1032.

## What

`_print_report` in `cli/gc_cmd.py` carried `# type: ignore[no-untyped-def]` because its `report` parameter was unannotated — even though the value is always an `OrphanProjectReport` (defined in `memtomem.storage.orphan_gc`).

## Change

```python
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from memtomem.storage.orphan_gc import OrphanProjectReport

def _print_report(report: OrphanProjectReport) -> None:
    ...
```

The module already has `from __future__ import annotations`, so the annotation is a string at runtime — importing `OrphanProjectReport` under `TYPE_CHECKING` adds **no** runtime coupling to the storage layer. The `# type: ignore[no-untyped-def]` is removed.

## Invariants held

- Renderer body untouched → `mm gc orphan-projects` output unchanged.
- Local type ignore removed.

## Checks

- `uv run mypy packages/memtomem/src/memtomem/cli/gc_cmd.py` → **Success: no issues found**.
- `uv run ruff check` (confirms the `TYPE_CHECKING` import is actually used) + format → clean.
- `uv run pytest packages/memtomem/tests/test_orphan_gc.py` → 15 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
