### PR TITLE
feat(context): per-project sync enrollment + filtered auto-display

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -1383,7 +1383,10 @@ def _run_update_all(
         )
         return
 
-    project_roots = [e.root for e in project_entries if e.root.is_dir()]
+    # Sync enrollment: a disabled (paused) known project is excluded from the
+    # batch, matching the web Sync gate and ``sync_eligible``. ``enabled``
+    # defaults True for legacy entries, so this only skips explicitly-paused ones.
+    project_roots = [e.root for e in project_entries if e.root.is_dir() and e.enabled]
     if not project_roots:
         click.echo(
             "No registered projects exist on disk; nothing to update.",

--- a/packages/memtomem/src/memtomem/config.py
+++ b/packages/memtomem/src/memtomem/config.py
@@ -779,8 +779,18 @@ class ContextGatewayConfig(BaseSettings):
     known_projects_path: Path = Path("~/.memtomem/known_projects.json")
     # Opt-in reverse-decode of ``~/.claude/projects/<encoded>`` directory
     # names. Off by default — the encoding is fragile around dash-containing
-    # paths, so this is gated behind explicit consent (RFC §Decision 2).
+    # paths, so this is gated behind explicit consent (RFC §Decision 2). When
+    # True the scan is *unfiltered* (the legacy escape hatch).
     experimental_claude_projects_scan: bool = False
+    # Filtered auto-display of ~/.claude/projects/ scan candidates: surfaces a
+    # discovered project only when its root carries a recognized runtime marker
+    # (.claude/.gemini/.codex/.agents/.kimi/.memtomem). On by default — this is
+    # the auto-display source. Independent of experimental_claude_projects_scan
+    # (which, when True, widens the same scan to unfiltered candidates). Added
+    # as a new field rather than flipping the experimental flag so no env var
+    # name changes (no validation_alias infra) and the unfiltered default is
+    # untouched.
+    auto_display_configured_projects: bool = True
     # PR3 surface — listed here for forward-compat. While ``False`` the user
     # scope is hidden from discovery responses entirely (RFC §Decision 5).
     user_tier_enabled: bool = False

--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -100,6 +100,12 @@ class ProjectScope:
     missing: bool = False
     stale: bool = False
     experimental: bool = False
+    # ``enabled`` — the known_projects entry's sync-enrollment flag (True for
+    # cwd-only / scan-only scopes, which have no entry). ``sync_eligible`` —
+    # derived: server-cwd OR (enrolled AND enabled). Only an enrolled+enabled
+    # scope (or the always-eligible server cwd) participates in sync.
+    enabled: bool = True
+    sync_eligible: bool = False
 
 
 # ── known_projects.json store ───────────────────────────────────────────
@@ -113,6 +119,13 @@ class _KnownProjectEntry:
     root: Path
     added_at: str
     label: str | None
+    # Per-project sync enrollment. Additive field — the schema stays version 1:
+    # legacy rows without the key read back as ``True`` (see ``load``), so old
+    # and new readers agree. Known downgrade hazard — an older writer that lacks
+    # this field drops it on rewrite, silently resuming a paused project;
+    # acceptable for single-user local use, revisit with unknown-field
+    # preservation if paused state must survive older tools.
+    enabled: bool = True
 
 
 class KnownProjectsStore:
@@ -167,6 +180,10 @@ class KnownProjectsStore:
                     root=Path(root),
                     added_at=str(item.get("added_at") or ""),
                     label=item.get("label") if isinstance(item.get("label"), str) else None,
+                    # Legacy rows (pre-``enabled`` schema) and any non-bool value
+                    # default to True — enrolled-but-unflagged means "participating",
+                    # matching ``add``'s default. Only an explicit JSON ``false`` disables.
+                    enabled=item.get("enabled") is not False,
                 )
             )
         return entries
@@ -185,6 +202,7 @@ class KnownProjectsStore:
                 root=normalized,
                 added_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 label=label,
+                enabled=True,
             )
             self._write(entries + [new_entry])
             return new_entry
@@ -204,23 +222,32 @@ class KnownProjectsStore:
             self._write(kept)
             return True
 
