### PR TITLE
feat(context): read-only runtime/client registration registry (ADR-0021 PR1)

### DIFF
--- a/packages/memtomem/src/memtomem/context/runtime_registry.py
+++ b/packages/memtomem/src/memtomem/context/runtime_registry.py
@@ -1,0 +1,332 @@
+"""Read-only detection of memtomem / mms registration across provider clients.
+
+ADR-0021 §"Runtime registration detection — trust boundary". This module
+*reads* a provider client's MCP-server config to answer two questions for the
+Context Portal runtime-status surface:
+
+* **installed** — does the client have a config dir/file on disk?
+* **registered** — is the ``memtomem`` (LTM) and/or ``mms`` (STM proxy) server
+  registered in that config?
+
+Constraints (enforced by design, not convention):
+
+* **Read-only.** This module never writes a client config; registration stays
+  owned by :mod:`memtomem.cli.init_cmd` / :mod:`memtomem.cli.uninstall_cmd`.
+* **No raw config egress.** Callers receive only booleans, the *kinds* of
+  locations where a registration was found, and ``$HOME``-collapsed config
+  paths — never raw config bytes or values, and never an exception *message*
+  (only a coarse :data:`error_kind`). Provider configs hold API tokens; this is
+  the trust boundary, so nothing read here is echoed back.
+* **No STM coupling.** "mms registered" is decided purely by inspecting the
+  config's MCP-server map for the server-id keys below — never by importing
+  ``memtomem_stm`` (forbidden cross-repo coupling, CLAUDE.md invariant).
+
+The in-scope provider clients and their config locations mirror
+``docs/guides/mcp-clients.md`` (the source of truth). ``test_runtime_registry``
+pins "registry locations ⊇ documented locations" so a newly-documented location
+for an in-scope client cannot silently drop out. Per ADR-0021 §Decision B the
+gemini-family client is **Antigravity** (CLI + IDE on the ``~/.gemini`` paths);
+the standalone Gemini CLI and generic MCP editors (Cursor, Windsurf, Claude
+Desktop) are out of scope for v1.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover — py<3.11 fallback; repo targets py312
+    tomllib = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+# Server-id keys that count as a registration. ``memtomem`` is the LTM server;
+# ``mms`` is the STM proxy (MMS_CLIENT_SERVER_NAME). Detected by key presence
+# only — never by importing the STM package.
+MEMTOMEM_SERVER_IDS: frozenset[str] = frozenset({"memtomem"})
+MMS_SERVER_IDS: frozenset[str] = frozenset({"mms"})
+
+# Provider clients in scope for the v1 Context Portal (ADR-0021 §Decision B).
+# Antigravity is the gemini-family client; the standalone Gemini CLI and generic
+# MCP editors are intentionally excluded.
+IN_SCOPE_CLIENTS: tuple[str, ...] = ("claude", "antigravity", "codex", "kimi")
+
+# Map artifact fan-out runtime ids (KNOWN_RUNTIMES) to the provider client whose
+# registration represents them on the status surface. Antigravity is the
+# gemini-family client (ADR-0021 §B), so the `gemini` runtime maps to it.
+RUNTIME_TO_CLIENT: dict[str, str] = {
+    "claude": "claude",
+    "gemini": "antigravity",
+    "codex": "codex",
+    "kimi": "kimi",
+}
+
+ConfigFormat = Literal["json", "toml"]
+
+# Coarse error categories (no exception message — see module docstring).
+_ERROR_PRECEDENCE: tuple[str, ...] = ("permission", "parse", "internal")
+
+
+# --- MCP-server-map extractors ------------------------------------------------
+# Each returns the ``{server_id: ...}`` mapping from parsed config, or None.
+
+
+def _mcp_servers(data: object, _root: Path | None) -> dict | None:
+    return data.get("mcpServers") if isinstance(data, dict) else None
+
+
+def _servers(data: object, _root: Path | None) -> dict | None:
+    # Antigravity VS Code-side config uses the key ``servers`` (mcp-clients.md §8).
+    return data.get("servers") if isinstance(data, dict) else None
+
+
+def _toml_mcp_servers(data: object, _root: Path | None) -> dict | None:
+    # Codex ``[mcp_servers.<id>]`` parses to {"mcp_servers": {"<id>": {...}}}.
+    return data.get("mcp_servers") if isinstance(data, dict) else None
+
+
+def _claude_local(data: object, root: Path | None) -> dict | None:
+    # Claude local scope: ~/.claude.json -> projects."<cwd>".mcpServers.
+    if not isinstance(data, dict) or root is None:
+        return None
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        return None
+    entry = projects.get(str(root))
+    return entry.get("mcpServers") if isinstance(entry, dict) else None
+
+
+# --- path resolvers -----------------------------------------------------------
+
+
+def _kimi_dir(home: Path) -> Path:
+    share = os.environ.get("KIMI_SHARE_DIR")
+    return Path(share).expanduser() if share else home / ".kimi"
+
+
+@dataclass(frozen=True)
+class _Location:
+    """One place an in-scope client may hold its MCP-server map.
+
+    ``resolve`` maps ``(home, project_root)`` to the config file (or None when
+    inapplicable, e.g. the Claude ``project`` scope without a project root).
+    ``container`` extracts the server map from parsed config.
+    """
+
+    kind: str  # user | local | project | cli | ide | ide_vscode
+    fmt: ConfigFormat
+    resolve: Callable[[Path, Path | None], Path | None]
+    container: Callable[[object, Path | None], dict | None]
+
+
+# Location table — mirrors docs/guides/mcp-clients.md (source of truth); the
+# conformance test pins coverage. Antigravity == gemini-family (ADR-0021 §B).
+_LOCATIONS: dict[str, tuple[_Location, ...]] = {
+    "claude": (
+        _Location("user", "json", lambda h, r: h / ".claude.json", _mcp_servers),
+        _Location("local", "json", lambda h, r: h / ".claude.json", _claude_local),
+        _Location("project", "json", lambda h, r: (r / ".mcp.json") if r else None, _mcp_servers),
+    ),
+    "antigravity": (
+        _Location(
+            "cli",
+            "json",
+            lambda h, r: h / ".gemini" / "antigravity-cli" / "mcp_config.json",
+            _mcp_servers,
+        ),
+        _Location(
+            "ide",
+            "json",
+            lambda h, r: h / ".gemini" / "antigravity" / "mcp_config.json",
+            _mcp_servers,
+        ),
+        _Location(
+            "ide_vscode",
+            "json",
+            lambda h, r: (
+                h / "Library" / "Application Support" / "Antigravity" / "User" / "mcp.json"
+            ),
+            _servers,
+        ),
+    ),
+    "codex": (
+        _Location("user", "toml", lambda h, r: h / ".codex" / "config.toml", _toml_mcp_servers),
+    ),
+    "kimi": (_Location("user", "json", lambda h, r: _kimi_dir(h) / "mcp.json", _mcp_servers),),
+}
+
+# Existence of any marker => the client is considered installed.
+_INSTALLED_MARKERS: dict[str, Callable[[Path], tuple[Path, ...]]] = {
+    "claude": lambda h: (h / ".claude.json", h / ".claude"),
+    "antigravity": lambda h: (
+        h / ".gemini" / "antigravity-cli",
+        h / ".gemini" / "antigravity",
+        h / "Library" / "Application Support" / "Antigravity",
+    ),
+    "codex": lambda h: (h / ".codex" / "config.toml", h / ".codex"),
+    "kimi": lambda h: (_kimi_dir(h),),
+}
+
+
+@dataclass(frozen=True)
+class RuntimeStatus:
+    """Read-only registration status for one provider client.
+
+    No field carries config contents: ``config_paths`` are ``$HOME``-collapsed
+    paths of the locations where a registration was found (parallel to
+    ``registered_locations``), and ``error_kind`` is a coarse category only.
+    """
+
+    name: str
+    installed: bool
+    memtomem_registered: bool
+    mms_registered: bool
+    registered_locations: tuple[str, ...]
+    config_paths: tuple[str, ...]
+    error_kind: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "installed": self.installed,
+            "memtomem_registered": self.memtomem_registered,
+            "mms_registered": self.mms_registered,
+            "registered_locations": list(self.registered_locations),
+            "config_paths": list(self.config_paths),
+            "error_kind": self.error_kind,
+        }
+
+
+def _collapse_home(path: Path, home: Path) -> str:
+    """Return ``path`` with the ``home`` prefix collapsed to ``~`` (POSIX form)."""
+    try:
+        return "~/" + path.relative_to(home).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _probe_location(
+    loc: _Location, home: Path, root: Path | None
+) -> tuple[Path | None, bool, bool, str | None]:
+    """Read one location; return only ``(path, found_memtomem, found_mms, error_kind)``.
+
+    The parsed config object **never escapes this function** — only the boolean
+    facts and a coarse error category cross the return. This is the trust
+    boundary (ADR-0021 §B): no raw config bytes/values and no exception
+    *message* leave the module via any return value. ``path`` is returned for
+    ``$HOME`` collapse by the caller and carries no secret (it is a fixed
+    config path). A missing file is not an error (``error_kind=None``).
+    """
+    path = loc.resolve(home, root)
+    if path is None:
+        return None, False, False, None
+    try:
+        if loc.fmt == "toml":
+            if tomllib is None:  # pragma: no cover — repo targets py312
+                return path, False, False, "internal"
+            with path.open("rb") as fh:
+                data: object = tomllib.load(fh)
+        else:
+            with path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+    except FileNotFoundError:
+        return path, False, False, None
+    except PermissionError:
+        return path, False, False, "permission"
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return path, False, False, "parse"
+    except Exception as exc:  # noqa: BLE001 — coarse classify; no message leaks out
+        if tomllib is not None and isinstance(exc, tomllib.TOMLDecodeError):
+            return path, False, False, "parse"
+        logger.debug("runtime_registry: unexpected read error for %s", path.name)
+        return path, False, False, "internal"
+    servers = loc.container(data, root)
+    if not isinstance(servers, dict):
+        return path, False, False, None
+    found_mt = any(k in servers for k in MEMTOMEM_SERVER_IDS)
+    found_mms = any(k in servers for k in MMS_SERVER_IDS)
+    return path, found_mt, found_mms, None
+
+
+def _pick_error(kinds: list[str]) -> str | None:
+    for kind in _ERROR_PRECEDENCE:
+        if kind in kinds:
+            return kind
+    return None
+
+
+def _is_installed(client: str, home: Path) -> bool:
+    markers = _INSTALLED_MARKERS.get(client)
+    if markers is None:
+        return False
+    return any(p.exists() for p in markers(home))
+
+
+def probe_runtime(
+    client: str, project_root: Path | None = None, *, home: Path | None = None
+) -> RuntimeStatus:
+    """Probe one in-scope provider client. Read-only; never raises on bad config.
+
+    ``home`` is injectable for test isolation and to sidestep the Windows
+    ``expanduser`` / ``$HOME`` no-op (cf. feedback on USERPROFILE); it defaults
+    to :func:`Path.home`.
+    """
+    home = home or Path.home()
+    error_kinds: list[str] = []
+    memtomem_reg = False
+    mms_reg = False
+    reg_locations: list[str] = []
+    reg_paths: list[str] = []
+
+    for loc in _LOCATIONS.get(client, ()):
+        path, found_mt, found_mms, err = _probe_location(loc, home, project_root)
+        if err is not None:
+            error_kinds.append(err)
+            continue
+        if (found_mt or found_mms) and path is not None:
+            memtomem_reg = memtomem_reg or found_mt
+            mms_reg = mms_reg or found_mms
+            reg_locations.append(loc.kind)
+            reg_paths.append(_collapse_home(path, home))
+
+    return RuntimeStatus(
+        name=client,
+        installed=_is_installed(client, home),
+        memtomem_registered=memtomem_reg,
+        mms_registered=mms_reg,
+        registered_locations=tuple(reg_locations),
+        config_paths=tuple(reg_paths),
+        error_kind=_pick_error(error_kinds),
+    )
+
+
+def probe_all_runtimes(
+    project_root: Path | None = None, *, home: Path | None = None
+) -> list[RuntimeStatus]:
+    """Probe every in-scope provider client, in :data:`IN_SCOPE_CLIENTS` order."""
+    return [probe_runtime(c, project_root, home=home) for c in IN_SCOPE_CLIENTS]
+
+
+def registry_location_paths(home: Path, project_root: Path | None = None) -> dict[str, list[str]]:
+    """Resolved (``$HOME``-collapsed) config paths the registry probes per client.
+
+    Exposed for the ``docs/guides/mcp-clients.md`` conformance test, which
+    asserts the registry covers every documented location for the in-scope
+    clients.
+    """
+    out: dict[str, list[str]] = {}
+    for client, locs in _LOCATIONS.items():
+        paths: list[str] = []
+        for loc in locs:
+            resolved = loc.resolve(home, project_root)
+            if resolved is not None:
+                paths.append(_collapse_home(resolved, home))
+        out[client] = paths
+    return out

--- a/packages/memtomem/src/memtomem/server/tools/context.py
+++ b/packages/memtomem/src/memtomem/server/tools/context.py
@@ -355,6 +355,7 @@ async def mem_context_init(
 @register("context")
 async def mem_context_detect(
     include: str = "",
+    include_runtimes: bool = False,
     ctx: CtxType = None,
 ) -> str:
     """Detect agent configuration files in the current project.
