### PR TITLE
i18n(web): localize Index streaming progress labels (#1027)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -6231,12 +6231,15 @@ async function runIndexStream() {
       const pct = event.files_total > 0
         ? Math.round((event.files_done / event.files_total) * 100) : 0;
       barEl.style.width = pct + '%';
-      labelEl.textContent = `${event.files_done} / ${event.files_total} files`;
+      labelEl.textContent = t('index.progress_files', {
+        done: event.files_done,
+        total: event.files_total,
+      });
       fileEl.textContent  = basename(event.file);
     } else if (event.type === 'complete') {
       es.close();
       barEl.style.width = '100%';
-      labelEl.textContent = `Done — ${event.total_files} files`;
+      labelEl.textContent = t('index.progress_done', { count: event.total_files });
       fileEl.textContent  = '';
 
       qs('r-files').textContent   = event.total_files;

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1457,7 +1457,7 @@
   <script src="/vendor/prism-bash.min.js?v=1"></script>
   <script src="/vendor/prism-yaml.min.js?v=1"></script>
   <script src="/i18n.js?v=3"></script>
-  <script src="/app.js?v=120"></script>
+  <script src="/app.js?v=121"></script>
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -253,6 +253,8 @@
   "index.browse_btn": "📁 Browse",
   "index.browse_aria": "Open folder picker",
   "index.progress_label": "0 / 0 files",
+  "index.progress_files": "{done} / {total} files",
+  "index.progress_done": "Done — {count} files",
   "index.indicator": "⏳ Indexing…",
   "index.result.files": "Files scanned",
   "index.result.chunks": "Total chunks",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -253,6 +253,8 @@
   "index.browse_btn": "📁 둘러보기",
   "index.browse_aria": "폴더 선택 창 열기",
   "index.progress_label": "0 / 0 파일",
+  "index.progress_files": "{done} / {total} 파일",
+  "index.progress_done": "완료 — {count} 파일",
   "index.indicator": "⏳ 인덱싱 중…",
   "index.result.files": "스캔된 파일",
   "index.result.chunks": "전체 청크",

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -389,6 +389,43 @@ class TestNoHardcodedStrings:
             "against I18N.init() (feedback_i18n_init_order_race.md)."
         )
 
+    def test_index_progress_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
+        """The Index streaming progress labels (#1027) must route through locale
+        keys with their interpolation placeholders intact, so the SSE handler's
+        in-progress / complete labels localize."""
+        required = {
+            "index.progress_files": {"done", "total"},
+            "index.progress_done": {"count"},
+        }
+        missing_en = set(required) - set(en)
+        missing_ko = set(required) - set(ko)
+        assert not missing_en, f"Index-progress keys missing from en.json: {sorted(missing_en)}"
+        assert not missing_ko, f"Index-progress keys missing from ko.json: {sorted(missing_ko)}"
+        bad_ph: list[str] = []
+        for key, params in required.items():
+            for name, locale in [("en", en), ("ko", ko)]:
+                got = set(_PLACEHOLDER_RE.findall(locale[key]))
+                if got != params:
+                    bad_ph.append(f"  {name} {key}: expected {params}, got {got}")
+        assert not bad_ph, "Index-progress placeholder drift:\n" + "\n".join(bad_ph)
+
+    def test_no_hardcoded_index_progress(self) -> None:
+        """``app.js`` SSE indexing handler must not rebuild the streaming
+        progress labels (#1027) as inline template literals. These interpolated
+        substrings only existed in the pre-i18n labels; their return means the
+        text regressed off ``t('index.progress_*')``."""
+        text = (_STATIC_JS_DIR / "app.js").read_text(encoding="utf-8")
+        forbidden = [
+            "${event.files_total} files",
+            "${event.total_files} files",
+        ]
+        bad = [s for s in forbidden if s in text]
+        assert not bad, (
+            f"Found re-introduced #1027 streaming-label literals in app.js: {bad}. "
+            "Use t('index.progress_files', {done, total}) / "
+            "t('index.progress_done', {count}) instead."
+        )
+
     def test_named_html_offenders_have_i18n(self) -> None:
         """``index.html`` elements claimed by #698 must carry ``data-i18n``
         bindings. These IDs displayed English-only fallback text before the


### PR DESCRIPTION
Closes #1027.

The Index tab's streaming progress label was built from inline English template literals in `app.js`, so it stayed English even though the surrounding indexing toasts already use locale keys.

## What changed
- `index.progress_files` = `{done} / {total} files` and `index.progress_done` = `Done — {count} files` added to `en.json` + `ko.json`.
- SSE `progress` / `complete` handlers now call `t(...)` with `{done}`/`{total}` and `{count}` interpolation.
- `app.js?v=120 → 121`.

## Unchanged
SSE parsing, progress-bar percentage math, and the result counters (`r-files`, `r-chunks`) are untouched — text-only change.

## Tests
- `test_index_progress_keys_present` — keys + `{done}`/`{total}`/`{count}` placeholders in both locales.
- `test_no_hardcoded_index_progress` — fails if the template literals return (mutation-validated).
- Parity guards cover the new keys; full `test_i18n.py`: 52 passed.

These labels render mid-SSE (user-triggered, well after `I18N.init()`), so there's no module-load init-order race like #976 had — structural guards are sufficient here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