-    def update_label_by_scope_id(
-        self, scope_id: str, label: str | None
+    def update_entry_by_scope_id(
+        self,
+        scope_id: str,
+        *,
+        label: str | None = None,
+        set_label: bool = False,
+        enabled: bool = True,
+        set_enabled: bool = False,
     ) -> _KnownProjectEntry | None:
-        """Set (or clear, when *label* is None) the label of the entry whose
-        computed scope_id matches. Returns the updated entry, or None if no
+        """Atomically update ``label`` and/or ``enabled`` of the matching entry in
+        a SINGLE locked load/write. Returns the first updated entry, or None if no
         entry matched.
 
-        Label-only: ``root`` and ``added_at`` are preserved (the registration's
-        identity is path-derived, so a rename never changes the scope_id). Holds
-        the same exclusive sidecar lock and atomic ``tmp + os.replace`` as
-        ``add`` / ``remove_by_scope_id``.
+        Each field is applied only when its ``set_*`` flag is True (an unset field
+        is preserved). Applying both in one lock window keeps a combined PATCH
+        atomic — a concurrent DELETE / PATCH cannot interleave between a label
+        write and an enabled write, so the request never partially applies, loses
+        the other field, nor 404s after a half-write. ``root`` / ``added_at`` are
+        always preserved (identity is path-derived, so this never changes the
+        scope_id). Holds the same exclusive sidecar lock + atomic
+        ``tmp + os.replace`` as ``add`` / ``remove_by_scope_id``.
 
         Updates *every* entry whose scope_id matches — mirroring
         ``remove_by_scope_id``'s all-matching semantics — so a manually corrupted
-        file with duplicate rows can't leave a stale label behind a "success".
+        file with duplicate rows can't leave a stale row behind a "success".
         ``add`` dedups by resolved path, so duplicates never arise via the API.
-        Returns the first updated entry.
         """
         with _file_lock(_lock_path_for(self._path)):
             entries = self.load()
@@ -228,7 +255,12 @@ class KnownProjectsStore:
             new_entries: list[_KnownProjectEntry] = []
             for e in entries:
                 if compute_scope_id(e.root) == scope_id:
-                    replacement = _KnownProjectEntry(root=e.root, added_at=e.added_at, label=label)
+                    replacement = _KnownProjectEntry(
+                        root=e.root,
+                        added_at=e.added_at,
+                        label=label if set_label else e.label,
+                        enabled=enabled if set_enabled else e.enabled,
+                    )
                     new_entries.append(replacement)
                     if first_updated is None:
                         first_updated = replacement
@@ -239,6 +271,25 @@ class KnownProjectsStore:
             self._write(new_entries)
             return first_updated
 
+    def update_label_by_scope_id(
+        self, scope_id: str, label: str | None
+    ) -> _KnownProjectEntry | None:
+        """Set (or clear, when *label* is None) the label of the matching entry.
+
+        Thin wrapper over :meth:`update_entry_by_scope_id` — ``enabled`` is
+        preserved, so a rename never silently resumes a paused project.
+        """
+        return self.update_entry_by_scope_id(scope_id, label=label, set_label=True)
+
+    def set_enabled_by_scope_id(self, scope_id: str, enabled: bool) -> _KnownProjectEntry | None:
+        """Set the per-project sync-enrollment flag of the matching entry.
+
+        Thin wrapper over :meth:`update_entry_by_scope_id` — the label is
+        preserved. A disabled project stays discoverable but is excluded from sync
+        (web sync button, Sync All, and CLI ``mm context update --all``).
+        """
+        return self.update_entry_by_scope_id(scope_id, enabled=enabled, set_enabled=True)
+
     def _write(self, entries: list[_KnownProjectEntry]) -> None:
         doc = {
             "version": _KNOWN_PROJECTS_VERSION,
@@ -247,6 +298,7 @@ class KnownProjectsStore:
                     "root": str(e.root),
                     "added_at": e.added_at,
                     "label": e.label,
+                    "enabled": e.enabled,
                 }
                 for e in entries
             ],
@@ -600,6 +652,7 @@ def discover_project_scopes(
     known_projects_file: Path,
     *,
     experimental_claude_projects_scan: bool,
+    auto_display_configured_projects: bool = True,
 ) -> list[ProjectScope]:
     """Enumerate all project scopes the UI should render, in display order.
 
@@ -607,6 +660,17 @@ def discover_project_scopes(
     visible even before Add Project is used). Entries with the same
     resolved path coalesce; ``sources`` then carries the union of every
     place each scope was discovered.
+
+    ``~/.claude/projects`` scan candidates are gated two ways:
+    ``experimental_claude_projects_scan`` admits them *unfiltered* (the legacy
+    escape hatch), while ``auto_display_configured_projects`` (on by default)
+    admits only candidates whose root carries a runtime marker
+    (``has_runtime_marker``). The filter applies *only* to scan rows — server
+    cwd and known-projects entries are always shown, even when missing/stale.
+
+    ``enabled`` / ``sync_eligible`` are read strictly from the matching
+    known_projects entry (never from cwd / scan sources) so a paused project
+    that also shows up in the scan cannot be silently re-enabled.
     """
     # Resolved-path → (display_path, sources, missing, stored_label)
     by_resolved: dict[str, tuple[Path, set[str], bool, str | None]] = {}
@@ -639,6 +703,10 @@ def discover_project_scopes(
     # 2. User-registered roots from known_projects.json.
     store = KnownProjectsStore(known_projects_file)
     known_entries = store.load()
+    # Sync enrollment (``enabled``) is read strictly from the known_projects
+    # entry, keyed the same way ``_add`` keys ``by_resolved`` so the lookup at
+    # emit time matches. cwd / scan sources never contribute enablement.
+    known_by_key = {_normalize_for_scope_id(e.root): e for e in known_entries}
     for entry in known_entries:
         _add(
             entry.root,
@@ -647,14 +715,18 @@ def discover_project_scopes(
             label=entry.label,
         )
 
-    # 3. Opt-in scan of ~/.claude/projects/ — silently skipped when the flag is
-    #    False so the default discovery path stays cheap. The cwd and the
-    #    user-registered roots are passed as authoritative decode anchors so a
-    #    kebab-case project resolves unambiguously even where the FS walk would
-    #    flag it ambiguous.
-    if experimental_claude_projects_scan:
+    # 3. Scan of ~/.claude/projects/. Admitted when EITHER gate is open:
+    #    - experimental_claude_projects_scan: unfiltered (legacy escape hatch).
+    #    - auto_display_configured_projects (default on): only candidates whose
+    #      root carries a runtime marker, so auto-display surfaces configured
+    #      projects only. The cwd and user-registered roots are passed as
+    #      authoritative decode anchors so a kebab-case project resolves
+    #      unambiguously even where the FS walk would flag it ambiguous.
+    if experimental_claude_projects_scan or auto_display_configured_projects:
         anchors = (cwd, *(entry.root for entry in known_entries))
         for decoded in _discover_claude_projects(anchors):
+            if not experimental_claude_projects_scan and not has_runtime_marker(decoded):
+                continue
             _add(decoded, "claude-projects", missing=False)
 
     scopes: list[ProjectScope] = []
@@ -675,6 +747,15 @@ def discover_project_scopes(
             label = "Server CWD"
         else:
             label = _label_for(resolved)
+        # Sync enrollment is read from the known entry only (cwd / scan never
+        # contribute), so a paused known project that is also scan-discovered
+        # stays ineligible. server-cwd is always eligible — the directory the
+        # server runs in cannot be "paused".
+        known_entry = known_by_key.get(key)
+        enabled = known_entry.enabled if known_entry is not None else True
+        sync_eligible = ("server-cwd" in sources) or (
+            known_entry is not None and known_entry.enabled
+        )
         scopes.append(
             ProjectScope(
                 scope_id=compute_scope_id(resolved),
@@ -687,6 +768,8 @@ def discover_project_scopes(
                 # and is never reported stale — the two flags are exclusive.
                 stale=(not missing) and _root_stale(resolved),
                 experimental=experimental,
+                enabled=enabled,
+                sync_eligible=sync_eligible,
             )
         )
     return scopes
@@ -695,7 +778,12 @@ def discover_project_scopes(
 # ── Validation helpers ──────────────────────────────────────────────────
 
 
-_MARKER_DIRS = (".claude", ".gemini", ".agents", ".kimi", ".memtomem")
+# One marker per in-scope runtime (claude / antigravity-on-.gemini / codex /
+# kimi) plus the canonical ``.memtomem`` store. ``.codex`` covers Codex agents
+# (``.codex/agents``) and ``.agents`` covers Codex skills (``.agents/skills``) —
+# see ``_runtime_targets.py``. Used both for the Add-Project "looks configured"
+# warning and as the auto-display filter on ``~/.claude/projects`` scan rows.
+_MARKER_DIRS = (".claude", ".gemini", ".codex", ".agents", ".kimi", ".memtomem")
 
 
 def has_runtime_marker(root: Path) -> bool:
@@ -703,7 +791,9 @@ def has_runtime_marker(root: Path) -> bool:
 
     Used by ``POST /api/context/known-projects`` to decide whether to
     emit a warning ("looks like a non-project directory") without rejecting
-    the registration outright. Empty parents are valid — the user might be
-    setting up a fresh checkout.
+    the registration outright, and by ``discover_project_scopes`` to filter
+    ``~/.claude/projects`` scan candidates to ones that actually carry runtime
+    config. Empty parents are valid — the user might be setting up a fresh
+    checkout.
     """
     return any((root / m).is_dir() for m in _MARKER_DIRS)

--- a/packages/memtomem/src/memtomem/web/routes/context_projects.py
+++ b/packages/memtomem/src/memtomem/web/routes/context_projects.py
@@ -8,8 +8,8 @@ Endpoints:
   optional (``?include=counts``) per-type item counts.
 - ``POST /api/context/known-projects`` — register a project root for the
   Add Project UI; idempotent.
-- ``PATCH /api/context/known-projects/{scope_id}`` — rename a registration
-  (label only).
+- ``PATCH /api/context/known-projects/{scope_id}`` — update a registration's
+  label and/or ``enabled`` (sync-enrollment) flag.
 - ``DELETE /api/context/known-projects/{scope_id}`` — drop a registration
   (including stale entries whose root no longer exists).
 
@@ -33,6 +33,7 @@ from memtomem.context.commands import (
     list_canonical_commands,
 )
 from memtomem.context.projects import (
+    _MARKER_DIRS,
     KnownProjectsStore,
     ProjectScope,
     compute_scope_id,
@@ -71,6 +72,7 @@ def _discover_for(request: Request) -> list[ProjectScope]:
         cwd,
         Path(cfg.known_projects_path).expanduser(),
         experimental_claude_projects_scan=cfg.experimental_claude_projects_scan,
+        auto_display_configured_projects=cfg.auto_display_configured_projects,
     )
 
 
@@ -241,6 +243,12 @@ def _scope_to_dict(
         "missing": scope.missing,
         "stale": scope.stale,
         "experimental": scope.experimental,
+        # ``enabled`` — the known_projects sync-enrollment flag. ``sync_eligible``
+        # — derived (server-cwd OR enrolled+enabled); the frontend gates the Sync
+        # button on it. ``enrolled`` is intentionally not a separate field — the
+        # client derives it from ``sources`` containing "known-projects".
+        "enabled": scope.enabled,
+        "sync_eligible": scope.sync_eligible,
         "counts": counts,
         "runtime_coverage": coverage,
     }
@@ -272,9 +280,11 @@ async def list_projects(
     Response shape (RFC §Decision 4, extended by ADR-0021 PR2):
 
     ``{target_scope, scopes: [{project_scope_id, scope_id, label, root, tier,
-    sources, missing, stale, experimental, counts}]}`` where ``counts`` is
-    ``{skills, commands, agents, mcp-servers}`` only when ``?include=counts``
-    is requested (else ``null``).
+    sources, missing, stale, experimental, enabled, sync_eligible, counts}]}``
+    where ``counts`` is ``{skills, commands, agents, mcp-servers}`` only when
+    ``?include=counts`` is requested (else ``null``). ``enabled`` is the
+    known_projects sync-enrollment flag; ``sync_eligible`` is the derived
+    server-cwd-OR-enrolled-and-enabled gate.
     """
     include_tokens = {tok.strip() for tok in include.split(",") if tok.strip()}
     with_counts = "counts" in include_tokens
@@ -308,9 +318,10 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
 
     Validation:
     - ``root`` must be an absolute path that resolves to an existing directory.
-    - Without a recognized runtime marker (``.claude``/``.gemini``/``.agents``/``.kimi``/``.memtomem``)
-      the registration still succeeds (HTTP 200) but carries a ``warning`` field
-      so the user can intentionally pre-register an empty checkout.
+    - Without a recognized runtime marker directory (the ``_MARKER_DIRS`` set:
+      ``.claude``/``.gemini``/``.codex``/``.agents``/``.kimi``/``.memtomem``) the
+      registration still succeeds (HTTP 200) but carries a ``warning`` field so
+      the user can intentionally pre-register an empty checkout.
     """
     raw = body.root.strip()
     if not raw:
