### PR TITLE
i18n(web): localize Decay scan status messages (#1024)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1461,7 +1461,7 @@
   <script src="/chunk-progress.js?v=1"></script>
   <script src="/settings-config.js?v=9"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
-  <script src="/settings-maintenance.js?v=2"></script>
+  <script src="/settings-maintenance.js?v=3"></script>
   <script src="/settings-namespaces.js?v=8"></script>
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=13"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -617,6 +617,8 @@
   "settings.decay.result.total": "Total chunks",
   "settings.decay.result.expired": "Expired candidates",
   "settings.decay.result.deleted": "Deleted chunks",
+  "settings.decay.no_expire": "No chunks to expire.",
+  "settings.decay.scan_failed": "Scan failed: {error}",
 
   "settings.reset.desc": "Permanently delete all memory data and reinitialize the database. Embedding config is kept.",
   "settings.reset.warning_title": "Danger Zone",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -617,6 +617,8 @@
   "settings.decay.result.total": "전체 청크",
   "settings.decay.result.expired": "만료 후보",
   "settings.decay.result.deleted": "삭제된 청크",
+  "settings.decay.no_expire": "만료할 청크가 없습니다.",
+  "settings.decay.scan_failed": "스캔 실패: {error}",
 
   "settings.reset.desc": "모든 기억 데이터를 영구 삭제하고 데이터베이스를 초기화합니다. 임베딩 설정은 보존됩니다.",
   "settings.reset.warning_title": "위험 구역",

--- a/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-maintenance.js
@@ -194,10 +194,10 @@ async function runDecayScan() {
     show(qs('decay-result'));
     qs('decay-expire-btn').disabled = data.expired_chunks === 0;
     if (data.expired_chunks === 0) {
-      setMsg(qs('decay-msg'), 'No chunks to expire.', false);
+      setMsg(qs('decay-msg'), t('settings.decay.no_expire'), false);
     }
   } catch (err) {
-    setMsg(qs('decay-msg'), 'Scan failed: ' + err.message, true);
+    setMsg(qs('decay-msg'), t('settings.decay.scan_failed', { error: err.message }), true);
   } finally {
     btnLoading(scanBtn, false);
   }

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -426,6 +426,41 @@ class TestNoHardcodedStrings:
             "t('index.progress_done', {count}) instead."
         )
 
+    def test_decay_scan_keys_present(self, en: dict[str, str], ko: dict[str, str]) -> None:
+        """The Decay scan status messages (#1024) must route through locale keys,
+        with the scan-failed key keeping its ``{error}`` detail placeholder."""
+        required = {
+            "settings.decay.no_expire": set(),
+            "settings.decay.scan_failed": {"error"},
+        }
+        missing_en = set(required) - set(en)
+        missing_ko = set(required) - set(ko)
+        assert not missing_en, f"Decay keys missing from en.json: {sorted(missing_en)}"
+        assert not missing_ko, f"Decay keys missing from ko.json: {sorted(missing_ko)}"
+        bad_ph: list[str] = []
+        for key, params in required.items():
+            for name, locale in [("en", en), ("ko", ko)]:
+                got = set(_PLACEHOLDER_RE.findall(locale[key]))
+                if got != params:
+                    bad_ph.append(f"  {name} {key}: expected {params}, got {got}")
+        assert not bad_ph, "Decay placeholder drift:\n" + "\n".join(bad_ph)
+
+    def test_no_hardcoded_decay_messages(self) -> None:
+        """``settings-maintenance.js`` ``runDecayScan()`` must not rebuild its
+        status messages (#1024) as English literals. Substrings are scoped to
+        the decay strings — the dedup ``'Scan failed'`` empty state (no colon)
+        is a separate concern (#1025) and intentionally not matched here."""
+        text = (_STATIC_JS_DIR / "settings-maintenance.js").read_text(encoding="utf-8")
+        forbidden = [
+            "'No chunks to expire.'",
+            "'Scan failed: ' +",
+        ]
+        bad = [s for s in forbidden if s in text]
+        assert not bad, (
+            f"Found re-introduced #1024 decay-scan literals in settings-maintenance.js: {bad}. "
+            "Use t('settings.decay.no_expire') / t('settings.decay.scan_failed', {error}) instead."
+        )
+
     def test_named_html_offenders_have_i18n(self) -> None:
         """``index.html`` elements claimed by #698 must carry ``data-i18n``
         bindings. These IDs displayed English-only fallback text before the


### PR DESCRIPTION
Closes #1024.

`runDecayScan()` in `settings-maintenance.js` set its two status messages as English literals via `setMsg(...)`, so they didn't localize.

## What changed
- `settings.decay.no_expire` = `No chunks to expire.` and `settings.decay.scan_failed` = `Scan failed: {error}` added to `en.json` + `ko.json`.
- The two `setMsg(qs('decay-msg'), ...)` calls now use `t(...)`, preserving the `{error}` detail.
- `settings-maintenance.js?v=2 → 3`.

## Scope
Decay only. The dedup `'Scan failed'` empty state (no colon, in `runDedupScan`) is left for #1025 and is **not** modified — verified it's still present. The negative guard matches the colon form so it won't false-trip on the dedup string.

## Tests
- `test_decay_scan_keys_present` — keys + `{error}` placeholder in both locales.
- `test_no_hardcoded_decay_messages` — decay literals absent (mutation-validated).
- Parity guards cover the new keys; `test_i18n.py`: 54 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