@@ -363,6 +364,12 @@ async def mem_context_detect(
     and .github/copilot-instructions.md. Pass
     ``include="skills,agents,commands"`` to also list runtime skill
     directories, sub-agent files, and slash-command files.
+
+    Pass ``include_runtimes=True`` to also report read-only provider-client
+    registration status (Claude / Antigravity / Codex / Kimi; ADR-0021 §B).
+    This is a separate boolean — it is intentionally NOT part of the ``include``
+    set, so the shared sync/generate/init/diff include contract is never
+    widened (``mem_context_sync(include="runtimes")`` still rejects).
     """
     from memtomem.context.detector import (
         detect_agent_dirs,
@@ -381,7 +388,7 @@ async def mem_context_detect(
         for f in files:
             rel = f.path.relative_to(root) if f.path.is_relative_to(root) else f.path
             lines.append(f"  {f.agent}: {rel} ({f.size} bytes)")
-    elif not inc:
+    elif not inc and not include_runtimes:
         return "No agent configuration files found."
 
     if "skills" in inc:
@@ -433,6 +440,28 @@ async def mem_context_detect(
                 lines.append(f"  {s.agent}: {s.path} {status}")
         else:
             lines.append("No settings files detected.")
+
+    if include_runtimes:
+        from memtomem.context.runtime_registry import probe_all_runtimes
+
+        if lines:
+            lines.append("")
+        lines.append("Provider-client registration:")
+        for st in probe_all_runtimes(root):
+            if st.memtomem_registered or st.mms_registered:
+                ids = "+".join(
+                    n
+                    for n, on in (("memtomem", st.memtomem_registered), ("mms", st.mms_registered))
+                    if on
+                )
+                locs = f" [{', '.join(st.registered_locations)}]" if st.registered_locations else ""
+                state = f"{ids} registered{locs}"
+            elif st.installed:
+                state = "installed, not registered"
+            else:
+                state = "not detected"
+            suffix = f" (error: {st.error_kind})" if st.error_kind else ""
+            lines.append(f"  {st.name}: {state}{suffix}")
 
     return "\n".join(lines) if lines else "Nothing detected."
 

--- a/packages/memtomem/src/memtomem/web/routes/context_gateway.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_gateway.py
@@ -218,6 +218,17 @@ def _compute_detected_runtimes(project_root: Path) -> list[dict[str, object]]:
         RUNTIME_MARKER_FILES,
         SKILL_DIRS,
     )
+    from memtomem.context.runtime_registry import RUNTIME_TO_CLIENT, probe_all_runtimes
+
+    # ADR-0021 §B: additively enrich each entry with the provider client's
+    # read-only registration status, mapped via RUNTIME_TO_CLIENT (the `gemini`
+    # runtime <-> the Antigravity client). `available` (artifact OR-probe) is
+    # unchanged. Registry failure must not break the chip strip.
+    try:
+        statuses = {s.name: s for s in probe_all_runtimes(project_root)}
+    except Exception:
+        logger.exception("probe_all_runtimes failed during detected_runtimes")
+        statuses = {}
 
     out: list[dict[str, object]] = []
     for rt in KNOWN_RUNTIMES:
@@ -233,7 +244,12 @@ def _compute_detected_runtimes(project_root: Path) -> list[dict[str, object]]:
         cmd = COMMAND_DIRS.get(f"{rt}_commands")
         if cmd is not None:
             probes.append((project_root / cmd[0]).is_dir())
-        out.append({"name": rt, "available": any(probes)})
+        entry: dict[str, object] = {"name": rt, "available": any(probes)}
+        st = statuses.get(RUNTIME_TO_CLIENT.get(rt, ""))
+        if st is not None:
+            entry["installed"] = st.installed
+            entry["memtomem_registered"] = st.memtomem_registered
+        out.append(entry)
     return out
 
 
@@ -388,3 +404,26 @@ async def context_overview(
         "last_synced_at": last_synced_at,
         **result,
     }
+
+
+@router.get("/context/runtimes")
+async def context_runtimes(
+    project_root: Path = Depends(resolve_scope_root),
+) -> dict:
+    """Read-only provider-client registration status (ADR-0021 §B).
+
+    Reports per-client install + ``memtomem``/``mms`` registration for the
+    in-scope provider clients (Claude, Antigravity, Codex, Kimi). This is the
+    client/provider axis — distinct from ``overview.detected_runtimes`` (the
+    artifact fan-out chip strip). Read-only; returns no raw config contents
+    (the registry's trust boundary returns only booleans, location kinds, and
+    ``$HOME``-collapsed paths).
+    """
+    from memtomem.context.runtime_registry import probe_all_runtimes
+
+    try:
+        runtimes = [s.to_dict() for s in probe_all_runtimes(project_root)]
+    except Exception:
+        logger.exception("probe_all_runtimes failed")
+        runtimes = []
+    return {"project_root": str(project_root), "runtimes": runtimes}

--- a/packages/memtomem/tests/test_context_runtimes.py
+++ b/packages/memtomem/tests/test_context_runtimes.py
@@ -1,0 +1,141 @@
+"""Context Portal runtime-registration surface (ADR-0021 §B).
+
+Covers the PR1 wrappers over ``runtime_registry``:
+- ``GET /api/context/runtimes`` (client axis: claude/antigravity/codex/kimi),
+- the additive ``overview.detected_runtimes`` enrichment (gemini->antigravity),
+- ``mem_context_detect(include_runtimes=True)``,
+- the invariant that ``runtimes`` never widens the shared MCP sync include set.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from memtomem.config import ContextGatewayConfig, Mem2MemConfig
+from memtomem.web.app import create_app
+
+from .helpers import set_home
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    set_home(monkeypatch, tmp_path)
+    return tmp_path
+
+
+def _register_antigravity(home: Path) -> None:
+    """Write a memtomem registration into the Antigravity CLI config under home."""
+    cfg = home / ".gemini" / "antigravity-cli" / "mcp_config.json"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(json.dumps({"mcpServers": {"memtomem": {}}}), encoding="utf-8")
+
+
+@pytest.fixture
+def app(home: Path, tmp_path: Path):
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    application = create_app(lifespan=None, mode="dev")
+    application.state.project_root = cwd
+    application.state.storage = AsyncMock()
+    config = Mem2MemConfig()
+    config.context_gateway = ContextGatewayConfig(
+        known_projects_path=tmp_path / "kp.json",
+        experimental_claude_projects_scan=False,
+    )
+    application.state.config = config
+    application.state.search_pipeline = None
+    application.state.index_engine = None
+    application.state.embedder = None
+    application.state.dedup_scanner = None
+    application.state.last_reload_error = None
+    return application
+
+
+@pytest.fixture
+async def client(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# --- GET /api/context/runtimes ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runtimes_route_shape(client) -> None:
+    resp = await client.get("/api/context/runtimes")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "project_root" in data
+    names = [r["name"] for r in data["runtimes"]]
+    assert names == ["claude", "antigravity", "codex", "kimi"]
+    for r in data["runtimes"]:
+        assert set(r) >= {
+            "name",
+            "installed",
+            "memtomem_registered",
+            "mms_registered",
+            "registered_locations",
+            "config_paths",
+            "error_kind",
+        }
+
+
+@pytest.mark.asyncio
+async def test_runtimes_route_detects_antigravity(client, home: Path) -> None:
+    _register_antigravity(home)
+    resp = await client.get("/api/context/runtimes")
+    agy = next(r for r in resp.json()["runtimes"] if r["name"] == "antigravity")
+    assert agy["installed"] is True
+    assert agy["memtomem_registered"] is True
+    assert agy["registered_locations"] == ["cli"]
+
+
+# --- overview.detected_runtimes additive enrichment ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_overview_detected_runtimes_enriched(client, home: Path) -> None:
+    _register_antigravity(home)
+    resp = await client.get("/api/context/overview")
+    assert resp.status_code == 200
+    runtimes = {r["name"]: r for r in resp.json()["detected_runtimes"]}
+    # Backward-compat: name + available preserved for every KNOWN_RUNTIME.
+    assert {"claude", "gemini", "codex", "kimi"} <= set(runtimes)
+    for r in runtimes.values():
+        assert "available" in r
+        assert "installed" in r
+        assert "memtomem_registered" in r
+    # gemini runtime entry reflects the Antigravity client (gemini->antigravity).
+    assert runtimes["gemini"]["memtomem_registered"] is True
+    assert runtimes["claude"]["memtomem_registered"] is False
+
+
+# --- mem_context_detect(include_runtimes=True) --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mem_context_detect_include_runtimes(home: Path, monkeypatch) -> None:
+    from memtomem.server.tools import context as ctxtool
+
+    monkeypatch.setattr(ctxtool, "_find_project_root", lambda: home)
+    _register_antigravity(home)
+    out = await ctxtool.mem_context_detect(include_runtimes=True)
+    assert "Provider-client registration:" in out
+    assert "antigravity: memtomem registered" in out
+
+
+# --- shared sync include contract is NOT widened (Codex round-3 Major-1) -------
+
+
+def test_runtimes_not_in_shared_sync_include() -> None:
+    from memtomem.server.tools.context import _KNOWN_INCLUDES, _parse_include
+
+    assert "runtimes" not in _KNOWN_INCLUDES
+    with pytest.raises(ValueError):
+        _parse_include("runtimes")

--- a/packages/memtomem/tests/test_runtime_registry.py
+++ b/packages/memtomem/tests/test_runtime_registry.py
@@ -1,0 +1,282 @@
+"""Tests for the read-only runtime/client registration registry (ADR-0021 §B).
+
+Covers: per-client multi-location detection, the Antigravity ``servers`` key,
+Codex TOML, Kimi ``$KIMI_SHARE_DIR``, coarse error classification, the
+secret-non-egress trust boundary, the gemini->antigravity client replacement,
+and the ``docs/guides/mcp-clients.md`` source-of-truth conformance.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from memtomem.context import runtime_registry as rr
+
+
+@pytest.fixture(autouse=True)
+def _clear_kimi_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Isolate from a runner that happens to export KIMI_SHARE_DIR.
+    monkeypatch.delenv("KIMI_SHARE_DIR", raising=False)
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# --- installed / unregistered baseline ---------------------------------------
+
+
+def test_empty_home_not_installed(tmp_path: Path) -> None:
+    status = rr.probe_runtime("claude", home=tmp_path)
+    assert status.installed is False
+    assert status.memtomem_registered is False
+    assert status.mms_registered is False
+    assert status.registered_locations == ()
+    assert status.config_paths == ()
+    assert status.error_kind is None
+
+
+def test_installed_but_unregistered(tmp_path: Path) -> None:
+    # Config file present, but no memtomem/mms server entry.
+    _write_json(tmp_path / ".claude.json", {"mcpServers": {"other": {}}})
+    status = rr.probe_runtime("claude", home=tmp_path)
+    assert status.installed is True
+    assert status.memtomem_registered is False
+    assert status.registered_locations == ()
+
+
+# --- Claude: three locations --------------------------------------------------
+
+
+def test_claude_user_scope(tmp_path: Path) -> None:
+    _write_json(tmp_path / ".claude.json", {"mcpServers": {"memtomem": {"command": "x"}}})
+    status = rr.probe_runtime("claude", home=tmp_path)
+    assert status.memtomem_registered is True
+    assert status.registered_locations == ("user",)
+    assert status.config_paths == ("~/.claude.json",)
+
+
+def test_claude_local_scope_keyed_by_project_root(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    _write_json(
+        tmp_path / ".claude.json",
+        {"projects": {str(project): {"mcpServers": {"memtomem": {}}}}},
+    )
+    status = rr.probe_runtime("claude", project, home=tmp_path)
+    assert status.registered_locations == ("local",)
+    # A different project root must NOT see this local registration.
+    other = rr.probe_runtime("claude", tmp_path / "elsewhere", home=tmp_path)
+    assert other.memtomem_registered is False
+
+
+def test_claude_project_mcp_json(tmp_path: Path) -> None:
+    # Project root outside home so the committed .mcp.json renders absolute.
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "proj"
+    _write_json(project / ".mcp.json", {"mcpServers": {"mms": {}}})
+    status = rr.probe_runtime("claude", project, home=home)
+    assert status.mms_registered is True
+    assert status.memtomem_registered is False
+    assert status.registered_locations == ("project",)
+    assert status.config_paths == ((project / ".mcp.json").as_posix(),)
+
+
+# --- Antigravity: gemini-family, three locations incl. the ``servers`` key ----
+
+
+def test_antigravity_cli(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / ".gemini" / "antigravity-cli" / "mcp_config.json",
+        {"mcpServers": {"memtomem": {}}},
+    )
+    status = rr.probe_runtime("antigravity", home=tmp_path)
+    assert status.installed is True
+    assert status.memtomem_registered is True
+    assert status.registered_locations == ("cli",)
+
+
+def test_antigravity_ide_vscode_uses_servers_key(tmp_path: Path) -> None:
+    # VS Code-side Antigravity config nests under ``servers`` (not mcpServers).
+    cfg = tmp_path / "Library" / "Application Support" / "Antigravity" / "User" / "mcp.json"
+    _write_json(cfg, {"servers": {"memtomem": {}}})
+    status = rr.probe_runtime("antigravity", home=tmp_path)
+    assert status.memtomem_registered is True
+    assert status.registered_locations == ("ide_vscode",)
+    # A wrong-key payload (mcpServers in the VS Code file) must not register.
+    _write_json(cfg, {"mcpServers": {"memtomem": {}}})
+    assert rr.probe_runtime("antigravity", home=tmp_path).memtomem_registered is False
+
+
+# --- Codex TOML ---------------------------------------------------------------
+
+
+def test_codex_toml(tmp_path: Path) -> None:
+    cfg = tmp_path / ".codex" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text('[mcp_servers.memtomem]\ncommand = "uv"\n', encoding="utf-8")
+    status = rr.probe_runtime("codex", home=tmp_path)
+    assert status.installed is True
+    assert status.memtomem_registered is True
+    assert status.registered_locations == ("user",)
+
+
+# --- Kimi: default dir and $KIMI_SHARE_DIR override ---------------------------
+
+
+def test_kimi_default_dir(tmp_path: Path) -> None:
+    _write_json(tmp_path / ".kimi" / "mcp.json", {"mcpServers": {"memtomem": {}}})
+    assert rr.probe_runtime("kimi", home=tmp_path).memtomem_registered is True
+
+
+def test_kimi_share_dir_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    share = tmp_path / "share"
+    monkeypatch.setenv("KIMI_SHARE_DIR", str(share))
+    _write_json(share / "mcp.json", {"mcpServers": {"mms": {}}})
+    status = rr.probe_runtime("kimi", home=tmp_path)
+    assert status.installed is True
+    assert status.mms_registered is True
+
+
+# --- error classification (coarse, no message) --------------------------------
+
+
+def test_malformed_json_is_parse_error(tmp_path: Path) -> None:
+    (tmp_path / ".claude.json").write_text("{not json", encoding="utf-8")
+    status = rr.probe_runtime("claude", home=tmp_path)
+    assert status.error_kind == "parse"
+    assert status.memtomem_registered is False
+
+
+def test_malformed_toml_is_parse_error(tmp_path: Path) -> None:
+    cfg = tmp_path / ".codex" / "config.toml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("this = = broken", encoding="utf-8")
+    assert rr.probe_runtime("codex", home=tmp_path).error_kind == "parse"
+
+
+# --- secret non-egress (trust boundary) ---------------------------------------
+
+
+def test_no_secret_egress(tmp_path: Path) -> None:
+    from memtomem.privacy import scan
+
+    # Use a token the repo's own secret scanner detects (sk- + 20+ alnum,
+    # DEFAULT_PATTERNS), so the trust boundary is pinned to the real scanner.
+    secret = "sk-" + "abcdEFGH1234ijklMNOP5678qrst"
+    assert scan(secret), "test token must be detectable by memtomem.privacy.scan"
+    _write_json(
+        tmp_path / ".claude.json",
+        {"mcpServers": {"memtomem": {"env": {"API_KEY": secret}}}},
+    )
+    status = rr.probe_runtime("claude", home=tmp_path)
+    assert status.memtomem_registered is True
+    # No secret/value/key may appear in the returned status (dict, repr, JSON),
+    # and the repo scanner must find nothing in the serialized output.
+    serialized = json.dumps(status.to_dict()) + repr(status)
+    assert secret not in serialized
+    assert "API_KEY" not in serialized
+    assert scan(serialized) == []
+
+
+# --- gemini -> antigravity replacement + ordering -----------------------------
+
+
+def test_probe_all_runtimes_client_set(tmp_path: Path) -> None:
+    names = [s.name for s in rr.probe_all_runtimes(home=tmp_path)]
+    assert names == ["claude", "antigravity", "codex", "kimi"]
+    # gemini-family is represented by antigravity; no standalone "gemini" client.
+    assert "gemini" not in names
+    assert rr.IN_SCOPE_CLIENTS == ("claude", "antigravity", "codex", "kimi")
+
+
+# --- mcp-clients.md source-of-truth conformance (ADR-0021 §B) ------------------
+
+
+def _find_repo_doc() -> Path:
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / "docs" / "guides" / "mcp-clients.md"
+        if candidate.exists():
+            return candidate
+    raise AssertionError("docs/guides/mcp-clients.md not found above test file")
+
+
+# Concrete MCP-config filenames (precise — avoids matching prose like GEMINI.md).
+_CONFIG_TOKEN_RE = re.compile(
+    r"`([^`]*(?:claude\.json|\.mcp\.json|mcp_config\.json|mcp\.json|config\.toml))`"
+)
+_INSCOPE_TITLES = ("Claude Code", "Kimi CLI", "Codex CLI", "Antigravity")
+_OUT_OF_SCOPE_TITLES = ("Cursor", "Windsurf", "Claude Desktop", "Gemini CLI")
+# Documented in-scope tokens the registry intentionally does not probe (none today).
+_DOC_TOKENS_NOT_PROBED: frozenset[str] = frozenset()
+
+
+def _inscope_doc_config_paths(doc: str) -> set[str]:
+    """Backtick-quoted MCP-config paths under the in-scope client sections only."""
+    found: set[str] = set()
+    inscope = False
+    for line in doc.splitlines():
+        header = re.match(r"^##\s+\d+\.\s+(.*\S)\s*$", line)
+        if header:
+            title = header.group(1)
+            inscope = any(t in title for t in _INSCOPE_TITLES) and not any(
+                t in title for t in _OUT_OF_SCOPE_TITLES
+            )
+            continue
+        if inscope:
+            found.update(_CONFIG_TOKEN_RE.findall(line))
+    return found
+
+
+def _norm_path(token: str) -> str:
+    """Reduce a documented/registry path to a comparable tail."""
+    return token.replace("<project-root>", "").replace("~", "").lstrip("/")
+
+
+def test_registry_covers_documented_locations() -> None:
+    """Every in-scope MCP-config path documented in mcp-clients.md is probed.
+
+    Expectations are derived BY PARSING the in-scope doc sections — not a
+    hardcoded list — so a newly-documented or renamed in-scope location that the
+    registry does not probe fails here. Out-of-scope sections (Cursor / Windsurf
+    / Claude Desktop / standalone Gemini CLI) are excluded.
+    """
+    doc = _find_repo_doc().read_text(encoding="utf-8")
+    documented = _inscope_doc_config_paths(doc)
+
+    # Sanity: the parser must find a known anchor per in-scope client. A failure
+    # here means an in-scope ## heading was renamed in mcp-clients.md so the
+    # section is no longer matched by _INSCOPE_TITLES (i.e. update the titles) —
+    # this makes the "silently missed section" failure mode loud and explained.
+    rename_hint = "in-scope section not parsed — was a ## heading renamed in mcp-clients.md?"
+    assert "~/.claude.json" in documented, rename_hint
+    assert "~/.codex/config.toml" in documented, rename_hint
+    assert "~/.kimi/mcp.json" in documented, rename_hint
+    assert any("antigravity-cli/mcp_config.json" in t for t in documented), rename_hint
+    assert any("Antigravity/User/mcp.json" in t for t in documented), rename_hint
+
+    home = Path("/home/u")
+    project = Path("/work/proj")  # outside home so the committed .mcp.json is absolute
+    resolved = [p for ps in rr.registry_location_paths(home, project).values() for p in ps]
+    registry_tails = {_norm_path(p) for p in resolved}
+
+    for token in documented:
+        if token in _DOC_TOKENS_NOT_PROBED:
+            continue
+        tail = _norm_path(token)
+        assert any(
+            rt == tail or rt.endswith("/" + tail) or rt.endswith(tail) for rt in registry_tails
+        ), (
+            f"documented in-scope location {token!r} (tail {tail!r}) is not probed by the "
+            f"registry; resolved tails: {sorted(registry_tails)}"
+        )
+
+    # Standalone Gemini CLI settings.json must never be probed (out of scope).
+    assert not any(p.endswith("/.gemini/settings.json") for p in resolved)


### PR DESCRIPTION
Implements the runtime-status surface of **ADR-0021 Context Portal** (#1191). Backend + MCP/HTTP wrappers only; no UI yet (Project Portal / chips land in later PRs).

## What

- **`context/runtime_registry.py`** — read-only registry reporting per-provider-client install + `memtomem`/`mms` registration. Multi-location probes: Claude (user `~/.claude.json` mcpServers / local `projects."<root>".mcpServers` / project `<root>/.mcp.json`), Antigravity (CLI + IDE + VS Code-side `mcp.json` with the `servers` key), Codex (`~/.codex/config.toml` TOML), Kimi (`~/.kimi/mcp.json` / `$KIMI_SHARE_DIR`).
- **`GET /api/context/runtimes`** — the client/provider axis.
- **`overview.detected_runtimes`** — additively enriched with `installed` / `memtomem_registered` (mapped `gemini`→antigravity via `RUNTIME_TO_CLIENT`); `name` + `available` preserved (**backward compatible**).
- **`mem_context_detect(include_runtimes=True)`** — reports registration via a *separate bool* so the shared sync/generate/init/diff `include` set is **not** widened (`mem_context_sync(include="runtimes")` still rejects).

## Trust boundary (ADR-0021 §B)

Read-only; never writes a client config. Returns only booleans, location kinds, and `$HOME`-collapsed paths plus a coarse `error_kind` — **never raw config bytes/values, never an exception message** (parsed config never escapes `_probe_location`). **Never imports `memtomem_stm`.** `docs/guides/mcp-clients.md` is the location source-of-truth, pinned by a conformance test.

## Tests

20 new (multi-location detection, Antigravity `servers` key, Codex TOML, Kimi share-dir, coarse error classification, **secret-non-egress pinned to `privacy.scan`**, **mcp-clients.md SoT-conformance**, route shape, overview enrichment, MCP detect, sync-include invariant). Existing context route + MCP suites green (253). `ruff` clean. Core module reviewed by codex (SHIP).

> Provider-client set is Claude / Antigravity / Codex / Kimi (Antigravity = gemini-family client; standalone Gemini CLI out of scope). Best reviewed after #1191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)