@@ -345,9 +356,10 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
         # client matching is i18n-stable. ``warning`` carries the human prose
         # for back-compat; new clients should switch on the code.
         response["warning_code"] = "no_runtime_marker"
-        response["warning"] = (
-            "No .claude/.gemini/.agents/.kimi/.memtomem directory found under this root."
-        )
+        # Derive the list from _MARKER_DIRS so it never drifts from the actual
+        # marker set (e.g. when .codex was added). Clients should switch on the
+        # i18n-stable warning_code, not this human prose.
+        response["warning"] = f"No {'/'.join(_MARKER_DIRS)} directory found under this root."
     return response
 
 
@@ -356,28 +368,52 @@ async def add_known_project(body: AddProjectRequest, request: Request) -> dict:
 
 class UpdateProjectLabelRequest(BaseModel):
     label: str | None = None
+    enabled: bool | None = None
 
 
 @router.patch("/context/known-projects/{scope_id}")
 async def update_known_project(
     scope_id: str, body: UpdateProjectLabelRequest, request: Request
 ) -> dict:
-    """Rename a registered project (label only).
+    """Update a registered project's label and/or sync-enrollment flag.
 
     The store is otherwise append/delete-only; this is the one mutator that
     edits an existing entry in place. ``root`` and ``added_at`` are preserved —
