### PR TITLE
fix(context): don't badge auto-displayed configured projects as experimental

### DIFF
--- a/packages/memtomem/src/memtomem/context/projects.py
+++ b/packages/memtomem/src/memtomem/context/projects.py
@@ -732,10 +732,13 @@ def discover_project_scopes(
     scopes: list[ProjectScope] = []
     for key in order:
         resolved, sources, missing, stored_label = by_resolved[key]
-        # ``experimental`` is true iff the *only* source is the opt-in scan.
-        # cwd / known-projects unions clear the flag so the most-trusted
-        # source wins for display purposes.
-        experimental = sources == {"claude-projects"}
+        # ``experimental`` flags a row present ONLY because the unfiltered opt-in
+        # scan gate is open: a scan-only source AND no runtime marker. A
+        # marker-bearing scan row is admitted by the default filtered auto-display
+        # path (auto_display_configured_projects), so it is a normal configured
+        # project — not opt-in/experimental — and must not carry the warning copy.
+        # cwd / known-projects unions also clear the flag (most-trusted source wins).
+        experimental = sources == {"claude-projects"} and not has_runtime_marker(resolved)
         # Label precedence: an explicit stored label (set via Add Project or the
         # rename PATCH) wins — it is the user's deliberate name, so it overrides
         # even the "Server CWD" auto-label when the cwd was also registered.

--- a/packages/memtomem/tests/test_context_projects.py
+++ b/packages/memtomem/tests/test_context_projects.py
@@ -770,6 +770,55 @@ def test_discover_paused_known_not_reenabled_by_scan(
     assert scope.sync_eligible is False  # the scan did NOT re-enable it
 
 
+def test_discover_auto_displayed_configured_scan_not_experimental(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A marker-bearing scan row admitted by the default filtered auto-display
+    path is NOT badged experimental — it is a normal configured project, not the
+    opt-in/experimental scan."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    configured = tmp_path / "cfg"
+    configured.mkdir()
+    (configured / ".claude").mkdir()
+
+    from memtomem.context import projects as proj_mod
+
+    monkeypatch.setattr(proj_mod, "_discover_claude_projects", lambda anchors=(): [configured])
+    scopes = proj_mod.discover_project_scopes(
+        cwd,
+        tmp_path / "kp.json",
+        experimental_claude_projects_scan=False,
+        auto_display_configured_projects=True,
+    )
+    scope = next(s for s in scopes if s.root == configured.resolve())
+    assert "claude-projects" in scope.sources
+    assert scope.experimental is False
+
+
+def test_discover_unconfigured_scan_row_is_experimental(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unmarked scan row — present only because the unfiltered experimental
+    gate is open — IS experimental."""
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    plain = tmp_path / "plain"
+    plain.mkdir()  # no runtime marker
+
+    from memtomem.context import projects as proj_mod
+
+    monkeypatch.setattr(proj_mod, "_discover_claude_projects", lambda anchors=(): [plain])
+    scopes = proj_mod.discover_project_scopes(
+        cwd,
+        tmp_path / "kp.json",
+        experimental_claude_projects_scan=True,
+        auto_display_configured_projects=False,
+    )
+    scope = next(s for s in scopes if s.root == plain.resolve())
+    assert scope.experimental is True
+
+
 # ── runtime marker helper (POST validation warning) ─────────────────────
 
 


### PR DESCRIPTION
## What
`discover_project_scopes` computed `experimental = sources == {"claude-projects"}`. That was right when `~/.claude/projects` discovery was opt-in only, but **#1203** made the **filtered** scan (`auto_display_configured_projects`) **on by default** — so a marker-bearing scan row is now admitted by default yet was still flagged `experimental`. The existing Portal/Gateway UI renders that as an **"opt-in experimental `~/.claude/projects` scan"** warning, mislabeling normal auto-displayed configured projects.

## Fix
A scan-only row is experimental **only when it lacks a runtime marker** — i.e. it is present solely because the unfiltered `experimental_claude_projects_scan` gate is open:

```python
experimental = sources == {"claude-projects"} and not has_runtime_marker(resolved)
```

Marker-bearing scan rows (admitted by the default filtered auto-display path) are normal configured projects and carry no experimental badge. cwd / known-projects unions already clear the flag.

Follow-up to **#1203** (P3 review finding).

## Test plan
- `uv run pytest -m "not ollama"` → **5847 passed**; ruff clean.
- New tests: marker-bearing scan row (default config) → `experimental=False`; unmarked scan row (experimental gate on) → `experimental=True`. Existing assertions unchanged (unmarked `/tmp` scan row stays `True`; cwd-union stays `False`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
