### PR TITLE
feat(web): default Context Gateway landing to Projects Portal (ctx-projects)

### DIFF
--- a/packages/memtomem/src/memtomem/web/static/app.js
+++ b/packages/memtomem/src/memtomem/web/static/app.js
@@ -1343,7 +1343,7 @@ function activateTab(tabName, opts = {}) {
     if (!start) {
       try { start = localStorage.getItem(LAST_SECTION_KEY); } catch {}
     }
-    if (!GATEWAY_SECTIONS.has(start)) start = 'ctx-overview';
+    if (!GATEWAY_SECTIONS.has(start)) start = 'ctx-projects';
     switchSettingsSection(start);
   }
   if (['search', 'timeline'].includes(tabName)) loadNamespaceDropdowns();

--- a/packages/memtomem/src/memtomem/web/static/index.html
+++ b/packages/memtomem/src/memtomem/web/static/index.html
@@ -495,14 +495,14 @@
           <span class="nav-group-caret" aria-hidden="true">▾</span>
           <span data-i18n="settings.nav.integrations">Agent Integrations</span>
         </button>
-        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-overview" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">🔄</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_overview">Context Gateway</span>
             <span class="nav-sub" data-i18n="settings.nav.ctx_overview_sub">Sync overview</span>
           </span>
         </button>
-        <button class="settings-nav-btn" data-ui-tier="prod" data-section="ctx-projects" data-group="integrations" role="tab" aria-selected="false">
+        <button class="settings-nav-btn settings-nav-btn--landing" data-ui-tier="prod" data-section="ctx-projects" data-group="integrations" role="tab" aria-selected="false">
           <span class="nav-icon" aria-hidden="true">📁</span>
           <span class="nav-labels">
             <span class="nav-label" data-i18n="settings.nav.ctx_projects">Projects</span>
@@ -548,7 +548,7 @@
       <div class="settings-content">
 
         <!-- Context Gateway: Overview -->
-        <div class="settings-section active" id="settings-ctx-overview">
+        <div class="settings-section" id="settings-ctx-overview">
           <p class="settings-section-desc" data-i18n="settings.ctx.overview_desc">Sync memtomem agent runtime artifacts to Claude Code, Codex, and other detected runtimes.</p>
           <div class="ctx-header">
             <h2 data-i18n="settings.ctx.overview_title">Context Gateway</h2>
@@ -572,7 +572,7 @@
         </div>
 
         <!-- Context Gateway: Projects (Portal) -->
-        <div class="settings-section" id="settings-ctx-projects">
+        <div class="settings-section active" id="settings-ctx-projects">
           <p class="settings-section-desc" data-i18n="settings.ctx.portal_desc">Browse, switch, rename, and unregister the projects memtomem tracks. Health shows which roots are missing or not yet initialized.</p>
           <div class="ctx-header">
             <h2 data-i18n="settings.ctx.portal_title">Projects</h2>

--- a/packages/memtomem/tests/test_web_mode.py
+++ b/packages/memtomem/tests/test_web_mode.py
@@ -327,8 +327,8 @@ def test_html_settings_nav_btns_all_carry_ui_tier_attr() -> None:
         assert "data-ui-tier=" in tag, f"settings-nav-btn missing data-ui-tier: {tag[:120]}"
 
 
-def test_ctx_overview_has_landing_modifier_for_group_dashboard() -> None:
-    """ctx-overview is the Agent Integrations group's dashboard card and must
+def test_ctx_projects_has_landing_modifier_for_group_dashboard() -> None:
+    """ctx-projects is the Agent Integrations group's dashboard card and must
     carry the ``settings-nav-btn--landing`` modifier so CSS gives it visual
     hierarchy distinct from the leaf rows.
 