-    the scope_id is path-derived, so a rename never moves the project. A blank
-    or whitespace-only label *clears* the custom label, so discovery falls back
-    to the directory basename. 404 when no registration matches (mirrors
-    DELETE) so the client can tell "renamed" from "never registered".
+    the scope_id is path-derived, so this never moves the project.
+
+    Each field is applied only when *present* so a single-field PATCH never
+    clobbers the other: a ``{"enabled": ...}`` request leaves the label intact,
+    and a label-only request leaves ``enabled`` intact. ``label`` presence is
+    detected via ``model_fields_set`` (so an explicit ``label: null`` still
+    *clears* the custom label → basename fallback); ``enabled`` is persisted
+    only for a real bool — an omitted key or ``enabled: null`` means "unchanged".
+    With no applicable field the request is a 400. 404 when no registration
+    matches (mirrors DELETE) so the client can tell "updated" from "never
+    registered".
 
     Only known-projects entries are editable — the implicit server-cwd scope
-    must be registered (POST) before it can be relabeled.
+    must be registered (POST) before it can be relabeled or paused. (Pausing a
+    server-cwd scope has no sync effect: ``sync_eligible`` keeps server-cwd
+    eligible regardless, since the running directory cannot be paused.)
     """
     cfg = _gateway_config(request)
     store = KnownProjectsStore(Path(cfg.known_projects_path).expanduser())
-    label = (body.label or "").strip() or None
-    updated = store.update_label_by_scope_id(scope_id, label)
+
+    label_present = "label" in body.model_fields_set
+    set_enabled = body.enabled is not None  # null / omitted both mean "unchanged"
+    if not set_enabled and not label_present:
+        raise HTTPException(status_code=400, detail="no fields to update (label and/or enabled)")
+
+    # Single atomic store write — applying label + enabled in one lock window so a
+    # concurrent DELETE / PATCH can't interleave and partially apply the combined
+    # update (Codex review). ``set_*`` flags gate which fields are touched.
+    updated = store.update_entry_by_scope_id(
+        scope_id,
+        label=(body.label or "").strip() or None,
+        set_label=label_present,
+        enabled=bool(body.enabled),
+        set_enabled=set_enabled,
+    )
     if updated is None:
         raise HTTPException(status_code=404, detail=f"unknown scope_id: {scope_id!r}")
     return {
@@ -385,6 +421,7 @@ async def update_known_project(
         "scope_id": scope_id,
         "root": str(updated.root),
         "label": updated.label,
+        "enabled": updated.enabled,
     }
 
 

--- a/packages/memtomem/tests/conftest.py
+++ b/packages/memtomem/tests/conftest.py
@@ -149,6 +149,25 @@ def _csrf_observe_only_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MEMTOMEM_WEB__CSRF_ENFORCE", "0")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_claude_projects_scan(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the ``~/.claude/projects`` scan at a nonexistent dir suite-wide.
+
+    ``auto_display_configured_projects`` is on by default in production, so
+    ``discover_project_scopes`` now scans ``~/.claude/projects/`` (filtered to
+    roots with a runtime marker) unless gated. Without this isolation any test
+    that lists project scopes — directly or via a route — would pick up the
+    developer's real Claude project history and break exact-count assertions.
+    ``_CLAUDE_PROJECTS_DIR`` is captured at import time, so sandboxing HOME does
+    not cover it; we patch the module attribute directly. Tests that exercise
+    the scan monkeypatch ``_CLAUDE_PROJECTS_DIR`` themselves, which overrides
+    this default cleanly (and reverts in LIFO order at teardown).
+    """
+    import memtomem.context.projects as _proj
+
+    monkeypatch.setattr(_proj, "_CLAUDE_PROJECTS_DIR", tmp_path / "no-claude-projects")
+
+
 @pytest.fixture
 async def components(tmp_path):
     """Create components with a temporary DB for isolated testing."""

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -201,6 +201,122 @@ def test_store_update_label_updates_all_duplicate_rows(tmp_path: Path) -> None:
     assert all(e.label == "new" for e in entries)
 
 
