### PR TITLE
lint(tests): remove unused noqa directives from test tree (#1034)

### DIFF
--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -18,7 +18,7 @@ from memtomem.server.component_factory import Components, create_components, clo
 # ``git_identity`` / ``wiki_root`` as a parameter without per-file imports.
 # Keeping the definitions in ``_wiki_fixtures.py`` avoids bloating this
 # already-heavy conftest with unrelated git-env plumbing.
-from _wiki_fixtures import git_identity, wiki_root  # noqa: E402, F401
+from _wiki_fixtures import git_identity, wiki_root  # noqa: F401
 
 
 def _ollama_available() -> bool:

--- a/packages/memtomem/tests/test_context_install.py
+++ b/packages/memtomem/tests/test_context_install.py
@@ -248,7 +248,7 @@ def test_install_project_root_missing(wiki_root: Path, tmp_path: Path) -> None:
 def test_install_wiki_missing_invariant3(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    git_identity: None,  # noqa: ARG001
+    git_identity: None,
 ) -> None:
     """Invariant 3: precise message including path and `mm wiki init`."""
     monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
@@ -394,7 +394,7 @@ def test_cli_install_wiki_missing_message(
     monkeypatch: pytest.MonkeyPatch,
     project_cwd: Path,
     tmp_path: Path,
-    git_identity: None,  # noqa: ARG001
+    git_identity: None,
 ) -> None:
     monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(tmp_path / "no-wiki"))
     runner = CliRunner()

--- a/packages/memtomem/tests/test_init_cmd.py
+++ b/packages/memtomem/tests/test_init_cmd.py
@@ -3445,7 +3445,7 @@ def test_memory_dirs_env_requires_json_array(monkeypatch: pytest.MonkeyPatch) ->
     # The bad format (plain string) must fail — this is the bug the docs and
     # wizard previously produced.
     monkeypatch.setenv("MEMTOMEM_INDEXING__MEMORY_DIRS", "~/notes")
-    with pytest.raises(Exception):  # noqa: BLE001 — pydantic SettingsError wraps JSONDecodeError
+    with pytest.raises(Exception):  # pydantic SettingsError wraps JSONDecodeError
         Mem2MemConfig()
 
 

--- a/packages/memtomem/tests/test_orphan_gc.py
+++ b/packages/memtomem/tests/test_orphan_gc.py
@@ -96,7 +96,7 @@ def _set_ai_summary(backend: SqliteBackend, source_file: str) -> None:
 
 
 def _row_count(backend: SqliteBackend, table: str) -> int:
-    return backend._get_db().execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    return backend._get_db().execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
 
 
 def _meta_count(backend: SqliteBackend, prefix: str = "ai_summary:") -> int:

--- a/packages/memtomem/tests/test_scope_context_threading.py
+++ b/packages/memtomem/tests/test_scope_context_threading.py
@@ -66,7 +66,7 @@ class _CallVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         self.offenders: list[tuple[int, str, str]] = []
 
-    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802 - ast hook
+    def visit_Call(self, node: ast.Call) -> None:  # ast.NodeVisitor dispatch hook
         # Match ``something.<method>(...)`` for the ADR-0011 read surfaces.
         if isinstance(node.func, ast.Attribute) and node.func.attr in _TARGET_METHODS:
             method = node.func.attr