@@ -338,32 +338,32 @@ def test_ctx_overview_has_landing_modifier_for_group_dashboard() -> None:
     class and the new tab ancestry.
     """
     html = _read_static("index.html")
-    overview_btn = re.search(r'<button[^>]*data-section="ctx-overview"[^>]*>', html)
-    assert overview_btn is not None, "ctx-overview button not found in markup"
-    assert "settings-nav-btn--landing" in overview_btn.group(0), (
-        "ctx-overview must carry settings-nav-btn--landing modifier "
+    projects_btn = re.search(r'<button[^>]*data-section="ctx-projects"[^>]*>', html)
+    assert projects_btn is not None, "ctx-projects button not found in markup"
+    assert "settings-nav-btn--landing" in projects_btn.group(0), (
+        "ctx-projects must carry settings-nav-btn--landing modifier "
         "(group dashboard, not a leaf); "
-        f"got: {overview_btn.group(0)[:200]}"
+        f"got: {projects_btn.group(0)[:200]}"
     )
     # Anchor the button inside the new Gateway tab. ``#tab-context-gateway``
-    # comes BEFORE the ctx-overview match site if the move was applied
+    # comes BEFORE the ctx-projects match site if the move was applied
     # correctly; a regression that re-nests the Gateway under Settings
     # would put ``#tab-settings`` between them.
-    head = html[: overview_btn.start()]
+    head = html[: projects_btn.start()]
     gateway_idx = head.rfind('id="tab-context-gateway"')
     settings_idx = head.rfind('id="tab-settings"')
     assert gateway_idx >= 0, (
-        "ctx-overview button is not under #tab-context-gateway — promotion regressed (#962)."
+        "ctx-projects button is not under #tab-context-gateway — promotion regressed (#962)."
     )
     assert gateway_idx > settings_idx, (
-        "ctx-overview must live under #tab-context-gateway, but its closest"
+        "ctx-projects must live under #tab-context-gateway, but its closest"
         " ancestor tab id is #tab-settings — restructure regressed (#962)."
     )
 
 
 def test_other_integration_leaves_lack_landing_modifier() -> None:
-    """Symmetric negative pin: only ctx-overview is the landing card. The
-    other Agent Integrations leaves (Skills / Custom Commands / Subagents /
+    """Symmetric negative pin: only ctx-projects is the landing card. The
+    other Agent Integrations leaves (Overview / Skills / Custom Commands / Subagents /
     MCP Servers / Hooks) must not carry the ``--landing`` modifier, otherwise the visual
     hierarchy collapses again.
 
@@ -371,12 +371,19 @@ def test_other_integration_leaves_lack_landing_modifier() -> None:
     partial revert doesn't silently leave the section back under Settings.
     """
     html = _read_static("index.html")
-    for section in ("ctx-skills", "ctx-commands", "ctx-agents", "ctx-mcp-servers", "hooks-sync"):
+    for section in (
+        "ctx-overview",
+        "ctx-skills",
+        "ctx-commands",
+        "ctx-agents",
+        "ctx-mcp-servers",
+        "hooks-sync",
+    ):
         tag = re.search(rf'<button[^>]*data-section="{section}"[^>]*>', html)
         assert tag is not None, f"{section} button not found in markup"
         assert "settings-nav-btn--landing" not in tag.group(0), (
             f"{section} must NOT carry --landing modifier "
-            "(reserved for ctx-overview only); "
+            "(reserved for ctx-projects only); "
             f"got: {tag.group(0)[:200]}"
         )
         head = html[: tag.start()]

--- a/packages/memtomem/tests/web/test_context_gateway_main_tab.py
+++ b/packages/memtomem/tests/web/test_context_gateway_main_tab.py
@@ -5,7 +5,7 @@ Pin three pieces of behavior so a partial revert can't silently re-nest
 the Gateway under Settings without breaking these tests:
 
 * Clicking ``#tabbtn-context-gateway`` lands the user on ``#tab-context-gateway``
-  with ``ctx-overview`` as the default active section.
+  with ``ctx-projects`` as the default active section.
 * ``switchSettingsSection('ctx-skills')`` (legacy caller pattern from
   e.g. ``settings-namespaces.js`` quick links) auto-redirects into the
   new Gateway tab — no per-call-site fix needed.
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.browser
 
 def test_main_tab_button_activates_gateway_panel(page, mm_web_url: str) -> None:
     """Click on the new top-level Gateway button → ``#tab-context-gateway``
-    becomes active and the default section ``ctx-overview`` populates.
+    becomes active and the default section ``ctx-projects`` populates.
     """
     install_default_stubs(page)
 
@@ -39,7 +39,7 @@ def test_main_tab_button_activates_gateway_panel(page, mm_web_url: str) -> None:
         timeout=4_000,
     )
 