+# ── enabled (sync enrollment) ────────────────────────────────────────────
+
+
+def test_store_add_enabled_default_true(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project)
+    assert store.load()[0].enabled is True
+
+
+def test_store_set_enabled_round_trip(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project)
+    sid = compute_scope_id(project)
+
+    paused = store.set_enabled_by_scope_id(sid, False)
+    assert paused is not None and paused.enabled is False
+    assert store.load()[0].enabled is False  # persisted
+
+    resumed = store.set_enabled_by_scope_id(sid, True)
+    assert resumed is not None and resumed.enabled is True
+    assert store.load()[0].enabled is True
+
+
+def test_store_legacy_entry_without_enabled_defaults_true(tmp_path: Path) -> None:
+    """A pre-``enabled`` schema row (no key) reads back as enabled — old and new
+    readers must agree without a version bump."""
+    project = tmp_path / "alpha"
+    project.mkdir()
+    kp = tmp_path / "kp.json"
+    kp.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [
+                    {"root": str(project), "added_at": "2026-01-01T00:00:00Z", "label": None}
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert KnownProjectsStore(kp).load()[0].enabled is True
+
+
+def test_store_set_enabled_unknown_returns_none(tmp_path: Path) -> None:
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    assert store.set_enabled_by_scope_id("p-deadbeefcafe", False) is None
+
+
+def test_store_set_enabled_preserves_label_and_added_at(tmp_path: Path) -> None:
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    added_at = store.add(project, label="Alpha").added_at
+    sid = compute_scope_id(project)
+
+    updated = store.set_enabled_by_scope_id(sid, False)
+    assert updated is not None
+    assert updated.label == "Alpha"  # toggling sync never touches the label
+    assert updated.added_at == added_at
+
+
+def test_store_update_label_preserves_enabled(tmp_path: Path) -> None:
+    """Regression: a rename must NOT silently resume a paused project (the
+    default-True dataclass field would otherwise reset ``enabled``)."""
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project)
+    sid = compute_scope_id(project)
+    store.set_enabled_by_scope_id(sid, False)
+
+    renamed = store.update_label_by_scope_id(sid, "Renamed")
+    assert renamed is not None
+    assert renamed.enabled is False  # rename preserved the paused state
+    assert store.load()[0].enabled is False
+
+
+def test_store_update_entry_both_fields_atomic(tmp_path: Path) -> None:
+    """``update_entry_by_scope_id`` applies label + enabled in one write."""
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project, label="Old")
+    sid = compute_scope_id(project)
+
+    updated = store.update_entry_by_scope_id(
+        sid, label="New", set_label=True, enabled=False, set_enabled=True
+    )
+    assert updated is not None
+    assert updated.label == "New"
+    assert updated.enabled is False
+    reloaded = store.load()[0]
+    assert reloaded.label == "New"
+    assert reloaded.enabled is False
+
+
+def test_store_update_entry_unset_fields_preserved(tmp_path: Path) -> None:
+    """Fields without their ``set_*`` flag are left untouched."""
+    project = tmp_path / "alpha"
+    project.mkdir()
+    store = KnownProjectsStore(tmp_path / "kp.json")
+    store.add(project, label="Keep")
+    sid = compute_scope_id(project)
+    store.set_enabled_by_scope_id(sid, False)
+
+    # Touch neither field → no-op update that still matches.
+    updated = store.update_entry_by_scope_id(sid)
+    assert updated is not None
+    assert updated.label == "Keep"
+    assert updated.enabled is False
+
+
 def test_store_corrupt_json_recovers_to_empty(tmp_path: Path) -> None:
     kp = tmp_path / "kp.json"
     kp.write_text("not valid {json")