--- a/packages/memtomem/tests/test_server_sigterm.py
+++ b/packages/memtomem/tests/test_server_sigterm.py
@@ -371,7 +371,7 @@ def test_server_warns_but_proceeds_when_legacy_lock_held_exclusively(
     env["HOME"] = str(home)
     env["XDG_RUNTIME_DIR"] = str(xdg)
 
-    holder = open(legacy_pid, "a+b")  # noqa: SIM115 — held for test scope
+    holder = open(legacy_pid, "a+b")  # held for test scope
     try:
         _fcntl.flock(holder, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
         proc = _spawn_server(env)
@@ -465,15 +465,15 @@ def test_legacy_lock_sh_allows_multiple_holders(tmp_path: Path) -> None:
     path = tmp_path / "shared-lock.pid"
     path.touch()
 
-    fp1 = open(path, "a+b")  # noqa: SIM115
-    fp2 = open(path, "a+b")  # noqa: SIM115
+    fp1 = open(path, "a+b")
+    fp2 = open(path, "a+b")
     try:
         _fcntl.flock(fp1, _fcntl.LOCK_SH | _fcntl.LOCK_NB)
         # The second acquire on a different fd of the same file must succeed.
         _fcntl.flock(fp2, _fcntl.LOCK_SH | _fcntl.LOCK_NB)
         # And a LOCK_EX from a third handle must fail while both SH are held,
         # which is how cross-version mutex stays intact.
-        fp3 = open(path, "a+b")  # noqa: SIM115
+        fp3 = open(path, "a+b")
         try:
             with pytest.raises((BlockingIOError, OSError)):
                 _fcntl.flock(fp3, _fcntl.LOCK_EX | _fcntl.LOCK_NB)
@@ -534,7 +534,7 @@ def test_contended_server_start_preserves_pid_file_content(tmp_path: Path) -> No
 
     import portalocker
 
-    holder = open(pid_file, "rb+")  # noqa: SIM115 — held for test scope
+    holder = open(pid_file, "rb+")  # held for test scope
     try:
         portalocker.lock(holder, portalocker.LOCK_EX | portalocker.LOCK_NB)
         proc = _spawn_server(env)

--- a/packages/memtomem/tests/test_server_tools_context_migrate.py
+++ b/packages/memtomem/tests/test_server_tools_context_migrate.py
@@ -130,7 +130,7 @@ async def test_mem_context_memory_migrate_unknown_scope_rejected_without_helper(
     # Sentinel pins that the helper is never reached.
     invoked = []
 
-    async def _sentinel(*args, **kwargs):  # noqa: ANN001
+    async def _sentinel(*args, **kwargs):
         invoked.append((args, kwargs))
 
     monkeypatch.setattr("memtomem.cli.context_cmd._memory_migrate_run", _sentinel)
@@ -179,7 +179,7 @@ async def test_mem_context_memory_migrate_project_shared_requires_confirmation(
     layout = fake_project_layout
     invoked = []
 
-    async def _sentinel(*args, **kwargs):  # noqa: ANN001
+    async def _sentinel(*args, **kwargs):
         invoked.append((args, kwargs))
 
     monkeypatch.setattr("memtomem.cli.context_cmd._memory_migrate_run", _sentinel)

--- a/packages/memtomem/tests/test_wiki_cmd.py
+++ b/packages/memtomem/tests/test_wiki_cmd.py
@@ -38,7 +38,7 @@ class TestInitCmd:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        git_identity: None,  # noqa: ARG002
+        git_identity: None,
     ) -> None:
         source = tmp_path / "source"
         monkeypatch.setenv("MEMTOMEM_WIKI_PATH", str(source))

--- a/packages/memtomem/tests/test_wiki_store.py
+++ b/packages/memtomem/tests/test_wiki_store.py
@@ -85,7 +85,7 @@ class TestInitFromUrl:
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        git_identity: None,  # noqa: ARG002
+        git_identity: None,
     ) -> None:
         # Set up a source wiki at one path…
         source = tmp_path / "source-wiki"


### PR DESCRIPTION
Closes #1034.

Removes `noqa` directives in `packages/memtomem/tests` whose codes are not active under the default ruff gate. Test-tree counterpart to #1182 (#1033); no production source touched.

## How they were found

```bash
uv run ruff check --extend-select RUF100 packages/memtomem/tests --fix
```

> [!NOTE]
> Same caveat as #1182: the issue's `ruff check --select RUF100` command is misleading — `--select` *replaces* the default rules with only RUF100, so it reports load-bearing `F401`/`F403`/`SIM115` directives as "unused" (19 hits vs the 15 genuinely-dead ones). On this tree it would wrongly delete the `# noqa` on `test_chunkers_extended.py` (3×) and `test_web_cli.py`, which the default gate needs. `--extend-select RUF100` keeps the gate's rules and adds RUF100 on top.

## What changed

- **`conftest.py`** — `# noqa: E402, F401` → `# noqa: F401`. The re-exported `_wiki_fixtures` (`git_identity`, `wiki_root`) still need `F401`; only the `E402` half was dead.
- Removed dead `# noqa: ARG001` / `ARG002` / `ANN001` / `S608` / `SIM115` / `N802` / `BLE001` (none of these rules are in the gate).
- **Preserved prose explaining intentional test patterns**, per the issue's "keep comments that explain unusual patterns" note, converting them to plain comments:
  - `test_init_cmd.py` — `pytest.raises(Exception)  # pydantic SettingsError wraps JSONDecodeError`
  - `test_scope_context_threading.py` — `visit_Call(...)  # ast.NodeVisitor dispatch hook`
  - `test_server_sigterm.py` — two `open(...)  # held for test scope` lock handles

## Kept on purpose (load-bearing under the default gate)

`# noqa` in `test_chunkers_extended.py` and `test_web_cli.py` whose codes the default `ruff check` enforces.

## Verification

- `uv run ruff check --extend-select RUF100 packages/memtomem/tests` → clean
- `uv run ruff check packages/memtomem/tests` → clean
- `uv run ruff format --check packages/memtomem/tests` → clean
- `git status packages/memtomem/src` → empty (no source files changed)
- 374 tests across the touched files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