-    # Default landing section is ctx-overview.
+    # Default landing section is ctx-projects.
     active_section = page.evaluate(
         "() => {"
         "  const sections = document.querySelectorAll("
@@ -50,8 +50,8 @@ def test_main_tab_button_activates_gateway_panel(page, mm_web_url: str) -> None:
         "  return null;"
         "}"
     )
-    assert active_section == "settings-ctx-overview", (
-        f"Default Gateway sub-section must be ctx-overview, got {active_section!r}"
+    assert active_section == "settings-ctx-projects", (
+        f"Default Gateway sub-section must be ctx-projects, got {active_section!r}"
     )
 
 

--- a/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
+++ b/packages/memtomem/tests/web/test_context_gateway_mobile_layout.py
@@ -61,6 +61,9 @@ def test_gateway_mobile_390px_no_overflow(page, mm_web_url) -> None:
         "() => document.querySelector('.tab-btn.active')?.dataset.tab === 'context-gateway'",
         timeout=4_000,
     )
+    # The Gateway now lands on Projects by default; this test pins the
+    # Overview section's mobile layout, so switch to Overview explicitly.
+    page.evaluate("() => switchSettingsSection('ctx-overview')")
     page.wait_for_selector("#ctx-sync-all-btn", timeout=4_000)
 
     metrics = page.evaluate(
@@ -136,6 +139,9 @@ def test_gateway_overview_grid_single_column_at_480px(page, mm_web_url) -> None:
         "() => document.querySelector('.tab-btn.active')?.dataset.tab === 'context-gateway'",
         timeout=4_000,
     )
+    # The Gateway now lands on Projects by default; this test pins the
+    # Overview grid's column count, so switch to Overview explicitly.
+    page.evaluate("() => switchSettingsSection('ctx-overview')")
     page.wait_for_selector("#tab-context-gateway .ctx-overview-grid", timeout=4_000)
 
     track_count = page.evaluate(


### PR DESCRIPTION
## What
Make the **Projects Portal** (`ctx-projects`) the default landing sub-section of the Context Gateway tab, replacing the Sync Overview (`ctx-overview`).

## Why
With ADR-0021 PR4–6 landing the multi-project board, the portal is the more useful at-a-glance entry point when opening the Gateway. Overview stays one click away.

## Scope (intentionally narrow)
Only the **cold-start fallback** changes:
- An explicit `?section=` deep-link still takes precedence.
- The persisted last-section (`localStorage`) still takes precedence.
- So returning users and share-URLs are unaffected.

`loadCtxProjects()` is already wired in `switchSettingsSection`, so the board populates on cold landing (no empty-portal).

## Changes
- `web/static/app.js`: cold-start fallback `ctx-overview` → `ctx-projects`
- `web/static/index.html`: move the `active` settings-section and the `settings-nav-btn--landing` modifier from overview to projects
- `tests/test_web_mode.py`, `tests/web/test_context_gateway_main_tab.py`: pin the new default + symmetric negative pin (overview now among the non-landing leaves)

## Test plan
- `ruff check` + `ruff format --check`: pass
- Non-browser lane (`-m "not ollama and not browser"`): **5616 passed**
- Browser lane (gateway + portal + smoke, incl. the landing-default assertion): **56 passed**
- Independent Codex review: **SHIP**, 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)