@@ -424,7 +540,7 @@ def test_annotate_health_file_root_is_missing_not_stale(tmp_path: Path) -> None:
 def test_discover_experimental_scan_disabled(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When the flag is False, ``~/.claude/projects/`` is never inspected."""
+    """When BOTH scan gates are off, ``~/.claude/projects/`` is never inspected."""
     claude_projects = tmp_path / "fake_home" / ".claude" / "projects"
     claude_projects.mkdir(parents=True)
     cwd = tmp_path / "work"
@@ -435,11 +551,14 @@ def test_discover_experimental_scan_disabled(
     monkeypatch.setattr(proj_mod, "_CLAUDE_PROJECTS_DIR", claude_projects)
 
     # ``-tmp`` decodes to ``/tmp`` which exists on every Unix host — would be
-    # picked up if the flag were True. With it False the scan never runs.
+    # picked up if a scan gate were open. With both off the scan never runs.
     (claude_projects / "-tmp").mkdir()
 
     scopes = proj_mod.discover_project_scopes(
-        cwd, tmp_path / "kp.json", experimental_claude_projects_scan=False
+        cwd,
+        tmp_path / "kp.json",
+        experimental_claude_projects_scan=False,
+        auto_display_configured_projects=False,
     )
     assert len(scopes) == 1
     assert "claude-projects" not in scopes[0].sources
@@ -519,11 +638,150 @@ def test_discover_experimental_dedup_with_cwd(
     assert cwd_scope.label == "Server CWD"
 
 
+# ── auto-display filter + enabled / sync_eligible ───────────────────────
+
+
+def test_discover_auto_display_filters_scan_by_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """auto_display on, experimental off: scan candidates are admitted only when
+    their root carries a runtime marker."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    configured = tmp_path / "cfg"
+    configured.mkdir()
+    (configured / ".codex").mkdir()  # codex-only project (exercises the .codex marker)
+    plain = tmp_path / "plain"
+    plain.mkdir()  # no runtime marker
+
+    from memtomem.context import projects as proj_mod
+
+    monkeypatch.setattr(
+        proj_mod, "_discover_claude_projects", lambda anchors=(): [configured, plain]
+    )
+    scopes = proj_mod.discover_project_scopes(
+        cwd,
+        tmp_path / "kp.json",
+        experimental_claude_projects_scan=False,
+        auto_display_configured_projects=True,
+    )
+    scan_roots = {s.root for s in scopes if "claude-projects" in s.sources}
+    assert configured.resolve() in scan_roots  # marker present → admitted
+    assert plain.resolve() not in scan_roots  # no marker → filtered out
+
+
+def test_discover_experimental_bypasses_marker_filter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The experimental flag is the unfiltered escape hatch — an unmarked scan
+    candidate still surfaces."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    plain = tmp_path / "plain"
+    plain.mkdir()  # no marker
+
+    from memtomem.context import projects as proj_mod
+
+    monkeypatch.setattr(proj_mod, "_discover_claude_projects", lambda anchors=(): [plain])
+    scopes = proj_mod.discover_project_scopes(
+        cwd,
+        tmp_path / "kp.json",
+        experimental_claude_projects_scan=True,
+        auto_display_configured_projects=False,
+    )
+    assert any(s.root == plain.resolve() and "claude-projects" in s.sources for s in scopes)
+
+
+def test_discover_filter_never_drops_known_or_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The marker filter applies only to scan rows — an unmarked known project
+    (and the cwd) are always shown."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()  # no marker
+    known = tmp_path / "known"
+    known.mkdir()  # no marker
+    kp = tmp_path / "kp.json"
+    KnownProjectsStore(kp).add(known)
+
+    from memtomem.context import projects as proj_mod
+
+    monkeypatch.setattr(proj_mod, "_discover_claude_projects", lambda anchors=(): [])
+    scopes = proj_mod.discover_project_scopes(
+        cwd, kp, experimental_claude_projects_scan=False, auto_display_configured_projects=True
+    )
+    roots = {s.root for s in scopes}
+    assert cwd.resolve() in roots
+    assert known.resolve() in roots
+
+
+def test_discover_sync_eligible_derivation(tmp_path: Path) -> None:
+    """sync_eligible = server-cwd OR (enrolled AND enabled)."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    enabled_proj = tmp_path / "en"
+    enabled_proj.mkdir()
+    disabled_proj = tmp_path / "dis"
+    disabled_proj.mkdir()
+    kp = tmp_path / "kp.json"
+    store = KnownProjectsStore(kp)
+    store.add(enabled_proj)
+    store.add(disabled_proj)
+    store.set_enabled_by_scope_id(compute_scope_id(disabled_proj), False)
+
+    scopes = discover_project_scopes(
+        cwd, kp, experimental_claude_projects_scan=False, auto_display_configured_projects=False
+    )
+    by_root = {s.root: s for s in scopes}
+    cwd_scope = next(s for s in scopes if "server-cwd" in s.sources)
+    assert cwd_scope.enabled is True and cwd_scope.sync_eligible is True
+    assert by_root[enabled_proj.resolve()].enabled is True
+    assert by_root[enabled_proj.resolve()].sync_eligible is True
+    assert by_root[disabled_proj.resolve()].enabled is False
+    assert by_root[disabled_proj.resolve()].sync_eligible is False
+
+
+def test_discover_paused_known_not_reenabled_by_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression (Blocker 2): a paused known project the scan also surfaces must
+    stay sync-ineligible — scan / cwd sources never contribute enablement."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".codex").mkdir()
+    kp = tmp_path / "kp.json"
+    store = KnownProjectsStore(kp)
+    store.add(project)
+    store.set_enabled_by_scope_id(compute_scope_id(project), False)
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+
+    from memtomem.context import projects as proj_mod
+
+    # Scan surfaces the SAME root → a naive OR-merge would flip enabled back True.
+    monkeypatch.setattr(proj_mod, "_discover_claude_projects", lambda anchors=(): [project])
+    scopes = proj_mod.discover_project_scopes(
+        cwd, kp, experimental_claude_projects_scan=False, auto_display_configured_projects=True
+    )
+    scope = next(s for s in scopes if s.root == project.resolve())
+    assert "known-projects" in scope.sources
+    assert "claude-projects" in scope.sources  # both sources coalesced onto one row
+    assert scope.enabled is False
+    assert scope.sync_eligible is False  # the scan did NOT re-enable it
+
+
 # ── runtime marker helper (POST validation warning) ─────────────────────
 
 
 def test_has_runtime_marker_true(tmp_path: Path) -> None:
     (tmp_path / ".claude").mkdir()
+    assert has_runtime_marker(tmp_path) is True
+
+
+def test_has_runtime_marker_codex(tmp_path: Path) -> None:
+    """Codex-configured projects (``.codex``) count as a runtime marker — the
+    user's explicit codex/agy/kimi coverage requirement."""
+    (tmp_path / ".codex").mkdir()
     assert has_runtime_marker(tmp_path) is True
 
 

--- a/packages/memtomem/tests/test_context_update.py
+++ b/packages/memtomem/tests/test_context_update.py
@@ -689,6 +689,48 @@ def test_cli_update_all_no_projects_have_asset_exits_zero(
     assert "No projects have skills/foo" in result.output
 
 
+def test_cli_update_all_skips_disabled_projects(
+    wiki_root: Path,
+    project_cwd: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A disabled (paused) known project is excluded from ``--all`` batch sync,
+    matching the web Sync gate / ``sync_eligible``. The project exists on disk
+    AND has the asset installed, so the *only* reason it is skipped is
+    ``enabled=False`` — with it paused the batch finds nothing to update."""
+    _initialized_wiki(wiki_root)
+    _seed_wiki_skill(wiki_root, "foo", {"SKILL.md": b"v1\n"})
+
+    paused = tmp_path / "paused"
+    paused.mkdir()
+    install_skill(paused, "foo")  # asset present, but the project is paused
+    known = tmp_path / "known.json"
+    known.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "projects": [
+                    {
+                        "root": str(paused),
+                        "added_at": "2026-01-01T00:00:00Z",
+                        "label": None,
+                        "enabled": False,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _patch_known_projects_path(monkeypatch, known)
+
+    runner = CliRunner()
+    result = runner.invoke(context_group, ["update", "skill", "foo", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to update" in result.output
+
+
 # ── CLI --all: refuse blocks batch ──────────────────────────────────────
 
 

--- a/packages/memtomem/tests/test_web_invariants_registry.py
+++ b/packages/memtomem/tests/test_web_invariants_registry.py
@@ -181,7 +181,7 @@ _REDACTION_EXEMPT: dict[str, str] = {
     "context_skills.import_skills": "bulk structured artifact import",
     "context_skills.sync_skills": "filesystem-driven sync",
     "context_projects.add_known_project": "path/label only, no prose",
-    "context_projects.update_known_project": "label-only rename, no prose",
+    "context_projects.update_known_project": "label/enabled update, no prose",
     # Tag mutations: short labels, separate validation at ingest.
     "chunks.update_chunk_tags": "tags are short labels; redaction not applicable to tag strings",
     "tags.run_auto_tag": "auto-tag operates on already-stored chunks; "

--- a/packages/memtomem/tests/test_web_routes_context_projects.py
+++ b/packages/memtomem/tests/test_web_routes_context_projects.py
@@ -85,6 +85,10 @@ async def test_get_projects_cwd_only(client) -> None:
     assert scope["tier"] == "project"
     assert scope["missing"] is False
     assert scope["experimental"] is False
+    # Sync-enrollment fields: the server cwd is always sync-eligible (it cannot
+    # be paused), and ``enabled`` defaults True for a scope with no known entry.
+    assert scope["enabled"] is True
+    assert scope["sync_eligible"] is True
     # cwd_root has a .claude marker but no .memtomem store → reported stale.
     assert scope["stale"] is True
     # Counts and runtime coverage are both opt-in now (ADR-0021 PR2): the
@@ -659,3 +663,116 @@ async def test_patch_blank_label_clears_to_basename(client, tmp_path: Path) -> N
 async def test_patch_unknown_scope_id_404(client) -> None:
     resp = await client.patch("/api/context/known-projects/p-deadbeefcafe", json={"label": "x"})
     assert resp.status_code == 404
+
+
+# ── PATCH /context/known-projects/{scope_id} (enabled / sync enrollment) ──
+
+
+async def _register(client, root: Path) -> str:
+    root.mkdir()
+    (root / ".claude").mkdir()
+    add = await client.post("/api/context/known-projects", json={"root": str(root)})
+    return add.json()["scope_id"]
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_toggle_round_trip(client, tmp_path: Path) -> None:
+    """PATCH {enabled} flips sync enrollment and is reflected in discovery."""
+    sid = await _register(client, tmp_path / "proj")
+
+    off = await client.patch(f"/api/context/known-projects/{sid}", json={"enabled": False})
+    assert off.status_code == 200, off.text
+    assert off.json()["enabled"] is False
+    scope = next(
+        s
+        for s in (await client.get("/api/context/projects")).json()["scopes"]
+        if s["scope_id"] == sid
+    )
+    assert scope["enabled"] is False
+    assert scope["sync_eligible"] is False
+
+    on = await client.patch(f"/api/context/known-projects/{sid}", json={"enabled": True})
+    assert on.json()["enabled"] is True
+    scope = next(
+        s
+        for s in (await client.get("/api/context/projects")).json()["scopes"]
+        if s["scope_id"] == sid
+    )
+    assert scope["sync_eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_only_preserves_label(client, tmp_path: Path) -> None:
+    """Regression: an enabled-only PATCH must not wipe the custom label."""
+    sid = await _register(client, tmp_path / "proj")
+    await client.patch(f"/api/context/known-projects/{sid}", json={"label": "Keep"})
+
+    resp = await client.patch(f"/api/context/known-projects/{sid}", json={"enabled": False})
+    assert resp.status_code == 200
+    assert resp.json()["label"] == "Keep"
+    assert resp.json()["enabled"] is False
+    scope = next(
+        s
+        for s in (await client.get("/api/context/projects")).json()["scopes"]
+        if s["scope_id"] == sid
+    )
+    assert scope["label"] == "Keep"
+
+
+@pytest.mark.asyncio
+async def test_patch_label_only_preserves_enabled(client, tmp_path: Path) -> None:
+    """A label-only PATCH must not silently resume a paused project."""
+    sid = await _register(client, tmp_path / "proj")
+    await client.patch(f"/api/context/known-projects/{sid}", json={"enabled": False})
+
+    resp = await client.patch(f"/api/context/known-projects/{sid}", json={"label": "Renamed"})
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False  # still paused
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_null_leaves_enabled_unchanged(client, tmp_path: Path) -> None:
+    """``enabled: null`` means 'unchanged' — it never persists None nor resumes."""
+    sid = await _register(client, tmp_path / "proj")
+    await client.patch(f"/api/context/known-projects/{sid}", json={"enabled": False})
+
+    resp = await client.patch(
+        f"/api/context/known-projects/{sid}", json={"enabled": None, "label": "Renamed"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["label"] == "Renamed"
+    assert resp.json()["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_patch_no_fields_is_400(client, tmp_path: Path) -> None:
+    sid = await _register(client, tmp_path / "proj")
+    resp = await client.patch(f"/api/context/known-projects/{sid}", json={})
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_enabled_unknown_scope_id_404(client) -> None:
+    resp = await client.patch("/api/context/known-projects/p-deadbeefcafe", json={"enabled": False})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_label_and_enabled_together(client, tmp_path: Path) -> None:
+    """A combined PATCH applies both fields in a single atomic store write."""
+    sid = await _register(client, tmp_path / "proj")
+
+    resp = await client.patch(
+        f"/api/context/known-projects/{sid}", json={"label": "Both", "enabled": False}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["label"] == "Both"
+    assert resp.json()["enabled"] is False
+    scope = next(
+        s
+        for s in (await client.get("/api/context/projects")).json()["scopes"]
+        if s["scope_id"] == sid
+    )
+    assert scope["label"] == "Both"
+    assert scope["enabled"] is False
+    assert scope["sync_eligible"] is False


### PR DESCRIPTION
## What

Decouples project **discovery** from **sync participation** in the Context Gateway Projects portal. **Backend only** — the frontend enroll/toggle UI is a separate follow-up.

### Auto-display (configured projects)
- `discover_project_scopes` filters `~/.claude/projects` scan candidates to roots carrying a runtime marker (`auto_display_configured_projects`, **on by default**; `experimental_claude_projects_scan` stays the unfiltered escape hatch).
- Adds **`.codex`** to `_MARKER_DIRS` so codex-configured projects are recognized. The marker set now covers claude / antigravity (`.gemini`) / codex / kimi + canonical `.memtomem`. Verified against the Kimi Code CLI docs that per-project config is `.kimi/`.

### Sync enrollment
- New **`enabled`** flag on `known_projects` entries. A disabled project stays discoverable but is excluded from sync: the web Sync button (via new wire field), Sync All, and CLI `mm context update --all`.
- `/api/context/projects` gains **`enabled`** + derived **`sync_eligible`** (`server-cwd OR (enrolled AND enabled)`).
- `enabled` is read strictly from the `known_projects` entry during discovery (`known_by_key`), so a scan/cwd source can **never** silently re-enable a paused project.

### PATCH atomicity & fixes
- `PATCH /known-projects/{id}` updates label and/or `enabled` in a **single locked store write** (`update_entry_by_scope_id`); each field applies only when present (`label` via `model_fields_set`, `enabled: null` = unchanged) so neither clobbers the other.
- Rename now **preserves `enabled`**; legacy rows default to enabled (schema stays v1); the `no_runtime_marker` warning derives from `_MARKER_DIRS`.

## Why
Previously the only project sources were server-cwd + explicit Add-Project + an off-by-default experimental scan, and every discovered project was implicitly a sync target. Goal: configured projects auto-appear, while sync stays an explicit, reversible per-project decision.

## Review
Design was adversarially reviewed (NEEDS-FIX → all findings fixed): non-atomic combined PATCH, scan re-enabling a paused project, label/enabled clobber, stale marker warning.

## Deferred (separate follow-ups)
- Frontend enroll/toggle UI + Playwright + i18n.
- API-direct write guard (`resolve_writable_scope_root` → 409) across artifact + `settings_sync` routes.
- `~/.kimi-code` install-detection marker (ADR-0021 §1 drift).

## Test plan
- `uv run pytest -m "not ollama"` → **5842 passed**, ruff clean, mypy advisory unchanged.
- New tests: store `enabled` round-trip + legacy default + rename-preserves-enabled + atomic combined update; discovery filter + `sync_eligible` + paused-not-reenabled-by-scan regression; route PATCH enabled/label independence + null-unchanged + combined; CLI `update --all` skips disabled; suite-wide scan-isolation fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
