### PR TITLE
feat(context): project health + label rename + lazy counts (ADR-0021 PR2)

### DIFF
--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -32,9 +32,11 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ProjectScope",
+    "ProjectHealth",
     "KnownProjectsStore",
     "compute_scope_id",
     "discover_project_scopes",
+    "annotate_project_health",
 ]
 
 
@@ -91,7 +93,12 @@ class ProjectScope:
     # stops advertising a tier the producer can't return.
     tier: Literal["project"]
     sources: tuple[str, ...]
+    # ``missing`` — the root is gone (registered but no longer a directory);
+    # ``stale`` — the root exists but has no ``.memtomem/`` store (never
+    # initialized as a memtomem project). Mutually exclusive: a missing root is
+    # never also stale. See ``annotate_project_health``.
     missing: bool = False
+    stale: bool = False
     experimental: bool = False
 
 
@@ -196,6 +203,41 @@ class KnownProjectsStore:
                 return False
             self._write(kept)
             return True
+
+    def update_label_by_scope_id(
+        self, scope_id: str, label: str | None
+    ) -> _KnownProjectEntry | None:
+        """Set (or clear, when *label* is None) the label of the entry whose
+        computed scope_id matches. Returns the updated entry, or None if no
+        entry matched.
+
+        Label-only: ``root`` and ``added_at`` are preserved (the registration's
+        identity is path-derived, so a rename never changes the scope_id). Holds
+        the same exclusive sidecar lock and atomic ``tmp + os.replace`` as
+        ``add`` / ``remove_by_scope_id``.
+
+        Updates *every* entry whose scope_id matches — mirroring
+        ``remove_by_scope_id``'s all-matching semantics — so a manually corrupted
+        file with duplicate rows can't leave a stale label behind a "success".
+        ``add`` dedups by resolved path, so duplicates never arise via the API.
+        Returns the first updated entry.
+        """
+        with _file_lock(_lock_path_for(self._path)):
+            entries = self.load()
+            first_updated: _KnownProjectEntry | None = None
+            new_entries: list[_KnownProjectEntry] = []
+            for e in entries:
+                if compute_scope_id(e.root) == scope_id:
+                    replacement = _KnownProjectEntry(root=e.root, added_at=e.added_at, label=label)
+                    new_entries.append(replacement)
+                    if first_updated is None:
+                        first_updated = replacement
+                else:
+                    new_entries.append(e)
+            if first_updated is None:
+                return None
+            self._write(new_entries)
+            return first_updated
 
     def _write(self, entries: list[_KnownProjectEntry]) -> None:
         doc = {
@@ -490,6 +532,69 @@ def _label_for(root: Path) -> str:
     return name
 
 
+# ── Project health ───────────────────────────────────────────────────────
+
+
+# A scope is *stale* iff its root exists but lacks this directory — i.e. the
+# tree is there but was never initialized as a memtomem project. It is the
+# memtomem-specific subset of ``_MARKER_DIRS`` (which also recognizes runtime
+# markers like ``.claude``); the Portal's "Initialize" affordance keys off
+# *this* marker, not the broader set.
+_MEMTOMEM_MARKER = ".memtomem"
+
+
+@dataclass(frozen=True)
+class ProjectHealth:
+    """The (``missing``, ``stale``) pair the Portal renders for one scope.
+
+    Mirrors the same-named ``ProjectScope`` fields; ``annotate_project_health``
+    is the single source that computes both from a root on disk.
+    """
+
+    missing: bool
+    stale: bool
+
+
+def _root_stale(root: Path) -> bool:
+    """True when *root* exists but has no ``.memtomem/`` store.
+
+    Only meaningful for a present root; the caller gates on ``missing`` first.
+    An unreadable root reads as stale (uninitialized from our vantage) rather
+    than crashing discovery.
+    """
+    try:
+        return not (root / _MEMTOMEM_MARKER).is_dir()
+    except OSError:
+        return True
+
+
+def annotate_project_health(scope: ProjectScope) -> ProjectHealth:
+    """Compute the Portal health pair (``missing``, ``stale``) for *scope*.
+
+    ``missing`` — the root is None / absent / not a directory: the tree is gone,
+    so the Portal greys the row out and offers only *unregister*. ``stale`` —
+    the root exists but has no ``.memtomem/`` store: registered or discovered
+    but never initialized, so the Portal offers *Initialize*. The two are
+    mutually exclusive — a missing root is never reported stale (there is
+    nothing to initialize until the tree returns).
+
+    Re-derives ``missing`` from disk so the pair is internally coherent; the
+    value agrees with the ``missing`` ``discover_project_scopes`` already sets
+    (its source union flags a known-project root missing iff it is not a
+    directory).
+    """
+    root = scope.root
+    if root is None:
+        return ProjectHealth(missing=True, stale=False)
+    try:
+        is_dir = root.is_dir()
+    except OSError:
+        is_dir = False
+    if not is_dir:
+        return ProjectHealth(missing=True, stale=False)
+    return ProjectHealth(missing=False, stale=_root_stale(root))
+
+
 def discover_project_scopes(
     cwd: Path,
     known_projects_file: Path,
@@ -503,11 +608,11 @@ def discover_project_scopes(
     resolved path coalesce; ``sources`` then carries the union of every
     place each scope was discovered.
     """
-    # Resolved-path → (display_path, sources, missing)
-    by_resolved: dict[str, tuple[Path, set[str], bool]] = {}
+    # Resolved-path → (display_path, sources, missing, stored_label)
+    by_resolved: dict[str, tuple[Path, set[str], bool, str | None]] = {}
     order: list[str] = []
 
-    def _add(display: Path, source: str, *, missing: bool) -> None:
+    def _add(display: Path, source: str, *, missing: bool, label: str | None = None) -> None:
         # Resolve aggressively — strict=False so a stale known-project root
         # that no longer exists still gets a scope_id (so the user can
         # DELETE it via the UI).
@@ -517,12 +622,15 @@ def discover_project_scopes(
             resolved = display
         key = _normalize_for_scope_id(resolved)
         if key in by_resolved:
-            _, sources, was_missing = by_resolved[key]
+            _, sources, was_missing, prev_label = by_resolved[key]
             sources.add(source)
             # `missing` only stays true if every source flagged it missing.
-            by_resolved[key] = (resolved, sources, was_missing and missing)
+            # The first non-empty stored label wins (only known-projects carries
+            # one; cwd / claude-projects pass None).
+            merged_label = prev_label if prev_label else label
+            by_resolved[key] = (resolved, sources, was_missing and missing, merged_label)
         else:
-            by_resolved[key] = (resolved, {source}, missing)
+            by_resolved[key] = (resolved, {source}, missing, label)
             order.append(key)
 
     # 1. Server cwd — always first, never missing (the process is running there).
@@ -532,7 +640,12 @@ def discover_project_scopes(
     store = KnownProjectsStore(known_projects_file)
     known_entries = store.load()
     for entry in known_entries:
-        _add(entry.root, "known-projects", missing=not entry.root.is_dir())
+        _add(
+            entry.root,
+            "known-projects",
+            missing=not entry.root.is_dir(),
+            label=entry.label,
+        )
 
     # 3. Opt-in scan of ~/.claude/projects/ — silently skipped when the flag is
     #    False so the default discovery path stays cheap. The cwd and the
@@ -546,19 +659,33 @@ def discover_project_scopes(
 
     scopes: list[ProjectScope] = []
     for key in order:
-        resolved, sources, missing = by_resolved[key]
+        resolved, sources, missing, stored_label = by_resolved[key]
         # ``experimental`` is true iff the *only* source is the opt-in scan.
         # cwd / known-projects unions clear the flag so the most-trusted
         # source wins for display purposes.
         experimental = sources == {"claude-projects"}
+        # Label precedence: an explicit stored label (set via Add Project or the
+        # rename PATCH) wins — it is the user's deliberate name, so it overrides
+        # even the "Server CWD" auto-label when the cwd was also registered.
+        # Otherwise the server cwd shows "Server CWD"; everything else falls back
+        # to the directory basename.
+        if stored_label:
+            label = stored_label
+        elif "server-cwd" in sources:
+            label = "Server CWD"
+        else:
+            label = _label_for(resolved)
         scopes.append(
             ProjectScope(
                 scope_id=compute_scope_id(resolved),
-                label="Server CWD" if "server-cwd" in sources else _label_for(resolved),
+                label=label,
                 root=resolved,
                 tier="project",
                 sources=tuple(sorted(sources)),
                 missing=missing,
+                # A missing root cannot be inspected for a ``.memtomem/`` marker
+                # and is never reported stale — the two flags are exclusive.
+                stale=(not missing) and _root_stale(resolved),
                 experimental=experimental,
             )
         )

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -4,9 +4,12 @@ PR2 of the multi-project context UI series — see
 ``memtomem-docs/memtomem/planning/multi-project-context-ui-rfc.md``.
 
 Endpoints:
-- ``GET /api/context/projects`` — list all discovered scopes with item counts.
+- ``GET /api/context/projects`` — list all discovered scopes with health and
+  optional (``?include=counts``) per-type item counts.
 - ``POST /api/context/known-projects`` — register a project root for the
   Add Project UI; idempotent.
+- ``PATCH /api/context/known-projects/{scope_id}`` — rename a registration
+  (label only).
 - ``DELETE /api/context/known-projects/{scope_id}`` — drop a registration
   (including stale entries whose root no longer exists).
 
@@ -209,11 +212,16 @@ def _scope_to_dict(scope: ProjectScope, *, with_counts: bool, target_scope: Targ
         "tier": scope.tier,
         "sources": list(scope.sources),
         "missing": scope.missing,
+        "stale": scope.stale,
         "experimental": scope.experimental,
+        # Counts are opt-in via ``?include=counts``: each scope costs several
+        # per-type artifact scans (see ``_counts_for``), so the N-project Portal
+        # list stays cheap by default. ``null`` means "not computed" — distinct
+        # from a genuine zero — and a missing root has nothing to count.
         "counts": (
             _counts_for(scope.root, target_scope=target_scope)
             if (with_counts and scope.root is not None and not scope.missing)
-            else {"skills": 0, "commands": 0, "agents": 0, "mcp-servers": 0}
+            else None
         ),
     }
 
@@ -228,18 +236,32 @@ async def list_projects(
             "is counted only when explicitly requested."
         ),
     ),
+    include: str = Query(
+        "",
+        description=(
+            "Comma-separated optional sections to compute. Recognized: 'counts' "
+            "(per-type item counts — omitted by default because each scope costs "
+            "several artifact scans). Unknown tokens are ignored."
+        ),
+    ),
 ) -> dict:
-    """Enumerate discovered project scopes with per-type item counts.
+    """Enumerate discovered project scopes with health and optional item counts.
 
-    Response shape (RFC §Decision 4):
+    Response shape (RFC §Decision 4, extended by ADR-0021 PR2):
 
-    ``{scopes: [{scope_id, label, root, tier, sources, missing,
-    experimental, counts: {skills, commands, agents}}]}``
+    ``{target_scope, scopes: [{project_scope_id, scope_id, label, root, tier,
+    sources, missing, stale, experimental, counts}]}`` where ``counts`` is
+    ``{skills, commands, agents, mcp-servers}`` only when ``?include=counts``
+    is requested (else ``null``).
     """
+    include_tokens = {tok.strip() for tok in include.split(",") if tok.strip()}
+    with_counts = "counts" in include_tokens
     scopes = _discover_for(request)
     return {
         "target_scope": target_scope,
-        "scopes": [_scope_to_dict(s, with_counts=True, target_scope=target_scope) for s in scopes],
+        "scopes": [
+            _scope_to_dict(s, with_counts=with_counts, target_scope=target_scope) for s in scopes
+        ],
     }
 
 
@@ -275,7 +297,12 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
 
     cfg = _gateway_config(request)
     store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
-    entry = store.add(candidate, label=body.label)
+    # Normalize the label the same way PATCH does: a blank / whitespace-only
+    # value stores None (basename fallback). Since a stored label now wins label
+    # precedence in discovery, an unnormalized "   " here would otherwise render
+    # a blank project name.
+    label = (body.label or "").strip() or None
+    entry = store.add(candidate, label=label)
     project_scope_id = compute_scope_id(entry.root)
 
     response: dict = {
@@ -293,6 +320,43 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
             "No .claude/.gemini/.agents/.kimi/.memtomem directory found under this root."
         )
     return response
+
+
+# ── PATCH /context/known-projects/{scope_id} ─────────────────────────────
+
+
+class UpdateProjectLabelRequest(BaseModel):
+    label: str | None = None
+
+
+@router.patch("/context/known-projects/{scope_id}")
+async def update_known_project(
+    scope_id: str, body: UpdateProjectLabelRequest, request: Request
+) -> dict:
+    """Rename a registered project (label only).
+
+    The store is otherwise append/delete-only; this is the one mutator that
+    edits an existing entry in place. ``root`` and ``added_at`` are preserved —
+    the scope_id is path-derived, so a rename never moves the project. A blank
+    or whitespace-only label *clears* the custom label, so discovery falls back
+    to the directory basename. 404 when no registration matches (mirrors
+    DELETE) so the client can tell "renamed" from "never registered".
+
+    Only known-projects entries are editable — the implicit server-cwd scope
+    must be registered (POST) before it can be relabeled.
+    """
+    cfg = _gateway_config(request)
+    store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
+    label = (body.label or "").strip() or None
+    updated = store.update_label_by_scope_id(scope_id, label)
+    if updated is None:
+        raise HTTPException(status_code=404, detail=f"unknown scope_id: {scope_id!r}")
+    return {
+        "project_scope_id": scope_id,
+        "scope_id": scope_id,
+        "root": str(updated.root),
+        "label": updated.label,
+    }
 
 
 # ── DELETE /context/known-projects/{scope_id} ────────────────────────────

--- a/packages/memtomem/src/memtomem/web/static/context-gateway.js
+++ b/packages/memtomem/src/memtomem/web/static/context-gateway.js
@@ -232,7 +232,11 @@ async function _ctxFetchProjects() {
   //     same "endpoint exists but failing" class, surface a toast (#1100).
   let warn = null;
   try {
-    const res = await fetch(_ctxWithTargetScope('/api/context/projects', { includeScope: false }));
+    // ``?include=counts`` is opt-in server-side (ADR-0021 PR2): the scope
+    // picker renders a per-scope count badge, so this shared loader must
+    // request counts. ``_ctxWithTargetScope`` appends ``&target_scope=`` after
+    // the existing ``?``.
+    const res = await fetch(_ctxWithTargetScope('/api/context/projects?include=counts', { includeScope: false }));
     if (!res.ok) {
       const detail = (await res.json().catch(() => ({}))).detail || `HTTP ${res.status}`;
       if (res.status !== 404) warn = { kind: 'http', status: res.status, detail };
@@ -269,8 +273,13 @@ async function _ctxFetchProjects() {
         tier: 'project',
         sources: ['server-cwd'],
         missing: false,
+        // Match the API scope shape: ``stale`` (ADR-0021 PR2) and the full
+        // four-key counts dict. The synthetic fallback is a safe default
+        // (never stale → no spurious "Initialize" prompt) so a fetch outage
+        // can't desync the rendered shape from a real response.
+        stale: false,
         experimental: false,
-        counts: { skills: 0, commands: 0, agents: 0 },
+        counts: { skills: 0, commands: 0, agents: 0, 'mcp-servers': 0 },
       }],
     };
   }

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -18,6 +18,9 @@ import pytest
 
 from memtomem.context.projects import (
     KnownProjectsStore,
+    ProjectHealth,
+    ProjectScope,
+    annotate_project_health,
     compute_scope_id,
     discover_project_scopes,
     has_runtime_marker,
@@ -120,6 +123,82 @@ def test_store_remove_stale_entry(tmp_path: Path) -> None:
     sid = compute_scope_id(project)
     project.rmdir()
     assert store.remove_by_scope_id(sid) is True
+
+
+def test_store_update_label_by_scope_id(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project)
+    sid = compute_scope_id(project)
+
+    updated = store.update_label_by_scope_id(sid, "Alpha Prod")
+    assert updated is not None
+    assert updated.label == "Alpha Prod"
+    assert updated.root == project
+    # Reload from disk to confirm the write persisted.
+    reloaded = store.load()
+    assert len(reloaded) == 1
+    assert reloaded[0].label == "Alpha Prod"
+
+
+def test_store_update_label_preserves_added_at(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    added_at = store.add(project).added_at
+    sid = compute_scope_id(project)
+
+    updated = store.update_label_by_scope_id(sid, "renamed")
+    assert updated is not None
+    assert updated.added_at == added_at  # rename never touches the registration time
+
+
+def test_store_update_label_clear_to_none(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project, label="Custom")
+    sid = compute_scope_id(project)
+
+    updated = store.update_label_by_scope_id(sid, None)
+    assert updated is not None
+    assert updated.label is None
+    assert store.load()[0].label is None
+
+
+def test_store_update_label_unknown_returns_none(tmp_path: Path) -> None:
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    assert store.update_label_by_scope_id("p-deadbeefcafe", "x") is None
+
+
+def test_store_update_label_updates_all_duplicate_rows(tmp_path: Path) -> None:
+    """A manually corrupted file with duplicate scope_id rows must not leave a
+    stale label behind a success (mirrors remove_by_scope_id's all-matching
+    semantics). ``add`` dedups by path, so the API never produces this."""
+    project = tmp_path / "alpha"
+    project.mkdir()
+    kp = tmp_path / "kp.json"
+    kp.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [
+                    {"root": str(project), "added_at": "2026-01-01T00:00:00Z", "label": "old1"},
+                    {"root": str(project), "added_at": "2026-01-02T00:00:00Z", "label": "old2"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    store = KnownProjectsStore(kp)
+    sid = compute_scope_id(project)
+
+    updated = store.update_label_by_scope_id(sid, "new")
+    assert updated is not None
+    entries = store.load()
+    assert len(entries) == 2
+    assert all(e.label == "new" for e in entries)
 
 
 def test_store_corrupt_json_recovers_to_empty(tmp_path: Path) -> None:
@@ -248,6 +327,98 @@ def test_discover_missing_known_project(tmp_path: Path) -> None:
     ghost_scopes = [s for s in scopes if s.label == "ghost"]
     assert len(ghost_scopes) == 1
     assert ghost_scopes[0].missing is True
+    # A missing root is never also stale — the two flags are exclusive.
+    assert ghost_scopes[0].stale is False
+
+
+def test_discover_uses_stored_label(tmp_path: Path) -> None:
+    """A known-projects entry registered with a label surfaces that label,
+    not the directory basename."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    other = tmp_path / "inflearn"
+    other.mkdir()
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(other, label="Inflearn Prod")
+
+    scopes = discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
+    labeled = next(s for s in scopes if "known-projects" in s.sources)
+    assert labeled.label == "Inflearn Prod"
+
+
+def test_discover_stored_label_overrides_server_cwd(tmp_path: Path) -> None:
+    """An explicit label wins even when the cwd is also a registered project —
+    the user's deliberate name beats the 'Server CWD' auto-label."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(cwd, label="My Main Tree")
+
+    scopes = discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
+    assert len(scopes) == 1
+    assert set(scopes[0].sources) == {"server-cwd", "known-projects"}
+    assert scopes[0].label == "My Main Tree"
+
+
+def test_discover_stale_without_memtomem(tmp_path: Path) -> None:
+    """A present root with no ``.memtomem/`` store is reported stale."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()  # no .memtomem
+    kp = tmp_path / "kp.json"
+    scopes = discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
+    assert scopes[0].missing is False
+    assert scopes[0].stale is True
+
+
+def test_discover_not_stale_with_memtomem(tmp_path: Path) -> None:
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    (cwd / ".memtomem").mkdir()
+    kp = tmp_path / "kp.json"
+    scopes = discover_project_scopes(cwd, kp, experimental_claude_projects_scan=False)
+    assert scopes[0].stale is False
+
+
+# ── annotate_project_health ──────────────────────────────────────────────
+
+
+def _scope(root: Path | None) -> ProjectScope:
+    return ProjectScope(
+        scope_id="p-000000000000",
+        label="x",
+        root=root,
+        tier="project",
+        sources=("server-cwd",),
+    )
+
+
+def test_annotate_health_missing_when_root_none() -> None:
+    health = annotate_project_health(_scope(None))
+    assert health == ProjectHealth(missing=True, stale=False)
+
+
+def test_annotate_health_missing_when_root_absent(tmp_path: Path) -> None:
+    health = annotate_project_health(_scope(tmp_path / "does_not_exist"))
+    assert health == ProjectHealth(missing=True, stale=False)
+
+
+def test_annotate_health_stale_without_memtomem(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    root.mkdir()
+    assert annotate_project_health(_scope(root)) == ProjectHealth(missing=False, stale=True)
+
+
+def test_annotate_health_healthy_with_memtomem(tmp_path: Path) -> None:
+    root = tmp_path / "proj"
+    (root / ".memtomem").mkdir(parents=True)
+    assert annotate_project_health(_scope(root)) == ProjectHealth(missing=False, stale=False)
+
+
+def test_annotate_health_file_root_is_missing_not_stale(tmp_path: Path) -> None:
+    """A root that exists but is a *file* (not a directory) is missing, not stale."""
+    f = tmp_path / "afile"
+    f.write_text("x")
+    assert annotate_project_health(_scope(f)) == ProjectHealth(missing=True, stale=False)
 
 
 def test_discover_experimental_scan_disabled(

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -75,6 +75,7 @@ _CSRF_PROTECTED: frozenset[str] = frozenset(
         "context_mcp_servers.update_mcp_server",
         "context_projects.add_known_project",
         "context_projects.delete_known_project",
+        "context_projects.update_known_project",
         "context_skills.create_skill",
         "context_skills.delete_skill",
         "context_skills.import_skill",
@@ -180,6 +181,7 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "context_skills.import_skills": "bulk structured artifact import",
     "context_skills.sync_skills": "filesystem-driven sync",
     "context_projects.add_known_project": "path/label only, no prose",
+    "context_projects.update_known_project": "label-only rename, no prose",
     # Tag mutations: short labels, separate validation at ingest.
     "chunks.update_chunk_tags": "tags are short labels; redaction not applicable to tag strings",
     "tags.run_auto_tag": "auto-tag operates on already-stored chunks; "

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -85,8 +85,11 @@ async def test_get_projects_cwd_only(client) -> None:
     assert scope["tier"] == "project"
     assert scope["missing"] is False
     assert scope["experimental"] is False
-    assert "counts" in scope
-    assert set(scope["counts"].keys()) == {"skills", "commands", "agents", "mcp-servers"}
+    # cwd_root has a .claude marker but no .memtomem store → reported stale.
+    assert scope["stale"] is True
+    # Counts are opt-in now (ADR-0021 PR2): the default response omits them
+    # (``null``, distinct from a real zero) so the project list stays cheap.
+    assert scope["counts"] is None
 
 
 @pytest.mark.asyncio
@@ -114,7 +117,7 @@ async def test_get_projects_counts_directory_layout_commands_agents(client, cwd_
     agent_dir.mkdir(parents=True)
     (agent_dir / "agent.md").write_text("# reviewer\n", encoding="utf-8")
 
-    resp = await client.get("/api/context/projects")
+    resp = await client.get("/api/context/projects", params={"include": "counts"})
     assert resp.status_code == 200
     scope = resp.json()["scopes"][0]
     counts = scope["counts"]
@@ -167,14 +170,14 @@ async def test_get_projects_project_local_counts_only_with_explicit_target_scope
     local_dir.mkdir(parents=True)
     (local_dir / "SKILL.md").write_text("# draft\n", encoding="utf-8")
 
-    default = await client.get("/api/context/projects")
+    default = await client.get("/api/context/projects", params={"include": "counts"})
     assert default.status_code == 200
     assert default.json()["target_scope"] == "project_shared"
     assert default.json()["scopes"][0]["counts"]["skills"] == 0
 
     explicit = await client.get(
         "/api/context/projects",
-        params={"target_scope": "project_local"},
+        params={"target_scope": "project_local", "include": "counts"},
     )
     assert explicit.status_code == 200
     data = explicit.json()
@@ -213,7 +216,7 @@ async def test_get_projects_project_local_dir_layout_commands_agents_count_disti
 
     resp = await client.get(
         "/api/context/projects",
-        params={"target_scope": "project_local"},
+        params={"target_scope": "project_local", "include": "counts"},
     )
     assert resp.status_code == 200
     counts = resp.json()["scopes"][0]["counts"]
@@ -248,11 +251,72 @@ async def test_get_projects_project_shared_dir_layout_commands_agents_count_dist
         agent_dir.mkdir(parents=True)
         (agent_dir / "agent.md").write_text(f"# {name}\n", encoding="utf-8")
 
-    resp = await client.get("/api/context/projects")
+    resp = await client.get("/api/context/projects", params={"include": "counts"})
     assert resp.status_code == 200
     counts = resp.json()["scopes"][0]["counts"]
     assert counts["commands"] == 2, counts
     assert counts["agents"] == 2, counts
+
+
+# ── ?include=counts opt-in + health (ADR-0021 PR2) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_projects_default_omits_counts(client) -> None:
+    """Without ``?include=counts`` every scope reports ``counts: null``."""
+    resp = await client.get("/api/context/projects")
+    assert resp.status_code == 200
+    for scope in resp.json()["scopes"]:
+        assert scope["counts"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_projects_include_counts_present(client) -> None:
+    """``?include=counts`` restores the full per-type count dict."""
+    resp = await client.get("/api/context/projects", params={"include": "counts"})
+    assert resp.status_code == 200
+    scope = resp.json()["scopes"][0]
+    assert scope["counts"] is not None
+    assert set(scope["counts"].keys()) == {"skills", "commands", "agents", "mcp-servers"}
+
+
+@pytest.mark.asyncio
+async def test_get_projects_unknown_include_token_ignored(client) -> None:
+    """Unrecognized include tokens are ignored (forward-compatible), so a
+    stray token neither errors nor accidentally turns counts on."""
+    resp = await client.get("/api/context/projects", params={"include": "bogus"})
+    assert resp.status_code == 200
+    assert resp.json()["scopes"][0]["counts"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_projects_stale_flips_when_memtomem_present(client, cwd_root: Path) -> None:
+    """A root without ``.memtomem/`` is stale; creating it clears the flag."""
+    # cwd_root has only a .claude marker → stale.
+    first = await client.get("/api/context/projects")
+    assert first.json()["scopes"][0]["stale"] is True
+
+    (cwd_root / ".memtomem").mkdir()
+    second = await client.get("/api/context/projects")
+    scope = second.json()["scopes"][0]
+    assert scope["stale"] is False
+    assert scope["missing"] is False
+
+
+@pytest.mark.asyncio
+async def test_get_projects_missing_is_not_stale(client, tmp_path: Path) -> None:
+    """A registered-but-deleted root reports missing=True, stale=False
+    (the two health flags are mutually exclusive)."""
+    gone = tmp_path / "ghost"
+    gone.mkdir()
+    add = await client.post("/api/context/known-projects", json={"root": str(gone)})
+    sid = add.json()["scope_id"]
+    gone.rmdir()
+
+    resp = await client.get("/api/context/projects")
+    ghost = next(s for s in resp.json()["scopes"] if s["scope_id"] == sid)
+    assert ghost["missing"] is True
+    assert ghost["stale"] is False
 
 
 # ── ?scope_id= on /context/skills ───────────────────────────────────────
@@ -440,6 +504,24 @@ async def test_post_no_warning_when_marker_present(client, tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_post_blank_label_falls_back_to_basename(client, tmp_path: Path) -> None:
+    """A whitespace-only POST label is normalized to None at ingest (matching
+    PATCH), so a stored blank can't suppress the basename via label precedence."""
+    proj = tmp_path / "inflearn"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    resp = await client.post(
+        "/api/context/known-projects", json={"root": str(proj), "label": "   "}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["label"] is None
+
+    listing = await client.get("/api/context/projects")
+    scope = next(s for s in listing.json()["scopes"] if s["scope_id"] == resp.json()["scope_id"])
+    assert scope["label"] == "inflearn"
+
+
+@pytest.mark.asyncio
 async def test_post_idempotent(client, tmp_path: Path) -> None:
     proj = tmp_path / "proj"
     proj.mkdir()
@@ -495,3 +577,66 @@ async def test_delete_removes_stale_entry(client, tmp_path: Path) -> None:
 
     resp = await client.delete(f"/api/context/known-projects/{sid}")
     assert resp.status_code == 200
+
+
+# ── PATCH /context/known-projects/{scope_id} (label rename) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_patch_label_round_trip(client, tmp_path: Path) -> None:
+    """PATCH sets the label and echoes it back; root/scope_id are unchanged."""
+    proj = tmp_path / "inflearn"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    add = await client.post("/api/context/known-projects", json={"root": str(proj)})
+    sid = add.json()["scope_id"]
+
+    resp = await client.patch(f"/api/context/known-projects/{sid}", json={"label": "Inflearn Prod"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["scope_id"] == sid
+    assert body["project_scope_id"] == sid
+    assert body["root"] == str(proj)
+    assert body["label"] == "Inflearn Prod"
+
+
+@pytest.mark.asyncio
+async def test_patch_label_reflected_in_discovery(client, tmp_path: Path) -> None:
+    """A renamed project shows its custom label in the GET listing, not the
+    directory basename."""
+    proj = tmp_path / "inflearn"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    add = await client.post("/api/context/known-projects", json={"root": str(proj)})
+    sid = add.json()["scope_id"]
+
+    await client.patch(f"/api/context/known-projects/{sid}", json={"label": "Renamed"})
+
+    listing = await client.get("/api/context/projects")
+    scope = next(s for s in listing.json()["scopes"] if s["scope_id"] == sid)
+    assert scope["label"] == "Renamed"
+
+
+@pytest.mark.asyncio
+async def test_patch_blank_label_clears_to_basename(client, tmp_path: Path) -> None:
+    """A whitespace-only label clears the custom label → falls back to basename."""
+    proj = tmp_path / "inflearn"
+    proj.mkdir()
+    (proj / ".claude").mkdir()
+    add = await client.post("/api/context/known-projects", json={"root": str(proj)})
+    sid = add.json()["scope_id"]
+
+    await client.patch(f"/api/context/known-projects/{sid}", json={"label": "Custom"})
+    cleared = await client.patch(f"/api/context/known-projects/{sid}", json={"label": "   "})
+    assert cleared.status_code == 200
+    assert cleared.json()["label"] is None
+
+    listing = await client.get("/api/context/projects")
+    scope = next(s for s in listing.json()["scopes"] if s["scope_id"] == sid)
+    assert scope["label"] == "inflearn"
+
+
+@pytest.mark.asyncio
+async def test_patch_unknown_scope_id_404(client) -> None:
+    resp = await client.patch("/api/context/known-projects/p-deadbeefcafe", json={"label": "x"})
+    assert resp.status_code == 404

--- a/packages/memtomem/tests/web/test_context_gateway_lists.py
+++ b/packages/memtomem/tests/web/test_context_gateway_lists.py
@@ -1001,7 +1001,11 @@ def test_q_pr4_langchange_off_section_does_not_call_loadCtxList(page, mm_web_url
             body=json.dumps(_CWD_PROJECTS_WITH_NON_CWD_MISSING),
         )
 
-    page.route("**/api/context/projects", _projects_handler)
+    # Trailing ``**`` so the now-``?include=counts`` query string still matches
+    # (ADR-0021 PR2 made counts opt-in; the loader appends the param). Without
+    # it a stray fetch would slip past this handler and the no-call assertion
+    # below would pass vacuously.
+    page.route("**/api/context/projects**", _projects_handler)
     _stub_skills(page, _CWD_SKILLS_ITEMS)
     page.goto(mm_web_url)
     page.locator("#tabbtn-search").click()


### PR DESCRIPTION
## Context Portal v1 (ADR-0021) — PR2: project health + label rename + lazy counts

Backend slice of the Gateway → Portal epic. Builds on PR0 (ADR-0021, #1191) and
PR1 (runtime registry, #1192). Frontend Project Portal section is PR4.

### What changed

**`context/projects.py`**
- `ProjectScope.stale` + `ProjectHealth` / `annotate_project_health(scope)`.
  *stale* = root exists but has no `.memtomem/` store (registered/discovered yet
  never initialized → the Portal will offer "Initialize"); *missing* = root
  gone. The two are mutually exclusive.
- `discover_project_scopes` is now **label-aware**: a stored `known_projects`
  label wins precedence (**stored > "Server CWD" > basename**) — it was ignored
  before.
- `KnownProjectsStore.update_label_by_scope_id` — atomic + lock-guarded, updates
  every matching row (mirrors `remove_by_scope_id`).

**`web/routes/context_projects.py`**
- `GET /api/context/projects`: per-type counts are now **opt-in via
  `?include=counts`** (default `counts: null`) — each scope costs several
  artifact scans, so the N-project list stays cheap. Response also carries
  `stale`.
- New **`PATCH /api/context/known-projects/{scope_id}` `{label}`** — rename a
  registration (label only; blank clears to basename; 404 mirrors `DELETE`).
- `POST` now normalizes a blank label to `None` too, so the new precedence can't
  render an all-whitespace name.

**`web/static/context-gateway.js`** (no-regression coupling)
- The shared `_ctxFetchProjects` loader requests `?include=counts` so the
  scope-picker count badges keep working under the lazy default.
- The fetch-failure fallback scope gains `stale` + the full four-key `counts`
  dict to match the API shape.

### Compatibility
The only semantic change to the existing surface is `counts` going
`{…}` → `null` by default; the live UI is kept whole by the one-line loader
change above. Response shape is otherwise additive (`stale` added). No new
`memtomem_stm` import; no raw config/secret egress (labels + paths only).

### Tests / verification
- `tests/test_context_projects.py`: store label update (duplicate-row + clear),
  label-aware + stale/missing discovery, `annotate_project_health`.
- `tests/test_web_routes_context_projects.py`: `?include=counts` opt-in +
  default-omit + unknown-token, stale flip, PATCH round-trip/clear/404, POST
  blank-label normalization. Existing count asserts migrated to
  `?include=counts`.
- Over-narrow Playwright projects stub broadened to match the query string.
- ruff + mypy clean; context suite (1311) + vitest (21) + Playwright (33) green.
- Reviewed by codex (**SHIP**, 0 blocker/major) + a consumer-sweep workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
