### PR TITLE
i18n(web): localize Context Gateway create-form name placeholder (#1022)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -3024,7 +3024,7 @@ document.querySelectorAll('.ctx-create-btn').forEach(btn => {
       : t('settings.ctx.create_content_placeholder');
     form.innerHTML = `
       <label>${escapeHtml(t('settings.ctx.create_name_label'))}</label>
-      <input type="text" class="ctx-create-name" placeholder="my-${type.slice(0, -1)}" style="width:100%" />
+      <input type="text" class="ctx-create-name" placeholder="${escapeHtml(t('settings.ctx.create_name_placeholder', { type: type.slice(0, -1) }))}" style="width:100%" />
       <label style="margin-top:8px">${escapeHtml(t('settings.ctx.create_content_label'))}</label>
       <textarea class="ctx-edit-area ctx-create-content" rows="6" placeholder="${escapeHtml(contentPlaceholder)}"></textarea>
       <div class="ctx-edit-actions">

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -1466,7 +1466,7 @@
   <script src="/settings-harness.js?v=2"></script>
   <script src="/settings-hooks-watchdog.js?v=13"></script>
   <script src="/timeline.js?v=3"></script>
-  <script src="/context-gateway.js?v=48"></script>
+  <script src="/context-gateway.js?v=49"></script>
   <script src="/path-picker.js?v=3"></script>
 </body>
 </html>

--- a/packages/memtomem/src/memtomem/web/static/locales/en.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/en.json
@@ -437,6 +437,7 @@
   "settings.ctx.create_name_label": "Name",
   "settings.ctx.create_content_label": "Content",
   "settings.ctx.create_content_placeholder": "# Content...",
+  "settings.ctx.create_name_placeholder": "my-{type}",
   "settings.ctx.import_skipped": "Skipped",
   "settings.ctx.empty_hint": "Place {type} under {canonical}/<name>/ then click Sync, or click Import to pull existing {type} from {scan_dirs} within this project.",
   "settings.ctx.empty_hint_user": "Place {type} under {canonical}/<name>/ then click Sync. User canonical is shared across all projects.",

--- a/packages/memtomem/src/memtomem/web/static/locales/ko.json
+++ b/packages/memtomem/src/memtomem/web/static/locales/ko.json
@@ -437,6 +437,7 @@
   "settings.ctx.create_name_label": "이름",
   "settings.ctx.create_content_label": "내용",
   "settings.ctx.create_content_placeholder": "# 내용...",
+  "settings.ctx.create_name_placeholder": "my-{type}",
   "settings.ctx.import_skipped": "건너뜀",
   "settings.ctx.empty_hint": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르거나, 이 프로젝트의 {scan_dirs} 에서 기존 {type} 폴더를 가져오기로 불러올 수 있습니다.",
   "settings.ctx.empty_hint_user": "{canonical}/<이름>/ 아래에 {type} 폴더를 두고 동기화를 누르세요. 사용자 canonical 은 모든 프로젝트에서 공유됩니다.",

--- a/packages/memtomem/tests/test_i18n.py
+++ b/packages/memtomem/tests/test_i18n.py
@@ -527,6 +527,35 @@ class TestNoHardcodedStrings:
             "t('search.recent_label') instead."
         )
 
+    def test_ctx_create_name_placeholder_key_present(
+        self, en: dict[str, str], ko: dict[str, str]
+    ) -> None:
+        """The Context Gateway create-form name placeholder (#1022) routes
+        through a key with a ``{type}`` placeholder so the same example works
+        across locales (skill/agent/command/mcp-server). The Name/Content
+        labels and content placeholder were already localized."""
+        required = {"settings.ctx.create_name_placeholder": {"type"}}
+        missing_en = set(required) - set(en)
+        missing_ko = set(required) - set(ko)
+        assert not missing_en, f"Ctx create-name key missing from en.json: {sorted(missing_en)}"
+        assert not missing_ko, f"Ctx create-name key missing from ko.json: {sorted(missing_ko)}"
+        bad_ph: list[str] = []
+        for key, params in required.items():
+            for name, locale in [("en", en), ("ko", ko)]:
+                got = set(_PLACEHOLDER_RE.findall(locale[key]))
+                if got != params:
+                    bad_ph.append(f"  {name} {key}: expected {params}, got {got}")
+        assert not bad_ph, "Ctx create-name placeholder drift:\n" + "\n".join(bad_ph)
+
+    def test_no_hardcoded_ctx_create_name_placeholder(self) -> None:
+        """``context-gateway.js`` create form must not rebuild the name input
+        placeholder as a raw ``my-${type...}`` template literal (#1022)."""
+        text = (_STATIC_JS_DIR / "context-gateway.js").read_text(encoding="utf-8")
+        assert 'placeholder="my-${type' not in text, (
+            "Found re-introduced #1022 hardcoded name placeholder in context-gateway.js. "
+            "Use t('settings.ctx.create_name_placeholder', { type: type.slice(0, -1) })."
+        )
+
     def test_named_html_offenders_have_i18n(self) -> None:
         """``index.html`` elements claimed by #698 must carry ``data-i18n``
         bindings. These IDs displayed English-only fallback text before the


### PR DESCRIPTION
Closes #1022.

## Verified against source first
The issue listed Name, Content, the `my-*` name placeholder, and the `# … content…` content placeholder. Checking the current `context-gateway.js`, **the Name/Content labels and the content placeholder already route through `t()`** (`settings.ctx.create_name_label` / `create_content_label` / `create_content_placeholder`) — localized by prior work. The only string still hardcoded is the **name input placeholder**, built as the raw template literal `my-${type.slice(0, -1)}` (line 3027).

## What changed
- Add `settings.ctx.create_name_placeholder` = `my-{type}` to `en.json` + `ko.json` (identical by design — it's an example identifier; `{type}` = `skill`/`agent`/`command`/`mcp-server`, so one string serves every kind, matching this file's existing `{type}`-interpolation pattern).
- Route the placeholder through `t('settings.ctx.create_name_placeholder', { type: type.slice(0, -1) })`.
- `context-gateway.js?v=48 → 49`.

## Tests
- `test_ctx_create_name_placeholder_key_present` — key + `{type}` placeholder in both locales.
- `test_no_hardcoded_ctx_create_name_placeholder` — fails if the `my-${type` literal returns (mutation-validated).
- Parity guards cover the key; `test_i18n.py`: 60 passed; full vitest suite (ctx-* tests exercise this file): 84 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
