### PR TITLE
feat(context): version snapshots + label pointers for agents/commands (ADR-0022 PR1)

### DIFF
--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 import click
 
+from memtomem.context import versioning
 from memtomem.context.agents import (
+    AGENT_DIR_FILENAME,
     ON_DROP_LEVELS,
     StrictDropError,
     canonical_agent_name,
@@ -16,12 +18,13 @@ from memtomem.context.agents import (
     generate_all_agents,
 )
 from memtomem.context.commands import (
+    COMMAND_DIR_FILENAME,
     StrictDropError as CommandStrictDropError,
     diff_commands,
     extract_commands_to_canonical,
     generate_all_commands,
 )
-from memtomem.context._names import InvalidNameError
+from memtomem.context._names import InvalidNameError, validate_name
 from memtomem.context.detector import (
     detect_agent_dirs,
     detect_agent_files,
@@ -89,7 +92,7 @@ from memtomem.context.skills import (
 )
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.wiki.store import WikiNotFoundError, WikiStore
-from typing import Any, cast, get_args
+from typing import Any, Literal, cast, get_args
 
 from memtomem.config import (
     ContextGatewayConfig,
@@ -289,9 +292,10 @@ def _print_agents_generate(
     on_drop: str = "ignore",
     *,
     scope: TargetScope = "project_shared",
+    label: str | None = None,
 ) -> None:
     try:
-        result = generate_all_agents(root, strict=strict, on_drop=on_drop, scope=scope)
+        result = generate_all_agents(root, strict=strict, on_drop=on_drop, scope=scope, label=label)
     except StrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort()
@@ -392,9 +396,12 @@ def _print_commands_generate(
     on_drop: str = "ignore",
     *,
     scope: TargetScope = "project_shared",
+    label: str | None = None,
 ) -> None:
     try:
-        result = generate_all_commands(root, strict=strict, on_drop=on_drop, scope=scope)
+        result = generate_all_commands(
+            root, strict=strict, on_drop=on_drop, scope=scope, label=label
+        )
     except CommandStrictDropError as exc:
         click.secho(f"  [strict] {exc}", fg="red")
         raise click.Abort() from exc
@@ -619,6 +626,46 @@ _SCOPE_OPTION = click.option(
         "so --scope=project_local skips the prompt (writes stay in-project)."
     ),
 )
+
+# ADR-0022: fan out a labeled version instead of the working canonical. Applies
+# only to the version-eligible kinds (agents / commands); ineligible included
+# kinds run label-less (see ``_warn_label_ineligible_kinds``).
+_LABEL_OPTION = click.option(
+    "--label",
+    default=None,
+    help=(
+        "Sync the version at this label (e.g. 'production') or a bare version "
+        "tag ('v2') instead of the working canonical. Applies to agents and "
+        "commands only; 'latest' / omitted means the working file."
+    ),
+)
+
+# Kinds whose fan-out honors --label (ADR-0022 v1 scope: agents + commands).
+_LABEL_ELIGIBLE_KINDS: frozenset[str] = frozenset({"agents", "commands"})
+
+
+def _warn_label_ineligible_kinds(label: str | None, inc: set[str]) -> None:
+    """Warn when --label is given but cannot apply to (some of) ``--include``.
+
+    ADR-0022 invariant 10: ``--label`` governs only agents/commands. Ineligible
+    included kinds (skills/settings/project-memory) run label-less; a label with
+    no eligible kind in ``--include`` is a warned no-op, never an error.
+    """
+    if label is None or label == "latest":
+        return
+    ineligible = sorted(inc - _LABEL_ELIGIBLE_KINDS)
+    if ineligible:
+        click.secho(
+            f"  note: --label does not apply to {', '.join(ineligible)} "
+            "(only agents/commands are versioned); they sync from the working file.",
+            fg="yellow",
+        )
+    if not (inc & _LABEL_ELIGIBLE_KINDS):
+        click.secho(
+            f"  note: --label={label} had no effect — no versioned kind "
+            "(agents/commands) in --include.",
+            fg="yellow",
+        )
 
 
 @click.group("context")
@@ -905,6 +952,7 @@ def _read_agent_file(path: Path) -> str:
     help="Skip confirmation prompts before writing settings files outside this project.",
 )
 @_SCOPE_OPTION
+@_LABEL_OPTION
 def generate_cmd(
     agent: str,
     include: tuple[str, ...],
@@ -912,6 +960,7 @@ def generate_cmd(
     on_drop: str,
     yes: bool,
     scope_flag: str | None,
+    label: str | None,
 ) -> None:
     """Generate agent files from .memtomem/context.md."""
     # Validate --agent up front so a typo fails loudly (exit 1) instead of
@@ -950,6 +999,7 @@ def generate_cmd(
     # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
     # ADR-0011 PR-E1 Codex review trip-wire).
     artifact_scope = _resolve_artifact_cli_scope(scope_flag)
+    _warn_label_ineligible_kinds(label, inc)
 
     if "skills" in inc:
         click.echo("")
@@ -957,11 +1007,15 @@ def generate_cmd(
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
+        _print_agents_generate(
+            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label
+        )
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
+        _print_commands_generate(
+            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label
+        )
 
     if "settings" in inc:
         click.echo("")
@@ -1073,12 +1127,14 @@ def diff_cmd(include: tuple[str, ...], scope_flag: str | None) -> None:
     help="Skip confirmation prompts before writing settings files outside this project.",
 )
 @_SCOPE_OPTION
+@_LABEL_OPTION
 def sync_cmd(
     include: tuple[str, ...],
     strict: bool,
     on_drop: str,
     yes: bool,
     scope_flag: str | None,
+    label: str | None,
 ) -> None:
     """Sync context.md to all detected agent files."""
     inc = _parse_include(include)
@@ -1129,6 +1185,7 @@ def sync_cmd(
     # which leaks ``cfg.hooks.target_scope`` into the artifact axis —
     # ADR-0011 PR-E1 Codex review trip-wire).
     artifact_scope = _resolve_artifact_cli_scope(scope_flag)
+    _warn_label_ineligible_kinds(label, inc)
 
     if "skills" in inc:
         click.echo("")
@@ -1136,11 +1193,15 @@ def sync_cmd(
 
     if "agents" in inc:
         click.echo("")
-        _print_agents_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
+        _print_agents_generate(
+            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label
+        )
 
     if "commands" in inc:
         click.echo("")
-        _print_commands_generate(root, strict=strict, on_drop=on_drop, scope=artifact_scope)
+        _print_commands_generate(
+            root, strict=strict, on_drop=on_drop, scope=artifact_scope, label=label
+        )
 
     if "settings" in inc:
         click.echo("")
@@ -1155,6 +1216,125 @@ def sync_cmd(
             click.secho("  Skipped settings sync (declined).", fg="yellow")
 
     click.secho("Synced.", fg="green")
+
+
+# ── Version snapshots + label pointers (ADR-0022) ────────────────────
+
+_VERSION_ARTIFACT_TYPES = ("agents", "commands")
+
+
+def _resolve_version_target(
+    artifact_type: str, name: str, scope_flag: str | None
+) -> tuple[Path, Path]:
+    """Resolve ``(artifact_dir, working_file)`` for a version operation.
+
+    Validates ``artifact_type`` (agents/commands) and ``name``, resolves the
+    scoped canonical root, and returns the per-artifact directory plus its
+    working canonical file (``agent.md`` / ``command.md``). Raises
+    ``click.ClickException`` on a bad type/name. The directory may not exist
+    yet (flat-layout or absent) — the versioning layer raises a clean error in
+    that case.
+    """
+    if artifact_type not in _VERSION_ARTIFACT_TYPES:
+        raise click.ClickException(
+            f"Unknown artifact type: {artifact_type}. "
+            f"Expected one of: {', '.join(_VERSION_ARTIFACT_TYPES)}."
+        )
+    try:
+        validate_name(name)
+    except InvalidNameError as exc:
+        raise click.ClickException(str(exc)) from exc
+    root = _find_project_root()
+    scope = _resolve_artifact_cli_scope(scope_flag)
+    # ``artifact_type`` is narrowed to agents/commands by the guard above; cast
+    # to the ``canonical_artifact_dir`` literal so mypy keeps the kind typed.
+    kind = cast("Literal['agents', 'commands']", artifact_type)
+    artifact_dir = canonical_artifact_dir(kind, scope, root) / name
+    working_filename = AGENT_DIR_FILENAME if artifact_type == "agents" else COMMAND_DIR_FILENAME
+    return artifact_dir, artifact_dir / working_filename
+
+
+@context.group("version")
+def version_group() -> None:
+    """Manage version snapshots + label pointers for agents/commands (ADR-0022).
+
+    A version is an immutable snapshot of an artifact's working canonical;
+    a label (e.g. 'production') is a movable pointer over versions. Use
+    `mm context sync --label <name>` to fan out a labeled version.
+    """
+
+
+@version_group.command("create")
+@click.argument("artifact_type")
+@click.argument("name")
+@click.option("--note", default="", help="Optional annotation stored with the snapshot.")
+@_SCOPE_OPTION
+def version_create_cmd(artifact_type: str, name: str, note: str, scope_flag: str | None) -> None:
+    """Snapshot the current working canonical as a new immutable version.
+
+    Example: `mm context version create agents my-agent --note "stable"`
+    """
+    artifact_dir, working_file = _resolve_version_target(artifact_type, name, scope_flag)
+    if not working_file.is_file():
+        raise click.ClickException(
+            f"No working canonical at {working_file}. The artifact must exist in "
+            f"directory layout — run `mm context migrate {artifact_type[:-1]} {name}` first."
+        )
+    try:
+        record = versioning.create_version(artifact_dir, working_file, note=note)
+    except versioning.VersionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.secho(f"Created {artifact_type}/{name} version {record.tag}", fg="green")
+
+
+@version_group.command("promote")
+@click.argument("artifact_type")
+@click.argument("name")
+@click.option(
+    "--to", "label", required=True, help="Label to point at the version (e.g. production)."
+)
+@click.option("--version", "version", required=True, help="Version tag to promote (e.g. v2).")
+@_SCOPE_OPTION
+def version_promote_cmd(
+    artifact_type: str, name: str, label: str, version: str, scope_flag: str | None
+) -> None:
+    """Move a label pointer to a specific version (rollout == rollback).
+
+    Example: `mm context version promote agents my-agent --to production --version v2`
+    """
+    artifact_dir, _ = _resolve_version_target(artifact_type, name, scope_flag)
+    try:
+        versioning.promote_label(artifact_dir, label, version)
+    except versioning.VersionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.secho(f"Promoted {artifact_type}/{name}: {label} → {version}", fg="green")
+
+
+@version_group.command("list")
+@click.argument("artifact_type")
+@click.argument("name")
+@_SCOPE_OPTION
+def version_list_cmd(artifact_type: str, name: str, scope_flag: str | None) -> None:
+    """List versions and label pointers for an artifact."""
+    artifact_dir, _ = _resolve_version_target(artifact_type, name, scope_flag)
+    try:
+        manifest = versioning.load_manifest(artifact_dir)
+    except versioning.VersionError as exc:
+        raise click.ClickException(str(exc)) from exc
+    if not manifest.versions:
+        click.echo(f"  (no versions for {artifact_type}/{name})")
+        return
+    # Reverse label map: tag → [labels] so each version line shows its pointers.
+    labels_by_tag: dict[str, list[str]] = {}
+    for label, tag in manifest.labels.items():
+        labels_by_tag.setdefault(tag, []).append(label)
+    click.secho(f"{artifact_type}/{name} versions:", fg="cyan")
+    for tag in sorted(manifest.versions, key=lambda t: int(t[1:])):
+        rec = manifest.versions[tag]
+        pointers = labels_by_tag.get(tag, [])
+        suffix = f"  [{', '.join(sorted(pointers))}]" if pointers else ""
+        note = f"  — {rec.note}" if rec.note else ""
+        click.echo(f"  {tag:6s} {rec.created_at}{suffix}{note}")
 
 
 @context.command("install")

--- a/packages/memtomem/src/memtomem/cli/context_cmd.py
+++ b/packages/memtomem/src/memtomem/cli/context_cmd.py
@@ -69,7 +69,12 @@ from memtomem.context.generator import (
     preamble_source,
 )
 from memtomem.context.parser import CONTEXT_FILENAME, parse_context, sections_to_markdown
-from memtomem.context.privacy_scan import PrivacyScanError, scan_artifact_tree
+from memtomem.context.privacy_scan import (
+    PrivacyScanError,
+    raise_or_collect,
+    scan_artifact_tree,
+    scan_text_content,
+)
 from memtomem.context.settings import (
     diff_settings,
     generate_all_settings,
@@ -1225,15 +1230,15 @@ _VERSION_ARTIFACT_TYPES = ("agents", "commands")
 
 def _resolve_version_target(
     artifact_type: str, name: str, scope_flag: str | None
-) -> tuple[Path, Path]:
-    """Resolve ``(artifact_dir, working_file)`` for a version operation.
+) -> tuple[Path, Path, TargetScope, Path]:
+    """Resolve ``(artifact_dir, working_file, scope, project_root)``.
 
     Validates ``artifact_type`` (agents/commands) and ``name``, resolves the
-    scoped canonical root, and returns the per-artifact directory plus its
-    working canonical file (``agent.md`` / ``command.md``). Raises
-    ``click.ClickException`` on a bad type/name. The directory may not exist
-    yet (flat-layout or absent) — the versioning layer raises a clean error in
-    that case.
+    scoped canonical root, and returns the per-artifact directory, its working
+    canonical file (``agent.md`` / ``command.md``), the resolved scope, and the
+    project root. Raises ``click.ClickException`` on a bad type/name. The
+    directory may not exist yet (flat-layout or absent) — the versioning layer
+    raises a clean error in that case.
     """
     if artifact_type not in _VERSION_ARTIFACT_TYPES:
         raise click.ClickException(
@@ -1251,7 +1256,7 @@ def _resolve_version_target(
     kind = cast("Literal['agents', 'commands']", artifact_type)
     artifact_dir = canonical_artifact_dir(kind, scope, root) / name
     working_filename = AGENT_DIR_FILENAME if artifact_type == "agents" else COMMAND_DIR_FILENAME
-    return artifact_dir, artifact_dir / working_filename
+    return artifact_dir, artifact_dir / working_filename, scope, root
 
 
 @context.group("version")
@@ -1274,14 +1279,42 @@ def version_create_cmd(artifact_type: str, name: str, note: str, scope_flag: str
 
     Example: `mm context version create agents my-agent --note "stable"`
     """
-    artifact_dir, working_file = _resolve_version_target(artifact_type, name, scope_flag)
+    artifact_dir, working_file, scope, root = _resolve_version_target(
+        artifact_type, name, scope_flag
+    )
     if not working_file.is_file():
         raise click.ClickException(
             f"No working canonical at {working_file}. The artifact must exist in "
             f"directory layout — run `mm context migrate {artifact_type[:-1]} {name}` first."
         )
+    # Gate A on the snapshot bytes (ADR-0011 trust boundary): creating a version
+    # is a new write into a git-tracked tree for project_shared, so a privacy
+    # hit must hard-refuse before versions/vN.md lands. user / project_local
+    # are permissive (the working file already holds the content locally, so a
+    # snapshot adds no exposure) — raise_or_collect only raises for
+    # project_shared and returns a skip tuple (ignored here) otherwise.
+    # Read ONCE and snapshot the SAME bytes (source_bytes=) so a concurrent edit
+    # between scan and write cannot slip unscanned bytes into the version.
     try:
-        record = versioning.create_version(artifact_dir, working_file, note=note)
+        snapshot_bytes = working_file.read_bytes()
+    except OSError as exc:
+        raise click.ClickException(f"cannot read {working_file}: {exc}") from exc
+    file_scan = scan_text_content(
+        snapshot_bytes.decode("utf-8", errors="replace"),
+        source_path=working_file,
+        surface="cli_context_version_create",
+        scope=scope,
+        project_root=root,
+    )
+    if file_scan.decision in ("blocked", "blocked_project_shared"):
+        try:
+            raise_or_collect(file_scan, scope=scope, kind=artifact_type[:-1], artifact_name=name)
+        except PrivacyScanError as exc:
+            raise click.ClickException(exc.message) from exc
+    try:
+        record = versioning.create_version(
+            artifact_dir, working_file, note=note, source_bytes=snapshot_bytes
+        )
     except versioning.VersionError as exc:
         raise click.ClickException(str(exc)) from exc
     click.secho(f"Created {artifact_type}/{name} version {record.tag}", fg="green")
@@ -1302,7 +1335,7 @@ def version_promote_cmd(
 
     Example: `mm context version promote agents my-agent --to production --version v2`
     """
-    artifact_dir, _ = _resolve_version_target(artifact_type, name, scope_flag)
+    artifact_dir, _, _, _ = _resolve_version_target(artifact_type, name, scope_flag)
     try:
         versioning.promote_label(artifact_dir, label, version)
     except versioning.VersionError as exc:
@@ -1316,7 +1349,7 @@ def version_promote_cmd(
 @_SCOPE_OPTION
 def version_list_cmd(artifact_type: str, name: str, scope_flag: str | None) -> None:
     """List versions and label pointers for an artifact."""
-    artifact_dir, _ = _resolve_version_target(artifact_type, name, scope_flag)
+    artifact_dir, _, _, _ = _resolve_version_target(artifact_type, name, scope_flag)
     try:
         manifest = versioning.load_manifest(artifact_dir)
     except versioning.VersionError as exc:

--- a/packages/memtomem/src/memtomem/context/_skip_reasons.py
+++ b/packages/memtomem/src/memtomem/context/_skip_reasons.py
@@ -38,6 +38,18 @@ TOML_PARSE_ERROR: Final = "toml_parse_error"
 PRIVACY_BLOCKED: Final = "privacy_blocked"
 PRIVACY_BLOCKED_PROJECT_SHARED: Final = "privacy_blocked_project_shared"
 
+# Versioning (ADR-0022) skip codes — emitted in Phase 1 of
+# ``sync_atomic_artifact`` when a label-aware ``resolve_canonical_bytes``
+# cannot resolve the requested label/version for one artifact. Per-item
+# isolation (a single artifact's missing label does not abort the whole
+# fan-out), consistent with the existing parse/read skip handling.
+LABEL_NOT_FOUND: Final = "label_not_found"
+VERSION_NOT_FOUND: Final = "version_not_found"
+# A non-``latest`` label / bare version tag was requested for a flat-layout
+# artifact, which has no per-artifact ``versions/`` store (ADR-0022 §3).
+# ``latest`` / no-label sync on a flat artifact is unaffected.
+VERSIONING_REQUIRES_DIR_LAYOUT: Final = "versioning_requires_dir_layout"
+
 # Closed set of skip codes — typing dataclass `skipped` triples and route
 # response builders against `SkipCode` catches typos at the construction site
 # instead of letting an arbitrary string slip through to the wire.
@@ -52,4 +64,7 @@ SkipCode = Literal[
     "toml_parse_error",
     "privacy_blocked",
     "privacy_blocked_project_shared",
+    "label_not_found",
+    "version_not_found",
+    "versioning_requires_dir_layout",
 ]

--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -35,6 +35,11 @@ from memtomem.context import override as _override
 from memtomem.context._atomic import atomic_write_bytes
 from memtomem.context._names import GENERATOR_VENDOR, Layout
 from memtomem.context.privacy_scan import raise_or_collect, scan_text_content
+from memtomem.context.versioning import (
+    LabelNotFoundError,
+    VersionNotFoundError,
+    VersionsDirMissingError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +146,14 @@ class AtomicSyncAdapter(Generic[T]):
     # appear under ``memtomem.context.agents`` / ``memtomem.context.commands``
     # for log filters that historically targeted those names.
     logger: logging.Logger = logger
+    # ADR-0022: optional label-aware canonical-bytes resolver. ``None``
+    # (default) ⇒ the engine reads ``item_path`` directly (today's behavior,
+    # byte-for-byte). When set, the engine calls this instead of
+    # ``item_path.read_bytes()`` in Phase 1, substituting a versioned snapshot
+    # for the working file. Signature ``(item_path, layout) -> bytes``; it may
+    # raise ``LabelNotFoundError`` / ``VersionNotFoundError`` /
+    # ``VersionsDirMissingError``, which the engine isolates as per-item skips.
+    resolve_canonical_bytes: Callable[[Path, Layout], bytes] | None = None
 
 
 def sync_atomic_artifact(
@@ -229,13 +242,42 @@ def sync_atomic_artifact(
             skipped.append((target, "unknown runtime", skip_codes.UNKNOWN_RUNTIME))
             continue
         for item_path, layout in canonicals:
+            # Artifact display name for skip rows: dir layout nests the file as
+            # ``<name>/agent.md``, so ``item_path.name`` would read "agent.md"
+            # — use the parent dir name instead so per-artifact skips (esp. the
+            # new label/version ones) name the artifact, not its filename.
+            display_name = item_path.parent.name if layout == "dir" else item_path.stem
             # PR-E3 Codex review fold: read canonical bytes ONCE and use
             # the captured buffer for both Gate A scan AND parse, closing
             # the scan→write TOCTOU window. A concurrent edit between
             # scan and parse would otherwise let an attacker present
             # clean bytes to scan and unsafe bytes to render.
+            #
+            # ADR-0022: when the adapter carries a label-aware resolver, it
+            # substitutes a versioned snapshot's bytes for the working file.
+            # Resolution failures isolate per-artifact as typed skips (a
+            # missing label on one artifact must not abort the whole fan-out),
+            # consistent with the OSError/parse handling below.
             try:
-                item_bytes = item_path.read_bytes()
+                if adapter.resolve_canonical_bytes is not None:
+                    item_bytes = adapter.resolve_canonical_bytes(item_path, layout)
+                else:
+                    item_bytes = item_path.read_bytes()
+            except LabelNotFoundError as exc:
+                skipped.append((display_name, f"label: {exc}", skip_codes.LABEL_NOT_FOUND))
+                continue
+            except VersionNotFoundError as exc:
+                skipped.append((display_name, f"version: {exc}", skip_codes.VERSION_NOT_FOUND))
+                continue
+            except VersionsDirMissingError as exc:
+                skipped.append(
+                    (
+                        display_name,
+                        f"versioning requires dir layout: {exc}",
+                        skip_codes.VERSIONING_REQUIRES_DIR_LAYOUT,
+                    )
+                )
+                continue
             except OSError as exc:
                 skipped.append((item_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
                 continue

--- a/packages/memtomem/src/memtomem/context/_sync_atomic.py
+++ b/packages/memtomem/src/memtomem/context/_sync_atomic.py
@@ -37,6 +37,7 @@ from memtomem.context._names import GENERATOR_VENDOR, Layout
 from memtomem.context.privacy_scan import raise_or_collect, scan_text_content
 from memtomem.context.versioning import (
     LabelNotFoundError,
+    VersionError,
     VersionNotFoundError,
     VersionsDirMissingError,
 )
@@ -150,10 +151,11 @@ class AtomicSyncAdapter(Generic[T]):
     # (default) ⇒ the engine reads ``item_path`` directly (today's behavior,
     # byte-for-byte). When set, the engine calls this instead of
     # ``item_path.read_bytes()`` in Phase 1, substituting a versioned snapshot
-    # for the working file. Signature ``(item_path, layout) -> bytes``; it may
-    # raise ``LabelNotFoundError`` / ``VersionNotFoundError`` /
-    # ``VersionsDirMissingError``, which the engine isolates as per-item skips.
-    resolve_canonical_bytes: Callable[[Path, Layout], bytes] | None = None
+    # for the working file. Returns ``(bytes, source_path)`` so the Gate A scan
+    # attributes to the actual ``versions/vN.md``, not the working file. It may
+    # raise the ``VersionError`` family (label/version not found, flat layout,
+    # malformed manifest), which the engine isolates as per-item skips.
+    resolve_canonical_bytes: Callable[[Path, Layout], tuple[bytes, Path]] | None = None
 
 
 def sync_atomic_artifact(
@@ -258,9 +260,13 @@ def sync_atomic_artifact(
             # Resolution failures isolate per-artifact as typed skips (a
             # missing label on one artifact must not abort the whole fan-out),
             # consistent with the OSError/parse handling below.
+            # ``scan_source`` is the path the Gate A scan attributes to — the
+            # resolved version file when a label is in play, else the working
+            # canonical. Defaults to ``item_path`` for the no-label path.
+            scan_source = item_path
             try:
                 if adapter.resolve_canonical_bytes is not None:
-                    item_bytes = adapter.resolve_canonical_bytes(item_path, layout)
+                    item_bytes, scan_source = adapter.resolve_canonical_bytes(item_path, layout)
                 else:
                     item_bytes = item_path.read_bytes()
             except LabelNotFoundError as exc:
@@ -277,6 +283,13 @@ def sync_atomic_artifact(
                         skip_codes.VERSIONING_REQUIRES_DIR_LAYOUT,
                     )
                 )
+                continue
+            except VersionError as exc:
+                # Catch-all for the rest of the family (malformed/tampered
+                # manifest → InvalidTagError / InvalidLabelError / base
+                # VersionError). Isolate per-artifact as a parse-class skip
+                # rather than aborting the whole fan-out with a raw traceback.
+                skipped.append((display_name, f"version store: {exc}", skip_codes.PARSE_ERROR))
                 continue
             except OSError as exc:
                 skipped.append((item_path.name, f"unreadable: {exc}", skip_codes.PARSE_ERROR))
@@ -308,9 +321,11 @@ def sync_atomic_artifact(
             # (same buffer the parse used). project_shared block raises
             # PrivacyBlockedError; user/project_local block emits
             # PRIVACY_BLOCKED skip and continues to next runtime.
+            # ``scan_source`` attributes the scan to the resolved version file
+            # when a label is in play (ADR-0022), else the working canonical.
             file_scan = scan_text_content(
                 item_text,
-                source_path=item_path,
+                source_path=scan_source,
                 surface="cli_context_sync",
                 scope=scope,
                 project_root=project_root,

--- a/packages/memtomem/src/memtomem/context/agents.py
+++ b/packages/memtomem/src/memtomem/context/agents.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import logging
 import json
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Protocol, cast
 
@@ -55,6 +55,7 @@ from memtomem.context._sync_atomic import (
     sync_atomic_artifact,
 )
 from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.versioning import make_label_resolver
 
 logger = logging.getLogger(__name__)
 
@@ -723,6 +724,7 @@ def generate_all_agents(
     on_drop: str = "ignore",
     *,
     scope: TargetScope = "project_shared",
+    label: str | None = None,
 ) -> AgentSyncResult:
     """Fan out every canonical sub-agent to the requested runtimes.
 
@@ -740,7 +742,15 @@ def generate_all_agents(
         scope: ADR-0011 PR-E3 — selects canonical root and runtime
             fan-out destination. Default ``project_shared`` preserves
             pre-PR-E3 behavior.
+        label: ADR-0022 — when set to a non-``latest`` value, fan out the
+            version pointed at by this label (or a bare ``vN`` tag) instead of
+            the working ``agent.md``. ``None`` / ``"latest"`` preserve today's
+            behavior byte-for-byte (the working file). Per-artifact resolution
+            failures isolate as skips; they never abort the whole fan-out.
     """
+    adapter = _AGENT_ADAPTER
+    if label is not None and label != "latest":
+        adapter = replace(_AGENT_ADAPTER, resolve_canonical_bytes=make_label_resolver(label))
     # Runtime type matches AgentSyncResult because _AGENT_ADAPTER's
     # ``result_type`` is AgentSyncResult; mypy can't infer that through the
     # engine's AtomicSyncResult signature, so cast to preserve the public
@@ -748,7 +758,7 @@ def generate_all_agents(
     return cast(
         "AgentSyncResult",
         sync_atomic_artifact(
-            _AGENT_ADAPTER,
+            adapter,
             project_root,
             runtimes,
             strict=strict,

--- a/packages/memtomem/src/memtomem/context/commands.py
+++ b/packages/memtomem/src/memtomem/context/commands.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import logging
 import re
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -57,6 +57,7 @@ from memtomem.context.agents import (
     _toml_scalar,
 )
 from memtomem.context.scope_resolver import canonical_artifact_dir
+from memtomem.context.versioning import make_label_resolver
 
 logger = logging.getLogger(__name__)
 
@@ -448,6 +449,7 @@ def generate_all_commands(
     on_drop: str = "ignore",
     *,
     scope: TargetScope = "project_shared",
+    label: str | None = None,
 ) -> CommandSyncResult:
     """Fan out every canonical command to the requested runtimes.
 
@@ -465,12 +467,20 @@ def generate_all_commands(
         scope: ADR-0011 PR-E3 — selects canonical root and runtime
             fan-out destination. Default ``project_shared`` preserves
             pre-PR-E3 behavior.
+        label: ADR-0022 — when set to a non-``latest`` value, fan out the
+            version pointed at by this label (or a bare ``vN`` tag) instead of
+            the working ``command.md``. ``None`` / ``"latest"`` preserve
+            today's behavior byte-for-byte. Per-artifact resolution failures
+            isolate as skips.
     """
+    adapter = _COMMAND_ADAPTER
+    if label is not None and label != "latest":
+        adapter = replace(_COMMAND_ADAPTER, resolve_canonical_bytes=make_label_resolver(label))
     # See note on the matching ``cast`` in agents.py.
     return cast(
         "CommandSyncResult",
         sync_atomic_artifact(
-            _COMMAND_ADAPTER,
+            adapter,
             project_root,
             runtimes,
             strict=strict,

--- a/packages/memtomem/src/memtomem/context/versioning.py
+++ b/packages/memtomem/src/memtomem/context/versioning.py
@@ -64,6 +64,7 @@ __all__ = [
     "VersionNotFoundError",
     "LabelNotFoundError",
     "ReservedLabelError",
+    "InvalidLabelError",
     "InvalidTagError",
     "VersionsDirMissingError",
     "versions_dir",
@@ -110,6 +111,12 @@ class ReservedLabelError(VersionError):
     """A reserved label (``latest``) was used as a writable label target."""
 
 
+class InvalidLabelError(VersionError):
+    """A label name is not allowed — e.g. it looks like a version tag
+    (``^v[1-9]\\d*$``), which the sync resolver always treats as a direct
+    version, so the label pointer could never be honored."""
+
+
 class InvalidTagError(VersionError):
     """A tag string does not match ``^v[1-9]\\d*$``."""
 
@@ -151,6 +158,25 @@ def _validate_tag(tag: str) -> str:
     if not _VALID_TAG_RE.fullmatch(tag):
         raise InvalidTagError(f"invalid version tag {tag!r} (expected ^v[1-9]\\d*$)")
     return tag
+
+
+def _validate_label_name(label: str) -> str:
+    """Reject label names that cannot be honored by the sync resolver.
+
+    ``--label`` shares one namespace with version tags: a ``^v[1-9]\\d*$`` value
+    always resolves as a direct version (``make_label_resolver``), so a label
+    *named* ``v1`` would be permanently shadowed by version ``v1``. Reject such
+    names (and the reserved ``latest``) at write time so they can never be
+    created, instead of storing an unreachable, misleading pointer.
+    """
+    if label in RESERVED_LABELS:
+        raise ReservedLabelError(f"{label!r} is a reserved label name")
+    if _VALID_TAG_RE.fullmatch(label):
+        raise InvalidLabelError(
+            f"label name {label!r} looks like a version tag — these are reserved for "
+            f"direct version addressing (`--label {label}` already deploys that version)"
+        )
+    return label
 
 
 def _now_iso() -> str:
@@ -203,13 +229,14 @@ def load_manifest(artifact_dir: Path) -> VersionsManifest:
 
     labels: dict[str, str] = {}
     for label, tag in raw_labels.items():
-        # ``latest`` is reserved and never stored; a hand-edited one would be
-        # an unmanageable pointer (every mutating API rejects it), so refuse to
-        # load it rather than surface an impossible state.
-        if label in RESERVED_LABELS:
-            raise ReservedLabelError(
-                f"malformed versions manifest at {path}: {label!r} is a reserved label"
-            )
+        # Refuse to load a label the write APIs would never create — a reserved
+        # ``latest`` or a version-shaped name (``v1``) that the sync resolver
+        # would permanently shadow with the same-named version. Fail loud on a
+        # tampered manifest rather than surface an impossible/unreachable state.
+        try:
+            _validate_label_name(str(label))
+        except VersionError as exc:
+            raise type(exc)(f"malformed versions manifest at {path}: {exc}") from exc
         _validate_tag(str(tag))
         labels[str(label)] = str(tag)
 
@@ -289,13 +316,12 @@ def create_version(artifact_dir: Path, working_file: Path, note: str = "") -> Ve
 def promote_label(artifact_dir: Path, label: str, version: str) -> None:
     """Point *label* at *version* (create-or-move). Rollout == rollback.
 
-    Raises :class:`ReservedLabelError` for ``latest``, :class:`InvalidTagError`
-    for a malformed tag, and :class:`VersionNotFoundError` if the tag is not in
-    the manifest. Holds ``_file_lock`` across ``load → validate → mutate →
-    save``.
+    Raises :class:`ReservedLabelError` for ``latest``, :class:`InvalidLabelError`
+    for a version-shaped label name, :class:`InvalidTagError` for a malformed
+    tag, and :class:`VersionNotFoundError` if the tag is not in the manifest.
+    Holds ``_file_lock`` across ``load → validate → mutate → save``.
     """
-    if label in RESERVED_LABELS:
-        raise ReservedLabelError(f"{label!r} is a reserved label and cannot be promoted")
+    _validate_label_name(label)
     _validate_tag(version)
     lock = _lock_path_for(versions_json_path(artifact_dir))
     with _file_lock(lock):
@@ -369,9 +395,11 @@ def make_label_resolver(label: str) -> Callable[[Path, Layout], bytes]:
     (``agents/<name>.md``) has no version store — resolving raises
     :class:`VersionsDirMissingError`, which the engine isolates as a skip.
 
-    A label matching ``^v[1-9]\\d*$`` is treated as a **direct version tag**
+    A value matching ``^v[1-9]\\d*$`` is treated as a **direct version tag**
     (``resolve_version``); any other string is a **named label**
-    (``resolve_label``).
+    (``resolve_label``). This precedence is unambiguous because
+    :func:`_validate_label_name` forbids creating a label whose name is
+    version-shaped, so a ``vN`` here can only ever mean the version ``vN``.
     """
 
     def _resolve(item_path: Path, layout: Layout) -> bytes:

--- a/packages/memtomem/src/memtomem/context/versioning.py
+++ b/packages/memtomem/src/memtomem/context/versioning.py
@@ -274,7 +274,13 @@ def next_version_tag(manifest: VersionsManifest) -> str:
     return f"v{max(_tag_num(t) for t in manifest.versions) + 1}"
 
 
-def create_version(artifact_dir: Path, working_file: Path, note: str = "") -> VersionRecord:
+def create_version(
+    artifact_dir: Path,
+    working_file: Path,
+    note: str = "",
+    *,
+    source_bytes: bytes | None = None,
+) -> VersionRecord:
     """Snapshot *working_file* into ``versions/<tag>.md`` and record it.
 
     Holds a single ``_file_lock`` on the ``versions.json`` sidecar across the
@@ -282,6 +288,12 @@ def create_version(artifact_dir: Path, working_file: Path, note: str = "") -> Ve
     so two concurrent callers cannot both allocate the same tag. The version
     file is write-once: if ``versions/<tag>.md`` already exists the call raises
     :class:`InvalidTagError` rather than overwriting.
+
+    ``source_bytes``: pass the bytes the caller already read (and privacy-
+    scanned) to snapshot *exactly* those, closing the scan→write TOCTOU window —
+    otherwise re-reading ``working_file`` here could capture a concurrently
+    edited (unsafe) file the caller never scanned. ``None`` (default) reads
+    ``working_file`` for callers with no pre-scan obligation.
 
     Raises :class:`VersionsDirMissingError` if *artifact_dir* does not exist
     (flat-layout artifact has no per-artifact directory).
@@ -291,19 +303,26 @@ def create_version(artifact_dir: Path, working_file: Path, note: str = "") -> Ve
             f"{artifact_dir} is not a directory — versioning requires directory layout "
             f"(run `mm context migrate` first)"
         )
-    try:
-        source_bytes = working_file.read_bytes()
-    except OSError as exc:
-        raise VersionError(f"cannot read working canonical {working_file}: {exc}") from exc
+    if source_bytes is None:
+        try:
+            source_bytes = working_file.read_bytes()
+        except OSError as exc:
+            raise VersionError(f"cannot read working canonical {working_file}: {exc}") from exc
 
     lock = _lock_path_for(versions_json_path(artifact_dir))
     with _file_lock(lock):
         manifest = load_manifest(artifact_dir)
-        tag = next_version_tag(manifest)
+        # Allocate against BOTH the manifest and any on-disk ``vN.md`` files.
+        # A crash between the version-file write and the manifest save (below)
+        # leaves an orphan ``vN.md`` absent from the manifest; allocating off
+        # the manifest alone would recompute the same tag, hit the
+        # write-once guard, and wedge every future create. Reconciling against
+        # disk skips past the orphan instead (the orphan stays unreferenced and
+        # harmless — it is not in the manifest, so it is never listed/resolved).
+        tag = _next_version_tag_reconciled(artifact_dir, manifest)
         vfile = versions_dir(artifact_dir) / f"{tag}.md"
-        # Write-once. next_version_tag() is monotonic over the manifest, but a
-        # stray on-disk vN.md not in the manifest would otherwise be silently
-        # clobbered by atomic_write_bytes' os.replace — refuse loudly instead.
+        # By construction ``tag`` is free on disk; keep the no-overwrite check
+        # as a defensive assertion against an unexpected race.
         if vfile.exists():
             raise InvalidTagError(f"version file already exists: {vfile}")
         atomic_write_bytes(vfile, source_bytes)
@@ -311,6 +330,22 @@ def create_version(artifact_dir: Path, working_file: Path, note: str = "") -> Ve
         manifest.versions[tag] = record
         _save_manifest(artifact_dir, manifest)
     return record
+
+
+def _next_version_tag_reconciled(artifact_dir: Path, manifest: VersionsManifest) -> str:
+    """Next tag considering both the manifest and on-disk ``vN.md`` files.
+
+    Crash-safe variant of :func:`next_version_tag`: an orphan version file
+    (written before its manifest entry was saved) bumps the allocation forward
+    instead of colliding. Caller must hold the sidecar lock.
+    """
+    nums = {_tag_num(t) for t in manifest.versions}
+    vdir = versions_dir(artifact_dir)
+    if vdir.is_dir():
+        for vfile in vdir.glob("v*.md"):
+            if _VALID_TAG_RE.fullmatch(vfile.stem):
+                nums.add(_tag_num(vfile.stem))
+    return f"v{max(nums) + 1}" if nums else "v1"
 
 
 def promote_label(artifact_dir: Path, label: str, version: str) -> None:
@@ -381,13 +416,18 @@ def resolve_label(artifact_dir: Path, label: str) -> Path:
     return resolve_version(artifact_dir, tag)
 
 
-def make_label_resolver(label: str) -> Callable[[Path, Layout], bytes]:
-    """Build a ``(item_path, layout) -> bytes`` resolver for the sync engine.
+def make_label_resolver(label: str) -> Callable[[Path, Layout], tuple[bytes, Path]]:
+    """Build a ``(item_path, layout) -> (bytes, source_path)`` resolver.
 
     Plugged into ``AtomicSyncAdapter.resolve_canonical_bytes`` (ADR-0022) so a
     labeled ``mm context sync`` fans out a frozen version's bytes instead of
     the working file. The caller must NOT pass ``label`` of ``None`` or
     ``latest`` here — those use the unmodified adapter (working-file path).
+
+    Returns the resolved bytes **and the version file they came from**, so the
+    engine can attribute its Gate A privacy scan to the actual
+    ``versions/vN.md`` (not the clean working ``agent.md``) — otherwise a secret
+    living only in a frozen version would point remediation at the wrong file.
 
     Layout handling (the flat-layout ``item_path.parent`` trap): only the
     directory layout has a per-artifact directory, so ``item_path.parent`` is
@@ -402,7 +442,7 @@ def make_label_resolver(label: str) -> Callable[[Path, Layout], bytes]:
     version-shaped, so a ``vN`` here can only ever mean the version ``vN``.
     """
 
-    def _resolve(item_path: Path, layout: Layout) -> bytes:
+    def _resolve(item_path: Path, layout: Layout) -> tuple[bytes, Path]:
         if layout != "dir":
             raise VersionsDirMissingError(
                 f"{item_path.name}: versioning requires directory layout "
@@ -410,7 +450,9 @@ def make_label_resolver(label: str) -> Callable[[Path, Layout], bytes]:
             )
         artifact_dir = item_path.parent
         if _VALID_TAG_RE.fullmatch(label):
-            return resolve_version(artifact_dir, label).read_bytes()
-        return resolve_label(artifact_dir, label).read_bytes()
+            vfile = resolve_version(artifact_dir, label)
+        else:
+            vfile = resolve_label(artifact_dir, label)
+        return vfile.read_bytes(), vfile
 
     return _resolve

--- a/packages/memtomem/src/memtomem/context/versioning.py
+++ b/packages/memtomem/src/memtomem/context/versioning.py
@@ -1,0 +1,388 @@
+"""Per-artifact version snapshots + label pointers (ADR-0022).
+
+Langfuse-style versioning for canonical context artifacts. A *version* is an
+immutable snapshot of one artifact's working canonical file; a *label* is a
+movable pointer (``production`` → ``v2``) over those versions. This lets
+editing a canonical and *deploying* it to runtimes become two separate acts
+with instant rollback (move the pointer).
+
+This module is **pure filesystem** — it has no awareness of the sync engine,
+CLI, MCP, or web. It owns one artifact's version store:
+
+::
+
+    .memtomem/agents/<name>/
+    ├── agent.md            ← working canonical (label "latest"; NOT touched here)
+    ├── versions/
+    │   ├── v1.md           ← immutable snapshot (write-once)
+    │   └── v2.md
+    └── versions.json       ← {"versions": {...}, "labels": {...}} — only mutable state
+
+The unit that owns a store is ``(scope, type, name)`` (ADR-0022 Decision (b)):
+the directory passed as ``artifact_dir`` is already scope-specific because the
+caller resolves it from the scoped canonical root. There is no global or
+cross-tier label lookup.
+
+Invariants (ADR-0022):
+
+- ``latest`` is reserved and NOT handled here — the caller branches on it and
+  reads the working file directly (it knows the real ``agent.md`` /
+  ``command.md`` path).
+- Version ``.md`` files are write-once; ``create_version`` refuses to
+  overwrite an existing ``vN.md``.
+- Tags match ``^v[1-9]\\d*$`` (``v0`` is invalid). Validated on create / load /
+  resolve / promote so a hand-edited ``versions.json`` cannot point a label at
+  a path-like tag (traversal guard).
+- ``create_version`` / ``promote_label`` / ``delete_label`` each hold a single
+  non-reentrant ``_file_lock`` on the ``versions.json`` sidecar across their
+  entire ``load → mutate → write`` transaction (the ``lockfile.py`` pattern),
+  so two racing ``create_version`` calls cannot both allocate the same tag.
+- Versions snapshot the base canonical only; per-vendor overrides stay live.
+
+Directory layout is required: a flat-layout artifact (``agents/<name>.md``) has
+no per-artifact directory, so it cannot carry a version store —
+``create_version`` raises :class:`VersionsDirMissingError`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+from memtomem.context._atomic import _file_lock, _lock_path_for, atomic_write_bytes
+from memtomem.context._names import Layout
+
+__all__ = [
+    "RESERVED_LABELS",
+    "VersionRecord",
+    "VersionsManifest",
+    "VersionError",
+    "VersionNotFoundError",
+    "LabelNotFoundError",
+    "ReservedLabelError",
+    "InvalidTagError",
+    "VersionsDirMissingError",
+    "versions_dir",
+    "versions_json_path",
+    "load_manifest",
+    "next_version_tag",
+    "create_version",
+    "promote_label",
+    "delete_label",
+    "resolve_label",
+    "resolve_version",
+    "make_label_resolver",
+]
+
+# Tag grammar: ``v`` + a positive integer starting at 1. ``v0`` is invalid
+# (ADR-0022 invariant 5). Anchored so a manifest cannot smuggle a path-like
+# tag (``v1/../../etc``) past validation.
+_VALID_TAG_RE: re.Pattern[str] = re.compile(r"^v[1-9]\d*$")
+
+#: Label names that are reserved and never stored in ``versions.json``.
+#: ``latest`` always means the working file and is resolved by the caller,
+#: never by :func:`resolve_label`.
+RESERVED_LABELS: frozenset[str] = frozenset({"latest"})
+
+_VERSIONS_DIRNAME = "versions"
+_MANIFEST_FILENAME = "versions.json"
+
+
+class VersionError(ValueError):
+    """Base class for all versioning errors (a ``ValueError`` subclass so the
+    CLI/MCP boundary can catch the family and translate to ``ClickException`` /
+    a tool error)."""
+
+
+class VersionNotFoundError(VersionError):
+    """A version tag is absent from the manifest or its ``vN.md`` is missing."""
+
+
+class LabelNotFoundError(VersionError):
+    """A label name is absent from the manifest's label map."""
+
+
+class ReservedLabelError(VersionError):
+    """A reserved label (``latest``) was used as a writable label target."""
+
+
+class InvalidTagError(VersionError):
+    """A tag string does not match ``^v[1-9]\\d*$``."""
+
+
+class VersionsDirMissingError(VersionError):
+    """Versioning was attempted on an artifact with no per-artifact directory
+    (flat layout). Run ``mm context migrate`` first."""
+
+
+@dataclass
+class VersionRecord:
+    """Metadata for one immutable version snapshot."""
+
+    tag: str  # "v1", "v2", … (validated against _VALID_TAG_RE)
+    created_at: str  # ISO-8601 UTC, e.g. "2026-06-03T09:00:00Z"
+    note: str = ""
+
+
+@dataclass
+class VersionsManifest:
+    """In-memory view of ``versions.json``. Mutated by callers under lock, then
+    written back via :func:`_save_manifest`."""
+
+    versions: dict[str, VersionRecord] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)  # label_name → tag
+
+
+def versions_dir(artifact_dir: Path) -> Path:
+    """Return the ``versions/`` subdirectory under *artifact_dir*."""
+    return artifact_dir / _VERSIONS_DIRNAME
+
+
+def versions_json_path(artifact_dir: Path) -> Path:
+    """Return the ``versions.json`` sidecar path under *artifact_dir*."""
+    return artifact_dir / _MANIFEST_FILENAME
+
+
+def _validate_tag(tag: str) -> str:
+    if not _VALID_TAG_RE.fullmatch(tag):
+        raise InvalidTagError(f"invalid version tag {tag!r} (expected ^v[1-9]\\d*$)")
+    return tag
+
+
+def _now_iso() -> str:
+    # Whole-second UTC with a trailing ``Z`` — matches the ADR's example shape
+    # and avoids microsecond noise in the manifest.
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_manifest(artifact_dir: Path) -> VersionsManifest:
+    """Read ``versions.json`` for *artifact_dir*.
+
+    READ-ONLY and UNSYNCHRONIZED (no lock held), mirroring
+    ``lockfile.Lockfile.load()`` — only the mutating helpers take the lock. A
+    missing file returns an empty manifest (no error). Every tag found (both
+    in ``versions`` and as a label target) is validated against
+    ``_VALID_TAG_RE``; a malformed manifest raises :class:`InvalidTagError`.
+    """
+    path = versions_json_path(artifact_dir)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return VersionsManifest()
+    except (OSError, json.JSONDecodeError) as exc:
+        raise VersionError(f"unreadable versions manifest at {path}: {exc}") from exc
+
+    # A hand-edited manifest may be the wrong JSON shape (e.g. ``[]`` or a
+    # string). Validate every container is a mapping before iterating so a
+    # malformed file surfaces a clean VersionError, not an AttributeError.
+    if not isinstance(raw, dict):
+        raise VersionError(f"malformed versions manifest at {path}: expected an object")
+    # ``None`` / absent → empty; any other non-dict shape (e.g. ``[]``) is
+    # malformed and must error rather than be coerced to empty (so a wrong-type
+    # ``"versions": []`` surfaces a clean VersionError, not a silent drop).
+    raw_versions = raw.get("versions") if raw.get("versions") is not None else {}
+    raw_labels = raw.get("labels") if raw.get("labels") is not None else {}
+    if not isinstance(raw_versions, dict) or not isinstance(raw_labels, dict):
+        raise VersionError(
+            f"malformed versions manifest at {path}: 'versions' and 'labels' must be objects"
+        )
+
+    versions: dict[str, VersionRecord] = {}
+    for tag, meta in raw_versions.items():
+        _validate_tag(tag)
+        meta = meta if isinstance(meta, dict) else {}
+        versions[tag] = VersionRecord(
+            tag=tag,
+            created_at=str(meta.get("created_at", "")),
+            note=str(meta.get("note", "")),
+        )
+
+    labels: dict[str, str] = {}
+    for label, tag in raw_labels.items():
+        # ``latest`` is reserved and never stored; a hand-edited one would be
+        # an unmanageable pointer (every mutating API rejects it), so refuse to
+        # load it rather than surface an impossible state.
+        if label in RESERVED_LABELS:
+            raise ReservedLabelError(
+                f"malformed versions manifest at {path}: {label!r} is a reserved label"
+            )
+        _validate_tag(str(tag))
+        labels[str(label)] = str(tag)
+
+    return VersionsManifest(versions=versions, labels=labels)
+
+
+def _save_manifest(artifact_dir: Path, manifest: VersionsManifest) -> None:
+    """Atomically write *manifest* to ``versions.json``.
+
+    PRIVATE. The caller MUST already hold ``_file_lock`` on the sidecar — there
+    is no public single-call path, because ``_file_lock`` is non-reentrant and
+    every mutation runs inside the larger ``create_version`` / ``promote_label``
+    / ``delete_label`` transaction.
+    """
+    payload = {
+        "versions": {
+            tag: {"created_at": rec.created_at, "note": rec.note}
+            for tag, rec in sorted(manifest.versions.items(), key=lambda kv: _tag_num(kv[0]))
+        },
+        "labels": {label: manifest.labels[label] for label in sorted(manifest.labels)},
+    }
+    data = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    atomic_write_bytes(versions_json_path(artifact_dir), data)
+
+
+def _tag_num(tag: str) -> int:
+    """Numeric suffix of a validated tag (``"v3"`` → ``3``)."""
+    return int(tag[1:])
+
+
+def next_version_tag(manifest: VersionsManifest) -> str:
+    """Return ``"v1"`` if no versions exist, else ``"v<max+1>"``. Pure (no I/O)."""
+    if not manifest.versions:
+        return "v1"
+    return f"v{max(_tag_num(t) for t in manifest.versions) + 1}"
+
+
+def create_version(artifact_dir: Path, working_file: Path, note: str = "") -> VersionRecord:
+    """Snapshot *working_file* into ``versions/<tag>.md`` and record it.
+
+    Holds a single ``_file_lock`` on the ``versions.json`` sidecar across the
+    whole transaction (``load → allocate tag → write vN.md → save manifest``),
+    so two concurrent callers cannot both allocate the same tag. The version
+    file is write-once: if ``versions/<tag>.md`` already exists the call raises
+    :class:`InvalidTagError` rather than overwriting.
+
+    Raises :class:`VersionsDirMissingError` if *artifact_dir* does not exist
+    (flat-layout artifact has no per-artifact directory).
+    """
+    if not artifact_dir.is_dir():
+        raise VersionsDirMissingError(
+            f"{artifact_dir} is not a directory — versioning requires directory layout "
+            f"(run `mm context migrate` first)"
+        )
+    try:
+        source_bytes = working_file.read_bytes()
+    except OSError as exc:
+        raise VersionError(f"cannot read working canonical {working_file}: {exc}") from exc
+
+    lock = _lock_path_for(versions_json_path(artifact_dir))
+    with _file_lock(lock):
+        manifest = load_manifest(artifact_dir)
+        tag = next_version_tag(manifest)
+        vfile = versions_dir(artifact_dir) / f"{tag}.md"
+        # Write-once. next_version_tag() is monotonic over the manifest, but a
+        # stray on-disk vN.md not in the manifest would otherwise be silently
+        # clobbered by atomic_write_bytes' os.replace — refuse loudly instead.
+        if vfile.exists():
+            raise InvalidTagError(f"version file already exists: {vfile}")
+        atomic_write_bytes(vfile, source_bytes)
+        record = VersionRecord(tag=tag, created_at=_now_iso(), note=note)
+        manifest.versions[tag] = record
+        _save_manifest(artifact_dir, manifest)
+    return record
+
+
+def promote_label(artifact_dir: Path, label: str, version: str) -> None:
+    """Point *label* at *version* (create-or-move). Rollout == rollback.
+
+    Raises :class:`ReservedLabelError` for ``latest``, :class:`InvalidTagError`
+    for a malformed tag, and :class:`VersionNotFoundError` if the tag is not in
+    the manifest. Holds ``_file_lock`` across ``load → validate → mutate →
+    save``.
+    """
+    if label in RESERVED_LABELS:
+        raise ReservedLabelError(f"{label!r} is a reserved label and cannot be promoted")
+    _validate_tag(version)
+    lock = _lock_path_for(versions_json_path(artifact_dir))
+    with _file_lock(lock):
+        manifest = load_manifest(artifact_dir)
+        if version not in manifest.versions:
+            raise VersionNotFoundError(f"version {version!r} does not exist")
+        manifest.labels[label] = version
+        _save_manifest(artifact_dir, manifest)
+
+
+def delete_label(artifact_dir: Path, label: str) -> None:
+    """Remove *label* from the manifest. No-op if absent. Raises
+    :class:`ReservedLabelError` for ``latest``. Holds ``_file_lock``."""
+    if label in RESERVED_LABELS:
+        raise ReservedLabelError(f"{label!r} is a reserved label and cannot be deleted")
+    lock = _lock_path_for(versions_json_path(artifact_dir))
+    with _file_lock(lock):
+        manifest = load_manifest(artifact_dir)
+        if label in manifest.labels:
+            del manifest.labels[label]
+            _save_manifest(artifact_dir, manifest)
+
+
+def resolve_version(artifact_dir: Path, tag: str) -> Path:
+    """Resolve a bare version *tag* to its ``versions/<tag>.md`` path.
+
+    READ-ONLY. Raises :class:`InvalidTagError` for a malformed tag and
+    :class:`VersionNotFoundError` if the tag is not in the manifest or its file
+    is missing.
+    """
+    _validate_tag(tag)
+    manifest = load_manifest(artifact_dir)
+    if tag not in manifest.versions:
+        raise VersionNotFoundError(f"version {tag!r} does not exist")
+    vfile = versions_dir(artifact_dir) / f"{tag}.md"
+    if not vfile.is_file():
+        raise VersionNotFoundError(f"version {tag!r} is recorded but {vfile} is missing")
+    return vfile
+
+
+def resolve_label(artifact_dir: Path, label: str) -> Path:
+    """Resolve a named *label* to the ``versions/<tag>.md`` it points at.
+
+    READ-ONLY. Does **not** handle ``latest`` — the caller must branch on it
+    and read the working file directly (``latest`` is artifact-name-aware;
+    this module is not). Raises :class:`LabelNotFoundError` if the label is
+    absent and :class:`VersionNotFoundError` if it points at a missing version.
+    """
+    if label in RESERVED_LABELS:
+        raise ReservedLabelError(
+            f"{label!r} is reserved — resolve it to the working file at the call site"
+        )
+    manifest = load_manifest(artifact_dir)
+    tag = manifest.labels.get(label)
+    if tag is None:
+        raise LabelNotFoundError(f"label {label!r} is not defined")
+    return resolve_version(artifact_dir, tag)
+
+
+def make_label_resolver(label: str) -> Callable[[Path, Layout], bytes]:
+    """Build a ``(item_path, layout) -> bytes`` resolver for the sync engine.
+
+    Plugged into ``AtomicSyncAdapter.resolve_canonical_bytes`` (ADR-0022) so a
+    labeled ``mm context sync`` fans out a frozen version's bytes instead of
+    the working file. The caller must NOT pass ``label`` of ``None`` or
+    ``latest`` here — those use the unmodified adapter (working-file path).
+
+    Layout handling (the flat-layout ``item_path.parent`` trap): only the
+    directory layout has a per-artifact directory, so ``item_path.parent`` is
+    the artifact root (``agents/<name>/``) there. A flat-layout artifact
+    (``agents/<name>.md``) has no version store — resolving raises
+    :class:`VersionsDirMissingError`, which the engine isolates as a skip.
+
+    A label matching ``^v[1-9]\\d*$`` is treated as a **direct version tag**
+    (``resolve_version``); any other string is a **named label**
+    (``resolve_label``).
+    """
+
+    def _resolve(item_path: Path, layout: Layout) -> bytes:
+        if layout != "dir":
+            raise VersionsDirMissingError(
+                f"{item_path.name}: versioning requires directory layout "
+                f"(run `mm context migrate` first)"
+            )
+        artifact_dir = item_path.parent
+        if _VALID_TAG_RE.fullmatch(label):
+            return resolve_version(artifact_dir, label).read_bytes()
+        return resolve_label(artifact_dir, label).read_bytes()
+
+    return _resolve

--- a/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
+++ b/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
@@ -108,6 +108,100 @@ class TestContextInitGenerateInline:
         assert not (home / ".codex" / "agents").exists()
 
 
+class TestContextVersionCliInline:
+    """In-process round-trip over ``mm context version`` + ``sync --label``
+    (ADR-0022). The pure module is covered in ``test_context_versioning.py``;
+    this pins the CLI surface and the edit/deploy split end-to-end."""
+
+    _AGENT = "---\nname: my-agent\ndescription: d\n---\n\nMARKER {m}\n"
+
+    def _dir_agent(self, project: Path, marker: str) -> Path:
+        adir = project / ".memtomem" / "agents" / "my-agent"
+        adir.mkdir(parents=True, exist_ok=True)
+        working = adir / "agent.md"
+        working.write_text(self._AGENT.format(m=marker), encoding="utf-8")
+        return working
+
+    def test_version_create_promote_sync_roundtrip(self, tmp_path, monkeypatch):
+        from memtomem.cli import _bootstrap
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        _seed_project(project)
+        set_home(monkeypatch, home)
+        monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+
+        working = self._dir_agent(project, marker="A")
+
+        # 1. create → versions/v1.md
+        r = runner.invoke(cli, ["context", "version", "create", "agents", "my-agent"])
+        assert r.exit_code == 0, r.output
+        assert (project / ".memtomem/agents/my-agent/versions/v1.md").is_file()
+
+        # 2. working file moves on to B
+        working.write_text(self._AGENT.format(m="B"), encoding="utf-8")
+
+        # 3. promote production → v1
+        r = runner.invoke(
+            cli,
+            [
+                "context",
+                "version",
+                "promote",
+                "agents",
+                "my-agent",
+                "--to",
+                "production",
+                "--version",
+                "v1",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+
+        # 4. list shows v1 + the production pointer
+        r = runner.invoke(cli, ["context", "version", "list", "agents", "my-agent"])
+        assert r.exit_code == 0, r.output
+        assert "v1" in r.output and "production" in r.output
+
+        # 5. sync --label production → frozen v1 (marker A) fans out
+        r = runner.invoke(cli, ["context", "sync", "--include=agents", "--label", "production"])
+        assert r.exit_code == 0, r.output
+        out = (project / ".claude/agents/my-agent.md").read_text(encoding="utf-8")
+        assert "MARKER A" in out and "MARKER B" not in out
+
+        # 6. backward-compat: no --label syncs the working file (marker B)
+        r = runner.invoke(cli, ["context", "sync", "--include=agents"])
+        assert r.exit_code == 0, r.output
+        out = (project / ".claude/agents/my-agent.md").read_text(encoding="utf-8")
+        assert "MARKER B" in out
+
+    def test_version_create_on_flat_layout_errors(self, tmp_path, monkeypatch):
+        from memtomem.cli import _bootstrap
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        _seed_project(project)
+        set_home(monkeypatch, home)
+        monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+
+        # Flat-layout agent (no per-artifact directory).
+        flat_root = project / ".memtomem" / "agents"
+        flat_root.mkdir(parents=True, exist_ok=True)
+        (flat_root / "flat-agent.md").write_text(self._AGENT.format(m="A"), encoding="utf-8")
+
+        r = runner.invoke(cli, ["context", "version", "create", "agents", "flat-agent"])
+        assert r.exit_code != 0
+        assert "migrate" in r.output.lower()
+
+
 class TestContextInitGenerateSubprocess:
     """Out-of-process ``mm`` round-trip — process-boundary regressions
     that the in-process variant cannot surface (HOME / USERPROFILE /

--- a/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
+++ b/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
@@ -220,6 +220,77 @@ class TestContextVersionCliInline:
         assert r.exit_code != 0
         assert "migrate" in r.output.lower()
 
+    def test_version_create_blocks_secret_in_project_shared(self, tmp_path, monkeypatch):
+        # Gate A: creating a version is a new git-tracked write for the default
+        # project_shared scope, so a secret in the working canonical must
+        # hard-refuse before versions/v1.md lands (Codex review).
+        from memtomem.cli import _bootstrap
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        _seed_project(project)
+        set_home(monkeypatch, home)
+        monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+
+        adir = project / ".memtomem" / "agents" / "leaky"
+        adir.mkdir(parents=True, exist_ok=True)
+        # Real AKIA fixture — generic placeholders do not trip Gate A.
+        (adir / "agent.md").write_text(
+            "---\nname: leaky\ndescription: d\n---\n\napi_key=AKIA1234567890ABCDEF\n",
+            encoding="utf-8",
+        )
+
+        r = runner.invoke(cli, ["context", "version", "create", "agents", "leaky"])
+        assert r.exit_code != 0, r.output
+        assert not (adir / "versions" / "v1.md").exists()  # refused before write
+
+    def test_command_version_roundtrip(self, tmp_path, monkeypatch):
+        # Commands have distinct parse/render paths — pin the CLI version flow
+        # for them too (Codex review).
+        from memtomem.cli import _bootstrap
+
+        home = tmp_path / "home"
+        home.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        _seed_project(project)
+        set_home(monkeypatch, home)
+        monkeypatch.setattr(_bootstrap, "_CONFIG_PATH", home / ".memtomem" / "config.json")
+        monkeypatch.chdir(project)
+        runner = CliRunner()
+
+        cdir = project / ".memtomem" / "commands" / "my-cmd"
+        cdir.mkdir(parents=True, exist_ok=True)
+        working = cdir / "command.md"
+        working.write_text("---\ndescription: c\n---\n\nDo $ARGUMENTS. M:A\n", encoding="utf-8")
+
+        r = runner.invoke(cli, ["context", "version", "create", "commands", "my-cmd"])
+        assert r.exit_code == 0, r.output
+        working.write_text("---\ndescription: c\n---\n\nDo $ARGUMENTS. M:B\n", encoding="utf-8")
+        r = runner.invoke(
+            cli,
+            [
+                "context",
+                "version",
+                "promote",
+                "commands",
+                "my-cmd",
+                "--to",
+                "production",
+                "--version",
+                "v1",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        r = runner.invoke(cli, ["context", "sync", "--include=commands", "--label", "production"])
+        assert r.exit_code == 0, r.output
+        out = (project / ".claude/commands/my-cmd.md").read_text(encoding="utf-8")
+        assert "M:A" in out and "M:B" not in out
+
 
 class TestContextInitGenerateSubprocess:
     """Out-of-process ``mm`` round-trip — process-boundary regressions

--- a/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
+++ b/packages/memtomem/tests/test_context_cli_subprocess_e2e.py
@@ -162,6 +162,25 @@ class TestContextVersionCliInline:
         )
         assert r.exit_code == 0, r.output
 
+        # 3b. a version-shaped label name is rejected cleanly (would be
+        #     shadowed by version v1 in the resolver).
+        r = runner.invoke(
+            cli,
+            [
+                "context",
+                "version",
+                "promote",
+                "agents",
+                "my-agent",
+                "--to",
+                "v1",
+                "--version",
+                "v1",
+            ],
+        )
+        assert r.exit_code != 0
+        assert "version tag" in r.output.lower()
+
         # 4. list shows v1 + the production pointer
         r = runner.invoke(cli, ["context", "version", "list", "agents", "my-agent"])
         assert r.exit_code == 0, r.output

--- a/packages/memtomem/tests/test_context_versioning.py
+++ b/packages/memtomem/tests/test_context_versioning.py
@@ -15,6 +15,7 @@ import pytest
 from memtomem.context import _skip_reasons as skip_codes
 from memtomem.context import versioning as v
 from memtomem.context.agents import CANONICAL_AGENT_ROOT, generate_all_agents
+from memtomem.context.commands import CANONICAL_COMMAND_ROOT, generate_all_commands
 
 # A dir-layout canonical agent whose rendered body carries a distinctive marker
 # so we can tell which version's bytes reached the runtime.
@@ -47,6 +48,19 @@ def _make_flat_agent(project_root, name="flat-agent", *, marker="A"):
         encoding="utf-8",
     )
     return path
+
+
+_COMMAND_TEMPLATE = "---\ndescription: a command\n---\n\nDo $ARGUMENTS. MARKER: {marker}\n"
+
+
+def _make_dir_command(project_root, name="my-cmd", *, marker="A"):
+    """Create a directory-layout canonical command and return its dir +
+    working file."""
+    artifact_dir = project_root / CANONICAL_COMMAND_ROOT / name
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    working = artifact_dir / "command.md"
+    working.write_text(_COMMAND_TEMPLATE.format(marker=marker), encoding="utf-8")
+    return artifact_dir, working
 
 
 # ── Pure versioning module ───────────────────────────────────────────
@@ -87,6 +101,21 @@ class TestCreateVersion:
         artifact_dir, working = _make_dir_agent(tmp_path)
         v.create_version(artifact_dir, working, note="stable release")
         assert v.load_manifest(artifact_dir).versions["v1"].note == "stable release"
+
+    def test_orphan_version_file_does_not_wedge(self, tmp_path):
+        # Crash between the vN.md write and the manifest save leaves an orphan
+        # file absent from the manifest. The next create must skip past it
+        # (allocate v2), not recompute v1 and wedge forever (Codex review).
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)  # v1.md + manifest{v1}
+        # Simulate the crash: manifest forgets v1, but v1.md stays on disk.
+        (artifact_dir / "versions.json").write_text(
+            json.dumps({"versions": {}, "labels": {}}), encoding="utf-8"
+        )
+        rec = v.create_version(artifact_dir, working)
+        assert rec.tag == "v2"
+        assert (artifact_dir / "versions" / "v2.md").is_file()
+        assert (artifact_dir / "versions" / "v1.md").is_file()  # orphan preserved
 
 
 class TestPromoteLabel:
@@ -359,3 +388,41 @@ class TestLabelAwareSync:
         result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="latest")
         assert result.generated
         assert (tmp_path / ".claude/agents/flat-agent.md").is_file()
+
+    def test_malformed_manifest_isolated_as_skip(self, tmp_path):
+        # A malformed/tampered versions.json during a labeled sync must not
+        # raise a raw traceback — the VersionError family is caught and isolated
+        # as a parse-class skip per artifact (Codex review).
+        artifact_dir, _ = _make_dir_agent(tmp_path, marker="A")
+        (artifact_dir / "versions.json").write_text("[]", encoding="utf-8")  # wrong shape
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="production")
+        codes = {code for _, _, code in result.skipped}
+        assert skip_codes.PARSE_ERROR in codes
+        assert not result.generated
+
+
+class TestLabelAwareSyncCommands:
+    """Commands have distinct parse/render paths from agents — pin that the
+    label-aware sync works end to end for them too (Codex review)."""
+
+    def test_label_fans_out_frozen_command_version(self, tmp_path):
+        artifact_dir, working = _make_dir_command(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)  # v1 = A
+        v.promote_label(artifact_dir, "production", "v1")
+        working.write_text(_COMMAND_TEMPLATE.format(marker="B"), encoding="utf-8")
+
+        result = generate_all_commands(tmp_path, runtimes=["claude_commands"], label="production")
+        assert result.generated
+        out = (tmp_path / ".claude/commands/my-cmd.md").read_text(encoding="utf-8")
+        assert "MARKER: A" in out and "MARKER: B" not in out
+
+    def test_command_label_latest_equals_no_label(self, tmp_path):
+        artifact_dir, working = _make_dir_command(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)
+        working.write_text(_COMMAND_TEMPLATE.format(marker="WORKING"), encoding="utf-8")
+        generate_all_commands(tmp_path, runtimes=["claude_commands"], label="latest")
+        latest_out = (tmp_path / ".claude/commands/my-cmd.md").read_text(encoding="utf-8")
+        generate_all_commands(tmp_path, runtimes=["claude_commands"])
+        nolabel_out = (tmp_path / ".claude/commands/my-cmd.md").read_text(encoding="utf-8")
+        assert latest_out == nolabel_out
+        assert "MARKER: WORKING" in latest_out

--- a/packages/memtomem/tests/test_context_versioning.py
+++ b/packages/memtomem/tests/test_context_versioning.py
@@ -127,6 +127,17 @@ class TestPromoteLabel:
         with pytest.raises(v.InvalidTagError):
             v.promote_label(artifact_dir, "production", "latest")
 
+    @pytest.mark.parametrize("bad_label", ["v1", "v2", "v10"])
+    def test_version_shaped_label_name_rejected(self, tmp_path, bad_label):
+        # A label named like a version tag would be permanently shadowed by the
+        # same-named version in the sync resolver — reject at write time.
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        with pytest.raises(v.InvalidLabelError):
+            v.promote_label(artifact_dir, bad_label, "v1")
+        # The shadowing label was never stored.
+        assert bad_label not in v.load_manifest(artifact_dir).labels
+
 
 class TestDeleteLabel:
     def test_removes_pointer(self, tmp_path):
@@ -219,6 +230,20 @@ class TestManifest:
             encoding="utf-8",
         )
         with pytest.raises(v.ReservedLabelError):
+            v.load_manifest(artifact_dir)
+
+    def test_load_rejects_version_shaped_label(self, tmp_path):
+        # A hand-edited version-shaped label is unreachable (shadowed by the
+        # same-named version) — refuse to load it (review P2).
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        (artifact_dir / "versions.json").write_text(
+            json.dumps(
+                {"versions": {"v1": {"created_at": "", "note": ""}}, "labels": {"v1": "v1"}}
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(v.InvalidLabelError):
             v.load_manifest(artifact_dir)
 
     @pytest.mark.parametrize("bad", ["[]", '"a string"', "42", '{"versions": []}', '{"labels": 3}'])

--- a/packages/memtomem/tests/test_context_versioning.py
+++ b/packages/memtomem/tests/test_context_versioning.py
@@ -1,0 +1,336 @@
+"""Tests for context/versioning.py — version snapshots + label pointers (ADR-0022).
+
+Covers the pure-filesystem versioning module (create/promote/resolve, tag
+validation, locking/no-overwrite) and its integration with the label-aware
+``generate_all_agents`` sync path.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+
+import pytest
+
+from memtomem.context import _skip_reasons as skip_codes
+from memtomem.context import versioning as v
+from memtomem.context.agents import CANONICAL_AGENT_ROOT, generate_all_agents
+
+# A dir-layout canonical agent whose rendered body carries a distinctive marker
+# so we can tell which version's bytes reached the runtime.
+_AGENT_TEMPLATE = """---
+name: my-agent
+description: {desc}
+---
+
+BODY MARKER: {marker}
+"""
+
+
+def _make_dir_agent(project_root, name="my-agent", *, marker="A", desc="v"):
+    """Create a directory-layout canonical agent and return its artifact dir +
+    working file."""
+    artifact_dir = project_root / CANONICAL_AGENT_ROOT / name
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    working = artifact_dir / "agent.md"
+    working.write_text(_AGENT_TEMPLATE.format(marker=marker, desc=desc), encoding="utf-8")
+    return artifact_dir, working
+
+
+def _make_flat_agent(project_root, name="flat-agent", *, marker="A"):
+    """Create a flat-layout canonical agent (no per-artifact directory)."""
+    root = project_root / CANONICAL_AGENT_ROOT
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.md"
+    path.write_text(
+        _AGENT_TEMPLATE.format(marker=marker, desc="flat").replace("my-agent", name),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ── Pure versioning module ───────────────────────────────────────────
+
+
+class TestCreateVersion:
+    def test_writes_immutable_file_with_working_bytes(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        rec = v.create_version(artifact_dir, working)
+        assert rec.tag == "v1"
+        vfile = artifact_dir / "versions" / "v1.md"
+        assert vfile.is_file()
+        assert vfile.read_bytes() == working.read_bytes()
+
+    def test_increments_tag(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        assert v.create_version(artifact_dir, working).tag == "v1"
+        assert v.create_version(artifact_dir, working).tag == "v2"
+        assert v.create_version(artifact_dir, working).tag == "v3"
+        manifest = v.load_manifest(artifact_dir)
+        assert set(manifest.versions) == {"v1", "v2", "v3"}
+
+    def test_snapshots_bytes_at_creation_time(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)
+        working.write_text("changed", encoding="utf-8")
+        # v1 still holds the original bytes — immutable.
+        assert b"BODY MARKER: A" in (artifact_dir / "versions" / "v1.md").read_bytes()
+
+    def test_flat_layout_raises(self, tmp_path):
+        # No per-artifact directory exists → versioning impossible.
+        missing_dir = tmp_path / CANONICAL_AGENT_ROOT / "flat-agent"
+        working = _make_flat_agent(tmp_path)  # creates agents/flat-agent.md, not a dir
+        with pytest.raises(v.VersionsDirMissingError):
+            v.create_version(missing_dir, working)
+
+    def test_note_persists(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working, note="stable release")
+        assert v.load_manifest(artifact_dir).versions["v1"].note == "stable release"
+
+
+class TestPromoteLabel:
+    def test_updates_manifest_pointer(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        v.create_version(artifact_dir, working)
+        v.promote_label(artifact_dir, "production", "v2")
+        manifest = v.load_manifest(artifact_dir)
+        assert manifest.labels["production"] == "v2"
+        # Persisted to disk.
+        raw = json.loads((artifact_dir / "versions.json").read_text())
+        assert raw["labels"]["production"] == "v2"
+
+    def test_move_pointer_is_rollback(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        v.create_version(artifact_dir, working)
+        v.promote_label(artifact_dir, "production", "v2")
+        v.promote_label(artifact_dir, "production", "v1")  # rollback
+        assert v.load_manifest(artifact_dir).labels["production"] == "v1"
+
+    def test_reserved_label_raises(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        with pytest.raises(v.ReservedLabelError):
+            v.promote_label(artifact_dir, "latest", "v1")
+
+    def test_unknown_version_raises(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        with pytest.raises(v.VersionNotFoundError):
+            v.promote_label(artifact_dir, "production", "v9")
+
+    def test_invalid_tag_raises(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        with pytest.raises(v.InvalidTagError):
+            v.promote_label(artifact_dir, "production", "latest")
+
+
+class TestDeleteLabel:
+    def test_removes_pointer(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        v.promote_label(artifact_dir, "production", "v1")
+        v.delete_label(artifact_dir, "production")
+        assert "production" not in v.load_manifest(artifact_dir).labels
+
+    def test_absent_is_noop(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        v.delete_label(artifact_dir, "nope")  # no raise
+
+    def test_reserved_raises(self, tmp_path):
+        artifact_dir, _ = _make_dir_agent(tmp_path)
+        with pytest.raises(v.ReservedLabelError):
+            v.delete_label(artifact_dir, "latest")
+
+
+class TestResolve:
+    def test_resolve_label_returns_version_path(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)
+        v.promote_label(artifact_dir, "production", "v1")
+        resolved = v.resolve_label(artifact_dir, "production")
+        assert resolved == artifact_dir / "versions" / "v1.md"
+        assert b"BODY MARKER: A" in resolved.read_bytes()
+
+    def test_resolve_label_latest_is_reserved(self, tmp_path):
+        # resolve_label deliberately does NOT handle "latest" — the caller
+        # branches on it and reads the working file directly.
+        artifact_dir, _ = _make_dir_agent(tmp_path)
+        with pytest.raises(v.ReservedLabelError):
+            v.resolve_label(artifact_dir, "latest")
+
+    def test_resolve_unknown_label_raises(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        with pytest.raises(v.LabelNotFoundError):
+            v.resolve_label(artifact_dir, "ghost")
+
+    def test_resolve_dangling_label_raises(self, tmp_path):
+        # Label points at a tag whose file was deleted out from under it.
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        v.promote_label(artifact_dir, "production", "v1")
+        (artifact_dir / "versions" / "v1.md").unlink()
+        with pytest.raises(v.VersionNotFoundError):
+            v.resolve_label(artifact_dir, "production")
+
+    def test_resolve_version_direct(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)
+        assert v.resolve_version(artifact_dir, "v1") == artifact_dir / "versions" / "v1.md"
+
+    def test_resolve_version_bad_tag_raises(self, tmp_path):
+        artifact_dir, _ = _make_dir_agent(tmp_path)
+        with pytest.raises(v.InvalidTagError):
+            v.resolve_version(artifact_dir, "v0")  # v0 invalid
+        with pytest.raises(v.InvalidTagError):
+            v.resolve_version(artifact_dir, "../etc")  # path-like rejected
+
+
+class TestManifest:
+    def test_load_absent_returns_empty(self, tmp_path):
+        artifact_dir, _ = _make_dir_agent(tmp_path)
+        manifest = v.load_manifest(artifact_dir)
+        assert manifest.versions == {}
+        assert manifest.labels == {}
+
+    def test_load_rejects_pathlike_tag(self, tmp_path):
+        artifact_dir, _ = _make_dir_agent(tmp_path)
+        (artifact_dir / "versions.json").write_text(
+            json.dumps({"versions": {"v1/../x": {"created_at": "", "note": ""}}, "labels": {}}),
+            encoding="utf-8",
+        )
+        with pytest.raises(v.InvalidTagError):
+            v.load_manifest(artifact_dir)
+
+    def test_load_rejects_reserved_label(self, tmp_path):
+        # A hand-edited 'latest' pointer is unmanageable (every mutating API
+        # rejects it) — refuse to load it (Codex review).
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        v.create_version(artifact_dir, working)
+        (artifact_dir / "versions.json").write_text(
+            json.dumps(
+                {"versions": {"v1": {"created_at": "", "note": ""}}, "labels": {"latest": "v1"}}
+            ),
+            encoding="utf-8",
+        )
+        with pytest.raises(v.ReservedLabelError):
+            v.load_manifest(artifact_dir)
+
+    @pytest.mark.parametrize("bad", ["[]", '"a string"', "42", '{"versions": []}', '{"labels": 3}'])
+    def test_load_rejects_malformed_shape(self, tmp_path, bad):
+        # Syntactically valid JSON of the wrong shape must surface a clean
+        # VersionError, not an AttributeError traceback (Codex review).
+        artifact_dir, _ = _make_dir_agent(tmp_path)
+        (artifact_dir / "versions.json").write_text(bad, encoding="utf-8")
+        with pytest.raises(v.VersionError):
+            v.load_manifest(artifact_dir)
+
+    def test_next_version_tag_pure(self):
+        m = v.VersionsManifest()
+        assert v.next_version_tag(m) == "v1"
+        m.versions["v1"] = v.VersionRecord("v1", "", "")
+        m.versions["v3"] = v.VersionRecord("v3", "", "")
+        assert v.next_version_tag(m) == "v4"  # max+1, not count
+
+
+class TestConcurrency:
+    def test_concurrent_create_no_overwrite(self, tmp_path):
+        """Two threads calling create_version must not both allocate v1 — the
+        single per-transaction _file_lock serializes tag allocation."""
+        artifact_dir, working = _make_dir_agent(tmp_path)
+        barrier = threading.Barrier(2)
+        tags: list[str] = []
+        errors: list[Exception] = []
+
+        def worker():
+            try:
+                barrier.wait()
+                tags.append(v.create_version(artifact_dir, working).tag)
+            except Exception as exc:  # noqa: BLE001 — surface for assertion
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, errors
+        # Distinct tags, both files present, manifest has both.
+        assert sorted(tags) == ["v1", "v2"]
+        assert (artifact_dir / "versions" / "v1.md").is_file()
+        assert (artifact_dir / "versions" / "v2.md").is_file()
+        assert set(v.load_manifest(artifact_dir).versions) == {"v1", "v2"}
+
+
+# ── Label-aware sync integration (generate_all_agents) ───────────────
+
+
+class TestLabelAwareSync:
+    def test_label_fans_out_frozen_version(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)  # v1 = A
+        v.promote_label(artifact_dir, "production", "v1")
+        # Working file moves on to B.
+        working.write_text(_AGENT_TEMPLATE.format(marker="B", desc="v"), encoding="utf-8")
+
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="production")
+        assert result.generated  # something fanned out
+        out = (tmp_path / ".claude/agents/my-agent.md").read_text(encoding="utf-8")
+        assert "BODY MARKER: A" in out  # frozen v1, not the working B
+        assert "BODY MARKER: B" not in out
+
+    def test_label_latest_equals_no_label(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)
+        working.write_text(_AGENT_TEMPLATE.format(marker="WORKING", desc="v"), encoding="utf-8")
+
+        generate_all_agents(tmp_path, runtimes=["claude_agents"], label="latest")
+        latest_out = (tmp_path / ".claude/agents/my-agent.md").read_text(encoding="utf-8")
+        generate_all_agents(tmp_path, runtimes=["claude_agents"])  # no label
+        nolabel_out = (tmp_path / ".claude/agents/my-agent.md").read_text(encoding="utf-8")
+        assert latest_out == nolabel_out
+        assert "BODY MARKER: WORKING" in latest_out  # both use the working file
+
+    def test_version_tag_direct(self, tmp_path):
+        artifact_dir, working = _make_dir_agent(tmp_path, marker="A")
+        v.create_version(artifact_dir, working)  # v1 = A
+        working.write_text(_AGENT_TEMPLATE.format(marker="B", desc="v"), encoding="utf-8")
+
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="v1")
+        assert result.generated
+        out = (tmp_path / ".claude/agents/my-agent.md").read_text(encoding="utf-8")
+        assert "BODY MARKER: A" in out
+
+    def test_unknown_label_isolated_as_skip(self, tmp_path):
+        _make_dir_agent(tmp_path, marker="A")  # no versions/labels created
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="ghost")
+        # Per-artifact isolation: skip with LABEL_NOT_FOUND, nothing fanned out,
+        # no raise.
+        assert not result.generated
+        codes = {code for _, _, code in result.skipped}
+        assert skip_codes.LABEL_NOT_FOUND in codes
+        # Skip row names the artifact (my-agent), not the dir-layout filename
+        # (agent.md) — Codex review.
+        names = {name for name, _, code in result.skipped if code == skip_codes.LABEL_NOT_FOUND}
+        assert names == {"my-agent"}
+        assert not (tmp_path / ".claude/agents/my-agent.md").exists()
+
+    def test_flat_layout_with_label_isolated_as_skip(self, tmp_path):
+        _make_flat_agent(tmp_path, name="flat-agent", marker="A")
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="production")
+        codes = {code for _, _, code in result.skipped}
+        assert skip_codes.VERSIONING_REQUIRES_DIR_LAYOUT in codes
+        assert not result.generated
+
+    def test_flat_layout_latest_still_works(self, tmp_path):
+        # latest / no-label on a flat artifact is unaffected (current behavior).
+        _make_flat_agent(tmp_path, name="flat-agent", marker="A")
+        result = generate_all_agents(tmp_path, runtimes=["claude_agents"], label="latest")
+        assert result.generated
+        assert (tmp_path / ".claude/agents/flat-agent.md").is_file()


### PR DESCRIPTION
## What

Implements the **edit/deploy split** from ADR-0022 (#1206) — PR1 of the stacked epic. Immutable per-artifact version snapshots plus movable label pointers, so a canonical can be **frozen → promoted → rolled back** by moving a pointer, instead of every `mm context sync` shipping the live working file.

```
.memtomem/agents/<name>/
├── agent.md            ← working canonical (label "latest"; unchanged)
├── versions/v1.md      ← immutable snapshot (write-once)
└── versions.json       ← {versions, labels} — the only mutable state
```

## Why

The canonical → runtime fan-out was **edit-coupled-to-deploy**: a bad edit to `agent.md` was one sync away from every runtime, with no freeze / promote / rollback.

## Surface

```bash
mm context version create agents my-agent --note "stable"   # → versions/v1.md
mm context version promote agents my-agent --to production --version v1
mm context version list agents my-agent
mm context sync --include=agents --label production          # fan out frozen v1
mm context sync --include=agents                             # no label = working file (unchanged)
```

## How

- **`context/versioning.py`** (new) — pure-filesystem store. `create_version`/`promote_label`/`delete_label` hold a single non-reentrant `_file_lock` across the whole `load→mutate→write` transaction (the `lockfile.py` pattern), so two racing creates can't both allocate a tag. Version files are write-once. Tags validated `^v[1-9]\d*$` on create/load/resolve/promote (path-traversal guard). `load_manifest` rejects malformed JSON shape and a hand-edited reserved `latest` label.
- **`_sync_atomic.py`** — optional `resolve_canonical_bytes` on `AtomicSyncAdapter` (default `None` ⇒ today's `read_bytes`, **byte-for-byte unchanged**). When set, Phase 1 substitutes a labeled snapshot's bytes; `LabelNotFound`/`VersionNotFound`/`VersionsDirMissing` isolate **per-artifact as typed skips**, never aborting the fan-out.
- **`agents.py`/`commands.py`** — `generate_all_*(label=...)`. `None`/`latest` ⇒ unchanged; a label builds a transient `dataclasses.replace` adapter via the shared `make_label_resolver` (flat layout → skip; bare `vN` → `resolve_version`, named label → `resolve_label`).
- **CLI** — `mm context version` group + `--label` on sync/generate. `--label` applies only to agents/commands; ineligible included kinds warn and run label-less (ADR-0022 invariant 10).

## Scope

`agents` + `commands` (skills deferred per the ADR-0022 TRACKER row). `diff` stays label-unaware in v1. **MCP tools (PR2)** and **web UI (PR3)** follow.

## Backward compatibility

Total — no `--label` ⇒ working file, byte-for-byte. The module-level adapters are never mutated; label-aware callers pass a transient `dataclasses.replace` copy.

## Tests

`test_context_versioning.py` (unit incl. **concurrency** no-double-allocate + **manifest robustness**) + a CLI e2e create→promote→sync→rollback roundtrip. Full suite green locally: **5886 passed**.

## Review trail

Reviewed by Codex (`NEEDS-FIX` → all fixed): reject reserved `latest` on manifest load; clean `VersionError` for malformed JSON shape (e.g. `[]`); skip rows name the artifact, not its `agent.md`/`command.md` filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)