### PR TITLE
i18n(web): localize settings recovery completion messages (#1023)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1459,7 +1459,7 @@
   <script src="/i18n.js?v=3"></script>
   <script src="/app.js?v=121"></script>
   <script src="/chunk-progress.js?v=1"></script>
-  <script src="/settings-config.js?v=9"></script>
+  <script src="/settings-config.js?v=10"></script>
   <script src="/sources-memory-dirs.js?v=12"></script>
   <script src="/settings-maintenance.js?v=3"></script>
   <script src="/settings-namespaces.js?v=8"></script>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -788,6 +788,7 @@
   "common.merge": "Merge",
   "common.expire": "Expire",
   "common.sync": "Sync",
+  "common.done": "Done",
   "common.dismiss_help": "Dismiss help",
   "common.file_chunk_progress": "{file} — {done}/{total} chunks",
 

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -788,6 +788,7 @@
   "common.merge": "병합",
   "common.expire": "만료",
   "common.sync": "동기화",
+  "common.done": "완료",
   "common.dismiss_help": "도움말 닫기",
   "common.file_chunk_progress": "{file} — {done}/{total} 청크",
 

--- a/packages/memtomem/src/memtomem/web/static/settings-config.js
+++ b/packages/memtomem/src/memtomem/web/static/settings-config.js
@@ -1456,8 +1456,8 @@ function _showReindexWarning(applied) {
       btnLoading(btn, true);
       try {
         const res = await api('POST', '/api/fts-rebuild', undefined, { timeout: 120_000 });
-        showToast(res.message || `FTS rebuilt: ${res.rebuilt_rows} chunks`, 'success');
-        btn.textContent = 'Done';
+        showToast(res.message || t('toast.fts_rebuilt', { count: res.rebuilt_rows }), 'success');
+        btn.textContent = t('common.done');
         btn.disabled = true;
       } catch (err) {
         showToast(t('toast.fts_rebuild_failed', { error: err.message }), 'error');
@@ -1478,7 +1478,7 @@ function _showReindexWarning(applied) {
           const total = (res.results || []).reduce((s, r) => s + (r.indexed_chunks || 0), 0);
           showToast(t('toast.reindex_complete', { count: total }), 'success');
         }
-        btn.textContent = 'Done';
+        btn.textContent = t('common.done');
         btn.disabled = true;
         _markDataStale();
         loadStats();

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -461,6 +461,41 @@ class TestNoHardcodedStrings:
             "Use t('settings.decay.no_expire') / t('settings.decay.scan_failed', {error}) instead."
         )
 
+    def test_settings_recovery_done_key_present(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """The settings recovery flow (#1023) localizes its completion buttons
+        via ``common.done`` and reuses the existing ``toast.fts_rebuilt`` key
+        (with its ``{count}``) for the FTS-rebuild fallback toast."""
+        required = {"common.done": set(), "toast.fts_rebuilt": {"count"}}
+        missing_en = set(required) - set(en)
+        missing_ko = set(required) - set(ko)
+        assert not missing_en, f"Recovery keys missing from en.json: {sorted(missing_en)}"
+        assert not missing_ko, f"Recovery keys missing from ko.json: {sorted(missing_ko)}"
+        bad_ph: list[str] = []
+        for key, params in required.items():
+            for name, locale in [("en", en), ("ko", ko)]:
+                got = set(_PLACEHOLDER_RE.findall(locale[key]))
+                if got != params:
+                    bad_ph.append(f"  {name} {key}: expected {params}, got {got}")
+        assert not bad_ph, "Recovery placeholder drift:\n" + "\n".join(bad_ph)
+
+    def test_no_hardcoded_settings_recovery(self) -> None:
+        """``settings-config.js`` recovery handlers must not rebuild the
+        completion labels / FTS fallback toast as English literals (#1023).
+        ``res.message`` (API-provided text) is intentionally preserved as the
+        primary, so only the fallback literal and the button text are pinned."""
+        text = (_STATIC_JS_DIR / "settings-config.js").read_text(encoding="utf-8")
+        forbidden = [
+            "btn.textContent = 'Done'",
+            "FTS rebuilt: ${res.rebuilt_rows}",
+        ]
+        bad = [s for s in forbidden if s in text]
+        assert not bad, (
+            f"Found re-introduced #1023 recovery literals in settings-config.js: {bad}. "
+            "Use t('common.done') / t('toast.fts_rebuilt', {count}) instead."
+        )
+
     def test_named_html_offenders_have_i18n(self) -> None:
         """``index.html`` elements claimed by #698 must carry ``data-i18n``
         bindings. These IDs displayed English-only fallback text before the


### PR DESCRIPTION
Closes #1023.

The settings recovery flow (`settings-config.js`) had three English literals: the FTS-rebuild fallback toast and two `'Done'` completion-button labels.

## What changed
- **Reuse** the existing `toast.fts_rebuilt` (`FTS index rebuilt ({count} chunks).`) for the FTS fallback toast — no duplicate key added.
- Add `common.done` (`Done` / `완료`); both recovery buttons now use `t('common.done')`.
- `settings-config.js?v=9 → 10`.

## Unchanged
`res.message` (API-provided text) remains the primary toast — only the `|| <fallback>` branch is localized. Recovery API/behavior untouched.

## Tests
- `test_settings_recovery_done_key_present` — `common.done` + `toast.fts_rebuilt` `{count}` in both locales.
- `test_no_hardcoded_settings_recovery` — fails if `btn.textContent = 'Done'` or the FTS template literal returns (mutation-validated).
- Parity guards cover the keys; `test_i18n.py`: 56 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
